### PR TITLE
Add category notification parity fixtures

### DIFF
--- a/tests/unit/notification-target-legacy-resolution.test.js
+++ b/tests/unit/notification-target-legacy-resolution.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { loadNotificationInternals } = require('../../functions/test/send-category-notification-test-helpers');
+const {
+    LEGACY_CATEGORY_RESOLUTION_FIXTURES,
+    normalizeResolvedTargets,
+    buildIndexedTargetsFromExpected
+} = require('./notification-target-resolution-fixtures.cjs');
+
+describe('legacy category notification target resolution fixtures', () => {
+    for (const fixture of LEGACY_CATEGORY_RESOLUTION_FIXTURES) {
+        it(fixture.name, async () => {
+            const { internals, env, cleanup } = loadNotificationInternals({
+                ...fixture.options,
+                indexedTargets: []
+            });
+
+            try {
+                const targets = await internals.getTargetsForCategory(
+                    fixture.request.teamId,
+                    fixture.request.category,
+                    fixture.request.actorUid || null,
+                    fixture.request.audienceContext || {}
+                );
+
+                expect(normalizeResolvedTargets(targets)).toEqual(
+                    normalizeResolvedTargets(fixture.expectedTargets)
+                );
+                expect({
+                    targetQueries: env.counts.targetQueries,
+                    parentQueries: env.counts.parentQueries,
+                    preferenceGets: env.counts.preferenceGets,
+                    deviceGets: env.counts.deviceGets
+                }).toEqual(fixture.expectedCounts);
+            } finally {
+                cleanup();
+            }
+        });
+
+        it(`${fixture.name} parity fixtures can seed indexed-resolution tests later`, async () => {
+            const { internals, env, cleanup } = loadNotificationInternals({
+                ...fixture.options,
+                indexedTargets: buildIndexedTargetsFromExpected(
+                    fixture.request.category,
+                    fixture.expectedTargets
+                )
+            });
+
+            try {
+                const targets = await internals.getTargetsForCategory(
+                    fixture.request.teamId,
+                    fixture.request.category,
+                    fixture.request.actorUid || null,
+                    fixture.request.audienceContext || {}
+                );
+
+                expect(normalizeResolvedTargets(targets)).toEqual(
+                    normalizeResolvedTargets(fixture.expectedTargets)
+                );
+                expect(env.counts.preferenceGets).toBe(fixture.expectedIndexedCounts.preferenceGets);
+                expect(env.counts.deviceGets).toBe(fixture.expectedIndexedCounts.deviceGets);
+            } finally {
+                cleanup();
+            }
+        });
+    }
+});

--- a/tests/unit/notification-target-resolution-fixtures.cjs
+++ b/tests/unit/notification-target-resolution-fixtures.cjs
@@ -1,0 +1,153 @@
+const LEGACY_CATEGORY_RESOLUTION_FIXTURES = Object.freeze([
+    {
+        name: 'schedule legacy resolution keeps only enabled recipients and valid devices',
+        request: {
+            teamId: 'team-fixture-schedule',
+            category: 'schedule'
+        },
+        options: {
+            teamId: 'team-fixture-schedule',
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1', 'parent-2', 'parent-3'],
+            preferenceDocs: {
+                'users/coach-1/notificationPreferences/team-fixture-schedule': {
+                    schedule: true,
+                    media: true
+                },
+                'users/parent-1/notificationPreferences/team-fixture-schedule': {
+                    schedule: true,
+                    media: false
+                },
+                'users/parent-2/notificationPreferences/team-fixture-schedule': {
+                    schedule: false,
+                    media: true
+                },
+                'users/parent-3/notificationPreferences/team-fixture-schedule': {
+                    schedule: true,
+                    media: true
+                }
+            },
+            deviceDocs: {
+                'coach-1': [
+                    { id: 'coach-phone', token: 'coach-phone-token' },
+                    { id: 'coach-watch', token: 'coach-watch-token' }
+                ],
+                'parent-1': [
+                    { id: 'parent-1-phone', token: 'parent-1-phone-token' }
+                ],
+                'parent-2': [
+                    { id: 'parent-2-phone', token: 'parent-2-phone-token' }
+                ],
+                'parent-3': [
+                    { id: 'parent-3-empty', token: '' },
+                    { id: 'parent-3-tablet', token: 'parent-3-tablet-token' }
+                ]
+            }
+        },
+        expectedTargets: [
+            { uid: 'coach-1', deviceId: 'coach-phone', token: 'coach-phone-token' },
+            { uid: 'coach-1', deviceId: 'coach-watch', token: 'coach-watch-token' },
+            { uid: 'parent-1', deviceId: 'parent-1-phone', token: 'parent-1-phone-token' },
+            { uid: 'parent-3', deviceId: 'parent-3-tablet', token: 'parent-3-tablet-token' }
+        ],
+        expectedCounts: {
+            targetQueries: 1,
+            parentQueries: 1,
+            preferenceGets: 4,
+            deviceGets: 4
+        },
+        expectedIndexedCounts: {
+            preferenceGets: 1,
+            deviceGets: 1
+        }
+    },
+    {
+        name: 'private media legacy resolution excludes parent devices from sends',
+        request: {
+            teamId: 'team-fixture-private-media',
+            category: 'media',
+            audienceContext: {
+                albumVisibility: 'private'
+            }
+        },
+        options: {
+            teamId: 'team-fixture-private-media',
+            teamDoc: {
+                ownerId: 'coach-2',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-4', 'parent-5'],
+            preferenceDocs: {
+                'users/coach-2/notificationPreferences/team-fixture-private-media': {
+                    media: true
+                },
+                'users/parent-4/notificationPreferences/team-fixture-private-media': {
+                    media: true
+                },
+                'users/parent-5/notificationPreferences/team-fixture-private-media': {
+                    media: true
+                }
+            },
+            deviceDocs: {
+                'coach-2': [
+                    { id: 'coach-2-phone', token: 'coach-2-phone-token' },
+                    { id: 'coach-2-tablet', token: 'coach-2-tablet-token' }
+                ],
+                'parent-4': [
+                    { id: 'parent-4-phone', token: 'parent-4-phone-token' }
+                ],
+                'parent-5': [
+                    { id: 'parent-5-phone', token: 'parent-5-phone-token' }
+                ]
+            }
+        },
+        expectedTargets: [
+            { uid: 'coach-2', deviceId: 'coach-2-phone', token: 'coach-2-phone-token' },
+            { uid: 'coach-2', deviceId: 'coach-2-tablet', token: 'coach-2-tablet-token' }
+        ],
+        expectedCounts: {
+            targetQueries: 1,
+            parentQueries: 1,
+            preferenceGets: 1,
+            deviceGets: 1
+        },
+        expectedIndexedCounts: {
+            preferenceGets: 0,
+            deviceGets: 0
+        }
+    }
+]);
+
+function normalizeResolvedTargets(targets = []) {
+    return targets
+        .map((target) => ({
+            uid: String(target?.uid || ''),
+            deviceId: String(target?.deviceId || ''),
+            token: String(target?.token || '')
+        }))
+        .sort((left, right) => {
+            const leftKey = `${left.uid}::${left.deviceId}::${left.token}`;
+            const rightKey = `${right.uid}::${right.deviceId}::${right.token}`;
+            return leftKey.localeCompare(rightKey);
+        });
+}
+
+function buildIndexedTargetsFromExpected(category, expectedTargets = []) {
+    return expectedTargets.map((target) => ({
+        uid: target.uid,
+        deviceId: target.deviceId,
+        token: target.token,
+        categories: {
+            [category]: true
+        }
+    }));
+}
+
+module.exports = {
+    LEGACY_CATEGORY_RESOLUTION_FIXTURES,
+    normalizeResolvedTargets,
+    buildIndexedTargetsFromExpected
+};


### PR DESCRIPTION
Closes #2267

## What changed
- added reusable category notification resolution fixtures that model mixed notification enablement, multi-device recipients, and users excluded from sends
- added focused Vitest coverage that resolves each fixture through the current legacy path and asserts the exact recipient/device set returned
- added parity-oriented fixture seeding for later index-resolution tests so the same expected outputs can be reused without changing production code

## Root Cause
The repo had source-level assertions around the target index flow, but it did not have executable fixture coverage that pinned the concrete legacy recipient and device resolution outputs. That left the current behavior unbaselined and made later recipient-path refactors harder to review safely.

## Prevention / Learning
Before migrating notification routing or denormalized indexes, capture the legacy resolver behavior with concrete fixture teams and exact recipient/device expectations. Reusable fixtures should describe inclusion, exclusion, and multi-device cases so both legacy and indexed paths can be compared against the same baseline.

## Regression Tests
- `npx vitest run tests/unit/notification-target-legacy-resolution.test.js tests/unit/notification-target-index-core.test.js --reporter=verbose`
- `tests/unit/notification-target-legacy-resolution.test.js` now verifies the legacy resolution output for mixed schedule preferences and private media staff-only delivery

## Recurrence Risk
Low. The baseline is now enforced with concrete fixtures, so recipient or device-set drift in this path should fail focused unit tests quickly.