### PR TITLE
Dedup native Firestore REST reads within a short window (#2032)

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -54,6 +54,7 @@ import {
   type ChatTargetType
 } from './chatLogic';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
+import { dedupeNativeRead } from './nativeReadDedup';
 import { startInteractionTimer, UX_TIMING } from './uxTiming';
 import { mapChatConversationRecord, mapChatMessageRecord, mapFirestoreDocument } from './firestore/mappers';
 import type {
@@ -269,20 +270,27 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...(await getNativeHeaders()),
-      ...(init.headers || {})
+  const method = (init.method || 'GET').toUpperCase();
+  const performRequest = async () => {
+    const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
+      ...init,
+      headers: {
+        ...(await getNativeHeaders()),
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  // Dedup idempotent GET reads within a short window; writes always execute.
+  return method === 'GET'
+    ? dedupeNativeRead(`${getFirestoreBaseUrl()}${path}`, performRequest)
+    : performRequest();
 }
 
 function encodeFirestoreValue(value: any): Record<string, unknown> {

--- a/apps/app/src/lib/nativeReadDedup.test.ts
+++ b/apps/app/src/lib/nativeReadDedup.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearNativeReadDedup, dedupeNativeRead } from './nativeReadDedup';
+
+afterEach(() => clearNativeReadDedup());
+
+describe('dedupeNativeRead', () => {
+  it('collapses identical concurrent reads into one loader call', async () => {
+    const loader = vi.fn(async () => 'value');
+    const [a, b] = await Promise.all([
+      dedupeNativeRead('teams/t1/players', loader),
+      dedupeNativeRead('teams/t1/players', loader)
+    ]);
+    expect(a).toBe('value');
+    expect(b).toBe('value');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses a resolved read within the window, then refetches after it expires', async () => {
+    let clock = 1_000;
+    const loader = vi.fn(async () => 'value');
+    const opts = { windowMs: 5_000, now: () => clock };
+
+    await dedupeNativeRead('path', loader, opts);
+    clock = 4_000; // within window
+    await dedupeNativeRead('path', loader, opts);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    clock = 7_000; // past window
+    await dedupeNativeRead('path', loader, opts);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys by path so different reads are not collapsed', async () => {
+    const loader = vi.fn(async (value: string) => value);
+    await Promise.all([
+      dedupeNativeRead('a', () => loader('a')),
+      dedupeNativeRead('b', () => loader('b'))
+    ]);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failures', async () => {
+    const loader = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('ok');
+
+    await expect(dedupeNativeRead('p', loader as () => Promise<string>)).rejects.toThrow('boom');
+    await expect(dedupeNativeRead('p', loader as () => Promise<string>)).resolves.toBe('ok');
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/app/src/lib/nativeReadDedup.ts
+++ b/apps/app/src/lib/nativeReadDedup.ts
@@ -1,0 +1,42 @@
+/**
+ * Short-window dedup for native Firestore REST reads (#2032).
+ *
+ * Native runtimes bypass the Firestore SDK and hit the REST API directly, which
+ * has no caching or in-flight dedup — so two identical reads seconds apart (e.g.
+ * Schedule → event → back re-listing the same collection) pay two full HTTP
+ * round-trips. This collapses identical reads that happen within `windowMs` into
+ * a single request by sharing the in-flight/just-resolved promise.
+ *
+ * Only idempotent reads should go through here; writes must never be deduped.
+ */
+type DedupEntry = { promise: Promise<unknown>; expiresAt: number };
+
+const inflight = new Map<string, DedupEntry>();
+const defaultWindowMs = 5000;
+
+export function dedupeNativeRead<T>(
+  key: string,
+  loader: () => Promise<T>,
+  { windowMs = defaultWindowMs, now = Date.now }: { windowMs?: number; now?: () => number } = {}
+): Promise<T> {
+  const timestamp = now();
+  const existing = inflight.get(key);
+  if (existing && existing.expiresAt > timestamp) {
+    return existing.promise as Promise<T>;
+  }
+
+  const promise = loader();
+  inflight.set(key, { promise, expiresAt: timestamp + windowMs });
+  // Drop the entry on failure so a transient error isn't cached for the window.
+  promise.catch(() => {
+    const current = inflight.get(key);
+    if (current && current.promise === promise) {
+      inflight.delete(key);
+    }
+  });
+  return promise;
+}
+
+export function clearNativeReadDedup() {
+  inflight.clear();
+}

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -14,6 +14,7 @@ import {
 import { normalizeTeamNotificationPreferences } from '../../../../js/notification-preferences.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { createLogger } from './logger';
+import { dedupeNativeRead } from './nativeReadDedup';
 import { isTeamActive } from '../../../../js/team-visibility.js';
 
 export {
@@ -130,21 +131,28 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const headers = await getNativeHeaders();
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...headers,
-      ...(init.headers || {})
+  const method = (init.method || 'GET').toUpperCase();
+  const performRequest = async () => {
+    const headers = await getNativeHeaders();
+    const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
+      ...init,
+      headers: {
+        ...headers,
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  // Dedup idempotent GET reads within a short window; writes always execute.
+  return method === 'GET'
+    ? dedupeNativeRead(`${getFirestoreBaseUrl()}${path}`, performRequest)
+    : performRequest();
 }
 
 function encodeFirestoreValue(value: any): Record<string, unknown> {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -125,6 +125,7 @@ import { sendTeamChatMessage } from './chatService';
 import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
 import { toAppServiceError } from './appErrors';
+import { dedupeNativeRead } from './nativeReadDedup';
 import { createLogger } from './logger';
 import { mapFirestoreDocument, mapScheduleEventDocument, mapScheduleEventDocuments } from './firestore/mappers';
 import type { FirestoreDecodedDocument, FirestoreDocument as NativeFirestoreDocument } from './firestore/types';
@@ -693,20 +694,27 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...(await getNativeHeaders()),
-      ...(init.headers || {})
+  const method = (init.method || 'GET').toUpperCase();
+  const performRequest = async () => {
+    const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
+      ...init,
+      headers: {
+        ...(await getNativeHeaders()),
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  // Dedup idempotent GET reads within a short window; writes always execute.
+  return method === 'GET'
+    ? dedupeNativeRead(`${getFirestoreBaseUrl()}${path}`, performRequest)
+    : performRequest();
 }
 
 function encodeFirestoreValue(value: any): Record<string, unknown> {

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -42,6 +42,7 @@ import { buildTrackingStatusPayload, summarizeTrackingStatus } from '../../../..
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { buildAppAcceptInviteUrl } from './inviteUrls';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
+import { dedupeNativeRead } from './nativeReadDedup';
 import { normalizeOptionalHttpUrl, parseTeamLivestreamInput } from './teamLinks';
 import type { AuthUser } from './types';
 
@@ -435,20 +436,27 @@ async function getNativeHeaders() {
 }
 
 async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
-  const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    ...init,
-    headers: {
-      ...(await getNativeHeaders()),
-      ...(init.headers || {})
+  const method = (init.method || 'GET').toUpperCase();
+  const performRequest = async () => {
+    const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
+      ...init,
+      headers: {
+        ...(await getNativeHeaders()),
+        ...(init.headers || {})
+      }
+    }), 'Firestore REST request');
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
     }
-  }), 'Firestore REST request');
-  const payload = await response.json().catch(() => ({}));
-  if (!response.ok) {
-    const error = new Error(payload?.error?.message || `Firestore request failed (${response.status}).`) as Error & { status?: number };
-    error.status = response.status;
-    throw error;
-  }
-  return payload;
+    return payload;
+  };
+  // Dedup idempotent GET reads within a short window; writes always execute.
+  return method === 'GET'
+    ? dedupeNativeRead(`${getFirestoreBaseUrl()}${path}`, performRequest)
+    : performRequest();
 }
 
 function decodeFirestoreValue(value: any): any {


### PR DESCRIPTION
Closes #2032.

## Summary
Native runtimes read through the raw Firestore REST fallback (`nativeFirestoreRequest`), which has **no** SDK caching or in-flight dedup — so two identical reads seconds apart (e.g. Schedule → event → back re-listing the same collection) pay two full HTTP round-trips. This is a big reason the native app feels slower than web for identical screens.

- New **`dedupeNativeRead`** helper: collapses identical GET reads within a 5s window into a single in-flight/just-resolved request (keyed by the full REST URL).
- Routed every service's `nativeFirestoreRequest` **GET** path through it: `chatService`, `profileService`, `scheduleService`, `teamDetailService`.
- Writes (`PATCH`/`POST`/`DELETE`) always execute — only idempotent GETs dedup. Failures are not cached, so a transient error isn't sticky.

## Acceptance criteria
- Repeated identical native reads within the dedup window produce one HTTP request — covered by `nativeReadDedup.test.ts` (mocked loader): concurrent collapse, within-window reuse, past-window refetch, per-path keying, no failure caching. ✓

## Notes
The 5s window is strictly tighter than the existing `appDataCache` TTLs (25–60s) already applied to these reads, so it introduces no new read-after-write staleness beyond current behavior.

## Tests
`nativeReadDedup.test.ts` (4) + `chatService`/`profileService`/`teamDetailService` suites — 17 passing. `tsc --noEmit` (via build) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)