### PR TITLE
Defer legacy public team search until the user types

### DIFF
--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,19 +1,24 @@
 import { escapeHtml } from './utils.js?v=8';
-import { getTeams } from './db.js?v=48';
+import { discoverPublicTeams } from './db.js?v=48';
 import { canUserDiscoverPlayerInSearch, filterSearchableTeams } from './global-search-visibility.js?v=2';
+import { isTeamActive } from './team-visibility.js?v=2';
 import {
     db,
     collection,
     getDocs,
+    getDoc,
+    doc,
     query,
     where,
     orderBy,
     limit
 } from './firebase.js?v=18';
 
-let cachedTeams = null;
-let cachedTeamsLoadedAt = 0;
+let cachedAccessibleTeams = null;
+let cachedAccessibleTeamsLoadedAt = 0;
+let cachedAccessibleTeamsUserKey = '';
 const playerSearchTeamLimit = 8;
+const teamSearchQueryLimit = 20;
 
 let currentUser = null;
 let keyHandlerInstalled = false;
@@ -94,12 +99,90 @@ function buildActions(user) {
 
 async function loadTeamsOnce() {
     const ttlMs = 10 * 60 * 1000;
-    if (cachedTeams && (nowMs() - cachedTeamsLoadedAt) < ttlMs) return cachedTeams;
+    const userKey = buildAccessibleTeamsCacheKey(currentUser);
+    if (cachedAccessibleTeams && cachedAccessibleTeamsUserKey === userKey && (nowMs() - cachedAccessibleTeamsLoadedAt) < ttlMs) {
+        return cachedAccessibleTeams;
+    }
 
-    const teams = await getTeams();
-    cachedTeams = Array.isArray(teams) ? teams : [];
-    cachedTeamsLoadedAt = nowMs();
-    return cachedTeams;
+    const teams = await loadAccessibleTeams(currentUser);
+    cachedAccessibleTeams = Array.isArray(teams) ? teams : [];
+    cachedAccessibleTeamsLoadedAt = nowMs();
+    cachedAccessibleTeamsUserKey = userKey;
+    return cachedAccessibleTeams;
+}
+
+function buildAccessibleTeamsCacheKey(user) {
+    if (!user) return 'anon';
+
+    const parentTeamIds = Array.from(new Set([
+        ...(Array.isArray(user.parentOf) ? user.parentOf.map((link) => String(link?.teamId || '').trim()) : []),
+        ...(Array.isArray(user.parentPlayerKeys) ? user.parentPlayerKeys.map((key) => String(key || '').split('::')[0] || '') : [])
+    ].filter(Boolean))).sort();
+
+    return JSON.stringify({
+        uid: String(user.uid || '').trim(),
+        email: String(user.email || user.profileEmail || '').trim().toLowerCase(),
+        isAdmin: user.isAdmin === true,
+        parentTeamIds
+    });
+}
+
+function getParentTeamIds(user) {
+    return Array.from(new Set([
+        ...(Array.isArray(user?.parentOf) ? user.parentOf.map((link) => String(link?.teamId || '').trim()) : []),
+        ...(Array.isArray(user?.parentPlayerKeys) ? user.parentPlayerKeys.map((key) => String(key || '').split('::')[0] || '') : [])
+    ].filter(Boolean)));
+}
+
+function normalizeAccessibleTeams(teams) {
+    return filterSearchableTeams((Array.isArray(teams) ? teams : []).filter(isTeamActive), currentUser)
+        .sort((a, b) => String(a?.name || '').localeCompare(String(b?.name || '')));
+}
+
+async function loadAccessibleTeams(user) {
+    if (!user) return [];
+
+    const uid = String(user.uid || '').trim();
+    const email = String(user.email || user.profileEmail || '').trim().toLowerCase();
+    const teamsRef = collection(db, 'teams');
+    const teamQueries = [];
+
+    if (uid) {
+        teamQueries.push(getDocs(query(teamsRef, where('ownerId', '==', uid))));
+        teamQueries.push(getDocs(query(teamsRef, where('teamPermissions.streaming.memberIds', 'array-contains', uid))));
+    }
+    if (email) {
+        teamQueries.push(getDocs(query(teamsRef, where('adminEmails', 'array-contains', email))));
+        teamQueries.push(getDocs(query(teamsRef, where('streamVolunteerEmails', 'array-contains', email))));
+    }
+
+    const [queryResults, parentTeamResults] = await Promise.all([
+        Promise.allSettled(teamQueries),
+        Promise.allSettled(getParentTeamIds(user).map((teamId) => getDoc(doc(db, 'teams', teamId))))
+    ]);
+
+    const teamsById = new Map();
+    queryResults.forEach((result) => {
+        if (result.status !== 'fulfilled') return;
+        (result.value?.docs || []).forEach((teamDoc) => {
+            teamsById.set(teamDoc.id, { id: teamDoc.id, ...(teamDoc.data() || {}) });
+        });
+    });
+    parentTeamResults.forEach((result, index) => {
+        if (result.status !== 'fulfilled') return;
+        const teamDoc = result.value;
+        if (!teamDoc?.exists?.()) return;
+        const teamId = getParentTeamIds(user)[index];
+        teamsById.set(teamDoc.id || teamId, { id: teamDoc.id || teamId, ...(teamDoc.data() || {}) });
+    });
+
+    if (!teamsById.size) {
+        const firstError = [...queryResults, ...parentTeamResults]
+            .find((result) => result.status === 'rejected')?.reason;
+        if (firstError) throw firstError;
+    }
+
+    return normalizeAccessibleTeams(Array.from(teamsById.values()));
 }
 
 function parseTeamAndPlayerIdFromPath(path) {
@@ -292,14 +375,18 @@ function openModal({ initialQuery = '' } = {}) {
         activeIndex: 0,
         flatResults: [],
         teams: [],
+        publicTeams: [],
         loadingTeams: true,
         teamsError: '',
+        loadingPublicTeams: false,
+        publicTeamsError: '',
+        publicTeamsReqId: 0,
         players: [],
         loadingPlayers: false,
         playersError: '',
         lastPlayersQuery: '',
         playersReqId: 0,
-        playersDebounce: null,
+        searchDebounce: null,
         teamsById: new Map()
     };
 
@@ -372,7 +459,7 @@ function openModal({ initialQuery = '' } = {}) {
         if (active && active.scrollIntoView) active.scrollIntoView({ block: 'nearest' });
     };
 
-    const computeResults = (q, teams, players) => {
+    const computeResults = (q, teams, publicTeams, players) => {
         const tokens = splitTokens(q);
         const actions = buildActions(currentUser);
 
@@ -386,7 +473,16 @@ function openModal({ initialQuery = '' } = {}) {
 
         const playerItems = (players || []);
 
-        const teamItems = filterSearchableTeams(teams, currentUser).map(t => ({
+        const visibleTeams = [];
+        const seenTeamIds = new Set();
+        filterSearchableTeams([...(teams || []), ...(publicTeams || [])], currentUser).forEach((team) => {
+            const teamId = String(team?.id || '').trim();
+            if (!teamId || seenTeamIds.has(teamId)) return;
+            seenTeamIds.add(teamId);
+            visibleTeams.push(team);
+        });
+
+        const teamItems = visibleTeams.map(t => ({
             kind: 'team',
             title: t.name || 'Team',
             subtitle: [t.sport, t.zip].filter(Boolean).join(' • '),
@@ -410,8 +506,9 @@ function openModal({ initialQuery = '' } = {}) {
 
         const q = modalState.input.value || '';
         const teams = modalState.teams || [];
+        const publicTeams = modalState.publicTeams || [];
         const players = modalState.players || [];
-        const { matchedActions, matchedPlayers, matchedTeams } = computeResults(q, teams, players);
+        const { matchedActions, matchedPlayers, matchedTeams } = computeResults(q, teams, publicTeams, players);
 
         // Order: Actions, Teams, Players
         modalState.flatResults = [...matchedActions, ...matchedTeams, ...matchedPlayers];
@@ -424,7 +521,15 @@ function openModal({ initialQuery = '' } = {}) {
             ? `<div class="text-sm text-gray-500 px-1 py-2">Loading teams...</div>`
             : modalState.teamsError
                 ? `<div class="text-sm text-red-600 px-1 py-2">${escapeHtml(modalState.teamsError)}</div>`
-                : (matchedTeams.length === 0 ? `<div class="text-sm text-gray-500 px-1 py-2">No matching teams</div>` : '');
+                : modalState.loadingPublicTeams
+                    ? `<div class="text-sm text-gray-500 px-1 py-2">Searching teams...</div>`
+                    : modalState.publicTeamsError
+                        ? `<div class="text-sm text-red-600 px-1 py-2">${escapeHtml(modalState.publicTeamsError)}</div>`
+                        : (matchedTeams.length === 0
+                            ? (q.trim().length < 2
+                                ? `<div class="text-sm text-gray-500 px-1 py-2">Type at least 2 characters to search public teams</div>`
+                                : `<div class="text-sm text-gray-500 px-1 py-2">No matching teams</div>`)
+                            : '');
 
         const teamsHtml = `
             <div>
@@ -466,6 +571,41 @@ function openModal({ initialQuery = '' } = {}) {
                 ${emptyHtml}
             </div>
         `;
+    };
+
+    const runTeamSearch = async (rawQuery) => {
+        const q = (rawQuery || '').trim();
+        if (!modalState) return;
+
+        if (q.length < 2) {
+            modalState.publicTeams = [];
+            modalState.loadingPublicTeams = false;
+            modalState.publicTeamsError = '';
+            renderResults();
+            return;
+        }
+
+        const reqId = ++modalState.publicTeamsReqId;
+        modalState.loadingPublicTeams = true;
+        modalState.publicTeamsError = '';
+        renderResults();
+
+        try {
+            const result = await discoverPublicTeams({ searchText: q, pageSize: teamSearchQueryLimit });
+            if (!modalState || reqId !== modalState.publicTeamsReqId) return;
+            const publicTeams = (result?.teams || []).filter((team) => isTeamActive(team) && !modalState.teamsById.has(team.id));
+            modalState.publicTeams = publicTeams;
+            modalState.loadingPublicTeams = false;
+            modalState.publicTeamsError = '';
+            renderResults();
+        } catch (e) {
+            console.error('[GlobalSearch] Team search failed:', e);
+            if (!modalState || reqId !== modalState.publicTeamsReqId) return;
+            modalState.publicTeams = [];
+            modalState.loadingPublicTeams = false;
+            modalState.publicTeamsError = 'Public team search unavailable.';
+            renderResults();
+        }
     };
 
     const runPlayerSearch = async (rawQuery) => {
@@ -556,18 +696,19 @@ function openModal({ initialQuery = '' } = {}) {
         }
     };
 
-    const schedulePlayerSearch = () => {
+    const scheduleSearches = () => {
         if (!modalState) return;
-        if (modalState.playersDebounce) clearTimeout(modalState.playersDebounce);
-        modalState.playersDebounce = setTimeout(() => {
+        if (modalState.searchDebounce) clearTimeout(modalState.searchDebounce);
+        modalState.searchDebounce = setTimeout(() => {
             if (!modalState) return;
+            runTeamSearch(modalState.input.value || '');
             runPlayerSearch(modalState.input.value || '');
         }, 180);
     };
 
     input.addEventListener('input', () => {
         modalState.activeIndex = 0;
-        schedulePlayerSearch();
+        scheduleSearches();
         renderResults();
     });
 
@@ -581,12 +722,14 @@ function openModal({ initialQuery = '' } = {}) {
             const teams = await loadTeamsOnce();
             if (!modalState) return;
             modalState.teams = teams;
+            modalState.publicTeams = [];
             modalState.loadingTeams = false;
             modalState.teamsError = '';
             modalState.teamsById = new Map((teams || []).map(t => [t.id, t]));
             modalState.activeIndex = 0;
             renderResults();
             if ((modalState.input.value || '').trim().length >= 2) {
+                runTeamSearch(modalState.input.value);
                 runPlayerSearch(modalState.input.value);
             }
         } catch (e) {

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -149,11 +149,9 @@ async function loadAccessibleTeams(user) {
 
     if (uid) {
         teamQueries.push(getDocs(query(teamsRef, where('ownerId', '==', uid))));
-        teamQueries.push(getDocs(query(teamsRef, where('teamPermissions.streaming.memberIds', 'array-contains', uid))));
     }
     if (email) {
         teamQueries.push(getDocs(query(teamsRef, where('adminEmails', 'array-contains', email))));
-        teamQueries.push(getDocs(query(teamsRef, where('streamVolunteerEmails', 'array-contains', email))));
     }
 
     const [queryResults, parentTeamResults] = await Promise.all([

--- a/js/utils.js
+++ b/js/utils.js
@@ -204,7 +204,7 @@ export function renderHeader(container, user) {
   // Global search: injected into the shared header in one place.
   // Lazy-import to avoid adding weight to initial render and to avoid circular deps.
   try {
-    import('./global-search.js?v=7')
+    import('./global-search.js?v=8')
       .then(({ setupHeaderSearch }) => {
         if (typeof setupHeaderSearch === 'function') {
           setupHeaderSearch({ user, headerContainer: container });

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+    discoverPublicTeams: vi.fn()
+}));
+
+const firebaseMocks = vi.hoisted(() => ({
+    db: {},
+    collection: vi.fn((db, path) => ({ db, path })),
+    getDocs: vi.fn(async () => ({ docs: [] })),
+    getDoc: vi.fn(),
+    doc: vi.fn((db, ...segments) => ({ db, path: segments.join('/') })),
+    query: vi.fn((...parts) => ({ parts })),
+    where: vi.fn((field, op, value) => ({ type: 'where', field, op, value })),
+    orderBy: vi.fn((field) => ({ type: 'orderBy', field })),
+    limit: vi.fn((count) => ({ type: 'limit', count }))
+}));
+
+vi.mock('../../js/db.js?v=48', () => dbMocks);
+vi.mock('../../js/firebase.js?v=18', () => firebaseMocks);
+vi.mock('../../js/utils.js?v=8', () => ({
+    escapeHtml: (value) => String(value || '')
+}));
+vi.mock('../../js/global-search-visibility.js?v=2', () => ({
+    filterSearchableTeams: (teams) => Array.isArray(teams) ? teams : [],
+    canUserDiscoverPlayerInSearch: () => true
+}));
+vi.mock('../../js/team-visibility.js?v=2', () => ({
+    isTeamActive: (team) => team?.active !== false && team?.archived !== true && String(team?.status || '').toLowerCase() !== 'archived'
+}));
+
+function firestoreDoc(id, data, exists = true) {
+    return {
+        id,
+        exists: () => exists,
+        data: () => data
+    };
+}
+
+async function flushAsyncWork() {
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe('legacy global search modal', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.useFakeTimers();
+        vi.clearAllMocks();
+        document.body.innerHTML = '';
+        firebaseMocks.getDocs.mockResolvedValue({ docs: [] });
+        firebaseMocks.getDoc.mockResolvedValue(firestoreDoc('team-access', {
+            name: 'Access Rockets',
+            sport: 'Basketball',
+            isPublic: false,
+            active: true
+        }));
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [{ id: 'team-public', name: 'Bearcats', sport: 'Soccer', isPublic: true, active: true }],
+            nextCursor: null
+        });
+    });
+
+    it('opens without bootstrapping all public teams and waits for a 2-character query before public discovery', async () => {
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=8');
+
+        setupHeaderSearch({
+            user: {
+                uid: 'parent-1',
+                email: 'parent@example.com',
+                parentOf: [{ teamId: 'team-access', playerId: 'player-1' }]
+            },
+            headerContainer: null
+        });
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).not.toHaveBeenCalled();
+        expect(document.body.textContent).toContain('Access Rockets');
+        expect(document.body.textContent).not.toContain('Bearcats');
+
+        const input = document.querySelector('[data-global-search-input="1"]');
+        input.value = 'b';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        vi.advanceTimersByTime(200);
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).not.toHaveBeenCalled();
+
+        input.value = 'be';
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+        vi.advanceTimersByTime(200);
+        await flushAsyncWork();
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'be', pageSize: 20 });
+        expect(document.body.textContent).toContain('Bearcats');
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-access');
+    });
+});

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -5,6 +5,15 @@ import { resolve } from 'node:path';
 const source = readFileSync(resolve(process.cwd(), 'js/global-search.js'), 'utf8');
 
 describe('legacy global player search scoping', () => {
+    it('uses bounded public team discovery instead of bootstrapping the full catalog', () => {
+        expect(source).toContain("import { discoverPublicTeams } from './db.js?v=48';");
+        expect(source).not.toContain('import { getTeams }');
+        expect(source).toContain('const teamSearchQueryLimit = 20;');
+        expect(source).toContain('if (q.length < 2) {');
+        expect(source).toContain("const result = await discoverPublicTeams({ searchText: q, pageSize: teamSearchQueryLimit });");
+        expect(source).not.toContain('const teams = await getTeams();');
+    });
+
     it('queries only accessible team player collections for normal searches', () => {
         expect(source).toContain('async function loadPlayerSearchDocsByTeam(');
         expect(source).toContain('async function loadPlayerSearchDocs(prefixes, rawQuery, isNumeric, teamsById)');

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -29,4 +29,11 @@ describe('legacy global player search scoping', () => {
         expect(source).toContain('.slice(0, playerSearchTeamLimit)');
         expect(source).toContain('const teamIds = getPlayerSearchTeamIds(rawQuery, teamsById);');
     });
+
+    it('avoids unreadable stream-only team queries when loading accessible teams', () => {
+        expect(source).toContain("teamQueries.push(getDocs(query(teamsRef, where('ownerId', '==', uid))));");
+        expect(source).toContain("teamQueries.push(getDocs(query(teamsRef, where('adminEmails', 'array-contains', email))));");
+        expect(source).not.toContain("teamPermissions.streaming.memberIds");
+        expect(source).not.toContain("streamVolunteerEmails");
+    });
 });


### PR DESCRIPTION
Closes #2266

## What changed
- Reworked legacy global search so modal open loads only directly accessible teams needed for private visibility instead of calling the default `getTeams()` path.
- Added on-demand public team discovery through `discoverPublicTeams({ searchText, pageSize: 20 })`, gated behind a minimum 2-character query.
- Kept player search behavior scoped to accessible teams and bumped the shared header import cache bust so browsers fetch the new search module.
- Added focused regression coverage for the bounded team-search path and a jsdom modal flow.

## Root Cause
Legacy global search called `getTeams()` during modal startup. The default `getTeams()` implementation includes an unbounded `isPublic == true` Firestore scan, so simply opening the modal bootstrapped the full public team catalog before the user entered any search text.

## Prevention / Learning
For hidden UI like modals and pickers, preload only directly accessible records. Public discovery must stay behind a minimum query threshold and use capped prefix queries instead of preload-all catalog reads.

## Regression Tests
- `tests/unit/global-search-player-fallback.test.js`
- `tests/unit/global-search-modal-integration.test.js`
- `npx vitest run tests/unit/global-search-player-fallback.test.js tests/unit/global-search-modal-integration.test.js --reporter=verbose`

## Recurrence Risk
Low. The legacy modal now avoids the preload-all path, and the new source-level plus jsdom regression tests lock in the 2-character gate and bounded public lookup behavior.