### PR TITLE
[codex] Improve app accessibility announcements

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -6,8 +6,9 @@ import { AppShell } from './AppShell';
 import type { AuthState } from '../lib/types';
 import { APP_BACK_DISMISS_EVENT } from '../lib/nativeBackButton';
 
-const { useShellLayoutMock } = vi.hoisted(() => ({
+const { useShellLayoutMock, subscribeToNotificationInboxMock } = vi.hoisted(() => ({
   useShellLayoutMock: vi.fn(() => ({ isDesktopWeb: true })),
+  subscribeToNotificationInboxMock: vi.fn(() => vi.fn()),
 }));
 
 vi.mock('../lib/useShellLayout', () => ({
@@ -16,6 +17,12 @@ vi.mock('../lib/useShellLayout', () => ({
 
 vi.mock('../lib/uxTiming', () => ({
   recordUxTiming: vi.fn(),
+}));
+
+vi.mock('../lib/notificationInboxService', () => ({
+  countUnread: (items: Array<{ readAt: unknown | null }>) => items.filter((item) => !item.readAt).length,
+  markNotificationRead: vi.fn(),
+  subscribeToNotificationInbox: subscribeToNotificationInboxMock,
 }));
 
 vi.mock('./AppSearchDialog', () => ({
@@ -36,6 +43,16 @@ const auth: AuthState = {
   signOut: vi.fn(),
 };
 
+const signedInAuth: AuthState = {
+  ...auth,
+  user: {
+    uid: 'user-123',
+    email: 'parent@example.com',
+    displayName: 'Parent User',
+    roles: ['parent'],
+  },
+};
+
 describe('AppShell', () => {
   beforeEach(() => {
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
@@ -44,6 +61,8 @@ describe('AppShell', () => {
     });
     vi.stubGlobal('cancelAnimationFrame', vi.fn());
     useShellLayoutMock.mockReturnValue({ isDesktopWeb: true });
+    subscribeToNotificationInboxMock.mockReset();
+    subscribeToNotificationInboxMock.mockReturnValue(vi.fn());
   });
 
   afterEach(() => {
@@ -77,6 +96,35 @@ describe('AppShell', () => {
     expect(notificationStatus.getAttribute('role')).toBe('status');
     expect(notificationStatus.getAttribute('aria-live')).toBe('polite');
     expect(notificationStatus.textContent).toBe('No unread notifications');
+  });
+
+  it('announces loading status until the signed-in inbox has loaded', () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('app-shell-notification-status').textContent).toBe('Loading notifications…');
+  });
+
+  it('announces load failures instead of a false empty inbox state', () => {
+    subscribeToNotificationInboxMock.mockImplementation((_uid, _onItems, onError) => {
+      onError?.(new Error('offline'));
+      return vi.fn();
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('app-shell-notification-status').textContent).toBe('Could not load notifications');
   });
 
   it('keeps the mobile search trigger discoverable with a stable selector', () => {

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -3,12 +3,19 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
+import type { NotificationInboxItem } from '../lib/notificationInboxService';
 import type { AuthState } from '../lib/types';
 import { APP_BACK_DISMISS_EVENT } from '../lib/nativeBackButton';
 
+type SubscribeToNotificationInbox = (
+  uid: string,
+  onItems: (items: NotificationInboxItem[]) => void,
+  onError?: (error: unknown) => void
+) => () => void;
+
 const { useShellLayoutMock, subscribeToNotificationInboxMock } = vi.hoisted(() => ({
   useShellLayoutMock: vi.fn(() => ({ isDesktopWeb: true })),
-  subscribeToNotificationInboxMock: vi.fn(() => vi.fn()),
+  subscribeToNotificationInboxMock: vi.fn<SubscribeToNotificationInbox>(() => vi.fn()),
 }));
 
 vi.mock('../lib/useShellLayout', () => ({

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -64,6 +64,21 @@ describe('AppShell', () => {
     expect(searchButton.getAttribute('data-testid')).toBe('app-shell-search-trigger');
   });
 
+  it('announces notification count changes through a live region', () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={auth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const notificationStatus = screen.getByTestId('app-shell-notification-status');
+    expect(notificationStatus.getAttribute('role')).toBe('status');
+    expect(notificationStatus.getAttribute('aria-live')).toBe('polite');
+    expect(notificationStatus.textContent).toBe('No unread notifications');
+  });
+
   it('keeps the mobile search trigger discoverable with a stable selector', () => {
     useShellLayoutMock.mockReturnValue({ isDesktopWeb: false });
 

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -79,8 +79,14 @@ export function AppShell({ auth, children }: AppShellProps) {
   // does not statically import the module (which pulls the vendored Firestore SDK
   // into the entry chunk). The module is dynamically imported on subscribe below.
   const unreadCount = inboxItems.filter((item) => !item.readAt).length;
-  const unreadNotificationStatus = unreadCount > 0
-    ? `${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}`
+  const unreadNotificationStatus = auth.user
+    ? inboxState === 'loading' && inboxItems.length === 0
+      ? 'Loading notifications…'
+      : inboxState === 'error' && inboxItems.length === 0
+        ? 'Could not load notifications'
+        : unreadCount > 0
+          ? `${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}`
+          : 'No unread notifications'
     : 'No unread notifications';
 
   useEffect(() => {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -79,6 +79,9 @@ export function AppShell({ auth, children }: AppShellProps) {
   // does not statically import the module (which pulls the vendored Firestore SDK
   // into the entry chunk). The module is dynamically imported on subscribe below.
   const unreadCount = inboxItems.filter((item) => !item.readAt).length;
+  const unreadNotificationStatus = unreadCount > 0
+    ? `${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}`
+    : 'No unread notifications';
 
   useEffect(() => {
     const startedAt = routeStartedAtRef.current;
@@ -173,6 +176,9 @@ export function AppShell({ auth, children }: AppShellProps) {
 
   return (
     <div className={isDesktopWeb ? `desktop-app-page ${isDesktopMessages ? 'desktop-app-page-messages' : ''}` : `app-page ${isMobileChatDetail ? 'app-page-chat-detail' : ''} ${isAiRoute ? 'app-page-ai' : ''}`}>
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" aria-label="Notification status" data-testid="app-shell-notification-status">
+        {unreadNotificationStatus}
+      </div>
       {isDesktopWeb ? (
         <>
           <header className="sticky top-0 z-40 border-b border-gray-200 bg-white/95 backdrop-blur">

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -234,8 +234,22 @@ describe('PlayerDetail athlete profile season selection', () => {
     fireEvent.click(currentSeason);
     fireEvent.click(screen.getByRole('button', { name: 'Save Athlete Profile' }));
 
-    expect(await screen.findByText('Select at least one linked season to build an athlete profile.')).toBeTruthy();
+    const status = await screen.findByText('Select at least one linked season to build an athlete profile.');
+    expect(status.closest('[role="alert"]')?.getAttribute('aria-live')).toBe('assertive');
     expect(playerServiceMocks.saveParentAthleteProfileDraft).not.toHaveBeenCalled();
+  });
+
+  it('uses descriptive alt text for the player photo', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      player: {
+        ...buildDetailData().player,
+        photoUrl: 'https://cdn.example.test/player.jpg'
+      }
+    }));
+
+    renderPlayerDetail();
+
+    expect(await screen.findByAltText('Sam Player profile photo')).toBeTruthy();
   });
 
   it('preselects saved seasons from older profile shapes without seasonKey', async () => {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -199,7 +199,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
             <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
           <div className="flex h-11 w-11 flex-none items-center justify-center overflow-hidden rounded-2xl bg-primary-50 text-base font-black text-primary-700">
-            {data.player.photoUrl ? <img src={data.player.photoUrl} alt="" className="h-full w-full object-cover" /> : <span>{jersey || getInitials(playerName)}</span>}
+            {data.player.photoUrl ? <img src={data.player.photoUrl} alt={`${playerName} profile photo`} className="h-full w-full object-cover" /> : <span>{jersey || getInitials(playerName)}</span>}
           </div>
           <div className="min-w-0 flex-1">
             <div className="app-label">Player</div>
@@ -586,7 +586,7 @@ function StaffRosterDetailsCard({ data, auth, onChanged }: { data: ParentPlayerD
     <section className="app-card p-4">
       <div className="flex items-start gap-3">
         <div className="flex h-14 w-14 flex-none items-center justify-center overflow-hidden rounded-2xl bg-primary-50 text-sm font-black text-primary-700">
-          {previewUrl ? <img src={previewUrl} alt="" className="h-full w-full object-cover" /> : getInitials(name || data.child.playerName || 'Player')}
+          {previewUrl ? <img src={previewUrl} alt={`${name || data.child.playerName || 'Player'} roster photo preview`} className="h-full w-full object-cover" /> : getInitials(name || data.child.playerName || 'Player')}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 text-sm font-black text-gray-950">
@@ -681,7 +681,7 @@ function EditablePlayerProfileCard({ data, auth, onChanged }: { data: ParentPlay
     <section className="app-card p-4">
       <div className="flex items-start gap-3">
         <div className="flex h-14 w-14 flex-none items-center justify-center overflow-hidden rounded-2xl bg-primary-50 text-sm font-black text-primary-700">
-          {previewUrl ? <img src={previewUrl} alt="" className="h-full w-full object-cover" /> : getInitials(playerName)}
+          {previewUrl ? <img src={previewUrl} alt={`${playerName} profile photo preview`} className="h-full w-full object-cover" /> : getInitials(playerName)}
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 text-sm font-black text-gray-950">
@@ -1912,7 +1912,12 @@ function CardText({ title, detail }: { title: string; detail: string }) {
 function Status({ tone, message }: { tone: 'error' | 'success'; message: string }) {
   const isError = tone === 'error';
   return (
-    <div className={`flex items-start gap-2 rounded-xl border px-3 py-2 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
+    <div
+      className={`flex items-start gap-2 rounded-xl border px-3 py-2 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      aria-atomic="true"
+    >
       {isError ? <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />}
       {message}
     </div>

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -349,7 +349,33 @@ describe('TeamDetail', () => {
       }
     }));
     await waitFor(() => expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2));
-    expect(await screen.findByText('Alex New added to roster.')).toBeTruthy();
+    const status = await screen.findByText('Alex New added to roster.');
+    expect(status.closest('[role="status"]')?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('uses descriptive alt text for team and roster photos', async () => {
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      team: {
+        ...model.team,
+        photoUrl: 'https://cdn.example.test/team.jpg'
+      },
+      players: [
+        { ...model.players[0], photoUrl: 'https://cdn.example.test/player.jpg' }
+      ]
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByAltText('Bears team photo')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /roster/i }));
+    expect(await screen.findByAltText('Pat Star player photo')).toBeTruthy();
   });
 
   it('lets team staff manage tracking items and player statuses from the roster tab', async () => {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -408,7 +408,7 @@ function TeamHero({ model }: { model: TeamDetailModel }) {
     <section className="app-card overflow-hidden">
       <div className="relative h-32 bg-gray-950 sm:h-44">
         {team.photoUrl ? (
-          <img src={team.photoUrl} alt="" className="h-full w-full object-cover opacity-90" />
+          <img src={team.photoUrl} alt={`${team.name} team photo`} className="h-full w-full object-cover opacity-90" />
         ) : (
           <div className="flex h-full w-full items-center justify-center bg-[linear-gradient(135deg,#111827_0%,#4338ca_50%,#047857_100%)]">
             <span className="text-5xl font-black text-white">{getInitials(team.name)}</span>
@@ -664,7 +664,7 @@ function AddPlayerCard({ teamId, authUser, onCreated }: {
           </button>
         )}
       </div>
-      {status ? <div className={`mt-3 text-xs font-black ${status.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{status.message}</div> : null}
+      {status ? <div className={`mt-3 text-xs font-black ${status.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status" aria-live="polite" aria-atomic="true">{status.message}</div> : null}
       {open ? (
         <form className="mt-3 space-y-3" onSubmit={submit}>
           <label className="block">
@@ -880,7 +880,7 @@ function TrackingAdminCard({
           Show archived
         </label>
       </div>
-      {statusMessage ? <div className={`mt-3 text-xs font-black ${statusMessage.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{statusMessage.message}</div> : null}
+      {statusMessage ? <div className={`mt-3 text-xs font-black ${statusMessage.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status" aria-live="polite" aria-atomic="true">{statusMessage.message}</div> : null}
       <form className="mt-3 space-y-3 rounded-xl border border-white/80 bg-white p-3" onSubmit={submitItem}>
         <div className="text-sm font-black text-gray-950">{editingItemId ? 'Edit tracking item' : 'Add tracking item'}</div>
         <label className="block">
@@ -2453,7 +2453,7 @@ function InternalAction({ icon: Icon, label, detail, to }: { icon: LucideIcon; l
 function PlayerPhoto({ name, photoUrl, small = false }: { name: string; photoUrl?: string | null; small?: boolean }) {
   const sizeClass = small ? 'h-8 w-8 text-[10px]' : 'h-11 w-11 text-xs';
   if (photoUrl) {
-    return <img src={photoUrl} alt="" className={`${sizeClass} flex-none rounded-full object-cover ring-1 ring-gray-200`} loading="lazy" />;
+    return <img src={photoUrl} alt={`${name} player photo`} className={`${sizeClass} flex-none rounded-full object-cover ring-1 ring-gray-200`} loading="lazy" />;
   }
   return (
     <span className={`${sizeClass} flex flex-none items-center justify-center rounded-full bg-gray-900 font-black text-white`}>
@@ -2463,7 +2463,7 @@ function PlayerPhoto({ name, photoUrl, small = false }: { name: string; photoUrl
 }
 
 function SponsorImage({ sponsor }: { sponsor: { name: string; imageUrl: string | null } }) {
-  if (sponsor.imageUrl) return <img src={sponsor.imageUrl} alt="" className="h-12 w-12 flex-none rounded-xl object-cover" loading="lazy" />;
+  if (sponsor.imageUrl) return <img src={sponsor.imageUrl} alt={`${sponsor.name} sponsor logo`} className="h-12 w-12 flex-none rounded-xl object-cover" loading="lazy" />;
   return (
     <span className="flex h-12 w-12 flex-none items-center justify-center rounded-xl bg-white text-gray-500">
       <LinkIcon className="h-5 w-5" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- Add an AppShell notification status live region so unread state changes are announced.
- Give informative player, team, and sponsor images descriptive alt text on detail pages.
- Add live/assertive semantics to PlayerDetail status messages and key TeamDetail roster/tracking status updates.

Fixes #2072.

## Validation
- npx vitest run apps/app/src/components/AppShell.test.tsx --reporter=verbose
- npx vitest run apps/app/src/pages/PlayerDetail.test.tsx --reporter=verbose
- npx vitest run apps/app/src/pages/TeamDetail.test.tsx --reporter=verbose
- npm run app:build

## Notes
- AppShell Vitest still prints existing Firebase source-map/runtime-config warnings; the focused test suite passed.