### PR TITLE
Type game report Firestore boundary

### DIFF
--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -1,4 +1,16 @@
-import type { FirestoreDecodedDocument, FirestoreDocument, FirestoreValue, ScheduleEventFirestoreRecord } from './types';
+import type {
+    FirestoreDecodedDocument,
+    FirestoreDocument,
+    FirestoreValue,
+    GameReportAggregatedStatsFirestoreRecord,
+    GameReportGameFirestoreRecord,
+    GameReportOpponentFirestoreRecord,
+    GameReportPlayerFirestoreRecord,
+    GameReportStatsRecord,
+    GameReportTeamFirestoreRecord,
+    GameReportTeamStatsFirestoreRecord,
+    ScheduleEventFirestoreRecord
+} from './types';
 
 function decodeFirestoreValue(value: FirestoreValue | undefined): unknown {
     if (!value || typeof value !== 'object') return null;
@@ -58,10 +70,91 @@ function asObject(value: unknown): Record<string, unknown> | null {
     return value as Record<string, unknown>;
 }
 
+function asLooseObject(value: unknown): Record<string, unknown> {
+    return asObject(value) || {};
+}
+
 function asObjectArray(value: unknown): Array<Record<string, unknown>> {
     return Array.isArray(value)
         ? value.filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === 'object' && !Array.isArray(entry))
         : [];
+}
+
+function asGameReportStatsRecord(value: unknown): GameReportStatsRecord {
+    const source = asObject(value);
+    if (!source) return {};
+
+    return Object.entries(source).reduce<GameReportStatsRecord>((acc, [key, entry]) => {
+        if (typeof entry === 'number' && Number.isFinite(entry)) {
+            acc[key] = entry;
+            return acc;
+        }
+        if (typeof entry === 'string' || typeof entry === 'boolean' || entry === null) {
+            acc[key] = entry;
+        }
+        return acc;
+    }, {});
+}
+
+export function mapGameReportTeamRecord(value: unknown, fallbackTeamId = ''): GameReportTeamFirestoreRecord {
+    const source = asLooseObject(value);
+    return {
+        ...source,
+        id: asTrimmedString(source.id) || fallbackTeamId,
+        name: asTrimmedString(source.name),
+        sport: asTrimmedString(source.sport)
+    };
+}
+
+export function mapGameReportPlayerRecords(value: unknown): GameReportPlayerFirestoreRecord[] {
+    if (!Array.isArray(value)) return [];
+
+    return value.map((entry) => {
+        const source = asLooseObject(entry);
+        return {
+            ...source,
+            id: asTrimmedString(source.id) || '',
+            name: asTrimmedString(source.name),
+            number: asTrimmedString(source.number),
+            photoUrl: asTrimmedString(source.photoUrl)
+        };
+    }).filter((entry) => Boolean(entry.id));
+}
+
+export function mapGameReportGameRecord(value: unknown, fallbackGameId = ''): GameReportGameFirestoreRecord {
+    const source = asLooseObject(value);
+    const opponentStatsSource = asObject(source.opponentStats);
+    const opponentStats = opponentStatsSource
+        ? Object.entries(opponentStatsSource).reduce<Record<string, GameReportOpponentFirestoreRecord>>((acc, [key, entry]) => {
+            acc[key] = asLooseObject(entry);
+            return acc;
+        }, {})
+        : {};
+
+    return {
+        ...source,
+        id: asTrimmedString(source.id) || fallbackGameId,
+        summary: asTrimmedString(source.summary),
+        statSheetPhotoUrl: asTrimmedString(source.statSheetPhotoUrl),
+        opponentStats
+    };
+}
+
+export function mapGameReportAggregatedStatsRecord(id: string, value: unknown): GameReportAggregatedStatsFirestoreRecord {
+    const source = asLooseObject(value);
+    return {
+        id,
+        stats: asGameReportStatsRecord(source.stats),
+        timeMs: asOptionalNumber(source.timeMs) || 0,
+        didNotPlay: source.didNotPlay === true,
+        participated: source.participated === true,
+        participationStatus: asTrimmedString(source.participationStatus) || '',
+        participationSource: asTrimmedString(source.participationSource) || ''
+    };
+}
+
+export function mapGameReportTeamStatsRecord(value: unknown): GameReportTeamStatsFirestoreRecord {
+    return asGameReportStatsRecord(value);
 }
 
 export function mapScheduleEventDocument(document: FirestoreDocument | null | undefined): ScheduleEventFirestoreRecord | null {

--- a/apps/app/src/lib/firestore/types.ts
+++ b/apps/app/src/lib/firestore/types.ts
@@ -76,3 +76,50 @@ export type ScheduleEventFirestoreRecord = {
     isSeriesMaster?: boolean;
     recurrence?: Record<string, unknown> | null;
 };
+
+export type GameReportStatValue = string | number | boolean | null;
+
+export type GameReportStatsRecord = Record<string, GameReportStatValue>;
+
+export type GameReportPlayerFirestoreRecord = {
+    id: string;
+    name?: string | null;
+    number?: string | null;
+    photoUrl?: string | null;
+    [key: string]: unknown;
+};
+
+export type GameReportTeamFirestoreRecord = {
+    id: string;
+    name?: string | null;
+    sport?: string | null;
+    [key: string]: unknown;
+};
+
+export type GameReportOpponentFirestoreRecord = {
+    name?: string | null;
+    number?: string | null;
+    notes?: string | null;
+    photoUrl?: string | null;
+    [key: string]: unknown;
+};
+
+export type GameReportGameFirestoreRecord = {
+    id: string;
+    summary?: string | null;
+    statSheetPhotoUrl?: string | null;
+    opponentStats?: Record<string, GameReportOpponentFirestoreRecord>;
+    [key: string]: unknown;
+};
+
+export type GameReportAggregatedStatsFirestoreRecord = {
+    id: string;
+    stats: GameReportStatsRecord;
+    timeMs: number;
+    didNotPlay: boolean;
+    participated: boolean;
+    participationStatus: string;
+    participationSource: string;
+};
+
+export type GameReportTeamStatsFirestoreRecord = GameReportStatsRecord;

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -72,4 +72,70 @@ describe('gameReportService', () => {
     expect(report.visiblePlayerRows.map((player) => player.playerId)).toEqual(['player-recorded']);
     expect(report.deferredPlayerRows.map((player) => player.playerId)).toEqual(['player-deferred']);
   });
+
+  it('normalizes malformed and partial Firestore stats payloads at the mapper boundary', async () => {
+    dbMocks.getGame.mockResolvedValue({
+      id: 'game-1',
+      summary: 42,
+      statSheetPhotoUrl: 123,
+      opponentStats: {
+        'opp-1': {
+          name: 'Opponent Guard',
+          number: 5,
+          pts: 11,
+          fouls: '2',
+          assists: { invalid: true },
+          photoUrl: false
+        },
+        'opp-2': 'bad-payload'
+      }
+    });
+    dbMocks.getTeamStatsForGame.mockResolvedValue({ turnovers: 7, assists: '11', nested: { invalid: true } });
+    firebaseMocks.getDocs.mockResolvedValue({
+      forEach(callback: (docSnap: any) => void) {
+        callback({
+          id: 'player-recorded',
+          data: () => ({
+            stats: { pts: 14, rebounds: '6', bogus: { nope: true }, tech: false },
+            timeMs: '900000',
+            didNotPlay: 'no',
+            participated: true,
+            participationStatus: 8,
+            participationSource: null
+          })
+        });
+      }
+    });
+
+    const report = await loadGameReportSections('team-1', 'game-1');
+
+    expect(report.summary).toBe('42');
+    expect(report.statSheetPhotoUrl).toBe('123');
+    expect(report.playerRows[0]).toMatchObject({
+      playerId: 'player-recorded',
+      stats: { pts: 14, rebounds: '6', tech: false },
+      timeMs: 900000,
+      didNotPlay: false,
+      participated: true,
+      participationStatus: '8',
+      participationSource: ''
+    });
+    expect(report.opponentRows).toEqual([
+      {
+        id: 'opp-1',
+        name: 'Opponent Guard',
+        number: '5',
+        photoUrl: undefined,
+        stats: { pts: 11, fouls: '2' }
+      },
+      {
+        id: 'opp-2',
+        name: 'Opponent Player',
+        number: '-',
+        photoUrl: undefined,
+        stats: {}
+      }
+    ]);
+    expect(report.teamStats).toEqual({ turnovers: 7, assists: '11' });
+  });
 });

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -14,6 +14,20 @@ import { resolveLiveStatConfig } from '../../../../js/live-game-state.js';
 import { generateGameInsights } from '../../../../js/post-game-insights.js';
 import { hasPlayerProfileParticipation } from '../../../../js/player-profile-stats.js';
 import { resolvePostGameTeamStatFields } from '../../../../js/post-game-stat-editor.js';
+import {
+  mapGameReportAggregatedStatsRecord,
+  mapGameReportGameRecord,
+  mapGameReportPlayerRecords,
+  mapGameReportTeamRecord,
+  mapGameReportTeamStatsRecord
+} from './firestore/mappers';
+import type {
+  GameReportGameFirestoreRecord,
+  GameReportPlayerFirestoreRecord,
+  GameReportStatsRecord,
+  GameReportTeamFirestoreRecord,
+  GameReportTeamStatsFirestoreRecord
+} from './firestore/types';
 
 export type GameReportInsight = {
   title: string;
@@ -26,7 +40,7 @@ export type GameReportPlayerRow = {
   playerName: string;
   number: string;
   photoUrl?: string;
-  stats: Record<string, any>;
+  stats: GameReportStatsRecord;
   timeMs: number;
   didNotPlay: boolean;
   participated: boolean;
@@ -39,7 +53,7 @@ export type GameReportOpponentRow = {
   name: string;
   number: string;
   photoUrl?: string;
-  stats: Record<string, any>;
+  stats: GameReportStatsRecord;
 };
 
 export type GameReportPlay = {
@@ -61,8 +75,8 @@ export type GameReportHighlightClip = {
 };
 
 export type GameReportData = {
-  team: Record<string, any>;
-  game: Record<string, any>;
+  team: GameReportTeamFirestoreRecord;
+  game: GameReportGameFirestoreRecord;
   summary: string;
   statKeys: string[];
   statLabels: Record<string, string>;
@@ -75,7 +89,7 @@ export type GameReportData = {
   opponentRows: GameReportOpponentRow[];
   teamStatKeys: string[];
   teamStatLabels: Record<string, string>;
-  teamStats: Record<string, any>;
+  teamStats: GameReportTeamStatsFirestoreRecord;
   statSheetPhotoUrl: string;
   highlightClips: GameReportHighlightClip[];
   plays: GameReportPlay[];
@@ -89,7 +103,7 @@ export type GameReportData = {
 };
 
 type AggregatedStatsResult = {
-  statsMap: Record<string, Record<string, any>>;
+  statsMap: Record<string, GameReportStatsRecord>;
   timeMap: Record<string, number>;
   didNotPlayMap: Record<string, boolean>;
   participatedMap: Record<string, boolean>;
@@ -120,7 +134,7 @@ function normalizeDate(value: any): Date | null {
 
 async function loadAggregatedStats(teamId: string, gameId: string): Promise<AggregatedStatsResult> {
   const snapshot = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
-  const statsMap: Record<string, Record<string, any>> = {};
+  const statsMap: Record<string, GameReportStatsRecord> = {};
   const timeMap: Record<string, number> = {};
   const didNotPlayMap: Record<string, boolean> = {};
   const participatedMap: Record<string, boolean> = {};
@@ -129,14 +143,15 @@ async function loadAggregatedStats(teamId: string, gameId: string): Promise<Aggr
   const recordedPlayerIds = new Set<string>();
 
   snapshot.forEach((docSnap: any) => {
-    const data = docSnap.data() || {};
-    recordedPlayerIds.add(String(docSnap.id || ''));
-    statsMap[docSnap.id] = data.stats || {};
-    timeMap[docSnap.id] = toNumber(data.timeMs);
-    didNotPlayMap[docSnap.id] = data.didNotPlay === true;
-    participatedMap[docSnap.id] = data.participated === true;
-    participationStatusMap[docSnap.id] = String(data.participationStatus || '');
-    participationSourceMap[docSnap.id] = String(data.participationSource || '');
+    const playerId = String(docSnap.id || '');
+    const data = mapGameReportAggregatedStatsRecord(playerId, docSnap.data());
+    recordedPlayerIds.add(playerId);
+    statsMap[playerId] = data.stats;
+    timeMap[playerId] = data.timeMs;
+    didNotPlayMap[playerId] = data.didNotPlay;
+    participatedMap[playerId] = data.participated;
+    participationStatusMap[playerId] = data.participationStatus;
+    participationSourceMap[playerId] = data.participationSource;
   });
 
   return { statsMap, timeMap, didNotPlayMap, participatedMap, participationStatusMap, participationSourceMap, recordedPlayerIds };
@@ -152,7 +167,7 @@ function normalizePlay(entry: any): GameReportPlay {
   };
 }
 
-function normalizeOpponentRows(opponentStats: Record<string, any> = {}): GameReportOpponentRow[] {
+function normalizeOpponentRows(opponentStats: GameReportGameFirestoreRecord['opponentStats'] = {}): GameReportOpponentRow[] {
   return Object.entries(opponentStats || {}).map(([id, rawStats]) => {
     const { name, number, notes, photoUrl, ...stats } = rawStats || {};
     void notes;
@@ -161,12 +176,12 @@ function normalizeOpponentRows(opponentStats: Record<string, any> = {}): GameRep
       name: String(name || 'Opponent Player'),
       number: String(number || '-'),
       photoUrl: photoUrl ? String(photoUrl) : undefined,
-      stats
+      stats: mapGameReportTeamStatsRecord(stats)
     };
   });
 }
 
-function normalizeHighlightClips(teamId: string, gameId: string, game: Record<string, any>): GameReportHighlightClip[] {
+function normalizeHighlightClips(teamId: string, gameId: string, game: GameReportGameFirestoreRecord): GameReportHighlightClip[] {
   return (normalizeGameRecapHighlightClips(game) || []).slice(0, 8).map((clip: any) => {
     const startMs = Number.isFinite(Number(clip.startMs)) ? Number(clip.startMs) : null;
     const endMs = Number.isFinite(Number(clip.endMs)) ? Number(clip.endMs) : null;
@@ -190,17 +205,21 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     throw new Error('Team and game are required.');
   }
 
-  const [team, game, players] = await Promise.all([
+  const [rawTeam, rawGame, rawPlayers] = await Promise.all([
     getTeam(teamId, { includeInactive: true }),
     getGame(teamId, gameId),
     getPlayers(teamId, { includeInactive: true })
   ]);
 
-  if (!game) {
+  const team = mapGameReportTeamRecord(rawTeam, teamId);
+  const game = mapGameReportGameRecord(rawGame, gameId);
+  const players = mapGameReportPlayerRecords(rawPlayers);
+
+  if (!rawGame) {
     throw new Error('Game not found.');
   }
 
-  const [configs, aggregateResult, rawEvents, teamStats] = await Promise.all([
+  const [configs, aggregateResult, rawEvents, rawTeamStats] = await Promise.all([
     getConfigs(teamId).catch(() => []),
     loadAggregatedStats(teamId, gameId).catch((): AggregatedStatsResult => ({
       statsMap: {},
@@ -214,6 +233,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     getGameEvents(teamId, gameId, { limit: 100 }).catch(() => []),
     getTeamStatsForGame(teamId, gameId).catch(() => ({}))
   ]);
+  const teamStats = mapGameReportTeamStatsRecord(rawTeamStats);
 
   const resolvedConfig = resolveLiveStatConfig({
     configs,
@@ -260,7 +280,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     events: insightEvents
   });
 
-  const safePlayers = Array.isArray(players) ? players : [];
+  const safePlayers: GameReportPlayerFirestoreRecord[] = Array.isArray(players) ? players : [];
   const playerRows = safePlayers.map((player: any) => ({
     playerId: String(player.id || ''),
     playerName: String(player.name || 'Player'),
@@ -287,7 +307,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
   })).filter((entry) => entry.insights.length > 0);
 
   return {
-    team: team || { id: teamId },
+    team,
     game,
     summary: String(game.summary || ''),
     statKeys,
@@ -301,7 +321,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     opponentRows: normalizeOpponentRows(opponentStats),
     teamStatKeys,
     teamStatLabels,
-    teamStats: teamStats || {},
+    teamStats,
     statSheetPhotoUrl: game.statSheetPhotoUrl ? String(game.statSheetPhotoUrl) : '',
     highlightClips: normalizeHighlightClips(teamId, gameId, game),
     plays,


### PR DESCRIPTION
Closes #2290

## What changed
- added explicit Firestore record types for the game report read path in `apps/app/src/lib/firestore/types.ts`
- added mapper functions in `apps/app/src/lib/firestore/mappers.ts` for team, game, player, aggregated stats, and team stats records
- updated `gameReportService` to consume typed mapper output instead of raw `Record<string, any>` report records on the migrated read path
- normalized malformed or partial stats payloads to safe defaults so missing optional fields do not break report rendering
- added regression coverage for malformed and partial stats payloads in `apps/app/src/lib/gameReportService.test.ts`

## Root Cause
The game report read path accepted raw Firestore-shaped objects through `Record<string, any>` containers, so nested stats payloads bypassed a typed normalization boundary. That let malformed or partial document data flow directly into report models.

## Prevention / Learning
When migrating a Firestore read path, define explicit record interfaces and mapper functions before the service layer. Normalize optional nested maps at that boundary so report and UI code never consume raw document shapes.

## Regression Tests
- `npx vitest run apps/app/src/lib/gameReportService.test.ts --reporter=verbose`
- `npm --prefix apps/app run build`