### PR TITLE
Move Schedule summary onto shared async loading

### DIFF
--- a/apps/app/src/lib/useAsyncOperation.ts
+++ b/apps/app/src/lib/useAsyncOperation.ts
@@ -1,0 +1,69 @@
+import { useCallback, useState } from 'react';
+
+type UseAsyncOperationRunOptions<T> = {
+    clearError?: boolean;
+    errorMessage?: string;
+    getErrorMessage?: (error: unknown) => string;
+    onSuccess?: (value: T) => void;
+    onError?: (error: unknown) => void;
+    onFinally?: () => void;
+    rethrow?: boolean;
+};
+
+function getDefaultErrorMessage(error: unknown) {
+    if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string' && error.message.trim()) {
+        return error.message;
+    }
+    return 'Something went wrong.';
+}
+
+export function useAsyncOperation() {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const clearError = useCallback(() => {
+        setError(null);
+    }, []);
+
+    const run = useCallback(async function runAsyncOperation<T>(
+        operation: () => Promise<T>,
+        {
+            clearError: shouldClearError = true,
+            errorMessage,
+            getErrorMessage,
+            onSuccess,
+            onError,
+            onFinally,
+            rethrow = true
+        }: UseAsyncOperationRunOptions<T> = {}
+    ) {
+        setLoading(true);
+        if (shouldClearError) {
+            setError(null);
+        }
+
+        try {
+            const value = await operation();
+            onSuccess?.(value);
+            return value;
+        } catch (error) {
+            setError(errorMessage || getErrorMessage?.(error) || getDefaultErrorMessage(error));
+            onError?.(error);
+            if (rethrow) {
+                throw error;
+            }
+            return null;
+        } finally {
+            setLoading(false);
+            onFinally?.();
+        }
+    }, []);
+
+    return {
+        loading,
+        error,
+        clearError,
+        setError,
+        run
+    };
+}

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Schedule } from './Schedule';
+import type { AuthState } from '../lib/types';
+
+const scheduleServiceMocks = vi.hoisted(() => ({
+  addTeamCalendarUrl: vi.fn(),
+  createScheduleImportGame: vi.fn(),
+  createScheduleImportPractice: vi.fn(),
+  loadParentSchedule: vi.fn(),
+  removeTeamCalendarUrl: vi.fn()
+}));
+
+const appDataCacheMocks = vi.hoisted(() => ({
+  getCachedAppData: vi.fn(() => null),
+  getParentScheduleSummaryCacheKey: vi.fn(() => 'parent-schedule:test-user'),
+  loadCachedAppData: vi.fn(async (_key: string, loader: () => Promise<unknown>) => loader())
+}));
+
+const uxTimingMocks = vi.hoisted(() => ({
+  end: vi.fn()
+}));
+
+vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('../lib/appDataCache', () => appDataCacheMocks);
+vi.mock('../lib/uxTiming', () => ({
+  startUxTimer: vi.fn(() => uxTimingMocks)
+}));
+vi.mock('../lib/useShellLayout', () => ({
+  useShellLayout: () => ({ isDesktopWeb: false })
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'test-user',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent',
+    roles: ['parent'],
+    parentOf: []
+  } as AuthState['user'],
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function renderSchedule() {
+  return render(
+    <MemoryRouter initialEntries={['/schedule']}>
+      <Routes>
+        <Route path="/schedule" element={<Schedule auth={auth} />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('Schedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows the service error after the initial load fails and clears the loading skeleton', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockRejectedValue(new Error('Schedule unavailable.'));
+
+    renderSchedule();
+
+    expect(screen.getByRole('status', { name: 'Loading schedule' })).toBeTruthy();
+    expect(await screen.findByText('Schedule unavailable.')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.queryByRole('status', { name: 'Loading schedule' })).toBeNull();
+    });
+    expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(auth.user, {
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    });
+  });
+});

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -81,6 +81,7 @@ describe('Schedule', () => {
     renderSchedule();
 
     expect(screen.getByRole('status', { name: 'Loading schedule' })).toBeTruthy();
+    expect(screen.queryByText('No events in this filter')).toBeNull();
     expect(await screen.findByText('Schedule unavailable.')).toBeTruthy();
     await waitFor(() => {
       expect(screen.queryByRole('status', { name: 'Loading schedule' })).toBeNull();
@@ -89,5 +90,30 @@ describe('Schedule', () => {
       hydrateDetails: false,
       expandStaffPlayers: false
     });
+  });
+
+  it('keeps team and player filters after an empty schedule refresh fails', async () => {
+    scheduleServiceMocks.loadParentSchedule
+      .mockResolvedValueOnce({
+        children: [
+          { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+        ],
+        events: []
+      })
+      .mockRejectedValueOnce(new Error('Refresh failed.'));
+
+    renderSchedule();
+
+    expect(await screen.findByText('No events in this filter')).toBeTruthy();
+    const teamFilter = screen.getByLabelText('Team filter') as HTMLSelectElement;
+    const playerFilter = screen.getByLabelText('Player filter') as HTMLSelectElement;
+    expect(teamFilter.innerHTML).toContain('Bears');
+    expect(playerFilter.innerHTML).toContain('Pat');
+
+    screen.getByRole('button', { name: 'Refresh schedule' }).click();
+
+    expect(await screen.findByText('Unable to refresh schedule. Showing the last loaded schedule. Try again.')).toBeTruthy();
+    expect(teamFilter.innerHTML).toContain('Bears');
+    expect(playerFilter.innerHTML).toContain('Pat');
   });
 });

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -5,6 +5,7 @@ import { SchedulePageSkeleton } from '../components/PageSkeletons';
 import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild } from '../lib/scheduleService';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from '../lib/appDataCache';
 import { startUxTimer } from '../lib/uxTiming';
+import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { useShellLayout } from '../lib/useShellLayout';
 import {
   buildScheduleIcs,
@@ -130,8 +131,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [timeRange, setTimeRange] = useState<ScheduleTimeRange>('all');
   const [children, setChildren] = useState<ParentScheduleChild[]>([]);
   const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { loading, error, clearError, run: runAsyncOperation } = useAsyncOperation();
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [visibleListCount, setVisibleListCount] = useState(upcomingListPageSize);
   const [calendarMonth, setCalendarMonth] = useState(() => {
@@ -162,6 +162,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [importingCsv, setImportingCsv] = useState(false);
   const [removingCalendarUrl, setRemovingCalendarUrl] = useState<string | null>(null);
   const [mobileStaffToolsOpen, setMobileStaffToolsOpen] = useState(false);
+  const eventsRef = useRef<ParentScheduleEvent[]>([]);
+
+  const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
+    eventsRef.current = data.events;
+    setChildren(data.children);
+    setEvents(data.events);
+  };
 
   const clearAiPreview = () => {
     if (scheduleImportPreviewSource === 'ai') {
@@ -171,60 +178,65 @@ export function Schedule({ auth }: { auth: AuthState }) {
   };
 
   const refreshSchedule = async (force = false) => {
-    if (!auth.user) return;
-    setLoading(true);
-    setError(null);
+    if (!auth.user) return null;
+    clearError();
     setStatusMessage(null);
     const timer = startUxTimer('schedule summary load');
-    const hasExistingSchedule = events.length > 0; // Check current state
-    try {
-      const cacheKey = getParentScheduleSummaryCacheKey(auth.user.uid);
-      const scheduleCacheTtlMs = 60 * 1000 * 5;
-      const cached = getCachedAppData(cacheKey);
+    const hasExistingSchedule = eventsRef.current.length > 0;
+    const cacheKey = getParentScheduleSummaryCacheKey(auth.user.uid);
+    const scheduleCacheTtlMs = 60 * 1000 * 5;
+    const cached = getCachedAppData(cacheKey);
 
-      const result = await loadCachedAppData(
+    return runAsyncOperation(
+      () => loadCachedAppData(
         cacheKey,
         () => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false }),
         { ttlMs: scheduleCacheTtlMs, force }
-      );
+      ),
+      {
+        errorMessage: hasExistingSchedule
+          ? 'Unable to refresh schedule. Showing the last loaded schedule. Try again.'
+          : 'Unable to load schedule. Try again.',
+        rethrow: false,
+        onSuccess: (result) => {
+          applyScheduleResult(result);
 
-      // Define applyScheduleResult here to access state setters
-      const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
-        setChildren(data.children);
-        setEvents(data.events);
-      };
-      applyScheduleResult(result);
+          if (selectedPlayerId && !result.children.some((child) => child.playerId === selectedPlayerId)) {
+            setSelectedPlayerId('');
+          }
+          if (selectedTeamId && !result.children.some((child) => child.teamId === selectedTeamId)) {
+            setSelectedTeamId('');
+          }
+          const firstUpcoming = filterParentScheduleEvents(result.events, { filter: 'upcoming-all' })[0];
+          if (firstUpcoming) {
+            setCalendarMonth(new Date(firstUpcoming.date.getFullYear(), firstUpcoming.date.getMonth(), 1));
+          }
 
-      // Logic from HEAD that adjusts selectedPlayerId, selectedTeamId, and calendarMonth
-      if (selectedPlayerId && !result.children.some((child) => child.playerId === selectedPlayerId)) {
-        setSelectedPlayerId('');
+          timer.end({
+            cacheHit: Boolean(cached) && !force,
+            force,
+            children: result.children.length,
+            eventRows: result.events.length,
+            groupedEvents: getCalendarScheduleEntries(result.events).length
+          });
+        },
+        onError: (loadError) => {
+          if (!hasExistingSchedule) {
+            applyScheduleResult({ children: [], events: [] });
+          }
+          timer.end({
+            force,
+            error: loadError && typeof loadError === 'object' && 'message' in loadError && typeof loadError.message === 'string'
+              ? loadError.message
+              : 'Unable to load schedule.'
+          });
+        }
       }
-      if (selectedTeamId && !result.children.some((child) => child.teamId === selectedTeamId)) {
-        setSelectedTeamId('');
-      }
-      const firstUpcoming = filterParentScheduleEvents(result.events, { filter: 'upcoming-all' })[0];
-      if (firstUpcoming) {
-        setCalendarMonth(new Date(firstUpcoming.date.getFullYear(), firstUpcoming.date.getMonth(), 1));
-      }
-
-      timer.end({
-        cacheHit: Boolean(cached) && !force,
-        force,
-        children: result.children.length,
-        eventRows: result.events.length,
-        groupedEvents: getCalendarScheduleEntries(result.events).length
-      });
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load schedule.');
-      if (!hasExistingSchedule) setEvents([]);
-      timer.end({ force: false, error: loadError?.message || 'Unable to load schedule.' }); // Use hardcoded false for force in catch
-    } finally {
-      setLoading(false);
-    }
+    );
   };
 
   useEffect(() => {
-    refreshSchedule();
+    void refreshSchedule();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid]);
 
@@ -376,7 +388,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setCsvPreviewRows([]);
     setScheduleImportPreviewSource(null);
     setStatusMessage(null);
-    setError(null);
+    clearError();
     const currentGames = events
       .filter((event) => event.teamId === selectedCalendarTeam.teamId && event.type === 'game' && event.isDbGame)
       .map((event) => ({
@@ -422,7 +434,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setImportingCsv(true);
     setCsvImportErrors([]);
     setStatusMessage(null);
-    setError(null);
+    clearError();
     const failedRows: ScheduleCsvImportPreviewRow[] = [];
     let importedCount = 0;
     for (const row of csvPreviewRows) {
@@ -461,7 +473,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setSavingCalendarUrl(true);
     setCalendarUrlError(null);
     setStatusMessage(null);
-    setError(null);
+    clearError();
     try {
       const result = await addTeamCalendarUrl(selectedCalendarTeam.teamId, validation.url, auth.user);
       setCalendarUrl('');
@@ -483,7 +495,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setRemovingCalendarUrl(url);
     setCalendarUrlError(null);
     setStatusMessage(null);
-    setError(null);
+    clearError();
     try {
       const result = await removeTeamCalendarUrl(selectedCalendarTeam.teamId, url, auth.user);
       setStatusMessage(result.removed ? 'Calendar link removed. Refreshing schedule…' : 'Calendar link was already removed. Refreshing schedule…');

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -195,12 +195,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
       ),
       {
         getErrorMessage: (loadError) => {
+          if (hasExistingSchedule) {
+            return 'Unable to refresh schedule. Showing the last loaded schedule. Try again.';
+          }
           if (loadError && typeof loadError === 'object' && 'message' in loadError && typeof loadError.message === 'string' && loadError.message.trim()) {
             return loadError.message;
           }
-          return hasExistingSchedule
-            ? 'Unable to refresh schedule. Showing the last loaded schedule. Try again.'
-            : 'Unable to load schedule. Try again.';
+          return 'Unable to load schedule. Try again.';
         },
         rethrow: false,
         onSuccess: (result) => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -162,13 +162,15 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [importingCsv, setImportingCsv] = useState(false);
   const [removingCalendarUrl, setRemovingCalendarUrl] = useState<string | null>(null);
   const [mobileStaffToolsOpen, setMobileStaffToolsOpen] = useState(false);
-  const eventsRef = useRef<ParentScheduleEvent[]>([]);
+  const [loadedScheduleUserId, setLoadedScheduleUserId] = useState<string | null>(null);
+  const hasLoadedScheduleRef = useRef(false);
 
   const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
-    eventsRef.current = data.events;
     setChildren(data.children);
     setEvents(data.events);
   };
+
+  const isInitialScheduleLoad = Boolean(auth.user?.uid) && loadedScheduleUserId !== auth.user?.uid;
 
   const clearAiPreview = () => {
     if (scheduleImportPreviewSource === 'ai') {
@@ -182,7 +184,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     clearError();
     setStatusMessage(null);
     const timer = startUxTimer('schedule summary load');
-    const hasExistingSchedule = eventsRef.current.length > 0;
+    const hasExistingSchedule = hasLoadedScheduleRef.current;
     const cacheKey = getParentScheduleSummaryCacheKey(auth.user.uid);
     const scheduleCacheTtlMs = 60 * 1000 * 5;
     const cached = getCachedAppData(cacheKey);
@@ -205,6 +207,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
         },
         rethrow: false,
         onSuccess: (result) => {
+          hasLoadedScheduleRef.current = true;
+          setLoadedScheduleUserId(auth.user?.uid || null);
           applyScheduleResult(result);
 
           if (selectedPlayerId && !result.children.some((child) => child.playerId === selectedPlayerId)) {
@@ -230,6 +234,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           if (!hasExistingSchedule) {
             applyScheduleResult({ children: [], events: [] });
           }
+          setLoadedScheduleUserId(auth.user?.uid || null);
           timer.end({
             force,
             error: loadError && typeof loadError === 'object' && 'message' in loadError && typeof loadError.message === 'string'
@@ -242,6 +247,12 @@ export function Schedule({ auth }: { auth: AuthState }) {
   };
 
   useEffect(() => {
+    hasLoadedScheduleRef.current = false;
+    if (!auth.user?.uid) {
+      setLoadedScheduleUserId(null);
+      applyScheduleResult({ children: [], events: [] });
+      return;
+    }
     void refreshSchedule();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid]);
@@ -820,7 +831,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
           {error ? <Status tone="error" message={error} /> : null}
 
-          {loading ? (
+          {loading || isInitialScheduleLoad ? (
             <LoadingSchedule />
           ) : view === 'calendar' ? (
             <CalendarSchedule

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -194,9 +194,14 @@ export function Schedule({ auth }: { auth: AuthState }) {
         { ttlMs: scheduleCacheTtlMs, force }
       ),
       {
-        errorMessage: hasExistingSchedule
-          ? 'Unable to refresh schedule. Showing the last loaded schedule. Try again.'
-          : 'Unable to load schedule. Try again.',
+        getErrorMessage: (loadError) => {
+          if (loadError && typeof loadError === 'object' && 'message' in loadError && typeof loadError.message === 'string' && loadError.message.trim()) {
+            return loadError.message;
+          }
+          return hasExistingSchedule
+            ? 'Unable to refresh schedule. Showing the last loaded schedule. Try again.'
+            : 'Unable to load schedule. Try again.';
+        },
         rethrow: false,
         onSuccess: (result) => {
           applyScheduleResult(result);

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -381,6 +381,7 @@ describe('React app desktop Schedule controls', () => {
         await clickButton(container, 'Refresh');
         await waitForText(container, 'Unable to refresh schedule. Showing the last loaded schedule. Try again.');
 
+        expect(container.textContent).not.toContain('network down');
         expect(container.textContent).toContain('Main Gym');
         expect(container.textContent).toContain('Falcons');
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -345,7 +345,45 @@ describe('React app desktop Schedule controls', () => {
 
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(1);
         expect(second.container.textContent).not.toContain('Loading schedule');
+    });
 
+    it('forces a fresh schedule reload when the user taps Refresh', async () => {
+        scheduleMocks.loadParentSchedule
+            .mockResolvedValueOnce({
+                children: [
+                    { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+                ],
+                events: [event({ location: 'Main Gym' })]
+            })
+            .mockResolvedValueOnce({
+                children: [
+                    { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+                ],
+                events: [event({ location: 'Fresh Field', opponent: 'Hawks' })]
+            });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Main Gym');
+
+        await clickButton(container, 'Refresh');
+        await waitForText(container, 'Fresh Field');
+
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+        expect(container.textContent).toContain('Hawks');
+    });
+
+    it('keeps the last loaded schedule visible when refresh fails', async () => {
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Main Gym');
+
+        scheduleMocks.loadParentSchedule.mockRejectedValueOnce(new Error('network down'));
+
+        await clickButton(container, 'Refresh');
+        await waitForText(container, 'Unable to refresh schedule. Showing the last loaded schedule. Try again.');
+
+        expect(container.textContent).toContain('Main Gym');
+        expect(container.textContent).toContain('Falcons');
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
     });
 
     it('shows saved staff calendar links and removes one after confirmation', async () => {

--- a/tests/unit/app-schedule-lazy-load.test.tsx
+++ b/tests/unit/app-schedule-lazy-load.test.tsx
@@ -9,6 +9,13 @@ describe('Schedule lazy-load guards', () => {
         expect(scheduleSource).not.toContain("from '../lib/scheduleCsvImport'");
     });
 
+    it('loads the summary workflow through the shared async operation hook', () => {
+        expect(scheduleSource).toContain("import { useAsyncOperation } from '../lib/useAsyncOperation'");
+        expect(scheduleSource).toContain('const { loading, error, clearError, run: runAsyncOperation } = useAsyncOperation();');
+        expect(scheduleSource).toContain('return runAsyncOperation(');
+        expect(scheduleSource).not.toContain('const [loading, setLoading] = useState(true);');
+    });
+
     it('loads staff AI and CSV helpers through on-demand dynamic imports', () => {
         expect(scheduleSource).toContain("scheduleCsvImportModulePromise = import('../lib/scheduleCsvImport')");
         expect(scheduleSource).toContain("scheduleAiImportModulePromise = import('../lib/scheduleAiImport')");


### PR DESCRIPTION
Closes #2293

## What changed
- added a shared `useAsyncOperation` hook in `apps/app/src/lib/useAsyncOperation.ts` to own route-level loading and error lifecycle boilerplate
- refactored `apps/app/src/pages/Schedule.tsx` so the summary load and manual refresh run through that shared hook while keeping the existing `loadCachedAppData` cache path intact
- preserved previously loaded schedule rows on forced refresh failures and surfaced a retryable message: `Unable to refresh schedule. Showing the last loaded schedule. Try again.`
- extended schedule regression coverage for cached remounts, explicit refresh, refresh-failure stale-data retention, and source-level verification that the page uses the shared async hook

## Root Cause
`Schedule.tsx` owned its own `loading` and `error` state with page-local `try/catch/finally` logic. That let the Schedule summary workflow drift from the shared async route pattern, so refresh behavior and retry messaging were not enforced through a reusable contract even though the data already depended on shared cache-backed loading.

## Prevention / Learning
When a route has both cached reads and a manual refresh action, move the load lifecycle into a shared async helper instead of duplicating `loading/error/finally` state in the page. Add regression coverage for three states together: cache reuse, forced refresh, and refresh failure with previously loaded data still rendered.

## Regression Tests
- `npx vitest run tests/unit/app-schedule-desktop-controls.test.jsx tests/unit/app-schedule-lazy-load.test.tsx tests/unit/app-schedule-service-contracts.test.js --reporter=verbose`
- `tests/unit/app-schedule-desktop-controls.test.jsx` covers cached remount reuse, forced refresh, and keeping prior schedule data visible when refresh fails
- `tests/unit/app-schedule-lazy-load.test.tsx` asserts the Schedule summary workflow now uses the shared async operation hook