### PR TITLE
Suppress parent media pushes for staff-only albums

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3337,13 +3337,17 @@ async function getUserRecordsByIds(userIds) {
 }
 
 function normalizeNotificationAlbumVisibility(value) {
-  return String(value || '').trim().toLowerCase() === 'private' ? 'private' : 'team';
+  const normalized = String(value || '').trim().toLowerCase().replace(/[\s_]+/g, '-');
+  return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';
 }
 
 function canReceiveCategoryNotification(category, user, audienceContext = {}) {
   if (!user?.uid || !notificationAudienceAllowsRoles(category, user.roles)) return false;
   if (category !== 'media') return true;
-  if (normalizeNotificationAlbumVisibility(audienceContext.albumVisibility) !== 'private') return true;
+  const albumVisibility = audienceContext?.staffOnly === true
+    ? 'private'
+    : normalizeNotificationAlbumVisibility(audienceContext.albumVisibility);
+  if (albumVisibility !== 'private') return true;
   return Array.isArray(user.roles) && user.roles.includes('staff');
 }
 

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -107,7 +107,9 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain('users/${uid}/notificationDevices');
         expect(targetResolverSource).toContain('if (!NOTIFICATION_CATEGORIES.includes(category)) return []');
         expect(targetResolverSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
-        expect(functionsSource).toContain("normalizeNotificationAlbumVisibility(audienceContext.albumVisibility) !== 'private'");
+        expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true");
+        expect(functionsSource).toContain("return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';");
+        expect(functionsSource).toContain("if (albumVisibility !== 'private') return true;");
         expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
         expect(targetResolverSource).toContain('const missingUsers = users.filter');
         expect(targetResolverSource).toContain('teamNotificationRecipientIndexIsEmpty(teamId)');

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -107,7 +107,13 @@ function createHarness({ candidateUsers = [], indexedTargets = [], preferences =
 }
 
 describe('team media notification recipients', () => {
-    it('filters private-album media recipients down to staff-only targets', async () => {
+    it.each([
+        { albumVisibility: 'private' },
+        { albumVisibility: 'staff-only' },
+        { albumVisibility: 'staff_only' },
+        { albumVisibility: 'staff' },
+        { albumVisibility: 'team', staffOnly: true }
+    ])('filters restricted-album media recipients down to staff-only targets for %j', async (audienceContext) => {
         const harness = createHarness({
             candidateUsers: [
                 { uid: 'parent-1', roles: ['parent'] },
@@ -119,7 +125,7 @@ describe('team media notification recipients', () => {
             ]
         });
 
-        const targets = await harness.getTargetsForCategory('team-1', 'media', null, { albumVisibility: 'private' });
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, audienceContext);
 
         expect(targets).toEqual([
             {


### PR DESCRIPTION
Closes #2300

## What changed
- normalized media notification album visibility so staff-only variants like `staff-only`, `staff_only`, and `staff` are treated as restricted albums
- honored an explicit `audienceContext.staffOnly === true` flag when resolving media notification recipients
- extended the focused notification recipient regression tests to prove parent devices are excluded for restricted staff-only album sends while team-visible albums still include eligible parents

## Root Cause
The media notification guard only treated `albumVisibility === 'private'` as staff-only. Any staff-only album path that surfaced a different restricted visibility token or an explicit staff-only flag bypassed that guard and was treated like a team-visible album, which left parent recipients eligible for `media` pushes.

## Prevention / Learning
When notification audience rules depend on visibility, normalize all equivalent restricted-state representations at the boundary before recipient filtering. Do not rely on a single literal visibility value when multiple persisted or derived forms can represent the same access rule.

## Regression Tests
- `npx vitest run tests/unit/team-media-notification-recipients.test.js tests/unit/notification-target-index-core.test.js --reporter=verbose`
- added coverage for `albumVisibility` values `private`, `staff-only`, `staff_only`, `staff`, and `staffOnly: true`