### PR TITLE
Lock game subcollection reads behind parent visibility

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -519,6 +519,11 @@ service cloud.firestore {
              (exists(teamPath) && canReadPublicGameDocument(get(teamPath).data, data));
     }
 
+    function canReadGameSubcollectionDocument(teamId, gameId) {
+      let gamePath = /databases/$(database)/documents/teams/$(teamId)/games/$(gameId);
+      return exists(gamePath) && canReadGameDocument(teamId, gameId, get(gamePath).data);
+    }
+
     function canReadCollectionGroupGameDocument(teamPath, data) {
       return exists(/databases/$(database)/documents/$(teamPath)) &&
              (
@@ -1863,14 +1868,14 @@ service cloud.firestore {
 
         // Events subcollection
         match /events/{eventId} {
-          allow read: if true;
+          allow read: if canReadGameSubcollectionDocument(teamId, gameId);
           allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);
           allow delete: if isTeamOwnerOrAdmin(teamId);
         }
 
         // Aggregated stats subcollection
         match /aggregatedStats/{statId} {
-          allow read: if true;
+          allow read: if canReadGameSubcollectionDocument(teamId, gameId);
           allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);
           allow delete: if isTeamOwnerOrAdmin(teamId);
         }

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -33,6 +33,8 @@ export function validateFirebaseRulesCi() {
     const firestoreRules = readText('firestore.rules');
     const storageRules = readText('storage.rules');
     const legacyGameClipRules = extractMatchBlock(storageRules, 'match /game-clips/{fileName} {');
+    const gameEventsRules = (firestoreRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/) || [''])[0];
+    const aggregatedStatsRules = (firestoreRules.match(/match \/aggregatedStats\/\{statId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const deployProd = readText('.github/workflows/deploy-prod.yml');
     const deployPreview = readText('.github/workflows/deploy-preview.yml');
     const regressionGuards = readText('.github/workflows/regression-guards.yml');
@@ -56,9 +58,17 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaFolder(teamId, resource.data);', 'Firestore media folder read rules');
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaItem(teamId, resource.data);', 'Firestore media item read rules');
     assertIncludes(firestoreRules, 'function canReadGameDocument(teamId, gameId, data)', 'Firestore game visibility helper');
+    assertIncludes(firestoreRules, 'function canReadGameSubcollectionDocument(teamId, gameId)', 'Firestore game subcollection visibility helper');
     assertIncludes(firestoreRules, 'function canReadCollectionGroupGameDocument(teamPath, data)', 'Firestore collection-group game visibility helper');
     assertIncludes(firestoreRules, 'allow read: if canReadGameDocument(teamId, gameId, resource.data);', 'Firestore team game read rules');
+    assertIncludes(firestoreRules, 'allow read: if canReadGameSubcollectionDocument(teamId, gameId);', 'Firestore game subcollection read rules');
     assertIncludes(firestoreRules, 'allow read: if canReadCollectionGroupGameDocument(path, resource.data);', 'Firestore collection-group game read rules');
+    if (gameEventsRules.includes('allow read: if true;')) {
+        throw new Error('Firestore game events read rules must not allow unconditional public reads.');
+    }
+    if (aggregatedStatsRules.includes('allow read: if true;')) {
+        throw new Error('Firestore aggregated stats read rules must not allow unconditional public reads.');
+    }
     assertIncludes(firestoreRules, 'allow create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media folder write rules');
     assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
     assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);', 'Firestore media item update rules');

--- a/tests/unit/game-read-rules.test.js
+++ b/tests/unit/game-read-rules.test.js
@@ -5,21 +5,30 @@ const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'u
 const collectionGroupGamesMatch = rules.match(/match \/{path=\*\*}\/games\/\{gameId} \{[\s\S]*?\n\s*}/);
 const collectionGroupGamesRules = collectionGroupGamesMatch?.[0] || '';
 const teamGamesStart = rules.indexOf('match /games/{gameId} {');
-const teamGamesEnd = rules.indexOf('// Events subcollection', teamGamesStart);
+const teamGamesEnd = rules.indexOf('// Live Events subcollection - for real-time game broadcasting', teamGamesStart);
 const teamGamesRules = teamGamesStart === -1 || teamGamesEnd === -1
     ? ''
     : rules.slice(teamGamesStart, teamGamesEnd);
+const eventsMatch = teamGamesRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/);
+const aggregatedStatsMatch = teamGamesRules.match(/match \/aggregatedStats\/\{statId} \{[\s\S]*?\n\s*}/);
+const eventsRules = eventsMatch?.[0] || '';
+const aggregatedStatsRules = aggregatedStatsMatch?.[0] || '';
 
 describe('game Firestore read rules', () => {
     it('replaces unconditional game reads with shared visibility helpers', () => {
         expect(rules).toContain('function canReadGameDocument(teamId, gameId, data)');
+        expect(rules).toContain('function canReadGameSubcollectionDocument(teamId, gameId)');
         expect(rules).toContain('function canReadCollectionGroupGameDocument(teamPath, data)');
         expect(rules).toContain('function canReadManagedTeamDocument(data)');
         expect(rules).toContain('function canReadPublicGameDocument(teamData, data)');
         expect(teamGamesRules).toContain('allow read: if canReadGameDocument(teamId, gameId, resource.data);');
+        expect(eventsRules).toContain('allow read: if canReadGameSubcollectionDocument(teamId, gameId);');
+        expect(aggregatedStatsRules).toContain('allow read: if canReadGameSubcollectionDocument(teamId, gameId);');
         expect(collectionGroupGamesRules).toContain('allow read: if canReadCollectionGroupGameDocument(path, resource.data);');
         expect(teamGamesRules).not.toContain('allow read: if true;');
         expect(collectionGroupGamesRules).not.toContain('allow read: if true;');
+        expect(eventsRules).not.toContain('allow read: if true;');
+        expect(aggregatedStatsRules).not.toContain('allow read: if true;');
     });
 
     it('keeps private-team private games unreadable to outsiders while allowing public or shareable games', () => {


### PR DESCRIPTION
Closes #2328

## What changed
- added a shared Firestore rules helper that resolves the parent `teams/{teamId}/games/{gameId}` document and reuses `canReadGameDocument(...)` for nested game reads
- replaced unconditional `allow read: if true;` on `games/{gameId}/events/{eventId}` and `games/{gameId}/aggregatedStats/{statId}` with the parent-derived helper
- extended the focused unit rule guard and the CI rules validator so both subcollections fail regression checks if they ever revert to public reads

## Root Cause
`events` and `aggregatedStats` were given unconditional public read rules instead of inheriting the same visibility decision as the parent game document. That let private-game subcollection data bypass the stricter parent-game authorization path entirely.

## Prevention / Learning
When a subcollection carries game-scoped or player-scoped data, its read rules must derive from the parent document's visibility helper rather than duplicating or relaxing access inline. Add a regression check for the denied shape, not just the parent document helper, whenever tightening Firebase rules.

## Regression Tests
- `tests/unit/game-read-rules.test.js`
- `node scripts/validate-firebase-rules-ci.mjs`

## Recurrence Risk
Low. The vulnerable subcollections now reuse the parent-game read helper, and CI has an explicit guard against unconditional reads returning on either block.