### PR TITLE
[codex] Show app shell during returning auth bootstrap

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -4,10 +4,31 @@ import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
+import { writeAuthBootstrapHint } from './lib/authBootstrapHint';
+import type { AuthState } from './lib/types';
 
 const suspendedHomePromise = new Promise<never>(() => {});
 let homeRenderMode: 'suspend' | 'throw' = 'suspend';
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
+const authMock = vi.hoisted(() => {
+  const signedInAuth: AuthState = {
+    user: { uid: 'user-1', email: 'parent@example.com', displayName: 'Pat Parent', roles: ['parent'] },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['parent'],
+    isParent: true,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn(),
+  };
+  return {
+    signedInAuth,
+    state: signedInAuth as AuthState
+  };
+});
 const nativeBackMock = vi.hoisted(() => {
   const state = {
     listeners: [] as Array<(event: { canGoBack: boolean }) => void>,
@@ -38,19 +59,7 @@ vi.mock('@capacitor/core', () => ({
 }));
 
 vi.mock('./lib/useAuth', () => ({
-  useAuth: () => ({
-    user: { uid: 'user-1', email: 'parent@example.com', displayName: 'Pat Parent' },
-    profile: null,
-    loading: false,
-    error: null,
-    roles: ['parent'],
-    isParent: true,
-    isCoach: false,
-    isAdmin: false,
-    isPlatformAdmin: false,
-    refresh: vi.fn(),
-    signOut: vi.fn(),
-  }),
+  useAuth: () => authMock.state,
 }));
 
 vi.mock('./components/AppShell', () => ({
@@ -101,9 +110,31 @@ vi.mock('./pages/ScheduleEventDetail', () => ({
   ScheduleEventDetail: () => <div>Event detail page</div>,
 }));
 
+function installTestLocalStorage() {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: vi.fn((key: string) => store.get(key) || null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, String(value));
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key);
+      }),
+      clear: vi.fn(() => {
+        store.clear();
+      })
+    }
+  });
+}
+
 describe('App protected route loading', () => {
   beforeEach(() => {
+    installTestLocalStorage();
     homeRenderMode = 'suspend';
+    authMock.state = { ...authMock.signedInAuth, refresh: vi.fn(), signOut: vi.fn() };
+    window.localStorage.clear();
     nativeBackMock.listeners.length = 0;
     nativeBackMock.addListener.mockClear();
     nativeBackMock.exitApp.mockClear();
@@ -128,6 +159,46 @@ describe('App protected route loading', () => {
     expect(screen.queryByText('Loading page')).toBeNull();
     expect(screen.queryByText('Preparing your ALL PLAYS workspace...')).toBeNull();
     expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
+  });
+
+  it('uses the app shell skeleton while returning-user auth is still resolving', async () => {
+    authMock.state = {
+      ...authMock.signedInAuth,
+      user: null,
+      loading: true,
+      roles: [],
+      isParent: false
+    };
+    writeAuthBootstrapHint({ uid: 'user-1', email: 'parent@example.com', displayName: 'Pat Parent', roles: ['parent'] });
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('navigation', { name: 'Primary navigation' })).toBeTruthy();
+    expect(screen.getByRole('status', { name: 'Loading Home' })).toBeTruthy();
+    expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
+  });
+
+  it('keeps the full auth loader for first-time indeterminate auth without a hint', () => {
+    authMock.state = {
+      ...authMock.signedInAuth,
+      user: null,
+      loading: true,
+      roles: [],
+      isParent: false
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Loading ALL PLAYS')).toBeTruthy();
+    expect(screen.queryByRole('navigation', { name: 'Primary navigation' })).toBeNull();
   });
 
   it('routes the dedicated public-team discovery screen ahead of dynamic team ids', async () => {

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { shouldReloadTeamsToHome } from './lib/reloadRouting';
 import { addPushNotificationOpenListener, ensureAndroidNotificationChannels } from './lib/pushService';
+import { readAuthBootstrapHint } from './lib/authBootstrapHint';
 import { useAuth } from './lib/useAuth';
 import type { AuthState } from './lib/types';
 
@@ -46,7 +47,7 @@ const TeamMedia = lazy(() => import('./pages/TeamMedia').then((module) => ({ def
 const Teams = lazy(() => import('./pages/Teams').then((module) => ({ default: module.Teams })));
 const VerifyPending = lazy(() => import('./pages/VerifyPending').then((module) => ({ default: module.VerifyPending })));
 
-const protectedRouteBootstrapGraceMs = 3000;
+const protectedRouteBootstrapGraceMs = 750;
 
 export default function App() {
   const auth = useAuth();
@@ -226,6 +227,7 @@ function Protected({ auth, children }: { auth: AuthState; children: ReactNode })
   const [bootstrapGraceExpired, setBootstrapGraceExpired] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
+  const hasAuthBootstrapHint = Boolean(readAuthBootstrapHint()?.uid);
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -234,6 +236,14 @@ function Protected({ auth, children }: { auth: AuthState; children: ReactNode })
 
     return () => window.clearTimeout(timeoutId);
   }, []);
+
+  if (auth.loading && !auth.user && hasAuthBootstrapHint) {
+    return (
+      <AppShell auth={auth}>
+        <ProtectedRouteLoadingState pathname={location.pathname} />
+      </AppShell>
+    );
+  }
 
   if (auth.loading && !auth.user) {
     return <LoadingScreen />;

--- a/apps/app/src/lib/authBootstrapHint.test.ts
+++ b/apps/app/src/lib/authBootstrapHint.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearAuthBootstrapHint, readAuthBootstrapHint, writeAuthBootstrapHint } from './authBootstrapHint';
+
+function installThrowingLocalStorageGetter() {
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        get() {
+            throw new DOMException('Access denied', 'SecurityError');
+        }
+    });
+}
+
+describe('authBootstrapHint storage access', () => {
+    beforeEach(() => {
+        installThrowingLocalStorageGetter();
+    });
+
+    it('returns null when reading storage throws a SecurityError', () => {
+        expect(readAuthBootstrapHint()).toBeNull();
+    });
+
+    it('swallows SecurityError when writing storage', () => {
+        expect(() => writeAuthBootstrapHint({ uid: 'user-1', email: 'parent@example.com', displayName: 'Pat Parent', roles: ['parent'] })).not.toThrow();
+    });
+
+    it('swallows SecurityError when clearing storage', () => {
+        expect(() => clearAuthBootstrapHint()).not.toThrow();
+    });
+});

--- a/apps/app/src/lib/authBootstrapHint.ts
+++ b/apps/app/src/lib/authBootstrapHint.ts
@@ -9,14 +9,12 @@ export type AuthBootstrapHint = {
   updatedAt: number;
 };
 
-function canUseStorage() {
-  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
-}
-
 export function readAuthBootstrapHint(): AuthBootstrapHint | null {
-  if (!canUseStorage()) return null;
+  if (typeof window === 'undefined') return null;
   try {
-    const raw = window.localStorage.getItem(authBootstrapHintKey);
+    const storage = window.localStorage;
+    if (typeof storage === 'undefined') return null;
+    const raw = storage.getItem(authBootstrapHintKey);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<AuthBootstrapHint>;
     if (!parsed.uid || typeof parsed.uid !== 'string') return null;
@@ -32,13 +30,15 @@ export function readAuthBootstrapHint(): AuthBootstrapHint | null {
 }
 
 export function writeAuthBootstrapHint(user: AuthUser | null) {
-  if (!canUseStorage()) return;
+  if (typeof window === 'undefined') return;
   if (!user?.uid) {
     clearAuthBootstrapHint();
     return;
   }
   try {
-    window.localStorage.setItem(authBootstrapHintKey, JSON.stringify({
+    const storage = window.localStorage;
+    if (typeof storage === 'undefined') return;
+    storage.setItem(authBootstrapHintKey, JSON.stringify({
       uid: user.uid,
       email: user.email || null,
       roles: Array.isArray(user.roles) ? user.roles : [],
@@ -50,9 +50,11 @@ export function writeAuthBootstrapHint(user: AuthUser | null) {
 }
 
 export function clearAuthBootstrapHint() {
-  if (!canUseStorage()) return;
+  if (typeof window === 'undefined') return;
   try {
-    window.localStorage.removeItem(authBootstrapHintKey);
+    const storage = window.localStorage;
+    if (typeof storage === 'undefined') return;
+    storage.removeItem(authBootstrapHintKey);
   } catch {
     // Ignore storage failures.
   }

--- a/apps/app/src/lib/authBootstrapHint.ts
+++ b/apps/app/src/lib/authBootstrapHint.ts
@@ -1,0 +1,59 @@
+import type { AuthUser } from './types';
+
+const authBootstrapHintKey = 'allplays:auth-bootstrap-hint:v1';
+
+export type AuthBootstrapHint = {
+  uid: string;
+  email?: string | null;
+  roles: string[];
+  updatedAt: number;
+};
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+export function readAuthBootstrapHint(): AuthBootstrapHint | null {
+  if (!canUseStorage()) return null;
+  try {
+    const raw = window.localStorage.getItem(authBootstrapHintKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AuthBootstrapHint>;
+    if (!parsed.uid || typeof parsed.uid !== 'string') return null;
+    return {
+      uid: parsed.uid,
+      email: typeof parsed.email === 'string' ? parsed.email : null,
+      roles: Array.isArray(parsed.roles) ? parsed.roles.filter((role): role is string => typeof role === 'string') : [],
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : 0
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeAuthBootstrapHint(user: AuthUser | null) {
+  if (!canUseStorage()) return;
+  if (!user?.uid) {
+    clearAuthBootstrapHint();
+    return;
+  }
+  try {
+    window.localStorage.setItem(authBootstrapHintKey, JSON.stringify({
+      uid: user.uid,
+      email: user.email || null,
+      roles: Array.isArray(user.roles) ? user.roles : [],
+      updatedAt: Date.now()
+    }));
+  } catch {
+    // Storage is best-effort only; auth itself remains Firebase-backed.
+  }
+}
+
+export function clearAuthBootstrapHint() {
+  if (!canUseStorage()) return;
+  try {
+    window.localStorage.removeItem(authBootstrapHintKey);
+  } catch {
+    // Ignore storage failures.
+  }
+}

--- a/apps/app/src/lib/useAuth.ts
+++ b/apps/app/src/lib/useAuth.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AuthState, AuthUser } from './types';
+import { clearAuthBootstrapHint, writeAuthBootstrapHint } from './authBootstrapHint';
 import { hydrateFirebaseUser, observeFirebaseUser, signOut } from './authService';
 
 export function useAuth(): AuthState {
@@ -23,6 +24,7 @@ export function useAuth(): AuthState {
     if (!currentUser) {
       setUser(null);
       setProfile(null);
+      clearAuthBootstrapHint();
       setLoading(false);
       return null;
     }
@@ -31,11 +33,13 @@ export function useAuth(): AuthState {
       const hydrated = await hydrateFirebaseUser(currentUser);
       setUser(hydrated.user);
       setProfile(hydrated.profile);
+      writeAuthBootstrapHint(hydrated.user);
       return hydrated.user;
     } catch (hydrateError: any) {
       setError(hydrateError?.message || 'Unable to load account profile.');
       setUser(null);
       setProfile(null);
+      clearAuthBootstrapHint();
       return null;
     } finally {
       setLoading(false);
@@ -50,6 +54,7 @@ export function useAuth(): AuthState {
       if (!firebaseUser) {
         setUser(null);
         setProfile(null);
+        clearAuthBootstrapHint();
         setLoading(false);
         return;
       }
@@ -58,10 +63,12 @@ export function useAuth(): AuthState {
         const hydrated = await hydrateFirebaseUser(firebaseUser);
         setUser(hydrated.user);
         setProfile(hydrated.profile);
+        writeAuthBootstrapHint(hydrated.user);
       } catch (hydrateError: any) {
         setError(hydrateError?.message || 'Unable to load account profile.');
         setUser(null);
         setProfile(null);
+        clearAuthBootstrapHint();
       } finally {
         setLoading(false);
       }
@@ -75,6 +82,7 @@ export function useAuth(): AuthState {
     const cleanup = signOut();
     setUser(null);
     setProfile(null);
+    clearAuthBootstrapHint();
     setLoading(false);
     try {
       await cleanup;
@@ -83,6 +91,7 @@ export function useAuth(): AuthState {
     } finally {
       setUser(null);
       setProfile(null);
+      clearAuthBootstrapHint();
       setLoading(false);
     }
   }, []);

--- a/tests/unit/app-protected-route-bootstrap.test.js
+++ b/tests/unit/app-protected-route-bootstrap.test.js
@@ -6,7 +6,7 @@ const appSource = readFileSync(path.resolve('apps/app/src/App.tsx'), 'utf8');
 
 describe('app protected route bootstrap guard', () => {
     it('keeps a protected-route grace period before redirecting to auth', () => {
-        expect(appSource).toContain('const protectedRouteBootstrapGraceMs = 3000;');
+        expect(appSource).toContain('const protectedRouteBootstrapGraceMs = 750;');
         expect(appSource).toContain('const [bootstrapGraceExpired, setBootstrapGraceExpired] = useState(false);');
         expect(appSource).toContain('setBootstrapGraceExpired(true);');
         expect(appSource).toContain('if (!auth.user && !bootstrapGraceExpired) {');


### PR DESCRIPTION
## Summary
- Persist a lightweight auth bootstrap hint after successful user hydration and clear it on signed-out/error paths.
- Use the hint to render the app shell plus protected-route skeleton while returning-user auth is still resolving.
- Shorten the protected-route grace window from 3000ms to 750ms.

Fixes #2038.

## Validation
- cd apps/app && npx vitest run src/App.test.tsx --reporter=verbose
- npm run app:build