### PR TITLE
Perf baseline doc + uxTiming interaction/FMR coverage (#2050)

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -53,6 +53,7 @@ import {
   type ChatTargetType
 } from './chatLogic';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
+import { startInteractionTimer, UX_TIMING } from './uxTiming';
 import { mapChatConversationRecord, mapChatMessageRecord, mapFirestoreDocument } from './firestore/mappers';
 import type {
   ChatAttachmentFirestoreRecord,
@@ -994,6 +995,10 @@ export async function sendTeamChatMessage({
     throw new Error('Choose at least one selected member before sending.');
   }
 
+  const interaction = startInteractionTimer(UX_TIMING.chatSend, {
+    attachments: files.length,
+    target: selectedRecipientTarget
+  });
   const uploadedAttachments: ChatAttachment[] = [];
   try {
     for (const file of files) {
@@ -1046,12 +1051,14 @@ export async function sendTeamChatMessage({
       await withTimeout(Promise.resolve(postChatMessage(teamId, payload)), 'Chat message send');
     }
 
+    interaction.end({ path: isNativeRuntime() ? 'native' : 'sdk' });
     return {
       conversationId,
       createdConversation,
       wantsAi: hasAllPlaysMention(text)
     };
   } catch (error) {
+    interaction.end({ error: (error as Error)?.message || 'Chat send failed' });
     if (uploadedAttachments.length > 0) {
       try {
         await deleteUploadedChatAttachments(uploadedAttachments);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -79,7 +79,7 @@ import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailability
 import { buildTrackerEventDocument } from './statTrackingService';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
-import { startUxTimer } from './uxTiming';
+import { startInteractionTimer, startUxTimer, UX_TIMING } from './uxTiming';
 import {
   getNextRideConfirmedSeatCount,
   getScheduleRideshareSummary,
@@ -3009,17 +3009,25 @@ export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user:
     throw new Error('Select a child before submitting RSVP.');
   }
 
+  const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });
   try {
-    return await withTimeout(Promise.resolve(submitRsvpForPlayer(event.teamId, event.id, user.uid, {
+    const result = await withTimeout(Promise.resolve(submitRsvpForPlayer(event.teamId, event.id, user.uid, {
       displayName: user.displayName || user.email,
       playerId: event.childId,
       response,
       note: compactString(note) || null
     })), 'RSVP submit');
+    interaction.end({ path: 'sdk' });
+    return result;
   } catch (error) {
-    if (!isNativeRuntime()) throw error;
+    if (!isNativeRuntime()) {
+      interaction.end({ error: (error as Error)?.message || 'RSVP submit failed' });
+      throw error;
+    }
     logScheduleWarning('Falling back to REST RSVP submit.', 'parent-rsvp-submit', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id, childId: event.childId });
-    return nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note);
+    const fallback = await nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note);
+    interaction.end({ path: 'rest' });
+    return fallback;
   }
 }
 

--- a/apps/app/src/lib/uxTiming.test.ts
+++ b/apps/app/src/lib/uxTiming.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const recordAppUxTiming = vi.fn();
+vi.mock('./telemetry', () => ({
+  recordAppUxTiming: (...args: unknown[]) => recordAppUxTiming(...args)
+}));
+
+import {
+  UX_TIMING,
+  recordFirstMeaningfulRender,
+  hasRecordedFirstMeaningfulRender,
+  resetFirstMeaningfulRenderForTests,
+  startInteractionTimer,
+  startUxTimer
+} from './uxTiming';
+
+describe('uxTiming', () => {
+  beforeEach(() => {
+    recordAppUxTiming.mockClear();
+    resetFirstMeaningfulRenderForTests();
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('startUxTimer merges base meta and recorded meta', () => {
+    const timer = startUxTimer('schedule load', { route: 'schedule' });
+    timer.end({ eventRows: 12 });
+    expect(recordAppUxTiming).toHaveBeenCalledWith('schedule load', expect.any(Number), {
+      route: 'schedule',
+      eventRows: 12
+    });
+  });
+
+  it('startInteractionTimer tags the span as an interaction', () => {
+    const timer = startInteractionTimer(UX_TIMING.rsvpTap, { response: 'going' });
+    timer.end({ path: 'sdk' });
+    expect(recordAppUxTiming).toHaveBeenCalledWith(UX_TIMING.rsvpTap, expect.any(Number), {
+      category: 'interaction',
+      response: 'going',
+      path: 'sdk'
+    });
+  });
+
+  it('records first meaningful render exactly once per load', () => {
+    expect(hasRecordedFirstMeaningfulRender()).toBe(false);
+    recordFirstMeaningfulRender('home', { warm: true });
+    recordFirstMeaningfulRender('schedule');
+    expect(hasRecordedFirstMeaningfulRender()).toBe(true);
+    expect(recordAppUxTiming).toHaveBeenCalledTimes(1);
+    expect(recordAppUxTiming).toHaveBeenCalledWith(UX_TIMING.firstMeaningfulRender, 0, {
+      route: 'home',
+      warm: true
+    });
+  });
+});

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -1,19 +1,68 @@
 import { recordAppUxTiming } from './telemetry';
 
-export function startUxTimer(label: string) {
-  const startedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
+/**
+ * Canonical span labels for the app-performance metric set (see
+ * docs/app-performance-baseline.md). Using shared constants keeps lab
+ * instrumentation and the production telemetry dashboard on the same names.
+ */
+export const UX_TIMING = {
+  appStartup: 'app startup',
+  firstMeaningfulRender: 'first meaningful render',
+  rsvpTap: 'rsvp tap latency',
+  chatSend: 'chat send latency'
+} as const;
+
+export function now() {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+export function startUxTimer(label: string, baseMeta: Record<string, unknown> = {}) {
+  const startedAt = now();
   return {
     end(meta: Record<string, unknown> = {}) {
-      recordUxTiming(label, startedAt, meta);
+      recordUxTiming(label, startedAt, { ...baseMeta, ...meta });
     }
   };
 }
 
+/**
+ * Times a discrete user interaction (RSVP tap, chat send, …) so we can report
+ * tap-to-confirmation latency percentiles alongside cold-start numbers.
+ */
+export function startInteractionTimer(label: string, baseMeta: Record<string, unknown> = {}) {
+  return startUxTimer(label, { category: 'interaction', ...baseMeta });
+}
+
 export function recordUxTiming(label: string, startedAt: number, meta: Record<string, unknown> = {}) {
-  const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
-  const durationMs = Math.round(now - startedAt);
+  const durationMs = Math.round(now() - startedAt);
   if (typeof console !== 'undefined') {
     console.info(`[ux] ${label} ${JSON.stringify({ durationMs, ...meta })}`);
   }
   recordAppUxTiming(label, startedAt, meta);
+}
+
+let firstMeaningfulRenderRecorded = false;
+
+/**
+ * Records app-start → first meaningful render exactly once per page load. The
+ * "start" baseline is navigation start (performance.now() is measured from it),
+ * so this captures the full cold-start cost the user actually feels — not just
+ * React's initial mount.
+ */
+export function recordFirstMeaningfulRender(route: string, meta: Record<string, unknown> = {}) {
+  if (firstMeaningfulRenderRecorded) return;
+  if (typeof performance === 'undefined') return;
+  firstMeaningfulRenderRecorded = true;
+  // performance.now() is relative to navigation start, so passing 0 yields
+  // "time since the page began loading".
+  recordUxTiming(UX_TIMING.firstMeaningfulRender, 0, { route, ...meta });
+}
+
+export function hasRecordedFirstMeaningfulRender() {
+  return firstMeaningfulRenderRecorded;
+}
+
+/** Test-only: reset the once-per-load guard. */
+export function resetFirstMeaningfulRenderForTests() {
+  firstMeaningfulRenderRecorded = false;
 }

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -320,8 +320,8 @@ describe('Home', () => {
   });
 
   it('waits for the initial secondary Home load to finish before recording first meaningful render', async () => {
-    let resolveBootstrap: ((value: { home: typeof baseHome; schedule: [] }) => void) | null = null;
-    let resolveSecondary: ((value: typeof baseHome) => void) | null = null;
+    let resolveBootstrap!: (value: { home: typeof baseHome; schedule: [] }) => void;
+    let resolveSecondary!: (value: typeof baseHome) => void;
     homeServiceMocks.loadParentHomeSummaryBootstrap.mockImplementationOnce(() => new Promise((resolve) => {
       resolveBootstrap = resolve;
     }));
@@ -333,12 +333,12 @@ describe('Home', () => {
 
     expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
 
-    resolveBootstrap?.({ home: baseHome, schedule: [] });
+    resolveBootstrap({ home: baseHome, schedule: [] });
 
     expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
     expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
 
-    resolveSecondary?.(baseHome);
+    resolveSecondary(baseHome);
 
     await waitFor(() => {
       expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -29,12 +29,17 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   loadOfficialAssignmentsAccess: vi.fn()
 }));
 
+const uxTimingMocks = vi.hoisted(() => ({
+  recordFirstMeaningfulRender: vi.fn()
+}));
+
 vi.mock('../components/PageSkeletons', () => ({
   HomePageSkeleton: () => <div>Loading Home</div>
 }));
 vi.mock('../lib/homeService', () => homeServiceMocks);
 vi.mock('../lib/socialService', () => socialServiceMocks);
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('../lib/uxTiming', () => uxTimingMocks);
 vi.mock('lucide-react', () => {
   const Icon = () => null;
   return {
@@ -312,6 +317,32 @@ describe('Home', () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it('waits for the initial secondary Home load to finish before recording first meaningful render', async () => {
+    let resolveBootstrap: ((value: { home: typeof baseHome; schedule: [] }) => void) | null = null;
+    let resolveSecondary: ((value: typeof baseHome) => void) | null = null;
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveBootstrap = resolve;
+    }));
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveSecondary = resolve;
+    }));
+
+    renderHome(signedInAuth);
+
+    expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
+
+    resolveBootstrap?.({ home: baseHome, schedule: [] });
+
+    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
+
+    resolveSecondary?.(baseHome);
+
+    await waitFor(() => {
+      expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('home');
+    });
   });
 
   it('renders the feed for signed-out users without crashing', async () => {

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -146,6 +146,7 @@ export function Home({ auth }: { auth: AuthState }) {
   const [homeLoadError, setHomeLoadError] = useState<AppServiceError | null>(null);
   const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
   const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();
+  const hasStartedInitialHomeLoadRef = useRef(false);
 
   const authUserId = auth.user?.uid || null;
   const hasLoadedHomeDetails = Boolean(authUserId) && authUserId === loadedHomeDetailsUserId;
@@ -205,6 +206,11 @@ export function Home({ auth }: { auth: AuthState }) {
   };
 
   useEffect(() => {
+    if (!auth.user?.uid) {
+      hasStartedInitialHomeLoadRef.current = false;
+      return;
+    }
+    hasStartedInitialHomeLoadRef.current = true;
     refreshHome();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid]);
@@ -212,10 +218,13 @@ export function Home({ auth }: { auth: AuthState }) {
   useRefreshOnResume(() => { void refreshHome({ force: true }); }, { enabled: Boolean(auth.user?.uid) });
 
   useEffect(() => {
-    if (!loading) {
+    if (!hasStartedInitialHomeLoadRef.current || loading || socialLoading) {
+      return;
+    }
+    if (hasLoadedHomeDetails || homeLoadError) {
       recordFirstMeaningfulRender('home');
     }
-  }, [loading]);
+  }, [hasLoadedHomeDetails, homeLoadError, loading, socialLoading]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -64,6 +64,7 @@ import {
   type RsvpResponse
 } from '../lib/scheduleLogic';
 import { loadOfficialAssignmentsAccess } from '../lib/scheduleService';
+import { recordFirstMeaningfulRender } from '../lib/uxTiming';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { useRefreshOnResume } from '../lib/useRefreshOnResume';
 import {
@@ -209,6 +210,12 @@ export function Home({ auth }: { auth: AuthState }) {
   }, [auth.user?.uid]);
 
   useRefreshOnResume(() => { void refreshHome({ force: true }); }, { enabled: Boolean(auth.user?.uid) });
+
+  useEffect(() => {
+    if (!loading) {
+      recordFirstMeaningfulRender('home');
+    }
+  }, [loading]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -21,13 +21,15 @@ const appDataCacheMocks = vi.hoisted(() => ({
 }));
 
 const uxTimingMocks = vi.hoisted(() => ({
-  end: vi.fn()
+  end: vi.fn(),
+  recordFirstMeaningfulRender: vi.fn()
 }));
 
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
 vi.mock('../lib/appDataCache', () => appDataCacheMocks);
 vi.mock('../lib/uxTiming', () => ({
-  startUxTimer: vi.fn(() => uxTimingMocks)
+  recordFirstMeaningfulRender: uxTimingMocks.recordFirstMeaningfulRender,
+  startUxTimer: vi.fn(() => ({ end: uxTimingMocks.end }))
 }));
 vi.mock('../lib/useShellLayout', () => ({
   useShellLayout: () => ({ isDesktopWeb: false })
@@ -74,6 +76,29 @@ describe('Schedule', () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it('waits for the first schedule load to finish before recording first meaningful render', async () => {
+    let resolveSchedule: ((value: { children: Array<{ playerId: string; playerName: string; teamId: string; teamName: string }>; events: [] }) => void) | null = null;
+    scheduleServiceMocks.loadParentSchedule.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveSchedule = resolve;
+    }));
+
+    renderSchedule();
+
+    expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
+
+    resolveSchedule?.({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: []
+    });
+
+    expect(await screen.findByText('No events in this filter')).toBeTruthy();
+    await waitFor(() => {
+      expect(uxTimingMocks.recordFirstMeaningfulRender).toHaveBeenCalledWith('schedule');
+    });
   });
 
   it.each([

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -79,7 +79,7 @@ describe('Schedule', () => {
   });
 
   it('waits for the first schedule load to finish before recording first meaningful render', async () => {
-    let resolveSchedule: ((value: { children: Array<{ playerId: string; playerName: string; teamId: string; teamName: string }>; events: [] }) => void) | null = null;
+    let resolveSchedule!: (value: { children: Array<{ playerId: string; playerName: string; teamId: string; teamName: string }>; events: [] }) => void;
     scheduleServiceMocks.loadParentSchedule.mockImplementationOnce(() => new Promise((resolve) => {
       resolveSchedule = resolve;
     }));
@@ -88,7 +88,7 @@ describe('Schedule', () => {
 
     expect(uxTimingMocks.recordFirstMeaningfulRender).not.toHaveBeenCalled();
 
-    resolveSchedule?.({
+    resolveSchedule({
       children: [
         { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
       ],

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -5,7 +5,7 @@ import { SchedulePageSkeleton } from '../components/PageSkeletons';
 import { addTeamCalendarUrl, createScheduledPracticeForApp, createScheduleImportGame, createScheduleImportPractice, finalizeScheduleImportBatch, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild, type SchedulePracticeFormInput, type PracticeRecurrenceFormInput } from '../lib/scheduleService';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from '../lib/appDataCache';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
-import { startUxTimer } from '../lib/uxTiming';
+import { recordFirstMeaningfulRender, startUxTimer } from '../lib/uxTiming';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { useRefreshOnResume } from '../lib/useRefreshOnResume';
 import { useShellLayout } from '../lib/useShellLayout';
@@ -261,6 +261,12 @@ export function Schedule({ auth }: { auth: AuthState }) {
   }, [auth.user?.uid]);
 
   useRefreshOnResume(() => { void refreshSchedule(true); }, { enabled: Boolean(auth.user?.uid) });
+
+  useEffect(() => {
+    if (!loading) {
+      recordFirstMeaningfulRender('schedule');
+    }
+  }, [loading]);
 
   const visibleEvents = useMemo(() => (
     filterParentScheduleEvents(events, { filter, playerId: selectedPlayerId, teamId: selectedTeamId, timeRange })

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -170,6 +170,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [practiceFormError, setPracticeFormError] = useState<string | null>(null);
   const [loadedScheduleUserId, setLoadedScheduleUserId] = useState<string | null>(null);
   const hasLoadedScheduleRef = useRef(false);
+  const hasStartedInitialScheduleLoadRef = useRef(false);
 
   const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
     setChildren(data.children);
@@ -251,11 +252,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
 
   useEffect(() => {
     hasLoadedScheduleRef.current = false;
+    hasStartedInitialScheduleLoadRef.current = false;
     if (!auth.user?.uid) {
       setLoadedScheduleUserId(null);
       applyScheduleResult({ children: [], events: [] });
       return;
     }
+    hasStartedInitialScheduleLoadRef.current = true;
     void refreshSchedule();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid]);
@@ -263,10 +266,11 @@ export function Schedule({ auth }: { auth: AuthState }) {
   useRefreshOnResume(() => { void refreshSchedule(true); }, { enabled: Boolean(auth.user?.uid) });
 
   useEffect(() => {
-    if (!loading) {
-      recordFirstMeaningfulRender('schedule');
+    if (!hasStartedInitialScheduleLoadRef.current || loading || isInitialScheduleLoad) {
+      return;
     }
-  }, [loading]);
+    recordFirstMeaningfulRender('schedule');
+  }, [isInitialScheduleLoad, loading]);
 
   const visibleEvents = useMemo(() => (
     filterParentScheduleEvents(events, { filter, playerId: selectedPlayerId, teamId: selectedTeamId, timeRange })

--- a/docs/app-performance-baseline.md
+++ b/docs/app-performance-baseline.md
@@ -1,0 +1,86 @@
+# App Performance Baseline & Verification
+
+This is the capstone measurement doc for the ALL PLAYS app-performance push
+(issues #2029, #2032, #2033, #2034, #2035, #2036, #2037, #2038, #2043). It
+defines the metric set, the repeatable measurement procedure, and a before/after
+table to fill in as each fix lands, so the effort is *verified* rather than
+assumed.
+
+> Status: **baseline template**. Capture the "Before" column from `master` prior
+> to merging the perf fixes, then re-measure after each fix and update the table.
+
+## Metric set
+
+| Metric | What it measures | How to capture |
+| --- | --- | --- |
+| Cold-start TTI (Home) | App launch → Home schedule cards interactive | `first meaningful render` span (web + device), Lighthouse TTI for web |
+| Warm resume time | Foreground after backgrounding → fresh data on screen | Manual stopwatch + `app startup` span on resume |
+| Firestore reads / Home mount | Read/REST count on a Home cold mount | Dev read-count instrumentation (see below) |
+| Firestore reads / Schedule mount | Read/REST count to render the schedule | Dev read-count instrumentation |
+| Firestore reads / Messages mount | Read/REST count to render the inbox | Dev read-count instrumentation |
+| Entry chunk size (gzip) | Bytes parsed/executed before first render | `npm run app:build` build log |
+| RSVP tap latency | Tap "Going" → confirmed | `rsvp tap latency` span |
+| Chat send latency | Tap send → message confirmed | `chat send latency` span |
+
+## Instrumentation
+
+The app records these spans through `recordUxTiming` /
+`recordAppUxTiming`, which already forwards to the production telemetry pipeline
+(`js/telemetry.js`, event `app_ux_timing`). Canonical span names live in
+`apps/app/src/lib/uxTiming.ts` (`UX_TIMING`):
+
+- `app startup` — emitted in `main.tsx` at initial React render.
+- `first meaningful render` — `recordFirstMeaningfulRender(route)`, fired once
+  per page load when Home/Schedule leave their loading state. Baseline is
+  navigation start, so this is the true cold-start cost.
+- `rsvp tap latency` — `startInteractionTimer(UX_TIMING.rsvpTap)` around the
+  parent RSVP submit in `scheduleService.ts`.
+- `chat send latency` — `startInteractionTimer(UX_TIMING.chatSend)` around
+  `sendTeamChatMessage` in `chatService.ts`.
+
+Each span logs `[ux] <label> {"durationMs":…}` to the console in dev and is
+captured as an `app_ux_timing` telemetry event in production, so lab numbers and
+production percentiles share the same names.
+
+### Reading Firestore read counts in dev
+
+Open the app with the network panel filtered to `firestore.googleapis.com`
+(web) or watch the native REST logs (`nativeRestLogging`), then cold-load each
+page and count distinct collection list/get requests. The hydration fan-out
+issue (#2033) tracks the 3×20-event scenario (~180 reads) explicitly.
+
+## Measurement procedure (repeatable)
+
+1. **Web (throttled 4G, desktop Chrome):**
+   - `npm run app:build && npm run app:preview`.
+   - DevTools → Performance/Lighthouse with "Slow 4G" + 4× CPU throttle.
+   - Record cold-start TTI, entry chunk gzip (from the build log), and the
+     `app_ux_timing` console spans for first meaningful render / RSVP / chat.
+2. **iPhone (physical or simulator):** `npm run mobile:run:ios`, launch from
+   cold, capture the resume case by backgrounding 6+ minutes then reopening.
+3. **Mid-range Android:** `npm run mobile:run:android`, same procedure.
+4. Record each number in the table below; keep the device/profile in the notes.
+
+## Baseline → After
+
+Fill the "Before" column from `master` at the start of the push; update the
+remaining columns as fixes land. Numbers are medians of 3 runs.
+
+| Metric | Before | After #2029 (bundle) | After #2033/#2037 (Home) | Target |
+| --- | --- | --- | --- | --- |
+| Cold-start TTI Home — web 4G | _tbd_ | | | < 2.5s |
+| Cold-start TTI Home — iPhone | _tbd_ | | | < 2.0s |
+| Cold-start TTI Home — Android | _tbd_ | | | < 3.0s |
+| Warm resume → fresh data | _tbd_ | | | < 1.5s |
+| Reads / Home mount (3×20) | ~180 | | | ≤ 30 |
+| Reads / Schedule mount | _tbd_ | | | windowed |
+| Reads / Messages mount | _tbd_ | | | parallel |
+| Entry chunk gzip | 399.7 KB | | | < 150 KB |
+| RSVP tap latency | _tbd_ | | | < 600ms |
+| Chat send latency | _tbd_ | | | < 800ms |
+
+## Closing the loop
+
+When the perf/UX fixes have landed, re-measure, fill the final column, and paste
+the completed table into #2050 before closing it. The procedure above is the
+contract: anyone should be able to reproduce these numbers from a clean checkout.


### PR DESCRIPTION
Addresses #2050 (the measurement capstone for the app-performance push).

## Summary
- **`docs/app-performance-baseline.md`** — defines the metric set (cold-start TTI, warm resume, Firestore reads per Home/Schedule/Messages mount, entry-chunk gzip, RSVP/chat interaction latency), a repeatable measurement procedure across web-4G / iPhone / Android, and a before/after table to fill in as each fix lands.
- **`uxTiming.ts`** — adds `UX_TIMING` canonical span names, `startInteractionTimer`, and `recordFirstMeaningfulRender` (fires once per page load, baseline = navigation start, so it captures true cold-start cost rather than just React's initial mount).
- **Instrumentation wired in:**
  - first-meaningful-render on Home and Schedule (when they leave the loading state),
  - RSVP tap latency around the parent RSVP submit in `scheduleService.ts`,
  - chat send latency around `sendTeamChatMessage` in `chatService.ts`.
- All spans flow through the existing telemetry pipeline (`app_ux_timing` → `js/telemetry.js`), so lab numbers and production percentiles share names.

## Tests
- New `uxTiming.test.ts` (base-meta merge, interaction tagging, once-per-load FMR guard).
- `npx tsc --noEmit` clean; `chatService.test.ts` green. (Two pre-existing date-sensitive `scheduleService.test.ts` failures are unrelated — they fail on `master` too.)

## Note
This issue is labeled `split-parent`; this PR delivers the doc + instrumentation foundation. Filling the before/after table happens as the sibling perf fixes merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)