### PR TITLE
[codex] Allow full ride offers to collect requests

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1141,8 +1141,7 @@ service cloud.firestore {
              get(offerPath).data.seatCapacity is int &&
              get(offerPath).data.seatCapacity > 0 &&
              get(offerPath).data.seatCountConfirmed is int &&
-             get(offerPath).data.seatCountConfirmed >= 0 &&
-             get(offerPath).data.seatCountConfirmed < get(offerPath).data.seatCapacity;
+             get(offerPath).data.seatCountConfirmed >= 0;
     }
 
     // Require request status decisions/deletes to keep parent offer seat counters consistent.

--- a/js/db.js
+++ b/js/db.js
@@ -7623,10 +7623,6 @@ export async function requestRideSpot(teamId, gameId, offerId, payload = {}) {
             }
         }
 
-        const seatCapacity = toNonNegativeInteger(offer.seatCapacity, 0);
-        const currentSeatCountConfirmed = toNonNegativeInteger(offer.seatCountConfirmed, 0);
-        if (currentSeatCountConfirmed >= seatCapacity) throw new Error('Offer is full.');
-
         const requestedAt = Timestamp.now();
         const updatedAt = Timestamp.now();
         const requestPayload = {
@@ -7896,4 +7892,3 @@ export async function revokeFamilyShareToken(tokenId) {
         updatedAt: Timestamp.now()
     });
 }
-

--- a/js/rideshare-helpers.js
+++ b/js/rideshare-helpers.js
@@ -79,8 +79,7 @@ export function canRequestRide(offer = {}, parentUserId, childId) {
     if (normalized.status !== OFFER_STATUS_OPEN) return false;
     if (!parentUserId || !childId) return false;
     if (normalized.driverUserId === parentUserId) return false;
-    const seatInfo = getOfferSeatInfo(normalized);
     const existing = findRequestForChild(normalized, parentUserId, childId);
     if (existing?.status === REQUEST_STATUS_PENDING || existing?.status === REQUEST_STATUS_CONFIRMED) return false;
-    return seatInfo.seatsLeft > 0;
+    return true;
 }

--- a/tests/unit/rideshare-helpers.test.js
+++ b/tests/unit/rideshare-helpers.test.js
@@ -85,7 +85,7 @@ describe('rideshare helpers', () => {
     expect(findRequestForChild(offer, 'u3', 'c9')).toBeNull();
   });
 
-  it('allows request only when rider is not driver and seat is available', () => {
+  it('allows requests on open offers so drivers can waitlist full rides', () => {
     const offer = {
       status: 'open',
       driverUserId: 'driver-1',
@@ -96,5 +96,10 @@ describe('rideshare helpers', () => {
     expect(canRequestRide(offer, 'parent-3', 'child-3')).toBe(true);
     expect(canRequestRide(offer, 'driver-1', 'child-4')).toBe(false);
     expect(canRequestRide(offer, 'parent-2', 'child-2')).toBe(false);
+    expect(canRequestRide({
+      ...offer,
+      seatCountConfirmed: 2,
+      requests: []
+    }, 'parent-4', 'child-4')).toBe(true);
   });
 });

--- a/tests/unit/rideshare-rerequest-policy.test.js
+++ b/tests/unit/rideshare-rerequest-policy.test.js
@@ -27,9 +27,7 @@ describe('rideshare re-request policy', () => {
         expect(source).toContain('const [offerSnap, existingRequestSnap] = await Promise.all([tx.get(offerRef), tx.get(requestRef)]);');
         expect(source).toContain("if (offerStatus !== RIDE_OFFER_STATUS.OPEN) throw new Error('Ride offer is closed.');");
         expect(source).toContain("if (existingStatus && existingStatus !== RIDE_REQUEST_STATUS.DECLINED && existingStatus !== RIDE_REQUEST_STATUS.WAITLISTED)");
-        expect(source).toContain('const seatCapacity = toNonNegativeInteger(offer.seatCapacity, 0);');
-        expect(source).toContain('const currentSeatCountConfirmed = toNonNegativeInteger(offer.seatCountConfirmed, 0);');
-        expect(source).toContain("if (currentSeatCountConfirmed >= seatCapacity) throw new Error('Offer is full.');");
+        expect(source).not.toContain("throw new Error('Offer is full.');");
         expect(source).toContain('tx.update(requestRef, requestPayload);');
         expect(source).toContain('tx.set(requestRef, {');
         expect(source).toContain('status: RIDE_REQUEST_STATUS.PENDING');
@@ -47,7 +45,7 @@ describe('rideshare re-request policy', () => {
         expect(rules).toContain('isParentForPlayer(teamId, resource.data.childId)');
         expect(rules).toContain('request.resource.data.diff(resource.data).affectedKeys().hasOnly([\'childName\', \'status\', \'requestedAt\', \'respondedAt\', \'updatedAt\'])');
         expect(rules).toContain('function isRideshareOfferAcceptingRequests(teamId, gameId, offerId)');
-        expect(rules).toContain('get(offerPath).data.seatCountConfirmed < get(offerPath).data.seatCapacity');
+        expect(rules).not.toContain('get(offerPath).data.seatCountConfirmed < get(offerPath).data.seatCapacity');
         expect(rules).toContain('isRideshareOfferAcceptingRequests(teamId, gameId, offerId)');
     });
 });


### PR DESCRIPTION
Closes #2199

## What changed
- Allows parents to submit ride requests on open offers even when confirmed seats already meet capacity, so drivers can waitlist them.
- Keeps driver/self and active-request guards in place.
- Aligns Firestore rules with the same open-offer request policy while keeping confirmation capacity protection separate.

## Validation
- `npx vitest run tests/unit/rideshare-helpers.test.js tests/unit/rideshare-rerequest-policy.test.js tests/unit/parent-dashboard-rideshare-controls.test.js --reporter=verbose`
- `npm run ci:firebase-rules`