### PR TITLE
[codex] Configure Capacitor native launch polish

### DIFF
--- a/.well-known/apple-app-site-association
+++ b/.well-known/apple-app-site-association
@@ -1,0 +1,18 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": [
+          "REPLACE_WITH_APPLE_TEAM_ID.ai.allplays.lite"
+        ],
+        "components": [
+          {
+            "/": "/app*",
+            "comment": "Route all hosted React app links into the native ALL PLAYS app."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "ai.allplays.lite",
+      "sha256_cert_fingerprints": [
+        "REPLACE_WITH_RELEASE_CERT_SHA256_FINGERPRINT"
+      ]
+    }
+  }
+]

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation project(':capacitor-camera')
     implementation project(':capacitor-filesystem')
     implementation project(':capacitor-share')
+    implementation project(':capacitor-splash-screen')
+    implementation project(':capacitor-status-bar')
     implementation project(':capgo-capacitor-speech-recognition')
 
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,24 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="allplays.ai"
+                    android:pathPrefix="/app" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="@string/custom_url_scheme" />
+                <data android:scheme="allplays" />
+            </intent-filter>
+
         </activity>
 
         <provider

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -23,5 +23,11 @@ project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacit
 include ':capacitor-share'
 project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/share/android')
 
+include ':capacitor-splash-screen'
+project(':capacitor-splash-screen').projectDir = new File('../node_modules/@capacitor/splash-screen/android')
+
+include ':capacitor-status-bar'
+project(':capacitor-status-bar').projectDir = new File('../node_modules/@capacitor/status-bar/android')
+
 include ':capgo-capacitor-speech-recognition'
 project(':capgo-capacitor-speech-recognition').projectDir = new File('../node_modules/@capgo/capacitor-speech-recognition/android')

--- a/apps/app/package-lock.json
+++ b/apps/app/package-lock.json
@@ -16,6 +16,8 @@
         "@capacitor/core": "^8.3.4",
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/share": "^8.0.1",
+        "@capacitor/splash-screen": "^8.0.1",
+        "@capacitor/status-bar": "^8.0.2",
         "@capawesome/capacitor-badge": "^8.0.2",
         "@capgo/capacitor-speech-recognition": "^8.1.3",
         "@sentry/browser": "^10.58.0",
@@ -530,6 +532,24 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
       "integrity": "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/splash-screen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-8.0.1.tgz",
+      "integrity": "sha512-c/ew/Z3eA7z8l06WoRAtzVF16VwYYrExmHmfGq1Cg675pVzaC/yuucB8/1xG1vhEfnW4fZ1KhSf/kzR1RiVYgg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.2.tgz",
+      "integrity": "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -23,6 +23,8 @@
     "@capacitor/core": "^8.3.4",
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/share": "^8.0.1",
+    "@capacitor/splash-screen": "^8.0.1",
+    "@capacitor/status-bar": "^8.0.2",
     "@capawesome/capacitor-badge": "^8.0.2",
     "@capgo/capacitor-speech-recognition": "^8.1.3",
     "@sentry/browser": "^10.58.0",

--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -32,13 +32,18 @@ const authMock = vi.hoisted(() => {
 const nativeBackMock = vi.hoisted(() => {
   const state = {
     listeners: [] as Array<(event: { canGoBack: boolean }) => void>,
+    urlOpenListeners: [] as Array<(event: { url: string }) => void>,
     exitApp: vi.fn(),
     remove: vi.fn()
   };
   return {
     ...state,
-    addListener: vi.fn(async (_eventName: 'backButton', listener: (event: { canGoBack: boolean }) => void) => {
-      state.listeners.push(listener);
+    addListener: vi.fn(async (eventName: 'appUrlOpen' | 'backButton', listener: ((event: { canGoBack: boolean }) => void) | ((event: { url: string }) => void)) => {
+      if (eventName === 'appUrlOpen') {
+        state.urlOpenListeners.push(listener as (event: { url: string }) => void);
+      } else {
+        state.listeners.push(listener as (event: { canGoBack: boolean }) => void);
+      }
       return { remove: state.remove };
     })
   };
@@ -136,6 +141,7 @@ describe('App protected route loading', () => {
     authMock.state = { ...authMock.signedInAuth, refresh: vi.fn(), signOut: vi.fn() };
     window.localStorage.clear();
     nativeBackMock.listeners.length = 0;
+    nativeBackMock.urlOpenListeners.length = 0;
     nativeBackMock.addListener.mockClear();
     nativeBackMock.exitApp.mockClear();
     nativeBackMock.remove.mockClear();
@@ -143,6 +149,7 @@ describe('App protected route loading', () => {
   });
 
   afterEach(() => {
+    cleanup();
     consoleErrorSpy?.mockRestore();
     consoleErrorSpy = null;
   });
@@ -251,6 +258,22 @@ describe('App protected route loading', () => {
 
     await act(async () => {
       nativeBackMock.listeners[0]({ canGoBack: true });
+    });
+
+    expect(await screen.findByText('Schedule page')).toBeTruthy();
+  });
+
+  it('routes native app links into the React app router', async () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(nativeBackMock.urlOpenListeners).toHaveLength(1));
+
+    await act(async () => {
+      nativeBackMock.urlOpenListeners[0]({ url: 'https://allplays.ai/app/schedule?range=week' });
     });
 
     expect(await screen.findByText('Schedule page')).toBeTruthy();

--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -59,7 +59,8 @@ vi.mock('@capacitor/app', () => ({
 vi.mock('@capacitor/core', () => ({
   Capacitor: {
     isNativePlatform: () => true,
-    isPluginAvailable: () => true
+    isPluginAvailable: () => true,
+    getPlatform: () => 'ios'
   }
 }));
 

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -12,6 +12,7 @@ import {
   nativeBackExitPressWindowMs,
   type NativeBackButtonEvent
 } from './lib/nativeBackButton';
+import { addNativeDeepLinkListener } from './lib/nativeDeepLinkRouting';
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { shouldReloadTeamsToHome } from './lib/reloadRouting';
 import { readAuthBootstrapHint } from './lib/authBootstrapHint';
@@ -128,6 +129,24 @@ export default function App() {
     }
 
     registerBackButtonListener();
+    return () => {
+      disposed = true;
+      removeListener();
+    };
+  }, [navigate]);
+
+  useEffect(() => {
+    let removeListener = () => {};
+    let disposed = false;
+
+    async function registerDeepLinkListener() {
+      removeListener = await addNativeDeepLinkListener((route) => {
+        navigate(route);
+      });
+      if (disposed) removeListener();
+    }
+
+    registerDeepLinkListener();
     return () => {
       disposed = true;
       removeListener();

--- a/apps/app/src/lib/nativeAppearance.ts
+++ b/apps/app/src/lib/nativeAppearance.ts
@@ -1,0 +1,33 @@
+import { Capacitor } from '@capacitor/core';
+
+export async function initializeNativeAppearance() {
+  if (!isNativeRuntime()) {
+    return;
+  }
+
+  try {
+    const { StatusBar, Style } = await import('@capacitor/status-bar');
+    await StatusBar.setOverlaysWebView({ overlay: false });
+    await StatusBar.setStyle({ style: Style.Dark });
+    await StatusBar.setBackgroundColor({ color: '#ffffff' });
+  } catch (error) {
+    console.warn('[native] Unable to configure status bar.', error);
+  }
+}
+
+export async function hideNativeSplashScreen() {
+  if (!isNativeRuntime()) {
+    return;
+  }
+
+  try {
+    const { SplashScreen } = await import('@capacitor/splash-screen');
+    await SplashScreen.hide({ fadeOutDuration: 150 });
+  } catch (error) {
+    console.warn('[native] Unable to hide splash screen.', error);
+  }
+}
+
+function isNativeRuntime() {
+  return Capacitor.isNativePlatform() || (typeof window !== 'undefined' && window.location.protocol === 'capacitor:');
+}

--- a/apps/app/src/lib/nativeAppearance.ts
+++ b/apps/app/src/lib/nativeAppearance.ts
@@ -8,7 +8,7 @@ export async function initializeNativeAppearance() {
   try {
     const { StatusBar, Style } = await import('@capacitor/status-bar');
     await StatusBar.setOverlaysWebView({ overlay: false });
-    await StatusBar.setStyle({ style: Style.Dark });
+    await StatusBar.setStyle({ style: Style.Light });
     await StatusBar.setBackgroundColor({ color: '#ffffff' });
   } catch (error) {
     console.warn('[native] Unable to configure status bar.', error);

--- a/apps/app/src/lib/nativeDeepLinkRouting.ts
+++ b/apps/app/src/lib/nativeDeepLinkRouting.ts
@@ -1,0 +1,90 @@
+import { App as CapacitorApp } from '@capacitor/app';
+import { Capacitor } from '@capacitor/core';
+
+type NativeDeepLinkEvent = {
+  url?: string | null;
+};
+
+type NativeDeepLinkPlugin = {
+  addListener: (eventName: 'appUrlOpen', listener: (event: NativeDeepLinkEvent) => void) => Promise<{ remove: () => Promise<void> | void }>;
+};
+
+type NativeDeepLinkDeps = {
+  appPlugin?: NativeDeepLinkPlugin;
+  isNativePlatform?: () => boolean;
+  isPluginAvailable?: (pluginName: string) => boolean;
+};
+
+const appHosts = new Set(['allplays.ai', 'www.allplays.ai']);
+const appPathPrefix = '/app';
+const customSchemes = new Set(['allplays', 'ai.allplays.lite']);
+
+export async function addNativeDeepLinkListener(onRoute: (route: string) => void, deps: NativeDeepLinkDeps = {}) {
+  const isNativePlatform = deps.isNativePlatform || (() => Capacitor.isNativePlatform());
+  const isPluginAvailable = deps.isPluginAvailable || ((pluginName: string) => (Capacitor as any).isPluginAvailable?.(pluginName) !== false);
+  if (!isNativePlatform() || !isPluginAvailable('App')) return () => {};
+
+  const plugin = deps.appPlugin || (CapacitorApp as NativeDeepLinkPlugin);
+  const handle = await plugin.addListener('appUrlOpen', (event) => {
+    const route = resolveNativeDeepLinkRoute(event.url);
+    if (route) onRoute(route);
+  });
+
+  return () => {
+    void handle.remove();
+  };
+}
+
+export function resolveNativeDeepLinkRoute(url: unknown) {
+  const rawUrl = String(url || '').trim();
+  if (!rawUrl) return null;
+
+  try {
+    const parsedUrl = new URL(rawUrl);
+    if ((parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:') && appHosts.has(parsedUrl.hostname)) {
+      return getRouteFromWebAppUrl(parsedUrl);
+    }
+
+    const scheme = parsedUrl.protocol.replace(/:$/, '');
+    if (customSchemes.has(scheme)) {
+      return getRouteFromCustomSchemeUrl(parsedUrl);
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function getRouteFromWebAppUrl(url: URL) {
+  if (url.pathname !== appPathPrefix && !url.pathname.startsWith(`${appPathPrefix}/`)) {
+    return null;
+  }
+
+  const hashRoute = getRouteFromHash(url.hash);
+  if (hashRoute) return hashRoute;
+
+  const pathWithoutAppPrefix = url.pathname === appPathPrefix ? '/' : `/${url.pathname.slice(appPathPrefix.length + 1)}`;
+  return normalizeRoute(`${pathWithoutAppPrefix}${url.search}`);
+}
+
+function getRouteFromCustomSchemeUrl(url: URL) {
+  const hashRoute = getRouteFromHash(url.hash);
+  if (hashRoute) return hashRoute;
+
+  const hostPath = url.hostname && url.hostname !== 'app' ? `/${url.hostname}` : '';
+  return normalizeRoute(`${hostPath}${url.pathname || ''}${url.search}`);
+}
+
+function getRouteFromHash(hash: string) {
+  if (!hash.startsWith('#/')) return null;
+  return normalizeRoute(hash.slice(1));
+}
+
+function normalizeRoute(route: string) {
+  const trimmed = String(route || '').trim();
+  if (!trimmed) return '/';
+  const routeWithSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+  if (routeWithSlash.startsWith('//')) return null;
+  return routeWithSlash;
+}

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -9,10 +9,12 @@ import {
   installReactErrorTelemetry,
   startAppStartupTimer
 } from './lib/telemetry';
+import { hideNativeSplashScreen, initializeNativeAppearance } from './lib/nativeAppearance';
 import './styles/index.css';
 
 initializeAppErrorTracking();
 installReactErrorTelemetry();
+void initializeNativeAppearance();
 const startupTimer = startAppStartupTimer();
 
 try {
@@ -30,6 +32,7 @@ try {
     : (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 0);
   scheduleRenderTiming(() => {
     startupTimer.end({ phase: 'initial-render' });
+    void hideNativeSplashScreen();
   });
 } catch (error) {
   captureAppStartupFailure(error, { phase: 'initial-render' });

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -15,6 +15,18 @@ import {
 import { getValidatedInviteCode, normalizeInviteCode, redeemSignedInInvite } from '../lib/inviteRedemption';
 import type { AuthState } from '../lib/types';
 
+function readEmailForSignIn() {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  try {
+    return window.localStorage.getItem('emailForSignIn') || '';
+  } catch {
+    return '';
+  }
+}
+
 export function AcceptInvite({ auth }: { auth: AuthState }) {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -23,7 +35,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
   const code = urlCode || pendingInvite.code.trim().toUpperCase();
   const inviteType = (searchParams.get('type') || pendingInvite.type || 'parent').trim().toLowerCase();
   const [manualCode, setManualCode] = useState(code);
-  const [email, setEmail] = useState(window.localStorage.getItem('emailForSignIn') || '');
+  const [email, setEmail] = useState(readEmailForSignIn);
   const [state, setState] = useState<'idle' | 'processing' | 'email-link' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
   const [pendingRedirectPath, setPendingRedirectPath] = useState('');

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -8,6 +8,21 @@
       "providers": [
         "google.com"
       ]
+    },
+    "SplashScreen": {
+      "launchAutoHide": false,
+      "launchShowDuration": 0,
+      "backgroundColor": "#f6f8fb",
+      "androidSplashResourceName": "splash",
+      "androidScaleType": "CENTER_CROP",
+      "showSpinner": false,
+      "splashFullScreen": false,
+      "splashImmersive": false
+    },
+    "StatusBar": {
+      "style": "DARK",
+      "backgroundColor": "#ffffff",
+      "overlaysWebView": false
     }
   },
   "server": {

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -20,7 +20,7 @@
       "splashImmersive": false
     },
     "StatusBar": {
-      "style": "DARK",
+      "style": "LIGHT",
       "backgroundColor": "#ffffff",
       "overlaysWebView": false
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -3574,7 +3574,8 @@ function formatPracticePacketDueDate(value) {
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
-    year: 'numeric'
+    year: 'numeric',
+    timeZone: 'UTC'
   });
 }
 

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:allplays.ai</string>
+	</array>
 	<key>aps-environment</key>
 	<string>development</string>
 	<key>keychain-access-groups</key>

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -28,6 +28,8 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>com.googleusercontent.apps.982493478258-94otj8a8ptke1avfdtviugsrj4nfgedg</string>
+				<string>allplays</string>
+				<string>ai.allplays.lite</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -19,6 +19,8 @@ let package = Package(
         .package(name: "CapacitorCamera", path: "../../../node_modules/@capacitor/camera"),
         .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
         .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
+        .package(name: "CapacitorSplashScreen", path: "../../../node_modules/@capacitor/splash-screen"),
+        .package(name: "CapacitorStatusBar", path: "../../../node_modules/@capacitor/status-bar"),
         .package(name: "CapgoCapacitorSpeechRecognition", path: "../../../node_modules/@capgo/capacitor-speech-recognition")
     ],
     targets: [
@@ -34,6 +36,8 @@ let package = Package(
                 .product(name: "CapacitorCamera", package: "CapacitorCamera"),
                 .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
+                .product(name: "CapacitorSplashScreen", package: "CapacitorSplashScreen"),
+                .product(name: "CapacitorStatusBar", package: "CapacitorStatusBar"),
                 .product(name: "CapgoCapacitorSpeechRecognition", package: "CapgoCapacitorSpeechRecognition")
             ]
         )

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/ios": "^8.3.4",
         "@capacitor/share": "^8.0.1",
+        "@capacitor/splash-screen": "^8.0.1",
+        "@capacitor/status-bar": "^8.0.2",
         "@capgo/capacitor-speech-recognition": "^8.1.3",
         "firebase": "^12.13.0",
         "html-to-image": "^1.11.13",
@@ -280,6 +282,24 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
       "integrity": "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/splash-screen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-8.0.1.tgz",
+      "integrity": "sha512-c/ew/Z3eA7z8l06WoRAtzVF16VwYYrExmHmfGq1Cg675pVzaC/yuucB8/1xG1vhEfnW4fZ1KhSf/kzR1RiVYgg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.2.tgz",
+      "integrity": "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/ios": "^8.3.4",
     "@capacitor/share": "^8.0.1",
+    "@capacitor/splash-screen": "^8.0.1",
+    "@capacitor/status-bar": "^8.0.2",
     "@capgo/capacitor-speech-recognition": "^8.1.3",
     "firebase": "^12.13.0",
     "html-to-image": "^1.11.13",

--- a/scripts/stage-pages-bundle.mjs
+++ b/scripts/stage-pages-bundle.mjs
@@ -48,7 +48,7 @@ function shouldExclude(rootDir, sourcePath, entry) {
     const relativePath = toRelativePath(rootDir, sourcePath);
     const parts = relativePath.split('/').filter(Boolean);
 
-    if (entry.name.startsWith('.')) {
+    if (entry.name.startsWith('.') && parts[0] !== '.well-known') {
         return true;
     }
 

--- a/tests/unit/app-capacitor-native-config.test.js
+++ b/tests/unit/app-capacitor-native-config.test.js
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readProjectFile(path) {
+    return readFileSync(path, 'utf8');
+}
+
+describe('Capacitor native config', () => {
+    it('declares splash screen and status bar plugins in app and native manifests', () => {
+        const config = JSON.parse(readProjectFile('capacitor.config.json'));
+        const rootPackage = JSON.parse(readProjectFile('package.json'));
+        const appPackage = JSON.parse(readProjectFile('apps/app/package.json'));
+        const rootPackageLock = readProjectFile('package-lock.json');
+        const appPackageLock = readProjectFile('apps/app/package-lock.json');
+        const androidSettings = readProjectFile('android/capacitor.settings.gradle');
+        const androidBuild = readProjectFile('android/app/capacitor.build.gradle');
+        const iosPackage = readProjectFile('ios/App/CapApp-SPM/Package.swift');
+
+        expect(rootPackage.dependencies['@capacitor/splash-screen']).toBeTruthy();
+        expect(rootPackage.dependencies['@capacitor/status-bar']).toBeTruthy();
+        expect(appPackage.dependencies['@capacitor/splash-screen']).toBeTruthy();
+        expect(appPackage.dependencies['@capacitor/status-bar']).toBeTruthy();
+        expect(rootPackageLock).toContain('"node_modules/@capacitor/splash-screen"');
+        expect(rootPackageLock).toContain('"node_modules/@capacitor/status-bar"');
+        expect(appPackageLock).toContain('"node_modules/@capacitor/splash-screen"');
+        expect(appPackageLock).toContain('"node_modules/@capacitor/status-bar"');
+
+        expect(config.plugins.SplashScreen).toMatchObject({
+            launchAutoHide: false,
+            backgroundColor: '#f6f8fb',
+            showSpinner: false
+        });
+        expect(config.plugins.StatusBar).toMatchObject({
+            style: 'DARK',
+            backgroundColor: '#ffffff',
+            overlaysWebView: false
+        });
+
+        expect(androidSettings).toContain("include ':capacitor-splash-screen'");
+        expect(androidSettings).toContain("include ':capacitor-status-bar'");
+        expect(androidBuild).toContain("implementation project(':capacitor-splash-screen')");
+        expect(androidBuild).toContain("implementation project(':capacitor-status-bar')");
+        expect(iosPackage).toContain('CapacitorSplashScreen');
+        expect(iosPackage).toContain('CapacitorStatusBar');
+    });
+
+    it('wires first paint splash hiding and status bar setup into the app bootstrap', () => {
+        const main = readProjectFile('apps/app/src/main.tsx');
+        const nativeAppearance = readProjectFile('apps/app/src/lib/nativeAppearance.ts');
+
+        expect(main).toContain('initializeNativeAppearance');
+        expect(main).toContain('hideNativeSplashScreen');
+        expect(nativeAppearance).toContain("import('@capacitor/status-bar')");
+        expect(nativeAppearance).toContain("import('@capacitor/splash-screen')");
+        expect(nativeAppearance).toContain('StatusBar.setOverlaysWebView({ overlay: false })');
+        expect(nativeAppearance).toContain('SplashScreen.hide({ fadeOutDuration: 150 })');
+    });
+
+    it('keeps safe-area CSS and native deep-link declarations in place', () => {
+        const appCss = readProjectFile('apps/app/src/styles/index.css');
+        const androidManifest = readProjectFile('android/app/src/main/AndroidManifest.xml');
+        const iosInfo = readProjectFile('ios/App/App/Info.plist');
+        const iosEntitlements = readProjectFile('ios/App/App/App.entitlements');
+
+        expect(appCss).toContain('env(safe-area-inset-top)');
+        expect(appCss).toContain('env(safe-area-inset-bottom)');
+        expect(androidManifest).toContain('android:autoVerify="true"');
+        expect(androidManifest).toContain('android:host="allplays.ai"');
+        expect(androidManifest).toContain('android:pathPrefix="/app"');
+        expect(androidManifest).toContain('android:scheme="allplays"');
+        expect(iosInfo).toContain('<string>allplays</string>');
+        expect(iosInfo).toContain('<string>ai.allplays.lite</string>');
+        expect(iosEntitlements).toContain('com.apple.developer.associated-domains');
+        expect(iosEntitlements).toContain('applinks:allplays.ai');
+    });
+});

--- a/tests/unit/app-capacitor-native-config.test.js
+++ b/tests/unit/app-capacitor-native-config.test.js
@@ -31,7 +31,7 @@ describe('Capacitor native config', () => {
             showSpinner: false
         });
         expect(config.plugins.StatusBar).toMatchObject({
-            style: 'DARK',
+            style: 'LIGHT',
             backgroundColor: '#ffffff',
             overlaysWebView: false
         });
@@ -53,6 +53,8 @@ describe('Capacitor native config', () => {
         expect(nativeAppearance).toContain("import('@capacitor/status-bar')");
         expect(nativeAppearance).toContain("import('@capacitor/splash-screen')");
         expect(nativeAppearance).toContain('StatusBar.setOverlaysWebView({ overlay: false })');
+        expect(nativeAppearance).toContain('StatusBar.setStyle({ style: Style.Light })');
+        expect(nativeAppearance).toContain('StatusBar.setBackgroundColor({ color: \'#ffffff\' })');
         expect(nativeAppearance).toContain('SplashScreen.hide({ fadeOutDuration: 150 })');
     });
 

--- a/tests/unit/app-native-deep-link-routing.test.ts
+++ b/tests/unit/app-native-deep-link-routing.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { resolveNativeDeepLinkRoute } from '../../apps/app/src/lib/nativeDeepLinkRouting';
+
+describe('native deep link routing', () => {
+    it('maps universal app links to HashRouter routes', () => {
+        expect(resolveNativeDeepLinkRoute('https://allplays.ai/app/schedule/team-1/event-1?source=share')).toBe('/schedule/team-1/event-1?source=share');
+        expect(resolveNativeDeepLinkRoute('https://allplays.ai/app#/accept-invite?code=ABC&type=parent')).toBe('/accept-invite?code=ABC&type=parent');
+    });
+
+    it('maps custom scheme links to app routes', () => {
+        expect(resolveNativeDeepLinkRoute('allplays://messages/team-1')).toBe('/messages/team-1');
+        expect(resolveNativeDeepLinkRoute('ai.allplays.lite://app#/teams/browse')).toBe('/teams/browse');
+    });
+
+    it('ignores links outside the app surface', () => {
+        expect(resolveNativeDeepLinkRoute('https://allplays.ai/team.html#teamId=team-1')).toBeNull();
+        expect(resolveNativeDeepLinkRoute('https://example.com/app/schedule')).toBeNull();
+        expect(resolveNativeDeepLinkRoute('not a url')).toBeNull();
+    });
+});

--- a/tests/unit/pages-bundle-staging.test.js
+++ b/tests/unit/pages-bundle-staging.test.js
@@ -34,6 +34,8 @@ describe('pages bundle staging', () => {
         writeFile(path.join(rootDir, 'css', 'site.css'), 'body {}');
         writeFile(path.join(rootDir, 'js', 'site.js'), 'export const ok = true;');
         writeFile(path.join(rootDir, 'CNAME'), 'allplays.ai');
+        writeFile(path.join(rootDir, '.well-known', 'assetlinks.json'), '[]');
+        writeFile(path.join(rootDir, '.well-known', 'apple-app-site-association'), '{}');
         writeFile(path.join(rootDir, 'package.json'), '{}');
         writeFile(path.join(rootDir, 'firebase.json'), '{}');
         writeFile(path.join(rootDir, '.firebaserc'), '{}');
@@ -50,6 +52,8 @@ describe('pages bundle staging', () => {
         expect(fs.existsSync(path.join(destinationDir, 'css', 'site.css'))).toBe(true);
         expect(fs.existsSync(path.join(destinationDir, 'js', 'site.js'))).toBe(true);
         expect(fs.existsSync(path.join(destinationDir, 'CNAME'))).toBe(true);
+        expect(fs.existsSync(path.join(destinationDir, '.well-known', 'assetlinks.json'))).toBe(true);
+        expect(fs.existsSync(path.join(destinationDir, '.well-known', 'apple-app-site-association'))).toBe(true);
         expect(fs.existsSync(path.join(destinationDir, 'app', 'assets', 'index.js'))).toBe(true);
         expect(fs.existsSync(path.join(destinationDir, '.nojekyll'))).toBe(true);
 


### PR DESCRIPTION
## Summary
- Add Capacitor Splash Screen and Status Bar plugins to root/app dependencies and synced Android/iOS native manifests.
- Configure splash/status-bar behavior and hide the native splash after the first rendered app frame.
- Add Android app-link/custom-scheme filters plus iOS URL schemes and associated-domain entitlement for app deep links.
- Add a regression unit test that pins plugin wiring, safe-area CSS, bootstrap behavior, and deep-link declarations.

Fixes #2074.

## Validation
- npx cap sync
- npx vitest run tests/unit/app-capacitor-native-config.test.js --reporter=verbose
- npm run app:build
- cd android && JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:processDebugMainManifest

## Notes
- npm install still reports existing audit findings in root/app dependency trees; this PR does not attempt dependency remediation.