### PR TITLE
Extract chat sheet visibility into hook

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -99,6 +99,7 @@ import { markTeamChatReadAndRefreshBadge, updateAppIconBadge } from '../lib/badg
 import { useShellLayout } from '../lib/useShellLayout';
 import type { AuthState } from '../lib/types';
 import { voiceRecognition, type VoiceListenerHandle } from '../lib/voiceService';
+import { useChatSheets } from './messages/hooks/useChatSheets';
 
 type StatusTone = 'neutral' | 'success' | 'error';
 
@@ -477,12 +478,26 @@ function ChatWindow({
   const [aiThinking, setAiThinking] = useState(false);
   const [voiceListening, setVoiceListening] = useState(false);
   const [voiceSupported, setVoiceSupported] = useState(() => voiceRecognition.isNativeRuntime() || voiceRecognition.hasBrowserSupport());
-  const [showConversationSheet, setShowConversationSheet] = useState(false);
-  const [showAudienceSheet, setShowAudienceSheet] = useState(false);
-  const [showMediaGallery, setShowMediaGallery] = useState(false);
-  const [showAttachSheet, setShowAttachSheet] = useState(false);
-  const [showLinkSheet, setShowLinkSheet] = useState(false);
-  const [showEmailSheet, setShowEmailSheet] = useState(false);
+  const {
+    showConversationSheet,
+    showAudienceSheet,
+    showMediaGallery,
+    showAttachSheet,
+    showLinkSheet,
+    showEmailSheet,
+    openConversationSheet,
+    closeConversationSheet,
+    openAudienceSheet,
+    closeAudienceSheet,
+    openMediaGallery,
+    closeMediaGallery,
+    openAttachSheet,
+    closeAttachSheet,
+    openLinkSheet,
+    closeLinkSheet,
+    openEmailSheet: openTeamEmailSheet,
+    closeEmailSheet: closeTeamEmailSheet
+  } = useChatSheets();
   const [emailSubject, setEmailSubject] = useState('');
   const [emailBody, setEmailBody] = useState('');
   const [emailTemplateName, setEmailTemplateName] = useState('');
@@ -948,7 +963,7 @@ function ChatWindow({
     setSelectedRecipientIds([]);
     setReactionMessageId('');
     setActionMessageId('');
-    setShowConversationSheet(false);
+    closeConversationSheet();
   };
 
   const handleAudienceTargetChange = async (target: ChatTargetType) => {
@@ -961,7 +976,7 @@ function ChatWindow({
       if (!isDefaultTeamConversation(selectedConversationId)) {
         switchConversation(DEFAULT_TEAM_CONVERSATION_ID);
       }
-      setShowAudienceSheet(false);
+      closeAudienceSheet();
       return;
     }
 
@@ -977,7 +992,7 @@ function ChatWindow({
         if (selectedConversationId !== staffConversation.id) {
           switchConversation(staffConversation.id);
         }
-        setShowAudienceSheet(false);
+        closeAudienceSheet();
       } catch (staffError: any) {
         setStatus({ tone: 'error', message: staffError?.message || 'Unable to open staff chat.' });
       }
@@ -1032,7 +1047,7 @@ function ChatWindow({
       ...selectedFiles.map((file) => ({ file, url: URL.createObjectURL(file) }))
     ]);
     event.target.value = '';
-    setShowAttachSheet(false);
+    closeAttachSheet();
   };
 
   const removeFile = (index: number) => {
@@ -1043,10 +1058,9 @@ function ChatWindow({
     });
   };
 
-  const openLinkSheet = () => {
-    setShowAttachSheet(false);
+  const handleOpenLinkSheet = () => {
     setLinkDraft('');
-    setShowLinkSheet(true);
+    openLinkSheet();
   };
 
   const addLinkToComposer = () => {
@@ -1058,7 +1072,7 @@ function ChatWindow({
       return;
     }
     setText((current) => `${current.trim()}${current.trim() ? ' ' : ''}${href}`);
-    setShowLinkSheet(false);
+    closeLinkSheet();
     setLinkDraft('');
   };
 
@@ -1073,7 +1087,7 @@ function ChatWindow({
       && selectedRecipientIds.map((id) => String(id || '').trim()).filter(Boolean).length === 0;
     if (hasEmptySelectedAudience) {
       setStatus({ tone: 'error', message: 'Choose at least one selected member before sending.' });
-      setShowAudienceSheet(true);
+      openAudienceSheet();
       return;
     }
 
@@ -1200,7 +1214,7 @@ function ChatWindow({
 
   const openEmailSheet = () => {
     if (!canModerate) return;
-    setShowEmailSheet(true);
+    openTeamEmailSheet();
     setEmailTemplateName('');
     setEmailStatus(null);
     setEmailHistoryStatus(null);
@@ -1557,7 +1571,7 @@ function ChatWindow({
             <button
               type="button"
               className="mt-0.5 flex max-w-full items-center gap-1 text-left text-xs font-bold text-gray-500"
-              onClick={() => setShowConversationSheet(true)}
+              onClick={openConversationSheet}
             >
               <span className="truncate">{getConversationDisplayName(selectedConversation, team || {})}</span>
               <ChevronDown className="h-3.5 w-3.5 flex-none" aria-hidden="true" />
@@ -1578,7 +1592,7 @@ function ChatWindow({
           >
             <BellOff className="h-5 w-5" aria-hidden="true" />
           </button>
-          <button type="button" className="ghost-button !h-10 !min-h-10 !w-10 !p-0" onClick={() => setShowMediaGallery(true)} aria-label="Open photos and videos">
+          <button type="button" className="ghost-button !h-10 !min-h-10 !w-10 !p-0" onClick={openMediaGallery} aria-label="Open photos and videos">
             <ImageIcon className="h-5 w-5" aria-hidden="true" />
             {mediaEntries.length ? <span className="sr-only">{mediaEntries.length} shared media items</span> : null}
           </button>
@@ -1672,11 +1686,11 @@ function ChatWindow({
         audienceSummary={audienceSummary}
         onTextChange={setText}
         onSubmit={handleSend}
-        onAttach={() => setShowAttachSheet(true)}
+        onAttach={openAttachSheet}
         onRemoveFile={removeFile}
         onVoice={toggleVoiceCapture}
         onAudience={() => {
-          setShowAudienceSheet(true);
+          openAudienceSheet();
           void ensureRecipientOptionsLoaded().catch(() => undefined);
         }}
         onTeamEmail={openEmailSheet}
@@ -1692,7 +1706,7 @@ function ChatWindow({
           team={team || {}}
           selectedConversationId={selectedConversationId}
           onSelect={switchConversation}
-          onClose={() => setShowConversationSheet(false)}
+          onClose={closeConversationSheet}
         />
       ) : null}
 
@@ -1708,7 +1722,7 @@ function ChatWindow({
           onRetryRecipientOptions={() => {
             void ensureRecipientOptionsLoaded().catch(() => undefined);
           }}
-          onClose={() => setShowAudienceSheet(false)}
+          onClose={closeAudienceSheet}
         />
       ) : null}
 
@@ -1716,9 +1730,9 @@ function ChatWindow({
         <AttachSheet
           onPhoto={() => photoInputRef.current?.click()}
           onVideo={() => videoInputRef.current?.click()}
-          onLink={openLinkSheet}
+          onLink={handleOpenLinkSheet}
           onMention={insertAllPlaysMention}
-          onClose={() => setShowAttachSheet(false)}
+          onClose={closeAttachSheet}
         />
       ) : null}
 
@@ -1727,7 +1741,7 @@ function ChatWindow({
           value={linkDraft}
           onChange={setLinkDraft}
           onAdd={addLinkToComposer}
-          onClose={() => setShowLinkSheet(false)}
+          onClose={closeLinkSheet}
         />
       ) : null}
 
@@ -1768,12 +1782,12 @@ function ChatWindow({
           }}
           onStatusClose={() => setEmailStatus(null)}
           onHistoryStatusClose={() => setEmailHistoryStatus(null)}
-          onClose={() => setShowEmailSheet(false)}
+          onClose={closeTeamEmailSheet}
         />
       ) : null}
 
       {showMediaGallery ? (
-        <MediaGallerySheet mediaEntries={mediaEntries} onClose={() => setShowMediaGallery(false)} onStatus={setStatus} />
+        <MediaGallerySheet mediaEntries={mediaEntries} onClose={closeMediaGallery} onStatus={setStatus} />
       ) : null}
 
       {editingMessage ? (

--- a/apps/app/src/pages/messages/hooks/useChatSheets.test.tsx
+++ b/apps/app/src/pages/messages/hooks/useChatSheets.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useChatSheets } from './useChatSheets';
+
+function HookProbe() {
+    const sheets = useChatSheets();
+
+    return (
+        <div>
+            <div data-testid="conversation">{String(sheets.showConversationSheet)}</div>
+            <div data-testid="audience">{String(sheets.showAudienceSheet)}</div>
+            <div data-testid="media">{String(sheets.showMediaGallery)}</div>
+            <div data-testid="attach">{String(sheets.showAttachSheet)}</div>
+            <div data-testid="link">{String(sheets.showLinkSheet)}</div>
+            <div data-testid="email">{String(sheets.showEmailSheet)}</div>
+            <button type="button" onClick={sheets.openConversationSheet}>Open conversation</button>
+            <button type="button" onClick={sheets.closeConversationSheet}>Close conversation</button>
+            <button type="button" onClick={sheets.openAudienceSheet}>Open audience</button>
+            <button type="button" onClick={sheets.closeAudienceSheet}>Close audience</button>
+            <button type="button" onClick={sheets.openMediaGallery}>Open media</button>
+            <button type="button" onClick={sheets.closeMediaGallery}>Close media</button>
+            <button type="button" onClick={sheets.openAttachSheet}>Open attach</button>
+            <button type="button" onClick={sheets.closeAttachSheet}>Close attach</button>
+            <button type="button" onClick={sheets.openLinkSheet}>Open link</button>
+            <button type="button" onClick={sheets.closeLinkSheet}>Close link</button>
+            <button type="button" onClick={sheets.openEmailSheet}>Open email</button>
+            <button type="button" onClick={sheets.closeEmailSheet}>Close email</button>
+        </div>
+    );
+}
+
+describe('useChatSheets', () => {
+    it('opens and closes each extracted sheet without leaking state', () => {
+        render(<HookProbe />);
+
+        expect(screen.getByTestId('conversation')).toHaveTextContent('false');
+        expect(screen.getByTestId('audience')).toHaveTextContent('false');
+        expect(screen.getByTestId('media')).toHaveTextContent('false');
+        expect(screen.getByTestId('attach')).toHaveTextContent('false');
+        expect(screen.getByTestId('link')).toHaveTextContent('false');
+        expect(screen.getByTestId('email')).toHaveTextContent('false');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open conversation' }));
+        expect(screen.getByTestId('conversation')).toHaveTextContent('true');
+        fireEvent.click(screen.getByRole('button', { name: 'Close conversation' }));
+        expect(screen.getByTestId('conversation')).toHaveTextContent('false');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open audience' }));
+        expect(screen.getByTestId('audience')).toHaveTextContent('true');
+        fireEvent.click(screen.getByRole('button', { name: 'Close audience' }));
+        expect(screen.getByTestId('audience')).toHaveTextContent('false');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open media' }));
+        expect(screen.getByTestId('media')).toHaveTextContent('true');
+        fireEvent.click(screen.getByRole('button', { name: 'Close media' }));
+        expect(screen.getByTestId('media')).toHaveTextContent('false');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open attach' }));
+        expect(screen.getByTestId('attach')).toHaveTextContent('true');
+        fireEvent.click(screen.getByRole('button', { name: 'Open link' }));
+        expect(screen.getByTestId('attach')).toHaveTextContent('false');
+        expect(screen.getByTestId('link')).toHaveTextContent('true');
+        fireEvent.click(screen.getByRole('button', { name: 'Close link' }));
+        expect(screen.getByTestId('link')).toHaveTextContent('false');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open email' }));
+        expect(screen.getByTestId('email')).toHaveTextContent('true');
+        fireEvent.click(screen.getByRole('button', { name: 'Close email' }));
+        expect(screen.getByTestId('email')).toHaveTextContent('false');
+    });
+});

--- a/apps/app/src/pages/messages/hooks/useChatSheets.ts
+++ b/apps/app/src/pages/messages/hooks/useChatSheets.ts
@@ -1,0 +1,91 @@
+import { useCallback, useState } from 'react';
+
+type ChatSheetsState = {
+    showConversationSheet: boolean;
+    showAudienceSheet: boolean;
+    showMediaGallery: boolean;
+    showAttachSheet: boolean;
+    showLinkSheet: boolean;
+    showEmailSheet: boolean;
+};
+
+const initialState: ChatSheetsState = {
+    showConversationSheet: false,
+    showAudienceSheet: false,
+    showMediaGallery: false,
+    showAttachSheet: false,
+    showLinkSheet: false,
+    showEmailSheet: false
+};
+
+export function useChatSheets() {
+    const [sheets, setSheets] = useState<ChatSheetsState>(initialState);
+
+    const openConversationSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showConversationSheet: true }));
+    }, []);
+
+    const closeConversationSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showConversationSheet: false }));
+    }, []);
+
+    const openAudienceSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showAudienceSheet: true }));
+    }, []);
+
+    const closeAudienceSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showAudienceSheet: false }));
+    }, []);
+
+    const openMediaGallery = useCallback(() => {
+        setSheets((current) => ({ ...current, showMediaGallery: true }));
+    }, []);
+
+    const closeMediaGallery = useCallback(() => {
+        setSheets((current) => ({ ...current, showMediaGallery: false }));
+    }, []);
+
+    const openAttachSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showAttachSheet: true }));
+    }, []);
+
+    const closeAttachSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showAttachSheet: false }));
+    }, []);
+
+    const openLinkSheet = useCallback(() => {
+        setSheets((current) => ({
+            ...current,
+            showAttachSheet: false,
+            showLinkSheet: true
+        }));
+    }, []);
+
+    const closeLinkSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showLinkSheet: false }));
+    }, []);
+
+    const openEmailSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showEmailSheet: true }));
+    }, []);
+
+    const closeEmailSheet = useCallback(() => {
+        setSheets((current) => ({ ...current, showEmailSheet: false }));
+    }, []);
+
+    return {
+        ...sheets,
+        openConversationSheet,
+        closeConversationSheet,
+        openAudienceSheet,
+        closeAudienceSheet,
+        openMediaGallery,
+        closeMediaGallery,
+        openAttachSheet,
+        closeAttachSheet,
+        openLinkSheet,
+        closeLinkSheet,
+        openEmailSheet,
+        closeEmailSheet
+    };
+}


### PR DESCRIPTION
Closes #2286

## What changed
- extracted Messages sheet and modal visibility flags into `useChatSheets`
- updated `Messages.tsx` to use hook-owned open/close helpers instead of owning the visibility `useState` values directly
- preserved the existing attach→link transition by having the hook close the attach sheet before opening the link sheet
- added a focused hook test covering the main open/close transitions for conversation, audience, media, attach, link, and email sheets

## Root Cause
`Messages.tsx` owned six separate sheet visibility booleans and their transitions inline, so UI presentation state was scattered across a very large component. That made it easy to miss close/open invariants during refactors and kept this decomposition slice from being isolated.

## Prevention / Learning
When a page has multiple related presentation-only toggles, extract them into a focused hook before deeper behavior refactors. Keep transition rules, like closing one sheet before opening a dependent one, in the hook so tests can lock the behavior down in one place.

## Regression Tests
- `npm test -- --run src/pages/messages/hooks/useChatSheets.test.tsx`
- `npm run build`