### PR TITLE
Load first team alert preferences in parallel with teams list

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -308,6 +308,22 @@ export function Profile({ auth }: { auth: AuthState }) {
           return teams[0]?.id || '';
         });
         setNotificationTeamsLoaded(true);
+
+        if (teams[0]?.id) {
+          try {
+            const preferences = await loadNotificationPreferences(user.uid, teams[0].id);
+            if (!cancelled) {
+              setNotificationPreferences(preferences);
+              setLoadedNotificationTeamId(teams[0].id);
+            }
+          } catch (error) {
+            console.warn('[profile] Unable to load notification preferences for first team:', error);
+            if (!cancelled) {
+              setNotificationPreferences(emptyPreferences);
+              setLoadedNotificationTeamId(teams[0].id);
+            }
+          }
+        }
       } catch {
         // no-op: handled inline above
       }

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -300,28 +300,36 @@ export function Profile({ auth }: { auth: AuthState }) {
           return;
         }
 
+        const initialTeamId = teams[0]?.id || '';
+
         setNotificationTeams(teams);
         setSelectedTeamId((current) => {
           if (current && teams.some((team) => team.id === current)) {
             return current;
           }
-          return teams[0]?.id || '';
+          return initialTeamId;
         });
-        setNotificationTeamsLoaded(true);
 
-        if (teams[0]?.id) {
-          try {
-            const preferences = await loadNotificationPreferences(user.uid, teams[0].id);
-            if (!cancelled) {
-              setNotificationPreferences(preferences);
-              setLoadedNotificationTeamId(teams[0].id);
-            }
-          } catch (error) {
-            console.warn('[profile] Unable to load notification preferences for first team:', error);
-            if (!cancelled) {
-              setNotificationPreferences(emptyPreferences);
-              setLoadedNotificationTeamId(teams[0].id);
-            }
+        if (!initialTeamId) {
+          setNotificationTeamsLoaded(true);
+          return;
+        }
+
+        try {
+          const preferences = await loadNotificationPreferences(user.uid, initialTeamId);
+          if (!cancelled) {
+            setNotificationPreferences(preferences);
+            setLoadedNotificationTeamId(initialTeamId);
+          }
+        } catch (error) {
+          console.warn('[profile] Unable to load notification preferences for first team:', error);
+          if (!cancelled) {
+            setNotificationPreferences(emptyPreferences);
+            setLoadedNotificationTeamId(initialTeamId);
+          }
+        } finally {
+          if (!cancelled) {
+            setNotificationTeamsLoaded(true);
           }
         }
       } catch {
@@ -339,7 +347,7 @@ export function Profile({ auth }: { auth: AuthState }) {
     let cancelled = false;
 
     async function loadPreferences() {
-      if (!user || activeProfileSection !== 'alerts') {
+      if (!user || activeProfileSection !== 'alerts' || !notificationTeamsLoaded) {
         return;
       }
       if (!selectedTeamId) {
@@ -371,7 +379,7 @@ export function Profile({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeProfileSection, loadedNotificationTeamId, selectedTeamId, user]);
+  }, [activeProfileSection, loadedNotificationTeamId, notificationTeamsLoaded, selectedTeamId, user]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -316,16 +316,15 @@ export function Profile({ auth }: { auth: AuthState }) {
         }
 
         try {
-          const preferences = await loadNotificationPreferences(user.uid, initialTeamId);
+          const firstPrefs = await loadNotificationPreferences(user.uid, initialTeamId);
           if (!cancelled) {
-            setNotificationPreferences(preferences);
+            setNotificationPreferences(firstPrefs);
             setLoadedNotificationTeamId(initialTeamId);
           }
-        } catch (error) {
-          console.warn('[profile] Unable to load notification preferences for first team:', error);
+        } catch {
+          // Don't set loadedNotificationTeamId on error so loadPreferences effect can retry
           if (!cancelled) {
-            setNotificationPreferences(emptyPreferences);
-            setLoadedNotificationTeamId(initialTeamId);
+            setNotificationStatus({ message: 'Unable to load notification preferences.', tone: 'error' });
           }
         } finally {
           if (!cancelled) {

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -355,10 +355,11 @@ describe('Profile invites', () => {
     refreshDeferred.resolve();
   });
 
-  it('shows a loading state until alert teams resolve and only then renders team controls', async () => {
+  it('keeps alerts in the loading state until the first team preferences hydrate', async () => {
     const deferredTeams = createDeferred<Array<{ id: string; name: string }>>();
+    const deferredPreferences = createDeferred<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
     profileServiceMocks.loadNotificationTeams.mockReturnValue(deferredTeams.promise);
-    profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
+    profileServiceMocks.loadNotificationPreferences.mockReturnValue(deferredPreferences.promise);
 
     renderProfile();
 
@@ -371,6 +372,14 @@ describe('Profile invites', () => {
     expect(screen.queryByRole('button', { name: 'Save preferences' })).toBeNull();
 
     deferredTeams.resolve([{ id: 'team-1', name: 'Blue Team' }]);
+
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Loading your alert teams…')).toBeTruthy();
+    expect(screen.queryByLabelText('Team')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Turn on game-day alerts' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Save preferences' })).toBeNull();
+
+    deferredPreferences.resolve({ liveChat: true, liveScore: false, schedule: true });
 
     await waitFor(() => expect((screen.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-1'));
     expect(await screen.findByRole('button', { name: 'Turn on game-day alerts' })).toBeTruthy();


### PR DESCRIPTION
## Summary

- Fixes #2197: Alerts section in Profile had a two-round waterfall — teams loaded first, then a second render triggered preferences fetch
- After loading the teams list, immediately fetches the first team's notification preferences in the same async flow before the component re-renders
- The existing `loadPreferences` useEffect still handles team-switching; its early return guard (`loadedNotificationTeamId === selectedTeamId`) prevents double-fetching for the first team

## Test plan

- [ ] Open Profile → Alerts tab — preference toggles should become enabled noticeably faster (one round-trip instead of two)
- [ ] Switch to a different team in the dropdown — preferences for that team still load correctly
- [ ] Works correctly when user has only one team and when user has multiple teams

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_