### PR TITLE
Fix #2273: Restore profile section and team from URL params after native handoff

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   Bell,
   ChevronDown,
@@ -83,6 +83,7 @@ const profileSections: Array<{ id: ProfileSectionId; label: string }> = [
 
 export function Profile({ auth }: { auth: AuthState }) {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { isDesktopWeb, isNative } = useShellLayout();
   const user = auth.user;
   const [profile, setProfile] = useState<ProfileDocument>({});
@@ -94,6 +95,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [photoChanged, setPhotoChanged] = useState(false);
   const [photoChooserOpen, setPhotoChooserOpen] = useState(false);
   const [notificationTeams, setNotificationTeams] = useState<NotificationTeam[]>([]);
+  const [initialUrlTeamId] = useState(() => searchParams.get('teamId') || '');
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [notificationPreferences, setNotificationPreferences] = useState<NotificationPreferences>(emptyPreferences);
   const [accessCodes, setAccessCodes] = useState<AccessCodeRecord[]>([]);
@@ -117,7 +119,10 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [accountMergeStatus, setAccountMergeStatus] = useState<Status | null>(null);
   const [inviteActionStatus, setInviteActionStatus] = useState('');
   const [inviteHistoryExpanded, setInviteHistoryExpanded] = useState(false);
-  const [activeProfileSection, setActiveProfileSection] = useState<ProfileSectionId>('account');
+  const [activeProfileSection, setActiveProfileSection] = useState<ProfileSectionId>(() => {
+    const s = searchParams.get('section');
+    return (s === 'account' || s === 'alerts' || s === 'invites' || s === 'security') ? s as ProfileSectionId : 'account';
+  });
   const [notificationTeamsLoaded, setNotificationTeamsLoaded] = useState(false);
   const [accessCodesLoaded, setAccessCodesLoaded] = useState(false);
   const [parentLinkedTeamsLoaded, setParentLinkedTeamsLoaded] = useState(false);
@@ -187,6 +192,12 @@ export function Profile({ auth }: { auth: AuthState }) {
 
   const selectProfileSection = (sectionId: ProfileSectionId) => {
     setActiveProfileSection(sectionId);
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current);
+      next.set('section', sectionId);
+      next.delete('teamId');
+      return next;
+    }, { replace: true });
     window.requestAnimationFrame(() => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
@@ -306,7 +317,11 @@ export function Profile({ auth }: { auth: AuthState }) {
           return;
         }
 
-        const initialTeamId = teams[0]?.id || '';
+        const fallbackTeamId = teams[0]?.id || '';
+        const preferredTeamId = initialUrlTeamId && teams.some((team) => team.id === initialUrlTeamId)
+          ? initialUrlTeamId
+          : fallbackTeamId;
+        const initialTeamId = preferredTeamId;
 
         setNotificationTeams(teams);
         setSelectedTeamId((current) => {
@@ -346,7 +361,7 @@ export function Profile({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeProfileSection, notificationTeamsLoaded, user]);
+  }, [activeProfileSection, initialUrlTeamId, notificationTeamsLoaded, user]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1073,7 +1088,20 @@ export function Profile({ auth }: { auth: AuthState }) {
             <div className="mt-4 grid gap-3">
               <label className="block">
                 <span className="mb-1.5 block text-xs font-extrabold uppercase tracking-[0.04em] text-gray-500">Team</span>
-                <select className="auth-input" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)}>
+                <select className="auth-input" value={selectedTeamId} onChange={(event) => {
+                  const nextTeamId = event.target.value;
+                  setSelectedTeamId(nextTeamId);
+                  setSearchParams((current) => {
+                    const next = new URLSearchParams(current);
+                    next.set('section', 'alerts');
+                    if (nextTeamId) {
+                      next.set('teamId', nextTeamId);
+                    } else {
+                      next.delete('teamId');
+                    }
+                    return next;
+                  }, { replace: true });
+                }}>
                   <option value="">Select a team</option>
                   {notificationTeams.map((team) => (
                     <option key={team.id} value={team.id}>{team.name || team.id}</option>

--- a/tests/unit/app-profile-section-restore.test.tsx
+++ b/tests/unit/app-profile-section-restore.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Profile } from '../../apps/app/src/pages/Profile';
+import type { AuthState } from '../../apps/app/src/lib/types';
+
+const profileServiceMocks = vi.hoisted(() => ({
+  acquireProfilePhoto: vi.fn(),
+  createProfileAccessCode: vi.fn(),
+  loadParentTeams: vi.fn(),
+  loadNotificationPreferences: vi.fn(),
+  loadNotificationTeams: vi.fn(),
+  loadProfileAccessCodes: vi.fn(),
+  loadProfileDocument: vi.fn(),
+  normalizeNotificationPreferences: vi.fn((preferences?: any) => ({
+    liveChat: preferences?.liveChat !== false,
+    liveScore: preferences?.liveScore === true,
+    schedule: preferences?.schedule !== false
+  })),
+  normalizeProfilePhoto: vi.fn(),
+  requestAccountMerge: vi.fn(),
+  saveNotificationPreferences: vi.fn(),
+  saveProfileDocument: vi.fn(),
+  uploadProfilePhoto: vi.fn()
+}));
+
+const publicActionsMocks = vi.hoisted(() => ({
+  sharePublicUrl: vi.fn()
+}));
+
+const pushServiceMocks = vi.hoisted(() => ({
+  enablePushNotificationsForUser: vi.fn(),
+  getPushNotificationPermissionStatus: vi.fn(),
+  openPushNotificationSettings: vi.fn()
+}));
+
+const shellLayoutState = vi.hoisted(() => ({
+  isDesktopWeb: false,
+  isNative: false
+}));
+
+vi.mock('../../apps/app/src/lib/profileService', () => profileServiceMocks);
+vi.mock('../../apps/app/src/lib/publicActions', () => publicActionsMocks);
+vi.mock('../../apps/app/src/lib/pushService', () => pushServiceMocks);
+vi.mock('../../apps/app/src/lib/useShellLayout', () => ({
+  useShellLayout: () => shellLayoutState
+}));
+vi.mock('lucide-react', () => {
+  const createIcon = (name: string) => (props: Record<string, unknown>) => React.createElement('svg', { ...props, 'data-icon': name });
+  return {
+    Bell: createIcon('Bell'),
+    ChevronDown: createIcon('ChevronDown'),
+    ChevronUp: createIcon('ChevronUp'),
+    CheckCircle2: createIcon('CheckCircle2'),
+    Clipboard: createIcon('Clipboard'),
+    Copy: createIcon('Copy'),
+    ImagePlus: createIcon('ImagePlus'),
+    KeyRound: createIcon('KeyRound'),
+    Link2: createIcon('Link2'),
+    Loader2: createIcon('Loader2'),
+    LogOut: createIcon('LogOut'),
+    Mail: createIcon('Mail'),
+    RefreshCw: createIcon('RefreshCw'),
+    Save: createIcon('Save'),
+    Send: createIcon('Send'),
+    Share2: createIcon('Share2'),
+    ShieldCheck: createIcon('ShieldCheck'),
+    Trash2: createIcon('Trash2'),
+    Upload: createIcon('Upload'),
+    UserCircle: createIcon('UserCircle'),
+    XCircle: createIcon('XCircle')
+  };
+});
+
+vi.mock('../../apps/app/src/lib/authService', () => ({
+  describeAuthError: (error: any) => error?.message || 'Authentication failed.',
+  reloadCurrentUser: vi.fn(),
+  resendVerificationEmail: vi.fn(),
+  sendResetEmail: vi.fn(),
+  setCurrentUserPassword: vi.fn()
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'user-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent',
+    emailVerified: false,
+    roles: ['parent'],
+    parentOf: []
+  },
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn().mockResolvedValue(undefined),
+  signOut: vi.fn().mockResolvedValue(undefined)
+};
+
+function renderProfileAt(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: '/profile', search }]}>
+      <Profile auth={auth} />
+    </MemoryRouter>
+  );
+}
+
+describe('Profile section restore from URL', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.refresh = vi.fn().mockResolvedValue(undefined);
+    auth.signOut = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('scrollTo', vi.fn());
+    window.URL.createObjectURL = vi.fn((file: File) => `blob:${(file as any).name}`);
+    window.URL.revokeObjectURL = vi.fn();
+
+    profileServiceMocks.loadProfileDocument.mockResolvedValue({
+      fullName: 'Pat Parent',
+      phone: '555-0100',
+      photoUrl: '',
+      signInMethod: 'emailLink',
+      hasPassword: false,
+      updatedAt: { seconds: 1717200000 }
+    });
+    profileServiceMocks.loadProfileAccessCodes.mockResolvedValue([]);
+    profileServiceMocks.loadParentTeams.mockResolvedValue([]);
+    profileServiceMocks.normalizeProfilePhoto.mockImplementation(async (file: File) => file);
+    profileServiceMocks.saveProfileDocument.mockResolvedValue(undefined);
+    profileServiceMocks.uploadProfilePhoto.mockResolvedValue('https://example.test/avatar.png');
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([
+      { id: 'team-1', name: 'Blue Team' },
+      { id: 'team-2', name: 'Gold Team' }
+    ]);
+    profileServiceMocks.loadNotificationPreferences.mockResolvedValue({
+      liveChat: true,
+      liveScore: false,
+      schedule: true
+    });
+    profileServiceMocks.saveNotificationPreferences.mockResolvedValue({
+      liveChat: true,
+      liveScore: false,
+      schedule: true
+    });
+    pushServiceMocks.getPushNotificationPermissionStatus.mockResolvedValue({
+      state: 'prompt',
+      isNative: false,
+      platform: 'web',
+      canPrompt: true,
+      canOpenSettings: false
+    });
+    pushServiceMocks.openPushNotificationSettings.mockResolvedValue(undefined);
+    pushServiceMocks.enablePushNotificationsForUser.mockResolvedValue(undefined);
+    publicActionsMocks.sharePublicUrl.mockResolvedValue('shared');
+    shellLayoutState.isDesktopWeb = false;
+    shellLayoutState.isNative = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('restores alerts section and selects the correct team when mounted with ?section=alerts&teamId=team-2', async () => {
+    renderProfileAt('?section=alerts&teamId=team-2');
+
+    // The Alerts section nav button should be visually active (aria-pressed)
+    const alertsButton = await screen.findByRole('button', { name: 'Alerts' });
+    expect(alertsButton.getAttribute('aria-pressed')).toBe('true');
+
+    // Account button should not be active
+    const accountButton = screen.getByRole('button', { name: 'Account' });
+    expect(accountButton.getAttribute('aria-pressed')).toBe('false');
+
+    // Wait for teams to load and team-2 to be selected
+    await waitFor(() => {
+      const teamSelect = screen.queryByLabelText('Team') as HTMLSelectElement | null;
+      return teamSelect !== null && teamSelect.value === 'team-2';
+    });
+
+    const teamSelect = screen.getByLabelText('Team') as HTMLSelectElement;
+    expect(teamSelect.value).toBe('team-2');
+
+    // Alert preferences should have loaded for team-2
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-2'));
+  });
+
+  it('falls back to the first team when the URL teamId does not match any loaded team', async () => {
+    renderProfileAt('?section=alerts&teamId=nonexistent-team');
+
+    // Should still show the Alerts section
+    const alertsButton = await screen.findByRole('button', { name: 'Alerts' });
+    expect(alertsButton.getAttribute('aria-pressed')).toBe('true');
+
+    // Should fall back to the first team (team-1)
+    await waitFor(() => {
+      const teamSelect = screen.queryByLabelText('Team') as HTMLSelectElement | null;
+      return teamSelect !== null && teamSelect.value !== '';
+    });
+
+    const teamSelect = screen.getByLabelText('Team') as HTMLSelectElement;
+    expect(teamSelect.value).toBe('team-1');
+
+    // Alert preferences should have loaded for team-1 (the fallback)
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1'));
+  });
+
+  it('defaults to the account section when no section param is in the URL', async () => {
+    renderProfileAt('');
+
+    const accountButton = await screen.findByRole('button', { name: 'Account' });
+    expect(accountButton.getAttribute('aria-pressed')).toBe('true');
+
+    const alertsButton = screen.getByRole('button', { name: 'Alerts' });
+    expect(alertsButton.getAttribute('aria-pressed')).toBe('false');
+
+    // Account form should be visible
+    expect(screen.getByRole('button', { name: 'Save profile' })).toBeTruthy();
+    // Team alerts data should not be loaded yet
+    expect(profileServiceMocks.loadNotificationTeams).not.toHaveBeenCalled();
+  });
+
+  it('defaults to the account section when an invalid section param is given', async () => {
+    renderProfileAt('?section=badvalue');
+
+    const accountButton = await screen.findByRole('button', { name: 'Account' });
+    expect(accountButton.getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'Save profile' })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- In `apps/app/src/pages/Profile.tsx`, reads `?section=` and `?teamId=` search params on mount to restore the active section and selected team after a native handoff
- When `auth.profile` has `?section=alerts&teamId=team-2`, the Alerts section opens with team-2 pre-selected
- Falls back gracefully when teamId doesn't match any loaded team
- `selectProfileSection` writes `?section=<id>` to URL params; team select writes `?section=alerts&teamId=<id>`
- Adds `tests/unit/app-profile-section-restore.test.tsx` with 4 tests covering restore, fallback, and default-section scenarios

## Test plan
- [ ] `npm test` passes
- [ ] Navigate to Profile > Alerts, select a team, handoff to native and return — Alerts section opens with the same team selected

Closes #2273

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_