### PR TITLE
Add 500-recipient category notification coverage

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3631,6 +3631,11 @@ async function sendDirectTargetsNotification({ targets, category, title, body, t
   };
 }
 
+exports._internal = {
+  getTargetsForCategory,
+  sendCategoryNotification
+};
+
 exports.markNotificationInboxItemRead = functions.https.onCall(async (data, context) => {
   if (!context.auth?.uid) {
     throw new functions.https.HttpsError('unauthenticated', 'Sign in before updating notification inbox items.');

--- a/functions/test/send-category-notification-load.test.js
+++ b/functions/test/send-category-notification-load.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { createRequire } from 'node:module';
-import { describe, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const { loadNotificationInternals } = require('./send-category-notification-test-helpers');

--- a/functions/test/send-category-notification-load.test.js
+++ b/functions/test/send-category-notification-load.test.js
@@ -1,6 +1,8 @@
-const assert = require('node:assert/strict');
-const test = require('node:test');
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { describe, it } from 'vitest';
 
+const require = createRequire(import.meta.url);
 const { loadNotificationInternals } = require('./send-category-notification-test-helpers');
 
 function buildLargeFixture({ recipients = 500, devicesPerRecipient = 1 }) {
@@ -27,58 +29,60 @@ function buildLargeFixture({ recipients = 500, devicesPerRecipient = 1 }) {
     };
 }
 
-test('sendCategoryNotification handles a 500-recipient indexed send without legacy per-user scans', async () => {
-    const { internals, env, cleanup } = loadNotificationInternals(buildLargeFixture({
-        recipients: 500,
-        devicesPerRecipient: 1
-    }));
+describe('sendCategoryNotification load coverage', () => {
+    it('handles a 500-recipient indexed send without legacy per-user scans', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals(buildLargeFixture({
+            recipients: 500,
+            devicesPerRecipient: 1
+        }));
 
-    try {
-        const result = await internals.sendCategoryNotification({
-            teamId: 'team-1',
-            category: 'schedule',
-            title: 'Schedule updated',
-            body: 'The bus leaves at 5:30.'
-        });
+        try {
+            const result = await internals.sendCategoryNotification({
+                teamId: 'team-1',
+                category: 'schedule',
+                title: 'Schedule updated',
+                body: 'The bus leaves at 5:30.'
+            });
 
-        assert.equal(result.successCount, 500);
-        assert.equal(result.failureCount, 0);
-        assert.equal(env.counts.targetQueries, 1);
-        assert.equal(env.counts.parentQueries, 1);
-        assert.equal(env.counts.preferenceGets, 0);
-        assert.equal(env.counts.deviceGets, 0);
-        assert.equal(env.messagingCalls.length, 1);
-        assert.equal(env.messagingCalls[0].tokens.length, 500);
-        assert.equal(env.inboxWrites.length, 500);
-    } finally {
-        cleanup();
-    }
-});
+            assert.equal(result.successCount, 500);
+            assert.equal(result.failureCount, 0);
+            assert.equal(env.counts.targetQueries, 1);
+            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.preferenceGets, 0);
+            assert.equal(env.counts.deviceGets, 0);
+            assert.equal(env.messagingCalls.length, 1);
+            assert.equal(env.messagingCalls[0].tokens.length, 500);
+            assert.equal(env.inboxWrites.length, 500);
+        } finally {
+            cleanup();
+        }
+    });
 
-test('sendCategoryNotification preserves 500-token FCM chunking for large indexed sends', async () => {
-    const { internals, env, cleanup } = loadNotificationInternals(buildLargeFixture({
-        recipients: 500,
-        devicesPerRecipient: 2
-    }));
+    it('preserves 500-token FCM chunking for large indexed sends', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals(buildLargeFixture({
+            recipients: 500,
+            devicesPerRecipient: 2
+        }));
 
-    try {
-        const result = await internals.sendCategoryNotification({
-            teamId: 'team-1',
-            category: 'schedule',
-            title: 'Schedule updated',
-            body: 'Two buses this time.'
-        });
+        try {
+            const result = await internals.sendCategoryNotification({
+                teamId: 'team-1',
+                category: 'schedule',
+                title: 'Schedule updated',
+                body: 'Two buses this time.'
+            });
 
-        assert.equal(result.successCount, 1000);
-        assert.equal(result.failureCount, 0);
-        assert.equal(env.counts.targetQueries, 1);
-        assert.equal(env.counts.parentQueries, 1);
-        assert.equal(env.counts.preferenceGets, 0);
-        assert.equal(env.counts.deviceGets, 0);
-        assert.equal(env.messagingCalls.length, 2);
-        assert.deepEqual(env.messagingCalls.map((call) => call.tokens.length), [500, 500]);
-        assert.equal(env.inboxWrites.length, 500);
-    } finally {
-        cleanup();
-    }
+            assert.equal(result.successCount, 1000);
+            assert.equal(result.failureCount, 0);
+            assert.equal(env.counts.targetQueries, 1);
+            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.preferenceGets, 0);
+            assert.equal(env.counts.deviceGets, 0);
+            assert.equal(env.messagingCalls.length, 2);
+            assert.deepEqual(env.messagingCalls.map((call) => call.tokens.length), [500, 500]);
+            assert.equal(env.inboxWrites.length, 500);
+        } finally {
+            cleanup();
+        }
+    });
 });

--- a/functions/test/send-category-notification-load.test.js
+++ b/functions/test/send-category-notification-load.test.js
@@ -1,249 +1,84 @@
-'use strict';
-
-/**
- * Load-oriented tests for sendCategoryNotification.
- *
- * Exercises the 500-recipient / 500-token-per-chunk FCM chunking path
- * using in-memory stubs so no Firebase connection is needed.
- */
-
-const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const test = require('node:test');
 
-// Re-use the already-loaded module from the stub setup in the sibling test.
-// If this file runs standalone we need to re-apply the stubs.
-function getHelpers() {
-    // Re-use cached module if already loaded
-    const cached = require.cache[require.resolve('../index.js')];
-    if (cached) {
-        return cached.exports._internal;
-    }
+const { loadNotificationInternals } = require('./send-category-notification-test-helpers');
 
-    // Provide minimal stubs so the module loads without Firebase
-    require.cache[require.resolve('firebase-functions')] = {
-        id: 'firebase-functions',
-        filename: require.resolve('firebase-functions'),
-        loaded: true,
-        exports: {
-            config: () => ({}),
-            runWith: () => ({ https: { onRequest: () => {} } }),
-            https: { onRequest: () => {} }
-        }
-    };
-
-    const adminStub = {
-        apps: [true],
-        initializeApp: () => {},
-        firestore: Object.assign(() => ({}), {
-            FieldValue: {
-                serverTimestamp: () => 'SERVERTIMESTAMP',
-                increment: (n) => ({ _inc: n })
-            }
-        }),
-        auth: () => ({ verifyIdToken: () => Promise.resolve(null) }),
-        messaging: () => ({})
-    };
-    require.cache[require.resolve('firebase-admin')] = {
-        id: 'firebase-admin',
-        filename: require.resolve('firebase-admin'),
-        loaded: true,
-        exports: adminStub
-    };
-
-    return require('../index.js')._internal;
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Build a fake Firestore QuerySnapshot.
- */
-function makeSnap(docs) {
-    return {
-        empty: docs.length === 0,
-        docs: docs.map((data, i) => ({ id: `doc-${i}`, data: () => data }))
-    };
-}
-
-/**
- * Build a Firestore stub that returns snapshot docs by collection name.
- */
-function makeDb(collectionSnaps) {
-    function makeCollRef(name) {
-        const docs = collectionSnaps[name] || [];
-        return {
-            where() { return this; },
-            get() { return Promise.resolve(makeSnap(docs)); },
-            doc() {
-                return {
-                    collection(subName) { return makeCollRef(subName); },
-                    set() { return Promise.resolve(); }
-                };
-            }
-        };
-    }
-
-    return {
-        collection(name) { return makeCollRef(name); },
-        batch() {
-            return {
-                set() {},
-                commit() { return Promise.resolve(); }
-            };
-        }
-    };
-}
-
-function makeMessaging() {
-    const calls = [];
-    return {
-        calls,
-        sendEachForMulticast(message) {
-            calls.push(message.tokens.length);
-            return Promise.resolve({
-                successCount: message.tokens.length,
-                failureCount: 0
+function buildLargeFixture({ recipients = 500, devicesPerRecipient = 1 }) {
+    const indexedTargets = [];
+    for (let recipientIndex = 0; recipientIndex < recipients; recipientIndex += 1) {
+        const uid = `user-${recipientIndex}`;
+        for (let deviceIndex = 0; deviceIndex < devicesPerRecipient; deviceIndex += 1) {
+            indexedTargets.push({
+                uid,
+                deviceId: `device-${deviceIndex}`,
+                token: `token-${recipientIndex}-${deviceIndex}`,
+                categories: { schedule: true }
             });
         }
+    }
+
+    return {
+        teamDoc: {
+            ownerId: 'user-0',
+            adminEmails: []
+        },
+        parentUserIds: Array.from({ length: recipients - 1 }, (_, index) => `user-${index + 1}`),
+        indexedTargets
     };
 }
 
-// ---------------------------------------------------------------------------
-// 500-recipient fixture
-// ---------------------------------------------------------------------------
+test('sendCategoryNotification handles a 500-recipient indexed send without legacy per-user scans', async () => {
+    const { internals, env, cleanup } = loadNotificationInternals(buildLargeFixture({
+        recipients: 500,
+        devicesPerRecipient: 1
+    }));
 
-describe('500-recipient load fixture', () => {
-    const helpers = getHelpers();
+    try {
+        const result = await internals.sendCategoryNotification({
+            teamId: 'team-1',
+            category: 'schedule',
+            title: 'Schedule updated',
+            body: 'The bus leaves at 5:30.'
+        });
 
-    it('resolves all 500 recipients from the index in a single Firestore query', async () => {
-        const recipientDocs = Array.from({ length: 500 }, (_, i) => ({
-            uid: `user-${i}`,
-            fcmTokens: [`token-${i}`],
-            categories: { schedule: true }
-        }));
-
-        const db = makeDb({ notificationRecipients: recipientDocs });
-        const tokens = await helpers.resolveTokensFromIndex(db, 'big-team', 'schedule');
-        assert.equal(tokens.length, 500);
-    });
-
-    it('sends 500 tokens in exactly 1 FCM multicast call', async () => {
-        const tokens = Array.from({ length: 500 }, (_, i) => `token-${i}`);
-        const messaging = makeMessaging();
-        const result = await helpers.sendInChunks(messaging, tokens, { title: 'Game update', body: 'See you there!' });
-
-        assert.equal(messaging.calls.length, 1, 'Should use exactly 1 FCM call for 500 tokens');
-        assert.equal(messaging.calls[0], 500);
         assert.equal(result.successCount, 500);
         assert.equal(result.failureCount, 0);
-    });
-
-    it('sends 500 recipients each with 1 token using 1 FCM multicast call', async () => {
-        const recipientDocs = Array.from({ length: 500 }, (_, i) => ({
-            uid: `user-${i}`,
-            fcmTokens: [`token-${i}`],
-            categories: { schedule: true }
-        }));
-
-        const db = makeDb({ notificationRecipients: recipientDocs });
-        const messaging = makeMessaging();
-
-        // Resolve from index
-        const tokens = await helpers.resolveTokensFromIndex(db, 'big-team', 'schedule');
-        assert.equal(tokens.length, 500);
-
-        // Send
-        const result = await helpers.sendInChunks(messaging, tokens, { title: 'Update', body: 'Hi' });
-
-        assert.equal(messaging.calls.length, 1, 'All 500 tokens should fit in one FCM multicast call');
-        assert.equal(result.successCount, 500);
-        assert.equal(result.failureCount, 0);
-    });
-
-    it('correctly chunks when 500 recipients each have 2 tokens (1000 total tokens -> 2 FCM calls)', async () => {
-        const recipientDocs = Array.from({ length: 500 }, (_, i) => ({
-            uid: `user-${i}`,
-            fcmTokens: [`token-${i}-a`, `token-${i}-b`],
-            categories: { schedule: true }
-        }));
-
-        const db = makeDb({ notificationRecipients: recipientDocs });
-        const messaging = makeMessaging();
-
-        const tokens = await helpers.resolveTokensFromIndex(db, 'big-team', 'schedule');
-        assert.equal(tokens.length, 1000);
-
-        const result = await helpers.sendInChunks(messaging, tokens, { title: 'Update', body: 'Hi' });
-
-        assert.equal(messaging.calls.length, 2, '1000 tokens should split into 2 FCM calls of 500 each');
-        assert.equal(messaging.calls[0], 500);
-        assert.equal(messaging.calls[1], 500);
-        assert.equal(result.successCount, 1000);
-    });
-
-    it('legacy fallback with 500 users triggers backfill and collects all tokens', async () => {
-        const userDocs = Array.from({ length: 500 }, (_, i) => ({
-            fcmTokens: [`token-${i}`],
-            notificationPreferences: { fees: true },
-            teamIds: ['big-team']
-        }));
-
-        const db = makeDb({ users: userDocs });
-        const recipients = await helpers.resolveRecipientsLegacy(db, 'big-team', 'fees');
-
-        assert.equal(recipients.length, 500);
-        const allTokens = recipients.flatMap((r) => r.fcmTokens);
-        assert.equal(allTokens.length, 500);
-    });
+        assert.equal(env.counts.targetQueries, 1);
+        assert.equal(env.counts.parentQueries, 1);
+        assert.equal(env.counts.preferenceGets, 0);
+        assert.equal(env.counts.deviceGets, 0);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].tokens.length, 500);
+        assert.equal(env.inboxWrites.length, 500);
+    } finally {
+        cleanup();
+    }
 });
 
-// ---------------------------------------------------------------------------
-// Index vs. legacy path routing
-// ---------------------------------------------------------------------------
+test('sendCategoryNotification preserves 500-token FCM chunking for large indexed sends', async () => {
+    const { internals, env, cleanup } = loadNotificationInternals(buildLargeFixture({
+        recipients: 500,
+        devicesPerRecipient: 2
+    }));
 
-describe('recipient source routing', () => {
-    const helpers = getHelpers();
+    try {
+        const result = await internals.sendCategoryNotification({
+            teamId: 'team-1',
+            category: 'schedule',
+            title: 'Schedule updated',
+            body: 'Two buses this time.'
+        });
 
-    it('uses the index path when notificationRecipients is populated', async () => {
-        const tokens = await helpers.resolveTokensFromIndex(
-            makeDb({ notificationRecipients: [{ uid: 'u1', fcmTokens: ['t1'], categories: { schedule: true } }] }),
-            'team-1',
-            'schedule'
-        );
-        assert.equal(tokens.length, 1);
-    });
-
-    it('returns empty from index when notificationRecipients is empty', async () => {
-        const tokens = await helpers.resolveTokensFromIndex(
-            makeDb({ notificationRecipients: [] }),
-            'team-1',
-            'schedule'
-        );
-        assert.equal(tokens.length, 0);
-    });
-
-    it('legacy returns same token set as index for equivalent fixture data', async () => {
-        const fixture = [
-            { uid: 'u1', fcmTokens: ['tok-A'], categories: { schedule: true }, notificationPreferences: { schedule: true }, teamIds: ['t1'] },
-            { uid: 'u2', fcmTokens: ['tok-B'], categories: { schedule: true }, notificationPreferences: { schedule: true }, teamIds: ['t1'] }
-        ];
-
-        const indexTokens = await helpers.resolveTokensFromIndex(
-            makeDb({ notificationRecipients: fixture }),
-            't1',
-            'schedule'
-        );
-
-        const legacyRecipients = await helpers.resolveRecipientsLegacy(
-            makeDb({ users: fixture }),
-            't1',
-            'schedule'
-        );
-        const legacyTokens = legacyRecipients.flatMap((r) => r.fcmTokens);
-
-        assert.deepEqual(indexTokens.sort(), legacyTokens.sort(),
-            'Index and legacy paths should resolve the same set of tokens for a consistent fixture');
-    });
+        assert.equal(result.successCount, 1000);
+        assert.equal(result.failureCount, 0);
+        assert.equal(env.counts.targetQueries, 1);
+        assert.equal(env.counts.parentQueries, 1);
+        assert.equal(env.counts.preferenceGets, 0);
+        assert.equal(env.counts.deviceGets, 0);
+        assert.equal(env.messagingCalls.length, 2);
+        assert.deepEqual(env.messagingCalls.map((call) => call.tokens.length), [500, 500]);
+        assert.equal(env.inboxWrites.length, 500);
+    } finally {
+        cleanup();
+    }
 });

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -1,0 +1,372 @@
+const Module = require('node:module');
+
+const repoIndexPath = require.resolve('../index.js');
+const originalModuleLoad = Module._load;
+
+function makeFunctionsStub() {
+    class HttpsError extends Error {
+        constructor(code, message) {
+            super(message);
+            this.code = code;
+        }
+    }
+
+    const triggerChain = {
+        onCall: (fn) => fn,
+        onRequest: (fn) => fn,
+        onCreate: (fn) => fn,
+        onUpdate: (fn) => fn,
+        onWrite: (fn) => fn,
+        onDelete: (fn) => fn,
+        onRun: (fn) => fn,
+        onFinalize: (fn) => fn,
+        document() {
+            return this;
+        },
+        schedule() {
+            return this;
+        },
+        timeZone() {
+            return this;
+        },
+        region() {
+            return this;
+        },
+        object() {
+            return this;
+        }
+    };
+    triggerChain.https = triggerChain;
+    triggerChain.firestore = triggerChain;
+    triggerChain.pubsub = triggerChain;
+    triggerChain.storage = triggerChain;
+
+    return {
+        config: () => ({}),
+        https: {
+            HttpsError,
+            onCall: (fn) => fn,
+            onRequest: (fn) => fn
+        },
+        firestore: {
+            document: () => triggerChain
+        },
+        pubsub: {
+            schedule: () => triggerChain
+        },
+        storage: {
+            object: () => triggerChain
+        },
+        runWith: () => triggerChain,
+        region: () => triggerChain,
+        logger: {
+            info: () => {},
+            warn: () => {},
+            error: () => {}
+        }
+    };
+}
+
+function makeDocSnapshot({ id, ref, data, exists = true }) {
+    return {
+        id,
+        ref,
+        exists,
+        data: () => (data == null ? data : JSON.parse(JSON.stringify(data)))
+    };
+}
+
+function makeQuerySnapshot(docSnaps) {
+    return {
+        empty: docSnaps.length === 0,
+        docs: docSnaps,
+        forEach(callback) {
+            docSnaps.forEach(callback);
+        }
+    };
+}
+
+function buildNotificationTestEnv({
+    teamId = 'team-1',
+    teamDoc = {},
+    parentUserIds = [],
+    indexedTargets = [],
+    preferenceDocs = {},
+    deviceDocs = {},
+    invalidTokenResponses = []
+} = {}) {
+    const dedupWrites = [];
+    const inboxWrites = [];
+    const deletedPaths = [];
+    const messagingCalls = [];
+    const counts = {
+        teamDocGets: 0,
+        parentQueries: 0,
+        targetQueries: 0,
+        preferenceGets: 0,
+        deviceGets: 0,
+        inboxAdds: 0,
+        inboxCleanupQueries: 0,
+        dedupTransactions: 0,
+        deleteCalls: 0
+    };
+
+    const notificationTargetDocs = indexedTargets.map((target, index) => ({
+        id: `${target.uid || `user-${index}`}__${target.deviceId || `device-${index}`}`,
+        data: {
+            uid: target.uid,
+            deviceId: target.deviceId,
+            token: target.token,
+            categories: target.categories || {}
+        }
+    }));
+
+    function doc(path) {
+        return {
+            path,
+            id: String(path).split('/').pop(),
+            async get() {
+                if (path === `teams/${teamId}`) {
+                    counts.teamDocGets += 1;
+                    return makeDocSnapshot({ id: teamId, ref: this, data: teamDoc, exists: true });
+                }
+                if (path.startsWith('users/') && path.includes('/notificationPreferences/')) {
+                    counts.preferenceGets += 1;
+                    const data = preferenceDocs[path];
+                    return makeDocSnapshot({
+                        id: String(path).split('/').pop(),
+                        ref: this,
+                        data,
+                        exists: data !== undefined
+                    });
+                }
+                if (path.startsWith(`teams/${teamId}/notificationSendLog/`)) {
+                    return makeDocSnapshot({ id: this.id, ref: this, data: undefined, exists: false });
+                }
+                return makeDocSnapshot({ id: this.id, ref: this, data: undefined, exists: false });
+            },
+            async set(value) {
+                dedupWrites.push({ path, value });
+            },
+            async delete() {
+                counts.deleteCalls += 1;
+                deletedPaths.push(path);
+            },
+            collection(name) {
+                return collection(`${path}/${name}`);
+            }
+        };
+    }
+
+    function collection(path) {
+        if (path === 'users') {
+            return {
+                where(field, op, value) {
+                    return {
+                        async get() {
+                            counts.parentQueries += 1;
+                            if (field !== 'parentTeamIds' || op !== 'array-contains' || value !== teamId) {
+                                return makeQuerySnapshot([]);
+                            }
+                            return makeQuerySnapshot(parentUserIds.map((uid) => makeDocSnapshot({
+                                id: uid,
+                                ref: doc(`users/${uid}`),
+                                data: { parentTeamIds: [teamId] },
+                                exists: true
+                            })));
+                        }
+                    };
+                }
+            };
+        }
+
+        if (path === `teams/${teamId}/notificationTargets`) {
+            return {
+                where(field, op, value) {
+                    return {
+                        async get() {
+                            counts.targetQueries += 1;
+                            const category = String(field || '').replace(/^categories\./, '');
+                            const docs = notificationTargetDocs.filter((entry) => op === '==' && value === true && entry.data.categories?.[category] === true)
+                                .map((entry) => makeDocSnapshot({
+                                    id: entry.id,
+                                    ref: doc(`${path}/${entry.id}`),
+                                    data: entry.data,
+                                    exists: true
+                                }));
+                            return makeQuerySnapshot(docs);
+                        }
+                    };
+                }
+            };
+        }
+
+        const inboxMatch = path.match(/^users\/([^/]+)\/notificationInbox$/);
+        if (inboxMatch) {
+            return {
+                async add(value) {
+                    counts.inboxAdds += 1;
+                    inboxWrites.push({ uid: inboxMatch[1], value });
+                    return { id: `inbox-${inboxWrites.length}` };
+                },
+                orderBy() {
+                    return {
+                        offset() {
+                            return {
+                                async get() {
+                                    counts.inboxCleanupQueries += 1;
+                                    return makeQuerySnapshot([]);
+                                }
+                            };
+                        }
+                    };
+                }
+            };
+        }
+
+        const deviceMatch = path.match(/^users\/([^/]+)\/notificationDevices$/);
+        if (deviceMatch) {
+            const uid = deviceMatch[1];
+            return {
+                async get() {
+                    counts.deviceGets += 1;
+                    const docs = (deviceDocs[uid] || []).map((entry, index) => makeDocSnapshot({
+                        id: entry.id || `device-${index}`,
+                        ref: doc(`${path}/${entry.id || `device-${index}`}`),
+                        data: { token: entry.token },
+                        exists: true
+                    }));
+                    return makeQuerySnapshot(docs);
+                }
+            };
+        }
+
+        return {
+            async add() {
+                return { id: 'noop' };
+            },
+            where() {
+                return { get: async () => makeQuerySnapshot([]) };
+            },
+            orderBy() {
+                return {
+                    offset() {
+                        return { get: async () => makeQuerySnapshot([]) };
+                    }
+                };
+            },
+            doc(id) {
+                return doc(`${path}/${id}`);
+            }
+        };
+    }
+
+    const firestoreState = {
+        doc,
+        collection,
+        async runTransaction(handler) {
+            counts.dedupTransactions += 1;
+            return handler({
+                get: (ref) => ref.get(),
+                set: (ref, value) => ref.set(value)
+            });
+        },
+        batch() {
+            return {
+                set() {},
+                delete() {},
+                update() {},
+                async commit() {}
+            };
+        }
+    };
+
+    const firestoreFactory = Object.assign(() => firestoreState, {
+        FieldValue: {
+            serverTimestamp: () => ({ __serverTimestamp: true }),
+            increment: (amount) => ({ __increment: amount })
+        }
+    });
+
+    const adminStub = {
+        apps: [true],
+        initializeApp: () => {},
+        firestore: firestoreFactory,
+        auth: () => ({
+            verifyIdToken: async () => null,
+            getUserByEmail: async () => ({ uid: '' })
+        }),
+        messaging: () => ({
+            async sendEachForMulticast(message) {
+                messagingCalls.push({
+                    tokens: [...message.tokens],
+                    title: message.notification?.title || '',
+                    body: message.notification?.body || ''
+                });
+                const responses = message.tokens.map((token, index) => invalidTokenResponses[index] || { success: true, token });
+                const failureCount = responses.filter((response) => response?.success === false).length;
+                return {
+                    responses,
+                    successCount: responses.length - failureCount,
+                    failureCount
+                };
+            }
+        }),
+        storage: () => ({
+            bucket: () => ({
+                file: () => ({})
+            })
+        })
+    };
+
+    const stripeStub = class StripeStub {
+        constructor() {
+            return {};
+        }
+    };
+
+    return {
+        counts,
+        dedupWrites,
+        deletedPaths,
+        inboxWrites,
+        messagingCalls,
+        adminStub,
+        firestoreState,
+        functionsStub: makeFunctionsStub(),
+        stripeStub
+    };
+}
+
+function loadNotificationInternals(options = {}) {
+    const env = buildNotificationTestEnv(options);
+
+    Module._load = function patchedModuleLoad(request, parent, isMain) {
+        if (request === 'firebase-admin') {
+            return env.adminStub;
+        }
+        if (request === 'firebase-functions') {
+            return env.functionsStub;
+        }
+        if (request === 'stripe') {
+            return env.stripeStub;
+        }
+        return originalModuleLoad(request, parent, isMain);
+    };
+
+    delete require.cache[repoIndexPath];
+    const internals = require(repoIndexPath)._internal;
+
+    return {
+        env,
+        internals,
+        cleanup() {
+            delete require.cache[repoIndexPath];
+            Module._load = originalModuleLoad;
+        }
+    };
+}
+
+module.exports = {
+    loadNotificationInternals
+};

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
 import { createRequire } from 'node:module';
-import { describe, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const { loadNotificationInternals } = require('./send-category-notification-test-helpers');

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -1,326 +1,86 @@
-'use strict';
-
-/**
- * Unit tests for sendCategoryNotification and its internal helpers.
- *
- * We exercise the module without a live Firebase instance by injecting stub
- * db/messaging objects and verifying the call-routing and return values.
- */
-
-const { describe, it, before, beforeEach } = require('node:test');
 const assert = require('node:assert/strict');
+const test = require('node:test');
 
-// ---------------------------------------------------------------------------
-// Minimal Firestore query stub helpers
-// ---------------------------------------------------------------------------
+const { loadNotificationInternals } = require('./send-category-notification-test-helpers');
 
-/**
- * Build a fake Firestore QuerySnapshot.
- * @param {object[]} docs  array of plain data objects
- */
-function makeSnap(docs) {
-    const docsList = docs.map((data, i) => ({
-        id: `doc-${i}`,
-        data: () => data
-    }));
-    return {
-        empty: docsList.length === 0,
-        docs: docsList
-    };
-}
-
-/**
- * Build a fake Firestore collection chain that returns a fixed snapshot.
- *
- * The chain understands: .collection().doc().collection().where().get()
- *
- * @param {Map<string, object[]>} snapshotsByPath
- *   key = "<collectionPath>" (simplified — just the last collection name used),
- *   value = array of doc data objects
- */
-function makeDb(collectionSnaps) {
-    // collectionSnaps: { 'notificationRecipients': [...docs], 'users': [...docs] }
-    function makeQuery(docs) {
-        return {
-            where() { return this; },
-            get() { return Promise.resolve(makeSnap(docs)); }
-        };
-    }
-
-    function makeCollRef(name) {
-        const docs = collectionSnaps[name] || [];
-        return {
-            where() { return makeQuery(docs); },
-            get() { return Promise.resolve(makeSnap(docs)); },
-            doc() {
-                return {
-                    collection(subName) { return makeCollRef(subName); },
-                    set() { return Promise.resolve(); }
-                };
-            }
-        };
-    }
-
-    const batchCommitSpy = { count: 0 };
-    function makeBatch() {
-        const ops = [];
-        return {
-            set(ref, data, opts) { ops.push({ ref, data, opts }); },
-            commit() {
-                batchCommitSpy.count++;
-                return Promise.resolve();
+test('getTargetsForCategory uses indexed targets without legacy per-user device scans when index coverage is complete', async () => {
+    const { internals, env, cleanup } = loadNotificationInternals({
+        teamDoc: {
+            ownerId: 'coach-1',
+            adminEmails: []
+        },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            {
+                uid: 'coach-1',
+                deviceId: 'coach-device',
+                token: 'coach-token',
+                categories: { schedule: true }
             },
-            _ops: ops
-        };
+            {
+                uid: 'parent-1',
+                deviceId: 'parent-device',
+                token: 'parent-token',
+                categories: { schedule: true }
+            }
+        ]
+    });
+
+    try {
+        const targets = await internals.getTargetsForCategory('team-1', 'schedule');
+
+        assert.equal(targets.length, 2);
+        assert.equal(env.counts.targetQueries, 1);
+        assert.equal(env.counts.parentQueries, 1);
+        assert.equal(env.counts.preferenceGets, 0);
+        assert.equal(env.counts.deviceGets, 0);
+        assert.deepEqual(
+            targets.map((target) => target.token).sort(),
+            ['coach-token', 'parent-token']
+        );
+    } finally {
+        cleanup();
     }
+});
 
-    return {
-        collection(name) { return makeCollRef(name); },
-        batch() { return makeBatch(); },
-        _batchCommitSpy: batchCommitSpy
-    };
-}
-
-/**
- * Build a fake messaging object that records multicast calls.
- * Each call resolves with { successCount, failureCount }.
- */
-function makeMessaging(successPerChunk) {
-    const calls = [];
-    return {
-        calls,
-        sendEachForMulticast(message) {
-            calls.push({ tokens: [...message.tokens] });
-            return Promise.resolve({
-                successCount: successPerChunk !== undefined ? successPerChunk : message.tokens.length,
-                failureCount: 0
-            });
-        }
-    };
-}
-
-// ---------------------------------------------------------------------------
-// Pull the internal helpers out of the module under test
-// ---------------------------------------------------------------------------
-
-// functions/index.js uses `admin` at module-level, so we can't simply
-// require() it without a Firebase app.  Instead we extract the internal
-// helpers that are exported via exports._internal, by providing a minimal
-// shim for `firebase-admin` and `firebase-functions`.
-let helpers;
-before(() => {
-    // Provide stubs so the module can be loaded without a real Firebase env.
-    require.cache[require.resolve('firebase-functions')] = {
-        id: 'firebase-functions',
-        filename: require.resolve('firebase-functions'),
-        loaded: true,
-        exports: {
-            config: () => ({}),
-            runWith: () => ({ https: { onRequest: () => {} } }),
-            https: { onRequest: () => {} }
-        }
-    };
-
-    const adminStub = {
-        apps: [true], // pretend already initialized so initializeApp is skipped
-        initializeApp: () => {},
-        firestore: Object.assign(() => ({}), {
-            FieldValue: {
-                serverTimestamp: () => 'SERVERTIMESTAMP',
-                increment: (n) => ({ _inc: n })
+test('getTargetsForCategory falls back only for users missing from the notification target index', async () => {
+    const { internals, env, cleanup } = loadNotificationInternals({
+        teamDoc: {
+            ownerId: 'coach-1',
+            adminEmails: []
+        },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            {
+                uid: 'coach-1',
+                deviceId: 'coach-device',
+                token: 'coach-token',
+                categories: { schedule: true }
             }
-        }),
-        auth: () => ({ verifyIdToken: () => Promise.resolve(null) }),
-        messaging: () => ({})
-    };
-    require.cache[require.resolve('firebase-admin')] = {
-        id: 'firebase-admin',
-        filename: require.resolve('firebase-admin'),
-        loaded: true,
-        exports: adminStub
-    };
-
-    // Now we can require the module
-    const mod = require('../index.js');
-    helpers = mod._internal;
-    assert.ok(helpers, 'exports._internal must be present');
-});
-
-// ---------------------------------------------------------------------------
-// resolveTokensFromIndex
-// ---------------------------------------------------------------------------
-
-describe('resolveTokensFromIndex', () => {
-    it('returns tokens from index docs that have the category enabled', async () => {
-        const db = makeDb({
-            notificationRecipients: [
-                { uid: 'u1', fcmTokens: ['tok-a', 'tok-b'], categories: { schedule: true } },
-                { uid: 'u2', fcmTokens: ['tok-c'], categories: { schedule: true } }
+        ],
+        preferenceDocs: {
+            'users/parent-1/notificationPreferences/team-1': { schedule: true }
+        },
+        deviceDocs: {
+            'parent-1': [
+                { id: 'parent-device', token: 'parent-token' }
             ]
-        });
-
-        const tokens = await helpers.resolveTokensFromIndex(db, 'team-1', 'schedule');
-        assert.deepEqual(tokens.sort(), ['tok-a', 'tok-b', 'tok-c'].sort());
+        }
     });
 
-    it('returns empty array when index collection is empty', async () => {
-        const db = makeDb({ notificationRecipients: [] });
-        const tokens = await helpers.resolveTokensFromIndex(db, 'team-1', 'schedule');
-        assert.deepEqual(tokens, []);
-    });
+    try {
+        const targets = await internals.getTargetsForCategory('team-1', 'schedule');
 
-    it('skips docs with no fcmTokens field', async () => {
-        const db = makeDb({
-            notificationRecipients: [
-                { uid: 'u1', categories: { schedule: true } }
-            ]
-        });
-        const tokens = await helpers.resolveTokensFromIndex(db, 'team-1', 'schedule');
-        assert.deepEqual(tokens, []);
-    });
-
-    it('filters out non-string entries in fcmTokens', async () => {
-        const db = makeDb({
-            notificationRecipients: [
-                { uid: 'u1', fcmTokens: ['good-token', null, 42, ''], categories: { schedule: true } }
-            ]
-        });
-        const tokens = await helpers.resolveTokensFromIndex(db, 'team-1', 'schedule');
-        assert.deepEqual(tokens, ['good-token']);
-    });
-});
-
-// ---------------------------------------------------------------------------
-// resolveRecipientsLegacy
-// ---------------------------------------------------------------------------
-
-describe('resolveRecipientsLegacy', () => {
-    it('returns users with tokens whose category preference is not false', async () => {
-        const db = makeDb({
-            users: [
-                { fcmTokens: ['tok-1'], notificationPreferences: { schedule: true }, teamIds: ['team-1'] },
-                { fcmTokens: ['tok-2'], notificationPreferences: {}, teamIds: ['team-1'] }
-            ]
-        });
-        const recipients = await helpers.resolveRecipientsLegacy(db, 'team-1', 'schedule');
-        const allTokens = recipients.flatMap((r) => r.fcmTokens).sort();
-        assert.deepEqual(allTokens, ['tok-1', 'tok-2']);
-    });
-
-    it('excludes users who explicitly disabled the category', async () => {
-        const db = makeDb({
-            users: [
-                { fcmTokens: ['tok-yes'], notificationPreferences: { schedule: true }, teamIds: ['team-1'] },
-                { fcmTokens: ['tok-no'], notificationPreferences: { schedule: false }, teamIds: ['team-1'] }
-            ]
-        });
-        const recipients = await helpers.resolveRecipientsLegacy(db, 'team-1', 'schedule');
-        const allTokens = recipients.flatMap((r) => r.fcmTokens);
-        assert.deepEqual(allTokens, ['tok-yes']);
-    });
-
-    it('excludes users with no fcmTokens', async () => {
-        const db = makeDb({
-            users: [
-                { fcmTokens: [], notificationPreferences: { schedule: true }, teamIds: ['team-1'] },
-                { notificationPreferences: { schedule: true }, teamIds: ['team-1'] }
-            ]
-        });
-        const recipients = await helpers.resolveRecipientsLegacy(db, 'team-1', 'schedule');
-        assert.equal(recipients.length, 0);
-    });
-});
-
-// ---------------------------------------------------------------------------
-// sendInChunks - 500-token chunking behavior
-// ---------------------------------------------------------------------------
-
-describe('sendInChunks', () => {
-    it('sends all tokens in a single call when count <= 500', async () => {
-        const messaging = makeMessaging();
-        const tokens = Array.from({ length: 10 }, (_, i) => `tok-${i}`);
-        const result = await helpers.sendInChunks(messaging, tokens, { title: 'Test', body: 'Hi' });
-        assert.equal(messaging.calls.length, 1);
-        assert.equal(result.successCount, 10);
-        assert.equal(result.failureCount, 0);
-    });
-
-    it('splits 500 tokens into exactly 1 FCM call', async () => {
-        const messaging = makeMessaging();
-        const tokens = Array.from({ length: 500 }, (_, i) => `tok-${i}`);
-        const result = await helpers.sendInChunks(messaging, tokens, { title: 'T', body: 'B' });
-        assert.equal(messaging.calls.length, 1);
-        assert.equal(messaging.calls[0].tokens.length, 500);
-        assert.equal(result.successCount, 500);
-    });
-
-    it('splits 501 tokens into 2 FCM calls', async () => {
-        const messaging = makeMessaging();
-        const tokens = Array.from({ length: 501 }, (_, i) => `tok-${i}`);
-        await helpers.sendInChunks(messaging, tokens, { title: 'T', body: 'B' });
-        assert.equal(messaging.calls.length, 2);
-        assert.equal(messaging.calls[0].tokens.length, 500);
-        assert.equal(messaging.calls[1].tokens.length, 1);
-    });
-
-    it('splits 1000 tokens into exactly 2 FCM calls', async () => {
-        const messaging = makeMessaging();
-        const tokens = Array.from({ length: 1000 }, (_, i) => `tok-${i}`);
-        const result = await helpers.sendInChunks(messaging, tokens, { title: 'T', body: 'B' });
-        assert.equal(messaging.calls.length, 2);
-        assert.equal(result.successCount, 1000);
-    });
-
-    it('aggregates successCount and failureCount across chunks', async () => {
-        const messaging = makeMessaging(200); // each chunk succeeds with 200
-        const tokens = Array.from({ length: 600 }, (_, i) => `tok-${i}`);
-        const result = await helpers.sendInChunks(messaging, tokens, { title: 'T', body: 'B' });
-        assert.equal(result.successCount, 400); // 200 + 200
-        assert.equal(result.failureCount, 0);
-    });
-});
-
-// ---------------------------------------------------------------------------
-// backfillNotificationRecipients
-// ---------------------------------------------------------------------------
-
-describe('backfillNotificationRecipients', () => {
-    it('writes one batch for recipients under the BATCH_LIMIT', async () => {
-        let batchCommitCount = 0;
-        let setCallCount = 0;
-
-        const db = {
-            collection() {
-                return {
-                    doc() {
-                        return {
-                            collection() {
-                                return {
-                                    doc() {
-                                        return {
-                                            // ref placeholder
-                                        };
-                                    }
-                                };
-                            }
-                        };
-                    }
-                };
-            },
-            batch() {
-                return {
-                    set() { setCallCount++; },
-                    commit() { batchCommitCount++; return Promise.resolve(); }
-                };
-            }
-        };
-
-        const recipients = [
-            { uid: 'u1', fcmTokens: ['t1'] },
-            { uid: 'u2', fcmTokens: ['t2', 't3'] }
-        ];
-        await helpers.backfillNotificationRecipients(db, 'team-1', recipients, 'schedule');
-        assert.equal(batchCommitCount, 1);
-        assert.equal(setCallCount, 2);
-    });
+        assert.equal(targets.length, 2);
+        assert.equal(env.counts.targetQueries, 1);
+        assert.equal(env.counts.parentQueries, 1);
+        assert.equal(env.counts.preferenceGets, 1);
+        assert.equal(env.counts.deviceGets, 1);
+        assert.deepEqual(
+            targets.map((target) => target.token).sort(),
+            ['coach-token', 'parent-token']
+        );
+    } finally {
+        cleanup();
+    }
 });

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -1,86 +1,90 @@
-const assert = require('node:assert/strict');
-const test = require('node:test');
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { describe, it } from 'vitest';
 
+const require = createRequire(import.meta.url);
 const { loadNotificationInternals } = require('./send-category-notification-test-helpers');
 
-test('getTargetsForCategory uses indexed targets without legacy per-user device scans when index coverage is complete', async () => {
-    const { internals, env, cleanup } = loadNotificationInternals({
-        teamDoc: {
-            ownerId: 'coach-1',
-            adminEmails: []
-        },
-        parentUserIds: ['parent-1'],
-        indexedTargets: [
-            {
-                uid: 'coach-1',
-                deviceId: 'coach-device',
-                token: 'coach-token',
-                categories: { schedule: true }
+describe('getTargetsForCategory', () => {
+    it('uses indexed targets without legacy per-user device scans when index coverage is complete', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
             },
-            {
-                uid: 'parent-1',
-                deviceId: 'parent-device',
-                token: 'parent-token',
-                categories: { schedule: true }
-            }
-        ]
-    });
-
-    try {
-        const targets = await internals.getTargetsForCategory('team-1', 'schedule');
-
-        assert.equal(targets.length, 2);
-        assert.equal(env.counts.targetQueries, 1);
-        assert.equal(env.counts.parentQueries, 1);
-        assert.equal(env.counts.preferenceGets, 0);
-        assert.equal(env.counts.deviceGets, 0);
-        assert.deepEqual(
-            targets.map((target) => target.token).sort(),
-            ['coach-token', 'parent-token']
-        );
-    } finally {
-        cleanup();
-    }
-});
-
-test('getTargetsForCategory falls back only for users missing from the notification target index', async () => {
-    const { internals, env, cleanup } = loadNotificationInternals({
-        teamDoc: {
-            ownerId: 'coach-1',
-            adminEmails: []
-        },
-        parentUserIds: ['parent-1'],
-        indexedTargets: [
-            {
-                uid: 'coach-1',
-                deviceId: 'coach-device',
-                token: 'coach-token',
-                categories: { schedule: true }
-            }
-        ],
-        preferenceDocs: {
-            'users/parent-1/notificationPreferences/team-1': { schedule: true }
-        },
-        deviceDocs: {
-            'parent-1': [
-                { id: 'parent-device', token: 'parent-token' }
+            parentUserIds: ['parent-1'],
+            indexedTargets: [
+                {
+                    uid: 'coach-1',
+                    deviceId: 'coach-device',
+                    token: 'coach-token',
+                    categories: { schedule: true }
+                },
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-device',
+                    token: 'parent-token',
+                    categories: { schedule: true }
+                }
             ]
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategory('team-1', 'schedule');
+
+            assert.equal(targets.length, 2);
+            assert.equal(env.counts.targetQueries, 1);
+            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.preferenceGets, 0);
+            assert.equal(env.counts.deviceGets, 0);
+            assert.deepEqual(
+                targets.map((target) => target.token).sort(),
+                ['coach-token', 'parent-token']
+            );
+        } finally {
+            cleanup();
         }
     });
 
-    try {
-        const targets = await internals.getTargetsForCategory('team-1', 'schedule');
+    it('falls back only for users missing from the notification target index', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            indexedTargets: [
+                {
+                    uid: 'coach-1',
+                    deviceId: 'coach-device',
+                    token: 'coach-token',
+                    categories: { schedule: true }
+                }
+            ],
+            preferenceDocs: {
+                'users/parent-1/notificationPreferences/team-1': { schedule: true }
+            },
+            deviceDocs: {
+                'parent-1': [
+                    { id: 'parent-device', token: 'parent-token' }
+                ]
+            }
+        });
 
-        assert.equal(targets.length, 2);
-        assert.equal(env.counts.targetQueries, 1);
-        assert.equal(env.counts.parentQueries, 1);
-        assert.equal(env.counts.preferenceGets, 1);
-        assert.equal(env.counts.deviceGets, 1);
-        assert.deepEqual(
-            targets.map((target) => target.token).sort(),
-            ['coach-token', 'parent-token']
-        );
-    } finally {
-        cleanup();
-    }
+        try {
+            const targets = await internals.getTargetsForCategory('team-1', 'schedule');
+
+            assert.equal(targets.length, 2);
+            assert.equal(env.counts.targetQueries, 1);
+            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.preferenceGets, 1);
+            assert.equal(env.counts.deviceGets, 1);
+            assert.deepEqual(
+                targets.map((target) => target.token).sort(),
+                ['coach-token', 'parent-token']
+            );
+        } finally {
+            cleanup();
+        }
+    });
 });


### PR DESCRIPTION
Closes #2269

## What changed
- replaced the stale notification send tests with self-contained module-stubbed regression coverage for the current `functions/index.js` send path
- added direct `getTargetsForCategory()` routing coverage to prove the indexed path avoids legacy per-user preference/device scans when index coverage is complete
- added load-oriented `sendCategoryNotification()` coverage for a 500-recipient fixture, including a 1000-token case that preserves the existing 500-token FCM chunking behavior
- exposed a minimal `_internal` test surface from `functions/index.js` so the focused regression tests can exercise the real resolver and sender logic without Firebase runtime setup

## Root Cause
The bug existed because the codebase had no executable regression coverage for the real `sendCategoryNotification()` path at scale. The existing tests were stale and targeted helper shapes that no longer matched the production implementation, so they did not guard against regressions back to legacy per-user scans or changes to the 500-token multicast boundary.

## Prevention / Learning
For notification-path changes that replace legacy scans with indexed resolution, always add an executable high-cardinality test against the real send entry point, not just helper-level assertions or source-string checks. The regression needs to assert both bounded read shape and chunking behavior at the production threshold.

## Regression Tests
- `cd functions && node --test test/send-category-notification.test.js test/send-category-notification-load.test.js`
- `getTargetsForCategory uses indexed targets without legacy per-user device scans when index coverage is complete`
- `getTargetsForCategory falls back only for users missing from the notification target index`
- `sendCategoryNotification handles a 500-recipient indexed send without legacy per-user scans`
- `sendCategoryNotification preserves 500-token FCM chunking for large indexed sends`