### PR TITLE
Block IPv6 site-local calendar proxy targets

### DIFF
--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -29,6 +29,8 @@ test('isPrivateIpAddress correctly identifies private IPs', () => {
   assert.strictEqual(isPrivateIpAddress('fe80::1'), true, 'fe80::1 should be private (IPv6 link-local)');
   assert.strictEqual(isPrivateIpAddress('fc00::1'), true, 'fc00::1 should be private (IPv6 ULA)');
   assert.strictEqual(isPrivateIpAddress('fd00::1'), true, 'fd00::1 should be private (IPv6 ULA)');
+  assert.strictEqual(isPrivateIpAddress('fec0::1'), true, 'fec0::1 should be private (IPv6 site-local)');
+  assert.strictEqual(isPrivateIpAddress('feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff'), true, 'feff::/16 upper bound should be private (IPv6 site-local)');
   assert.strictEqual(isPrivateIpAddress('2001:0db8::1'), false, '2001:0db8::1 should be public');
 
   assert.strictEqual(isPrivateIpAddress('::ffff:127.0.0.1'), true, 'IPv4-mapped IPv6 loopback should be private');
@@ -50,6 +52,7 @@ test('assertPublicHost prevents blocked hosts and private IPs', async () => {
   await assert.rejects(assertPublicHost('::ffff:127.0.0.1'), { message: 'Blocked host address' }, 'IPv4-mapped IPv6 loopback should be blocked');
   await assert.rejects(assertPublicHost('::ffff:169.254.169.254'), { message: 'Blocked host address' }, 'IPv4-mapped IPv6 link-local should be blocked');
   await assert.rejects(assertPublicHost('0000:0000:0000:0000:0000:ffff:7f00:0001'), { message: 'Blocked host address' }, 'zero-padded IPv4-mapped IPv6 loopback should be blocked');
+  await assert.rejects(assertPublicHost('fec0::1234'), { message: 'Blocked host address' }, 'IPv6 site-local should be blocked');
 
   const publicIp = await assertPublicHost('8.8.8.8');
   assert.deepStrictEqual(publicIp, ['8.8.8.8'], 'public IP should be allowed');

--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -1,4 +1,4 @@
-import { test } from 'vitest';
+import test from 'node:test';
 import assert from 'node:assert';
 import { promises as dns } from 'node:dns';
 import * as https from 'node:https';

--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert';
 import { promises as dns } from 'node:dns';
 import * as https from 'node:https';

--- a/functions/utils/security-utils.js
+++ b/functions/utils/security-utils.js
@@ -79,6 +79,8 @@ function isPrivateIpAddress(ip) {
   if (normalized === '::1' || normalized === '::') return true;
   if (normalized.startsWith('fe80:')) return true;
   if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+  const siteLocalPrefix = normalized.slice(0, 3);
+  if (siteLocalPrefix >= 'fec' && siteLocalPrefix <= 'fef') return true;
   return false;
 }
 


### PR DESCRIPTION
Closes #2409

## What changed
- Marked IPv6 `fec0::/10` site-local addresses as private in `functions/utils/security-utils.js`
- Added SSRF regression coverage in `functions/test/ssrf.test.js` for both direct private-IP classification and `assertPublicHost()` rejection of `fec0::/10` targets

## Root Cause
`functions/utils/security-utils.js` had a hand-maintained IPv6 private-range check that covered loopback, unspecified, link-local, and ULA ranges, but omitted deprecated IPv6 site-local `fec0::/10`. Because `assertPublicHost()` trusts that helper for IP literals, a `fec0::` host was incorrectly treated as public and allowed through the ICS proxy validation path.

## Prevention / Learning
When SSRF guards duplicate IP classification logic across utilities, keep the private-range coverage aligned and add regression tests at the enforcement boundary, not just in a sibling helper. For future host-validation changes, verify every reserved/private IPv6 range used elsewhere in the repo is also covered in the production fetch gate.

## Regression Tests
- `node --test functions/test/ssrf.test.js`
- Added assertions that `isPrivateIpAddress('fec0::1')` and an upper-bound `feff:...` address are treated as private
- Added an assertion that `assertPublicHost('fec0::1234')` rejects with `Blocked host address`