### PR TITLE
Add help page reference coverage for shipped pages

### DIFF
--- a/help-page-reference.html
+++ b/help-page-reference.html
@@ -30,28 +30,34 @@
           <tr><td class="px-4 py-3 font-mono">reset-password.html</td><td class="px-4 py-3">Password reset entry and completion</td><td class="px-4 py-3">All</td></tr>
           <tr><td class="px-4 py-3 font-mono">verify-pending.html</td><td class="px-4 py-3">Pending verification state guidance</td><td class="px-4 py-3">All new users</td></tr>
           <tr><td class="px-4 py-3 font-mono">profile.html</td><td class="px-4 py-3">Profile settings and account details</td><td class="px-4 py-3">Member, Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">athlete-profile-builder.html</td><td class="px-4 py-3">Parent-managed athlete profile builder, headshots, and highlight sharing</td><td class="px-4 py-3">Parent</td></tr>
+          <tr><td class="px-4 py-3 font-mono">athlete-profile.html</td><td class="px-4 py-3">Read-only athlete profile with stats and highlight media</td><td class="px-4 py-3">All</td></tr>
 
           <tr><td class="px-4 py-3 font-mono">teams.html</td><td class="px-4 py-3">Browse teams and discovery</td><td class="px-4 py-3">All</td></tr>
           <tr><td class="px-4 py-3 font-mono">team.html</td><td class="px-4 py-3">Team details, schedule, roster, links to operations</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
           <tr><td class="px-4 py-3 font-mono">dashboard.html</td><td class="px-4 py-3">My Teams management dashboard</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">parent-dashboard.html</td><td class="px-4 py-3">Parent-centric schedule/player actions</td><td class="px-4 py-3">Parent</td></tr>
+          <tr><td class="px-4 py-3 font-mono">family.html</td><td class="px-4 py-3">Read-only family share page for schedules, players, and team info</td><td class="px-4 py-3">Shared families</td></tr>
           <tr><td class="px-4 py-3 font-mono">admin.html</td><td class="px-4 py-3">Global admin tools and access control</td><td class="px-4 py-3">Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">check-admin-status.html</td><td class="px-4 py-3">Admin entitlement check and access troubleshooting</td><td class="px-4 py-3">Admin</td></tr>
 
           <tr><td class="px-4 py-3 font-mono">edit-team.html</td><td class="px-4 py-3">Team metadata updates</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">edit-roster.html</td><td class="px-4 py-3">Player roster create/update/delete</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">edit-schedule.html</td><td class="px-4 py-3">Game/practice planning, event editing, tracker launching</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">organization-schedule.html</td><td class="px-4 py-3">Organization-wide shared matchups, venue availability, and blackout controls</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">calendar.html</td><td class="px-4 py-3">Calendar/schedule visualization</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
           <tr><td class="px-4 py-3 font-mono">edit-config.html</td><td class="px-4 py-3">Stats and tracker config management</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">drills.html</td><td class="px-4 py-3">Drill planning and library workflows</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">game-plan.html</td><td class="px-4 py-3">Game plan creation and review</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">game-day.html</td><td class="px-4 py-3">Game-day operational controls</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">tracking-items.html</td><td class="px-4 py-3">Tracking item templates and admin setup</td><td class="px-4 py-3">Coach, Admin</td></tr>
 
           <tr><td class="px-4 py-3 font-mono">track.html</td><td class="px-4 py-3">Standard game tracking</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">track-live.html</td><td class="px-4 py-3">Live tracker (multi-sport), chat, unified notes, game log</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">live-tracker.html</td><td class="px-4 py-3">Basketball-specific live tracker</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">track-basketball.html</td><td class="px-4 py-3">Basketball beta tracker flow</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">track-statsheet.html</td><td class="px-4 py-3">Statsheet tracking/import path</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">officials.html</td><td class="px-4 py-3">Official assignments, self-claiming open slots, and result submission</td><td class="px-4 py-3">Officials</td></tr>
 
           <tr><td class="px-4 py-3 font-mono">game.html</td><td class="px-4 py-3">Post-game report view, score/stats outcomes</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
           <tr><td class="px-4 py-3 font-mono">live-game.html</td><td class="px-4 py-3">Live/replay game viewing and chat eligibility</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
@@ -59,10 +65,13 @@
           <tr><td class="px-4 py-3 font-mono">team-chat.html</td><td class="px-4 py-3">Team chat room, mentions/tags, communication thread</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">certificates.html</td><td class="px-4 py-3">Awards, certificates, publishing, and parent viewing</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">registration.html</td><td class="px-4 py-3">Program registration form and submission confirmation</td><td class="px-4 py-3">Parent</td></tr>
-          <tr><td class="px-4 py-3 font-mono">team-fees.html</td><td class="px-4 py-3">Team fee management, invoices, and payments</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">public-rsvp.html</td><td class="px-4 py-3">No-sign-in RSVP responses from secure invite links</td><td class="px-4 py-3">Parents, invited family</td></tr>
+          <tr><td class="px-4 py-3 font-mono">team-fees.html</td><td class="px-4 py-3">Offline fee batch management, invoices, and payment tracking</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">team-media.html</td><td class="px-4 py-3">Team media albums, uploads, and video links</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">widget-scoreboard.html</td><td class="px-4 py-3">Embeddable live scoreboard widget for public viewing</td><td class="px-4 py-3">All</td></tr>
 
           <tr><td class="px-4 py-3 font-mono">help.html</td><td class="px-4 py-3">Help portal landing and topic routing</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">changelog.html</td><td class="px-4 py-3">Product release notes, fixes, and feature history</td><td class="px-4 py-3">All</td></tr>
           <tr><td class="px-4 py-3 font-mono">help-account.html</td><td class="px-4 py-3">Account/access ownership by role</td><td class="px-4 py-3">All</td></tr>
           <tr><td class="px-4 py-3 font-mono">help-team-operations.html</td><td class="px-4 py-3">Team setup and management ownership by role</td><td class="px-4 py-3">All</td></tr>
           <tr><td class="px-4 py-3 font-mono">help-game-operations.html</td><td class="px-4 py-3">Game planning/tracking ownership by role</td><td class="px-4 py-3">All</td></tr>

--- a/help-page-reference.html
+++ b/help-page-reference.html
@@ -36,6 +36,7 @@
           <tr><td class="px-4 py-3 font-mono">dashboard.html</td><td class="px-4 py-3">My Teams management dashboard</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">parent-dashboard.html</td><td class="px-4 py-3">Parent-centric schedule/player actions</td><td class="px-4 py-3">Parent</td></tr>
           <tr><td class="px-4 py-3 font-mono">admin.html</td><td class="px-4 py-3">Global admin tools and access control</td><td class="px-4 py-3">Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">check-admin-status.html</td><td class="px-4 py-3">Admin entitlement check and access troubleshooting</td><td class="px-4 py-3">Admin</td></tr>
 
           <tr><td class="px-4 py-3 font-mono">edit-team.html</td><td class="px-4 py-3">Team metadata updates</td><td class="px-4 py-3">Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">edit-roster.html</td><td class="px-4 py-3">Player roster create/update/delete</td><td class="px-4 py-3">Coach, Admin</td></tr>
@@ -56,6 +57,10 @@
           <tr><td class="px-4 py-3 font-mono">live-game.html</td><td class="px-4 py-3">Live/replay game viewing and chat eligibility</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
           <tr><td class="px-4 py-3 font-mono">player.html</td><td class="px-4 py-3">Player profile and game report drilldown</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
           <tr><td class="px-4 py-3 font-mono">team-chat.html</td><td class="px-4 py-3">Team chat room, mentions/tags, communication thread</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">certificates.html</td><td class="px-4 py-3">Awards, certificates, publishing, and parent viewing</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">registration.html</td><td class="px-4 py-3">Program registration form and submission confirmation</td><td class="px-4 py-3">Parent</td></tr>
+          <tr><td class="px-4 py-3 font-mono">team-fees.html</td><td class="px-4 py-3">Team fee management, invoices, and payments</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">team-media.html</td><td class="px-4 py-3">Team media albums, uploads, and video links</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
 
           <tr><td class="px-4 py-3 font-mono">help.html</td><td class="px-4 py-3">Help portal landing and topic routing</td><td class="px-4 py-3">All</td></tr>
           <tr><td class="px-4 py-3 font-mono">help-account.html</td><td class="px-4 py-3">Account/access ownership by role</td><td class="px-4 py-3">All</td></tr>

--- a/tests/smoke/help-center.spec.js
+++ b/tests/smoke/help-center.spec.js
@@ -26,6 +26,15 @@ async function readPageReferenceFiles(page) {
     return values.filter((value) => value.endsWith('.html'));
 }
 
+async function expectReferenceRow(page, file, roles) {
+    const row = page.locator('tbody tr').filter({
+        has: page.locator('td.font-mono', { hasText: file })
+    });
+
+    await expect(row, `${file} row should be visible`).toBeVisible();
+    await expect(row, `${file} row should show ${roles}`).toContainText(roles);
+}
+
 function readRepoHtml(relativePath) {
     return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
 }
@@ -119,6 +128,11 @@ test('help center supports workflow discovery and page-reference navigation', as
     await expect(page.locator('tbody')).toContainText('edit-schedule.html');
     await expect(page.locator('tbody')).toContainText('live-game.html');
     await expect(page.locator('tbody')).toContainText('help-page-reference.html');
+    await expectReferenceRow(page, 'certificates.html', 'Parent, Coach, Admin');
+    await expectReferenceRow(page, 'check-admin-status.html', 'Admin');
+    await expectReferenceRow(page, 'registration.html', 'Parent');
+    await expectReferenceRow(page, 'team-fees.html', 'Parent, Coach, Admin');
+    await expectReferenceRow(page, 'team-media.html', 'Parent, Coach, Admin');
 
     await page.getByRole('link', { name: '← Back to Help Portal' }).click();
     await expect(page).toHaveURL(/help\.html/);
@@ -148,6 +162,13 @@ test('help manifest and page-reference files resolve successfully', async ({ pag
     expect(referenceFiles).toContain('edit-schedule.html');
     expect(referenceFiles).toContain('live-game.html');
     expect(referenceFiles).toContain('help-page-reference.html');
+    expect(referenceFiles).toEqual(expect.arrayContaining([
+        'certificates.html',
+        'check-admin-status.html',
+        'registration.html',
+        'team-fees.html',
+        'team-media.html'
+    ]));
 
     const uniqueFiles = [...new Set([...workflowFiles, ...referenceFiles])];
     const indexResponse = await request.get(buildUrl(baseURL, '/index.html'));

--- a/tests/smoke/help-center.spec.js
+++ b/tests/smoke/help-center.spec.js
@@ -131,7 +131,7 @@ test('help center supports workflow discovery and page-reference navigation', as
     await expectReferenceRow(page, 'certificates.html', 'Parent, Coach, Admin');
     await expectReferenceRow(page, 'check-admin-status.html', 'Admin');
     await expectReferenceRow(page, 'registration.html', 'Parent');
-    await expectReferenceRow(page, 'team-fees.html', 'Parent, Coach, Admin');
+    await expectReferenceRow(page, 'team-fees.html', 'Coach, Admin');
     await expectReferenceRow(page, 'team-media.html', 'Parent, Coach, Admin');
 
     await page.getByRole('link', { name: '← Back to Help Portal' }).click();

--- a/tests/unit/help-page-reference-integrity.test.js
+++ b/tests/unit/help-page-reference-integrity.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,8 +10,12 @@ function readRepoFile(relativePath) {
     return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
 }
 
-function extractReferenceFiles(html) {
-    return [...html.matchAll(/<td class="px-4 py-3 font-mono">([^<]+\.html)<\/td>/g)].map((match) => match[1]);
+function extractReferenceRows(html) {
+    return [...html.matchAll(/<tr><td class="px-4 py-3 font-mono">([^<]+\.html)<\/td><td class="px-4 py-3">([^<]+)<\/td><td class="px-4 py-3">([^<]+)<\/td><\/tr>/g)].map((match) => ({
+        file: match[1],
+        features: match[2],
+        roles: match[3]
+    }));
 }
 
 describe('help page reference integrity', () => {
@@ -27,7 +31,8 @@ describe('help page reference integrity', () => {
         expect(referenceHtml).toContain('data-help-back-link');
         expect(referenceHtml).toContain('./js/help-context.js?v=1');
 
-        const referencedFiles = extractReferenceFiles(referenceHtml);
+        const referenceRows = extractReferenceRows(referenceHtml);
+        const referencedFiles = referenceRows.map((row) => row.file);
 
         expect(referencedFiles).toContain('edit-schedule.html');
         expect(referencedFiles).toContain('live-game.html');
@@ -35,6 +40,29 @@ describe('help page reference integrity', () => {
 
         referencedFiles.forEach((file) => {
             expect(existsSync(resolve(REPO_ROOT, file)), `${file} should exist in the repo`).toBe(true);
+        });
+
+        const requiredUserFacingPages = new Set([
+            'certificates.html',
+            'check-admin-status.html',
+            'registration.html',
+            'team-fees.html',
+            'team-media.html'
+        ]);
+        const expectedUserFacingPages = readdirSync(REPO_ROOT)
+            .filter((file) => requiredUserFacingPages.has(file))
+            .sort();
+
+        expect(expectedUserFacingPages).toEqual([
+            'certificates.html',
+            'check-admin-status.html',
+            'registration.html',
+            'team-fees.html',
+            'team-media.html'
+        ]);
+
+        expectedUserFacingPages.forEach((file) => {
+            expect(referencedFiles, `${file} should be listed in help-page-reference.html`).toContain(file);
         });
     });
 

--- a/tests/unit/help-page-reference-integrity.test.js
+++ b/tests/unit/help-page-reference-integrity.test.js
@@ -18,6 +18,15 @@ function extractReferenceRows(html) {
     }));
 }
 
+function listTrackedShippedPages() {
+    return readdirSync(REPO_ROOT)
+        .filter((file) => file.endsWith('.html'))
+        .filter((file) => !file.startsWith('test-'))
+        .filter((file) => !file.startsWith('workflow-'))
+        .filter((file) => !file.startsWith('help-'))
+        .sort();
+}
+
 describe('help page reference integrity', () => {
     it('keeps the file-by-file page reference discoverable from help center', () => {
         const helpHtml = readRepoFile('help.html');
@@ -42,27 +51,13 @@ describe('help page reference integrity', () => {
             expect(existsSync(resolve(REPO_ROOT, file)), `${file} should exist in the repo`).toBe(true);
         });
 
-        const requiredUserFacingPages = new Set([
-            'certificates.html',
-            'check-admin-status.html',
-            'registration.html',
-            'team-fees.html',
-            'team-media.html'
-        ]);
-        const expectedUserFacingPages = readdirSync(REPO_ROOT)
-            .filter((file) => requiredUserFacingPages.has(file))
-            .sort();
+        const trackedShippedPages = listTrackedShippedPages();
+        const missingTrackedPages = trackedShippedPages.filter((file) => !referencedFiles.includes(file));
 
-        expect(expectedUserFacingPages).toEqual([
-            'certificates.html',
-            'check-admin-status.html',
-            'registration.html',
-            'team-fees.html',
-            'team-media.html'
-        ]);
-
-        expectedUserFacingPages.forEach((file) => {
-            expect(referencedFiles, `${file} should be listed in help-page-reference.html`).toContain(file);
+        expect(missingTrackedPages).toEqual([]);
+        expect(referenceRows.find((row) => row.file === 'team-fees.html')).toMatchObject({
+            features: 'Offline fee batch management, invoices, and payment tracking',
+            roles: 'Coach, Admin'
         });
     });
 


### PR DESCRIPTION
Closes #2337

## What changed
- added the missing shipped page rows to `help-page-reference.html` for `certificates.html`, `check-admin-status.html`, `registration.html`, `team-fees.html`, and `team-media.html`
- extended `tests/unit/help-page-reference-integrity.test.js` so the integrity check derives the required shipped-page subset from the repo root and fails if any of those user-facing pages are missing from the reference table
- extended `tests/smoke/help-center.spec.js` so `/help-page-reference.html` must visibly render those rows with stable role labels

## Root Cause
The help page reference was maintained manually, but the existing integrity test only verified that already-listed rows existed on disk and the smoke test only spot-checked a few rows. That left no completeness guard for newly shipped pages, so omissions could ship silently.

## Prevention / Learning
When a help index or navigation matrix is expected to cover shipped pages, tests need a completeness assertion derived from a source of truth such as repo files or a manifest, not just validation of rows that already exist. For user-facing help tables, add a smoke assertion for visible labels when role guidance matters.

## Regression Tests
- passed: `npx vitest run tests/unit/help-page-reference-integrity.test.js --reporter=verbose`
- updated: `tests/smoke/help-center.spec.js` now asserts visible rows and role labels for the newly covered pages
- local Playwright execution is currently blocked in this workspace because the Chromium binary is not installed yet and `npx playwright install` has not been run