### PR TITLE
Add legacy adapter boundary for utility-backed app pages

### DIFF
--- a/apps/app/src/lib/adapters/legacyCertificates.ts
+++ b/apps/app/src/lib/adapters/legacyCertificates.ts
@@ -1,0 +1,11 @@
+import { renderCertificate as legacyRenderCertificate } from '@legacy/certificates/renderer.js';
+
+export type LegacyCertificateRenderInput = {
+    shared?: Record<string, unknown>;
+    draft?: Record<string, unknown>;
+    team?: Record<string, unknown>;
+};
+
+export function renderCertificate(input: LegacyCertificateRenderInput): HTMLDivElement {
+    return legacyRenderCertificate(input);
+}

--- a/apps/app/src/lib/adapters/legacyDrills.ts
+++ b/apps/app/src/lib/adapters/legacyDrills.ts
@@ -1,0 +1,15 @@
+import {
+    DRILL_LEVELS as legacyDrillLevels,
+    DRILL_TYPES as legacyDrillTypes,
+    DRILL_TYPE_COLORS as legacyDrillTypeColors
+} from '@legacy/drill-constants.js';
+
+export type LegacyDrillTypeColor = {
+    bg: string;
+    text: string;
+    bar: string;
+};
+
+export const DRILL_TYPES = legacyDrillTypes as readonly string[];
+export const DRILL_LEVELS = legacyDrillLevels as readonly string[];
+export const DRILL_TYPE_COLORS = legacyDrillTypeColors as Record<string, LegacyDrillTypeColor>;

--- a/apps/app/src/lib/adapters/legacyProfile.ts
+++ b/apps/app/src/lib/adapters/legacyProfile.ts
@@ -1,0 +1,14 @@
+import { NOTIFICATION_PREFERENCE_GROUPS as legacyNotificationPreferenceGroups } from '@legacy/notification-preferences.js';
+
+export type LegacyNotificationPreferenceCategory = {
+    id: string;
+    label: string;
+};
+
+export type LegacyNotificationPreferenceGroup = {
+    id: string;
+    label: string;
+    categories: readonly LegacyNotificationPreferenceCategory[];
+};
+
+export const NOTIFICATION_PREFERENCE_GROUPS = legacyNotificationPreferenceGroups as readonly LegacyNotificationPreferenceGroup[];

--- a/apps/app/src/lib/adapters/legacyRegistration.ts
+++ b/apps/app/src/lib/adapters/legacyRegistration.ts
@@ -1,0 +1,93 @@
+import {
+    calculateRegistrationFeeSnapshot as legacyCalculateRegistrationFeeSnapshot,
+    decideRegistrationPlacement as legacyDecideRegistrationPlacement,
+    formatFeeSnapshotLines as legacyFormatFeeSnapshotLines,
+    getActiveRegistrationOptions as legacyGetActiveRegistrationOptions,
+    getPaymentPlanChoices as legacyGetPaymentPlanChoices,
+    hasQuantityDiscountRule as legacyHasQuantityDiscountRule,
+    requiresRegistrationOption as legacyRequiresRegistrationOption
+} from '@legacy/registration-flow.js';
+
+export type LegacyRegistrationOption = {
+    id: string;
+    countKey?: string;
+    title: string;
+    description?: string;
+    capacityLimit?: number | null;
+    waitlistEnabled?: boolean;
+    active?: boolean;
+};
+
+export type LegacyRegistrationPaymentPlanChoice = {
+    id: string;
+    type: string;
+    title: string;
+};
+
+export type LegacyRegistrationFeeSnapshot = {
+    currency: string;
+    quantity: number;
+    originalFeeAmountCents: number;
+    subtotalAmountCents: number;
+    appliedDiscounts: Array<{
+        id?: string;
+        type?: string;
+        label: string;
+        amountType?: string;
+        amountValue?: number;
+        amountCents: number;
+    }>;
+    finalAmountDueCents: number;
+};
+
+export type LegacyRegistrationFeeSummaryLine = {
+    label: string;
+    amountCents: number;
+    strong?: boolean;
+};
+
+export type LegacyRegistrationPlacement =
+    | {
+        status: 'pending' | 'waitlisted';
+        selectedOption: LegacyRegistrationOption;
+        nextCounts: { enrolled: number; waitlisted: number };
+        message?: string;
+    }
+    | {
+        status: 'blocked';
+        reason: string;
+        selectedOption?: LegacyRegistrationOption;
+        message: string;
+    };
+
+export function getActiveRegistrationOptions(form: Record<string, unknown>, registrationOptionCounts: Record<string, unknown>): LegacyRegistrationOption[] {
+    return legacyGetActiveRegistrationOptions(form, registrationOptionCounts) as LegacyRegistrationOption[];
+}
+
+export function getPaymentPlanChoices(form: Record<string, unknown>): LegacyRegistrationPaymentPlanChoice[] {
+    return legacyGetPaymentPlanChoices(form) as LegacyRegistrationPaymentPlanChoice[];
+}
+
+export function requiresRegistrationOption(form: Record<string, unknown>): boolean {
+    return legacyRequiresRegistrationOption(form);
+}
+
+export function hasQuantityDiscountRule(rules: unknown[] | undefined): boolean {
+    return legacyHasQuantityDiscountRule(rules);
+}
+
+export function calculateRegistrationFeeSnapshot(form: Record<string, unknown>, options: { quantity?: number; now?: Date }): LegacyRegistrationFeeSnapshot {
+    return legacyCalculateRegistrationFeeSnapshot(form, options) as LegacyRegistrationFeeSnapshot;
+}
+
+export function formatFeeSnapshotLines(snapshot: LegacyRegistrationFeeSnapshot): LegacyRegistrationFeeSummaryLine[] {
+    return legacyFormatFeeSnapshotLines(snapshot) as LegacyRegistrationFeeSummaryLine[];
+}
+
+export function decideRegistrationPlacement(input: {
+    form: Record<string, unknown>;
+    selectedOptionId: string;
+    counts?: Record<string, unknown>;
+}): LegacyRegistrationPlacement {
+    return legacyDecideRegistrationPlacement(input) as LegacyRegistrationPlacement;
+}

--- a/apps/app/src/lib/adapters/legacyTeamMedia.ts
+++ b/apps/app/src/lib/adapters/legacyTeamMedia.ts
@@ -1,0 +1,5 @@
+import { isSupportedTeamMediaDocument as legacyIsSupportedTeamMediaDocument } from '@legacy/team-media-utils.js';
+
+export function isSupportedTeamMediaDocument(file: File): boolean {
+    return legacyIsSupportedTeamMediaDocument(file);
+}

--- a/apps/app/src/lib/adapters/legacyUtilityAdapters.test.ts
+++ b/apps/app/src/lib/adapters/legacyUtilityAdapters.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@legacy/certificates/renderer.js', () => ({
+    renderCertificate: vi.fn(() => document.createElement('div'))
+}));
+vi.mock('@legacy/notification-preferences.js', () => ({
+    NOTIFICATION_PREFERENCE_GROUPS: [{ id: 'gameDay', label: 'Game day', categories: [{ id: 'gameDay', label: 'Game Day' }] }]
+}));
+vi.mock('@legacy/registration-flow.js', () => ({
+    calculateRegistrationFeeSnapshot: vi.fn(() => ({
+        currency: 'USD',
+        quantity: 1,
+        originalFeeAmountCents: 1000,
+        subtotalAmountCents: 1000,
+        appliedDiscounts: [],
+        finalAmountDueCents: 1000
+    })),
+    decideRegistrationPlacement: vi.fn(() => ({
+        status: 'pending',
+        selectedOption: { id: 'option-1', title: 'Camp' },
+        nextCounts: { enrolled: 1, waitlisted: 0 }
+    })),
+    formatFeeSnapshotLines: vi.fn(() => [{ label: 'Final amount due', amountCents: 1000, strong: true }]),
+    getActiveRegistrationOptions: vi.fn(() => [{ id: 'option-1', title: 'Camp' }]),
+    getPaymentPlanChoices: vi.fn(() => [{ id: 'pay_full', type: 'pay_full', title: 'Pay in full' }]),
+    hasQuantityDiscountRule: vi.fn(() => true),
+    requiresRegistrationOption: vi.fn(() => true)
+}));
+vi.mock('@legacy/drill-constants.js', () => ({
+    DRILL_LEVELS: ['All', 'Advanced'],
+    DRILL_TYPES: ['Technical'],
+    DRILL_TYPE_COLORS: { Technical: { bg: 'bg-purple-100', text: 'text-purple-800', bar: 'bg-purple-400' } }
+}));
+vi.mock('@legacy/team-media-utils.js', () => ({
+    isSupportedTeamMediaDocument: vi.fn(() => true)
+}));
+
+import { renderCertificate } from './legacyCertificates';
+import { DRILL_LEVELS, DRILL_TYPES, DRILL_TYPE_COLORS } from './legacyDrills';
+import { NOTIFICATION_PREFERENCE_GROUPS } from './legacyProfile';
+import {
+    calculateRegistrationFeeSnapshot,
+    decideRegistrationPlacement,
+    formatFeeSnapshotLines,
+    getActiveRegistrationOptions,
+    getPaymentPlanChoices,
+    hasQuantityDiscountRule,
+    requiresRegistrationOption
+} from './legacyRegistration';
+import { isSupportedTeamMediaDocument } from './legacyTeamMedia';
+
+it('keeps utility-backed pages behind legacy adapters and the shared alias boundary', () => {
+    const profileSource = readFileSync('src/pages/Profile.tsx', 'utf8');
+    const registrationDetailSource = readFileSync('src/pages/RegistrationDetail.tsx', 'utf8');
+    const teamCertificatesSource = readFileSync('src/pages/TeamCertificates.tsx', 'utf8');
+    const teamDrillsSource = readFileSync('src/pages/TeamDrills.tsx', 'utf8');
+    const teamMediaSource = readFileSync('src/pages/TeamMedia.tsx', 'utf8');
+    const viteConfigSource = readFileSync('vite.config.ts', 'utf8');
+
+    expect(profileSource).not.toContain('../../../../js/');
+    expect(profileSource).toContain('../lib/adapters/legacyProfile');
+    expect(registrationDetailSource).not.toContain('../../../../js/');
+    expect(registrationDetailSource).toContain('../lib/adapters/legacyRegistration');
+    expect(teamCertificatesSource).not.toContain('../../../../js/');
+    expect(teamCertificatesSource).toContain('../lib/adapters/legacyCertificates');
+    expect(teamDrillsSource).not.toContain('../../../../js/');
+    expect(teamDrillsSource).toContain('../lib/adapters/legacyDrills');
+    expect(teamMediaSource).not.toContain('../../../../js/');
+    expect(teamMediaSource).toContain('../lib/adapters/legacyTeamMedia');
+    expect(viteConfigSource).toContain("'@legacy'");
+});
+
+describe('legacy utility adapters', () => {
+    it('returns typed values from the adapter boundary', () => {
+        expect(renderCertificate({})).toBeInstanceOf(HTMLDivElement);
+        expect(NOTIFICATION_PREFERENCE_GROUPS[0]?.categories[0]?.id).toBe('gameDay');
+        expect(getActiveRegistrationOptions({}, {})).toEqual([{ id: 'option-1', title: 'Camp' }]);
+        expect(getPaymentPlanChoices({})).toEqual([{ id: 'pay_full', type: 'pay_full', title: 'Pay in full' }]);
+        expect(requiresRegistrationOption({})).toBe(true);
+        expect(hasQuantityDiscountRule([])).toBe(true);
+        expect(calculateRegistrationFeeSnapshot({}, { quantity: 1 })).toMatchObject({ finalAmountDueCents: 1000 });
+        expect(formatFeeSnapshotLines(calculateRegistrationFeeSnapshot({}, { quantity: 1 }))[0]).toMatchObject({ strong: true });
+        expect(decideRegistrationPlacement({ form: {}, selectedOptionId: 'option-1', counts: {} })).toMatchObject({ status: 'pending' });
+        expect(DRILL_TYPES).toEqual(['Technical']);
+        expect(DRILL_LEVELS).toEqual(['All', 'Advanced']);
+        expect(DRILL_TYPE_COLORS.Technical.text).toBe('text-purple-800');
+        expect(isSupportedTeamMediaDocument(new File(['demo'], 'doc.pdf', { type: 'application/pdf' }))).toBe(true);
+    });
+});

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -45,7 +45,7 @@ import {
 import { buildAppAcceptInviteUrl } from '../lib/inviteUrls';
 import { sharePublicUrl } from '../lib/publicActions';
 import { useShellLayout } from '../lib/useShellLayout';
-import { NOTIFICATION_PREFERENCE_GROUPS } from '../../../../js/notification-preferences.js';
+import { NOTIFICATION_PREFERENCE_GROUPS } from '../lib/adapters/legacyProfile';
 import type { AccessCodeRecord, NotificationCategory, NotificationPreferences, NotificationTeam, ProfileDocument } from '../lib/profileService';
 import type { ProfilePhotoSource } from '../lib/profilePhotoService';
 import type { AuthState } from '../lib/types';

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -16,7 +16,7 @@ import {
   getPaymentPlanChoices,
   requiresRegistrationOption,
   hasQuantityDiscountRule
-} from '../../../../js/registration-flow.js';
+} from '../lib/adapters/legacyRegistration';
 import type { AuthState } from '../lib/types';
 
 type FieldErrors = Record<string, string>;

--- a/apps/app/src/pages/TeamCertificates.test.tsx
+++ b/apps/app/src/pages/TeamCertificates.test.tsx
@@ -16,7 +16,7 @@ const publicActionMocks = vi.hoisted(() => ({
 
 vi.mock('../lib/certificateDraftService', () => certificateDraftServiceMocks);
 vi.mock('../lib/publicActions', () => publicActionMocks);
-vi.mock('../../../../js/certificates/renderer.js', () => ({
+vi.mock('../lib/adapters/legacyCertificates', () => ({
   renderCertificate: vi.fn(() => {
     const node = document.createElement('div');
     node.textContent = 'Certificate preview';

--- a/apps/app/src/pages/TeamCertificates.tsx
+++ b/apps/app/src/pages/TeamCertificates.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Navigate, useParams } from 'react-router-dom';
 import { Award, ExternalLink, Loader2, RefreshCw, Sparkles } from 'lucide-react';
-import { renderCertificate } from '../../../../js/certificates/renderer.js';
+import { renderCertificate } from '../lib/adapters/legacyCertificates';
 import { loadCertificateDraftComposer, saveCertificateDraftsForApp, type CertificateDraftComposerModel, type CertificateDraftPlayer, type CertificateDraftSharedState } from '../lib/certificateDraftService';
 import { openPublicUrl } from '../lib/publicActions';
 import { useAsyncOperation } from '../lib/useAsyncOperation';

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Link, Navigate, useParams } from 'react-router-dom';
 import { ChevronLeft, ExternalLink, Heart, Loader2, Search, Shield } from 'lucide-react';
-import { DRILL_LEVELS, DRILL_TYPES, DRILL_TYPE_COLORS } from '../../../../js/drill-constants.js';
+import { DRILL_LEVELS, DRILL_TYPES, DRILL_TYPE_COLORS } from '../lib/adapters/legacyDrills';
 import { openPublicUrl } from '../lib/publicActions';
 import { filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite, type TeamDrillSummary } from '../lib/teamDrillsService';
 import type { AuthState } from '../lib/types';

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import { flushSync } from 'react-dom';
 import { Link, Navigate, useParams } from 'react-router-dom';
-import { isSupportedTeamMediaDocument } from '../../../../js/team-media-utils.js';
+import { isSupportedTeamMediaDocument } from '../lib/adapters/legacyTeamMedia';
 import {
   AlertCircle,
   CheckCircle2,

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -6,6 +6,11 @@ import { visualizer } from 'rollup-plugin-visualizer';
 // https://vitejs.dev/config/
 export default defineConfig({
   base: './',
+  resolve: {
+    alias: {
+      '@legacy': path.resolve(__dirname, '../../js')
+    }
+  },
   plugins: [
     react(),
     visualizer({

--- a/tests/unit/app-registration-detail.test.jsx
+++ b/tests/unit/app-registration-detail.test.jsx
@@ -59,7 +59,7 @@ const registrationFlowMocks = vi.hoisted(() => ({
 
 vi.mock('../../apps/app/src/lib/parentToolsService.ts', () => parentToolsServiceMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionsMocks);
-vi.mock('../../js/registration-flow.js', () => registrationFlowMocks);
+vi.mock('@legacy/registration-flow.js', () => registrationFlowMocks);
 
 import { RegistrationDetail, TeamRegistrationReview, selectInitialRegistrationOption } from '../../apps/app/src/pages/RegistrationDetail.tsx';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,7 +43,8 @@ export default defineConfig({
       '@capacitor/share': resolveModule('@capacitor/share'),
       '@capacitor-firebase/messaging': resolveModule('@capacitor-firebase/messaging'),
       '@capawesome/capacitor-badge': resolveModule('@capawesome/capacitor-badge'),
-      'dompurify': resolveModule('dompurify')
+      'dompurify': resolveModule('dompurify'),
+      '@legacy': path.resolve(workspaceRoot, 'js')
     },
     dedupe: ['react', 'react-dom', 'react-router-dom']
   }


### PR DESCRIPTION
Closes #2277

## What changed
- added a shared `@legacy` Vite alias for app-to-legacy imports
- created typed adapter modules for certificates, profile notification groups, registration helpers, drill constants, and team media document checks under `apps/app/src/lib/adapters/`
- migrated `TeamCertificates.tsx`, `Profile.tsx`, `RegistrationDetail.tsx`, `TeamDrills.tsx`, and `TeamMedia.tsx` off direct `../../../../js/*` imports and onto adapter exports
- updated the certificate page test to mock the adapter boundary and added an invariant adapter test that fails if these pages regress to direct legacy imports

## Root Cause
The React app did not have a stable boundary for legacy utility imports, so pages reached directly into `js/` with brittle relative paths. That bypassed typed adapter wrappers and made future migration slices easy to regress.

## Prevention / Learning
When app code needs legacy JS behavior, import it only through `apps/app/src/lib/adapters/` and keep the page layer free of direct `js/` imports. Back that boundary with a shared alias plus a source-level invariant test so future slices fail fast.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/TeamCertificates.test.tsx src/pages/RegistrationDetail.test.tsx src/pages/TeamDrills.test.tsx src/pages/TeamMedia.test.tsx src/lib/adapters/legacyUtilityAdapters.test.ts --reporter=verbose`
- `cd apps/app && npx vitest run src/lib/adapters/legacyUtilityAdapters.test.ts src/pages/RegistrationDetail.test.tsx --reporter=verbose`
- `npm run app:build`