### PR TITLE
[codex] Default team schedule to upcoming events

### DIFF
--- a/team.html
+++ b/team.html
@@ -2405,7 +2405,7 @@
                 return filtered.sort((a, b) => a.date - b.date);
             }
             if (scheduleViewFilter === 'all-upcoming') {
-                filtered = events.filter((event) => event.date >= cutoff && !event.isCancelled);
+                filtered = events.filter((event) => event.date >= cutoff && !event.isCancelled && event.status !== 'completed');
                 return filtered.sort((a, b) => a.date - b.date);
             }
             if (scheduleViewFilter === 'availability') {

--- a/team.html
+++ b/team.html
@@ -230,11 +230,11 @@
                     </div>
                     <div class="px-6 py-3 border-b border-gray-100 bg-gray-50">
                         <div class="flex flex-wrap items-center gap-2">
-                            <button id="schedule-filter-recent-results" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-primary-200 bg-primary-50 text-primary-700">Recent Results</button>
+                            <button id="schedule-filter-all-upcoming" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-primary-200 bg-primary-50 text-primary-700">All Upcoming</button>
                             <button id="schedule-filter-upcoming-games" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Upcoming Games</button>
                             <button id="schedule-filter-upcoming-practices" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Upcoming Practices</button>
-                            <button id="schedule-filter-all-upcoming" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">All Upcoming</button>
                             <button id="schedule-filter-availability" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Availability</button>
+                            <button id="schedule-filter-recent-results" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Recent Results</button>
                             <button id="schedule-filter-past-events" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Past Events</button>
                         </div>
                     </div>
@@ -378,7 +378,7 @@
         let gamesById = {};
         let allScheduleEvents = [];
         let adSpaceSponsors = [];
-        let scheduleViewFilter = 'recent-results';
+        let scheduleViewFilter = 'all-upcoming';
         let scheduleViewMode = 'list';
         let scheduleCalendarMonth = new Date().getMonth();
         let scheduleCalendarYear = new Date().getFullYear();
@@ -2376,7 +2376,7 @@
 
         async function renderSchedule(team, dbGames) {
             allScheduleEvents = await getAllEvents(team, dbGames);
-            setScheduleFilter('recent-results');
+            setScheduleFilter('all-upcoming');
         }
 
         function getFilteredScheduleEvents() {
@@ -2628,7 +2628,7 @@
         }
 
         function setScheduleFilter(next) {
-            scheduleViewFilter = next || 'recent-results';
+            scheduleViewFilter = next || 'all-upcoming';
             const ids = ['recent-results', 'upcoming-games', 'upcoming-practices', 'all-upcoming', 'availability', 'past-events'];
             ids.forEach((id) => {
                 const btn = document.getElementById(`schedule-filter-${id}`);

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -681,6 +681,7 @@ test('team schedule keeps tracked duplicates and cancelled items out of the wron
     await mockTeamPageModules(page, scenario);
     await page.goto(buildUrl(baseURL, '/team.html#teamId=team-a'), { waitUntil: 'domcontentloaded' });
 
+    await page.locator('#schedule-filter-recent-results').click();
     await expect(page.locator('#schedule-list')).toContainText('Falcons');
     await expect(page.locator('#schedule-list')).not.toContainText('Meteors');
     await expect(page.locator('#schedule-list')).not.toContainText('Storm');

--- a/tests/unit/team-schedule-filter.test.js
+++ b/tests/unit/team-schedule-filter.test.js
@@ -53,6 +53,14 @@ describe('team schedule filtering', () => {
             date: hoursFromNow(-24),
             opponent: 'Past Win'
         };
+        const justFinishedGame = {
+            type: 'db',
+            isPractice: false,
+            status: 'completed',
+            isCancelled: false,
+            date: hoursFromNow(-1),
+            opponent: 'Just Finished'
+        };
         const laterGame = {
             type: 'db',
             isPractice: false,
@@ -73,12 +81,12 @@ describe('team schedule filtering', () => {
         const initialEvents = getFilteredScheduleEvents({
             showPractices: true,
             scheduleViewFilter: 'all-upcoming',
-            allScheduleEvents: [completedGame, laterGame, nextPractice]
+            allScheduleEvents: [completedGame, justFinishedGame, laterGame, nextPractice]
         });
         const recentResults = getFilteredScheduleEvents({
             showPractices: true,
             scheduleViewFilter: 'recent-results',
-            allScheduleEvents: [completedGame, laterGame, nextPractice]
+            allScheduleEvents: [completedGame, justFinishedGame, laterGame, nextPractice]
         });
 
         expect(source).toContain("let scheduleViewFilter = 'all-upcoming';");
@@ -86,7 +94,7 @@ describe('team schedule filtering', () => {
         expect(source).toContain("scheduleViewFilter = next || 'all-upcoming';");
         expect(source.indexOf('id="schedule-filter-all-upcoming"')).toBeLessThan(source.indexOf('id="schedule-filter-recent-results"'));
         expect(initialEvents.map((event) => event.opponent)).toEqual(['Practice', 'Future Game']);
-        expect(recentResults.map((event) => event.opponent)).toEqual(['Past Win']);
+        expect(recentResults.map((event) => event.opponent)).toEqual(['Just Finished', 'Past Win']);
     });
 
     it('forces practice visibility for the upcoming-practices filter even when the checkbox is off', () => {

--- a/tests/unit/team-schedule-filter.test.js
+++ b/tests/unit/team-schedule-filter.test.js
@@ -43,6 +43,52 @@ function hoursFromNow(offsetHours) {
 }
 
 describe('team schedule filtering', () => {
+    it('defaults the team page schedule to all upcoming events while keeping recent results manual', () => {
+        const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+        const getFilteredScheduleEvents = loadGetFilteredScheduleEvents();
+        const completedGame = {
+            type: 'db',
+            isPractice: false,
+            status: 'completed',
+            date: hoursFromNow(-24),
+            opponent: 'Past Win'
+        };
+        const laterGame = {
+            type: 'db',
+            isPractice: false,
+            status: 'scheduled',
+            isCancelled: false,
+            date: hoursFromNow(48),
+            opponent: 'Future Game'
+        };
+        const nextPractice = {
+            type: 'db',
+            isPractice: true,
+            status: 'scheduled',
+            isCancelled: false,
+            date: hoursFromNow(24),
+            opponent: 'Practice'
+        };
+
+        const initialEvents = getFilteredScheduleEvents({
+            showPractices: true,
+            scheduleViewFilter: 'all-upcoming',
+            allScheduleEvents: [completedGame, laterGame, nextPractice]
+        });
+        const recentResults = getFilteredScheduleEvents({
+            showPractices: true,
+            scheduleViewFilter: 'recent-results',
+            allScheduleEvents: [completedGame, laterGame, nextPractice]
+        });
+
+        expect(source).toContain("let scheduleViewFilter = 'all-upcoming';");
+        expect(source).toContain("setScheduleFilter('all-upcoming');");
+        expect(source).toContain("scheduleViewFilter = next || 'all-upcoming';");
+        expect(source.indexOf('id="schedule-filter-all-upcoming"')).toBeLessThan(source.indexOf('id="schedule-filter-recent-results"'));
+        expect(initialEvents.map((event) => event.opponent)).toEqual(['Practice', 'Future Game']);
+        expect(recentResults.map((event) => event.opponent)).toEqual(['Past Win']);
+    });
+
     it('forces practice visibility for the upcoming-practices filter even when the checkbox is off', () => {
         const getFilteredScheduleEvents = loadGetFilteredScheduleEvents();
         const result = getFilteredScheduleEvents({


### PR DESCRIPTION
Closes #2241

## What changed
- Makes All Upcoming the default active schedule filter on the legacy team page.
- Keeps Recent Results available as a manual filter, but moves it after upcoming-focused filters.
- Preserves all-upcoming chronological sorting and recent-results reverse chronological completed-game behavior.
- Adds regression coverage for the default source wiring and both default/manual filter results.

## Validation
- `npx vitest run tests/unit/team-schedule-filter.test.js --reporter=verbose`