### PR TITLE
[codex] Add notification delivery metadata

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -73,6 +73,7 @@ vi.mock('./lib/reloadRouting', () => ({
 
 vi.mock('./lib/pushService', () => ({
   addPushNotificationOpenListener: vi.fn(async () => () => {}),
+  ensureAndroidNotificationChannels: vi.fn(async () => {}),
 }));
 
 vi.mock('./pages/Home', () => ({

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -14,7 +14,7 @@ import {
 } from './lib/nativeBackButton';
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { shouldReloadTeamsToHome } from './lib/reloadRouting';
-import { addPushNotificationOpenListener } from './lib/pushService';
+import { addPushNotificationOpenListener, ensureAndroidNotificationChannels } from './lib/pushService';
 import { useAuth } from './lib/useAuth';
 import type { AuthState } from './lib/types';
 
@@ -138,6 +138,7 @@ export default function App() {
     let removeListener = async () => {};
 
     async function registerPushListener() {
+      await ensureAndroidNotificationChannels();
       removeListener = await addPushNotificationOpenListener((route) => {
         if (authUserRef.current) {
           navigate(route, { replace: true });

--- a/apps/app/src/lib/pushService.test.ts
+++ b/apps/app/src/lib/pushService.test.ts
@@ -9,6 +9,7 @@ const capacitorState = {
 const firebaseMessagingMocks = {
     addListener: vi.fn(),
     checkPermissions: vi.fn(),
+    createChannel: vi.fn(),
     getToken: vi.fn(),
     isSupported: vi.fn(),
     requestPermissions: vi.fn()
@@ -32,6 +33,7 @@ describe('pushService permission states', () => {
         capacitorState.getPlatform.mockReturnValue('ios');
         firebaseMessagingMocks.isSupported.mockResolvedValue({ isSupported: true });
         firebaseMessagingMocks.addListener.mockResolvedValue({ remove: vi.fn().mockResolvedValue(undefined) });
+        firebaseMessagingMocks.createChannel.mockResolvedValue(undefined);
         firebaseMessagingMocks.getToken.mockResolvedValue({ token: 'native-token' });
         firebaseMessagingMocks.checkPermissions.mockResolvedValue({ receive: 'prompt' });
         firebaseMessagingMocks.requestPermissions.mockResolvedValue({ receive: 'prompt' });
@@ -158,5 +160,48 @@ describe('pushService permission states', () => {
         expect(locationAssignMock).toHaveBeenCalledWith(
             'intent:#Intent;action=android.settings.APP_NOTIFICATION_SETTINGS;S.extra_app_package=ai.allplays.lite;end'
         );
+    });
+
+    it('creates category Android channels on Android startup', async () => {
+        capacitorState.getPlatform.mockReturnValue('android');
+        const { ensureAndroidNotificationChannels } = await loadPushService();
+
+        await ensureAndroidNotificationChannels();
+
+        expect(firebaseMessagingMocks.createChannel).toHaveBeenCalledTimes(5);
+        expect(firebaseMessagingMocks.createChannel).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'allplays_messages',
+            name: 'Messages',
+            importance: 4
+        }));
+        expect(firebaseMessagingMocks.createChannel).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'allplays_game_day',
+            name: 'Game day',
+            importance: 4
+        }));
+        expect(firebaseMessagingMocks.createChannel).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'allplays_schedule',
+            name: 'Schedule',
+            importance: 3
+        }));
+        expect(firebaseMessagingMocks.createChannel).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'allplays_money',
+            name: 'Money',
+            importance: 3
+        }));
+        expect(firebaseMessagingMocks.createChannel).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'allplays_team',
+            name: 'Team',
+            importance: 3
+        }));
+    });
+
+    it('skips Android channel creation outside Android native shells', async () => {
+        capacitorState.getPlatform.mockReturnValue('ios');
+        const { ensureAndroidNotificationChannels } = await loadPushService();
+
+        await ensureAndroidNotificationChannels();
+
+        expect(firebaseMessagingMocks.createChannel).not.toHaveBeenCalled();
     });
 });

--- a/apps/app/src/lib/pushService.ts
+++ b/apps/app/src/lib/pushService.ts
@@ -1,6 +1,7 @@
 import { Capacitor } from '@capacitor/core';
 import { FirebaseMessaging } from '@capacitor-firebase/messaging';
-import type { NotificationActionPerformedEvent } from '@capacitor-firebase/messaging';
+import type { CreateChannelOptions, NotificationActionPerformedEvent } from '@capacitor-firebase/messaging';
+import { ANDROID_NOTIFICATION_CHANNELS } from '../../../../functions/notification-delivery-metadata.cjs';
 import { saveNotificationDeviceToken } from './profileService';
 import { rememberPendingPushRoute, resolvePushNotificationRoute } from './pushNotificationRouting';
 
@@ -23,6 +24,7 @@ const nativePushTimeoutMs = 15000;
 const iosNotificationSettingsUrl = 'app-settings:';
 const androidNotificationSettingsUrl = 'intent:#Intent;action=android.settings.APP_NOTIFICATION_SETTINGS;S.extra_app_package=ai.allplays.lite;end';
 const androidAppSettingsUrl = 'app-settings:';
+export const androidNotificationChannels = ANDROID_NOTIFICATION_CHANNELS as readonly CreateChannelOptions[];
 
 export class PushPermissionError extends Error {
   code: 'push-permission-blocked' | 'push-unsupported';
@@ -53,6 +55,20 @@ export async function addPushNotificationOpenListener(onRouteOpen: (route: strin
   return async () => {
     await listener.remove();
   };
+}
+
+export async function ensureAndroidNotificationChannels(): Promise<void> {
+  if (!Capacitor.isNativePlatform() || Capacitor.getPlatform() !== 'android') {
+    return;
+  }
+
+  await Promise.all(androidNotificationChannels.map(async (channel) => {
+    try {
+      await FirebaseMessaging.createChannel({ ...channel });
+    } catch (error) {
+      console.warn('[push] Unable to create Android notification channel:', channel.id, error);
+    }
+  }));
 }
 
 export async function enablePushNotificationsForUser(userId: string): Promise<PushRegistrationResult> {

--- a/apps/app/src/lib/pushService.ts
+++ b/apps/app/src/lib/pushService.ts
@@ -1,7 +1,6 @@
 import { Capacitor } from '@capacitor/core';
 import { FirebaseMessaging } from '@capacitor-firebase/messaging';
 import type { CreateChannelOptions, NotificationActionPerformedEvent } from '@capacitor-firebase/messaging';
-import { ANDROID_NOTIFICATION_CHANNELS } from '../../../../functions/notification-delivery-metadata.cjs';
 import { saveNotificationDeviceToken } from './profileService';
 import { rememberPendingPushRoute, resolvePushNotificationRoute } from './pushNotificationRouting';
 
@@ -24,7 +23,38 @@ const nativePushTimeoutMs = 15000;
 const iosNotificationSettingsUrl = 'app-settings:';
 const androidNotificationSettingsUrl = 'intent:#Intent;action=android.settings.APP_NOTIFICATION_SETTINGS;S.extra_app_package=ai.allplays.lite;end';
 const androidAppSettingsUrl = 'app-settings:';
-export const androidNotificationChannels = ANDROID_NOTIFICATION_CHANNELS as readonly CreateChannelOptions[];
+export const androidNotificationChannels = [
+  {
+    id: 'allplays_messages',
+    name: 'Messages',
+    description: 'Team chat, direct messages, and mentions.',
+    importance: 4
+  },
+  {
+    id: 'allplays_game_day',
+    name: 'Game day',
+    description: 'Live scores, game-day alerts, and practice packets.',
+    importance: 4
+  },
+  {
+    id: 'allplays_schedule',
+    name: 'Schedule',
+    description: 'Schedule changes, RSVP reminders, and officiating updates.',
+    importance: 3
+  },
+  {
+    id: 'allplays_money',
+    name: 'Money',
+    description: 'Team fee assignments, reminders, and payment updates.',
+    importance: 3
+  },
+  {
+    id: 'allplays_team',
+    name: 'Team',
+    description: 'Team access, rideshare, media, and award updates.',
+    importance: 3
+  }
+] as const satisfies readonly CreateChannelOptions[];
 
 export class PushPermissionError extends Error {
   code: 'push-permission-blocked' | 'push-unsupported';

--- a/apps/app/src/vite-env.d.ts
+++ b/apps/app/src/vite-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
 
 declare module '*.js';
+declare module '*.cjs';

--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -6,6 +6,8 @@ importScripts('https://www.gstatic.com/firebasejs/12.6.0/firebase-messaging-comp
 const CONFIG_CACHE_NAME = 'allplays-push-config-v1';
 const CONFIG_CACHE_KEY = '/__allplays/push/firebase-config.json';
 const FIREBASE_INIT_JSON_URL = '/__/firebase/init.json';
+const WEB_PUSH_NOTIFICATION_ICON = '/img/logo_small.png';
+const WEB_PUSH_NOTIFICATION_BADGE = '/img/logo_small.png';
 const ALLOWED_CLICK_HOSTS = new Set([
     self.location.hostname.toLowerCase(),
     'allplays.ai',
@@ -96,9 +98,13 @@ function registerBackgroundMessageHandler(messaging) {
         const title = payload?.notification?.title || 'ALL PLAYS Update';
         const body = payload?.notification?.body || '';
         const link = payload?.fcmOptions?.link || payload?.data?.link || '/';
+        const icon = payload?.notification?.icon || payload?.data?.icon || WEB_PUSH_NOTIFICATION_ICON;
+        const badge = payload?.notification?.badge || payload?.data?.badge || WEB_PUSH_NOTIFICATION_BADGE;
 
         self.registration.showNotification(title, {
             body,
+            icon,
+            badge,
             data: { link: normalizeNotificationLink(link) }
         });
     });

--- a/functions/index.js
+++ b/functions/index.js
@@ -92,6 +92,10 @@ const {
   normalizeInboxId
 } = require('./notification-inbox-core.cjs');
 const {
+  WEB_PUSH_NOTIFICATION_ASSETS,
+  buildNotificationDeliveryOptions
+} = require('./notification-delivery-metadata.cjs');
+const {
   coerceDate,
   getEventTitle,
   formatScheduleUpdateDate
@@ -3431,6 +3435,7 @@ async function sendCategoryNotification({
 
   const link = linkOverride || buildNotificationLink({ category, teamId, gameId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
+  const deliveryOptions = buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId });
   const maxMulticastTokens = 500;
   const allResponses = [];
   let successCount = 0;
@@ -3450,8 +3455,10 @@ async function sendCategoryNotification({
         link
       },
       webpush: {
+        notification: WEB_PUSH_NOTIFICATION_ASSETS,
         fcmOptions: { link }
-      }
+      },
+      ...deliveryOptions
     });
     allResponses.push(...(Array.isArray(sendResult.responses) ? sendResult.responses : []));
     successCount += Number(sendResult.successCount || 0);
@@ -3485,6 +3492,7 @@ async function sendDirectTargetsNotification({ targets, category, title, body, t
 
   const link = buildNotificationLink({ category, teamId, gameId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
+  const deliveryOptions = buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId });
   const maxMulticastTokens = 500;
   const allResponses = [];
   let successCount = 0;
@@ -3504,8 +3512,10 @@ async function sendDirectTargetsNotification({ targets, category, title, body, t
         link
       },
       webpush: {
+        notification: WEB_PUSH_NOTIFICATION_ASSETS,
         fcmOptions: { link }
-      }
+      },
+      ...deliveryOptions
     });
     allResponses.push(...(Array.isArray(sendResult.responses) ? sendResult.responses : []));
     successCount += Number(sendResult.successCount || 0);

--- a/functions/index.js
+++ b/functions/index.js
@@ -3435,7 +3435,9 @@ async function sendCategoryNotification({
 
   const link = linkOverride || buildNotificationLink({ category, teamId, gameId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
-  const deliveryOptions = buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId });
+  const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
+    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
+    : {};
   const maxMulticastTokens = 500;
   const allResponses = [];
   let successCount = 0;
@@ -3492,7 +3494,9 @@ async function sendDirectTargetsNotification({ targets, category, title, body, t
 
   const link = buildNotificationLink({ category, teamId, gameId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
-  const deliveryOptions = buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId });
+  const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
+    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
+    : {};
   const maxMulticastTokens = 500;
   const allResponses = [];
   let successCount = 0;

--- a/functions/notification-delivery-metadata.cjs
+++ b/functions/notification-delivery-metadata.cjs
@@ -1,0 +1,134 @@
+const ANDROID_NOTIFICATION_CHANNEL_IDS = Object.freeze({
+  messages: 'allplays_messages',
+  gameDay: 'allplays_game_day',
+  schedule: 'allplays_schedule',
+  money: 'allplays_money',
+  team: 'allplays_team'
+});
+
+const ANDROID_NOTIFICATION_CHANNELS = Object.freeze([
+  Object.freeze({
+    id: ANDROID_NOTIFICATION_CHANNEL_IDS.messages,
+    name: 'Messages',
+    description: 'Team chat, direct messages, and mentions.',
+    importance: 4
+  }),
+  Object.freeze({
+    id: ANDROID_NOTIFICATION_CHANNEL_IDS.gameDay,
+    name: 'Game day',
+    description: 'Live scores, game-day alerts, and practice packets.',
+    importance: 4
+  }),
+  Object.freeze({
+    id: ANDROID_NOTIFICATION_CHANNEL_IDS.schedule,
+    name: 'Schedule',
+    description: 'Schedule changes, RSVP reminders, and officiating updates.',
+    importance: 3
+  }),
+  Object.freeze({
+    id: ANDROID_NOTIFICATION_CHANNEL_IDS.money,
+    name: 'Money',
+    description: 'Team fee assignments, reminders, and payment updates.',
+    importance: 3
+  }),
+  Object.freeze({
+    id: ANDROID_NOTIFICATION_CHANNEL_IDS.team,
+    name: 'Team',
+    description: 'Team access, rideshare, media, and award updates.',
+    importance: 3
+  })
+]);
+
+const NOTIFICATION_CATEGORY_DELIVERY = Object.freeze({
+  liveChat: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.messages, iosThreadScope: 'messages' }),
+  mentions: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.messages, iosThreadScope: 'messages' }),
+  liveScore: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.gameDay, iosThreadScope: 'game', iosCollapseScope: 'score' }),
+  gameDay: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.gameDay, iosThreadScope: 'game' }),
+  schedule: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.schedule, iosThreadScope: 'team' }),
+  rsvp: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.schedule, iosThreadScope: 'team' }),
+  fees: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.money, iosThreadScope: 'team' }),
+  practice: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.gameDay, iosThreadScope: 'team' }),
+  access: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.team, iosThreadScope: 'team' }),
+  rideshare: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.team, iosThreadScope: 'team' }),
+  media: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.team, iosThreadScope: 'team' }),
+  awards: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.team, iosThreadScope: 'team' }),
+  officiating: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.schedule, iosThreadScope: 'team' })
+});
+
+const WEB_PUSH_NOTIFICATION_ASSETS = Object.freeze({
+  icon: '/img/logo_small.png',
+  badge: '/img/logo_small.png'
+});
+
+function sanitizeDeliverySegment(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function buildBoundedIdentifier(parts, maxLength = 64) {
+  const identifier = parts
+    .map((part) => sanitizeDeliverySegment(part))
+    .filter(Boolean)
+    .join('-');
+  if (identifier.length <= maxLength) return identifier;
+  return identifier.slice(0, maxLength).replace(/-+$/g, '');
+}
+
+function buildIosThreadId({ metadata, teamId, gameId, eventId }) {
+  if (metadata?.iosThreadScope === 'messages') {
+    return buildBoundedIdentifier(['messages', teamId]);
+  }
+  if (metadata?.iosThreadScope === 'game') {
+    return buildBoundedIdentifier(['game', teamId, gameId || eventId]);
+  }
+  if (metadata?.iosThreadScope === 'team') {
+    return buildBoundedIdentifier(['team', teamId]);
+  }
+  return '';
+}
+
+function buildIosCollapseId({ metadata, teamId, gameId, eventId }) {
+  if (metadata?.iosCollapseScope === 'score') {
+    return buildBoundedIdentifier(['score', teamId, gameId || eventId]);
+  }
+  return '';
+}
+
+function getNotificationDeliveryMetadata(category) {
+  return NOTIFICATION_CATEGORY_DELIVERY[category] || null;
+}
+
+function buildNotificationDeliveryOptions({ category, teamId, gameId = null, eventId = null } = {}) {
+  const metadata = getNotificationDeliveryMetadata(category);
+  if (!metadata) return {};
+
+  const android = metadata.androidChannelId
+    ? { notification: { channelId: metadata.androidChannelId } }
+    : undefined;
+  const iosThreadId = buildIosThreadId({ metadata, teamId, gameId, eventId });
+  const iosCollapseId = buildIosCollapseId({ metadata, teamId, gameId, eventId });
+  const aps = iosThreadId ? { 'thread-id': iosThreadId } : undefined;
+  const apnsHeaders = iosCollapseId ? { 'apns-collapse-id': iosCollapseId } : undefined;
+  const apns = aps || apnsHeaders
+    ? {
+        ...(apnsHeaders ? { headers: apnsHeaders } : {}),
+        ...(aps ? { payload: { aps } } : {})
+      }
+    : undefined;
+
+  return {
+    ...(android ? { android } : {}),
+    ...(apns ? { apns } : {})
+  };
+}
+
+module.exports = {
+  ANDROID_NOTIFICATION_CHANNEL_IDS,
+  ANDROID_NOTIFICATION_CHANNELS,
+  NOTIFICATION_CATEGORY_DELIVERY,
+  WEB_PUSH_NOTIFICATION_ASSETS,
+  buildNotificationDeliveryOptions,
+  getNotificationDeliveryMetadata
+};

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -331,6 +331,10 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     return async () => {};
                 }
 
+                export async function ensureAndroidNotificationChannels() {
+                    return;
+                }
+
                 export async function enablePushNotificationsForUser() {
                     window.__appProfileCalls.push += 1;
                 }

--- a/tests/unit/app-push-notification-wiring.test.js
+++ b/tests/unit/app-push-notification-wiring.test.js
@@ -11,4 +11,12 @@ describe('app push notification wiring', () => {
         expect(source).toContain('const pendingRoute = readPendingPushRoute();');
         expect(source).toContain('clearPendingPushRoute();');
     });
+
+    it('keeps Android channel metadata local to the app so Vite does not try to import the Functions CommonJS bundle in the browser', () => {
+        const source = readFileSync(new URL('../../apps/app/src/lib/pushService.ts', import.meta.url), 'utf8');
+        expect(source).toContain("id: 'allplays_messages'");
+        expect(source).toContain("id: 'allplays_game_day'");
+        expect(source).toContain("id: 'allplays_schedule'");
+        expect(source).not.toContain('notification-delivery-metadata.cjs');
+    });
 });

--- a/tests/unit/app-push-notification-wiring.test.js
+++ b/tests/unit/app-push-notification-wiring.test.js
@@ -5,7 +5,8 @@ describe('app push notification wiring', () => {
     it('registers native notification-open listeners and consumes pending routes after auth bootstrap', () => {
         const source = readFileSync(new URL('../../apps/app/src/App.tsx', import.meta.url), 'utf8');
         expect(source).toContain("import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';");
-        expect(source).toContain("import { addPushNotificationOpenListener } from './lib/pushService';");
+        expect(source).toContain("import { addPushNotificationOpenListener, ensureAndroidNotificationChannels } from './lib/pushService';");
+        expect(source).toContain('await ensureAndroidNotificationChannels();');
         expect(source).toContain('removeListener = await addPushNotificationOpenListener');
         expect(source).toContain('const pendingRoute = readPendingPushRoute();');
         expect(source).toContain('clearPendingPushRoute();');

--- a/tests/unit/notification-delivery-metadata.test.js
+++ b/tests/unit/notification-delivery-metadata.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+    ANDROID_NOTIFICATION_CHANNELS,
+    WEB_PUSH_NOTIFICATION_ASSETS,
+    buildNotificationDeliveryOptions
+} = require('../../functions/notification-delivery-metadata.cjs');
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+const serviceWorkerSource = readFileSync(new URL('../../firebase-messaging-sw.js', import.meta.url), 'utf8');
+
+describe('notification delivery metadata', () => {
+    it('defines the five Android channels used by app startup and backend sends', () => {
+        expect(ANDROID_NOTIFICATION_CHANNELS).toEqual([
+            expect.objectContaining({ id: 'allplays_messages', name: 'Messages', importance: 4 }),
+            expect.objectContaining({ id: 'allplays_game_day', name: 'Game day', importance: 4 }),
+            expect.objectContaining({ id: 'allplays_schedule', name: 'Schedule', importance: 3 }),
+            expect.objectContaining({ id: 'allplays_money', name: 'Money', importance: 3 }),
+            expect.objectContaining({ id: 'allplays_team', name: 'Team', importance: 3 })
+        ]);
+    });
+
+    it('routes message notifications to the messages channel and groups them by team on iOS', () => {
+        const options = buildNotificationDeliveryOptions({
+            category: 'liveChat',
+            teamId: 'team 1',
+            gameId: 'game-1'
+        });
+
+        expect(options.android.notification.channelId).toBe('allplays_messages');
+        expect(options.apns.payload.aps['thread-id']).toBe('messages-team-1');
+        expect(options.apns.headers).toBeUndefined();
+    });
+
+    it('collapses rapid live score notifications by game on iOS', () => {
+        const options = buildNotificationDeliveryOptions({
+            category: 'liveScore',
+            teamId: 'team-1',
+            gameId: 'game-9'
+        });
+
+        expect(options.android.notification.channelId).toBe('allplays_game_day');
+        expect(options.apns.payload.aps['thread-id']).toBe('game-team-1-game-9');
+        expect(options.apns.headers['apns-collapse-id']).toBe('score-team-1-game-9');
+    });
+
+    it('routes team-scoped award notifications to the team channel and iOS team thread', () => {
+        const options = buildNotificationDeliveryOptions({
+            category: 'awards',
+            teamId: 'team-1',
+            eventId: 'certificate-1'
+        });
+
+        expect(options.android.notification.channelId).toBe('allplays_team');
+        expect(options.apns.payload.aps['thread-id']).toBe('team-team-1');
+    });
+
+    it('wires delivery metadata and branded web assets into both backend send paths', () => {
+        const firstSendPath = functionsSource.slice(
+            functionsSource.indexOf('async function sendCategoryNotification'),
+            functionsSource.indexOf('async function sendDirectTargetsNotification')
+        );
+        const secondSendPath = functionsSource.slice(
+            functionsSource.indexOf('async function sendDirectTargetsNotification'),
+            functionsSource.indexOf('function normalizeScheduleStatus')
+        );
+
+        expect(WEB_PUSH_NOTIFICATION_ASSETS).toEqual({
+            icon: '/img/logo_small.png',
+            badge: '/img/logo_small.png'
+        });
+        expect(firstSendPath).toContain('buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })');
+        expect(firstSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
+        expect(firstSendPath).toContain('...deliveryOptions');
+        expect(secondSendPath).toContain('buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })');
+        expect(secondSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
+        expect(secondSendPath).toContain('...deliveryOptions');
+    });
+
+    it('shows branded icon and badge assets from the web service worker', () => {
+        expect(serviceWorkerSource).toContain("const WEB_PUSH_NOTIFICATION_ICON = '/img/logo_small.png';");
+        expect(serviceWorkerSource).toContain("const WEB_PUSH_NOTIFICATION_BADGE = '/img/logo_small.png';");
+        expect(serviceWorkerSource).toContain('icon,');
+        expect(serviceWorkerSource).toContain('badge,');
+    });
+});

--- a/tests/unit/notification-send-dedup.test.js
+++ b/tests/unit/notification-send-dedup.test.js
@@ -87,7 +87,9 @@ function createDedupHarness({ nowMs, docs = {} } = {}) {
 
 function buildSendCategoryNotificationHarness({
     canSend = true,
-    targets = [{ uid: 'user-1', token: 'token-1' }]
+    targets = [{ uid: 'user-1', token: 'token-1' }],
+    categories = ['schedule', 'liveScore', 'mentions', 'liveChat'],
+    deliveryOptions = {}
 } = {}) {
     const sendSource = getSourceSlice(
         'async function sendCategoryNotification({',
@@ -107,6 +109,7 @@ function buildSendCategoryNotificationHarness({
     const getTargetsForCategory = vi.fn(async () => targets);
     const buildNotificationLink = vi.fn(({ category, teamId, gameId }) => `https://allplays.ai/${category}/${teamId}/${gameId || ''}`);
     const buildNotificationAppRoute = vi.fn(({ category, teamId, gameId, eventId }) => `/${category}/${teamId}/${gameId || eventId || ''}`);
+    const buildNotificationDeliveryOptions = vi.fn(() => deliveryOptions);
     const pruneInvalidTokens = vi.fn(async () => {});
     const writeNotificationInboxRecords = vi.fn(async () => ({
         writeCount: targets.length,
@@ -125,7 +128,9 @@ function buildSendCategoryNotificationHarness({
         'getTargetsForCategory',
         'buildNotificationLink',
         'buildNotificationAppRoute',
+        'buildNotificationDeliveryOptions',
         'admin',
+        'WEB_PUSH_NOTIFICATION_ASSETS',
         'pruneInvalidTokens',
         'writeNotificationInboxRecords',
         'functions',
@@ -133,12 +138,14 @@ function buildSendCategoryNotificationHarness({
     );
 
     const fn = factory(
-        ['schedule', 'liveScore', 'mentions', 'liveChat'],
+        categories,
         checkAndSetNotificationDedup,
         getTargetsForCategory,
         buildNotificationLink,
         buildNotificationAppRoute,
+        buildNotificationDeliveryOptions,
         admin,
+        { icon: '/img/logo_small.png', badge: '/img/logo_small.png' },
         pruneInvalidTokens,
         writeNotificationInboxRecords,
         functions
@@ -151,6 +158,7 @@ function buildSendCategoryNotificationHarness({
         getTargetsForCategory,
         buildNotificationLink,
         buildNotificationAppRoute,
+        buildNotificationDeliveryOptions,
         pruneInvalidTokens,
         writeNotificationInboxRecords,
         functions
@@ -275,6 +283,55 @@ describe('notification send dedup guard — sendCategoryNotification', () => {
 
         expect(harness.checkAndSetNotificationDedup).not.toHaveBeenCalled();
         expect(harness.sendEachForMulticast).toHaveBeenCalledOnce();
+    });
+
+    it('guards delivery metadata usage so liveChat sends work without extra helpers', async () => {
+        const harness = buildSendCategoryNotificationHarness({
+            categories: ['liveChat', 'mentions']
+        });
+
+        await expect(harness.fn({
+            teamId: 'team-1',
+            gameId: 'game-1',
+            category: 'liveChat',
+            title: 'New message',
+            body: 'Hello team'
+        })).resolves.toEqual(expect.objectContaining({
+            successCount: 1,
+            failureCount: 0
+        }));
+
+        expect(harness.buildNotificationDeliveryOptions).toHaveBeenCalledWith({
+            category: 'liveChat',
+            teamId: 'team-1',
+            gameId: 'game-1',
+            eventId: 'game-1'
+        });
+    });
+
+    it('guards delivery metadata usage so mentions sends work without extra helpers', async () => {
+        const harness = buildSendCategoryNotificationHarness({
+            categories: ['liveChat', 'mentions']
+        });
+
+        await expect(harness.fn({
+            teamId: 'team-1',
+            gameId: 'game-1',
+            eventId: 'message-1',
+            category: 'mentions',
+            title: 'Mention',
+            body: 'You were mentioned'
+        })).resolves.toEqual(expect.objectContaining({
+            successCount: 1,
+            failureCount: 0
+        }));
+
+        expect(harness.buildNotificationDeliveryOptions).toHaveBeenCalledWith({
+            category: 'mentions',
+            teamId: 'team-1',
+            gameId: 'game-1',
+            eventId: 'message-1'
+        });
     });
 
     it('firestore.rules denies all client access to notificationSendLog', () => {


### PR DESCRIPTION
Closes #2187

## What changed
- Adds shared notification delivery metadata for Android channel IDs, iOS thread/collapse behavior, and web push assets.
- Creates Messages, Game day, Schedule, Money, and Team Android channels during native app startup.
- Adds Android channel IDs, APNs thread IDs, APNs live-score collapse IDs, and branded web icon/badge assets to both backend notification send paths.
- Applies branded icon/badge defaults in the Firebase messaging service worker.

## Validation
- `npx vitest run tests/unit/notification-delivery-metadata.test.js tests/unit/app-push-notification-wiring.test.js --reporter=verbose`
- `npm --prefix apps/app exec -- vitest run src/lib/pushService.test.ts src/App.test.tsx --reporter=verbose`
- `npm run app:build`