### PR TITLE
Filter media notifications by album visibility

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3260,9 +3260,20 @@ async function getUserRecordsByIds(userIds) {
   return records;
 }
 
-async function getLegacyTargetsForCategory(teamId, category, users, actorUid = null) {
+function normalizeNotificationAlbumVisibility(value) {
+  return String(value || '').trim().toLowerCase() === 'private' ? 'private' : 'team';
+}
+
+function canReceiveCategoryNotification(category, user, audienceContext = {}) {
+  if (!user?.uid || !notificationAudienceAllowsRoles(category, user.roles)) return false;
+  if (category !== 'media') return true;
+  if (normalizeNotificationAlbumVisibility(audienceContext.albumVisibility) !== 'private') return true;
+  return Array.isArray(user.roles) && user.roles.includes('staff');
+}
+
+async function getLegacyTargetsForCategory(teamId, category, users, actorUid = null, audienceContext = {}) {
   const queryTasks = users
-    .filter((user) => user?.uid && user.uid !== actorUid && notificationAudienceAllowsRoles(category, user.roles))
+    .filter((user) => user?.uid && user.uid !== actorUid && canReceiveCategoryNotification(category, user, audienceContext))
     .map(async (user) => {
       const uid = user.uid;
       const prefRef = firestore.doc(`users/${uid}/notificationPreferences/${teamId}`);
@@ -3294,14 +3305,16 @@ async function getLegacyTargetsForCategory(teamId, category, users, actorUid = n
   return targetGroups.flat();
 }
 
-async function getTargetsForCategory(teamId, category, actorUid = null) {
+async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
 
   const targetSnap = await firestore.collection(`teams/${teamId}/notificationTargets`)
     .where(`categories.${category}`, '==', true)
     .get();
   const users = await getCandidateUsersForTeam(teamId);
-  const eligibleUsers = new Map(users.filter((user) => notificationAudienceAllowsRoles(category, user.roles)).map((user) => [user.uid, user]));
+  const eligibleUsers = new Map(users
+    .filter((user) => canReceiveCategoryNotification(category, user, audienceContext))
+    .map((user) => [user.uid, user]));
   const indexedTargets = targetSnap.docs
     .map((docSnap) => {
       const data = docSnap.data() || {};
@@ -3321,12 +3334,17 @@ async function getTargetsForCategory(teamId, category, actorUid = null) {
     .filter(Boolean);
 
   const indexedUserIds = new Set(indexedTargets.map((target) => target.uid));
-  const missingUsers = users.filter((user) => user?.uid && user.uid !== actorUid && !indexedUserIds.has(user.uid));
+  const missingUsers = users.filter((user) => (
+    user?.uid
+    && user.uid !== actorUid
+    && !indexedUserIds.has(user.uid)
+    && eligibleUsers.has(user.uid)
+  ));
   if (!missingUsers.length) {
     return indexedTargets;
   }
 
-  const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid);
+  const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);
   return [...indexedTargets, ...fallbackTargets];
 }
 
@@ -3477,7 +3495,8 @@ async function sendCategoryNotification({
   body,
   actorUid = null,
   linkOverride = null,
-  excludeUids = []
+  excludeUids = [],
+  audienceContext = {}
 }) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return null;
 
@@ -3490,7 +3509,7 @@ async function sendCategoryNotification({
     }
   }
 
-  const allTargets = await getTargetsForCategory(teamId, category, actorUid);
+  const allTargets = await getTargetsForCategory(teamId, category, actorUid, audienceContext);
   const excludeSet = new Set(Array.isArray(excludeUids) ? excludeUids : []);
   const targets = excludeSet.size
     ? allTargets.filter((t) => !excludeSet.has(t.uid))

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -103,8 +103,10 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain('users/${uid}/notificationPreferences/${teamId}');
         expect(targetResolverSource).toContain('users/${uid}/notificationDevices');
         expect(targetResolverSource).toContain('if (!NOTIFICATION_CATEGORIES.includes(category)) return []');
-        expect(targetResolverSource).toContain('notificationAudienceAllowsRoles(category, user.roles)');
+        expect(targetResolverSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
+        expect(functionsSource).toContain("normalizeNotificationAlbumVisibility(audienceContext.albumVisibility) !== 'private'");
+        expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
         expect(targetResolverSource).toContain('const missingUsers = users.filter');
-        expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid)');
+        expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
     });
 });

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+function getSourceSlice(startMarker, endMarker) {
+    const start = functionsSource.indexOf(startMarker);
+    const end = functionsSource.indexOf(endMarker, start);
+    if (start === -1 || end === -1) {
+        throw new Error(`Unable to extract source between ${startMarker} and ${endMarker}`);
+    }
+    return functionsSource.slice(start, end);
+}
+
+function createFirestoreMock({ indexedTargets = [], preferences = {}, devices = {} } = {}) {
+    return {
+        collection: vi.fn((path) => {
+            if (path.startsWith('teams/') && path.endsWith('/notificationTargets')) {
+                return {
+                    where: vi.fn(() => ({
+                        get: vi.fn(async () => ({
+                            docs: indexedTargets.map((target) => ({
+                                id: `${target.uid}__${target.deviceId}`,
+                                data: () => ({ ...target })
+                            }))
+                        }))
+                    }))
+                };
+            }
+
+            if (path.startsWith('users/') && path.endsWith('/notificationDevices')) {
+                const uid = path.split('/')[1];
+                return {
+                    get: vi.fn(async () => ({
+                        docs: (devices[uid] || []).map((device) => ({
+                            id: device.deviceId,
+                            data: () => ({ token: device.token })
+                        }))
+                    }))
+                };
+            }
+
+            throw new Error(`Unexpected collection path: ${path}`);
+        }),
+        doc: vi.fn((path) => ({
+            get: vi.fn(async () => {
+                const match = path.match(/^users\/([^/]+)\/notificationPreferences\/([^/]+)$/);
+                if (!match) {
+                    throw new Error(`Unexpected doc path: ${path}`);
+                }
+                const [, uid, teamId] = match;
+                const data = preferences[uid]?.[teamId];
+                return {
+                    exists: Boolean(data),
+                    data: () => data
+                };
+            })
+        }))
+    };
+}
+
+function createHarness({ candidateUsers = [], indexedTargets = [], preferences = {}, devices = {} } = {}) {
+    const helperSource = getSourceSlice(
+        'function normalizeNotificationAlbumVisibility',
+        '\nasync function pruneInvalidTokens'
+    );
+    const firestore = createFirestoreMock({ indexedTargets, preferences, devices });
+    const getCandidateUsersForTeam = vi.fn(async () => candidateUsers);
+    const notificationAudienceAllowsRoles = vi.fn((category, roles = []) => {
+        if (category !== 'media') return false;
+        return Array.isArray(roles) && (roles.includes('parent') || roles.includes('staff'));
+    });
+
+    const factory = new Function(
+        'firestore',
+        'NOTIFICATION_CATEGORIES',
+        'notificationAudienceAllowsRoles',
+        'DEFAULT_NOTIFICATION_PREFERENCES',
+        'normalizeNotificationPreferences',
+        'getCandidateUsersForTeam',
+        `${helperSource}\nreturn { getTargetsForCategory, getLegacyTargetsForCategory, canReceiveCategoryNotification };`
+    );
+
+    const helpers = factory(
+        firestore,
+        ['media'],
+        notificationAudienceAllowsRoles,
+        { media: false },
+        (prefs) => ({ media: prefs?.media === true }),
+        getCandidateUsersForTeam
+    );
+
+    return {
+        ...helpers,
+        firestore,
+        getCandidateUsersForTeam,
+        notificationAudienceAllowsRoles
+    };
+}
+
+describe('team media notification recipients', () => {
+    it('filters private-album media recipients down to staff-only targets', async () => {
+        const harness = createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            indexedTargets: [
+                { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token' },
+                { uid: 'staff-1', deviceId: 'staff-device', token: 'staff-token' }
+            ]
+        });
+
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, { albumVisibility: 'private' });
+
+        expect(targets).toEqual([
+            {
+                uid: 'staff-1',
+                deviceId: 'staff-device',
+                token: 'staff-token',
+                teamId: 'team-1'
+            }
+        ]);
+    });
+
+    it('keeps otherwise eligible parent and staff recipients for team-visible albums', async () => {
+        const harness = createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            preferences: {
+                'parent-1': { 'team-1': { media: true } },
+                'staff-1': { 'team-1': { media: true } }
+            },
+            devices: {
+                'parent-1': [{ deviceId: 'parent-device', token: 'parent-token' }],
+                'staff-1': [{ deviceId: 'staff-device', token: 'staff-token' }]
+            }
+        });
+
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, { albumVisibility: 'team' });
+
+        expect(targets).toEqual([
+            {
+                uid: 'parent-1',
+                deviceId: 'parent-device',
+                token: 'parent-token',
+                teamId: 'team-1'
+            },
+            {
+                uid: 'staff-1',
+                deviceId: 'staff-device',
+                token: 'staff-token',
+                teamId: 'team-1'
+            }
+        ]);
+    });
+
+    it('skips fallback parent targets for private albums even when media notifications are enabled', async () => {
+        const harness = createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            preferences: {
+                'parent-1': { 'team-1': { media: true } },
+                'staff-1': { 'team-1': { media: true } }
+            },
+            devices: {
+                'parent-1': [{ deviceId: 'parent-device', token: 'parent-token' }],
+                'staff-1': [{ deviceId: 'staff-device', token: 'staff-token' }]
+            }
+        });
+
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, { albumVisibility: 'private' });
+
+        expect(targets).toEqual([
+            {
+                uid: 'staff-1',
+                deviceId: 'staff-device',
+                token: 'staff-token',
+                teamId: 'team-1'
+            }
+        ]);
+    });
+});


### PR DESCRIPTION
Closes #2301

## What changed
- threaded optional `audienceContext` through `sendCategoryNotification()` and `getTargetsForCategory()` so notification recipient resolution can apply media-specific visibility rules
- added a media recipient filter that treats private albums as staff-only while leaving team-visible albums on the normal parent+staff audience path
- constrained both indexed notification targets and legacy fallback targets with the same visibility check
- added focused unit coverage for private-album filtering and team-visible fallback behavior

## Root Cause
The shared notification recipient builder only checked category audience roles and notification preferences. It had no album visibility context, so `media` pushes could include parents for private albums as long as they had media notifications enabled.

## Prevention / Learning
When a feature has its own visibility model, pass that context into shared notification recipient helpers instead of assuming category-level audience filters are enough. Apply the same restriction to both indexed and fallback recipient paths so legacy behavior cannot bypass the newer rule.

## Regression Tests
- `npx vitest run tests/unit/team-media-notification-recipients.test.js tests/unit/notification-target-index-core.test.js tests/unit/notification-send-dedup.test.js --reporter=verbose`
- added `tests/unit/team-media-notification-recipients.test.js` to verify private albums only keep staff targets and team-visible albums still include eligible parents
- updated `tests/unit/notification-target-index-core.test.js` to lock in the new visibility-aware recipient filtering path