### PR TITLE
Add fee due reminder deep links and amounts

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3179,7 +3179,21 @@ function detectGameNotificationCategory(beforeGame, afterGame) {
   return scheduleChanged ? 'schedule' : null;
 }
 
-function buildNotificationLink({ category, teamId, gameId, conversationId = null }) {
+function buildNotificationLink({ category, teamId, gameId, batchId = null, recipientId = null, conversationId = null }) {
+  if (category === 'fees') {
+    const params = new URLSearchParams();
+    if (teamId) {
+      params.set('teamId', teamId);
+    }
+    if (batchId) {
+      params.set('batchId', batchId);
+    }
+    if (recipientId) {
+      params.set('recipientId', recipientId);
+    }
+    const query = params.toString();
+    return `https://allplays.ai/app/#/parent-tools/fees${query ? `?${query}` : ''}`;
+  }
   if (category === 'liveChat' || category === 'mentions') {
     const params = [`teamId=${encodeURIComponent(teamId)}`];
     if (conversationId) {
@@ -3193,7 +3207,21 @@ function buildNotificationLink({ category, teamId, gameId, conversationId = null
   return `https://allplays.ai/team.html?teamId=${encodeURIComponent(teamId)}`;
 }
 
-function buildNotificationAppRoute({ category, teamId, gameId, eventId, conversationId = null }) {
+function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId = null, recipientId = null, conversationId = null }) {
+  if (category === 'fees') {
+    const params = new URLSearchParams();
+    if (teamId) {
+      params.set('teamId', teamId);
+    }
+    if (batchId) {
+      params.set('batchId', batchId);
+    }
+    if (recipientId) {
+      params.set('recipientId', recipientId);
+    }
+    const query = params.toString();
+    return `/parent-tools/fees${query ? `?${query}` : ''}`;
+  }
   if ((category === 'liveChat' || category === 'mentions') && teamId) {
     const route = `/messages/${encodeURIComponent(teamId)}`;
     if (!conversationId) {
@@ -3685,11 +3713,11 @@ async function sendCategoryNotification({
   };
 }
 
-async function sendDirectTargetsNotification({ targets, category, title, body, teamId, gameId = null, eventId = null, conversationId = null }) {
+async function sendDirectTargetsNotification({ targets, category, title, body, teamId, gameId = null, eventId = null, batchId = null, recipientId = null, conversationId = null }) {
   if (!targets.length) return null;
 
-  const link = buildNotificationLink({ category, teamId, gameId, conversationId });
-  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
+  const link = buildNotificationLink({ category, teamId, gameId, batchId, recipientId, conversationId });
+  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
@@ -4159,10 +4187,13 @@ async function sendFeeUnpaidDueReminders() {
     // Skip if reminder already sent (deduplication guard)
     if (data.reminderSentAt) return null;
     const pathParts = doc.ref.path.split('/');
-    // Path structure: teams/{teamId}/.../{feeId}/feeRecipients/{recipientId}
+    // Path structure: teams/{teamId}/feeBatches/{batchId}/feeRecipients/{recipientId}
     const teamId = pathParts[1];
+    const batchId = pathParts[3];
+    const recipientId = pathParts[5];
     if (!teamId) return null;
     const title = data.feeTitle || data.title || 'Team fee due soon';
+    const amountLabel = formatFeeReminderAmount(getTeamFeeBalanceCents(data), data.currency || 'USD');
 
     try {
       const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, data);
@@ -4180,8 +4211,10 @@ async function sendFeeUnpaidDueReminders() {
         targets: payerTargets,
         category: 'fees',
         title: `Reminder: ${title} is due soon`,
-        body: 'Your team fee payment is due in 3 days or less.',
+        body: `${amountLabel} is due in 3 days or less.`,
         teamId,
+        batchId,
+        recipientId,
       });
       return { teamId, payerUserIds: candidateUserIds, feeTitle: title };
     } catch (err) {
@@ -4198,6 +4231,19 @@ async function sendFeeUnpaidDueReminders() {
 exports.sendFeeUnpaidDueReminders = functions.pubsub
   .schedule('every 24 hours')
   .onRun(() => sendFeeUnpaidDueReminders());
+
+function formatFeeReminderAmount(amountCents, currency = 'USD') {
+  const cents = Math.max(0, Math.round(Number(amountCents || 0)));
+  const normalizedCurrency = String(currency || 'USD').trim().toUpperCase() || 'USD';
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: normalizedCurrency
+    }).format(cents / 100);
+  } catch (error) {
+    return `$${(cents / 100).toFixed(2)}`;
+  }
+}
 
 function normalizeTeamChatConversationId(value) {
   const conversationId = String(value || '').trim();

--- a/functions/index.js
+++ b/functions/index.js
@@ -3179,6 +3179,24 @@ function detectGameNotificationCategory(beforeGame, afterGame) {
   return scheduleChanged ? 'schedule' : null;
 }
 
+function buildStaffFeeNotificationDestination({ teamId, batchId = null, recipientId = null }) {
+  const encodedTeamId = encodeURIComponent(teamId);
+  const encodedBatchId = batchId ? encodeURIComponent(batchId) : '';
+  const baseRoute = encodedBatchId
+    ? `/teams/${encodedTeamId}/fees/${encodedBatchId}`
+    : `/teams/${encodedTeamId}/fees`;
+  const params = new URLSearchParams();
+  if (recipientId) {
+    params.set('recipientId', recipientId);
+  }
+  const query = params.toString();
+  const appRoute = `${baseRoute}${query ? `?${query}` : ''}`;
+  return {
+    appRoute,
+    link: `https://allplays.ai/app/#${appRoute}`
+  };
+}
+
 function buildNotificationLink({ category, teamId, gameId, batchId = null, recipientId = null, conversationId = null }) {
   if (category === 'fees') {
     const params = new URLSearchParams();
@@ -3713,11 +3731,24 @@ async function sendCategoryNotification({
   };
 }
 
-async function sendDirectTargetsNotification({ targets, category, title, body, teamId, gameId = null, eventId = null, batchId = null, recipientId = null, conversationId = null }) {
+async function sendDirectTargetsNotification({
+  targets,
+  category,
+  title,
+  body,
+  teamId,
+  gameId = null,
+  eventId = null,
+  batchId = null,
+  recipientId = null,
+  conversationId = null,
+  linkOverride = null,
+  appRouteOverride = null
+}) {
   if (!targets.length) return null;
 
-  const link = buildNotificationLink({ category, teamId, gameId, batchId, recipientId, conversationId });
-  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId });
+  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, batchId, recipientId, conversationId });
+  const appRoute = appRouteOverride || buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
@@ -4818,9 +4849,10 @@ exports.notifyFeeMarkedPaid = functions.firestore
       return null;
     }
 
-    const { teamId } = context.params;
+    const { teamId, batchId, recipientId } = context.params;
     const title = String(after.feeTitle || after.title || 'Team fee').trim();
     const payerUserId = String(after.userId || after.parentUserId || '').trim() || null;
+    const staffFeeDestination = buildStaffFeeNotificationDestination({ teamId, batchId, recipientId });
 
     const [allFeeTargets, candidateUsers] = await Promise.all([
       getTargetsForCategory(teamId, 'fees', null),
@@ -4853,7 +4885,11 @@ exports.notifyFeeMarkedPaid = functions.firestore
         category: 'fees',
         title: `Fee marked paid: ${title}`,
         body: 'A team fee has been marked as paid.',
-        teamId
+        teamId,
+        batchId,
+        recipientId,
+        linkOverride: staffFeeDestination.link,
+        appRouteOverride: staffFeeDestination.appRoute
       }));
     } else {
       functions.logger.warn('notifyFeeMarkedPaid found no staff notification targets.', {

--- a/functions/index.js
+++ b/functions/index.js
@@ -4852,7 +4852,20 @@ exports.notifyFeeMarkedPaid = functions.firestore
     const { teamId, batchId, recipientId } = context.params;
     const title = String(after.feeTitle || after.title || 'Team fee').trim();
     const payerUserId = String(after.userId || after.parentUserId || '').trim() || null;
-    const staffFeeDestination = buildStaffFeeNotificationDestination({ teamId, batchId, recipientId });
+    const encodedTeamId = encodeURIComponent(teamId);
+    const encodedBatchId = batchId ? encodeURIComponent(batchId) : '';
+    const staffFeeBaseRoute = encodedBatchId
+      ? `/teams/${encodedTeamId}/fees/${encodedBatchId}`
+      : `/teams/${encodedTeamId}/fees`;
+    const staffFeeParams = new URLSearchParams();
+    if (recipientId) {
+      staffFeeParams.set('recipientId', recipientId);
+    }
+    const staffFeeQuery = staffFeeParams.toString();
+    const staffFeeDestination = {
+      appRoute: `${staffFeeBaseRoute}${staffFeeQuery ? `?${staffFeeQuery}` : ''}`,
+      link: `https://allplays.ai/app/#${staffFeeBaseRoute}${staffFeeQuery ? `?${staffFeeQuery}` : ''}`
+    };
 
     const [allFeeTargets, candidateUsers] = await Promise.all([
       getTargetsForCategory(teamId, 'fees', null),

--- a/tests/unit/fee-due-reminders-source.test.js
+++ b/tests/unit/fee-due-reminders-source.test.js
@@ -45,4 +45,13 @@ describe('fee due reminder source wiring', () => {
         expect(functionsSource).toContain('const candidateUserIdSet = new Set(candidateUserIds);');
         expect(functionsSource).toContain('await doc.ref.update({ reminderSentAt: admin.firestore.FieldValue.serverTimestamp() });');
     });
+
+    it('formats the reminder amount and attaches fee-specific routing identifiers', () => {
+        expect(functionsSource).toContain("const batchId = pathParts[3];");
+        expect(functionsSource).toContain("const recipientId = pathParts[5];");
+        expect(functionsSource).toContain("const amountLabel = formatFeeReminderAmount(getTeamFeeBalanceCents(data), data.currency || 'USD');");
+        expect(functionsSource).toContain('body: `${amountLabel} is due in 3 days or less.`,');
+        expect(functionsSource).toContain('batchId,');
+        expect(functionsSource).toContain('recipientId,');
+    });
 });

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -10,6 +10,7 @@ function getHelper(name, nextMarker) {
     return new Function(`${slice}; return ${name};`)();
 }
 
+const buildStaffFeeNotificationDestination = getHelper('buildStaffFeeNotificationDestination', 'function buildNotificationLink');
 const buildNotificationLink = getHelper('buildNotificationLink', 'function buildNotificationAppRoute');
 const buildNotificationAppRoute = getHelper('buildNotificationAppRoute', 'async function getUserIdsByEmails');
 
@@ -41,5 +42,18 @@ describe('push notification payload contract', () => {
             batchId: 'batch/1',
             recipientId: 'recipient?1'
         })).toBe('/parent-tools/fees?teamId=team+1&batchId=batch%2F1&recipientId=recipient%3F1');
+    });
+
+    it('builds staff fee notification routes to the team fee management page', () => {
+        expect(buildStaffFeeNotificationDestination({
+            teamId: 'team 1',
+            batchId: 'batch/1',
+            recipientId: 'recipient?1'
+        })).toEqual({
+            appRoute: '/teams/team%201/fees/batch%2F1?recipientId=recipient%3F1',
+            link: 'https://allplays.ai/app/#/teams/team%201/fees/batch%2F1?recipientId=recipient%3F1'
+        });
+        expect(source).toContain('linkOverride: staffFeeDestination.link');
+        expect(source).toContain('appRouteOverride: staffFeeDestination.appRoute');
     });
 });

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -1,9 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
+const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+function getHelper(name, nextMarker) {
+    const start = source.indexOf(`function ${name}(`);
+    const end = source.indexOf(`\n${nextMarker}`, start);
+    const slice = source.slice(start, end);
+    return new Function(`${slice}; return ${name};`)();
+}
+
+const buildNotificationLink = getHelper('buildNotificationLink', 'function buildNotificationAppRoute');
+const buildNotificationAppRoute = getHelper('buildNotificationAppRoute', 'async function getUserIdsByEmails');
+
 describe('push notification payload contract', () => {
     it('includes native app routing fields alongside the legacy web link', () => {
-        const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
         expect(source).toContain('function buildNotificationAppRoute');
         expect(source).toContain('appRoute,');
         expect(source).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}`;");
@@ -14,5 +25,21 @@ describe('push notification payload contract', () => {
         expect(source).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
         expect(source).toContain('params.push(`conversationId=${encodeURIComponent(conversationId)}`);');
         expect(source).toContain('fcmOptions: { link }');
+    });
+
+    it('builds fee notification deep links to the parent fees view with fee identifiers', () => {
+        expect(buildNotificationLink({
+            category: 'fees',
+            teamId: 'team 1',
+            batchId: 'batch/1',
+            recipientId: 'recipient?1'
+        })).toBe('https://allplays.ai/app/#/parent-tools/fees?teamId=team+1&batchId=batch%2F1&recipientId=recipient%3F1');
+
+        expect(buildNotificationAppRoute({
+            category: 'fees',
+            teamId: 'team 1',
+            batchId: 'batch/1',
+            recipientId: 'recipient?1'
+        })).toBe('/parent-tools/fees?teamId=team+1&batchId=batch%2F1&recipientId=recipient%3F1');
     });
 });

--- a/tests/unit/team-fee-paid-notifications.test.js
+++ b/tests/unit/team-fee-paid-notifications.test.js
@@ -78,7 +78,7 @@ describe('notifyFeeMarkedPaid trigger', () => {
             before: { exists: true, data: () => ({ status: 'unpaid' }) },
             after: { exists: true, data: () => ({ status: 'paid', feeTitle: 'Spring dues', parentUserId: 'parent-1' }) }
         }, {
-            params: { teamId: 'team-1', recipientId: 'recipient-1' }
+            params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
         });
 
         expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'fees', null);
@@ -93,7 +93,11 @@ describe('notifyFeeMarkedPaid trigger', () => {
                 { uid: 'staff-1', token: 'staff-token', teamId: 'team-1' },
                 { uid: 'staff-2', token: 'staff-2-token', teamId: 'team-1' }
             ],
-            title: 'Fee marked paid: Spring dues'
+            title: 'Fee marked paid: Spring dues',
+            batchId: 'batch-1',
+            recipientId: 'recipient-1',
+            linkOverride: 'https://allplays.ai/app/#/teams/team-1/fees/batch-1?recipientId=recipient-1',
+            appRouteOverride: '/teams/team-1/fees/batch-1?recipientId=recipient-1'
         }));
     });
 


### PR DESCRIPTION
Closes #2194

## What changed
- updated the unpaid fee reminder scheduled function to include the formatted outstanding balance in the push body
- attached fee-specific `teamId`, `batchId`, and `recipientId` routing data so fee reminders deep link to the parent fees view instead of falling back to home or the generic team page
- extended focused unit coverage to lock the reminder payload contract and fee-routing behavior

## Root Cause
The existing reminder job already found unpaid recipients and deduplicated sends, but it still emitted generic fee notifications. The payload did not include fee-specific routing metadata and the reminder copy did not format the outstanding amount from cents, so parents landed on fallback destinations and lost the due-fee context.

## Prevention / Learning
For notification work, do not stop at delivery plumbing. Verify the payload contract end to end: recipient filter, copy content, routing target, and any identifiers the destination view needs.

## Regression Tests
- `npx vitest run tests/unit/fee-due-reminders-source.test.js tests/unit/push-notification-payload-contract.test.js --reporter=verbose`
- `tests/unit/fee-due-reminders-source.test.js` now asserts the reminder amount formatting and fee routing identifiers
- `tests/unit/push-notification-payload-contract.test.js` now asserts fee notifications build parent-fees deep links with the expected identifiers