### PR TITLE
Notify parents on first certificate publish

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3365,6 +3365,83 @@ function hasPracticePacketContent(packet = null) {
   return Array.isArray(packet?.blocks) && packet.blocks.length > 0;
 }
 
+function getCertificateNotificationPlayerKey(certificate = {}, teamId = '') {
+  const resolvedTeamId = String(certificate.teamId || teamId || '').trim();
+  const playerId = String(certificate.playerId || certificate.childId || '').trim();
+  if (!resolvedTeamId || !playerId) return '';
+  return `${resolvedTeamId}::${playerId}`;
+}
+
+async function resolvePublishedCertificateParentUserIds(teamId, certificate = {}) {
+  const resolvedTeamId = String(teamId || certificate.teamId || '').trim();
+  const playerId = String(certificate.playerId || certificate.childId || '').trim();
+  if (!resolvedTeamId || !playerId) return [];
+
+  const playerKey = getCertificateNotificationPlayerKey(certificate, resolvedTeamId);
+  const [playerKeySnap, teamParentSnap] = await Promise.all([
+    playerKey
+      ? firestore.collection('users').where('parentPlayerKeys', 'array-contains', playerKey).get()
+      : Promise.resolve({ docs: [] }),
+    firestore.collection('users').where('parentTeamIds', 'array-contains', resolvedTeamId).get()
+  ]);
+
+  const userIds = new Set(
+    (playerKeySnap.docs || [])
+      .map((docSnap) => String(docSnap.id || '').trim())
+      .filter(Boolean)
+  );
+
+  (teamParentSnap.docs || []).forEach((docSnap) => {
+    const data = docSnap.data() || {};
+    const linkedPlayer = Array.isArray(data.parentOf) && data.parentOf.some((entry) => (
+      String(entry?.teamId || '').trim() === resolvedTeamId
+      && String(entry?.playerId || '').trim() === playerId
+    ));
+    if (linkedPlayer) {
+      userIds.add(String(docSnap.id || '').trim());
+    }
+  });
+
+  return Array.from(userIds).filter(Boolean);
+}
+
+async function claimPublishedCertificateAwardNotification(certificateRef) {
+  if (!certificateRef) return false;
+
+  return firestore.runTransaction(async (transaction) => {
+    const snap = await transaction.get(certificateRef);
+    if (!snap.exists) return false;
+
+    const data = snap.data() || {};
+    if (String(data.status || '').trim() !== 'published') {
+      return false;
+    }
+    if (data.awardNotificationProcessedAt) {
+      return false;
+    }
+
+    transaction.update(certificateRef, {
+      awardNotificationProcessedAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+    return true;
+  });
+}
+
+function buildAwardNotificationDestination({ teamId, certificateId }) {
+  const params = new URLSearchParams();
+  if (teamId) {
+    params.set('teamId', teamId);
+  }
+  if (certificateId) {
+    params.set('certificateId', certificateId);
+  }
+  const query = params.toString();
+  return {
+    link: `https://allplays.ai/app/#/parent-tools/certificates${query ? `?${query}` : ''}`,
+    appRoute: `/parent-tools/certificates${query ? `?${query}` : ''}`
+  };
+}
+
 async function practicePacketAssignedNotification(beforeData = null, afterData = null, context = {}) {
   if (!afterData) return null;
 
@@ -5548,6 +5625,54 @@ exports.notifyFeeMarkedPaid = functions.firestore
     }
 
     await Promise.allSettled(promises);
+    return null;
+  });
+
+exports.notifyPublishedCertificateAward = functions.firestore
+  .document('teams/{teamId}/certificates/{certificateId}')
+  .onWrite(async (change, context) => {
+    const beforeData = change.before.exists ? (change.before.data() || null) : null;
+    const afterData = change.after.exists ? (change.after.data() || null) : null;
+    if (!afterData) return null;
+
+    const wasPublished = String(beforeData?.status || '').trim() === 'published';
+    const isPublished = String(afterData.status || '').trim() === 'published';
+    if (!isPublished || wasPublished) return null;
+
+    if (!NOTIFICATION_CATEGORIES.includes('awards')) {
+      functions.logger.error('notifyPublishedCertificateAward requires the awards notification category.', {
+        teamId: context.params?.teamId || null,
+        availableCategories: NOTIFICATION_CATEGORIES
+      });
+      return null;
+    }
+
+    const claimed = await claimPublishedCertificateAwardNotification(change.after.ref);
+    if (!claimed) return null;
+
+    const { teamId, certificateId } = context.params || {};
+    const parentUserIds = await resolvePublishedCertificateParentUserIds(teamId, afterData);
+    if (!parentUserIds.length) return null;
+
+    const allAwardTargets = await getTargetsForCategory(teamId, 'awards', null);
+    const parentUserIdSet = new Set(parentUserIds);
+    const parentTargets = allAwardTargets.filter((target) => parentUserIdSet.has(target.uid));
+    if (!parentTargets.length) return null;
+
+    const destination = buildAwardNotificationDestination({ teamId, certificateId });
+    const playerName = String(afterData.recipientName || afterData.playerName || 'A player').trim() || 'A player';
+    const awardTitle = String(afterData.awardTitle || afterData.title || 'Award').trim() || 'Award';
+
+    await sendDirectTargetsNotification({
+      targets: parentTargets,
+      category: 'awards',
+      title: `Award published for ${playerName}`,
+      body: `${awardTitle} is ready to view in ParentTools.`,
+      teamId,
+      eventId: certificateId,
+      linkOverride: destination.link,
+      appRouteOverride: destination.appRoute
+    });
     return null;
   });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -3405,7 +3405,7 @@ async function resolvePublishedCertificateParentUserIds(teamId, certificate = {}
   return Array.from(userIds).filter(Boolean);
 }
 
-async function claimPublishedCertificateAwardNotification(certificateRef) {
+async function claimPublishedCertificateAwardNotification(certificateRef, eventId = '') {
   if (!certificateRef) return false;
 
   return firestore.runTransaction(async (transaction) => {
@@ -3420,11 +3420,36 @@ async function claimPublishedCertificateAwardNotification(certificateRef) {
       return false;
     }
 
+    const normalizedEventId = String(eventId || '').trim();
+    const processingEventId = String(data.awardNotificationProcessingEventId || '').trim();
+    if (processingEventId) {
+      return normalizedEventId && processingEventId === normalizedEventId;
+    }
+
     transaction.update(certificateRef, {
-      awardNotificationProcessedAt: admin.firestore.FieldValue.serverTimestamp()
+      awardNotificationProcessingEventId: normalizedEventId || 'pending',
+      awardNotificationProcessingStartedAt: admin.firestore.FieldValue.serverTimestamp()
     });
     return true;
   });
+}
+
+async function markPublishedCertificateAwardNotificationProcessed(certificateRef, eventId = '') {
+  if (!certificateRef) return null;
+
+  const normalizedEventId = String(eventId || '').trim();
+  const update = {
+    awardNotificationProcessedAt: admin.firestore.FieldValue.serverTimestamp(),
+    awardNotificationProcessingEventId: admin.firestore.FieldValue.delete(),
+    awardNotificationProcessingStartedAt: admin.firestore.FieldValue.delete()
+  };
+
+  if (normalizedEventId) {
+    update.awardNotificationProcessedEventId = normalizedEventId;
+  }
+
+  await certificateRef.update(update);
+  return null;
 }
 
 function buildAwardNotificationDestination({ teamId, certificateId }) {
@@ -3758,13 +3783,35 @@ async function backfillNotificationRecipientsForTeam(teamId, users) {
   return writeCount;
 }
 
-async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}) {
+async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
 
   const targetSnap = await firestore.collection(`teams/${teamId}/notificationRecipients`)
     .where(`categories.${category}`, '==', true)
     .get();
-  const users = await getCandidateUsersForTeam(teamId);
+  const candidateUsers = await getCandidateUsersForTeam(teamId);
+  const mergedUsers = new Map();
+  const mergeUser = (user) => {
+    const uid = String(user?.uid || '').trim();
+    if (!uid) return;
+    const entry = mergedUsers.get(uid) || { uid, roles: new Set() };
+    const roles = Array.isArray(user?.roles) ? user.roles : [];
+    roles.forEach((role) => {
+      const normalizedRole = String(role || '').trim();
+      if (normalizedRole) {
+        entry.roles.add(normalizedRole);
+      }
+    });
+    mergedUsers.set(uid, entry);
+  };
+
+  candidateUsers.forEach(mergeUser);
+  (Array.isArray(additionalUsers) ? additionalUsers : []).forEach(mergeUser);
+
+  const users = Array.from(mergedUsers.values()).map((entry) => ({
+    uid: entry.uid,
+    roles: Array.from(entry.roles)
+  }));
   const eligibleUsers = new Map(users
     .filter((user) => canReceiveCategoryNotification(category, user, audienceContext))
     .map((user) => [user.uid, user]));
@@ -5647,17 +5694,30 @@ exports.notifyPublishedCertificateAward = functions.firestore
       return null;
     }
 
-    const claimed = await claimPublishedCertificateAwardNotification(change.after.ref);
+    const eventId = String(context.eventId || '').trim();
+    const claimed = await claimPublishedCertificateAwardNotification(change.after.ref, eventId);
     if (!claimed) return null;
 
     const { teamId, certificateId } = context.params || {};
     const parentUserIds = await resolvePublishedCertificateParentUserIds(teamId, afterData);
-    if (!parentUserIds.length) return null;
+    if (!parentUserIds.length) {
+      await markPublishedCertificateAwardNotificationProcessed(change.after.ref, eventId);
+      return null;
+    }
 
-    const allAwardTargets = await getTargetsForCategory(teamId, 'awards', null);
+    const allAwardTargets = await getTargetsForCategory(
+      teamId,
+      'awards',
+      null,
+      {},
+      parentUserIds.map((uid) => ({ uid, roles: ['parent'] }))
+    );
     const parentUserIdSet = new Set(parentUserIds);
     const parentTargets = allAwardTargets.filter((target) => parentUserIdSet.has(target.uid));
-    if (!parentTargets.length) return null;
+    if (!parentTargets.length) {
+      await markPublishedCertificateAwardNotificationProcessed(change.after.ref, eventId);
+      return null;
+    }
 
     const destination = buildAwardNotificationDestination({ teamId, certificateId });
     const playerName = String(afterData.recipientName || afterData.playerName || 'A player').trim() || 'A player';
@@ -5673,6 +5733,7 @@ exports.notifyPublishedCertificateAward = functions.firestore
       linkOverride: destination.link,
       appRouteOverride: destination.appRoute
     });
+    await markPublishedCertificateAwardNotificationProcessed(change.after.ref, eventId);
     return null;
   });
 

--- a/tests/unit/certificate-award-notifications.test.js
+++ b/tests/unit/certificate-award-notifications.test.js
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+function extractChunk(startMarker, endMarker) {
+    const start = functionsSource.indexOf(startMarker);
+    const end = functionsSource.indexOf(endMarker, start);
+    if (start === -1 || end === -1) {
+        throw new Error(`Unable to extract source chunk for ${startMarker}.`);
+    }
+    return functionsSource.slice(start, end);
+}
+
+function getAwardHelpers() {
+    return new Function(
+        'firestore',
+        'admin',
+        `${extractChunk('function getCertificateNotificationPlayerKey(', 'async function practicePacketAssignedNotification')}
+        return {
+            getCertificateNotificationPlayerKey,
+            resolvePublishedCertificateParentUserIds,
+            claimPublishedCertificateAwardNotification,
+            buildAwardNotificationDestination
+        };`
+    );
+}
+
+function getAwardTriggerFactory() {
+    return new Function(
+        'exports',
+        'functions',
+        'NOTIFICATION_CATEGORIES',
+        'claimPublishedCertificateAwardNotification',
+        'resolvePublishedCertificateParentUserIds',
+        'getTargetsForCategory',
+        'sendDirectTargetsNotification',
+        'buildAwardNotificationDestination',
+        `${extractChunk('exports.notifyPublishedCertificateAward = functions.firestore', 'exports.notifyFeeAssigned = functions.firestore')}
+        return exports.notifyPublishedCertificateAward;`
+    );
+}
+
+function buildFirestoreForParentLookup({ byPlayerKey = [], byTeamId = [] } = {}) {
+    return {
+        collection: vi.fn((path) => {
+            expect(path).toBe('users');
+            return {
+                where: vi.fn((field, operator, value) => {
+                    expect(operator).toBe('array-contains');
+                    if (field === 'parentPlayerKeys') {
+                        return {
+                            get: vi.fn(async () => ({
+                                docs: byPlayerKey
+                                    .filter((entry) => entry.parentPlayerKeys?.includes(value))
+                                    .map((entry) => ({
+                                        id: entry.id,
+                                        data: () => entry
+                                    }))
+                            }))
+                        };
+                    }
+                    if (field === 'parentTeamIds') {
+                        return {
+                            get: vi.fn(async () => ({
+                                docs: byTeamId
+                                    .filter((entry) => entry.parentTeamIds?.includes(value))
+                                    .map((entry) => ({
+                                        id: entry.id,
+                                        data: () => entry
+                                    }))
+                            }))
+                        };
+                    }
+                    throw new Error(`Unexpected where field: ${field}`);
+                })
+            };
+        }),
+        runTransaction: vi.fn(async (handler) => handler({
+            get: vi.fn(async () => ({ exists: false, data: () => ({}) })),
+            update: vi.fn()
+        }))
+    };
+}
+
+function buildTriggerHarness({
+    categories = ['awards', 'schedule'],
+    claimResult = true,
+    parentUserIds = [],
+    targets = []
+} = {}) {
+    const claimPublishedCertificateAwardNotification = vi.fn(async () => claimResult);
+    const resolvePublishedCertificateParentUserIds = vi.fn(async () => parentUserIds);
+    const getTargetsForCategory = vi.fn(async () => targets);
+    const sendDirectTargetsNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
+    const buildAwardNotificationDestination = vi.fn(({ teamId, certificateId }) => ({
+        link: `https://allplays.ai/app/#/parent-tools/certificates?teamId=${teamId}&certificateId=${certificateId}`,
+        appRoute: `/parent-tools/certificates?teamId=${teamId}&certificateId=${certificateId}`
+    }));
+    const functions = {
+        firestore: {
+            document: vi.fn(() => ({
+                onWrite: vi.fn((handler) => handler)
+            }))
+        },
+        logger: {
+            error: vi.fn(),
+            warn: vi.fn()
+        }
+    };
+    const exportsObject = {};
+    const trigger = getAwardTriggerFactory()(
+        exportsObject,
+        functions,
+        categories,
+        claimPublishedCertificateAwardNotification,
+        resolvePublishedCertificateParentUserIds,
+        getTargetsForCategory,
+        sendDirectTargetsNotification,
+        buildAwardNotificationDestination
+    );
+
+    return {
+        trigger,
+        functions,
+        claimPublishedCertificateAwardNotification,
+        resolvePublishedCertificateParentUserIds,
+        getTargetsForCategory,
+        sendDirectTargetsNotification,
+        buildAwardNotificationDestination
+    };
+}
+
+describe('published certificate award helpers', () => {
+    it('builds a stable player key and resolves parent ids from direct keys plus parentOf fallback', async () => {
+        const firestore = buildFirestoreForParentLookup({
+            byPlayerKey: [
+                { id: 'parent-1', parentPlayerKeys: ['team-1::player-1'] }
+            ],
+            byTeamId: [
+                { id: 'parent-2', parentTeamIds: ['team-1'], parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] },
+                { id: 'parent-3', parentTeamIds: ['team-1'], parentOf: [{ teamId: 'team-1', playerId: 'player-9' }] }
+            ]
+        });
+        const admin = { firestore: { FieldValue: { serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP') } } };
+        const helpers = getAwardHelpers()(firestore, admin);
+
+        expect(helpers.getCertificateNotificationPlayerKey({ playerId: 'player-1' }, 'team-1')).toBe('team-1::player-1');
+        await expect(helpers.resolvePublishedCertificateParentUserIds('team-1', { playerId: 'player-1' })).resolves.toEqual(['parent-1', 'parent-2']);
+        expect(helpers.buildAwardNotificationDestination({ teamId: 'team-1', certificateId: 'cert-1' })).toEqual({
+            link: 'https://allplays.ai/app/#/parent-tools/certificates?teamId=team-1&certificateId=cert-1',
+            appRoute: '/parent-tools/certificates?teamId=team-1&certificateId=cert-1'
+        });
+    });
+
+    it('claims the first published notification send with a transaction guard', async () => {
+        const firestore = {
+            collection: vi.fn(),
+            runTransaction: vi.fn(async (handler) => {
+                const transaction = {
+                    get: vi.fn(async () => ({ exists: true, data: () => ({ status: 'published' }) })),
+                    update: vi.fn()
+                };
+                const result = await handler(transaction);
+                expect(transaction.update).toHaveBeenCalledWith({ path: 'teams/team-1/certificates/cert-1' }, {
+                    awardNotificationProcessedAt: 'SERVER_TIMESTAMP'
+                });
+                return result;
+            })
+        };
+        const admin = { firestore: { FieldValue: { serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP') } } };
+        const helpers = getAwardHelpers()(firestore, admin);
+
+        await expect(helpers.claimPublishedCertificateAwardNotification({ path: 'teams/team-1/certificates/cert-1' })).resolves.toBe(true);
+    });
+});
+
+describe('notifyPublishedCertificateAward trigger', () => {
+    it('sends one awards push only to linked parent targets on first publish', async () => {
+        const harness = buildTriggerHarness({
+            parentUserIds: ['parent-1', 'parent-2'],
+            targets: [
+                { uid: 'parent-1', token: 'token-1', deviceId: 'device-1', teamId: 'team-1' },
+                { uid: 'other-parent', token: 'token-2', deviceId: 'device-2', teamId: 'team-1' }
+            ]
+        });
+
+        const liveData = { status: 'published' };
+        await harness.trigger({
+            before: { exists: true, data: () => ({ status: 'draft' }) },
+            after: {
+                exists: true,
+                ref: { liveData },
+                data: () => ({
+                    status: 'published',
+                    playerId: 'player-1',
+                    recipientName: 'Avery Cruz',
+                    awardTitle: 'Hustle Award'
+                })
+            }
+        }, {
+            params: { teamId: 'team-1', certificateId: 'cert-1' }
+        });
+
+        expect(harness.claimPublishedCertificateAwardNotification).toHaveBeenCalled();
+        expect(harness.resolvePublishedCertificateParentUserIds).toHaveBeenCalledWith('team-1', expect.objectContaining({ playerId: 'player-1' }));
+        expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'awards', null);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledWith(expect.objectContaining({
+            category: 'awards',
+            teamId: 'team-1',
+            eventId: 'cert-1',
+            title: 'Award published for Avery Cruz',
+            body: 'Hustle Award is ready to view in ParentTools.',
+            linkOverride: 'https://allplays.ai/app/#/parent-tools/certificates?teamId=team-1&certificateId=cert-1',
+            appRouteOverride: '/parent-tools/certificates?teamId=team-1&certificateId=cert-1',
+            targets: [
+                { uid: 'parent-1', token: 'token-1', deviceId: 'device-1', teamId: 'team-1' }
+            ]
+        }));
+    });
+
+    it('skips edits to already published certificates', async () => {
+        const harness = buildTriggerHarness({
+            parentUserIds: ['parent-1'],
+            targets: [{ uid: 'parent-1', token: 'token-1', deviceId: 'device-1', teamId: 'team-1' }]
+        });
+
+        await harness.trigger({
+            before: { exists: true, data: () => ({ status: 'published' }) },
+            after: {
+                exists: true,
+                ref: { liveData: { status: 'published' } },
+                data: () => ({ status: 'published', playerId: 'player-1', awardTitle: 'Hustle Award' })
+            }
+        }, {
+            params: { teamId: 'team-1', certificateId: 'cert-1' }
+        });
+
+        expect(harness.claimPublishedCertificateAwardNotification).not.toHaveBeenCalled();
+        expect(harness.sendDirectTargetsNotification).not.toHaveBeenCalled();
+    });
+
+    it('skips re-publish attempts after the transaction guard has already claimed the send', async () => {
+        const harness = buildTriggerHarness({
+            claimResult: false,
+            parentUserIds: ['parent-1'],
+            targets: [{ uid: 'parent-1', token: 'token-1', deviceId: 'device-1', teamId: 'team-1' }]
+        });
+
+        await harness.trigger({
+            before: { exists: true, data: () => ({ status: 'draft' }) },
+            after: {
+                exists: true,
+                ref: { liveData: { status: 'published', awardNotificationProcessedAt: 'already-set' } },
+                data: () => ({ status: 'published', playerId: 'player-1', awardTitle: 'Hustle Award' })
+            }
+        }, {
+            params: { teamId: 'team-1', certificateId: 'cert-1' }
+        });
+
+        expect(harness.claimPublishedCertificateAwardNotification).toHaveBeenCalled();
+        expect(harness.sendDirectTargetsNotification).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/certificate-award-notifications.test.js
+++ b/tests/unit/certificate-award-notifications.test.js
@@ -21,23 +21,24 @@ function getAwardHelpers() {
             getCertificateNotificationPlayerKey,
             resolvePublishedCertificateParentUserIds,
             claimPublishedCertificateAwardNotification,
+            markPublishedCertificateAwardNotificationProcessed,
             buildAwardNotificationDestination
         };`
     );
 }
 
-function getAwardTriggerFactory() {
+function getTargetsForCategoryFactory() {
     return new Function(
-        'exports',
-        'functions',
         'NOTIFICATION_CATEGORIES',
-        'claimPublishedCertificateAwardNotification',
-        'resolvePublishedCertificateParentUserIds',
-        'getTargetsForCategory',
-        'sendDirectTargetsNotification',
-        'buildAwardNotificationDestination',
-        `${extractChunk('exports.notifyPublishedCertificateAward = functions.firestore', 'exports.notifyFeeAssigned = functions.firestore')}
-        return exports.notifyPublishedCertificateAward;`
+        'firestore',
+        'getCandidateUsersForTeam',
+        'canReceiveCategoryNotification',
+        'teamNotificationRecipientIndexIsEmpty',
+        'backfillNotificationRecipientsForTeam',
+        'getLegacyTargetsForCategory',
+        'functions',
+        `${extractChunk('async function getTargetsForCategory(', 'async function pruneInvalidTokens')}
+        return getTargetsForCategory;`
     );
 }
 
@@ -93,6 +94,7 @@ function buildTriggerHarness({
     const resolvePublishedCertificateParentUserIds = vi.fn(async () => parentUserIds);
     const getTargetsForCategory = vi.fn(async () => targets);
     const sendDirectTargetsNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
+    const markPublishedCertificateAwardNotificationProcessed = vi.fn(async () => null);
     const buildAwardNotificationDestination = vi.fn(({ teamId, certificateId }) => ({
         link: `https://allplays.ai/app/#/parent-tools/certificates?teamId=${teamId}&certificateId=${certificateId}`,
         appRoute: `/parent-tools/certificates?teamId=${teamId}&certificateId=${certificateId}`
@@ -109,7 +111,19 @@ function buildTriggerHarness({
         }
     };
     const exportsObject = {};
-    const trigger = getAwardTriggerFactory()(
+    const trigger = new Function(
+        'exports',
+        'functions',
+        'NOTIFICATION_CATEGORIES',
+        'claimPublishedCertificateAwardNotification',
+        'resolvePublishedCertificateParentUserIds',
+        'getTargetsForCategory',
+        'sendDirectTargetsNotification',
+        'markPublishedCertificateAwardNotificationProcessed',
+        'buildAwardNotificationDestination',
+        `${extractChunk('exports.notifyPublishedCertificateAward = functions.firestore', 'exports.notifyFeeAssigned = functions.firestore')}
+        return exports.notifyPublishedCertificateAward;`
+    )(
         exportsObject,
         functions,
         categories,
@@ -117,6 +131,7 @@ function buildTriggerHarness({
         resolvePublishedCertificateParentUserIds,
         getTargetsForCategory,
         sendDirectTargetsNotification,
+        markPublishedCertificateAwardNotificationProcessed,
         buildAwardNotificationDestination
     );
 
@@ -127,6 +142,7 @@ function buildTriggerHarness({
         resolvePublishedCertificateParentUserIds,
         getTargetsForCategory,
         sendDirectTargetsNotification,
+        markPublishedCertificateAwardNotificationProcessed,
         buildAwardNotificationDestination
     };
 }
@@ -153,7 +169,11 @@ describe('published certificate award helpers', () => {
         });
     });
 
-    it('claims the first published notification send with a transaction guard', async () => {
+    it('claims the first published notification send with a retry-safe transaction guard and marks it processed after send', async () => {
+        const certificateRef = {
+            path: 'teams/team-1/certificates/cert-1',
+            update: vi.fn(async () => null)
+        };
         const firestore = {
             collection: vi.fn(),
             runTransaction: vi.fn(async (handler) => {
@@ -162,16 +182,79 @@ describe('published certificate award helpers', () => {
                     update: vi.fn()
                 };
                 const result = await handler(transaction);
-                expect(transaction.update).toHaveBeenCalledWith({ path: 'teams/team-1/certificates/cert-1' }, {
-                    awardNotificationProcessedAt: 'SERVER_TIMESTAMP'
+                expect(transaction.update).toHaveBeenCalledWith(certificateRef, {
+                    awardNotificationProcessingEventId: 'event-1',
+                    awardNotificationProcessingStartedAt: 'SERVER_TIMESTAMP'
                 });
                 return result;
             })
         };
+        const admin = { firestore: { FieldValue: { serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP'), delete: vi.fn(() => 'DELETE_FIELD') } } };
+        const helpers = getAwardHelpers()(firestore, admin);
+
+        await expect(helpers.claimPublishedCertificateAwardNotification(certificateRef, 'event-1')).resolves.toBe(true);
+        await expect(helpers.markPublishedCertificateAwardNotificationProcessed(certificateRef, 'event-1')).resolves.toBeNull();
+        expect(certificateRef.update).toHaveBeenCalledWith({
+            awardNotificationProcessedAt: 'SERVER_TIMESTAMP',
+            awardNotificationProcessingEventId: 'DELETE_FIELD',
+            awardNotificationProcessingStartedAt: 'DELETE_FIELD',
+            awardNotificationProcessedEventId: 'event-1'
+        });
+    });
+
+    it('keeps the same publish event claimable across retries until processing completes', async () => {
+        const firestore = {
+            collection: vi.fn(),
+            runTransaction: vi.fn(async (handler) => handler({
+                get: vi.fn(async () => ({
+                    exists: true,
+                    data: () => ({
+                        status: 'published',
+                        awardNotificationProcessingEventId: 'event-1'
+                    })
+                })),
+                update: vi.fn()
+            }))
+        };
         const admin = { firestore: { FieldValue: { serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP') } } };
         const helpers = getAwardHelpers()(firestore, admin);
 
-        await expect(helpers.claimPublishedCertificateAwardNotification({ path: 'teams/team-1/certificates/cert-1' })).resolves.toBe(true);
+        await expect(helpers.claimPublishedCertificateAwardNotification({ path: 'teams/team-1/certificates/cert-1' }, 'event-1')).resolves.toBe(true);
+    });
+});
+
+
+describe('getTargetsForCategory', () => {
+    it('includes extra parent users when their eligibility comes only from parentPlayerKeys', async () => {
+        const getTargetsForCategory = getTargetsForCategoryFactory()(
+            ['awards'],
+            {
+                collection: vi.fn(() => ({
+                    where: vi.fn(() => ({
+                        get: vi.fn(async () => ({
+                            empty: false,
+                            docs: [{
+                                data: () => ({
+                                    uid: 'parent-1',
+                                    deviceId: 'device-1',
+                                    token: 'token-1'
+                                })
+                            }]
+                        }))
+                    }))
+                }))
+            },
+            vi.fn(async () => []),
+            vi.fn((category, user) => category === 'awards' && user.roles.includes('parent')),
+            vi.fn(async () => false),
+            vi.fn(async () => 0),
+            vi.fn(async () => []),
+            { logger: { warn: vi.fn() } }
+        );
+
+        await expect(getTargetsForCategory('team-1', 'awards', null, {}, [{ uid: 'parent-1', roles: ['parent'] }])).resolves.toEqual([
+            { uid: 'parent-1', deviceId: 'device-1', token: 'token-1', teamId: 'team-1' }
+        ]);
     });
 });
 
@@ -199,12 +282,16 @@ describe('notifyPublishedCertificateAward trigger', () => {
                 })
             }
         }, {
+            eventId: 'event-1',
             params: { teamId: 'team-1', certificateId: 'cert-1' }
         });
 
-        expect(harness.claimPublishedCertificateAwardNotification).toHaveBeenCalled();
+        expect(harness.claimPublishedCertificateAwardNotification).toHaveBeenCalledWith({ liveData }, 'event-1');
         expect(harness.resolvePublishedCertificateParentUserIds).toHaveBeenCalledWith('team-1', expect.objectContaining({ playerId: 'player-1' }));
-        expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'awards', null);
+        expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'awards', null, {}, [
+            { uid: 'parent-1', roles: ['parent'] },
+            { uid: 'parent-2', roles: ['parent'] }
+        ]);
         expect(harness.sendDirectTargetsNotification).toHaveBeenCalledWith(expect.objectContaining({
             category: 'awards',
             teamId: 'team-1',
@@ -217,6 +304,7 @@ describe('notifyPublishedCertificateAward trigger', () => {
                 { uid: 'parent-1', token: 'token-1', deviceId: 'device-1', teamId: 'team-1' }
             ]
         }));
+        expect(harness.markPublishedCertificateAwardNotificationProcessed).toHaveBeenCalledWith({ liveData }, 'event-1');
     });
 
     it('skips edits to already published certificates', async () => {
@@ -233,6 +321,7 @@ describe('notifyPublishedCertificateAward trigger', () => {
                 data: () => ({ status: 'published', playerId: 'player-1', awardTitle: 'Hustle Award' })
             }
         }, {
+            eventId: 'event-1',
             params: { teamId: 'team-1', certificateId: 'cert-1' }
         });
 
@@ -255,6 +344,7 @@ describe('notifyPublishedCertificateAward trigger', () => {
                 data: () => ({ status: 'published', playerId: 'player-1', awardTitle: 'Hustle Award' })
             }
         }, {
+            eventId: 'event-1',
             params: { teamId: 'team-1', certificateId: 'cert-1' }
         });
 


### PR DESCRIPTION
Closes #2161

## What changed
- added a Firestore certificate publish trigger that fires only on the first draft to published transition
- resolved notification recipients from the awarded player's linked parent accounts only, honoring existing `awards` notification preferences via the notification target index
- routed the push deep link into ParentTools for the published certificate
- added a transaction-backed `awardNotificationProcessedAt` guard so edits and re-publish attempts do not send duplicates
- added focused regression coverage for recipient resolution, one-time claim behavior, first-publish sends, and duplicate-send suppression

## Root Cause
Certificate publishing had no backend publish-transition notification workflow, so published awards never resolved the awarded player's linked parents or recorded a one-time send guard.

## Prevention / Learning
When a notification category and destination already exist, ship the publish-transition trigger, recipient-resolution helper, and persisted dedup guard together. Do not rely on UI publish state alone to imply notifications will happen once.

## Regression Tests
- `npx vitest run tests/unit/certificate-award-notifications.test.js --reporter=verbose`
- `npx vitest run tests/unit/certificate-award-notifications.test.js tests/unit/notification-delivery-metadata.test.js tests/unit/push-notification-payload-contract.test.js --reporter=verbose`