### PR TITLE
[codex] Restore scroll on back navigation

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -135,6 +135,10 @@ describe('App protected route loading', () => {
     homeRenderMode = 'suspend';
     authMock.state = { ...authMock.signedInAuth, refresh: vi.fn(), signOut: vi.fn() };
     window.localStorage.clear();
+    Object.defineProperty(window, 'scrollTo', {
+      configurable: true,
+      value: vi.fn()
+    });
     nativeBackMock.listeners.length = 0;
     nativeBackMock.addListener.mockClear();
     nativeBackMock.exitApp.mockClear();

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-
 import { AppShell } from './components/AppShell';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { ProtectedRouteSkeleton } from './components/PageSkeletons';
+import { ScrollRestoration } from './components/ScrollRestoration';
 import {
   addNativeBackButtonListener,
   dispatchNativeBackDismissEvent,
@@ -181,6 +182,7 @@ export default function App() {
 
   return (
     <Suspense fallback={<LoadingScreen />}>
+      <ScrollRestoration />
       <Routes>
         <Route path="/auth" element={<AuthPage auth={auth} />} />
         <Route path="/accept-invite" element={<AcceptInvite auth={auth} />} />

--- a/apps/app/src/components/ScrollRestoration.test.tsx
+++ b/apps/app/src/components/ScrollRestoration.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Link, MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Link, MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearScrollRestorationForTests, ScrollRestoration } from './ScrollRestoration';
 
 let scrollYValue = 0;
@@ -16,12 +16,24 @@ function BackButton() {
   return <button type="button" onClick={() => navigate(-1)}>Back</button>;
 }
 
+function HomeRoute() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return (
+    <>
+      <Link to="/detail">Open detail</Link>
+      <button type="button" onClick={() => navigate(`${location.pathname}?panel=filters`, { replace: true })}>Replace filters</button>
+      <span data-testid="current-search">{location.search}</span>
+    </>
+  );
+}
+
 function TestRoutes() {
   return (
     <>
       <ScrollRestoration />
       <Routes>
-        <Route path="/" element={<Link to="/detail">Open detail</Link>} />
+        <Route path="/" element={<HomeRoute />} />
         <Route path="/detail" element={<BackButton />} />
       </Routes>
     </>
@@ -29,6 +41,10 @@ function TestRoutes() {
 }
 
 describe('ScrollRestoration', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     scrollYValue = 0;
     scrollToMock.mockClear();
@@ -67,5 +83,23 @@ describe('ScrollRestoration', () => {
 
     await waitFor(() => expect(screen.getByRole('link', { name: 'Open detail' })).toBeTruthy());
     await waitFor(() => expect(scrollToMock).toHaveBeenLastCalledWith({ top: 420, left: 0, behavior: 'auto' }));
+  });
+
+  it('preserves scroll when replacing query params on the same page', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <TestRoutes />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(scrollToMock).toHaveBeenLastCalledWith({ top: 0, left: 0, behavior: 'auto' }));
+
+    scrollToMock.mockClear();
+    scrollYValue = 360;
+    fireEvent.click(screen.getByRole('button', { name: 'Replace filters' }));
+
+    await waitFor(() => expect(screen.getByTestId('current-search').textContent).toBe('?panel=filters'));
+    expect(scrollYValue).toBe(360);
+    expect(scrollToMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/components/ScrollRestoration.test.tsx
+++ b/apps/app/src/components/ScrollRestoration.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Link, MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearScrollRestorationForTests, ScrollRestoration } from './ScrollRestoration';
+
+let scrollYValue = 0;
+const scrollToMock = vi.fn((optionsOrX: ScrollToOptions | number, y?: number) => {
+  scrollYValue = typeof optionsOrX === 'number'
+    ? Number(y || 0)
+    : Number(optionsOrX.top || 0);
+});
+
+function BackButton() {
+  const navigate = useNavigate();
+  return <button type="button" onClick={() => navigate(-1)}>Back</button>;
+}
+
+function TestRoutes() {
+  return (
+    <>
+      <ScrollRestoration />
+      <Routes>
+        <Route path="/" element={<Link to="/detail">Open detail</Link>} />
+        <Route path="/detail" element={<BackButton />} />
+      </Routes>
+    </>
+  );
+}
+
+describe('ScrollRestoration', () => {
+  beforeEach(() => {
+    scrollYValue = 0;
+    scrollToMock.mockClear();
+    clearScrollRestorationForTests();
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      get: () => scrollYValue
+    });
+    Object.defineProperty(window, 'pageYOffset', {
+      configurable: true,
+      get: () => scrollYValue
+    });
+    Object.defineProperty(window, 'scrollTo', {
+      configurable: true,
+      value: scrollToMock
+    });
+  });
+
+  it('restores the previous entry scroll on back navigation and starts pushed pages at top', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <TestRoutes />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(scrollToMock).toHaveBeenLastCalledWith({ top: 0, left: 0, behavior: 'auto' }));
+
+    scrollYValue = 420;
+    fireEvent.click(screen.getByRole('link', { name: 'Open detail' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Back' })).toBeTruthy());
+    await waitFor(() => expect(scrollToMock).toHaveBeenLastCalledWith({ top: 0, left: 0, behavior: 'auto' }));
+
+    scrollYValue = 80;
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+
+    await waitFor(() => expect(screen.getByRole('link', { name: 'Open detail' })).toBeTruthy());
+    await waitFor(() => expect(scrollToMock).toHaveBeenLastCalledWith({ top: 420, left: 0, behavior: 'auto' }));
+  });
+});

--- a/apps/app/src/components/ScrollRestoration.tsx
+++ b/apps/app/src/components/ScrollRestoration.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLocation, useNavigationType } from 'react-router-dom';
 
 const scrollPositions = new Map<string, number>();
@@ -7,8 +7,18 @@ export function ScrollRestoration() {
   const location = useLocation();
   const navigationType = useNavigationType();
   const scrollKey = getScrollKey(location);
+  const previousPathnameRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const previousPathname = previousPathnameRef.current;
+    previousPathnameRef.current = location.pathname;
+
+    if (navigationType === 'REPLACE' && previousPathname === location.pathname) {
+      return () => {
+        scrollPositions.set(scrollKey, getWindowScrollY());
+      };
+    }
+
     const frame = window.requestAnimationFrame(() => {
       const top = navigationType === 'POP' ? scrollPositions.get(scrollKey) || 0 : 0;
       restoreWindowScroll(top);
@@ -18,7 +28,7 @@ export function ScrollRestoration() {
       window.cancelAnimationFrame(frame);
       scrollPositions.set(scrollKey, getWindowScrollY());
     };
-  }, [navigationType, scrollKey]);
+  }, [location.pathname, navigationType, scrollKey]);
 
   return null;
 }

--- a/apps/app/src/components/ScrollRestoration.tsx
+++ b/apps/app/src/components/ScrollRestoration.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigationType } from 'react-router-dom';
+
+const scrollPositions = new Map<string, number>();
+
+export function ScrollRestoration() {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  const scrollKey = getScrollKey(location);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      const top = navigationType === 'POP' ? scrollPositions.get(scrollKey) || 0 : 0;
+      restoreWindowScroll(top);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      scrollPositions.set(scrollKey, getWindowScrollY());
+    };
+  }, [navigationType, scrollKey]);
+
+  return null;
+}
+
+export function clearScrollRestorationForTests() {
+  scrollPositions.clear();
+}
+
+function getScrollKey(location: { key?: string; pathname: string; search: string }) {
+  return location.key || `${location.pathname}${location.search}`;
+}
+
+function getWindowScrollY() {
+  return Math.max(0, Number(window.scrollY || window.pageYOffset || 0));
+}
+
+function restoreWindowScroll(top: number) {
+  try {
+    window.scrollTo({ top, left: 0, behavior: 'auto' });
+  } catch {
+    try {
+      window.scrollTo(0, top);
+    } catch {
+      // Some test environments expose scrollTo but do not implement it.
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add route-level scroll restoration keyed by React Router history entries.
- Restore saved scroll offsets only on POP/back navigation; PUSH/forward route changes start at the top.
- Mount the behavior once in App and cover the back-navigation flow with a focused component test.

Fixes #2045.

## Validation
- cd apps/app && npx vitest run src/components/ScrollRestoration.test.tsx --reporter=verbose
- cd apps/app && npx vitest run src/App.test.tsx --reporter=verbose
- npm run app:build