### PR TITLE
Fix liveScore push taps always route to game hub regardless of appRoute

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -117,6 +117,12 @@ export function resolvePushNotificationRoute(input: unknown) {
     if (category === 'liveChat' && teamId && conversationId) {
         return buildMessagesRoute(teamId, conversationId);
     }
+    if (category === 'liveScore' && gameId) {
+        if (teamId) {
+            return buildScheduleEventRoute(teamId, gameId, 'game');
+        }
+        return `/games/${encodeRouteParam(gameId)}`;
+    }
     if (appRoute) {
         return appRoute;
     }

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -22,6 +22,12 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
 
+    it('routes liveScore to the game hub even when a backend-supplied appRoute is present', () => {
+        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7' })).toBe('/schedule/team-1/game-7?section=game');
+        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7?section=availability' })).toBe('/schedule/team-1/game-7?section=game');
+        expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9', appRoute: '/schedule/team-1/event-9' })).toBe('/schedule/team-1/event-9');
+    });
+
     it('falls back to legacy web links when an explicit app route is absent', () => {
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1' })).toBe('/messages/team-1');
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff-2' })).toBe('/messages/team-1?conversationId=staff-2');


### PR DESCRIPTION
## Summary

- Fixes #2340: live-score push notifications that included a backend-supplied `appRoute` (e.g. `/schedule/team-1/game-7`) were hitting the early-return on line 114 before the `liveScore` section=game enforcement, so users landed on the Availability tab instead of the Game hub
- Moves the `liveScore` category check above the `appRoute` fallback — consistent with how `liveChat` with `conversationId` is already handled before `appRoute`
- Non-liveScore schedule notifications still use `appRoute` when present
- Adds a regression test covering a `liveScore` payload that includes `appRoute` with and without an existing `section` param

## Test plan

- [ ] `npx vitest run tests/unit/app-push-notification-routing.test.ts` — 4 tests pass
- [ ] Manual: send a live-score push in the Capacitor shell and verify the Game hub is the first visible tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_