### PR TITLE
Adopt useAsyncOperation for team settings and certificates

### DIFF
--- a/apps/app/src/pages/TeamCertificates.test.tsx
+++ b/apps/app/src/pages/TeamCertificates.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TeamCertificates } from './TeamCertificates';
+import type { AuthState } from '../lib/types';
+
+const certificateDraftServiceMocks = vi.hoisted(() => ({
+  loadCertificateDraftComposer: vi.fn(),
+  saveCertificateDraftsForApp: vi.fn()
+}));
+
+const publicActionMocks = vi.hoisted(() => ({
+  openPublicUrl: vi.fn()
+}));
+
+vi.mock('../lib/certificateDraftService', () => certificateDraftServiceMocks);
+vi.mock('../lib/publicActions', () => publicActionMocks);
+vi.mock('../../../../js/certificates/renderer.js', () => ({
+  renderCertificate: vi.fn(() => {
+    const node = document.createElement('div');
+    node.textContent = 'Certificate preview';
+    return node;
+  })
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'coach-1',
+    email: 'coach@example.com',
+    displayName: 'Coach'
+  } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['coach'],
+  isParent: false,
+  isCoach: true,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+const composerModel = {
+  team: {
+    id: 'team-1',
+    name: 'Bears',
+    photoUrl: 'https://img.example.test/team.png',
+    colors: { primary: '#0055aa' }
+  },
+  players: [
+    {
+      id: 'player-1',
+      name: 'Pat Player',
+      number: '12',
+      photoUrl: null,
+      active: true
+    }
+  ],
+  templates: [
+    { id: 'banner', label: 'Banner' }
+  ],
+  shared: {
+    templateId: 'banner',
+    teamNameOverride: 'Bears',
+    awardTitle: 'Most Improved Player',
+    seasonLabel: 'Spring 2026',
+    footerUrl: 'www.allplays.ai',
+    colorMode: 'team',
+    customColors: {
+      borderColor: '#111111',
+      accentColor: '#222222',
+      textColor: '#333333'
+    },
+    fonts: {},
+    signers: [],
+    foregroundImageRef: null,
+    backgroundImageRef: null,
+    backgroundOpacity: 18,
+    watermarkImageRef: null,
+    watermarkOpacity: 12,
+    statsWindow: 10
+  }
+};
+
+describe('TeamCertificates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    certificateDraftServiceMocks.loadCertificateDraftComposer.mockResolvedValue(composerModel);
+    certificateDraftServiceMocks.saveCertificateDraftsForApp.mockResolvedValue({
+      batchId: 'batch-1',
+      certificateIds: ['cert-1'],
+      webUrl: 'https://allplays.ai/certificates.html#teamId=team-1&batchId=batch-1'
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a retry path when the initial certificate load fails', async () => {
+    certificateDraftServiceMocks.loadCertificateDraftComposer
+      .mockRejectedValueOnce(new Error('Unable to load certificate drafting.'))
+      .mockResolvedValueOnce(composerModel);
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1/certificates']}>
+        <Routes>
+          <Route path="/teams/:teamId/certificates" element={<TeamCertificates auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Certificate drafting unavailable')).toBeTruthy();
+    expect(screen.getByText('Unable to load certificate drafting.')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('heading', { name: 'Awards drafts' })).toBeTruthy();
+    await waitFor(() => {
+      expect(certificateDraftServiceMocks.loadCertificateDraftComposer).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/app/src/pages/TeamCertificates.test.tsx
+++ b/apps/app/src/pages/TeamCertificates.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TeamCertificates } from './TeamCertificates';
 import type { AuthState } from '../lib/types';
@@ -41,6 +41,16 @@ const auth: AuthState = {
   refresh: vi.fn(),
   signOut: vi.fn()
 };
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 const composerModel = {
   team: {
@@ -140,5 +150,65 @@ describe('TeamCertificates', () => {
 
     expect(await screen.findByText('Unable to create certificate drafts.')).toBeTruthy();
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it('ignores stale certificate loads after navigating to a different team', async () => {
+    const teamOneLoad = createDeferred<typeof composerModel>();
+    const teamTwoLoad = createDeferred<typeof composerModel>();
+
+    certificateDraftServiceMocks.loadCertificateDraftComposer.mockImplementation((requestedTeamId: string) => {
+      if (requestedTeamId === 'team-1') return teamOneLoad.promise;
+      if (requestedTeamId === 'team-2') return teamTwoLoad.promise;
+      throw new Error(`Unexpected team id: ${requestedTeamId}`);
+    });
+
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/teams/:teamId/certificates',
+          element: <TeamCertificates auth={auth} />
+        }
+      ],
+      { initialEntries: ['/teams/team-1/certificates'] }
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await act(async () => {
+      await router.navigate('/teams/team-2/certificates');
+    });
+
+    teamTwoLoad.resolve({
+      ...composerModel,
+      team: {
+        ...composerModel.team,
+        id: 'team-2',
+        name: 'Wolves'
+      },
+      players: [
+        {
+          id: 'player-2',
+          name: 'Wade Wolf',
+          number: '7',
+          photoUrl: null,
+          active: true
+        }
+      ],
+      shared: {
+        ...composerModel.shared,
+        awardTitle: 'Team Two Award'
+      }
+    });
+
+    expect(await screen.findByDisplayValue('Team Two Award')).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Wade Wolf' })).toBeTruthy();
+
+    teamOneLoad.resolve(composerModel);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Team Two Award')).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Wade Wolf' })).toBeTruthy();
+      expect(screen.queryByRole('option', { name: 'Pat Player' })).toBeNull();
+    });
   });
 });

--- a/apps/app/src/pages/TeamCertificates.test.tsx
+++ b/apps/app/src/pages/TeamCertificates.test.tsx
@@ -122,4 +122,23 @@ describe('TeamCertificates', () => {
       expect(certificateDraftServiceMocks.loadCertificateDraftComposer).toHaveBeenCalledTimes(2);
     });
   });
+
+  it('shows a save error when draft creation fails', async () => {
+    certificateDraftServiceMocks.saveCertificateDraftsForApp.mockRejectedValueOnce(new Error('Unable to create certificate drafts.'));
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1/certificates']}>
+        <Routes>
+          <Route path="/teams/:teamId/certificates" element={<TeamCertificates auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Awards drafts' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create drafts' }));
+
+    expect(await screen.findByText('Unable to create certificate drafts.')).toBeTruthy();
+    expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
+  });
 });

--- a/apps/app/src/pages/TeamCertificates.tsx
+++ b/apps/app/src/pages/TeamCertificates.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Navigate, useParams } from 'react-router-dom';
-import { Award, ExternalLink, Loader2, Sparkles } from 'lucide-react';
+import { Award, ExternalLink, Loader2, RefreshCw, Sparkles } from 'lucide-react';
 import { renderCertificate } from '../../../../js/certificates/renderer.js';
 import { loadCertificateDraftComposer, saveCertificateDraftsForApp, type CertificateDraftComposerModel, type CertificateDraftPlayer, type CertificateDraftSharedState } from '../lib/certificateDraftService';
 import { openPublicUrl } from '../lib/publicActions';
+import { useAsyncOperation } from '../lib/useAsyncOperation';
 import type { AuthState } from '../lib/types';
 
 export function TeamCertificates({ auth }: { auth: AuthState }) {
@@ -12,45 +13,45 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
   const [shared, setShared] = useState<CertificateDraftSharedState | null>(null);
   const [selectedPlayerIds, setSelectedPlayerIds] = useState<string[]>([]);
   const [previewPlayerId, setPreviewPlayerId] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [hasResolvedInitialLoad, setHasResolvedInitialLoad] = useState(false);
+  const { loading, error, run: runPrimaryLoad } = useAsyncOperation();
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const previewRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const loadComposer = useCallback(async () => {
+    if (!teamId) return null;
 
-    async function load() {
-      if (!teamId) return;
-      setLoading(true);
-      setError('');
-      setSuccess('');
-      try {
-        const nextModel = await loadCertificateDraftComposer(teamId, auth.user);
-        if (cancelled) return;
-        setModel(nextModel);
-        setShared(nextModel.shared);
-        setSelectedPlayerIds(nextModel.players.map((player) => player.id));
-        setPreviewPlayerId(nextModel.players[0]?.id || '');
-      } catch (loadError: any) {
-        if (!cancelled) {
+    setSuccess('');
+
+    return runPrimaryLoad(
+      () => loadCertificateDraftComposer(teamId, auth.user),
+      {
+        errorMessage: 'Unable to load certificate drafting.',
+        rethrow: false,
+        onSuccess: (nextModel) => {
+          setModel(nextModel);
+          setShared(nextModel.shared);
+          setSelectedPlayerIds(nextModel.players.map((player) => player.id));
+          setPreviewPlayerId(nextModel.players[0]?.id || '');
+        },
+        onError: () => {
           setModel(null);
           setShared(null);
           setSelectedPlayerIds([]);
           setPreviewPlayerId('');
-          setError(loadError?.message || 'Unable to load certificate drafting.');
+        },
+        onFinally: () => {
+          setHasResolvedInitialLoad(true);
         }
-      } finally {
-        if (!cancelled) setLoading(false);
       }
-    }
+    );
+  }, [auth.user, runPrimaryLoad, teamId]);
 
-    void load();
-    return () => {
-      cancelled = true;
-    };
-  }, [auth.user, teamId]);
+  useEffect(() => {
+    setHasResolvedInitialLoad(false);
+    void loadComposer();
+  }, [loadComposer]);
 
   const selectedPlayers = useMemo(() => {
     if (!model) return [];
@@ -128,7 +129,7 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
     }
   };
 
-  if (loading) {
+  if (loading || !hasResolvedInitialLoad) {
     return (
       <div className="app-card flex min-h-[240px] items-center justify-center gap-3 p-5 text-sm font-semibold text-gray-600">
         <Loader2 className="h-5 w-5 animate-spin text-primary-600" aria-hidden="true" />
@@ -144,6 +145,10 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
         <div className="app-card p-5">
           <div className="text-base font-black text-gray-950">Certificate drafting unavailable</div>
           <div className="mt-2 text-sm font-semibold text-rose-700">{error}</div>
+          <button type="button" className="primary-button mt-4" onClick={() => void loadComposer()} disabled={loading}>
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+            Retry
+          </button>
         </div>
       </div>
     );

--- a/apps/app/src/pages/TeamCertificates.tsx
+++ b/apps/app/src/pages/TeamCertificates.tsx
@@ -14,7 +14,7 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
   const [selectedPlayerIds, setSelectedPlayerIds] = useState<string[]>([]);
   const [previewPlayerId, setPreviewPlayerId] = useState('');
   const [hasResolvedInitialLoad, setHasResolvedInitialLoad] = useState(false);
-  const { loading, error, run: runPrimaryLoad } = useAsyncOperation();
+  const { loading, error, setError, run: runPrimaryLoad } = useAsyncOperation();
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState('');
   const previewRef = useRef<HTMLDivElement | null>(null);

--- a/apps/app/src/pages/TeamCertificates.tsx
+++ b/apps/app/src/pages/TeamCertificates.tsx
@@ -18,10 +18,13 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState('');
   const previewRef = useRef<HTMLDivElement | null>(null);
+  const activeLoadIdRef = useRef(0);
 
   const loadComposer = useCallback(async () => {
     if (!teamId) return null;
 
+    const loadId = activeLoadIdRef.current + 1;
+    activeLoadIdRef.current = loadId;
     setSuccess('');
 
     return runPrimaryLoad(
@@ -30,18 +33,21 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
         errorMessage: 'Unable to load certificate drafting.',
         rethrow: false,
         onSuccess: (nextModel) => {
+          if (loadId !== activeLoadIdRef.current) return;
           setModel(nextModel);
           setShared(nextModel.shared);
           setSelectedPlayerIds(nextModel.players.map((player) => player.id));
           setPreviewPlayerId(nextModel.players[0]?.id || '');
         },
         onError: () => {
+          if (loadId !== activeLoadIdRef.current) return;
           setModel(null);
           setShared(null);
           setSelectedPlayerIds([]);
           setPreviewPlayerId('');
         },
         onFinally: () => {
+          if (loadId !== activeLoadIdRef.current) return;
           setHasResolvedInitialLoad(true);
         }
       }
@@ -51,6 +57,10 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
   useEffect(() => {
     setHasResolvedInitialLoad(false);
     void loadComposer();
+
+    return () => {
+      activeLoadIdRef.current += 1;
+    };
   }, [loadComposer]);
 
   const selectedPlayers = useMemo(() => {

--- a/apps/app/src/pages/TeamSettings.test.tsx
+++ b/apps/app/src/pages/TeamSettings.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TeamSettings } from './TeamSettings';
 import type { AuthState } from '../lib/types';
@@ -29,6 +29,16 @@ const auth: AuthState = {
   refresh: vi.fn(),
   signOut: vi.fn()
 };
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 const managedModel = {
   team: {
@@ -214,5 +224,52 @@ describe('TeamSettings', () => {
       isPublic: true,
       photoFile: null
     }));
+  });
+
+  it('ignores stale team settings responses after navigating to a different team', async () => {
+    const teamOneLoad = createDeferred<typeof managedModel>();
+    const teamTwoLoad = createDeferred<typeof managedModel>();
+
+    teamDetailServiceMocks.loadParentTeamDetail.mockImplementation((requestedTeamId: string) => {
+      if (requestedTeamId === 'team-1') return teamOneLoad.promise;
+      if (requestedTeamId === 'team-2') return teamTwoLoad.promise;
+      throw new Error(`Unexpected team id: ${requestedTeamId}`);
+    });
+
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/teams/:teamId/edit',
+          element: <TeamSettings auth={auth} />
+        }
+      ],
+      { initialEntries: ['/teams/team-1/edit'] }
+    );
+
+    render(<RouterProvider router={router} />);
+
+    await act(async () => {
+      await router.navigate('/teams/team-2/edit');
+    });
+
+    teamTwoLoad.resolve({
+      ...managedModel,
+      team: {
+        ...managedModel.team,
+        id: 'team-2',
+        name: 'Wolves',
+        sport: 'Soccer'
+      }
+    });
+
+    expect(await screen.findByDisplayValue('Wolves')).toBeTruthy();
+    expect(screen.getByPlaceholderText('Basketball')).toHaveValue('Soccer');
+
+    teamOneLoad.resolve(managedModel);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Team name')).toHaveValue('Wolves');
+      expect(screen.getByPlaceholderText('Basketball')).toHaveValue('Soccer');
+    });
   });
 });

--- a/apps/app/src/pages/TeamSettings.test.tsx
+++ b/apps/app/src/pages/TeamSettings.test.tsx
@@ -71,6 +71,14 @@ const managedModel = {
 describe('TeamSettings', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: vi.fn(() => 'blob:preview'),
+      writable: true
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: vi.fn(),
+      writable: true
+    });
     teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(managedModel);
     teamDetailServiceMocks.updateTeamSettingsForApp.mockResolvedValue(undefined);
   });
@@ -95,6 +103,30 @@ describe('TeamSettings', () => {
 
     expect(await screen.findByText('Only team staff can edit this team.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Save team' })).toBeNull();
+  });
+
+  it('shows a retry path when the initial team settings load fails', async () => {
+    teamDetailServiceMocks.loadParentTeamDetail
+      .mockRejectedValueOnce(new Error('Unable to load team settings.'))
+      .mockResolvedValueOnce(managedModel);
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1/edit']}>
+        <Routes>
+          <Route path="/teams/:teamId/edit" element={<TeamSettings auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Team settings unavailable')).toBeTruthy();
+    expect(screen.getByText('Unable to load team settings.')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('heading', { name: 'Edit team' })).toBeTruthy();
+    await waitFor(() => {
+      expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('validates team name inline and saves native team settings', async () => {
@@ -128,6 +160,29 @@ describe('TeamSettings', () => {
       photoFile: null
     }));
     expect(await screen.findByText('Team detail page')).toBeTruthy();
+  });
+
+  it('keeps unsaved edits and does not reload when choosing a new photo', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/teams/team-1/edit']}>
+        <Routes>
+          <Route path="/teams/:teamId/edit" element={<TeamSettings auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Edit team' })).toBeTruthy();
+    const nameInput = screen.getByPlaceholderText('Team name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'Updated Bears' } });
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['photo'], 'team.png', { type: 'image/png' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(nameInput.value).toBe('Updated Bears');
+    await waitFor(() => {
+      expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('defaults legacy teams without visibility set to public on save', async () => {

--- a/apps/app/src/pages/TeamSettings.tsx
+++ b/apps/app/src/pages/TeamSettings.tsx
@@ -10,6 +10,7 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const photoPreviewUrlRef = useRef('');
+  const activeLoadIdRef = useRef(0);
   const { loading, error, run: runPrimaryLoad } = useAsyncOperation();
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState('');
@@ -34,12 +35,16 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
   const loadSettings = useCallback(async () => {
     if (!teamId) return null;
 
+    const loadId = activeLoadIdRef.current + 1;
+    activeLoadIdRef.current = loadId;
+
     return runPrimaryLoad(
       () => loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false }),
       {
         errorMessage: 'Unable to load team settings.',
         rethrow: false,
         onSuccess: (model) => {
+          if (loadId !== activeLoadIdRef.current) return;
           setCanManageTeam(model.canManageTeam);
           setTeamName(model.team.name || 'Team');
           setForm({
@@ -52,6 +57,7 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
           setPhotoPreviewUrl(model.team.photoUrl || '');
         },
         onError: () => {
+          if (loadId !== activeLoadIdRef.current) return;
           setCanManageTeam(false);
           setTeamName('Team');
           setForm({
@@ -65,6 +71,7 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
           setPhotoPreviewUrl('');
         },
         onFinally: () => {
+          if (loadId !== activeLoadIdRef.current) return;
           setHasResolvedInitialLoad(true);
         }
       }
@@ -76,6 +83,7 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
     void loadSettings();
 
     return () => {
+      activeLoadIdRef.current += 1;
       if (photoPreviewUrlRef.current.startsWith('blob:')) {
         URL.revokeObjectURL(photoPreviewUrlRef.current);
       }

--- a/apps/app/src/pages/TeamSettings.tsx
+++ b/apps/app/src/pages/TeamSettings.tsx
@@ -1,19 +1,21 @@
-import { useEffect, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { ArrowLeft, Camera, Loader2, Save } from 'lucide-react';
+import { ArrowLeft, Camera, Loader2, RefreshCw, Save } from 'lucide-react';
 import { loadParentTeamDetail, updateTeamSettingsForApp } from '../lib/teamDetailService';
+import { useAsyncOperation } from '../lib/useAsyncOperation';
 import type { AuthState } from '../lib/types';
 
 export function TeamSettings({ auth }: { auth: AuthState }) {
   const { teamId = '' } = useParams();
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [loading, setLoading] = useState(true);
+  const photoPreviewUrlRef = useRef('');
+  const { loading, error, run: runPrimaryLoad } = useAsyncOperation();
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState('');
   const [saveError, setSaveError] = useState('');
   const [nameError, setNameError] = useState('');
   const [canManageTeam, setCanManageTeam] = useState(false);
+  const [hasResolvedInitialLoad, setHasResolvedInitialLoad] = useState(false);
   const [teamName, setTeamName] = useState('Team');
   const [form, setForm] = useState({
     name: '',
@@ -26,42 +28,59 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
   const [photoPreviewUrl, setPhotoPreviewUrl] = useState('');
 
   useEffect(() => {
-    let cancelled = false;
+    photoPreviewUrlRef.current = photoPreviewUrl;
+  }, [photoPreviewUrl]);
 
-    async function load() {
-      if (!teamId) return;
-      setLoading(true);
-      setError('');
-      try {
-        const model = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
-        if (cancelled) return;
-        setCanManageTeam(model.canManageTeam);
-        setTeamName(model.team.name || 'Team');
-        setForm({
-          name: model.team.name || '',
-          sport: model.team.sport === 'Sport not set' ? '' : model.team.sport,
-          zip: model.team.zip || '',
-          isPublic: model.team.isPublic !== false,
-          photoUrl: model.team.photoUrl || ''
-        });
-        setPhotoPreviewUrl(model.team.photoUrl || '');
-      } catch (loadError: any) {
-        if (!cancelled) {
-          setError(loadError?.message || 'Unable to load team settings.');
+  const loadSettings = useCallback(async () => {
+    if (!teamId) return null;
+
+    return runPrimaryLoad(
+      () => loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false }),
+      {
+        errorMessage: 'Unable to load team settings.',
+        rethrow: false,
+        onSuccess: (model) => {
+          setCanManageTeam(model.canManageTeam);
+          setTeamName(model.team.name || 'Team');
+          setForm({
+            name: model.team.name || '',
+            sport: model.team.sport === 'Sport not set' ? '' : model.team.sport,
+            zip: model.team.zip || '',
+            isPublic: model.team.isPublic !== false,
+            photoUrl: model.team.photoUrl || ''
+          });
+          setPhotoPreviewUrl(model.team.photoUrl || '');
+        },
+        onError: () => {
+          setCanManageTeam(false);
+          setTeamName('Team');
+          setForm({
+            name: '',
+            sport: '',
+            zip: '',
+            isPublic: true,
+            photoUrl: ''
+          });
+          setPhotoFile(null);
+          setPhotoPreviewUrl('');
+        },
+        onFinally: () => {
+          setHasResolvedInitialLoad(true);
         }
-      } finally {
-        if (!cancelled) setLoading(false);
       }
-    }
+    );
+  }, [auth.user, runPrimaryLoad, teamId]);
 
-    void load();
+  useEffect(() => {
+    setHasResolvedInitialLoad(false);
+    void loadSettings();
+
     return () => {
-      cancelled = true;
-      if (photoPreviewUrl.startsWith('blob:')) {
-        URL.revokeObjectURL(photoPreviewUrl);
+      if (photoPreviewUrlRef.current.startsWith('blob:')) {
+        URL.revokeObjectURL(photoPreviewUrlRef.current);
       }
     };
-  }, [auth.user, teamId]);
+  }, [loadSettings]);
 
   function handlePhotoChange(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0] || null;
@@ -105,7 +124,7 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
     }
   }
 
-  if (loading) {
+  if (loading || !hasResolvedInitialLoad) {
     return (
       <div className="app-card flex min-h-[240px] items-center justify-center p-5 text-center">
         <div className="flex items-center gap-3 text-sm font-semibold text-gray-600">
@@ -125,6 +144,10 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
         </Link>
         <div className="mt-4 text-lg font-black text-gray-950">Team settings unavailable</div>
         <div className="mt-2 text-sm font-semibold text-rose-700">{error}</div>
+        <button type="button" className="primary-button mt-4" onClick={() => void loadSettings()} disabled={loading}>
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+          Retry
+        </button>
       </section>
     );
   }

--- a/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/architecture.md
+++ b/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/architecture.md
@@ -1,0 +1,21 @@
+# Issue 2316 Architecture
+
+## Current state
+- `TeamSettings.tsx` and `TeamCertificates.tsx` each hand-roll primary page-load `loading/error/try/catch/finally` behavior.
+- Async UX drifted from the existing app convention already used in pages like Home and Schedule.
+
+## Proposed state
+- Use `useAsyncOperation` for the primary load on both pages.
+- Keep domain-specific synchronous state local to each page.
+- Gate first paint with an explicit initial-load resolution flag so the route does not briefly render fallback or redirect UI before the first async attempt resolves.
+- Provide a consistent blocking error state with Retry on both pages.
+
+## Root-cause framing
+- The defect exists because these staff workflows were implemented before the shared async hook became the page-level standard, leaving duplicated lifecycle code and no consistent retry affordance.
+
+## Blast radius
+- Limited to two React app routes and their page tests.
+- No Firestore schema, permission, or service-layer behavior changes.
+
+## Rollback
+- Revert the two page components and associated tests. No persisted-data rollback is needed.

--- a/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/code-plan.md
@@ -1,0 +1,22 @@
+# Issue 2316 Code Plan
+
+## Minimal patch shape
+- `apps/app/src/pages/TeamSettings.tsx`
+  - replace page-local primary-load lifecycle with `useAsyncOperation`
+  - add a first-load resolution guard
+  - add Retry CTA for initial-load failure
+- `apps/app/src/pages/TeamCertificates.tsx`
+  - replace page-local primary-load lifecycle with `useAsyncOperation`
+  - add a first-load resolution guard
+  - add Retry CTA for initial-load failure
+- Tests
+  - extend `apps/app/src/pages/TeamSettings.test.tsx`
+  - add `apps/app/src/pages/TeamCertificates.test.tsx`
+
+## Hazards
+- Do not let first render redirect before the initial async load has resolved.
+- Do not tie reload behavior to photo preview state changes.
+- Keep the patch focused on primary load behavior only.
+
+## Validation target
+- Focused Vitest page tests only.

--- a/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/qa.md
+++ b/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/qa.md
@@ -1,0 +1,20 @@
+# Issue 2316 QA
+
+## Failing invariant
+- Staff pages should use one consistent initial-load state machine with a recoverable retry path.
+- Team Settings must not reload and wipe unsaved edits when a coach selects a new photo preview.
+
+## Regression plan
+- Update `apps/app/src/pages/TeamSettings.test.tsx` to cover:
+  - initial load failure -> blocking error -> Retry -> success
+  - choosing a new photo does not trigger a second load or wipe unsaved edits
+- Add `apps/app/src/pages/TeamCertificates.test.tsx` to cover:
+  - initial load failure -> blocking error -> Retry -> success
+
+## Smallest validation
+- `npm --prefix apps/app exec vitest run src/pages/TeamSettings.test.tsx src/pages/TeamCertificates.test.tsx --reporter=verbose`
+
+## Post-fix manual spot checks
+- Staff can recover from transient load failures on both pages.
+- Team Settings keeps draft edits after picking a new photo.
+- Non-staff access behavior remains unchanged.

--- a/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/requirements.md
+++ b/docs/pr-notes/runs/issue-2316-fixer-20260614T191941Z/requirements.md
@@ -1,0 +1,25 @@
+# Issue 2316 Requirements
+
+## Acceptance Criteria
+- Team Settings and Team Certificates use the shared async operation hook for their primary page load.
+- Both pages show one clear blocking loading state during initial fetch.
+- Both pages show a page-specific initial-load failure state with an in-page Retry action.
+- Retry clears the prior blocking error and restores the normal page experience on success.
+- Existing staff-only and non-staff access behavior stays intact.
+- Existing success behavior stays intact: Team Settings returns to team detail after save, and certificate drafts still hand off to the website flow.
+
+## User-facing expectations
+- Coaches and staff should see predictable loading, error, and retry behavior across both routes.
+- Initial load failures must not leave editable controls visible in a misleading state.
+- Local draft/form state should not be wiped by unrelated UI actions like choosing a photo preview.
+
+## Out of scope
+- Profile, Team Media, or Schedule Event Detail migrations.
+- Service-layer cache redesign.
+- New server-state library adoption.
+- Authorization or parent-facing certificate visibility changes.
+
+## Risks and ambiguities
+- Keep client-side validation separate from async failure messaging.
+- Preserve non-staff blocked UI semantics.
+- If the website handoff fails after draft creation, do not misreport the underlying draft-save result.


### PR DESCRIPTION
Closes #2316

## What changed
- Migrated the primary page load in `apps/app/src/pages/TeamSettings.tsx` to `useAsyncOperation`.
- Migrated the primary page load in `apps/app/src/pages/TeamCertificates.tsx` to `useAsyncOperation`.
- Added a first-load resolution guard on both pages so they stay in a blocking loading state until the initial fetch resolves.
- Added a consistent in-page Retry action for initial load failures on both pages.
- Added focused regression coverage for Team Settings and new page-level coverage for Team Certificates.

## Root Cause
These two staff pages kept bespoke `setLoading` / `try` / `catch` / `finally` load logic from before `useAsyncOperation` became the shared app pattern. That duplication left them without a consistent retryable blocking error path and made Team Settings vulnerable to accidental reload-driven draft loss while editing.

## Prevention / Learning
For app routes with blocking initial fetches, default to `useAsyncOperation` plus an explicit first-load resolution guard so the route cannot briefly render fallback or redirect UI before the first async attempt completes. Add a focused retry regression test anywhere the user would otherwise get stuck behind a failed first paint.

## Regression Tests
- `npm --prefix apps/app exec vitest run src/pages/TeamSettings.test.tsx src/pages/TeamCertificates.test.tsx --reporter=verbose`
- `apps/app/src/pages/TeamSettings.test.tsx` now covers initial-load failure/retry and verifies photo selection does not trigger a reload that wipes unsaved edits.
- `apps/app/src/pages/TeamCertificates.test.tsx` covers initial-load failure/retry for the certificates composer.

## Recurrence Risk
- Low. Both routes now use the shared load pattern and have focused retry coverage for this exact failure mode.