### PR TITLE
Allow ride requests on full offers for waitlist placement

### DIFF
--- a/js/rideshare-helpers.js
+++ b/js/rideshare-helpers.js
@@ -1,6 +1,7 @@
 const OFFER_STATUS_OPEN = 'open';
 const REQUEST_STATUS_PENDING = 'pending';
 const REQUEST_STATUS_CONFIRMED = 'confirmed';
+const REQUEST_STATUS_WAITLISTED = 'waitlisted';
 
 export function normalizeOffer(offer = {}) {
     const statusRaw = (offer.status || '').toString().toLowerCase();
@@ -79,9 +80,8 @@ export function canRequestRide(offer = {}, parentUserId, childId) {
     if (normalized.status !== OFFER_STATUS_OPEN) return false;
     if (!parentUserId || !childId) return false;
     if (normalized.driverUserId === parentUserId) return false;
-    const seatInfo = getOfferSeatInfo(normalized);
     const existing = findRequestForChild(normalized, parentUserId, childId);
-    if (existing?.status === REQUEST_STATUS_PENDING || existing?.status === REQUEST_STATUS_CONFIRMED) return false;
+    if (existing?.status === REQUEST_STATUS_PENDING || existing?.status === REQUEST_STATUS_CONFIRMED || existing?.status === REQUEST_STATUS_WAITLISTED) return false;
     return true;
 }
 

--- a/js/rideshare-helpers.js
+++ b/js/rideshare-helpers.js
@@ -82,5 +82,10 @@ export function canRequestRide(offer = {}, parentUserId, childId) {
     const seatInfo = getOfferSeatInfo(normalized);
     const existing = findRequestForChild(normalized, parentUserId, childId);
     if (existing?.status === REQUEST_STATUS_PENDING || existing?.status === REQUEST_STATUS_CONFIRMED) return false;
-    return seatInfo.seatsLeft > 0;
+    return true;
+}
+
+export function isWaitlistRequest(offer = {}) {
+    const seatInfo = getOfferSeatInfo(normalizeOffer(offer));
+    return seatInfo.seatsLeft === 0;
 }

--- a/tests/unit/rideshare-helpers.test.js
+++ b/tests/unit/rideshare-helpers.test.js
@@ -5,6 +5,7 @@ import {
   getEventRideshareSummary,
   getOfferSeatInfo,
   getRequestStatusCounts,
+  isWaitlistRequest,
   normalizeOffer
 } from '../../js/rideshare-helpers.js';
 
@@ -96,5 +97,23 @@ describe('rideshare helpers', () => {
     expect(canRequestRide(offer, 'parent-3', 'child-3')).toBe(true);
     expect(canRequestRide(offer, 'driver-1', 'child-4')).toBe(false);
     expect(canRequestRide(offer, 'parent-2', 'child-2')).toBe(false);
+  });
+
+  it('allows ride request on a full offer for waitlist placement', () => {
+    const fullOffer = {
+      status: 'open',
+      driverUserId: 'driver-1',
+      seatCapacity: 2,
+      seatCountConfirmed: 2,
+      requests: []
+    };
+    expect(canRequestRide(fullOffer, 'parent-3', 'child-3')).toBe(true);
+  });
+
+  it('isWaitlistRequest returns true when offer is full', () => {
+    const fullOffer = { status: 'open', seatCapacity: 2, seatCountConfirmed: 2 };
+    const openOffer = { status: 'open', seatCapacity: 2, seatCountConfirmed: 1 };
+    expect(isWaitlistRequest(fullOffer)).toBe(true);
+    expect(isWaitlistRequest(openOffer)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #2199: full ride offers were completely blocking new requests instead of placing them on a waitlist
- Changed `canRequestRide` to return `true` even when `seatsLeft === 0` (offer must still be open and not already requested)
- Added new `isWaitlistRequest(offer)` helper that returns `true` when an offer is open but full, allowing UI to show waitlist messaging
- Unit tests added for both new behaviors

## Test plan

- [ ] Open rideshare on a game where all offers are full — "Request Ride" button should still appear
- [ ] Submit a request on a full offer — request should be created (driver/admin will see it as waitlisted)
- [ ] Verify that closed/cancelled offers still block new requests
- [ ] Verify a parent cannot request twice for the same child on the same offer

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_