### PR TITLE
[codex] Render Home secondary data progressively

### DIFF
--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -4,6 +4,7 @@ import { loadChatInbox } from './chatService';
 import { startUxTimer } from './uxTiming';
 import {
   buildParentHomeModel,
+  type ParentHomeFee,
   type ParentHomeInboxTeam,
   type ParentHomeModel
 } from './homeLogic';
@@ -20,6 +21,12 @@ import type { AuthUser } from './types';
 const homeSummaryTtlMs = 45 * 1000;
 const homeSecondaryTtlMs = 30 * 1000;
 const teamsSummaryTtlMs = 30 * 1000;
+
+export type ParentHomeSecondarySnapshot = {
+  schedule: ParentScheduleLoadResult;
+  inboxTeams: ParentHomeInboxTeam[];
+  fees: ParentHomeFee[];
+};
 
 export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeModel> {
   if (!user?.uid) {
@@ -119,22 +126,45 @@ export async function loadParentHomeWithSecondaryData(
   const cacheKey = `home-secondary:${user.uid}`;
   return loadCachedAppData(cacheKey, async () => {
     const schedule = options.schedule || await loadParentScheduleSummary(user, { force: options.force });
-    await hydrateParentScheduleDetails(schedule, user);
-    const [chatInbox, rawFees] = await Promise.all([
-      loadChatInbox(user).catch((error) => {
-        throw toAppServiceError(error, 'Unable to load Home chat.');
-      }),
-      Promise.resolve(listParentTeamFeeRecipients(user.uid, schedule.children)).catch((error) => {
-        throw toAppServiceError(error, 'Unable to load Home fees.');
-      })
+    const [hydratedSchedule, inboxTeams, fees] = await Promise.all([
+      hydrateParentHomeScheduleSlice(user, schedule),
+      loadParentHomeInboxSlice(user),
+      loadParentHomeFeesSlice(user, schedule)
     ]);
-    return buildParentHomeModel({
-      children: schedule.children,
-      events: schedule.events,
-      inboxTeams: normalizeInboxTeams(chatInbox.teams || []),
-      fees: (rawFees || []).map((fee: any) => normalizeParentFeeRecord(fee))
-    });
+    return buildParentHomeFromSecondarySnapshot({ schedule: hydratedSchedule, inboxTeams, fees });
   }, { ttlMs: homeSecondaryTtlMs, force: options.force });
+}
+
+export async function hydrateParentHomeScheduleSlice(user: AuthUser, schedule: ParentScheduleLoadResult) {
+  await hydrateParentScheduleDetails(schedule, user);
+  return schedule;
+}
+
+export async function loadParentHomeInboxSlice(user: AuthUser) {
+  const chatInbox = await loadChatInbox(user).catch((error) => {
+    throw toAppServiceError(error, 'Unable to load Home chat.');
+  });
+  return normalizeInboxTeams(chatInbox.teams || []);
+}
+
+export async function loadParentHomeFeesSlice(user: AuthUser, schedule: ParentScheduleLoadResult) {
+  const rawFees = await Promise.resolve(listParentTeamFeeRecipients(user.uid, schedule.children)).catch((error) => {
+    throw toAppServiceError(error, 'Unable to load Home fees.');
+  });
+  return (rawFees || []).map((fee: any) => normalizeParentFeeRecord(fee));
+}
+
+export function buildParentHomeFromSecondarySnapshot({
+  schedule,
+  inboxTeams = [],
+  fees = []
+}: ParentHomeSecondarySnapshot): ParentHomeModel {
+  return buildParentHomeModel({
+    children: schedule.children,
+    events: schedule.events,
+    inboxTeams,
+    fees
+  });
 }
 
 export async function loadParentScheduleSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentScheduleLoadResult> {

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -6,6 +6,10 @@ import { Home } from './Home';
 import type { AuthState } from '../lib/types';
 
 const homeServiceMocks = vi.hoisted(() => ({
+  buildParentHomeFromSecondarySnapshot: vi.fn(),
+  hydrateParentHomeScheduleSlice: vi.fn(),
+  loadParentHomeFeesSlice: vi.fn(),
+  loadParentHomeInboxSlice: vi.fn(),
   loadParentHomeSummaryBootstrap: vi.fn(),
   loadParentHomeWithSecondaryData: vi.fn()
 }));
@@ -309,7 +313,11 @@ describe('Home', () => {
       value: vi.fn(),
       writable: true
     });
-    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValue({ home: baseHome, schedule: [] });
+    homeServiceMocks.buildParentHomeFromSecondarySnapshot.mockImplementation(() => baseHome);
+    homeServiceMocks.hydrateParentHomeScheduleSlice.mockImplementation((_, schedule) => Promise.resolve(schedule));
+    homeServiceMocks.loadParentHomeFeesSlice.mockResolvedValue([]);
+    homeServiceMocks.loadParentHomeInboxSlice.mockResolvedValue([]);
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValue({ home: baseHome, schedule: { children: [], events: [] } });
     homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValue(baseHome);
     socialServiceMocks.loadSocialHome.mockResolvedValue(baseSocial);
     scheduleServiceMocks.loadOfficialAssignmentsAccess.mockResolvedValue({ hasAccess: false, teamCount: 0 });
@@ -362,14 +370,14 @@ describe('Home', () => {
     expect(screen.getByText('Check your connection and try loading Home again.')).toBeTruthy();
   });
 
-  it('shows retryable Home error UI when the initial secondary load fails', async () => {
-    homeServiceMocks.loadParentHomeWithSecondaryData.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+  it('keeps summary content visible when an initial secondary slice fails', async () => {
+    homeServiceMocks.loadParentHomeInboxSlice.mockRejectedValueOnce(new TypeError('Failed to fetch'));
 
     renderHome(signedInAuth);
 
-    expect(await screen.findByText('Home could not connect')).toBeTruthy();
-    expect(screen.getByText('Check your connection and try loading Home again.')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Retry loading Home' })).toBeTruthy();
+    expect(await screen.findByRole('heading', { name: 'Today for your players' })).toBeTruthy();
+    expect(await screen.findByText('Home details could not refresh while offline.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Retry loading Home' })).toBeNull();
   });
 
   it('refreshes the social feed with the async loading helper', async () => {
@@ -549,8 +557,8 @@ describe('Home', () => {
 
   it('renders Today content from larger Home payloads and keeps it visible after refresh', async () => {
     const largeHome = buildLargeHomeModel();
-    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: largeHome, schedule: [] });
-    homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValue(largeHome);
+    homeServiceMocks.buildParentHomeFromSecondarySnapshot.mockImplementation(() => largeHome);
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: largeHome, schedule: { children: [], events: [] } });
 
     renderHome(signedInAuth);
 
@@ -564,7 +572,9 @@ describe('Home', () => {
 
     await waitFor(() => {
       expect(homeServiceMocks.loadParentHomeSummaryBootstrap).toHaveBeenCalledTimes(2);
-      expect(homeServiceMocks.loadParentHomeWithSecondaryData).toHaveBeenCalledTimes(2);
+      expect(homeServiceMocks.hydrateParentHomeScheduleSlice).toHaveBeenCalledTimes(2);
+      expect(homeServiceMocks.loadParentHomeInboxSlice).toHaveBeenCalledTimes(2);
+      expect(homeServiceMocks.loadParentHomeFeesSlice).toHaveBeenCalledTimes(2);
     });
 
     expect(screen.getByRole('heading', { name: 'Today for your players' })).toBeTruthy();

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -27,7 +27,14 @@ import {
   type LucideIcon
 } from 'lucide-react';
 import { HomePageSkeleton } from '../components/PageSkeletons';
-import { loadParentHomeSummaryBootstrap, loadParentHomeWithSecondaryData } from '../lib/homeService';
+import {
+  buildParentHomeFromSecondarySnapshot,
+  hydrateParentHomeScheduleSlice,
+  loadParentHomeFeesSlice,
+  loadParentHomeInboxSlice,
+  loadParentHomeSummaryBootstrap,
+  type ParentHomeSecondarySnapshot
+} from '../lib/homeService';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import {
   blockFriend,
@@ -144,16 +151,95 @@ export function Home({ auth }: { auth: AuthState }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const [loadedHomeDetailsUserId, setLoadedHomeDetailsUserId] = useState<string | null>(null);
   const [homeLoadError, setHomeLoadError] = useState<AppServiceError | null>(null);
+  const [homeSecondaryPending, setHomeSecondaryPending] = useState(0);
+  const homeRefreshRequestId = useRef(0);
   const { loading, error, clearError, run: runPrimaryLoad } = useAsyncOperation();
   const { loading: socialLoading, run: runSecondaryLoad } = useAsyncOperation();
   const hasStartedInitialHomeLoadRef = useRef(false);
 
   const authUserId = auth.user?.uid || null;
   const hasLoadedHomeDetails = Boolean(authUserId) && authUserId === loadedHomeDetailsUserId;
+  const homeRefreshing = loading || homeSecondaryPending > 0;
+
+  const startProgressiveHomeSecondaryLoad = (
+    user: NonNullable<AuthState['user']>,
+    schedule: Awaited<ReturnType<typeof loadParentHomeSummaryBootstrap>>['schedule'],
+    refreshId: number
+  ) => {
+    const snapshot: ParentHomeSecondarySnapshot = {
+      schedule,
+      inboxTeams: [],
+      fees: []
+    };
+    let latestHome = buildParentHomeFromSecondarySnapshot(snapshot);
+    const isCurrentRefresh = () => homeRefreshRequestId.current === refreshId && auth.user?.uid === user.uid;
+    const publishHome = () => {
+      latestHome = buildParentHomeFromSecondarySnapshot(snapshot);
+      if (isCurrentRefresh()) {
+        setHome(latestHome);
+      }
+    };
+    const runSlice = async <T,>(loadSlice: () => Promise<T>, applySlice: (value: T) => void) => {
+      setHomeSecondaryPending((count) => count + 1);
+      try {
+        const value = await loadSlice();
+        if (!isCurrentRefresh()) return;
+        applySlice(value);
+        publishHome();
+      } catch (sliceError) {
+        if (!isCurrentRefresh()) return;
+        const appError = toAppServiceError(sliceError, 'Unable to refresh Home details.');
+        setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(appError) });
+      } finally {
+        setHomeSecondaryPending((count) => Math.max(0, count - 1));
+      }
+    };
+
+    const sliceTasks = [
+      runSlice(
+        () => hydrateParentHomeScheduleSlice(user, snapshot.schedule),
+        (hydratedSchedule) => {
+          snapshot.schedule = hydratedSchedule;
+        }
+      ),
+      runSlice(
+        () => loadParentHomeInboxSlice(user),
+        (inboxTeams) => {
+          snapshot.inboxTeams = inboxTeams;
+        }
+      ),
+      runSlice(
+        () => loadParentHomeFeesSlice(user, snapshot.schedule),
+        (fees) => {
+          snapshot.fees = fees;
+        }
+      )
+    ];
+
+    void Promise.allSettled(sliceTasks).then(() => {
+      if (!isCurrentRefresh()) return;
+      setLoadedHomeDetailsUserId(user.uid);
+      void runSecondaryLoad(
+        async () => {
+          setSocial(await loadSocialHome(user, latestHome));
+        },
+        {
+          getErrorMessage: (secondaryError) => getHomeSecondaryErrorMessage(toAppServiceError(secondaryError, 'Unable to refresh Home details.')),
+          rethrow: false,
+          onError: (secondaryError) => {
+            if (!isCurrentRefresh()) return;
+            setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(toAppServiceError(secondaryError, 'Unable to refresh Home details.')) });
+          }
+        }
+      );
+    });
+  };
 
   const refreshHome = async ({ force = false }: { force?: boolean } = {}) => {
     const user = auth.user;
     if (!user) return;
+    const refreshId = homeRefreshRequestId.current + 1;
+    homeRefreshRequestId.current = refreshId;
     const hasExistingHome = loadedHomeDetailsUserId === user.uid;
     clearError();
     setHomeLoadError(null);
@@ -161,32 +247,13 @@ export function Home({ auth }: { auth: AuthState }) {
     return runPrimaryLoad(
       async () => {
         const summary = await loadParentHomeSummaryBootstrap(user, { force });
+        if (homeRefreshRequestId.current !== refreshId || auth.user?.uid !== user.uid) {
+          return summary;
+        }
         setHome(summary.home);
+        setLoadedHomeDetailsUserId(user.uid);
         setHomeLoadError(null);
-
-        void runSecondaryLoad(
-          async () => {
-            const secondaryHome = await loadParentHomeWithSecondaryData(user, { force, schedule: summary.schedule });
-            setHome(secondaryHome);
-            setSocial(await loadSocialHome(user, secondaryHome));
-            setLoadedHomeDetailsUserId(user.uid);
-            setHomeLoadError(null);
-          },
-          {
-            rethrow: false,
-            getErrorMessage: (secondaryError) => getHomeSecondaryErrorMessage(toAppServiceError(secondaryError, 'Unable to refresh Home details.')),
-            onError: (secondaryError) => {
-              const appError = toAppServiceError(secondaryError, 'Unable to refresh Home details.');
-              if (!hasExistingHome) {
-                setHomeLoadError(appError);
-                setLoadedHomeDetailsUserId(null);
-                setSocial(emptySocialHome());
-                return;
-              }
-              setSocialStatus({ tone: 'error', message: getHomeSecondaryErrorMessage(appError) });
-            }
-          }
-        );
+        startProgressiveHomeSecondaryLoad(user, summary.schedule, refreshId);
 
         return summary;
       },
@@ -342,8 +409,8 @@ export function Home({ auth }: { auth: AuthState }) {
             <h1 className="mt-0.5 truncate text-xl font-black leading-tight text-gray-950">Today for your players</h1>
             <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">{displayName}</p>
           </div>
-          <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0 sm:!w-auto sm:!px-3 text-xs" onClick={() => refreshHome({ force: true })} disabled={loading} aria-label="Refresh Home" title="Refresh Home">
-            {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+          <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0 sm:!w-auto sm:!px-3 text-xs" onClick={() => refreshHome({ force: true })} disabled={homeRefreshing} aria-label="Refresh Home" title="Refresh Home">
+            {homeRefreshing ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
             <span className="hidden sm:inline">Refresh</span>
           </button>
         </div>

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -92,28 +92,7 @@ async function mockHomePlayerModules(page) {
                     };
                 }
 
-                export async function loadParentHomeSummary(...args) {
-                    return loadParentHome(...args);
-                }
-
-                export async function loadParentHomeSummaryBootstrap(...args) {
-                    const home = await loadParentHome(...args);
-                    return { home, schedule: [] };
-                }
-
-                export async function loadParentTeamsSummary(...args) {
-                    return loadParentHome(...args);
-                }
-
-                export async function loadParentScheduleSummary() {
-                    return [];
-                }
-
-                export async function loadParentHomeWithSecondaryData(...args) {
-                    return loadParentHome(...args);
-                }
-
-                export async function loadParentHome() {
+                function buildHomeModel() {
                     const nextEvent = event();
                     const practice = event({
                         eventKey: 'team-1::practice-1::player-1',
@@ -168,6 +147,47 @@ async function mockHomePlayerModules(page) {
                             packetsReady: 1
                         }
                     };
+                }
+
+                export async function loadParentHomeSummary(...args) {
+                    return loadParentHome(...args);
+                }
+
+                export async function loadParentHomeSummaryBootstrap(...args) {
+                    const home = await loadParentHome(...args);
+                    return { home, schedule: [] };
+                }
+
+                export async function loadParentTeamsSummary(...args) {
+                    return loadParentHome(...args);
+                }
+
+                export async function loadParentScheduleSummary() {
+                    return [];
+                }
+
+                export async function loadParentHomeWithSecondaryData(...args) {
+                    return loadParentHome(...args);
+                }
+
+                export async function hydrateParentHomeScheduleSlice(user, schedule) {
+                    return schedule;
+                }
+
+                export async function loadParentHomeInboxSlice() {
+                    return [];
+                }
+
+                export async function loadParentHomeFeesSlice() {
+                    return [];
+                }
+
+                export function buildParentHomeFromSecondarySnapshot() {
+                    return buildHomeModel();
+                }
+
+                export async function loadParentHome() {
+                    return buildHomeModel();
                 }
             `
         });

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -7,7 +7,12 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 const mountedRoots = [];
 
 const homeMocks = vi.hoisted(() => ({
+    __currentHome: null,
+    buildParentHomeFromSecondarySnapshot: vi.fn(),
+    hydrateParentHomeScheduleSlice: vi.fn(),
     loadParentHome: vi.fn(),
+    loadParentHomeFeesSlice: vi.fn(),
+    loadParentHomeInboxSlice: vi.fn(),
     loadParentHomeSummary: vi.fn(),
     loadParentHomeSummaryBootstrap: vi.fn(),
     loadParentHomeWithSecondaryData: vi.fn()
@@ -267,12 +272,80 @@ beforeEach(() => {
     window.URL.createObjectURL = vi.fn((file) => `blob:${file.name}`);
     window.URL.revokeObjectURL = vi.fn();
     window.scrollTo = vi.fn();
+    homeMocks.__currentHome = null;
     homeMocks.loadParentHomeSummary.mockImplementation((user) => homeMocks.loadParentHome(user));
-    homeMocks.loadParentHomeSummaryBootstrap.mockImplementation(async (user) => ({
-        home: await homeMocks.loadParentHome(user),
-        schedule: { children: [], events: [] }
-    }));
-    homeMocks.loadParentHomeWithSecondaryData.mockImplementation((user) => homeMocks.loadParentHome(user));
+    homeMocks.buildParentHomeFromSecondarySnapshot.mockImplementation(({ schedule, inboxTeams = [], fees = [] }) => {
+        const baseHome = homeMocks.__currentHome || {
+            players: [],
+            teams: [],
+            upcomingEvents: [],
+            actionItems: [],
+            fees: [],
+            metrics: {
+                players: 0,
+                teams: 0,
+                rsvpNeeded: 0,
+                unreadMessages: 0,
+                packetsReady: 0
+            }
+        };
+        const teams = inboxTeams.length
+            ? inboxTeams.map((team) => {
+                const matchingTeam = (baseHome.teams || []).find((candidate) => candidate.teamId === team.id || candidate.teamId === team.teamId);
+                return matchingTeam
+                    ? { ...matchingTeam, unreadCount: team.unreadCount ?? matchingTeam.unreadCount ?? 0 }
+                    : {
+                        teamId: team.id || team.teamId,
+                        teamName: team.name || team.teamName || 'Team',
+                        role: team.role || 'Parent',
+                        sport: team.sport || null,
+                        players: [],
+                        nextEvent: null,
+                        eventCount: 0,
+                        unreadCount: team.unreadCount || 0,
+                        openActions: 0
+                    };
+            })
+            : (baseHome.teams || []);
+        return {
+            ...baseHome,
+            players: schedule.children || [],
+            teams,
+            upcomingEvents: schedule.events || [],
+            fees,
+            metrics: {
+                ...baseHome.metrics,
+                players: Array.isArray(schedule.children) ? schedule.children.length : 0,
+                teams: teams.length,
+                unreadMessages: teams.reduce((sum, team) => sum + Number(team.unreadCount || 0), 0)
+            }
+        };
+    });
+    homeMocks.hydrateParentHomeScheduleSlice.mockImplementation(async (_user, schedule) => schedule);
+    homeMocks.loadParentHomeInboxSlice.mockImplementation(async () => (homeMocks.__currentHome?.teams || []).map((team) => ({
+        id: team.teamId,
+        name: team.teamName,
+        role: team.role,
+        sport: team.sport,
+        unreadCount: team.unreadCount || 0
+    })));
+    homeMocks.loadParentHomeFeesSlice.mockImplementation(async () => homeMocks.__currentHome?.fees || []);
+    homeMocks.loadParentHomeSummaryBootstrap.mockImplementation(async (user) => {
+        const home = await homeMocks.loadParentHome(user);
+        homeMocks.__currentHome = home;
+        return {
+            home,
+            schedule: {
+                children: home.players || [],
+                events: home.upcomingEvents || []
+            }
+        };
+    });
+    homeMocks.loadParentHomeWithSecondaryData.mockImplementation(async (user) => {
+        const home = await homeMocks.loadParentHome(user);
+        homeMocks.__currentHome = home;
+        return home;
+    });
 
     const nextEvent = event({ id: 'game-next', opponent: 'Falcons' });
     const practice = event({
@@ -918,7 +991,7 @@ describe('React app Home and player drill-in integration', () => {
 
         await waitForText(container, 'Pat Star highlight');
         expect(container.textContent).toContain('Team chats');
-        expect(homeMocks.loadParentHome).toHaveBeenCalledTimes(3);
+        expect(homeMocks.loadParentHome).toHaveBeenCalledTimes(2);
     });
 
     it('keeps the last loaded Home visible when a refresh fails', async () => {


### PR DESCRIPTION
## Summary
- Split Home secondary work into independent schedule, inbox, and fee slices.
- Render the schedule summary immediately, then patch Home metrics/action items as each slice resolves.
- Keep summary content visible when a secondary slice fails and surface a non-blocking status message.

Fixes #2037.

## Validation
- npx vitest run tests/unit/app-home-service.test.js --reporter=verbose
- cd apps/app && npx vitest run src/pages/Home.test.tsx --reporter=verbose
- npm run app:build