### PR TITLE
[codex] Cap app player search team fan-out

### DIFF
--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -16,6 +16,7 @@ import type { AuthState, AuthUser, UserRole } from './types';
 
 const teamsCacheTtlMs = 10 * 60 * 1000;
 const playerSearchQueryLimit = 20;
+const playerSearchTeamLimit = 8;
 const teamSearchQueryLimit = 20;
 
 let cachedTeams: AppSearchTeam[] | null = null;
@@ -428,7 +429,8 @@ export async function searchAppPlayers(queryText: string, teamsById: Map<string,
     }
   }
 
-  const playerSearchPromise = loadPlayerSearchDocs(rawQuery, prefixes, isNumeric, Array.from(teamsById.keys()))
+  const teamIds = getPlayerSearchTeamIds(rawQuery, teamsById, user);
+  const playerSearchPromise = loadPlayerSearchDocs(rawQuery, prefixes, isNumeric, teamIds)
     .then(({ docs, exhaustiveForNarrowerQueries }) => {
       const players = buildAppSearchPlayersFromDocs(docs, teamsById, user, tokens);
       playerSearchCache.set(cacheKey, {
@@ -714,6 +716,33 @@ function rankTeamsForQuery(teams: AppSearchTeam[], queryText: string) {
   return rankedItems
     .map((item) => itemsById.get(item.id.replace(/^team:/, '')))
     .filter(Boolean) as AppSearchTeam[];
+}
+
+function getPlayerSearchTeamIds(rawQuery: string, teamsById: Map<string, AppSearchTeam>, user: AuthUser | null) {
+  const searchableTeams = Array.from(teamsById.values()).filter((team) => canUserDiscoverTeamInAppSearch(team, user));
+  if (!searchableTeams.length) return [];
+
+  const privateTeams = searchableTeams.filter((team) => team.isPublic === false);
+  const publicTeams = searchableTeams.filter((team) => team.isPublic !== false);
+  const rankedPublicTeams = rankPlayerSearchTeamsForQuery(publicTeams, rawQuery);
+
+  return [...privateTeams, ...rankedPublicTeams]
+    .slice(0, playerSearchTeamLimit)
+    .map((team) => cleanString(team.id))
+    .filter(Boolean);
+}
+
+function rankPlayerSearchTeamsForQuery(teams: AppSearchTeam[], queryText: string) {
+  const tokens = splitSearchTokens(queryText);
+  if (!tokens.length) return teams;
+  return teams
+    .map((team, index) => ({
+      team,
+      index,
+      score: scoreSearchText([team.name, team.sport, team.zip || [team.city, team.state].filter(Boolean).join(' ')].filter(Boolean).join(' '), tokens)
+    }))
+    .sort((a, b) => (b.score - a.score) || (a.index - b.index))
+    .map((entry) => entry.team);
 }
 
 function teamToSearchItem(team: AppSearchTeam): AppSearchItem {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -744,7 +744,7 @@ describe('React app search service', () => {
 
         expect(firebaseMocks.collectionGroup).not.toHaveBeenCalled();
         expect(firebaseMocks.collection).toHaveBeenCalledWith(firebaseMocks.db, 'teams/team-1/players');
-        expect(firebaseMocks.collection).toHaveBeenCalledWith(firebaseMocks.db, 'teams/team-private/players');
+        expect(firebaseMocks.collection).not.toHaveBeenCalledWith(firebaseMocks.db, 'teams/team-private/players');
         expect(firebaseMocks.getDocs).toHaveBeenCalled();
         expect(players).toEqual([{
             id: 'player:team-1:player-1',
@@ -755,6 +755,30 @@ describe('React app search service', () => {
             teamId: 'team-1',
             playerId: 'player-1'
         }]);
+    });
+
+    it('caps player-search fan-out to the top ranked searchable teams', async () => {
+        const visibleTeams = new Map(Array.from({ length: 12 }, (_, index) => [
+            `team-${index}`,
+            {
+                id: `team-${index}`,
+                name: `Bear Team ${index}`,
+                sport: 'Basketball',
+                isPublic: true
+            }
+        ]));
+        firebaseMocks.getDocs.mockResolvedValue({ docs: [] });
+
+        await searchAppPlayers('bear', visibleTeams, auth.user);
+
+        const playerCollectionPaths = firebaseMocks.collection.mock.calls
+            .map(([, path]) => path)
+            .filter((path) => String(path).endsWith('/players'));
+        const uniquePlayerCollections = Array.from(new Set(playerCollectionPaths));
+
+        expect(uniquePlayerCollections).toHaveLength(8);
+        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(16);
+        expect(uniquePlayerCollections).toEqual(Array.from({ length: 8 }, (_, index) => `teams/team-${index}/players`));
     });
 
     it('reuses cached broader player prefixes for narrower refinements when local filtering is sufficient', async () => {


### PR DESCRIPTION
Superseded by #2219, which already covers #2188.

Closing this duplicate so the current batch can focus on uncovered issues.