### PR TITLE
[codex] Add retry states for detail loads

### DIFF
--- a/apps/app/src/components/DetailLoadErrorState.test.tsx
+++ b/apps/app/src/components/DetailLoadErrorState.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AlertTriangle } from 'lucide-react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { DetailLoadErrorState } from './DetailLoadErrorState';
+
+describe('DetailLoadErrorState', () => {
+    it('falls back when the error message is missing', () => {
+        const onRetry = vi.fn();
+        const error = {
+            name: 'AppServiceError',
+            type: 'unknown',
+            message: undefined
+        } as unknown as Parameters<typeof DetailLoadErrorState>[0]['error'];
+
+        render(
+            <MemoryRouter>
+                <DetailLoadErrorState
+                    icon={AlertTriangle}
+                    title="Unable to load player"
+                    error={error}
+                    fallbackMessage="An error occurred"
+                    backTo="/home"
+                    backLabel="Back home"
+                    onRetry={onRetry}
+                />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('An error occurred')).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/app/src/components/DetailLoadErrorState.tsx
+++ b/apps/app/src/components/DetailLoadErrorState.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { RefreshCw, type LucideIcon } from 'lucide-react';
-import type { AppServiceError } from '../lib/appErrors';
+import { getAppServiceErrorMessage, type AppServiceError } from '../lib/appErrors';
 
 type DetailLoadErrorStateProps = {
   icon: LucideIcon;
@@ -30,7 +30,7 @@ export function DetailLoadErrorState({
           <Icon className="mt-0.5 h-5 w-5 flex-none text-rose-600" aria-hidden="true" />
           <div className="min-w-0 flex-1">
             <div className="text-sm font-black text-gray-950">{title}</div>
-            <div className="mt-1 text-sm font-semibold text-gray-600">{error?.message || fallbackMessage}</div>
+            <div className="mt-1 text-sm font-semibold text-gray-600">{getAppServiceErrorMessage(error, fallbackMessage)}</div>
             <div className="mt-3 flex flex-wrap gap-2">
               <button type="button" className="primary-button !min-h-9 text-xs" onClick={onRetry} disabled={retrying}>
                 <RefreshCw className={`h-4 w-4 ${retrying ? 'animate-spin' : ''}`} aria-hidden="true" />

--- a/apps/app/src/components/DetailLoadErrorState.tsx
+++ b/apps/app/src/components/DetailLoadErrorState.tsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router-dom';
+import { RefreshCw, type LucideIcon } from 'lucide-react';
+import type { AppServiceError } from '../lib/appErrors';
+
+type DetailLoadErrorStateProps = {
+  icon: LucideIcon;
+  title: string;
+  error: AppServiceError | null;
+  fallbackMessage: string;
+  backTo: string;
+  backLabel: string;
+  onRetry: () => void;
+  retrying?: boolean;
+};
+
+export function DetailLoadErrorState({
+  icon: Icon,
+  title,
+  error,
+  fallbackMessage,
+  backTo,
+  backLabel,
+  onRetry,
+  retrying = false
+}: DetailLoadErrorStateProps) {
+  return (
+    <div className="space-y-4">
+      <section className="app-card p-5">
+        <div className="flex items-start gap-3">
+          <Icon className="mt-0.5 h-5 w-5 flex-none text-rose-600" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-black text-gray-950">{title}</div>
+            <div className="mt-1 text-sm font-semibold text-gray-600">{error?.message || fallbackMessage}</div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button type="button" className="primary-button !min-h-9 text-xs" onClick={onRetry} disabled={retrying}>
+                <RefreshCw className={`h-4 w-4 ${retrying ? 'animate-spin' : ''}`} aria-hidden="true" />
+                Retry
+              </button>
+              <Link to={backTo} className="secondary-button !min-h-9 text-xs">{backLabel}</Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -160,6 +160,20 @@ describe('PlayerDetail athlete profile season selection', () => {
     cleanup();
   });
 
+  it('shows a retryable player detail error state and reloads on retry', async () => {
+    playerServiceMocks.loadParentPlayerDetail
+      .mockRejectedValueOnce(new Error('Player detail unavailable.'))
+      .mockResolvedValueOnce(buildDetailData());
+
+    renderPlayerDetail();
+
+    expect(await screen.findByText('Player detail unavailable.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('Sam Player')).toBeTruthy();
+    expect(playerServiceMocks.loadParentPlayerDetail).toHaveBeenCalledTimes(2);
+  });
+
   it('preselects existing saved seasons and passes updated selections on save', async () => {
     playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
       athleteProfile: {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -42,7 +42,9 @@ import {
   type ParentPlayerDetailData,
   type ParentPlayerStatRow
 } from '../lib/playerService';
+import { DetailLoadErrorState } from '../components/DetailLoadErrorState';
 import { getEventDetailPath } from '../lib/homeLogic';
+import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import {
   formatEventDateLabel,
   formatEventTimeLabel,
@@ -122,7 +124,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
   const [activeSection, setActiveSection] = useState<PlayerSectionId>('overview');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
 
   const refreshPlayer = async ({ showLoading = data === null }: { showLoading?: boolean } = {}) => {
     const fullPageLoading = showLoading || data === null;
@@ -131,14 +133,14 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
     } else {
       setRefreshing(true);
     }
-    setError('');
+    setError(null);
     try {
       setData(await loadParentPlayerDetail(auth.user, teamId, playerId));
     } catch (loadError: any) {
       if (fullPageLoading) {
         setData(null);
       }
-      setError(loadError?.message || 'Unable to load player.');
+      setError(toAppServiceError(loadError, 'Unable to load player.'));
     } finally {
       if (fullPageLoading) {
         setLoading(false);
@@ -172,13 +174,16 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
 
   if (!data) {
     return (
-      <div className="space-y-3">
-        <Link to="/home" className="ghost-button min-h-9 px-3 text-xs">
-          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-          Home
-        </Link>
-        <Status tone="error" message={error || 'This player is not available for your account.'} />
-      </div>
+      <DetailLoadErrorState
+        icon={UserRound}
+        title="Player unavailable"
+        error={error}
+        fallbackMessage="This player is not available for your account."
+        backTo="/home"
+        backLabel="Home"
+        onRetry={() => refreshPlayer({ showLoading: true })}
+        retrying={loading}
+      />
     );
   }
 
@@ -232,7 +237,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
         </div>
       </div>
 
-      {error ? <Status tone="error" message={error} /> : null}
+      {error ? <Status tone="error" message={error.message} /> : null}
       {activeSection === 'overview' ? <OverviewSection data={data} /> : null}
       {activeSection === 'schedule' ? <PlayerScheduleSection events={data.events} /> : null}
       {activeSection === 'performance' ? <ReportsSection data={data} /> : null}

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -171,6 +171,26 @@ describe('TeamDetail', () => {
     expect(screen.queryByText('Getting the team photo, roster, schedule, standings, and parent-visible insights.')).toBeNull();
   });
 
+  it('shows a retryable team detail error state and reloads on retry', async () => {
+    teamDetailServiceMocks.loadParentTeamDetail
+      .mockRejectedValueOnce(new Error('Team detail unavailable.'))
+      .mockResolvedValueOnce(model);
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Team detail unavailable.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+  });
+
   it('does not reload team detail when the auth object identity changes but the signed-in user does not', async () => {
     const initialAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
     const nextAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -28,7 +28,9 @@ import {
   Zap
 } from 'lucide-react';
 import { TeamDetailPageSkeleton } from '../components/PageSkeletons';
+import { DetailLoadErrorState } from '../components/DetailLoadErrorState';
 import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
+import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { getEventDetailPath } from '../lib/homeLogic';
 import { buildPrivateTeamCalendarFeedUrl, getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl } from '../lib/parentToolsService';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
@@ -53,7 +55,8 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   const authUserId = auth.user?.uid || '';
   const [model, setModel] = useState<TeamDetailModel | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState<AppServiceError | null>(null);
+  const [reloadVersion, setReloadVersion] = useState(0);
   const [activeTab, setActiveTab] = useState<TeamTab>('overview');
   const [staffPermissionsLoading, setStaffPermissionsLoading] = useState(false);
   const [staffPermissionsError, setStaffPermissionsError] = useState('');
@@ -84,7 +87,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     async function load() {
       if (!teamId) return;
       setLoading(true);
-      setError('');
+      setError(null);
       try {
         const nextModel = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
         if (!cancelled) {
@@ -108,7 +111,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
         }
       } catch (loadError: any) {
         if (!cancelled) {
-          setError(loadError?.message || 'Unable to load this team.');
+          setError(toAppServiceError(loadError, 'Unable to load this team.'));
           setModel(null);
           setStaffPermissionsError('');
           setStaffPermissionsLoading(false);
@@ -135,7 +138,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [authUserId, teamId]);
+  }, [authUserId, teamId, reloadVersion]);
 
   useEffect(() => {
     let cancelled = false;
@@ -348,18 +351,16 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
 
   if (error || !model) {
     return (
-      <div className="space-y-4">
-        <section className="app-card p-5">
-          <div className="flex items-start gap-3">
-            <Shield className="mt-0.5 h-5 w-5 flex-none text-rose-600" aria-hidden="true" />
-            <div>
-              <div className="text-sm font-black text-gray-950">Team unavailable</div>
-              <div className="mt-1 text-sm font-semibold text-gray-600">{error || 'Team not found.'}</div>
-              <Link to="/teams" className="secondary-button mt-3 !min-h-9 text-xs">Back to teams</Link>
-            </div>
-          </div>
-        </section>
-      </div>
+      <DetailLoadErrorState
+        icon={Shield}
+        title="Team unavailable"
+        error={error}
+        fallbackMessage="Team not found."
+        backTo="/teams"
+        backLabel="Back to teams"
+        onRetry={() => setReloadVersion((current) => current + 1)}
+        retrying={loading}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- add a shared DetailLoadErrorState for retryable Team and Player detail load failures
- convert primary Team Detail and Player Detail load errors to typed AppServiceError values
- add retry regressions for failed initial team/player detail loads

## Tests
- npx vitest run apps/app/src/pages/TeamDetail.test.tsx apps/app/src/pages/PlayerDetail.test.tsx --reporter=verbose
- npm run app:build

Closes #2361