### PR TITLE
[codex] Add mobile form input hints

### DIFF
--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -166,7 +166,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
       {state === 'email-link' ? (
         <form className="mt-4 space-y-3" onSubmit={handleEmailLink}>
           <p className="text-sm font-semibold leading-6 text-gray-600">Enter the email address that received this invite link.</p>
-          <input className="auth-input" type="email" value={email} onChange={(event) => setEmail(event.target.value)} required placeholder="you@example.com" />
+          <input className="auth-input" type="email" inputMode="email" autoComplete="email" enterKeyHint="next" value={email} onChange={(event) => setEmail(event.target.value)} required placeholder="you@example.com" />
           <button type="submit" className="primary-button w-full justify-center">Continue</button>
         </form>
       ) : null}
@@ -177,7 +177,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
             <KeyRound className="h-3.5 w-3.5" aria-hidden="true" />
             Invite code
           </span>
-          <input className="auth-input text-center font-mono uppercase tracking-widest" value={manualCode} onChange={(event) => setManualCode(event.target.value.toUpperCase())} maxLength={8} placeholder="XXXXXXXX" />
+          <input className="auth-input text-center font-mono uppercase tracking-widest" value={manualCode} onChange={(event) => setManualCode(event.target.value.toUpperCase())} maxLength={8} placeholder="XXXXXXXX" inputMode="text" autoCapitalize="characters" autoComplete="one-time-code" enterKeyHint="go" />
         </label>
         <button type="submit" className="secondary-button w-full justify-center" disabled={state === 'processing'}>
           {auth.user ? 'Join team' : 'Continue with code'}

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -296,6 +296,7 @@ function InboxSearch({ query, onChange }: { query: string; onChange: (value: str
         onChange={(event) => onChange(event.target.value)}
         className="min-w-0 flex-1 border-0 bg-transparent text-base font-semibold text-gray-900 outline-none placeholder:text-gray-400"
         placeholder="Search team chats"
+        enterKeyHint="search"
       />
     </label>
   );
@@ -2065,6 +2066,7 @@ function TeamEmailSheet({
                 className="min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
                 placeholder="Weekly reminder"
                 maxLength={120}
+                enterKeyHint="next"
               />
               <button type="button" className="secondary-button sm:min-w-[148px]" disabled={!canSaveTemplate} onClick={onSaveTemplate}>
                 {savingTemplate ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
@@ -2081,6 +2083,7 @@ function TeamEmailSheet({
             className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
             placeholder="Team update"
             maxLength={160}
+            enterKeyHint="next"
           />
         </label>
         <label className="block">
@@ -2091,6 +2094,7 @@ function TeamEmailSheet({
             className="mt-1 min-h-36 w-full rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
             placeholder="Write the email body..."
             maxLength={5000}
+            enterKeyHint="send"
           />
         </label>
         <button type="submit" className="primary-button w-full" disabled={!canSendEmail}>
@@ -2599,6 +2603,7 @@ function Composer({
           maxLength={2000}
           className="chat-composer-textarea"
           placeholder={placeholder}
+          enterKeyHint="send"
           onKeyDown={(event) => {
             if (event.key === 'Enter' && !event.shiftKey) {
               event.preventDefault();

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -389,6 +389,10 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
                     onChange={(event) => setRedeemCode(event.target.value.toUpperCase())}
                     maxLength={8}
                     placeholder="XXXXXXXX"
+                    inputMode="text"
+                    autoCapitalize="characters"
+                    autoComplete="one-time-code"
+                    enterKeyHint="go"
                     disabled={redeeming || saving}
                   />
                 </label>
@@ -770,10 +774,10 @@ function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState; refres
               </select>
             </label>
             <div className="grid gap-3 sm:grid-cols-2">
-              <input className="auth-input" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Name (optional)" disabled={saving || !linkedPlayers.length} />
-              <input className="auth-input" type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="Household contact email" disabled={saving || !linkedPlayers.length} />
+              <input className="auth-input" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Name (optional)" autoComplete="name" enterKeyHint="next" disabled={saving || !linkedPlayers.length} />
+              <input className="auth-input" type="email" inputMode="email" autoComplete="email" enterKeyHint="send" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="Household contact email" disabled={saving || !linkedPlayers.length} />
             </div>
-            <input className="auth-input" value={relation} onChange={(event) => setRelation(event.target.value)} placeholder="Relation, like grandparent or guardian" disabled={saving || !linkedPlayers.length} />
+            <input className="auth-input" value={relation} onChange={(event) => setRelation(event.target.value)} placeholder="Relation, like grandparent or guardian" autoComplete="off" enterKeyHint="next" disabled={saving || !linkedPlayers.length} />
             <button type="submit" className="primary-button" disabled={saving || loading || !linkedPlayers.length}>
               {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Users className="h-4 w-4" aria-hidden="true" />}
               Create household invite

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, type InputHTMLAttributes } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import {
   AlertCircle,
@@ -594,7 +594,7 @@ function StaffRosterDetailsCard({ data, auth, onChanged }: { data: ParentPlayerD
       <form className="mt-4 space-y-3" onSubmit={submit}>
         <div className="grid gap-3 sm:grid-cols-2">
           <TextField label="Player name" value={name} onChange={setName} placeholder="Player name" />
-          <TextField label="Jersey number" value={number} onChange={setNumber} placeholder="Number" />
+          <TextField label="Jersey number" value={number} onChange={setNumber} placeholder="Number" inputMode="numeric" />
         </div>
         <label className="block">
           <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Roster photo</span>
@@ -1754,12 +1754,18 @@ function IncentivesCard({ data, auth, onChanged }: { data: ParentPlayerDetailDat
   );
 }
 
-function TextField({ label, value, onChange, placeholder = '', type = 'text' }: { label: string; value: string; onChange: (value: string) => void; placeholder?: string; type?: string }) {
+type TextFieldHints = Pick<InputHTMLAttributes<HTMLInputElement>, 'inputMode' | 'autoComplete' | 'enterKeyHint'>;
+
+function TextField({ label, value, onChange, placeholder = '', type = 'text', inputMode, autoComplete, enterKeyHint }: { label: string; value: string; onChange: (value: string) => void; placeholder?: string; type?: string } & TextFieldHints) {
+  const hints = inferInputHints(type);
   return (
     <label className="block">
       <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">{label}</span>
       <input
         type={type}
+        inputMode={inputMode || hints.inputMode}
+        autoComplete={autoComplete || hints.autoComplete}
+        enterKeyHint={enterKeyHint || hints.enterKeyHint}
         value={value}
         onChange={(event) => onChange(event.currentTarget.value)}
         placeholder={placeholder}
@@ -1767,6 +1773,13 @@ function TextField({ label, value, onChange, placeholder = '', type = 'text' }: 
       />
     </label>
   );
+}
+
+function inferInputHints(type: string): TextFieldHints {
+  if (type === 'email') return { inputMode: 'email', autoComplete: 'email', enterKeyHint: 'next' };
+  if (type === 'tel') return { inputMode: 'tel', autoComplete: 'tel', enterKeyHint: 'next' };
+  if (type === 'number') return { inputMode: 'decimal', enterKeyHint: 'next' };
+  return { enterKeyHint: 'next' };
 }
 
 function MiniMoney({ label, cents = 0, value, warn = false, inverse = false }: { label: string; cents?: number; value?: string; warn?: boolean; inverse?: boolean }) {

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type InputHTMLAttributes, type SyntheticEvent } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import * as parentToolsService from '../lib/parentToolsService';
 import { AlertCircle, CheckCircle2, ChevronLeft, ExternalLink, Loader2, Send, Ticket, UserPlus, XCircle, type LucideIcon } from 'lucide-react';
@@ -21,6 +21,7 @@ import type { AuthState } from '../lib/types';
 
 type FieldErrors = Record<string, string>;
 type FeeSummaryLine = { label: string; amountCents: number; strong?: boolean };
+type FieldInputHints = Pick<InputHTMLAttributes<HTMLInputElement>, 'inputMode' | 'autoComplete' | 'enterKeyHint'>;
 
 export function selectInitialRegistrationOption(form: ParentRegistrationCard | null, options: any[]) {
   if (!form || !Array.isArray(options) || !options.length) return '';
@@ -496,7 +497,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
           {hasQuantityDiscount ? (
             <label className="min-w-0">
               <span className="app-label">Quantity</span>
-              <input className="auth-input mt-1" data-quantity-field type="number" min="1" value={quantity} onChange={(event) => setQuantity(Math.max(1, Number(event.target.value) || 1))} disabled={saving} />
+              <input className="auth-input mt-1" data-quantity-field type="number" inputMode="numeric" enterKeyHint="next" min="1" value={quantity} onChange={(event) => setQuantity(Math.max(1, Number(event.target.value) || 1))} disabled={saving} />
               {fieldErrors.quantity ? <InlineError message={fieldErrors.quantity} /> : null}
             </label>
           ) : null}
@@ -654,14 +655,14 @@ function FieldGroup({ title, fields, values, errors, prefix, onChange, disabled 
           <label key={field.id} htmlFor={`${prefix}-${field.id}`} className="min-w-0">
             <span className="app-label">{field.label}{field.required ? ' *' : ''}</span>
             {field.type === 'textarea' ? (
-              <textarea id={`${prefix}-${field.id}`} className="auth-input mt-1 min-h-24" data-field-group={prefix} data-field-id={field.id} value={values[field.id] || ''} onChange={(event) => onChange(field.id, event.target.value)} disabled={disabled} />
+              <textarea id={`${prefix}-${field.id}`} className="auth-input mt-1 min-h-24" data-field-group={prefix} data-field-id={field.id} value={values[field.id] || ''} onChange={(event) => onChange(field.id, event.target.value)} disabled={disabled} enterKeyHint="next" />
             ) : field.type === 'select' ? (
               <select id={`${prefix}-${field.id}`} className="auth-input mt-1" data-field-group={prefix} data-field-id={field.id} value={values[field.id] || ''} onChange={(event) => onChange(field.id, event.target.value)} disabled={disabled}>
                 <option value="">Select</option>
                 {(field.options || []).map((option: string) => <option key={option} value={option}>{option}</option>)}
               </select>
             ) : (
-              <input id={`${prefix}-${field.id}`} className="auth-input mt-1" data-field-group={prefix} data-field-id={field.id} type={field.type || 'text'} value={values[field.id] || ''} onChange={(event) => onChange(field.id, event.target.value)} disabled={disabled} />
+              <input id={`${prefix}-${field.id}`} className="auth-input mt-1" data-field-group={prefix} data-field-id={field.id} type={field.type || 'text'} {...getFieldInputHints(field.type)} value={values[field.id] || ''} onChange={(event) => onChange(field.id, event.target.value)} disabled={disabled} />
             )}
             {errors[errorKey] ? <InlineError message={errors[errorKey]} /> : null}
           </label>
@@ -669,6 +670,13 @@ function FieldGroup({ title, fields, values, errors, prefix, onChange, disabled 
       })}
     </div>
   );
+}
+
+function getFieldInputHints(type?: string): FieldInputHints {
+  if (type === 'email') return { inputMode: 'email', autoComplete: 'email', enterKeyHint: 'next' };
+  if (type === 'tel') return { inputMode: 'tel', autoComplete: 'tel', enterKeyHint: 'next' };
+  if (type === 'number') return { inputMode: 'numeric', enterKeyHint: 'next' };
+  return { enterKeyHint: 'next' };
 }
 
 function InlineError({ message }: { message: string }) {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -610,6 +610,8 @@ function AddPlayerCard({ teamId, authUser, onCreated }: {
             <span className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">Jersey number</span>
             <input
               type="text"
+              inputMode="numeric"
+              enterKeyHint="next"
               value={number}
               onChange={(event) => setNumber(event.target.value)}
               className="mt-2 min-h-10 w-full rounded-xl border border-primary-200 bg-white px-3 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
@@ -1358,6 +1360,9 @@ function StaffPermissionsCard({ model, auth, onInviteSuccess }: { model: TeamDet
             <input
               id="team-admin-invite-email"
               type="email"
+              inputMode="email"
+              autoComplete="email"
+              enterKeyHint="send"
               value={email}
               onChange={(event) => {
                 setEmail(event.target.value);

--- a/tests/unit/app-form-input-hints.test.js
+++ b/tests/unit/app-form-input-hints.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+
+function readSource(relativePath) {
+  return readFileSync(join(root, relativePath), 'utf8');
+}
+
+describe('app form mobile input hints', () => {
+  test('invite acceptance fields expose email and one-time-code hints', () => {
+    const source = readSource('apps/app/src/pages/AcceptInvite.tsx');
+
+    expect(source).toContain('type="email" inputMode="email" autoComplete="email" enterKeyHint="next"');
+    expect(source).toContain('inputMode="text" autoCapitalize="characters" autoComplete="one-time-code" enterKeyHint="go"');
+  });
+
+  test('registration detail fields infer keyboard and autocomplete hints', () => {
+    const source = readSource('apps/app/src/pages/RegistrationDetail.tsx');
+
+    expect(source).toContain('data-quantity-field type="number" inputMode="numeric" enterKeyHint="next"');
+    expect(source).toContain('{...getFieldInputHints(field.type)}');
+    expect(source).toContain("if (type === 'email') return { inputMode: 'email', autoComplete: 'email', enterKeyHint: 'next' };");
+    expect(source).toContain("if (type === 'tel') return { inputMode: 'tel', autoComplete: 'tel', enterKeyHint: 'next' };");
+    expect(source).toContain("if (type === 'number') return { inputMode: 'numeric', enterKeyHint: 'next' };");
+  });
+
+  test('parent tools invite and household fields expose expected hints', () => {
+    const source = readSource('apps/app/src/pages/ParentTools.tsx');
+
+    expect(source).toContain('autoComplete="one-time-code"');
+    expect(source).toContain('autoComplete="email" enterKeyHint="send"');
+    expect(source).toContain('autoComplete="name" enterKeyHint="next"');
+  });
+
+  test('messages search and composers expose search/send enter key hints', () => {
+    const source = readSource('apps/app/src/pages/Messages.tsx');
+
+    expect(source).toContain('placeholder="Search team chats"');
+    expect(source).toContain('enterKeyHint="search"');
+    expect(source).toContain('className="chat-composer-textarea"');
+    expect(source).toContain('enterKeyHint="send"');
+  });
+
+  test('team and player detail numeric and email fields expose keyboard hints', () => {
+    const teamDetail = readSource('apps/app/src/pages/TeamDetail.tsx');
+    const playerDetail = readSource('apps/app/src/pages/PlayerDetail.tsx');
+
+    expect(teamDetail).toContain('inputMode="numeric"');
+    expect(teamDetail).toContain('type="email"');
+    expect(teamDetail).toContain('autoComplete="email"');
+    expect(playerDetail).toContain('label="Jersey number" value={number} onChange={setNumber} placeholder="Number" inputMode="numeric"');
+    expect(playerDetail).toContain("if (type === 'email') return { inputMode: 'email', autoComplete: 'email', enterKeyHint: 'next' };");
+    expect(playerDetail).toContain("if (type === 'tel') return { inputMode: 'tel', autoComplete: 'tel', enterKeyHint: 'next' };");
+    expect(playerDetail).toContain("if (type === 'number') return { inputMode: 'decimal', enterKeyHint: 'next' };");
+  });
+});


### PR DESCRIPTION
Closes #2047.

## Summary
- adds mobile keyboard, autocomplete, and enter-key hints to invite, registration, parent tools, team, player, and message forms
- adds source-level coverage for the form hint audit

## Tests
- npx vitest run tests/unit/app-form-input-hints.test.js --reporter=verbose
- npm run app:build







