### PR TITLE
Fetch registration sources from Firestore on Create Team

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -604,7 +604,7 @@
             return sources
                 .map((record) => ({
                     provider: String(record.provider || record.providerId || '').trim(),
-                    sourceId: String(record.sourceId || record.registrationSourceId || '').trim(),
+                    sourceId: String(record.sourceId || record.registrationSourceId || record.id || '').trim(),
                     externalTeamId: String(record.externalTeamId || record.teamId || '').trim(),
                     externalTeamName: String(record.externalTeamName || record.teamName || record.name || '').trim(),
                     sport: String(record.sport || '').trim(),

--- a/edit-team.html
+++ b/edit-team.html
@@ -555,7 +555,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame } from './js/db.js?v=50';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources } from './js/db.js?v=51';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
@@ -595,7 +595,7 @@
         let lastRenderedRolloverSourceTeamId = null;
         let isInitPending = true;
         let selectedRegistrationTeam = null;
-        const configuredRegistrationTeams = getConfiguredRegistrationTeams();
+        let configuredRegistrationTeams = getConfiguredRegistrationTeams();
         let rosterRolloverPreviewRequestId = 0;
         let rosterRolloverPlayers = [];
 
@@ -947,6 +947,16 @@
         }
 
         initRegistrationImportControls();
+
+        if (!initialTeamId) {
+            getRegistrationSources().then((sources) => {
+                window.allplaysRegistrationSources = sources;
+                configuredRegistrationTeams = getConfiguredRegistrationTeams();
+                populateRegistrationSourcePicker();
+            }).catch(() => {
+                // Firestore unavailable — picker stays empty and radio stays disabled
+            });
+        }
 
         function setRosterRolloverStatus(message, isError = false) {
             const status = document.getElementById('roster-rollover-status');

--- a/firestore.rules
+++ b/firestore.rules
@@ -1635,6 +1635,12 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Registration sources configured by global admins for the Create Team import path.
+    match /registrationSources/{sourceId} {
+      allow read: if isSignedIn();
+      allow write: if isGlobalAdmin();
+    }
+
     // Teams - only public teams are readable by anonymous browse/listing paths.
     match /teams/{teamId} {
       allow read: if canReadTeamDocument(resource.data);

--- a/js/db.js
+++ b/js/db.js
@@ -1495,6 +1495,11 @@ export async function upsertNotificationDeviceToken(userId, { token, platform = 
     return deviceId;
 }
 
+export async function getRegistrationSources() {
+    const snapshot = await getDocs(collection(db, "registrationSources"));
+    return snapshot.docs.map(docSnap => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
 export async function getAllUsers() {
     const q = query(collection(db, "users"), orderBy("email"));
     const snapshot = await getDocs(q);

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -74,6 +74,10 @@ export async function updateGame() {
     return undefined;
 }
 
+export async function getRegistrationSources() {
+    return [];
+}
+
 export async function inviteAdmin(teamId, email) {
     window.__lastAdminInvite = { teamId, email };
     return {

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -351,8 +351,8 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getAllUsers,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
-            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame } = deps.db;'
+            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getAllUsers,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?(?:,\s*getRegistrationSources)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
+            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources } = deps.db;'
         )
         .replace(
             "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';",
@@ -478,6 +478,9 @@ async function bootEditTeam(initialState, overrides = {}, dependencyOverrides = 
             async updateGame(teamId, gameId, gameData) {
                 env.state.updateGameCalls = env.state.updateGameCalls || [];
                 env.state.updateGameCalls.push({ teamId, gameId, gameData: deepClone(gameData) });
+            },
+            async getRegistrationSources() {
+                return [];
             }
         },
         utils: {

--- a/tests/unit/edit-team-registration-import.test.js
+++ b/tests/unit/edit-team-registration-import.test.js
@@ -58,4 +58,29 @@ describe('edit team registration import', () => {
         expect(workflow.searchText).toContain('Import from registration system');
         expect(workflow.searchText).toContain('If no sources are configured');
     });
+
+    it('imports getRegistrationSources from db.js and fetches on create-team init', () => {
+        const source = readRepoFile('edit-team.html');
+
+        expect(source).toContain('getRegistrationSources');
+        expect(source).toContain('getRegistrationSources().then(');
+        expect(source).toContain('window.allplaysRegistrationSources = sources');
+        expect(source).toContain('configuredRegistrationTeams = getConfiguredRegistrationTeams()');
+        expect(source).toContain('populateRegistrationSourcePicker()');
+    });
+
+    it('uses getRegistrationSources in db.js to read the registrationSources collection', () => {
+        const source = readRepoFile('js/db.js');
+
+        expect(source).toContain('export async function getRegistrationSources()');
+        expect(source).toContain("collection(db, \"registrationSources\")");
+    });
+
+    it('adds Firestore security rules for the registrationSources collection', () => {
+        const rules = readRepoFile('firestore.rules');
+
+        expect(rules).toContain('match /registrationSources/{sourceId}');
+        expect(rules).toContain('allow read: if isSignedIn()');
+        expect(rules).toContain('allow write: if isGlobalAdmin()');
+    });
 });

--- a/tests/unit/edit-team-rollover-wiring.test.js
+++ b/tests/unit/edit-team-rollover-wiring.test.js
@@ -237,6 +237,7 @@ async function loadEditTeamHarness({ copyRejects = false } = {}) {
         inviteAdmin: vi.fn(),
         addTeamAdminEmail: vi.fn(),
         getAllUsers: vi.fn(async () => []),
+        getRegistrationSources: vi.fn(async () => []),
         getDefaultStatConfigForSport: vi.fn(() => ({ name: 'Basketball defaults' })),
         renderHeader: vi.fn(),
         renderFooter: vi.fn(),


### PR DESCRIPTION
## Summary

- Adds `getRegistrationSources()` to `db.js` — reads the `registrationSources` Firestore collection and returns all documents as plain objects
- On Create Team init (`!initialTeamId`), calls `getRegistrationSources()` asynchronously after `initRegistrationImportControls()`, stores results to `window.allplaysRegistrationSources`, recomputes `configuredRegistrationTeams`, and re-calls `populateRegistrationSourcePicker()` so the import radio and select become enabled when sources exist
- Falls back silently on Firestore errors — picker stays empty and radio stays disabled (same UX as before, no regression)
- Adds Firestore security rules for the new `registrationSources/{sourceId}` collection: any signed-in user can read; only global admins can write
- Adds three regression tests verifying the fetch wiring, the `db.js` function, and the Firestore rules

## Test plan

- [ ] Run `npx vitest run tests/unit/edit-team-registration-import.test.js --reporter=verbose` — all 8 tests pass
- [ ] Open Create New Team as a signed-in coach — page loads, `getRegistrationSources()` fires and populates the picker when sources exist in Firestore
- [ ] With no records in `registrationSources` collection — import radio stays disabled and empty state message is shown as before
- [ ] Edit existing team — `initRegistrationImportControls()` hides the `team-create-options` div and no Firestore fetch runs

Closes #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_