### PR TITLE
Add typed Firestore chat mappers

### DIFF
--- a/apps/app/src/lib/chatService.test.ts
+++ b/apps/app/src/lib/chatService.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapChatConversationDocument, mapChatMessageDocument, mapChatMessageRecord } from './firestore/mappers';
+import type { FirestoreDocument } from './firestore/types';
+
+describe('chat Firestore mappers', () => {
+  it('maps a valid Firestore chat message document into a typed message model', () => {
+    const document: FirestoreDocument = {
+      name: 'projects/allplays-test/databases/(default)/documents/teams/team-1/chatMessages/message-1',
+      fields: {
+        text: { stringValue: '  Great pass  ' },
+        senderId: { stringValue: 'user-1' },
+        senderName: { stringValue: 'Coach Kim' },
+        senderEmail: { stringValue: 'coach@example.com' },
+        attachments: {
+          arrayValue: {
+            values: [
+              {
+                mapValue: {
+                  fields: {
+                    type: { stringValue: 'image' },
+                    url: { stringValue: 'https://example.com/photo.jpg' },
+                    mimeType: { stringValue: 'image/jpeg' },
+                    size: { integerValue: '2048' },
+                    uploadedAt: { timestampValue: '2026-06-19T19:00:00.000Z' }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        createdAt: { timestampValue: '2026-06-19T19:01:00.000Z' },
+        reactions: {
+          mapValue: {
+            fields: {
+              heart: {
+                arrayValue: {
+                  values: [
+                    { stringValue: 'user-2' },
+                    { stringValue: 'user-3' }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        targetType: { stringValue: 'individuals' },
+        recipientIds: {
+          arrayValue: {
+            values: [
+              { stringValue: 'user-2' },
+              { stringValue: 'user-3' }
+            ]
+          }
+        }
+      }
+    };
+
+    expect(mapChatMessageDocument(document)).toEqual({
+      id: 'message-1',
+      text: 'Great pass',
+      senderId: 'user-1',
+      senderName: 'Coach Kim',
+      senderEmail: 'coach@example.com',
+      senderPhotoUrl: null,
+      attachments: [
+        {
+          type: 'image',
+          url: 'https://example.com/photo.jpg',
+          path: null,
+          thumbnailUrl: null,
+          name: null,
+          mimeType: 'image/jpeg',
+          size: 2048,
+          uploadedAt: new Date('2026-06-19T19:00:00.000Z')
+        }
+      ],
+      imageUrl: null,
+      imagePath: null,
+      imageName: null,
+      imageType: null,
+      imageSize: null,
+      createdAt: new Date('2026-06-19T19:01:00.000Z'),
+      editedAt: null,
+      deleted: false,
+      ai: false,
+      aiName: null,
+      aiQuestion: null,
+      aiMeta: null,
+      reactions: {
+        heart: ['user-2', 'user-3']
+      },
+      targetType: 'individuals',
+      recipientIds: ['user-2', 'user-3'],
+      targetRole: null,
+      conversationId: null,
+      _doc: undefined
+    });
+  });
+
+  it('normalizes partial Firestore chat message records without breaking preview fields', () => {
+    expect(mapChatMessageRecord({
+      id: 'message-2',
+      text: '   ',
+      attachments: [{ mimeType: 'video/mp4', url: ' https://example.com/clip.mp4 ' }],
+      reactions: {
+        heart: [' user-2 ', '', 'user-2'],
+        ignored: 'not-an-array'
+      },
+      targetType: 'unsupported',
+      recipientIds: [' user-4 ', '', 'user-4']
+    })).toEqual({
+      id: 'message-2',
+      text: null,
+      senderId: null,
+      senderName: null,
+      senderEmail: null,
+      senderPhotoUrl: null,
+      attachments: [
+        {
+          type: 'video',
+          url: 'https://example.com/clip.mp4',
+          path: null,
+          thumbnailUrl: null,
+          name: null,
+          mimeType: 'video/mp4',
+          size: null,
+          uploadedAt: null
+        }
+      ],
+      imageUrl: null,
+      imagePath: null,
+      imageName: null,
+      imageType: null,
+      imageSize: null,
+      createdAt: null,
+      editedAt: null,
+      deleted: false,
+      ai: false,
+      aiName: null,
+      aiQuestion: null,
+      aiMeta: null,
+      reactions: {
+        heart: ['user-2']
+      },
+      targetType: 'full_team',
+      recipientIds: ['user-4'],
+      targetRole: null,
+      conversationId: null,
+      _doc: undefined
+    });
+  });
+
+  it('maps conversation preview metadata from partial Firestore documents', () => {
+    const document: FirestoreDocument = {
+      name: 'projects/allplays-test/databases/(default)/documents/teams/team-1/chatConversations/conversation-1',
+      fields: {
+        type: { stringValue: 'direct' },
+        participantIds: {
+          arrayValue: {
+            values: [
+              { stringValue: 'user-1' },
+              { stringValue: ' user-2 ' },
+              { stringValue: 'user-2' }
+            ]
+          }
+        },
+        updatedAt: { timestampValue: '2026-06-19T18:30:00.000Z' }
+      }
+    };
+
+    expect(mapChatConversationDocument(document)).toEqual({
+      id: 'conversation-1',
+      type: 'direct',
+      name: null,
+      participantIds: ['user-1', 'user-2'],
+      participantRoles: [],
+      mutedBy: [],
+      isDefault: false,
+      isLegacy: false,
+      updatedAt: new Date('2026-06-19T18:30:00.000Z'),
+      lastMessageAt: null
+    });
+  });
+});

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -53,6 +53,14 @@ import {
   type ChatTargetType
 } from './chatLogic';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
+import { mapChatConversationRecord, mapChatMessageRecord, mapFirestoreDocument } from './firestore/mappers';
+import type {
+  ChatAttachmentFirestoreRecord,
+  ChatConversationFirestoreRecord,
+  ChatMessageFirestoreRecord,
+  FirestoreDecodedDocument,
+  FirestoreDocument as NativeFirestoreDocument
+} from './firestore/types';
 import type { AuthUser } from './types';
 
 const primaryDataTimeoutMs = 5000;
@@ -77,57 +85,11 @@ export type ChatTeam = {
   isMuted?: boolean;
 };
 
-export type ChatConversation = {
-  id: string;
-  type: 'team' | 'group' | 'direct';
-  name?: string | null;
-  participantIds?: string[];
-  participantRoles?: string[];
-  mutedBy?: string[];
-  isDefault?: boolean;
-  isLegacy?: boolean;
-  updatedAt?: unknown;
-  lastMessageAt?: unknown;
-};
+export type ChatConversation = ChatConversationFirestoreRecord;
 
-export type ChatAttachment = {
-  type: 'image' | 'video';
-  url: string | null;
-  path?: string | null;
-  thumbnailUrl?: string | null;
-  name?: string | null;
-  mimeType?: string | null;
-  size?: number | null;
-  uploadedAt?: unknown;
-};
+export type ChatAttachment = ChatAttachmentFirestoreRecord;
 
-export type ChatMessage = {
-  id: string;
-  text?: string | null;
-  senderId?: string | null;
-  senderName?: string | null;
-  senderEmail?: string | null;
-  senderPhotoUrl?: string | null;
-  attachments?: ChatAttachment[];
-  imageUrl?: string | null;
-  imagePath?: string | null;
-  imageName?: string | null;
-  imageType?: string | null;
-  imageSize?: number | null;
-  createdAt?: unknown;
-  editedAt?: unknown;
-  deleted?: boolean;
-  ai?: boolean;
-  aiName?: string | null;
-  aiQuestion?: string | null;
-  aiMeta?: Record<string, unknown> | null;
-  reactions?: Record<string, string[]>;
-  targetType?: ChatTargetType;
-  recipientIds?: string[];
-  targetRole?: string | null;
-  conversationId?: string | null;
-  _doc?: unknown;
-};
+export type ChatMessage = ChatMessageFirestoreRecord;
 
 export type SentTeamEmail = {
   id: string;
@@ -200,7 +162,7 @@ export type ChatSubscribeResult = {
   unsubscribe: () => void;
 };
 
-type FirestoreDocument = Record<string, any> & { id: string };
+type FirestoreDocument = FirestoreDecodedDocument;
 
 type ImageUploadSession = {
   apiKey: string;
@@ -340,37 +302,9 @@ function encodeFirestoreValue(value: any): Record<string, unknown> {
   return { stringValue: String(value) };
 }
 
-function decodeFirestoreValue(value: any): any {
-  if (!value || typeof value !== 'object') return null;
-  if ('stringValue' in value) return value.stringValue;
-  if ('booleanValue' in value) return value.booleanValue;
-  if ('integerValue' in value) return Number(value.integerValue || 0);
-  if ('doubleValue' in value) return Number(value.doubleValue || 0);
-  if ('timestampValue' in value) return new Date(value.timestampValue);
-  if ('nullValue' in value) return null;
-  if ('arrayValue' in value) return (value.arrayValue?.values || []).map((entry: any) => decodeFirestoreValue(entry));
-  if ('mapValue' in value) return decodeFirestoreFields(value.mapValue?.fields || {});
-  return null;
-}
-
-function decodeFirestoreFields(fields: Record<string, any> = {}) {
-  return Object.keys(fields).reduce<Record<string, any>>((acc, key) => {
-    acc[key] = decodeFirestoreValue(fields[key]);
-    return acc;
-  }, {});
-}
-
-function decodeFirestoreDocument(document: any): FirestoreDocument | null {
-  if (!document?.name) return null;
-  return {
-    id: String(document.name).split('/').pop() || '',
-    ...decodeFirestoreFields(document.fields || {})
-  };
-}
-
 async function nativeGetDocument(path: string) {
   try {
-    return decodeFirestoreDocument(await nativeFirestoreRequest(`/${path}`));
+    return mapFirestoreDocument(await nativeFirestoreRequest(`/${path}`) as NativeFirestoreDocument);
   } catch (error: any) {
     const message = String(error?.message || '').toLowerCase();
     if (error?.status === 404 || message.includes('not_found') || message.includes('not found')) {
@@ -386,7 +320,7 @@ async function nativeListCollection(path: string, params: Record<string, string 
   const suffix = query.toString() ? `?${query.toString()}` : '';
   const payload = await nativeFirestoreRequest(`/${path}${suffix}`);
   return (payload.documents || [])
-    .map((document: any) => decodeFirestoreDocument(document))
+    .map((document: NativeFirestoreDocument) => mapFirestoreDocument(document))
     .filter(Boolean) as FirestoreDocument[];
 }
 
@@ -409,10 +343,10 @@ async function nativeCreateDocument(path: string, data: Record<string, unknown>)
     acc[key] = encodeFirestoreValue(data[key]);
     return acc;
   }, {});
-  return decodeFirestoreDocument(await nativeFirestoreRequest(`/${path}`, {
+  return mapFirestoreDocument(await nativeFirestoreRequest(`/${path}`, {
     method: 'POST',
     body: JSON.stringify({ fields })
-  }));
+  }) as NativeFirestoreDocument);
 }
 
 async function nativeRunQuery(structuredQuery: Record<string, unknown>) {
@@ -421,7 +355,7 @@ async function nativeRunQuery(structuredQuery: Record<string, unknown>) {
     body: JSON.stringify({ structuredQuery })
   });
   return (Array.isArray(payload) ? payload : [])
-    .map((entry) => decodeFirestoreDocument(entry.document))
+    .map((entry) => mapFirestoreDocument(entry.document as NativeFirestoreDocument))
     .filter(Boolean) as FirestoreDocument[];
 }
 
@@ -531,7 +465,7 @@ function getConversationActivityTime(conversation: ChatConversation | null | und
 async function getLatestConversationMessage(teamId: string, conversationId: string): Promise<ChatMessage | null> {
   try {
     const [message] = await withTimeout(Promise.resolve(getChatMessages(teamId, { limit: 1, conversationId })), `latest chat ${teamId}/${conversationId}`, 2500);
-    return message || null;
+    return mapChatMessageRecord(message, message?.id || '') || null;
   } catch (error) {
     if (!isNativeRuntime()) return null;
     const path = isDefaultTeamConversation(conversationId)
@@ -541,7 +475,7 @@ async function getLatestConversationMessage(teamId: string, conversationId: stri
       orderBy: 'createdAt desc',
       pageSize: 1
     }).catch(() => []);
-    return message as ChatMessage || null;
+    return mapChatMessageRecord(message, message?.id || '') || null;
   }
 }
 
@@ -553,8 +487,13 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
       `latest chat conversations ${teamId}`,
       2500
     ) as ChatConversation[];
-    conversations = Array.isArray(loadedConversations) && loadedConversations.length
+    const mappedConversations = Array.isArray(loadedConversations)
       ? loadedConversations
+        .map((conversation) => mapChatConversationRecord(conversation, conversation?.id || ''))
+        .filter((conversation): conversation is ChatConversation => Boolean(conversation))
+      : [];
+    conversations = mappedConversations.length
+      ? mappedConversations
       : [buildDefaultTeamConversation(team)];
   } catch (error) {
     if (!isNativeRuntime()) {
@@ -744,7 +683,10 @@ export async function loadChatTeamContext(teamId: string, user: AuthUser | null)
 
 export async function loadChatConversations(teamId: string, user: AuthUser, team: Record<string, any>, canModerate: boolean): Promise<ChatConversation[]> {
   try {
-    return await withTimeout(Promise.resolve(getChatConversations(teamId, user, { team, canModerate })), 'Chat conversations load') as ChatConversation[];
+    const conversations = await withTimeout(Promise.resolve(getChatConversations(teamId, user, { team, canModerate })), 'Chat conversations load') as ChatConversation[];
+    return (Array.isArray(conversations) ? conversations : [])
+      .map((conversation) => mapChatConversationRecord(conversation, conversation?.id || ''))
+      .filter((conversation): conversation is ChatConversation => Boolean(conversation));
   } catch (error) {
     console.warn('[chat-service] Falling back to default chat conversation:', sanitizeErrorForLogging(error));
     return [buildDefaultTeamConversation(team) as ChatConversation];
@@ -782,7 +724,10 @@ export function subscribeToTeamChatMessages(
           orderBy: 'createdAt desc',
           pageSize: 50
         });
-        onMessages(messages as ChatMessage[], messages[messages.length - 1]?._doc || null);
+        const mappedMessages = messages
+          .map((message) => mapChatMessageRecord(message, message?.id || ''))
+          .filter((message): message is ChatMessage => Boolean(message));
+        onMessages(mappedMessages, mappedMessages[mappedMessages.length - 1]?._doc || null);
       } catch (error: any) {
         onError?.(error);
       }
@@ -795,7 +740,12 @@ export function subscribeToTeamChatMessages(
 
   try {
     unsubscribe = subscribeToChatMessages(teamId, { limit: 50, conversationId }, (messages: ChatMessage[], oldestDoc: unknown | null) => {
-      if (!cancelled) onMessages(messages, oldestDoc);
+      if (!cancelled) {
+        const mappedMessages = (Array.isArray(messages) ? messages : [])
+          .map((message) => mapChatMessageRecord(message, message?.id || ''))
+          .filter((message): message is ChatMessage => Boolean(message));
+        onMessages(mappedMessages, oldestDoc);
+      }
     });
   } catch (error: any) {
     if (!isNativeRuntime()) {
@@ -817,11 +767,14 @@ export function subscribeToTeamChatMessages(
 export async function loadOlderTeamChatMessages(teamId: string, conversationId: string, startAfterDoc: unknown | null) {
   if (!startAfterDoc) return [];
   try {
-    return await withTimeout(Promise.resolve(getChatMessages(teamId, {
+    const messages = await withTimeout(Promise.resolve(getChatMessages(teamId, {
       limit: 50,
       startAfterDoc,
       conversationId
     })), 'Older chat messages load') as ChatMessage[];
+    return (Array.isArray(messages) ? messages : [])
+      .map((message) => mapChatMessageRecord(message, message?.id || ''))
+      .filter((message): message is ChatMessage => Boolean(message));
   } catch (error) {
     if (!isNativeRuntime()) throw error;
     console.warn('[chat-service] Older chat history is limited in native REST fallback:', sanitizeErrorForLogging(error));
@@ -1285,7 +1238,9 @@ export async function toggleTeamChatReaction(teamId: string, messageId: string, 
     const path = getMessageDocumentPath(teamId, messageId, conversationId);
     const message = await nativeGetDocument(path);
     if (!message) throw new Error('Message not found.');
-    const reactions = message.reactions && typeof message.reactions === 'object' ? message.reactions : {};
+    const reactions = message.reactions && typeof message.reactions === 'object'
+      ? message.reactions as Record<string, unknown>
+      : {} as Record<string, unknown>;
     const existing = Array.isArray(reactions[reactionKey]) ? reactions[reactionKey].map(String) : [];
     const next = existing.includes(userId)
       ? existing.filter((id: string) => id !== userId)

--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -1,4 +1,7 @@
 import type {
+    ChatAttachmentFirestoreRecord,
+    ChatConversationFirestoreRecord,
+    ChatMessageFirestoreRecord,
     FirestoreDecodedDocument,
     FirestoreDocument,
     FirestoreValue,
@@ -45,6 +48,13 @@ function asTrimmedString(value: unknown): string | null {
     return normalized || null;
 }
 
+function asUniqueStringArray(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return Array.from(new Set(value
+        .map((entry) => asTrimmedString(entry))
+        .filter((entry): entry is string => Boolean(entry))));
+}
+
 function asOptionalDate(value: unknown): Date | null {
     if (value instanceof Date) {
         return Number.isNaN(value.getTime()) ? null : value;
@@ -70,6 +80,19 @@ function asObject(value: unknown): Record<string, unknown> | null {
     return value as Record<string, unknown>;
 }
 
+function asTemporalValue(value: unknown): unknown {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value;
+    }
+    if (value && typeof (value as { toDate?: unknown }).toDate === 'function') {
+        return value;
+    }
+    if (typeof (value as { seconds?: unknown })?.seconds === 'number') {
+        return value;
+    }
+    return asOptionalDate(value);
+}
+
 function asLooseObject(value: unknown): Record<string, unknown> {
     return asObject(value) || {};
 }
@@ -78,6 +101,115 @@ function asObjectArray(value: unknown): Array<Record<string, unknown>> {
     return Array.isArray(value)
         ? value.filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === 'object' && !Array.isArray(entry))
         : [];
+}
+
+function asChatConversationType(value: unknown): ChatConversationFirestoreRecord['type'] {
+    return value === 'team' || value === 'group' || value === 'direct' ? value : 'group';
+}
+
+function asChatAttachmentType(value: unknown, mimeType: unknown): ChatAttachmentFirestoreRecord['type'] {
+    if (value === 'image' || value === 'video') return value;
+    return asTrimmedString(mimeType)?.toLowerCase().startsWith('video/') ? 'video' : 'image';
+}
+
+function asChatTargetType(value: unknown): ChatMessageFirestoreRecord['targetType'] {
+    return value === 'staff' || value === 'individuals' || value === 'full_team' ? value : 'full_team';
+}
+
+function asReactionMap(value: unknown): Record<string, string[]> {
+    const source = asObject(value);
+    if (!source) return {};
+
+    return Object.entries(source).reduce<Record<string, string[]>>((acc, [key, entry]) => {
+        const normalizedKey = asTrimmedString(key);
+        const normalizedUsers = asUniqueStringArray(entry);
+        if (normalizedKey && normalizedUsers.length > 0) {
+            acc[normalizedKey] = normalizedUsers;
+        }
+        return acc;
+    }, {});
+}
+
+export function mapChatAttachmentRecord(value: unknown): ChatAttachmentFirestoreRecord | null {
+    const source = asObject(value);
+    if (!source) return null;
+
+    const mimeType = asTrimmedString(source.mimeType);
+    return {
+        type: asChatAttachmentType(source.type, mimeType),
+        url: asTrimmedString(source.url),
+        path: asTrimmedString(source.path),
+        thumbnailUrl: asTrimmedString(source.thumbnailUrl),
+        name: asTrimmedString(source.name),
+        mimeType,
+        size: asOptionalNumber(source.size),
+        uploadedAt: asTemporalValue(source.uploadedAt)
+    };
+}
+
+export function mapChatConversationRecord(value: unknown, fallbackId = ''): ChatConversationFirestoreRecord | null {
+    const source = asLooseObject(value);
+    const id = asTrimmedString(source.id) || fallbackId;
+    if (!id) return null;
+
+    return {
+        id,
+        type: asChatConversationType(source.type),
+        name: asTrimmedString(source.name),
+        participantIds: asUniqueStringArray(source.participantIds),
+        participantRoles: asUniqueStringArray(source.participantRoles),
+        mutedBy: asUniqueStringArray(source.mutedBy),
+        isDefault: source.isDefault === true,
+        isLegacy: source.isLegacy === true,
+        updatedAt: asTemporalValue(source.updatedAt),
+        lastMessageAt: asTemporalValue(source.lastMessageAt)
+    };
+}
+
+export function mapChatConversationDocument(document: FirestoreDocument | null | undefined): ChatConversationFirestoreRecord | null {
+    const decoded = mapFirestoreDocument(document);
+    return decoded ? mapChatConversationRecord(decoded, decoded.id) : null;
+}
+
+export function mapChatMessageRecord(value: unknown, fallbackId = ''): ChatMessageFirestoreRecord | null {
+    const source = asLooseObject(value);
+    const id = asTrimmedString(source.id) || fallbackId;
+    if (!id) return null;
+
+    return {
+        id,
+        text: asTrimmedString(source.text),
+        senderId: asTrimmedString(source.senderId),
+        senderName: asTrimmedString(source.senderName),
+        senderEmail: asTrimmedString(source.senderEmail),
+        senderPhotoUrl: asTrimmedString(source.senderPhotoUrl),
+        attachments: asObjectArray(source.attachments)
+            .map((attachment) => mapChatAttachmentRecord(attachment))
+            .filter((attachment): attachment is ChatAttachmentFirestoreRecord => Boolean(attachment)),
+        imageUrl: asTrimmedString(source.imageUrl),
+        imagePath: asTrimmedString(source.imagePath),
+        imageName: asTrimmedString(source.imageName),
+        imageType: asTrimmedString(source.imageType),
+        imageSize: asOptionalNumber(source.imageSize),
+        createdAt: asTemporalValue(source.createdAt),
+        editedAt: asTemporalValue(source.editedAt),
+        deleted: source.deleted === true,
+        ai: source.ai === true,
+        aiName: asTrimmedString(source.aiName),
+        aiQuestion: asTrimmedString(source.aiQuestion),
+        aiMeta: asObject(source.aiMeta),
+        reactions: asReactionMap(source.reactions),
+        targetType: asChatTargetType(source.targetType),
+        recipientIds: asUniqueStringArray(source.recipientIds),
+        targetRole: asTrimmedString(source.targetRole),
+        conversationId: asTrimmedString(source.conversationId),
+        _doc: source._doc
+    };
+}
+
+export function mapChatMessageDocument(document: FirestoreDocument | null | undefined): ChatMessageFirestoreRecord | null {
+    const decoded = mapFirestoreDocument(document);
+    return decoded ? mapChatMessageRecord(decoded, decoded.id) : null;
 }
 
 function asGameReportStatsRecord(value: unknown): GameReportStatsRecord {

--- a/apps/app/src/lib/firestore/types.ts
+++ b/apps/app/src/lib/firestore/types.ts
@@ -30,6 +30,58 @@ export type FirestoreDecodedDocument = Record<string, unknown> & {
     id: string;
 };
 
+export type ChatConversationFirestoreRecord = {
+    id: string;
+    type: 'team' | 'group' | 'direct';
+    name?: string | null;
+    participantIds?: string[];
+    participantRoles?: string[];
+    mutedBy?: string[];
+    isDefault?: boolean;
+    isLegacy?: boolean;
+    updatedAt?: unknown;
+    lastMessageAt?: unknown;
+};
+
+export type ChatAttachmentFirestoreRecord = {
+    type: 'image' | 'video';
+    url: string | null;
+    path?: string | null;
+    thumbnailUrl?: string | null;
+    name?: string | null;
+    mimeType?: string | null;
+    size?: number | null;
+    uploadedAt?: unknown;
+};
+
+export type ChatMessageFirestoreRecord = {
+    id: string;
+    text?: string | null;
+    senderId?: string | null;
+    senderName?: string | null;
+    senderEmail?: string | null;
+    senderPhotoUrl?: string | null;
+    attachments?: ChatAttachmentFirestoreRecord[];
+    imageUrl?: string | null;
+    imagePath?: string | null;
+    imageName?: string | null;
+    imageType?: string | null;
+    imageSize?: number | null;
+    createdAt?: unknown;
+    editedAt?: unknown;
+    deleted?: boolean;
+    ai?: boolean;
+    aiName?: string | null;
+    aiQuestion?: string | null;
+    aiMeta?: Record<string, unknown> | null;
+    reactions?: Record<string, string[]>;
+    targetType?: 'full_team' | 'staff' | 'individuals';
+    recipientIds?: string[];
+    targetRole?: string | null;
+    conversationId?: string | null;
+    _doc?: unknown;
+};
+
 export type ScheduleEventFirestoreRecord = {
     id: string;
     type: 'game' | 'practice';


### PR DESCRIPTION
Closes #2291

## What changed
- added typed Firestore record interfaces for chat conversations, messages, and attachments
- added chat-specific mapper functions that normalize partial sender, attachment, reaction, and preview metadata
- updated `chatService` read paths to map SDK and native REST chat reads through the typed mapper boundary instead of returning raw decoded payloads
- added focused regression tests for valid and partial chat message and conversation Firestore records

## Root Cause
`chatService` was letting chat message and inbox-preview data cross the Firestore boundary as raw `any`-decoded objects. That meant missing sender metadata, malformed reactions, attachment fields, and partial conversation preview fields were never normalized before inbox rendering consumed them.

## Prevention / Learning
When migrating Firestore reads, add explicit record interfaces and mapper functions at the service boundary first, then route both SDK and native REST reads through the same normalization path. Cover valid and partial documents in tests before wiring the UI to the data.

## Regression Tests
- `npx vitest run src/lib/chatService.test.ts src/lib/badgeService.test.ts --reporter=verbose`
- `npm run app:build`