### PR TITLE
Lock parent invite access code scope to team admins

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -67,6 +67,58 @@ service cloud.firestore {
              data.usedAt == null;
     }
 
+    function isParentInvitePayloadValid(data) {
+      return data.keys().hasOnly([
+               'code', 'type', 'teamId', 'playerId', 'playerNum', 'playerName',
+               'teamName', 'relation', 'email', 'generatedBy', 'createdAt',
+               'expiresAt', 'used', 'usedBy', 'usedAt'
+             ]) &&
+             data.keys().hasAll([
+               'code', 'type', 'teamId', 'playerId', 'generatedBy',
+               'createdAt', 'expiresAt', 'used', 'usedBy', 'usedAt'
+             ]) &&
+             data.type == 'parent_invite' &&
+             data.code is string &&
+             data.code.size() > 0 &&
+             data.teamId is string &&
+             data.teamId.size() > 0 &&
+             data.playerId is string &&
+             data.playerId.size() > 0 &&
+             (!('playerNum' in data) || data.playerNum == null || data.playerNum is string || data.playerNum is int) &&
+             (!('playerName' in data) || data.playerName == null || data.playerName is string) &&
+             (!('teamName' in data) || data.teamName == null || data.teamName is string) &&
+             (!('relation' in data) || data.relation == null || data.relation is string) &&
+             (!('email' in data) || data.email == null || data.email is string) &&
+             data.generatedBy == request.auth.uid &&
+             data.createdAt is timestamp &&
+             data.expiresAt is timestamp &&
+             data.expiresAt > request.time &&
+             data.used == false &&
+             data.usedBy == null &&
+             data.usedAt == null;
+    }
+
+    function isParentInviteRedemptionUpdate() {
+      return resource.data.type == 'parent_invite' &&
+             request.resource.data.get('type', resource.data.get('type', null)) == 'parent_invite' &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
+             request.resource.data.used == true &&
+             request.resource.data.usedBy == request.auth.uid &&
+             request.resource.data.usedAt is timestamp;
+    }
+
+    function isParentInviteRevocationUpdate() {
+      return resource.data.type == 'parent_invite' &&
+             resource.data.generatedBy == request.auth.uid &&
+             resource.data.teamId is string &&
+             isTeamOwnerOrAdmin(resource.data.teamId) &&
+             request.resource.data.get('type', resource.data.get('type', null)) == 'parent_invite' &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'updatedAt']) &&
+             request.resource.data.revoked == true &&
+             request.resource.data.revokedAt is timestamp &&
+             (!request.resource.data.keys().hasAny(['updatedAt']) || request.resource.data.updatedAt is timestamp);
+    }
+
     function canReadManagedTeamDocument(data) {
       return isSignedIn() &&
              (data.ownerId == request.auth.uid ||
@@ -1334,28 +1386,38 @@ service cloud.firestore {
       allow create: if isSignedIn() &&
                        request.resource.data.generatedBy == request.auth.uid &&
                        (
-                         request.resource.data.get('type', null) != 'admin_invite' ||
-                         (
-                           request.resource.data.teamId is string &&
-                           isTeamOwnerOrAdmin(request.resource.data.teamId) &&
-                           isAdminInvitePayloadValid(request.resource.data) &&
-                           request.resource.data.code == codeId
-                         )
+                         (request.resource.data.get('type', null) == 'admin_invite' &&
+                          request.resource.data.teamId is string &&
+                          isTeamOwnerOrAdmin(request.resource.data.teamId) &&
+                          isAdminInvitePayloadValid(request.resource.data) &&
+                          request.resource.data.code == codeId) ||
+                         (request.resource.data.get('type', null) == 'parent_invite' &&
+                          request.resource.data.teamId is string &&
+                          isTeamOwnerOrAdmin(request.resource.data.teamId) &&
+                          isParentInvitePayloadValid(request.resource.data) &&
+                          request.resource.data.code == codeId) ||
+                         (request.resource.data.get('type', null) != 'admin_invite' &&
+                          request.resource.data.get('type', null) != 'parent_invite')
                        );
       // Only allow the code generator to update/delete, OR allow system to mark as used during signup
       allow update: if isSignedIn() &&
                        ((resource.data.generatedBy == request.auth.uid &&
-                         request.resource.data.get('type', resource.data.get('type', null)) != 'admin_invite') ||
+                         request.resource.data.get('type', resource.data.get('type', null)) != 'admin_invite' &&
+                         request.resource.data.get('type', resource.data.get('type', null)) != 'parent_invite') ||
                         (resource.data.generatedBy == request.auth.uid &&
                          request.resource.data.get('type', resource.data.get('type', null)) == 'admin_invite' &&
                          request.resource.data.teamId is string &&
                          isTeamOwnerOrAdmin(request.resource.data.teamId) &&
                          isAdminInvitePayloadValid(request.resource.data) &&
                          request.resource.data.code == codeId) ||
+                        isParentInviteRedemptionUpdate() ||
+                        isParentInviteRevocationUpdate() ||
                         // Allow marking as used only if setting these specific fields
-                        (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
+                        (resource.data.type != 'parent_invite' &&
+                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
                          request.resource.data.usedBy == request.auth.uid) ||
-                        (resource.data.generatedBy == request.auth.uid &&
+                        (resource.data.type != 'parent_invite' &&
+                         resource.data.generatedBy == request.auth.uid &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt'])));
 	      allow delete: if isSignedIn() && resource.data.generatedBy == request.auth.uid;
 	    }

--- a/firestore.rules
+++ b/firestore.rules
@@ -99,7 +99,7 @@ service cloud.firestore {
     }
 
     function isParentInviteRedemptionUpdate() {
-      return resource.data.type == 'parent_invite' &&
+      return resource.data.get('type', null) == 'parent_invite' &&
              request.resource.data.get('type', resource.data.get('type', null)) == 'parent_invite' &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
              request.resource.data.used == true &&
@@ -108,7 +108,7 @@ service cloud.firestore {
     }
 
     function isParentInviteRevocationUpdate() {
-      return resource.data.type == 'parent_invite' &&
+      return resource.data.get('type', null) == 'parent_invite' &&
              resource.data.generatedBy == request.auth.uid &&
              resource.data.teamId is string &&
              isTeamOwnerOrAdmin(resource.data.teamId) &&
@@ -1413,10 +1413,10 @@ service cloud.firestore {
                         isParentInviteRedemptionUpdate() ||
                         isParentInviteRevocationUpdate() ||
                         // Allow marking as used only if setting these specific fields
-                        (resource.data.type != 'parent_invite' &&
+                        (resource.data.get('type', null) != 'parent_invite' &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
                          request.resource.data.usedBy == request.auth.uid) ||
-                        (resource.data.type != 'parent_invite' &&
+                        (resource.data.get('type', null) != 'parent_invite' &&
                          resource.data.generatedBy == request.auth.uid &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt'])));
 	      allow delete: if isSignedIn() && resource.data.generatedBy == request.auth.uid;

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -57,11 +57,13 @@ describe('access code Firestore rules', () => {
 
     it('locks parent_invite targeting to redemption and revoke-only updates', () => {
         expect(rules).toContain('function isParentInviteRedemptionUpdate()');
+        expect(rules).toContain("resource.data.get('type', null) == 'parent_invite'");
         expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
         expect(rules).toContain('function isParentInviteRevocationUpdate()');
         expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'updatedAt'])");
         expect(accessCodeRules).toContain("request.resource.data.get('type', resource.data.get('type', null)) != 'parent_invite'");
-        expect(accessCodeRules).toContain("resource.data.type != 'parent_invite'");
+        expect(accessCodeRules).toContain("resource.data.get('type', null) != 'parent_invite'");
+        expect(accessCodeRules).not.toContain("resource.data.type != 'parent_invite'");
     });
 
     it('validates the allowed admin_invite payload fields before redemption can trust the record', () => {

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -30,7 +30,7 @@ describe('access code Firestore rules', () => {
 
     it('blocks self-minted admin invites unless the caller already administers the target team', () => {
         expect(rules).toContain('function isAdminInvitePayloadValid(data)');
-        expect(accessCodeRules).toContain("request.resource.data.get('type', null) != 'admin_invite' ||");
+        expect(accessCodeRules).toContain("request.resource.data.get('type', null) == 'admin_invite'");
         expect(accessCodeRules).toContain('isTeamOwnerOrAdmin(request.resource.data.teamId)');
         expect(accessCodeRules).toContain('isAdminInvitePayloadValid(request.resource.data)');
         expect(accessCodeRules).toContain('request.resource.data.code == codeId');
@@ -43,6 +43,25 @@ describe('access code Firestore rules', () => {
         expect(accessCodeRules).toContain('isTeamOwnerOrAdmin(request.resource.data.teamId)');
         expect(accessCodeRules).toContain('isAdminInvitePayloadValid(request.resource.data)');
         expect(accessCodeRules).toContain('request.resource.data.code == codeId');
+    });
+
+    it('requires team-admin authorization and an explicit schema for parent_invite creation', () => {
+        expect(rules).toContain('function isParentInvitePayloadValid(data)');
+        expect(accessCodeRules).toContain("request.resource.data.get('type', null) == 'parent_invite'");
+        expect(accessCodeRules).toContain('isTeamOwnerOrAdmin(request.resource.data.teamId)');
+        expect(accessCodeRules).toContain('isParentInvitePayloadValid(request.resource.data)');
+        expect(accessCodeRules).toContain('request.resource.data.code == codeId');
+        expect(rules).toContain("'code', 'type', 'teamId', 'playerId', 'playerNum', 'playerName'");
+        expect(rules).toContain("'teamName', 'relation', 'email', 'generatedBy', 'createdAt'");
+    });
+
+    it('locks parent_invite targeting to redemption and revoke-only updates', () => {
+        expect(rules).toContain('function isParentInviteRedemptionUpdate()');
+        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
+        expect(rules).toContain('function isParentInviteRevocationUpdate()');
+        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'updatedAt'])");
+        expect(accessCodeRules).toContain("request.resource.data.get('type', resource.data.get('type', null)) != 'parent_invite'");
+        expect(accessCodeRules).toContain("resource.data.type != 'parent_invite'");
     });
 
     it('validates the allowed admin_invite payload fields before redemption can trust the record', () => {


### PR DESCRIPTION
Closes #2264

## What changed
- added a dedicated `parent_invite` Firestore rules validator so only team owners/admins can create team-scoped parent invites
- restricted `parent_invite` updates to two narrow paths: invite redemption (`used/usedBy/usedAt`) and explicit revoke fields (`revoked/revokedAt/updatedAt`)
- extended `tests/unit/access-code-rules.test.js` to cover parent invite create authorization and immutable targeting rules

## Root Cause
`parent_invite` documents were falling through the generic `accessCodes` create and update rules that were meant for self-service signup codes. That let any signed-in creator mint or retarget a team/player-scoped invite, and later redemption trusted those mutable `teamId` and `playerId` fields to grant durable parent access.

## Prevention / Learning
Any client-created authorization artifact that carries team or player scope needs its own explicit rules schema and immutable target fields. Do not let team-scoped invites inherit generic create/update paths that were designed for unscoped access codes.

## Regression Tests
- `npx vitest run tests/unit/access-code-rules.test.js tests/unit/access-code-atomic-redemption-guard.test.js --reporter=verbose`
- `tests/unit/access-code-rules.test.js` now asserts `parent_invite` creation requires `isTeamOwnerOrAdmin(teamId)` and that updates are limited to redemption or revoke fields only