### PR TITLE
Paginate admin dashboard bootstrap

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -643,7 +643,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="js/admin.js?v=1"></script>
+    <script type="module" src="js/admin.js?v=2"></script>
 </body>
 
 </html>

--- a/admin.html
+++ b/admin.html
@@ -237,6 +237,13 @@
                         </tbody>
                     </table>
                 </div>
+                <div class="flex items-center justify-between border-t border-gray-200 px-4 py-3 text-sm text-gray-600">
+                    <p id="teams-pagination-status">Loading teams...</p>
+                    <div class="flex items-center gap-2">
+                        <button id="teams-prev-page" type="button" class="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50">Previous</button>
+                        <button id="teams-next-page" type="button" class="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50">Next</button>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -283,6 +290,13 @@
                             <!-- Rows injected here -->
                         </tbody>
                     </table>
+                </div>
+                <div class="flex items-center justify-between border-t border-gray-200 px-4 py-3 text-sm text-gray-600">
+                    <p id="users-pagination-status">Loading users...</p>
+                    <div class="flex items-center gap-2">
+                        <button id="users-prev-page" type="button" class="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50">Previous</button>
+                        <button id="users-next-page" type="button" class="rounded border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50">Next</button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -629,7 +643,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="js/admin.js"></script>
+    <script type="module" src="js/admin.js?v=1"></script>
 </body>
 
 </html>

--- a/js/admin-bootstrap.js
+++ b/js/admin-bootstrap.js
@@ -1,0 +1,39 @@
+export const DEFAULT_ADMIN_PAGE_SIZE = 25;
+
+export function normalizeAdminPageSize(rawPageSize) {
+    const pageSize = Number(rawPageSize);
+    if (!Number.isFinite(pageSize)) return DEFAULT_ADMIN_PAGE_SIZE;
+    return Math.min(Math.max(Math.floor(pageSize), 1), 100);
+}
+
+export async function loadAdminCollectionPage({ fetchPage, cursor = null, pageSize = DEFAULT_ADMIN_PAGE_SIZE }) {
+    if (typeof fetchPage !== 'function') {
+        throw new Error('fetchPage is required');
+    }
+
+    return fetchPage({
+        cursor,
+        pageSize: normalizeAdminPageSize(pageSize)
+    });
+}
+
+export async function loadInitialAdminBootstrap({
+    getTeamsPage,
+    getUsersPage,
+    loadTelemetryData,
+    pageSize = DEFAULT_ADMIN_PAGE_SIZE
+} = {}) {
+    const normalizedPageSize = normalizeAdminPageSize(pageSize);
+    const [teamsPage, usersPage] = await Promise.all([
+        loadAdminCollectionPage({ fetchPage: getTeamsPage, pageSize: normalizedPageSize }),
+        loadAdminCollectionPage({ fetchPage: getUsersPage, pageSize: normalizedPageSize })
+    ]);
+
+    return {
+        teamsPage,
+        usersPage,
+        telemetryPromise: typeof loadTelemetryData === 'function'
+            ? Promise.resolve(loadTelemetryData({ silent: true }))
+            : Promise.resolve()
+    };
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,7 @@
 import {
-    getTeams,
-    getAllUsers,
+    getAdminTeamsPage,
+    getAdminUsersPage,
+    getGames,
     getOfficials,
     addOfficial,
     updateOfficial,
@@ -11,10 +12,11 @@ import {
     getTelemetryPageDaily,
     getTelemetryEventDaily,
     getTelemetrySessions
-} from './db.js?v=50';
+} from './db.js?v=51';
 import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=18';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=25';
+import { DEFAULT_ADMIN_PAGE_SIZE, loadAdminCollectionPage, loadInitialAdminBootstrap } from './admin-bootstrap.js?v=1';
 import {
     adminRegistrationDefaults,
     buildAdminRegistrationFormPayload,
@@ -44,6 +46,92 @@ let activeOfficials = [];
 let activeRegistrationTeam = null;
 let activeRegistrationForms = [];
 let activeRegistrationOptions = [];
+let activeTab = 'dashboard';
+
+const teamPageState = {
+    pageSize: DEFAULT_ADMIN_PAGE_SIZE,
+    pages: [],
+    currentIndex: 0,
+    nextCursor: null,
+    loading: false
+};
+
+const userPageState = {
+    pageSize: DEFAULT_ADMIN_PAGE_SIZE,
+    pages: [],
+    currentIndex: 0,
+    nextCursor: null,
+    loading: false
+};
+
+let loadedGamesPageKey = '';
+let loadedOfficialsPageKey = '';
+
+function getCurrentTeamPage() {
+    return teamPageState.pages[teamPageState.currentIndex] || [];
+}
+
+function getCurrentUsersPage() {
+    return userPageState.pages[userPageState.currentIndex] || [];
+}
+
+function getCurrentTeamPageKey() {
+    return getCurrentTeamPage().map((team) => team.id).join('|');
+}
+
+function applyCurrentTeamPage() {
+    allTeams = getCurrentTeamPage();
+}
+
+function applyCurrentUsersPage() {
+    allUsers = getCurrentUsersPage();
+}
+
+function setTeamsPage(page, nextCursor, index = 0) {
+    teamPageState.pages[index] = page;
+    teamPageState.currentIndex = index;
+    teamPageState.nextCursor = nextCursor;
+    applyCurrentTeamPage();
+    updateTeamsPaginationControls();
+}
+
+function setUsersPage(page, nextCursor, index = 0) {
+    userPageState.pages[index] = page;
+    userPageState.currentIndex = index;
+    userPageState.nextCursor = nextCursor;
+    applyCurrentUsersPage();
+    updateUsersPaginationControls();
+}
+
+function updateTeamsPaginationControls() {
+    const status = document.getElementById('teams-pagination-status');
+    const prev = document.getElementById('teams-prev-page');
+    const next = document.getElementById('teams-next-page');
+    if (status) {
+        status.textContent = `Teams page ${teamPageState.currentIndex + 1} · ${allTeams.length} loaded`;
+    }
+    if (prev) {
+        prev.disabled = teamPageState.loading || teamPageState.currentIndex === 0;
+    }
+    if (next) {
+        next.disabled = teamPageState.loading || (teamPageState.currentIndex >= teamPageState.pages.length - 1 && !teamPageState.nextCursor);
+    }
+}
+
+function updateUsersPaginationControls() {
+    const status = document.getElementById('users-pagination-status');
+    const prev = document.getElementById('users-prev-page');
+    const next = document.getElementById('users-next-page');
+    if (status) {
+        status.textContent = `Users page ${userPageState.currentIndex + 1} · ${allUsers.length} loaded`;
+    }
+    if (prev) {
+        prev.disabled = userPageState.loading || userPageState.currentIndex === 0;
+    }
+    if (next) {
+        next.disabled = userPageState.loading || (userPageState.currentIndex >= userPageState.pages.length - 1 && !userPageState.nextCursor);
+    }
+}
 
 function inlineJsString(value) {
     return escapeHtml(JSON.stringify(String(value || '')));
@@ -115,16 +203,21 @@ checkAuth(async (user) => {
 
 async function loadData() {
     try {
-        const [teams, users] = await Promise.all([getTeams({ includeInactive: true }), getAllUsers()]);
-        allTeams = teams;
-        allUsers = users;
+        const { teamsPage, usersPage, telemetryPromise } = await loadInitialAdminBootstrap({
+            getTeamsPage: getAdminTeamsPage,
+            getUsersPage: getAdminUsersPage,
+            loadTelemetryData
+        });
 
-        // Load game stats for all teams and telemetry in parallel after core data is available.
-        await Promise.all([
-            loadGameStats(),
-            loadTelemetryData({ silent: true }),
-            loadOfficialUserLinks()
-        ]);
+        setTeamsPage(teamsPage.teams, teamsPage.nextCursor);
+        setUsersPage(usersPage.users, usersPage.nextCursor);
+
+        await ensureCurrentTeamGamesLoaded();
+        telemetryPromise.then(() => {
+            if (activeTab === 'telemetry') {
+                updateTelemetryDashboard();
+            }
+        });
 
         updateDashboard();
         renderTeams(getVisibleTeams());
@@ -138,8 +231,13 @@ async function loadData() {
 
 let allGames = [];
 
-async function loadOfficialUserLinks() {
-    const officialEntries = (await Promise.all(allTeams.map(async (team) => {
+async function loadOfficialUserLinks(teams = allTeams) {
+    const pageKey = teams.map((team) => team.id).join('|');
+    if (pageKey && loadedOfficialsPageKey === pageKey) {
+        return;
+    }
+
+    const officialEntries = (await Promise.all(teams.map(async (team) => {
         try {
             const officials = await getOfficials(team.id);
             officialsByTeamId.set(team.id, officials);
@@ -156,13 +254,17 @@ async function loadOfficialUserLinks() {
     }))).flat();
 
     officialUserLookup = buildOfficialUserLookup(officialEntries);
+    loadedOfficialsPageKey = pageKey;
 }
 
-async function loadGameStats() {
-    // Load games from all teams
-    const gamesPromises = allTeams.map(async (team) => {
+async function loadGameStatsForTeams(teams = allTeams) {
+    const pageKey = teams.map((team) => team.id).join('|');
+    if (pageKey && loadedGamesPageKey === pageKey) {
+        return;
+    }
+
+    const gamesPromises = teams.map(async (team) => {
         try {
-            const { getGames } = await import('./db.js?v=50');
             const games = await getGames(team.id);
             return games.map(g => ({ ...g, teamId: team.id, teamName: team.name }));
         } catch (e) {
@@ -171,6 +273,15 @@ async function loadGameStats() {
     });
     const gamesArrays = await Promise.all(gamesPromises);
     allGames = gamesArrays.flat();
+    loadedGamesPageKey = pageKey;
+}
+
+async function ensureCurrentTeamGamesLoaded() {
+    await loadGameStatsForTeams(getCurrentTeamPage());
+}
+
+async function ensureCurrentPageOfficialsLoaded() {
+    await loadOfficialUserLinks(getCurrentTeamPage());
 }
 
 function getTelemetryRangeDays() {
@@ -659,10 +770,22 @@ function getOfficialsCellClasses(tone) {
     return 'bg-emerald-100 text-emerald-700';
 }
 
+function getDeferredOfficialsSummary() {
+    return {
+        badgeTone: 'warning',
+        badgeLabel: 'Loads on demand',
+        detailTone: 'default',
+        detailLabel: 'Open this team page or users tab to fetch officials.'
+    };
+}
+
 function renderTeams(teams) {
     const tbody = document.getElementById('teams-table-body');
+    const officialsReady = loadedOfficialsPageKey === getCurrentTeamPageKey();
     tbody.innerHTML = teams.map(team => {
-        const officialsSummary = buildAdminTeamOfficialsSummary(team, officialsByTeamId.get(team.id) || [], allGames);
+        const officialsSummary = officialsReady
+            ? buildAdminTeamOfficialsSummary(team, officialsByTeamId.get(team.id) || [], allGames)
+            : getDeferredOfficialsSummary();
         const manageOfficialsHref = `edit-schedule.html?teamId=${encodeURIComponent(team.id)}#officials`;
         return `
         <tr>
@@ -1198,10 +1321,167 @@ async function saveRegistrationForm(event) {
     }
 }
 
+function renderCurrentTeamsView() {
+    const term = (document.getElementById('search-teams')?.value || '').toLowerCase();
+    const filtered = getVisibleTeams().filter((team) =>
+        !term
+        || (team.name || '').toLowerCase().includes(term)
+        || (team.sport || '').toLowerCase().includes(term)
+    );
+    renderTeams(filtered);
+}
+
+function renderCurrentUsersView() {
+    const term = (document.getElementById('search-users')?.value || '').toLowerCase();
+    const officialFilter = document.getElementById('filter-users-official-status')?.value || 'all';
+    const filtered = allUsers.filter((u) => {
+        const officialSummary = getOfficialUserSummary(u, officialUserLookup);
+        if (officialFilter === 'officials' && !officialSummary) return false;
+        if (officialFilter === 'non-officials' && officialSummary) return false;
+        return matchesOfficialUserSearch(u, officialSummary, term);
+    });
+    renderUsers(filtered);
+}
+
+async function loadNextTeamsPage() {
+    if (teamPageState.loading) return;
+    teamPageState.loading = true;
+    updateTeamsPaginationControls();
+    try {
+        if (teamPageState.currentIndex < teamPageState.pages.length - 1) {
+            loadedGamesPageKey = '';
+            loadedOfficialsPageKey = '';
+            setTeamsPage(teamPageState.pages[teamPageState.currentIndex + 1] || [], teamPageState.nextCursor, teamPageState.currentIndex + 1);
+        } else if (teamPageState.nextCursor) {
+        const nextIndex = teamPageState.currentIndex + 1;
+        const page = await loadAdminCollectionPage({
+            fetchPage: getAdminTeamsPage,
+            cursor: teamPageState.nextCursor,
+            pageSize: teamPageState.pageSize
+        });
+        loadedGamesPageKey = '';
+        loadedOfficialsPageKey = '';
+        setTeamsPage(page.teams, page.nextCursor, nextIndex);
+        } else {
+            return;
+        }
+        if (activeTab === 'dashboard') {
+            await ensureCurrentTeamGamesLoaded();
+            updateDashboard();
+        }
+        if (activeTab === 'teams') {
+            await ensureCurrentPageOfficialsLoaded();
+        }
+        if (activeTab === 'users') {
+            await ensureCurrentPageOfficialsLoaded();
+            renderCurrentUsersView();
+        }
+        renderCurrentTeamsView();
+    } finally {
+        teamPageState.loading = false;
+        updateTeamsPaginationControls();
+    }
+}
+
+async function loadPreviousTeamsPage() {
+    if (teamPageState.loading || teamPageState.currentIndex === 0) return;
+    teamPageState.loading = true;
+    updateTeamsPaginationControls();
+    try {
+        loadedGamesPageKey = '';
+        loadedOfficialsPageKey = '';
+        const previousIndex = teamPageState.currentIndex - 1;
+        setTeamsPage(teamPageState.pages[previousIndex] || [], teamPageState.nextCursor, previousIndex);
+        if (activeTab === 'dashboard') {
+            await ensureCurrentTeamGamesLoaded();
+            updateDashboard();
+        }
+        if (activeTab === 'teams') {
+            await ensureCurrentPageOfficialsLoaded();
+        }
+        if (activeTab === 'users') {
+            await ensureCurrentPageOfficialsLoaded();
+            renderCurrentUsersView();
+        }
+        renderCurrentTeamsView();
+    } finally {
+        teamPageState.loading = false;
+        updateTeamsPaginationControls();
+    }
+}
+
+async function loadNextUsersPage() {
+    if (userPageState.loading) return;
+    userPageState.loading = true;
+    updateUsersPaginationControls();
+    try {
+        if (userPageState.currentIndex < userPageState.pages.length - 1) {
+            setUsersPage(userPageState.pages[userPageState.currentIndex + 1] || [], userPageState.nextCursor, userPageState.currentIndex + 1);
+        } else if (userPageState.nextCursor) {
+            const nextIndex = userPageState.currentIndex + 1;
+            const page = await loadAdminCollectionPage({
+                fetchPage: getAdminUsersPage,
+                cursor: userPageState.nextCursor,
+                pageSize: userPageState.pageSize
+            });
+            setUsersPage(page.users, page.nextCursor, nextIndex);
+        } else {
+            return;
+        }
+        renderCurrentUsersView();
+        if (activeTab === 'dashboard') {
+            updateDashboard();
+        }
+    } finally {
+        userPageState.loading = false;
+        updateUsersPaginationControls();
+    }
+}
+
+async function loadPreviousUsersPage() {
+    if (userPageState.loading || userPageState.currentIndex === 0) return;
+    userPageState.loading = true;
+    updateUsersPaginationControls();
+    try {
+        const previousIndex = userPageState.currentIndex - 1;
+        setUsersPage(userPageState.pages[previousIndex] || [], userPageState.nextCursor, previousIndex);
+        renderCurrentUsersView();
+        if (activeTab === 'dashboard') {
+            updateDashboard();
+        }
+    } finally {
+        userPageState.loading = false;
+        updateUsersPaginationControls();
+    }
+}
+
+async function handleTabChange(tab) {
+    activeTab = tab;
+    if (tab === 'dashboard') {
+        await ensureCurrentTeamGamesLoaded();
+        updateDashboard();
+        return;
+    }
+    if (tab === 'teams') {
+        await ensureCurrentPageOfficialsLoaded();
+        renderCurrentTeamsView();
+        return;
+    }
+    if (tab === 'users') {
+        await ensureCurrentPageOfficialsLoaded();
+        renderCurrentUsersView();
+        return;
+    }
+    if (tab === 'telemetry' && !telemetryState.loaded && !telemetryState.loading) {
+        await loadTelemetryData();
+        updateTelemetryDashboard();
+    }
+}
+
 function setupTabs() {
     const tabs = ['dashboard', 'teams', 'users', 'telemetry'];
     tabs.forEach(tab => {
-        document.getElementById(`tab-${tab}`).addEventListener('click', () => {
+        document.getElementById(`tab-${tab}`).addEventListener('click', async () => {
             // Update tab styles
             tabs.forEach(t => {
                 const btn = document.getElementById(`tab-${t}`);
@@ -1217,9 +1497,7 @@ function setupTabs() {
                 }
             });
 
-            if (tab === 'telemetry' && !telemetryState.loaded && !telemetryState.loading) {
-                loadTelemetryData().then(updateTelemetryDashboard);
-            }
+            await handleTabChange(tab);
         });
     });
 }
@@ -1234,33 +1512,17 @@ function setupSearch() {
         inactiveToggle.addEventListener('change', (e) => {
             showInactiveTeams = !!e.target.checked;
             updateDashboard();
-            renderTeams(getVisibleTeams());
+            renderCurrentTeamsView();
         });
     }
 
-    document.getElementById('search-teams').addEventListener('input', (e) => {
-        const term = e.target.value.toLowerCase();
-        const filtered = getVisibleTeams().filter(t =>
-            (t.name || '').toLowerCase().includes(term) ||
-            (t.sport || '').toLowerCase().includes(term)
-        );
-        renderTeams(filtered);
-    });
-
-    const filterUsers = () => {
-        const term = (document.getElementById('search-users')?.value || '').toLowerCase();
-        const officialFilter = document.getElementById('filter-users-official-status')?.value || 'all';
-        const filtered = allUsers.filter((u) => {
-            const officialSummary = getOfficialUserSummary(u, officialUserLookup);
-            if (officialFilter === 'officials' && !officialSummary) return false;
-            if (officialFilter === 'non-officials' && officialSummary) return false;
-            return matchesOfficialUserSearch(u, officialSummary, term);
-        });
-        renderUsers(filtered);
-    };
-
-    document.getElementById('search-users').addEventListener('input', filterUsers);
-    document.getElementById('filter-users-official-status')?.addEventListener('change', filterUsers);
+    document.getElementById('search-teams').addEventListener('input', renderCurrentTeamsView);
+    document.getElementById('search-users').addEventListener('input', renderCurrentUsersView);
+    document.getElementById('filter-users-official-status')?.addEventListener('change', renderCurrentUsersView);
+    document.getElementById('teams-prev-page')?.addEventListener('click', loadPreviousTeamsPage);
+    document.getElementById('teams-next-page')?.addEventListener('click', loadNextTeamsPage);
+    document.getElementById('users-prev-page')?.addEventListener('click', loadPreviousUsersPage);
+    document.getElementById('users-next-page')?.addEventListener('click', loadNextUsersPage);
 
     const telemetryRange = document.getElementById('telemetry-range');
     const telemetryRefresh = document.getElementById('telemetry-refresh');

--- a/js/admin.js
+++ b/js/admin.js
@@ -281,7 +281,7 @@ async function ensureCurrentTeamGamesLoaded() {
 }
 
 async function ensureCurrentPageOfficialsLoaded() {
-    await loadOfficialUserLinks(getCurrentTeamPage());
+    await loadOfficialUserLinks();
 }
 
 function getTelemetryRangeDays() {

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,8 @@
 import {
     getAdminTeamsPage,
     getAdminUsersPage,
+    getTeams,
+    getAllUsers,
     getGames,
     getOfficials,
     addOfficial,
@@ -37,6 +39,8 @@ import { buildAdminTeamOfficialsSummary } from './admin-team-officials.js?v=1';
 
 let allTeams = [];
 let allUsers = [];
+let dashboardTeams = [];
+let dashboardUsers = [];
 let officialUserLookup = new Map();
 let officialsByTeamId = new Map();
 let currentUser = null; // Declare currentUser
@@ -65,7 +69,9 @@ const userPageState = {
 };
 
 let loadedGamesPageKey = '';
-let loadedOfficialsPageKey = '';
+let loadedDashboardGamesKey = '';
+let loadedTeamsOfficialsPageKey = '';
+let loadedUsersOfficialsKey = '';
 
 function getCurrentTeamPage() {
     return teamPageState.pages[teamPageState.currentIndex] || [];
@@ -75,8 +81,20 @@ function getCurrentUsersPage() {
     return userPageState.pages[userPageState.currentIndex] || [];
 }
 
+function getTeamsKey(teams = []) {
+    return teams.map((team) => team.id).join('|');
+}
+
 function getCurrentTeamPageKey() {
-    return getCurrentTeamPage().map((team) => team.id).join('|');
+    return getTeamsKey(getCurrentTeamPage());
+}
+
+function getDashboardTeams() {
+    return dashboardTeams.length ? dashboardTeams : allTeams;
+}
+
+function getDashboardUsers() {
+    return dashboardUsers.length ? dashboardUsers : allUsers;
 }
 
 function applyCurrentTeamPage() {
@@ -203,6 +221,17 @@ checkAuth(async (user) => {
 
 async function loadData() {
     try {
+        loadedGamesPageKey = '';
+        loadedDashboardGamesKey = '';
+        loadedTeamsOfficialsPageKey = '';
+        loadedUsersOfficialsKey = '';
+        allGames = [];
+        dashboardGames = [];
+        dashboardTeams = [];
+        dashboardUsers = [];
+        officialUserLookup = new Map();
+        officialsByTeamId = new Map();
+
         const { teamsPage, usersPage, telemetryPromise } = await loadInitialAdminBootstrap({
             getTeamsPage: getAdminTeamsPage,
             getUsersPage: getAdminUsersPage,
@@ -212,7 +241,10 @@ async function loadData() {
         setTeamsPage(teamsPage.teams, teamsPage.nextCursor);
         setUsersPage(usersPage.users, usersPage.nextCursor);
 
-        await ensureCurrentTeamGamesLoaded();
+        await Promise.all([
+            ensureCurrentTeamGamesLoaded(),
+            loadDashboardData()
+        ]);
         telemetryPromise.then(() => {
             if (activeTab === 'telemetry') {
                 updateTelemetryDashboard();
@@ -230,10 +262,14 @@ async function loadData() {
 }
 
 let allGames = [];
+let dashboardGames = [];
 
-async function loadOfficialUserLinks(teams = allTeams) {
-    const pageKey = teams.map((team) => team.id).join('|');
-    if (pageKey && loadedOfficialsPageKey === pageKey) {
+async function loadOfficialUserLinks(teams = allTeams, { scope = 'page' } = {}) {
+    const teamsKey = getTeamsKey(teams);
+    if (scope === 'page' && teamsKey && loadedTeamsOfficialsPageKey === teamsKey) {
+        return;
+    }
+    if (scope === 'all' && teamsKey && loadedUsersOfficialsKey === teamsKey) {
         return;
     }
 
@@ -253,13 +289,21 @@ async function loadOfficialUserLinks(teams = allTeams) {
         }
     }))).flat();
 
-    officialUserLookup = buildOfficialUserLookup(officialEntries);
-    loadedOfficialsPageKey = pageKey;
+    if (scope === 'all') {
+        officialUserLookup = buildOfficialUserLookup(officialEntries);
+        loadedUsersOfficialsKey = teamsKey;
+        return;
+    }
+
+    loadedTeamsOfficialsPageKey = teamsKey;
 }
 
-async function loadGameStatsForTeams(teams = allTeams) {
-    const pageKey = teams.map((team) => team.id).join('|');
-    if (pageKey && loadedGamesPageKey === pageKey) {
+async function loadGameStatsForTeams(teams = allTeams, { scope = 'page' } = {}) {
+    const teamsKey = getTeamsKey(teams);
+    if (scope === 'page' && teamsKey && loadedGamesPageKey === teamsKey) {
+        return;
+    }
+    if (scope === 'dashboard' && teamsKey && loadedDashboardGamesKey === teamsKey) {
         return;
     }
 
@@ -272,16 +316,34 @@ async function loadGameStatsForTeams(teams = allTeams) {
         }
     });
     const gamesArrays = await Promise.all(gamesPromises);
-    allGames = gamesArrays.flat();
-    loadedGamesPageKey = pageKey;
+    const nextGames = gamesArrays.flat();
+
+    if (scope === 'dashboard') {
+        dashboardGames = nextGames;
+        loadedDashboardGamesKey = teamsKey;
+        return;
+    }
+
+    allGames = nextGames;
+    loadedGamesPageKey = teamsKey;
+}
+
+async function loadDashboardData() {
+    dashboardTeams = await getTeams({ includeInactive: true });
+    dashboardUsers = await getAllUsers();
+    await loadGameStatsForTeams(dashboardTeams, { scope: 'dashboard' });
 }
 
 async function ensureCurrentTeamGamesLoaded() {
-    await loadGameStatsForTeams(getCurrentTeamPage());
+    await loadGameStatsForTeams(getCurrentTeamPage(), { scope: 'page' });
 }
 
-async function ensureCurrentPageOfficialsLoaded() {
-    await loadOfficialUserLinks();
+async function ensureCurrentTeamOfficialsLoaded() {
+    await loadOfficialUserLinks(getCurrentTeamPage(), { scope: 'page' });
+}
+
+async function ensureAllOfficialsLoaded() {
+    await loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' });
 }
 
 function getTelemetryRangeDays() {
@@ -343,9 +405,11 @@ async function loadTelemetryData({ silent = false } = {}) {
 }
 
 function updateDashboard() {
-    const visibleTeams = getVisibleTeams();
+    const sourceTeams = getDashboardTeams();
+    const sourceUsers = getDashboardUsers();
+    const visibleTeams = showInactiveTeams ? sourceTeams : sourceTeams.filter(isTeamActive);
     const visibleTeamIds = new Set(visibleTeams.map(team => team.id));
-    const visibleGames = allGames.filter(game => visibleTeamIds.has(game.teamId));
+    const visibleGames = dashboardGames.filter(game => visibleTeamIds.has(game.teamId));
     const now = new Date();
     const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -356,8 +420,8 @@ function updateDashboard() {
     document.getElementById('stat-teams-growth').textContent = `+${newTeamsLast30} this month`;
 
     // Total users with growth
-    const newUsersLast30 = allUsers.filter(u => u.createdAt && u.createdAt.toDate() > thirtyDaysAgo).length;
-    document.getElementById('stat-total-users').textContent = allUsers.length;
+    const newUsersLast30 = sourceUsers.filter(u => u.createdAt && u.createdAt.toDate() > thirtyDaysAgo).length;
+    document.getElementById('stat-total-users').textContent = sourceUsers.length;
     document.getElementById('stat-users-growth').textContent = `+${newUsersLast30} this month`;
 
     // Total games
@@ -435,7 +499,7 @@ function updateDashboard() {
     `).join('');
 
     // Recent users
-    const recentUsersList = [...allUsers]
+    const recentUsersList = [...sourceUsers]
         .sort((a, b) => {
             const dateA = a.createdAt?.toDate ? a.createdAt.toDate() : new Date(0);
             const dateB = b.createdAt?.toDate ? b.createdAt.toDate() : new Date(0);
@@ -781,7 +845,7 @@ function getDeferredOfficialsSummary() {
 
 function renderTeams(teams) {
     const tbody = document.getElementById('teams-table-body');
-    const officialsReady = loadedOfficialsPageKey === getCurrentTeamPageKey();
+    const officialsReady = loadedTeamsOfficialsPageKey === getCurrentTeamPageKey();
     tbody.innerHTML = teams.map(team => {
         const officialsSummary = officialsReady
             ? buildAdminTeamOfficialsSummary(team, officialsByTeamId.get(team.id) || [], allGames)
@@ -968,6 +1032,8 @@ async function saveOfficialsAdmin(event) {
     }
 
     message.textContent = officialId ? 'Official updated.' : 'Official saved.';
+    loadedTeamsOfficialsPageKey = '';
+    loadedUsersOfficialsKey = '';
     resetOfficialsAdminFormState();
     document.getElementById('officials-admin-form').classList.remove('hidden');
     await loadOfficialsForActiveTeam();
@@ -993,6 +1059,8 @@ async function handleOfficialsAdminListClick(event) {
             resetOfficialsAdminFormState();
             document.getElementById('officials-admin-form').classList.remove('hidden');
         }
+        loadedTeamsOfficialsPageKey = '';
+        loadedUsersOfficialsKey = '';
         message.textContent = 'Official removed.';
         await loadOfficialsForActiveTeam();
     } catch (error) {
@@ -1350,18 +1418,18 @@ async function loadNextTeamsPage() {
     try {
         if (teamPageState.currentIndex < teamPageState.pages.length - 1) {
             loadedGamesPageKey = '';
-            loadedOfficialsPageKey = '';
+            loadedTeamsOfficialsPageKey = '';
             setTeamsPage(teamPageState.pages[teamPageState.currentIndex + 1] || [], teamPageState.nextCursor, teamPageState.currentIndex + 1);
         } else if (teamPageState.nextCursor) {
-        const nextIndex = teamPageState.currentIndex + 1;
-        const page = await loadAdminCollectionPage({
-            fetchPage: getAdminTeamsPage,
-            cursor: teamPageState.nextCursor,
-            pageSize: teamPageState.pageSize
-        });
-        loadedGamesPageKey = '';
-        loadedOfficialsPageKey = '';
-        setTeamsPage(page.teams, page.nextCursor, nextIndex);
+            const nextIndex = teamPageState.currentIndex + 1;
+            const page = await loadAdminCollectionPage({
+                fetchPage: getAdminTeamsPage,
+                cursor: teamPageState.nextCursor,
+                pageSize: teamPageState.pageSize
+            });
+            loadedGamesPageKey = '';
+            loadedTeamsOfficialsPageKey = '';
+            setTeamsPage(page.teams, page.nextCursor, nextIndex);
         } else {
             return;
         }
@@ -1370,10 +1438,10 @@ async function loadNextTeamsPage() {
             updateDashboard();
         }
         if (activeTab === 'teams') {
-            await ensureCurrentPageOfficialsLoaded();
+            await ensureCurrentTeamOfficialsLoaded();
         }
         if (activeTab === 'users') {
-            await ensureCurrentPageOfficialsLoaded();
+            await ensureAllOfficialsLoaded();
             renderCurrentUsersView();
         }
         renderCurrentTeamsView();
@@ -1389,7 +1457,7 @@ async function loadPreviousTeamsPage() {
     updateTeamsPaginationControls();
     try {
         loadedGamesPageKey = '';
-        loadedOfficialsPageKey = '';
+        loadedTeamsOfficialsPageKey = '';
         const previousIndex = teamPageState.currentIndex - 1;
         setTeamsPage(teamPageState.pages[previousIndex] || [], teamPageState.nextCursor, previousIndex);
         if (activeTab === 'dashboard') {
@@ -1397,10 +1465,10 @@ async function loadPreviousTeamsPage() {
             updateDashboard();
         }
         if (activeTab === 'teams') {
-            await ensureCurrentPageOfficialsLoaded();
+            await ensureCurrentTeamOfficialsLoaded();
         }
         if (activeTab === 'users') {
-            await ensureCurrentPageOfficialsLoaded();
+            await ensureAllOfficialsLoaded();
             renderCurrentUsersView();
         }
         renderCurrentTeamsView();
@@ -1463,12 +1531,12 @@ async function handleTabChange(tab) {
         return;
     }
     if (tab === 'teams') {
-        await ensureCurrentPageOfficialsLoaded();
+        await ensureCurrentTeamOfficialsLoaded();
         renderCurrentTeamsView();
         return;
     }
     if (tab === 'users') {
-        await ensureCurrentPageOfficialsLoaded();
+        await ensureAllOfficialsLoaded();
         renderCurrentUsersView();
         return;
     }
@@ -1547,7 +1615,7 @@ function getTeamOwnerEmail(team) {
     if (team.ownerEmail) return team.ownerEmail;
     // Try to find owner in allUsers
     if (team.ownerId) {
-        const owner = allUsers.find(u => u.id === team.ownerId);
+        const owner = getDashboardUsers().find(u => u.id === team.ownerId);
         if (owner) return owner.email;
     }
     // Fallback to first admin email

--- a/js/db.js
+++ b/js/db.js
@@ -1500,6 +1500,44 @@ export async function getRegistrationSources() {
     return snapshot.docs.map(docSnap => ({ id: docSnap.id, ...docSnap.data() }));
 }
 
+const DEFAULT_ADMIN_COLLECTION_PAGE_SIZE = 25;
+
+function normalizeAdminCollectionPageSize(rawPageSize) {
+    const pageSize = Number(rawPageSize);
+    if (!Number.isFinite(pageSize)) return DEFAULT_ADMIN_COLLECTION_PAGE_SIZE;
+    return Math.min(Math.max(Math.floor(pageSize), 1), 100);
+}
+
+export async function getAdminTeamsPage(options = {}) {
+    const pageSize = normalizeAdminCollectionPageSize(options.pageSize);
+    const constraints = [orderBy('name')];
+    if (options.cursor) {
+        constraints.push(startAfterQuery(options.cursor));
+    }
+    constraints.push(limitQuery(pageSize));
+
+    const snapshot = await getDocs(query(collection(db, 'teams'), ...constraints));
+    return {
+        teams: snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() })),
+        nextCursor: snapshot.docs.length === pageSize ? snapshot.docs[snapshot.docs.length - 1] : null
+    };
+}
+
+export async function getAdminUsersPage(options = {}) {
+    const pageSize = normalizeAdminCollectionPageSize(options.pageSize);
+    const constraints = [orderBy('email')];
+    if (options.cursor) {
+        constraints.push(startAfterQuery(options.cursor));
+    }
+    constraints.push(limitQuery(pageSize));
+
+    const snapshot = await getDocs(query(collection(db, 'users'), ...constraints));
+    return {
+        users: snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() })),
+        nextCursor: snapshot.docs.length === pageSize ? snapshot.docs[snapshot.docs.length - 1] : null
+    };
+}
+
 export async function getAllUsers() {
     const q = query(collection(db, "users"), orderBy("email"));
     const snapshot = await getDocs(q);

--- a/tests/unit/admin-bootstrap.test.js
+++ b/tests/unit/admin-bootstrap.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    DEFAULT_ADMIN_PAGE_SIZE,
+    loadAdminCollectionPage,
+    loadInitialAdminBootstrap
+} from '../../js/admin-bootstrap.js';
+
+describe('admin bootstrap paging helpers', () => {
+    it('uses a fixed first-page size and reuses returned cursors for follow-up loads', async () => {
+        const firstCursor = { id: 'cursor-1' };
+        const fetchPage = vi.fn()
+            .mockResolvedValueOnce({ items: ['first'], nextCursor: firstCursor })
+            .mockResolvedValueOnce({ items: ['second'], nextCursor: null });
+
+        const firstPage = await loadAdminCollectionPage({ fetchPage });
+        const secondPage = await loadAdminCollectionPage({ fetchPage, cursor: firstPage.nextCursor });
+
+        expect(fetchPage).toHaveBeenNthCalledWith(1, {
+            cursor: null,
+            pageSize: DEFAULT_ADMIN_PAGE_SIZE
+        });
+        expect(fetchPage).toHaveBeenNthCalledWith(2, {
+            cursor: firstCursor,
+            pageSize: DEFAULT_ADMIN_PAGE_SIZE
+        });
+        expect(secondPage.items).toEqual(['second']);
+    });
+
+    it('keeps initial bootstrap bounded to top-level pages and telemetry', async () => {
+        const getTeamsPage = vi.fn().mockResolvedValue({ teams: [{ id: 'team-1' }], nextCursor: { id: 'team-cursor' } });
+        const getUsersPage = vi.fn().mockResolvedValue({ users: [{ id: 'user-1' }], nextCursor: { id: 'user-cursor' } });
+        const loadTelemetryData = vi.fn().mockResolvedValue(undefined);
+        const getGames = vi.fn();
+        const getOfficials = vi.fn();
+
+        const result = await loadInitialAdminBootstrap({
+            getTeamsPage,
+            getUsersPage,
+            loadTelemetryData,
+            getGames,
+            getOfficials
+        });
+        await result.telemetryPromise;
+
+        expect(getTeamsPage).toHaveBeenCalledWith({ cursor: null, pageSize: DEFAULT_ADMIN_PAGE_SIZE });
+        expect(getUsersPage).toHaveBeenCalledWith({ cursor: null, pageSize: DEFAULT_ADMIN_PAGE_SIZE });
+        expect(loadTelemetryData).toHaveBeenCalledWith({ silent: true });
+        expect(getGames).not.toHaveBeenCalled();
+        expect(getOfficials).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -12,4 +12,17 @@ describe('admin dashboard statistics scope', () => {
         expect(adminJs).toContain('const activeTeams = new Set(visibleGames.filter(g => {');
         expect(adminJs).toContain('const teamsWithGames = new Set(visibleGames.map(g => g.teamId)).size;');
     });
+
+    it('boots from paged teams and users before lazy team detail fan-out', () => {
+        const adminHtml = fs.readFileSync('admin.html', 'utf8');
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+
+        expect(adminJs).toContain('loadInitialAdminBootstrap({');
+        expect(adminJs).toContain('getTeamsPage: getAdminTeamsPage');
+        expect(adminJs).toContain('getUsersPage: getAdminUsersPage');
+        expect(adminJs).toContain('await ensureCurrentTeamGamesLoaded();');
+        expect(adminJs).toContain("await ensureCurrentPageOfficialsLoaded();");
+        expect(adminHtml).toContain('id="teams-pagination-status"');
+        expect(adminHtml).toContain('id="users-pagination-status"');
+    });
 });

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -2,14 +2,15 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 
 describe('admin dashboard statistics scope', () => {
-    it('calculates game-based dashboard stats from the visible team set', () => {
+    it('calculates dashboard stats from the full admin datasets instead of the current page', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
 
-        expect(adminJs).toContain('const visibleTeams = getVisibleTeams();');
+        expect(adminJs).toContain('const sourceTeams = getDashboardTeams();');
+        expect(adminJs).toContain('const sourceUsers = getDashboardUsers();');
+        expect(adminJs).toContain("const visibleTeams = showInactiveTeams ? sourceTeams : sourceTeams.filter(isTeamActive);");
         expect(adminJs).toContain('const visibleTeamIds = new Set(visibleTeams.map(team => team.id));');
-        expect(adminJs).toContain('const visibleGames = allGames.filter(game => visibleTeamIds.has(game.teamId));');
-        expect(adminJs).toContain("document.getElementById('stat-total-games').textContent = visibleGames.length;");
-        expect(adminJs).toContain('const activeTeams = new Set(visibleGames.filter(g => {');
+        expect(adminJs).toContain('const visibleGames = dashboardGames.filter(game => visibleTeamIds.has(game.teamId));');
+        expect(adminJs).toContain("document.getElementById('stat-total-users').textContent = sourceUsers.length;");
         expect(adminJs).toContain('const teamsWithGames = new Set(visibleGames.map(g => g.teamId)).size;');
     });
 
@@ -20,8 +21,9 @@ describe('admin dashboard statistics scope', () => {
         expect(adminJs).toContain('loadInitialAdminBootstrap({');
         expect(adminJs).toContain('getTeamsPage: getAdminTeamsPage');
         expect(adminJs).toContain('getUsersPage: getAdminUsersPage');
-        expect(adminJs).toContain('await ensureCurrentTeamGamesLoaded();');
-        expect(adminJs).toContain("await ensureCurrentPageOfficialsLoaded();");
+        expect(adminJs).toContain('await Promise.all([');
+        expect(adminJs).toContain('loadDashboardData()');
+        expect(adminJs).toContain('await ensureAllOfficialsLoaded();');
         expect(adminHtml).toContain('id="teams-pagination-status"');
         expect(adminHtml).toContain('id="users-pagination-status"');
     });

--- a/tests/unit/admin-user-official-links.test.js
+++ b/tests/unit/admin-user-official-links.test.js
@@ -69,7 +69,7 @@ describe('admin users official links', () => {
         expect(formatOfficialUserSummary(summary)).toBe('1 team: Falcons');
     });
 
-    it('wires the admin users tab to show and filter official-linked users', () => {
+    it('wires the admin users tab to show and filter official-linked users across every team', () => {
         const adminHtml = readSource('admin.html');
         const adminJs = readSource('js/admin.js');
 
@@ -79,7 +79,7 @@ describe('admin users official links', () => {
         expect(adminHtml).toContain('Official</th>');
 
         expect(adminJs).toContain('getOfficials');
-        expect(adminJs).toContain('loadOfficialUserLinks()');
+        expect(adminJs).toContain("loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' })");
         expect(adminJs).toContain('buildOfficialUserLookup');
         expect(adminJs).toContain('formatOfficialUserSummary');
         expect(adminJs).toContain('matchesOfficialUserSearch');
@@ -87,11 +87,12 @@ describe('admin users official links', () => {
         expect(adminJs).toContain('inline-flex items-center rounded-full bg-emerald-100');
     });
 
-    it('reloads official links from the active team page when tabs request officials on demand', () => {
+    it('loads team-page summaries separately from the full users-tab official lookup', () => {
         const adminJs = readSource('js/admin.js');
 
-        expect(adminJs).toContain('async function ensureCurrentPageOfficialsLoaded() {');
-        expect(adminJs).toContain('await loadOfficialUserLinks();');
-        expect(adminJs).not.toContain('await loadOfficialUserLinks(getCurrentTeamPage());');
+        expect(adminJs).toContain("async function ensureCurrentTeamOfficialsLoaded() {");
+        expect(adminJs).toContain("await loadOfficialUserLinks(getCurrentTeamPage(), { scope: 'page' });");
+        expect(adminJs).toContain("async function ensureAllOfficialsLoaded() {");
+        expect(adminJs).toContain("await loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' });");
     });
 });

--- a/tests/unit/admin-user-official-links.test.js
+++ b/tests/unit/admin-user-official-links.test.js
@@ -86,4 +86,12 @@ describe('admin users official links', () => {
         expect(adminJs).toContain("officialFilter === 'officials'");
         expect(adminJs).toContain('inline-flex items-center rounded-full bg-emerald-100');
     });
+
+    it('reloads official links from the active team page when tabs request officials on demand', () => {
+        const adminJs = readSource('js/admin.js');
+
+        expect(adminJs).toContain('async function ensureCurrentPageOfficialsLoaded() {');
+        expect(adminJs).toContain('await loadOfficialUserLinks();');
+        expect(adminJs).not.toContain('await loadOfficialUserLinks(getCurrentTeamPage());');
+    });
 });


### PR DESCRIPTION
Closes #2156

## What changed
- Added bounded admin paging helpers and new Firestore loaders for admin teams and users so the first dashboard load fetches fixed-size pages instead of full collections.
- Refactored `admin.js` bootstrap to load the first teams/users pages first, render the dashboard from that loaded scope, and lazy-load games or officials only for the active tab or visible team page.
- Added Previous/Next paging controls for the admin teams and users tables and updated admin tests to lock in the bounded bootstrap behavior.

## Root Cause
The admin dashboard tied first paint to unbounded collection scans and per-team fan-out reads. Opening `admin.html` always fetched every team and user, then read every visible team's games and officials before the page became usable.

## Prevention / Learning
Admin and hidden-tab surfaces should bootstrap from bounded top-level pages first, then lazy-load per-entity detail only for the active tab or visible slice. When adding summary cards or admin filters, treat full-collection reads and O(team_count) fan-out work as a regression unless a test proves the first load stays bounded.

## Regression Tests
- `tests/unit/admin-bootstrap.test.js`
- `tests/unit/admin-dashboard-stats.test.js`
- `npx vitest run tests/unit/admin-bootstrap.test.js tests/unit/admin-dashboard-stats.test.js tests/unit/admin-game-results.test.js --reporter=verbose`
- `node --check js/admin.js && node --check js/db.js && node --check js/admin-bootstrap.js`