### PR TITLE
Fix chat mention pushes and conversation mute routing

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -61,8 +61,8 @@ const auth: AuthState = {
     signOut: vi.fn().mockResolvedValue(undefined)
 };
 
-function ParentToolsRoute() {
-    return <ParentTools auth={auth} />;
+function ParentToolsRoute({ authState = auth }: { authState?: AuthState }) {
+    return <ParentTools auth={authState} />;
 }
 
 function InvalidParentToolsButton() {
@@ -70,7 +70,11 @@ function InvalidParentToolsButton() {
     return <button type="button" onClick={() => navigate('/parent-tools/not-a-real-tab')}>Go invalid</button>;
 }
 
-function renderParentTools(initialEntries: string[] = ['/parent-tools/access'], includeInvalidButton = false) {
+function renderParentTools(
+    initialEntries: string[] = ['/parent-tools/access'],
+    includeInvalidButton = false,
+    authState: AuthState = auth
+) {
     return render(
         <MemoryRouter initialEntries={initialEntries}>
             <Routes>
@@ -79,7 +83,7 @@ function renderParentTools(initialEntries: string[] = ['/parent-tools/access'], 
                     element={(
                         <>
                             {includeInvalidButton ? <InvalidParentToolsButton /> : null}
-                            <ParentToolsRoute />
+                            <ParentToolsRoute authState={authState} />
                         </>
                     )}
                 />
@@ -143,6 +147,23 @@ describe('ParentTools access', () => {
 
         expect(await screen.findByText('Invite code expired.')).toBeTruthy();
         expect(screen.getByRole('button', { name: 'Request access without a code' })).toBeTruthy();
+    });
+
+    it('blocks inline redeem when the signed-in user is unavailable', async () => {
+        const signedOutAuth: AuthState = {
+            ...auth,
+            user: null,
+            roles: [],
+            isParent: false
+        };
+        renderParentTools(['/parent-tools/access'], false, signedOutAuth);
+
+        await screen.findByText('Request player access');
+        fireEvent.change(screen.getByPlaceholderText('XXXXXXXX'), { target: { value: 'ab12cd34' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Redeem code' }));
+
+        expect(await screen.findByText('Sign in to redeem an invite code.')).toBeTruthy();
+        expect(inviteRedemptionMocks.redeemSignedInInvite).not.toHaveBeenCalled();
     });
 
     it('opens the manual request form immediately while public teams finish loading', async () => {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -361,7 +361,8 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
 
   const redeem = async (event: FormEvent) => {
     event.preventDefault();
-    if (!auth.user?.uid) {
+    const currentUser = auth.user;
+    if (!currentUser?.uid) {
       setActionError(toAppServiceError(new Error('Sign in to redeem an invite code.'), 'Sign in to redeem an invite code.'));
       return;
     }
@@ -370,9 +371,9 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
     setMessage('');
     await redeemOperation.run(
       () => redeemSignedInInvite({
-        userId: auth.user.uid,
+        userId: currentUser.uid,
         code: redeemCode,
-        email: auth.user.email,
+        email: currentUser.email,
         refresh: auth.refresh
       }),
       {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react';
 import { exportCalendarIcsFile, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { redeemSignedInInvite } from '../lib/inviteRedemption';
+import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import {
   buildParentScheduleIcs,
   createParentFamilyShare,
@@ -53,6 +54,7 @@ import {
   type ParentRegistrationCard
 } from '../lib/parentToolsService';
 import { getCalendarEventShareText } from '../lib/parentToolsService';
+import { useAsyncOperation } from '../lib/useAsyncOperation';
 import type { ParentScheduleEvent } from '../lib/scheduleLogic';
 import type { AuthState } from '../lib/types';
 
@@ -236,33 +238,41 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [selectedPlayerId, setSelectedPlayerId] = useState('');
   const [relation, setRelation] = useState('Parent');
-  const [loading, setLoading] = useState(true);
-  const [loadingTeams, setLoadingTeams] = useState(false);
-  const [loadingPlayers, setLoadingPlayers] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [redeemCode, setRedeemCode] = useState('');
-  const [redeeming, setRedeeming] = useState(false);
   const [message, setMessage] = useState('');
-  const [error, setError] = useState('');
+  const [loadError, setLoadError] = useState<AppServiceError | null>(null);
+  const [manualLookupError, setManualLookupError] = useState<AppServiceError | null>(null);
+  const [actionError, setActionError] = useState<AppServiceError | null>(null);
+  const accessLoadOperation = useAsyncOperation();
+  const teamLoadOperation = useAsyncOperation();
+  const playerLoadOperation = useAsyncOperation();
+  const submitOperation = useAsyncOperation();
+  const redeemOperation = useAsyncOperation();
 
-  const loadAccessModel = async () => {
-    const model = await loadParentAccessModel(auth.user);
-    setRequests(model.requests);
-  };
+  const loading = accessLoadOperation.loading;
+  const loadingTeams = teamLoadOperation.loading;
+  const loadingPlayers = playerLoadOperation.loading;
+  const saving = submitOperation.loading;
+  const redeeming = redeemOperation.loading;
 
   const loadTeams = useCallback(async () => {
-    setLoadingTeams(true);
-    setError('');
-    try {
-      const rows = await loadParentAccessTeams();
-      setTeams(rows);
-      setSelectedTeamId((current) => rows.some((team) => team.id === current) ? current : '');
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load public teams.');
-    } finally {
-      setLoadingTeams(false);
-    }
-  }, []);
+    setManualLookupError(null);
+    setActionError(null);
+    return teamLoadOperation.run(
+      () => loadParentAccessTeams(),
+      {
+        rethrow: false,
+        getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load public teams.'), 'Unable to load public teams.'),
+        onSuccess: (rows) => {
+          setTeams(rows);
+          setSelectedTeamId((current) => rows.some((team) => team.id === current) ? current : '');
+        },
+        onError: (error) => {
+          setManualLookupError(toAppServiceError(error, 'Unable to load public teams.'));
+        }
+      }
+    );
+  }, [teamLoadOperation]);
 
   const openManualRequest = useCallback(() => {
     setManualRequestOpen(true);
@@ -271,18 +281,25 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
     }
   }, [loadTeams, loadingTeams, teams.length]);
 
-  const refresh = async () => {
-    setLoading(true);
-    setError('');
+  const refresh = useCallback(async () => {
+    setLoadError(null);
+    setManualLookupError(null);
+    setActionError(null);
     setMessage('');
-    try {
-      await loadAccessModel();
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load team access.');
-    } finally {
-      setLoading(false);
-    }
-  };
+    return accessLoadOperation.run(
+      () => loadParentAccessModel(auth.user),
+      {
+        rethrow: false,
+        getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load team access.'), 'Unable to load team access.'),
+        onSuccess: (model) => {
+          setRequests(model.requests);
+        },
+        onError: (error) => {
+          setLoadError(toAppServiceError(error, 'Unable to load team access.'));
+        }
+      }
+    );
+  }, [accessLoadOperation, auth.user]);
 
   useEffect(() => {
     void refresh();
@@ -297,23 +314,43 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
     setSelectedPlayerId('');
   }, [auth.user?.uid]);
 
+  const loadPlayersForTeam = useCallback(async (teamId: string) => {
+    setManualLookupError(null);
+    const rows = await playerLoadOperation.run(
+      () => loadParentAccessPlayers(teamId),
+      {
+        rethrow: false,
+        getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load players for this team.'), 'Unable to load players for this team.')
+      }
+    );
+    if (rows) {
+      setPlayers(rows);
+      setSelectedPlayerId(rows[0]?.id || '');
+      return;
+    }
+    setManualLookupError(toAppServiceError(playerLoadOperation.error || new Error('Unable to load players for this team.'), 'Unable to load players for this team.'));
+  }, [playerLoadOperation]);
+
   useEffect(() => {
     let cancelled = false;
     async function loadPlayers() {
       setPlayers([]);
       setSelectedPlayerId('');
       if (!selectedTeamId) return;
-      setLoadingPlayers(true);
-      try {
-        const rows = await loadParentAccessPlayers(selectedTeamId);
-        if (!cancelled) {
-          setPlayers(rows);
-          setSelectedPlayerId(rows[0]?.id || '');
+      const rows = await playerLoadOperation.run(
+        () => loadParentAccessPlayers(selectedTeamId),
+        {
+          rethrow: false,
+          getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load players for this team.'), 'Unable to load players for this team.')
         }
-      } catch (loadError: any) {
-        if (!cancelled) setError(loadError?.message || 'Unable to load players for this team.');
-      } finally {
-        if (!cancelled) setLoadingPlayers(false);
+      );
+      if (!cancelled && rows) {
+        setManualLookupError(null);
+        setPlayers(rows);
+        setSelectedPlayerId(rows[0]?.id || '');
+      }
+      if (!cancelled && !rows) {
+        setManualLookupError(toAppServiceError(playerLoadOperation.error || new Error('Unable to load players for this team.'), 'Unable to load players for this team.'));
       }
     }
     void loadPlayers();
@@ -325,57 +362,66 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
   const redeem = async (event: FormEvent) => {
     event.preventDefault();
     if (!auth.user?.uid) {
-      setError('Sign in to redeem an invite code.');
+      setActionError(toAppServiceError(new Error('Sign in to redeem an invite code.'), 'Sign in to redeem an invite code.'));
       return;
     }
 
-    setRedeeming(true);
-    setError('');
+    setActionError(null);
     setMessage('');
-    try {
-      const result = await redeemSignedInInvite({
+    await redeemOperation.run(
+      () => redeemSignedInInvite({
         userId: auth.user.uid,
         code: redeemCode,
         email: auth.user.email,
         refresh: auth.refresh
-      });
-      await loadAccessModel();
-      onAccessChanged();
-      setRedeemCode('');
-      setMessage(result.message);
-    } catch (redeemError: any) {
-      setError(redeemError?.message || 'Unable to redeem this invite code.');
-    } finally {
-      setRedeeming(false);
-    }
+      }),
+      {
+        rethrow: false,
+        getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to redeem this invite code.'), 'Unable to redeem this invite code.'),
+        onSuccess: async (result) => {
+          await refresh();
+          onAccessChanged();
+          setRedeemCode('');
+          setMessage(result.message);
+        },
+        onError: (error) => {
+          setActionError(toAppServiceError(error, 'Unable to redeem this invite code.'));
+        }
+      }
+    );
   };
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     if (!selectedTeamId || !selectedPlayerId) {
-      setError('Choose a team and player first.');
+      setActionError(toAppServiceError(new Error('Choose a team and player first.'), 'Choose a team and player first.'));
       return;
     }
-    setSaving(true);
-    setError('');
+    setActionError(null);
     setMessage('');
-    try {
-      await submitParentAccessRequest(selectedTeamId, selectedPlayerId, relation);
-      setMessage('Access request sent.');
-      await loadAccessModel();
-      onAccessChanged();
-    } catch (submitError: any) {
-      setError(submitError?.message || 'Unable to send access request.');
-    } finally {
-      setSaving(false);
-    }
+    await submitOperation.run(
+      () => submitParentAccessRequest(selectedTeamId, selectedPlayerId, relation),
+      {
+        rethrow: false,
+        getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to send access request.'), 'Unable to send access request.'),
+        onSuccess: async () => {
+          await refresh();
+          onAccessChanged();
+          setMessage('Access request sent.');
+        },
+        onError: (error) => {
+          setActionError(toAppServiceError(error, 'Unable to send access request.'));
+        }
+      }
+    );
   };
 
   return (
     <div className="space-y-3">
       <section className="app-card p-4">
         <ToolHeader icon={Shield} title="Request player access" detail="Use this when you do not have an invite code." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading || redeeming}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
-        {error ? <Status tone="error" message={error} /> : null}
+        {loadError ? <RetryableStatus error={loadError} fallbackMessage="Unable to load team access." onRetry={refresh} retrying={loading} /> : null}
+        {actionError ? <Status tone="error" message={getParentToolErrorMessage(actionError, 'Unable to complete that action.')} /> : null}
         {message ? <Status tone="success" message={message} /> : null}
         {loading ? <LoadingBlock label="Loading access tools" /> : (
           <>
@@ -405,6 +451,7 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
             </form>
             {manualRequestOpen ? (
               <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
+                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : loadTeams} retrying={loadingTeams || loadingPlayers} /></div> : null}
                 <div className="min-w-0">
                   <label className="app-label" htmlFor="parent-access-team">Team</label>
                   <select id="parent-access-team" aria-label="Team" className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>
@@ -471,22 +518,30 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
 function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [fees, setFees] = useState<ParentFeeAppRecord[]>([]);
   const [filter, setFilter] = useState<'open' | 'all' | 'paid'>('open');
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
   const [payingFeeId, setPayingFeeId] = useState('');
   const [feeErrors, setFeeErrors] = useState<Record<string, string>>({});
+  const loadOperation = useAsyncOperation();
+  const payOperation = useAsyncOperation();
+  const loading = loadOperation.loading;
 
-  const refresh = async () => {
-    setLoading(true);
-    setError('');
-    try {
-      setFees(await loadParentFeesForApp(auth.user));
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load fees.');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const refresh = useCallback(async () => {
+    setError(null);
+    return loadOperation.run(
+      () => loadParentFeesForApp(auth.user),
+      {
+        rethrow: false,
+        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load fees.'), 'Unable to load fees.'),
+        onSuccess: (result) => {
+          setFees(result);
+          setError(null);
+        },
+        onError: (loadError) => {
+          setError(toAppServiceError(loadError, 'Unable to load fees.'));
+        }
+      }
+    );
+  }, [auth.user, loadOperation]);
 
   useEffect(() => {
     void refresh();
@@ -507,25 +562,33 @@ function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: n
     const reusableCheckoutUrl = Boolean(fee.checkoutUrl) && (!checkoutStatus || checkoutStatus === 'open');
     setPayingFeeId(feeKey);
     setFeeErrors((current) => ({ ...current, [feeKey]: '' }));
-    try {
-      if (fee.paymentAction === 'checkoutUrl' || (!fee.paymentAction && reusableCheckoutUrl)) {
+    await payOperation.run(
+      async () => {
+        if (fee.paymentAction === 'checkoutUrl' || (!fee.paymentAction && reusableCheckoutUrl)) {
+          await openPublicUrl(String(fee.checkoutUrl));
+          return;
+        }
+        if (fee.paymentAction === 'createCheckout' || (!fee.paymentAction && fee.checkoutInitiatable)) {
+          const checkout = await initiateParentTeamFeeCheckout(String(fee.teamId || ''), String(fee.batchId || ''), String(fee.recipientId || ''));
+          await openPublicUrl(checkout.checkoutUrl);
+          return;
+        }
+        if (!reusableCheckoutUrl) {
+          throw new Error('Checkout is not available for this fee.');
+        }
         await openPublicUrl(String(fee.checkoutUrl));
-        return;
+      },
+      {
+        rethrow: false,
+        getErrorMessage: (payError) => getParentToolErrorMessage(toAppServiceError(payError, 'Unable to open checkout. Please try again.'), 'Unable to open checkout. Please try again.'),
+        onError: (payError) => {
+          setFeeErrors((current) => ({ ...current, [feeKey]: getParentToolErrorMessage(toAppServiceError(payError, 'Unable to open checkout. Please try again.'), 'Unable to open checkout. Please try again.') }));
+        },
+        onFinally: () => {
+          setPayingFeeId('');
+        }
       }
-      if (fee.paymentAction === 'createCheckout' || (!fee.paymentAction && fee.checkoutInitiatable)) {
-        const checkout = await initiateParentTeamFeeCheckout(String(fee.teamId || ''), String(fee.batchId || ''), String(fee.recipientId || ''));
-        await openPublicUrl(checkout.checkoutUrl);
-        return;
-      }
-      if (!reusableCheckoutUrl) {
-        throw new Error('Checkout is not available for this fee.');
-      }
-      await openPublicUrl(String(fee.checkoutUrl));
-    } catch (payError: any) {
-      setFeeErrors((current) => ({ ...current, [feeKey]: payError?.message || 'Unable to open checkout. Please try again.' }));
-    } finally {
-      setPayingFeeId('');
-    }
+    );
   };
 
   return (
@@ -546,7 +609,7 @@ function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: n
         </div>
       </section>
 
-      {error ? <Status tone="error" message={error} /> : null}
+      {error ? <RetryableStatus error={error} fallbackMessage="Unable to load fees." onRetry={refresh} retrying={loading} /> : null}
       {loading ? <LoadingBlock label="Loading fees" /> : (
         <div className="grid gap-3 lg:grid-cols-2">
           {visibleFees.length ? visibleFees.map((fee) => {
@@ -568,26 +631,33 @@ function getFeeCardKey(fee: ParentFeeAppRecord) {
 function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
   const [teams, setTeams] = useState<ParentCalendarTeam[]>([]);
-  const [loading, setLoading] = useState(true);
   const [busyTeamId, setBusyTeamId] = useState('');
-  const [exporting, setExporting] = useState(false);
   const [message, setMessage] = useState('');
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
+  const loadOperation = useAsyncOperation();
+  const exportOperation = useAsyncOperation();
+  const feedOperation = useAsyncOperation();
+  const loading = loadOperation.loading;
+  const exporting = exportOperation.loading;
 
-  const refresh = async (options: { force?: boolean } = {}) => {
-    setLoading(true);
-    setError('');
+  const refresh = useCallback(async (options: { force?: boolean } = {}) => {
+    setError(null);
     setMessage('');
-    try {
-      const model = await loadParentCalendarTools(auth.user, options);
-      setEvents(model.events);
-      setTeams(model.teams);
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load calendar tools.');
-    } finally {
-      setLoading(false);
-    }
-  };
+    return loadOperation.run(
+      () => loadParentCalendarTools(auth.user, options),
+      {
+        rethrow: false,
+        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load calendar tools.'), 'Unable to load calendar tools.'),
+        onSuccess: (model) => {
+          setEvents(model.events);
+          setTeams(model.teams);
+        },
+        onError: (loadError) => {
+          setError(toAppServiceError(loadError, 'Unable to load calendar tools.'));
+        }
+      }
+    );
+  }, [auth.user, loadOperation]);
 
   useEffect(() => {
     void refresh(refreshVersion > 0 ? { force: true } : {});
@@ -599,17 +669,21 @@ function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersio
       setMessage('No events to export yet.');
       return;
     }
-    setExporting(true);
-    setError('');
+    setError(null);
     setMessage('');
-    try {
-      await exportCalendarIcsFile('all-plays-family-schedule.ics', buildParentScheduleIcs(events));
-      setMessage('Calendar file ready to share.');
-    } catch (downloadError: any) {
-      setError(downloadError?.message || 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.');
-    } finally {
-      setExporting(false);
-    }
+    await exportOperation.run(
+      () => exportCalendarIcsFile('all-plays-family-schedule.ics', buildParentScheduleIcs(events)),
+      {
+        rethrow: false,
+        getErrorMessage: (downloadError) => getParentToolErrorMessage(toAppServiceError(downloadError, 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.'), 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.'),
+        onSuccess: () => {
+          setMessage('Calendar file ready to share.');
+        },
+        onError: (downloadError) => {
+          setError(toAppServiceError(downloadError, 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.'));
+        }
+      }
+    );
   };
 
   const copyAgenda = async () => {
@@ -623,28 +697,36 @@ function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersio
 
   const openFeed = async (team: ParentCalendarTeam, target: 'copy' | 'apple' | 'google') => {
     setBusyTeamId(team.teamId);
-    setError('');
+    setError(null);
     setMessage('');
-    try {
-      const feedUrl = await getPrivateTeamCalendarFeedUrl(team.teamId);
-      if (!feedUrl) throw new Error('Unable to create private calendar feed. Sign in again and retry.');
-      if (target === 'copy') {
-        await copyText(feedUrl, setMessage);
-      } else {
+    await feedOperation.run(
+      async () => {
+        const feedUrl = await getPrivateTeamCalendarFeedUrl(team.teamId);
+        if (!feedUrl) throw new Error('Unable to create private calendar feed. Sign in again and retry.');
+        if (target === 'copy') {
+          await copyText(feedUrl, setMessage);
+          return;
+        }
         await openPublicUrl(target === 'apple' ? getAppleCalendarFeedUrl(feedUrl) : getGoogleCalendarFeedUrl(feedUrl));
+      },
+      {
+        rethrow: false,
+        getErrorMessage: (feedError) => getParentToolErrorMessage(toAppServiceError(feedError, 'Unable to open calendar feed.'), 'Unable to open calendar feed.'),
+        onError: (feedError) => {
+          setError(toAppServiceError(feedError, 'Unable to open calendar feed.'));
+        },
+        onFinally: () => {
+          setBusyTeamId('');
+        }
       }
-    } catch (feedError: any) {
-      setError(feedError?.message || 'Unable to open calendar feed.');
-    } finally {
-      setBusyTeamId('');
-    }
+    );
   };
 
   return (
     <div className="space-y-3">
       <section className="app-card p-4">
         <ToolHeader icon={CalendarDays} title="Calendar tools" detail="Download your family schedule or subscribe by team." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={() => { void refresh({ force: true }); }} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
-        {error ? <Status tone="error" message={error} /> : null}
+        {error ? <RetryableStatus error={error} fallbackMessage="Unable to load calendar tools." onRetry={loading ? undefined : () => refresh({ force: true })} retrying={loading} /> : null}
         {message ? <Status tone="success" message={message} /> : null}
         <div className="mt-3 grid gap-2 sm:grid-cols-3">
           <button type="button" className="secondary-button justify-center" onClick={() => { void download(); }} disabled={loading || exporting}>
@@ -692,27 +774,33 @@ function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState; refres
   const [email, setEmail] = useState('');
   const [relation, setRelation] = useState('');
   const [createdInvite, setCreatedInvite] = useState<{ code: string; inviteUrl: string } | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
+  const loadOperation = useAsyncOperation();
+  const submitOperation = useAsyncOperation();
+  const loading = loadOperation.loading;
+  const saving = submitOperation.loading;
 
   const pendingMembers = useMemo(() => members.filter((member) => String(member.status || '').toLowerCase() === 'pending'), [members]);
 
-  const refresh = async () => {
-    setLoading(true);
-    setError('');
-    try {
-      const model = await loadParentHouseholdInviteModel(auth.user);
-      setLinkedPlayers(model.linkedPlayers);
-      setMembers(model.members);
-      setPlayerKey((current) => current || (model.linkedPlayers[0] ? `${model.linkedPlayers[0].teamId}::${model.linkedPlayers[0].playerId}` : ''));
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load household invites.');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const refresh = useCallback(async () => {
+    setError(null);
+    return loadOperation.run(
+      () => loadParentHouseholdInviteModel(auth.user),
+      {
+        rethrow: false,
+        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load household invites.'), 'Unable to load household invites.'),
+        onSuccess: (model) => {
+          setLinkedPlayers(model.linkedPlayers);
+          setMembers(model.members);
+          setPlayerKey((current) => current || (model.linkedPlayers[0] ? `${model.linkedPlayers[0].teamId}::${model.linkedPlayers[0].playerId}` : ''));
+        },
+        onError: (loadError) => {
+          setError(toAppServiceError(loadError, 'Unable to load household invites.'));
+        }
+      }
+    );
+  }, [auth.user, loadOperation]);
 
   useEffect(() => {
     void refresh();
@@ -724,46 +812,50 @@ function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState; refres
     const trimmedEmail = email.trim();
     const trimmedRelation = relation.trim();
     if (!playerKey) {
-      setError('Choose a linked player first.');
+      setError(toAppServiceError(new Error('Choose a linked player first.'), 'Choose a linked player first.'));
       return;
     }
     if (!trimmedEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
-      setError('Enter a valid email for the household contact.');
+      setError(toAppServiceError(new Error('Enter a valid email for the household contact.'), 'Enter a valid email for the household contact.'));
       return;
     }
     if (!trimmedRelation) {
-      setError('Enter the household contact relation.');
+      setError(toAppServiceError(new Error('Enter the household contact relation.'), 'Enter the household contact relation.'));
       return;
     }
-    setSaving(true);
-    setError('');
+    setError(null);
     setMessage('');
     setCreatedInvite(null);
-    try {
-      const result = await createParentHouseholdMemberInvite(auth.user, {
+    await submitOperation.run(
+      () => createParentHouseholdMemberInvite(auth.user, {
         playerKey,
         displayName,
         email: trimmedEmail,
         relation: trimmedRelation
-      });
-      setCreatedInvite(result);
-      setMessage('Household invite created.');
-      setDisplayName('');
-      setEmail('');
-      setRelation('');
-      await refresh();
-    } catch (createError: any) {
-      setError(createError?.message || 'Unable to create household invite.');
-    } finally {
-      setSaving(false);
-    }
+      }),
+      {
+        rethrow: false,
+        getErrorMessage: (createError) => getParentToolErrorMessage(toAppServiceError(createError, 'Unable to create household invite.'), 'Unable to create household invite.'),
+        onSuccess: async (result) => {
+          setCreatedInvite(result);
+          setMessage('Household invite created.');
+          setDisplayName('');
+          setEmail('');
+          setRelation('');
+          await refresh();
+        },
+        onError: (createError) => {
+          setError(toAppServiceError(createError, 'Unable to create household invite.'));
+        }
+      }
+    );
   };
 
   return (
     <div className="space-y-3">
       <section className="app-card p-4">
         <ToolHeader icon={Users} title="Household member invite" detail="Create one pending family plan invite for a linked player. This is separate from co-parent and token share links." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
-        {error ? <Status tone="error" message={error} /> : null}
+        {error ? <RetryableStatus error={error} fallbackMessage="Unable to load household invites." onRetry={loading ? undefined : refresh} retrying={loading} /> : null}
         {message ? <Status tone="success" message={message} /> : null}
         {createdInvite ? (
           <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
@@ -819,24 +911,30 @@ function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
   const [calendarText, setCalendarText] = useState('');
   const [editingTokenId, setEditingTokenId] = useState('');
   const [pendingRevokeToken, setPendingRevokeToken] = useState<FamilyShareTokenCard | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
+  const loadOperation = useAsyncOperation();
+  const saveOperation = useAsyncOperation();
+  const loading = loadOperation.loading;
+  const saving = saveOperation.loading;
 
-  const refresh = async () => {
-    setLoading(true);
-    setError('');
-    try {
-      const model = await loadFamilyShareModel(auth.user);
-      setChildren(model.children);
-      setTokens(model.tokens);
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load family share links.');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const refresh = useCallback(async () => {
+    setError(null);
+    return loadOperation.run(
+      () => loadFamilyShareModel(auth.user),
+      {
+        rethrow: false,
+        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load family share links.'), 'Unable to load family share links.'),
+        onSuccess: (model) => {
+          setChildren(model.children);
+          setTokens(model.tokens);
+        },
+        onError: (loadError) => {
+          setError(toAppServiceError(loadError, 'Unable to load family share links.'));
+        }
+      }
+    );
+  }, [auth.user, loadOperation]);
 
   useEffect(() => {
     void refresh();
@@ -845,60 +943,74 @@ function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
 
   const create = async (event: FormEvent) => {
     event.preventDefault();
-    setSaving(true);
-    setError('');
+    setError(null);
     setMessage('');
-    try {
-      const result = await createParentFamilyShare(auth.user, label || 'Family share', splitLines(calendarText));
-      setMessage('Family link created.');
-      setLabel('');
-      setCalendarText('');
-      await copyText(result.url, setMessage);
-      await refresh();
-    } catch (createError: any) {
-      setError(createError?.message || 'Unable to create family share link.');
-    } finally {
-      setSaving(false);
-    }
+    await saveOperation.run(
+      () => createParentFamilyShare(auth.user, label || 'Family share', splitLines(calendarText)),
+      {
+        rethrow: false,
+        getErrorMessage: (createError) => getParentToolErrorMessage(toAppServiceError(createError, 'Unable to create family share link.'), 'Unable to create family share link.'),
+        onSuccess: async (result) => {
+          setMessage('Family link created.');
+          setLabel('');
+          setCalendarText('');
+          await copyText(result.url, setMessage);
+          await refresh();
+        },
+        onError: (createError) => {
+          setError(toAppServiceError(createError, 'Unable to create family share link.'));
+        }
+      }
+    );
   };
 
   const revoke = async (tokenId: string) => {
-    setSaving(true);
-    setError('');
+    setError(null);
     setMessage('');
-    try {
-      await revokeParentFamilyShare(tokenId);
-      setMessage('Family link revoked.');
-      await refresh();
-    } catch (revokeError: any) {
-      setError(revokeError?.message || 'Unable to revoke family link.');
-    } finally {
-      setSaving(false);
-      setPendingRevokeToken(null);
-    }
+    await saveOperation.run(
+      () => revokeParentFamilyShare(tokenId),
+      {
+        rethrow: false,
+        getErrorMessage: (revokeError) => getParentToolErrorMessage(toAppServiceError(revokeError, 'Unable to revoke family share link.'), 'Unable to revoke family share link.'),
+        onSuccess: async () => {
+          setMessage('Family link revoked.');
+          await refresh();
+        },
+        onError: (revokeError) => {
+          setError(toAppServiceError(revokeError, 'Unable to revoke family share link.'));
+        },
+        onFinally: () => {
+          setPendingRevokeToken(null);
+        }
+      }
+    );
   };
 
   const saveCalendars = async (tokenId: string, value: string) => {
-    setSaving(true);
-    setError('');
+    setError(null);
     setMessage('');
-    try {
-      await updateParentFamilyShareCalendars(tokenId, splitLines(value));
-      setEditingTokenId('');
-      setMessage('Calendar links updated.');
-      await refresh();
-    } catch (saveError: any) {
-      setError(saveError?.message || 'Unable to update calendar links.');
-    } finally {
-      setSaving(false);
-    }
+    await saveOperation.run(
+      () => updateParentFamilyShareCalendars(tokenId, splitLines(value)),
+      {
+        rethrow: false,
+        getErrorMessage: (saveError) => getParentToolErrorMessage(toAppServiceError(saveError, 'Unable to update calendar links.'), 'Unable to update calendar links.'),
+        onSuccess: async () => {
+          setEditingTokenId('');
+          setMessage('Calendar links updated.');
+          await refresh();
+        },
+        onError: (saveError) => {
+          setError(toAppServiceError(saveError, 'Unable to update calendar links.'));
+        }
+      }
+    );
   };
 
   return (
     <div className="space-y-3">
       <section className="app-card p-4">
         <ToolHeader icon={Share2} title="Family share" detail="Share a private family page with relatives and caregivers." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
-        {error ? <Status tone="error" message={error} /> : null}
+        {error ? <RetryableStatus error={error} fallbackMessage="Unable to load family share links." onRetry={loading ? undefined : refresh} retrying={loading} /> : null}
         {message ? <Status tone="success" message={message} /> : null}
         <div className="mt-3 flex flex-wrap gap-1.5">
           {children.length ? children.map((child) => (
@@ -957,20 +1069,26 @@ function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
 
 function RegistrationsTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [cards, setCards] = useState<ParentRegistrationCard[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
+  const loadOperation = useAsyncOperation();
+  const loading = loadOperation.loading;
 
-  const refresh = async () => {
-    setLoading(true);
-    setError('');
-    try {
-      setCards(await loadParentRegistrations(auth.user));
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load registrations.');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const refresh = useCallback(async () => {
+    setError(null);
+    return loadOperation.run(
+      () => loadParentRegistrations(auth.user),
+      {
+        rethrow: false,
+        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load registrations.'), 'Unable to load registrations.'),
+        onSuccess: (result) => {
+          setCards(result);
+        },
+        onError: (loadError) => {
+          setError(toAppServiceError(loadError, 'Unable to load registrations.'));
+        }
+      }
+    );
+  }, [auth.user, loadOperation]);
 
   useEffect(() => {
     void refresh();
@@ -981,7 +1099,7 @@ function RegistrationsTool({ auth, refreshVersion }: { auth: AuthState; refreshV
     <div className="space-y-3">
       <section className="app-card p-4">
         <ToolHeader icon={Ticket} title="Registrations" detail="Published team registration forms linked to your family." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
-        {error ? <Status tone="error" message={error} /> : null}
+        {error ? <RetryableStatus error={error} fallbackMessage="Unable to load registrations." onRetry={refresh} retrying={loading} /> : null}
       </section>
       {loading ? <LoadingBlock label="Loading registrations" /> : (
         <div className="grid gap-3 lg:grid-cols-2">
@@ -996,20 +1114,26 @@ function RegistrationsTool({ auth, refreshVersion }: { auth: AuthState; refreshV
 
 function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [cards, setCards] = useState<ParentCertificateCard[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
+  const loadOperation = useAsyncOperation();
+  const loading = loadOperation.loading;
 
-  const refresh = async () => {
-    setLoading(true);
-    setError('');
-    try {
-      setCards(await loadParentCertificates(auth.user));
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load awards.');
-    } finally {
-      setLoading(false);
-    }
-  };
+  const refresh = useCallback(async () => {
+    setError(null);
+    return loadOperation.run(
+      () => loadParentCertificates(auth.user),
+      {
+        rethrow: false,
+        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load awards.'), 'Unable to load awards.'),
+        onSuccess: (result) => {
+          setCards(result);
+        },
+        onError: (loadError) => {
+          setError(toAppServiceError(loadError, 'Unable to load awards.'));
+        }
+      }
+    );
+  }, [auth.user, loadOperation]);
 
   useEffect(() => {
     void refresh();
@@ -1020,7 +1144,7 @@ function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; refreshVe
     <div className="space-y-3">
       <section className="app-card p-4">
         <ToolHeader icon={Award} title="Awards" detail="Published certificates for linked players." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
-        {error ? <Status tone="error" message={error} /> : null}
+        {error ? <RetryableStatus error={error} fallbackMessage="Unable to load awards." onRetry={refresh} retrying={loading} /> : null}
       </section>
       {loading ? <LoadingBlock label="Loading awards" /> : (
         <div className="grid gap-3 lg:grid-cols-2">
@@ -1266,6 +1390,40 @@ function Status({ tone, message }: { tone: 'error' | 'success'; message: string 
       <span>{message}</span>
     </div>
   );
+}
+
+function RetryableStatus({
+  error,
+  fallbackMessage,
+  onRetry,
+  retrying,
+  buttonLabel = 'Retry'
+}: {
+  error: AppServiceError | null;
+  fallbackMessage: string;
+  onRetry?: () => void;
+  retrying?: boolean;
+  buttonLabel?: string;
+}) {
+  return (
+    <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm font-semibold text-rose-800">
+      <div className="flex items-start gap-3">
+        <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
+        <div className="min-w-0 flex-1">{getParentToolErrorMessage(error, fallbackMessage)}</div>
+        {onRetry ? (
+          <button type="button" className="ghost-button !min-h-8 !px-2 text-xs" onClick={onRetry} disabled={retrying}>
+            <RefreshCw className={`h-4 w-4 ${retrying ? 'animate-spin' : ''}`} aria-hidden="true" />
+            {buttonLabel}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function getParentToolErrorMessage(error: AppServiceError | null, fallbackMessage: string) {
+  if (!error) return fallbackMessage;
+  return String(error.message || '').trim() || fallbackMessage;
 }
 
 function LoadingBlock({ label }: { label: string }) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -3631,7 +3631,7 @@ async function sendCategoryNotification({
   const link = linkOverride || buildNotificationLink({ category, teamId, gameId, conversationId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
-    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId, conversationId })
+    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
   const maxMulticastTokens = 500;
   const allResponses = [];
@@ -3691,7 +3691,7 @@ async function sendDirectTargetsNotification({ targets, category, title, body, t
   const link = buildNotificationLink({ category, teamId, gameId, conversationId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
-    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId, conversationId })
+    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
   const maxMulticastTokens = 500;
   const allResponses = [];

--- a/functions/index.js
+++ b/functions/index.js
@@ -3180,7 +3180,7 @@ function detectGameNotificationCategory(beforeGame, afterGame) {
 }
 
 function buildNotificationLink({ category, teamId, gameId, conversationId = null }) {
-  if (category === 'liveChat') {
+  if (category === 'liveChat' || category === 'mentions') {
     const params = [`teamId=${encodeURIComponent(teamId)}`];
     if (conversationId) {
       params.push(`conversationId=${encodeURIComponent(conversationId)}`);
@@ -3194,7 +3194,7 @@ function buildNotificationLink({ category, teamId, gameId, conversationId = null
 }
 
 function buildNotificationAppRoute({ category, teamId, gameId, eventId, conversationId = null }) {
-  if (category === 'liveChat' && teamId) {
+  if ((category === 'liveChat' || category === 'mentions') && teamId) {
     const route = `/messages/${encodeURIComponent(teamId)}`;
     if (!conversationId) {
       return route;

--- a/functions/index.js
+++ b/functions/index.js
@@ -3179,9 +3179,13 @@ function detectGameNotificationCategory(beforeGame, afterGame) {
   return scheduleChanged ? 'schedule' : null;
 }
 
-function buildNotificationLink({ category, teamId, gameId }) {
+function buildNotificationLink({ category, teamId, gameId, conversationId = null }) {
   if (category === 'liveChat') {
-    return `https://allplays.ai/team-chat.html?teamId=${encodeURIComponent(teamId)}`;
+    const params = [`teamId=${encodeURIComponent(teamId)}`];
+    if (conversationId) {
+      params.push(`conversationId=${encodeURIComponent(conversationId)}`);
+    }
+    return `https://allplays.ai/team-chat.html?${params.join('&')}`;
   }
   if (category === 'liveScore' && gameId) {
     return `https://allplays.ai/live-game.html?teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}`;
@@ -3189,9 +3193,13 @@ function buildNotificationLink({ category, teamId, gameId }) {
   return `https://allplays.ai/team.html?teamId=${encodeURIComponent(teamId)}`;
 }
 
-function buildNotificationAppRoute({ category, teamId, gameId, eventId }) {
+function buildNotificationAppRoute({ category, teamId, gameId, eventId, conversationId = null }) {
   if (category === 'liveChat' && teamId) {
-    return `/messages/${encodeURIComponent(teamId)}`;
+    const route = `/messages/${encodeURIComponent(teamId)}`;
+    if (!conversationId) {
+      return route;
+    }
+    return `${route}?conversationId=${encodeURIComponent(conversationId)}`;
   }
   if (category === 'liveScore' && gameId) {
     if (teamId) {
@@ -3593,6 +3601,7 @@ async function sendCategoryNotification({
   teamId,
   gameId = null,
   eventId = null,
+  conversationId = null,
   category,
   title,
   body,
@@ -3619,10 +3628,10 @@ async function sendCategoryNotification({
     : allTargets;
   if (!targets.length) return null;
 
-  const link = linkOverride || buildNotificationLink({ category, teamId, gameId });
-  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
+  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, conversationId });
+  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
-    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
+    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId, conversationId })
     : {};
   const maxMulticastTokens = 500;
   const allResponses = [];
@@ -3638,6 +3647,7 @@ async function sendCategoryNotification({
         teamId: String(teamId),
         gameId: String(gameId || ''),
         eventId: String(eventId || gameId || ''),
+        conversationId: String(conversationId || ''),
         category: String(category),
         appRoute,
         link
@@ -3675,13 +3685,13 @@ async function sendCategoryNotification({
   };
 }
 
-async function sendDirectTargetsNotification({ targets, category, title, body, teamId, gameId = null, eventId = null }) {
+async function sendDirectTargetsNotification({ targets, category, title, body, teamId, gameId = null, eventId = null, conversationId = null }) {
   if (!targets.length) return null;
 
-  const link = buildNotificationLink({ category, teamId, gameId });
-  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
+  const link = buildNotificationLink({ category, teamId, gameId, conversationId });
+  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
-    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
+    ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId, conversationId })
     : {};
   const maxMulticastTokens = 500;
   const allResponses = [];
@@ -3697,6 +3707,7 @@ async function sendDirectTargetsNotification({ targets, category, title, body, t
         teamId: String(teamId),
         gameId: String(gameId || ''),
         eventId: String(eventId || gameId || ''),
+        conversationId: String(conversationId || ''),
         category: String(category),
         appRoute,
         link
@@ -4188,13 +4199,20 @@ exports.sendFeeUnpaidDueReminders = functions.pubsub
   .schedule('every 24 hours')
   .onRun(() => sendFeeUnpaidDueReminders());
 
-function detectMentionedUids(text, members) {
+function normalizeTeamChatConversationId(value) {
+  const conversationId = String(value || '').trim();
+  return conversationId || 'team';
+}
+
+function detectMentionedUids(text, members, options = {}) {
   if (!text) return [];
+  const { allowReservedMentions = false } = options || {};
   const mentioned = new Set();
   const tokens = text.match(/@[\w.'"-]+/gi) || [];
   for (const token of tokens) {
     const name = token.slice(1).toLowerCase();
     if (name === 'all' || name === 'team') {
+      if (!allowReservedMentions) continue;
       members.forEach((m) => mentioned.add(m.uid));
       break;
     }
@@ -4211,7 +4229,8 @@ function detectMentionedUids(text, members) {
 }
 
 async function buildTeamChatNotificationContext(teamId, options = {}) {
-  const { includeMentions = true } = options || {};
+  const { includeMentions = true, conversationId = null } = options || {};
+  const normalizedConversationId = normalizeTeamChatConversationId(conversationId);
   const teamSnap = await firestore.doc(`teams/${teamId}`).get();
   if (!teamSnap.exists) {
     return {
@@ -4302,12 +4321,18 @@ async function buildTeamChatNotificationContext(teamId, options = {}) {
   const hydratedMembers = members.map((member) => {
     const userRecord = userRecords.get(member.uid) || {};
     const chatMuted = userRecord.chatMuted;
+    const mutedConversations = userRecord.teamChatState?.[teamId]?.mutedConversations;
+    const conversationMuted = Boolean(
+      mutedConversations
+      && typeof mutedConversations === 'object'
+      && mutedConversations[normalizedConversationId]
+    );
     return {
       ...member,
       displayName: includeMentions
         ? String(userRecord.displayName || userRecord.fullName || userRecord.name || '').trim()
         : '',
-      muted: Boolean(chatMuted && chatMuted[teamId])
+      muted: conversationMuted || Boolean(normalizedConversationId === 'team' && chatMuted && chatMuted[teamId])
     };
   });
 
@@ -4337,8 +4362,13 @@ function buildTeamChatNotificationPlan({ text, actorUid = null, recipientContext
   const mentionMembers = Array.isArray(context.members)
     ? context.members.filter((member) => mentionEligibleUids.has(member.uid))
     : [];
+  const actorIsStaff = Boolean(
+    actorUid
+    && Array.isArray(context.members)
+    && context.members.some((member) => member.uid === actorUid && Array.isArray(member.roles) && member.roles.includes('staff'))
+  );
   const mentionedUids = text
-    ? detectMentionedUids(text, mentionMembers).filter((uid) => uid !== actorUid)
+    ? detectMentionedUids(text, mentionMembers, { allowReservedMentions: actorIsStaff }).filter((uid) => uid !== actorUid)
     : [];
   const mentionedSet = new Set(mentionedUids);
   const mutedSet = new Set(Array.isArray(context.mutedUids) ? context.mutedUids : []);
@@ -4365,6 +4395,7 @@ exports.notifyTeamChatMessageCreated = functions.firestore
 
     const teamId = context.params.teamId;
     const actorUid = data.senderId || null;
+    const conversationId = normalizeTeamChatConversationId(data.conversationId);
     const senderName = String(data.senderName || 'Team').trim();
     const body = text
       ? (text.length > 120 ? `${text.slice(0, 117)}...` : text)
@@ -4372,7 +4403,8 @@ exports.notifyTeamChatMessageCreated = functions.firestore
 
     const shouldResolveMentions = Boolean(text);
     const recipientContext = await buildTeamChatNotificationContext(teamId, {
-      includeMentions: shouldResolveMentions
+      includeMentions: shouldResolveMentions,
+      conversationId
     });
     const notificationPlan = buildTeamChatNotificationPlan({
       text,
@@ -4394,7 +4426,8 @@ exports.notifyTeamChatMessageCreated = functions.firestore
           category: 'mentions',
           title: `${senderName} mentioned you`,
           body,
-          teamId
+          teamId,
+          conversationId
         }));
       }
     }
@@ -4409,7 +4442,8 @@ exports.notifyTeamChatMessageCreated = functions.firestore
       category: 'liveChat',
       title: `${senderName}: Team Chat`,
       body,
-      teamId
+      teamId,
+      conversationId
     }));
 
     return results;

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -320,7 +320,9 @@ function buildNotificationTestEnv({
                 messagingCalls.push({
                     tokens: [...message.tokens],
                     title: message.notification?.title || '',
-                    body: message.notification?.body || ''
+                    body: message.notification?.body || '',
+                    data: { ...(message.data || {}) },
+                    webLink: message.webpush?.fcmOptions?.link || ''
                 });
                 const responses = message.tokens.map((token, index) => invalidTokenResponses[index] || { success: true, token });
                 const failureCount = responses.filter((response) => response?.success === false).length;

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -183,6 +183,47 @@ describe('getTargetsForCategory', () => {
 
 
 describe('sendCategoryNotification', () => {
+    it('includes conversation deep links for live chat notifications', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            indexedTargets: [
+                {
+                    uid: 'coach-1',
+                    deviceId: 'coach-device',
+                    token: 'coach-token',
+                    categories: { liveChat: true }
+                }
+            ]
+        });
+
+        try {
+            const result = await internals.sendCategoryNotification({
+                teamId: 'team-1',
+                category: 'liveChat',
+                title: 'New message',
+                body: 'Check chat',
+                conversationId: 'staff room'
+            });
+
+            expect(result?.successCount).toBe(1);
+            expect(env.messagingCalls).toHaveLength(1);
+            expect(env.messagingCalls[0].data).toMatchObject({
+                category: 'liveChat',
+                conversationId: 'staff room',
+                appRoute: '/messages/team-1?conversationId=staff%20room',
+                link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff%20room'
+            });
+            expect(env.messagingCalls[0].webLink).toBe('https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff%20room');
+            expect(env.inboxWrites).toHaveLength(1);
+            expect(env.inboxWrites[0].value.appRoute).toBe('/messages/team-1?conversationId=staff%20room');
+        } finally {
+            cleanup();
+        }
+    });
+
     it('prunes invalid tokens from both notification index collections', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -183,7 +183,10 @@ describe('getTargetsForCategory', () => {
 
 
 describe('sendCategoryNotification', () => {
-    it('includes conversation deep links for live chat notifications', async () => {
+    it.each([
+        ['liveChat', { liveChat: true }],
+        ['mentions', { mentions: true }]
+    ])('includes conversation deep links for %s notifications', async (category, categories) => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {
                 ownerId: 'coach-1',
@@ -194,7 +197,7 @@ describe('sendCategoryNotification', () => {
                     uid: 'coach-1',
                     deviceId: 'coach-device',
                     token: 'coach-token',
-                    categories: { liveChat: true }
+                    categories
                 }
             ]
         });
@@ -202,7 +205,7 @@ describe('sendCategoryNotification', () => {
         try {
             const result = await internals.sendCategoryNotification({
                 teamId: 'team-1',
-                category: 'liveChat',
+                category,
                 title: 'New message',
                 body: 'Check chat',
                 conversationId: 'staff room'
@@ -211,7 +214,7 @@ describe('sendCategoryNotification', () => {
             expect(result?.successCount).toBe(1);
             expect(env.messagingCalls).toHaveLength(1);
             expect(env.messagingCalls[0].data).toMatchObject({
-                category: 'liveChat',
+                category,
                 conversationId: 'staff room',
                 appRoute: '/messages/team-1?conversationId=staff%20room',
                 link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff%20room'

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -14,6 +14,20 @@ function getDetectMentionedUids() {
     return new Function(`${slice}; return detectMentionedUids;`)();
 }
 
+function getBuildTeamChatNotificationContext() {
+    const start = functionsSource.indexOf('function normalizeTeamChatConversationId(');
+    const end = functionsSource.indexOf('\nfunction buildTeamChatNotificationPlan');
+    const slice = functionsSource.slice(start, end);
+    return new Function(
+        'firestore',
+        'getUserIdsByEmails',
+        'getUserRecordsByIds',
+        'notificationAudienceAllowsRoles',
+        'getLegacyTargetsForCategory',
+        `${slice}; return buildTeamChatNotificationContext;`
+    );
+}
+
 function getBuildTeamChatNotificationPlan() {
     const start = functionsSource.indexOf('function buildTeamChatNotificationPlan(');
     const end = functionsSource.indexOf('\nexports.notifyTeamChatMessageCreated');
@@ -65,7 +79,7 @@ describe('detectMentionedUids', () => {
             { uid: 'u2', displayName: 'Bob' },
             { uid: 'u3', displayName: 'Carol' }
         ];
-        const result = detectMentionedUids('Heads up @all!', members);
+        const result = detectMentionedUids('Heads up @all!', members, { allowReservedMentions: true });
         expect(result.sort()).toEqual(['u1', 'u2', 'u3']);
     });
 
@@ -74,7 +88,7 @@ describe('detectMentionedUids', () => {
             { uid: 'u1', displayName: 'Alice' },
             { uid: 'u2', displayName: 'Bob' }
         ];
-        const result = detectMentionedUids('Hey @team listen up', members);
+        const result = detectMentionedUids('Hey @team listen up', members, { allowReservedMentions: true });
         expect(result.sort()).toEqual(['u1', 'u2']);
     });
 
@@ -99,9 +113,90 @@ describe('detectMentionedUids', () => {
         expect(detectMentionedUids('Hello @unknown', members)).toEqual([]);
     });
 
+    it('does not treat partial strings as exact @mentions', () => {
+        const members = [{ uid: 'u1', displayName: 'Alice' }];
+        expect(detectMentionedUids('Hello @ali', members)).toEqual([]);
+    });
+
     it('falls back to name field when displayName is missing', () => {
         const members = [{ uid: 'u5', displayName: '', name: 'Eve' }];
         expect(detectMentionedUids('Hey @eve!', members)).toEqual(['u5']);
+    });
+
+    it('ignores reserved tokens unless the caller explicitly allows them', () => {
+        const members = [
+            { uid: 'u1', displayName: 'Alice' },
+            { uid: 'u2', displayName: 'Bob' }
+        ];
+        expect(detectMentionedUids('Heads up @all', members)).toEqual([]);
+        expect(detectMentionedUids('Heads up @team', members, { allowReservedMentions: true }).sort()).toEqual(['u1', 'u2']);
+    });
+});
+
+describe('buildTeamChatNotificationContext', () => {
+    it('uses per-conversation mute state before falling back to team-wide chatMuted', async () => {
+        const teamData = { ownerId: 'coach-1', adminEmails: ['assistant@example.com'] };
+        const parentDocs = [{ id: 'parent-1' }];
+        const targetDocs = [
+            {
+                data: () => ({ uid: 'coach-1', deviceId: 'device-1', token: 'token-1', categories: { mentions: true, liveChat: true } })
+            },
+            {
+                data: () => ({ uid: 'assistant-1', deviceId: 'device-2', token: 'token-2', categories: { mentions: true, liveChat: true } })
+            },
+            {
+                data: () => ({ uid: 'parent-1', deviceId: 'device-3', token: 'token-3', categories: { mentions: true, liveChat: true } })
+            }
+        ];
+
+        const firestore = {
+            doc: (path) => ({
+                get: async () => ({
+                    exists: path === 'teams/team-1',
+                    data: () => teamData
+                })
+            }),
+            collection: (path) => {
+                if (path === 'users') {
+                    return {
+                        where: () => ({
+                            get: async () => ({ forEach: (callback) => parentDocs.forEach((doc) => callback(doc)) })
+                        })
+                    };
+                }
+                if (path === 'teams/team-1/notificationTargets') {
+                    return {
+                        get: async () => ({ forEach: (callback) => targetDocs.forEach((doc) => callback(doc)) })
+                    };
+                }
+                throw new Error(`Unexpected collection path: ${path}`);
+            }
+        };
+
+        const factory = getBuildTeamChatNotificationContext();
+        const buildTeamChatNotificationContext = factory(
+            firestore,
+            async () => ['assistant-1'],
+            async () => new Map([
+                ['coach-1', { displayName: 'Coach Kim', teamChatState: { 'team-1': { mutedConversations: { staff: { seconds: 1 } } } } }],
+                ['assistant-1', { displayName: 'Assistant Lee', chatMuted: { 'team-1': { seconds: 2 } } }],
+                ['parent-1', { displayName: 'Pat Parent', teamChatState: { 'team-1': { mutedConversations: { team: { seconds: 3 } } } } }]
+            ]),
+            (category, roles = []) => category === 'mentions' || roles.includes('parent') || roles.includes('staff'),
+            async () => []
+        );
+
+        const teamConversationContext = await buildTeamChatNotificationContext('team-1', {
+            includeMentions: true,
+            conversationId: null
+        });
+        const staffConversationContext = await buildTeamChatNotificationContext('team-1', {
+            includeMentions: true,
+            conversationId: 'staff'
+        });
+
+        expect(teamConversationContext.mutedUids.sort()).toEqual(['assistant-1', 'parent-1']);
+        expect(staffConversationContext.mutedUids).toEqual(['coach-1']);
     });
 });
 
@@ -117,8 +212,10 @@ describe('notifyTeamChatMessageCreated source wiring', () => {
 
     it('builds one shared recipient context for mentions and live chat delivery', () => {
         expect(notifyTeamChatMessageCreatedSource).toContain('const shouldResolveMentions = Boolean(text);');
+        expect(notifyTeamChatMessageCreatedSource).toContain('const conversationId = normalizeTeamChatConversationId(data.conversationId);');
         expect(notifyTeamChatMessageCreatedSource).toContain('const recipientContext = await buildTeamChatNotificationContext(teamId, {');
         expect(notifyTeamChatMessageCreatedSource).toContain('includeMentions: shouldResolveMentions');
+        expect(notifyTeamChatMessageCreatedSource).toContain('conversationId');
         expect(notifyTeamChatMessageCreatedSource).toContain('const notificationPlan = buildTeamChatNotificationPlan({');
         expect(notifyTeamChatMessageCreatedSource).not.toContain('const candidateUsers = await getCandidateUsersForTeam(teamId);');
         expect(notifyTeamChatMessageCreatedSource).not.toContain('await getMutedUserIdsForTeam(');
@@ -143,6 +240,12 @@ describe('notifyTeamChatMessageCreated source wiring', () => {
     it('skips mention target resolution for photo-only chats', () => {
         expect(functionsSource).toContain("const categories = includeMentions ? ['mentions', 'liveChat'] : ['liveChat'];");
         expect(functionsSource).toContain("displayName: includeMentions");
+    });
+
+    it('includes the conversation deep-link target in both mention and live chat payloads', () => {
+        expect(notifyTeamChatMessageCreatedSource).toContain('conversationId');
+        expect(functionsSource).toContain('conversationId: String(conversationId || \'\')');
+        expect(functionsSource).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
     });
 });
 
@@ -217,5 +320,42 @@ describe('buildTeamChatNotificationPlan', () => {
         expect(plan.liveChatTargets.some((target) => target.uid === 'user-111')).toBe(false);
         expect(plan.liveChatTargets.some((target) => target.uid === 'user-222')).toBe(false);
         expect(plan.liveChatTargets.some((target) => mentionedUserIds.includes(target.uid))).toBe(false);
+    });
+
+    it('honors reserved @team mentions only for staff senders and still dedupes live chat', () => {
+        const recipientContext = {
+            members: [
+                { uid: 'coach-1', displayName: 'Coach Kim', roles: ['staff'] },
+                { uid: 'player-1', displayName: 'Alex', roles: ['parent'] },
+                { uid: 'player-2', displayName: 'Blair', roles: ['parent'] }
+            ],
+            mutedUids: [],
+            targetsByCategory: {
+                mentions: [
+                    { uid: 'player-1', token: 'mention-1' },
+                    { uid: 'player-2', token: 'mention-2' }
+                ],
+                liveChat: [
+                    { uid: 'player-1', token: 'chat-1' },
+                    { uid: 'player-2', token: 'chat-2' }
+                ]
+            }
+        };
+
+        const staffPlan = buildTeamChatNotificationPlan({
+            text: 'Heads up @team',
+            actorUid: 'coach-1',
+            recipientContext
+        });
+        const parentPlan = buildTeamChatNotificationPlan({
+            text: 'Heads up @team',
+            actorUid: 'player-1',
+            recipientContext
+        });
+
+        expect(staffPlan.mentionedUids.sort()).toEqual(['player-1', 'player-2']);
+        expect(staffPlan.liveChatTargets).toEqual([]);
+        expect(parentPlan.mentionedUids).toEqual([]);
+        expect(parentPlan.liveChatTargets.map((target) => target.uid).sort()).toEqual(['player-2']);
     });
 });

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -9,6 +9,8 @@ describe('push notification payload contract', () => {
         expect(source).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}`;");
         expect(source).toContain('eventId: String(eventId || gameId || \'\')');
         expect(source).toContain('conversationId: String(conversationId || \'\')');
+        expect(source).toContain("if (category === 'liveChat' || category === 'mentions') {");
+        expect(source).toContain("if ((category === 'liveChat' || category === 'mentions') && teamId) {");
         expect(source).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
         expect(source).toContain('params.push(`conversationId=${encodeURIComponent(conversationId)}`);');
         expect(source).toContain('fcmOptions: { link }');

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -8,6 +8,9 @@ describe('push notification payload contract', () => {
         expect(source).toContain('appRoute,');
         expect(source).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}`;");
         expect(source).toContain('eventId: String(eventId || gameId || \'\')');
+        expect(source).toContain('conversationId: String(conversationId || \'\')');
+        expect(source).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
+        expect(source).toContain('params.push(`conversationId=${encodeURIComponent(conversationId)}`);');
         expect(source).toContain('fcmOptions: { link }');
     });
 });


### PR DESCRIPTION
Closes #2413

## What changed
- tightened server-side `@mention` handling so exact name matches still work, partial non-matches stay ignored, and reserved `@all` / `@team` tokens only expand when the sender is staff
- switched chat mute suppression to read per-conversation mute state from `teamChatState.{teamId}.mutedConversations`, while still honoring the legacy team-level mute for the default team chat
- passed `conversationId` through chat push payload generation so mention and live-chat pushes carry both a deep-link route and legacy web link for the specific conversation
- expanded focused functions tests to cover reserved-token gating, partial non-match behavior, per-conversation mute suppression, mention/live-chat dedupe, and payload routing fields

## Root Cause
The chat notification path mixed old and new chat assumptions. It treated reserved mention tokens as universally valid, only checked the legacy team-level `chatMuted` flag instead of per-conversation mute state, and built live-chat payloads without conversation-specific routing data.

## Prevention / Learning
When notification behavior depends on conversation context, carry that context end-to-end through detection, eligibility, mute checks, and payload construction. Also require explicit authorization for broadcast-style tokens like `@all` and `@team` instead of letting the parser expand them by default.

## Regression Tests
- `npx vitest run tests/unit/functions-chat-mention-detection.test.js tests/unit/push-notification-payload-contract.test.js tests/unit/app-push-notification-routing.test.ts --reporter=verbose`
- `tests/unit/functions-chat-mention-detection.test.js` now covers exact match, partial non-match, staff-only reserved mentions, per-conversation mute handling, and live-chat dedupe
- `tests/unit/push-notification-payload-contract.test.js` asserts `conversationId` is included in the push payload contract