### PR TITLE
[codex] Expand notification app route coverage

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -65,13 +65,6 @@ function normalizeAppRoute(route: unknown) {
     return value;
 }
 
-function readPayload(input: unknown): PushPayload {
-    if (!input || typeof input !== 'object') {
-        return {};
-    }
-    return input as PushPayload;
-}
-
 function buildLegacyLinkFallback(link: string) {
     if (!link) {
         return '';
@@ -115,7 +108,11 @@ function buildLegacyLinkFallback(link: string) {
 }
 
 export function resolvePushNotificationRoute(input: unknown) {
-    const payload = readPayload(input);
+    if (!input || typeof input !== 'object') {
+        return '/home';
+    }
+
+    const payload = input as PushPayload;
     const appRoute = normalizeAppRoute(payload.appRoute);
     if (appRoute) {
         return appRoute;

--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -7,6 +7,9 @@ type PushPayload = {
     conversationId?: string;
     gameId?: string;
     eventId?: string;
+    batchId?: string;
+    recipientId?: string;
+    certificateId?: string;
     link?: string;
 };
 
@@ -42,9 +45,21 @@ function buildScheduleEventRoute(teamId: string, eventId: string, section?: stri
     return normalizedSection ? `${route}?section=${encodeRouteParam(normalizedSection)}` : route;
 }
 
+function appendQuery(route: string, params: Record<string, string>) {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+        const normalized = normalizeValue(value);
+        if (normalized) {
+            query.set(key, normalized);
+        }
+    });
+    const queryString = query.toString();
+    return queryString ? `${route}?${queryString}` : route;
+}
+
 function normalizeAppRoute(route: unknown) {
     const value = normalizeValue(route);
-    if (!value.startsWith('/')) {
+    if (!value.startsWith('/') || value.startsWith('//')) {
         return '';
     }
     return value;
@@ -102,11 +117,18 @@ function buildLegacyLinkFallback(link: string) {
 export function resolvePushNotificationRoute(input: unknown) {
     const payload = readPayload(input);
     const appRoute = normalizeAppRoute(payload.appRoute);
+    if (appRoute) {
+        return appRoute;
+    }
+
     const category = normalizeValue(payload.category);
     const teamId = normalizeValue(payload.teamId);
     const conversationId = normalizeValue(payload.conversationId);
     const gameId = normalizeValue(payload.gameId);
     const eventId = normalizeValue(payload.eventId) || gameId;
+    const batchId = normalizeValue(payload.batchId);
+    const recipientId = normalizeValue(payload.recipientId);
+    const certificateId = normalizeValue(payload.certificateId);
 
     if (category === 'liveScore' && gameId) {
         if (teamId) {
@@ -114,25 +136,52 @@ export function resolvePushNotificationRoute(input: unknown) {
         }
         return `/games/${encodeRouteParam(gameId)}`;
     }
-    if (category === 'practice') {
-        if (appRoute) {
-            return appRoute;
-        }
+    if (category === 'gameDay') {
         if (teamId && eventId) {
             return buildScheduleEventRoute(teamId, eventId, 'game');
+        }
+        if (eventId) {
+            return `/games/${encodeRouteParam(eventId)}`;
+        }
+    }
+    if (category === 'practice') {
+        if (teamId && eventId) {
+            return buildScheduleEventRoute(teamId, eventId, 'game');
+        }
+        if (teamId) {
+            return `/schedule?teamId=${encodeRouteParam(teamId)}&section=game`;
         }
     }
     if (category === 'liveChat' && teamId && conversationId) {
         return buildMessagesRoute(teamId, conversationId);
     }
-    if (category === 'liveScore' && gameId) {
-        if (teamId) {
-            return buildScheduleEventRoute(teamId, gameId, 'game');
-        }
-        return `/games/${encodeRouteParam(gameId)}`;
+    if (category === 'mentions' && teamId) {
+        return buildMessagesRoute(teamId, conversationId);
     }
-    if (appRoute) {
-        return appRoute;
+    if (category === 'fees') {
+        if (teamId && batchId) {
+            const route = `/teams/${encodeRouteParam(teamId)}/fees/${encodeRouteParam(batchId)}`;
+            return appendQuery(route, { recipientId });
+        }
+        return appendQuery('/parent-tools/fees', { teamId, batchId, recipientId });
+    }
+    if (category === 'access') {
+        return appendQuery('/parent-tools/access', { teamId });
+    }
+    if (category === 'rideshare') {
+        if (teamId && eventId) {
+            return buildScheduleEventRoute(teamId, eventId, 'rideshare');
+        }
+        return teamId ? `/schedule?teamId=${encodeRouteParam(teamId)}&section=rideshare` : '/schedule?section=rideshare';
+    }
+    if (category === 'media' && teamId) {
+        return `/teams/${encodeRouteParam(teamId)}/media`;
+    }
+    if (category === 'awards') {
+        return appendQuery('/parent-tools/certificates', { teamId, certificateId });
+    }
+    if (category === 'officiating') {
+        return teamId ? `/officials?teamId=${encodeRouteParam(teamId)}` : '/officials';
     }
 
     if (category === 'liveChat' && teamId) {

--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -93,11 +93,26 @@ function normalizeNotificationLink(rawLink) {
     }
 }
 
+function normalizeAppRoute(rawRoute) {
+    const route = typeof rawRoute === 'string' ? rawRoute.trim() : '';
+    if (!route.startsWith('/') || route.startsWith('//')) return '';
+    return route;
+}
+
+function buildAppRouteNotificationLink(rawRoute) {
+    const appRoute = normalizeAppRoute(rawRoute);
+    if (!appRoute) return '';
+    return new URL(`/app/#${appRoute}`, self.location.origin).toString();
+}
+
 function registerBackgroundMessageHandler(messaging) {
     messaging.onBackgroundMessage((payload) => {
         const title = payload?.notification?.title || 'ALL PLAYS Update';
         const body = payload?.notification?.body || '';
-        const link = payload?.fcmOptions?.link || payload?.data?.link || '/';
+        const link = buildAppRouteNotificationLink(payload?.data?.appRoute)
+            || payload?.fcmOptions?.link
+            || payload?.data?.link
+            || '/';
         const icon = payload?.notification?.icon || payload?.data?.icon || WEB_PUSH_NOTIFICATION_ICON;
         const badge = payload?.notification?.badge || payload?.data?.badge || WEB_PUSH_NOTIFICATION_BADGE;
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -3808,7 +3808,7 @@ function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId 
   }
   if (category === 'liveScore' && gameId) {
     if (teamId) {
-      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}`;
+      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}?section=game`;
     }
     return '/schedule';
   }

--- a/tests/unit/app-notification-open-routing.test.jsx
+++ b/tests/unit/app-notification-open-routing.test.jsx
@@ -51,6 +51,9 @@ function NotificationOpenHarness() {
                 <Route path="/messages/:teamId" element={<div>Messages</div>} />
                 <Route path="/schedule/:teamId/:eventId" element={<div>Schedule Event</div>} />
                 <Route path="/games/:gameId" element={<div>Game Detail</div>} />
+                <Route path="/teams/:teamId/fees/:batchId" element={<div>Team Fees</div>} />
+                <Route path="/parent-tools/:toolId" element={<div>Parent Tools</div>} />
+                <Route path="/officials" element={<div>Officials</div>} />
             </Routes>
             <LocationProbe />
         </>
@@ -83,12 +86,26 @@ async function renderHarness(initialEntry = '/home') {
     return { container, root };
 }
 
+function installLocalStorageMock() {
+    const store = new Map();
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        value: {
+            getItem: (key) => store.get(key) ?? null,
+            setItem: (key, value) => store.set(key, String(value)),
+            removeItem: (key) => store.delete(key),
+            clear: () => store.clear()
+        }
+    });
+}
+
 describe('app notification open routing', () => {
     afterEach(() => {
         document.body.innerHTML = '';
     });
 
     beforeEach(() => {
+        installLocalStorageMock();
         window.localStorage.clear();
         pushListenerState.listener = null;
         vi.clearAllMocks();
@@ -98,7 +115,11 @@ describe('app notification open routing', () => {
         [{ category: 'liveChat', teamId: 'team-1' }, '/messages/team-1'],
         [{ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' }, '/schedule/team-1/game-7?section=game'],
         [{ category: 'liveScore', gameId: 'game-7' }, '/games/game-7'],
-        [{ category: 'schedule', teamId: 'team-1', eventId: 'event-9' }, '/schedule/team-1/event-9']
+        [{ category: 'schedule', teamId: 'team-1', eventId: 'event-9' }, '/schedule/team-1/event-9'],
+        [{ category: 'fees', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }, '/teams/team-1/fees/batch-1?recipientId=recipient-1'],
+        [{ category: 'rideshare', teamId: 'team-1', eventId: 'game-7' }, '/schedule/team-1/game-7?section=rideshare'],
+        [{ category: 'awards', teamId: 'team-1', certificateId: 'cert-1' }, '/parent-tools/certificates?teamId=team-1&certificateId=cert-1'],
+        [{ category: 'officiating', teamId: 'team-1' }, '/officials?teamId=team-1']
     ])('navigates to the expected route when a notification is opened: %o', async (payload, expectedRoute) => {
         const { container, root } = await renderHarness();
 

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -63,6 +63,11 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/game-day.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7?section=game');
     });
 
+    it('returns the home route when notification data is missing', () => {
+        expect(resolvePushNotificationRoute(undefined)).toBe('/home');
+        expect(resolvePushNotificationRoute(null)).toBe('/home');
+    });
+
     it('keeps and clears pending notification routes for delayed auth hydration', () => {
         rememberPendingPushRoute('/teams/team-1/fees/batch-1?recipientId=recipient-1');
         expect(readPendingPushRoute()).toBe('/teams/team-1/fees/batch-1?recipientId=recipient-1');

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -7,27 +7,53 @@ import {
     resolvePushNotificationRoute
 } from '../../apps/app/src/lib/pushNotificationRouting.ts';
 
+function installLocalStorageMock() {
+    const store = new Map<string, string>();
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        value: {
+            getItem: (key: string) => store.get(key) ?? null,
+            setItem: (key: string, value: string) => store.set(key, String(value)),
+            removeItem: (key: string) => store.delete(key),
+            clear: () => store.clear()
+        }
+    });
+}
+
 describe('app push notification routing', () => {
     beforeEach(() => {
+        installLocalStorageMock();
         window.localStorage.clear();
     });
 
     it('maps live chat, live score, and schedule payloads to app routes', () => {
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1' })).toBe('/messages/team-1');
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
-        expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2', appRoute: '/messages/team-1' })).toBe('/messages/team-1?conversationId=staff-2');
+        expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2', appRoute: '/messages/team-1' })).toBe('/messages/team-1');
         expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7?section=game');
-        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7' })).toBe('/schedule/team-1/game-7?section=game');
+        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7?section=game' })).toBe('/schedule/team-1/game-7?section=game');
         expect(resolvePushNotificationRoute({ category: 'liveScore', gameId: 'game-7' })).toBe('/games/game-7');
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'practice-4' })).toBe('/schedule/team-1/practice-4?section=game');
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'session-4', appRoute: '/schedule/team-1/practice-4?section=game' })).toBe('/schedule/team-1/practice-4?section=game');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
 
-    it('routes liveScore to the game hub even when a backend-supplied appRoute is present', () => {
-        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7' })).toBe('/schedule/team-1/game-7?section=game');
-        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7?section=availability' })).toBe('/schedule/team-1/game-7?section=game');
+    it('uses backend-supplied appRoute as the source of truth when present', () => {
+        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7' })).toBe('/schedule/team-1/game-7');
+        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7', appRoute: '/schedule/team-1/game-7?section=availability' })).toBe('/schedule/team-1/game-7?section=availability');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9', appRoute: '/schedule/team-1/event-9' })).toBe('/schedule/team-1/event-9');
+    });
+
+    it('maps expanded notification categories to deterministic fallback routes', () => {
+        expect(resolvePushNotificationRoute({ category: 'fees', teamId: 'team 1', batchId: 'batch/1', recipientId: 'recipient?1' })).toBe('/teams/team%201/fees/batch%2F1?recipientId=recipient%3F1');
+        expect(resolvePushNotificationRoute({ category: 'fees', teamId: 'team 1' })).toBe('/parent-tools/fees?teamId=team+1');
+        expect(resolvePushNotificationRoute({ category: 'access', teamId: 'team 1' })).toBe('/parent-tools/access?teamId=team+1');
+        expect(resolvePushNotificationRoute({ category: 'rideshare', teamId: 'team-1', eventId: 'game-7' })).toBe('/schedule/team-1/game-7?section=rideshare');
+        expect(resolvePushNotificationRoute({ category: 'media', teamId: 'team-1' })).toBe('/teams/team-1/media');
+        expect(resolvePushNotificationRoute({ category: 'awards', teamId: 'team-1', certificateId: 'cert-9' })).toBe('/parent-tools/certificates?teamId=team-1&certificateId=cert-9');
+        expect(resolvePushNotificationRoute({ category: 'mentions', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
+        expect(resolvePushNotificationRoute({ category: 'gameDay', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7?section=game');
+        expect(resolvePushNotificationRoute({ category: 'officiating', teamId: 'team-1' })).toBe('/officials?teamId=team-1');
     });
 
     it('falls back to legacy web links when an explicit app route is absent', () => {
@@ -38,8 +64,12 @@ describe('app push notification routing', () => {
     });
 
     it('keeps and clears pending notification routes for delayed auth hydration', () => {
-        rememberPendingPushRoute('/messages/team-1');
-        expect(readPendingPushRoute()).toBe('/messages/team-1');
+        rememberPendingPushRoute('/teams/team-1/fees/batch-1?recipientId=recipient-1');
+        expect(readPendingPushRoute()).toBe('/teams/team-1/fees/batch-1?recipientId=recipient-1');
+        rememberPendingPushRoute('https://allplays.ai/app/#/messages/team-1');
+        expect(readPendingPushRoute()).toBe('/teams/team-1/fees/batch-1?recipientId=recipient-1');
+        rememberPendingPushRoute('//evil.example/app/#/messages/team-1');
+        expect(readPendingPushRoute()).toBe('/teams/team-1/fees/batch-1?recipientId=recipient-1');
         clearPendingPushRoute();
         expect(readPendingPushRoute()).toBe('');
     });

--- a/tests/unit/notification-delivery-metadata.test.js
+++ b/tests/unit/notification-delivery-metadata.test.js
@@ -137,4 +137,12 @@ describe('notification delivery metadata', () => {
         expect(serviceWorkerSource).toContain('icon,');
         expect(serviceWorkerSource).toContain('badge,');
     });
+
+    it('normalizes web notification taps to native app hash routes when appRoute is present', () => {
+        expect(serviceWorkerSource).toContain('function buildAppRouteNotificationLink');
+        expect(serviceWorkerSource).toContain("new URL(`/app/#${appRoute}`, self.location.origin).toString()");
+        expect(serviceWorkerSource).toContain('buildAppRouteNotificationLink(payload?.data?.appRoute)');
+        expect(serviceWorkerSource).toContain('payload?.fcmOptions?.link');
+        expect(serviceWorkerSource).toContain('event.waitUntil(clients.openWindow(link));');
+    });
 });

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -18,7 +18,7 @@ describe('push notification payload contract', () => {
     it('includes native app routing fields alongside the legacy web link', () => {
         expect(source).toContain('function buildNotificationAppRoute');
         expect(source).toContain('appRoute,');
-        expect(source).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}`;");
+        expect(source).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}?section=game`;");
         expect(source).toContain('eventId: String(eventId || gameId || \'\')');
         expect(source).toContain('conversationId: String(conversationId || \'\')');
         expect(source).toContain("if (category === 'liveChat' || category === 'mentions') {");


### PR DESCRIPTION
## Summary
- Make explicit notification `data.appRoute` the app-side source of truth, with protocol-relative route hardening.
- Add deterministic fallback routes for fees, access, rideshare, media, awards, mentions, game-day, and officiating categories.
- Make web notification clicks prefer `data.appRoute` and open `/app/#...` routes before falling back to legacy links.
- Align backend live-score app routes with the game section and extend notification routing tests.

Fixes #2101.

## Validation
- npx vitest run tests/unit/app-push-notification-routing.test.ts --reporter=verbose
- npx vitest run tests/unit/app-notification-open-routing.test.jsx --reporter=verbose
- npx vitest run tests/unit/notification-delivery-metadata.test.js tests/unit/push-notification-payload-contract.test.js --reporter=verbose
- npm run app:build