### PR TITLE
Migrate player services to typed legacy adapters

### DIFF
--- a/apps/app/src/lib/adapters/legacyPlayerDb.ts
+++ b/apps/app/src/lib/adapters/legacyPlayerDb.ts
@@ -1,0 +1,136 @@
+import {
+    getAggregatedStatsForPlayer as legacyGetAggregatedStatsForPlayer,
+    getGames as legacyGetGames,
+    getPlayerPrivateProfile as legacyGetPlayerPrivateProfile,
+    getPlayerTrackingStatuses as legacyGetPlayerTrackingStatuses,
+    getPlayers as legacyGetPlayers,
+    getPublicTrackingItems as legacyGetPublicTrackingItems,
+    getRosterFieldDefinitions as legacyGetRosterFieldDefinitions,
+    getTeam as legacyGetTeam,
+    deleteAthleteProfileMediaByPath as legacyDeleteAthleteProfileMediaByPath,
+    inviteCoParentToAthlete as legacyInviteCoParentToAthlete,
+    listAthleteProfilesForParent as legacyListAthleteProfilesForParent,
+    listCertificatesForPlayer as legacyListCertificatesForPlayer,
+    saveAthleteProfile as legacySaveAthleteProfile,
+    setPlayerPrivateRosterProfileFields as legacySetPlayerPrivateRosterProfileFields,
+    updatePlayer as legacyUpdatePlayer,
+    updatePlayerProfile as legacyUpdatePlayerProfile,
+    uploadAthleteProfileMedia as legacyUploadAthleteProfileMedia,
+    uploadPlayerPhoto as legacyUploadPlayerPhoto
+} from '../../../../../js/db.js';
+
+export type LegacyTeamRecord = {
+    id?: string;
+    name?: string;
+    ownerId?: string;
+    adminEmails?: string[];
+    [key: string]: any;
+};
+
+export type LegacyPlayerRecord = {
+    id?: string;
+    name?: string;
+    number?: string | null;
+    photoUrl?: string | null;
+    teamName?: string;
+    profile?: {
+        customFields?: Record<string, unknown>;
+        rosterFields?: Record<string, unknown>;
+        [key: string]: any;
+    };
+    rosterFieldValues?: Record<string, unknown>;
+    customFields?: Record<string, unknown>;
+    [key: string]: any;
+};
+
+export type LegacyPlayerPrivateProfileRecord = {
+    emergencyContact?: {
+        name?: string | null;
+        phone?: string | null;
+    } | null;
+    medicalInfo?: string | null;
+    rosterFields?: Record<string, unknown>;
+    [key: string]: any;
+};
+
+export type LegacyCertificateRecord = Record<string, any>;
+export type LegacyTrackingItemRecord = Record<string, any>;
+export type LegacyTrackingStatusRecord = Record<string, any>;
+export type LegacyGameRecord = Record<string, any>;
+export type LegacyAthleteProfileRecord = {
+    id?: string;
+    seasons?: Array<{ teamId?: string; playerId?: string; [key: string]: any }>;
+    [key: string]: any;
+};
+
+export async function getTeam(teamId: string, options?: { includeInactive?: boolean }): Promise<LegacyTeamRecord | null> {
+    return await Promise.resolve(legacyGetTeam(teamId, options)).catch(() => null);
+}
+
+export async function getPlayers(teamId: string, options?: { includeInactive?: boolean }): Promise<LegacyPlayerRecord[]> {
+    return await Promise.resolve(legacyGetPlayers(teamId, options));
+}
+
+export async function getGames(teamId: string): Promise<LegacyGameRecord[]> {
+    return await Promise.resolve(legacyGetGames(teamId));
+}
+
+export async function listCertificatesForPlayer(teamId: string, playerId: string, options?: { status?: string; limit?: number }): Promise<LegacyCertificateRecord[]> {
+    return await Promise.resolve(legacyListCertificatesForPlayer(teamId, playerId, options));
+}
+
+export async function getPublicTrackingItems(teamId: string): Promise<LegacyTrackingItemRecord[]> {
+    return await Promise.resolve(legacyGetPublicTrackingItems(teamId));
+}
+
+export async function getPlayerTrackingStatuses(teamId: string, playerIds: string[]): Promise<LegacyTrackingStatusRecord[]> {
+    return await Promise.resolve(legacyGetPlayerTrackingStatuses(teamId, playerIds));
+}
+
+export async function getPlayerPrivateProfile(teamId: string, playerId: string): Promise<LegacyPlayerPrivateProfileRecord | null> {
+    return await Promise.resolve(legacyGetPlayerPrivateProfile(teamId, playerId));
+}
+
+export async function getRosterFieldDefinitions(teamId: string, team: LegacyTeamRecord | null) {
+    return await Promise.resolve(legacyGetRosterFieldDefinitions(teamId, team));
+}
+
+export async function getAggregatedStatsForPlayer(teamId: string, gameId: string, playerId: string): Promise<Record<string, unknown>> {
+    return await Promise.resolve(legacyGetAggregatedStatsForPlayer(teamId, gameId, playerId));
+}
+
+export async function listAthleteProfilesForParent(userId: string): Promise<LegacyAthleteProfileRecord[]> {
+    return await Promise.resolve(legacyListAthleteProfilesForParent(userId));
+}
+
+export async function updatePlayer(teamId: string, playerId: string, payload: Record<string, unknown>) {
+    return await Promise.resolve(legacyUpdatePlayer(teamId, playerId, payload));
+}
+
+export async function setPlayerPrivateRosterProfileFields(teamId: string, playerId: string, values: Record<string, unknown>) {
+    return await Promise.resolve(legacySetPlayerPrivateRosterProfileFields(teamId, playerId, values));
+}
+
+export async function updatePlayerProfile(teamId: string, playerId: string, payload: Record<string, unknown>) {
+    return await Promise.resolve(legacyUpdatePlayerProfile(teamId, playerId, payload));
+}
+
+export async function uploadPlayerPhoto(file: File): Promise<string> {
+    return await Promise.resolve(legacyUploadPlayerPhoto(file));
+}
+
+export async function inviteCoParentToAthlete(userId: string, teamId: string, playerId: string, email: string, playerName: string) {
+    return await Promise.resolve(legacyInviteCoParentToAthlete(userId, teamId, playerId, email, playerName));
+}
+
+export async function saveAthleteProfile(userId: string, draft: Record<string, unknown>, options: { profileId: string }) {
+    return await Promise.resolve(legacySaveAthleteProfile(userId, draft, options));
+}
+
+export async function uploadAthleteProfileMedia(userId: string, profileId: string, file: File, options: { kind: 'profile-photo' | 'clip' }) {
+    return await Promise.resolve(legacyUploadAthleteProfileMedia(userId, profileId, file, options));
+}
+
+export async function deleteAthleteProfileMediaByPath(storagePath: string) {
+    return await Promise.resolve(legacyDeleteAthleteProfileMediaByPath(storagePath));
+}

--- a/apps/app/src/lib/adapters/legacyPlayerProfile.ts
+++ b/apps/app/src/lib/adapters/legacyPlayerProfile.ts
@@ -1,0 +1,93 @@
+import {
+    calculateEarnings as legacyCalculateEarnings,
+    getApplicableRulesForGame as legacyGetApplicableRulesForGame,
+    getCapSetting as legacyGetCapSetting,
+    getIncentiveRules as legacyGetIncentiveRules,
+    getPaidGames as legacyGetPaidGames,
+    getStatOptionsForTeam as legacyGetStatOptionsForTeam,
+    isCurrentRuleVersion as legacyIsCurrentRuleVersion,
+    markGamePaid as legacyMarkGamePaid,
+    retireIncentiveRule as legacyRetireIncentiveRule,
+    saveCapSetting as legacySaveCapSetting,
+    saveIncentiveRule as legacySaveIncentiveRule,
+    toggleIncentiveRule as legacyToggleIncentiveRule
+} from '../../../../../js/parent-incentives.js';
+import { buildAthleteProfileShareUrl as legacyBuildAthleteProfileShareUrl } from '../../../../../js/athlete-profile-utils.js';
+import { collectPlayerVideoClips as legacyCollectPlayerVideoClips } from '../../../../../js/player-profile-stats.js';
+import { getVisiblePlayerTrackingSummary as legacyGetVisiblePlayerTrackingSummary } from '../../../../../js/player-tracking-summary.js';
+
+export type LegacyIncentiveRule = Record<string, any>;
+export type LegacyPaidGameRecord = Record<string, any>;
+export type LegacyStatOption = { key: string; label: string };
+export type LegacyPlayerClip = Record<string, any>;
+export type LegacyTrackingSummaryItem = Record<string, any>;
+export type LegacyCalculatedEarnings = {
+    totalCents: number;
+    uncappedTotalCents: number;
+    wasCapped: boolean;
+    breakdown: Array<Record<string, any>>;
+};
+
+export async function getIncentiveRules(userId: string, playerId: string): Promise<LegacyIncentiveRule[]> {
+    return await Promise.resolve(legacyGetIncentiveRules(userId, playerId));
+}
+
+export async function getPaidGames(userId: string, playerId: string): Promise<Map<string, LegacyPaidGameRecord>> {
+    return await Promise.resolve(legacyGetPaidGames(userId, playerId));
+}
+
+export async function getCapSetting(userId: string, playerId: string): Promise<number | null> {
+    return await Promise.resolve(legacyGetCapSetting(userId, playerId));
+}
+
+export async function getStatOptionsForTeam(teamId: string): Promise<LegacyStatOption[]> {
+    return await Promise.resolve(legacyGetStatOptionsForTeam(teamId));
+}
+
+export function getApplicableRulesForGame(rules: LegacyIncentiveRule[], date: Date) {
+    return legacyGetApplicableRulesForGame(rules, date) as LegacyIncentiveRule[];
+}
+
+export function calculateEarnings(rules: LegacyIncentiveRule[], stats: Record<string, unknown>, maxPerGameCents: number | null): LegacyCalculatedEarnings {
+    return legacyCalculateEarnings(rules, stats, maxPerGameCents) as LegacyCalculatedEarnings;
+}
+
+export function isCurrentRuleVersion(rule: LegacyIncentiveRule) {
+    return legacyIsCurrentRuleVersion(rule);
+}
+
+export async function markGamePaid(userId: string, gameId: string, playerId: string, teamId: string, amountCents: number) {
+    return await Promise.resolve(legacyMarkGamePaid(userId, gameId, playerId, teamId, amountCents));
+}
+
+export async function saveCapSetting(userId: string, teamId: string, playerId: string, maxPerGameCents: number | null) {
+    return await Promise.resolve(legacySaveCapSetting(userId, teamId, playerId, maxPerGameCents));
+}
+
+export async function saveIncentiveRule(userId: string, rule: Record<string, unknown>) {
+    return await Promise.resolve(legacySaveIncentiveRule(userId, rule));
+}
+
+export async function toggleIncentiveRule(userId: string, rule: LegacyIncentiveRule) {
+    return await Promise.resolve(legacyToggleIncentiveRule(userId, rule));
+}
+
+export async function retireIncentiveRule(userId: string, ruleId: string) {
+    return await Promise.resolve(legacyRetireIncentiveRule(userId, ruleId));
+}
+
+export function buildAthleteProfileShareUrl(origin: string, profileId: string) {
+    return legacyBuildAthleteProfileShareUrl(origin, profileId);
+}
+
+export function collectPlayerVideoClips(games: Array<Record<string, any>>, input: { teamId: string; playerId: string }): LegacyPlayerClip[] {
+    return legacyCollectPlayerVideoClips(games, input) as LegacyPlayerClip[];
+}
+
+export function getVisiblePlayerTrackingSummary(input: {
+    items: Array<Record<string, any>>;
+    statuses: Array<Record<string, any>>;
+    playerIds: string[];
+}): LegacyTrackingSummaryItem[] {
+    return legacyGetVisiblePlayerTrackingSummary(input) as LegacyTrackingSummaryItem[];
+}

--- a/apps/app/src/lib/adapters/legacyRosterPrivacy.ts
+++ b/apps/app/src/lib/adapters/legacyRosterPrivacy.ts
@@ -1,0 +1,55 @@
+import {
+    getRosterProfileValues as legacyGetRosterProfileValues,
+    normalizeRosterFieldDefinitions as legacyNormalizeRosterFieldDefinitions,
+    splitRosterProfileValuesByVisibility as legacySplitRosterProfileValuesByVisibility,
+    validateRosterProfileValues as legacyValidateRosterProfileValues
+} from '../../../../../js/roster-profile-fields.js';
+import { canViewRosterField as legacyCanViewRosterFieldVisibility } from '../../../../../js/roster-field-privacy.js';
+
+export type LegacyRosterFieldOption = {
+    value: string;
+    label: string;
+};
+
+export type LegacyRosterFieldDefinition = {
+    key: string;
+    label: string;
+    type: 'text' | 'menu' | 'checkbox' | 'date';
+    section?: string;
+    description?: string;
+    visibility: string;
+    required?: boolean;
+    options?: LegacyRosterFieldOption[];
+    active?: boolean;
+    sortOrder?: number;
+    [key: string]: any;
+};
+
+export type LegacyRosterFieldAccess = {
+    isAdmin: boolean;
+    isTeamMember: boolean;
+    isLinkedParent: boolean;
+};
+
+export function normalizeRosterFieldDefinitions(fields: unknown[]): LegacyRosterFieldDefinition[] {
+    return legacyNormalizeRosterFieldDefinitions(fields) as LegacyRosterFieldDefinition[];
+}
+
+export function getRosterProfileValues(player: Record<string, any>) {
+    return legacyGetRosterProfileValues(player) as Record<string, unknown>;
+}
+
+export function validateRosterProfileValues(fields: LegacyRosterFieldDefinition[], values: Record<string, unknown>) {
+    return legacyValidateRosterProfileValues(fields, values);
+}
+
+export function splitRosterProfileValuesByVisibility(fields: LegacyRosterFieldDefinition[], values: Record<string, unknown>) {
+    return legacySplitRosterProfileValuesByVisibility(fields, values) as {
+        publicValues: Record<string, unknown>;
+        privateValues: Record<string, unknown>;
+    };
+}
+
+export function canViewRosterField(field: { id: string; visibility: string }, access: LegacyRosterFieldAccess) {
+    return legacyCanViewRosterFieldVisibility(field, access);
+}

--- a/apps/app/src/lib/playerService.test.ts
+++ b/apps/app/src/lib/playerService.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const dbMocks = vi.hoisted(() => ({
+const legacyPlayerDbMocks = vi.hoisted(() => ({
   deleteAthleteProfileMediaByPath: vi.fn(),
   getAggregatedStatsForPlayer: vi.fn(),
   getGames: vi.fn(),
@@ -22,30 +22,48 @@ const dbMocks = vi.hoisted(() => ({
   uploadPlayerPhoto: vi.fn()
 }));
 
-vi.mock('../../../../js/db.js', () => dbMocks);
-vi.mock('../../../../js/parent-incentives.js', () => ({
-  calculateEarnings: vi.fn(),
-  getApplicableRulesForGame: vi.fn(),
-  getCapSetting: vi.fn(),
-  getIncentiveRules: vi.fn(),
-  getPaidGames: vi.fn(),
-  getStatOptionsForTeam: vi.fn(),
-  isCurrentRuleVersion: vi.fn(),
+const legacyPlayerProfileMocks = vi.hoisted(() => ({
+  calculateEarnings: vi.fn(() => ({ totalCents: 0, uncappedTotalCents: 0, wasCapped: false, breakdown: [] })),
+  buildAthleteProfileShareUrl: vi.fn(() => 'https://allplays.ai/athlete-profile.html?profileId=profile-1'),
+  collectPlayerVideoClips: vi.fn(() => []),
+  getApplicableRulesForGame: vi.fn((rules) => rules),
+  getCapSetting: vi.fn().mockResolvedValue(null),
+  getIncentiveRules: vi.fn().mockResolvedValue([]),
+  getPaidGames: vi.fn().mockResolvedValue(new Map()),
+  getStatOptionsForTeam: vi.fn().mockResolvedValue([]),
+  getVisiblePlayerTrackingSummary: vi.fn(() => []),
+  isCurrentRuleVersion: vi.fn(() => true),
   markGamePaid: vi.fn(),
   retireIncentiveRule: vi.fn(),
   saveCapSetting: vi.fn(),
   saveIncentiveRule: vi.fn(),
   toggleIncentiveRule: vi.fn()
 }));
-vi.mock('../../../../js/athlete-profile-utils.js', () => ({
-  buildAthleteProfileShareUrl: vi.fn(() => 'https://allplays.ai/athlete-profile.html?profileId=profile-1')
+const legacyRosterPrivacyMocks = vi.hoisted(() => ({
+  canViewRosterField: vi.fn((field, access) => {
+    if (field?.visibility === 'admins') return Boolean(access?.isAdmin);
+    if (field?.visibility === 'team' || field?.visibility === 'parents') {
+      return Boolean(access?.isAdmin || access?.isTeamMember || access?.isLinkedParent);
+    }
+    return true;
+  }),
+  getRosterProfileValues: vi.fn((player) => ({
+    ...(player?.rosterFieldValues || {}),
+    ...(player?.customFields || {}),
+    ...(player?.profile?.rosterFields || {}),
+    ...(player?.profile?.customFields || {})
+  })),
+  normalizeRosterFieldDefinitions: vi.fn((fields) => fields),
+  splitRosterProfileValuesByVisibility: vi.fn((fields, values) => ({
+    publicValues: Object.fromEntries(Object.entries(values || {}).filter(([key]) => !fields.find((field: any) => field.key === key && field.visibility === 'admins'))),
+    privateValues: Object.fromEntries(Object.entries(values || {}).filter(([key]) => !!fields.find((field: any) => field.key === key && field.visibility === 'admins')))
+  })),
+  validateRosterProfileValues: vi.fn(() => [])
 }));
-vi.mock('../../../../js/player-profile-stats.js', () => ({
-  collectPlayerVideoClips: vi.fn(() => [])
-}));
-vi.mock('../../../../js/player-tracking-summary.js', () => ({
-  getVisiblePlayerTrackingSummary: vi.fn(() => [])
-}));
+
+vi.mock('./adapters/legacyPlayerDb', () => legacyPlayerDbMocks);
+vi.mock('./adapters/legacyPlayerProfile', () => legacyPlayerProfileMocks);
+vi.mock('./adapters/legacyRosterPrivacy', () => legacyRosterPrivacyMocks);
 vi.mock('./scheduleLogic', () => ({
   getOpenScheduleAssignments: vi.fn(() => []),
   normalizeRsvpResponse: vi.fn(() => 'not_responded')
@@ -66,7 +84,7 @@ import { loadParentPlayerDetail, saveParentAthleteProfileDraft, savePlayerCustom
 describe('saveParentAthleteProfileDraft', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dbMocks.saveAthleteProfile.mockResolvedValue({ id: 'profile-1' });
+    legacyPlayerDbMocks.saveAthleteProfile.mockResolvedValue({ id: 'profile-1' });
   });
 
   it('passes caller-provided selectedSeasonKeys to saveAthleteProfile', async () => {
@@ -89,7 +107,7 @@ describe('saveParentAthleteProfileDraft', () => {
       }
     });
 
-    expect(dbMocks.saveAthleteProfile).toHaveBeenCalledWith(
+    expect(legacyPlayerDbMocks.saveAthleteProfile).toHaveBeenCalledWith(
       'parent-1',
       expect.objectContaining({
         selectedSeasonKeys: ['team-current::player-current', 'team-prior::player-prior']
@@ -103,13 +121,13 @@ describe('saveParentAthleteProfileDraft', () => {
 describe('saveStaffPlayerRosterDetails', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dbMocks.getTeam.mockResolvedValue({
+    legacyPlayerDbMocks.getTeam.mockResolvedValue({
       id: 'team-1',
       ownerId: 'owner-1',
       adminEmails: ['coach@example.com']
     });
-    dbMocks.uploadPlayerPhoto.mockResolvedValue('https://cdn.example.com/photo.jpg');
-    dbMocks.updatePlayer.mockResolvedValue(undefined);
+    legacyPlayerDbMocks.uploadPlayerPhoto.mockResolvedValue('https://cdn.example.com/photo.jpg');
+    legacyPlayerDbMocks.updatePlayer.mockResolvedValue(undefined);
   });
 
   it('updates only dirty public roster fields and clears app cache', async () => {
@@ -129,11 +147,11 @@ describe('saveStaffPlayerRosterDetails', () => {
       photoFile: file
     });
 
-    expect(dbMocks.updatePlayer).toHaveBeenCalledWith('team-1', 'player-1', {
+    expect(legacyPlayerDbMocks.updatePlayer).toHaveBeenCalledWith('team-1', 'player-1', {
       number: '44',
       photoUrl: 'https://cdn.example.com/photo.jpg'
     });
-    expect(dbMocks.setPlayerPrivateRosterProfileFields).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.setPlayerPrivateRosterProfileFields).not.toHaveBeenCalled();
     expect(appDataCacheMocks.clearAppDataCache).toHaveBeenCalledWith();
     expect(result).toEqual({
       updatedFields: ['number', 'photoUrl'],
@@ -158,7 +176,7 @@ describe('saveStaffPlayerRosterDetails', () => {
       number: '12'
     })).rejects.toThrow('Only team owners and admins can edit roster details.');
 
-    expect(dbMocks.updatePlayer).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.updatePlayer).not.toHaveBeenCalled();
     expect(appDataCacheMocks.clearAppDataCache).not.toHaveBeenCalled();
   });
 
@@ -176,7 +194,7 @@ describe('saveStaffPlayerRosterDetails', () => {
       number: '12'
     })).rejects.toThrow('Only team owners and admins can edit roster details.');
 
-    expect(dbMocks.updatePlayer).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.updatePlayer).not.toHaveBeenCalled();
     expect(appDataCacheMocks.clearAppDataCache).not.toHaveBeenCalled();
   });
 });
@@ -184,12 +202,12 @@ describe('saveStaffPlayerRosterDetails', () => {
 describe('savePlayerCustomRosterFieldValues', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    dbMocks.getTeam.mockResolvedValue({
+    legacyPlayerDbMocks.getTeam.mockResolvedValue({
       id: 'team-1',
       ownerId: 'owner-1',
       adminEmails: ['coach@example.com']
     });
-    dbMocks.getPlayers.mockResolvedValue([
+    legacyPlayerDbMocks.getPlayers.mockResolvedValue([
       {
         id: 'player-1',
         profile: {
@@ -201,17 +219,17 @@ describe('savePlayerCustomRosterFieldValues', () => {
         }
       }
     ]);
-    dbMocks.getPlayerPrivateProfile.mockResolvedValue({
+    legacyPlayerDbMocks.getPlayerPrivateProfile.mockResolvedValue({
       rosterFields: {
         jerseySize: 'YM'
       }
     });
-    dbMocks.getRosterFieldDefinitions.mockResolvedValue([
+    legacyPlayerDbMocks.getRosterFieldDefinitions.mockResolvedValue([
       { key: 'nickname', label: 'Nickname', type: 'text', visibility: 'team', sortOrder: 1 },
       { key: 'jerseySize', label: 'Jersey Size', type: 'menu', visibility: 'admins', options: ['YS', 'YM'], sortOrder: 2 }
     ]);
-    dbMocks.updatePlayer.mockResolvedValue(undefined);
-    dbMocks.setPlayerPrivateRosterProfileFields.mockResolvedValue(undefined);
+    legacyPlayerDbMocks.updatePlayer.mockResolvedValue(undefined);
+    legacyPlayerDbMocks.setPlayerPrivateRosterProfileFields.mockResolvedValue(undefined);
   });
 
   it('writes only currently defined custom roster values to public and private containers', async () => {
@@ -226,7 +244,7 @@ describe('savePlayerCustomRosterFieldValues', () => {
       }
     });
 
-    expect(dbMocks.updatePlayer).toHaveBeenCalledWith('team-1', 'player-1', {
+    expect(legacyPlayerDbMocks.updatePlayer).toHaveBeenCalledWith('team-1', 'player-1', {
       profile: {
         position: 'Guard',
         customFields: {
@@ -234,7 +252,7 @@ describe('savePlayerCustomRosterFieldValues', () => {
         }
       }
     });
-    expect(dbMocks.setPlayerPrivateRosterProfileFields).toHaveBeenCalledWith('team-1', 'player-1', {
+    expect(legacyPlayerDbMocks.setPlayerPrivateRosterProfileFields).toHaveBeenCalledWith('team-1', 'player-1', {
       jerseySize: 'YS'
     });
   });
@@ -251,8 +269,8 @@ describe('savePlayerCustomRosterFieldValues', () => {
       values: { nickname: 'Speedy' }
     })).rejects.toThrow('Only team owners and admins can edit custom roster fields.');
 
-    expect(dbMocks.updatePlayer).not.toHaveBeenCalled();
-    expect(dbMocks.setPlayerPrivateRosterProfileFields).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.updatePlayer).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.setPlayerPrivateRosterProfileFields).not.toHaveBeenCalled();
   });
 
   it('rejects custom roster field edits from coachOf-only users without team admin rights', async () => {
@@ -267,8 +285,8 @@ describe('savePlayerCustomRosterFieldValues', () => {
       values: { nickname: 'Speedy' }
     })).rejects.toThrow('Only team owners and admins can edit custom roster fields.');
 
-    expect(dbMocks.updatePlayer).not.toHaveBeenCalled();
-    expect(dbMocks.setPlayerPrivateRosterProfileFields).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.updatePlayer).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.setPlayerPrivateRosterProfileFields).not.toHaveBeenCalled();
   });
 });
 
@@ -280,12 +298,12 @@ describe('loadParentPlayerDetail custom roster fields', () => {
       children: [{ teamId: 'team-1', teamName: 'Comets', playerId: 'player-1', playerName: 'Sam Player' }],
       events: []
     });
-    dbMocks.getTeam.mockResolvedValue({
+    legacyPlayerDbMocks.getTeam.mockResolvedValue({
       id: 'team-1',
       name: 'Comets',
       adminEmails: ['coach@example.com']
     });
-    dbMocks.getPlayers.mockResolvedValue([
+    legacyPlayerDbMocks.getPlayers.mockResolvedValue([
       {
         id: 'player-1',
         name: 'Sam Player',
@@ -296,20 +314,20 @@ describe('loadParentPlayerDetail custom roster fields', () => {
         }
       }
     ]);
-    dbMocks.getPlayerPrivateProfile.mockResolvedValue({
+    legacyPlayerDbMocks.getPlayerPrivateProfile.mockResolvedValue({
       rosterFields: {
         jerseySize: 'YM'
       }
     });
-    dbMocks.getRosterFieldDefinitions.mockResolvedValue([
+    legacyPlayerDbMocks.getRosterFieldDefinitions.mockResolvedValue([
       { key: 'nickname', label: 'Nickname', type: 'text', visibility: 'team', sortOrder: 1 },
       { key: 'jerseySize', label: 'Jersey Size', type: 'menu', visibility: 'admins', options: ['YS', 'YM'], sortOrder: 2 }
     ]);
-    dbMocks.getGames.mockResolvedValue([]);
-    dbMocks.listCertificatesForPlayer.mockResolvedValue([]);
-    dbMocks.getPublicTrackingItems.mockResolvedValue([]);
-    dbMocks.getPlayerTrackingStatuses.mockResolvedValue([]);
-    dbMocks.listAthleteProfilesForParent.mockResolvedValue([]);
+    legacyPlayerDbMocks.getGames.mockResolvedValue([]);
+    legacyPlayerDbMocks.listCertificatesForPlayer.mockResolvedValue([]);
+    legacyPlayerDbMocks.getPublicTrackingItems.mockResolvedValue([]);
+    legacyPlayerDbMocks.getPlayerTrackingStatuses.mockResolvedValue([]);
+    legacyPlayerDbMocks.listAthleteProfilesForParent.mockResolvedValue([]);
   });
 
   it('applies roster field privacy so parents do not receive admin-only custom values', async () => {

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -1,13 +1,13 @@
 import {
+  deleteAthleteProfileMediaByPath,
   getAggregatedStatsForPlayer,
   getGames,
   getPlayerPrivateProfile,
-  getPlayerTrackingStatuses,
   getPlayers,
+  getPlayerTrackingStatuses,
   getPublicTrackingItems,
   getRosterFieldDefinitions,
   getTeam,
-  deleteAthleteProfileMediaByPath,
   inviteCoParentToAthlete,
   listAthleteProfilesForParent,
   listCertificatesForPlayer,
@@ -16,32 +16,39 @@ import {
   updatePlayer,
   updatePlayerProfile,
   uploadAthleteProfileMedia,
-  uploadPlayerPhoto
-} from '../../../../js/db.js';
+  uploadPlayerPhoto,
+  type LegacyAthleteProfileRecord,
+  type LegacyPlayerPrivateProfileRecord,
+  type LegacyPlayerRecord,
+  type LegacyTeamRecord
+} from './adapters/legacyPlayerDb';
 import {
+  buildAthleteProfileShareUrl,
   calculateEarnings,
+  collectPlayerVideoClips,
   getApplicableRulesForGame,
   getCapSetting,
   getIncentiveRules,
   getPaidGames,
   getStatOptionsForTeam,
+  getVisiblePlayerTrackingSummary,
   isCurrentRuleVersion,
   markGamePaid,
   retireIncentiveRule,
   saveCapSetting,
   saveIncentiveRule,
-  toggleIncentiveRule
-} from '../../../../js/parent-incentives.js';
-import { buildAthleteProfileShareUrl } from '../../../../js/athlete-profile-utils.js';
-import { collectPlayerVideoClips } from '../../../../js/player-profile-stats.js';
-import { getVisiblePlayerTrackingSummary } from '../../../../js/player-tracking-summary.js';
-import { canViewRosterField } from '../../../../js/roster-field-privacy.js';
+  toggleIncentiveRule,
+  type LegacyIncentiveRule,
+  type LegacyStatOption
+} from './adapters/legacyPlayerProfile';
 import {
+  canViewRosterField,
   getRosterProfileValues,
   normalizeRosterFieldDefinitions,
   splitRosterProfileValuesByVisibility,
-  validateRosterProfileValues
-} from '../../../../js/roster-profile-fields.js';
+  validateRosterProfileValues,
+  type LegacyRosterFieldDefinition
+} from './adapters/legacyRosterPrivacy';
 import { getOpenScheduleAssignments, normalizeRsvpResponse, type ParentScheduleEvent } from './scheduleLogic';
 import { loadParentPlayerSchedule, type ParentScheduleChild } from './scheduleService';
 import { clearAppDataCache } from './appDataCache';
@@ -93,16 +100,7 @@ export type ParentAthleteProfileData = {
   }>;
 };
 
-type CustomRosterFieldDefinition = {
-  key: string;
-  label: string;
-  type: 'text' | 'menu' | 'checkbox' | 'date';
-  section?: string;
-  description?: string;
-  visibility: string;
-  required?: boolean;
-  options?: Array<{ value: string; label: string }>;
-};
+type CustomRosterFieldDefinition = LegacyRosterFieldDefinition;
 
 export type ParentPlayerDetailData = {
   child: ParentScheduleChild;
@@ -150,7 +148,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
   const requestedTeamId = decodeURIComponent(teamId || '');
   const requestedPlayerId = decodeURIComponent(playerId || '');
   const linkedChild = findLinkedChild(schedule.children, teamId, playerId);
-  const initialTeam = await Promise.resolve(getTeam(requestedTeamId, { includeInactive: true })).catch(() => null);
+  const initialTeam = await getTeam(requestedTeamId, { includeInactive: true });
   const routeAccess = buildPlayerAccess(user, requestedTeamId, requestedPlayerId, initialTeam);
   if (!linkedChild && !routeAccess.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
@@ -165,7 +163,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
 
   const team = requestedTeamId === resolvedTeamId
     ? initialTeam
-    : await Promise.resolve(getTeam(resolvedTeamId, { includeInactive: true })).catch(() => null);
+    : await getTeam(resolvedTeamId, { includeInactive: true });
 
   const [
     players,
@@ -181,21 +179,21 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     statOptions,
     athleteProfiles
   ] = await Promise.all([
-    Promise.resolve(getPlayers(resolvedTeamId, { includeInactive: true })).catch(() => []),
-    Promise.resolve(getGames(resolvedTeamId)).catch(() => []),
-    Promise.resolve(listCertificatesForPlayer(resolvedTeamId, resolvedPlayerId, { status: 'published', limit: 5 })).catch(() => []),
-    Promise.resolve(getPublicTrackingItems(resolvedTeamId)).catch(() => []),
-    Promise.resolve(getPlayerTrackingStatuses(resolvedTeamId, [resolvedPlayerId])).catch(() => []),
-    Promise.resolve(getPlayerPrivateProfile(resolvedTeamId, resolvedPlayerId)).catch(() => null),
-    Promise.resolve(getRosterFieldDefinitions(resolvedTeamId, team || null)).catch(() => []),
-    Promise.resolve(getIncentiveRules(user.uid, resolvedPlayerId)).catch(() => []),
-    Promise.resolve(getPaidGames(user.uid, resolvedPlayerId)).catch(() => new Map()),
-    Promise.resolve(getCapSetting(user.uid, resolvedPlayerId)).catch(() => null),
-    Promise.resolve(getStatOptionsForTeam(resolvedTeamId)).catch(() => []),
-    Promise.resolve(listAthleteProfilesForParent(user.uid)).catch(() => [])
+    getPlayers(resolvedTeamId, { includeInactive: true }).catch(() => []),
+    getGames(resolvedTeamId).catch(() => []),
+    listCertificatesForPlayer(resolvedTeamId, resolvedPlayerId, { status: 'published', limit: 5 }).catch(() => []),
+    getPublicTrackingItems(resolvedTeamId).catch(() => []),
+    getPlayerTrackingStatuses(resolvedTeamId, [resolvedPlayerId]).catch(() => []),
+    getPlayerPrivateProfile(resolvedTeamId, resolvedPlayerId).catch(() => null),
+    getRosterFieldDefinitions(resolvedTeamId, team || null).catch(() => []),
+    getIncentiveRules(user.uid, resolvedPlayerId).catch(() => []),
+    getPaidGames(user.uid, resolvedPlayerId).catch(() => new Map()),
+    getCapSetting(user.uid, resolvedPlayerId).catch(() => null),
+    getStatOptionsForTeam(resolvedTeamId).catch(() => []),
+    listAthleteProfilesForParent(user.uid).catch(() => [])
   ]);
 
-  const playerDoc = (Array.isArray(players) ? players : []).find((candidate: any) => candidate?.id === resolvedPlayerId) || {};
+  const playerDoc = (Array.isArray(players) ? players : []).find((candidate: LegacyPlayerRecord) => candidate?.id === resolvedPlayerId) || {};
   const access = buildPlayerAccess(user, resolvedTeamId, resolvedPlayerId, team);
   const child = linkedChild || {
     teamId: resolvedTeamId,
@@ -216,7 +214,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
 
   const statRows = await Promise.all(completedGameEvents.map(async (event) => ({
     event,
-    stats: await Promise.resolve(getAggregatedStatsForPlayer(resolvedTeamId, event.id, resolvedPlayerId)).catch(() => ({})) || {}
+    stats: await getAggregatedStatsForPlayer(resolvedTeamId, event.id, resolvedPlayerId).catch(() => ({})) || {}
   })));
 
   const clips = collectPlayerVideoClips(Array.isArray(games) ? games : [], {
@@ -289,16 +287,16 @@ export async function savePlayerCustomRosterFieldValues({
     throw new Error('A signed-in team staff account is required.');
   }
 
-  const team = await Promise.resolve(getTeam(teamId, { includeInactive: true })).catch(() => null);
+  const team = await getTeam(teamId, { includeInactive: true });
   const access = buildPlayerAccess(user, teamId, playerId, team);
   if (!access.canEditCustomRosterFields) {
     throw new Error('Only team owners and admins can edit custom roster fields.');
   }
 
   const [players, privateProfile, rosterFieldDefinitions] = await Promise.all([
-    Promise.resolve(getPlayers(teamId, { includeInactive: true })).catch(() => []),
-    Promise.resolve(getPlayerPrivateProfile(teamId, playerId)).catch(() => null),
-    Promise.resolve(getRosterFieldDefinitions(teamId, team || null)).catch(() => [])
+    getPlayers(teamId, { includeInactive: true }).catch(() => []),
+    getPlayerPrivateProfile(teamId, playerId).catch(() => null),
+    getRosterFieldDefinitions(teamId, team || null).catch(() => [])
   ]);
 
   const player = (Array.isArray(players) ? players : []).find((candidate: any) => candidate?.id === playerId) || {};
@@ -391,7 +389,7 @@ export async function saveStaffPlayerRosterDetails({
     throw new Error('A signed-in team staff account is required.');
   }
 
-  const team = await Promise.resolve(getTeam(teamId, { includeInactive: true })).catch(() => null);
+  const team = await getTeam(teamId, { includeInactive: true });
   const access = buildPlayerAccess(user, teamId, playerId, team);
   if (!access.canEditRosterDetails) {
     throw new Error('Only team owners and admins can edit roster details.');
@@ -606,9 +604,9 @@ function buildPlayerIncentiveData({
   maxPerGameCents,
   statRows
 }: {
-  rules: Array<Record<string, any>>;
-  paidGames: Map<string, any>;
-  statOptions: Array<{ key: string; label: string }>;
+  rules: LegacyIncentiveRule[];
+  paidGames: Map<string, Record<string, any>>;
+  statOptions: LegacyStatOption[];
   maxPerGameCents: number | null;
   statRows: ParentPlayerStatRow[];
 }): ParentPlayerIncentiveData {
@@ -651,7 +649,7 @@ function buildAthleteProfileData({
   teamId,
   playerId
 }: {
-  profiles: Array<Record<string, any>>;
+  profiles: LegacyAthleteProfileRecord[];
   parentLinks: Array<Record<string, any>>;
   teamId: string;
   playerId: string;
@@ -709,7 +707,7 @@ function normalizeEmail(value: unknown) {
   return String(value || '').trim().toLowerCase();
 }
 
-function isTeamOwnerOrAdminUser(user: AuthUser | null, team: Record<string, any> | null) {
+function isTeamOwnerOrAdminUser(user: AuthUser | null, team: LegacyTeamRecord | null) {
   if (!user?.uid) return false;
   if (isElevatedAppAdmin(user)) return true;
   if (team?.ownerId === user.uid) return true;
@@ -718,12 +716,12 @@ function isTeamOwnerOrAdminUser(user: AuthUser | null, team: Record<string, any>
   return !!(email && adminEmails.includes(email));
 }
 
-function isTeamStaffUser(user: AuthUser | null, team: Record<string, any> | null) {
+function isTeamStaffUser(user: AuthUser | null, team: LegacyTeamRecord | null) {
   if (isTeamOwnerOrAdminUser(user, team)) return true;
   return !!(Array.isArray(user?.coachOf) && user.coachOf.map((value) => String(value || '').trim()).includes(String(team?.id || '').trim()));
 }
 
-function buildPlayerAccess(user: AuthUser | null, teamId: string, playerId: string, team: Record<string, any> | null) {
+function buildPlayerAccess(user: AuthUser | null, teamId: string, playerId: string, team: LegacyTeamRecord | null) {
   const linkedParent = isLinkedParent(user, teamId, playerId);
   const resolvedTeam = team ? { ...team, id: team.id || teamId } : { id: teamId };
   const isTeamStaff = isTeamStaffUser(user, resolvedTeam);
@@ -744,8 +742,8 @@ function buildVisibleCustomRosterFields({
   access
 }: {
   definitions: any[];
-  player: Record<string, any>;
-  privateProfile: Record<string, any> | null;
+  player: LegacyPlayerRecord;
+  privateProfile: LegacyPlayerPrivateProfileRecord | null;
   access: { isLinkedParent: boolean; isTeamStaff: boolean; canEditRosterDetails: boolean; canEditCustomRosterFields: boolean };
 }) {
   const normalizedFields = normalizeRosterFieldDefinitions(definitions) as CustomRosterFieldDefinition[];


### PR DESCRIPTION
Closes #2279

## What changed
- added typed adapter modules for the player workflow legacy boundaries: `legacyPlayerDb`, `legacyPlayerProfile`, and `legacyRosterPrivacy`
- repointed `playerService.ts` to those adapters so the app service no longer imports `../../../../js/*` directly for roster, player profile, stat, share-link, and privacy behavior
- updated `playerService.test.ts` to mock the new adapter seams and keep the existing player roster/privacy regression coverage focused at the service boundary

## Root Cause
`playerService.ts` was tightly coupled to untyped legacy `js/*` modules, so app-layer code and tests depended directly on legacy import paths instead of a stable typed boundary. That made the player workflow slice harder to migrate safely and kept service tests anchored to implementation details.

## Prevention / Learning
When migrating app services off legacy modules, add a typed adapter at the workflow boundary first, then make service tests mock the adapter instead of the underlying `js/*` modules. That keeps the app contract stable while legacy internals continue to evolve behind the adapter.

## Regression Tests
- `cd apps/app && npx vitest run src/lib/playerService.test.ts`
- `cd apps/app && npx tsc --noEmit`

## Recurrence Risk
Medium. Other app services still import legacy `js/*` modules directly until their slices are moved behind typed adapters too.