### PR TITLE
Reset recurring checkbox state when editing a non-recurring practice

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -3407,6 +3407,13 @@
             editingSeriesId = practice.seriesId || null;
             switchTab('tab-add-practice');
 
+            const recurrenceEndInputs = Array.from(document.querySelectorAll('input[name="recurrenceEnd"]'));
+            const setRecurrenceEnd = (value) => {
+                recurrenceEndInputs.forEach((input) => {
+                    input.checked = input.value === value;
+                });
+            };
+
             document.getElementById('practiceTitle').value = practice.title || 'Practice';
             document.getElementById('practiceStart').value = formatIsoForInput(practice.date);
 
@@ -3433,14 +3440,14 @@
 
                 // Set end condition
                 if (practice.recurrence.until) {
-                    document.querySelector('input[name="recurrenceEnd"][value="until"]').checked = true;
+                    setRecurrenceEnd('until');
                     const untilDate = practice.recurrence.until?.toDate ? practice.recurrence.until.toDate() : new Date(practice.recurrence.until);
                     document.getElementById('recurrenceUntil').value = untilDate.toISOString().split('T')[0];
                 } else if (practice.recurrence.count) {
-                    document.querySelector('input[name="recurrenceEnd"][value="count"]').checked = true;
+                    setRecurrenceEnd('count');
                     document.getElementById('recurrenceCount').value = practice.recurrence.count;
                 } else {
-                    document.querySelector('input[name="recurrenceEnd"][value="never"]').checked = true;
+                    setRecurrenceEnd('never');
                 }
             } else {
                 // Explicitly reset recurring state so stale form state from a previous edit
@@ -3448,7 +3455,7 @@
                 document.getElementById('practiceRecurring').checked = false;
                 document.getElementById('recurrence-builder').classList.add('hidden');
                 document.querySelectorAll('.day-checkbox').forEach(cb => { cb.checked = false; });
-                document.querySelector('input[name="recurrenceEnd"][value="never"]').checked = true;
+                setRecurrenceEnd('never');
                 document.getElementById('recurrenceUntil').value = '';
                 document.getElementById('recurrenceCount').value = '10';
                 document.getElementById('recurrenceFreq').value = 'weekly';

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -3442,6 +3442,17 @@
                 } else {
                     document.querySelector('input[name="recurrenceEnd"][value="never"]').checked = true;
                 }
+            } else {
+                // Explicitly reset recurring state so stale form state from a previous edit
+                // does not carry over when editing a non-recurring practice.
+                document.getElementById('practiceRecurring').checked = false;
+                document.getElementById('recurrence-builder').classList.add('hidden');
+                document.querySelectorAll('.day-checkbox').forEach(cb => { cb.checked = false; });
+                document.querySelector('input[name="recurrenceEnd"][value="never"]').checked = true;
+                document.getElementById('recurrenceUntil').value = '';
+                document.getElementById('recurrenceCount').value = '10';
+                document.getElementById('recurrenceFreq').value = 'weekly';
+                document.getElementById('recurrenceInterval').value = '1';
             }
 
             document.getElementById('submit-practice-btn').textContent = 'Update Practice';

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -162,4 +162,73 @@ describe('edit schedule practice save flow', () => {
         expect(source).toContain('const { savedPracticeId } = await savePracticeForm({');
         expect(source).toContain('applyPracticeRecurrenceFields');
     });
+
+    it('does not save isSeriesMaster or recurrence when editing a non-recurring practice', async () => {
+        // Regression test for issue #2201: editing a non-recurring practice after a recurring one
+        // would carry over the stale recurring checkbox state and accidentally persist recurrence fields.
+        const addPractice = vi.fn();
+        const updateEvent = vi.fn().mockResolvedValue(undefined);
+        const deletedFields = [];
+        const deleteField = () => {
+            const sentinel = Symbol('deleteField');
+            deletedFields.push(sentinel);
+            return sentinel;
+        };
+        const startDate = createLocalDate(2026, 3, 10, 9, 0);
+        const endDate = createLocalDate(2026, 3, 10, 10, 0);
+        const Timestamp = {
+            fromDate: (value) => ({ iso: value.toISOString() })
+        };
+
+        // Simulate the form state as it would be after a user previously edited a recurring
+        // practice and left the recurring checkbox checked, then opens a non-recurring practice.
+        // The form code should supply isRecurring: false derived from the practice's own data.
+        const result = await savePracticeForm({
+            teamId: 'team-1',
+            editingPracticeId: 'practice-nonrecurring',
+            editingSeriesId: null,
+            formState: {
+                title: 'One-Off Practice',
+                startDate,
+                endDate,
+                location: 'Field A',
+                notes: '',
+                scheduleNotifications: { enabled: false }
+            },
+            recurrenceState: {
+                isRecurring: false,
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['MO'],
+                endType: 'never',
+                untilValue: '',
+                countValue: '10'
+            },
+            Timestamp,
+            deleteField,
+            generateSeriesId: () => 'should-not-be-called',
+            addPractice,
+            updateEvent
+        });
+
+        expect(addPractice).not.toHaveBeenCalled();
+        const savedPayload = updateEvent.mock.calls[0][2];
+
+        // Recurrence fields must be wiped (set to deleteField()) — not persisted as true
+        expect(savedPayload.isSeriesMaster).not.toBe(true);
+        expect(savedPayload.recurrence).not.toMatchObject({ freq: expect.any(String) });
+
+        // The deleteField sentinel must have been applied (recurrence fields cleared)
+        expect(deletedFields.length).toBeGreaterThan(0);
+
+        expect(result.savedPracticeId).toBe('practice-nonrecurring');
+    });
+
+    it('resets recurring checkbox and builder when startEditPractice loads a non-recurring practice', () => {
+        const source = readEditSchedule();
+
+        // The else branch that resets recurring state must exist in startEditPractice
+        expect(source).toContain("practiceRecurring').checked = false");
+        expect(source).toContain("recurrence-builder').classList.add('hidden')");
+    });
 });

--- a/tests/unit/edit-schedule-practice-timezone.test.js
+++ b/tests/unit/edit-schedule-practice-timezone.test.js
@@ -60,11 +60,11 @@ console.log(formatIsoForInput('2026-01-16T00:00:00.000Z'));
 let editingPracticeId = null;
 let editingSeriesId = null;
 const elements = {};
-const recurrenceEndInputs = {
-    never: { checked: false, value: 'never' },
-    until: { checked: false, value: 'until' },
-    count: { checked: false, value: 'count' }
-};
+const recurrenceEndInputs = [
+    { checked: false, value: 'never' },
+    { checked: false, value: 'until' },
+    { checked: false, value: 'count' }
+];
 const document = {
     getElementById(id) {
         if (!elements[id]) {
@@ -79,13 +79,10 @@ const document = {
         }
         return elements[id];
     },
-    querySelector(selector) {
-        if (selector.includes('[value="never"]')) return recurrenceEndInputs.never;
-        if (selector.includes('[value="until"]')) return recurrenceEndInputs.until;
-        if (selector.includes('[value="count"]')) return recurrenceEndInputs.count;
-        return null;
-    },
-    querySelectorAll() {
+    querySelectorAll(selector) {
+        if (selector === 'input[name="recurrenceEnd"]') {
+            return recurrenceEndInputs;
+        }
         return [];
     }
 };

--- a/tests/unit/edit-schedule-practice-timezone.test.js
+++ b/tests/unit/edit-schedule-practice-timezone.test.js
@@ -60,6 +60,11 @@ console.log(formatIsoForInput('2026-01-16T00:00:00.000Z'));
 let editingPracticeId = null;
 let editingSeriesId = null;
 const elements = {};
+const recurrenceEndInputs = {
+    never: { checked: false, value: 'never' },
+    until: { checked: false, value: 'until' },
+    count: { checked: false, value: 'count' }
+};
 const document = {
     getElementById(id) {
         if (!elements[id]) {
@@ -73,6 +78,12 @@ const document = {
             };
         }
         return elements[id];
+    },
+    querySelector(selector) {
+        if (selector.includes('[value="never"]')) return recurrenceEndInputs.never;
+        if (selector.includes('[value="until"]')) return recurrenceEndInputs.until;
+        if (selector.includes('[value="count"]')) return recurrenceEndInputs.count;
+        return null;
     },
     querySelectorAll() {
         return [];


### PR DESCRIPTION
## Summary
- Root cause: `startEditPractice()` in `edit-schedule.html` only set `practiceRecurring.checked = true` when loading a series-master practice, with no `else` branch — if the user had previously edited a recurring practice, those DOM elements retained their state
- Add an `else` branch that explicitly unchecks `practiceRecurring`, hides `recurrence-builder`, unchecks all `.day-checkbox` elements, and resets `recurrenceEnd`, `recurrenceUntil`, `recurrenceCount`, `recurrenceFreq`, and `recurrenceInterval` to defaults

## Test plan
- [ ] Unit: 2 new regression tests in `edit-schedule-practice-submit.test.js` — `savePracticeForm` with `isRecurring: false` for an existing practice produces no `isSeriesMaster`/`recurrence` in the payload; `else` branch reset logic is present in the HTML source — both pass
- [ ] Manual: edit a recurring practice, close the dialog, then open a non-recurring practice for edit — confirm the recurring checkbox is unchecked and the recurrence builder is hidden; submit and confirm the saved practice is still non-recurring

Closes #2201

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_