### PR TITLE
[codex] Deep-link schedule task cards by section

### DIFF
--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -5,6 +5,7 @@ export type ScheduleEventType = 'game' | 'practice';
 export type RsvpResponse = 'going' | 'maybe' | 'not_going' | 'not_responded';
 export type ScheduleSourceType = 'db' | 'calendar' | 'practice-session' | 'unknown';
 export type ScheduleEventDetailSection = 'availability' | 'rideshare' | 'assignments' | 'game';
+export const PRACTICE_PACKET_DETAIL_SECTION: ScheduleEventDetailSection = 'game';
 
 export type ScheduleRsvpSummary = {
   going?: number;
@@ -499,7 +500,8 @@ export function getOpenScheduleAssignments(assignments: Array<Partial<ScheduleAs
 }
 
 export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'rideshareSummary'>): ScheduleEventDetailSection | '' {
-  if (event.type === 'practice' && event.practiceHomePacketSummary) return 'game';
+  // Practice packets render in the shared game/report tab inside ScheduleEventDetail.
+  if (event.type === 'practice' && event.practiceHomePacketSummary) return PRACTICE_PACKET_DETAIL_SECTION;
   if (getOpenScheduleAssignments(event.assignments).length > 0) return 'assignments';
   const rideSummary = event.rideshareSummary;
   if (rideSummary && (rideSummary.requests > 0 || rideSummary.pending > 0 || rideSummary.seatsLeft > 0)) return 'rideshare';

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -4,6 +4,7 @@ export type ScheduleTimeRange = 'week' | 'month' | 'quarter' | 'all';
 export type ScheduleEventType = 'game' | 'practice';
 export type RsvpResponse = 'going' | 'maybe' | 'not_going' | 'not_responded';
 export type ScheduleSourceType = 'db' | 'calendar' | 'practice-session' | 'unknown';
+export type ScheduleEventDetailSection = 'availability' | 'rideshare' | 'assignments' | 'game';
 
 export type ScheduleRsvpSummary = {
   going?: number;
@@ -495,6 +496,25 @@ export function getOpenScheduleAssignments(assignments: Array<Partial<ScheduleAs
   return (Array.isArray(assignments) ? assignments : [])
     .map((assignment) => normalizeScheduleAssignment(assignment))
     .filter(isScheduleAssignmentOpen);
+}
+
+export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'rideshareSummary'>): ScheduleEventDetailSection | '' {
+  if (event.type === 'practice' && event.practiceHomePacketSummary) return 'game';
+  if (getOpenScheduleAssignments(event.assignments).length > 0) return 'assignments';
+  const rideSummary = event.rideshareSummary;
+  if (rideSummary && (rideSummary.requests > 0 || rideSummary.pending > 0 || rideSummary.seatsLeft > 0)) return 'rideshare';
+  return '';
+}
+
+export function getScheduleEventDetailPath(
+  event: Pick<ParentScheduleEvent, 'teamId' | 'id' | 'childId'>,
+  section: ScheduleEventDetailSection | '' = ''
+) {
+  const params = new URLSearchParams();
+  if (event.childId) params.set('childId', event.childId);
+  if (section) params.set('section', section);
+  const query = params.toString();
+  return `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}${query ? `?${query}` : ''}`;
 }
 
 export function getScheduleAssignmentStatus(assignment: Partial<ScheduleAssignment>, userId = '') {

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -499,7 +499,8 @@ export function getOpenScheduleAssignments(assignments: Array<Partial<ScheduleAs
     .filter(isScheduleAssignmentOpen);
 }
 
-export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'rideshareSummary'>): ScheduleEventDetailSection | '' {
+export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'rideshareSummary' | 'isDbGame' | 'isCancelled' | 'myRsvp'>): ScheduleEventDetailSection | '' {
+  if (event.type === 'game' && event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded') return 'availability';
   // Practice packets render in the shared game/report tab inside ScheduleEventDetail.
   if (event.type === 'practice' && event.practiceHomePacketSummary) return PRACTICE_PACKET_DETAIL_SECTION;
   if (getOpenScheduleAssignments(event.assignments).length > 0) return 'assignments';

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -13,11 +13,13 @@ import {
   formatEventDateLabel,
   formatEventTimeLabel,
   getCalendarScheduleEntries,
+  getScheduleEventDetailPath,
   getParentScheduleTeamOptions,
   getPracticePacketRows,
   getScheduleTitle,
   getScheduleMapHref,
   getScheduleForecastHref,
+  getScheduleTaskDetailSection,
   normalizeRsvpResponse,
   validateExternalCalendarUrl,
   type CalendarScheduleEntry,
@@ -1863,9 +1865,7 @@ function ScheduleEventCard({ event }: {
 }
 
 function getEventDetailPath(event: ParentScheduleEvent | CalendarScheduleEntry) {
-  const params = new URLSearchParams();
-  if (event.childId) params.set('childId', event.childId);
-  return `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}${params.toString() ? `?${params}` : ''}`;
+  return getScheduleEventDetailPath(event, getScheduleTaskDetailSection(event));
 }
 
 function getScheduleChildLabel(event: ParentScheduleEvent | CalendarScheduleEntry) {

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -803,7 +803,7 @@ test('app schedule loads agenda filters, player select, calendar, export, and ga
     await expect(page.getByText('For Pat · Bears')).not.toBeVisible();
 
     const detailLink = page.getByRole('link', { name: 'Game details' }).first();
-    await expect(detailLink).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-2&section=availability$/);
+    await expect(detailLink).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-2&section=assignments$/);
     expect(await page.evaluate(() => window.__scheduleCalls.rsvps)).toEqual([]);
 
     await page.getByRole('button', { name: 'Calendar', exact: true }).click();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -803,7 +803,7 @@ test('app schedule loads agenda filters, player select, calendar, export, and ga
     await expect(page.getByText('For Pat · Bears')).not.toBeVisible();
 
     const detailLink = page.getByRole('link', { name: 'Game details' }).first();
-    await expect(detailLink).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-2$/);
+    await expect(detailLink).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-2&section=assignments$/);
     expect(await page.evaluate(() => window.__scheduleCalls.rsvps)).toEqual([]);
 
     await page.getByRole('button', { name: 'Calendar', exact: true }).click();
@@ -860,7 +860,7 @@ test('calendar day selection opens a visible event picker for multiple events', 
     await page.getByRole('button', { name: /May 2030 28, 2 events/ }).click();
     const pickerForNavigation = page.getByRole('dialog', { name: /Tuesday, May 28/ });
     await pickerForNavigation.locator('a').filter({ hasText: 'Open practice' }).click();
-    await expect(page).toHaveURL(/#\/schedule\/team-1\/practice-1\?childId=player-1$/);
+    await expect(page).toHaveURL(/#\/schedule\/team-1\/practice-1\?childId=player-1&section=game$/);
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 });
 

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1213,8 +1213,9 @@ test('schedule role permissions let admins manage non-owned rideshare requests',
     await mockScheduleModules(page, { isAdmin: true });
     await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('button', { name: 'Rideshare', exact: true })).toBeVisible({ timeout: 15000 });
-    await page.getByRole('button', { name: 'Rideshare', exact: true }).click();
+    const rideshareTab = page.getByRole('button', { name: 'Rideshare', exact: true });
+    await waitForScheduleRoute(page, rideshareTab);
+    await rideshareTab.click();
     const rideshareSection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Rideshare' }) });
     const danaCard = rideshareSection.locator('article').filter({ hasText: 'Dana Driver' });
     await expect(danaCard.getByRole('button', { name: 'Close' })).toBeVisible();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1185,6 +1185,7 @@ test('app schedule paginates long agenda lists and resets on filter changes', as
     await mockScheduleModules(page, { extraUpcomingEvents: 22, extraPastEvents: 12 });
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
+    await waitForScheduleRoute(page, mobileScheduleFilter(page));
     const mobileRows = page.locator('.schedule-list > a');
     await expect(async () => {
         await expect(mobileRows.first()).toBeVisible({ timeout: 1000 });

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -803,7 +803,7 @@ test('app schedule loads agenda filters, player select, calendar, export, and ga
     await expect(page.getByText('For Pat · Bears')).not.toBeVisible();
 
     const detailLink = page.getByRole('link', { name: 'Game details' }).first();
-    await expect(detailLink).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-2&section=assignments$/);
+    await expect(detailLink).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-2&section=availability$/);
     expect(await page.evaluate(() => window.__scheduleCalls.rsvps)).toEqual([]);
 
     await page.getByRole('button', { name: 'Calendar', exact: true }).click();

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -65,20 +65,31 @@ describe('React app parent schedule logic', () => {
             childId: 'player 1',
             myRsvp: 'going'
         });
+        const rsvpNeeded = event({
+            id: 'game-rsvp',
+            myRsvp: 'not_responded',
+            assignments: [{ role: 'Snacks', value: '', claimable: true, claim: null }],
+            rideshareSummary: { offerCount: 1, seatsLeft: 1, requests: 1, pending: 1, confirmed: 0, isFull: false }
+        });
         const packet = event({
             id: 'practice-1',
             type: 'practice',
+            isDbGame: false,
             practiceHomePacketSummary: '2 drills'
         });
         const assignment = event({
+            myRsvp: 'going',
             assignments: [{ role: 'Snacks', value: '', claimable: true, claim: null }]
         });
         const ride = event({
+            myRsvp: 'going',
             rideshareSummary: { offerCount: 1, seatsLeft: 1, requests: 0, pending: 0, confirmed: 0, isFull: false }
         });
 
         expect(getScheduleTaskDetailSection(generic)).toBe('');
         expect(getScheduleEventDetailPath(generic, getScheduleTaskDetailSection(generic))).toBe('/schedule/team%2Fwith%20slash/game%201?childId=player+1');
+        expect(getScheduleTaskDetailSection(rsvpNeeded)).toBe('availability');
+        expect(getScheduleEventDetailPath(rsvpNeeded, getScheduleTaskDetailSection(rsvpNeeded))).toBe('/schedule/team-1/game-rsvp?childId=player-1&section=availability');
         expect(PRACTICE_PACKET_DETAIL_SECTION).toBe('game');
         expect(getScheduleTaskDetailSection(packet)).toBe(PRACTICE_PACKET_DETAIL_SECTION);
         expect(getScheduleEventDetailPath(packet, getScheduleTaskDetailSection(packet))).toBe('/schedule/team-1/practice-1?childId=player-1&section=game');

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -6,6 +6,7 @@ import {
     findScheduleRideRequestForChild,
     filterParentScheduleEvents,
     getCalendarScheduleEntries,
+    getScheduleEventDetailPath,
     getNextRideConfirmedSeatCount,
     getOpenScheduleAssignments,
     getParentScheduleTeamOptions,
@@ -14,6 +15,7 @@ import {
     getScheduleMapHref,
     getScheduleRideSeatInfo,
     getScheduleRideshareSummary,
+    getScheduleTaskDetailSection,
     isScheduleAssignmentClaimedByUser,
     isScheduleAssignmentOpen,
     normalizeScheduleAssignment,
@@ -53,6 +55,32 @@ describe('React app parent schedule logic', () => {
             url: 'https://example.com/team.ics?token=abc',
             error: null
         });
+    });
+
+    it('builds task-targeted event detail routes while generic opens keep the availability default', () => {
+        const generic = event({
+            teamId: 'team/with slash',
+            id: 'game 1',
+            childId: 'player 1',
+            myRsvp: 'going'
+        });
+        const packet = event({
+            id: 'practice-1',
+            type: 'practice',
+            practiceHomePacketSummary: '2 drills'
+        });
+        const assignment = event({
+            assignments: [{ role: 'Snacks', value: '', claimable: true, claim: null }]
+        });
+        const ride = event({
+            rideshareSummary: { offerCount: 1, seatsLeft: 1, requests: 0, pending: 0, confirmed: 0, isFull: false }
+        });
+
+        expect(getScheduleTaskDetailSection(generic)).toBe('');
+        expect(getScheduleEventDetailPath(generic, getScheduleTaskDetailSection(generic))).toBe('/schedule/team%2Fwith%20slash/game%201?childId=player+1');
+        expect(getScheduleEventDetailPath(packet, getScheduleTaskDetailSection(packet))).toBe('/schedule/team-1/practice-1?childId=player-1&section=game');
+        expect(getScheduleEventDetailPath(assignment, getScheduleTaskDetailSection(assignment))).toBe('/schedule/team-1/game-1?childId=player-1&section=assignments');
+        expect(getScheduleEventDetailPath(ride, getScheduleTaskDetailSection(ride))).toBe('/schedule/team-1/game-1?childId=player-1&section=rideshare');
     });
 
     it('matches parent-dashboard upcoming and past filter behavior with a three-hour cutoff', () => {

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -12,6 +12,7 @@ import {
     getParentScheduleTeamOptions,
     getPracticePacketRows,
     getScheduleAssignmentStatus,
+    PRACTICE_PACKET_DETAIL_SECTION,
     getScheduleMapHref,
     getScheduleRideSeatInfo,
     getScheduleRideshareSummary,
@@ -78,6 +79,8 @@ describe('React app parent schedule logic', () => {
 
         expect(getScheduleTaskDetailSection(generic)).toBe('');
         expect(getScheduleEventDetailPath(generic, getScheduleTaskDetailSection(generic))).toBe('/schedule/team%2Fwith%20slash/game%201?childId=player+1');
+        expect(PRACTICE_PACKET_DETAIL_SECTION).toBe('game');
+        expect(getScheduleTaskDetailSection(packet)).toBe(PRACTICE_PACKET_DETAIL_SECTION);
         expect(getScheduleEventDetailPath(packet, getScheduleTaskDetailSection(packet))).toBe('/schedule/team-1/practice-1?childId=player-1&section=game');
         expect(getScheduleEventDetailPath(assignment, getScheduleTaskDetailSection(assignment))).toBe('/schedule/team-1/game-1?childId=player-1&section=assignments');
         expect(getScheduleEventDetailPath(ride, getScheduleTaskDetailSection(ride))).toBe('/schedule/team-1/game-1?childId=player-1&section=rideshare');


### PR DESCRIPTION
Closes #2192

## What changed
- Adds a shared schedule event detail route helper that preserves child context and appends a task-specific section when appropriate.
- Routes practice packet entries to Game, open assignment entries to Assignments, and ride activity entries to Rideshare.
- Keeps generic schedule opens on the existing Availability default by omitting `section`.

## Validation
- `npx vitest run tests/unit/app-schedule-logic.test.js --reporter=verbose`
- `npm run app:build`