### PR TITLE
[codex] Guard Sports Connect import entry points

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -919,6 +919,7 @@
                 ${rowHtml.length ? rowHtml.join('') : '<div class="rounded-md border border-gray-200 bg-white p-3 text-gray-600">No source roster rows found.</div>'}
             `;
             importButton.disabled = plan.operations.length === 0;
+            importButton.setAttribute('aria-disabled', String(importButton.disabled));
             importButton.classList.toggle('opacity-50', importButton.disabled);
         }
 
@@ -1048,6 +1049,7 @@
                 status.textContent = 'Roster import failed: ' + (error?.message || 'Please try again.');
             } finally {
                 button.disabled = !registrationRosterImportPlan;
+                button.setAttribute('aria-disabled', String(button.disabled));
                 button.classList.toggle('opacity-50', button.disabled);
                 button.textContent = 'Import Roster';
             }

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -954,8 +954,10 @@
             previewButton.classList.toggle('hidden', !hasImportableSnapshot);
             importButton.classList.toggle('hidden', !hasImportableSnapshot);
             previewButton.disabled = !hasImportableSnapshot;
+            previewButton.setAttribute('aria-disabled', String(previewButton.disabled));
             previewButton.classList.toggle('opacity-50', previewButton.disabled);
             importButton.disabled = true;
+            importButton.setAttribute('aria-disabled', 'true');
             importButton.classList.toggle('opacity-50', importButton.disabled);
             status.textContent = hasImportableSnapshot
                 ? `${sourcePlayers.length} player${sourcePlayers.length === 1 ? '' : 's'} available in the latest stored roster snapshot. Preview before importing.`

--- a/edit-team.html
+++ b/edit-team.html
@@ -60,7 +60,7 @@
                         </span>
                     </label>
                     <label class="flex items-start rounded-lg border border-indigo-200 bg-white p-3 cursor-pointer hover:bg-indigo-50">
-                        <input type="radio" name="teamCreateMode" value="registration" class="mt-1 text-indigo-600 focus:ring-indigo-500">
+                        <input id="team-create-mode-registration" type="radio" name="teamCreateMode" value="registration" class="mt-1 text-indigo-600 focus:ring-indigo-500">
                         <span class="ml-3">
                             <span class="block text-sm font-semibold text-gray-900">Import from registration system</span>
                             <span class="block text-xs text-gray-600">Create a team shell from a configured registration source.</span>
@@ -74,7 +74,7 @@
                         <option value="">Select a registration team...</option>
                     </select>
                     <p id="registration-empty-state" class="hidden mt-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">
-                        No registration sources are configured yet. Start with a blank team or ask an admin to configure a registration source.
+                        No stored registration source snapshots are available yet. Start with a blank team or load provider data before using this import path.
                     </p>
                     <p id="registration-import-help" class="mt-2 text-xs text-gray-500">
                         This only imports team identity and source identifiers. Rosters and schedules are not imported in this step.
@@ -882,6 +882,13 @@
             });
 
             select.disabled = configuredRegistrationTeams.length === 0;
+            const registrationMode = document.getElementById('team-create-mode-registration');
+            if (registrationMode) {
+                registrationMode.disabled = configuredRegistrationTeams.length === 0;
+                registrationMode.setAttribute('aria-disabled', String(registrationMode.disabled));
+                registrationMode.closest('label')?.classList.toggle('opacity-60', registrationMode.disabled);
+                registrationMode.closest('label')?.classList.toggle('cursor-not-allowed', registrationMode.disabled);
+            }
             emptyState.classList.toggle('hidden', configuredRegistrationTeams.length > 0);
         }
 
@@ -905,6 +912,12 @@
         function setCreateMode(mode) {
             const panel = document.getElementById('registration-import-panel');
             const isRegistration = mode === 'registration';
+            if (isRegistration && configuredRegistrationTeams.length === 0) {
+                document.querySelector('input[name="teamCreateMode"][value="manual"]')?.click();
+                selectedRegistrationTeam = null;
+                panel.classList.add('hidden');
+                return;
+            }
             panel.classList.toggle('hidden', !isRegistration);
             if (!isRegistration) {
                 selectedRegistrationTeam = null;

--- a/edit-team.html
+++ b/edit-team.html
@@ -74,7 +74,7 @@
                         <option value="">Select a registration team...</option>
                     </select>
                     <p id="registration-empty-state" class="hidden mt-2 text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded p-3">
-                        No stored registration source snapshots are available yet. Start with a blank team or load provider data before using this import path.
+                        No registration sources are configured yet. Start with a blank team or load provider data before using this import path.
                     </p>
                     <p id="registration-import-help" class="mt-2 text-xs text-gray-500">
                         This only imports team identity and source identifiers. Rosters and schedules are not imported in this step.
@@ -886,8 +886,11 @@
             if (registrationMode) {
                 registrationMode.disabled = configuredRegistrationTeams.length === 0;
                 registrationMode.setAttribute('aria-disabled', String(registrationMode.disabled));
-                registrationMode.closest('label')?.classList.toggle('opacity-60', registrationMode.disabled);
-                registrationMode.closest('label')?.classList.toggle('cursor-not-allowed', registrationMode.disabled);
+                const registrationModeLabel = typeof registrationMode.closest === 'function'
+                    ? registrationMode.closest('label')
+                    : null;
+                registrationModeLabel?.classList.toggle('opacity-60', registrationMode.disabled);
+                registrationModeLabel?.classList.toggle('cursor-not-allowed', registrationMode.disabled);
             }
             emptyState.classList.toggle('hidden', configuredRegistrationTeams.length > 0);
         }

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -365,6 +365,9 @@ describe('registration roster import wiring', () => {
         expect(source).toContain('Registration provider metadata saved');
         expect(source).toContain('This page does not fetch provider data live.');
         expect(source).toContain('save or load a registration roster snapshot for this team');
+        expect(source).toContain('previewButton.setAttribute(\'aria-disabled\', String(previewButton.disabled));');
+        expect(source).toContain('importButton.setAttribute(\'aria-disabled\', \'true\');');
+        expect(source).toContain('No stored registration roster snapshot is available yet.');
         expect(source).toContain('planRegistrationRosterImport({');
         expect(source).toContain('renderRegistrationRosterImportPreview');
         expect(source).toContain('registration-roster-import-row');

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -367,6 +367,8 @@ describe('registration roster import wiring', () => {
         expect(source).toContain('save or load a registration roster snapshot for this team');
         expect(source).toContain('previewButton.setAttribute(\'aria-disabled\', String(previewButton.disabled));');
         expect(source).toContain('importButton.setAttribute(\'aria-disabled\', \'true\');');
+        expect(source).toContain('importButton.setAttribute(\'aria-disabled\', String(importButton.disabled));');
+        expect(source).toContain('button.setAttribute(\'aria-disabled\', String(button.disabled));');
         expect(source).toContain('No stored registration roster snapshot is available yet.');
         expect(source).toContain('planRegistrationRosterImport({');
         expect(source).toContain('renderRegistrationRosterImportPreview');

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -78,6 +78,7 @@ class MockElement {
         this.textContent = '';
         this.href = '';
         this.files = [];
+        this.attributes = {};
         this.dataset = {};
         this.listeners = new Map();
         this.classList = new MockClassList();
@@ -107,6 +108,14 @@ class MockElement {
     }
 
     focus() {}
+
+    setAttribute(name, value) {
+        this.attributes[name] = String(value);
+    }
+
+    closest() {
+        return this;
+    }
 
     querySelectorAll(selector) {
         if (selector === '.remove-admin-btn') {
@@ -185,6 +194,7 @@ function createEnvironment(initialState, overrides = {}) {
         'team-admin-banner',
         'page-title',
         'team-create-options',
+        'team-create-mode-registration',
         'registration-import-panel',
         'registration-source-select',
         'registration-empty-state',
@@ -615,6 +625,10 @@ describe('edit team admin access persistence', () => {
         expect(html.indexOf('id="registrationProviderName"')).toBeGreaterThan(advancedIndex);
         expect(html).toContain('Registration Provider Connection');
         expect(html).toContain('No provider login, sync job, or network call runs from these fields.');
+        expect(html).toContain('id="team-create-mode-registration"');
+        expect(html).toContain('No stored registration source snapshots are available yet.');
+        expect(html).toContain('registrationMode.setAttribute(\'aria-disabled\', String(registrationMode.disabled));');
+        expect(html).toContain('configuredRegistrationTeams.length === 0');
 
         const createEnv = await bootEditTeam({
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -626,7 +626,7 @@ describe('edit team admin access persistence', () => {
         expect(html).toContain('Registration Provider Connection');
         expect(html).toContain('No provider login, sync job, or network call runs from these fields.');
         expect(html).toContain('id="team-create-mode-registration"');
-        expect(html).toContain('No stored registration source snapshots are available yet.');
+        expect(html).toContain('No registration sources are configured yet. Start with a blank team or load provider data before using this import path.');
         expect(html).toContain('registrationMode.setAttribute(\'aria-disabled\', String(registrationMode.disabled));');
         expect(html).toContain('configuredRegistrationTeams.length === 0');
 

--- a/tests/unit/edit-team-registration-import.test.js
+++ b/tests/unit/edit-team-registration-import.test.js
@@ -6,12 +6,16 @@ function readRepoFile(relativePath) {
 }
 
 describe('edit team registration import', () => {
-    it('offers a registration import path with an empty state on team creation', () => {
+    it('offers a guarded registration import path with an empty state on team creation', () => {
         const source = readRepoFile('edit-team.html');
 
         expect(source).toContain('Import from registration system');
+        expect(source).toContain('id="team-create-mode-registration"');
         expect(source).toContain('registration-source-select');
-        expect(source).toContain('No registration sources are configured yet');
+        expect(source).toContain('No registration sources are configured yet. Start with a blank team or load provider data before using this import path.');
+        expect(source).toContain('registrationMode.disabled = configuredRegistrationTeams.length === 0;');
+        expect(source).toContain('registrationMode.setAttribute(\'aria-disabled\', String(registrationMode.disabled));');
+        expect(source).toContain('document.querySelector(\'input[name="teamCreateMode"][value="manual"]\')?.click();');
         expect(source).toContain('getConfiguredRegistrationTeams');
     });
 


### PR DESCRIPTION
Closes #2245

## What changed
- Disables the edit-team registration import create-mode option when no stored registration source snapshots exist.
- Updates the empty-state copy to explain that provider data must be loaded before the import path is usable.
- Adds programmatic guardrails so registration mode cannot open without configured source snapshots.
- Marks edit-roster preview/import disabled states with `aria-disabled` while keeping stored-snapshot import behavior intact.
- Extends edit-team and edit-roster tests for the disabled/empty-state behavior.

## Validation
- `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js tests/unit/edit-roster-registration-import.test.js --reporter=verbose`