### PR TITLE
Notify staff and payer when fees are paid

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4387,8 +4387,7 @@ function getFeePaymentAmountCents(before = {}, after = {}) {
     return Math.round(afterPaid - beforePaid);
   }
 
-  const totalAmount = Number(after.amountDueCents ?? after.balanceDueCents ?? after.adjustedAmountCents ?? after.amountCents ?? after.totalAmountCents ?? 0);
-  return Number.isFinite(totalAmount) && totalAmount > 0 ? Math.round(totalAmount) : 0;
+  return 0;
 }
 
 function getFeePayerIdentity(recipient = {}) {
@@ -4983,11 +4982,13 @@ exports.notifyFeeMarkedPaid = functions.firestore
     const title = String(after.feeTitle || after.title || 'Team fee').trim();
     const payerUserId = String(after.userId || after.parentUserId || '').trim() || null;
     const staffFeeDestination = buildStaffFeeNotificationDestination({ teamId, batchId, recipientId });
+    const paymentAmountCents = getFeePaymentAmountCents(before, after);
     const paymentAmountDisplay = formatMoneyFromCents(
-      getFeePaymentAmountCents(before, after),
+      paymentAmountCents,
       after.currency || after.receiptMetadata?.currency || 'USD'
     );
     const payerIdentity = getFeePayerIdentity(after);
+    const wasPaymentRecorded = paymentAmountCents > 0;
 
     const [allFeeTargets, candidateUsers] = await Promise.all([
       getTargetsForCategory(teamId, 'fees', null),
@@ -5006,8 +5007,10 @@ exports.notifyFeeMarkedPaid = functions.firestore
         promises.push(sendDirectTargetsNotification({
           targets: payerTargets,
           category: 'fees',
-          title: `Payment received: ${title}`,
-          body: `We received your ${paymentAmountDisplay} payment. Thank you!`,
+          title: wasPaymentRecorded ? `Payment received: ${title}` : `Fee paid: ${title}`,
+          body: wasPaymentRecorded
+            ? `We received your ${paymentAmountDisplay} payment. Thank you!`
+            : 'Your fee balance is now marked as paid.',
           teamId
         }));
       }
@@ -5019,7 +5022,9 @@ exports.notifyFeeMarkedPaid = functions.firestore
         targets: staffTargets,
         category: 'fees',
         title: `Fee paid: ${title}`,
-        body: `${payerIdentity} paid ${paymentAmountDisplay}.`,
+        body: wasPaymentRecorded
+          ? `${payerIdentity} paid ${paymentAmountDisplay}.`
+          : `${payerIdentity}'s fee balance is now marked as paid.`,
         teamId,
         batchId,
         recipientId,

--- a/functions/index.js
+++ b/functions/index.js
@@ -4318,7 +4318,7 @@ async function sendFeeUnpaidDueReminders() {
     const recipientId = pathParts[5];
     if (!teamId) return null;
     const title = data.feeTitle || data.title || 'Team fee due soon';
-    const amountLabel = formatFeeReminderAmount(getTeamFeeBalanceCents(data), data.currency || 'USD');
+    const amountLabel = formatMoneyFromCents(getTeamFeeBalanceCents(data), data.currency || 'USD');
 
     try {
       const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, data);
@@ -4357,7 +4357,7 @@ exports.sendFeeUnpaidDueReminders = functions.pubsub
   .schedule('every 24 hours')
   .onRun(() => sendFeeUnpaidDueReminders());
 
-function formatFeeReminderAmount(amountCents, currency = 'USD') {
+function formatMoneyFromCents(amountCents, currency = 'USD') {
   const cents = Math.max(0, Math.round(Number(amountCents || 0)));
   const normalizedCurrency = String(currency || 'USD').trim().toUpperCase() || 'USD';
   try {
@@ -4368,6 +4368,42 @@ function formatFeeReminderAmount(amountCents, currency = 'USD') {
   } catch (error) {
     return `$${(cents / 100).toFixed(2)}`;
   }
+}
+
+function getFeePaymentAmountCents(before = {}, after = {}) {
+  const explicitAmount = Number(
+    after.stripePaymentAmountCents
+    ?? after.manualPayment?.amountPaidCents
+    ?? after.receiptMetadata?.amountPaidCents
+    ?? after.adminBilling?.amountPaidCents
+  );
+  if (Number.isFinite(explicitAmount) && explicitAmount > 0) {
+    return Math.round(explicitAmount);
+  }
+
+  const afterPaid = Number(after.paidAmountCents ?? after.amountPaidCents ?? after.totalPaidCents ?? 0);
+  const beforePaid = Number(before.paidAmountCents ?? before.amountPaidCents ?? before.totalPaidCents ?? 0);
+  if (Number.isFinite(afterPaid) && Number.isFinite(beforePaid) && afterPaid > beforePaid) {
+    return Math.round(afterPaid - beforePaid);
+  }
+
+  const totalAmount = Number(after.amountDueCents ?? after.balanceDueCents ?? after.adjustedAmountCents ?? after.amountCents ?? after.totalAmountCents ?? 0);
+  return Number.isFinite(totalAmount) && totalAmount > 0 ? Math.round(totalAmount) : 0;
+}
+
+function getFeePayerIdentity(recipient = {}) {
+  return [
+    recipient.parentName,
+    recipient.payerName,
+    recipient.receiptMetadata?.receiptName,
+    recipient.receiptMetadata?.receiptEmail,
+    recipient.parentEmail,
+    recipient.guardianName,
+    recipient.guardianEmail,
+    recipient.userDisplayName,
+    recipient.userEmail,
+    recipient.email
+  ].map((value) => String(value || '').trim()).find(Boolean) || 'A parent';
 }
 
 function normalizeTeamChatConversationId(value) {
@@ -4946,20 +4982,12 @@ exports.notifyFeeMarkedPaid = functions.firestore
     const { teamId, batchId, recipientId } = context.params;
     const title = String(after.feeTitle || after.title || 'Team fee').trim();
     const payerUserId = String(after.userId || after.parentUserId || '').trim() || null;
-    const encodedTeamId = encodeURIComponent(teamId);
-    const encodedBatchId = batchId ? encodeURIComponent(batchId) : '';
-    const staffFeeBaseRoute = encodedBatchId
-      ? `/teams/${encodedTeamId}/fees/${encodedBatchId}`
-      : `/teams/${encodedTeamId}/fees`;
-    const staffFeeParams = new URLSearchParams();
-    if (recipientId) {
-      staffFeeParams.set('recipientId', recipientId);
-    }
-    const staffFeeQuery = staffFeeParams.toString();
-    const staffFeeDestination = {
-      appRoute: `${staffFeeBaseRoute}${staffFeeQuery ? `?${staffFeeQuery}` : ''}`,
-      link: `https://allplays.ai/app/#${staffFeeBaseRoute}${staffFeeQuery ? `?${staffFeeQuery}` : ''}`
-    };
+    const staffFeeDestination = buildStaffFeeNotificationDestination({ teamId, batchId, recipientId });
+    const paymentAmountDisplay = formatMoneyFromCents(
+      getFeePaymentAmountCents(before, after),
+      after.currency || after.receiptMetadata?.currency || 'USD'
+    );
+    const payerIdentity = getFeePayerIdentity(after);
 
     const [allFeeTargets, candidateUsers] = await Promise.all([
       getTargetsForCategory(teamId, 'fees', null),
@@ -4978,8 +5006,8 @@ exports.notifyFeeMarkedPaid = functions.firestore
         promises.push(sendDirectTargetsNotification({
           targets: payerTargets,
           category: 'fees',
-          title: `Fee paid: ${title}`,
-          body: 'Your payment has been received. Thank you!',
+          title: `Payment received: ${title}`,
+          body: `We received your ${paymentAmountDisplay} payment. Thank you!`,
           teamId
         }));
       }
@@ -4990,8 +5018,8 @@ exports.notifyFeeMarkedPaid = functions.firestore
       promises.push(sendDirectTargetsNotification({
         targets: staffTargets,
         category: 'fees',
-        title: `Fee marked paid: ${title}`,
-        body: 'A team fee has been marked as paid.',
+        title: `Fee paid: ${title}`,
+        body: `${payerIdentity} paid ${paymentAmountDisplay}.`,
         teamId,
         batchId,
         recipientId,
@@ -5045,7 +5073,7 @@ exports.notifyFeeAssigned = functions.firestore
 
     const title = String(data.feeTitle || data.title || 'Team fee').trim();
     const amountCents = Number(data.amountCents || data.feeAmountCents || 0);
-    const amountDisplay = amountCents > 0 ? ` ($${(amountCents / 100).toFixed(2)})` : '';
+    const amountDisplay = amountCents > 0 ? ` (${formatMoneyFromCents(amountCents, data.currency || 'USD')})` : '';
 
     await sendDirectTargetsNotification({
       targets: payerTargets,

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -268,6 +268,46 @@ test('notifyFeeMarkedPaid sends fees notifications to payer and staff and record
     }
 });
 
+
+test('notifyFeeMarkedPaid avoids payment wording when a credit marks the fee as paid', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: ['assistant@example.com'] },
+        parentUserIds: ['parent-1'],
+        authUsersByEmail: { 'assistant@example.com': 'coach-2' },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } },
+            { uid: 'coach-1', deviceId: 'coach-device', token: 'coach-token', categories: { fees: true } },
+            { uid: 'coach-2', deviceId: 'assistant-device', token: 'assistant-token', categories: { fees: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/feeBatches/batch-1/feeRecipients/recipient-3');
+        const change = makeChange(ref, { status: 'pending', amountPaidCents: 2500 }, {
+            status: 'paid',
+            feeTitle: 'Tournament dues',
+            userId: 'parent-1',
+            parentName: 'Pat Parent',
+            amountPaidCents: 2500,
+            amountDueCents: 2500
+        });
+        const context = { params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-3' } };
+
+        const result = await moduleExports.notifyFeeMarkedPaid(change, context);
+
+        assert.equal(result, null);
+        assert.equal(env.messagingCalls.length, 2);
+        const payerNotification = env.messagingCalls.find((call) => call.tokens.includes('parent-token'));
+        const staffNotification = env.messagingCalls.find((call) => call.tokens.includes('coach-token'));
+        assert.equal(payerNotification.title, 'Fee paid: Tournament dues');
+        assert.equal(payerNotification.body, 'Your fee balance is now marked as paid.');
+        assert.equal(staffNotification.title, 'Fee paid: Tournament dues');
+        assert.equal(staffNotification.body, "Pat Parent's fee balance is now marked as paid.");
+    } finally {
+        cleanup();
+    }
+});
+
 for (const category of ['schedule', 'practice', 'liveScore', 'liveChat', 'mentions', 'fees']) {
     test(`sendCategoryNotification suppresses ${category} when every indexed recipient opted out`, async () => {
         const { internals, env, cleanup } = loadNotificationInternals({

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -240,7 +240,14 @@ test('notifyFeeMarkedPaid sends fees notifications to payer and staff and record
 
     try {
         const ref = env.firestoreState.doc('teams/team-1/feeBatches/batch-1/feeRecipients/recipient-2');
-        const change = makeChange(ref, { status: 'pending' }, { status: 'paid', feeTitle: 'Tournament dues', userId: 'parent-1' });
+        const change = makeChange(ref, { status: 'pending', amountPaidCents: 0 }, {
+            status: 'paid',
+            feeTitle: 'Tournament dues',
+            userId: 'parent-1',
+            parentName: 'Pat Parent',
+            amountPaidCents: 2500,
+            manualPayment: { amountPaidCents: 2500 }
+        });
         const context = { params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-2' } };
 
         const result = await moduleExports.notifyFeeMarkedPaid(change, context);
@@ -248,6 +255,12 @@ test('notifyFeeMarkedPaid sends fees notifications to payer and staff and record
         assert.equal(result, null);
         assert.equal(env.messagingCalls.length, 2);
         assert.deepEqual(env.messagingCalls.map((call) => call.tokens.length).sort(), [1, 2]);
+        const payerNotification = env.messagingCalls.find((call) => call.tokens.includes('parent-token'));
+        const staffNotification = env.messagingCalls.find((call) => call.tokens.includes('coach-token'));
+        assert.equal(payerNotification.title, 'Payment received: Tournament dues');
+        assert.equal(payerNotification.body, 'We received your $25.00 payment. Thank you!');
+        assert.equal(staffNotification.title, 'Fee paid: Tournament dues');
+        assert.equal(staffNotification.body, 'Pat Parent paid $25.00.');
         assert.equal(env.auditWrites.length, 2);
         assert.deepEqual(env.auditWrites.map((entry) => entry.value.category), ['fees', 'fees']);
     } finally {

--- a/tests/unit/fee-due-reminders-source.test.js
+++ b/tests/unit/fee-due-reminders-source.test.js
@@ -49,7 +49,7 @@ describe('fee due reminder source wiring', () => {
     it('formats the reminder amount and attaches fee-specific routing identifiers', () => {
         expect(functionsSource).toContain("const batchId = pathParts[3];");
         expect(functionsSource).toContain("const recipientId = pathParts[5];");
-        expect(functionsSource).toContain("const amountLabel = formatFeeReminderAmount(getTeamFeeBalanceCents(data), data.currency || 'USD');");
+        expect(functionsSource).toContain("const amountLabel = formatMoneyFromCents(getTeamFeeBalanceCents(data), data.currency || 'USD');");
         expect(functionsSource).toContain('body: `${amountLabel} is due in 3 days or less.`,');
         expect(functionsSource).toContain('batchId,');
         expect(functionsSource).toContain('recipientId,');

--- a/tests/unit/team-fee-paid-notifications.test.js
+++ b/tests/unit/team-fee-paid-notifications.test.js
@@ -3,13 +3,23 @@ import { readFileSync } from 'node:fs';
 
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 
-function extractNotifyFeeMarkedPaid() {
-    const start = functionsSource.indexOf('exports.notifyFeeMarkedPaid = functions.firestore');
-    const end = functionsSource.indexOf('\n\nexports.notifyFeeAssigned = functions.firestore', start);
+function extractChunk(startMarker, endMarker) {
+    const start = functionsSource.indexOf(startMarker);
+    const end = functionsSource.indexOf(endMarker, start);
     if (start === -1 || end === -1) {
-        throw new Error('Unable to extract notifyFeeMarkedPaid source.');
+        throw new Error(`Unable to extract source chunk for ${startMarker}.`);
     }
     return functionsSource.slice(start, end);
+}
+
+function extractNotifyFeeMarkedPaid() {
+    return [
+        extractChunk('function buildStaffFeeNotificationDestination(', 'function buildNotificationLink'),
+        extractChunk('function formatMoneyFromCents(', 'function normalizeTeamChatConversationId'),
+        extractChunk('function getFeePaymentAmountCents(', 'function getFeePayerIdentity'),
+        extractChunk('function getFeePayerIdentity(', 'function normalizeTeamChatConversationId'),
+        extractChunk('exports.notifyFeeMarkedPaid = functions.firestore', 'exports.notifyFeeAssigned = functions.firestore')
+    ].join('\n');
 }
 
 function buildTriggerHarness({
@@ -76,7 +86,7 @@ describe('notifyFeeMarkedPaid trigger', () => {
 
         await harness.trigger({
             before: { exists: true, data: () => ({ status: 'unpaid' }) },
-            after: { exists: true, data: () => ({ status: 'paid', feeTitle: 'Spring dues', parentUserId: 'parent-1' }) }
+            after: { exists: true, data: () => ({ status: 'paid', feeTitle: 'Spring dues', parentUserId: 'parent-1', parentName: 'Pat Parent', manualPayment: { amountPaidCents: 10000 } }) }
         }, {
             params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
         });
@@ -86,19 +96,38 @@ describe('notifyFeeMarkedPaid trigger', () => {
         expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(2);
         expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(1, expect.objectContaining({
             targets: [{ uid: 'parent-1', token: 'parent-token', teamId: 'team-1' }],
-            title: 'Fee paid: Spring dues'
+            title: 'Payment received: Spring dues',
+            body: 'We received your $100.00 payment. Thank you!'
         }));
         expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(2, expect.objectContaining({
             targets: [
                 { uid: 'staff-1', token: 'staff-token', teamId: 'team-1' },
                 { uid: 'staff-2', token: 'staff-2-token', teamId: 'team-1' }
             ],
-            title: 'Fee marked paid: Spring dues',
+            title: 'Fee paid: Spring dues',
+            body: 'Pat Parent paid $100.00.',
             batchId: 'batch-1',
             recipientId: 'recipient-1',
             linkOverride: 'https://allplays.ai/app/#/teams/team-1/fees/batch-1?recipientId=recipient-1',
             appRouteOverride: '/teams/team-1/fees/batch-1?recipientId=recipient-1'
         }));
+    });
+
+    it('does not send when an already-paid recipient gets an unrelated update', async () => {
+        const harness = buildTriggerHarness({
+            targets: [{ uid: 'staff-1', token: 'staff-token', teamId: 'team-1' }],
+            users: [{ uid: 'staff-1', roles: ['staff'] }]
+        });
+
+        await harness.trigger({
+            before: { exists: true, data: () => ({ status: 'paid', feeTitle: 'Spring dues', parentName: 'Pat Parent', amountPaidCents: 10000 }) },
+            after: { exists: true, data: () => ({ status: 'paid', feeTitle: 'Spring dues', parentName: 'Pat Parent', amountPaidCents: 10000, updatedAt: 'later' }) }
+        }, {
+            params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
+        });
+
+        expect(harness.getTargetsForCategory).not.toHaveBeenCalled();
+        expect(harness.sendDirectTargetsNotification).not.toHaveBeenCalled();
     });
 
     it('logs and exits when the fees notification category is unavailable', async () => {

--- a/tests/unit/team-fee-paid-notifications.test.js
+++ b/tests/unit/team-fee-paid-notifications.test.js
@@ -113,6 +113,43 @@ describe('notifyFeeMarkedPaid trigger', () => {
         }));
     });
 
+    it('sends a balance-paid message instead of a payment receipt when credits mark the fee paid', async () => {
+        const harness = buildTriggerHarness({
+            targets: [
+                { uid: 'parent-1', token: 'parent-token', teamId: 'team-1' },
+                { uid: 'staff-1', token: 'staff-token', teamId: 'team-1' }
+            ],
+            users: [{ uid: 'staff-1', roles: ['staff'] }]
+        });
+
+        await harness.trigger({
+            before: { exists: true, data: () => ({ status: 'pending', parentName: 'Pat Parent', amountPaidCents: 2500 }) },
+            after: {
+                exists: true,
+                data: () => ({
+                    status: 'paid',
+                    feeTitle: 'Spring dues',
+                    userId: 'parent-1',
+                    parentName: 'Pat Parent',
+                    amountPaidCents: 2500,
+                    amountDueCents: 2500
+                })
+            }
+        }, {
+            params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
+        });
+
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(2);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            title: 'Fee paid: Spring dues',
+            body: 'Your fee balance is now marked as paid.'
+        }));
+        expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            title: 'Fee paid: Spring dues',
+            body: "Pat Parent's fee balance is now marked as paid."
+        }));
+    });
+
     it('does not send when an already-paid recipient gets an unrelated update', async () => {
         const harness = buildTriggerHarness({
             targets: [{ uid: 'staff-1', token: 'staff-token', teamId: 'team-1' }],


### PR DESCRIPTION
Closes #2195

## What changed
- updated the fee paid recipient trigger to fire only on unpaid or partial to paid transitions and send payment-complete pushes to both the payer and opted-in staff
- added shared cents-to-currency formatting for fee notification copy and reused it for paid and assigned fee notifications
- included payer identity and formatted payment amount in staff push copy while sending a receipt-style confirmation to the payer
- kept staff deep links on `/teams/{teamId}/fees/{batchId}` with `recipientId` context and preserved parent routing to the parent fees view
- added focused regression coverage for payment copy, staff routing, and non-transition updates

## Root Cause
The paid-recipient trigger existed without payment-aware notification copy. It sent generic messages, did not resolve payer identity from the recipient document, and formatted fee amounts inline elsewhere instead of reusing a shared formatter, so payment-complete pushes missed the required receipt details.

## Prevention / Learning
For payment-state notifications, always derive the human-facing payment amount from the transition payload or paid delta, resolve the payer label from the stored recipient fields, and route cents formatting through one shared helper before shipping. Add a regression test that proves the trigger only fires on the relevant state transition and that notification copy includes the required business details.

## Regression Tests
- `npx vitest run tests/unit/team-fee-paid-notifications.test.js tests/unit/push-notification-payload-contract.test.js functions/test/notification-triggers.test.js --reporter=verbose`