### PR TITLE
Preserve Officials action success state

### DIFF
--- a/apps/app/src/pages/Officials.test.tsx
+++ b/apps/app/src/pages/Officials.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Officials } from './Officials';
+import type { OfficialAssignmentItem } from '../lib/scheduleService';
+import type { AuthState } from '../lib/types';
+
+const scheduleServiceMocks = vi.hoisted(() => ({
+    loadOfficialAssignments: vi.fn(),
+    respondToOfficialAssignmentItem: vi.fn(),
+    claimOfficialAssignmentItem: vi.fn()
+}));
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => navigateMock
+    };
+});
+
+vi.mock('../lib/homeLogic', () => ({
+    getEventDetailPath: vi.fn(() => '/schedule/team-1/game-1')
+}));
+
+vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+
+const auth: AuthState = {
+    user: {
+        uid: 'official-1',
+        email: 'ref@example.com',
+        displayName: 'Riley Ref',
+        roles: []
+    },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: [],
+    isParent: false,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn()
+};
+
+function buildAssignment(overrides: Partial<OfficialAssignmentItem> = {}): OfficialAssignmentItem {
+    return {
+        kind: 'assigned',
+        teamId: 'team-1',
+        teamName: 'Bears FC',
+        gameId: 'game-1',
+        slotId: 'slot-1',
+        position: 'Center Referee',
+        status: 'pending',
+        opponent: 'Tigers',
+        location: 'Field 2',
+        date: new Date('2026-06-20T18:00:00.000Z'),
+        canClaim: false,
+        scheduleReviewRequired: false,
+        ...overrides
+    };
+}
+
+function LocationProbe() {
+    const location = useLocation();
+    return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderOfficials(path = '/officials') {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route path="/officials" element={<Officials auth={auth} />} />
+                <Route path="/home" element={<div><div>Home page</div><LocationProbe /></div>} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+describe('Officials', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        navigateMock.mockReset();
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders assignment and open-slot summaries with the correct action controls', async () => {
+        scheduleServiceMocks.loadOfficialAssignments.mockResolvedValue({
+            hasAccess: true,
+            teamIds: ['team-1'],
+            teamCount: 1,
+            assignments: [
+                buildAssignment({ scheduleReviewRequired: true }),
+                buildAssignment({
+                    kind: 'open',
+                    slotId: 'slot-2',
+                    position: 'Line Judge',
+                    status: 'open',
+                    canClaim: true
+                })
+            ]
+        });
+
+        renderOfficials('/officials?teamId=team-1');
+
+        expect(await screen.findByRole('heading', { name: 'Assignments' })).toBeTruthy();
+        expect(screen.getByText('Assigned').nextElementSibling?.textContent).toBe('1');
+        expect(screen.getByText('Open').nextElementSibling?.textContent).toBe('1');
+        expect(screen.getByText('Pending').nextElementSibling?.textContent).toBe('1');
+        expect(screen.getAllByText('Center Referee · vs. Tigers')).toHaveLength(1);
+        expect(screen.getByRole('button', { name: 'Accept' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Decline' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Claim slot' })).toBeTruthy();
+        expect(screen.getByText('Needs review')).toBeTruthy();
+        expect(scheduleServiceMocks.loadOfficialAssignments).toHaveBeenCalledWith(auth.user, { teamId: 'team-1' });
+    });
+
+    it('refreshes the page after accepting an assignment and shows the success state', async () => {
+        const pendingAssignment = buildAssignment({ scheduleReviewRequired: true });
+        const refreshedAssignment = buildAssignment({ status: 'accepted', scheduleReviewRequired: false });
+        const acceptRequest = deferred<void>();
+
+        scheduleServiceMocks.loadOfficialAssignments
+            .mockResolvedValueOnce({
+                hasAccess: true,
+                teamIds: ['team-1'],
+                teamCount: 1,
+                assignments: [pendingAssignment]
+            })
+            .mockResolvedValueOnce({
+                hasAccess: true,
+                teamIds: ['team-1'],
+                teamCount: 1,
+                assignments: [refreshedAssignment]
+            });
+        scheduleServiceMocks.respondToOfficialAssignmentItem.mockReturnValue(acceptRequest.promise);
+
+        renderOfficials();
+
+        const acceptButton = await screen.findByRole('button', { name: 'Accept' });
+        fireEvent.click(acceptButton);
+
+        await waitFor(() => {
+            expect(screen.getAllByRole('button', { name: 'Saving' })).toHaveLength(2);
+        });
+        expect(scheduleServiceMocks.respondToOfficialAssignmentItem).toHaveBeenCalledWith(pendingAssignment, 'accepted');
+
+        acceptRequest.resolve();
+
+        expect(await screen.findByText('Center Referee accepted.')).toBeTruthy();
+        await waitFor(() => {
+            expect(scheduleServiceMocks.loadOfficialAssignments).toHaveBeenCalledTimes(2);
+        });
+        expect(screen.getByText('Assigned').nextElementSibling?.textContent).toBe('1');
+        expect(screen.getByText('Open').nextElementSibling?.textContent).toBe('0');
+        expect(screen.getByText('Pending').nextElementSibling?.textContent).toBe('0');
+        expect(screen.getByText('Status saved on the team schedule.')).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Accept' })).toBeNull();
+        expect(screen.queryByText('Needs review')).toBeNull();
+    });
+
+    it('refreshes the page after claiming an open slot and shows updated counts', async () => {
+        const openAssignment = buildAssignment({
+            kind: 'open',
+            slotId: 'slot-2',
+            position: 'Line Judge',
+            status: 'open',
+            canClaim: true
+        });
+        const claimedAssignment = buildAssignment({
+            slotId: 'slot-2',
+            position: 'Line Judge',
+            status: 'accepted',
+            canClaim: false
+        });
+        const claimRequest = deferred<void>();
+
+        scheduleServiceMocks.loadOfficialAssignments
+            .mockResolvedValueOnce({
+                hasAccess: true,
+                teamIds: ['team-1'],
+                teamCount: 1,
+                assignments: [openAssignment]
+            })
+            .mockResolvedValueOnce({
+                hasAccess: true,
+                teamIds: ['team-1'],
+                teamCount: 1,
+                assignments: [claimedAssignment]
+            });
+        scheduleServiceMocks.claimOfficialAssignmentItem.mockReturnValue(claimRequest.promise);
+
+        renderOfficials();
+
+        await screen.findByText('Line Judge · vs. Tigers');
+        const claimButton = screen.getByRole('button', { name: 'Claim slot' });
+        fireEvent.click(claimButton);
+
+        expect(await screen.findByRole('button', { name: 'Claiming' })).toBeTruthy();
+        expect(scheduleServiceMocks.claimOfficialAssignmentItem).toHaveBeenCalledWith(openAssignment, auth.user);
+
+        claimRequest.resolve();
+
+        expect(await screen.findByText('Line Judge claimed.')).toBeTruthy();
+        await waitFor(() => {
+            expect(scheduleServiceMocks.loadOfficialAssignments).toHaveBeenCalledTimes(2);
+        });
+        expect(screen.getByText('Assigned').nextElementSibling?.textContent).toBe('1');
+        expect(screen.getByText('Open').nextElementSibling?.textContent).toBe('0');
+        expect(screen.getByText('Pending').nextElementSibling?.textContent).toBe('0');
+        expect(screen.getByText('Status saved on the team schedule.')).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Claim slot' })).toBeNull();
+    });
+
+    it('redirects unauthorized officials back home without rendering stale assignments', async () => {
+        scheduleServiceMocks.loadOfficialAssignments.mockResolvedValue({
+            hasAccess: false,
+            teamIds: [],
+            teamCount: 0,
+            assignments: [buildAssignment()]
+        });
+
+        renderOfficials();
+
+        await waitFor(() => {
+            expect(navigateMock).toHaveBeenCalledWith('/home', { replace: true });
+        });
+        await waitFor(() => {
+            expect(screen.queryByText('Assignments')).toBeNull();
+        });
+        expect(screen.queryByText('Center Referee · vs. Tigers')).toBeNull();
+    });
+});

--- a/apps/app/src/pages/Officials.tsx
+++ b/apps/app/src/pages/Officials.tsx
@@ -16,10 +16,12 @@ export function Officials({ auth }: { auth: AuthState }) {
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [hasAccess, setHasAccess] = useState(true);
 
-  const refresh = async () => {
+  const refresh = async ({ preserveStatus = false }: { preserveStatus?: boolean } = {}) => {
     if (!auth.user) return;
     setLoading(true);
-    setStatus(null);
+    if (!preserveStatus) {
+      setStatus(null);
+    }
     try {
       const result = await loadOfficialAssignments(auth.user, requestedTeamId ? { teamId: requestedTeamId } : {});
       if (!result.hasAccess) {
@@ -52,7 +54,7 @@ export function Officials({ auth }: { auth: AuthState }) {
     try {
       await action();
       setStatus({ tone: 'success', message: successMessage });
-      await refresh();
+      await refresh({ preserveStatus: true });
     } catch (error: any) {
       setStatus({ tone: 'error', message: error?.message || 'Unable to update assignment.' });
     } finally {

--- a/tests/unit/app-officials.test.tsx
+++ b/tests/unit/app-officials.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
+import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Officials } from './Officials';
-import type { OfficialAssignmentItem } from '../lib/scheduleService';
-import type { AuthState } from '../lib/types';
+import { Officials } from '../../apps/app/src/pages/Officials';
+import type { OfficialAssignmentItem } from '../../apps/app/src/lib/scheduleService';
+import type { AuthState } from '../../apps/app/src/lib/types';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
     loadOfficialAssignments: vi.fn(),
@@ -22,11 +23,11 @@ vi.mock('react-router-dom', async () => {
     };
 });
 
-vi.mock('../lib/homeLogic', () => ({
+vi.mock('../../apps/app/src/lib/homeLogic', () => ({
     getEventDetailPath: vi.fn(() => '/schedule/team-1/game-1')
 }));
 
-vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('../../apps/app/src/lib/scheduleService', () => scheduleServiceMocks);
 
 const auth: AuthState = {
     user: {


### PR DESCRIPTION
Closes #2345

## What changed
- added a focused `Officials` page component test covering initial load/render, unauthorized redirect, accept busy/success/refresh flow, and claim busy/success/refresh flow
- updated the Officials page refresh helper so post-action reloads preserve the success banner instead of clearing it immediately
- verified refreshed summary counts and stale-assignment suppression after unauthorized access

## Root Cause
The Officials page reused `refresh()` for both initial loads and post-action reloads, and `refresh()` always cleared `status` before fetching. That meant successful accept and claim actions briefly set a success banner and then immediately erased it during the follow-up refresh. Because the page only had route smoke coverage, this async UI regression was not tested.

## Prevention / Learning
When a write flow intentionally refreshes page data, preserve or explicitly restate the user-visible success state across the reload. For stateful app pages with redirects and async actions, add a page-level interaction test that covers loading, busy, success, refresh, and unauthorized redirect behavior together.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/Officials.test.tsx --reporter=verbose`
- new assertions in `apps/app/src/pages/Officials.test.tsx` cover load/render, accept refresh, claim refresh, and unauthorized redirect behavior