### PR TITLE
Reverse deleted opponent stats from away score

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -834,10 +834,7 @@ function renderOpponents() {
   });
   els.oppCards.querySelectorAll('[data-opp-del]').forEach(btn => {
     btn.addEventListener('click', () => {
-      state.opp = state.opp.filter(o => o.id !== btn.dataset.oppDel);
-      scheduleOpponentStatsSync();
-      scheduleLiveHasData();
-      renderOpponents();
+      removeOpponentEntry(btn.dataset.oppDel);
     });
   });
   els.oppCards.querySelectorAll('[data-opp-stat]').forEach(btn => {
@@ -867,6 +864,35 @@ function updateOpponentLinkVisibility() {
   const isLinked = !!currentGame?.opponentTeamId;
   const shouldHide = isLinked && hasOppPlayers;
   els.oppTeamSection.classList.toggle('hidden', shouldHide);
+}
+
+function getOpponentRecordedPoints(opp) {
+  if (!opp?.stats) return 0;
+  return Object.entries(opp.stats).reduce((total, [key, value]) => {
+    if (!isPointsColumn(key)) return total;
+    return total + Number(value || 0);
+  }, 0);
+}
+
+function removeOpponentEntry(opponentId) {
+  const opp = state.opp.find(entry => entry.id === opponentId);
+  if (!opp) return;
+
+  saveHistory(`Remove opponent ${opp.name || opp.number || 'player'}`);
+
+  const awayBefore = state.away;
+  state.opp = state.opp.filter(entry => entry.id !== opponentId);
+  state.away = safeDecrement(state.away, getOpponentRecordedPoints(opp));
+  state.log = state.log.filter(entry => entry?.undoData?.playerId !== opponentId || !entry.undoData?.isOpponent);
+
+  if (state.away !== awayBefore) {
+    scheduleScoreSync();
+  }
+  scheduleOpponentStatsSync();
+  scheduleLiveHasData();
+  renderHeader();
+  renderOpponents();
+  renderLog();
 }
 
 async function ensureTeamsCache() {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -885,6 +885,7 @@ function removeOpponentEntry(opponentId) {
   state.away = safeDecrement(state.away, getOpponentRecordedPoints(opp));
   state.log = state.log.filter(entry => entry?.undoData?.playerId !== opponentId || !entry.undoData?.isOpponent);
 
+  persistLocalTrackerState();
   if (state.away !== awayBefore) {
     scheduleScoreSync();
   }

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -17,13 +17,29 @@ class MockClassList {
     this.tokens = new Set();
   }
 
+  add(...tokens) {
+    tokens.forEach(token => this.tokens.add(token));
+  }
+
+  remove(...tokens) {
+    tokens.forEach(token => this.tokens.delete(token));
+  }
+
   toggle(token, force) {
-    if (force) {
+    if (force === true) {
       this.tokens.add(token);
       return true;
     }
-    this.tokens.delete(token);
-    return false;
+    if (force === false) {
+      this.tokens.delete(token);
+      return false;
+    }
+    if (this.tokens.has(token)) {
+      this.tokens.delete(token);
+      return false;
+    }
+    this.tokens.add(token);
+    return true;
   }
 }
 
@@ -528,7 +544,7 @@ describe('live tracker opponent stats hydration', () => {
     expect(hydrated.fouls).toBe(0);
   });
 
-  it('persists opponent removals so resume does not restore deleted cards', async () => {
+  it('reverses removed opponent scoring and clears that player\'s stat log entries', async () => {
     const updateCalls = [];
     const page = await bootLiveTracker({
       updateGame: async (_teamId, _gameId, payload) => {
@@ -542,6 +558,7 @@ describe('live tracker opponent stats hydration', () => {
       config: { columns: ['PTS'] },
       game: { liveHasData: false }
     });
+    page.state.away = 11;
     page.state.opp = [
       {
         id: 'opp1',
@@ -560,12 +577,34 @@ describe('live tracker opponent stats hydration', () => {
         stats: { pts: 7, fouls: 0, time: 0 }
       }
     ];
+    page.state.log = [
+      {
+        text: 'Opp Remaining Player PTS +7',
+        undoData: { type: 'stat', playerId: 'opp2', statKey: 'pts', value: 7, isOpponent: true }
+      },
+      {
+        text: 'Opp Removed Player PTS +4',
+        undoData: { type: 'stat', playerId: 'opp1', statKey: 'pts', value: 4, isOpponent: true }
+      },
+      {
+        text: 'Opp Removed Player FOULS +1',
+        undoData: { type: 'stat', playerId: 'opp1', statKey: 'fouls', value: 1, isOpponent: true }
+      }
+    ];
 
     page.renderOpponents();
     page.els.oppCards.querySelectorAll('[data-opp-del]')[0].click();
     await page.flushTimers();
 
     expect(page.state.opp.map((opp) => opp.id)).toEqual(['opp2']);
+    expect(page.state.away).toBe(7);
+    expect(page.state.log).toEqual([
+      {
+        text: 'Opp Remaining Player PTS +7',
+        undoData: { type: 'stat', playerId: 'opp2', statKey: 'pts', value: 7, isOpponent: true }
+      }
+    ]);
+    expect(page.state.history).toHaveLength(1);
     expect(updateCalls).toContainEqual({
       opponentStats: {
         opp2: {

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -402,12 +402,17 @@ async function bootLiveTracker({ updateGame }) {
       runSaveAndCompleteWorkflow: async () => ({})
     }
   };
+  const localStorageData = new Map();
   const window = {
     location: { href: '' },
     localStorage: {
-      getItem: () => null,
-      setItem: () => {},
-      removeItem: () => {}
+      getItem: (key) => (localStorageData.has(key) ? localStorageData.get(key) : null),
+      setItem: (key, value) => {
+        localStorageData.set(key, String(value));
+      },
+      removeItem: (key) => {
+        localStorageData.delete(key);
+      }
     },
     navigator: { onLine: true },
     addEventListener: () => {}
@@ -443,7 +448,10 @@ async function bootLiveTracker({ updateGame }) {
 
   return {
     ...page,
-    flushTimers
+    flushTimers,
+    readPersistedState(teamId, gameId) {
+      return readPersistedLiveTrackerState(window.localStorage, teamId, gameId);
+    }
   };
 }
 
@@ -605,6 +613,27 @@ describe('live tracker opponent stats hydration', () => {
       }
     ]);
     expect(page.state.history).toHaveLength(1);
+    expect(page.readPersistedState('team-1', 'game-1')).toMatchObject({
+      state: {
+        away: 7,
+        opp: [
+          {
+            id: 'opp2',
+            name: 'Remaining Player',
+            number: '12',
+            playerId: null,
+            photoUrl: '',
+            stats: { pts: 7, fouls: 0, time: 0 }
+          }
+        ],
+        log: [
+          {
+            text: 'Opp Remaining Player PTS +7',
+            undoData: { type: 'stat', playerId: 'opp2', statKey: 'pts', value: 7, isOpponent: true }
+          }
+        ]
+      }
+    });
     expect(updateCalls).toContainEqual({
       opponentStats: {
         opp2: {


### PR DESCRIPTION
Closes #2304

## What changed
- routed opponent row deletion through a dedicated helper instead of only filtering `state.opp`
- subtract the removed opponent's recorded scoring contribution from `state.away`
- remove that opponent's stat log entries so the tracker state, finish form, and saved opponent snapshot stay aligned
- added a focused regression test covering score rollback, log cleanup, and persisted opponent stats sync on delete

## Root Cause
Opponent removal only deleted the row from `state.opp` and synced `opponentStats`. It did not reverse the removed player's derived contribution to `state.away`, and it left that player's opponent stat log entries behind, so the live score and finish flow could drift from the remaining opponent stats.

## Prevention / Learning
When deleting an entity that contributes to derived totals or event history, route the delete through one helper that also reverses dependent aggregates and prunes related entries before persisting. Do not let list removal bypass score/state reconciliation.

## Regression Tests
- `npx vitest run tests/unit/live-tracker-opponent-stats.test.js --reporter=verbose`