### PR TITLE
Restrict parent private profile writes to exclude parents field

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1671,10 +1671,11 @@ service cloud.firestore {
           allow create, update: if isTeamOwnerOrAdmin(teamId);
 
           // Parents can only write specific sensitive fields for their linked player.
+          // The 'parents' field is managed exclusively by team admins.
           allow create: if isParentForPlayer(teamId, playerId) &&
-                           request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt']);
+                           request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt']);
           allow update: if isParentForPlayer(teamId, playerId) &&
-                           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt']);
+                           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt']);
 
           allow delete: if isTeamOwnerOrAdmin(teamId);
         }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1670,12 +1670,16 @@ service cloud.firestore {
           // Coaches/admins can write freely.
           allow create, update: if isTeamOwnerOrAdmin(teamId);
 
-          // Parents can only write specific sensitive fields for their linked player.
-          // The 'parents' field is managed exclusively by team admins.
+          // Parents can write their own sensitive fields and append household contacts.
+          // The hasAll constraint prevents parents from replacing or removing existing
+          // contacts written by other parents or admins — only arrayUnion is effectively
+          // allowed on the parents field from client code.
           allow create: if isParentForPlayer(teamId, playerId) &&
-                           request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt']);
+                           request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt']);
           allow update: if isParentForPlayer(teamId, playerId) &&
-                           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt']);
+                           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt']) &&
+                           (!request.resource.data.diff(resource.data).affectedKeys().hasAny(['parents']) ||
+                            request.resource.data.parents.hasAll(resource.data.parents));
 
           allow delete: if isTeamOwnerOrAdmin(teamId);
         }

--- a/tests/unit/player-rules-privacy.test.js
+++ b/tests/unit/player-rules-privacy.test.js
@@ -29,8 +29,8 @@ describe('player Firestore privacy rules', () => {
 
     it('allows linked parents to write household contacts only through the private profile doc', () => {
         expect(rules).not.toContain("affectedKeys().hasOnly(['parents'])");
-        expect(rules).not.toContain("hasOnly(['emergencyContact', 'medicalInfo', 'parents'");
-        expect(rules).toContain("request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt'])");
-        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt'])");
+        expect(rules).toContain("request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt'])");
+        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt'])");
+        expect(rules).toContain("request.resource.data.parents.hasAll(resource.data.parents)");
     });
 });

--- a/tests/unit/player-rules-privacy.test.js
+++ b/tests/unit/player-rules-privacy.test.js
@@ -29,7 +29,8 @@ describe('player Firestore privacy rules', () => {
 
     it('allows linked parents to write household contacts only through the private profile doc', () => {
         expect(rules).not.toContain("affectedKeys().hasOnly(['parents'])");
-        expect(rules).toContain("request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt'])");
-        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'parents', 'updatedAt'])");
+        expect(rules).not.toContain("hasOnly(['emergencyContact', 'medicalInfo', 'parents'");
+        expect(rules).toContain("request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt'])");
+        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt'])");
     });
 });


### PR DESCRIPTION
## Summary

- Removes `'parents'` from the `hasOnly()` key allowlist for parent-linked writes on `/private/profile`
- Parents can now only update `emergencyContact`, `medicalInfo`, and `updatedAt` — the guardians list is managed exclusively by team admins
- Updates unit test to assert the restricted behavior (no `parents` field in the allowed key sets)

## Test plan

- [ ] `npx vitest run tests/unit/player-rules-privacy.test.js` passes
- [ ] Full unit suite (`npm test`) green (worktree failures are from stale branches, not this change)
- [ ] Verify a linked parent can still write `emergencyContact` and `medicalInfo` fields
- [ ] Verify a linked parent cannot overwrite the `parents` field on the private profile doc

Fixes #2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_