### PR TITLE
[codex] Normalize Parent Tools async retries

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -652,6 +652,34 @@ describe('ParentTools access', () => {
         await waitFor(() => expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2));
     });
 
+    it('shows a retryable registrations load error and refreshes the section on retry', async () => {
+        parentToolsServiceMocks.loadParentRegistrations
+            .mockRejectedValueOnce(new Error('Registration service unavailable.'))
+            .mockResolvedValueOnce([
+                {
+                    id: 'form-1',
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    programName: 'Spring Skills',
+                    description: 'Sunday clinic',
+                    season: 'Spring',
+                    feeLabel: '$50.00',
+                    paymentNotice: '',
+                    onlineCheckout: true,
+                    options: [],
+                    url: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1'
+                }
+            ]);
+
+        renderParentTools(['/parent-tools/registrations']);
+
+        expect(await screen.findByText('Registration service unavailable.')).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+        expect(await screen.findByText('Spring Skills')).toBeTruthy();
+        expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
+
     it('defers public team and player loading until manual access starts', async () => {
         renderParentTools();
 

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -230,6 +230,55 @@ function KeepAliveTool({ active, mounted, children }: { active: boolean; mounted
   return <div hidden={!active}>{children}</div>;
 }
 
+type ParentToolAsyncOptions<T> = {
+  onSuccess?: (value: T) => void | Promise<void>;
+  onError?: (error: AppServiceError) => void | Promise<void>;
+  clearError?: boolean;
+};
+
+function useParentToolAsyncOperation() {
+  const { loading, clearError: clearOperationError, run: runOperation } = useAsyncOperation();
+  const [error, setError] = useState<AppServiceError | null>(null);
+
+  const clearError = useCallback(() => {
+    setError(null);
+    clearOperationError();
+  }, [clearOperationError]);
+
+  const run = useCallback(async function runParentToolAsyncOperation<T>(
+    task: () => Promise<T>,
+    fallbackMessage: string,
+    options: ParentToolAsyncOptions<T> = {}
+  ) {
+    if (options.clearError ?? true) {
+      setError(null);
+      clearOperationError();
+    }
+
+    return runOperation(task, {
+      rethrow: false,
+      getErrorMessage: (taskError) => getParentToolErrorMessage(toAppServiceError(taskError, fallbackMessage), fallbackMessage),
+      onSuccess: async (value) => {
+        setError(null);
+        await options.onSuccess?.(value);
+      },
+      onError: async (taskError) => {
+        const appError = toAppServiceError(taskError, fallbackMessage);
+        setError(appError);
+        await options.onError?.(appError);
+      }
+    });
+  }, [clearOperationError, runOperation]);
+
+  return {
+    loading,
+    error,
+    setError,
+    clearError,
+    run
+  };
+}
+
 function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChanged: () => void }) {
   const [teams, setTeams] = useState<ParentAccessTeam[]>([]);
   const [requests, setRequests] = useState<ParentAccessRequest[]>([]);
@@ -519,30 +568,22 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
 function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [fees, setFees] = useState<ParentFeeAppRecord[]>([]);
   const [filter, setFilter] = useState<'open' | 'all' | 'paid'>('open');
-  const [error, setError] = useState<AppServiceError | null>(null);
   const [payingFeeId, setPayingFeeId] = useState('');
   const [feeErrors, setFeeErrors] = useState<Record<string, string>>({});
-  const loadOperation = useAsyncOperation();
+  const { loading, error, run: runLoad } = useParentToolAsyncOperation();
   const payOperation = useAsyncOperation();
-  const loading = loadOperation.loading;
 
   const refresh = useCallback(async () => {
-    setError(null);
-    return loadOperation.run(
+    return runLoad(
       () => loadParentFeesForApp(auth.user),
+      'Unable to load fees.',
       {
-        rethrow: false,
-        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load fees.'), 'Unable to load fees.'),
         onSuccess: (result) => {
           setFees(result);
-          setError(null);
-        },
-        onError: (loadError) => {
-          setError(toAppServiceError(loadError, 'Unable to load fees.'));
         }
       }
     );
-  }, [auth.user, loadOperation]);
+  }, [auth.user, runLoad]);
 
   useEffect(() => {
     void refresh();
@@ -1070,26 +1111,19 @@ function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
 
 function RegistrationsTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [cards, setCards] = useState<ParentRegistrationCard[]>([]);
-  const [error, setError] = useState<AppServiceError | null>(null);
-  const loadOperation = useAsyncOperation();
-  const loading = loadOperation.loading;
+  const { loading, error, run: runLoad } = useParentToolAsyncOperation();
 
   const refresh = useCallback(async () => {
-    setError(null);
-    return loadOperation.run(
+    return runLoad(
       () => loadParentRegistrations(auth.user),
+      'Unable to load registrations.',
       {
-        rethrow: false,
-        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load registrations.'), 'Unable to load registrations.'),
         onSuccess: (result) => {
           setCards(result);
-        },
-        onError: (loadError) => {
-          setError(toAppServiceError(loadError, 'Unable to load registrations.'));
         }
       }
     );
-  }, [auth.user, loadOperation]);
+  }, [auth.user, runLoad]);
 
   useEffect(() => {
     void refresh();
@@ -1115,26 +1149,19 @@ function RegistrationsTool({ auth, refreshVersion }: { auth: AuthState; refreshV
 
 function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [cards, setCards] = useState<ParentCertificateCard[]>([]);
-  const [error, setError] = useState<AppServiceError | null>(null);
-  const loadOperation = useAsyncOperation();
-  const loading = loadOperation.loading;
+  const { loading, error, run: runLoad } = useParentToolAsyncOperation();
 
   const refresh = useCallback(async () => {
-    setError(null);
-    return loadOperation.run(
+    return runLoad(
       () => loadParentCertificates(auth.user),
+      'Unable to load awards.',
       {
-        rethrow: false,
-        getErrorMessage: (loadError) => getParentToolErrorMessage(toAppServiceError(loadError, 'Unable to load awards.'), 'Unable to load awards.'),
         onSuccess: (result) => {
           setCards(result);
-        },
-        onError: (loadError) => {
-          setError(toAppServiceError(loadError, 'Unable to load awards.'));
         }
       }
     );
-  }, [auth.user, loadOperation]);
+  }, [auth.user, runLoad]);
 
   useEffect(() => {
     void refresh();


### PR DESCRIPTION
## Summary
- add a Parent Tools async wrapper around the shared useAsyncOperation helper that preserves typed AppServiceError retry state
- migrate Fees, Registrations, and Awards loads onto the shared retry path
- add a regression for a failed registrations load followed by a successful section retry

## Tests
- npx vitest run apps/app/src/pages/ParentTools.test.tsx --reporter=verbose
- npm run app:build

Closes #2359