### PR TITLE
Standardize parent dashboard load errors

### DIFF
--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -83,7 +83,9 @@ export async function loadParentTeamsSummary(user: AuthUser | null, options: { f
     async () => {
       const timer = startUxTimer('teams summary load');
       try {
-        const chatInbox = await loadChatInbox(user, { includeLastMessages: false }).catch(() => ({ teams: [] }));
+        const chatInbox = await loadChatInbox(user, { includeLastMessages: false }).catch((error) => {
+          throw toAppServiceError(error, 'Unable to load teams.');
+        });
         const children = normalizeChildLinks(user, { parentOf: user.parentOf || [] });
         const model = buildParentHomeModel({
           children,

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -199,6 +199,16 @@ describe('Home', () => {
     expect(screen.getByText('Check your connection and try loading Home again.')).toBeTruthy();
   });
 
+  it('shows retryable Home error UI when the initial secondary load fails', async () => {
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    renderHome(signedInAuth);
+
+    expect(await screen.findByText('Home could not connect')).toBeTruthy();
+    expect(screen.getByText('Check your connection and try loading Home again.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry loading Home' })).toBeTruthy();
+  });
+
   it('refreshes the social feed with the async loading helper', async () => {
     renderHome(signedInAuth, '/home?section=feed');
 

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -140,18 +140,18 @@ export function Home({ auth }: { auth: AuthState }) {
   const [socialStatus, setSocialStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
-  const [loadedHomeUserId, setLoadedHomeUserId] = useState<string | null>(null);
+  const [loadedHomeDetailsUserId, setLoadedHomeDetailsUserId] = useState<string | null>(null);
   const [homeLoadError, setHomeLoadError] = useState<AppServiceError | null>(null);
   const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
   const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();
 
   const authUserId = auth.user?.uid || null;
-  const hasLoadedHome = Boolean(authUserId) && authUserId === loadedHomeUserId;
+  const hasLoadedHomeDetails = Boolean(authUserId) && authUserId === loadedHomeDetailsUserId;
 
   const refreshHome = async ({ force = false }: { force?: boolean } = {}) => {
     const user = auth.user;
     if (!user) return;
-    const hasExistingHome = loadedHomeUserId === user.uid;
+    const hasExistingHome = loadedHomeDetailsUserId === user.uid;
     clearError();
     setHomeLoadError(null);
     setSocialStatus(null);
@@ -159,7 +159,6 @@ export function Home({ auth }: { auth: AuthState }) {
       async () => {
         const summary = await loadParentHomeSummaryBootstrap(user, { force });
         setHome(summary.home);
-        setLoadedHomeUserId(user.uid);
         setHomeLoadError(null);
 
         void runSecondaryLoad(
@@ -167,12 +166,21 @@ export function Home({ auth }: { auth: AuthState }) {
             const secondaryHome = await loadParentHomeWithSecondaryData(user, { force, schedule: summary.schedule });
             setHome(secondaryHome);
             setSocial(await loadSocialHome(user, secondaryHome));
+            setLoadedHomeDetailsUserId(user.uid);
+            setHomeLoadError(null);
           },
           {
             rethrow: false,
             getErrorMessage: (secondaryError) => getHomeSecondaryErrorMessage(toAppServiceError(secondaryError, 'Unable to refresh Home details.')),
             onError: (secondaryError) => {
-              setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(toAppServiceError(secondaryError, 'Unable to refresh Home details.')) });
+              const appError = toAppServiceError(secondaryError, 'Unable to refresh Home details.');
+              if (!hasExistingHome) {
+                setHomeLoadError(appError);
+                setLoadedHomeDetailsUserId(null);
+                setSocial(emptySocialHome());
+                return;
+              }
+              setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(appError) });
             }
           }
         );
@@ -187,7 +195,7 @@ export function Home({ auth }: { auth: AuthState }) {
           if (!hasExistingHome) {
             setHome(emptyHome());
             setSocial(emptySocialHome());
-            setLoadedHomeUserId(null);
+            setLoadedHomeDetailsUserId(null);
           }
         }
       }
@@ -232,7 +240,7 @@ export function Home({ auth }: { auth: AuthState }) {
   }, [searchParams]);
 
   const topAction = home.actionItems[0] || null;
-  const showBlockingErrorState = !loading && !hasLoadedHome && Boolean(error);
+  const showBlockingErrorState = !loading && !hasLoadedHomeDetails && Boolean(homeLoadError);
   const displayName = auth.user?.displayName || auth.user?.email || 'ALL PLAYS User';
   const openCount = home.metrics.rsvpNeeded + home.metrics.packetsReady + home.metrics.unreadMessages + home.fees.length + social.metrics.incomingRequests;
   const today = new Date();

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -138,6 +138,16 @@ describe('Teams empty state', () => {
     expect(await screen.findByText('Browse public teams route')).toBeTruthy();
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
   });
+
+  it('shows retryable Teams error UI when the initial summary load fails', async () => {
+    homeServiceMocks.loadParentTeamsSummary.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    renderTeams();
+
+    expect(await screen.findByText('Teams could not connect')).toBeTruthy();
+    expect(screen.getByText('Check your connection and try loading teams again.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry loading teams' })).toBeTruthy();
+  });
 });
 
 describe('Teams single-team auto-navigate', () => {

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Teams } from './Teams';
@@ -84,8 +85,8 @@ const emptyHome = {
   }
 };
 
-function renderTeams() {
-  return render(
+function renderTeams({ strictMode = false }: { strictMode?: boolean } = {}) {
+  const tree = (
     <MemoryRouter initialEntries={["/teams"]}>
       <Routes>
         <Route path="/teams" element={<Teams auth={auth} />} />
@@ -94,6 +95,8 @@ function renderTeams() {
       </Routes>
     </MemoryRouter>
   );
+
+  return render(strictMode ? <StrictMode>{tree}</StrictMode> : tree);
 }
 
 function TeamHubRoute() {
@@ -110,6 +113,16 @@ function renderTeamsWithNav() {
       </Routes>
     </MemoryRouter>
   );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe('Teams empty state', () => {
@@ -148,6 +161,29 @@ describe('Teams empty state', () => {
     expect(screen.getByText('Try loading teams again to restore your team dashboard.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Retry loading teams' })).toBeTruthy();
     expect(screen.queryByText('No teams available')).toBeNull();
+    expect(screen.queryByText('Loading teams')).toBeNull();
+  });
+
+  it('keeps the loading state bound to the latest initial request under StrictMode before showing the retryable error UI', async () => {
+    const firstLoad = deferred<typeof emptyHome>();
+    const secondLoad = deferred<typeof emptyHome>();
+    homeServiceMocks.loadParentTeamsSummary
+      .mockImplementationOnce(() => firstLoad.promise)
+      .mockImplementationOnce(() => secondLoad.promise);
+
+    renderTeams({ strictMode: true });
+
+    expect(await screen.findByText('Loading teams')).toBeTruthy();
+
+    firstLoad.reject(new Error('First request failed'));
+    await waitFor(() => {
+      expect(screen.getByText('Loading teams')).toBeTruthy();
+    });
+
+    secondLoad.reject(new Error('Second request failed'));
+
+    expect(await screen.findByText('Teams could not load')).toBeTruthy();
+    expect(screen.getByText('Try loading teams again to restore your team dashboard.')).toBeTruthy();
     expect(screen.queryByText('Loading teams')).toBeNull();
   });
 });

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -139,14 +139,15 @@ describe('Teams empty state', () => {
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
   });
 
-  it('shows the load error while keeping the empty-state recovery actions available', async () => {
+  it('shows retryable blocking error UI instead of the empty state when the first team load fails', async () => {
     homeServiceMocks.loadParentTeamsSummary.mockRejectedValueOnce(new Error('Team service down'));
 
     renderTeams();
 
-    expect(await screen.findByText('Team service down')).toBeTruthy();
-    expect(screen.getByText('No teams available')).toBeTruthy();
-    expect(screen.getByRole('link', { name: 'Accept invite' })).toBeTruthy();
+    expect(await screen.findByText('Teams could not load')).toBeTruthy();
+    expect(screen.getByText('Try loading teams again to restore your team dashboard.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry loading teams' })).toBeTruthy();
+    expect(screen.queryByText('No teams available')).toBeNull();
     expect(screen.queryByText('Loading teams')).toBeNull();
   });
 });

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -139,14 +139,15 @@ describe('Teams empty state', () => {
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
   });
 
-  it('shows retryable Teams error UI when the initial summary load fails', async () => {
-    homeServiceMocks.loadParentTeamsSummary.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+  it('shows the load error while keeping the empty-state recovery actions available', async () => {
+    homeServiceMocks.loadParentTeamsSummary.mockRejectedValueOnce(new Error('Team service down'));
 
     renderTeams();
 
-    expect(await screen.findByText('Teams could not connect')).toBeTruthy();
-    expect(screen.getByText('Check your connection and try loading teams again.')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Retry loading teams' })).toBeTruthy();
+    expect(await screen.findByText('Team service down')).toBeTruthy();
+    expect(screen.getByText('No teams available')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Accept invite' })).toBeTruthy();
+    expect(screen.queryByText('Loading teams')).toBeNull();
   });
 });
 

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -164,6 +164,39 @@ describe('Teams empty state', () => {
     expect(screen.queryByText('Loading teams')).toBeNull();
   });
 
+  it('keeps the fast team launcher visible when enrichment fails after the initial team summary loads', async () => {
+    const fastTeamHome = {
+      players: [],
+      teams: [{
+        teamId: 'team-fast',
+        teamName: 'Fast Falcons',
+        role: 'Parent' as const,
+        sport: 'Basketball',
+        photoUrl: null,
+        players: [{ teamId: 'team-fast', teamName: 'Fast Falcons', playerId: 'player-1', playerName: 'Avery Ace' }],
+        nextEvent: null,
+        eventCount: 2,
+        unreadCount: 1,
+        openActions: 0
+      }],
+      upcomingEvents: [],
+      actionItems: [],
+      fees: [],
+      metrics: { players: 1, teams: 1, rsvpNeeded: 0, unreadMessages: 1, packetsReady: 0 }
+    };
+    homeServiceMocks.loadParentTeamsSummary.mockResolvedValueOnce(fastTeamHome);
+    homeServiceMocks.loadParentHomeSummary.mockRejectedValueOnce(new Error('Enrichment outage'));
+
+    renderTeams();
+
+    expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeInTheDocument();
+    expect(screen.getByText('Choose a team')).toBeInTheDocument();
+    expect(screen.getByText('Unable to refresh teams. Showing the last loaded teams. Try again.')).toBeInTheDocument();
+    expect(screen.getByText('Fast Falcons')).toBeInTheDocument();
+    expect(screen.queryByText('Teams could not load')).toBeNull();
+    expect(screen.queryByText('No teams available')).toBeNull();
+  });
+
   it('keeps the loading state bound to the latest initial request under StrictMode before showing the retryable error UI', async () => {
     const firstLoad = deferred<typeof emptyHome>();
     const secondLoad = deferred<typeof emptyHome>();

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -159,7 +159,7 @@ describe('Teams empty state', () => {
 
     expect(await screen.findByText('Teams could not load')).toBeTruthy();
     expect(screen.getByText('Try loading teams again to restore your team dashboard.')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Retry loading teams' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry team load' })).toBeTruthy();
     expect(screen.queryByText('No teams available')).toBeNull();
     expect(screen.queryByText('Loading teams')).toBeNull();
   });

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -64,7 +64,6 @@ export function Teams({ auth }: { auth: AuthState }) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
-  const [loadError, setLoadError] = useState<AppServiceError | null>(null);
   const [loadedTeamUserId, setLoadedTeamUserId] = useState<string | null>(null);
   const selectedTeamId = searchParams.get('selectedTeamId') || '';
 
@@ -78,7 +77,6 @@ export function Teams({ auth }: { auth: AuthState }) {
       setRefreshing(true);
     }
     setError('');
-    setLoadError(null);
     try {
       const fastHome = await loadParentTeamsSummary(user, { force: !showLoading });
       setHome(fastHome);
@@ -91,7 +89,6 @@ export function Teams({ auth }: { auth: AuthState }) {
       } catch (enrichError) {
         const appError = toAppServiceError(enrichError, 'Unable to load teams.');
         if (!hasExistingTeams) {
-          setLoadError(appError);
           setHome(emptyHome());
           setLoadedTeamUserId(null);
         } else {
@@ -100,7 +97,6 @@ export function Teams({ auth }: { auth: AuthState }) {
       }
     } catch (loadError: any) {
       const appError = toAppServiceError(loadError, 'Unable to load teams.');
-      setLoadError(appError);
       setError(getTeamsLoadErrorMessage(appError, hasExistingTeams));
       if (!hasExistingTeams) {
         setHome(emptyHome());
@@ -149,11 +145,9 @@ export function Teams({ auth }: { auth: AuthState }) {
         onRefresh={() => loadTeams()}
       />
 
-      {error && !(loadError && !loading && !home.teams.length) ? <Status tone="error" message={error} /> : null}
+      {error ? <Status tone="error" message={error} /> : null}
 
-      {!loading && !home.teams.length && loadError ? (
-        <TeamsLoadErrorState error={loadError} onRetry={() => loadTeams({ showLoading: true })} retrying={refreshing} />
-      ) : loading ? (
+      {loading ? (
         <section className="app-card p-6 text-center">
           <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
           <div className="mt-3 text-sm font-black text-gray-900">Loading teams</div>

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -640,7 +640,7 @@ function TeamsLoadErrorState({ error, onRetry, retrying }: { error: AppServiceEr
       <Shield className="mx-auto h-8 w-8 text-rose-400" aria-hidden="true" />
       <div className="mt-3 text-sm font-black text-gray-900">{copy.title}</div>
       <div className="mt-1 text-xs font-semibold text-gray-500">{copy.detail}</div>
-      <button type="button" className="primary-button mx-auto mt-4 !min-h-10 !px-4 text-sm" onClick={onRetry} disabled={retrying} aria-label="Retry loading teams">
+      <button type="button" className="primary-button mx-auto mt-4 !min-h-10 !px-4 text-sm" onClick={onRetry} disabled={retrying} aria-label="Retry team load">
         <RefreshCw className={`h-4 w-4 ${retrying ? 'animate-spin' : ''}`} aria-hidden="true" />
         Retry
       </button>

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -25,6 +25,7 @@ import {
   WalletCards
 } from 'lucide-react';
 import { RoleBadge } from '../components/Badges';
+import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { getEventDetailPath, getPlayerDetailPath, type ParentHomeModel, type ParentHomeTeam } from '../lib/homeLogic';
 import { loadParentHomeSummary, loadParentTeamsSummary } from '../lib/homeService';
 import { openPublicUrl } from '../lib/publicActions';
@@ -63,30 +64,48 @@ export function Teams({ auth }: { auth: AuthState }) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
+  const [loadError, setLoadError] = useState<AppServiceError | null>(null);
+  const [loadedTeamUserId, setLoadedTeamUserId] = useState<string | null>(null);
   const selectedTeamId = searchParams.get('selectedTeamId') || '';
 
   const loadTeams = async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
-    if (!auth.user) return;
+    const user = auth.user;
+    if (!user) return;
+    const hasExistingTeams = loadedTeamUserId === user.uid;
     if (showLoading) {
       setLoading(true);
     } else {
       setRefreshing(true);
     }
     setError('');
+    setLoadError(null);
     try {
-      const fastHome = await loadParentTeamsSummary(auth.user, { force: !showLoading });
+      const fastHome = await loadParentTeamsSummary(user, { force: !showLoading });
       setHome(fastHome);
       setLoading(false);
       setRefreshing(true);
       try {
-        const enrichedHome = await loadParentHomeSummary(auth.user, { force: !showLoading });
+        const enrichedHome = await loadParentHomeSummary(user, { force: !showLoading });
         setHome((current) => mergeTeamSummary(current, enrichedHome));
+        setLoadedTeamUserId(user.uid);
       } catch (enrichError) {
-        console.warn('[teams-page] Unable to enrich team summary:', enrichError);
+        const appError = toAppServiceError(enrichError, 'Unable to load teams.');
+        if (!hasExistingTeams) {
+          setLoadError(appError);
+          setHome(emptyHome());
+          setLoadedTeamUserId(null);
+        } else {
+          setError(getTeamsLoadErrorMessage(appError, true));
+        }
       }
     } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load teams.');
-      setHome(emptyHome());
+      const appError = toAppServiceError(loadError, 'Unable to load teams.');
+      setLoadError(appError);
+      setError(getTeamsLoadErrorMessage(appError, hasExistingTeams));
+      if (!hasExistingTeams) {
+        setHome(emptyHome());
+        setLoadedTeamUserId(null);
+      }
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -130,9 +149,11 @@ export function Teams({ auth }: { auth: AuthState }) {
         onRefresh={() => loadTeams()}
       />
 
-      {error ? <Status tone="error" message={error} /> : null}
+      {error && !(loadError && !loading && !home.teams.length) ? <Status tone="error" message={error} /> : null}
 
-      {loading ? (
+      {!loading && !home.teams.length && loadError ? (
+        <TeamsLoadErrorState error={loadError} onRetry={() => loadTeams({ showLoading: true })} retrying={refreshing} />
+      ) : loading ? (
         <section className="app-card p-6 text-center">
           <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
           <div className="mt-3 text-sm font-black text-gray-900">Loading teams</div>
@@ -595,6 +616,21 @@ function EmptyTeams() {
   );
 }
 
+function TeamsLoadErrorState({ error, onRetry, retrying }: { error: AppServiceError; onRetry: () => void; retrying: boolean }) {
+  const copy = getTeamsLoadErrorStateCopy(error);
+  return (
+    <section className="app-card p-5 text-center">
+      <Shield className="mx-auto h-8 w-8 text-rose-400" aria-hidden="true" />
+      <div className="mt-3 text-sm font-black text-gray-900">{copy.title}</div>
+      <div className="mt-1 text-xs font-semibold text-gray-500">{copy.detail}</div>
+      <button type="button" className="primary-button mx-auto mt-4 !min-h-10 !px-4 text-sm" onClick={onRetry} disabled={retrying} aria-label="Retry loading teams">
+        <RefreshCw className={`h-4 w-4 ${retrying ? 'animate-spin' : ''}`} aria-hidden="true" />
+        Retry
+      </button>
+    </section>
+  );
+}
+
 export function Status({ tone, message }: { tone: 'error' | 'success'; message: string }) {
   const isError = tone === 'error';
   return (
@@ -675,6 +711,52 @@ function getTeamHeaderMetrics(teams: ParentHomeTeam[]) {
     metrics.unread += Number(team.unreadCount || 0);
     return metrics;
   }, { teams: 0, players: 0, unread: 0 });
+}
+
+function getTeamsLoadErrorMessage(error: AppServiceError, hasExistingTeams: boolean) {
+  if (hasExistingTeams) {
+    if (error.type === 'network') return 'Unable to refresh teams while offline. Showing the last loaded teams.';
+    if (error.type === 'permission') return 'Unable to refresh teams because access was denied. Showing the last loaded teams.';
+    if (error.type === 'not_found') return 'Unable to refresh teams because the requested data was not found. Showing the last loaded teams.';
+    if (error.type === 'validation') return error.message;
+    return 'Unable to refresh teams. Showing the last loaded teams. Try again.';
+  }
+  if (error.type === 'network') return 'Unable to load teams while offline. Check your connection and try again.';
+  if (error.type === 'permission') return 'You do not have permission to load these teams.';
+  if (error.type === 'not_found') return 'Team data was not found. Try again or check the linked team access.';
+  if (error.type === 'validation') return error.message;
+  return error.message || 'Unable to load teams. Try again.';
+}
+
+function getTeamsLoadErrorStateCopy(error: AppServiceError) {
+  if (error.type === 'network') {
+    return {
+      title: 'Teams could not connect',
+      detail: 'Check your connection and try loading teams again.'
+    };
+  }
+  if (error.type === 'permission') {
+    return {
+      title: 'Teams access is blocked',
+      detail: 'Your account does not have permission to load these teams.'
+    };
+  }
+  if (error.type === 'not_found') {
+    return {
+      title: 'Team data was not found',
+      detail: 'The linked team data is missing. Try again after refreshing your team access.'
+    };
+  }
+  if (error.type === 'validation') {
+    return {
+      title: 'Teams request needs attention',
+      detail: error.message
+    };
+  }
+  return {
+    title: 'Teams could not load',
+    detail: 'Try loading teams again to restore your team dashboard.'
+  };
 }
 
 function getTeamHeaderDetail(teams: ParentHomeTeam[]) {

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -64,8 +64,11 @@ export function Teams({ auth }: { auth: AuthState }) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
+  const [teamsLoadError, setTeamsLoadError] = useState<AppServiceError | null>(null);
   const [loadedTeamUserId, setLoadedTeamUserId] = useState<string | null>(null);
   const selectedTeamId = searchParams.get('selectedTeamId') || '';
+  const authUserId = auth.user?.uid || null;
+  const hasLoadedTeamDetails = Boolean(authUserId) && authUserId === loadedTeamUserId;
 
   const loadTeams = async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
     const user = auth.user;
@@ -77,20 +80,24 @@ export function Teams({ auth }: { auth: AuthState }) {
       setRefreshing(true);
     }
     setError('');
+    setTeamsLoadError(null);
     try {
       const fastHome = await loadParentTeamsSummary(user, { force: !showLoading });
       setHome(fastHome);
+      setTeamsLoadError(null);
       setLoading(false);
       setRefreshing(true);
       try {
         const enrichedHome = await loadParentHomeSummary(user, { force: !showLoading });
         setHome((current) => mergeTeamSummary(current, enrichedHome));
         setLoadedTeamUserId(user.uid);
+        setTeamsLoadError(null);
       } catch (enrichError) {
         const appError = toAppServiceError(enrichError, 'Unable to load teams.');
         if (!hasExistingTeams) {
           setHome(emptyHome());
           setLoadedTeamUserId(null);
+          setTeamsLoadError(appError);
         } else {
           setError(getTeamsLoadErrorMessage(appError, true));
         }
@@ -98,6 +105,7 @@ export function Teams({ auth }: { auth: AuthState }) {
     } catch (loadError: any) {
       const appError = toAppServiceError(loadError, 'Unable to load teams.');
       setError(getTeamsLoadErrorMessage(appError, hasExistingTeams));
+      setTeamsLoadError(appError);
       if (!hasExistingTeams) {
         setHome(emptyHome());
         setLoadedTeamUserId(null);
@@ -119,6 +127,8 @@ export function Teams({ auth }: { auth: AuthState }) {
       navigate(`/teams/${encodeURIComponent(home.teams[0].teamId)}`, { replace: true });
     }
   }, [loading, home.teams, navigate, selectedTeamId]);
+
+  const showBlockingErrorState = !loading && !hasLoadedTeamDetails && Boolean(teamsLoadError);
 
   const selectedTeam = useMemo(() => (
     home.teams.find((team) => team.teamId === selectedTeamId) || home.teams[0] || null
@@ -153,6 +163,8 @@ export function Teams({ auth }: { auth: AuthState }) {
           <div className="mt-3 text-sm font-black text-gray-900">Loading teams</div>
           <div className="mt-1 text-xs font-semibold text-gray-500">Pulling team access, linked players, schedule, and chat counts.</div>
         </section>
+      ) : showBlockingErrorState && teamsLoadError ? (
+        <TeamsLoadErrorState error={teamsLoadError} onRetry={() => loadTeams({ showLoading: true })} retrying={loading || refreshing} />
       ) : home.teams.length ? (
         isDesktopWeb ? (
           <div className="teams-web-workbench">

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -87,6 +87,7 @@ export function Teams({ auth }: { auth: AuthState }) {
     try {
       const fastHome = await loadParentTeamsSummary(user, { force: !showLoading });
       if (loadId !== activeLoadIdRef.current) return;
+      const hasFastTeams = fastHome.teams.length > 0;
       setHome(fastHome);
       setTeamsLoadError(null);
       setLoading(false);
@@ -100,7 +101,7 @@ export function Teams({ auth }: { auth: AuthState }) {
       } catch (enrichError) {
         if (loadId !== activeLoadIdRef.current) return;
         const appError = toAppServiceError(enrichError, 'Unable to load teams.');
-        if (!hasExistingTeams) {
+        if (!hasExistingTeams && !hasFastTeams) {
           setHome(emptyHome());
           setLoadedTeamUserId(null);
           setTeamsLoadError(appError);

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   BarChart3,
@@ -66,6 +66,7 @@ export function Teams({ auth }: { auth: AuthState }) {
   const [error, setError] = useState('');
   const [teamsLoadError, setTeamsLoadError] = useState<AppServiceError | null>(null);
   const [loadedTeamUserId, setLoadedTeamUserId] = useState<string | null>(null);
+  const activeLoadIdRef = useRef(0);
   const selectedTeamId = searchParams.get('selectedTeamId') || '';
   const authUserId = auth.user?.uid || null;
   const hasLoadedTeamDetails = Boolean(authUserId) && authUserId === loadedTeamUserId;
@@ -73,6 +74,8 @@ export function Teams({ auth }: { auth: AuthState }) {
   const loadTeams = async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
     const user = auth.user;
     if (!user) return;
+    const loadId = activeLoadIdRef.current + 1;
+    activeLoadIdRef.current = loadId;
     const hasExistingTeams = loadedTeamUserId === user.uid;
     if (showLoading) {
       setLoading(true);
@@ -83,16 +86,19 @@ export function Teams({ auth }: { auth: AuthState }) {
     setTeamsLoadError(null);
     try {
       const fastHome = await loadParentTeamsSummary(user, { force: !showLoading });
+      if (loadId !== activeLoadIdRef.current) return;
       setHome(fastHome);
       setTeamsLoadError(null);
       setLoading(false);
       setRefreshing(true);
       try {
         const enrichedHome = await loadParentHomeSummary(user, { force: !showLoading });
+        if (loadId !== activeLoadIdRef.current) return;
         setHome((current) => mergeTeamSummary(current, enrichedHome));
         setLoadedTeamUserId(user.uid);
         setTeamsLoadError(null);
       } catch (enrichError) {
+        if (loadId !== activeLoadIdRef.current) return;
         const appError = toAppServiceError(enrichError, 'Unable to load teams.');
         if (!hasExistingTeams) {
           setHome(emptyHome());
@@ -103,6 +109,7 @@ export function Teams({ auth }: { auth: AuthState }) {
         }
       }
     } catch (loadError: any) {
+      if (loadId !== activeLoadIdRef.current) return;
       const appError = toAppServiceError(loadError, 'Unable to load teams.');
       setError(getTeamsLoadErrorMessage(appError, hasExistingTeams));
       setTeamsLoadError(appError);
@@ -111,6 +118,7 @@ export function Teams({ auth }: { auth: AuthState }) {
         setLoadedTeamUserId(null);
       }
     } finally {
+      if (loadId !== activeLoadIdRef.current) return;
       setLoading(false);
       setRefreshing(false);
     }
@@ -118,6 +126,9 @@ export function Teams({ auth }: { auth: AuthState }) {
 
   useEffect(() => {
     loadTeams({ showLoading: true });
+    return () => {
+      activeLoadIdRef.current += 1;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid]);
 

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -18,9 +18,10 @@ async function waitForHomeRoute(page, readyLocator) {
 }
 
 async function waitForTeamsRoute(page, readyLocator) {
+    const teamsLoadingState = page.getByText(/^Loading teams$/);
     await expect(async () => {
         await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 5000 });
-        await expect(page.getByText('Loading teams')).toHaveCount(0, { timeout: 5000 });
+        await expect(teamsLoadingState).toHaveCount(0, { timeout: 5000 });
         await expect(readyLocator).toBeVisible({ timeout: 5000 });
     }).toPass({ timeout: 45000 });
 }

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -534,6 +534,7 @@ test('messages defer offscreen media requests until scroll or video interaction'
 
     await thread.evaluate((element) => {
         element.scrollTop = 0;
+        element.dispatchEvent(new Event('scroll', { bubbles: true }));
     });
     await expect(page.getByAltText('Deferred lineup 1')).toBeVisible();
     await expect.poll(() => mediaRequests.filter((path) => path.endsWith('.jpg')).sort()).toEqual([

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -490,7 +490,7 @@ test.describe('mobile My Teams', () => {
         await waitForTeamsRoute(page, page.getByText('Teams could not load'), { requireSearchInput: false });
         await expect(page.getByText('Teams could not load')).toBeVisible();
         await expect(page.getByText('Try loading teams again to restore your team dashboard.')).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Retry loading teams' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Retry team load' })).toBeVisible();
         await expect(page.getByText('Loading teams')).toHaveCount(0);
         await expect(page.getByText('No teams available')).toHaveCount(0);
     });

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -487,10 +487,12 @@ test.describe('mobile My Teams', () => {
         await mockTeamsModules(page, { scenario: 'error' });
         await page.goto(appUrl(baseURL, '/teams?scenario=error'), { waitUntil: 'domcontentloaded' });
 
-        await waitForTeamsRoute(page, page.getByText('Team service down'), { requireSearchInput: false });
-        await expect(page.getByText('Team service down')).toBeVisible();
-        await expect(page.getByText('No teams available')).toBeVisible();
+        await waitForTeamsRoute(page, page.getByText('Teams could not load'), { requireSearchInput: false });
+        await expect(page.getByText('Teams could not load')).toBeVisible();
+        await expect(page.getByText('Try loading teams again to restore your team dashboard.')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Retry loading teams' })).toBeVisible();
         await expect(page.getByText('Loading teams')).toHaveCount(0);
+        await expect(page.getByText('No teams available')).toHaveCount(0);
     });
 
     test('team detail tabs expose parent-facing team page features', async ({ page, baseURL }) => {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -10,9 +10,10 @@ function appUrl(baseURL, hashPath) {
 
 async function waitForTeamsRoute(page, readyLocator, { requireSearchInput = true } = {}) {
     const searchInput = page.getByPlaceholder('Search teams or players');
+    const teamsLoadingState = page.getByText(/^Loading teams$/);
     await expect(async () => {
         await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
-        await expect(page.getByText('Loading teams')).toHaveCount(0, { timeout: 3000 });
+        await expect(teamsLoadingState).toHaveCount(0, { timeout: 3000 });
         if (requireSearchInput) {
             await expect(searchInput).toBeVisible({ timeout: 3000 });
         }
@@ -480,7 +481,7 @@ test.describe('mobile My Teams', () => {
         await emptyState.getByRole('link', { name: 'Browse teams' }).click();
         await expect(page).toHaveURL(/#\/teams\/browse$/);
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls)).toEqual([]);
-        await expect(page.getByText('Loading teams')).toHaveCount(0);
+        await expect(page.getByText(/^Loading teams$/)).toHaveCount(0);
     });
 
     test('shows load failures without trapping the user in loading state', async ({ page, baseURL }) => {
@@ -491,7 +492,7 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Teams could not load')).toBeVisible();
         await expect(page.getByText('Try loading teams again to restore your team dashboard.')).toBeVisible();
         await expect(page.getByRole('button', { name: 'Retry team load' })).toBeVisible();
-        await expect(page.getByText('Loading teams')).toHaveCount(0);
+        await expect(page.getByText(/^Loading teams$/)).toHaveCount(0);
         await expect(page.getByText('No teams available')).toHaveCount(0);
     });
 

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -194,26 +194,17 @@ describe('React app Home service', () => {
         });
     });
 
-    it('keeps the Teams summary usable when chat fails', async () => {
+    it('throws a typed network error when the Teams summary chat load fails', async () => {
         chatMocks.loadChatInbox.mockRejectedValueOnce(new TypeError('Failed to fetch'));
         const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');
 
-        const home = await loadParentTeamsSummary(user, { force: true });
+        await expect(loadParentTeamsSummary(user, { force: true })).rejects.toMatchObject({
+            name: 'AppServiceError',
+            type: 'network',
+            message: 'Failed to fetch'
+        });
 
         expect(chatMocks.loadChatInbox).toHaveBeenCalledWith(user, { includeLastMessages: false });
-        expect(home.teams).toEqual([
-            expect.objectContaining({
-                teamId: 'team-1',
-                teamName: 'Bears',
-                unreadCount: 0,
-                players: [expect.objectContaining({ playerId: 'player-1' })]
-            })
-        ]);
-        expect(home.metrics).toEqual(expect.objectContaining({
-            teams: 1,
-            players: 1,
-            unreadMessages: 0
-        }));
     });
 
     it('composes the fast Home summary without optional secondary data', async () => {

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -375,14 +375,16 @@ describe('React app Teams page', () => {
         expect(hrefs).toContain('/players/team-multi/player-2');
     });
 
-    it('shows clear empty and error states instead of a spinner', async () => {
+    it('shows clear retryable error UI instead of a spinner when the initial load fails', async () => {
         homeMocks.loadParentTeamsSummary.mockRejectedValueOnce(new Error('Team service down'));
 
         const { container } = await renderTeams('/teams');
 
-        await waitForText(container, 'Team service down');
-        expect(container.textContent).toContain('No teams available');
+        await waitForText(container, 'Teams could not load');
+        expect(container.textContent).toContain('Try loading teams again to restore your team dashboard.');
+        expect(buttonByText(container, 'Retry')).toBeTruthy();
         expect(container.textContent).not.toContain('Loading teams');
+        expect(container.textContent).not.toContain('No teams available');
     });
 
     it('handles signed-in accounts that do not have team access yet', async () => {


### PR DESCRIPTION
Closes #2315

## What changed
- removed the silent `loadChatInbox(...).catch(() => ({ teams: [] }))` fallback from the parent teams summary service and now map chat failures through the shared app error contract
- upgraded the Teams page to render retryable, typed load-error UI for initial network, permission, and not-found failures while still preserving last-loaded data on refresh failures
- tightened the Home page so an initial secondary data failure now blocks with the same retryable error treatment instead of degrading into a partial dashboard plus status banner
- added focused regression tests for failing Home and Teams load paths

## Root Cause
The parent dashboard had two inconsistent failure paths. Teams summary converted chat fetch failures into empty data, which made real request failures look like a valid empty state. Home's initial secondary load treated detail fetch failures as a non-blocking status banner, so the page could render an incomplete dashboard without a consistent retryable error state.

## Prevention / Learning
When a dashboard summary depends on async child loads, never translate request failures into empty collections unless the contract explicitly defines that fallback as valid data. Route both initial and refresh failures through the shared app error mapper, then decide explicitly whether the UI should block with retry or preserve previously loaded state.

## Regression Tests
- `npm test -- --run src/pages/Home.test.tsx src/pages/Teams.test.tsx`
- `npm run build`