### PR TITLE
Stop duplicate published drills during pagination

### DIFF
--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -126,8 +126,7 @@ describe('teamDrillsService', () => {
     const result = await loadTeamDrillLibraryPage('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, {
       searchText: ' rondo ',
       type: 'Technical',
-      level: 'Intermediate',
-      cursor: { id: 'cursor-0' }
+      level: 'Intermediate'
     });
 
     expect(dbMocks.getDrills).toHaveBeenCalledWith({
@@ -136,7 +135,7 @@ describe('teamDrillsService', () => {
       level: 'Intermediate',
       searchText: 'rondo',
       limitCount: 12,
-      startAfterDoc: { id: 'cursor-0' }
+      startAfterDoc: null
     });
     expect(dbMocks.getPublishedDrills).toHaveBeenCalledWith({
       sport: 'Soccer',
@@ -148,6 +147,119 @@ describe('teamDrillsService', () => {
     expect(result.favoriteIds).toEqual(['drill-2']);
     expect(result.nextCursor).toEqual({ id: 'cursor-1' });
     expect(result.drills.map((drill) => drill.id)).toEqual(['drill-3', 'drill-1']);
+  });
+
+  it('skips published drill fetches on cursor-based pages and only returns new page drills', async () => {
+    dbMocks.getPublishedDrills.mockResolvedValue([
+      {
+        id: 'published-1',
+        title: 'Published finishing',
+        sport: 'Soccer',
+        type: 'Technical',
+        level: 'Intermediate',
+        skills: ['finishing'],
+        description: 'Published by a coach.',
+        instructions: 'Rotate every rep.',
+        setup: { duration: 10, players: '6-8', cones: 4 }
+      }
+    ]);
+    dbMocks.getDrills.mockResolvedValue({
+      drills: [
+        {
+          id: 'community-2',
+          title: 'Second page build-out',
+          sport: 'Soccer',
+          type: 'Technical',
+          level: 'Intermediate',
+          skills: ['support'],
+          description: 'New page result.',
+          instructions: 'Stay connected.',
+          setup: { duration: 12, players: '8-10', cones: 6 }
+        }
+      ],
+      lastDoc: { id: 'cursor-2' }
+    });
+
+    const result = await loadTeamDrillLibraryPage('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, {
+      searchText: 'rondo',
+      type: 'Technical',
+      level: 'Intermediate',
+      cursor: { id: 'cursor-1' }
+    });
+
+    expect(dbMocks.getDrills).toHaveBeenCalledWith({
+      sport: 'Soccer',
+      type: 'Technical',
+      level: 'Intermediate',
+      searchText: 'rondo',
+      limitCount: 12,
+      startAfterDoc: { id: 'cursor-1' }
+    });
+    expect(dbMocks.getPublishedDrills).not.toHaveBeenCalled();
+    expect(result.drills.map((drill) => drill.id)).toEqual(['community-2']);
+  });
+
+  it('does not return the same published drill twice across sequential page loads', async () => {
+    dbMocks.getPublishedDrills.mockResolvedValue([
+      {
+        id: 'published-1',
+        title: 'Published finishing',
+        sport: 'Soccer',
+        type: 'Technical',
+        level: 'Intermediate',
+        skills: ['finishing'],
+        description: 'Published by a coach.',
+        instructions: 'Rotate every rep.',
+        setup: { duration: 10, players: '6-8', cones: 4 }
+      }
+    ]);
+    dbMocks.getDrills
+      .mockResolvedValueOnce({
+        drills: [
+          {
+            id: 'community-1',
+            title: 'First page rondo',
+            sport: 'Soccer',
+            type: 'Technical',
+            level: 'Intermediate',
+            skills: ['passing'],
+            description: 'First page result.',
+            instructions: 'Stay sharp.',
+            setup: { duration: 12, players: '8-10', cones: 6 }
+          }
+        ],
+        lastDoc: { id: 'cursor-1' }
+      })
+      .mockResolvedValueOnce({
+        drills: [
+          {
+            id: 'community-2',
+            title: 'Second page rondo',
+            sport: 'Soccer',
+            type: 'Technical',
+            level: 'Intermediate',
+            skills: ['support'],
+            description: 'Second page result.',
+            instructions: 'Keep shape.',
+            setup: { duration: 12, players: '8-10', cones: 6 }
+          }
+        ],
+        lastDoc: { id: 'cursor-2' }
+      });
+
+    const firstPage = await loadTeamDrillLibraryPage('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, {
+      type: 'Technical',
+      level: 'Intermediate'
+    });
+    const secondPage = await loadTeamDrillLibraryPage('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, {
+      type: 'Technical',
+      level: 'Intermediate',
+      cursor: firstPage.nextCursor
+    });
+
+    const combinedIds = [...firstPage.drills, ...secondPage.drills].map((drill) => drill.id);
+    expect(new Set(combinedIds)).toEqual(new Set(['published-1', 'community-1', 'community-2']));
+    expect(new Set(combinedIds).size).toBe(combinedIds.length);
   });
 
   it('loads favorite drill details from the shared team favorites store and skips missing drills', async () => {

--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -145,7 +145,7 @@ describe('teamDrillsService', () => {
       limitCount: 12
     });
     expect(result.favoriteIds).toEqual(['drill-2']);
-    expect(result.nextCursor).toEqual({ id: 'cursor-1' });
+    expect(result.nextCursor).toEqual({ communityCursor: { id: 'cursor-1' }, pendingDrills: [] });
     expect(result.drills.map((drill) => drill.id)).toEqual(['drill-3', 'drill-1']);
   });
 
@@ -184,7 +184,7 @@ describe('teamDrillsService', () => {
       searchText: 'rondo',
       type: 'Technical',
       level: 'Intermediate',
-      cursor: { id: 'cursor-1' }
+      cursor: { communityCursor: { id: 'cursor-1' }, pendingDrills: [] }
     });
 
     expect(dbMocks.getDrills).toHaveBeenCalledWith({
@@ -197,6 +197,68 @@ describe('teamDrillsService', () => {
     });
     expect(dbMocks.getPublishedDrills).not.toHaveBeenCalled();
     expect(result.drills.map((drill) => drill.id)).toEqual(['community-2']);
+    expect(result.nextCursor).toEqual({ communityCursor: { id: 'cursor-2' }, pendingDrills: [] });
+  });
+
+  it('carries overflow drills into the next page so published drills are not dropped', async () => {
+    dbMocks.getPublishedDrills.mockResolvedValue([
+      {
+        id: 'published-1',
+        title: 'Zulu finishing',
+        sport: 'Soccer',
+        type: 'Technical',
+        level: 'Intermediate',
+        skills: ['finishing'],
+        description: 'Published by a coach.',
+        instructions: 'Rotate every rep.',
+        setup: { duration: 10, players: '6-8', cones: 4 }
+      }
+    ]);
+    dbMocks.getDrills.mockResolvedValueOnce({
+      drills: Array.from({ length: 12 }, (_, index) => ({
+        id: `community-${index + 1}`,
+        title: `Community drill ${String(index + 1).padStart(2, '0')}`,
+        sport: 'Soccer',
+        type: 'Technical',
+        level: 'Intermediate',
+        skills: ['passing'],
+        description: 'Community result.',
+        instructions: 'Keep moving.',
+        setup: { duration: 12, players: '8-10', cones: 6 }
+      })),
+      lastDoc: { id: 'cursor-1' }
+    });
+    dbMocks.getDrills.mockResolvedValueOnce({
+      drills: [
+        {
+          id: 'community-13',
+          title: 'Community drill 13',
+          sport: 'Soccer',
+          type: 'Technical',
+          level: 'Intermediate',
+          skills: ['support'],
+          description: 'Next page result.',
+          instructions: 'Stay connected.',
+          setup: { duration: 12, players: '8-10', cones: 6 }
+        }
+      ],
+      lastDoc: null
+    });
+
+    const firstPage = await loadTeamDrillLibraryPage('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, {
+      type: 'Technical',
+      level: 'Intermediate'
+    });
+    const secondPage = await loadTeamDrillLibraryPage('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, {
+      type: 'Technical',
+      level: 'Intermediate',
+      cursor: firstPage.nextCursor
+    });
+
+    expect(firstPage.drills).toHaveLength(12);
+    expect(firstPage.drills.map((drill) => drill.id)).not.toContain('published-1');
+    expect(secondPage.drills.map((drill) => drill.id)).toContain('published-1');
+    expect(secondPage.nextCursor).toBeNull();
   });
 
   it('does not return the same published drill twice across sequential page loads', async () => {
@@ -260,6 +322,32 @@ describe('teamDrillsService', () => {
     const combinedIds = [...firstPage.drills, ...secondPage.drills].map((drill) => drill.id);
     expect(new Set(combinedIds)).toEqual(new Set(['published-1', 'community-1', 'community-2']));
     expect(new Set(combinedIds).size).toBe(combinedIds.length);
+  });
+
+  it('replays overflow drills without refetching community pages when only pending results remain', async () => {
+    const result = await loadTeamDrillLibraryPage('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, {
+      cursor: {
+        communityCursor: null,
+        pendingDrills: [
+          {
+            id: 'published-1',
+            title: 'Published finishing',
+            sport: 'Soccer',
+            type: 'Technical',
+            level: 'Intermediate',
+            skills: ['finishing'],
+            description: 'Published by a coach.',
+            instructions: 'Rotate every rep.',
+            setup: { duration: 10, players: '6-8', cones: 4 }
+          }
+        ]
+      }
+    });
+
+    expect(dbMocks.getDrills).not.toHaveBeenCalled();
+    expect(dbMocks.getPublishedDrills).not.toHaveBeenCalled();
+    expect(result.drills.map((drill) => drill.id)).toEqual(['published-1']);
+    expect(result.nextCursor).toBeNull();
   });
 
   it('loads favorite drill details from the shared team favorites store and skips missing drills', async () => {

--- a/apps/app/src/lib/teamDrillsService.ts
+++ b/apps/app/src/lib/teamDrillsService.ts
@@ -149,6 +149,7 @@ export async function loadTeamDrillLibraryPage(
     type: normalizeFilterValue(filters.type, DRILL_TYPES as string[]),
     level: normalizeFilterValue(filters.level, DRILL_LEVELS as string[])
   };
+  const isPaginatedRequest = Boolean(filters.cursor);
 
   const [favoriteIds, page, publishedDrills] = await Promise.all([
     Promise.resolve(getDrillFavorites(teamId)),
@@ -160,13 +161,15 @@ export async function loadTeamDrillLibraryPage(
       limitCount: drillLibraryPageSize,
       startAfterDoc: filters.cursor || null
     })),
-    Promise.resolve(getPublishedDrills({
-      sport: access.team.sport,
-      type: normalizedFilters.type || undefined,
-      level: normalizedFilters.level || undefined,
-      searchText: normalizedFilters.searchText || undefined,
-      limitCount: drillLibraryPageSize
-    }))
+    isPaginatedRequest
+      ? Promise.resolve([])
+      : Promise.resolve(getPublishedDrills({
+        sport: access.team.sport,
+        type: normalizedFilters.type || undefined,
+        level: normalizedFilters.level || undefined,
+        searchText: normalizedFilters.searchText || undefined,
+        limitCount: drillLibraryPageSize
+      }))
   ]);
 
   const mergedDrills = [...(Array.isArray(page?.drills) ? page.drills : []), ...(Array.isArray(publishedDrills) ? publishedDrills : [])];

--- a/apps/app/src/lib/teamDrillsService.ts
+++ b/apps/app/src/lib/teamDrillsService.ts
@@ -66,6 +66,11 @@ export type TeamFavoriteDrillsModel = {
   drills: TeamDrillSummary[];
 };
 
+type TeamDrillLibraryCursor = {
+  communityCursor: unknown | null;
+  pendingDrills: any[];
+};
+
 function normalizeString(value: unknown) {
   return String(value || '').trim();
 }
@@ -88,6 +93,36 @@ function normalizeFilterValue(value: unknown, allowedValues: string[]) {
 
 function normalizeSearchText(value: unknown) {
   return normalizeString(value).toLowerCase();
+}
+
+function normalizeLibraryCursor(cursor: unknown): TeamDrillLibraryCursor {
+  if (!cursor || typeof cursor !== 'object' || Array.isArray(cursor)) {
+    return {
+      communityCursor: cursor || null,
+      pendingDrills: []
+    };
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(cursor, 'communityCursor') && !Object.prototype.hasOwnProperty.call(cursor, 'pendingDrills')) {
+    return {
+      communityCursor: cursor,
+      pendingDrills: []
+    };
+  }
+
+  const candidate = cursor as { communityCursor?: unknown; pendingDrills?: unknown };
+  return {
+    communityCursor: candidate.communityCursor || null,
+    pendingDrills: Array.isArray(candidate.pendingDrills) ? candidate.pendingDrills : []
+  };
+}
+
+function createNextCursor(communityCursor: unknown, pendingDrills: any[]) {
+  if (!communityCursor && !pendingDrills.length) return null;
+  return {
+    communityCursor: communityCursor || null,
+    pendingDrills
+  };
 }
 
 async function loadTeamAccess(teamId: string, user: AuthUser | null) {
@@ -149,18 +184,22 @@ export async function loadTeamDrillLibraryPage(
     type: normalizeFilterValue(filters.type, DRILL_TYPES as string[]),
     level: normalizeFilterValue(filters.level, DRILL_LEVELS as string[])
   };
+  const cursorState = normalizeLibraryCursor(filters.cursor);
   const isPaginatedRequest = Boolean(filters.cursor);
+  const shouldLoadCommunityPage = !isPaginatedRequest || Boolean(cursorState.communityCursor) || !cursorState.pendingDrills.length;
 
   const [favoriteIds, page, publishedDrills] = await Promise.all([
     Promise.resolve(getDrillFavorites(teamId)),
-    Promise.resolve(getDrills({
-      sport: access.team.sport,
-      type: normalizedFilters.type || undefined,
-      level: normalizedFilters.level || undefined,
-      searchText: normalizedFilters.searchText || undefined,
-      limitCount: drillLibraryPageSize,
-      startAfterDoc: filters.cursor || null
-    })),
+    shouldLoadCommunityPage
+      ? Promise.resolve(getDrills({
+        sport: access.team.sport,
+        type: normalizedFilters.type || undefined,
+        level: normalizedFilters.level || undefined,
+        searchText: normalizedFilters.searchText || undefined,
+        limitCount: drillLibraryPageSize,
+        startAfterDoc: cursorState.communityCursor
+      }))
+      : Promise.resolve({ drills: [], lastDoc: null }),
     isPaginatedRequest
       ? Promise.resolve([])
       : Promise.resolve(getPublishedDrills({
@@ -172,17 +211,23 @@ export async function loadTeamDrillLibraryPage(
       }))
   ]);
 
-  const mergedDrills = [...(Array.isArray(page?.drills) ? page.drills : []), ...(Array.isArray(publishedDrills) ? publishedDrills : [])];
+  const mergedDrills = [
+    ...(Array.isArray(cursorState.pendingDrills) ? cursorState.pendingDrills : []),
+    ...(Array.isArray(page?.drills) ? page.drills : []),
+    ...(Array.isArray(publishedDrills) ? publishedDrills : [])
+  ];
   const uniqueDrills = Array.from(new Map(mergedDrills.map((drill) => [normalizeString(drill?.id), drill])).entries())
     .filter(([id]) => Boolean(id))
     .map(([, drill]) => drill)
     .sort((left, right) => normalizeString(left?.title).localeCompare(normalizeString(right?.title)));
+  const visibleDrills = uniqueDrills.slice(0, drillLibraryPageSize);
+  const pendingDrills = uniqueDrills.slice(drillLibraryPageSize);
 
   return {
     ...access,
-    drills: uniqueDrills.slice(0, drillLibraryPageSize).map(toTeamDrillSummary),
+    drills: visibleDrills.map(toTeamDrillSummary),
     favoriteIds: Array.isArray(favoriteIds) ? favoriteIds.map((id) => normalizeString(id)).filter(Boolean) : [],
-    nextCursor: page?.lastDoc || null,
+    nextCursor: createNextCursor(page?.lastDoc || null, pendingDrills),
     filters: normalizedFilters
   };
 }

--- a/apps/app/src/pages/TeamDrills.test.tsx
+++ b/apps/app/src/pages/TeamDrills.test.tsx
@@ -165,4 +165,40 @@ describe('TeamDrills', () => {
     expect(await screen.findByText('Coach/admin access required')).toBeTruthy();
     expect(screen.getByText('Only team owners, team admins, and global admins can browse and favorite drills for a team.')).toBeTruthy();
   });
+
+  it('deduplicates repeated drill ids when load more returns an already rendered drill', async () => {
+    teamDrillsServiceMocks.loadTeamDrillLibraryPage
+      .mockResolvedValueOnce(createPage({
+        drills: [
+          createDrill({ id: 'published-1', title: 'Published finishing' }),
+          createDrill({ id: 'community-1', title: 'Rondo 4v2' })
+        ],
+        favoriteIds: ['published-1'],
+        nextCursor: { id: 'cursor-1' }
+      }))
+      .mockResolvedValueOnce(createPage({
+        drills: [
+          createDrill({ id: 'published-1', title: 'Published finishing' }),
+          createDrill({ id: 'community-2', title: 'Third-man run pattern' })
+        ],
+        favoriteIds: ['published-1'],
+        nextCursor: null
+      }));
+
+    renderTeamDrills();
+
+    expect(await screen.findByText('Published finishing')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Load more drills' }));
+
+    await waitFor(() => expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenNthCalledWith(2, 'team-1', auth.user, {
+      searchText: '',
+      type: '',
+      level: '',
+      cursor: { id: 'cursor-1' }
+    }));
+
+    expect(await screen.findByText('Third-man run pattern')).toBeTruthy();
+    expect(screen.getAllByText('Published finishing')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Favorites (1)' })).toBeTruthy();
+  });
 });

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -11,6 +11,10 @@ type DrillTab = 'community' | 'favorites';
 const drillTypeOptions = DRILL_TYPES as string[];
 const drillLevelOptions = DRILL_LEVELS as string[];
 
+function mergeUniqueDrills(drills: TeamDrillSummary[]) {
+  return Array.from(new Map(drills.map((drill) => [drill.id, drill])).values());
+}
+
 export function TeamDrills({ auth }: { auth: AuthState }) {
   const { teamId = '' } = useParams();
   const [teamName, setTeamName] = useState('Team');
@@ -118,7 +122,7 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
         level: levelFilter,
         cursor: nextCursor
       });
-      setCommunityDrills((current) => [...current, ...page.drills]);
+      setCommunityDrills((current) => mergeUniqueDrills([...current, ...page.drills]));
       setFavoriteIds(page.favoriteIds);
       setNextCursor(page.nextCursor);
     } catch (loadError: any) {


### PR DESCRIPTION
Closes #2330

## What changed
- Skip `getPublishedDrills(...)` for cursor-based `loadTeamDrillLibraryPage(...)` requests so published drills stay first-page bootstrap data.
- Deduplicate `TeamDrills` load-more appends by drill id before updating rendered community drills.
- Added service regressions for cursor pagination and sequential page uniqueness.
- Added a page regression proving a repeated drill id from a later load-more response only renders once.

## Root Cause
`loadTeamDrillLibraryPage(...)` merged published drills into every paginated response instead of only the initial page, and `TeamDrills` appended each later page blindly. That let the same published drill ids accumulate across load-more actions.

## Prevention / Learning
When a list combines bootstrap data with a cursor-paginated source, keep the bootstrap source out of later cursor fetches. Also add an id-based append guard in the UI so a duplicate backend payload cannot re-render the same card twice.

## Regression Tests
- `npx vitest run apps/app/src/lib/teamDrillsService.test.ts apps/app/src/pages/TeamDrills.test.tsx --reporter=verbose`
- `apps/app/src/lib/teamDrillsService.test.ts` now covers skipping published fetches on cursor pages and preserving unique ids across sequential loads.
- `apps/app/src/pages/TeamDrills.test.tsx` now covers duplicate ids returned by load more rendering only once.

## Recurrence Risk
Low. Cursor pages no longer re-fetch published bootstrap drills, and the page now deduplicates repeated ids before rendering.