### PR TITLE
Optimistic boot shell for returning users (#2038)

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { shouldReloadTeamsToHome } from './lib/reloadRouting';
 import { addPushNotificationOpenListener, ensureAndroidNotificationChannels } from './lib/pushService';
+import { hasAuthHint } from './lib/authHint';
 import { useAuth } from './lib/useAuth';
 import type { AuthState } from './lib/types';
 
@@ -46,7 +47,7 @@ const TeamMedia = lazy(() => import('./pages/TeamMedia').then((module) => ({ def
 const Teams = lazy(() => import('./pages/Teams').then((module) => ({ default: module.Teams })));
 const VerifyPending = lazy(() => import('./pages/VerifyPending').then((module) => ({ default: module.VerifyPending })));
 
-const protectedRouteBootstrapGraceMs = 3000;
+const protectedRouteBootstrapGraceMs = 800;
 
 export default function App() {
   const auth = useAuth();
@@ -224,6 +225,9 @@ function isBrowserReload() {
 
 function Protected({ auth, children }: { auth: AuthState; children: ReactNode }) {
   const [bootstrapGraceExpired, setBootstrapGraceExpired] = useState(false);
+  // Snapshot the persisted hint once at mount so a returning signed-in user gets
+  // the app shell + skeleton immediately instead of a blocking spinner (#2038).
+  const optimisticReturningUser = useRef(hasAuthHint()).current;
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -235,31 +239,35 @@ function Protected({ auth, children }: { auth: AuthState; children: ReactNode })
     return () => window.clearTimeout(timeoutId);
   }, []);
 
-  if (auth.loading && !auth.user) {
-    return <LoadingScreen />;
+  // Auth not yet resolved: optimistically render the shell+skeleton for a known
+  // returning user; otherwise hold the lightweight loading screen briefly.
+  if (!auth.user && (auth.loading || !bootstrapGraceExpired)) {
+    return optimisticReturningUser ? renderShell(<ProtectedRouteLoadingState pathname={location.pathname} />) : <LoadingScreen />;
   }
 
-  if (!auth.user && !bootstrapGraceExpired) {
-    return <LoadingScreen />;
-  }
-
+  // Resolved signed-out: redirect (no protected content rendered for users
+  // without a hint, so there is no flash of protected UI).
   if (!auth.user) {
     return <Navigate to="/auth" replace />;
   }
 
-  return (
-    <AppShell auth={auth}>
-      <ErrorBoundary
-        name={`route:${location.pathname}`}
-        resetKey={`${location.pathname}${location.search}`}
-        onGoHome={() => navigate('/home', { replace: true })}
-      >
-        <Suspense fallback={<ProtectedRouteLoadingState pathname={location.pathname} />}>
-          {children}
-        </Suspense>
-      </ErrorBoundary>
-    </AppShell>
-  );
+  return renderShell(children);
+
+  function renderShell(content: ReactNode) {
+    return (
+      <AppShell auth={auth}>
+        <ErrorBoundary
+          name={`route:${location.pathname}`}
+          resetKey={`${location.pathname}${location.search}`}
+          onGoHome={() => navigate('/home', { replace: true })}
+        >
+          <Suspense fallback={<ProtectedRouteLoadingState pathname={location.pathname} />}>
+            {content}
+          </Suspense>
+        </ErrorBoundary>
+      </AppShell>
+    );
+  }
 }
 
 function LoadingScreen() {

--- a/apps/app/src/lib/authHint.test.ts
+++ b/apps/app/src/lib/authHint.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearAuthHint, hasAuthHint, readAuthHint, writeAuthHint } from './authHint';
+
+// The test runtime's built-in localStorage isn't a full implementation, so install
+// a deterministic Map-backed stub for these tests.
+function installMemoryLocalStorage() {
+  const store = new Map<string, string>();
+  const memoryStorage = {
+    getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+    setItem: (key: string, value: string) => { store.set(key, String(value)); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() { return store.size; }
+  };
+  Object.defineProperty(window, 'localStorage', { value: memoryStorage, configurable: true, writable: true });
+}
+
+beforeEach(() => {
+  installMemoryLocalStorage();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('authHint', () => {
+  it('round-trips a uid hint', () => {
+    expect(readAuthHint()).toBeNull();
+    expect(hasAuthHint()).toBe(false);
+
+    writeAuthHint('user-123');
+    expect(readAuthHint()).toEqual({ uid: 'user-123' });
+    expect(hasAuthHint()).toBe(true);
+  });
+
+  it('clears the hint', () => {
+    writeAuthHint('user-123');
+    clearAuthHint();
+    expect(readAuthHint()).toBeNull();
+    expect(hasAuthHint()).toBe(false);
+  });
+
+  it('ignores empty uids and malformed storage', () => {
+    writeAuthHint('');
+    expect(readAuthHint()).toBeNull();
+
+    window.localStorage.setItem('allplays:auth-hint', 'not json');
+    expect(readAuthHint()).toBeNull();
+
+    window.localStorage.setItem('allplays:auth-hint', JSON.stringify({ uid: '' }));
+    expect(readAuthHint()).toBeNull();
+  });
+});

--- a/apps/app/src/lib/authHint.ts
+++ b/apps/app/src/lib/authHint.ts
@@ -1,0 +1,59 @@
+/**
+ * Lightweight, persisted hint that the user was signed in on the last session
+ * (#2038). On boot, protected routes can optimistically render the app shell +
+ * skeleton for a returning user instead of holding a blocking spinner while
+ * Firebase auth resolves from IndexedDB — and only redirect to /auth once auth
+ * actually resolves signed-out. The hint stores no sensitive data, just a uid.
+ */
+const storageKey = 'allplays:auth-hint';
+
+export type AuthHint = { uid: string };
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const storage = window.localStorage;
+    if (!storage || typeof storage.getItem !== 'function') return null;
+    return storage;
+  } catch {
+    return null;
+  }
+}
+
+export function readAuthHint(): AuthHint | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AuthHint> | null;
+    const uid = parsed && typeof parsed.uid === 'string' ? parsed.uid.trim() : '';
+    return uid ? { uid } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasAuthHint(): boolean {
+  return readAuthHint() !== null;
+}
+
+export function writeAuthHint(uid: string) {
+  const storage = getStorage();
+  if (!storage || !uid) return;
+  try {
+    storage.setItem(storageKey, JSON.stringify({ uid }));
+  } catch {
+    // Best-effort: a full/disabled storage just means no optimistic boot.
+  }
+}
+
+export function clearAuthHint() {
+  const storage = getStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(storageKey);
+  } catch {
+    // ignore
+  }
+}

--- a/apps/app/src/lib/useAuth.ts
+++ b/apps/app/src/lib/useAuth.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AuthState, AuthUser } from './types';
 import { hydrateFirebaseUser, observeFirebaseUser, signOut } from './authService';
+import { clearAuthHint, writeAuthHint } from './authHint';
 
 export function useAuth(): AuthState {
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -21,6 +22,7 @@ export function useAuth(): AuthState {
     });
 
     if (!currentUser) {
+      clearAuthHint();
       setUser(null);
       setProfile(null);
       setLoading(false);
@@ -29,6 +31,7 @@ export function useAuth(): AuthState {
 
     try {
       const hydrated = await hydrateFirebaseUser(currentUser);
+      if (hydrated.user?.uid) writeAuthHint(hydrated.user.uid);
       setUser(hydrated.user);
       setProfile(hydrated.profile);
       return hydrated.user;
@@ -48,6 +51,7 @@ export function useAuth(): AuthState {
       setError(null);
 
       if (!firebaseUser) {
+        clearAuthHint();
         setUser(null);
         setProfile(null);
         setLoading(false);
@@ -56,6 +60,7 @@ export function useAuth(): AuthState {
 
       try {
         const hydrated = await hydrateFirebaseUser(firebaseUser);
+        if (hydrated.user?.uid) writeAuthHint(hydrated.user.uid);
         setUser(hydrated.user);
         setProfile(hydrated.profile);
       } catch (hydrateError: any) {
@@ -72,6 +77,7 @@ export function useAuth(): AuthState {
 
   const signOutAndClear = useCallback(async () => {
     setError(null);
+    clearAuthHint();
     const cleanup = signOut();
     setUser(null);
     setProfile(null);

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -33,7 +33,7 @@ describe('React app auth/profile capability parity', () => {
     it('does not replace signed-in screens with the loading splash during background auth refreshes', () => {
         const appRoutes = readProjectFile('apps/app/src/App.tsx');
 
-        expect(appRoutes).toContain('auth.loading && !auth.user');
+        expect(appRoutes).toContain('!auth.user && (auth.loading || !bootstrapGraceExpired)');
         expect(appRoutes).not.toContain('if (auth.loading) {');
     });
 

--- a/tests/unit/app-protected-route-bootstrap.test.js
+++ b/tests/unit/app-protected-route-bootstrap.test.js
@@ -6,11 +6,12 @@ const appSource = readFileSync(path.resolve('apps/app/src/App.tsx'), 'utf8');
 
 describe('app protected route bootstrap guard', () => {
     it('keeps a protected-route grace period before redirecting to auth', () => {
-        expect(appSource).toContain('const protectedRouteBootstrapGraceMs = 3000;');
+        expect(appSource).toContain('const protectedRouteBootstrapGraceMs = 800;');
         expect(appSource).toContain('const [bootstrapGraceExpired, setBootstrapGraceExpired] = useState(false);');
         expect(appSource).toContain('setBootstrapGraceExpired(true);');
-        expect(appSource).toContain('if (!auth.user && !bootstrapGraceExpired) {');
-        expect(appSource).toContain('return <LoadingScreen />;');
+        expect(appSource).toContain('const optimisticReturningUser = useRef(hasAuthHint()).current;');
+        expect(appSource).toContain('if (!auth.user && (auth.loading || !bootstrapGraceExpired)) {');
+        expect(appSource).toContain('return optimisticReturningUser ? renderShell(<ProtectedRouteLoadingState pathname={location.pathname} />) : <LoadingScreen />;');
         expect(appSource).toContain('return <Navigate to="/auth" replace />;');
     });
 });


### PR DESCRIPTION
Closes #2038.

## Summary
Protected routes held a full-screen "Loading ALL PLAYS" spinner for up to **3s** while Firebase auth resolved from IndexedDB, so a returning signed-in user stared at a spinner well past the point the app could be interactive (made worse by the entry bundle).

- **Persist a lightweight auth hint** (`authHint.ts`, uid only — no sensitive data) in `useAuth` on sign-in; clear it on sign-out and on signed-out resolution.
- On boot, `Protected` reads the hint and **optimistically renders the app shell + page skeleton** for a returning user instead of a blocking spinner, redirecting to `/auth` only once Firebase actually resolves signed-out.
- Users with **no hint** (never signed in) still get the lightweight loader, then `/auth` — so there's no flash of protected UI for genuinely signed-out users.
- **Shorten the bootstrap grace** from 3000ms → 800ms (IndexedDB auth resolution is typically <500ms).

## Acceptance criteria
- Returning signed-in user sees shell + skeleton immediately, real content as data arrives ✓
- Signed-out user (no hint) lands on `/auth` without a flash of protected UI ✓
- A stale hint (expired session) renders the skeleton briefly, then redirects when Firebase resolves signed-out — matching "only redirect once resolved signed-out."

## Tests
- New `authHint.test.ts` (round-trip, clear, malformed/empty handling).
- `AppShell` + `authService` suites pass; production build + `tsc --noEmit` clean.

## Manual test
1. Sign in, fully close and reopen the app → shell + skeleton appears instantly, no "Loading ALL PLAYS" spinner.
2. Sign out, reopen → lands on `/auth`, no protected UI flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)