### PR TITLE
Index Home schedule derivation

### DIFF
--- a/apps/app/src/lib/homeLogic.ts
+++ b/apps/app/src/lib/homeLogic.ts
@@ -112,6 +112,26 @@ export function getUpcomingHomeEvents(events: ParentScheduleEvent[], limit = 5, 
     .slice(0, limit);
 }
 
+type HomePlayerAggregate = {
+  nextEvent: ParentScheduleEvent | null;
+  rsvpNeeded: number;
+  packetsReady: number;
+  openAssignments: number;
+};
+
+type HomeTeamAggregate = {
+  nextEvent: ParentScheduleEvent | null;
+  eventCount: number;
+  openActions: number;
+};
+
+type HomeEventIndex = {
+  upcomingEventRows: ParentScheduleEvent[];
+  upcomingEvents: ParentScheduleEvent[];
+  playerAggregates: Map<string, HomePlayerAggregate>;
+  teamAggregates: Map<string, HomeTeamAggregate>;
+};
+
 export function buildParentHomeModel({
   children,
   events,
@@ -126,10 +146,11 @@ export function buildParentHomeModel({
   now?: Date;
 }): ParentHomeModel {
   const inboxByTeamId = new Map(inboxTeams.map((team) => [team.id, team]));
-  const players = buildHomePlayers(children, events, inboxByTeamId, now);
-  const teams = buildHomeTeams(children, events, inboxByTeamId, now);
-  const actionItems = buildHomeActionItems({ events, fees, inboxTeams, now });
-  const upcomingEvents = getUpcomingHomeEvents(events, 5, now);
+  const eventIndex = buildHomeEventIndex(events, now);
+  const players = buildHomePlayers(children, eventIndex, inboxByTeamId);
+  const teams = buildHomeTeams(children, eventIndex, inboxByTeamId);
+  const actionItems = buildHomeActionItems({ upcomingEvents: eventIndex.upcomingEventRows, fees, inboxTeams });
+  const upcomingEvents = eventIndex.upcomingEvents.slice(0, 5);
   const openFees = getOpenFees(fees);
 
   return {
@@ -149,17 +170,19 @@ export function buildParentHomeModel({
 }
 
 export function buildHomeActionItems({
-  events,
+  events = [],
+  upcomingEvents,
   fees = [],
   inboxTeams = [],
   now = new Date()
 }: {
-  events: ParentScheduleEvent[];
+  events?: ParentScheduleEvent[];
+  upcomingEvents?: ParentScheduleEvent[];
   fees?: ParentHomeFee[];
   inboxTeams?: ParentHomeInboxTeam[];
   now?: Date;
 }): ParentHomeAction[] {
-  const upcoming = events.filter((event) => isUpcomingHomeEvent(event, now));
+  const upcoming = upcomingEvents || events.filter((event) => isUpcomingHomeEvent(event, now));
   const actions: ParentHomeAction[] = [];
 
   upcoming.forEach((event) => {
@@ -255,16 +278,15 @@ export function buildHomeActionItems({
   });
 }
 
-function buildHomePlayers(children: ParentScheduleChild[], events: ParentScheduleEvent[], inboxByTeamId: Map<string, ParentHomeInboxTeam>, now: Date): ParentHomePlayer[] {
+function buildHomePlayers(children: ParentScheduleChild[], eventIndex: HomeEventIndex, inboxByTeamId: Map<string, ParentHomeInboxTeam>): ParentHomePlayer[] {
   return children.map((child) => {
-    const playerEvents = events.filter((event) => event.teamId === child.teamId && event.childId === child.playerId);
-    const upcoming = playerEvents.filter((event) => isUpcomingHomeEvent(event, now));
+    const aggregate = eventIndex.playerAggregates.get(getPlayerAggregateKey(child.teamId, child.playerId));
     return {
       ...child,
-      nextEvent: getUpcomingHomeEvents(playerEvents, 1, now)[0] || null,
-      rsvpNeeded: upcoming.filter((event) => event.isDbGame && !event.availabilityLocked && normalizeRsvpResponse(event.myRsvp) === 'not_responded').length,
-      packetsReady: upcoming.filter((event) => event.type === 'practice' && event.practiceHomePacketSummary).length,
-      openAssignments: upcoming.reduce((total, event) => total + getOpenScheduleAssignments(event.assignments).length, 0),
+      nextEvent: aggregate?.nextEvent || null,
+      rsvpNeeded: aggregate?.rsvpNeeded || 0,
+      packetsReady: aggregate?.packetsReady || 0,
+      openAssignments: aggregate?.openAssignments || 0,
       unreadCount: Number(inboxByTeamId.get(child.teamId)?.unreadCount || 0)
     };
   }).sort((a, b) => {
@@ -274,12 +296,12 @@ function buildHomePlayers(children: ParentScheduleChild[], events: ParentSchedul
   });
 }
 
-function buildHomeTeams(children: ParentScheduleChild[], events: ParentScheduleEvent[], inboxByTeamId: Map<string, ParentHomeInboxTeam>, now: Date): ParentHomeTeam[] {
+function buildHomeTeams(children: ParentScheduleChild[], eventIndex: HomeEventIndex, inboxByTeamId: Map<string, ParentHomeInboxTeam>): ParentHomeTeam[] {
   const byTeam = new Map<string, ParentHomeTeam>();
   children.forEach((child) => {
     const inbox = inboxByTeamId.get(child.teamId);
     if (!byTeam.has(child.teamId)) {
-      const teamEvents = events.filter((event) => event.teamId === child.teamId);
+      const aggregate = eventIndex.teamAggregates.get(child.teamId);
       byTeam.set(child.teamId, {
         teamId: child.teamId,
         teamName: inbox?.name || child.teamName || child.teamId,
@@ -287,8 +309,8 @@ function buildHomeTeams(children: ParentScheduleChild[], events: ParentScheduleE
         sport: inbox?.sport || null,
         photoUrl: inbox?.photoUrl || null,
         players: [],
-        nextEvent: getUpcomingHomeEvents(teamEvents, 1, now)[0] || null,
-        eventCount: dedupeEvents(teamEvents).length,
+        nextEvent: aggregate?.nextEvent || null,
+        eventCount: aggregate?.eventCount || 0,
         unreadCount: Number(inbox?.unreadCount || 0),
         openActions: 0
       });
@@ -313,12 +335,8 @@ function buildHomeTeams(children: ParentScheduleChild[], events: ParentScheduleE
   });
 
   byTeam.forEach((team) => {
-    const teamEvents = events.filter((event) => event.teamId === team.teamId && isUpcomingHomeEvent(event, now));
-    team.openActions = teamEvents.reduce((total, event) => {
-      const needsRsvp = event.isDbGame && !event.availabilityLocked && normalizeRsvpResponse(event.myRsvp) === 'not_responded' ? 1 : 0;
-      const packet = event.type === 'practice' && event.practiceHomePacketSummary ? 1 : 0;
-      return total + needsRsvp + packet + getOpenScheduleAssignments(event.assignments).length;
-    }, team.unreadCount > 0 ? 1 : 0);
+    const aggregate = eventIndex.teamAggregates.get(team.teamId);
+    team.openActions = (aggregate?.openActions || 0) + (team.unreadCount > 0 ? 1 : 0);
   });
 
   return [...byTeam.values()].sort((a, b) => {
@@ -345,6 +363,138 @@ function dedupeEvents(events: ParentScheduleEvent[]) {
     if (!byId.has(key)) byId.set(key, event);
   });
   return [...byId.values()];
+}
+
+function buildHomeEventIndex(events: ParentScheduleEvent[], now: Date): HomeEventIndex {
+  const playerBuckets = new Map<string, {
+    upcomingByKey: Map<string, ParentScheduleEvent>;
+    rsvpNeeded: number;
+    packetsReady: number;
+    openAssignments: number;
+  }>();
+  const teamBuckets = new Map<string, {
+    allByKey: Map<string, ParentScheduleEvent>;
+    upcomingByKey: Map<string, ParentScheduleEvent>;
+    openActions: number;
+  }>();
+  const upcomingByKey = new Map<string, ParentScheduleEvent>();
+  const upcomingEventRows: ParentScheduleEvent[] = [];
+
+  events.forEach((event) => {
+    const teamBucket = getOrCreateTeamBucket(teamBuckets, event.teamId);
+    const eventKey = getHomeEventDedupeKey(event);
+    if (!teamBucket.allByKey.has(eventKey)) {
+      teamBucket.allByKey.set(eventKey, event);
+    }
+
+    const playerBucket = event.childId
+      ? getOrCreatePlayerBucket(playerBuckets, getPlayerAggregateKey(event.teamId, event.childId))
+      : null;
+
+    if (!isUpcomingHomeEvent(event, now)) {
+      return;
+    }
+
+    upcomingEventRows.push(event);
+
+    if (!upcomingByKey.has(eventKey)) {
+      upcomingByKey.set(eventKey, event);
+    }
+    if (!teamBucket.upcomingByKey.has(eventKey)) {
+      teamBucket.upcomingByKey.set(eventKey, event);
+    }
+    if (playerBucket && !playerBucket.upcomingByKey.has(eventKey)) {
+      playerBucket.upcomingByKey.set(eventKey, event);
+    }
+
+    const openAssignments = getOpenScheduleAssignments(event.assignments).length;
+    const needsRsvp = event.isDbGame && !event.availabilityLocked && normalizeRsvpResponse(event.myRsvp) === 'not_responded' ? 1 : 0;
+    const packetReady = event.type === 'practice' && event.practiceHomePacketSummary ? 1 : 0;
+
+    teamBucket.openActions += needsRsvp + Number(packetReady) + openAssignments;
+
+    if (playerBucket) {
+      playerBucket.rsvpNeeded += needsRsvp;
+      playerBucket.packetsReady += Number(packetReady);
+      playerBucket.openAssignments += openAssignments;
+    }
+  });
+
+  const playerAggregates = new Map<string, HomePlayerAggregate>();
+  playerBuckets.forEach((bucket, playerKey) => {
+    playerAggregates.set(playerKey, {
+      nextEvent: sortEventsByDate([...bucket.upcomingByKey.values()])[0] || null,
+      rsvpNeeded: bucket.rsvpNeeded,
+      packetsReady: bucket.packetsReady,
+      openAssignments: bucket.openAssignments
+    });
+  });
+
+  const teamAggregates = new Map<string, HomeTeamAggregate>();
+  teamBuckets.forEach((bucket, teamId) => {
+    teamAggregates.set(teamId, {
+      nextEvent: sortEventsByDate([...bucket.upcomingByKey.values()])[0] || null,
+      eventCount: bucket.allByKey.size,
+      openActions: bucket.openActions
+    });
+  });
+
+  return {
+    upcomingEventRows,
+    upcomingEvents: sortEventsByDate([...upcomingByKey.values()]),
+    playerAggregates,
+    teamAggregates
+  };
+}
+
+function getOrCreatePlayerBucket(
+  buckets: Map<string, {
+    upcomingByKey: Map<string, ParentScheduleEvent>;
+    rsvpNeeded: number;
+    packetsReady: number;
+    openAssignments: number;
+  }>,
+  playerKey: string
+) {
+  if (!buckets.has(playerKey)) {
+    buckets.set(playerKey, {
+      upcomingByKey: new Map<string, ParentScheduleEvent>(),
+      rsvpNeeded: 0,
+      packetsReady: 0,
+      openAssignments: 0
+    });
+  }
+  return buckets.get(playerKey)!;
+}
+
+function getOrCreateTeamBucket(
+  buckets: Map<string, {
+    allByKey: Map<string, ParentScheduleEvent>;
+    upcomingByKey: Map<string, ParentScheduleEvent>;
+    openActions: number;
+  }>,
+  teamId: string
+) {
+  if (!buckets.has(teamId)) {
+    buckets.set(teamId, {
+      allByKey: new Map<string, ParentScheduleEvent>(),
+      upcomingByKey: new Map<string, ParentScheduleEvent>(),
+      openActions: 0
+    });
+  }
+  return buckets.get(teamId)!;
+}
+
+function getPlayerAggregateKey(teamId: string, playerId: string) {
+  return `${teamId}::${playerId}`;
+}
+
+function getHomeEventDedupeKey(event: ParentScheduleEvent) {
+  return `${event.teamId}::${event.id}::${event.date.toISOString()}`;
+}
+
+function sortEventsByDate(events: ParentScheduleEvent[]) {
+  return events.sort((a, b) => a.date.getTime() - b.date.getTime());
 }
 
 function getPlayerActionCount(player: Pick<ParentHomePlayer, 'rsvpNeeded' | 'packetsReady' | 'openAssignments' | 'unreadCount'>) {

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -124,6 +124,115 @@ const baseSocial = {
   }
 };
 
+function buildLargeHomeModel() {
+  return {
+    players: Array.from({ length: 4 }, (_, index) => ({
+      teamId: index < 2 ? 'team-1' : index === 2 ? 'team-2' : 'team-3',
+      teamName: index < 2 ? 'Bears' : index === 2 ? 'Storm' : 'Falcons',
+      playerId: `player-${index + 1}`,
+      playerName: `Player ${index + 1}`,
+      nextEvent: {
+        teamId: index < 2 ? 'team-1' : index === 2 ? 'team-2' : 'team-3',
+        id: `event-${index + 1}`,
+        childId: `player-${index + 1}`,
+        childName: `Player ${index + 1}`,
+        teamName: index < 2 ? 'Bears' : index === 2 ? 'Storm' : 'Falcons',
+        type: 'game',
+        date: new Date(`2100-06-0${index + 1}T18:00:00Z`),
+        location: 'Main Gym',
+        opponent: 'Rivals',
+        title: null,
+        eventKey: `team-${index + 1}::event-${index + 1}::player-${index + 1}`,
+        isDbGame: true,
+        isCancelled: false,
+        myRsvp: 'not_responded',
+        assignments: []
+      },
+      rsvpNeeded: index < 2 ? 1 : 0,
+      packetsReady: index === 2 ? 1 : 0,
+      openAssignments: index === 3 ? 2 : 0,
+      unreadCount: index < 2 ? 3 : 0
+    })),
+    teams: [
+      {
+        teamId: 'team-1',
+        teamName: 'Bears',
+        role: 'Parent',
+        sport: 'Basketball',
+        players: [
+          { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Player 1' },
+          { teamId: 'team-1', teamName: 'Bears', playerId: 'player-2', playerName: 'Player 2' }
+        ],
+        nextEvent: null,
+        eventCount: 4,
+        unreadCount: 3,
+        openActions: 5
+      },
+      {
+        teamId: 'team-2',
+        teamName: 'Storm',
+        role: 'Parent',
+        sport: 'Soccer',
+        players: [
+          { teamId: 'team-2', teamName: 'Storm', playerId: 'player-3', playerName: 'Player 3' }
+        ],
+        nextEvent: null,
+        eventCount: 2,
+        unreadCount: 0,
+        openActions: 2
+      },
+      {
+        teamId: 'team-3',
+        teamName: 'Falcons',
+        role: 'Parent',
+        sport: 'Volleyball',
+        players: [
+          { teamId: 'team-3', teamName: 'Falcons', playerId: 'player-4', playerName: 'Player 4' }
+        ],
+        nextEvent: null,
+        eventCount: 3,
+        unreadCount: 1,
+        openActions: 3
+      }
+    ],
+    upcomingEvents: Array.from({ length: 6 }, (_, index) => ({
+      teamId: index < 3 ? 'team-1' : index < 5 ? 'team-2' : 'team-3',
+      id: `upcoming-${index + 1}`,
+      childId: `player-${(index % 4) + 1}`,
+      childName: `Player ${(index % 4) + 1}`,
+      teamName: index < 3 ? 'Bears' : index < 5 ? 'Storm' : 'Falcons',
+      type: index % 2 === 0 ? 'game' : 'practice',
+      date: new Date(`2100-06-${String(index + 1).padStart(2, '0')}T18:00:00Z`),
+      location: 'Main Gym',
+      opponent: 'Rivals',
+      title: index % 2 === 0 ? null : 'Practice',
+      eventKey: `team-${index + 1}::upcoming-${index + 1}::player-${(index % 4) + 1}`,
+      isDbGame: true,
+      isCancelled: false,
+      myRsvp: 'going',
+      assignments: []
+    })),
+    actionItems: [
+      { id: 'rsvp:1', kind: 'rsvp', tone: 'amber', title: 'Player 1 needs availability', detail: 'Bears Game · Tue, Jun 1', to: '/schedule/team-1/upcoming-1', priority: 10, date: new Date('2100-06-01T18:00:00Z') },
+      { id: 'packet:1', kind: 'packet', tone: 'blue', title: 'Practice packet ready', detail: 'Player 3 · Skills packet', to: '/schedule/team-2/upcoming-4', priority: 20, date: new Date('2100-06-04T18:00:00Z') },
+      { id: 'assignment:1', kind: 'assignment', tone: 'emerald', title: '2 open assignments', detail: 'Falcons Game · Clock, Book', to: '/schedule/team-3/upcoming-6', priority: 30, date: new Date('2100-06-06T18:00:00Z') },
+      { id: 'fee:1', kind: 'fee', tone: 'rose', title: 'Tournament fee', detail: 'Bears · Player 2 · $20.00 due', to: '/parent-tools/fees', priority: 50, date: new Date('2100-06-02T18:00:00Z') },
+      { id: 'message:1', kind: 'message', tone: 'blue', title: '3 unread messages', detail: 'Bears', to: '/messages/team-1', priority: 60, date: null },
+      { id: 'message:2', kind: 'message', tone: 'blue', title: '1 unread message', detail: 'Falcons', to: '/messages/team-3', priority: 60, date: null }
+    ],
+    fees: [
+      { id: 'fee-1', title: 'Tournament fee', teamId: 'team-1', teamName: 'Bears', playerName: 'Player 2', status: 'partial', balanceDueCents: 2000 }
+    ],
+    metrics: {
+      players: 4,
+      teams: 3,
+      rsvpNeeded: 1,
+      unreadMessages: 4,
+      packetsReady: 1
+    }
+  };
+}
+
 const signedInAuth: AuthState = {
   user: {
     uid: 'parent-1',
@@ -293,5 +402,29 @@ describe('Home', () => {
       expect(socialServiceMocks.respondToFriendRequest).toHaveBeenCalledWith('friendship-1', 'accepted');
       expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('renders Today content from larger Home payloads and keeps it visible after refresh', async () => {
+    const largeHome = buildLargeHomeModel();
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: largeHome, schedule: [] });
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValue(largeHome);
+
+    renderHome(signedInAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(screen.getByText('Upcoming')).toBeTruthy();
+    expect(screen.getAllByText('Player 1 needs availability').length).toBeGreaterThan(0);
+    expect(screen.getByText('Falcons')).toBeTruthy();
+    expect(screen.getAllByText('Tournament fee').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Home' }));
+
+    await waitFor(() => {
+      expect(homeServiceMocks.loadParentHomeSummaryBootstrap).toHaveBeenCalledTimes(2);
+      expect(homeServiceMocks.loadParentHomeWithSecondaryData).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.getByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(screen.getByText('1 unread message')).toBeTruthy();
   });
 });

--- a/tests/unit/app-home-logic.test.js
+++ b/tests/unit/app-home-logic.test.js
@@ -8,6 +8,18 @@ import {
     getTeamHomePath
 } from '../../apps/app/src/lib/homeLogic.ts';
 
+class InstrumentedEvents extends Array {
+    constructor(...items) {
+        super(...items);
+        this.rootFilterCalls = 0;
+    }
+
+    filter(callback, thisArg) {
+        this.rootFilterCalls += 1;
+        return Array.prototype.filter.call(this, callback, thisArg);
+    }
+}
+
 function child(overrides = {}) {
     return {
         teamId: overrides.teamId || 'team-1',
@@ -191,5 +203,162 @@ describe('React app Home model helpers', () => {
             kind: 'message',
             to: '/messages/team-staff'
         });
+    });
+
+    it('builds the same Home outputs from indexed event aggregates across multiple teams and players', () => {
+        const now = new Date('2100-05-30T12:00:00Z');
+        const model = buildParentHomeModel({
+            children: [
+                child({ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat' }),
+                child({ teamId: 'team-1', teamName: 'Bears', playerId: 'player-2', playerName: 'Sam' }),
+                child({ teamId: 'team-2', teamName: 'Storm', playerId: 'player-3', playerName: 'Alex' })
+            ],
+            events: [
+                event({
+                    id: 'game-1',
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    childId: 'player-1',
+                    childName: 'Pat',
+                    date: new Date('2100-06-01T18:00:00Z'),
+                    myRsvp: 'not_responded'
+                }),
+                event({
+                    eventKey: 'team-1::game-1::player-2',
+                    id: 'game-1',
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    childId: 'player-2',
+                    childName: 'Sam',
+                    date: new Date('2100-06-01T18:00:00Z'),
+                    myRsvp: 'going'
+                }),
+                event({
+                    id: 'practice-1',
+                    type: 'practice',
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    childId: 'player-1',
+                    childName: 'Pat',
+                    date: new Date('2100-06-02T18:00:00Z'),
+                    myRsvp: 'going',
+                    practiceHomePacketSummary: 'Mobility packet'
+                }),
+                event({
+                    id: 'game-2',
+                    teamId: 'team-2',
+                    teamName: 'Storm',
+                    childId: 'player-3',
+                    childName: 'Alex',
+                    date: new Date('2100-06-03T18:00:00Z'),
+                    myRsvp: 'going',
+                    assignments: [
+                        { role: 'Clock', value: '', claimable: true, claim: null },
+                        { role: 'Scorebook', value: '', claimable: true, claim: null }
+                    ]
+                }),
+                event({
+                    eventKey: 'team-2::game-2::player-3::duplicate',
+                    id: 'game-2',
+                    teamId: 'team-2',
+                    teamName: 'Storm',
+                    childId: 'player-3',
+                    childName: 'Alex',
+                    date: new Date('2100-06-03T18:00:00Z'),
+                    myRsvp: 'going',
+                    assignments: [
+                        { role: 'Clock', value: '', claimable: true, claim: null },
+                        { role: 'Scorebook', value: '', claimable: true, claim: null }
+                    ]
+                })
+            ],
+            inboxTeams: [
+                { id: 'team-1', name: 'Bears', role: 'Parent', unreadCount: 2, sport: 'Basketball' },
+                { id: 'team-2', name: 'Storm', role: 'Parent', unreadCount: 0, sport: 'Soccer' }
+            ],
+            fees: [
+                { id: 'fee-1', title: 'Travel', teamId: 'team-2', teamName: 'Storm', status: 'partial', balanceDueCents: 2000 }
+            ],
+            now
+        });
+
+        expect(model.upcomingEvents.map((entry) => `${entry.teamId}:${entry.id}`)).toEqual([
+            'team-1:game-1',
+            'team-1:practice-1',
+            'team-2:game-2'
+        ]);
+        expect(model.players.map((player) => ({
+            name: player.playerName,
+            nextEvent: player.nextEvent?.id || null,
+            rsvpNeeded: player.rsvpNeeded,
+            packetsReady: player.packetsReady,
+            openAssignments: player.openAssignments,
+            unreadCount: player.unreadCount
+        }))).toEqual([
+            { name: 'Alex', nextEvent: 'game-2', rsvpNeeded: 0, packetsReady: 0, openAssignments: 4, unreadCount: 0 },
+            { name: 'Pat', nextEvent: 'game-1', rsvpNeeded: 1, packetsReady: 1, openAssignments: 0, unreadCount: 2 },
+            { name: 'Sam', nextEvent: 'game-1', rsvpNeeded: 0, packetsReady: 0, openAssignments: 0, unreadCount: 2 }
+        ]);
+        expect(model.teams.map((team) => ({
+            teamId: team.teamId,
+            nextEvent: team.nextEvent?.id || null,
+            eventCount: team.eventCount,
+            unreadCount: team.unreadCount,
+            openActions: team.openActions
+        }))).toEqual([
+            { teamId: 'team-1', nextEvent: 'game-1', eventCount: 2, unreadCount: 2, openActions: 3 },
+            { teamId: 'team-2', nextEvent: 'game-2', eventCount: 1, unreadCount: 0, openActions: 4 }
+        ]);
+        expect(model.actionItems.map((action) => action.kind)).toEqual(['rsvp', 'packet', 'assignment', 'assignment', 'fee', 'message']);
+        expect(model.metrics).toEqual({
+            players: 3,
+            teams: 2,
+            rsvpNeeded: 1,
+            unreadMessages: 2,
+            packetsReady: 1
+        });
+    });
+
+    it('avoids repeated full-event scans when building large Home models', () => {
+        const now = new Date('2100-05-30T12:00:00Z');
+        const children = [];
+        const events = new InstrumentedEvents();
+
+        for (let teamIndex = 1; teamIndex <= 12; teamIndex += 1) {
+            for (let playerIndex = 1; playerIndex <= 5; playerIndex += 1) {
+                const teamId = `team-${teamIndex}`;
+                const playerId = `player-${teamIndex}-${playerIndex}`;
+                children.push(child({
+                    teamId,
+                    teamName: `Team ${teamIndex}`,
+                    playerId,
+                    playerName: `Player ${teamIndex}-${playerIndex}`
+                }));
+
+                for (let eventIndex = 1; eventIndex <= 4; eventIndex += 1) {
+                    events.push(event({
+                        eventKey: `${teamId}::event-${playerId}-${eventIndex}`,
+                        id: `event-${teamIndex}-${eventIndex}`,
+                        teamId,
+                        teamName: `Team ${teamIndex}`,
+                        childId: playerId,
+                        childName: `Player ${teamIndex}-${playerIndex}`,
+                        type: eventIndex % 2 === 0 ? 'practice' : 'game',
+                        myRsvp: eventIndex % 2 === 0 ? 'going' : 'not_responded',
+                        date: new Date(`2100-06-${String(eventIndex + 1).padStart(2, '0')}T18:00:00Z`),
+                        practiceHomePacketSummary: eventIndex % 2 === 0 ? 'Skills packet' : null,
+                        assignments: eventIndex % 2 === 0 ? [] : [
+                            { role: 'Clock', value: '', claimable: true, claim: null }
+                        ]
+                    }));
+                }
+            }
+        }
+
+        const model = buildParentHomeModel({ children, events, now });
+
+        expect(model.players).toHaveLength(children.length);
+        expect(model.teams).toHaveLength(12);
+        expect(events.rootFilterCalls).toBe(0);
     });
 });


### PR DESCRIPTION
Closes #2404

## What changed
- refactored `buildParentHomeModel` to build reusable team and player event aggregates in one pass instead of repeatedly filtering the full schedule per child and per team
- reused the indexed aggregates for player cards, team cards, next-event selection, upcoming events, and Home action counts while preserving existing Home output behavior
- added a unit regression that verifies indexed Home output across multi-team, multi-player data and another regression that proves Home model building no longer calls `filter()` on the root events array
- added a Home page test with a larger mocked payload to keep Today content and refresh behavior covered

## Root Cause
`buildParentHomeModel` derived multiple Home sections by re-filtering and re-sorting the full schedule array for each player and team, then repeated upcoming-event work again for action items and next-event selection. That turned every busy Home load into nested whole-array scans.

## Prevention / Learning
When one route derives several views from the same large collection, build a shared index/aggregate pass first and feed every downstream section from that indexed state. Add a regression that watches root-collection scan behavior so repeated full-array work does not creep back in.

## Regression Tests
- `npx vitest run tests/unit/app-home-logic.test.js apps/app/src/pages/Home.test.tsx --reporter=verbose`
- `tests/unit/app-home-logic.test.js` now checks indexed output parity and asserts zero root-array `filter()` scans during large Home model builds
- `apps/app/src/pages/Home.test.tsx` now covers larger Today payload rendering and refresh behavior