### PR TITLE
[codex] Persist ScheduleEventDetail route state

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
@@ -232,6 +232,23 @@ function renderScheduleEventDetailWithRouteControls(initialEntry = '/schedule/te
   );
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="event-route">{`${location.pathname}${location.search}`}</output>;
+}
+
+function renderScheduleEventDetailWithLocation(initialEntry = '/schedule/team-1/game-1?childId=player-1') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/schedule/:teamId/:eventId" element={<ScheduleEventDetail auth={auth} />} />
+        <Route path="/schedule" element={<div>Schedule</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe('ScheduleEventDetail loading states', () => {
   afterEach(() => {
     cleanup();
@@ -273,6 +290,66 @@ describe('ScheduleEventDetail lineup draft guards', () => {
       { formationId: 'basketball-5v5', lineups: { 'Q1-pg': 'p1' } },
       { formationId: 'basketball-5v5', lineups: { 'Q1-pg': 'p1', 'Q1-sg': 'p2' } }
     )).toBe(false);
+  });
+});
+
+describe('ScheduleEventDetail route state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true
+    });
+    scheduleServiceMocks.loadParentScheduleRideOffers.mockResolvedValue([]);
+    scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue([]);
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [
+        buildEvent({ childId: 'player-1', childName: 'Avery Smith' }),
+        buildEvent({
+          eventKey: 'team-1::game-1::player-2::2026-06-04T18:00:00.000Z::game',
+          childId: 'player-2',
+          childName: 'Sam Lee'
+        })
+      ],
+      children: []
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('writes selected tab and child context back to the event route', async () => {
+    renderScheduleEventDetailWithLocation();
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Avery Smith/).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Rideshare' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=rideshare');
+    });
+
+    fireEvent.click(within(screen.getByTestId('event-player-switcher')).getByRole('button', { name: 'Sam Lee' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-2&section=rideshare');
+    });
+  });
+
+  it('rehydrates the selected tab and child from the route query', async () => {
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-2&section=assignments');
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Sam Lee/).length).toBeGreaterThan(0);
+    });
+
+    const switcher = screen.getByTestId('event-player-switcher');
+    expect(within(switcher).getByRole('button', { name: 'Sam Lee' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getAllByRole('button', { name: 'Assignments' })[0].className).toContain('bg-primary-600');
+    expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-2&section=assignments');
   });
 });
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -285,7 +285,7 @@ export function shouldAutosaveGeneratedLineupDraft(existingGamePlan: Record<stri
 
 export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const { teamId = '', eventId = '' } = useParams();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
   const [selectedChildId, setSelectedChildId] = useState(searchParams.get('childId') || '');
   const [loading, setLoading] = useState(true);
@@ -305,11 +305,31 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const decodedTeamId = decodeURIComponent(teamId);
   const decodedEventId = decodeURIComponent(eventId);
 
+  const replaceEventRouteParams = (updates: { section?: EventDetailSectionId; childId?: string }) => {
+    const nextParams = new URLSearchParams(searchParams);
+    if (updates.section) nextParams.set('section', updates.section);
+    if (Object.prototype.hasOwnProperty.call(updates, 'childId')) {
+      const nextChildId = String(updates.childId || '').trim();
+      if (nextChildId) {
+        nextParams.set('childId', nextChildId);
+      } else {
+        nextParams.delete('childId');
+      }
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
   const selectSection = (sectionId: EventDetailSectionId) => {
     setActiveSection(sectionId);
+    replaceEventRouteParams({ section: sectionId });
     window.requestAnimationFrame(() => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
+  };
+
+  const selectChild = (childId: string) => {
+    setSelectedChildId(childId);
+    replaceEventRouteParams({ childId });
   };
 
   const loadEvent = async () => {
@@ -338,6 +358,10 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
 
   useEffect(() => {
     setActiveSection(parseEventDetailSection(searchParams.get('section')));
+    const routeChildId = searchParams.get('childId') || '';
+    if (routeChildId) {
+      setSelectedChildId(routeChildId);
+    }
   }, [searchParams]);
 
   const selectedEvent = useMemo(() => {
@@ -607,7 +631,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
               <div className="min-w-0 flex-1">
                 {events.length > 1 ? (
                   <>
-                    <PlayerSwitcher events={events} selectedChildId={selectedEvent.childId} onSelect={setSelectedChildId} compact />
+                    <PlayerSwitcher events={events} selectedChildId={selectedEvent.childId} onSelect={selectChild} compact />
                     <div className="mt-1 truncate text-xs font-bold text-gray-600">{selectedEvent.childName} · {selectedEvent.teamName}</div>
                   </>
                 ) : (


### PR DESCRIPTION
Closes #2162

## What changed
- Writes selected ScheduleEventDetail tabs back to the route as `section=<tab>` with replace-style query updates.
- Writes selected child context back to `childId` without leaving the event page.
- Rehydrates the active tab and child from route query params so reload/resume/deep links restore the same workflow.
- Adds router-location coverage for tab and child query updates plus route rehydration.

## Validation
- `npm --prefix apps/app exec -- vitest run src/pages/ScheduleEventDetail.test.tsx -t "ScheduleEventDetail route state" --reporter=verbose`
- `npm run app:build`

## Note
- A full `ScheduleEventDetail.test.tsx` run still hits an unrelated existing foul-tracker assertion that expects an undo live-event description text not rendered by the current panel.