### PR TITLE
Allow saving mobile availability notes without RSVP retap

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -861,10 +861,10 @@ describe('ScheduleEventDetail assignments', () => {
       children: []
     }));
     scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
-    gameReportServiceMocks.loadGameReportSections.mockImplementation(async (event) => ({
-      game: { id: event.id, liveStatus: 'completed', status: 'completed', homeScore: 42, awayScore: 38 },
+    gameReportServiceMocks.loadGameReportSections.mockImplementation(async (_teamId, eventId) => ({
+      game: { id: eventId, liveStatus: 'completed', status: 'completed', homeScore: 42, awayScore: 38 },
       plays: [],
-      summary: event.id === 'game-2' ? 'Second game report.' : 'First game report.',
+      summary: eventId === 'game-2' ? 'Second game report.' : 'First game report.',
       opponentRows: [],
       opponentStatKeys: [],
       teamInsights: [],
@@ -877,7 +877,7 @@ describe('ScheduleEventDetail assignments', () => {
       playerRows: [],
       statLabels: {},
       hasPlayingTime: false,
-      team: { id: event.teamId }
+      team: { id: _teamId }
     }));
 
     renderScheduleEventDetailWithRouteControls();

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -254,6 +254,20 @@ const rsvpBadgeClasses: Record<RsvpResponse, string> = {
   not_responded: 'border-primary-200 bg-primary-50 text-primary-700'
 };
 
+export function getAvailabilityNoteSaveState(rsvp: RsvpResponse, availabilityNote: string, savedAvailabilityNote: string) {
+  const trimmedAvailabilityNote = String(availabilityNote || '').trim();
+  const trimmedSavedAvailabilityNote = String(savedAvailabilityNote || '').trim();
+  const isDirty = trimmedAvailabilityNote !== trimmedSavedAvailabilityNote;
+  const canSaveNote = rsvp !== 'not_responded' && isDirty;
+
+  return {
+    isDirty,
+    canSaveNote,
+    trimmedAvailabilityNote,
+    trimmedSavedAvailabilityNote
+  };
+}
+
 type AttentionItem = {
   title: string;
   detail: string;
@@ -503,6 +517,8 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     setError(null);
     setStatusMessage(null);
     try {
+      const previousRsvp = normalizeRsvpResponse(selectedEvent.myRsvp);
+      const previousNote = String(selectedEvent.myRsvpNote || '').trim();
       const note = availabilityNote.trim();
       const summary = await submitParentScheduleRsvp(selectedEvent, auth.user, response, note);
       setEvents((current) => current.map((event) => {
@@ -515,7 +531,10 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
           rsvpSummary: summary || event.rsvpSummary
         };
       }));
-      setStatusMessage(`${selectedEvent.childName} marked ${rsvpLabels[response].toLowerCase()}.`);
+      const noteOnlySave = previousRsvp === response && previousNote !== note;
+      setStatusMessage(noteOnlySave
+        ? `${selectedEvent.childName} availability note saved.`
+        : `${selectedEvent.childName} marked ${rsvpLabels[response].toLowerCase()}.`);
     } catch (submitError: any) {
       setError(submitError?.message || 'Unable to submit availability.');
     } finally {
@@ -796,13 +815,15 @@ function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting, availa
   onSubmit: (response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
 }) {
   const needsResponse = rsvp === 'not_responded';
+  const noteSaveState = getAvailabilityNoteSaveState(rsvp, availabilityNote, event.myRsvpNote || '');
+  const showDirtyState = rsvp !== 'not_responded' && noteSaveState.isDirty;
   return (
     <div className={`border-b px-3 py-2.5 sm:px-4 sm:py-3 ${needsResponse ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
       <div className="flex items-center gap-2.5 sm:items-start sm:gap-3">
         <PlayerInitials name={event.childName} />
         <div className="min-w-0 flex-1">
-          <div className={`text-[11px] font-black uppercase tracking-[0.06em] ${needsResponse ? 'text-amber-800' : 'text-gray-500'}`}>
-            {needsResponse ? 'Availability needed' : 'Availability saved'}
+          <div className={`text-[11px] font-black uppercase tracking-[0.06em] ${needsResponse ? 'text-amber-800' : showDirtyState ? 'text-amber-800' : 'text-gray-500'}`}>
+            {needsResponse ? 'Availability needed' : showDirtyState ? 'Unsaved note changes' : 'Availability saved'}
           </div>
           <div className="mt-0.5 text-sm font-black leading-tight text-gray-950 sm:mt-1 sm:text-base">Is {event.childName} going?</div>
           <div className="mt-2 grid grid-cols-3 gap-1.5">
@@ -836,6 +857,19 @@ function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting, availa
           <div className="mt-1 text-[11px] font-semibold text-gray-500">
             {event.availabilityNotesVisible ? 'Team note sharing is on for this team.' : 'Notes are visible to team staff unless sharing is enabled.'}
           </div>
+          {noteSaveState.canSaveNote ? (
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
+              <div className="text-xs font-black text-amber-900">Note edited but not saved yet.</div>
+              <button
+                type="button"
+                className="min-h-8 rounded-full border border-primary-200 bg-white px-3 text-xs font-black text-primary-700 transition hover:border-primary-300 hover:bg-primary-50"
+                disabled={!canSubmitRsvp || submitting === rsvp}
+                onClick={() => onSubmit(rsvp as Exclude<RsvpResponse, 'not_responded'>)}
+              >
+                {submitting === rsvp ? 'Saving' : 'Save note'}
+              </button>
+            </div>
+          ) : null}
           {!canSubmitRsvp ? <div className="mt-2 text-xs font-semibold text-gray-500">Availability is not open for this event.</div> : null}
         </div>
       </div>

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -40,6 +40,8 @@ async function mockScheduleModules(page, options = {}) {
     const gameLiveStatus = options.gameLiveStatus || null;
     const gameHomeScore = options.gameHomeScore ?? null;
     const gameAwayScore = options.gameAwayScore ?? null;
+    const gameMyRsvp = options.gameMyRsvp || 'not_responded';
+    const gameMyRsvpNote = options.gameMyRsvpNote || '';
     const extraUpcomingEvents = Array.from({ length: options.extraUpcomingEvents || 0 }, (_, index) => {
         const day = String(index + 1).padStart(2, '0');
         return `baseEvent({ eventKey: 'bulk-upcoming-${index}', id: 'bulk-upcoming-${index}', childId: 'player-1', childName: 'Pat', date: new Date('2030-06-${day}T18:00:00Z'), opponent: 'Team ${index + 1}', location: 'Field ${index + 1}' })`;
@@ -175,8 +177,8 @@ async function mockScheduleModules(page, options = {}) {
                         sourceLabel: overrides.sourceLabel || 'ALL PLAYS schedule',
                         isImported: overrides.isImported === true,
                         visibility: 'team',
-                        myRsvp: overrides.myRsvp || 'not_responded',
-                        myRsvpNote: overrides.myRsvpNote || '',
+                        myRsvp: overrides.myRsvp || ${JSON.stringify(gameMyRsvp)},
+                        myRsvpNote: overrides.myRsvpNote || ${JSON.stringify(gameMyRsvpNote)},
                         rsvpSummary: overrides.rsvpSummary || { going: 1, maybe: 0, notGoing: 0, notResponded: 1 },
                         rideshareSummary: overrides.rideshareSummary || { offerCount: 1, seatsLeft: 2, requests: 1, pending: 1, confirmed: 0, isFull: false },
                         assignments: overrides.assignments || getAssignments(),
@@ -1074,6 +1076,34 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
         { eventKey: 'game-1-player-1', childId: 'player-1', userId: 'user-1', response: 'going', note: 'Arriving after school pickup.' }
     ]);
     await expect(page.getByText('Pat marked going.')).toBeVisible();
+});
+
+test('app schedule saves edited availability notes without re-tapping RSVP', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockScheduleModules(page, {
+        gameMyRsvp: 'going',
+        gameMyRsvpNote: 'Original note'
+    });
+    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
+
+    const availabilitySection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Availability' }) });
+    await waitForScheduleRoute(page, availabilitySection.getByRole('heading', { name: 'Availability' }));
+    await expect(availabilitySection.getByText('Availability saved')).toBeVisible();
+
+    const noteInput = availabilitySection.getByLabel('Availability note');
+    await noteInput.fill('Running late from pickup.');
+    await expect(availabilitySection.getByText('Unsaved note changes')).toBeVisible();
+    await availabilitySection.getByRole('button', { name: 'Save note' }).click();
+
+    await expect(page.getByText('Pat availability note saved.')).toBeVisible();
+    expect(await page.evaluate(() => window.__scheduleCalls.rsvps)).toEqual([
+        { eventKey: 'game-1-player-1', childId: 'player-1', userId: 'user-1', response: 'going', note: 'Running late from pickup.' }
+    ]);
+
+    await page.getByRole('button', { name: 'Rideshare', exact: true }).click();
+    await page.getByRole('button', { name: 'Availability', exact: true }).click();
+    await expect(availabilitySection.getByLabel('Availability note')).toHaveValue('Running late from pickup.');
+    await expect(availabilitySection.getByRole('button', { name: 'Save note' })).toHaveCount(0);
 });
 
 test('app practice more tab uses hub cards and shares event details without a link', async ({ page, baseURL }) => {

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -61,7 +61,7 @@ vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
 vi.mock('../../apps/app/src/lib/gameReportService.ts', () => reportMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 
-import { ScheduleEventDetail, parseEventDetailSection } from '../../apps/app/src/pages/ScheduleEventDetail.tsx';
+import { ScheduleEventDetail, getAvailabilityNoteSaveState, parseEventDetailSection } from '../../apps/app/src/pages/ScheduleEventDetail.tsx';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -253,6 +253,53 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         expect(parseEventDetailSection('assignments')).toBe('assignments');
         expect(parseEventDetailSection('invalid')).toBe('availability');
         expect(parseEventDetailSection(null)).toBe('availability');
+    });
+
+    it('enables Save note only for dirty notes on existing RSVPs', () => {
+        expect(getAvailabilityNoteSaveState('going', 'Running late', 'Original note')).toMatchObject({
+            isDirty: true,
+            canSaveNote: true
+        });
+        expect(getAvailabilityNoteSaveState('going', 'Original note', 'Original note')).toMatchObject({
+            isDirty: false,
+            canSaveNote: false
+        });
+        expect(getAvailabilityNoteSaveState('not_responded', 'Need a ride', '')).toMatchObject({
+            isDirty: true,
+            canSaveNote: false
+        });
+    });
+
+    it('saves an edited RSVP note without reselecting the current response', async () => {
+        scheduleMocks.loadParentScheduleEventDetail.mockResolvedValue({
+            events: [event({ myRsvp: 'going', myRsvpNote: 'Original note' })]
+        });
+        scheduleMocks.submitParentScheduleRsvp.mockResolvedValue({ going: 1, maybe: 0, notGoing: 0, notResponded: 0 });
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'Is Pat going?');
+
+        const noteInput = container.querySelector('textarea[aria-label="Availability note"]');
+        await act(async () => {
+            const setValue = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+            setValue.call(noteInput, 'Running late from pickup');
+            noteInput.dispatchEvent(new Event('input', { bubbles: true }));
+        });
+
+        await waitForText(container, 'Unsaved note changes');
+        expect(buttonByText(container, 'Save note')).not.toBeNull();
+
+        await clickButton(container, 'Save note');
+
+        expect(scheduleMocks.submitParentScheduleRsvp).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 'game-1', childId: 'player-1' }),
+            auth.user,
+            'going',
+            'Running late from pickup'
+        );
+        await waitForText(container, 'Pat availability note saved.');
+        await waitForText(container, 'Availability saved');
+        expect(container.querySelector('textarea[aria-label="Availability note"]')?.value).toBe('Running late from pickup');
     });
 
     it('renders the practice More tab with text-only sharing wired to the primary top card', async () => {


### PR DESCRIPTION
Closes #2272

## What changed
- added `getAvailabilityNoteSaveState` so the Availability panel can detect dirty note edits separately from RSVP changes
- updated `QuickAvailabilityPanel` to show an unsaved-state banner and a `Save note` action when a parent already has a non-`not_responded` RSVP
- reused `submitParentScheduleRsvp` with the existing RSVP value so note-only saves persist without changing the current response
- adjusted the success message so note-only saves report that the availability note was saved
- added focused integration coverage and a mobile smoke regression for editing, saving, and reloading the saved note

## Root Cause
`QuickAvailabilityPanel` let parents edit `availabilityNote` as standalone local state, but persistence was still only wired to the Going / Maybe / Can't go buttons. That left existing RSVP note edits with no dedicated save path, and the existing `selectedEvent` reset effect could silently discard the unsaved local note.

## Prevention / Learning
When a UI exposes an editable child field from a previously saved parent record, do not assume users will replay the original parent action to persist it. Add an explicit dirty-state helper and a save path that can reuse the already-selected parent value.

## Regression Tests
- `npx vitest run tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose`
- `npx playwright test tests/smoke/app-schedule.spec.js --list`
- added integration coverage for dirty-state/save-note behavior in `tests/unit/app-schedule-more-tab-integration.test.jsx`
- added mobile smoke coverage for saving the note and revisiting Availability in `tests/smoke/app-schedule.spec.js`