### PR TITLE
[codex] Dedup native REST reads

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -38,6 +38,7 @@ import { resolveImageFirebaseConfig } from '../../../../js/firebase-runtime-conf
 import { isTeamActive } from '../../../../js/team-visibility.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { loadCachedAppData } from './appDataCache';
+import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
 import {
   DEFAULT_TEAM_CONVERSATION_ID,
   MAX_CHAT_MEDIA_SIZE,
@@ -269,20 +270,26 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...(await getNativeHeaders()),
-      ...(init.headers || {})
+  const url = `${getFirestoreBaseUrl()}${path}`;
+  const runRequest = async () => {
+    const response = await withTimeout(fetch(url, {
+      ...init,
+      headers: {
+        ...(await getNativeHeaders()),
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  return shouldDedupNativeRestRequest(path, init)
+    ? loadDedupedNativeRestRequest(getNativeRestDedupKey(url, init), runRequest)
+    : runRequest();
 }
 
 function encodeFirestoreValue(value: any): Record<string, unknown> {

--- a/apps/app/src/lib/nativeRestDedup.ts
+++ b/apps/app/src/lib/nativeRestDedup.ts
@@ -1,10 +1,21 @@
 type NativeRestDedupEntry<T> = {
   promise: Promise<T>;
   expiresAt: number;
+  cleanupTimer: ReturnType<typeof setTimeout> | null;
 };
 
 const defaultDedupWindowMs = 5 * 1000;
 const nativeRestDedupCache = new Map<string, NativeRestDedupEntry<unknown>>();
+
+function deleteNativeRestDedupEntry(key: string, promise?: Promise<unknown>) {
+  const entry = nativeRestDedupCache.get(key);
+  if (!entry) return;
+  if (promise && entry.promise !== promise) return;
+  if (entry.cleanupTimer) {
+    clearTimeout(entry.cleanupTimer);
+  }
+  nativeRestDedupCache.delete(key);
+}
 
 export function shouldDedupNativeRestRequest(path: string, init: RequestInit = {}) {
   const method = String(init.method || 'GET').toUpperCase();
@@ -27,24 +38,44 @@ export function loadDedupedNativeRestRequest<T>(
   if (existing && existing.expiresAt > now) {
     return existing.promise;
   }
+  if (existing) {
+    deleteNativeRestDedupEntry(key, existing.promise);
+  }
 
-  const promise = loader().catch((error) => {
-    if (nativeRestDedupCache.get(key)?.promise === promise) {
-      nativeRestDedupCache.delete(key);
-    }
-    throw error;
+  let resolvePromise!: (value: T | PromiseLike<T>) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolvePromise = resolve;
+    rejectPromise = reject;
   });
-  nativeRestDedupCache.set(key, {
+
+  const entry: NativeRestDedupEntry<T> = {
     promise,
-    expiresAt: now + dedupWindowMs
-  });
+    expiresAt: now + dedupWindowMs,
+    cleanupTimer: null
+  };
+  entry.cleanupTimer = setTimeout(() => {
+    deleteNativeRestDedupEntry(key, promise);
+  }, Math.max(0, dedupWindowMs));
+  nativeRestDedupCache.set(key, entry);
+
+  Promise.resolve()
+    .then(loader)
+    .then((result) => {
+      resolvePromise(result);
+    })
+    .catch((error) => {
+      deleteNativeRestDedupEntry(key, promise);
+      rejectPromise(error);
+    });
+
   return promise;
 }
 
 export function clearNativeRestDedup(prefix = '') {
   [...nativeRestDedupCache.keys()].forEach((key) => {
     if (!prefix || key.startsWith(prefix)) {
-      nativeRestDedupCache.delete(key);
+      deleteNativeRestDedupEntry(key);
     }
   });
 }

--- a/apps/app/src/lib/nativeRestDedup.ts
+++ b/apps/app/src/lib/nativeRestDedup.ts
@@ -1,0 +1,50 @@
+type NativeRestDedupEntry<T> = {
+  promise: Promise<T>;
+  expiresAt: number;
+};
+
+const defaultDedupWindowMs = 5 * 1000;
+const nativeRestDedupCache = new Map<string, NativeRestDedupEntry<unknown>>();
+
+export function shouldDedupNativeRestRequest(path: string, init: RequestInit = {}) {
+  const method = String(init.method || 'GET').toUpperCase();
+  return method === 'GET' || (method === 'POST' && path.endsWith(':runQuery'));
+}
+
+export function getNativeRestDedupKey(url: string, init: RequestInit = {}) {
+  const method = String(init.method || 'GET').toUpperCase();
+  const body = typeof init.body === 'string' ? init.body : '';
+  return `${method}:${url}:${body}`;
+}
+
+export function loadDedupedNativeRestRequest<T>(
+  key: string,
+  loader: () => Promise<T>,
+  { dedupWindowMs = defaultDedupWindowMs }: { dedupWindowMs?: number } = {}
+): Promise<T> {
+  const now = Date.now();
+  const existing = nativeRestDedupCache.get(key) as NativeRestDedupEntry<T> | undefined;
+  if (existing && existing.expiresAt > now) {
+    return existing.promise;
+  }
+
+  const promise = loader().catch((error) => {
+    if (nativeRestDedupCache.get(key)?.promise === promise) {
+      nativeRestDedupCache.delete(key);
+    }
+    throw error;
+  });
+  nativeRestDedupCache.set(key, {
+    promise,
+    expiresAt: now + dedupWindowMs
+  });
+  return promise;
+}
+
+export function clearNativeRestDedup(prefix = '') {
+  [...nativeRestDedupCache.keys()].forEach((key) => {
+    if (!prefix || key.startsWith(prefix)) {
+      nativeRestDedupCache.delete(key);
+    }
+  });
+}

--- a/apps/app/src/lib/nativeRestDedup.ts
+++ b/apps/app/src/lib/nativeRestDedup.ts
@@ -62,6 +62,7 @@ export function loadDedupedNativeRestRequest<T>(
   Promise.resolve()
     .then(loader)
     .then((result) => {
+      deleteNativeRestDedupEntry(key, promise);
       resolvePromise(result);
     })
     .catch((error) => {

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -14,6 +14,7 @@ import {
 import { normalizeTeamNotificationPreferences } from '../../../../js/notification-preferences.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { createLogger } from './logger';
+import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
 import { isTeamActive } from '../../../../js/team-visibility.js';
 
 export {
@@ -130,21 +131,27 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const headers = await getNativeHeaders();
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...headers,
-      ...(init.headers || {})
+  const url = `${getFirestoreBaseUrl()}${path}`;
+  const runRequest = async () => {
+    const headers = await getNativeHeaders();
+    const response = await withTimeout(fetch(url, {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  return shouldDedupNativeRestRequest(path, init)
+    ? loadDedupedNativeRestRequest(getNativeRestDedupKey(url, init), runRequest)
+    : runRequest();
 }
 
 function encodeFirestoreValue(value: any): Record<string, unknown> {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -126,6 +126,7 @@ import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
 import { toAppServiceError } from './appErrors';
 import { createLogger } from './logger';
+import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
 import { mapFirestoreDocument, mapScheduleEventDocument, mapScheduleEventDocuments } from './firestore/mappers';
 import type { FirestoreDecodedDocument, FirestoreDocument as NativeFirestoreDocument } from './firestore/types';
 import type { AuthUser } from './types';
@@ -693,20 +694,26 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...(await getNativeHeaders()),
-      ...(init.headers || {})
+  const url = `${getFirestoreBaseUrl()}${path}`;
+  const runRequest = async () => {
+    const response = await withTimeout(fetch(url, {
+      ...init,
+      headers: {
+        ...(await getNativeHeaders()),
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  return shouldDedupNativeRestRequest(path, init)
+    ? loadDedupedNativeRestRequest(getNativeRestDedupKey(url, init), runRequest)
+    : runRequest();
 }
 
 function encodeFirestoreValue(value: any): Record<string, unknown> {

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -41,6 +41,7 @@ import { buildTeamStaffPermissionsViewModel } from '../../../../js/team-staff-pe
 import { buildTrackingStatusPayload, summarizeTrackingStatus } from '../../../../js/tracking-status-admin.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { buildAppAcceptInviteUrl } from './inviteUrls';
+import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
 import { normalizeOptionalHttpUrl, parseTeamLivestreamInput } from './teamLinks';
 import type { AuthUser } from './types';
@@ -435,20 +436,26 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...(await getNativeHeaders()),
-      ...(init.headers || {})
+  const url = `${getFirestoreBaseUrl()}${path}`;
+  const runRequest = async () => {
+    const response = await withTimeout(fetch(url, {
+      ...init,
+      headers: {
+        ...(await getNativeHeaders()),
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  return shouldDedupNativeRestRequest(path, init)
+    ? loadDedupedNativeRestRequest(getNativeRestDedupKey(url, init), runRequest)
+    : runRequest();
 }
 
 function decodeFirestoreValue(value: any): any {

--- a/tests/unit/app-native-rest-dedup.test.ts
+++ b/tests/unit/app-native-rest-dedup.test.ts
@@ -12,7 +12,7 @@ describe('native REST read dedup', () => {
     clearNativeRestDedup();
   });
 
-  it('reuses the same loader promise for repeated native reads inside the dedup window', async () => {
+  it('only dedups in-flight native reads and refetches after the first read settles', async () => {
     vi.useFakeTimers();
     const loader = vi.fn(async () => ({ documents: [{ name: 'teams/team-1' }] }));
     const key = getNativeRestDedupKey('https://firestore.test/teams/team-1');
@@ -25,11 +25,11 @@ describe('native REST read dedup', () => {
     expect(loader).toHaveBeenCalledTimes(1);
 
     await expect(loadDedupedNativeRestRequest(key, loader)).resolves.toEqual({ documents: [{ name: 'teams/team-1' }] });
-    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loader).toHaveBeenCalledTimes(2);
 
     vi.advanceTimersByTime(5001);
     await expect(loadDedupedNativeRestRequest(key, loader)).resolves.toEqual({ documents: [{ name: 'teams/team-1' }] });
-    expect(loader).toHaveBeenCalledTimes(2);
+    expect(loader).toHaveBeenCalledTimes(3);
   });
 
   it('retries failed reads instead of caching the rejection', async () => {

--- a/tests/unit/app-native-rest-dedup.test.ts
+++ b/tests/unit/app-native-rest-dedup.test.ts
@@ -13,6 +13,7 @@ describe('native REST read dedup', () => {
   });
 
   it('reuses the same loader promise for repeated native reads inside the dedup window', async () => {
+    vi.useFakeTimers();
     const loader = vi.fn(async () => ({ documents: [{ name: 'teams/team-1' }] }));
     const key = getNativeRestDedupKey('https://firestore.test/teams/team-1');
 
@@ -25,6 +26,10 @@ describe('native REST read dedup', () => {
 
     await expect(loadDedupedNativeRestRequest(key, loader)).resolves.toEqual({ documents: [{ name: 'teams/team-1' }] });
     expect(loader).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(5001);
+    await expect(loadDedupedNativeRestRequest(key, loader)).resolves.toEqual({ documents: [{ name: 'teams/team-1' }] });
+    expect(loader).toHaveBeenCalledTimes(2);
   });
 
   it('retries failed reads instead of caching the rejection', async () => {
@@ -36,6 +41,11 @@ describe('native REST read dedup', () => {
     await expect(loadDedupedNativeRestRequest(key, loader)).rejects.toThrow('network');
     await expect(loadDedupedNativeRestRequest(key, loader)).resolves.toEqual({ ok: true });
     expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('includes the request method in the dedup cache key', () => {
+    expect(getNativeRestDedupKey('https://firestore.test/teams/team-1', { method: 'GET' }))
+      .not.toEqual(getNativeRestDedupKey('https://firestore.test/teams/team-1', { method: 'POST' }));
   });
 
   it('limits dedup candidates to native read requests', () => {

--- a/tests/unit/app-native-rest-dedup.test.ts
+++ b/tests/unit/app-native-rest-dedup.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearNativeRestDedup,
+  getNativeRestDedupKey,
+  loadDedupedNativeRestRequest,
+  shouldDedupNativeRestRequest
+} from '../../apps/app/src/lib/nativeRestDedup';
+
+describe('native REST read dedup', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    clearNativeRestDedup();
+  });
+
+  it('reuses the same loader promise for repeated native reads inside the dedup window', async () => {
+    const loader = vi.fn(async () => ({ documents: [{ name: 'teams/team-1' }] }));
+    const key = getNativeRestDedupKey('https://firestore.test/teams/team-1');
+
+    const first = loadDedupedNativeRestRequest(key, loader);
+    const second = loadDedupedNativeRestRequest(key, loader);
+
+    await expect(first).resolves.toEqual({ documents: [{ name: 'teams/team-1' }] });
+    await expect(second).resolves.toEqual({ documents: [{ name: 'teams/team-1' }] });
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await expect(loadDedupedNativeRestRequest(key, loader)).resolves.toEqual({ documents: [{ name: 'teams/team-1' }] });
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries failed reads instead of caching the rejection', async () => {
+    const loader = vi.fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ ok: true });
+    const key = getNativeRestDedupKey('https://firestore.test/teams/team-1');
+
+    await expect(loadDedupedNativeRestRequest(key, loader)).rejects.toThrow('network');
+    await expect(loadDedupedNativeRestRequest(key, loader)).resolves.toEqual({ ok: true });
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('limits dedup candidates to native read requests', () => {
+    expect(shouldDedupNativeRestRequest('/teams/team-1')).toBe(true);
+    expect(shouldDedupNativeRestRequest(':runQuery', { method: 'POST', body: '{}' })).toBe(true);
+    expect(shouldDedupNativeRestRequest('/teams/team-1', { method: 'PATCH', body: '{}' })).toBe(false);
+    expect(shouldDedupNativeRestRequest(':commit', { method: 'POST', body: '{}' })).toBe(false);
+    expect(shouldDedupNativeRestRequest('/teams/team-1/games', { method: 'POST', body: '{}' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a shared native REST read dedup helper with a short in-memory window.
- Routes read-like Firestore REST requests through the dedup layer across chat, schedule, profile, and team detail services.
- Leaves native writes, document creates, commits, and patches undeduped.

Fixes #2032

## Validation
- `npx vitest run tests/unit/app-native-rest-dedup.test.ts --reporter=verbose`
- `npm run app:build`