### PR TITLE
Fix #2265: Seed Profile form from hydrated auth.profile, skip network round-trip

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -239,12 +239,15 @@ export function Profile({ auth }: { auth: AuthState }) {
       setAccountMergeEmail('');
 
       try {
-        // Seed form fields directly from the already-hydrated auth.profile when
-        // available, avoiding a redundant Firestore round-trip and loading spinner.
-        // Only fall back to loadProfileDocument when auth.profile is absent.
+        // Seed form fields from the already-hydrated auth.profile when it is
+        // fully populated (has at least fullName and phone), avoiding a redundant
+        // Firestore round-trip. Fall back to loadProfileDocument otherwise.
         const seededProfile = auth.profile;
+        const isFullyHydrated = seededProfile != null &&
+          typeof seededProfile.fullName === 'string' &&
+          'phone' in seededProfile;
         let loadedProfile: ProfileDocument;
-        if (seededProfile) {
+        if (isFullyHydrated) {
           loadedProfile = seededProfile as ProfileDocument;
         } else {
           loadedProfile = await loadProfileDocument(user.uid).catch((error) => {

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -239,11 +239,20 @@ export function Profile({ auth }: { auth: AuthState }) {
       setAccountMergeEmail('');
 
       try {
-        const loadedProfile = await loadProfileDocument(user.uid).catch((error) => {
-          console.warn('[profile] Unable to load profile:', error);
-          setProfileStatus({ message: 'Profile details could not be loaded yet.', tone: 'error' });
-          return {} as ProfileDocument;
-        });
+        // Seed form fields directly from the already-hydrated auth.profile when
+        // available, avoiding a redundant Firestore round-trip and loading spinner.
+        // Only fall back to loadProfileDocument when auth.profile is absent.
+        const seededProfile = auth.profile;
+        let loadedProfile: ProfileDocument;
+        if (seededProfile) {
+          loadedProfile = seededProfile as ProfileDocument;
+        } else {
+          loadedProfile = await loadProfileDocument(user.uid).catch((error) => {
+            console.warn('[profile] Unable to load profile:', error);
+            setProfileStatus({ message: 'Profile details could not be loaded yet.', tone: 'error' });
+            return {} as ProfileDocument;
+          });
+        }
 
         if (cancelled) {
           return;
@@ -271,7 +280,7 @@ export function Profile({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [user]);
+  }, [auth.profile, user]);
 
   useEffect(() => {
     void refreshPushPermissionStatus();

--- a/tests/unit/app-profile-seed-from-auth.test.tsx
+++ b/tests/unit/app-profile-seed-from-auth.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Profile } from '../../apps/app/src/pages/Profile';
+import type { AuthState } from '../../apps/app/src/lib/types';
+
+const profileServiceMocks = vi.hoisted(() => ({
+    acquireProfilePhoto: vi.fn(),
+    createProfileAccessCode: vi.fn(),
+    loadParentTeams: vi.fn(),
+    loadNotificationPreferences: vi.fn(),
+    loadNotificationTeams: vi.fn(),
+    loadProfileAccessCodes: vi.fn(),
+    loadProfileDocument: vi.fn(),
+    normalizeNotificationPreferences: vi.fn((preferences?: any) => ({
+        liveChat: preferences?.liveChat !== false,
+        liveScore: preferences?.liveScore === true,
+        schedule: preferences?.schedule !== false
+    })),
+    normalizeProfilePhoto: vi.fn(),
+    requestAccountMerge: vi.fn(),
+    saveNotificationPreferences: vi.fn(),
+    saveProfileDocument: vi.fn(),
+    uploadProfilePhoto: vi.fn()
+}));
+
+const publicActionsMocks = vi.hoisted(() => ({
+    sharePublicUrl: vi.fn()
+}));
+
+const pushServiceMocks = vi.hoisted(() => ({
+    enablePushNotificationsForUser: vi.fn(),
+    getPushNotificationPermissionStatus: vi.fn(),
+    openPushNotificationSettings: vi.fn()
+}));
+
+const shellLayoutState = vi.hoisted(() => ({
+    isDesktopWeb: false,
+    isNative: false
+}));
+
+vi.mock('../../apps/app/src/lib/profileService', () => profileServiceMocks);
+vi.mock('../../apps/app/src/lib/publicActions', () => publicActionsMocks);
+vi.mock('../../apps/app/src/lib/pushService', () => pushServiceMocks);
+vi.mock('../../apps/app/src/lib/useShellLayout', () => ({
+    useShellLayout: () => shellLayoutState
+}));
+vi.mock('lucide-react', () => {
+    const createIcon = (name: string) => (props: Record<string, unknown>) => React.createElement('svg', { ...props, 'data-icon': name });
+    return {
+        Bell: createIcon('Bell'),
+        ChevronDown: createIcon('ChevronDown'),
+        ChevronUp: createIcon('ChevronUp'),
+        CheckCircle2: createIcon('CheckCircle2'),
+        Clipboard: createIcon('Clipboard'),
+        Copy: createIcon('Copy'),
+        ImagePlus: createIcon('ImagePlus'),
+        KeyRound: createIcon('KeyRound'),
+        Link2: createIcon('Link2'),
+        Loader2: createIcon('Loader2'),
+        LogOut: createIcon('LogOut'),
+        Mail: createIcon('Mail'),
+        RefreshCw: createIcon('RefreshCw'),
+        Save: createIcon('Save'),
+        Send: createIcon('Send'),
+        Share2: createIcon('Share2'),
+        ShieldCheck: createIcon('ShieldCheck'),
+        Trash2: createIcon('Trash2'),
+        Upload: createIcon('Upload'),
+        UserCircle: createIcon('UserCircle'),
+        XCircle: createIcon('XCircle')
+    };
+});
+
+vi.mock('../../apps/app/src/lib/authService', () => ({
+    describeAuthError: (error: any) => error?.message || 'Authentication failed.',
+    reloadCurrentUser: vi.fn(),
+    resendVerificationEmail: vi.fn(),
+    sendResetEmail: vi.fn(),
+    setCurrentUserPassword: vi.fn()
+}));
+
+function buildAuth(overrides: Partial<AuthState> = {}): AuthState {
+    return {
+        user: {
+            uid: 'user-1',
+            email: 'test@example.com',
+            displayName: 'Test User',
+            emailVerified: true,
+            roles: ['parent'],
+            parentOf: []
+        },
+        profile: null,
+        loading: false,
+        error: null,
+        roles: ['parent'],
+        isParent: true,
+        isCoach: false,
+        isAdmin: false,
+        isPlatformAdmin: false,
+        refresh: vi.fn().mockResolvedValue(undefined),
+        signOut: vi.fn().mockResolvedValue(undefined),
+        ...overrides
+    };
+}
+
+describe('Profile seed from auth.profile', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('scrollTo', vi.fn());
+        window.URL.createObjectURL = vi.fn((file: File) => `blob:${file.name}`);
+        window.URL.revokeObjectURL = vi.fn();
+        profileServiceMocks.normalizeNotificationPreferences.mockClear();
+        profileServiceMocks.loadNotificationTeams.mockResolvedValue([]);
+        profileServiceMocks.loadProfileAccessCodes.mockResolvedValue([]);
+        profileServiceMocks.loadParentTeams.mockResolvedValue([]);
+        profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
+        profileServiceMocks.saveNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
+        profileServiceMocks.saveProfileDocument.mockResolvedValue(undefined);
+        profileServiceMocks.uploadProfilePhoto.mockResolvedValue('https://example.test/avatar.png');
+        profileServiceMocks.normalizeProfilePhoto.mockImplementation(async (file: File) => file);
+        pushServiceMocks.getPushNotificationPermissionStatus.mockResolvedValue({
+            state: 'prompt',
+            isNative: false,
+            platform: 'web',
+            canPrompt: true,
+            canOpenSettings: false
+        });
+        pushServiceMocks.openPushNotificationSettings.mockResolvedValue(undefined);
+        shellLayoutState.isDesktopWeb = false;
+        shellLayoutState.isNative = false;
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('seeds fullName from auth.profile without calling loadProfileDocument', async () => {
+        const auth = buildAuth({
+            profile: {
+                fullName: 'Test User',
+                phone: '555-0199',
+                photoUrl: '',
+                email: 'test@example.com'
+            }
+        });
+
+        render(
+            <MemoryRouter>
+                <Profile auth={auth} />
+            </MemoryRouter>
+        );
+
+        // The full name field should be populated immediately from auth.profile
+        const fullNameInput = await screen.findByPlaceholderText('Your name') as HTMLInputElement;
+        await waitFor(() => expect(fullNameInput.value).toBe('Test User'));
+
+        // loadProfileDocument must NOT have been called since auth.profile was present
+        expect(profileServiceMocks.loadProfileDocument).not.toHaveBeenCalled();
+    });
+
+    it('seeds phone from auth.profile without a network round-trip', async () => {
+        const auth = buildAuth({
+            profile: {
+                fullName: 'Test User',
+                phone: '555-0199',
+                photoUrl: '',
+                email: 'test@example.com'
+            }
+        });
+
+        render(
+            <MemoryRouter>
+                <Profile auth={auth} />
+            </MemoryRouter>
+        );
+
+        const phoneInput = await screen.findByPlaceholderText('123-456-7890') as HTMLInputElement;
+        await waitFor(() => expect(phoneInput.value).toBe('555-0199'));
+
+        expect(profileServiceMocks.loadProfileDocument).not.toHaveBeenCalled();
+    });
+
+    it('seeds photoPreview from auth.profile without calling loadProfileDocument', async () => {
+        const auth = buildAuth({
+            profile: {
+                fullName: 'Test User',
+                phone: '',
+                photoUrl: 'https://example.test/profile.png',
+                email: 'test@example.com'
+            }
+        });
+
+        const { container } = render(
+            <MemoryRouter>
+                <Profile auth={auth} />
+            </MemoryRouter>
+        );
+
+        // Wait for the loading spinner to disappear and photo to appear
+        await waitFor(() => {
+            const img = container.querySelector('img') as HTMLImageElement | null;
+            expect(img?.getAttribute('src')).toBe('https://example.test/profile.png');
+        });
+
+        expect(profileServiceMocks.loadProfileDocument).not.toHaveBeenCalled();
+    });
+
+    it('falls back to loadProfileDocument when auth.profile is null', async () => {
+        profileServiceMocks.loadProfileDocument.mockResolvedValue({
+            fullName: 'Loaded User',
+            phone: '555-0200',
+            photoUrl: '',
+            email: 'test@example.com'
+        });
+
+        const auth = buildAuth({ profile: null });
+
+        render(
+            <MemoryRouter>
+                <Profile auth={auth} />
+            </MemoryRouter>
+        );
+
+        const fullNameInput = await screen.findByPlaceholderText('Your name') as HTMLInputElement;
+        await waitFor(() => expect(fullNameInput.value).toBe('Loaded User'));
+
+        expect(profileServiceMocks.loadProfileDocument).toHaveBeenCalledTimes(1);
+        expect(profileServiceMocks.loadProfileDocument).toHaveBeenCalledWith('user-1');
+    });
+});


### PR DESCRIPTION
## Summary

- In `apps/app/src/pages/Profile.tsx`, the `loadProfile` effect now checks `auth.profile` first
- When `auth.profile` is already populated (hydrated during session bootstrap), the form fields (`fullName`, `phone`, `photoPreview`) are seeded directly — no `loadProfileDocument` call, no loading spinner
- Falls back to `loadProfileDocument` when `auth.profile` is null (existing behavior preserved)
- Adds `auth.profile` to the `useEffect` dependency array
- Adds `tests/unit/app-profile-seed-from-auth.test.tsx` with 4 tests covering both seed-from-auth and fallback paths

## Test plan
- [ ] `npm test` passes
- [ ] Profile page shows name/photo immediately without spinner on return visits

Closes #2265

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_