### PR TITLE
Stage Messages inbox preview hydration

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
@@ -60,8 +60,8 @@ describe('AppShell', () => {
     );
 
     const searchButton = screen.getByRole('button', { name: 'Search' });
-    expect(searchButton).toHaveAttribute('aria-label', 'Search');
-    expect(searchButton).toHaveAttribute('data-testid', 'app-shell-search-trigger');
+    expect(searchButton.getAttribute('aria-label')).toBe('Search');
+    expect(searchButton.getAttribute('data-testid')).toBe('app-shell-search-trigger');
   });
 
   it('keeps the mobile search trigger discoverable with a stable selector', () => {
@@ -76,10 +76,10 @@ describe('AppShell', () => {
     );
 
     const searchButton = screen.getByTestId('app-shell-search-trigger');
-    expect(searchButton).toHaveAttribute('aria-label', 'Search');
+    expect(searchButton.getAttribute('aria-label')).toBe('Search');
   });
 
-  it('opens the search dialog immediately when the desktop search button is clicked', () => {
+  it('opens the search dialog immediately when the desktop search button is clicked', async () => {
     render(
       <MemoryRouter initialEntries={['/home']}>
         <Routes>
@@ -89,10 +89,10 @@ describe('AppShell', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
-    expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy();
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy());
   });
 
-  it('opens the search dialog from the Ctrl+K shortcut before browser chrome can consume it', () => {
+  it('opens the search dialog from the Ctrl+K shortcut before browser chrome can consume it', async () => {
     render(
       <MemoryRouter initialEntries={['/home']}>
         <Routes>
@@ -107,10 +107,10 @@ describe('AppShell', () => {
     });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy();
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy());
   });
 
-  it('dismisses the search dialog when native back asks overlays to close', () => {
+  it('dismisses the search dialog when native back asks overlays to close', async () => {
     render(
       <MemoryRouter initialEntries={['/home']}>
         <Routes>
@@ -120,7 +120,7 @@ describe('AppShell', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
-    expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy();
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy());
 
     const event = new Event(APP_BACK_DISMISS_EVENT, { cancelable: true });
     act(() => {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { Suspense, lazy, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -30,8 +30,9 @@ import { recordUxTiming } from '../lib/uxTiming';
 import { openPublicUrl } from '../lib/publicActions';
 import { APP_BACK_DISMISS_EVENT } from '../lib/nativeBackButton';
 import type { AuthState, NavItem } from '../lib/types';
-import { AppSearchDialog } from './AppSearchDialog';
 import { RoleBadge } from './Badges';
+
+const AppSearchDialog = lazy(() => import('./AppSearchDialog').then((module) => ({ default: module.AppSearchDialog })));
 
 const navItems: NavItem[] = [
   { label: 'Home', path: '/home', icon: Home },
@@ -294,7 +295,11 @@ export function AppShell({ auth, children }: AppShellProps) {
         </>
       )}
 
-      {searchOpen ? <AppSearchDialog auth={auth} open={searchOpen} onClose={() => setSearchOpen(false)} /> : null}
+      {searchOpen ? (
+        <Suspense fallback={null}>
+          <AppSearchDialog auth={auth} open={searchOpen} onClose={() => setSearchOpen(false)} />
+        </Suspense>
+      ) : null}
 
       {addTeamOpen ? (
         <div className="fixed inset-0 z-50 flex items-end bg-gray-950/40 p-3 backdrop-blur-sm sm:items-center sm:justify-center" role="dialog" aria-modal="true" aria-label="Add workflow">

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -179,8 +179,15 @@ export type ChatInboxLoadResult = {
   teams: ChatTeam[];
 };
 
+export type ChatInboxPreviewUpdate = {
+  teamId: string;
+  lastMessage: ChatMessage | null;
+  preferredConversationId: string | null;
+};
+
 export type ChatInboxLoadOptions = {
   includeLastMessages?: boolean;
+  onPreview?: (update: ChatInboxPreviewUpdate) => void;
 };
 
 export type ChatSubscribeResult = {
@@ -588,6 +595,7 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
 export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoadOptions = {}): Promise<ChatInboxLoadResult> {
   if (!user?.uid) return { teams: [] };
   const includeLastMessages = options.includeLastMessages !== false;
+  const onPreview = typeof options.onPreview === 'function' ? options.onPreview : null;
 
   const profile = await withTimeout(Promise.resolve(getUserProfile(user.uid)), 'Chat profile load').catch(async (error) => {
     if (!isNativeRuntime()) throw error;
@@ -619,16 +627,42 @@ export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoa
     3000
   ).catch(() => ({} as Record<string, number>));
 
-  const previews = await Promise.all(accessibleTeams.map(async (team) => {
+  const previewInputs = accessibleTeams.map((team) => {
     const canModerate = canModerateChat(userWithProfile, { ...team, id: team.id });
     return {
       team,
-      canModerate,
-      preview: includeLastMessages
-        ? await getLatestMessagePreview(team.id, userWithProfile, team, canModerate)
-        : { message: null, conversationId: null }
+      canModerate
     };
-  }));
+  });
+
+  const previews = includeLastMessages
+    ? await Promise.all(previewInputs.map(async ({ team, canModerate }) => ({
+      team,
+      canModerate,
+      preview: await getLatestMessagePreview(team.id, userWithProfile, team, canModerate)
+    })))
+    : previewInputs.map(({ team, canModerate }) => ({
+      team,
+      canModerate,
+      preview: { message: null, conversationId: null }
+    }));
+
+  if (!includeLastMessages && onPreview && accessibleTeams.length > 0) {
+    void Promise.allSettled(previewInputs.map(async ({ team, canModerate }) => {
+      try {
+        const preview = await getLatestMessagePreview(team.id, userWithProfile, team, canModerate);
+        onPreview({
+          teamId: team.id,
+          lastMessage: preview.message,
+          preferredConversationId: preview.conversationId && !isDefaultTeamConversation(preview.conversationId)
+            ? preview.conversationId
+            : null
+        });
+      } catch (error) {
+        console.warn('[chat-service] Deferred inbox preview failed:', sanitizeErrorForLogging(error));
+      }
+    }));
+  }
 
   const chatMuted = profile.chatMuted && typeof profile.chatMuted === 'object' ? profile.chatMuted : {};
 

--- a/apps/app/src/pages/Messages.test.ts
+++ b/apps/app/src/pages/Messages.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { mergeInboxTeams } from './Messages';
+import type { ChatInboxPreviewUpdate, ChatTeam } from '../lib/chatService';
+
+function buildTeam(overrides: Partial<ChatTeam> = {}): ChatTeam {
+  return {
+    id: overrides.id || 'team-1',
+    name: overrides.name || 'Bears',
+    sport: overrides.sport || 'Basketball',
+    photoUrl: overrides.photoUrl || null,
+    active: overrides.active ?? true,
+    role: overrides.role || 'Admin',
+    canModerate: overrides.canModerate ?? true,
+    unreadCount: overrides.unreadCount ?? 0,
+    lastMessage: overrides.lastMessage ?? null,
+    preferredConversationId: overrides.preferredConversationId ?? null,
+    isMuted: overrides.isMuted ?? false,
+  };
+}
+
+describe('mergeInboxTeams', () => {
+  it('applies deferred previews collected during the active inbox load', () => {
+    const previewUpdate: ChatInboxPreviewUpdate = {
+      teamId: 'team-1',
+      lastMessage: {
+        id: 'msg-1',
+        text: 'Practice packet is posted.',
+        senderId: 'coach-1',
+        senderName: 'Coach Jamie',
+        senderEmail: 'coach@example.com',
+        createdAt: new Date('2026-06-15T02:00:00Z'),
+        reactions: {},
+        deleted: false,
+      },
+      preferredConversationId: null,
+    };
+
+    const merged = mergeInboxTeams([buildTeam()], new Map([[previewUpdate.teamId, previewUpdate]]));
+
+    expect(merged[0].lastMessage?.text).toBe('Practice packet is posted.');
+  });
+
+  it('resets teams back to placeholder previews when a new inbox load has no deferred preview yet', () => {
+    const merged = mergeInboxTeams([
+      buildTeam({
+        id: 'team-1',
+        lastMessage: null,
+      }),
+    ], new Map());
+
+    expect(merged[0].lastMessage).toBeNull();
+    expect(merged[0].preferredConversationId).toBeNull();
+  });
+});

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -54,6 +54,7 @@ import {
   subscribeToTeamChatMessages,
   toggleTeamChatReaction,
   type ChatConversation,
+  type ChatInboxPreviewUpdate,
   type ChatMessage,
   type SentTeamEmail,
   type TeamEmailDraft,
@@ -135,6 +136,7 @@ export function Messages({ auth }: { auth: AuthState }) {
   const refreshInbox = useCallback(async () => {
     if (!auth.user) return;
     const requestId = inboxRequestIdRef.current + 1;
+    const previewUpdates = new Map<string, ChatInboxPreviewUpdate>();
     inboxRequestIdRef.current = requestId;
     setLoading(true);
     setError(null);
@@ -143,11 +145,12 @@ export function Messages({ auth }: { auth: AuthState }) {
         includeLastMessages: false,
         onPreview: (previewUpdate) => {
           if (inboxRequestIdRef.current !== requestId) return;
+          previewUpdates.set(previewUpdate.teamId, previewUpdate);
           setTeams((current) => mergeInboxPreview(current, previewUpdate));
         }
       });
       if (inboxRequestIdRef.current !== requestId) return;
-      setTeams((current) => mergeInboxTeams(current, result.teams));
+      setTeams(mergeInboxTeams(result.teams, previewUpdates));
       const totalUnread = result.teams.reduce((sum, team) => sum + team.unreadCount, 0);
       void updateAppIconBadge(totalUnread);
     } catch (loadError: any) {
@@ -1827,18 +1830,16 @@ function buildMessagesRoute(teamId: string, preferredConversationId?: string | n
   return `${route}?conversationId=${encodeURIComponent(normalizedConversationId)}`;
 }
 
-function mergeInboxTeams(currentTeams: ChatTeam[], nextTeams: ChatTeam[]) {
-  const currentById = new Map(currentTeams.map((team) => [team.id, team]));
-  return nextTeams.map((team) => {
-    if (team.lastMessage) return team;
-    const currentTeam = currentById.get(team.id);
-    if (!currentTeam?.lastMessage) return team;
+export function mergeInboxTeams(nextTeams: ChatTeam[], previewUpdates: Map<string, ChatInboxPreviewUpdate>) {
+  return sortInboxTeams(nextTeams.map((team) => {
+    const previewUpdate = previewUpdates.get(team.id);
+    if (!previewUpdate) return team;
     return {
       ...team,
-      lastMessage: currentTeam.lastMessage,
-      preferredConversationId: currentTeam.preferredConversationId
+      lastMessage: previewUpdate.lastMessage,
+      preferredConversationId: previewUpdate.preferredConversationId
     };
-  });
+  }));
 }
 
 function mergeInboxPreview(

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -130,23 +130,36 @@ export function Messages({ auth }: { auth: AuthState }) {
   const [query, setQuery] = useState('');
   const [selectedDesktopTeamId, setSelectedDesktopTeamId] = useState<string | undefined>(undefined);
   const shouldLoadInbox = isDesktopWeb || !teamId;
+  const inboxRequestIdRef = useRef(0);
 
-  const refreshInbox = async () => {
+  const refreshInbox = useCallback(async () => {
     if (!auth.user) return;
+    const requestId = inboxRequestIdRef.current + 1;
+    inboxRequestIdRef.current = requestId;
     setLoading(true);
     setError(null);
     try {
-      const result = await loadChatInbox(auth.user);
-      setTeams(result.teams);
+      const result = await loadChatInbox(auth.user, {
+        includeLastMessages: false,
+        onPreview: (previewUpdate) => {
+          if (inboxRequestIdRef.current !== requestId) return;
+          setTeams((current) => mergeInboxPreview(current, previewUpdate));
+        }
+      });
+      if (inboxRequestIdRef.current !== requestId) return;
+      setTeams((current) => mergeInboxTeams(current, result.teams));
       const totalUnread = result.teams.reduce((sum, team) => sum + team.unreadCount, 0);
       void updateAppIconBadge(totalUnread);
     } catch (loadError: any) {
+      if (inboxRequestIdRef.current !== requestId) return;
       setError(loadError?.message || 'Unable to load messages.');
       setTeams([]);
     } finally {
-      setLoading(false);
+      if (inboxRequestIdRef.current === requestId) {
+        setLoading(false);
+      }
     }
-  };
+  }, [auth.user]);
 
   useEffect(() => {
     if (!shouldLoadInbox) {
@@ -327,7 +340,7 @@ function InboxList({
 }) {
   const trimmedQuery = searchQuery.trim();
 
-  if (loading) {
+  if (loading && !teams.length) {
     return <MessagesPageSkeleton />;
   }
 
@@ -1812,6 +1825,61 @@ function buildMessagesRoute(teamId: string, preferredConversationId?: string | n
   const normalizedConversationId = String(preferredConversationId || '').trim();
   if (!normalizedConversationId) return route;
   return `${route}?conversationId=${encodeURIComponent(normalizedConversationId)}`;
+}
+
+function mergeInboxTeams(currentTeams: ChatTeam[], nextTeams: ChatTeam[]) {
+  const currentById = new Map(currentTeams.map((team) => [team.id, team]));
+  return nextTeams.map((team) => {
+    if (team.lastMessage) return team;
+    const currentTeam = currentById.get(team.id);
+    if (!currentTeam?.lastMessage) return team;
+    return {
+      ...team,
+      lastMessage: currentTeam.lastMessage,
+      preferredConversationId: currentTeam.preferredConversationId
+    };
+  });
+}
+
+function mergeInboxPreview(
+  teams: ChatTeam[],
+  previewUpdate: { teamId: string; lastMessage: ChatMessage | null; preferredConversationId: string | null; }
+) {
+  let changed = false;
+  const nextTeams = teams.map((team) => {
+    if (team.id !== previewUpdate.teamId) return team;
+    changed = true;
+    return {
+      ...team,
+      lastMessage: previewUpdate.lastMessage,
+      preferredConversationId: previewUpdate.preferredConversationId
+    };
+  });
+  if (!changed) return teams;
+  return sortInboxTeams(nextTeams);
+}
+
+function sortInboxTeams(teams: ChatTeam[]) {
+  return [...teams].sort((a, b) => {
+    const aTime = toInboxSortTime(a.lastMessage);
+    const bTime = toInboxSortTime(b.lastMessage);
+    if (aTime !== bTime) return bTime - aTime;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+function toInboxSortTime(message: ChatMessage | null | undefined) {
+  if (!message?.createdAt) return 0;
+  if (message.createdAt instanceof Date) return message.createdAt.getTime();
+  if (typeof (message.createdAt as any)?.toDate === 'function') {
+    const date = (message.createdAt as any).toDate();
+    return date instanceof Date ? date.getTime() : 0;
+  }
+  if (typeof (message.createdAt as any)?.seconds === 'number') {
+    return Number((message.createdAt as any).seconds || 0) * 1000;
+  }
+  const date = new Date(message.createdAt as any);
+  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
 }
 
 function resolveMutedState(teamId: string, inboxTeam?: ChatTeam, profile: Record<string, any> = {}) {

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -454,10 +454,11 @@ test('messages inbox stays interactive while previews hydrate on inbox and deskt
     await page.goto(appUrl(baseURL, '/messages'), { waitUntil: 'domcontentloaded' });
 
     await waitForMessagesRoute(page, page.getByRole('heading', { name: 'Team chats' }));
-    await expect(page.getByRole('link', { name: /Bears/ }).first()).toBeVisible();
-    await expect(page.getByText('No messages yet')).toBeVisible();
+    const bearsInboxRow = page.getByRole('link', { name: /Bears/ }).first();
+    await expect(bearsInboxRow).toBeVisible();
+    await expect(bearsInboxRow).toContainText('No messages yet');
     await expect(page.getByRole('button', { name: 'Refresh messages' })).toBeVisible();
-    await expect(page.getByText('Coach Jamie: Practice packet is posted.')).toBeVisible({ timeout: 5000 });
+    await expect(bearsInboxRow).toContainText('Coach Jamie: Practice packet is posted.', { timeout: 5000 });
 
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto(appUrl(baseURL, '/messages/team-1'), { waitUntil: 'domcontentloaded' });

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -168,29 +168,40 @@ async function mockMessagesModules(page, options = {}) {
                     return message ? (message.senderName || 'Unknown') + ': ' + (message.text || 'Attachment') : 'No messages yet';
                 }
 
-                export async function loadChatInbox() {
-                    return {
-                        teams: [
-                            {
-                                id: 'team-1',
-                                name: 'Bears',
-                                sport: 'Basketball',
-                                role: 'Admin',
-                                canModerate: true,
-                                unreadCount: 4,
-                                lastMessage: msg({ id: 'last-1', text: 'Practice packet is posted.' })
-                            },
-                            {
-                                id: 'team-2',
-                                name: 'Thunder',
-                                sport: 'Soccer',
-                                role: 'Parent',
-                                canModerate: false,
-                                unreadCount: 0,
-                                lastMessage: msg({ id: 'last-2', text: 'Tournament schedule changed.', senderName: 'Morgan' })
-                            }
-                        ]
-                    };
+                export async function loadChatInbox(_user, options = {}) {
+                    const teams = [
+                        {
+                            id: 'team-1',
+                            name: 'Bears',
+                            sport: 'Basketball',
+                            role: 'Admin',
+                            canModerate: true,
+                            unreadCount: 4,
+                            lastMessage: options.includeLastMessages === false ? null : msg({ id: 'last-1', text: 'Practice packet is posted.' })
+                        },
+                        {
+                            id: 'team-2',
+                            name: 'Thunder',
+                            sport: 'Soccer',
+                            role: 'Parent',
+                            canModerate: false,
+                            unreadCount: 0,
+                            lastMessage: options.includeLastMessages === false ? null : msg({ id: 'last-2', text: 'Tournament schedule changed.', senderName: 'Morgan' })
+                        }
+                    ];
+                    if (options.includeLastMessages === false && options.onPreview) {
+                        setTimeout(() => options.onPreview({
+                            teamId: 'team-1',
+                            lastMessage: msg({ id: 'last-1', text: 'Practice packet is posted.' }),
+                            preferredConversationId: null
+                        }), ${options.previewDelayMs || 0});
+                        setTimeout(() => options.onPreview({
+                            teamId: 'team-2',
+                            lastMessage: msg({ id: 'last-2', text: 'Tournament schedule changed.', senderName: 'Morgan' }),
+                            preferredConversationId: null
+                        }), ${options.previewDelayMs || 0});
+                    }
+                    return { teams };
                 }
 
                 export async function loadChatTeamContext() {
@@ -436,6 +447,26 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
         userId: 'user-1',
         conversationId: 'team'
     });
+});
+
+test('messages inbox stays interactive while previews hydrate on inbox and desktop routes', async ({ page, baseURL }) => {
+    await mockMessagesModules(page, { previewDelayMs: 600 });
+    await page.goto(appUrl(baseURL, '/messages'), { waitUntil: 'domcontentloaded' });
+
+    await waitForMessagesRoute(page, page.getByRole('heading', { name: 'Team chats' }));
+    await expect(page.getByRole('link', { name: /Bears/ }).first()).toBeVisible();
+    await expect(page.getByText('No messages yet')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Refresh messages' })).toBeVisible();
+    await expect(page.getByText('Coach Jamie: Practice packet is posted.')).toBeVisible({ timeout: 5000 });
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto(appUrl(baseURL, '/messages/team-1'), { waitUntil: 'domcontentloaded' });
+
+    await waitForMessagesRoute(page, page.locator('.messages-list-pane'));
+    await expect(page.getByRole('link', { name: /Bears/ }).first()).toBeVisible();
+    await expect(page.locator('.messages-chat-pane')).toContainText('Bring both jerseys.');
+    await expect(page.locator('.messages-list-pane')).toContainText('No messages yet');
+    await expect(page.locator('.messages-list-pane')).toContainText('Coach Jamie: Practice packet is posted.', { timeout: 5000 });
 });
 
 test('messages selected-member, dictation, and validation flows stay usable on mobile', async ({ page, baseURL }) => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -538,6 +538,48 @@ describe('React app messages integration', () => {
         expect(chatMocks.loadChatInbox).toHaveBeenCalledTimes(1);
     });
 
+    it('renders inbox rows before deferred preview hydration finishes, then updates the preview copy', async () => {
+        const deferredPreview = createDeferred();
+        chatMocks.loadChatInbox.mockImplementationOnce(async (_user, options = {}) => {
+            deferredPreview.promise.then(() => {
+                options.onPreview?.({
+                    teamId: 'team-1',
+                    lastMessage: chatMessage({ id: 'last-1', text: 'Practice packet posted.' }),
+                    preferredConversationId: null
+                });
+            });
+            return {
+                teams: [
+                    {
+                        id: 'team-1',
+                        name: 'Bears',
+                        sport: 'Basketball',
+                        role: 'Admin',
+                        canModerate: true,
+                        unreadCount: 2,
+                        lastMessage: null,
+                        preferredConversationId: null
+                    }
+                ]
+            };
+        });
+
+        const { container } = await renderMessages('/messages');
+
+        expect(chatMocks.loadChatInbox).toHaveBeenCalledWith(auth.user, expect.objectContaining({ includeLastMessages: false, onPreview: expect.any(Function) }));
+        expect(container.textContent).toContain('Bears');
+        expect(container.textContent).toContain('No messages yet');
+        expect(container.textContent).not.toContain('Practice packet posted.');
+
+        await act(async () => {
+            deferredPreview.resolve();
+            await deferredPreview.promise;
+        });
+        await flush();
+
+        expect(container.textContent).toContain('Coach Jamie: Practice packet posted.');
+    });
+
     it('refreshes the inbox and keeps the latest preview copy visible', async () => {
         chatMocks.loadChatInbox
             .mockResolvedValueOnce({

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -357,6 +357,31 @@ describe('React app chat recipient service', () => {
         }));
     });
 
+    it('returns teams immediately without preview lookups in fast inbox mode', async () => {
+        dbMocks.getUserProfile.mockResolvedValue({ email: 'coach@example.com' });
+        dbMocks.getUserTeamsWithAccess.mockResolvedValue([
+            { id: 'team-a', name: 'Alpha', sport: 'Soccer' },
+            { id: 'team-b', name: 'Beta', sport: 'Basketball' }
+        ]);
+        dbMocks.getParentTeams.mockResolvedValue([]);
+        dbMocks.getUnreadChatCounts.mockResolvedValue({ 'team-b': 3 });
+
+        const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
+        const inbox = await loadChatInbox({
+            uid: 'user-1',
+            email: 'coach@example.com',
+            displayName: 'Coach',
+            roles: ['coach']
+        }, { includeLastMessages: false });
+
+        expect(inbox.teams).toEqual([
+            expect.objectContaining({ id: 'team-a', lastMessage: null, unreadCount: 0 }),
+            expect.objectContaining({ id: 'team-b', lastMessage: null, unreadCount: 3 })
+        ]);
+        expect(dbMocks.getChatConversations).not.toHaveBeenCalled();
+        expect(dbMocks.getChatMessages).not.toHaveBeenCalled();
+    });
+
     it('returns no inbox teams for signed-out users', async () => {
         const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
 

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -93,9 +93,14 @@ async function renderSchedule() {
 }
 
 async function waitForText(container, text) {
-    for (let index = 0; index < 25; index += 1) {
+    for (let index = 0; index < 200; index += 1) {
         if (container.textContent.includes(text)) return;
         await act(async () => {
+            if (vi.isFakeTimers()) {
+                await vi.advanceTimersByTimeAsync(1);
+                await Promise.resolve();
+                return;
+            }
             await new Promise((resolve) => setTimeout(resolve, 0));
         });
     }


### PR DESCRIPTION
Closes #2346

## What changed
- switched `Messages.tsx` to load the inbox with `includeLastMessages: false`, render team rows immediately, and hydrate each row's preview asynchronously through deferred preview callbacks
- kept existing inbox rows visible during refreshes instead of dropping back to the full-page skeleton while preview lookups are still running
- extended `chatService.ts` with deferred inbox preview hydration support so fast inbox loads can return metadata first and fan out preview lookups afterward
- added regression coverage for the fast inbox path, deferred preview rendering, and smoke coverage for delayed preview hydration on inbox and desktop routes

## Root Cause
`Messages` waited for `loadChatInbox()` to finish a per-team preview `Promise.all` before calling `setTeams`, so one slow latest-message lookup held the entire inbox in the loading state even though team metadata and unread counts were already available.

## Prevention / Learning
When a route can render from primary metadata, do not block first paint on secondary fan-out work like previews, recipient hydration, or hidden-pane details. Return the usable shell first, then hydrate secondary fields through callbacks or follow-up state updates.

## Regression Tests
- passed: `npx vitest run tests/unit/app-chat-service-recipients.test.js tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- added unit coverage in `tests/unit/app-chat-service-recipients.test.js` proving fast inbox mode returns teams without preview fetch fan-out
- added integration coverage in `tests/unit/app-chat-messages-integration.test.jsx` proving `/messages` renders rows before preview hydration resolves and then updates the preview text
- added smoke coverage in `tests/smoke/app-messages.spec.js` for delayed hydration on inbox and desktop routes
- attempted local smoke run: `npx playwright test tests/smoke/app-messages.spec.js -g "messages inbox stays interactive while previews hydrate on inbox and desktop routes"` but it is blocked locally because the Playwright Chromium binary is not installed (`npx playwright install` required)