### PR TITLE
Enforce private team media access in Storage

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -890,7 +890,21 @@ export async function getTeamMediaItems(teamId, folderId = null) {
         .map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }))
         .filter((item) => item.deleted !== true)
         .filter((item) => !folderId || item.folderId === folderId);
-    return sortByMediaOrder(items);
+
+    const resolvedItems = await Promise.all(items.map(async (item) => {
+        if (!['photo', 'file'].includes(String(item?.type || '').toLowerCase())) return item;
+        if (String(item.downloadUrl || item.url || item.src || '').trim()) return item;
+        if (!item.storagePath) return item;
+        try {
+            const downloadUrl = await getDownloadURL(ref(storage, item.storagePath));
+            return { ...item, downloadUrl };
+        } catch (error) {
+            console.warn('Unable to resolve team media download URL:', error);
+            return item;
+        }
+    }));
+
+    return sortByMediaOrder(resolvedItems);
 }
 
 export async function createTeamMediaFolder(teamId, draft = {}) {
@@ -1023,13 +1037,11 @@ export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {})
         }, reject, () => resolve(uploadTask.snapshot));
     });
 
-    const url = await getDownloadURL(snapshot.ref);
     const order = await reserveNextTeamMediaOrder(cleanTeamId, cleanFolderId);
     const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), {
         folderId: cleanFolderId,
         title: String(file.name || 'Uploaded photo').trim() || 'Uploaded photo',
         type: 'photo',
-        url,
         storagePath,
         uploadedBy: currentUser.uid,
         size: Number(file.size || 0),
@@ -1069,14 +1081,12 @@ export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) 
         }, reject, () => resolve(uploadTask.snapshot));
     });
 
-    const url = await getDownloadURL(snapshot.ref);
     const order = await reserveNextTeamMediaOrder(cleanTeamId, cleanFolderId);
     const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), {
         folderId: cleanFolderId,
         title: String(file.name || 'Uploaded file').trim() || 'Uploaded file',
         fileName: String(file.name || '').trim(),
         type: 'file',
-        url,
         storagePath,
         uploadedBy: currentUser.uid,
         size: Number(file.size || 0),

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem // Add this new import
-} from './db.js?v=48';
+} from './db.js?v=49';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,

--- a/storage.rules
+++ b/storage.rules
@@ -50,6 +50,15 @@ service firebase.storage {
         (hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId));
     }
 
+    function canReadTeamMediaObject(teamId, folderId) {
+      let folderPath = /databases/(default)/documents/teams/$(teamId)/mediaFolders/$(folderId);
+      return isTeamOwnerOrAdmin(teamId) ||
+        (isParentForTeam(teamId) &&
+         folderId.size() > 0 &&
+         firestore.exists(folderPath) &&
+         firestore.get(folderPath).data.get('visibility', 'team') == 'team');
+    }
+
     function isAllowedTeamMediaUploadType(contentType) {
       return contentType.matches('image/.*') ||
         contentType in [
@@ -78,7 +87,7 @@ service firebase.storage {
     }
 
     match /team-media/{teamId}/{folderId}/{userId}/{fileName} {
-      allow get: if canAccessTeamMedia(teamId);
+      allow get: if canReadTeamMediaObject(teamId, folderId);
       allow list: if false;
       allow create: if canCreateTeamMediaUpload(teamId, folderId) &&
         request.auth.uid == userId &&

--- a/team-media.html
+++ b/team-media.html
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=6"></script>
+    <script type="module" src="js/team-media.js?v=7"></script>
 </body>
 </html>

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -105,7 +105,7 @@ describe('team media db ordering', () => {
         uploadTaskQueue.length = 0;
     });
 
-    it('assigns unique sequential orders to concurrent photo uploads without album reads', async () => {
+    it('assigns unique sequential orders to concurrent photo uploads without album reads or stored bearer URLs', async () => {
         const { uploadTeamMediaPhoto } = await import('../../js/db.js');
         const files = [
             new File(['photo-1'], 'tipoff.jpg', { type: 'image/jpeg' }),
@@ -126,15 +126,18 @@ describe('team media db ordering', () => {
             order: 0,
             type: 'photo'
         }));
+        expect(firebaseMocks.addDoc.mock.calls[0][1]).not.toHaveProperty('url');
         expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
             folderId: 'folder-1',
             title: 'bench.jpg',
             order: 1,
             type: 'photo'
         }));
+        expect(firebaseMocks.addDoc.mock.calls[1][1]).not.toHaveProperty('url');
+        expect(firebaseMocks.getDownloadURL).not.toHaveBeenCalled();
     });
 
-    it('starts legacy folders at zero when the media order counter is missing', async () => {
+    it('starts legacy folders at zero when the media order counter is missing and omits stored file URLs', async () => {
         folderState.nextMediaOrder = Number.NaN;
         const { createTeamMediaLink, uploadTeamMediaFile } = await import('../../js/db.js');
         const file = new File(['doc'], 'lineup.pdf', { type: 'application/pdf' });
@@ -160,5 +163,33 @@ describe('team media db ordering', () => {
             order: 1,
             type: 'file'
         }));
+        expect(firebaseMocks.addDoc.mock.calls[1][1]).not.toHaveProperty('url');
+        expect(firebaseMocks.getDownloadURL).not.toHaveBeenCalled();
+    });
+
+    it('resolves team media download URLs from storagePath after reading authorized metadata', async () => {
+        firebaseMocks.getDocs.mockResolvedValueOnce({
+            docs: [{
+                id: 'media-1',
+                data: () => ({
+                    folderId: 'folder-1',
+                    type: 'photo',
+                    storagePath: 'team-media/team-1/folder-1/user-1/tipoff.jpg',
+                    order: 0,
+                    deleted: false
+                })
+            }]
+        });
+        firebaseMocks.getDownloadURL.mockResolvedValueOnce('https://cdn.example.test/resolved-tipoff.jpg');
+
+        const { getTeamMediaItems } = await import('../../js/db.js');
+        const items = await getTeamMediaItems('team-1', 'folder-1');
+
+        expect(firebaseMocks.getDownloadURL).toHaveBeenCalledWith({ fullPath: 'team-media/team-1/folder-1/user-1/tipoff.jpg' });
+        expect(items).toEqual([expect.objectContaining({
+            id: 'media-1',
+            storagePath: 'team-media/team-1/folder-1/user-1/tipoff.jpg',
+            downloadUrl: 'https://cdn.example.test/resolved-tipoff.jpg'
+        })]);
     });
 });

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=48', () => {
+vi.mock('../../js/db.js?v=49', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -21,7 +21,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=6"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=7"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -33,7 +33,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toMatch(/from '\.\/db\.js\?v=\d+';/);
+        expect(pageJs).toContain("from './db.js?v=49'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -20,7 +20,7 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=6"');
+        expect(page).toContain('src="js/team-media.js?v=7"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -4,6 +4,12 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
 
+function canReadTeamMediaObject({ authUid, isTeamAdmin = false, isTeamParent = false, folderExists = true, folderVisibility = 'team' }) {
+    if (!authUid) return false;
+    if (isTeamAdmin) return true;
+    return isTeamParent && folderExists && folderVisibility === 'team';
+}
+
 describe('team media page wiring', () => {
     it('links the dashboard to the team media library', () => {
         const dashboard = fs.readFileSync(path.join(repoRoot, 'dashboard.html'), 'utf8');
@@ -18,7 +24,7 @@ describe('team media page wiring', () => {
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=48'");
+        expect(source).toContain("from './db.js?v=49'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=23';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
@@ -53,11 +59,21 @@ describe('team media page wiring', () => {
 
         expect(firebaseJson.storage.rules).toBe('storage.rules');
         expect(storageRules).toContain('match /team-media/{teamId}/{folderId}/{userId}/{fileName}');
+        expect(storageRules).toContain('function canReadTeamMediaObject(teamId, folderId)');
+        expect(storageRules).toContain('allow get: if canReadTeamMediaObject(teamId, folderId);');
+        expect(storageRules).toContain("firestore.get(folderPath).data.get('visibility', 'team') == 'team'");
         expect(storageRules).toContain('canCreateTeamMediaUpload(teamId, folderId)');
         expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('teamMediaUploadTeamIds', [])");
         expect(storageRules).toContain('canUploadTeamMediaFolder(teamId, folderId)');
         expect(storageRules).toContain('isAllowedTeamMediaUploadType(request.resource.contentType)');
         expect(storageRules).toContain('application/pdf');
         expect(storageRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+    });
+
+    it('denies parent reads for private team-media objects while preserving admin access', () => {
+        expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderVisibility: 'team' })).toBe(true);
+        expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderVisibility: 'private' })).toBe(false);
+        expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderExists: false })).toBe(false);
+        expect(canReadTeamMediaObject({ authUid: 'admin-1', isTeamAdmin: true, folderVisibility: 'private' })).toBe(true);
     });
 });


### PR DESCRIPTION
Closes #2138

## What changed
- tightened `storage.rules` for `team-media/{teamId}/{folderId}/{userId}/{fileName}` so blob reads now consult the album folder document and only allow parents when the folder visibility is `team`
- stopped persisting bearer-style `url` fields for new `uploadTeamMediaPhoto` and `uploadTeamMediaFile` records in `js/db.js`
- updated `getTeamMediaItems` to resolve `downloadUrl` from `storagePath` after the caller has already passed the Firestore metadata read path
- bumped the `js/team-media.js` cache-bust import for `db.js` and updated adjacent regression tests

## Root Cause
Team media privacy was split across layers. Firestore metadata and UI helpers already treated `private` albums as admin-only, but `storage.rules` only checked team membership, so any parent with the object path could fetch the blob directly. Upload flows also stored long-lived `getDownloadURL` values on media documents, which preserved a bearer-style path around the intended folder visibility boundary.

## Prevention / Learning
For private media, access control has to be equivalent at both the metadata layer and the blob layer. When a feature stores protected files in Firebase Storage, the safe default is to persist `storagePath` and derive download URLs only after an authorized metadata read, with regression tests that cover both Storage rules and document shape.

## Regression Tests
- `npx vitest run tests/unit/team-media-db-ordering.test.js tests/unit/team-media-wiring.test.js tests/unit/team-media-page.test.js`
- `node scripts/check-critical-cache-bust.mjs`
- added assertions that parent reads are denied for private team-media objects while admins still pass
- added assertions that new uploaded team-media docs omit stored `url` fields and that reads resolve `downloadUrl` from `storagePath`