### PR TITLE
Add due-tomorrow home packet reminder notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4179,7 +4179,8 @@ async function sendDirectTargetsNotification({
 
 exports._internal = {
   getTargetsForCategory,
-  sendCategoryNotification
+  sendCategoryNotification,
+  sendPracticePacketDueTomorrowReminders
 };
 
 exports.markNotificationInboxItemRead = functions.https.onCall(async (data, context) => {
@@ -4542,6 +4543,162 @@ exports.dispatchDuePreEventReminders = functions.pubsub
 exports.queueDueRegistrationFailedPaymentReminders = functions.pubsub
   .schedule('every 6 hours')
   .onRun(() => queueDueRegistrationFailedPaymentReminders());
+
+function getPracticePacketReminderDueDate(packet = {}, session = {}) {
+  return coercePracticePacketDate(
+    packet.dueDate
+    || packet.dueAt
+    || packet.deadline
+    || packet.deadlineAt
+    || packet.completeBy
+    || packet.completeByAt
+    || session.date
+  );
+}
+
+function getTomorrowDateRange(now = new Date()) {
+  const start = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1,
+    0,
+    0,
+    0,
+    0
+  ));
+  const end = new Date(start.getTime());
+  end.setUTCDate(end.getUTCDate() + 1);
+  return { start, end };
+}
+
+function isPracticePacketDueTomorrow(packet = {}, session = {}, now = new Date()) {
+  const dueDate = getPracticePacketReminderDueDate(packet, session);
+  if (!dueDate) return false;
+  const { start, end } = getTomorrowDateRange(now);
+  return dueDate >= start && dueDate < end;
+}
+
+function getPracticePacketReminderDocRef(teamId, sessionId, playerId) {
+  return firestore.doc(`teams/${teamId}/practiceSessions/${sessionId}/packetReminderSends/${playerId}`);
+}
+
+async function claimPracticePacketReminder(teamId, sessionId, playerId) {
+  const reminderRef = getPracticePacketReminderDocRef(teamId, sessionId, playerId);
+  return firestore.runTransaction(async (transaction) => {
+    const reminderSnap = await transaction.get(reminderRef);
+    if (reminderSnap.exists && reminderSnap.data()?.reminderSentAt) {
+      return false;
+    }
+
+    transaction.set(reminderRef, {
+      playerId,
+      reminderSentAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    return true;
+  });
+}
+
+async function getPracticePacketReminderTargetUserIds(teamId, playerId, player = {}) {
+  const directUserIds = getTeamFeeRecipientTargetUserIds({}, player, {});
+  if (directUserIds.length > 0) return directUserIds;
+
+  const privateProfileSnap = await firestore.doc(`teams/${teamId}/players/${playerId}/private/profile`).get();
+  const privateProfile = privateProfileSnap.exists ? (privateProfileSnap.data() || {}) : {};
+  return getTeamFeeRecipientTargetUserIds({}, player, privateProfile);
+}
+
+async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
+  if (!NOTIFICATION_CATEGORIES.includes('practice')) {
+    functions.logger.error('sendPracticePacketDueTomorrowReminders requires the practice notification category.', {
+      availableCategories: NOTIFICATION_CATEGORIES
+    });
+    return [];
+  }
+
+  const sessionSnap = await firestore.collectionGroup('practiceSessions')
+    .where('homePacketGenerated', '==', true)
+    .get();
+
+  const practiceTargetsByTeam = new Map();
+  const results = [];
+
+  for (const docSnap of sessionSnap.docs) {
+    const session = docSnap.data() || {};
+    const packet = session.homePacketContent || null;
+    if (!hasPracticePacketContent(packet)) continue;
+    if (!isPracticePacketDueTomorrow(packet, session, now)) continue;
+
+    const pathParts = docSnap.ref.path.split('/');
+    const teamId = pathParts[1];
+    const sessionId = docSnap.id;
+    if (!teamId || !sessionId) continue;
+
+    const [playersSnap, completionsSnap] = await Promise.all([
+      firestore.collection(`teams/${teamId}/players`).get(),
+      firestore.collection(`teams/${teamId}/practiceSessions/${sessionId}/packetCompletions`).get()
+    ]);
+    const completedPlayerIds = new Set(
+      completionsSnap.docs
+        .map((completionSnap) => completionSnap.data() || {})
+        .filter((completion) => String(completion.status || 'completed').trim().toLowerCase() === 'completed')
+        .map((completion) => String(completion.childId || '').trim())
+        .filter(Boolean)
+    );
+
+    let practiceTargets = practiceTargetsByTeam.get(teamId);
+    if (!practiceTargets) {
+      practiceTargets = await getTargetsForCategory(teamId, 'practice', null);
+      practiceTargetsByTeam.set(teamId, practiceTargets);
+    }
+    if (!practiceTargets.length) continue;
+
+    const scheduleEventId = String(session.eventId || '').trim() || sessionId;
+    const destination = buildPracticePacketNotificationDestination({ teamId, eventId: scheduleEventId, sessionId });
+    const packetTitle = getPracticePacketNotificationTitle(packet, session);
+
+    for (const playerSnap of playersSnap.docs) {
+      const playerId = String(playerSnap.id || '').trim();
+      const player = playerSnap.data() || {};
+      if (!playerId || player.active === false) continue;
+      if (completedPlayerIds.has(playerId)) continue;
+
+      const candidateUserIds = await getPracticePacketReminderTargetUserIds(teamId, playerId, player);
+      if (!candidateUserIds.length) continue;
+
+      const candidateUserIdSet = new Set(candidateUserIds);
+      const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
+      if (!parentTargets.length) continue;
+
+      const claimed = await claimPracticePacketReminder(teamId, sessionId, playerId);
+      if (!claimed) continue;
+
+      await sendDirectTargetsNotification({
+        targets: parentTargets,
+        category: 'practice',
+        title: `Reminder: ${packetTitle} is due tomorrow`,
+        body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
+        teamId,
+        eventId: sessionId,
+        linkOverride: destination.link,
+        appRouteOverride: destination.appRoute
+      });
+
+      results.push({
+        teamId,
+        sessionId,
+        playerId,
+        targetCount: parentTargets.length
+      });
+    }
+  }
+
+  return results;
+}
+
+exports.sendPracticePacketDueTomorrowReminders = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(() => sendPracticePacketDueTomorrowReminders());
 
 function getFeeReminderPlayerKey(recipient = {}, teamId = '') {
   const explicitPlayerKey = String(recipient.playerKey || '').trim();

--- a/functions/index.js
+++ b/functions/index.js
@@ -4582,30 +4582,88 @@ function getPracticePacketReminderDocRef(teamId, sessionId, playerId) {
   return firestore.doc(`teams/${teamId}/practiceSessions/${sessionId}/packetReminderSends/${playerId}`);
 }
 
-async function claimPracticePacketReminder(teamId, sessionId, playerId) {
+const PRACTICE_PACKET_REMINDER_CLAIM_TTL_MS = 15 * 60 * 1000;
+
+function buildPracticePacketReminderClaimId() {
+  return `practice-packet-${crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex')}`;
+}
+
+async function claimPracticePacketReminder(teamId, sessionId, playerId, now = new Date()) {
   const reminderRef = getPracticePacketReminderDocRef(teamId, sessionId, playerId);
   return firestore.runTransaction(async (transaction) => {
     const reminderSnap = await transaction.get(reminderRef);
-    if (reminderSnap.exists && reminderSnap.data()?.reminderSentAt) {
+    const reminder = reminderSnap.exists ? (reminderSnap.data() || {}) : {};
+    if (reminder.reminderSentAt) {
+      return null;
+    }
+
+    const deliveryClaimedAt = coercePracticePacketDate(reminder.deliveryClaimedAt);
+    const hasActiveClaim = reminder.deliveryClaimId
+      && deliveryClaimedAt
+      && (now.getTime() - deliveryClaimedAt.getTime()) < PRACTICE_PACKET_REMINDER_CLAIM_TTL_MS;
+    if (hasActiveClaim) {
+      return null;
+    }
+
+    const claimId = buildPracticePacketReminderClaimId();
+    transaction.set(reminderRef, {
+      playerId,
+      deliveryClaimId: claimId,
+      deliveryClaimedAt: admin.firestore.FieldValue.serverTimestamp(),
+      reminderSentAt: null,
+      lastError: null,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    return claimId;
+  });
+}
+
+async function getPracticePacketReminderTargetUserIds(teamId, playerId, player = {}) {
+  const privateProfileSnap = await firestore.doc(`teams/${teamId}/players/${playerId}/private/profile`).get();
+  const privateProfile = privateProfileSnap.exists ? (privateProfileSnap.data() || {}) : {};
+  return getTeamFeeRecipientTargetUserIds({}, player, privateProfile);
+}
+
+async function markPracticePacketReminderSent(teamId, sessionId, playerId, claimId) {
+  const reminderRef = getPracticePacketReminderDocRef(teamId, sessionId, playerId);
+  return firestore.runTransaction(async (transaction) => {
+    const reminderSnap = await transaction.get(reminderRef);
+    const reminder = reminderSnap.exists ? (reminderSnap.data() || {}) : {};
+    if (reminder.reminderSentAt || reminder.deliveryClaimId !== claimId) {
       return false;
     }
 
     transaction.set(reminderRef, {
       playerId,
       reminderSentAt: admin.firestore.FieldValue.serverTimestamp(),
+      deliveryClaimId: null,
+      deliveryClaimedAt: null,
+      lastError: null,
       updatedAt: admin.firestore.FieldValue.serverTimestamp()
     }, { merge: true });
     return true;
   });
 }
 
-async function getPracticePacketReminderTargetUserIds(teamId, playerId, player = {}) {
-  const directUserIds = getTeamFeeRecipientTargetUserIds({}, player, {});
-  if (directUserIds.length > 0) return directUserIds;
+async function clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error) {
+  const reminderRef = getPracticePacketReminderDocRef(teamId, sessionId, playerId);
+  return firestore.runTransaction(async (transaction) => {
+    const reminderSnap = await transaction.get(reminderRef);
+    const reminder = reminderSnap.exists ? (reminderSnap.data() || {}) : {};
+    if (reminder.deliveryClaimId !== claimId || reminder.reminderSentAt) {
+      return false;
+    }
 
-  const privateProfileSnap = await firestore.doc(`teams/${teamId}/players/${playerId}/private/profile`).get();
-  const privateProfile = privateProfileSnap.exists ? (privateProfileSnap.data() || {}) : {};
-  return getTeamFeeRecipientTargetUserIds({}, player, privateProfile);
+    transaction.set(reminderRef, {
+      playerId,
+      deliveryClaimId: null,
+      deliveryClaimedAt: null,
+      lastError: error?.message || 'Unknown practice packet reminder error',
+      lastAttemptAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    return true;
+  });
 }
 
 async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
@@ -4670,26 +4728,39 @@ async function sendPracticePacketDueTomorrowReminders(now = new Date()) {
       const parentTargets = practiceTargets.filter((target) => candidateUserIdSet.has(target.uid));
       if (!parentTargets.length) continue;
 
-      const claimed = await claimPracticePacketReminder(teamId, sessionId, playerId);
-      if (!claimed) continue;
+      const claimId = await claimPracticePacketReminder(teamId, sessionId, playerId, now);
+      if (!claimId) continue;
 
-      await sendDirectTargetsNotification({
-        targets: parentTargets,
-        category: 'practice',
-        title: `Reminder: ${packetTitle} is due tomorrow`,
-        body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
-        teamId,
-        eventId: sessionId,
-        linkOverride: destination.link,
-        appRouteOverride: destination.appRoute
-      });
+      try {
+        await sendDirectTargetsNotification({
+          targets: parentTargets,
+          category: 'practice',
+          title: `Reminder: ${packetTitle} is due tomorrow`,
+          body: `${String(player.name || 'Your player').trim() || 'Your player'} has not completed the ${getPracticePacketNotificationLabel(session)} yet.`,
+          teamId,
+          eventId: sessionId,
+          linkOverride: destination.link,
+          appRouteOverride: destination.appRoute
+        });
 
-      results.push({
-        teamId,
-        sessionId,
-        playerId,
-        targetCount: parentTargets.length
-      });
+        const markedSent = await markPracticePacketReminderSent(teamId, sessionId, playerId, claimId);
+        if (!markedSent) continue;
+
+        results.push({
+          teamId,
+          sessionId,
+          playerId,
+          targetCount: parentTargets.length
+        });
+      } catch (error) {
+        await clearPracticePacketReminderClaim(teamId, sessionId, playerId, claimId, error);
+        functions.logger.error('Failed to send practice packet due tomorrow reminder.', {
+          teamId,
+          sessionId,
+          playerId,
+          error: error?.message || error
+        });
+      }
     }
   }
 

--- a/tests/unit/practice-packet-due-reminders.test.js
+++ b/tests/unit/practice-packet-due-reminders.test.js
@@ -1,0 +1,302 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+function extractChunk(startMarker, endMarker) {
+    const start = functionsSource.indexOf(startMarker);
+    const end = functionsSource.indexOf(endMarker, start);
+    if (start === -1 || end === -1) {
+        throw new Error(`Unable to extract source chunk for ${startMarker}.`);
+    }
+    return functionsSource.slice(start, end);
+}
+
+function extractReminderSource() {
+    return [
+        extractChunk('function buildPracticePacketNotificationDestination(', 'function buildNotificationLink'),
+        extractChunk('function getPracticePacketReminderDueDate(', 'function getFeeReminderPlayerKey')
+    ].join('\n');
+}
+
+function makeDocSnapshot(ref, data, exists = true) {
+    return {
+        id: ref.id,
+        ref,
+        exists,
+        data: () => data
+    };
+}
+
+function makeQuerySnapshot(docs) {
+    return {
+        docs,
+        empty: docs.length === 0,
+        size: docs.length,
+        forEach(callback) {
+            docs.forEach(callback);
+        }
+    };
+}
+
+function buildHarness({
+    categories = ['practice', 'schedule'],
+    now = new Date('2026-06-20T12:00:00.000Z'),
+    sessions = [],
+    playersByTeam = {},
+    completionsBySessionPath = {},
+    privateProfiles = {},
+    practiceTargetsByTeam = {},
+    existingReminderDocs = {}
+} = {}) {
+    const reminderDocStore = new Map(Object.entries(existingReminderDocs));
+    const sendDirectTargetsNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
+    const getTargetsForCategory = vi.fn(async (teamId) => practiceTargetsByTeam[teamId] || []);
+    const getTeamFeeRecipientTargetUserIds = vi.fn((recipient = {}, player = {}, privateProfile = {}) => {
+        const ids = [
+            recipient.parentUserId,
+            recipient.accountUserId,
+            recipient.userId,
+            player.parentUserId,
+            player.guardianUserId,
+            privateProfile.parentUserId,
+            privateProfile.guardianUserId,
+            ...(Array.isArray(player.parents) ? player.parents.map((parent) => parent?.userId || parent?.uid) : []),
+            ...(Array.isArray(player.privateProfileParents) ? player.privateProfileParents.map((parent) => parent?.userId || parent?.uid) : []),
+            ...(Array.isArray(privateProfile.parents) ? privateProfile.parents.map((parent) => parent?.userId || parent?.uid) : [])
+        ];
+        return [...new Set(ids.map((value) => String(value || '').trim()).filter(Boolean))];
+    });
+
+    const firestore = {
+        collectionGroup: vi.fn((name) => {
+            if (name !== 'practiceSessions') {
+                throw new Error(`Unexpected collectionGroup ${name}`);
+            }
+            return {
+                where: vi.fn(() => ({
+                    get: vi.fn(async () => makeQuerySnapshot(sessions.map((session) => {
+                        const ref = { path: session.path, id: session.path.split('/').pop() };
+                        return makeDocSnapshot(ref, session.data, true);
+                    })))
+                }))
+            };
+        }),
+        collection: vi.fn((path) => ({
+            get: vi.fn(async () => {
+                if (path.endsWith('/players')) {
+                    const teamId = path.split('/')[1];
+                    const players = playersByTeam[teamId] || [];
+                    return makeQuerySnapshot(players.map((player) => {
+                        const ref = { path: `${path}/${player.id}`, id: player.id };
+                        return makeDocSnapshot(ref, player.data, true);
+                    }));
+                }
+                if (path.endsWith('/packetCompletions')) {
+                    const completions = completionsBySessionPath[path.replace('/packetCompletions', '')] || [];
+                    return makeQuerySnapshot(completions.map((completion) => {
+                        const ref = { path: `${path}/${completion.id}`, id: completion.id };
+                        return makeDocSnapshot(ref, completion.data, true);
+                    }));
+                }
+                return makeQuerySnapshot([]);
+            })
+        })),
+        doc: vi.fn((path) => ({
+            path,
+            id: path.split('/').pop(),
+            async get() {
+                if (path.includes('/private/profile')) {
+                    const data = privateProfiles[path];
+                    return makeDocSnapshot(this, data, data !== undefined);
+                }
+                const data = reminderDocStore.get(path);
+                return makeDocSnapshot(this, data, data !== undefined);
+            },
+            async set(value) {
+                reminderDocStore.set(path, { ...(reminderDocStore.get(path) || {}), ...(value || {}) });
+            }
+        })),
+        async runTransaction(handler) {
+            return handler({
+                get: (ref) => ref.get(),
+                set: (ref, value) => {
+                    reminderDocStore.set(ref.path, { ...(reminderDocStore.get(ref.path) || {}), ...(value || {}) });
+                }
+            });
+        }
+    };
+
+    const functions = {
+        pubsub: {
+            schedule: vi.fn(() => ({
+                onRun: vi.fn((handler) => handler)
+            }))
+        },
+        logger: {
+            error: vi.fn()
+        }
+    };
+    const admin = {
+        firestore: {
+            FieldValue: {
+                serverTimestamp: () => ({ __serverTimestamp: true })
+            }
+        }
+    };
+    const exportsObject = {};
+    const factory = new Function(
+        'exports',
+        'functions',
+        'admin',
+        'firestore',
+        'NOTIFICATION_CATEGORIES',
+        'getTargetsForCategory',
+        'getTeamFeeRecipientTargetUserIds',
+        'sendDirectTargetsNotification',
+        `${extractReminderSource()}\nreturn { trigger: exports.sendPracticePacketDueTomorrowReminders, sendPracticePacketDueTomorrowReminders };`
+    );
+
+    const built = factory(
+        exportsObject,
+        functions,
+        admin,
+        firestore,
+        categories,
+        getTargetsForCategory,
+        getTeamFeeRecipientTargetUserIds,
+        sendDirectTargetsNotification
+    );
+
+    return {
+        now,
+        trigger: built.trigger,
+        sendPracticePacketDueTomorrowReminders: built.sendPracticePacketDueTomorrowReminders,
+        functions,
+        firestore,
+        getTargetsForCategory,
+        getTeamFeeRecipientTargetUserIds,
+        sendDirectTargetsNotification,
+        reminderDocStore
+    };
+}
+
+describe('sendPracticePacketDueTomorrowReminders', () => {
+    it('sends one practice reminder only for incomplete players with enabled parent targets', async () => {
+        const harness = buildHarness({
+            sessions: [
+                {
+                    path: 'teams/team-1/practiceSessions/session-1',
+                    data: {
+                        title: 'Thursday Practice',
+                        eventId: 'practice-44',
+                        homePacketGenerated: true,
+                        homePacketContent: {
+                            blocks: [{ id: 'block-1' }],
+                            dueDate: '2026-06-21T09:00:00.000Z'
+                        }
+                    }
+                }
+            ],
+            playersByTeam: {
+                'team-1': [
+                    { id: 'player-1', data: { name: 'Pat', parents: [{ userId: 'parent-1' }] } },
+                    { id: 'player-2', data: { name: 'Sam' } },
+                    { id: 'player-3', data: { name: 'Alex', parents: [{ userId: 'parent-3' }] } }
+                ]
+            },
+            completionsBySessionPath: {
+                'teams/team-1/practiceSessions/session-1': [
+                    { id: 'parent-1__player-1', data: { childId: 'player-1', status: 'completed' } }
+                ]
+            },
+            privateProfiles: {
+                'teams/team-1/players/player-2/private/profile': {
+                    parents: [{ userId: 'parent-2' }]
+                }
+            },
+            practiceTargetsByTeam: {
+                'team-1': [
+                    { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' }
+                ]
+            }
+        });
+
+        const result = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+
+        expect(result).toEqual([
+            { teamId: 'team-1', sessionId: 'session-1', playerId: 'player-2', targetCount: 1 }
+        ]);
+        expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'practice', null);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(1);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledWith(expect.objectContaining({
+            targets: [{ uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' }],
+            category: 'practice',
+            title: 'Reminder: Thursday Practice is due tomorrow',
+            body: 'Sam has not completed the home packet for Thursday Practice yet.',
+            teamId: 'team-1',
+            eventId: 'session-1',
+            linkOverride: 'https://allplays.ai/app/#/schedule/team-1/practice-44?section=game',
+            appRouteOverride: '/schedule/team-1/practice-44?section=game'
+        }));
+        expect(
+            harness.reminderDocStore.get('teams/team-1/practiceSessions/session-1/packetReminderSends/player-2')
+        ).toEqual(expect.objectContaining({ playerId: 'player-2' }));
+        expect(
+            harness.reminderDocStore.has('teams/team-1/practiceSessions/session-1/packetReminderSends/player-1')
+        ).toBe(false);
+    });
+
+    it('uses reminderSentAt guard to avoid duplicate sends for the same player and packet', async () => {
+        const harness = buildHarness({
+            sessions: [
+                {
+                    path: 'teams/team-1/practiceSessions/session-1',
+                    data: {
+                        title: 'Thursday Practice',
+                        homePacketGenerated: true,
+                        homePacketContent: {
+                            blocks: [{ id: 'block-1' }],
+                            dueDate: '2026-06-21T09:00:00.000Z'
+                        }
+                    }
+                }
+            ],
+            playersByTeam: {
+                'team-1': [
+                    { id: 'player-2', data: { name: 'Sam', parents: [{ userId: 'parent-2' }] } }
+                ]
+            },
+            practiceTargetsByTeam: {
+                'team-1': [
+                    { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' }
+                ]
+            }
+        });
+
+        const firstResult = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+        const secondResult = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+
+        expect(firstResult).toEqual([
+            { teamId: 'team-1', sessionId: 'session-1', playerId: 'player-2', targetCount: 1 }
+        ]);
+        expect(secondResult).toEqual([]);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs and exits when practice notifications are unavailable', async () => {
+        const harness = buildHarness({
+            categories: ['schedule']
+        });
+
+        const result = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+
+        expect(result).toEqual([]);
+        expect(harness.functions.logger.error).toHaveBeenCalledWith(
+            'sendPracticePacketDueTomorrowReminders requires the practice notification category.',
+            expect.objectContaining({ availableCategories: ['schedule'] })
+        );
+        expect(harness.getTargetsForCategory).not.toHaveBeenCalled();
+        expect(harness.sendDirectTargetsNotification).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/practice-packet-due-reminders.test.js
+++ b/tests/unit/practice-packet-due-reminders.test.js
@@ -144,6 +144,9 @@ function buildHarness({
             }
         }
     };
+    const crypto = {
+        randomUUID: () => 'claim-1234'
+    };
     const exportsObject = {};
     const factory = new Function(
         'exports',
@@ -154,6 +157,7 @@ function buildHarness({
         'getTargetsForCategory',
         'getTeamFeeRecipientTargetUserIds',
         'sendDirectTargetsNotification',
+        'crypto',
         `${extractReminderSource()}\nreturn { trigger: exports.sendPracticePacketDueTomorrowReminders, sendPracticePacketDueTomorrowReminders };`
     );
 
@@ -165,7 +169,8 @@ function buildHarness({
         categories,
         getTargetsForCategory,
         getTeamFeeRecipientTargetUserIds,
-        sendDirectTargetsNotification
+        sendDirectTargetsNotification,
+        crypto
     );
 
     return {
@@ -182,7 +187,7 @@ function buildHarness({
 }
 
 describe('sendPracticePacketDueTomorrowReminders', () => {
-    it('sends one practice reminder only for incomplete players with enabled parent targets', async () => {
+    it('sends one practice reminder only for incomplete players with enabled parent targets, including private-profile caregivers', async () => {
         const harness = buildHarness({
             sessions: [
                 {
@@ -201,7 +206,7 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
             playersByTeam: {
                 'team-1': [
                     { id: 'player-1', data: { name: 'Pat', parents: [{ userId: 'parent-1' }] } },
-                    { id: 'player-2', data: { name: 'Sam' } },
+                    { id: 'player-2', data: { name: 'Sam', parents: [{ userId: 'parent-2' }] } },
                     { id: 'player-3', data: { name: 'Alex', parents: [{ userId: 'parent-3' }] } }
                 ]
             },
@@ -212,12 +217,13 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
             },
             privateProfiles: {
                 'teams/team-1/players/player-2/private/profile': {
-                    parents: [{ userId: 'parent-2' }]
+                    parents: [{ userId: 'caregiver-2' }]
                 }
             },
             practiceTargetsByTeam: {
                 'team-1': [
-                    { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' }
+                    { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' },
+                    { uid: 'caregiver-2', token: 'caregiver-2-token', teamId: 'team-1' }
                 ]
             }
         });
@@ -225,12 +231,15 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
         const result = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
 
         expect(result).toEqual([
-            { teamId: 'team-1', sessionId: 'session-1', playerId: 'player-2', targetCount: 1 }
+            { teamId: 'team-1', sessionId: 'session-1', playerId: 'player-2', targetCount: 2 }
         ]);
         expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'practice', null);
         expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(1);
         expect(harness.sendDirectTargetsNotification).toHaveBeenCalledWith(expect.objectContaining({
-            targets: [{ uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' }],
+            targets: [
+                { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' },
+                { uid: 'caregiver-2', token: 'caregiver-2-token', teamId: 'team-1' }
+            ],
             category: 'practice',
             title: 'Reminder: Thursday Practice is due tomorrow',
             body: 'Sam has not completed the home packet for Thursday Practice yet.',
@@ -241,13 +250,17 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
         }));
         expect(
             harness.reminderDocStore.get('teams/team-1/practiceSessions/session-1/packetReminderSends/player-2')
-        ).toEqual(expect.objectContaining({ playerId: 'player-2' }));
+        ).toEqual(expect.objectContaining({
+            playerId: 'player-2',
+            deliveryClaimId: null,
+            deliveryClaimedAt: null
+        }));
         expect(
             harness.reminderDocStore.has('teams/team-1/practiceSessions/session-1/packetReminderSends/player-1')
         ).toBe(false);
     });
 
-    it('uses reminderSentAt guard to avoid duplicate sends for the same player and packet', async () => {
+    it('clears failed reminder claims so later players still send and retries can deliver later', async () => {
         const harness = buildHarness({
             sessions: [
                 {
@@ -264,24 +277,54 @@ describe('sendPracticePacketDueTomorrowReminders', () => {
             ],
             playersByTeam: {
                 'team-1': [
-                    { id: 'player-2', data: { name: 'Sam', parents: [{ userId: 'parent-2' }] } }
+                    { id: 'player-2', data: { name: 'Sam', parents: [{ userId: 'parent-2' }] } },
+                    { id: 'player-3', data: { name: 'Alex', parents: [{ userId: 'parent-3' }] } }
                 ]
             },
             practiceTargetsByTeam: {
                 'team-1': [
-                    { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' }
+                    { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' },
+                    { uid: 'parent-3', token: 'parent-3-token', teamId: 'team-1' }
                 ]
             }
         });
+        harness.sendDirectTargetsNotification
+            .mockRejectedValueOnce(new Error('FCM unavailable'))
+            .mockResolvedValue({ successCount: 1, failureCount: 0 });
 
         const firstResult = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
-        const secondResult = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
 
         expect(firstResult).toEqual([
+            { teamId: 'team-1', sessionId: 'session-1', playerId: 'player-3', targetCount: 1 }
+        ]);
+        expect(
+            harness.reminderDocStore.get('teams/team-1/practiceSessions/session-1/packetReminderSends/player-2')
+        ).toEqual(expect.objectContaining({
+            playerId: 'player-2',
+            reminderSentAt: null,
+            deliveryClaimId: null,
+            deliveryClaimedAt: null,
+            lastError: 'FCM unavailable'
+        }));
+        expect(harness.functions.logger.error).toHaveBeenCalledWith(
+            'Failed to send practice packet due tomorrow reminder.',
+            expect.objectContaining({ teamId: 'team-1', sessionId: 'session-1', playerId: 'player-2', error: 'FCM unavailable' })
+        );
+
+        const secondResult = await harness.sendPracticePacketDueTomorrowReminders(harness.now);
+
+        expect(secondResult).toEqual([
             { teamId: 'team-1', sessionId: 'session-1', playerId: 'player-2', targetCount: 1 }
         ]);
-        expect(secondResult).toEqual([]);
-        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(1);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(3);
+        expect(
+            harness.reminderDocStore.get('teams/team-1/practiceSessions/session-1/packetReminderSends/player-2')
+        ).toEqual(expect.objectContaining({
+            playerId: 'player-2',
+            deliveryClaimId: null,
+            deliveryClaimedAt: null,
+            lastError: null
+        }));
     });
 
     it('logs and exits when practice notifications are unavailable', async () => {


### PR DESCRIPTION
Closes #2142

## What changed
- added a scheduled `sendPracticePacketDueTomorrowReminders` path in `functions/index.js`
- filtered due-tomorrow home packets to players without a completed `packetCompletions` record
- resolved parent recipients through the existing player-to-parent linkage model, then filtered through enabled `practice` notification targets
- added a per-session, per-player `packetReminderSends/{playerId}` guard using `reminderSentAt` so the same player/packet reminder only sends once
- added focused unit coverage for incomplete-player filtering, disabled-parent exclusion, and once-only behavior

## Root Cause
The backend had no scheduled reminder workflow for home packets at all. Assignment and completion notifications existed, but there was no server path that read `practiceSessions/.../packetCompletions`, resolved parent targets for incomplete players, and persisted a once-only reminder guard.

## Prevention / Learning
When a notification feature has assigned and completed states, explicitly check for the pending-state reminder path too. The durable pattern is: identify the state transition, define the idempotency guard up front, and add a focused test that proves both recipient filtering and retry safety.

## Regression Tests
- `npx vitest run tests/unit/practice-packet-due-reminders.test.js tests/unit/practice-packet-assigned-notifications.test.js tests/unit/practice-packet-completion-notifications.test.js --reporter=verbose`
- `node --check functions/index.js`