### PR TITLE
Hide admin-only practice timeline from non-admin viewers

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1610,7 +1610,10 @@ describe('ScheduleEventDetail practice timeline', () => {
     const packetPanel = container.querySelector('#practice-packet-panel');
     const practiceHubTitle = screen.getByText('Practice hub');
     expect(packetPanel).toBeTruthy();
-    expect(packetPanel?.compareDocumentPosition(practiceHubTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    if (!packetPanel) {
+      throw new Error('Expected practice packet panel to be rendered');
+    }
+    expect(packetPanel.compareDocumentPosition(practiceHubTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByText('Packet ready')).toBeTruthy();
     expect(screen.queryByText('Practice timeline')).toBeNull();
     expect(screen.queryByText('No practice timeline yet. Add drills above to build this practice plan.')).toBeNull();

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -200,6 +200,31 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
   } as any;
 }
 
+function buildPracticePacket(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: 'session-1',
+    teamId: 'team-1',
+    eventId: 'practice-1',
+    title: 'Thursday Practice Packet',
+    date: new Date('2026-06-12T18:00:00.000Z'),
+    location: 'Home court',
+    homePacket: {
+      totalMinutes: 12,
+      blocks: [
+        {
+          title: 'Ball mastery',
+          type: 'Technical',
+          duration: 12,
+          description: '50 touches before dinner'
+        }
+      ]
+    },
+    completions: [],
+    children: [{ id: 'player-1', name: 'Avery Smith' }],
+    ...overrides
+  } as any;
+}
+
 function renderScheduleEventDetail(authOverride: AuthState = auth) {
   return render(
     <MemoryRouter initialEntries={['/schedule/team-1/game-1?childId=player-1']}>
@@ -1556,13 +1581,49 @@ describe('ScheduleEventDetail practice timeline', () => {
     });
   });
 
-  it('hides practice timeline management for coach-only staff without admin write access', async () => {
+  it('shows the practice packet first and hides the timeline for non-admin practice viewers', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({
         id: 'practice-1',
         type: 'practice',
         title: 'Thursday Practice',
         isTeamStaff: true,
+        isTeamAdmin: false,
+        practiceSessionId: 'session-1'
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadParentPracticePacket.mockResolvedValue(buildPracticePacket());
+    scheduleServiceMocks.loadStaffPracticeAttendance.mockResolvedValue(null);
+
+    const { container } = renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'More' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'More' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Practice packet')).toBeTruthy();
+    });
+
+    const packetPanel = container.querySelector('#practice-packet-panel');
+    const practiceHubTitle = screen.getByText('Practice hub');
+    expect(packetPanel).toBeTruthy();
+    expect(packetPanel?.compareDocumentPosition(practiceHubTitle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('Packet ready')).toBeTruthy();
+    expect(screen.queryByText('Practice timeline')).toBeNull();
+    expect(screen.queryByText('No practice timeline yet. Add drills above to build this practice plan.')).toBeNull();
+    expect(practiceTimelineServiceMocks.loadPracticeTimelineModel).not.toHaveBeenCalled();
+  });
+
+  it('shows a neutral packet empty state for non-admin practice viewers when no packet exists', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        id: 'practice-1',
+        type: 'practice',
+        title: 'Thursday Practice',
+        isTeamStaff: false,
         isTeamAdmin: false,
         practiceSessionId: 'session-1'
       })],
@@ -1579,10 +1640,12 @@ describe('ScheduleEventDetail practice timeline', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'More' })[0]);
 
     await waitFor(() => {
-      expect(screen.getByText('Practice timeline')).toBeTruthy();
+      expect(screen.getByText('No packet posted yet')).toBeTruthy();
     });
 
-    expect(screen.queryByRole('button', { name: 'Add drill' })).toBeNull();
+    expect(screen.getByText('Packets appear here when coaches publish home drills for this practice.')).toBeTruthy();
+    expect(screen.queryByText('Practice timeline')).toBeNull();
+    expect(screen.queryByText('No practice timeline yet. Add drills above to build this practice plan.')).toBeNull();
     expect(practiceTimelineServiceMocks.loadPracticeTimelineModel).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2016,6 +2016,8 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
   const [liveClockNow, setLiveClockNow] = useState(() => new Date());
   const liveClockView = getLiveClockViewModel(event, liveClockNow);
   const isPractice = event.type === 'practice';
+  const showAdminPracticeTimeline = Boolean(isPractice && event.isTeamAdmin);
+  const showNonAdminPracticePacketFirst = Boolean(isPractice && !event.isTeamAdmin);
   const canUpdateScore = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
   const canWrapup = canUpdateScore;
   const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
@@ -2102,8 +2104,9 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
 
   return (
     <section className="space-y-3">
-      {isPractice ? <PracticeTimelineSection auth={auth} event={event} /> : null}
-      {isPractice ? <PracticePacketSection auth={auth} event={event} childEvents={childEvents} /> : null}
+      {showNonAdminPracticePacketFirst ? <PracticePacketSection auth={auth} event={event} childEvents={childEvents} /> : null}
+      {showAdminPracticeTimeline ? <PracticeTimelineSection auth={auth} event={event} /> : null}
+      {isPractice && !showNonAdminPracticePacketFirst ? <PracticePacketSection auth={auth} event={event} childEvents={childEvents} /> : null}
       <div className="app-card overflow-hidden p-0">
         <div className="border-b border-gray-100 px-3 py-3 sm:px-4">
           <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
Closes #2353

## What changed
- gated the practice timeline section at the practice hub render boundary so only team admins see the timeline builder
- moved the practice packet section ahead of the practice hub content for non-admin practice viewers
- added non-admin regressions that verify the packet leads the workflow, the builder empty state never appears, and the no-packet state stays neutral
- kept the existing admin practice timeline regression in place to confirm timeline tools still render for team admins

## Root Cause
`ScheduleEventDetail` always rendered `PracticeTimelineSection` before `PracticePacketSection` for every practice viewer. The timeline component then short-circuited internally for non-admins, but the section shell still mounted and fell through to the builder-oriented empty state, which exposed admin-only copy and pushed the parent packet workflow down the page.

## Prevention / Learning
When a workflow section is admin-only, gate it at the parent render boundary instead of mounting it for everyone and relying on child loaders to clear state later. Add role-based regression coverage that checks both section order and empty-state copy for non-admin viewers.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/ScheduleEventDetail.test.tsx --reporter=verbose`
- non-admin practice viewer regression verifies the practice packet renders before the practice hub and the timeline empty state is absent
- non-admin no-packet regression verifies the neutral packet waiting state renders instead of builder copy
- existing admin regression still verifies timeline planning controls render for team admins

## Recurrence Risk
Low. The admin-only panel is now gated before mount, and focused tests cover both the non-admin and admin practice detail paths that previously drifted apart.