### PR TITLE
Cache Team Detail member hydration across tabs

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -284,7 +284,16 @@ type TeamDetailBaseSnapshot = {
 type FirestoreDocument = Record<string, any> & { id: string };
 
 const teamDetailBaseSnapshotCache = new Map<string, TeamDetailBaseSnapshot>();
-const relevantTeamMembersCache = new Map<string, any[]>();
+type RelevantTeamMembersCacheEntry = {
+  baseMembersPromise: Promise<any[]> | null;
+  baseMembers: any[];
+  membersById: Map<string, any>;
+  membersByEmail: Map<string, any>;
+  loadedInviteEmails: Set<string>;
+  inviteEmailPromises: Map<string, Promise<void>>;
+};
+
+const relevantTeamMembersCache = new Map<string, RelevantTeamMembersCacheEntry>();
 
 export function __resetTeamDetailBaseSnapshotCacheForTests() {
   teamDetailBaseSnapshotCache.clear();
@@ -645,22 +654,28 @@ function collectRelevantTeamMemberEmails(team: any, players: any[] = [], invites
   return [...emails];
 }
 
-function buildRelevantTeamMembersCacheKey(team: any, pendingAdminInvites: any[] = [], pendingParentInvites: any[] = []) {
-  const normalizedTeamId = cleanString(team?.id || team?.teamId);
-  if (!normalizedTeamId) return '';
+function createRelevantTeamMembersCacheEntry(): RelevantTeamMembersCacheEntry {
+  return {
+    baseMembersPromise: null,
+    baseMembers: [],
+    membersById: new Map<string, any>(),
+    membersByEmail: new Map<string, any>(),
+    loadedInviteEmails: new Set<string>(),
+    inviteEmailPromises: new Map<string, Promise<void>>()
+  };
+}
 
-  const inviteSignature = [...pendingAdminInvites, ...pendingParentInvites]
-    .map((invite) => [
-      cleanString(invite?.type).toLowerCase(),
-      cleanString(invite?.email).toLowerCase(),
-      cleanString(invite?.playerId),
-      cleanString(invite?.code).toUpperCase()
-    ].join(':'))
-    .filter(Boolean)
-    .sort()
-    .join('|');
+function mergeRelevantTeamMembers(entry: RelevantTeamMembersCacheEntry, members: any[] = []) {
+  (Array.isArray(members) ? members : []).forEach((member) => {
+    const normalizedUserId = cleanString(member?.id || member?.uid);
+    const normalizedEmail = cleanString(member?.email).toLowerCase();
+    if (normalizedUserId && !entry.membersById.has(normalizedUserId)) entry.membersById.set(normalizedUserId, member);
+    if (normalizedEmail && !entry.membersByEmail.has(normalizedEmail)) entry.membersByEmail.set(normalizedEmail, member);
+  });
+}
 
-  return inviteSignature ? `${normalizedTeamId}::${inviteSignature}` : normalizedTeamId;
+function getCachedRelevantTeamMembers(entry: RelevantTeamMembersCacheEntry) {
+  return Array.from(new Set([...entry.membersById.values(), ...entry.membersByEmail.values()]));
 }
 
 async function loadRelevantTeamMembers({
@@ -674,11 +689,15 @@ async function loadRelevantTeamMembers({
   pendingAdminInvites?: any[];
   pendingParentInvites?: any[];
 }) {
-  const cacheKey = buildRelevantTeamMembersCacheKey(team, pendingAdminInvites, pendingParentInvites);
-  const cached = cacheKey ? relevantTeamMembersCache.get(cacheKey) : undefined;
-  if (cached) return cached;
-
   const normalizedTeamId = cleanString(team?.id || team?.teamId);
+  if (!normalizedTeamId) return [];
+
+  let cacheEntry = relevantTeamMembersCache.get(normalizedTeamId);
+  if (!cacheEntry) {
+    cacheEntry = createRelevantTeamMembersCacheEntry();
+    relevantTeamMembersCache.set(normalizedTeamId, cacheEntry);
+  }
+
   const userIds = collectRelevantTeamMemberUserIds(team, players);
   const emails = collectRelevantTeamMemberEmails(team, players, [...pendingAdminInvites, ...pendingParentInvites]);
   const parentPlayerKeys = (Array.isArray(players) ? players : [])
@@ -688,30 +707,48 @@ async function loadRelevantTeamMembers({
     })
     .filter(Boolean);
 
-  const [usersById, usersByEmail, usersByParentTeamId, usersByParentPlayerKey] = await Promise.all([
-    Promise.all(userIds.map((userId) => loadUserById(userId).catch(() => null))),
-    Promise.all(emails.map((email) => loadUsersByEmail(email).catch(() => []))),
-    loadUsersByParentTeamId(normalizedTeamId).catch(() => []),
-    Promise.all(parentPlayerKeys.map((parentPlayerKey) => loadUsersByParentPlayerKey(parentPlayerKey).catch(() => [])))
-  ]);
+  if (!cacheEntry.baseMembersPromise) {
+    cacheEntry.baseMembersPromise = Promise.all([
+      Promise.all(userIds.map((userId) => loadUserById(userId).catch(() => null))),
+      loadUsersByParentTeamId(normalizedTeamId).catch(() => []),
+      Promise.all(parentPlayerKeys.map((parentPlayerKey) => loadUsersByParentPlayerKey(parentPlayerKey).catch(() => [])))
+    ]).then(([usersById, usersByParentTeamId, usersByParentPlayerKey]) => {
+      mergeRelevantTeamMembers(cacheEntry!, [
+        ...usersById.filter(Boolean),
+        ...usersByParentTeamId,
+        ...usersByParentPlayerKey.flat()
+      ]);
+      cacheEntry!.baseMembers = getCachedRelevantTeamMembers(cacheEntry!);
+      return cacheEntry!.baseMembers;
+    });
+  }
 
-  const membersById = new Map<string, any>();
-  const membersByEmail = new Map<string, any>();
-  [
-    ...usersById.filter(Boolean),
-    ...usersByEmail.flat(),
-    ...usersByParentTeamId,
-    ...usersByParentPlayerKey.flat()
-  ].forEach((member) => {
-    const normalizedUserId = cleanString(member?.id || member?.uid);
-    const normalizedEmail = cleanString(member?.email).toLowerCase();
-    if (normalizedUserId && !membersById.has(normalizedUserId)) membersById.set(normalizedUserId, member);
-    if (normalizedEmail && !membersByEmail.has(normalizedEmail)) membersByEmail.set(normalizedEmail, member);
-  });
+  await cacheEntry.baseMembersPromise;
 
-  const members = Array.from(new Set([...membersById.values(), ...membersByEmail.values()]));
-  if (cacheKey) relevantTeamMembersCache.set(cacheKey, members);
-  return members;
+  const inviteEmailsToLoad = emails.filter((email) => (
+    email
+    && !cacheEntry!.loadedInviteEmails.has(email)
+    && !cacheEntry!.membersByEmail.has(email)
+  ));
+
+  await Promise.all(inviteEmailsToLoad.map((email) => {
+    let invitePromise = cacheEntry!.inviteEmailPromises.get(email);
+    if (!invitePromise) {
+      invitePromise = loadUsersByEmail(email)
+        .catch(() => [])
+        .then((members) => {
+          mergeRelevantTeamMembers(cacheEntry!, members);
+          cacheEntry!.loadedInviteEmails.add(email);
+        })
+        .finally(() => {
+          cacheEntry!.inviteEmailPromises.delete(email);
+        });
+      cacheEntry!.inviteEmailPromises.set(email, invitePromise);
+    }
+    return invitePromise;
+  }));
+
+  return getCachedRelevantTeamMembers(cacheEntry);
 }
 
 export async function inviteTeamAdminForApp(teamId: string, email: string, user: AuthUser | null = null): Promise<InviteTeamAdminForAppResult> {
@@ -732,6 +769,7 @@ export async function inviteTeamAdminForApp(teamId: string, email: string, user:
     addTeamAdminEmail,
     sendInviteEmail
   });
+  invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
   const code = cleanString(result?.code) || null;
   return {
     email: normalizedEmail,
@@ -781,6 +819,7 @@ export async function createRosterParentInviteForApp(teamId: string, user: AuthU
   const inviteResult = await inviteParent(normalizedTeamId, normalizedPlayerId, cleanString(player?.number), '', 'Parent');
   const code = cleanString(inviteResult?.code).toUpperCase();
   if (!code) throw new Error('Invite code was not created.');
+  invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 
   return {
     code,

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -285,6 +285,7 @@ type FirestoreDocument = Record<string, any> & { id: string };
 
 const teamDetailBaseSnapshotCache = new Map<string, TeamDetailBaseSnapshot>();
 type RelevantTeamMembersCacheEntry = {
+  inviteStateKey: string;
   baseMembersPromise: Promise<any[]> | null;
   baseMembers: any[];
   membersById: Map<string, any>;
@@ -656,6 +657,7 @@ function collectRelevantTeamMemberEmails(team: any, players: any[] = [], invites
 
 function createRelevantTeamMembersCacheEntry(): RelevantTeamMembersCacheEntry {
   return {
+    inviteStateKey: '',
     baseMembersPromise: null,
     baseMembers: [],
     membersById: new Map<string, any>(),
@@ -663,6 +665,29 @@ function createRelevantTeamMembersCacheEntry(): RelevantTeamMembersCacheEntry {
     loadedInviteEmails: new Set<string>(),
     inviteEmailPromises: new Map<string, Promise<void>>()
   };
+}
+
+function buildRelevantTeamMemberInviteStateKey(pendingAdminInvites: any[] = [], pendingParentInvites: any[] = []) {
+  return [...pendingAdminInvites, ...pendingParentInvites]
+    .map((invite) => [
+      cleanString(invite?.type).toLowerCase(),
+      cleanString(invite?.email).toLowerCase(),
+      cleanString(invite?.playerId),
+      cleanString(invite?.code).toUpperCase()
+    ].join(':'))
+    .filter(Boolean)
+    .sort()
+    .join('|');
+}
+
+function resetRelevantTeamMembersCacheEntry(entry: RelevantTeamMembersCacheEntry, inviteStateKey: string) {
+  entry.inviteStateKey = inviteStateKey;
+  entry.baseMembersPromise = null;
+  entry.baseMembers = [];
+  entry.membersById.clear();
+  entry.membersByEmail.clear();
+  entry.loadedInviteEmails.clear();
+  entry.inviteEmailPromises.clear();
 }
 
 function mergeRelevantTeamMembers(entry: RelevantTeamMembersCacheEntry, members: any[] = []) {
@@ -696,6 +721,11 @@ async function loadRelevantTeamMembers({
   if (!cacheEntry) {
     cacheEntry = createRelevantTeamMembersCacheEntry();
     relevantTeamMembersCache.set(normalizedTeamId, cacheEntry);
+  }
+
+  const inviteStateKey = buildRelevantTeamMemberInviteStateKey(pendingAdminInvites, pendingParentInvites);
+  if (cacheEntry.inviteStateKey !== inviteStateKey) {
+    resetRelevantTeamMembersCacheEntry(cacheEntry, inviteStateKey);
   }
 
   const userIds = collectRelevantTeamMemberUserIds(team, players);

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -286,6 +286,7 @@ type FirestoreDocument = Record<string, any> & { id: string };
 const teamDetailBaseSnapshotCache = new Map<string, TeamDetailBaseSnapshot>();
 type RelevantTeamMembersCacheEntry = {
   inviteStateKey: string;
+  parentInviteStateKey: string;
   baseMembersPromise: Promise<any[]> | null;
   baseMembers: any[];
   membersById: Map<string, any>;
@@ -658,6 +659,7 @@ function collectRelevantTeamMemberEmails(team: any, players: any[] = [], invites
 function createRelevantTeamMembersCacheEntry(): RelevantTeamMembersCacheEntry {
   return {
     inviteStateKey: '',
+    parentInviteStateKey: '',
     baseMembersPromise: null,
     baseMembers: [],
     membersById: new Map<string, any>(),
@@ -680,12 +682,16 @@ function buildRelevantTeamMemberInviteStateKey(pendingAdminInvites: any[] = [], 
     .join('|');
 }
 
-function resetRelevantTeamMembersCacheEntry(entry: RelevantTeamMembersCacheEntry, inviteStateKey: string) {
+function resetRelevantTeamMembersCacheEntry(entry: RelevantTeamMembersCacheEntry, inviteStateKey: string, options: { resetBaseMembers?: boolean; parentInviteStateKey?: string } = {}) {
   entry.inviteStateKey = inviteStateKey;
-  entry.baseMembersPromise = null;
-  entry.baseMembers = [];
+  if (typeof options.parentInviteStateKey === 'string') entry.parentInviteStateKey = options.parentInviteStateKey;
+  if (options.resetBaseMembers) {
+    entry.baseMembersPromise = null;
+    entry.baseMembers = [];
+  }
   entry.membersById.clear();
   entry.membersByEmail.clear();
+  mergeRelevantTeamMembers(entry, entry.baseMembers);
   entry.loadedInviteEmails.clear();
   entry.inviteEmailPromises.clear();
 }
@@ -724,8 +730,11 @@ async function loadRelevantTeamMembers({
   }
 
   const inviteStateKey = buildRelevantTeamMemberInviteStateKey(pendingAdminInvites, pendingParentInvites);
-  if (cacheEntry.inviteStateKey !== inviteStateKey) {
-    resetRelevantTeamMembersCacheEntry(cacheEntry, inviteStateKey);
+  const parentInviteStateKey = buildRelevantTeamMemberInviteStateKey([], pendingParentInvites);
+  if (cacheEntry.parentInviteStateKey !== parentInviteStateKey) {
+    resetRelevantTeamMembersCacheEntry(cacheEntry, inviteStateKey, { resetBaseMembers: true, parentInviteStateKey });
+  } else if (cacheEntry.inviteStateKey !== inviteStateKey) {
+    resetRelevantTeamMembersCacheEntry(cacheEntry, inviteStateKey, { parentInviteStateKey });
   }
 
   const userIds = collectRelevantTeamMemberUserIds(team, players);

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -1125,6 +1125,75 @@ describe('React app team detail model', () => {
         expect(parentPlayerKeyQueries).toHaveLength(1);
     });
 
+    it('preserves base member hydration when only admin invites change between team manager views', async () => {
+        getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            adminEmails: [],
+            teamPermissions: {
+                videography: { mode: 'selected', memberIds: ['video-1'] }
+            }
+        });
+        getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star' }]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        getDoc.mockImplementation(async (ref) => {
+            if (ref.path === 'users/coach-1') {
+                return { id: 'coach-1', exists: () => true, data: () => ({ email: 'coach@example.com', fullName: 'Coach Owner' }) };
+            }
+            if (ref.path === 'users/video-1') {
+                return { id: 'video-1', exists: () => true, data: () => ({ email: 'video@example.com', fullName: 'Video Parent', parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] }) };
+            }
+            return { id: ref.id, exists: () => false, data: () => ({}) };
+        });
+        const future = Date.now() + 60_000;
+        let teamIdQueryCount = 0;
+        getDocs.mockImplementation(async (queryParts) => {
+            const filters = Array.isArray(queryParts) ? queryParts.slice(1) : [];
+            const filter = filters[0] || {};
+            if (filter.field === 'teamId') {
+                teamIdQueryCount += 1;
+                return {
+                    docs: [
+                        {
+                            id: `invite-${teamIdQueryCount}`,
+                            data: () => ({
+                                teamId: 'team-1',
+                                type: 'admin_invite',
+                                email: `pending${teamIdQueryCount}@example.com`,
+                                used: false,
+                                expiresAt: { toMillis: () => future }
+                            })
+                        }
+                    ]
+                };
+            }
+            return { docs: [] };
+        });
+
+        const coachUser = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] };
+
+        const firstPermissions = await loadTeamStaffPermissions('team-1', coachUser);
+        const secondPermissions = await loadTeamStaffPermissions('team-1', coachUser);
+
+        expect(firstPermissions.pendingInvites).toEqual(['pending1@example.com']);
+        expect(secondPermissions.pendingInvites).toEqual(['pending2@example.com']);
+        expect(secondPermissions.videographerGrantTargets).toEqual([
+            { userId: 'video-1', name: 'Video Parent', email: 'video@example.com', playerNames: ['Pat Star'], isGranted: true }
+        ]);
+
+        const parentTeamIdQueries = getDocs.mock.calls.filter(
+            (args) => Array.isArray(args[0]) && args[0].some((part) => part?.field === 'parentTeamIds' && part?.value === 'team-1')
+        );
+        const parentPlayerKeyQueries = getDocs.mock.calls.filter(
+            (args) => Array.isArray(args[0]) && args[0].some((part) => part?.field === 'parentPlayerKeys' && part?.value === 'team-1::player-1')
+        );
+
+        expect(parentTeamIdQueries).toHaveLength(1);
+        expect(parentPlayerKeyQueries).toHaveLength(1);
+    });
+
     it('loads deferred insights and sponsors only when requested', async () => {
         getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', sport: 'Basketball' });
         getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', photoUrl: 'https://img.example.test/player.png' }]);

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -1059,6 +1059,72 @@ describe('React app team detail model', () => {
         expect(sponsors.sponsors).toEqual([]);
     });
 
+    it('reuses the same relevant member hydration across roster and more tabs for one team', async () => {
+        getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            adminEmails: [],
+            teamPermissions: {
+                videography: { mode: 'selected', memberIds: ['video-1'] }
+            }
+        });
+        getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star' }]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        getDoc.mockImplementation(async (ref) => {
+            if (ref.path === 'users/coach-1') {
+                return { id: 'coach-1', exists: () => true, data: () => ({ email: 'coach@example.com', fullName: 'Coach Owner' }) };
+            }
+            if (ref.path === 'users/video-1') {
+                return { id: 'video-1', exists: () => true, data: () => ({ email: 'video@example.com', fullName: 'Video Parent', parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] }) };
+            }
+            return { id: ref.id, exists: () => false, data: () => ({}) };
+        });
+        const future = Date.now() + 60_000;
+        getDocs.mockImplementation(async (queryParts) => {
+            const filters = Array.isArray(queryParts) ? queryParts.slice(1) : [];
+            const filter = filters[0] || {};
+            if (filter.field === 'teamId') {
+                return { docs: [{ id: 'invite-1', data: () => ({ teamId: 'team-1', type: 'admin_invite', email: 'pending@example.com', used: false, expiresAt: { toMillis: () => future } }) }] };
+            }
+            return { docs: [] };
+        });
+
+        const coachUser = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] };
+
+        const rosterSummaries = await loadTeamRosterParentInvites('team-1', coachUser);
+        const staffPermissions = await loadTeamStaffPermissions('team-1', coachUser);
+
+        expect(rosterSummaries).toEqual([
+            {
+                playerId: 'player-1',
+                status: 'accepted',
+                acceptedParentCount: 1,
+                pendingInviteCount: 0,
+                latestPendingCode: ''
+            }
+        ]);
+        expect(staffPermissions.videographerGrantTargets).toEqual([
+            { userId: 'video-1', name: 'Video Parent', email: 'video@example.com', playerNames: ['Pat Star'], isGranted: true }
+        ]);
+        expect(getTeam).toHaveBeenCalledTimes(1);
+        expect(getPlayers).toHaveBeenCalledTimes(1);
+        expect(getGames).toHaveBeenCalledTimes(1);
+        expect(getConfigs).toHaveBeenCalledTimes(1);
+        expect(getDoc).toHaveBeenCalledTimes(2);
+
+        const parentTeamIdQueries = getDocs.mock.calls.filter(
+            (args) => Array.isArray(args[0]) && args[0].some((part) => part?.field === 'parentTeamIds' && part?.value === 'team-1')
+        );
+        const parentPlayerKeyQueries = getDocs.mock.calls.filter(
+            (args) => Array.isArray(args[0]) && args[0].some((part) => part?.field === 'parentPlayerKeys' && part?.value === 'team-1::player-1')
+        );
+
+        expect(parentTeamIdQueries).toHaveLength(1);
+        expect(parentPlayerKeyQueries).toHaveLength(1);
+    });
+
     it('loads deferred insights and sponsors only when requested', async () => {
         getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', sport: 'Basketball' });
         getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', photoUrl: 'https://img.example.test/player.png' }]);
@@ -1161,15 +1227,12 @@ describe('React app team detail model', () => {
         expect(getAllUsers).not.toHaveBeenCalled();
         expect(doc).toHaveBeenCalledWith({}, 'users', 'coach-1');
         expect(doc).toHaveBeenCalledWith({}, 'users', 'video-1');
-        expect(getDocs).toHaveBeenCalledTimes(4);
         expect(collection).toHaveBeenCalledWith({}, 'accessCodes');
         expect(collection).toHaveBeenCalledWith({}, 'users');
         expect(where).toHaveBeenCalledWith('teamId', '==', 'team-1');
-        expect(where).toHaveBeenCalledWith('email', '==', 'pending@example.com');
         expect(where).toHaveBeenCalledWith('parentTeamIds', 'array-contains', 'team-1');
         expect(where).toHaveBeenCalledWith('parentPlayerKeys', 'array-contains', 'team-1::player-1');
         expect(query).toHaveBeenCalledWith({ db: {}, name: 'accessCodes' }, { field: 'teamId', op: '==', value: 'team-1' });
-        expect(query).toHaveBeenCalledWith({ db: {}, name: 'users' }, { field: 'email', op: '==', value: 'pending@example.com' });
         expect(query).toHaveBeenCalledWith({ db: {}, name: 'users' }, { field: 'parentTeamIds', op: 'array-contains', value: 'team-1' });
         expect(query).toHaveBeenCalledWith({ db: {}, name: 'users' }, { field: 'parentPlayerKeys', op: 'array-contains', value: 'team-1::player-1' });
 
@@ -1181,6 +1244,78 @@ describe('React app team detail model', () => {
         expect(getDocs).not.toHaveBeenCalled();
         expect(getDoc).not.toHaveBeenCalled();
         expect(getAllUsers).not.toHaveBeenCalled();
+    });
+
+    it('invalidates cached team detail snapshots after creating a parent invite so follow-up roster reads refresh membership state', async () => {
+        getTeam
+            .mockResolvedValueOnce({ id: 'team-1', ownerId: 'owner-1', adminEmails: ['coach@example.com'] })
+            .mockResolvedValueOnce({ id: 'team-1', ownerId: 'owner-1', adminEmails: ['coach@example.com'] });
+        getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star' }]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        inviteParent.mockResolvedValue({ code: 'ABCD1234', autoLinked: false, existingUser: false, teamName: 'Bears', playerName: 'Pat Star' });
+        const future = Date.now() + 60_000;
+        let teamIdQueryCount = 0;
+        getDocs.mockImplementation(async (queryParts) => {
+            const filters = Array.isArray(queryParts) ? queryParts.slice(1) : [];
+            const filter = filters[0] || {};
+            if (filter.field === 'teamId') {
+                teamIdQueryCount += 1;
+                return {
+                    docs: teamIdQueryCount === 1
+                        ? []
+                        : [{ id: 'invite-1', data: () => ({ teamId: 'team-1', playerId: 'player-1', code: 'ABCD1234', type: 'parent_invite', used: false, expiresAt: { toMillis: () => future } }) }]
+                };
+            }
+            return { docs: [] };
+        });
+
+        const coachUser = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] };
+
+        const beforeInvite = await loadTeamRosterParentInvites('team-1', coachUser);
+        await createRosterParentInviteForApp('team-1', coachUser, { id: 'player-1', number: '9' });
+        const afterInvite = await loadTeamRosterParentInvites('team-1', coachUser);
+
+        expect(beforeInvite[0]).toMatchObject({ status: 'none', pendingInviteCount: 0 });
+        expect(afterInvite[0]).toMatchObject({ status: 'pending', pendingInviteCount: 1, latestPendingCode: 'ABCD1234' });
+        expect(getTeam).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates cached team detail snapshots after creating an admin invite so follow-up staff reads refresh membership state', async () => {
+        getTeam
+            .mockResolvedValueOnce({ id: 'team-1', ownerId: 'owner-1', adminEmails: [], teamPermissions: {} })
+            .mockResolvedValueOnce({ id: 'team-1', ownerId: 'owner-1', adminEmails: [], teamPermissions: {} });
+        getPlayers.mockResolvedValue([]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        inviteAdmin.mockResolvedValue({ code: 'CODE123', teamName: 'Bears', existingUser: false });
+        addTeamAdminEmail.mockResolvedValue(undefined);
+        sendInviteEmail.mockResolvedValue({ success: true });
+        const future = Date.now() + 60_000;
+        let teamIdQueryCount = 0;
+        getDocs.mockImplementation(async (queryParts) => {
+            const filters = Array.isArray(queryParts) ? queryParts.slice(1) : [];
+            const filter = filters[0] || {};
+            if (filter.field === 'teamId') {
+                teamIdQueryCount += 1;
+                return {
+                    docs: teamIdQueryCount === 1
+                        ? []
+                        : [{ id: 'invite-1', data: () => ({ teamId: 'team-1', email: 'newcoach@example.com', type: 'admin_invite', used: false, expiresAt: { toMillis: () => future } }) }]
+                };
+            }
+            return { docs: [] };
+        });
+
+        const ownerUser = { uid: 'owner-1', email: 'owner@example.com', displayName: 'Owner', roles: ['coach'] };
+
+        const beforeInvite = await loadTeamStaffPermissions('team-1', ownerUser);
+        await inviteTeamAdminForApp('team-1', 'newcoach@example.com', ownerUser);
+        const afterInvite = await loadTeamStaffPermissions('team-1', ownerUser);
+
+        expect(beforeInvite.pendingInvites).toEqual([]);
+        expect(afterInvite.pendingInvites).toEqual(['newcoach@example.com']);
+        expect(getTeam).toHaveBeenCalledTimes(2);
     });
 
     it('updates only the managed basic team settings fields for app editing', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -1448,4 +1448,93 @@ describe('React app team detail model', () => {
             (args) => Array.isArray(args[0]) && args[0].some((part) => part?.field === 'email' && part?.value === 'parentinvite@example.com')
         )).toBe(true);
     });
+
+    it('rebuilds cached member hydration when a pending parent invite becomes accepted', async () => {
+        getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            adminEmails: []
+        });
+        getPlayers.mockResolvedValue([
+            { id: 'player-1', name: 'Pat Star' }
+        ]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        getDoc.mockImplementation(async (ref) => {
+            if (ref.path === 'users/coach-1') {
+                return { id: 'coach-1', exists: () => true, data: () => ({ email: 'coach@example.com', fullName: 'Coach Owner' }) };
+            }
+            return { id: ref.id, exists: () => false, data: () => ({}) };
+        });
+        const future = Date.now() + 60_000;
+        let teamIdQueryCount = 0;
+        let parentTeamLookupCount = 0;
+        let parentPlayerKeyLookupCount = 0;
+        getDocs.mockImplementation(async (queryParts) => {
+            const filters = Array.isArray(queryParts) ? queryParts.slice(1) : [];
+            const filter = filters[0] || {};
+            if (filter.field === 'teamId') {
+                teamIdQueryCount += 1;
+                if (teamIdQueryCount === 1) {
+                    return {
+                        docs: [
+                            { id: 'invite-1', data: () => ({ email: 'parent@example.com', playerId: 'player-1', teamId: 'team-1', code: 'PARENT1', type: 'parent_invite', used: false, expiresAt: { toMillis: () => future } }) }
+                        ]
+                    };
+                }
+                return { docs: [] };
+            }
+            if (filter.field === 'email' && filter.value === 'parent@example.com') {
+                return {
+                    docs: [
+                        { id: 'parent-1', data: () => ({ email: 'parent@example.com' }) }
+                    ]
+                };
+            }
+            if (filter.field === 'parentTeamIds') {
+                parentTeamLookupCount += 1;
+                return {
+                    docs: parentTeamLookupCount === 1
+                        ? []
+                        : [{ id: 'parent-1', data: () => ({ email: 'parent@example.com', parentTeamIds: ['team-1'], parentPlayerKeys: ['team-1::player-1'] }) }]
+                };
+            }
+            if (filter.field === 'parentPlayerKeys') {
+                parentPlayerKeyLookupCount += 1;
+                return {
+                    docs: parentPlayerKeyLookupCount === 1
+                        ? []
+                        : [{ id: 'parent-1', data: () => ({ email: 'parent@example.com', parentTeamIds: ['team-1'], parentPlayerKeys: ['team-1::player-1'] }) }]
+                };
+            }
+            return { docs: [] };
+        });
+
+        const coachUser = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] };
+
+        const beforeAcceptance = await loadTeamRosterParentInvites('team-1', coachUser);
+        const afterAcceptance = await loadTeamRosterParentInvites('team-1', coachUser);
+
+        expect(beforeAcceptance).toEqual([
+            {
+                playerId: 'player-1',
+                status: 'pending',
+                acceptedParentCount: 0,
+                pendingInviteCount: 1,
+                latestPendingCode: 'PARENT1'
+            }
+        ]);
+        expect(afterAcceptance).toEqual([
+            {
+                playerId: 'player-1',
+                status: 'accepted',
+                acceptedParentCount: 1,
+                pendingInviteCount: 0,
+                latestPendingCode: ''
+            }
+        ]);
+        expect(parentTeamLookupCount).toBe(2);
+        expect(parentPlayerKeyLookupCount).toBe(2);
+    });
 });


### PR DESCRIPTION
Closes #2380

## What changed
- changed `apps/app/src/lib/teamDetailService.ts` so relevant managed-team member hydration is cached per team instead of per tab-specific invite signature
- split the shared hydration into one base membership pass plus incremental invite-email lookups, with in-flight promise reuse so Roster and More share the same Firestore fan-out
- invalidated the shared team-detail caches after parent invite creation and admin invite creation, alongside the existing permission mutation invalidations
- added focused unit coverage proving sequential Roster -> More loads reuse the same hydration work and that invite mutations refresh the next read

## Root Cause
`loadRelevantTeamMembers(...)` cached results with keys that included pending invite state. Roster and More each supplied different invite inputs, so the same unchanged team generated different cache keys and re-ran the identical `loadUserById`, `loadUsersByParentTeamId`, and `loadUsersByParentPlayerKey` fan-out when staff switched tabs.

## Prevention / Learning
When multiple deferred Team Detail tabs derive from the same membership graph, cache the shared base hydration by stable team scope and layer invite-specific lookups incrementally. Do not key the full hydration result off tab-local invite state unless the entire graph actually changes.

## Regression Tests
- `npx vitest run tests/unit/app-team-detail-service.test.js --reporter=verbose`
- `npx tsc --noEmit` in `apps/app`
- Added unit coverage that sequential `loadTeamRosterParentInvites('team-1', user)` then `loadTeamStaffPermissions('team-1', user)` performs one shared relevant-member hydration path for the unchanged team
- Added invalidation tests proving parent invite creation and admin invite creation clear the shared cache so follow-up reads fetch fresh membership-derived state