### PR TITLE
Use recipient index for category notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2979,6 +2979,12 @@ function buildTeamNotificationTargetRef(teamId, uid, deviceId) {
   return firestore.doc(`teams/${teamId}/notificationTargets/${docId}`);
 }
 
+function buildTeamNotificationRecipientRef(teamId, uid, deviceId) {
+  const docId = buildNotificationTargetDocId({ uid, deviceId });
+  if (!docId) return null;
+  return firestore.doc(`teams/${teamId}/notificationRecipients/${docId}`);
+}
+
 function normalizeNotificationDeviceRecord(deviceId, raw) {
   const token = String(raw?.token || '').trim();
   if (!token) return null;
@@ -3305,10 +3311,81 @@ async function getLegacyTargetsForCategory(teamId, category, users, actorUid = n
   return targetGroups.flat();
 }
 
+async function backfillNotificationRecipientsForTeam(teamId, users) {
+  const uniqueUsers = Array.from(new Map(
+    (Array.isArray(users) ? users : [])
+      .filter((user) => user?.uid)
+      .map((user) => [user.uid, user])
+  ).values());
+  if (!uniqueUsers.length) return 0;
+
+  const userRecords = await Promise.all(uniqueUsers.map(async (user) => {
+    const uid = user.uid;
+    const prefRef = firestore.doc(`users/${uid}/notificationPreferences/${teamId}`);
+    const devicesRef = firestore.collection(`users/${uid}/notificationDevices`);
+    const [prefSnap, devicesSnap] = await Promise.all([
+      prefRef.get(),
+      devicesRef.get()
+    ]);
+    return {
+      uid,
+      preferences: prefSnap.exists
+        ? normalizeNotificationPreferences(prefSnap.data())
+        : DEFAULT_NOTIFICATION_PREFERENCES,
+      devicesSnap
+    };
+  }));
+
+  let batch = firestore.batch();
+  let pendingOps = 0;
+  let writeCount = 0;
+  const commitBatch = async () => {
+    if (!pendingOps) return;
+    await batch.commit();
+    batch = firestore.batch();
+    pendingOps = 0;
+  };
+
+  for (const record of userRecords) {
+    const hasAnyEnabledCategory = hasEnabledNotificationCategory(record.preferences);
+    for (const deviceSnap of record.devicesSnap.docs) {
+      const device = normalizeNotificationDeviceRecord(deviceSnap.id, deviceSnap.data());
+      const recipientRef = buildTeamNotificationRecipientRef(teamId, record.uid, deviceSnap.id);
+      if (!recipientRef) continue;
+
+      if (!device || !hasAnyEnabledCategory) {
+        batch.delete(recipientRef);
+      } else {
+        batch.set(recipientRef, {
+          ...buildNotificationTargetPayload({
+            uid: record.uid,
+            teamId,
+            deviceId: device.deviceId,
+            token: device.token,
+            platform: device.platform,
+            userAgent: device.userAgent,
+            preferences: record.preferences
+          }),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp()
+        }, { merge: true });
+        writeCount += 1;
+      }
+
+      pendingOps += 1;
+      if (pendingOps === 450) {
+        await commitBatch();
+      }
+    }
+  }
+
+  await commitBatch();
+  return writeCount;
+}
+
 async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
 
-  const targetSnap = await firestore.collection(`teams/${teamId}/notificationTargets`)
+  const targetSnap = await firestore.collection(`teams/${teamId}/notificationRecipients`)
     .where(`categories.${category}`, '==', true)
     .get();
   const users = await getCandidateUsersForTeam(teamId);
@@ -3342,6 +3419,18 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
   ));
   if (!missingUsers.length) {
     return indexedTargets;
+  }
+
+  if (targetSnap.empty) {
+    try {
+      await backfillNotificationRecipientsForTeam(teamId, users);
+    } catch (error) {
+      functions.logger.warn('Failed to backfill notification recipient index after empty lookup', {
+        teamId,
+        category,
+        error: error?.message || String(error || 'Unknown error')
+      });
+    }
   }
 
   const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);

--- a/functions/index.js
+++ b/functions/index.js
@@ -2985,6 +2985,13 @@ function buildTeamNotificationRecipientRef(teamId, uid, deviceId) {
   return firestore.doc(`teams/${teamId}/notificationRecipients/${docId}`);
 }
 
+function buildTeamNotificationIndexRefs(teamId, uid, deviceId) {
+  return [
+    buildTeamNotificationTargetRef(teamId, uid, deviceId),
+    buildTeamNotificationRecipientRef(teamId, uid, deviceId)
+  ].filter(Boolean);
+}
+
 function normalizeNotificationDeviceRecord(deviceId, raw) {
   const token = String(raw?.token || '').trim();
   if (!token) return null;
@@ -3028,14 +3035,14 @@ async function syncNotificationTargetsForPreference(uid, teamId, preferences) {
   const batch = firestore.batch();
   devicesSnap.docs.forEach((deviceSnap) => {
     const device = normalizeNotificationDeviceRecord(deviceSnap.id, deviceSnap.data());
-    const targetRef = buildTeamNotificationTargetRef(teamId, uid, deviceSnap.id);
-    if (!targetRef) return;
+    const indexRefs = buildTeamNotificationIndexRefs(teamId, uid, deviceSnap.id);
+    if (!indexRefs.length) return;
     if (teamAccessMap.get(teamId) !== true || !device || !hasEnabledNotificationCategory(normalizedPreferences)) {
-      batch.delete(targetRef);
+      indexRefs.forEach((ref) => batch.delete(ref));
       return;
     }
 
-    batch.set(targetRef, {
+    const payload = {
       ...buildNotificationTargetPayload({
         uid,
         teamId,
@@ -3046,7 +3053,8 @@ async function syncNotificationTargetsForPreference(uid, teamId, preferences) {
         preferences: normalizedPreferences
       }),
       updatedAt: admin.firestore.FieldValue.serverTimestamp()
-    }, { merge: true });
+    };
+    indexRefs.forEach((ref) => batch.set(ref, payload, { merge: true }));
   });
   await batch.commit();
 }
@@ -3059,15 +3067,15 @@ async function syncNotificationTargetsForDevice(uid, deviceId, rawDevice) {
   const teamAccessMap = await getNotificationTargetTeamAccessMap(uid, prefsSnap.docs.map((prefSnap) => prefSnap.id));
   const batch = firestore.batch();
   prefsSnap.docs.forEach((prefSnap) => {
-    const targetRef = buildTeamNotificationTargetRef(prefSnap.id, uid, deviceId);
+    const indexRefs = buildTeamNotificationIndexRefs(prefSnap.id, uid, deviceId);
     const preferences = normalizeNotificationPreferences(prefSnap.data());
-    if (!targetRef) return;
+    if (!indexRefs.length) return;
     if (teamAccessMap.get(prefSnap.id) !== true || !targetDevice || !hasEnabledNotificationCategory(preferences)) {
-      batch.delete(targetRef);
+      indexRefs.forEach((ref) => batch.delete(ref));
       return;
     }
 
-    batch.set(targetRef, {
+    const payload = {
       ...buildNotificationTargetPayload({
         uid,
         teamId: prefSnap.id,
@@ -3078,9 +3086,17 @@ async function syncNotificationTargetsForDevice(uid, deviceId, rawDevice) {
         preferences
       }),
       updatedAt: admin.firestore.FieldValue.serverTimestamp()
-    }, { merge: true });
+    };
+    indexRefs.forEach((ref) => batch.set(ref, payload, { merge: true }));
   });
   await batch.commit();
+}
+
+async function teamNotificationRecipientIndexIsEmpty(teamId) {
+  const recipientSnap = await firestore.collection(`teams/${teamId}/notificationRecipients`)
+    .limit(1)
+    .get();
+  return recipientSnap.empty;
 }
 
 exports.syncTeamNotificationTargetsOnPreferenceWrite = functions.firestore
@@ -3421,7 +3437,7 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
     return indexedTargets;
   }
 
-  if (targetSnap.empty) {
+  if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId)) {
     try {
       await backfillNotificationRecipientsForTeam(teamId, users);
     } catch (error) {
@@ -3454,10 +3470,8 @@ async function pruneInvalidTokens(sendResult, targets) {
     removals.push(
       firestore.doc(`users/${target.uid}/notificationDevices/${target.deviceId}`).delete()
     );
-    const teamTargetRef = buildTeamNotificationTargetRef(target.teamId, target.uid, target.deviceId);
-    if (teamTargetRef) {
-      removals.push(teamTargetRef.delete());
-    }
+    buildTeamNotificationIndexRefs(target.teamId, target.uid, target.deviceId)
+      .forEach((ref) => removals.push(ref.delete()));
   });
 
   if (removals.length) {

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -90,6 +90,7 @@ function buildNotificationTestEnv({
     teamId = 'team-1',
     teamDoc = {},
     parentUserIds = [],
+    indexedRecipients = [],
     indexedTargets = [],
     preferenceDocs = {},
     deviceDocs = {},
@@ -102,7 +103,7 @@ function buildNotificationTestEnv({
     const counts = {
         teamDocGets: 0,
         parentQueries: 0,
-        targetQueries: 0,
+        recipientQueries: 0,
         preferenceGets: 0,
         deviceGets: 0,
         inboxAdds: 0,
@@ -111,7 +112,7 @@ function buildNotificationTestEnv({
         deleteCalls: 0
     };
 
-    const notificationTargetDocs = indexedTargets.map((target, index) => ({
+    const notificationRecipientDocs = (indexedRecipients.length ? indexedRecipients : indexedTargets).map((target, index) => ({
         id: `${target.uid || `user-${index}`}__${target.deviceId || `device-${index}`}`,
         data: {
             uid: target.uid,
@@ -180,14 +181,14 @@ function buildNotificationTestEnv({
             };
         }
 
-        if (path === `teams/${teamId}/notificationTargets`) {
+        if (path === `teams/${teamId}/notificationRecipients`) {
             return {
                 where(field, op, value) {
                     return {
                         async get() {
-                            counts.targetQueries += 1;
+                            counts.recipientQueries += 1;
                             const category = String(field || '').replace(/^categories\./, '');
-                            const docs = notificationTargetDocs.filter((entry) => op === '==' && value === true && entry.data.categories?.[category] === true)
+                            const docs = notificationRecipientDocs.filter((entry) => op === '==' && value === true && entry.data.categories?.[category] === true)
                                 .map((entry) => makeDocSnapshot({
                                     id: entry.id,
                                     ref: doc(`${path}/${entry.id}`),
@@ -273,8 +274,12 @@ function buildNotificationTestEnv({
         },
         batch() {
             return {
-                set() {},
-                delete() {},
+                set(ref, value) {
+                    dedupWrites.push({ path: ref.path, value });
+                },
+                delete(ref) {
+                    deletedPaths.push(ref.path);
+                },
                 update() {},
                 async commit() {}
             };

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -104,6 +104,7 @@ function buildNotificationTestEnv({
         teamDocGets: 0,
         parentQueries: 0,
         recipientQueries: 0,
+        recipientCollectionGets: 0,
         preferenceGets: 0,
         deviceGets: 0,
         inboxAdds: 0,
@@ -196,6 +197,19 @@ function buildNotificationTestEnv({
                                     exists: true
                                 }));
                             return makeQuerySnapshot(docs);
+                        }
+                    };
+                },
+                limit() {
+                    return {
+                        async get() {
+                            counts.recipientCollectionGets += 1;
+                            return makeQuerySnapshot(notificationRecipientDocs.slice(0, 1).map((entry) => makeDocSnapshot({
+                                id: entry.id,
+                                ref: doc(`${path}/${entry.id}`),
+                                data: entry.data,
+                                exists: true
+                            })));
                         }
                     };
                 }

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -1,5 +1,4 @@
-import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, expect, it } from 'vitest';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -32,15 +31,14 @@ describe('getTargetsForCategory', () => {
         try {
             const targets = await internals.getTargetsForCategory('team-1', 'schedule');
 
-            assert.equal(targets.length, 2);
-            assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.parentQueries, 1);
-            assert.equal(env.counts.preferenceGets, 0);
-            assert.equal(env.counts.deviceGets, 0);
-            assert.deepEqual(
-                targets.map((target) => target.token).sort(),
-                ['coach-token', 'parent-token']
-            );
+            expect(targets).toHaveLength(2);
+            expect(env.counts.recipientQueries).toBe(1);
+            expect(env.counts.parentQueries).toBe(1);
+            expect(env.counts.preferenceGets).toBe(0);
+            expect(env.counts.deviceGets).toBe(0);
+            expect(targets.map((target) => target.token).sort()).toEqual([
+                'coach-token', 'parent-token'
+            ]);
         } finally {
             cleanup();
         }
@@ -74,15 +72,14 @@ describe('getTargetsForCategory', () => {
         try {
             const targets = await internals.getTargetsForCategory('team-1', 'schedule');
 
-            assert.equal(targets.length, 2);
-            assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.parentQueries, 1);
-            assert.equal(env.counts.preferenceGets, 1);
-            assert.equal(env.counts.deviceGets, 1);
-            assert.deepEqual(
-                targets.map((target) => target.token).sort(),
-                ['coach-token', 'parent-token']
-            );
+            expect(targets).toHaveLength(2);
+            expect(env.counts.recipientQueries).toBe(1);
+            expect(env.counts.parentQueries).toBe(1);
+            expect(env.counts.preferenceGets).toBe(1);
+            expect(env.counts.deviceGets).toBe(1);
+            expect(targets.map((target) => target.token).sort()).toEqual([
+                'coach-token', 'parent-token'
+            ]);
         } finally {
             cleanup();
         }
@@ -112,27 +109,23 @@ describe('getTargetsForCategory', () => {
         try {
             const targets = await internals.getTargetsForCategory('team-1', 'schedule');
 
-            assert.equal(targets.length, 2);
-            assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.preferenceGets, 4);
-            assert.equal(env.counts.deviceGets, 4);
-            assert.deepEqual(
-                targets.map((target) => `${target.uid}:${target.deviceId}:${target.token}`).sort(),
-                [
-                    'coach-1:coach-device:coach-token',
-                    'parent-1:parent-device:parent-token'
-                ]
-            );
-            assert.deepEqual(
+            expect(targets).toHaveLength(2);
+            expect(env.counts.recipientQueries).toBe(1);
+            expect(env.counts.preferenceGets).toBe(4);
+            expect(env.counts.deviceGets).toBe(4);
+            expect(targets.map((target) => `${target.uid}:${target.deviceId}:${target.token}`).sort()).toEqual([
+                'coach-1:coach-device:coach-token',
+                'parent-1:parent-device:parent-token'
+            ]);
+            expect(
                 env.dedupWrites
                     .filter((write) => write.path.includes('/notificationRecipients/'))
                     .map((write) => write.path)
-                    .sort(),
-                [
-                    'teams/team-1/notificationRecipients/coach-1__coach-device',
-                    'teams/team-1/notificationRecipients/parent-1__parent-device'
-                ]
-            );
+                    .sort()
+            ).toEqual([
+                'teams/team-1/notificationRecipients/coach-1__coach-device',
+                'teams/team-1/notificationRecipients/parent-1__parent-device'
+            ]);
         } finally {
             cleanup();
         }

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -33,7 +33,7 @@ describe('getTargetsForCategory', () => {
             const targets = await internals.getTargetsForCategory('team-1', 'schedule');
 
             assert.equal(targets.length, 2);
-            assert.equal(env.counts.targetQueries, 1);
+            assert.equal(env.counts.recipientQueries, 1);
             assert.equal(env.counts.parentQueries, 1);
             assert.equal(env.counts.preferenceGets, 0);
             assert.equal(env.counts.deviceGets, 0);
@@ -75,13 +75,63 @@ describe('getTargetsForCategory', () => {
             const targets = await internals.getTargetsForCategory('team-1', 'schedule');
 
             assert.equal(targets.length, 2);
-            assert.equal(env.counts.targetQueries, 1);
+            assert.equal(env.counts.recipientQueries, 1);
             assert.equal(env.counts.parentQueries, 1);
             assert.equal(env.counts.preferenceGets, 1);
             assert.equal(env.counts.deviceGets, 1);
             assert.deepEqual(
                 targets.map((target) => target.token).sort(),
                 ['coach-token', 'parent-token']
+            );
+        } finally {
+            cleanup();
+        }
+    });
+
+    it('falls back to legacy resolution and backfills recipients when the team index is empty', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            preferenceDocs: {
+                'users/coach-1/notificationPreferences/team-1': { schedule: true },
+                'users/parent-1/notificationPreferences/team-1': { schedule: true }
+            },
+            deviceDocs: {
+                'coach-1': [
+                    { id: 'coach-device', token: 'coach-token', platform: 'ios' }
+                ],
+                'parent-1': [
+                    { id: 'parent-device', token: 'parent-token', platform: 'android' }
+                ]
+            }
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategory('team-1', 'schedule');
+
+            assert.equal(targets.length, 2);
+            assert.equal(env.counts.recipientQueries, 1);
+            assert.equal(env.counts.preferenceGets, 4);
+            assert.equal(env.counts.deviceGets, 4);
+            assert.deepEqual(
+                targets.map((target) => `${target.uid}:${target.deviceId}:${target.token}`).sort(),
+                [
+                    'coach-1:coach-device:coach-token',
+                    'parent-1:parent-device:parent-token'
+                ]
+            );
+            assert.deepEqual(
+                env.dedupWrites
+                    .filter((write) => write.path.includes('/notificationRecipients/'))
+                    .map((write) => write.path)
+                    .sort(),
+                [
+                    'teams/team-1/notificationRecipients/coach-1__coach-device',
+                    'teams/team-1/notificationRecipients/parent-1__parent-device'
+                ]
             );
         } finally {
             cleanup();

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -34,11 +34,58 @@ describe('getTargetsForCategory', () => {
             expect(targets).toHaveLength(2);
             expect(env.counts.recipientQueries).toBe(1);
             expect(env.counts.parentQueries).toBe(1);
+            expect(env.counts.recipientCollectionGets).toBe(0);
             expect(env.counts.preferenceGets).toBe(0);
             expect(env.counts.deviceGets).toBe(0);
             expect(targets.map((target) => target.token).sort()).toEqual([
                 'coach-token', 'parent-token'
             ]);
+        } finally {
+            cleanup();
+        }
+    });
+
+
+    it('does not backfill repeatedly when the recipient collection already contains disabled-category docs', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            indexedRecipients: [
+                {
+                    uid: 'coach-1',
+                    deviceId: 'coach-device',
+                    token: 'coach-token',
+                    categories: { media: false }
+                }
+            ],
+            preferenceDocs: {
+                'users/coach-1/notificationPreferences/team-1': { media: false },
+                'users/parent-1/notificationPreferences/team-1': { media: false }
+            },
+            deviceDocs: {
+                'coach-1': [
+                    { id: 'coach-device', token: 'coach-token', platform: 'ios' }
+                ],
+                'parent-1': [
+                    { id: 'parent-device', token: 'parent-token', platform: 'android' }
+                ]
+            }
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategory('team-1', 'media');
+
+            expect(targets).toEqual([]);
+            expect(env.counts.recipientQueries).toBe(1);
+            expect(env.counts.recipientCollectionGets).toBe(1);
+            expect(env.counts.preferenceGets).toBe(2);
+            expect(env.counts.deviceGets).toBe(2);
+            expect(
+                env.dedupWrites.filter((write) => write.path.includes('/notificationRecipients/'))
+            ).toHaveLength(0);
         } finally {
             cleanup();
         }
@@ -75,6 +122,7 @@ describe('getTargetsForCategory', () => {
             expect(targets).toHaveLength(2);
             expect(env.counts.recipientQueries).toBe(1);
             expect(env.counts.parentQueries).toBe(1);
+            expect(env.counts.recipientCollectionGets).toBe(0);
             expect(env.counts.preferenceGets).toBe(1);
             expect(env.counts.deviceGets).toBe(1);
             expect(targets.map((target) => target.token).sort()).toEqual([
@@ -111,6 +159,7 @@ describe('getTargetsForCategory', () => {
 
             expect(targets).toHaveLength(2);
             expect(env.counts.recipientQueries).toBe(1);
+            expect(env.counts.recipientCollectionGets).toBe(1);
             expect(env.counts.preferenceGets).toBe(4);
             expect(env.counts.deviceGets).toBe(4);
             expect(targets.map((target) => `${target.uid}:${target.deviceId}:${target.token}`).sort()).toEqual([
@@ -125,6 +174,50 @@ describe('getTargetsForCategory', () => {
             ).toEqual([
                 'teams/team-1/notificationRecipients/coach-1__coach-device',
                 'teams/team-1/notificationRecipients/parent-1__parent-device'
+            ]);
+        } finally {
+            cleanup();
+        }
+    });
+});
+
+
+describe('sendCategoryNotification', () => {
+    it('prunes invalid tokens from both notification index collections', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            indexedTargets: [
+                {
+                    uid: 'coach-1',
+                    deviceId: 'coach-device',
+                    token: 'coach-token',
+                    categories: { schedule: true }
+                }
+            ],
+            invalidTokenResponses: [
+                {
+                    success: false,
+                    error: { code: 'messaging/registration-token-not-registered' }
+                }
+            ]
+        });
+
+        try {
+            const result = await internals.sendCategoryNotification({
+                teamId: 'team-1',
+                category: 'schedule',
+                title: 'Schedule changed',
+                body: 'Updated'
+            });
+
+            expect(result?.failureCount).toBe(1);
+            expect(env.deletedPaths.sort()).toEqual([
+                'teams/team-1/notificationRecipients/coach-1__coach-device',
+                'teams/team-1/notificationTargets/coach-1__coach-device',
+                'users/coach-1/notificationDevices/coach-device'
             ]);
         } finally {
             cleanup();

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -89,6 +89,9 @@ describe('notification target index core helpers', () => {
         expect(syncSource).toContain('teamAccessMap.get(teamId) !== true');
         expect(syncSource).toContain('teamAccessMap.get(prefSnap.id) !== true');
         expect(syncSource).toContain('hasParentAccess || hasTeamAdminAccess');
+        expect(syncSource).toContain('buildTeamNotificationIndexRefs');
+        expect(syncSource).toContain('indexRefs.forEach((ref) => batch.set(ref, payload, { merge: true }))');
+        expect(syncSource).toContain('indexRefs.forEach((ref) => batch.delete(ref));');
     });
 
     it('uses the team recipient index first and falls back to legacy user scans for missing indexed recipients', () => {
@@ -107,8 +110,10 @@ describe('notification target index core helpers', () => {
         expect(functionsSource).toContain("normalizeNotificationAlbumVisibility(audienceContext.albumVisibility) !== 'private'");
         expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
         expect(targetResolverSource).toContain('const missingUsers = users.filter');
-        expect(targetResolverSource).toContain('if (targetSnap.empty)');
+        expect(targetResolverSource).toContain('teamNotificationRecipientIndexIsEmpty(teamId)');
+        expect(targetResolverSource).toContain('if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId))');
         expect(targetResolverSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users);');
         expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
+        expect(functionsSource).toContain('buildTeamNotificationIndexRefs(target.teamId, target.uid, target.deviceId)');
     });
 });

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -91,13 +91,13 @@ describe('notification target index core helpers', () => {
         expect(syncSource).toContain('hasParentAccess || hasTeamAdminAccess');
     });
 
-    it('uses the team target index first and falls back to legacy user scans for missing indexed recipients', () => {
+    it('uses the team recipient index first and falls back to legacy user scans for missing indexed recipients', () => {
         const targetResolverSource = functionsSource.slice(
             functionsSource.indexOf('async function getLegacyTargetsForCategory'),
             functionsSource.indexOf('async function pruneInvalidTokens')
         );
 
-        expect(targetResolverSource).toContain("firestore.collection(`teams/${teamId}/notificationTargets`)");
+        expect(targetResolverSource).toContain("firestore.collection(`teams/${teamId}/notificationRecipients`)");
         expect(targetResolverSource).toContain("where(`categories.${category}`, '==', true)");
         expect(targetResolverSource).toContain('if (uid === actorUid) return null;');
         expect(targetResolverSource).toContain('users/${uid}/notificationPreferences/${teamId}');
@@ -107,6 +107,8 @@ describe('notification target index core helpers', () => {
         expect(functionsSource).toContain("normalizeNotificationAlbumVisibility(audienceContext.albumVisibility) !== 'private'");
         expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
         expect(targetResolverSource).toContain('const missingUsers = users.filter');
+        expect(targetResolverSource).toContain('if (targetSnap.empty)');
+        expect(targetResolverSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users);');
         expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
     });
 });

--- a/tests/unit/notification-target-legacy-resolution.test.js
+++ b/tests/unit/notification-target-legacy-resolution.test.js
@@ -29,7 +29,7 @@ describe('legacy category notification target resolution fixtures', () => {
                     normalizeResolvedTargets(fixture.expectedTargets)
                 );
                 expect({
-                    targetQueries: env.counts.targetQueries,
+                    targetQueries: env.counts.recipientQueries ?? env.counts.targetQueries,
                     parentQueries: env.counts.parentQueries,
                     preferenceGets: env.counts.preferenceGets,
                     deviceGets: env.counts.deviceGets

--- a/tests/unit/notification-target-resolution-fixtures.cjs
+++ b/tests/unit/notification-target-resolution-fixtures.cjs
@@ -56,8 +56,8 @@ const LEGACY_CATEGORY_RESOLUTION_FIXTURES = Object.freeze([
         expectedCounts: {
             targetQueries: 1,
             parentQueries: 1,
-            preferenceGets: 4,
-            deviceGets: 4
+            preferenceGets: 8,
+            deviceGets: 8
         },
         expectedIndexedCounts: {
             preferenceGets: 1,
@@ -111,8 +111,8 @@ const LEGACY_CATEGORY_RESOLUTION_FIXTURES = Object.freeze([
         expectedCounts: {
             targetQueries: 1,
             parentQueries: 1,
-            preferenceGets: 1,
-            deviceGets: 1
+            preferenceGets: 4,
+            deviceGets: 4
         },
         expectedIndexedCounts: {
             preferenceGets: 0,

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -15,14 +15,22 @@ function getSourceSlice(startMarker, endMarker) {
 function createFirestoreMock({ indexedTargets = [], preferences = {}, devices = {} } = {}) {
     return {
         collection: vi.fn((path) => {
-            if (path.startsWith('teams/') && path.endsWith('/notificationTargets')) {
+            if (path.startsWith('teams/') && path.endsWith('/notificationRecipients')) {
                 return {
-                    where: vi.fn(() => ({
+                    where: vi.fn((field) => ({
                         get: vi.fn(async () => ({
-                            docs: indexedTargets.map((target) => ({
-                                id: `${target.uid}__${target.deviceId}`,
-                                data: () => ({ ...target })
-                            }))
+                            docs: indexedTargets
+                                .filter((target) => {
+                                    const categories = target.categories || { media: true };
+                                    return categories[String(field).replace(/^categories\./, '')] === true;
+                                })
+                                .map((target) => ({
+                                    id: `${target.uid}__${target.deviceId}`,
+                                    data: () => ({
+                                        ...target,
+                                        categories: target.categories || { media: true }
+                                    })
+                                }))
                         }))
                     }))
                 };


### PR DESCRIPTION
Closes #2268

## What changed
- switched `getTargetsForCategory()` to read the primary recipient set from `teams/{teamId}/notificationRecipients`
- kept the existing legacy per-user/device resolution path for any missing users, including the fully empty-index case
- added an empty-index backfill that writes `notificationRecipients` docs for the team from current notification preferences and registered devices
- extended focused tests to cover indexed resolution, partial legacy fallback, and empty-index backfill behavior

## Root Cause
`sendCategoryNotification()` was still hard-wired to the older team notification index path and had no migration backfill when the new recipient index was empty. That meant the new `notificationRecipients` collection was never used here and an empty new index would stay empty instead of being repopulated from legacy data.

## Prevention / Learning
When moving read paths to a new Firestore index, keep a safe fallback and add an explicit self-healing backfill for empty-index cases. Also add a focused regression test that proves both the primary index path and the migration fallback return the same recipient/device set.

## Regression Tests
- `node --test functions/test/send-category-notification.test.js`
- `npx vitest run tests/unit/notification-target-index-core.test.js --reporter=verbose`

## Recurrence Risk
Medium: this send path now self-heals, but the broader writer/trigger migration to keep `notificationRecipients` continuously populated is still separate work.