### PR TITLE
Normalize punctuation in post-game stat editor column keys

### DIFF
--- a/game.html
+++ b/game.html
@@ -398,7 +398,7 @@
         import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
         import { splitPlayerStatsByVisibility } from './js/stat-leaderboards.js?v=2';
         import { formatGameReportEventTimestamp, resolveReportStatColumns, resolveOpponentReportStatColumns } from './js/game-report-stats.js?v=2';
-        import { resolvePostGameStatFields, resolvePostGameTeamStatFields, resolvePostGameEditorDidNotPlay, buildCompletedGamePlayerStatsPayload, buildCompletedGameTeamStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=3';
+        import { normalizeStatKey, resolvePostGameStatFields, resolvePostGameTeamStatFields, resolvePostGameEditorDidNotPlay, buildCompletedGamePlayerStatsPayload, buildCompletedGameTeamStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=4';
         import { buildHighlightShareUrl, normalizeGameRecapHighlightClips } from './js/live-game-video.js?v=3';
 
         let currentUser = null;
@@ -1005,7 +1005,7 @@ Write the match report now:`;
 
             function renderEditor() {
                 fieldsEl.innerHTML = teamStatFields.map((field) => {
-                    const key = field.fieldName;
+                    const key = normalizeStatKey(field.fieldName);
                     const value = teamStats[key] || 0;
                     return `
                         <label class="block">
@@ -1132,7 +1132,7 @@ Write the match report now:`;
                 metaEl.textContent = `#${player.number || '-'} • Player ${currentIndex + 1} of ${players.length}`;
                 dnpToggle.checked = didNotPlay;
                 fieldsEl.innerHTML = statFields.map((field) => {
-                    const key = field.fieldName;
+                    const key = normalizeStatKey(field.fieldName);
                     const value = didNotPlay ? 0 : (playerStats[key] || 0);
                     return `
                         <label class="block">

--- a/js/post-game-stat-editor.js
+++ b/js/post-game-stat-editor.js
@@ -10,7 +10,12 @@ export function resolvePostGameStatFields({ resolvedConfig = null, statsMap = {}
     let fields = [];
 
     if (Array.isArray(resolvedConfig?.columns) && resolvedConfig.columns.length > 0) {
-        fields = buildConfiguredStatFields(resolvedConfig.columns, statsObjects);
+        fields = buildConfiguredStatFields(resolvedConfig.columns, statsObjects)
+            .map((field) => ({
+                ...field,
+                fieldName: normalizeStatKey(field?.fieldName)
+            }))
+            .filter((field) => field.fieldName);
     }
 
     if (fields.length === 0) {
@@ -24,10 +29,13 @@ export function resolvePostGameStatFields({ resolvedConfig = null, statsMap = {}
             .map((key) => ({ fieldName: key, label: key.toUpperCase() }));
     }
 
-    const existingFieldNames = new Set(fields.map((field) => field.fieldName));
+    const existingFieldNames = new Set(fields.map((field) => normalizeStatKey(field?.fieldName)).filter(Boolean));
     const privatePlayerFields = normalizeStatTrackerConfig(resolvedConfig || {}).statDefinitions
         .filter((definition) => definition.scope === 'player' && definition.visibility === 'private' && definition.type === 'base')
-        .map((definition) => ({ fieldName: definition.id, label: definition.label || definition.acronym || definition.id.toUpperCase() }))
+        .map((definition) => ({
+            fieldName: normalizeStatKey(definition.id),
+            label: definition.label || definition.acronym || definition.id.toUpperCase()
+        }))
         .filter((field) => field.fieldName && !existingFieldNames.has(field.fieldName));
 
     privatePlayerFields.forEach((field) => {

--- a/js/post-game-stat-editor.js
+++ b/js/post-game-stat-editor.js
@@ -1,7 +1,7 @@
 import { buildConfiguredStatFields } from './game-report-stats.js?v=1';
 import { normalizeStatTrackerConfig } from './stat-leaderboards.js?v=2';
 
-function normalizeStatKey(key) {
+export function normalizeStatKey(key) {
     return String(key || '').trim().toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 

--- a/js/post-game-stat-editor.js
+++ b/js/post-game-stat-editor.js
@@ -2,7 +2,7 @@ import { buildConfiguredStatFields } from './game-report-stats.js?v=1';
 import { normalizeStatTrackerConfig } from './stat-leaderboards.js?v=2';
 
 function normalizeStatKey(key) {
-    return String(key || '').trim().toLowerCase().replace(/\s+/g, '');
+    return String(key || '').trim().toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
 export function resolvePostGameStatFields({ resolvedConfig = null, statsMap = {} } = {}) {

--- a/tests/unit/post-game-stat-editor.test.js
+++ b/tests/unit/post-game-stat-editor.test.js
@@ -68,9 +68,9 @@ describe('post-game stat editor helpers', () => {
         });
     });
 
-    it('strips punctuation from stat keys so custom column names round-trip consistently', () => {
-        // Regression for issue #2196: "3-Pt", "FG%", "Reb." stored without punctuation but
-        // re-written with punctuation on save, wiping the original stats.
+    it('normalizes configured custom stat keys so editor inputs and payloads stay aligned', () => {
+        // Regression for issue #2196: configured columns like "3-Pt" rendered raw data-stat-field keys
+        // while completed-game saves normalized to "3pt", dropping edited values on submit.
         const statFields = resolvePostGameStatFields({
             resolvedConfig: {
                 columns: ['3-Pt', 'FG%', 'Reb.']
@@ -79,6 +79,13 @@ describe('post-game stat editor helpers', () => {
                 p1: { '3pt': 8, fg: 5, reb: 4 }
             }
         });
+
+        expect(statFields).toEqual([
+            { fieldName: '3pt', label: '3-Pt' },
+            { fieldName: 'fg', label: 'FG%' },
+            { fieldName: 'reb', label: 'Reb.' },
+            { fieldName: 'fouls', label: 'FOULS' }
+        ]);
 
         expect(buildCompletedGamePlayerStatsPayload({
             player: { name: 'Ava Cole', number: '3' },

--- a/tests/unit/post-game-stat-editor.test.js
+++ b/tests/unit/post-game-stat-editor.test.js
@@ -68,28 +68,26 @@ describe('post-game stat editor helpers', () => {
         });
     });
 
-    it('preserves punctuation in configured stat keys when building correction payloads', () => {
+    it('strips punctuation from stat keys so custom column names round-trip consistently', () => {
+        // Regression for issue #2196: "3-Pt", "FG%", "Reb." stored without punctuation but
+        // re-written with punctuation on save, wiping the original stats.
         const statFields = resolvePostGameStatFields({
             resolvedConfig: {
-                columns: ['AST/TO', 'FG%']
+                columns: ['3-Pt', 'FG%', 'Reb.']
             },
             statsMap: {
-                p1: { 'ast/to': 2, 'fg%': 45 }
+                p1: { '3pt': 8, fg: 5, reb: 4 }
             }
         });
 
-        expect(statFields).toEqual([
-            { fieldName: 'ast/to', label: 'AST/TO' },
-            { fieldName: 'fg%', label: 'FG%' },
-            { fieldName: 'fouls', label: 'FOULS' }
-        ]);
         expect(buildCompletedGamePlayerStatsPayload({
             player: { name: 'Ava Cole', number: '3' },
             statFields,
-            values: { 'ast/to': '3', 'fg%': '47', fouls: '1' }
+            values: { '3pt': '8', fg: '5', reb: '4', fouls: '1' }
         }).stats).toEqual({
-            'ast/to': 3,
-            'fg%': 47,
+            '3pt': 8,
+            fg: 5,
+            reb: 4,
             fouls: 1
         });
     });

--- a/tests/unit/post-game-stat-editor.test.js
+++ b/tests/unit/post-game-stat-editor.test.js
@@ -181,4 +181,26 @@ describe('post-game stat editor helpers', () => {
         expect(pageSource).toContain("hasRecordedStatValue(pStats, key) ? pStats[key] : '&mdash;'");
         expect(pageSource).toContain("hasRecordedStatValue(p.stats, key) ? p.stats[key] : '&mdash;'");
     });
+
+    it('uses normalizeStatKey for form input keys so custom stat names round-trip correctly', () => {
+        // Regression for issue #2196: form inputs were rendered with raw fieldName (e.g. "3-pt")
+        // but buildCompletedGamePlayerStatsPayload reads back using normalizeStatKey (e.g. "3pt"),
+        // causing a key mismatch that wiped custom stat values on save.
+        const pageSource = readFileSync(new URL('../../game.html', import.meta.url), 'utf8');
+
+        // The team stat editor comes first in the file, then the player stat editor
+        const teamEditorStart = pageSource.indexOf('function setupPostGameTeamStatEditor({');
+        const playerEditorStart = pageSource.indexOf('function setupPostGameStatEditor({');
+
+        // The team stat editor renderEditor function must normalize field keys before use
+        const teamEditorEnd = playerEditorStart;
+        const teamEditorSource = pageSource.slice(teamEditorStart, teamEditorEnd);
+        expect(teamEditorSource).toContain('normalizeStatKey(field.fieldName)');
+        expect(teamEditorSource).toContain('data-team-stat-field=');
+
+        // The player stat editor renderEditor function must also normalize field keys
+        const playerEditorSource = pageSource.slice(playerEditorStart);
+        expect(playerEditorSource).toContain('normalizeStatKey(field.fieldName)');
+        expect(playerEditorSource).toContain('data-stat-field=');
+    });
 });


### PR DESCRIPTION
## Summary

- Fixes #2196: custom stat columns with punctuation (e.g. "3-Pt", "FG%", "Reb.") were being wiped when saving from the post-game stat editor
- Updated `normalizeStatKey` in `js/post-game-stat-editor.js` to strip all non-alphanumeric characters (not just whitespace), so keys like "3-Pt" → "3pt" consistently in both read and write directions
- Added regression test covering the exact round-trip scenario from the issue

## Test plan

- [ ] Open a game with custom stats containing hyphens, percent signs, or periods in column names
- [ ] Edit any stat value and save — existing custom stat values should be preserved (not wiped)
- [ ] Standard stat columns (no punctuation) continue to save correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_