### PR TITLE
[codex] Split Team Fees history from outstanding balances

### DIFF
--- a/src/app/team-fees/team-fees.component.css
+++ b/src/app/team-fees/team-fees.component.css
@@ -16,6 +16,35 @@
   margin-bottom: 5px;
 }
 
+.team-fees-history {
+  margin-top: 20px;
+}
+
+.payment-history-toggle {
+  background-color: #444;
+}
+
+.payment-history-list {
+  margin-top: 12px;
+}
+
+.historical-fee-item {
+  background-color: #f7f7f7;
+}
+
+.no-outstanding-fees {
+  border: 1px solid #b7dfc0;
+  background-color: #f0fff4;
+  padding: 15px;
+  margin-bottom: 15px;
+  border-radius: 5px;
+}
+
+.no-outstanding-fees h3 {
+  margin-top: 0;
+  color: #246b36;
+}
+
 .paid {
   color: green;
   font-weight: bold;

--- a/src/app/team-fees/team-fees.component.html
+++ b/src/app/team-fees/team-fees.component.html
@@ -10,17 +10,40 @@
 
 <ng-template #feesReady>
   <div *ngIf="teamFees.length > 0; else noFees">
-    <div *ngFor="let fee of teamFees" class="team-fee-item">
-      <h3>{{ fee.name }}</h3>
-      <p>Amount: {{ fee.amount | currency }}</p>
-      <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid && fee.status !== 'canceled'">{{ fee.status === 'canceled' ? 'Canceled' : fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
-      <p *ngIf="!fee.canPayOnline && !fee.isPaid && fee.status !== 'canceled' && fee.offlinePaymentInstructions" class="offline-payment-instructions">{{ fee.offlinePaymentInstructions }}</p>
+    <section *ngIf="outstandingFees.length > 0; else noOutstandingFees" class="team-fees-outstanding" aria-label="Outstanding team fees">
+      <div *ngFor="let fee of outstandingFees" class="team-fee-item">
+        <h3>{{ fee.name }}</h3>
+        <p>Amount: {{ fee.amount | currency }}</p>
+        <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid && fee.status !== 'canceled'">{{ fee.status === 'canceled' ? 'Canceled' : fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
+        <p *ngIf="!fee.canPayOnline && !fee.isPaid && fee.status !== 'canceled' && fee.offlinePaymentInstructions" class="offline-payment-instructions">{{ fee.offlinePaymentInstructions }}</p>
 
-      <button *ngIf="fee.canPayOnline" (click)="handlePayFee(fee)" [disabled]="isPaymentPending()">
-        <span *ngIf="!isPaymentLoading(fee.id)">Pay Team Fee</span>
-        <span *ngIf="isPaymentLoading(fee.id)">Initiating Payment...</span>
+        <button *ngIf="fee.canPayOnline" (click)="handlePayFee(fee)" [disabled]="isPaymentPending()">
+          <span *ngIf="!isPaymentLoading(fee.id)">Pay Team Fee</span>
+          <span *ngIf="isPaymentLoading(fee.id)">Initiating Payment...</span>
+        </button>
+      </div>
+    </section>
+
+    <ng-template #noOutstandingFees>
+      <div class="no-outstanding-fees">
+        <h3>No outstanding team fees</h3>
+        <p>Your current balances are paid or canceled. Payment history is still available below.</p>
+      </div>
+    </ng-template>
+
+    <section *ngIf="feeHistory.length > 0" class="team-fees-history" aria-label="Payment history">
+      <button type="button" class="payment-history-toggle" (click)="togglePaymentHistory()" [attr.aria-expanded]="paymentHistoryOpen">
+        {{ paymentHistoryOpen ? 'Hide payment history' : 'Show payment history' }} ({{ feeHistory.length }})
       </button>
-    </div>
+
+      <div *ngIf="paymentHistoryOpen" class="payment-history-list">
+        <div *ngFor="let fee of feeHistory" class="team-fee-item historical-fee-item">
+          <h3>{{ fee.name }}</h3>
+          <p>Amount: {{ fee.amount | currency }}</p>
+          <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid && fee.status !== 'canceled'">{{ fee.status === 'canceled' ? 'Canceled' : fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
+        </div>
+      </div>
+    </section>
   </div>
 </ng-template>
 

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -396,6 +396,47 @@ describe('TeamFeesComponent checkout flow', () => {
       { id: 'recipient-paid', status: 'paid', canPayOnline: false },
       { id: 'recipient-canceled', status: 'canceled', canPayOnline: false }
     ]);
+    expect(component.outstandingFees.map((fee) => fee.id)).toEqual(['recipient-online', 'recipient-offline']);
+    expect(component.feeHistory.map((fee) => fee.id)).toEqual(['recipient-paid', 'recipient-canceled']);
+    expect(template).toContain('*ngFor="let fee of outstandingFees"');
+    expect(template).toContain('*ngFor="let fee of feeHistory"');
+    expect(template).toContain('paymentHistoryOpen');
+    expect(template).toContain('togglePaymentHistory()');
+    expect(template).toContain('No outstanding team fees');
+  });
+
+  it('keeps paid and canceled fees accessible when there are no outstanding balances', async () => {
+    const paidFee = feeDoc('teams/team-real/feeBatches/batch-paid/feeRecipients/recipient-paid', 'recipient-paid', {
+      parentUserId: 'parent-123',
+      title: 'Paid registration',
+      balanceDueCents: 0,
+      status: 'paid',
+      collectionMode: 'online_stripe'
+    });
+    const canceledFee = feeDoc('teams/team-real/feeBatches/batch-canceled/feeRecipients/recipient-canceled', 'recipient-canceled', {
+      parentUserId: 'parent-123',
+      title: 'Canceled registration',
+      balanceDueCents: 6500,
+      status: 'canceled',
+      collectionMode: 'online_stripe'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [paidFee, canceledFee] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] });
+
+    await component.ngOnInit();
+
+    expect(component.outstandingFees).toEqual([]);
+    expect(component.feeHistory.map((fee) => ({ id: fee.id, status: fee.status, canPayOnline: fee.canPayOnline }))).toEqual([
+      { id: 'recipient-paid', status: 'paid', canPayOnline: false },
+      { id: 'recipient-canceled', status: 'canceled', canPayOnline: false }
+    ]);
+    expect(component.paymentHistoryOpen).toBe(false);
+
+    component.togglePaymentHistory();
+
+    expect(component.paymentHistoryOpen).toBe(true);
   });
 
   it('passes the selected fee recipient IDs to StripeService before redirecting', async () => {

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -439,6 +439,37 @@ describe('TeamFeesComponent checkout flow', () => {
     expect(component.paymentHistoryOpen).toBe(true);
   });
 
+  it('treats zero-balance unpaid records as paid history entries', async () => {
+    const zeroRemainingBalanceFee = feeDoc('teams/team-real/feeBatches/batch-zero-balance/feeRecipients/recipient-zero-balance', 'recipient-zero-balance', {
+      parentUserId: 'parent-123',
+      title: 'Zero remaining balance',
+      amountCents: 12500,
+      remainingBalanceCents: 0,
+      status: 'unpaid',
+      collectionMode: 'online_stripe'
+    });
+    const fullyPaidFee = feeDoc('teams/team-real/feeBatches/batch-fully-paid/feeRecipients/recipient-fully-paid', 'recipient-fully-paid', {
+      parentUserId: 'parent-123',
+      title: 'Fully paid by amount',
+      amountCents: 12500,
+      paidAmountCents: 12500,
+      status: 'unpaid',
+      collectionMode: 'online_stripe'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [zeroRemainingBalanceFee, fullyPaidFee] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] });
+
+    await component.ngOnInit();
+
+    expect(component.outstandingFees).toEqual([]);
+    expect(component.feeHistory.map((fee) => ({ id: fee.id, status: fee.status, isPaid: fee.isPaid, canPayOnline: fee.canPayOnline }))).toEqual([
+      { id: 'recipient-zero-balance', status: 'paid', isPaid: true, canPayOnline: false },
+      { id: 'recipient-fully-paid', status: 'paid', isPaid: true, canPayOnline: false }
+    ]);
+  });
+
   it('passes the selected fee recipient IDs to StripeService before redirecting', async () => {
     const selectedFee = {
       id: 'recipient-real',

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -143,7 +143,7 @@ function isFeePaid(data: FeeRecipientData): boolean {
   const status = getFeeStatus(data);
   if (status === 'paid') return true;
   if (data.paid === true || data.isPaid === true) return true;
-  return typeof data.balanceDueCents === 'number' && data.balanceDueCents <= 0;
+  return getFeeBalanceCents(data) <= 0;
 }
 
 function isFeeCanceled(data: FeeRecipientData): boolean {

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -188,6 +188,7 @@ export class TeamFeesComponent implements OnInit {
   pendingPaymentFeeId: string | null = null;
   paymentErrorMessage: string | null = null;
   isLoadingFees = false;
+  paymentHistoryOpen = false;
 
   constructor(private stripeService: StripeService) { }
 
@@ -318,6 +319,22 @@ export class TeamFeesComponent implements OnInit {
 
   isPaymentPending(): boolean {
     return this.pendingPaymentFeeId !== null;
+  }
+
+  get outstandingFees(): TeamFee[] {
+    return this.teamFees.filter((fee) => !this.isHistoricalFee(fee));
+  }
+
+  get feeHistory(): TeamFee[] {
+    return this.teamFees.filter((fee) => this.isHistoricalFee(fee));
+  }
+
+  togglePaymentHistory(): void {
+    this.paymentHistoryOpen = !this.paymentHistoryOpen;
+  }
+
+  private isHistoricalFee(fee: TeamFee): boolean {
+    return fee.isPaid || fee.status === 'paid' || fee.status === 'canceled';
   }
 
   async handlePayFee(fee: TeamFee): Promise<void> {


### PR DESCRIPTION
Closes #2198

## What changed
- Shows only unpaid Team Fees in the default outstanding list.
- Moves paid and canceled fees into a collapsed payment history section.
- Adds the no-outstanding-fees state while keeping history accessible.
- Keeps online checkout and offline instructions limited to unpaid fees.

## Validation
- `npx vitest run src/app/team-fees/team-fees.component.spec.ts --reporter=verbose`