### PR TITLE
Extend native REST log redaction to cover bearer tokens in error messages and request init

### DIFF
--- a/apps/app/src/lib/nativeRestLogging.ts
+++ b/apps/app/src/lib/nativeRestLogging.ts
@@ -69,3 +69,11 @@ function sanitizeValue(value: unknown, seen: WeakSet<object>, depth: number, key
 export function sanitizeErrorForLogging(error: unknown) {
     return sanitizeValue(error, new WeakSet<object>(), 0);
 }
+
+export function sanitizeRequestInitForLogging(init: RequestInit): Partial<RequestInit> {
+    const { headers, ...rest } = init;
+    return {
+        ...rest,
+        headers: '[REDACTED]' as unknown as HeadersInit
+    };
+}

--- a/apps/app/src/lib/nativeRestLogging.ts
+++ b/apps/app/src/lib/nativeRestLogging.ts
@@ -70,10 +70,13 @@ export function sanitizeErrorForLogging(error: unknown) {
     return sanitizeValue(error, new WeakSet<object>(), 0);
 }
 
-export function sanitizeRequestInitForLogging(init: RequestInit): Partial<RequestInit> {
-    const { headers, ...rest } = init;
+export type SanitizedRequestInitForLogging = Record<string, unknown>;
+
+export function sanitizeRequestInitForLogging(init: RequestInit): SanitizedRequestInitForLogging {
+    const sanitized = sanitizeValue(init, new WeakSet<object>(), 0);
+
     return {
-        ...rest,
-        headers: '[REDACTED]' as unknown as HeadersInit
+        ...(sanitized as Record<string, unknown>),
+        headers: redactedValue
     };
 }

--- a/tests/unit/app-native-rest-logging.test.ts
+++ b/tests/unit/app-native-rest-logging.test.ts
@@ -46,17 +46,35 @@ describe('native REST logging sanitizer', () => {
         expect(sanitized.message).toContain('Bearer [REDACTED]');
     });
 
-    it('sanitizeRequestInitForLogging replaces headers with [REDACTED]', () => {
-        const init: RequestInit = {
+    it('sanitizeRequestInitForLogging redacts headers and nested body secrets', () => {
+        const init = {
             method: 'POST',
             headers: { Authorization: 'Bearer abc123', 'Content-Type': 'application/json' },
-            body: JSON.stringify({ foo: 'bar' })
-        };
+            body: {
+                idToken: 'id-token-123',
+                refreshToken: 'refresh-token-456',
+                nested: {
+                    authorization: 'Bearer nested-token-789'
+                }
+            } as unknown as BodyInit
+        } as RequestInit;
+
         const sanitized = sanitizeRequestInitForLogging(init);
+        const serialized = JSON.stringify(sanitized);
+
         expect(sanitized.headers).toBe('[REDACTED]');
         expect(sanitized.method).toBe('POST');
-        expect(sanitized.body).toBe(JSON.stringify({ foo: 'bar' }));
-        expect(JSON.stringify(sanitized)).not.toContain('abc123');
-        expect(JSON.stringify(sanitized)).not.toContain('Authorization');
+        expect(serialized).not.toContain('abc123');
+        expect(serialized).not.toContain('Authorization');
+        expect(serialized).not.toContain('id-token-123');
+        expect(serialized).not.toContain('refresh-token-456');
+        expect(serialized).not.toContain('nested-token-789');
+        expect(sanitized.body).toEqual({
+            idToken: '[REDACTED]',
+            refreshToken: '[REDACTED]',
+            nested: {
+                authorization: '[REDACTED]'
+            }
+        });
     });
 });

--- a/tests/unit/app-native-rest-logging.test.ts
+++ b/tests/unit/app-native-rest-logging.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { sanitizeErrorForLogging } from '../../apps/app/src/lib/nativeRestLogging.ts';
+import { sanitizeErrorForLogging, sanitizeRequestInitForLogging } from '../../apps/app/src/lib/nativeRestLogging.ts';
 
 describe('native REST logging sanitizer', () => {
     it('redacts bearer auth and token fields from nested log payloads', () => {
@@ -37,5 +37,26 @@ describe('native REST logging sanitizer', () => {
                 }
             }
         });
+    });
+
+    it('redacts bearer token appearing in an error message string', () => {
+        const error = new Error('Request failed: Bearer sometoken123 was rejected');
+        const sanitized = sanitizeErrorForLogging(error) as { message: string };
+        expect(sanitized.message).not.toContain('sometoken123');
+        expect(sanitized.message).toContain('Bearer [REDACTED]');
+    });
+
+    it('sanitizeRequestInitForLogging replaces headers with [REDACTED]', () => {
+        const init: RequestInit = {
+            method: 'POST',
+            headers: { Authorization: 'Bearer abc123', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ foo: 'bar' })
+        };
+        const sanitized = sanitizeRequestInitForLogging(init);
+        expect(sanitized.headers).toBe('[REDACTED]');
+        expect(sanitized.method).toBe('POST');
+        expect(sanitized.body).toBe(JSON.stringify({ foo: 'bar' }));
+        expect(JSON.stringify(sanitized)).not.toContain('abc123');
+        expect(JSON.stringify(sanitized)).not.toContain('Authorization');
     });
 });


### PR DESCRIPTION
## Summary
- Audit confirmed all four native REST service files (`profileService.ts`, `scheduleService.ts`, `teamDetailService.ts`, `chatService.ts`) already use `sanitizeErrorForLogging(error)` on every catch block — no raw token leakage found
- Add `sanitizeRequestInitForLogging(init: RequestInit)` export to `nativeRestLogging.ts` — strips the `headers` field (which contains `Authorization: Bearer ...`) and replaces it with `'[REDACTED]'`, preserving other diagnostic fields (`method`, `body`) for future use if callers ever need to log the request config

## Test plan
- [ ] Unit: 2 new regression tests in `app-native-rest-logging.test.ts` — `sanitizeErrorForLogging` redacts `Bearer sometoken123` from an error message string; `sanitizeRequestInitForLogging` removes `Authorization` header and the token value while keeping `method`/`body` — all 3 tests in the file pass
- [ ] Manual security review: search the console output of a failing native REST call — confirm no `Bearer` tokens appear in logs

Closes #2058

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_