### PR TITLE
Fix roster import blocking siblings with shared parent contact

### DIFF
--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -446,19 +446,22 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
             }
         }
 
-        const sourceContacts = [...(payload.guardians || []), ...(payload.contacts || [])];
-        const contactConflict = findContactConflict(sourceContacts, existingContactOwners, existing);
-        if (contactConflict) {
-            const conflictDetail = {
-                externalPlayerId,
-                existingPlayerId: contactConflict.existingPlayerId,
-                conflictType: 'contact',
-                contact: contactConflict.contact
-            };
-            results.conflicted += 1;
-            results.conflicts.push(conflictDetail);
-            previewRows.push(buildPreviewRow({ status: 'conflict', sourcePlayer, payload, existingPlayer: existing, conflict: conflictDetail }));
-            return;
+        // Only check for contact conflicts on updates (not new additions) — siblings share parent contacts
+        if (existing) {
+            const sourceContacts = [...(payload.guardians || []), ...(payload.contacts || [])];
+            const contactConflict = findContactConflict(sourceContacts, existingContactOwners, existing);
+            if (contactConflict) {
+                const conflictDetail = {
+                    externalPlayerId,
+                    existingPlayerId: contactConflict.existingPlayerId,
+                    conflictType: 'contact',
+                    contact: contactConflict.contact
+                };
+                results.conflicted += 1;
+                results.conflicts.push(conflictDetail);
+                previewRows.push(buildPreviewRow({ status: 'conflict', sourcePlayer, payload, existingPlayer: existing, conflict: conflictDetail }));
+                return;
+            }
         }
 
         const fieldValues = collectRegistrationRosterFieldValues(sourcePlayer, fields, results);

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -179,7 +179,7 @@ describe('registration roster import planning', () => {
         expect(plan.operations[0]).toMatchObject({ type: 'update', playerId: 'player-legacy' });
     });
 
-    it('flags contact conflicts before import operations are applied', () => {
+    it('allows new sibling imports to reuse an existing parent contact without flagging a conflict', () => {
         const plan = planRegistrationRosterImport({
             source: { type: 'sports-connect', id: 'league-1' },
             sourcePlayers: [
@@ -198,11 +198,18 @@ describe('registration roster import planning', () => {
             ]
         });
 
-        expect(plan.results).toMatchObject({ added: 0, updated: 0, skipped: 0, conflicted: 1 });
-        expect(plan.results.conflicts).toEqual([
-            { externalPlayerId: 'ext-2', existingPlayerId: 'player-1', conflictType: 'contact', contact: 'email: pat@example.com' }
-        ]);
-        expect(plan.operations).toHaveLength(0);
+        expect(plan.results).toMatchObject({ added: 1, updated: 0, skipped: 0, conflicted: 0 });
+        expect(plan.results.conflicts).toEqual([]);
+        expect(plan.operations).toHaveLength(1);
+        expect(plan.operations[0]).toMatchObject({
+            id: 'source-ext-2',
+            type: 'add',
+            payload: {
+                name: 'New Player',
+                guardians: [{ name: 'Pat Lee', email: 'pat@example.com', phone: '', relation: 'Parent' }]
+            }
+        });
+        expect(plan.previewRows.map((row) => row.status)).toEqual(['add']);
     });
 
     it('maps configured roster profile fields from matching registration answer keys and labels', () => {


### PR DESCRIPTION
## Summary

- Fixes #2242: roster import was falsely blocking siblings who share the same parent email or phone number
- Wrapped the `findContactConflict` call in an `if (existing)` guard so contact-conflict checks only run on the update path (when an existing player is being matched), not when adding a brand-new player
- Siblings legitimately share parent contacts — this conflict type is only meaningful when two import rows would resolve to the same existing player

## Test plan

- [ ] Import a roster CSV with two sibling players sharing the same parent email — both should import successfully without a conflict error
- [ ] Import a roster where the same player appears twice with the same parent email — the name/number conflict check still catches the duplicate
- [ ] Update an existing player whose parent email already appears on another player — contact conflict is still raised (update path unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_