### PR TITLE
Add staff home packet completion notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3830,6 +3830,22 @@ async function checkAndSetNotificationDedup(teamId, category, gameId) {
 }
 
 
+function mergeNotificationWebpushOptions(baseWebpush = {}, deliveryOptions = {}) {
+  if (!deliveryOptions?.webpush) return baseWebpush;
+  return {
+    ...baseWebpush,
+    ...deliveryOptions.webpush,
+    notification: {
+      ...(baseWebpush.notification || {}),
+      ...(deliveryOptions.webpush.notification || {})
+    },
+    fcmOptions: {
+      ...(baseWebpush.fcmOptions || {}),
+      ...(deliveryOptions.webpush.fcmOptions || {})
+    }
+  };
+}
+
 async function sendCategoryNotification({
   teamId,
   gameId = null,
@@ -3885,11 +3901,11 @@ async function sendCategoryNotification({
         appRoute,
         link
       },
-      webpush: {
+      ...deliveryOptions,
+      webpush: mergeNotificationWebpushOptions({
         notification: WEB_PUSH_NOTIFICATION_ASSETS,
         fcmOptions: { link }
-      },
-      ...deliveryOptions
+      }, deliveryOptions)
     });
     allResponses.push(...(Array.isArray(sendResult.responses) ? sendResult.responses : []));
     successCount += Number(sendResult.successCount || 0);
@@ -3975,11 +3991,11 @@ async function sendDirectTargetsNotification({
         appRoute,
         link
       },
-      webpush: {
+      ...deliveryOptions,
+      webpush: mergeNotificationWebpushOptions({
         notification: WEB_PUSH_NOTIFICATION_ASSETS,
         fcmOptions: { link }
-      },
-      ...deliveryOptions
+      }, deliveryOptions)
     });
     allResponses.push(...(Array.isArray(sendResult.responses) ? sendResult.responses : []));
     successCount += Number(sendResult.successCount || 0);

--- a/functions/index.js
+++ b/functions/index.js
@@ -3305,6 +3305,23 @@ function buildStaffFeeNotificationDestination({ teamId, batchId = null, recipien
   };
 }
 
+function buildPracticePacketNotificationDestination({ teamId, eventId = null, sessionId = null }) {
+  const encodedTeamId = encodeURIComponent(teamId);
+  const effectiveEventId = String(eventId || sessionId || '').trim();
+  const appRoute = effectiveEventId
+    ? `/schedule/${encodedTeamId}/${encodeURIComponent(effectiveEventId)}`
+    : `/schedule?teamId=${encodedTeamId}`;
+  return {
+    appRoute,
+    link: `https://allplays.ai/app/#${appRoute}`
+  };
+}
+
+function getPracticePacketNotificationLabel(session = {}) {
+  const sessionTitle = String(session?.title || session?.eventTitle || '').trim();
+  return sessionTitle ? `home packet for ${sessionTitle}` : 'home packet';
+}
+
 function buildNotificationLink({ category, teamId, gameId, batchId = null, recipientId = null, conversationId = null }) {
   if (category === 'fees') {
     const params = new URLSearchParams();
@@ -5198,6 +5215,67 @@ exports.notifyFeeAssigned = functions.firestore
       title: `New fee assigned: ${title}${amountDisplay}`,
       body: 'A new team fee has been assigned to your account.',
       teamId,
+    });
+    return null;
+  });
+
+exports.notifyPracticePacketCompleted = functions.firestore
+  .document('teams/{teamId}/practiceSessions/{sessionId}/packetCompletions/{completionId}')
+  .onCreate(async (snapshot, context) => {
+    const data = snapshot.data();
+    if (!data) return null;
+
+    if (!NOTIFICATION_CATEGORIES.includes('practice')) {
+      functions.logger.error('notifyPracticePacketCompleted requires the practice notification category.', {
+        teamId: context.params?.teamId || null,
+        availableCategories: NOTIFICATION_CATEGORIES
+      });
+      return null;
+    }
+
+    const { teamId, sessionId, completionId } = context.params;
+    const parentUserId = String(data.parentUserId || '').trim() || null;
+    const playerName = String(data.childName || 'A player').trim() || 'A player';
+
+    const [allPracticeTargets, candidateUsers, sessionSnap] = await Promise.all([
+      getTargetsForCategory(teamId, 'practice', null),
+      getCandidateUsersForTeam(teamId),
+      firestore.doc(`teams/${teamId}/practiceSessions/${sessionId}`).get()
+    ]);
+    const staffUserIds = new Set(
+      candidateUsers
+        .filter((user) => Array.isArray(user?.roles) && user.roles.includes('staff'))
+        .map((user) => user.uid)
+    );
+    const staffTargets = allPracticeTargets.filter((target) => (
+      staffUserIds.has(target.uid)
+      && target.uid !== parentUserId
+    ));
+
+    if (!staffTargets.length) {
+      functions.logger.warn('notifyPracticePacketCompleted found no staff notification targets.', {
+        teamId,
+        sessionId,
+        completionId,
+        parentUserId,
+        totalPracticeTargets: allPracticeTargets.length
+      });
+      return null;
+    }
+
+    const session = sessionSnap.exists ? (sessionSnap.data() || {}) : {};
+    const scheduleEventId = String(session.eventId || '').trim() || sessionId;
+    const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
+
+    await sendDirectTargetsNotification({
+      targets: staffTargets,
+      category: 'practice',
+      title: `Home packet completed: ${playerName}`,
+      body: `${playerName} completed the ${getPracticePacketNotificationLabel(session)}.`,
+      teamId,
+      eventId: sessionId,
+      linkOverride: destination.link,
+      appRouteOverride: destination.appRoute
     });
     return null;
   });

--- a/functions/index.js
+++ b/functions/index.js
@@ -3882,6 +3882,23 @@ async function sendCategoryNotification({
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
+  const mergeWebpushOptions = typeof mergeNotificationWebpushOptions === 'function'
+    ? mergeNotificationWebpushOptions
+    : (baseWebpush = {}, runtimeDeliveryOptions = {}) => {
+      if (!runtimeDeliveryOptions?.webpush) return baseWebpush;
+      return {
+        ...baseWebpush,
+        ...runtimeDeliveryOptions.webpush,
+        notification: {
+          ...(baseWebpush.notification || {}),
+          ...(runtimeDeliveryOptions.webpush.notification || {})
+        },
+        fcmOptions: {
+          ...(baseWebpush.fcmOptions || {}),
+          ...(runtimeDeliveryOptions.webpush.fcmOptions || {})
+        }
+      };
+    };
   const maxMulticastTokens = 500;
   const allResponses = [];
   let successCount = 0;
@@ -3902,7 +3919,7 @@ async function sendCategoryNotification({
         link
       },
       ...deliveryOptions,
-      webpush: mergeNotificationWebpushOptions({
+      webpush: mergeWebpushOptions({
         notification: WEB_PUSH_NOTIFICATION_ASSETS,
         fcmOptions: { link }
       }, deliveryOptions)
@@ -3972,6 +3989,23 @@ async function sendDirectTargetsNotification({
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
+  const mergeWebpushOptions = typeof mergeNotificationWebpushOptions === 'function'
+    ? mergeNotificationWebpushOptions
+    : (baseWebpush = {}, runtimeDeliveryOptions = {}) => {
+      if (!runtimeDeliveryOptions?.webpush) return baseWebpush;
+      return {
+        ...baseWebpush,
+        ...runtimeDeliveryOptions.webpush,
+        notification: {
+          ...(baseWebpush.notification || {}),
+          ...(runtimeDeliveryOptions.webpush.notification || {})
+        },
+        fcmOptions: {
+          ...(baseWebpush.fcmOptions || {}),
+          ...(runtimeDeliveryOptions.webpush.fcmOptions || {})
+        }
+      };
+    };
   const maxMulticastTokens = 500;
   const allResponses = [];
   let successCount = 0;
@@ -3992,7 +4026,7 @@ async function sendDirectTargetsNotification({
         link
       },
       ...deliveryOptions,
-      webpush: mergeNotificationWebpushOptions({
+      webpush: mergeWebpushOptions({
         notification: WEB_PUSH_NOTIFICATION_ASSETS,
         fcmOptions: { link }
       }, deliveryOptions)

--- a/functions/notification-delivery-metadata.cjs
+++ b/functions/notification-delivery-metadata.cjs
@@ -47,7 +47,7 @@ const NOTIFICATION_CATEGORY_DELIVERY = Object.freeze({
   schedule: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.schedule, iosThreadScope: 'team' }),
   rsvp: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.schedule, iosThreadScope: 'team' }),
   fees: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.money, iosThreadScope: 'team' }),
-  practice: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.gameDay, iosThreadScope: 'team' }),
+  practice: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.gameDay, iosThreadScope: 'team', iosCollapseScope: 'event' }),
   access: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.team, iosThreadScope: 'team' }),
   rideshare: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.team, iosThreadScope: 'team' }),
   media: Object.freeze({ androidChannelId: ANDROID_NOTIFICATION_CHANNEL_IDS.team, iosThreadScope: 'team' }),
@@ -93,6 +93,19 @@ function buildIosCollapseId({ metadata, teamId, gameId, eventId }) {
   if (metadata?.iosCollapseScope === 'score') {
     return buildBoundedIdentifier(['score', teamId, gameId || eventId]);
   }
+  if (metadata?.iosCollapseScope === 'event') {
+    return buildBoundedIdentifier(['event', teamId, eventId || gameId]);
+  }
+  return '';
+}
+
+function buildNotificationCollapseTag({ metadata, teamId, gameId, eventId }) {
+  if (metadata?.iosCollapseScope === 'score') {
+    return buildBoundedIdentifier(['score', teamId, gameId || eventId]);
+  }
+  if (metadata?.iosCollapseScope === 'event') {
+    return buildBoundedIdentifier(['event', teamId, eventId || gameId]);
+  }
   return '';
 }
 
@@ -104,8 +117,14 @@ function buildNotificationDeliveryOptions({ category, teamId, gameId = null, eve
   const metadata = getNotificationDeliveryMetadata(category);
   if (!metadata) return {};
 
+  const collapseTag = buildNotificationCollapseTag({ metadata, teamId, gameId, eventId });
   const android = metadata.androidChannelId
-    ? { notification: { channelId: metadata.androidChannelId } }
+    ? {
+        notification: {
+          channelId: metadata.androidChannelId,
+          ...(collapseTag ? { tag: collapseTag } : {})
+        }
+      }
     : undefined;
   const iosThreadId = buildIosThreadId({ metadata, teamId, gameId, eventId });
   const iosCollapseId = buildIosCollapseId({ metadata, teamId, gameId, eventId });
@@ -120,6 +139,7 @@ function buildNotificationDeliveryOptions({ category, teamId, gameId = null, eve
 
   return {
     ...(android ? { android } : {}),
+    ...(collapseTag ? { webpush: { notification: { tag: collapseTag } } } : {}),
     ...(apns ? { apns } : {})
   };
 }

--- a/tests/unit/notification-delivery-metadata.test.js
+++ b/tests/unit/notification-delivery-metadata.test.js
@@ -100,12 +100,16 @@ describe('notification delivery metadata', () => {
             badge: '/img/logo_small.png'
         });
         expect(firstSendPath).toContain('buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })');
+        expect(firstSendPath).toContain('const mergeWebpushOptions = typeof mergeNotificationWebpushOptions === \'function\'');
+        expect(firstSendPath).toContain('if (!runtimeDeliveryOptions?.webpush) return baseWebpush;');
         expect(firstSendPath).toContain('...deliveryOptions');
-        expect(firstSendPath).toContain('webpush: mergeNotificationWebpushOptions({');
+        expect(firstSendPath).toContain('webpush: mergeWebpushOptions({');
         expect(firstSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
         expect(secondSendPath).toContain('buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })');
+        expect(secondSendPath).toContain('const mergeWebpushOptions = typeof mergeNotificationWebpushOptions === \'function\'');
+        expect(secondSendPath).toContain('if (!runtimeDeliveryOptions?.webpush) return baseWebpush;');
         expect(secondSendPath).toContain('...deliveryOptions');
-        expect(secondSendPath).toContain('webpush: mergeNotificationWebpushOptions({');
+        expect(secondSendPath).toContain('webpush: mergeWebpushOptions({');
         expect(secondSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
     });
 

--- a/tests/unit/notification-delivery-metadata.test.js
+++ b/tests/unit/notification-delivery-metadata.test.js
@@ -47,6 +47,20 @@ describe('notification delivery metadata', () => {
         expect(options.apns.headers['apns-collapse-id']).toBe('score-team-1-game-9');
     });
 
+    it('collapses practice packet notifications by session while keeping them in the team thread', () => {
+        const options = buildNotificationDeliveryOptions({
+            category: 'practice',
+            teamId: 'team-1',
+            eventId: 'session-1'
+        });
+
+        expect(options.android.notification.channelId).toBe('allplays_game_day');
+        expect(options.android.notification.tag).toBe('event-team-1-session-1');
+        expect(options.webpush.notification.tag).toBe('event-team-1-session-1');
+        expect(options.apns.payload.aps['thread-id']).toBe('team-team-1');
+        expect(options.apns.headers['apns-collapse-id']).toBe('event-team-1-session-1');
+    });
+
     it('routes team-scoped award notifications to the team channel and iOS team thread', () => {
         const options = buildNotificationDeliveryOptions({
             category: 'awards',

--- a/tests/unit/notification-delivery-metadata.test.js
+++ b/tests/unit/notification-delivery-metadata.test.js
@@ -12,6 +12,19 @@ const {
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 const serviceWorkerSource = readFileSync(new URL('../../firebase-messaging-sw.js', import.meta.url), 'utf8');
 
+function extractChunk(startMarker, endMarker) {
+    const start = functionsSource.indexOf(startMarker);
+    const end = functionsSource.indexOf(endMarker, start);
+    if (start === -1 || end === -1) {
+        throw new Error(`Unable to extract source chunk for ${startMarker}.`);
+    }
+    return functionsSource.slice(start, end);
+}
+
+const mergeNotificationWebpushOptions = new Function(
+    `${extractChunk('function mergeNotificationWebpushOptions(', 'async function sendCategoryNotification(')}\nreturn mergeNotificationWebpushOptions;`
+)();
+
 describe('notification delivery metadata', () => {
     it('defines the five Android channels used by app startup and backend sends', () => {
         expect(ANDROID_NOTIFICATION_CHANNELS).toEqual([
@@ -87,11 +100,31 @@ describe('notification delivery metadata', () => {
             badge: '/img/logo_small.png'
         });
         expect(firstSendPath).toContain('buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })');
-        expect(firstSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
         expect(firstSendPath).toContain('...deliveryOptions');
+        expect(firstSendPath).toContain('webpush: mergeNotificationWebpushOptions({');
+        expect(firstSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
         expect(secondSendPath).toContain('buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })');
-        expect(secondSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
         expect(secondSendPath).toContain('...deliveryOptions');
+        expect(secondSendPath).toContain('webpush: mergeNotificationWebpushOptions({');
+        expect(secondSendPath).toContain('notification: WEB_PUSH_NOTIFICATION_ASSETS');
+    });
+
+    it('merges web push collapse tags without dropping the notification link', () => {
+        expect(mergeNotificationWebpushOptions({
+            notification: WEB_PUSH_NOTIFICATION_ASSETS,
+            fcmOptions: { link: 'https://allplays.ai/app/#/schedule/team-1/practice-1' }
+        }, {
+            webpush: {
+                notification: { tag: 'event-team-1-session-1' }
+            }
+        })).toEqual({
+            notification: {
+                icon: '/img/logo_small.png',
+                badge: '/img/logo_small.png',
+                tag: 'event-team-1-session-1'
+            },
+            fcmOptions: { link: 'https://allplays.ai/app/#/schedule/team-1/practice-1' }
+        });
     });
 
     it('shows branded icon and badge assets from the web service worker', () => {

--- a/tests/unit/practice-packet-completion-notifications.test.js
+++ b/tests/unit/practice-packet-completion-notifications.test.js
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+function extractChunk(startMarker, endMarker) {
+    const start = functionsSource.indexOf(startMarker);
+    const end = functionsSource.indexOf(endMarker, start);
+    if (start === -1 || end === -1) {
+        throw new Error(`Unable to extract source chunk for ${startMarker}.`);
+    }
+    return functionsSource.slice(start, end);
+}
+
+function extractNotifyPracticePacketCompleted() {
+    return [
+        extractChunk('function buildPracticePacketNotificationDestination(', 'function buildNotificationLink'),
+        extractChunk('exports.notifyPracticePacketCompleted = functions.firestore', 'const PUBLIC_RSVP_TOKEN_TTL_DAYS')
+    ].join('\n');
+}
+
+function buildTriggerHarness({
+    categories = ['practice', 'schedule'],
+    targets = [],
+    users = [],
+    session = { eventId: 'practice-1', title: 'Practice' }
+} = {}) {
+    const sendDirectTargetsNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
+    const getTargetsForCategory = vi.fn(async () => targets);
+    const getCandidateUsersForTeam = vi.fn(async () => users);
+    const firestore = {
+        doc: vi.fn((path) => ({
+            get: vi.fn(async () => ({
+                exists: path === 'teams/team-1/practiceSessions/session-1',
+                data: () => session
+            }))
+        }))
+    };
+    const functions = {
+        firestore: {
+            document: vi.fn(() => ({
+                onCreate: vi.fn((handler) => handler)
+            }))
+        },
+        logger: {
+            error: vi.fn(),
+            warn: vi.fn()
+        }
+    };
+    const exportsObject = {};
+    const factory = new Function(
+        'exports',
+        'functions',
+        'firestore',
+        'NOTIFICATION_CATEGORIES',
+        'getTargetsForCategory',
+        'getCandidateUsersForTeam',
+        'sendDirectTargetsNotification',
+        `${extractNotifyPracticePacketCompleted()}\nreturn exports.notifyPracticePacketCompleted;`
+    );
+    const trigger = factory(
+        exportsObject,
+        functions,
+        firestore,
+        categories,
+        getTargetsForCategory,
+        getCandidateUsersForTeam,
+        sendDirectTargetsNotification
+    );
+
+    return {
+        trigger,
+        firestore,
+        functions,
+        getTargetsForCategory,
+        getCandidateUsersForTeam,
+        sendDirectTargetsNotification
+    };
+}
+
+describe('notifyPracticePacketCompleted trigger', () => {
+    it('sends practice notifications only to staff targets and excludes parent devices', async () => {
+        const harness = buildTriggerHarness({
+            targets: [
+                { uid: 'parent-1', token: 'parent-token', teamId: 'team-1' },
+                { uid: 'staff-1', token: 'staff-token', teamId: 'team-1' },
+                { uid: 'staff-2', token: 'staff-2-token', teamId: 'team-1' }
+            ],
+            users: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] },
+                { uid: 'staff-2', roles: ['staff', 'parent'] }
+            ]
+        });
+
+        await harness.trigger({
+            data: () => ({
+                parentUserId: 'parent-1',
+                childId: 'player-1',
+                childName: 'Pat'
+            })
+        }, {
+            params: { teamId: 'team-1', sessionId: 'session-1', completionId: 'parent-1__player-1' }
+        });
+
+        expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'practice', null);
+        expect(harness.getCandidateUsersForTeam).toHaveBeenCalledWith('team-1');
+        expect(harness.firestore.doc).toHaveBeenCalledWith('teams/team-1/practiceSessions/session-1');
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledWith(expect.objectContaining({
+            targets: [
+                { uid: 'staff-1', token: 'staff-token', teamId: 'team-1' },
+                { uid: 'staff-2', token: 'staff-2-token', teamId: 'team-1' }
+            ],
+            category: 'practice',
+            title: 'Home packet completed: Pat',
+            body: 'Pat completed the home packet for Practice.',
+            eventId: 'session-1',
+            linkOverride: 'https://allplays.ai/app/#/schedule/team-1/practice-1',
+            appRouteOverride: '/schedule/team-1/practice-1'
+        }));
+    });
+
+    it('reuses the same collapse-scoped event id for repeated completions on one packet', async () => {
+        const harness = buildTriggerHarness({
+            targets: [{ uid: 'staff-1', token: 'staff-token', teamId: 'team-1' }],
+            users: [{ uid: 'staff-1', roles: ['staff'] }]
+        });
+
+        await harness.trigger({
+            data: () => ({ parentUserId: 'parent-1', childName: 'Pat' })
+        }, {
+            params: { teamId: 'team-1', sessionId: 'session-1', completionId: 'parent-1__player-1' }
+        });
+        await harness.trigger({
+            data: () => ({ parentUserId: 'parent-2', childName: 'Sam' })
+        }, {
+            params: { teamId: 'team-1', sessionId: 'session-1', completionId: 'parent-2__player-2' }
+        });
+
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(2);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(1, expect.objectContaining({ eventId: 'session-1' }));
+        expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(2, expect.objectContaining({ eventId: 'session-1' }));
+    });
+
+    it('logs and exits when the practice notification category is unavailable', async () => {
+        const harness = buildTriggerHarness({ categories: ['schedule'] });
+
+        await harness.trigger({
+            data: () => ({ parentUserId: 'parent-1', childName: 'Pat' })
+        }, {
+            params: { teamId: 'team-1', sessionId: 'session-1', completionId: 'parent-1__player-1' }
+        });
+
+        expect(harness.functions.logger.error).toHaveBeenCalledWith(
+            'notifyPracticePacketCompleted requires the practice notification category.',
+            expect.objectContaining({ teamId: 'team-1' })
+        );
+        expect(harness.getTargetsForCategory).not.toHaveBeenCalled();
+        expect(harness.sendDirectTargetsNotification).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #2143

## What changed
- added a Cloud Function trigger for `teams/{teamId}/practiceSessions/{sessionId}/packetCompletions/{completionId}`
- sends `practice` notifications only to staff/coaches who already have `practice` pushes enabled
- excludes the completing parent from this staff-facing notification path
- routes staff taps back to the related schedule event while using the practice session id as the collapse key
- extended delivery metadata so `practice` notifications reuse the same Android tag, web push tag, and iOS collapse id for repeated completions on one packet
- added focused unit coverage for staff-only targeting and collapse behavior

## Root Cause
The app already wrote home packet completion records, but the backend had no Cloud Function listener for those writes. That left the completion flow without any notification path, and there was no packet-specific collapse metadata to group repeated completions for the same packet.

## Prevention / Learning
When a new Firestore write path is introduced for a user-visible workflow, the adjacent notification trigger and the nearest delivery-metadata test need to be added in the same change. For staff-only notifications, reuse existing category preference filtering first, then apply an explicit staff-role filter in the trigger so parent devices are not pulled in accidentally.

## Regression Tests
- `npx vitest run tests/unit/practice-packet-completion-notifications.test.js tests/unit/notification-delivery-metadata.test.js`
- verifies only staff targets receive the push
- verifies repeated completions for the same packet reuse the same collapse-scoped event id
- verifies `practice` delivery metadata sets the expected Android tag, web push tag, team thread, and iOS collapse id