### PR TITLE
Render live tracker periods from sport config

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -389,6 +389,7 @@ const els = {
   onCourtCount: q('#on-court-count-mobile'),
   startStop: q('#start-stop'),
   undoMini: q('#undo-mini'),
+  periodButtons: q('#period-buttons'),
   preTab: q('#pre-game-tab'),
   liveTab: q('#live-tab'),
   oppTab: q('#opponents-tab'),
@@ -2215,12 +2216,22 @@ function setPeriod(p) {
 }
 
 function applyPeriodButtons() {
-  const labels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig }).slice(0, 5);
-  const fallbackLabel = labels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
-  document.querySelectorAll('.period-btn').forEach((button, index) => {
-    const label = labels[index] || fallbackLabel;
-    button.dataset.period = label;
-    button.textContent = label;
+  if (!els.periodButtons) return;
+
+  const labels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig });
+  const fallbackLabel = getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
+  const resolvedLabels = labels.length ? labels : [fallbackLabel];
+  const activePeriod = resolvedLabels.includes(state.period) ? state.period : resolvedLabels[0];
+
+  els.periodButtons.innerHTML = resolvedLabels.map((label) => `
+    <button
+      class="pill px-2 py-1.5 border period-btn ${label === activePeriod ? 'bg-teal text-ink border-teal font-bold' : 'bg-white border-slate/10 font-semibold'}"
+      data-period="${escapeHtml(label)}"
+    >${escapeHtml(label)}</button>
+  `).join('');
+
+  els.periodButtons.querySelectorAll('.period-btn').forEach((button) => {
+    button.addEventListener('click', () => setPeriod(button.dataset.period));
   });
 }
 
@@ -2316,7 +2327,6 @@ function attachEvents() {
     persistLocalTrackerState();
     broadcastLineupUpdate('Lineup cleared');
   });
-  document.querySelectorAll('.period-btn').forEach(b => b.addEventListener('click', () => setPeriod(b.dataset.period)));
   els.livePlayers.addEventListener('click', (e) => {
     const btn = e.target.closest('[data-stat]');
     if (!btn) return;

--- a/live-tracker.html
+++ b/live-tracker.html
@@ -45,6 +45,7 @@
     .pill { border-radius: 999px; }
     .stat-btn { touch-action: manipulation; }
     .grid-cols-auto { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
+    .grid-cols-periods { grid-template-columns: repeat(auto-fit, minmax(56px, 1fr)); }
     @keyframes pulse-live { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
     .live-pulse { animation: pulse-live 1.5s ease-in-out infinite; }
     .sync-status--offline { background: rgba(220, 38, 38, 0.1); border-color: rgba(220, 38, 38, 0.35); color: #991b1b; }
@@ -88,12 +89,7 @@
         </div>
       </div>
       <!-- Periods row (compact) -->
-      <div id="period-buttons" class="grid grid-cols-4 gap-1 text-center text-[11px]">
-        <button class="pill px-2 py-1.5 bg-teal text-ink border border-teal period-btn font-bold" data-period="Q1">Q1</button>
-        <button class="pill px-2 py-1.5 bg-white border border-slate/10 period-btn font-semibold" data-period="Q2">Q2</button>
-        <button class="pill px-2 py-1.5 bg-white border border-slate/10 period-btn font-semibold" data-period="Q3">Q3</button>
-        <button class="pill px-2 py-1.5 bg-white border border-slate/10 period-btn font-semibold" data-period="Q4">Q4</button>
-      </div>
+      <div id="period-buttons" class="grid grid-cols-periods gap-1 text-center text-[11px]"></div>
       <!-- Actions row -->
       <div class="grid grid-cols-2 gap-2 text-center text-[11px]">
         <button class="pill px-2 py-1.5 bg-purple-600 text-white border border-purple-700 font-bold" id="sub-open">Subs</button>

--- a/tests/unit/live-tracker-period-buttons.test.js
+++ b/tests/unit/live-tracker-period-buttons.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { getSportPeriodLabels } from '../../js/live-sport-config.js';
+
+const liveTrackerHtml = readFileSync(new URL('../../live-tracker.html', import.meta.url), 'utf8');
+const liveTrackerSource = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+
+describe('live tracker period selector', () => {
+    it('keeps overtime and extra-period sport labels available in config', () => {
+        expect(getSportPeriodLabels({ sport: 'soccer' })).toEqual(['H1', 'H2', 'ET1', 'ET2', 'PK']);
+        expect(getSportPeriodLabels({ sport: 'basketball' })).toEqual(['Q1', 'Q2', 'Q3', 'Q4', 'OT']);
+    });
+
+    it('renders period buttons from configured labels instead of a four-button template', () => {
+        expect(liveTrackerHtml).toContain('id="period-buttons"');
+        expect(liveTrackerHtml).not.toContain('data-period="Q1"');
+        expect(liveTrackerSource).not.toContain('.slice(0, 5)');
+        expect(liveTrackerSource).toContain('const resolvedLabels = labels.length ? labels : [fallbackLabel];');
+        expect(liveTrackerSource).toContain('els.periodButtons.innerHTML = resolvedLabels.map((label) => `');
+        expect(liveTrackerSource).toContain("button.addEventListener('click', () => setPeriod(button.dataset.period));");
+    });
+});


### PR DESCRIPTION
Closes #2351

## What changed
- Replaced the hardcoded four-button period row in `live-tracker.html` with an empty container sized for a dynamic button grid.
- Updated `js/live-tracker.js` to render period buttons from the full configured sport period label list, preserve the active period styling, and bind clicks on the generated buttons.
- Added a focused regression test covering the config-driven period selector path and guarding against reintroducing a fixed four-button template or a five-label cap.

## Root Cause
The live tracker period selector was split between a hardcoded four-button HTML template and JavaScript that only relabeled the existing nodes. Even though sport config could define OT, PK, or other extra periods, the UI never rendered buttons beyond the prebuilt template, and `applyPeriodButtons()` also imposed a `.slice(0, 5)` cap.

## Prevention / Learning
When a workflow is driven by sport or product configuration, render the control set directly from the configured list. Do not relabel a fixed template or add silent UI caps unless the product requirement explicitly calls for them.

## Regression Tests
- `npx vitest run tests/unit/live-tracker-period-buttons.test.js --reporter=verbose`
- The new test asserts that soccer and basketball still expose their extra-period labels in config, that `live-tracker.html` no longer hardcodes four period buttons, and that `live-tracker.js` renders buttons from the full configured label list without a `.slice(0, 5)` cap.

## Recurrence Risk
Low. The selector now renders directly from the sport-config labels, and the regression test will fail if a fixed button template or hard label cap is reintroduced.