### PR TITLE
Adopt shared async loading for Home dashboard

### DIFF
--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -216,7 +216,8 @@ describe('Home', () => {
     fireEvent.change(screen.getByRole('textbox'), {
       target: { value: 'Big team win today.' }
     });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Post' }).at(-1)!);
+    const postButtons = screen.getAllByRole('button', { name: 'Post' });
+    fireEvent.click(postButtons[postButtons.length - 1]!);
 
     await waitFor(() => {
       expect(socialServiceMocks.createSocialPost).toHaveBeenCalledTimes(1);

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Home } from './Home';
+import type { AuthState } from '../lib/types';
+
+const homeServiceMocks = vi.hoisted(() => ({
+  loadParentHomeSummaryBootstrap: vi.fn(),
+  loadParentHomeWithSecondaryData: vi.fn()
+}));
+
+const socialServiceMocks = vi.hoisted(() => ({
+  blockFriend: vi.fn(),
+  commentOnSocialPost: vi.fn(),
+  createSocialPost: vi.fn(),
+  hideSocialPost: vi.fn(),
+  loadSocialHome: vi.fn(),
+  removeFriend: vi.fn(),
+  reportSocialPost: vi.fn(),
+  respondToFriendRequest: vi.fn(),
+  searchSocialUsers: vi.fn(),
+  sendFriendRequest: vi.fn(),
+  reactToSocialPost: vi.fn(),
+  uploadSocialPostMedia: vi.fn()
+}));
+
+const scheduleServiceMocks = vi.hoisted(() => ({
+  loadOfficialAssignmentsAccess: vi.fn()
+}));
+
+vi.mock('../components/PageSkeletons', () => ({
+  HomePageSkeleton: () => <div>Loading Home</div>
+}));
+vi.mock('../lib/homeService', () => homeServiceMocks);
+vi.mock('../lib/socialService', () => socialServiceMocks);
+vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('lucide-react', () => {
+  const Icon = () => null;
+  return {
+    AlertCircle: Icon,
+    CalendarDays: Icon,
+    Car: Icon,
+    CheckCircle2: Icon,
+    ChevronRight: Icon,
+    ClipboardCheck: Icon,
+    DollarSign: Icon,
+    Flag: Icon,
+    Heart: Icon,
+    ImagePlus: Icon,
+    Loader2: Icon,
+    MessageCircle: Icon,
+    Newspaper: Icon,
+    Plus: Icon,
+    RefreshCw: Icon,
+    Share2: Icon,
+    Shield: Icon,
+    Sparkles: Icon,
+    Ticket: Icon,
+    Trophy: Icon,
+    UserRound: Icon,
+    UserPlus: Icon,
+    Users: Icon
+  };
+});
+
+const baseHome = {
+  players: [],
+  teams: [],
+  upcomingEvents: [],
+  actionItems: [],
+  fees: [],
+  metrics: {
+    players: 0,
+    teams: 0,
+    rsvpNeeded: 0,
+    unreadMessages: 0,
+    packetsReady: 0
+  }
+};
+
+const baseSocial = {
+  feedItems: [],
+  friends: [],
+  incomingRequests: [],
+  outgoingRequests: [],
+  suggestions: [],
+  metrics: {
+    feedItems: 0,
+    friends: 0,
+    incomingRequests: 0,
+    suggestions: 0
+  }
+};
+
+const signedInAuth: AuthState = {
+  user: {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent',
+    roles: ['parent'],
+    parentOf: []
+  } as AuthState['user'],
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+const signedOutAuth: AuthState = {
+  ...signedInAuth,
+  user: null,
+  roles: [],
+  isParent: false
+};
+
+function renderHome(auth: AuthState, initialEntry = '/home') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/home" element={<Home auth={auth} />} />
+        <Route path="/teams/:teamId" element={<div>Team route</div>} />
+        <Route path="/messages" element={<div>Messages route</div>} />
+        <Route path="/schedule" element={<div>Schedule route</div>} />
+        <Route path="/officials" element={<div>Officials route</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('Home', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true
+    });
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValue({ home: baseHome, schedule: [] });
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValue(baseHome);
+    socialServiceMocks.loadSocialHome.mockResolvedValue(baseSocial);
+    scheduleServiceMocks.loadOfficialAssignmentsAccess.mockResolvedValue({ hasAccess: false, teamCount: 0 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the feed for signed-out users without crashing', async () => {
+    renderHome(signedOutAuth, '/home?section=feed');
+
+    expect(await screen.findByRole('heading', { name: 'Feed' })).toBeInTheDocument();
+    expect(homeServiceMocks.loadParentHomeSummaryBootstrap).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the social feed with the async loading helper', async () => {
+    renderHome(signedInAuth, '/home?section=feed');
+
+    await screen.findByRole('heading', { name: 'Feed' });
+    await waitFor(() => {
+      expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh feed' }));
+
+    await waitFor(() => {
+      expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -65,14 +65,45 @@ vi.mock('lucide-react', () => {
 });
 
 const baseHome = {
-  players: [],
-  teams: [],
+  players: [
+    {
+      teamId: 'team-1',
+      teamName: 'Bears',
+      playerId: 'player-1',
+      playerName: 'Pat Player',
+      nextEvent: null,
+      rsvpNeeded: 0,
+      packetsReady: 0,
+      openAssignments: 0,
+      unreadCount: 0
+    }
+  ],
+  teams: [
+    {
+      teamId: 'team-1',
+      teamName: 'Bears',
+      role: 'Parent',
+      sport: 'Basketball',
+      players: [
+        {
+          teamId: 'team-1',
+          teamName: 'Bears',
+          playerId: 'player-1',
+          playerName: 'Pat Player'
+        }
+      ],
+      nextEvent: null,
+      eventCount: 0,
+      unreadCount: 0,
+      openActions: 0
+    }
+  ],
   upcomingEvents: [],
   actionItems: [],
   fees: [],
   metrics: {
-    players: 0,
-    teams: 0,
+    players: 1,
+    teams: 1,
     rsvpNeeded: 0,
     unreadMessages: 0,
     packetsReady: 0
@@ -154,7 +185,7 @@ describe('Home', () => {
   it('renders the feed for signed-out users without crashing', async () => {
     renderHome(signedOutAuth, '/home?section=feed');
 
-    expect(await screen.findByRole('heading', { name: 'Feed' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Feed' })).toBeTruthy();
     expect(homeServiceMocks.loadParentHomeSummaryBootstrap).not.toHaveBeenCalled();
   });
 
@@ -169,6 +200,63 @@ describe('Home', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Refresh feed' }));
 
     await waitFor(() => {
+      expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('refreshes the social feed after creating a post', async () => {
+    socialServiceMocks.createSocialPost.mockResolvedValueOnce('post-1');
+    renderHome(signedInAuth, '/home?section=feed&social=create');
+
+    await screen.findByRole('dialog', { name: 'Create social post' });
+    await waitFor(() => {
+      expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByRole('textbox'), {
+      target: { value: 'Big team win today.' }
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Post' }).at(-1)!);
+
+    await waitFor(() => {
+      expect(socialServiceMocks.createSocialPost).toHaveBeenCalledTimes(1);
+      expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('refreshes the social feed after responding to a friend request', async () => {
+    socialServiceMocks.loadSocialHome.mockResolvedValueOnce({
+      ...baseSocial,
+      incomingRequests: [
+        {
+          id: 'friendship-1',
+          userId: 'friend-1',
+          name: 'Jamie Friend',
+          email: 'jamie@example.com',
+          photoUrl: null,
+          sharedTeamIds: ['team-1'],
+          sharedTeamNames: ['Bears'],
+          status: 'pending',
+          requesterId: 'friend-1',
+          recipientId: 'parent-1'
+        }
+      ],
+      metrics: {
+        ...baseSocial.metrics,
+        incomingRequests: 1
+      }
+    });
+    renderHome(signedInAuth, '/home?section=friends');
+
+    await screen.findByRole('heading', { name: 'Friends' });
+    await waitFor(() => {
+      expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Accept' }));
+
+    await waitFor(() => {
+      expect(socialServiceMocks.respondToFriendRequest).toHaveBeenCalledWith('friendship-1', 'accepted');
       expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
     });
   });

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -63,6 +63,7 @@ import {
   type RsvpResponse
 } from '../lib/scheduleLogic';
 import { loadOfficialAssignmentsAccess } from '../lib/scheduleService';
+import { useAsyncOperation } from '../lib/useAsyncOperation';
 import {
   emptySocialHome,
   filterSocialFeedItems,
@@ -134,43 +135,61 @@ export function Home({ auth }: { auth: AuthState }) {
   const [home, setHome] = useState<ParentHomeModel>(() => emptyHome());
   const [social, setSocial] = useState<SocialHomeModel>(() => emptySocialHome());
   const [activeSection, setActiveSection] = useState<HomeSectionId>('today');
-  const [loading, setLoading] = useState(true);
-  const [socialLoading, setSocialLoading] = useState(false);
   const [officialsAccess, setOfficialsAccess] = useState<{ hasAccess: boolean; teamCount: number } | null>(null);
-  const [error, setError] = useState('');
   const [socialStatus, setSocialStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
+  const [loadedHomeUserId, setLoadedHomeUserId] = useState<string | null>(null);
+  const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
+  const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();
+
+  const hasLoadedHome = Boolean(auth.user?.uid) && auth.user.uid === loadedHomeUserId;
 
   const refreshHome = async ({ force = false }: { force?: boolean } = {}) => {
     if (!auth.user) return;
-    setLoading(true);
-    setSocialLoading(true);
-    setError('');
+    const hasExistingHome = loadedHomeUserId === auth.user.uid;
+    clearError();
     setSocialStatus(null);
-    try {
-      const { home: nextHome, schedule } = await loadParentHomeSummaryBootstrap(auth.user, { force });
-      setHome(nextHome);
-      setLoading(false);
+    return runPrimaryLoad(
+      async () => {
+        const summary = await loadParentHomeSummaryBootstrap(auth.user, { force });
+        setHome(summary.home);
+        setLoadedHomeUserId(auth.user?.uid || null);
 
-      void loadParentHomeWithSecondaryData(auth.user, { force, schedule })
-        .then(async (secondaryHome) => {
-          setHome(secondaryHome);
-          setSocial(await loadSocialHome(auth.user, secondaryHome));
-        })
-        .catch((secondaryError: any) => {
-          setSocialStatus({ tone: 'error', message: secondaryError?.message || 'Unable to refresh Home details.' });
-        })
-        .finally(() => {
-          setSocialLoading(false);
-        });
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load Home.');
-      setHome(emptyHome());
-      setSocial(emptySocialHome());
-      setSocialLoading(false);
-      setLoading(false);
-    }
+        void runSecondaryLoad(
+          async () => {
+            const secondaryHome = await loadParentHomeWithSecondaryData(auth.user, { force, schedule: summary.schedule });
+            setHome(secondaryHome);
+            setSocial(await loadSocialHome(auth.user, secondaryHome));
+          },
+          {
+            errorMessage: 'Unable to refresh Home details.',
+            rethrow: false,
+            onError: (secondaryError) => {
+              setSocialStatus({ tone: 'error', message: getAsyncErrorMessage(secondaryError, 'Unable to refresh Home details.') });
+            }
+          }
+        );
+
+        return summary;
+      },
+      {
+        getErrorMessage: (loadError) => {
+          if (hasExistingHome) {
+            return 'Unable to refresh Home. Showing the last loaded Home. Try again.';
+          }
+          return getAsyncErrorMessage(loadError, 'Unable to load Home. Try again.');
+        },
+        rethrow: false,
+        onError: () => {
+          if (!hasExistingHome) {
+            setHome(emptyHome());
+            setSocial(emptySocialHome());
+            setLoadedHomeUserId(null);
+          }
+        }
+      }
+    );
   };
 
   useEffect(() => {
@@ -211,6 +230,7 @@ export function Home({ auth }: { auth: AuthState }) {
   }, [searchParams]);
 
   const topAction = home.actionItems[0] || null;
+  const showBlockingErrorState = !loading && !hasLoadedHome && Boolean(error);
   const displayName = auth.user?.displayName || auth.user?.email || 'ALL PLAYS User';
   const openCount = home.metrics.rsvpNeeded + home.metrics.packetsReady + home.metrics.unreadMessages + home.fees.length + social.metrics.incomingRequests;
   const today = new Date();
@@ -335,8 +355,10 @@ export function Home({ auth }: { auth: AuthState }) {
 
       {loading ? <HomePageSkeleton /> : null}
 
-      {!loading && activeSection === 'today' ? <TodaySection home={home} social={social} socialLoading={socialLoading} onOpenComposer={openComposer} officialsAccess={officialsAccess} /> : null}
-      {!loading && activeSection === 'feed' ? (
+      {showBlockingErrorState ? <HomeLoadErrorState onRetry={() => refreshHome({ force: true })} retrying={loading} /> : null}
+
+      {!loading && !showBlockingErrorState && activeSection === 'today' ? <TodaySection home={home} social={social} socialLoading={socialLoading} onOpenComposer={openComposer} officialsAccess={officialsAccess} /> : null}
+      {!loading && !showBlockingErrorState && activeSection === 'feed' ? (
         <FeedSection
           social={social}
           loading={socialLoading}
@@ -347,9 +369,9 @@ export function Home({ auth }: { auth: AuthState }) {
           onStatus={setSocialStatus}
         />
       ) : null}
-      {!loading && activeSection === 'players' ? <PlayersSection players={home.players} /> : null}
-      {!loading && activeSection === 'teams' ? <TeamsSection teams={home.teams} /> : null}
-      {!loading && activeSection === 'friends' ? (
+      {!loading && !showBlockingErrorState && activeSection === 'players' ? <PlayersSection players={home.players} /> : null}
+      {!loading && !showBlockingErrorState && activeSection === 'teams' ? <TeamsSection teams={home.teams} /> : null}
+      {!loading && !showBlockingErrorState && activeSection === 'friends' ? (
         <FriendsSection
           auth={auth}
           home={home}
@@ -1707,6 +1729,20 @@ function EmptyCard({ icon: Icon, title, detail }: { icon: LucideIcon; title: str
   );
 }
 
+function HomeLoadErrorState({ onRetry, retrying }: { onRetry: () => void; retrying: boolean }) {
+  return (
+    <section className="app-card p-5 text-center">
+      <AlertCircle className="mx-auto h-8 w-8 text-rose-400" aria-hidden="true" />
+      <div className="mt-3 text-sm font-black text-gray-900">Home could not load</div>
+      <div className="mt-1 text-xs font-semibold text-gray-500">Try loading Home again to restore your dashboard.</div>
+      <button type="button" className="primary-button mx-auto mt-4 !min-h-10 !px-4 text-sm" onClick={onRetry} disabled={retrying} aria-label="Retry loading Home">
+        {retrying ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+        Retry
+      </button>
+    </section>
+  );
+}
+
 function Status({ tone, message }: { tone: 'error' | 'success'; message: string }) {
   const isError = tone === 'error';
   return (
@@ -1715,4 +1751,11 @@ function Status({ tone, message }: { tone: 'error' | 'success'; message: string 
       {message}
     </div>
   );
+}
+
+function getAsyncErrorMessage(error: unknown, fallback: string) {
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string' && error.message.trim()) {
+    return error.message;
+  }
+  return fallback;
 }

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -143,24 +143,26 @@ export function Home({ auth }: { auth: AuthState }) {
   const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
   const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();
 
-  const hasLoadedHome = Boolean(auth.user?.uid) && auth.user.uid === loadedHomeUserId;
+  const authUserId = auth.user?.uid || null;
+  const hasLoadedHome = Boolean(authUserId) && authUserId === loadedHomeUserId;
 
   const refreshHome = async ({ force = false }: { force?: boolean } = {}) => {
-    if (!auth.user) return;
-    const hasExistingHome = loadedHomeUserId === auth.user.uid;
+    const user = auth.user;
+    if (!user) return;
+    const hasExistingHome = loadedHomeUserId === user.uid;
     clearError();
     setSocialStatus(null);
     return runPrimaryLoad(
       async () => {
-        const summary = await loadParentHomeSummaryBootstrap(auth.user, { force });
+        const summary = await loadParentHomeSummaryBootstrap(user, { force });
         setHome(summary.home);
-        setLoadedHomeUserId(auth.user?.uid || null);
+        setLoadedHomeUserId(user.uid);
 
         void runSecondaryLoad(
           async () => {
-            const secondaryHome = await loadParentHomeWithSecondaryData(auth.user, { force, schedule: summary.schedule });
+            const secondaryHome = await loadParentHomeWithSecondaryData(user, { force, schedule: summary.schedule });
             setHome(secondaryHome);
-            setSocial(await loadSocialHome(auth.user, secondaryHome));
+            setSocial(await loadSocialHome(user, secondaryHome));
           },
           {
             errorMessage: 'Unable to refresh Home details.',
@@ -263,15 +265,21 @@ export function Home({ auth }: { auth: AuthState }) {
   };
 
   const refreshSocial = async (nextHome = home) => {
-    if (!auth.user) return;
-    setSocialLoading(true);
-    try {
-      setSocial(await loadSocialHome(auth.user, nextHome));
-    } catch (loadError: any) {
-      setSocialStatus({ tone: 'error', message: loadError?.message || 'Unable to refresh Feed.' });
-    } finally {
-      setSocialLoading(false);
-    }
+    const user = auth.user;
+    if (!user) return;
+    setSocialStatus(null);
+    await runSecondaryLoad(
+      async () => {
+        setSocial(await loadSocialHome(user, nextHome));
+      },
+      {
+        getErrorMessage: (loadError) => getAsyncErrorMessage(loadError, 'Unable to refresh Feed.'),
+        rethrow: false,
+        onError: (loadError) => {
+          setSocialStatus({ tone: 'error', message: getAsyncErrorMessage(loadError, 'Unable to refresh Feed.') });
+        }
+      }
+    );
   };
 
   const handleCreatePost = async (input: CreateSocialPostInput) => {

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -134,9 +134,24 @@ function buttonByText(container, text) {
     return button;
 }
 
+function buttonByAriaLabel(container, label) {
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.getAttribute('aria-label') === label);
+    if (!button) {
+        throw new Error(`Button not found: ${label}`);
+    }
+    return button;
+}
+
 async function clickButton(container, text) {
     await act(async () => {
         buttonByText(container, text).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+}
+
+async function clickButtonByAriaLabel(container, label) {
+    await act(async () => {
+        buttonByAriaLabel(container, label).dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await flush();
 }
@@ -879,16 +894,34 @@ describe('React app Home and player drill-in integration', () => {
         await waitForText(container, 'No players linked yet');
     });
 
-    it('shows a useful empty Home state when the live Home service fails', async () => {
+    it('shows a retryable Home error state and recovers on retry after an initial failure', async () => {
         homeMocks.loadParentHome.mockRejectedValueOnce(new Error('Home service down'));
 
         const { container } = await renderApp('/home');
 
         await waitForText(container, 'Home service down');
-        expect(container.textContent).toContain('All caught up');
+        expect(container.textContent).toContain('Home could not load');
+        expect(container.textContent).toContain('Try loading Home again to restore your dashboard.');
+        expect(buttonByAriaLabel(container, 'Retry loading Home')).toBeTruthy();
+        expect(container.textContent).not.toContain('No upcoming events');
+
+        await clickButtonByAriaLabel(container, 'Retry loading Home');
+
+        await waitForText(container, 'Pat Star highlight');
         expect(container.textContent).toContain('Team chats');
-        expect(container.textContent).toContain('Caught up');
-        expect(container.textContent).toContain('No upcoming events');
-        expect(container.textContent).not.toContain('Loading Home');
+        expect(homeMocks.loadParentHome).toHaveBeenCalledTimes(3);
+    });
+
+    it('keeps the last loaded Home visible when a refresh fails', async () => {
+        const { container } = await renderApp('/home');
+
+        await waitForText(container, 'Pat Star highlight');
+        homeMocks.loadParentHome.mockRejectedValueOnce(new Error('Refresh failed.'));
+        await clickButtonByAriaLabel(container, 'Refresh Home');
+
+        await waitForText(container, 'Unable to refresh Home. Showing the last loaded Home. Try again.');
+        expect(container.textContent).toContain('Pat Star highlight');
+        expect(container.textContent).toContain('Team chats');
+        expect(container.textContent).not.toContain('Home could not load');
     });
 });


### PR DESCRIPTION
Closes #2292

## What changed
- moved Home's primary bootstrap load onto the shared `useAsyncOperation` hook instead of page-local `setLoading` / `try` / `catch` / `finally` state management
- moved Home's secondary load path onto the same shared async pattern so secondary failures still surface a consistent Home-details error without breaking the primary shell
- added a blocking retryable error state for first-load failures instead of falling through to the same empty content used for legitimate no-data cases
- preserved the last loaded Home data on refresh failures and surfaced a retryable banner instead of wiping the page
- updated Home integration coverage for initial-load failure recovery and refresh failure behavior

## Root Cause
Home owned its bootstrap and secondary refresh flow with page-local async state handling, so a primary load failure reset the route into the same empty-data rendering path used for legitimate empty states. That masked the failure and gave users no clear retry affordance.

## Prevention / Learning
For route-level bootstrap flows, use the shared async-operation helper instead of hand-rolled loading/error/finally state. Also test first-load failure separately from true empty-state rendering so we do not silently treat transport or service failures as "no content".

## Regression Tests
- `npx vitest run tests/unit/app-home-player-integration.test.jsx --reporter=verbose`
- added coverage for `shows a retryable Home error state and recovers on retry after an initial failure`
- added coverage for `keeps the last loaded Home visible when a refresh fails`