### PR TITLE
Restrict team-fee checkout to player-linked parents only

### DIFF
--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -140,13 +140,9 @@ function isEligibleTeamFeePayer({ team = {}, user = {}, uid = '', email = '', re
     const teamId = normalizeString(recipient.teamId || team.id);
     const playerId = normalizeString(recipient.playerId);
     const playerKey = normalizeString(recipient.playerKey || (teamId && playerId ? `${teamId}::${playerId}` : ''));
-    const parentTeamIds = Array.isArray(user.parentTeamIds) ? user.parentTeamIds : [];
     const parentPlayerKeys = Array.isArray(user.parentPlayerKeys) ? user.parentPlayerKeys : [];
 
-    return Boolean(
-        (teamId && parentTeamIds.includes(teamId)) ||
-        (playerKey && parentPlayerKeys.includes(playerKey))
-    );
+    return Boolean(playerKey && parentPlayerKeys.includes(playerKey));
 }
 
 function buildTeamFeeCheckoutUrls(appUrl, { teamId, batchId, recipientId }) {

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -71,6 +71,7 @@ describe('team fee checkout function helpers', () => {
         expect(isEligibleTeamFeePayer({ team, recipient, uid: 'parent_1' })).toBe(true);
         expect(isEligibleTeamFeePayer({ team, recipient, uid: 'parent_2', user: { parentPlayerKeys: ['team_123::player_1'] } })).toBe(true);
         expect(isEligibleTeamFeePayer({ team, recipient, uid: 'fan_1', email: 'fan@example.com' })).toBe(false);
+        expect(isEligibleTeamFeePayer({ team, recipient, uid: 'other_parent', user: { parentTeamIds: ['team_123'] } })).toBe(false);
     });
 
     it('builds parent-dashboard return URLs and safe Stripe metadata', () => {


### PR DESCRIPTION
## Summary

- Fixes #2325: removes the `parentTeamIds.includes(teamId)` check from `isEligibleTeamFeePayer` in `functions/team-fees-core.cjs`, which was allowing any parent on a team to open a Stripe checkout for a different family's fee recipient
- Keeps only the `parentPlayerKeys.includes(playerKey)` check, aligning the callable's auth boundary with Firestore rules (`isTeamFeeRecipientForCurrentParent`) that already require an exact player key match
- Adds a regression test asserting a user with only `parentTeamIds: ['team_123']` (no matching `parentPlayerKeys`) is denied

## Test plan

- [ ] `npx vitest run tests/unit/team-fees-functions.test.js` — all tests pass
- [ ] Manual: sign in as Parent A linked to a team, attempt checkout for Parent B's player — confirm permission denied
- [ ] Manual: Parent A linked via `parentPlayerKeys` to their own player — checkout still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_