### PR TITLE
Stop Team Media from prefetching unopened albums

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -848,15 +848,15 @@ export async function loadTeamMediaForApp(
     if (!folderId) return;
     const storedCount = getStoredMediaCount(folder);
     const shouldLoadItems = requestedFolderIds.has(folderId);
-    if (!shouldLoadItems && storedCount !== null) {
-      fallbackCounts.set(folderId, storedCount);
+    if (!shouldLoadItems) {
+      if (storedCount !== null) fallbackCounts.set(folderId, storedCount);
       return;
     }
     const items = sortByMediaOrder(await Promise.resolve(getTeamMediaItems(teamId, folderId)).catch(() => []))
       .map(toTeamMediaItem)
       .filter((item: TeamMediaItem) => item.url && isSafeTeamMediaUrl(item.url));
     fallbackCounts.set(folderId, items.length);
-    if (shouldLoadItems) itemSets.set(folderId, items);
+    itemSets.set(folderId, items);
   }));
 
   const folderCards = visibleFolders.map((folder: any) => {

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -247,4 +247,84 @@ describe('TeamMedia bulk delete', () => {
     await screen.findByText('Bears media');
     expect(container.querySelector('img[src="https://example.com/cover.jpg"]')).toBeTruthy();
   });
+
+  it('loads unopened albums only when tapped and keeps earlier album items cached', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        canManage: true,
+        canContribute: false,
+        canPostChat: false,
+        folders: [
+          {
+            id: 'album-1',
+            name: 'Game day',
+            visibility: 'team',
+            itemCount: 1,
+            itemsLoaded: true,
+            items: [
+              { id: 'photo-1', title: 'Photo one', type: 'photo', url: 'https://example.com/photo-1.jpg', uploadedBy: 'coach-1' }
+            ]
+          },
+          {
+            id: 'album-2',
+            name: 'Highlights',
+            visibility: 'team',
+            itemCount: 0,
+            itemsLoaded: false,
+            items: []
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        canManage: true,
+        canContribute: false,
+        canPostChat: false,
+        folders: [
+          {
+            id: 'album-1',
+            name: 'Game day',
+            visibility: 'team',
+            itemCount: 1,
+            itemsLoaded: false,
+            items: []
+          },
+          {
+            id: 'album-2',
+            name: 'Highlights',
+            visibility: 'team',
+            itemCount: 1,
+            itemsLoaded: true,
+            items: [
+              { id: 'photo-2', title: 'Photo two', type: 'photo', url: 'https://example.com/photo-2.jpg', uploadedBy: 'coach-1' }
+            ]
+          }
+        ]
+      });
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenNthCalledWith(1, auth.user, 'team-1', {
+      initialFolderId: '',
+      folderIds: []
+    });
+    expect(screen.getByRole('button', { name: 'Game day1' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Highlights0' })).toBeTruthy();
+    expect(screen.getByText('Photo one')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Highlights0' }));
+
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenNthCalledWith(2, auth.user, 'team-1', {
+      initialFolderId: 'album-2',
+      folderIds: ['album-2']
+    });
+    expect(await screen.findByText('Photo two')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Game day1' }));
+
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText('Photo one')).toBeTruthy();
+  });
 });

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -1017,7 +1017,7 @@ describe('React app parent tools service', () => {
                 },
                 {
                     id: 'folder-2',
-                    itemCount: 1,
+                    itemCount: 0,
                     itemsLoaded: false,
                     items: []
                 },
@@ -1029,9 +1029,8 @@ describe('React app parent tools service', () => {
                 }
             ]
         });
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(2);
-        expect(dbMocks.getTeamMediaItems).toHaveBeenNthCalledWith(1, 'team-1', 'folder-1');
-        expect(dbMocks.getTeamMediaItems).toHaveBeenNthCalledWith(2, 'team-1', 'folder-2');
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledWith('team-1', 'folder-1');
 
         await expect(loadTeamMediaForApp(user, 'team-1', { folderIds: ['folder-2'] })).resolves.toMatchObject({
             folders: [
@@ -1040,7 +1039,7 @@ describe('React app parent tools service', () => {
                 { id: 'folder-3', itemCount: 2, itemsLoaded: false, items: [] }
             ]
         });
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(3);
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(2);
         expect(dbMocks.getTeamMediaItems).toHaveBeenLastCalledWith('team-1', 'folder-2');
 
         await expect(createTeamMediaAlbumForApp('team-1', { name: '  Spring photos  ', visibility: 'private' })).resolves.toBe('folder-new');


### PR DESCRIPTION
Closes #2393

## What changed
- Updated `loadTeamMediaForApp()` so it only calls `getTeamMediaItems()` for explicitly requested folder IDs.
- Preserved stored album counts for unopened folders when metadata exists, and left missing counts untouched until that album is opened.
- Updated the parent tools unit test to prove missing-count unopened folders stay unfetched on initial load.
- Added a `TeamMedia` page test that verifies unopened albums do not load until tapped and that previously loaded album items stay cached when switching back.

## Root Cause
`loadTeamMediaForApp()` treated missing `itemCount` metadata as a reason to fetch every visible album, even when the page requested only the active folder. That service-side fallback broke the lazy-load contract from `TeamMedia.tsx` and caused hidden Firestore and media URL hydration work on first open.

## Prevention / Learning
When a route passes an explicit subset of IDs for lazy loading, service helpers must not widen that scope just to derive secondary metadata like counts. Keep missing metadata unknown until the user opens that specific entity, or reuse already cached values instead of doing hidden fan-out reads.

## Regression Tests
- `tests/unit/app-parent-tools-service.test.js`
  - initial Team Media load now expects only `folder-1` to fetch
  - unopened `folder-2` without stored count stays `itemsLoaded: false` and unfetched until requested
- `apps/app/src/pages/TeamMedia.test.tsx`
  - first render shows both album chips without loading the unopened album
  - tapping the unopened album triggers exactly one targeted load
  - switching back reuses the already cached first album items without another fetch

## Recurrence Risk
Low. The service now honors `requestedFolderIds`, and both service-level and page-level tests lock the lazy-load boundary that regressed here.