### PR TITLE
Default postgame player performance to participants

### DIFF
--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  getConfigs: vi.fn(),
+  getGame: vi.fn(),
+  getGameEvents: vi.fn(),
+  getPlayers: vi.fn(),
+  getTeam: vi.fn(),
+  getTeamStatsForGame: vi.fn()
+}));
+
+const firebaseMocks = vi.hoisted(() => ({
+  collection: vi.fn(() => 'aggregated-stats-ref'),
+  db: {},
+  getDocs: vi.fn()
+}));
+
+vi.mock('../../../../js/db.js', () => dbMocks);
+vi.mock('../../../../js/firebase.js', () => firebaseMocks);
+vi.mock('../../../../js/game-report-stats.js', () => ({
+  resolveReportStatColumns: vi.fn(() => ({ statKeys: [], statLabels: {} })),
+  resolveOpponentReportStatColumns: vi.fn(() => ({ oppKeys: [], oppLabels: {} }))
+}));
+vi.mock('../../../../js/live-game-video.js', () => ({
+  buildHighlightShareUrl: vi.fn(() => ''),
+  normalizeGameRecapHighlightClips: vi.fn(() => [])
+}));
+vi.mock('../../../../js/live-game-state.js', () => ({
+  resolveLiveStatConfig: vi.fn(() => ({}))
+}));
+vi.mock('../../../../js/post-game-insights.js', () => ({
+  generateGameInsights: vi.fn(() => ({ teamInsights: [], playerInsightsById: {}, emptyMessage: '' }))
+}));
+vi.mock('../../../../js/post-game-stat-editor.js', () => ({
+  resolvePostGameTeamStatFields: vi.fn(() => [])
+}));
+
+import { loadGameReportSections } from './gameReportService';
+
+describe('gameReportService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Falcons' });
+    dbMocks.getGame.mockResolvedValue({ id: 'game-1', summary: 'Final' });
+    dbMocks.getPlayers.mockResolvedValue([
+      { id: 'player-recorded', name: 'Recorded Player', number: '3' },
+      { id: 'player-deferred', name: 'Deferred Player', number: '9' }
+    ]);
+    dbMocks.getConfigs.mockResolvedValue([]);
+    dbMocks.getGameEvents.mockResolvedValue([]);
+    dbMocks.getTeamStatsForGame.mockResolvedValue({});
+    firebaseMocks.getDocs.mockResolvedValue({
+      forEach(callback: (docSnap: any) => void) {
+        callback({
+          id: 'player-recorded',
+          data: () => ({
+            stats: {},
+            timeMs: 0,
+            didNotPlay: false,
+            participated: false,
+            participationStatus: '',
+            participationSource: ''
+          })
+        });
+      }
+    });
+  });
+
+  it('keeps recorded players visible even when they have no explicit participation markers', async () => {
+    const report = await loadGameReportSections('team-1', 'game-1');
+
+    expect(report.visiblePlayerRows.map((player) => player.playerId)).toEqual(['player-recorded']);
+    expect(report.deferredPlayerRows.map((player) => player.playerId)).toEqual(['player-deferred']);
+  });
+});

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -276,7 +276,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
   const visiblePlayerRows = playerRows.filter((player) => (
     hasPlayerProfileParticipation(player)
     || player.didNotPlay
-    || (recordedPlayerIds.has(player.playerId) && player.didNotPlay !== true)
+    || recordedPlayerIds.has(player.playerId)
   ));
   const deferredPlayerRows = playerRows.filter((player) => !visiblePlayerRows.includes(player));
   const playerLookup = new Map(playerRows.map((player) => [player.playerId, player]));

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -95,6 +95,7 @@ type AggregatedStatsResult = {
   participatedMap: Record<string, boolean>;
   participationStatusMap: Record<string, string>;
   participationSourceMap: Record<string, string>;
+  recordedPlayerIds: Set<string>;
 };
 
 function toNumber(value: unknown) {
@@ -125,9 +126,11 @@ async function loadAggregatedStats(teamId: string, gameId: string): Promise<Aggr
   const participatedMap: Record<string, boolean> = {};
   const participationStatusMap: Record<string, string> = {};
   const participationSourceMap: Record<string, string> = {};
+  const recordedPlayerIds = new Set<string>();
 
   snapshot.forEach((docSnap: any) => {
     const data = docSnap.data() || {};
+    recordedPlayerIds.add(String(docSnap.id || ''));
     statsMap[docSnap.id] = data.stats || {};
     timeMap[docSnap.id] = toNumber(data.timeMs);
     didNotPlayMap[docSnap.id] = data.didNotPlay === true;
@@ -136,7 +139,7 @@ async function loadAggregatedStats(teamId: string, gameId: string): Promise<Aggr
     participationSourceMap[docSnap.id] = String(data.participationSource || '');
   });
 
-  return { statsMap, timeMap, didNotPlayMap, participatedMap, participationStatusMap, participationSourceMap };
+  return { statsMap, timeMap, didNotPlayMap, participatedMap, participationStatusMap, participationSourceMap, recordedPlayerIds };
 }
 
 function normalizePlay(entry: any): GameReportPlay {
@@ -205,7 +208,8 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
       didNotPlayMap: {},
       participatedMap: {},
       participationStatusMap: {},
-      participationSourceMap: {}
+      participationSourceMap: {},
+      recordedPlayerIds: new Set<string>()
     })),
     getGameEvents(teamId, gameId, { limit: 100 }).catch(() => []),
     getTeamStatsForGame(teamId, gameId).catch(() => ({}))
@@ -216,7 +220,15 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     game,
     team
   });
-  const { statsMap, timeMap, didNotPlayMap, participatedMap, participationStatusMap, participationSourceMap } = aggregateResult;
+  const {
+    statsMap,
+    timeMap,
+    didNotPlayMap,
+    participatedMap,
+    participationStatusMap,
+    participationSourceMap,
+    recordedPlayerIds
+  } = aggregateResult;
   const { statKeys, statLabels } = resolveReportStatColumns({
     statsMap,
     resolvedConfig
@@ -261,7 +273,11 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     participationStatus: participationStatusMap[player.id] || '',
     participationSource: participationSourceMap[player.id] || ''
   }));
-  const visiblePlayerRows = playerRows.filter((player) => hasPlayerProfileParticipation(player) || player.didNotPlay);
+  const visiblePlayerRows = playerRows.filter((player) => (
+    hasPlayerProfileParticipation(player)
+    || player.didNotPlay
+    || (recordedPlayerIds.has(player.playerId) && player.didNotPlay !== true)
+  ));
   const deferredPlayerRows = playerRows.filter((player) => !visiblePlayerRows.includes(player));
   const playerLookup = new Map(playerRows.map((player) => [player.playerId, player]));
   const playerInsightRows = Object.entries(insights.playerInsightsById || {}).map(([playerId, playerInsights]) => ({

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -12,6 +12,7 @@ import { resolveReportStatColumns, resolveOpponentReportStatColumns } from '../.
 import { buildHighlightShareUrl, normalizeGameRecapHighlightClips } from '../../../../js/live-game-video.js';
 import { resolveLiveStatConfig } from '../../../../js/live-game-state.js';
 import { generateGameInsights } from '../../../../js/post-game-insights.js';
+import { hasPlayerProfileParticipation } from '../../../../js/player-profile-stats.js';
 import { resolvePostGameTeamStatFields } from '../../../../js/post-game-stat-editor.js';
 
 export type GameReportInsight = {
@@ -28,6 +29,9 @@ export type GameReportPlayerRow = {
   stats: Record<string, any>;
   timeMs: number;
   didNotPlay: boolean;
+  participated: boolean;
+  participationStatus: string;
+  participationSource: string;
 };
 
 export type GameReportOpponentRow = {
@@ -64,6 +68,8 @@ export type GameReportData = {
   statLabels: Record<string, string>;
   hasPlayingTime: boolean;
   playerRows: GameReportPlayerRow[];
+  visiblePlayerRows: GameReportPlayerRow[];
+  deferredPlayerRows: GameReportPlayerRow[];
   opponentStatKeys: string[];
   opponentStatLabels: Record<string, string>;
   opponentRows: GameReportOpponentRow[];
@@ -86,6 +92,9 @@ type AggregatedStatsResult = {
   statsMap: Record<string, Record<string, any>>;
   timeMap: Record<string, number>;
   didNotPlayMap: Record<string, boolean>;
+  participatedMap: Record<string, boolean>;
+  participationStatusMap: Record<string, string>;
+  participationSourceMap: Record<string, string>;
 };
 
 function toNumber(value: unknown) {
@@ -113,15 +122,21 @@ async function loadAggregatedStats(teamId: string, gameId: string): Promise<Aggr
   const statsMap: Record<string, Record<string, any>> = {};
   const timeMap: Record<string, number> = {};
   const didNotPlayMap: Record<string, boolean> = {};
+  const participatedMap: Record<string, boolean> = {};
+  const participationStatusMap: Record<string, string> = {};
+  const participationSourceMap: Record<string, string> = {};
 
   snapshot.forEach((docSnap: any) => {
     const data = docSnap.data() || {};
     statsMap[docSnap.id] = data.stats || {};
     timeMap[docSnap.id] = toNumber(data.timeMs);
     didNotPlayMap[docSnap.id] = data.didNotPlay === true;
+    participatedMap[docSnap.id] = data.participated === true;
+    participationStatusMap[docSnap.id] = String(data.participationStatus || '');
+    participationSourceMap[docSnap.id] = String(data.participationSource || '');
   });
 
-  return { statsMap, timeMap, didNotPlayMap };
+  return { statsMap, timeMap, didNotPlayMap, participatedMap, participationStatusMap, participationSourceMap };
 }
 
 function normalizePlay(entry: any): GameReportPlay {
@@ -184,7 +199,14 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
 
   const [configs, aggregateResult, rawEvents, teamStats] = await Promise.all([
     getConfigs(teamId).catch(() => []),
-    loadAggregatedStats(teamId, gameId).catch((): AggregatedStatsResult => ({ statsMap: {}, timeMap: {}, didNotPlayMap: {} })),
+    loadAggregatedStats(teamId, gameId).catch((): AggregatedStatsResult => ({
+      statsMap: {},
+      timeMap: {},
+      didNotPlayMap: {},
+      participatedMap: {},
+      participationStatusMap: {},
+      participationSourceMap: {}
+    })),
     getGameEvents(teamId, gameId, { limit: 100 }).catch(() => []),
     getTeamStatsForGame(teamId, gameId).catch(() => ({}))
   ]);
@@ -194,7 +216,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     game,
     team
   });
-  const { statsMap, timeMap, didNotPlayMap } = aggregateResult;
+  const { statsMap, timeMap, didNotPlayMap, participatedMap, participationStatusMap, participationSourceMap } = aggregateResult;
   const { statKeys, statLabels } = resolveReportStatColumns({
     statsMap,
     resolvedConfig
@@ -234,8 +256,13 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     photoUrl: player.photoUrl ? String(player.photoUrl) : undefined,
     stats: statsMap[player.id] || {},
     timeMs: timeMap[player.id] || 0,
-    didNotPlay: didNotPlayMap[player.id] === true
+    didNotPlay: didNotPlayMap[player.id] === true,
+    participated: participatedMap[player.id] === true,
+    participationStatus: participationStatusMap[player.id] || '',
+    participationSource: participationSourceMap[player.id] || ''
   }));
+  const visiblePlayerRows = playerRows.filter((player) => hasPlayerProfileParticipation(player) || player.didNotPlay);
+  const deferredPlayerRows = playerRows.filter((player) => !visiblePlayerRows.includes(player));
   const playerLookup = new Map(playerRows.map((player) => [player.playerId, player]));
   const playerInsightRows = Object.entries(insights.playerInsightsById || {}).map(([playerId, playerInsights]) => ({
     playerId,
@@ -251,6 +278,8 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     statLabels,
     hasPlayingTime: Object.values(timeMap).some((time) => time > 0),
     playerRows,
+    visiblePlayerRows,
+    deferredPlayerRows,
     opponentStatKeys: oppKeys,
     opponentStatLabels: oppLabels,
     opponentRows: normalizeOpponentRows(opponentStats),

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -840,6 +840,55 @@ describe('ScheduleEventDetail assignments', () => {
     });
   });
 
+  it('falls back to player rows when older report payloads omit roster partitions', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'completed',
+        status: 'completed',
+        canUpdateScore: true,
+        isTeamStaff: true
+      })],
+      children: []
+    });
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue({
+      game: { id: 'game-1', liveStatus: 'completed', status: 'completed', homeScore: 42, awayScore: 38 },
+      plays: [],
+      summary: 'Loaded on demand.',
+      opponentRows: [],
+      opponentStatKeys: [],
+      teamInsights: [],
+      playerInsightRows: [],
+      highlightClips: [],
+      statSheetPhotoUrl: null,
+      teamStatKeys: [],
+      teamStats: {},
+      statKeys: ['pts'],
+      playerRows: [
+        { playerId: 'player-1', playerName: 'Avery Smith', number: '1', stats: { pts: 8 }, timeMs: 600000, didNotPlay: false }
+      ],
+      statLabels: { pts: 'PTS' },
+      hasPlayingTime: true,
+      team: { id: 'team-1' }
+    } as any);
+
+    renderScheduleEventDetailWithRouteControls();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Game hub' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Report sections' }));
+    await waitFor(() => {
+      expect(screen.getByText('Loaded on demand.')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Players' }));
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /#1 Avery Smith/i })).toBeTruthy();
+      expect(screen.getByText('8')).toBeTruthy();
+    });
+  });
+
   it('resets deferred game hub panels before rendering a switched event', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockImplementation(async (_user, { eventId }) => ({
       events: [eventId === 'game-2'

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -4685,10 +4685,13 @@ function MatchSummarySection({ report }: { report: GameReportData }) {
 function PlayerPerformanceSection({ report }: { report: GameReportData }) {
   const [showFullRoster, setShowFullRoster] = useState(false);
   const statKeys = report.statKeys.slice(0, 4);
-  const visiblePlayers = report.visiblePlayerRows.length ? report.visiblePlayerRows : report.playerRows;
-  const deferredPlayers = report.deferredPlayerRows || [];
+  const playerRows = Array.isArray(report.playerRows) ? report.playerRows : [];
+  const visiblePlayerRows = Array.isArray(report.visiblePlayerRows) ? report.visiblePlayerRows : [];
+  const deferredPlayerRows = Array.isArray(report.deferredPlayerRows) ? report.deferredPlayerRows : [];
+  const visiblePlayers = visiblePlayerRows.length ? visiblePlayerRows : playerRows;
+  const deferredPlayers = deferredPlayerRows;
 
-  if (!report.playerRows.length) {
+  if (!playerRows.length) {
     return <EmptyReportState title="No players found" detail="Player performance will appear after roster and stats load." />;
   }
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -4683,7 +4683,11 @@ function MatchSummarySection({ report }: { report: GameReportData }) {
 }
 
 function PlayerPerformanceSection({ report }: { report: GameReportData }) {
+  const [showFullRoster, setShowFullRoster] = useState(false);
   const statKeys = report.statKeys.slice(0, 4);
+  const visiblePlayers = report.visiblePlayerRows.length ? report.visiblePlayerRows : report.playerRows;
+  const deferredPlayers = report.deferredPlayerRows || [];
+
   if (!report.playerRows.length) {
     return <EmptyReportState title="No players found" detail="Player performance will appear after roster and stats load." />;
   }
@@ -4694,7 +4698,7 @@ function PlayerPerformanceSection({ report }: { report: GameReportData }) {
         <span>Player</span>
         <span>Stats</span>
       </div>
-      {report.playerRows.map((player) => (
+      {visiblePlayers.map((player) => (
         <PlayerPerformanceRow
           key={player.playerId}
           player={player}
@@ -4705,6 +4709,40 @@ function PlayerPerformanceSection({ report }: { report: GameReportData }) {
           gameId={report.game.id || ''}
         />
       ))}
+      {deferredPlayers.length ? (
+        <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-3">
+          <button
+            type="button"
+            className="flex w-full items-center justify-between gap-3 text-left"
+            onClick={() => setShowFullRoster((current) => !current)}
+            aria-expanded={showFullRoster}
+            aria-label={showFullRoster ? 'Hide full roster' : `Show full roster (${deferredPlayers.length})`}
+          >
+            <div>
+              <div className="text-sm font-black text-gray-950">Other rostered players</div>
+              <div className="mt-0.5 text-xs font-semibold text-gray-500">Show the full roster, including players without participation records for this game.</div>
+            </div>
+            <span className="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-black text-gray-700">
+              {showFullRoster ? 'Hide full roster' : `Show full roster (${deferredPlayers.length})`}
+            </span>
+          </button>
+          {showFullRoster ? (
+            <div className="mt-3 space-y-2">
+              {deferredPlayers.map((player) => (
+                <PlayerPerformanceRow
+                  key={player.playerId}
+                  player={player}
+                  statKeys={statKeys}
+                  statLabels={report.statLabels}
+                  hasPlayingTime={report.hasPlayingTime}
+                  teamId={report.team.id || ''}
+                  gameId={report.game.id || ''}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/tests/unit/app-game-report-service.test.js
+++ b/tests/unit/app-game-report-service.test.js
@@ -64,7 +64,7 @@ beforeEach(() => {
     dbMocks.getTeamStatsForGame.mockResolvedValue({ turnovers: 6, assists: 11 });
     firebaseMocks.getDocs.mockResolvedValue(snapshot([
         { id: 'player-1', data: { stats: { pts: 12, reb: 5, fouls: 1 }, timeMs: 1200000 } },
-        { id: 'player-2', data: { stats: {}, timeMs: 0, participated: true, participationStatus: 'appeared', participationSource: 'app-stat-tracker' } },
+        { id: 'player-2', data: { stats: {}, timeMs: 0, didNotPlay: false } },
         { id: 'player-3', data: { stats: {}, timeMs: 0, didNotPlay: true, participationStatus: 'did-not-appear' } }
     ]));
 });
@@ -92,9 +92,10 @@ describe('React app game report service', () => {
         expect(report.deferredPlayerRows.map((player) => player.playerId)).toEqual(['player-4']);
         expect(report.visiblePlayerRows[1]).toMatchObject({
             playerId: 'player-2',
-            participated: true,
-            participationStatus: 'appeared',
-            participationSource: 'app-stat-tracker'
+            didNotPlay: false,
+            participated: false,
+            participationStatus: '',
+            participationSource: ''
         });
         expect(report.visiblePlayerRows[2]).toMatchObject({
             playerId: 'player-3',

--- a/tests/unit/app-game-report-service.test.js
+++ b/tests/unit/app-game-report-service.test.js
@@ -50,7 +50,9 @@ beforeEach(() => {
     });
     dbMocks.getPlayers.mockResolvedValue([
         { id: 'player-1', name: 'Pat', number: '7' },
-        { id: 'player-2', name: 'Sam', number: '9' }
+        { id: 'player-2', name: 'Sam', number: '9' },
+        { id: 'player-3', name: 'Drew', number: '11' },
+        { id: 'player-4', name: 'Casey', number: '15' }
     ]);
     dbMocks.getConfigs.mockResolvedValue([
         { id: 'cfg-1', baseType: 'basketball', columns: ['PTS', 'REB'] }
@@ -62,7 +64,8 @@ beforeEach(() => {
     dbMocks.getTeamStatsForGame.mockResolvedValue({ turnovers: 6, assists: 11 });
     firebaseMocks.getDocs.mockResolvedValue(snapshot([
         { id: 'player-1', data: { stats: { pts: 12, reb: 5, fouls: 1 }, timeMs: 1200000 } },
-        { id: 'player-2', data: { stats: { pts: 4, reb: 2 }, timeMs: 900000 } }
+        { id: 'player-2', data: { stats: {}, timeMs: 0, participated: true, participationStatus: 'appeared', participationSource: 'app-stat-tracker' } },
+        { id: 'player-3', data: { stats: {}, timeMs: 0, didNotPlay: true, participationStatus: 'did-not-appear' } }
     ]));
 });
 
@@ -85,6 +88,18 @@ describe('React app game report service', () => {
             stats: { pts: 12, reb: 5, fouls: 1 },
             timeMs: 1200000
         });
+        expect(report.visiblePlayerRows.map((player) => player.playerId)).toEqual(['player-1', 'player-2', 'player-3']);
+        expect(report.deferredPlayerRows.map((player) => player.playerId)).toEqual(['player-4']);
+        expect(report.visiblePlayerRows[1]).toMatchObject({
+            playerId: 'player-2',
+            participated: true,
+            participationStatus: 'appeared',
+            participationSource: 'app-stat-tracker'
+        });
+        expect(report.visiblePlayerRows[2]).toMatchObject({
+            playerId: 'player-3',
+            didNotPlay: true
+        });
         expect(report.hasPlayingTime).toBe(true);
         expect(report.plays.map((play) => play.id)).toEqual(['play-1', 'play-2']);
         expect(report.opponentRows[0]).toMatchObject({
@@ -105,7 +120,9 @@ describe('React app game report service', () => {
 
         const report = await loadGameReportSections('team-1', 'game-1');
 
-        expect(report.playerRows).toHaveLength(2);
+        expect(report.playerRows).toHaveLength(4);
+        expect(report.visiblePlayerRows).toHaveLength(0);
+        expect(report.deferredPlayerRows).toHaveLength(4);
         expect(report.playerRows[0].stats).toEqual({});
         expect(report.plays).toEqual([]);
         expect(report.teamStats).toEqual({});

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -104,6 +104,8 @@ function report(overrides = {}) {
         statKeys: [],
         statLabels: {},
         playerRows: [],
+        visiblePlayerRows: [],
+        deferredPlayerRows: [],
         hasPlayingTime: false,
         plays: [],
         opponentRows: [],
@@ -535,6 +537,51 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         expect(queryButtonByText(container, 'Opponent')).not.toBeNull();
         expect(queryButtonByText(container, 'Media')).not.toBeNull();
         expect(queryButtonByText(container, 'Insights')).toBeNull();
+    });
+
+    it('defaults Player Performance to participants and reveals the full roster on demand', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ liveStatus: 'completed', homeScore: 4, awayScore: 2 })]
+        });
+        reportMocks.loadGameReportSections.mockResolvedValue(report({
+            statKeys: ['pts'],
+            statLabels: { pts: 'PTS' },
+            playerRows: [
+                { playerId: 'player-1', playerName: 'Pat', number: '7', stats: { pts: 8 }, timeMs: 1200000, didNotPlay: false, participated: true, participationStatus: 'appeared', participationSource: 'app-stat-tracker' },
+                { playerId: 'player-2', playerName: 'Sam', number: '9', stats: {}, timeMs: 0, didNotPlay: false, participated: true, participationStatus: 'appeared', participationSource: 'app-stat-tracker' },
+                { playerId: 'player-3', playerName: 'Drew', number: '11', stats: {}, timeMs: 0, didNotPlay: true, participated: false, participationStatus: 'did-not-appear', participationSource: '' },
+                { playerId: 'player-4', playerName: 'Casey', number: '15', stats: {}, timeMs: 0, didNotPlay: false, participated: false, participationStatus: '', participationSource: '' }
+            ],
+            visiblePlayerRows: [
+                { playerId: 'player-1', playerName: 'Pat', number: '7', stats: { pts: 8 }, timeMs: 1200000, didNotPlay: false, participated: true, participationStatus: 'appeared', participationSource: 'app-stat-tracker' },
+                { playerId: 'player-2', playerName: 'Sam', number: '9', stats: {}, timeMs: 0, didNotPlay: false, participated: true, participationStatus: 'appeared', participationSource: 'app-stat-tracker' },
+                { playerId: 'player-3', playerName: 'Drew', number: '11', stats: {}, timeMs: 0, didNotPlay: true, participated: false, participationStatus: 'did-not-appear', participationSource: '' }
+            ],
+            deferredPlayerRows: [
+                { playerId: 'player-4', playerName: 'Casey', number: '15', stats: {}, timeMs: 0, didNotPlay: false, participated: false, participationStatus: '', participationSource: '' }
+            ],
+            hasPlayingTime: true
+        }));
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Report sections');
+        await clickButton(container, 'Report sections');
+        await waitForText(container, 'Match Summary');
+        await clickButton(container, 'Players');
+
+        expect(container.textContent).toContain('#7 Pat');
+        expect(container.textContent).toContain('#9 Sam');
+        expect(container.textContent).toContain('#11 Drew');
+        expect(container.textContent).toContain('DNP');
+        expect(container.textContent).not.toContain('#15 Casey');
+        expect(container.textContent).toContain('Show full roster (1)');
+
+        await clickButton(container, 'Show full roster (1)');
+
+        expect(container.textContent).toContain('#15 Casey');
+        expect(container.textContent).toContain('Hide full roster');
     });
 
     it('does not refresh completed game reports on focus or while Plays stays open', async () => {


### PR DESCRIPTION
Closes #2322

## What changed
- Updated `gameReportService` to keep loading the full roster with inactive players available, but now carry forward participation markers from aggregated stats and split report rows into:
  - `visiblePlayerRows` for players with stats, playing time, participation evidence, or `didNotPlay=true`
  - `deferredPlayerRows` for rostered players with no game participation evidence
- Updated the Schedule Event Detail Players report tab to render the participant-first list by default and expose the remaining roster behind an `Other rostered players` / `Show full roster` expander.
- Added focused unit and integration coverage for mixed-roster postgame behavior.

## Root Cause
`GameReportService` flattened the full `includeInactive` roster directly into `playerRows` without preserving participation markers or separating no-record players from actual game participants. The Players UI then rendered every row equally, so inactive or untouched roster entries appeared as misleading zero-value player performance rows.

## Prevention / Learning
When a workflow intentionally loads a superset data source for auditability, return both the complete dataset and an explicit default-visible subset aligned to the primary user task. Do not leave participation filtering implicit in the rendering layer when the service already has the evidence needed to classify rows.

## Regression Tests
- `npx vitest run tests/unit/app-game-report-service.test.js tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Medium. Other report-style roster surfaces could repeat this pattern if they map full rosters directly into UI rows without an explicit visible-vs-deferred model.