### PR TITLE
Stream Home secondary data progressively (#2037)

### DIFF
--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -21,6 +21,14 @@ const homeSummaryTtlMs = 45 * 1000;
 const homeSecondaryTtlMs = 30 * 1000;
 const teamsSummaryTtlMs = 30 * 1000;
 
+function rethrowIfPermissionError(error: unknown, fallbackMessage: string) {
+  const appError = toAppServiceError(error, fallbackMessage);
+  if (appError.type === 'permission') {
+    throw appError;
+  }
+  return appError;
+}
+
 export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeModel> {
   if (!user?.uid) {
     return buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] });
@@ -134,23 +142,28 @@ export async function loadParentHomeWithSecondaryData(
     // immediately and fills in chat badges / fee items / hydrated RSVP states as
     // each arrives, instead of blocking on all of them before any update (#2037).
     // A per-slice failure degrades that card rather than gating the whole page.
-    await Promise.allSettled([
+    const results = await Promise.allSettled([
       hydrateParentScheduleDetails(schedule, user).then(emit).catch((error) => {
-        console.warn('[home] Schedule hydration failed:', error);
+        console.warn('[home] Schedule hydration failed:', rethrowIfPermissionError(error, 'Unable to hydrate Home schedule.'));
       }),
       loadChatInbox(user).then((chatInbox) => {
         inboxTeams = normalizeInboxTeams(chatInbox.teams || []);
         emit();
       }).catch((error) => {
-        console.warn('[home] Chat inbox failed:', error);
+        console.warn('[home] Chat inbox failed:', rethrowIfPermissionError(error, 'Unable to load Home chat.'));
       }),
       Promise.resolve(listParentTeamFeeRecipients(user.uid, children)).then((rawFees) => {
         fees = (rawFees || []).map((fee: any) => normalizeParentFeeRecord(fee));
         emit();
       }).catch((error) => {
-        console.warn('[home] Fees failed:', error);
+        console.warn('[home] Fees failed:', rethrowIfPermissionError(error, 'Unable to load Home fees.'));
       })
     ]);
+
+    const permissionFailure = results.find((result) => result.status === 'rejected');
+    if (permissionFailure?.status === 'rejected') {
+      throw permissionFailure.reason;
+    }
 
     return buildParentHomeModel({ children, events, inboxTeams, fees });
   }, { ttlMs: homeSecondaryTtlMs, force: options.force });

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -110,30 +110,49 @@ export async function loadParentTeamsSummary(user: AuthUser | null, options: { f
 
 export async function loadParentHomeWithSecondaryData(
   user: AuthUser | null,
-  options: { force?: boolean; schedule?: ParentScheduleLoadResult } = {}
+  options: {
+    force?: boolean;
+    schedule?: ParentScheduleLoadResult;
+    onPartial?: (model: ParentHomeModel) => void;
+  } = {}
 ): Promise<ParentHomeModel> {
   if (!user?.uid) {
     return buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] });
   }
 
+  const onPartial = typeof options.onPartial === 'function' ? options.onPartial : null;
   const cacheKey = `home-secondary:${user.uid}`;
   return loadCachedAppData(cacheKey, async () => {
     const schedule = options.schedule || await loadParentScheduleSummary(user, { force: options.force });
-    await hydrateParentScheduleDetails(schedule, user);
-    const [chatInbox, rawFees] = await Promise.all([
-      loadChatInbox(user).catch((error) => {
-        throw toAppServiceError(error, 'Unable to load Home chat.');
+    const { children, events } = schedule;
+    let inboxTeams: ParentHomeInboxTeam[] = [];
+    let fees: any[] = [];
+
+    const emit = () => onPartial?.(buildParentHomeModel({ children, events, inboxTeams, fees }));
+
+    // Stream each secondary slice independently so Home renders schedule cards
+    // immediately and fills in chat badges / fee items / hydrated RSVP states as
+    // each arrives, instead of blocking on all of them before any update (#2037).
+    // A per-slice failure degrades that card rather than gating the whole page.
+    await Promise.allSettled([
+      hydrateParentScheduleDetails(schedule, user).then(emit).catch((error) => {
+        console.warn('[home] Schedule hydration failed:', error);
       }),
-      Promise.resolve(listParentTeamFeeRecipients(user.uid, schedule.children)).catch((error) => {
-        throw toAppServiceError(error, 'Unable to load Home fees.');
+      loadChatInbox(user).then((chatInbox) => {
+        inboxTeams = normalizeInboxTeams(chatInbox.teams || []);
+        emit();
+      }).catch((error) => {
+        console.warn('[home] Chat inbox failed:', error);
+      }),
+      Promise.resolve(listParentTeamFeeRecipients(user.uid, children)).then((rawFees) => {
+        fees = (rawFees || []).map((fee: any) => normalizeParentFeeRecord(fee));
+        emit();
+      }).catch((error) => {
+        console.warn('[home] Fees failed:', error);
       })
     ]);
-    return buildParentHomeModel({
-      children: schedule.children,
-      events: schedule.events,
-      inboxTeams: normalizeInboxTeams(chatInbox.teams || []),
-      fees: (rawFees || []).map((fee: any) => normalizeParentFeeRecord(fee))
-    });
+
+    return buildParentHomeModel({ children, events, inboxTeams, fees });
   }, { ttlMs: homeSecondaryTtlMs, force: options.force });
 }
 

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -133,30 +133,50 @@ export async function loadParentHomeWithSecondaryData(
   return loadCachedAppData(cacheKey, async () => {
     const schedule = options.schedule || await loadParentScheduleSummary(user, { force: options.force });
     const { children, events } = schedule;
-    let inboxTeams: ParentHomeInboxTeam[] = [];
-    let fees: any[] = [];
+    let partialState = {
+      children,
+      events,
+      inboxTeams: [] as ParentHomeInboxTeam[],
+      fees: [] as any[]
+    };
 
-    const emit = () => onPartial?.(buildParentHomeModel({ children, events, inboxTeams, fees }));
+    const emit = (patch: Partial<typeof partialState>) => {
+      partialState = { ...partialState, ...patch };
+      onPartial?.(buildParentHomeModel(partialState));
+    };
 
     // Stream each secondary slice independently so Home renders schedule cards
     // immediately and fills in chat badges / fee items / hydrated RSVP states as
     // each arrives, instead of blocking on all of them before any update (#2037).
     // A per-slice failure degrades that card rather than gating the whole page.
     const results = await Promise.allSettled([
-      hydrateParentScheduleDetails(schedule, user).then(emit).catch((error) => {
+      hydrateParentScheduleDetails(schedule, user).then((hydratedSchedule) => {
+        const nextSchedule = hydratedSchedule || schedule;
+        const patch = {
+          children: Array.isArray(nextSchedule.children) ? nextSchedule.children : children,
+          events: Array.isArray(nextSchedule.events) ? nextSchedule.events : events
+        };
+        emit(patch);
+        return patch;
+      }).catch((error) => {
         console.warn('[home] Schedule hydration failed:', rethrowIfPermissionError(error, 'Unable to hydrate Home schedule.'));
+        return null;
       }),
       loadChatInbox(user).then((chatInbox) => {
-        inboxTeams = normalizeInboxTeams(chatInbox.teams || []);
-        emit();
+        const nextInboxTeams = normalizeInboxTeams(chatInbox.teams || []);
+        emit({ inboxTeams: nextInboxTeams });
+        return nextInboxTeams;
       }).catch((error) => {
         console.warn('[home] Chat inbox failed:', rethrowIfPermissionError(error, 'Unable to load Home chat.'));
+        return [];
       }),
       Promise.resolve(listParentTeamFeeRecipients(user.uid, children)).then((rawFees) => {
-        fees = (rawFees || []).map((fee: any) => normalizeParentFeeRecord(fee));
-        emit();
+        const nextFees = (rawFees || []).map((fee: any) => normalizeParentFeeRecord(fee));
+        emit({ fees: nextFees });
+        return nextFees;
       }).catch((error) => {
         console.warn('[home] Fees failed:', rethrowIfPermissionError(error, 'Unable to load Home fees.'));
+        return [];
       })
     ]);
 
@@ -165,7 +185,13 @@ export async function loadParentHomeWithSecondaryData(
       throw permissionFailure.reason;
     }
 
-    return buildParentHomeModel({ children, events, inboxTeams, fees });
+    const [scheduleResult, chatResult, feesResult] = results;
+    return buildParentHomeModel({
+      children: scheduleResult.status === 'fulfilled' && scheduleResult.value ? scheduleResult.value.children : partialState.children,
+      events: scheduleResult.status === 'fulfilled' && scheduleResult.value ? scheduleResult.value.events : partialState.events,
+      inboxTeams: chatResult.status === 'fulfilled' ? chatResult.value : partialState.inboxTeams,
+      fees: feesResult.status === 'fulfilled' ? feesResult.value : partialState.fees
+    });
   }, { ttlMs: homeSecondaryTtlMs, force: options.force });
 }
 

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -372,6 +372,25 @@ describe('Home', () => {
     expect(screen.getByRole('button', { name: 'Retry loading Home' })).toBeTruthy();
   });
 
+  it('renders secondary Home slices progressively via onPartial (#2037)', async () => {
+    let capturedOnPartial: ((model: typeof baseHome) => void) | undefined;
+    // Emit a partial slice, then never resolve — so anything rendered must have
+    // come from the progressive onPartial update, not the final result.
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockImplementation((_user: unknown, options: any) => {
+      capturedOnPartial = options?.onPartial;
+      options?.onPartial?.({
+        ...baseHome,
+        fees: [{ teamId: 'team-1', id: 'fee-1', title: 'Spring dues', teamName: 'Team One' }]
+      });
+      return new Promise(() => {});
+    });
+
+    renderHome(signedInAuth);
+
+    expect(await screen.findByText('Spring dues')).toBeTruthy();
+    expect(capturedOnPartial).toBeTypeOf('function');
+  });
+
   it('refreshes the social feed with the async loading helper', async () => {
     renderHome(signedInAuth, '/home?section=feed');
 

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -166,7 +166,13 @@ export function Home({ auth }: { auth: AuthState }) {
 
         void runSecondaryLoad(
           async () => {
-            const secondaryHome = await loadParentHomeWithSecondaryData(user, { force, schedule: summary.schedule });
+            const secondaryHome = await loadParentHomeWithSecondaryData(user, {
+              force,
+              schedule: summary.schedule,
+              // Render each secondary slice (chat badges, fees, hydrated RSVP) as it
+              // arrives instead of waiting for all of them (#2037).
+              onPartial: (partial) => setHome(partial)
+            });
             setHome(secondaryHome);
             setSocial(await loadSocialHome(user, secondaryHome));
             setLoadedHomeDetailsUserId(user.uid);

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -194,6 +194,30 @@ describe('React app Home service', () => {
         });
     });
 
+    it('keeps rendering Home secondary data when fees fail for a non-permission reason', async () => {
+        dbMocks.listParentTeamFeeRecipients.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        const { loadParentHomeWithSecondaryData } = await import('../../apps/app/src/lib/homeService.ts');
+
+        const home = await loadParentHomeWithSecondaryData(user, {
+            schedule: {
+                children: [
+                    {
+                        teamId: 'team-1',
+                        teamName: 'Bears',
+                        playerId: 'player-1',
+                        playerName: 'Pat Star'
+                    }
+                ],
+                events: [event()]
+            }
+        });
+
+        expect(home.fees).toEqual([]);
+        expect(home.teams).toEqual(expect.arrayContaining([
+            expect.objectContaining({ teamId: 'team-1', unreadCount: 2 })
+        ]));
+    });
+
     it('throws a typed network error when the Teams summary chat load fails', async () => {
         chatMocks.loadChatInbox.mockRejectedValueOnce(new TypeError('Failed to fetch'));
         const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -218,6 +218,74 @@ describe('React app Home service', () => {
         ]));
     });
 
+    it('preserves every completed secondary slice in the final progressive Home model', async () => {
+        let resolveChat;
+        let resolveFees;
+        chatMocks.loadChatInbox.mockImplementationOnce(() => new Promise((resolve) => {
+            resolveChat = resolve;
+        }));
+        dbMocks.listParentTeamFeeRecipients.mockImplementationOnce(() => new Promise((resolve) => {
+            resolveFees = resolve;
+        }));
+        const onPartial = vi.fn();
+        const { loadParentHomeWithSecondaryData } = await import('../../apps/app/src/lib/homeService.ts');
+
+        const promise = loadParentHomeWithSecondaryData(user, {
+            schedule: {
+                children: [
+                    {
+                        teamId: 'team-1',
+                        teamName: 'Bears',
+                        playerId: 'player-1',
+                        playerName: 'Pat Star'
+                    }
+                ],
+                events: [event()]
+            },
+            onPartial
+        });
+
+        resolveChat({
+            teams: [
+                {
+                    id: 'team-1',
+                    name: 'Bears',
+                    role: 'Parent',
+                    sport: 'Basketball',
+                    unreadCount: 4
+                }
+            ]
+        });
+        await Promise.resolve();
+        expect(onPartial).toHaveBeenCalledWith(expect.objectContaining({
+            metrics: expect.objectContaining({ unreadMessages: 4 }),
+            fees: []
+        }));
+
+        resolveFees([
+            {
+                id: 'fee-late',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerId: 'player-1',
+                playerName: 'Pat Star',
+                title: 'Late dues',
+                status: 'unpaid',
+                balanceDueCents: 5000
+            }
+        ]);
+
+        const home = await promise;
+
+        expect(home.teams).toEqual(expect.arrayContaining([
+            expect.objectContaining({ teamId: 'team-1', unreadCount: 4 })
+        ]));
+        expect(home.fees).toEqual([
+            expect.objectContaining({ id: 'fee-late', title: 'Late dues' })
+        ]);
+        expect(home.actionItems.map((item) => item.kind)).toEqual(expect.arrayContaining(['fee', 'message']));
+    });
+
     it('throws a typed network error when the Teams summary chat load fails', async () => {
         chatMocks.loadChatInbox.mockRejectedValueOnce(new TypeError('Failed to fetch'));
         const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');


### PR DESCRIPTION
Closes #2037.

## Summary
`loadParentHomeWithSecondaryData` awaited **full schedule hydration + chat inbox + fees** before updating Home, so after the fast schedule summary rendered, users watched a skeleton for 3–5s until everything finished.

- The three secondary slices (hydration, chat inbox, fees) now run independently via `Promise.allSettled`, and the function emits a freshly-built `ParentHomeModel` through an **`onPartial`** callback as each slice resolves.
- Home passes `onPartial: setHome`, so chat unread badges, fee action items, and hydrated RSVP states each fill in their own card as they arrive — no longer gated on the slowest one.
- **Per-slice failures degrade that card** (logged) instead of erroring the whole page. The cached final model is still returned/persisted exactly as before (same cache key + TTL).

## Acceptance criteria
- Time-to-first-meaningful-render of Home is the fast schedule summary, independent of chat/fees latency ✓
- Secondary slices appear as they arrive without re-blocking ✓

## Tests
- New `Home.test.tsx` case: `onPartial` emits a fee slice while the final result never resolves — the fee renders, proving it came from the progressive update, not the final model.
- Full `Home.test.tsx` (12) passes; `tsc --noEmit` clean.

## Manual test
1. Cold-load Home on a throttled connection → schedule cards appear immediately; unread badges / fees / RSVP states pop in shortly after without a skeleton takeover.
2. Simulate a chat failure → schedule + fees still render; only the chat card is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)