### PR TITLE
Open notifications without waiting for mark-read

### DIFF
--- a/apps/app/src/components/NotificationInboxSheet.tsx
+++ b/apps/app/src/components/NotificationInboxSheet.tsx
@@ -13,14 +13,17 @@ interface NotificationInboxSheetProps {
 export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMarkRead }: NotificationInboxSheetProps) {
     const navigate = useNavigate();
 
-    const handleItemClick = async (item: NotificationInboxItem) => {
-        if (!item.readAt) {
-            await onMarkRead(uid, item.id);
-        }
+    const handleItemClick = (item: NotificationInboxItem) => {
         if (item.appRoute) {
             navigate(item.appRoute);
         }
         onClose();
+
+        if (!item.readAt) {
+            void onMarkRead(uid, item.id).catch((error) => {
+                console.error('Failed to mark notification read:', error);
+            });
+        }
     };
 
     const renderBody = () => {

--- a/tests/unit/app-notification-bell.test.tsx
+++ b/tests/unit/app-notification-bell.test.tsx
@@ -70,7 +70,10 @@ vi.mock('../../apps/app/src/components/NotificationInboxSheet', () => ({
                                 <button
                                     type="button"
                                     data-testid={`notification-item-${item.id}`}
-                                    onClick={() => void onMarkRead(uid, item.id).then(onClose)}
+                                    onClick={() => {
+                                        onClose();
+                                        void onMarkRead(uid, item.id).catch(() => undefined);
+                                    }}
                                 >
                                     {item.text}
                                 </button>
@@ -212,16 +215,60 @@ describe('Notification bell in AppShell', () => {
 
         renderShell(true);
 
-        // Open the inbox
         fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
         await waitFor(() => screen.getByRole('dialog', { name: 'Notifications' }));
 
-        // Click the notification item
         fireEvent.click(screen.getByTestId('notification-item-notif-42'));
 
         await waitFor(() => {
             expect(inboxServiceMocks.markNotificationRead).toHaveBeenCalledWith('user-1', 'notif-42');
         });
+    });
+
+    it('closes the mobile inbox immediately when mark-read is delayed', async () => {
+        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
+            (_uid: string, callback: (items: Array<{ id: string; text: string; appRoute: string; readAt: unknown }>) => void) => {
+                callback([
+                    { id: 'notif-slow', text: 'Game starting now', appRoute: '/games/game-1', readAt: null },
+                ]);
+                return vi.fn();
+            }
+        );
+        inboxServiceMocks.markNotificationRead.mockImplementation(() => new Promise<void>(() => undefined));
+
+        renderShell(false);
+
+        fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+        await waitFor(() => screen.getByRole('dialog', { name: 'Notifications' }));
+
+        fireEvent.click(screen.getByTestId('notification-item-notif-slow'));
+
+        expect(screen.queryByRole('dialog', { name: 'Notifications' })).toBeNull();
+        expect(inboxServiceMocks.markNotificationRead).toHaveBeenCalledWith('user-1', 'notif-slow');
+    });
+
+    it('closes the mobile inbox immediately when mark-read rejects', async () => {
+        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
+            (_uid: string, callback: (items: Array<{ id: string; text: string; appRoute: string; readAt: unknown }>) => void) => {
+                callback([
+                    { id: 'notif-fail', text: 'Schedule update', appRoute: '/schedule/game-2', readAt: null },
+                ]);
+                return vi.fn();
+            }
+        );
+        inboxServiceMocks.markNotificationRead.mockRejectedValue(new Error('offline'));
+
+        renderShell(false);
+
+        fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+        await waitFor(() => screen.getByRole('dialog', { name: 'Notifications' }));
+
+        fireEvent.click(screen.getByTestId('notification-item-notif-fail'));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', { name: 'Notifications' })).toBeNull();
+        });
+        expect(inboxServiceMocks.markNotificationRead).toHaveBeenCalledWith('user-1', 'notif-fail');
     });
 
     it('closes the inbox sheet when close is triggered', async () => {

--- a/tests/unit/app-notification-inbox-review.test.tsx
+++ b/tests/unit/app-notification-inbox-review.test.tsx
@@ -65,10 +65,77 @@ describe('Notification inbox review regressions', () => {
 
         await waitFor(() => {
             expect(onMarkRead).toHaveBeenCalledWith('user-1', 'notif-1');
-            expect(navigateMock).toHaveBeenCalledWith('/messages');
-            expect(onClose).toHaveBeenCalled();
         });
+        expect(navigateMock).toHaveBeenCalledWith('/messages');
+        expect(onClose).toHaveBeenCalled();
         expect(navigateMock.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0]);
+        expect(onClose.mock.invocationCallOrder[0]).toBeLessThan(onMarkRead.mock.invocationCallOrder[0]);
+    });
+
+    it('navigates and closes immediately when mark-read never resolves', () => {
+        const onClose = vi.fn();
+        const onMarkRead = vi.fn(() => new Promise<void>(() => undefined));
+
+        render(
+            <NotificationInboxSheet
+                items={[
+                    {
+                        id: 'notif-pending',
+                        type: 'live_score',
+                        text: 'Live score update',
+                        appRoute: '/games/game-1',
+                        createdAt: null,
+                        readAt: null,
+                    },
+                ]}
+                inboxState="ready"
+                uid="user-1"
+                onClose={onClose}
+                onMarkRead={onMarkRead}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId('notification-item-notif-pending'));
+
+        expect(navigateMock).toHaveBeenCalledWith('/games/game-1');
+        expect(onClose).toHaveBeenCalled();
+        expect(onMarkRead).toHaveBeenCalledWith('user-1', 'notif-pending');
+        expect(navigateMock.mock.invocationCallOrder[0]).toBeLessThan(onClose.mock.invocationCallOrder[0]);
+        expect(onClose.mock.invocationCallOrder[0]).toBeLessThan(onMarkRead.mock.invocationCallOrder[0]);
+    });
+
+    it('still navigates when mark-read rejects and logs the failure', async () => {
+        const onClose = vi.fn();
+        const rejection = new Error('offline');
+        const onMarkRead = vi.fn(() => Promise.reject(rejection));
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        render(
+            <NotificationInboxSheet
+                items={[
+                    {
+                        id: 'notif-error',
+                        type: 'schedule',
+                        text: 'Schedule changed',
+                        appRoute: '/schedule/game-2',
+                        createdAt: null,
+                        readAt: null,
+                    },
+                ]}
+                inboxState="ready"
+                uid="user-1"
+                onClose={onClose}
+                onMarkRead={onMarkRead}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId('notification-item-notif-error'));
+
+        expect(navigateMock).toHaveBeenCalledWith('/schedule/game-2');
+        expect(onClose).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to mark notification read:', rejection);
+        });
     });
 
     it('logs Firestore subscription errors when no error callback is provided', () => {


### PR DESCRIPTION
Closes #2397

## What changed
- Made `NotificationInboxSheet` navigate to the notification route and close the sheet before firing `onMarkRead`.
- Converted mark-read into a best-effort background promise with error logging so rejected Firestore writes do not break the tap flow.
- Added focused regressions for pending and rejected mark-read behavior in both the sheet-level and AppShell mobile inbox tests.

## Root Cause
`NotificationInboxSheet` awaited the Firestore mark-read promise before calling `navigate(item.appRoute)` and `onClose()`. On slow or failed field connections, that made route transitions and sheet dismissal depend on a network write that could hang or reject.

## Prevention / Learning
For tap paths into live content, treat read-state and analytics writes as best-effort side effects after navigation instead of synchronous prerequisites. When a UI action must stay responsive, add regressions for both never-resolving and rejected async branches, not just the happy path.

## Regression Tests
- `tests/unit/app-notification-inbox-review.test.tsx`
  - verifies navigation and close happen immediately when mark-read never resolves
  - verifies navigation still succeeds and the rejection is handled when mark-read fails
- `tests/unit/app-notification-bell.test.tsx`
  - verifies the mobile inbox closes immediately when AppShell wires a delayed or rejected mark-read implementation
- Validation run:
  - `npx vitest run tests/unit/app-notification-inbox-review.test.tsx tests/unit/app-notification-bell.test.tsx --reporter=verbose`

## Recurrence Risk
Low. The tap path no longer awaits Firestore writes, and the delayed/rejected branches are now locked down with focused regressions.