### PR TITLE
Feat #2189: Notification bell with unread badge and inbox sheet

### DIFF
--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import { Suspense, lazy, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
+  Bell,
   CalendarDays,
   CalendarPlus,
   ClipboardList,
@@ -29,10 +30,17 @@ import { useShellLayout } from '../lib/useShellLayout';
 import { recordUxTiming } from '../lib/uxTiming';
 import { openPublicUrl } from '../lib/publicActions';
 import { APP_BACK_DISMISS_EVENT } from '../lib/nativeBackButton';
+import {
+  countUnread,
+  markNotificationRead,
+  subscribeToNotificationInbox,
+  type NotificationInboxItem
+} from '../lib/notificationInboxService';
 import type { AuthState, NavItem } from '../lib/types';
 import { RoleBadge } from './Badges';
 
 const AppSearchDialog = lazy(() => import('./AppSearchDialog').then((module) => ({ default: module.AppSearchDialog })));
+const NotificationInboxSheet = lazy(() => import('./NotificationInboxSheet').then((module) => ({ default: module.NotificationInboxSheet })));
 
 const navItems: NavItem[] = [
   { label: 'Home', path: '/home', icon: Home },
@@ -61,6 +69,8 @@ interface AppShellProps {
 export function AppShell({ auth, children }: AppShellProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [addTeamOpen, setAddTeamOpen] = useState(false);
+  const [inboxOpen, setInboxOpen] = useState(false);
+  const [inboxItems, setInboxItems] = useState<NotificationInboxItem[]>([]);
   const { isDesktopWeb } = useShellLayout();
   const navigate = useNavigate();
   const location = useLocation();
@@ -68,6 +78,7 @@ export function AppShell({ auth, children }: AppShellProps) {
   const isAiRoute = location.pathname === '/ai';
   const isMobileChatDetail = !isDesktopWeb && location.pathname.startsWith('/messages/') && location.pathname !== '/messages';
   const isDesktopMessages = isDesktopWeb && (location.pathname.startsWith('/messages') || isAiRoute);
+  const unreadCount = countUnread(inboxItems);
 
   useEffect(() => {
     const startedAt = routeStartedAtRef.current;
@@ -103,11 +114,22 @@ export function AppShell({ auth, children }: AppShellProps) {
         setAddTeamOpen(false);
         event.preventDefault();
       }
+      if (inboxOpen) {
+        setInboxOpen(false);
+        event.preventDefault();
+      }
     };
 
     window.addEventListener(APP_BACK_DISMISS_EVENT, onNativeBackDismiss);
     return () => window.removeEventListener(APP_BACK_DISMISS_EVENT, onNativeBackDismiss);
-  }, [addTeamOpen, searchOpen]);
+  }, [addTeamOpen, inboxOpen, searchOpen]);
+
+  useEffect(() => {
+    const uid = auth.user?.uid;
+    if (!uid) return;
+    const unsubscribe = subscribeToNotificationInbox(uid, setInboxItems);
+    return unsubscribe;
+  }, [auth.user?.uid]);
 
   const addWorkflows = buildAddWorkflows();
 
@@ -150,6 +172,25 @@ export function AppShell({ auth, children }: AppShellProps) {
                 >
                   <Sparkles className="h-5 w-5" aria-hidden="true" />
                   AI
+                </button>
+                <button
+                  type="button"
+                  className="ghost-button !h-10 !min-h-10 relative"
+                  onClick={() => setInboxOpen(true)}
+                  aria-label="Notifications"
+                  title="Notifications"
+                  data-testid="app-shell-notifications-trigger"
+                >
+                  <Bell className="h-5 w-5" aria-hidden="true" />
+                  {unreadCount > 0 && (
+                    <span
+                      className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-500 px-1 text-[10px] font-black text-white"
+                      aria-label={`${unreadCount} unread`}
+                      data-testid="notification-unread-badge"
+                    >
+                      {unreadCount > 99 ? '99+' : unreadCount}
+                    </span>
+                  )}
                 </button>
                 <button
                   type="button"
@@ -237,6 +278,26 @@ export function AppShell({ auth, children }: AppShellProps) {
                 </button>
                 <button
                   type="button"
+                  className="ghost-button !h-10 !min-h-10 !w-10 !p-0 relative"
+                  onClick={() => setInboxOpen(true)}
+                  aria-label="Notifications"
+                  title="Notifications"
+                  data-testid="app-shell-notifications-trigger"
+                >
+                  <Bell className="h-5 w-5" aria-hidden="true" />
+                  <span className="sr-only">Notifications</span>
+                  {unreadCount > 0 && (
+                    <span
+                      className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-500 px-1 text-[10px] font-black text-white"
+                      aria-label={`${unreadCount} unread`}
+                      data-testid="notification-unread-badge"
+                    >
+                      {unreadCount > 99 ? '99+' : unreadCount}
+                    </span>
+                  )}
+                </button>
+                <button
+                  type="button"
                   className="ghost-button !h-10 !min-h-10 !w-10 !p-0"
                   onClick={() => setSearchOpen(true)}
                   aria-label="Search"
@@ -294,6 +355,17 @@ export function AppShell({ auth, children }: AppShellProps) {
           </nav>
         </>
       )}
+
+      {inboxOpen ? (
+        <Suspense fallback={null}>
+          <NotificationInboxSheet
+            items={inboxItems}
+            uid={auth.user?.uid ?? ''}
+            onClose={() => setInboxOpen(false)}
+            onMarkRead={markNotificationRead}
+          />
+        </Suspense>
+      ) : null}
 
       {searchOpen ? (
         <Suspense fallback={null}>

--- a/apps/app/src/components/NotificationInboxSheet.tsx
+++ b/apps/app/src/components/NotificationInboxSheet.tsx
@@ -1,0 +1,90 @@
+import { Bell, X } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import type { NotificationInboxItem } from '../lib/notificationInboxService';
+
+interface NotificationInboxSheetProps {
+    items: NotificationInboxItem[];
+    uid: string;
+    onClose: () => void;
+    onMarkRead: (uid: string, itemId: string) => Promise<void>;
+}
+
+export function NotificationInboxSheet({ items, uid, onClose, onMarkRead }: NotificationInboxSheetProps) {
+    const navigate = useNavigate();
+
+    const handleItemClick = async (item: NotificationInboxItem) => {
+        if (!item.readAt) {
+            await onMarkRead(uid, item.id);
+        }
+        onClose();
+        if (item.appRoute) {
+            navigate(item.appRoute);
+        }
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-end bg-gray-950/40 p-3 backdrop-blur-sm sm:items-center sm:justify-center"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Notifications"
+        >
+            <div className="w-full max-w-lg rounded-2xl bg-white shadow-app-lg">
+                <div className="flex items-center justify-between border-b border-gray-200 p-4">
+                    <div>
+                        <div className="app-label">Inbox</div>
+                        <h2 className="text-lg font-black text-gray-950">Notifications</h2>
+                    </div>
+                    <button
+                        type="button"
+                        className="ghost-button !h-10 !min-h-10 !w-10 !p-0"
+                        onClick={onClose}
+                        aria-label="Close notifications"
+                    >
+                        <X className="h-5 w-5" aria-hidden="true" />
+                    </button>
+                </div>
+
+                <div className="max-h-[70vh] overflow-y-auto">
+                    {items.length === 0 ? (
+                        <div className="flex flex-col items-center gap-3 px-4 py-12 text-center">
+                            <Bell className="h-10 w-10 text-gray-300" aria-hidden="true" />
+                            <p className="text-sm font-semibold text-gray-500">No notifications yet</p>
+                        </div>
+                    ) : (
+                        <ul role="list" className="divide-y divide-gray-100">
+                            {items.map((item) => {
+                                const isUnread = !item.readAt;
+                                return (
+                                    <li key={item.id}>
+                                        <button
+                                            type="button"
+                                            className={`flex w-full items-start gap-3 px-4 py-3 text-left transition hover:bg-gray-50 ${isUnread ? 'bg-primary-50' : ''}`}
+                                            onClick={() => void handleItemClick(item)}
+                                            data-testid={`notification-item-${item.id}`}
+                                        >
+                                            {isUnread && (
+                                                <span className="mt-1.5 h-2 w-2 flex-none rounded-full bg-primary-500" aria-label="Unread" />
+                                            )}
+                                            {!isUnread && <span className="mt-1.5 h-2 w-2 flex-none" />}
+                                            <span className="min-w-0 flex-1">
+                                                <span className={`block text-sm leading-snug ${isUnread ? 'font-bold text-gray-950' : 'font-semibold text-gray-700'}`}>
+                                                    {item.text}
+                                                </span>
+                                                {item.type ? (
+                                                    <span className="mt-0.5 block text-xs font-medium text-gray-400 capitalize">
+                                                        {item.type.replace(/_/g, ' ')}
+                                                    </span>
+                                                ) : null}
+                                            </span>
+                                        </button>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/app/src/components/NotificationInboxSheet.tsx
+++ b/apps/app/src/components/NotificationInboxSheet.tsx
@@ -16,10 +16,10 @@ export function NotificationInboxSheet({ items, uid, onClose, onMarkRead }: Noti
         if (!item.readAt) {
             await onMarkRead(uid, item.id);
         }
-        onClose();
         if (item.appRoute) {
             navigate(item.appRoute);
         }
+        onClose();
     };
 
     return (

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -1,3 +1,4 @@
+import type { QuerySnapshot, DocumentData } from 'firebase/firestore';
 import {
     collection,
     db,
@@ -36,7 +37,7 @@ export function subscribeToNotificationInbox(
 
     return onSnapshot(
         q,
-        (snapshot) => {
+        (snapshot: QuerySnapshot<DocumentData>) => {
             const items: NotificationInboxItem[] = snapshot.docs.map((docSnap) => {
                 const data = docSnap.data();
                 return {
@@ -50,8 +51,12 @@ export function subscribeToNotificationInbox(
             });
             callback(items);
         },
-        (error) => {
-            if (onError) onError(error);
+        (error: unknown) => {
+            if (onError) {
+                onError(error);
+            } else {
+                console.error('Failed to subscribe to notification inbox:', error);
+            }
         }
     );
 }

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -1,0 +1,72 @@
+import {
+    collection,
+    db,
+    doc,
+    limit,
+    onSnapshot,
+    orderBy,
+    query,
+    updateDoc,
+    serverTimestamp
+} from '../../../../js/firebase.js';
+
+export type NotificationInboxItem = {
+    id: string;
+    type: string;
+    text: string;
+    appRoute: string;
+    createdAt: unknown;
+    readAt: unknown | null;
+};
+
+/**
+ * Subscribe to the user's notification inbox (newest first, limit 50).
+ * Returns an unsubscribe function.
+ */
+export function subscribeToNotificationInbox(
+    uid: string,
+    callback: (items: NotificationInboxItem[]) => void,
+    onError?: (error: unknown) => void
+): () => void {
+    const q = query(
+        collection(db, `users/${uid}/notificationInbox`),
+        orderBy('createdAt', 'desc'),
+        limit(50)
+    );
+
+    return onSnapshot(
+        q,
+        (snapshot) => {
+            const items: NotificationInboxItem[] = snapshot.docs.map((docSnap) => {
+                const data = docSnap.data();
+                return {
+                    id: docSnap.id,
+                    type: typeof data['type'] === 'string' ? data['type'] : '',
+                    text: typeof data['text'] === 'string' ? data['text'] : '',
+                    appRoute: typeof data['appRoute'] === 'string' ? data['appRoute'] : '',
+                    createdAt: data['createdAt'] ?? null,
+                    readAt: data['readAt'] ?? null
+                };
+            });
+            callback(items);
+        },
+        (error) => {
+            if (onError) onError(error);
+        }
+    );
+}
+
+/**
+ * Count unread items (those without a readAt value).
+ */
+export function countUnread(items: NotificationInboxItem[]): number {
+    return items.filter((item) => !item.readAt).length;
+}
+
+/**
+ * Mark a notification inbox item as read by setting its readAt to now.
+ */
+export async function markNotificationRead(uid: string, itemId: string): Promise<void> {
+    const docRef = doc(db, `users/${uid}/notificationInbox`, itemId);
+    await updateDoc(docRef, { readAt: serverTimestamp() });
+}

--- a/tests/unit/app-notification-bell.test.tsx
+++ b/tests/unit/app-notification-bell.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppShell } from '../../apps/app/src/components/AppShell';
+import type { AuthState } from '../../apps/app/src/lib/types';
+
+// --- Hoisted mocks ---
+
+const { useShellLayoutMock } = vi.hoisted(() => ({
+    useShellLayoutMock: vi.fn(() => ({ isDesktopWeb: true })),
+}));
+
+const inboxServiceMocks = vi.hoisted(() => ({
+    subscribeToNotificationInbox: vi.fn(() => vi.fn()),
+    countUnread: vi.fn((items: Array<{ readAt: unknown }>) => items.filter((i) => !i.readAt).length),
+    markNotificationRead: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../../apps/app/src/lib/useShellLayout', () => ({
+    useShellLayout: useShellLayoutMock,
+}));
+
+vi.mock('../../apps/app/src/lib/uxTiming', () => ({
+    recordUxTiming: vi.fn(),
+}));
+
+vi.mock('../../apps/app/src/lib/nativeBackButton', () => ({
+    APP_BACK_DISMISS_EVENT: 'allplays:native-back-dismiss',
+    addNativeBackListener: vi.fn(() => ({ remove: vi.fn() })),
+}));
+
+vi.mock('../../apps/app/src/lib/notificationInboxService', () => inboxServiceMocks);
+
+vi.mock('../../apps/app/src/components/AppSearchDialog', () => ({
+    AppSearchDialog: ({ open }: { open: boolean }) =>
+        open ? <div role="dialog" aria-label="Search teams, players, actions, and help" /> : null,
+}));
+
+vi.mock('../../apps/app/src/components/NotificationInboxSheet', () => ({
+    NotificationInboxSheet: ({
+        items,
+        onClose,
+        onMarkRead,
+        uid,
+    }: {
+        items: Array<{ id: string; text: string; appRoute: string; readAt: unknown }>;
+        uid: string;
+        onClose: () => void;
+        onMarkRead: (uid: string, itemId: string) => Promise<void>;
+    }) => (
+        <div role="dialog" aria-label="Notifications" data-testid="notification-inbox-sheet">
+            {items.length === 0 ? (
+                <p>No notifications yet</p>
+            ) : (
+                <ul>
+                    {items.map((item) => (
+                        <li key={item.id}>
+                            <button
+                                type="button"
+                                data-testid={`notification-item-${item.id}`}
+                                onClick={() => void onMarkRead(uid, item.id).then(onClose)}
+                            >
+                                {item.text}
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+            <button type="button" onClick={onClose} aria-label="Close notifications">
+                Close
+            </button>
+        </div>
+    ),
+}));
+
+// --- Auth fixture ---
+
+const auth: AuthState = {
+    user: {
+        uid: 'user-1',
+        email: 'user@example.com',
+        displayName: 'Test User',
+        roles: ['parent'],
+    },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['parent'],
+    isParent: true,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn(),
+};
+
+function renderShell(isDesktop = true) {
+    useShellLayoutMock.mockReturnValue({ isDesktopWeb: isDesktop });
+    return render(
+        <MemoryRouter initialEntries={['/home']}>
+            <Routes>
+                <Route
+                    path="/home"
+                    element={
+                        <AppShell auth={auth}>
+                            <div>Home content</div>
+                        </AppShell>
+                    }
+                />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+// --- Tests ---
+
+describe('Notification bell in AppShell', () => {
+    beforeEach(() => {
+        vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+            callback(0);
+            return 1;
+        });
+        vi.stubGlobal('cancelAnimationFrame', vi.fn());
+        inboxServiceMocks.subscribeToNotificationInbox.mockReturnValue(vi.fn());
+        inboxServiceMocks.markNotificationRead.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('renders a notification bell button in the desktop header', () => {
+        renderShell(true);
+        const bellButton = screen.getByRole('button', { name: 'Notifications' });
+        expect(bellButton).toBeTruthy();
+        expect(bellButton.getAttribute('data-testid')).toBe('app-shell-notifications-trigger');
+    });
+
+    it('renders a notification bell button in the mobile header', () => {
+        renderShell(false);
+        const bellButton = screen.getByTestId('app-shell-notifications-trigger');
+        expect(bellButton.getAttribute('aria-label')).toBe('Notifications');
+    });
+
+    it('subscribes to the notification inbox for the signed-in user', () => {
+        renderShell(true);
+        expect(inboxServiceMocks.subscribeToNotificationInbox).toHaveBeenCalledWith(
+            'user-1',
+            expect.any(Function)
+        );
+    });
+
+    it('does not show an unread badge when there are no unread items', () => {
+        // subscribeToNotificationInbox never calls back — items stay empty
+        renderShell(true);
+        expect(screen.queryByTestId('notification-unread-badge')).toBeNull();
+    });
+
+    it('shows the unread badge with the correct count when there are unread notifications', async () => {
+        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
+            (_uid: string, callback: (items: Array<{ id: string; text: string; appRoute: string; readAt: unknown }>) => void) => {
+                callback([
+                    { id: 'n1', text: 'Game tonight', appRoute: '/schedule', readAt: null },
+                    { id: 'n2', text: 'Practice update', appRoute: '/schedule', readAt: 'some-ts' },
+                    { id: 'n3', text: 'New message', appRoute: '/messages', readAt: null },
+                ]);
+                return vi.fn();
+            }
+        );
+
+        renderShell(true);
+
+        await waitFor(() => {
+            const badge = screen.getByTestId('notification-unread-badge');
+            expect(badge).toBeTruthy();
+            expect(badge.textContent).toBe('2');
+        });
+    });
+
+    it('opens the notification inbox sheet when the bell is clicked', async () => {
+        renderShell(true);
+        fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+        await waitFor(() => {
+            expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeTruthy();
+        });
+    });
+
+    it('calls markNotificationRead when an inbox item is clicked', async () => {
+        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
+            (_uid: string, callback: (items: Array<{ id: string; text: string; appRoute: string; readAt: unknown }>) => void) => {
+                callback([
+                    { id: 'notif-42', text: 'You were tagged', appRoute: '/home', readAt: null },
+                ]);
+                return vi.fn();
+            }
+        );
+
+        renderShell(true);
+
+        // Open the inbox
+        fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+        await waitFor(() => screen.getByRole('dialog', { name: 'Notifications' }));
+
+        // Click the notification item
+        fireEvent.click(screen.getByTestId('notification-item-notif-42'));
+
+        await waitFor(() => {
+            expect(inboxServiceMocks.markNotificationRead).toHaveBeenCalledWith('user-1', 'notif-42');
+        });
+    });
+
+    it('closes the inbox sheet when close is triggered', async () => {
+        renderShell(true);
+        fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+        await waitFor(() => screen.getByRole('dialog', { name: 'Notifications' }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close notifications' }));
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', { name: 'Notifications' })).toBeNull();
+        });
+    });
+
+    it('caps the badge display at 99+ for very large unread counts', async () => {
+        const manyItems = Array.from({ length: 105 }, (_, i) => ({
+            id: `n${i}`,
+            text: `Notification ${i}`,
+            appRoute: '/home',
+            readAt: null,
+        }));
+
+        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
+            (_uid: string, callback: (items: typeof manyItems) => void) => {
+                callback(manyItems);
+                return vi.fn();
+            }
+        );
+
+        renderShell(true);
+
+        await waitFor(() => {
+            const badge = screen.getByTestId('notification-unread-badge');
+            expect(badge.textContent).toBe('99+');
+        });
+    });
+});

--- a/tests/unit/app-notification-inbox-review.test.tsx
+++ b/tests/unit/app-notification-inbox-review.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NotificationInboxSheet } from '../../apps/app/src/components/NotificationInboxSheet';
+import { subscribeToNotificationInbox } from '../../apps/app/src/lib/notificationInboxService';
+
+const { navigateMock } = vi.hoisted(() => ({
+    navigateMock: vi.fn(),
+}));
+
+const firebaseMocks = vi.hoisted(() => ({
+    collection: vi.fn((_db: unknown, path: string) => ({ path })),
+    db: {},
+    doc: vi.fn(),
+    limit: vi.fn((count: number) => ({ type: 'limit', count })),
+    onSnapshot: vi.fn(() => vi.fn()),
+    orderBy: vi.fn((field: string, direction: string) => ({ type: 'orderBy', field, direction })),
+    query: vi.fn((...args: unknown[]) => ({ args })),
+    serverTimestamp: vi.fn(),
+    updateDoc: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+    return {
+        ...actual,
+        useNavigate: () => navigateMock,
+    };
+});
+
+vi.mock('../../js/firebase.js', () => firebaseMocks);
+
+afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+});
+
+describe('Notification inbox review regressions', () => {
+    it('navigates to an item route before closing the sheet', async () => {
+        const onClose = vi.fn();
+        const onMarkRead = vi.fn(() => Promise.resolve());
+
+        render(
+            <NotificationInboxSheet
+                items={[
+                    {
+                        id: 'notif-1',
+                        type: 'team_message',
+                        text: 'New team message',
+                        appRoute: '/messages',
+                        createdAt: null,
+                        readAt: null,
+                    },
+                ]}
+                uid="user-1"
+                onClose={onClose}
+                onMarkRead={onMarkRead}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId('notification-item-notif-1'));
+
+        await waitFor(() => {
+            expect(onMarkRead).toHaveBeenCalledWith('user-1', 'notif-1');
+            expect(navigateMock).toHaveBeenCalledWith('/messages');
+            expect(onClose).toHaveBeenCalled();
+        });
+        expect(navigateMock.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0]);
+    });
+
+    it('logs Firestore subscription errors when no error callback is provided', () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const subscriptionError = new Error('subscription failed');
+
+        subscribeToNotificationInbox('user-1', vi.fn());
+
+        const errorHandler = firebaseMocks.onSnapshot.mock.calls[0][2] as (error: unknown) => void;
+        errorHandler(subscriptionError);
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+            'Failed to subscribe to notification inbox:',
+            subscriptionError
+        );
+    });
+});

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -20,7 +20,10 @@ const firebaseMocks = vi.hoisted(() => ({
     doc: vi.fn(),
     getDoc: vi.fn(),
     getDocs: vi.fn(),
+    onSnapshot: vi.fn(() => vi.fn()),
     query: vi.fn((...parts) => ({ parts })),
+    serverTimestamp: vi.fn(() => ({ _isServerTimestamp: true })),
+    updateDoc: vi.fn(),
     where: vi.fn((field, op, value) => ({ type: 'where', field, op, value })),
     orderBy: vi.fn((field) => ({ type: 'orderBy', field })),
     limit: vi.fn((count) => ({ type: 'limit', count }))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,15 @@ export default defineConfig({
       'react-dom': resolveModule('react-dom'),
       'react-router-dom': resolveModule('react-router-dom'),
       'lucide-react': resolveModule('lucide-react'),
-      '@testing-library/react': resolveModule('@testing-library/react')
+      '@testing-library/react': resolveModule('@testing-library/react'),
+      '@capacitor/app': resolveModule('@capacitor/app'),
+      '@capacitor/core': resolveModule('@capacitor/core'),
+      '@capacitor/browser': resolveModule('@capacitor/browser'),
+      '@capacitor/camera': resolveModule('@capacitor/camera'),
+      '@capacitor/filesystem': resolveModule('@capacitor/filesystem'),
+      '@capacitor/share': resolveModule('@capacitor/share'),
+      '@capacitor-firebase/messaging': resolveModule('@capacitor-firebase/messaging'),
+      '@capawesome/capacitor-badge': resolveModule('@capawesome/capacitor-badge')
     },
     dedupe: ['react', 'react-dom', 'react-router-dom']
   }


### PR DESCRIPTION
## Summary

- Adds a Bell icon to both desktop and mobile headers in `AppShell.tsx` with a real-time unread badge
- `notificationInboxService.ts` subscribes to `users/{uid}/notificationInbox` (limit 50, newest-first), exposes `countUnread()` and `markNotificationRead()` (writes `readAt: serverTimestamp()`)
- `NotificationInboxSheet.tsx` — bottom sheet listing inbox items with unread dot styling, empty state, and click-to-mark-read-and-navigate behavior
- `NotificationInboxSheet` is lazy-loaded via `React.lazy()` / `Suspense` so it doesn't affect initial bundle
- `vitest.config.ts` gains Capacitor package aliases for consistent test resolution
- 9 unit tests in `tests/unit/app-notification-bell.test.tsx`

## Test plan
- [ ] `npm test` passes (424 test files, 2544 tests)
- [ ] Bell appears in app header; badge shows count of unread notifications
- [ ] Clicking bell opens inbox sheet; clicking an item marks it read and navigates
- [ ] Badge caps at 99+ for large inboxes

Closes #2189

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_