### PR TITLE
Roll back retry capacity when Stripe checkout creation fails

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2033,24 +2033,41 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   const { appUrl } = getStripeConfig();
   const { successUrl, cancelUrl } = buildRegistrationCheckoutUrls(appUrl, input);
   const title = registration.programName || form.programName || form.title || form.name || 'Program registration';
-  const session = await stripe.checkout.sessions.create({
-    mode: 'payment',
-    line_items: [{
-      price_data: {
-        currency,
-        unit_amount: amountCents,
-        product_data: {
-          name: title
-        }
-      },
-      quantity: 1
-    }],
-    success_url: successUrl,
-    cancel_url: cancelUrl,
-    customer_email: getRegistrationCustomerEmail(registration),
-    client_reference_id: `${input.teamId}:${input.formId}:${input.registrationId}`,
-    metadata: buildRegistrationCheckoutMetadata({ input, registration })
-  });
+  let session;
+  try {
+    session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [{
+        price_data: {
+          currency,
+          unit_amount: amountCents,
+          product_data: {
+            name: title
+          }
+        },
+        quantity: 1
+      }],
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      customer_email: getRegistrationCustomerEmail(registration),
+      client_reference_id: `${input.teamId}:${input.formId}:${input.registrationId}`,
+      metadata: buildRegistrationCheckoutMetadata({ input, registration })
+    });
+  } catch (error) {
+    if (input.retryPayment && registration.registrationCapacityReleased === true) {
+      try {
+        await releaseRegistrationCheckoutCapacity(input);
+      } catch (releaseError) {
+        functions.logger.error('Failed to roll back registration retry capacity after Stripe checkout creation failed.', {
+          teamId: input.teamId,
+          formId: input.formId,
+          registrationId: input.registrationId,
+          releaseError: releaseError?.message || releaseError
+        });
+      }
+    }
+    throw error;
+  }
 
   const now = admin.firestore.FieldValue.serverTimestamp();
   await buildRegistrationRef(input).set({

--- a/functions/index.js
+++ b/functions/index.js
@@ -579,10 +579,11 @@ async function queueDueRegistrationFailedPaymentReminders() {
   return results;
 }
 
-async function reserveRegistrationCheckoutCapacityForRetry(input) {
+async function reserveRegistrationCheckoutCapacityForRetry(input, options = {}) {
   const formRef = buildRegistrationFormRef(input);
   const registrationRef = buildRegistrationRef(input);
   const now = admin.firestore.FieldValue.serverTimestamp();
+  const retryCapacityReservationId = String(options.retryCapacityReservationId || '').trim();
 
   return firestore.runTransaction(async (transaction) => {
     const [formSnap, registrationSnap] = await Promise.all([
@@ -633,14 +634,18 @@ async function reserveRegistrationCheckoutCapacityForRetry(input) {
     transaction.set(registrationRef, {
       registrationCapacityReleased: false,
       capacityReleasedAt: admin.firestore.FieldValue.delete(),
+      retryCapacityReservationId: retryCapacityReservationId || admin.firestore.FieldValue.delete(),
       updatedAt: now
     }, { merge: true });
 
-    return { reserved: true };
+    return {
+      reserved: true,
+      retryCapacityReservationId: retryCapacityReservationId || null
+    };
   });
 }
 
-async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}) {
+async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}, options = {}) {
   const formRef = buildRegistrationFormRef(input);
   const registrationRef = buildRegistrationRef(input);
   const now = admin.firestore.FieldValue.serverTimestamp();
@@ -667,8 +672,14 @@ async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}) {
       return { released: false, reason: 'already-paid' };
     }
 
+    const retryCapacityReservationId = String(options.retryCapacityReservationId || '').trim();
+    const hasMatchingRetryCapacityReservation = Boolean(
+      retryCapacityReservationId
+      && String(registration.retryCapacityReservationId || '').trim() === retryCapacityReservationId
+    );
     const registrationUpdate = {
       ...statusUpdate,
+      retryCapacityReservationId: admin.firestore.FieldValue.delete(),
       updatedAt: now
     };
 
@@ -681,13 +692,17 @@ async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}) {
     const canReleasePreCheckoutReservation = !registration.checkoutStatus
       && !registration.paymentStatus
       && ['pending', 'waitlisted'].includes(registration.status);
-    if (!checkoutIsOpen && !canReleasePreCheckoutReservation) {
+    const canReleaseRetryCapacityReservation = hasMatchingRetryCapacityReservation && registration.status === 'pending';
+    if (!checkoutIsOpen && !canReleasePreCheckoutReservation && !canReleaseRetryCapacityReservation) {
       throw new functions.https.HttpsError('failed-precondition', 'Registration checkout is not releasable.');
     }
-    if (canReleasePreCheckoutReservation && !registrationCheckoutAttemptStrictlyMatches(registration, input)) {
+    if ((canReleasePreCheckoutReservation || canReleaseRetryCapacityReservation)
+      && !registrationCheckoutAttemptStrictlyMatches(registration, input)) {
       throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt is required to release this reservation.');
     }
-    if (!canReleasePreCheckoutReservation && !registrationCheckoutAttemptMatches(registration, input)) {
+    if (!canReleasePreCheckoutReservation
+      && !canReleaseRetryCapacityReservation
+      && !registrationCheckoutAttemptMatches(registration, input)) {
       throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt does not match.');
     }
 
@@ -2022,8 +2037,12 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   if (!registrationCheckoutAttemptMatches(registration, input)) {
     throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt does not match.');
   }
+  const retryCapacityReservationId = input.retryPayment ? crypto.randomUUID() : '';
+  let retryCapacityReservation = { reserved: false, retryCapacityReservationId: null };
   if (input.retryPayment && registration.registrationCapacityReleased === true) {
-    await reserveRegistrationCheckoutCapacityForRetry(input);
+    retryCapacityReservation = await reserveRegistrationCheckoutCapacityForRetry(input, {
+      retryCapacityReservationId
+    });
   }
   if (canReuseRegistrationCheckoutSession(registration, amountCents, input)) {
     return { checkoutUrl: registration.checkoutUrl, sessionId: registration.stripeCheckoutSessionId };
@@ -2054,9 +2073,11 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
       metadata: buildRegistrationCheckoutMetadata({ input, registration })
     });
   } catch (error) {
-    if (input.retryPayment && registration.registrationCapacityReleased === true) {
+    if (retryCapacityReservation.reserved) {
       try {
-        await releaseRegistrationCheckoutCapacity(input);
+        await releaseRegistrationCheckoutCapacity(input, {}, {
+          retryCapacityReservationId: retryCapacityReservation.retryCapacityReservationId
+        });
       } catch (releaseError) {
         functions.logger.error('Failed to roll back registration retry capacity after Stripe checkout creation failed.', {
           teamId: input.teamId,
@@ -2081,6 +2102,7 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
     checkoutAmountCents: amountCents,
     checkoutAttemptToken: input.checkoutAttemptToken || null,
     checkoutCreatedAt: now,
+    retryCapacityReservationId: admin.firestore.FieldValue.delete(),
     updatedAt: now
   }, { merge: true });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -696,14 +696,16 @@ async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}, opt
     if (!checkoutIsOpen && !canReleasePreCheckoutReservation && !canReleaseRetryCapacityReservation) {
       throw new functions.https.HttpsError('failed-precondition', 'Registration checkout is not releasable.');
     }
-    if ((canReleasePreCheckoutReservation || canReleaseRetryCapacityReservation)
-      && !registrationCheckoutAttemptStrictlyMatches(registration, input)) {
+    if (canReleasePreCheckoutReservation && !registrationCheckoutAttemptStrictlyMatches(registration, input)) {
       throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt is required to release this reservation.');
     }
-    if (!canReleasePreCheckoutReservation
-      && !canReleaseRetryCapacityReservation
-      && !registrationCheckoutAttemptMatches(registration, input)) {
-      throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt does not match.');
+    if (canReleaseRetryCapacityReservation && !registrationCheckoutAttemptStrictlyMatches(registration, input)) {
+      throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt is required to release this reservation.');
+    }
+    if (!canReleasePreCheckoutReservation && !registrationCheckoutAttemptMatches(registration, input)) {
+      if (!canReleaseRetryCapacityReservation) {
+        throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt does not match.');
+      }
     }
 
     const selectedOption = registration.selectedOption || {};

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -1,8 +1,7 @@
-'use strict';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Module, { createRequire } from 'node:module';
 
-const { beforeEach, describe, it } = require('node:test');
-const assert = require('node:assert/strict');
-const Module = require('node:module');
+const require = createRequire(import.meta.url);
 
 const repoIndexPath = require.resolve('../index.js');
 const originalModuleLoad = Module._load;
@@ -286,6 +285,14 @@ describe('createStripeRegistrationCheckout retry capacity handling', () => {
     StripeStub = null;
   });
 
+  afterEach(() => {
+    delete require.cache[repoIndexPath];
+    Module._load = originalModuleLoad;
+    adminStub = null;
+    functionsStub = null;
+    StripeStub = null;
+  });
+
   it('rolls back reserved capacity when Stripe checkout creation fails', async () => {
     const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
       seed: buildSeedState(),
@@ -294,20 +301,17 @@ describe('createStripeRegistrationCheckout retry capacity handling', () => {
       }
     });
 
-    await assert.rejects(
-      () => createStripeRegistrationCheckout(checkoutInput),
-      /Stripe checkout creation failed\./
-    );
+    await expect(createStripeRegistrationCheckout(checkoutInput)).rejects.toThrow('Stripe checkout creation failed.');
 
     const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
     const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
 
-    assert.equal(form.registrationOptionCounts.u10.enrolled, 0);
-    assert.equal(registration.registrationCapacityReleased, true);
-    assert.equal(registration.capacityReleasedAt, 'SERVER_TIMESTAMP');
-    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'checkoutStatus'), false);
-    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'paymentStatus'), false);
-    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'checkoutUrl'), false);
+    expect(form.registrationOptionCounts.u10.enrolled).toBe(0);
+    expect(registration.registrationCapacityReleased).toBe(true);
+    expect(registration.capacityReleasedAt).toBe('SERVER_TIMESTAMP');
+    expect(Object.prototype.hasOwnProperty.call(registration, 'checkoutStatus')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(registration, 'paymentStatus')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(registration, 'checkoutUrl')).toBe(false);
   });
 
   it('reserves capacity exactly once after a failed retry is retried successfully', async () => {
@@ -323,10 +327,7 @@ describe('createStripeRegistrationCheckout retry capacity handling', () => {
       }
     });
 
-    await assert.rejects(
-      () => createStripeRegistrationCheckout(checkoutInput),
-      /Stripe checkout creation failed\./
-    );
+    await expect(createStripeRegistrationCheckout(checkoutInput)).rejects.toThrow('Stripe checkout creation failed.');
 
     delete require.cache[repoIndexPath];
     adminStub = {
@@ -360,16 +361,16 @@ describe('createStripeRegistrationCheckout retry capacity handling', () => {
     const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
     const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
 
-    assert.deepEqual(result, {
+    expect(result).toEqual({
       checkoutUrl: 'https://checkout.stripe.com/c/session_123',
       sessionId: 'cs_test_123'
     });
-    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
-    assert.equal(registration.registrationCapacityReleased, false);
-    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'capacityReleasedAt'), false);
-    assert.equal(registration.checkoutStatus, 'open');
-    assert.equal(registration.paymentStatus, 'checkout_open');
-    assert.equal(registration.stripeCheckoutSessionId, 'cs_test_123');
-    assert.equal(registration.checkoutAmountCents, 5000);
+    expect(form.registrationOptionCounts.u10.enrolled).toBe(1);
+    expect(registration.registrationCapacityReleased).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(registration, 'capacityReleasedAt')).toBe(false);
+    expect(registration.checkoutStatus).toBe('open');
+    expect(registration.paymentStatus).toBe('checkout_open');
+    expect(registration.stripeCheckoutSessionId).toBe('cs_test_123');
+    expect(registration.checkoutAmountCents).toBe(5000);
   });
 });

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -1,0 +1,375 @@
+'use strict';
+
+const { beforeEach, describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+const repoIndexPath = require.resolve('../index.js');
+const originalModuleLoad = Module._load;
+
+let adminStub = null;
+let functionsStub = null;
+let StripeStub = null;
+
+function patchedModuleLoad(request, parent, isMain) {
+  if (request === 'firebase-admin' && adminStub) {
+    return adminStub;
+  }
+  if (request === 'firebase-functions' && functionsStub) {
+    return functionsStub;
+  }
+  if (request === 'stripe' && StripeStub) {
+    return StripeStub;
+  }
+  return originalModuleLoad(request, parent, isMain);
+}
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function setNested(target, path, value) {
+  const parts = String(path || '').split('.').filter(Boolean);
+  let cursor = target;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const key = parts[i];
+    if (!cursor[key] || typeof cursor[key] !== 'object' || Array.isArray(cursor[key])) {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  cursor[parts[parts.length - 1]] = value;
+}
+
+function deleteNested(target, path) {
+  const parts = String(path || '').split('.').filter(Boolean);
+  let cursor = target;
+  for (let i = 0; i < parts.length - 1; i++) {
+    cursor = cursor?.[parts[i]];
+    if (!cursor || typeof cursor !== 'object') return;
+  }
+  if (cursor && typeof cursor === 'object') {
+    delete cursor[parts[parts.length - 1]];
+  }
+}
+
+function makeFirestore(seed = {}) {
+  const state = new Map(Object.entries(clone(seed)));
+
+  const fieldValue = {
+    serverTimestamp: () => ({ __op: 'serverTimestamp' }),
+    delete: () => ({ __op: 'delete' }),
+    increment: (amount) => ({ __op: 'increment', amount }),
+    arrayUnion: (...items) => ({ __op: 'arrayUnion', items })
+  };
+
+  const isOp = (value, kind) => value && typeof value === 'object' && value.__op === kind;
+
+  function applyPatch(baseValue, patchValue, merge) {
+    const target = merge ? clone(baseValue || {}) : {};
+    Object.entries(patchValue || {}).forEach(([key, value]) => {
+      if (isOp(value, 'delete')) {
+        deleteNested(target, key);
+      } else if (isOp(value, 'serverTimestamp')) {
+        setNested(target, key, 'SERVER_TIMESTAMP');
+      } else if (isOp(value, 'increment')) {
+        const current = Number(key.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), target) || 0);
+        setNested(target, key, current + value.amount);
+      } else if (isOp(value, 'arrayUnion')) {
+        const current = key.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), target);
+        const array = Array.isArray(current) ? [...current] : [];
+        value.items.forEach((item) => array.push(clone(item)));
+        setNested(target, key, array);
+      } else {
+        setNested(target, key, clone(value));
+      }
+    });
+    return target;
+  }
+
+  function write(path, value, options = {}) {
+    const current = state.get(path);
+    const next = applyPatch(current, value, options.merge === true);
+    state.set(path, next);
+  }
+
+  function doc(path) {
+    return {
+      path,
+      id: String(path).split('/').pop(),
+      async get() {
+        const data = state.get(path);
+        return {
+          exists: data !== undefined,
+          id: String(path).split('/').pop(),
+          ref: this,
+          data: () => clone(data)
+        };
+      },
+      async set(value, options) {
+        write(path, value, options || {});
+      },
+      async update(value) {
+        const current = state.get(path);
+        if (current === undefined) {
+          throw new Error(`Missing document for update: ${path}`);
+        }
+        write(path, value, { merge: true });
+      },
+      collection(name) {
+        return collection(`${path}/${name}`);
+      }
+    };
+  }
+
+  function collection(path) {
+    return {
+      path,
+      doc(id) {
+        return doc(`${path}/${id}`);
+      }
+    };
+  }
+
+  return {
+    _state: state,
+    doc,
+    collection,
+    async runTransaction(handler) {
+      const transaction = {
+        get: (ref) => ref.get(),
+        set: (ref, value, options) => ref.set(value, options),
+        update: (ref, value) => ref.update(value)
+      };
+      return handler(transaction);
+    },
+    snapshot(path) {
+      return clone(state.get(path));
+    },
+    FieldValue: fieldValue
+  };
+}
+
+function makeFunctionsStub() {
+  class HttpsError extends Error {
+    constructor(code, message) {
+      super(message);
+      this.code = code;
+    }
+  }
+
+  const triggerChain = {
+    onCall: (fn) => fn,
+    onRequest: (fn) => fn,
+    onCreate: (fn) => fn,
+    onUpdate: (fn) => fn,
+    onWrite: (fn) => fn,
+    onRun: (fn) => fn,
+    document() {
+      return this;
+    },
+    schedule() {
+      return this;
+    },
+    timeZone() {
+      return this;
+    }
+  };
+  triggerChain.https = triggerChain;
+  triggerChain.firestore = triggerChain;
+  triggerChain.pubsub = triggerChain;
+
+  return {
+    config: () => ({ stripe: { secret_key: 'sk_test_123', app_url: 'https://allplays.test' } }),
+    https: {
+      HttpsError,
+      onCall: (fn) => fn,
+      onRequest: (fn) => fn
+    },
+    firestore: {
+      document: () => triggerChain
+    },
+    pubsub: {
+      schedule: () => triggerChain
+    },
+    runWith: () => triggerChain,
+    logger: {
+      error: () => {},
+      warn: () => {},
+      info: () => {}
+    }
+  };
+}
+
+function loadCheckoutHandler({ seed, stripeCreateImpl }) {
+  delete require.cache[repoIndexPath];
+
+  const firestore = makeFirestore(seed);
+  adminStub = {
+    apps: [true],
+    initializeApp: () => {},
+    firestore: Object.assign(() => firestore, { FieldValue: firestore.FieldValue }),
+    auth: () => ({ verifyIdToken: async () => null }),
+    messaging: () => ({})
+  };
+  functionsStub = makeFunctionsStub();
+  StripeStub = class StripeMock {
+    constructor() {
+      return {
+        checkout: {
+          sessions: {
+            create: stripeCreateImpl
+          }
+        },
+        webhooks: {
+          constructEvent: () => {
+            throw new Error('Not implemented in test.');
+          }
+        }
+      };
+    }
+  };
+
+  const mod = require('../index.js');
+  return {
+    firestore,
+    createStripeRegistrationCheckout: mod.createStripeRegistrationCheckout
+  };
+}
+
+function buildSeedState() {
+  return {
+    'teams/team-1/registrationForms/form-1': {
+      published: true,
+      paymentSettings: { onlineCheckoutEnabled: true },
+      feeAmountCents: 5000,
+      currency: 'USD',
+      registrationOptionCounts: {
+        u10: {
+          enrolled: 0,
+          waitlisted: 0
+        }
+      }
+    },
+    'teams/team-1/registrationForms/form-1/registrations/reg-1': {
+      teamId: 'team-1',
+      formId: 'form-1',
+      status: 'pending',
+      registrationCapacityReleased: true,
+      checkoutAttemptToken: 'attempttoken12345',
+      selectedOption: {
+        id: 'u10',
+        countKey: 'u10',
+        capacityLimit: 5
+      },
+      guardian: {
+        email: 'parent@example.com'
+      }
+    }
+  };
+}
+
+const checkoutInput = {
+  teamId: 'team-1',
+  formId: 'form-1',
+  registrationId: 'reg-1',
+  checkoutAttemptToken: 'attempttoken12345',
+  retryPayment: true
+};
+
+describe('createStripeRegistrationCheckout retry capacity handling', () => {
+  beforeEach(() => {
+    delete require.cache[repoIndexPath];
+    Module._load = patchedModuleLoad;
+    adminStub = null;
+    functionsStub = null;
+    StripeStub = null;
+  });
+
+  it('rolls back reserved capacity when Stripe checkout creation fails', async () => {
+    const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
+      seed: buildSeedState(),
+      stripeCreateImpl: async () => {
+        throw new Error('Stripe checkout creation failed.');
+      }
+    });
+
+    await assert.rejects(
+      () => createStripeRegistrationCheckout(checkoutInput),
+      /Stripe checkout creation failed\./
+    );
+
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
+
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 0);
+    assert.equal(registration.registrationCapacityReleased, true);
+    assert.equal(registration.capacityReleasedAt, 'SERVER_TIMESTAMP');
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'checkoutStatus'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'paymentStatus'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'checkoutUrl'), false);
+  });
+
+  it('reserves capacity exactly once after a failed retry is retried successfully', async () => {
+    const stripeCreateImpl = async () => ({
+      id: 'cs_test_123',
+      url: 'https://checkout.stripe.com/c/session_123',
+      payment_status: 'unpaid'
+    });
+    const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
+      seed: buildSeedState(),
+      stripeCreateImpl: async () => {
+        throw new Error('Stripe checkout creation failed.');
+      }
+    });
+
+    await assert.rejects(
+      () => createStripeRegistrationCheckout(checkoutInput),
+      /Stripe checkout creation failed\./
+    );
+
+    delete require.cache[repoIndexPath];
+    adminStub = {
+      apps: [true],
+      initializeApp: () => {},
+      firestore: Object.assign(() => firestore, { FieldValue: firestore.FieldValue }),
+      auth: () => ({ verifyIdToken: async () => null }),
+      messaging: () => ({})
+    };
+    functionsStub = makeFunctionsStub();
+    StripeStub = class StripeMock {
+      constructor() {
+        return {
+          checkout: {
+            sessions: {
+              create: stripeCreateImpl
+            }
+          },
+          webhooks: {
+            constructEvent: () => {
+              throw new Error('Not implemented in test.');
+            }
+          }
+        };
+      }
+    };
+
+    const mod = require('../index.js');
+    const result = await mod.createStripeRegistrationCheckout(checkoutInput);
+
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
+
+    assert.deepEqual(result, {
+      checkoutUrl: 'https://checkout.stripe.com/c/session_123',
+      sessionId: 'cs_test_123'
+    });
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
+    assert.equal(registration.registrationCapacityReleased, false);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'capacityReleasedAt'), false);
+    assert.equal(registration.checkoutStatus, 'open');
+    assert.equal(registration.paymentStatus, 'checkout_open');
+    assert.equal(registration.stripeCheckoutSessionId, 'cs_test_123');
+    assert.equal(registration.checkoutAmountCents, 5000);
+  });
+});

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -1,7 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import Module, { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const Module = require('node:module');
 
 const repoIndexPath = require.resolve('../index.js');
 const originalModuleLoad = Module._load;
@@ -11,366 +10,432 @@ let functionsStub = null;
 let StripeStub = null;
 
 function patchedModuleLoad(request, parent, isMain) {
-  if (request === 'firebase-admin' && adminStub) {
-    return adminStub;
-  }
-  if (request === 'firebase-functions' && functionsStub) {
-    return functionsStub;
-  }
-  if (request === 'stripe' && StripeStub) {
-    return StripeStub;
-  }
-  return originalModuleLoad(request, parent, isMain);
+    if (request === 'firebase-admin' && adminStub) {
+        return adminStub;
+    }
+    if (request === 'firebase-functions' && functionsStub) {
+        return functionsStub;
+    }
+    if (request === 'stripe' && StripeStub) {
+        return StripeStub;
+    }
+    return originalModuleLoad(request, parent, isMain);
 }
 
 function clone(value) {
-  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+    return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
 }
 
 function setNested(target, path, value) {
-  const parts = String(path || '').split('.').filter(Boolean);
-  let cursor = target;
-  for (let i = 0; i < parts.length - 1; i++) {
-    const key = parts[i];
-    if (!cursor[key] || typeof cursor[key] !== 'object' || Array.isArray(cursor[key])) {
-      cursor[key] = {};
+    const parts = String(path || '').split('.').filter(Boolean);
+    let cursor = target;
+    for (let i = 0; i < parts.length - 1; i++) {
+        const key = parts[i];
+        if (!cursor[key] || typeof cursor[key] !== 'object' || Array.isArray(cursor[key])) {
+            cursor[key] = {};
+        }
+        cursor = cursor[key];
     }
-    cursor = cursor[key];
-  }
-  cursor[parts[parts.length - 1]] = value;
+    cursor[parts[parts.length - 1]] = value;
 }
 
 function deleteNested(target, path) {
-  const parts = String(path || '').split('.').filter(Boolean);
-  let cursor = target;
-  for (let i = 0; i < parts.length - 1; i++) {
-    cursor = cursor?.[parts[i]];
-    if (!cursor || typeof cursor !== 'object') return;
-  }
-  if (cursor && typeof cursor === 'object') {
-    delete cursor[parts[parts.length - 1]];
-  }
+    const parts = String(path || '').split('.').filter(Boolean);
+    let cursor = target;
+    for (let i = 0; i < parts.length - 1; i++) {
+        cursor = cursor?.[parts[i]];
+        if (!cursor || typeof cursor !== 'object') return;
+    }
+    if (cursor && typeof cursor === 'object') {
+        delete cursor[parts[parts.length - 1]];
+    }
 }
 
-function makeFirestore(seed = {}) {
-  const state = new Map(Object.entries(clone(seed)));
+function makeFirestore(seed = {}, options = {}) {
+    const state = new Map(Object.entries(clone(seed)));
+    const getCounts = new Map();
 
-  const fieldValue = {
-    serverTimestamp: () => ({ __op: 'serverTimestamp' }),
-    delete: () => ({ __op: 'delete' }),
-    increment: (amount) => ({ __op: 'increment', amount }),
-    arrayUnion: (...items) => ({ __op: 'arrayUnion', items })
-  };
+    const fieldValue = {
+        serverTimestamp: () => ({ __op: 'serverTimestamp' }),
+        delete: () => ({ __op: 'delete' }),
+        increment: (amount) => ({ __op: 'increment', amount }),
+        arrayUnion: (...items) => ({ __op: 'arrayUnion', items })
+    };
 
-  const isOp = (value, kind) => value && typeof value === 'object' && value.__op === kind;
+    const isOp = (value, kind) => value && typeof value === 'object' && value.__op === kind;
 
-  function applyPatch(baseValue, patchValue, merge) {
-    const target = merge ? clone(baseValue || {}) : {};
-    Object.entries(patchValue || {}).forEach(([key, value]) => {
-      if (isOp(value, 'delete')) {
-        deleteNested(target, key);
-      } else if (isOp(value, 'serverTimestamp')) {
-        setNested(target, key, 'SERVER_TIMESTAMP');
-      } else if (isOp(value, 'increment')) {
-        const current = Number(key.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), target) || 0);
-        setNested(target, key, current + value.amount);
-      } else if (isOp(value, 'arrayUnion')) {
-        const current = key.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), target);
-        const array = Array.isArray(current) ? [...current] : [];
-        value.items.forEach((item) => array.push(clone(item)));
-        setNested(target, key, array);
-      } else {
-        setNested(target, key, clone(value));
-      }
-    });
-    return target;
-  }
+    function applyPatch(baseValue, patchValue, merge) {
+        const target = merge ? clone(baseValue || {}) : {};
+        Object.entries(patchValue || {}).forEach(([key, value]) => {
+            if (isOp(value, 'delete')) {
+                deleteNested(target, key);
+            } else if (isOp(value, 'serverTimestamp')) {
+                setNested(target, key, 'SERVER_TIMESTAMP');
+            } else if (isOp(value, 'increment')) {
+                const current = Number(key.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), target) || 0);
+                setNested(target, key, current + value.amount);
+            } else if (isOp(value, 'arrayUnion')) {
+                const current = key.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), target);
+                const array = Array.isArray(current) ? [...current] : [];
+                value.items.forEach((item) => array.push(clone(item)));
+                setNested(target, key, array);
+            } else {
+                setNested(target, key, clone(value));
+            }
+        });
+        return target;
+    }
 
-  function write(path, value, options = {}) {
-    const current = state.get(path);
-    const next = applyPatch(current, value, options.merge === true);
-    state.set(path, next);
-  }
-
-  function doc(path) {
-    return {
-      path,
-      id: String(path).split('/').pop(),
-      async get() {
-        const data = state.get(path);
-        return {
-          exists: data !== undefined,
-          id: String(path).split('/').pop(),
-          ref: this,
-          data: () => clone(data)
-        };
-      },
-      async set(value, options) {
-        write(path, value, options || {});
-      },
-      async update(value) {
+    function write(path, value, options = {}) {
         const current = state.get(path);
-        if (current === undefined) {
-          throw new Error(`Missing document for update: ${path}`);
+        const next = applyPatch(current, value, options.merge === true);
+        state.set(path, next);
+    }
+
+    function runGetHook(path, ref) {
+        const count = (getCounts.get(path) || 0) + 1;
+        getCounts.set(path, count);
+        if (typeof options.onGet === 'function') {
+            options.onGet({ path, count, state, write, ref });
         }
-        write(path, value, { merge: true });
-      },
-      collection(name) {
-        return collection(`${path}/${name}`);
-      }
-    };
-  }
+    }
 
-  function collection(path) {
+    function doc(path) {
+        return {
+            path,
+            id: String(path).split('/').pop(),
+            async get() {
+                const data = state.get(path);
+                const snapshot = {
+                    exists: data !== undefined,
+                    id: String(path).split('/').pop(),
+                    ref: this,
+                    data: () => clone(data)
+                };
+                runGetHook(path, this);
+                return snapshot;
+            },
+            async set(value, options) {
+                write(path, value, options || {});
+            },
+            async update(value) {
+                const current = state.get(path);
+                if (current === undefined) {
+                    throw new Error(`Missing document for update: ${path}`);
+                }
+                write(path, value, { merge: true });
+            },
+            collection(name) {
+                return collection(`${path}/${name}`);
+            }
+        };
+    }
+
+    function collection(path) {
+        return {
+            path,
+            doc(id) {
+                return doc(`${path}/${id}`);
+            }
+        };
+    }
+
     return {
-      path,
-      doc(id) {
-        return doc(`${path}/${id}`);
-      }
+        _state: state,
+        doc,
+        collection,
+        async runTransaction(handler) {
+            const transaction = {
+                get: (ref) => ref.get(),
+                set: (ref, value, options) => ref.set(value, options),
+                update: (ref, value) => ref.update(value)
+            };
+            return handler(transaction);
+        },
+        snapshot(path) {
+            return clone(state.get(path));
+        },
+        FieldValue: fieldValue
     };
-  }
-
-  return {
-    _state: state,
-    doc,
-    collection,
-    async runTransaction(handler) {
-      const transaction = {
-        get: (ref) => ref.get(),
-        set: (ref, value, options) => ref.set(value, options),
-        update: (ref, value) => ref.update(value)
-      };
-      return handler(transaction);
-    },
-    snapshot(path) {
-      return clone(state.get(path));
-    },
-    FieldValue: fieldValue
-  };
 }
 
 function makeFunctionsStub() {
-  class HttpsError extends Error {
-    constructor(code, message) {
-      super(message);
-      this.code = code;
+    class HttpsError extends Error {
+        constructor(code, message) {
+            super(message);
+            this.code = code;
+        }
     }
-  }
 
-  const triggerChain = {
-    onCall: (fn) => fn,
-    onRequest: (fn) => fn,
-    onCreate: (fn) => fn,
-    onUpdate: (fn) => fn,
-    onWrite: (fn) => fn,
-    onRun: (fn) => fn,
-    document() {
-      return this;
-    },
-    schedule() {
-      return this;
-    },
-    timeZone() {
-      return this;
-    }
-  };
-  triggerChain.https = triggerChain;
-  triggerChain.firestore = triggerChain;
-  triggerChain.pubsub = triggerChain;
-
-  return {
-    config: () => ({ stripe: { secret_key: 'sk_test_123', app_url: 'https://allplays.test' } }),
-    https: {
-      HttpsError,
-      onCall: (fn) => fn,
-      onRequest: (fn) => fn
-    },
-    firestore: {
-      document: () => triggerChain
-    },
-    pubsub: {
-      schedule: () => triggerChain
-    },
-    runWith: () => triggerChain,
-    logger: {
-      error: () => {},
-      warn: () => {},
-      info: () => {}
-    }
-  };
-}
-
-function loadCheckoutHandler({ seed, stripeCreateImpl }) {
-  delete require.cache[repoIndexPath];
-
-  const firestore = makeFirestore(seed);
-  adminStub = {
-    apps: [true],
-    initializeApp: () => {},
-    firestore: Object.assign(() => firestore, { FieldValue: firestore.FieldValue }),
-    auth: () => ({ verifyIdToken: async () => null }),
-    messaging: () => ({})
-  };
-  functionsStub = makeFunctionsStub();
-  StripeStub = class StripeMock {
-    constructor() {
-      return {
-        checkout: {
-          sessions: {
-            create: stripeCreateImpl
-          }
+    const triggerChain = {
+        onCall: (fn) => fn,
+        onRequest: (fn) => fn,
+        onCreate: (fn) => fn,
+        onUpdate: (fn) => fn,
+        onWrite: (fn) => fn,
+        onRun: (fn) => fn,
+        document() {
+            return this;
         },
-        webhooks: {
-          constructEvent: () => {
-            throw new Error('Not implemented in test.');
-          }
+        schedule() {
+            return this;
+        },
+        timeZone() {
+            return this;
         }
-      };
-    }
-  };
+    };
+    triggerChain.https = triggerChain;
+    triggerChain.firestore = triggerChain;
+    triggerChain.pubsub = triggerChain;
 
-  const mod = require('../index.js');
-  return {
-    firestore,
-    createStripeRegistrationCheckout: mod.createStripeRegistrationCheckout
-  };
+    return {
+        config: () => ({ stripe: { secret_key: 'sk_test_123', app_url: 'https://allplays.test' } }),
+        https: {
+            HttpsError,
+            onCall: (fn) => fn,
+            onRequest: (fn) => fn
+        },
+        firestore: {
+            document: () => triggerChain
+        },
+        pubsub: {
+            schedule: () => triggerChain
+        },
+        runWith: () => triggerChain,
+        logger: {
+            error: () => {},
+            warn: () => {},
+            info: () => {}
+        }
+    };
 }
 
-function buildSeedState() {
-  return {
-    'teams/team-1/registrationForms/form-1': {
-      published: true,
-      paymentSettings: { onlineCheckoutEnabled: true },
-      feeAmountCents: 5000,
-      currency: 'USD',
-      registrationOptionCounts: {
-        u10: {
-          enrolled: 0,
-          waitlisted: 0
+function installModuleStubs({ firestore, stripeCreateImpl }) {
+    adminStub = {
+        apps: [true],
+        initializeApp: () => {},
+        firestore: Object.assign(() => firestore, { FieldValue: firestore.FieldValue }),
+        auth: () => ({ verifyIdToken: async () => null }),
+        messaging: () => ({})
+    };
+    functionsStub = makeFunctionsStub();
+    StripeStub = class StripeMock {
+        constructor() {
+            return {
+                checkout: {
+                    sessions: {
+                        create: stripeCreateImpl
+                    }
+                },
+                webhooks: {
+                    constructEvent: () => {
+                        throw new Error('Not implemented in test.');
+                    }
+                }
+            };
         }
-      }
-    },
-    'teams/team-1/registrationForms/form-1/registrations/reg-1': {
-      teamId: 'team-1',
-      formId: 'form-1',
-      status: 'pending',
-      registrationCapacityReleased: true,
-      checkoutAttemptToken: 'attempttoken12345',
-      selectedOption: {
-        id: 'u10',
-        countKey: 'u10',
-        capacityLimit: 5
-      },
-      guardian: {
-        email: 'parent@example.com'
-      }
-    }
-  };
+    };
+}
+
+function loadCheckoutHandler({ seed, stripeCreateImpl, firestoreOptions }) {
+    delete require.cache[repoIndexPath];
+    const firestore = makeFirestore(seed, firestoreOptions);
+    installModuleStubs({ firestore, stripeCreateImpl });
+    const mod = require('../index.js');
+    return {
+        firestore,
+        createStripeRegistrationCheckout: mod.createStripeRegistrationCheckout
+    };
+}
+
+function buildSeedState(overrides = {}) {
+    return {
+        'teams/team-1/registrationForms/form-1': {
+            published: true,
+            paymentSettings: { onlineCheckoutEnabled: true },
+            feeAmountCents: 5000,
+            currency: 'USD',
+            registrationOptionCounts: {
+                u10: {
+                    enrolled: 0,
+                    waitlisted: 0
+                }
+            }
+        },
+        'teams/team-1/registrationForms/form-1/registrations/reg-1': {
+            teamId: 'team-1',
+            formId: 'form-1',
+            status: 'pending',
+            registrationCapacityReleased: true,
+            checkoutAttemptToken: 'attempttoken12345',
+            selectedOption: {
+                id: 'u10',
+                countKey: 'u10',
+                capacityLimit: 5
+            },
+            guardian: {
+                email: 'parent@example.com'
+            },
+            ...overrides
+        }
+    };
 }
 
 const checkoutInput = {
-  teamId: 'team-1',
-  formId: 'form-1',
-  registrationId: 'reg-1',
-  checkoutAttemptToken: 'attempttoken12345',
-  retryPayment: true
+    teamId: 'team-1',
+    formId: 'form-1',
+    registrationId: 'reg-1',
+    checkoutAttemptToken: 'attempttoken12345',
+    retryPayment: true
 };
 
-describe('createStripeRegistrationCheckout retry capacity handling', () => {
-  beforeEach(() => {
+test.beforeEach(() => {
     delete require.cache[repoIndexPath];
     Module._load = patchedModuleLoad;
     adminStub = null;
     functionsStub = null;
     StripeStub = null;
-  });
+});
 
-  afterEach(() => {
+test.afterEach(() => {
     delete require.cache[repoIndexPath];
     Module._load = originalModuleLoad;
     adminStub = null;
     functionsStub = null;
     StripeStub = null;
-  });
+});
 
-  it('rolls back reserved capacity when Stripe checkout creation fails', async () => {
+test('rolls back reserved capacity when Stripe checkout creation fails', async () => {
     const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
-      seed: buildSeedState(),
-      stripeCreateImpl: async () => {
-        throw new Error('Stripe checkout creation failed.');
-      }
+        seed: buildSeedState(),
+        stripeCreateImpl: async () => {
+            throw new Error('Stripe checkout creation failed.');
+        }
     });
 
-    await expect(createStripeRegistrationCheckout(checkoutInput)).rejects.toThrow('Stripe checkout creation failed.');
+    await assert.rejects(
+        createStripeRegistrationCheckout(checkoutInput),
+        /Stripe checkout creation failed\./
+    );
 
     const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
     const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
 
-    expect(form.registrationOptionCounts.u10.enrolled).toBe(0);
-    expect(registration.registrationCapacityReleased).toBe(true);
-    expect(registration.capacityReleasedAt).toBe('SERVER_TIMESTAMP');
-    expect(Object.prototype.hasOwnProperty.call(registration, 'checkoutStatus')).toBe(false);
-    expect(Object.prototype.hasOwnProperty.call(registration, 'paymentStatus')).toBe(false);
-    expect(Object.prototype.hasOwnProperty.call(registration, 'checkoutUrl')).toBe(false);
-  });
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 0);
+    assert.equal(registration.registrationCapacityReleased, true);
+    assert.equal(registration.capacityReleasedAt, 'SERVER_TIMESTAMP');
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'checkoutStatus'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'paymentStatus'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'checkoutUrl'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'retryCapacityReservationId'), false);
+});
 
-  it('reserves capacity exactly once after a failed retry is retried successfully', async () => {
-    const stripeCreateImpl = async () => ({
-      id: 'cs_test_123',
-      url: 'https://checkout.stripe.com/c/session_123',
-      payment_status: 'unpaid'
+test('does not release an overlapping retry reservation this call did not acquire', async () => {
+    const registrationPath = 'teams/team-1/registrationForms/form-1/registrations/reg-1';
+    const formPath = 'teams/team-1/registrationForms/form-1';
+    const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
+        seed: buildSeedState(),
+        firestoreOptions: {
+            onGet: ({ path, count, state }) => {
+                if (path === registrationPath && count === 1) {
+                    const registration = clone(state.get(registrationPath));
+                    registration.registrationCapacityReleased = false;
+                    registration.retryCapacityReservationId = 'existing-retry-reservation';
+                    state.set(registrationPath, registration);
+
+                    const form = clone(state.get(formPath));
+                    form.registrationOptionCounts.u10.enrolled = 1;
+                    state.set(formPath, form);
+                }
+            }
+        },
+        stripeCreateImpl: async () => {
+            throw new Error('Stripe checkout creation failed.');
+        }
+    });
+
+    await assert.rejects(
+        createStripeRegistrationCheckout(checkoutInput),
+        /Stripe checkout creation failed\./
+    );
+
+    const form = firestore.snapshot(formPath);
+    const registration = firestore.snapshot(registrationPath);
+
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
+    assert.equal(registration.registrationCapacityReleased, false);
+    assert.equal(registration.retryCapacityReservationId, 'existing-retry-reservation');
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'capacityReleasedAt'), false);
+});
+
+test('restores capacity after retrying a previously failed session when Stripe creation fails again', async () => {
+    const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
+        seed: buildSeedState({
+            checkoutStatus: 'payment_failed',
+            paymentStatus: 'payment_failed',
+            checkoutUrl: 'https://checkout.stripe.com/c/old_session',
+            paymentLink: 'https://checkout.stripe.com/c/old_session',
+            stripeCheckoutSessionId: 'cs_old_failed',
+            stripePaymentStatus: 'unpaid'
+        }),
+        stripeCreateImpl: async () => {
+            throw new Error('Stripe checkout creation failed.');
+        }
+    });
+
+    await assert.rejects(
+        createStripeRegistrationCheckout(checkoutInput),
+        /Stripe checkout creation failed\./
+    );
+
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
+
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 0);
+    assert.equal(registration.registrationCapacityReleased, true);
+    assert.equal(registration.checkoutStatus, 'payment_failed');
+    assert.equal(registration.paymentStatus, 'payment_failed');
+    assert.equal(registration.checkoutUrl, 'https://checkout.stripe.com/c/old_session');
+    assert.equal(registration.stripeCheckoutSessionId, 'cs_old_failed');
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'retryCapacityReservationId'), false);
+});
+
+test('reserves capacity exactly once after a failed retry is retried successfully', async () => {
+    const stripeCreateSuccess = async () => ({
+        id: 'cs_test_123',
+        url: 'https://checkout.stripe.com/c/session_123',
+        payment_status: 'unpaid'
     });
     const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
-      seed: buildSeedState(),
-      stripeCreateImpl: async () => {
-        throw new Error('Stripe checkout creation failed.');
-      }
+        seed: buildSeedState(),
+        stripeCreateImpl: async () => {
+            throw new Error('Stripe checkout creation failed.');
+        }
     });
 
-    await expect(createStripeRegistrationCheckout(checkoutInput)).rejects.toThrow('Stripe checkout creation failed.');
+    await assert.rejects(
+        createStripeRegistrationCheckout(checkoutInput),
+        /Stripe checkout creation failed\./
+    );
 
     delete require.cache[repoIndexPath];
-    adminStub = {
-      apps: [true],
-      initializeApp: () => {},
-      firestore: Object.assign(() => firestore, { FieldValue: firestore.FieldValue }),
-      auth: () => ({ verifyIdToken: async () => null }),
-      messaging: () => ({})
-    };
-    functionsStub = makeFunctionsStub();
-    StripeStub = class StripeMock {
-      constructor() {
-        return {
-          checkout: {
-            sessions: {
-              create: stripeCreateImpl
-            }
-          },
-          webhooks: {
-            constructEvent: () => {
-              throw new Error('Not implemented in test.');
-            }
-          }
-        };
-      }
-    };
-
+    installModuleStubs({ firestore, stripeCreateImpl: stripeCreateSuccess });
     const mod = require('../index.js');
     const result = await mod.createStripeRegistrationCheckout(checkoutInput);
 
     const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
     const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
 
-    expect(result).toEqual({
-      checkoutUrl: 'https://checkout.stripe.com/c/session_123',
-      sessionId: 'cs_test_123'
+    assert.deepEqual(result, {
+        checkoutUrl: 'https://checkout.stripe.com/c/session_123',
+        sessionId: 'cs_test_123'
     });
-    expect(form.registrationOptionCounts.u10.enrolled).toBe(1);
-    expect(registration.registrationCapacityReleased).toBe(false);
-    expect(Object.prototype.hasOwnProperty.call(registration, 'capacityReleasedAt')).toBe(false);
-    expect(registration.checkoutStatus).toBe('open');
-    expect(registration.paymentStatus).toBe('checkout_open');
-    expect(registration.stripeCheckoutSessionId).toBe('cs_test_123');
-    expect(registration.checkoutAmountCents).toBe(5000);
-  });
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
+    assert.equal(registration.registrationCapacityReleased, false);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'capacityReleasedAt'), false);
+    assert.equal(registration.checkoutStatus, 'open');
+    assert.equal(registration.paymentStatus, 'checkout_open');
+    assert.equal(registration.stripeCheckoutSessionId, 'cs_test_123');
+    assert.equal(registration.checkoutAmountCents, 5000);
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'retryCapacityReservationId'), false);
 });

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -400,6 +400,33 @@ test('restores capacity after retrying a previously failed session when Stripe c
     assert.equal(Object.prototype.hasOwnProperty.call(registration, 'retryCapacityReservationId'), false);
 });
 
+test('records and clears a retry capacity reservation id around Stripe checkout creation failures', async () => {
+    const registrationPath = 'teams/team-1/registrationForms/form-1/registrations/reg-1';
+    let firestore = null;
+    let reservedRetryCapacityReservationId = '';
+    const loaded = loadCheckoutHandler({
+        seed: buildSeedState(),
+        stripeCreateImpl: async () => {
+            const registration = firestore.snapshot(registrationPath);
+            reservedRetryCapacityReservationId = String(registration.retryCapacityReservationId || '');
+            throw new Error('Stripe checkout creation failed.');
+        }
+    });
+    firestore = loaded.firestore;
+
+    await assert.rejects(
+        loaded.createStripeRegistrationCheckout(checkoutInput),
+        /Stripe checkout creation failed\./
+    );
+
+    const registration = firestore.snapshot(registrationPath);
+
+    assert.match(reservedRetryCapacityReservationId, /^[0-9a-f-]{36}$/i);
+    assert.equal(registration.registrationCapacityReleased, true);
+    assert.equal(registration.capacityReleasedAt, 'SERVER_TIMESTAMP');
+    assert.equal(Object.prototype.hasOwnProperty.call(registration, 'retryCapacityReservationId'), false);
+});
+
 test('reserves capacity exactly once after a failed retry is retried successfully', async () => {
     const stripeCreateSuccess = async () => ({
         id: 'cs_test_123',


### PR DESCRIPTION
Closes #2312

## What changed
- wrapped registration retry Stripe Checkout session creation in a rollback guard
- if `stripe.checkout.sessions.create(...)` throws after retry capacity is re-reserved, the function now releases that reservation so Firestore returns to the pre-retry state
- added a focused function-level regression test that exercises both the failed retry path and the subsequent successful retry path against Firestore-backed state transitions

## Root Cause
The retry-payment path called `reserveRegistrationCheckoutCapacityForRetry(...)` before creating the Stripe Checkout session, but if Stripe session creation threw, there was no compensating rollback. That left `registrationOptionCounts` incremented and `registrationCapacityReleased` flipped back to `false` even though no checkout session existed.

## Prevention / Learning
When a retry flow mutates capacity, inventory, or other scarce-state counters before an external payment/session call, treat the external call as a failure boundary. Add compensating rollback around that boundary and cover the exact state transition sequence with a behavior-level regression test.

## Regression Tests
- `node --test functions/test/registration-checkout-retry-capacity.test.js`
  - verifies Stripe checkout creation failure restores released capacity and leaves checkout/payment state unset
  - verifies a later successful retry reserves capacity exactly once and opens checkout normally

## Recurrence Risk
Low. The failure path now restores Firestore state before surfacing the Stripe error, and the regression test covers both the rollback and recovery paths that previously had no behavior-level protection.