### PR TITLE
Fix #2274: Add test coverage for lazy-loaded AppSearchDialog in AppShell

### DIFF
--- a/tests/unit/app-search-lazy-load.test.js
+++ b/tests/unit/app-search-lazy-load.test.js
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const appShellSource = readFileSync(new URL('../../apps/app/src/components/AppShell.tsx', import.meta.url), 'utf8');
+
+describe('AppSearchDialog lazy-load guards', () => {
+    it('does not statically import AppSearchDialog at the top of AppShell', () => {
+        // A static ESM import would look like: import { AppSearchDialog } from './AppSearchDialog'
+        // or: import AppSearchDialog from './AppSearchDialog'
+        expect(appShellSource).not.toMatch(/^import\s+.*AppSearchDialog.*from\s+['"]\.\/AppSearchDialog['"]/m);
+    });
+
+    it('loads AppSearchDialog through React.lazy with a dynamic import', () => {
+        // Should use lazy() wrapping a dynamic import() for AppSearchDialog
+        expect(appShellSource).toMatch(/lazy\s*\(\s*\(\s*\)\s*=>\s*import\s*\(\s*['"]\.\/AppSearchDialog['"]\s*\)/);
+    });
+
+    it('wraps the lazy AppSearchDialog in a Suspense boundary with a null fallback', () => {
+        expect(appShellSource).toContain('<Suspense fallback={null}>');
+        expect(appShellSource).toContain('AppSearchDialog');
+    });
+
+    it('imports Suspense and lazy from react', () => {
+        expect(appShellSource).toMatch(/import\s*\{[^}]*\blazy\b[^}]*\}\s*from\s*['"]react['"]/);
+        expect(appShellSource).toMatch(/import\s*\{[^}]*\bSuspense\b[^}]*\}\s*from\s*['"]react['"]/);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/unit/app-search-lazy-load.test.js` to assert that `AppSearchDialog` is lazy-loaded in `AppShell.tsx`
- Verifies no static import of `AppSearchDialog` exists
- Verifies `React.lazy()` wrapping a dynamic import is used
- Verifies `<Suspense fallback={null}>` wraps the usage

The lazy-load implementation was already in master. This PR adds the missing test coverage required by issue #2274.

## Test plan
- [ ] `npm test` passes
- [ ] `npx vitest run tests/unit/app-search-lazy-load.test.js --reporter=verbose` shows 4 passing tests

Closes #2274

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_