### PR TITLE
[codex] Add notification permission primer

### DIFF
--- a/apps/app/src/lib/pushService.test.ts
+++ b/apps/app/src/lib/pushService.test.ts
@@ -20,6 +20,7 @@ const profileServiceMocks = {
 };
 
 const locationAssignMock = vi.fn();
+let localStorageEntries: Map<string, string>;
 
 async function loadPushService() {
     return await import('./pushService');
@@ -54,6 +55,22 @@ describe('pushService permission states', () => {
             value: {
                 ...window.location,
                 assign: locationAssignMock
+            }
+        });
+        localStorageEntries = new Map();
+        Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            value: {
+                getItem: vi.fn((key: string) => localStorageEntries.get(key) || null),
+                setItem: vi.fn((key: string, value: string) => {
+                    localStorageEntries.set(key, value);
+                }),
+                removeItem: vi.fn((key: string) => {
+                    localStorageEntries.delete(key);
+                }),
+                clear: vi.fn(() => {
+                    localStorageEntries.clear();
+                })
             }
         });
     });
@@ -148,6 +165,61 @@ describe('pushService permission states', () => {
                 state: 'blocked',
                 canOpenSettings: true
             }
+        });
+    });
+
+    it('registers the native token after the OS prompt is granted', async () => {
+        firebaseMessagingMocks.checkPermissions.mockResolvedValue({ receive: 'prompt' });
+        firebaseMessagingMocks.requestPermissions.mockResolvedValue({ receive: 'granted' });
+        const { enablePushNotificationsForUser } = await loadPushService();
+
+        await expect(enablePushNotificationsForUser('user-1')).resolves.toEqual({
+            token: 'native-token',
+            platform: 'ios'
+        });
+
+        expect(firebaseMessagingMocks.requestPermissions).toHaveBeenCalledTimes(1);
+        expect(profileServiceMocks.saveNotificationDeviceToken).toHaveBeenCalledWith('user-1', {
+            token: 'native-token',
+            platform: 'ios',
+            userAgent: navigator.userAgent || ''
+        });
+    });
+
+    it('tracks notification primer decline while allowing the app to ask again later', async () => {
+        const {
+            getPushNotificationPrimerState,
+            runPushNotificationPrimer
+        } = await loadPushService();
+
+        expect(getPushNotificationPrimerState('messages')).toMatchObject({
+            hasResponded: false,
+            accepted: false,
+            declined: false,
+            canAskAgain: true
+        });
+
+        const declinePrimer = vi.fn(() => false);
+        await expect(runPushNotificationPrimer('messages', { confirm: declinePrimer })).resolves.toBe(false);
+        expect(declinePrimer).toHaveBeenCalledWith(expect.objectContaining({
+            title: 'Turn on message notifications?'
+        }), expect.objectContaining({
+            context: 'messages'
+        }));
+        expect(getPushNotificationPrimerState('messages')).toMatchObject({
+            hasResponded: true,
+            accepted: false,
+            declined: true,
+            canAskAgain: true
+        });
+
+        const acceptPrimer = vi.fn(() => true);
+        await expect(runPushNotificationPrimer('messages', { confirm: acceptPrimer })).resolves.toBe(true);
+        expect(getPushNotificationPrimerState('messages')).toMatchObject({
+            hasResponded: true,
+            accepted: true,
+            declined: false,
+            canAskAgain: false
         });
     });
 

--- a/apps/app/src/lib/pushService.ts
+++ b/apps/app/src/lib/pushService.ts
@@ -14,6 +14,33 @@ export type PushNotificationPermissionStatus = {
   canOpenSettings: boolean;
 };
 
+export type PushNotificationPrimerContext =
+  | 'profile_device_push'
+  | 'game_day_alerts'
+  | 'messages'
+  | 'team_join'
+  | 'rsvp';
+
+export type PushNotificationPrimerDecision = 'accepted' | 'declined';
+
+export type PushNotificationPrimerState = {
+  context: PushNotificationPrimerContext;
+  hasResponded: boolean;
+  accepted: boolean;
+  declined: boolean;
+  canAskAgain: boolean;
+  decidedAt: string | null;
+};
+
+type PushNotificationPrimerCopy = {
+  title: string;
+  body: string;
+};
+
+type PushNotificationPrimerOptions = {
+  confirm?: (copy: PushNotificationPrimerCopy, state: PushNotificationPrimerState) => boolean | Promise<boolean>;
+};
+
 type PushRegistrationResult = {
   token: string;
   platform: string;
@@ -23,6 +50,7 @@ const nativePushTimeoutMs = 15000;
 const iosNotificationSettingsUrl = 'app-settings:';
 const androidNotificationSettingsUrl = 'intent:#Intent;action=android.settings.APP_NOTIFICATION_SETTINGS;S.extra_app_package=ai.allplays.lite;end';
 const androidAppSettingsUrl = 'app-settings:';
+const pushPrimerStoragePrefix = 'allplays.pushPrimer.';
 export const androidNotificationChannels = [
   {
     id: 'allplays_messages',
@@ -157,6 +185,46 @@ export async function enablePushNotificationsForUser(userId: string): Promise<Pu
   };
 }
 
+export function getPushNotificationPrimerState(context: PushNotificationPrimerContext): PushNotificationPrimerState {
+  const raw = readPushPrimerDecision(context);
+  const accepted = raw?.decision === 'accepted';
+  const declined = raw?.decision === 'declined';
+  return {
+    context,
+    hasResponded: accepted || declined,
+    accepted,
+    declined,
+    canAskAgain: !accepted,
+    decidedAt: raw?.decidedAt || null
+  };
+}
+
+export function recordPushNotificationPrimerDecision(context: PushNotificationPrimerContext, decision: PushNotificationPrimerDecision) {
+  try {
+    getPushPrimerStorage()?.setItem(getPushPrimerStorageKey(context), JSON.stringify({
+      decision,
+      decidedAt: new Date().toISOString()
+    }));
+  } catch {
+    // Primer state is best-effort; permission flow must continue if storage is unavailable.
+  }
+}
+
+export async function runPushNotificationPrimer(
+  context: PushNotificationPrimerContext,
+  options: PushNotificationPrimerOptions = {}
+) {
+  const state = getPushNotificationPrimerState(context);
+  if (state.accepted) {
+    return true;
+  }
+
+  const copy = getPushNotificationPrimerCopy(context);
+  const accepted = await (options.confirm || confirmPushNotificationPrimer)(copy, state);
+  recordPushNotificationPrimerDecision(context, accepted ? 'accepted' : 'declined');
+  return accepted;
+}
+
 export async function getPushNotificationPermissionStatus(): Promise<PushNotificationPermissionStatus> {
   if (!Capacitor.isNativePlatform()) {
     return buildPushPermissionStatus('unsupported', 'web');
@@ -202,6 +270,67 @@ function buildPushPermissionStatus(state: PushNotificationPermissionState, platf
     canPrompt: state === 'prompt',
     canOpenSettings: state === 'blocked'
   };
+}
+
+function getPushNotificationPrimerCopy(context: PushNotificationPrimerContext): PushNotificationPrimerCopy {
+  if (context === 'game_day_alerts') {
+    return {
+      title: 'Turn on game-day notifications?',
+      body: 'ALL PLAYS will ask your device for permission before sending schedule changes, RSVP reminders, and live score updates.'
+    };
+  }
+  if (context === 'messages') {
+    return {
+      title: 'Turn on message notifications?',
+      body: 'ALL PLAYS will ask your device for permission so team chat and mention alerts can reach this device.'
+    };
+  }
+  if (context === 'team_join') {
+    return {
+      title: 'Turn on team notifications?',
+      body: 'ALL PLAYS will ask your device for permission so team updates can reach this device after you join.'
+    };
+  }
+  if (context === 'rsvp') {
+    return {
+      title: 'Turn on RSVP reminders?',
+      body: 'ALL PLAYS will ask your device for permission before sending schedule and RSVP reminders.'
+    };
+  }
+  return {
+    title: 'Turn on notifications?',
+    body: 'ALL PLAYS will ask your device for permission before registering this device for push notifications.'
+  };
+}
+
+function confirmPushNotificationPrimer(copy: PushNotificationPrimerCopy) {
+  if (typeof window === 'undefined' || typeof window.confirm !== 'function') {
+    return true;
+  }
+  return window.confirm(`${copy.title}\n\n${copy.body}`);
+}
+
+function readPushPrimerDecision(context: PushNotificationPrimerContext): { decision?: PushNotificationPrimerDecision; decidedAt?: string } | null {
+  try {
+    const raw = getPushPrimerStorage()?.getItem(getPushPrimerStorageKey(context));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed?.decision !== 'accepted' && parsed?.decision !== 'declined') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function getPushPrimerStorage() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.localStorage || null;
+}
+
+function getPushPrimerStorageKey(context: PushNotificationPrimerContext) {
+  return `${pushPrimerStoragePrefix}${context}`;
 }
 
 async function getNativeMessagingToken(): Promise<string> {

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -142,10 +142,10 @@ describe('Profile', () => {
     renderProfile();
 
     expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeInTheDocument();
-    const alertsButton = screen.getByRole('button', { name: 'Alerts', exact: true });
+    const alertsButton = screen.getByRole('button', { name: /^Alerts$/ });
     expect(alertsButton).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Invites', exact: true })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Security', exact: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Invites$/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^Security$/ })).toBeInTheDocument();
 
     const sectionGrid = alertsButton.parentElement;
     expect(sectionGrid).not.toBeNull();

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Profile } from './Profile';
+import type { AuthState } from '../lib/types';
+
+const authServiceMocks = vi.hoisted(() => ({
+  describeAuthError: vi.fn((error: unknown) => (error instanceof Error ? error.message : 'Authentication failed.')),
+  reloadCurrentUser: vi.fn(async () => undefined),
+  resendVerificationEmail: vi.fn(async () => undefined),
+  sendResetEmail: vi.fn(async () => undefined),
+  setCurrentUserPassword: vi.fn(async () => undefined)
+}));
+
+const profileServiceMocks = vi.hoisted(() => ({
+  createProfileAccessCode: vi.fn(async () => 'CODE1234'),
+  loadNotificationPreferences: vi.fn(async () => ({ liveChat: true, liveScore: false, schedule: true })),
+  loadNotificationTeams: vi.fn(async () => ([{ id: 'team-1', name: 'Blue Team' }])),
+  loadParentTeams: vi.fn(async () => ([{ id: 'team-1', name: 'Blue Team' }])),
+  loadProfileAccessCodes: vi.fn(async () => []),
+  loadProfileDocument: vi.fn(async () => ({
+    fullName: 'Pat Parent',
+    phone: '555-0100',
+    photoUrl: '',
+    signInMethod: 'emailLink',
+    hasPassword: false,
+    updatedAt: { seconds: 1717200000 }
+  })),
+  normalizeNotificationPreferences: vi.fn((preferences: { liveChat?: boolean; liveScore?: boolean; schedule?: boolean } | null) => ({
+    liveChat: preferences?.liveChat !== false,
+    liveScore: preferences?.liveScore === true,
+    schedule: preferences?.schedule !== false
+  })),
+  requestAccountMerge: vi.fn(async () => undefined),
+  saveNotificationPreferences: vi.fn(async (_userId: string, _teamId: string, preferences: unknown) => preferences),
+  saveProfileDocument: vi.fn(async () => undefined)
+}));
+
+const pushServiceMocks = vi.hoisted(() => ({
+  enablePushNotificationsForUser: vi.fn(async () => undefined),
+  getPushNotificationPermissionStatus: vi.fn(async () => ({
+    state: 'prompt',
+    isNative: false,
+    platform: 'web',
+    canPrompt: true,
+    canOpenSettings: false
+  })),
+  openPushNotificationSettings: vi.fn(async () => undefined),
+  runPushNotificationPrimer: vi.fn(async () => ({ completed: false, status: 'skipped' }))
+}));
+
+vi.mock('../lib/authService', () => authServiceMocks);
+vi.mock('../lib/profileService', () => profileServiceMocks);
+vi.mock('../lib/pushService', () => pushServiceMocks);
+vi.mock('../lib/inviteUrls', () => ({
+  buildAppAcceptInviteUrl: vi.fn((code: string) => `https://example.test/app#/accept-invite?code=${code}`)
+}));
+vi.mock('../lib/publicActions', () => ({
+  sharePublicUrl: vi.fn(async () => ({ shared: true }))
+}));
+vi.mock('../lib/useShellLayout', () => ({
+  useShellLayout: () => ({ isDesktop: false, isNative: false, isDesktopWeb: false })
+}));
+vi.mock('lucide-react', () => {
+  const Icon = () => null;
+  return {
+    Bell: Icon,
+    ChevronDown: Icon,
+    ChevronUp: Icon,
+    CheckCircle2: Icon,
+    Clipboard: Icon,
+    Copy: Icon,
+    ImagePlus: Icon,
+    KeyRound: Icon,
+    Link2: Icon,
+    Loader2: Icon,
+    LogOut: Icon,
+    Mail: Icon,
+    RefreshCw: Icon,
+    Save: Icon,
+    Send: Icon,
+    Share2: Icon,
+    ShieldCheck: Icon,
+    Trash2: Icon,
+    Upload: Icon,
+    UserCircle: Icon,
+    XCircle: Icon
+  };
+});
+
+const auth: AuthState = {
+  user: {
+    uid: 'user-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent',
+    roles: ['parent']
+  } as AuthState['user'],
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function renderProfile() {
+  return render(
+    <MemoryRouter initialEntries={['/profile']}>
+      <Routes>
+        <Route path="/profile" element={<Profile auth={auth} />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('Profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true
+    });
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      value: (callback: FrameRequestCallback) => {
+        callback(0);
+        return 0;
+      },
+      writable: true
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('keeps mobile profile section buttons in a two-column grid so Alerts stays reachable', async () => {
+    renderProfile();
+
+    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeInTheDocument();
+    const alertsButton = screen.getByRole('button', { name: 'Alerts', exact: true });
+    expect(alertsButton).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Invites', exact: true })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Security', exact: true })).toBeInTheDocument();
+
+    const sectionGrid = alertsButton.parentElement;
+    expect(sectionGrid).not.toBeNull();
+    expect(sectionGrid?.className).toContain('grid-cols-2');
+    expect(sectionGrid?.className).toContain('sm:grid-cols-4');
+    expect(sectionGrid?.className).not.toContain('min-w-max');
+  });
+});

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -40,6 +40,8 @@ import {
   enablePushNotificationsForUser,
   getPushNotificationPermissionStatus,
   openPushNotificationSettings,
+  runPushNotificationPrimer,
+  type PushNotificationPrimerContext,
   type PushNotificationPermissionStatus
 } from '../lib/pushService';
 import { buildAppAcceptInviteUrl } from '../lib/inviteUrls';
@@ -700,6 +702,18 @@ export function Profile({ auth }: { auth: AuthState }) {
     setNotificationStatus(null);
 
     try {
+      const currentPermissionStatus = isNative
+        ? (pushPermissionStatus || await getPushNotificationPermissionStatus())
+        : null;
+
+      if (currentPermissionStatus) {
+        setPushPermissionStatus(currentPermissionStatus);
+      }
+
+      if (!(await confirmPushPrimer('profile_device_push', currentPermissionStatus))) {
+        return;
+      }
+
       await enablePushNotificationsForUser(user.uid);
       await refreshPushPermissionStatus({ silent: true });
       setNotificationStatus({ message: 'Push is enabled on this device.', tone: 'success' });
@@ -714,6 +728,18 @@ export function Profile({ auth }: { auth: AuthState }) {
   const openDeviceSettingsForPush = async (statusMessage = 'Open device settings, allow notifications, then return here. We will refresh this screen when you come back.') => {
     setNotificationStatus({ message: statusMessage, tone: 'neutral' });
     await openPushNotificationSettings();
+  };
+
+  const confirmPushPrimer = async (context: PushNotificationPrimerContext, permissionStatus: PushNotificationPermissionStatus | null) => {
+    if (permissionStatus && permissionStatus.state !== 'prompt') {
+      return true;
+    }
+
+    const accepted = await runPushNotificationPrimer(context);
+    if (!accepted) {
+      setNotificationStatus({ message: 'Push setup was skipped. You can turn notifications on later from Alerts.', tone: 'neutral' });
+    }
+    return accepted;
   };
 
   const turnOnGameDayAlerts = async () => {
@@ -743,6 +769,10 @@ export function Profile({ auth }: { auth: AuthState }) {
 
       if (currentPermissionStatus?.state === 'unsupported') {
         setNotificationStatus({ message: 'Push notifications are not supported on this device.', tone: 'error' });
+        return;
+      }
+
+      if (!(await confirmPushPrimer('game_day_alerts', currentPermissionStatus))) {
         return;
       }
 

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -976,8 +976,8 @@ export function Profile({ auth }: { auth: AuthState }) {
         </div>
       </section>
 
-      <div className="profile-section-nav sticky top-24 z-30 -mx-1 overflow-x-auto bg-gray-50/95 py-2 backdrop-blur">
-        <div className="grid min-w-max grid-cols-4 gap-1 rounded-2xl border border-gray-200 bg-white p-1 shadow-sm">
+      <div className="profile-section-nav sticky top-24 z-30 bg-gray-50/95 py-2 backdrop-blur">
+        <div className="grid grid-cols-2 gap-1 rounded-2xl border border-gray-200 bg-white p-1 shadow-sm sm:grid-cols-4">
           {profileSections.map((section) => {
             const active = activeProfileSection === section.id;
             return (

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -356,6 +356,10 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                 export async function openPushNotificationSettings() {
                     window.__appProfileCalls.openPushSettings += 1;
                 }
+
+                export async function runPushNotificationPrimer() {
+                    return { completed: false, status: 'skipped' };
+                }
             `
         });
     });

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -36,7 +36,8 @@ const publicActionsMocks = vi.hoisted(() => ({
 const pushServiceMocks = vi.hoisted(() => ({
   enablePushNotificationsForUser: vi.fn(),
   getPushNotificationPermissionStatus: vi.fn(),
-  openPushNotificationSettings: vi.fn()
+  openPushNotificationSettings: vi.fn(),
+  runPushNotificationPrimer: vi.fn()
 }));
 
 const shellLayoutState = vi.hoisted(() => ({
@@ -173,6 +174,7 @@ describe('Profile invites', () => {
       canOpenSettings: false
     });
     pushServiceMocks.openPushNotificationSettings.mockResolvedValue(undefined);
+    pushServiceMocks.runPushNotificationPrimer.mockResolvedValue(true);
     profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
     profileServiceMocks.loadParentTeams.mockResolvedValue([]);
     profileServiceMocks.requestAccountMerge.mockResolvedValue(undefined);
@@ -430,6 +432,25 @@ describe('Profile invites', () => {
       schedule: true
     });
     expect(await screen.findByText('Game-day alerts are on for this team.')).toBeTruthy();
+  });
+
+  it('does not request push or save alerts when the notification primer is declined', async () => {
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([{ id: 'team-1', name: 'Blue Team' }]);
+    profileServiceMocks.loadNotificationPreferences.mockResolvedValueOnce({ liveChat: true, liveScore: false, schedule: false });
+    pushServiceMocks.runPushNotificationPrimer.mockResolvedValueOnce(false);
+
+    renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+
+    await waitFor(() => expect((screen.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-1'));
+    const gameDayButton = await screen.findByRole('button', { name: 'Turn on game-day alerts' });
+    fireEvent.click(gameDayButton);
+
+    await waitFor(() => expect(pushServiceMocks.runPushNotificationPrimer).toHaveBeenCalledWith('game_day_alerts'));
+    expect(pushServiceMocks.enablePushNotificationsForUser).not.toHaveBeenCalled();
+    expect(profileServiceMocks.saveNotificationPreferences).not.toHaveBeenCalled();
+    expect(await screen.findByText('Push setup was skipped. You can turn notifications on later from Alerts.')).toBeTruthy();
   });
 
   it('hides stale team toggles and disables team actions until the new team preferences finish hydrating', async () => {

--- a/tests/unit/app-profile-section-restore.test.tsx
+++ b/tests/unit/app-profile-section-restore.test.tsx
@@ -33,7 +33,8 @@ const publicActionsMocks = vi.hoisted(() => ({
 const pushServiceMocks = vi.hoisted(() => ({
   enablePushNotificationsForUser: vi.fn(),
   getPushNotificationPermissionStatus: vi.fn(),
-  openPushNotificationSettings: vi.fn()
+  openPushNotificationSettings: vi.fn(),
+  runPushNotificationPrimer: vi.fn()
 }));
 
 const shellLayoutState = vi.hoisted(() => ({
@@ -156,6 +157,7 @@ describe('Profile section restore from URL', () => {
     });
     pushServiceMocks.openPushNotificationSettings.mockResolvedValue(undefined);
     pushServiceMocks.enablePushNotificationsForUser.mockResolvedValue(undefined);
+    pushServiceMocks.runPushNotificationPrimer.mockResolvedValue(true);
     publicActionsMocks.sharePublicUrl.mockResolvedValue('shared');
     shellLayoutState.isDesktopWeb = false;
     shellLayoutState.isNative = false;

--- a/tests/unit/app-profile-seed-from-auth.test.tsx
+++ b/tests/unit/app-profile-seed-from-auth.test.tsx
@@ -33,7 +33,8 @@ const publicActionsMocks = vi.hoisted(() => ({
 const pushServiceMocks = vi.hoisted(() => ({
     enablePushNotificationsForUser: vi.fn(),
     getPushNotificationPermissionStatus: vi.fn(),
-    openPushNotificationSettings: vi.fn()
+    openPushNotificationSettings: vi.fn(),
+    runPushNotificationPrimer: vi.fn()
 }));
 
 const shellLayoutState = vi.hoisted(() => ({
@@ -129,6 +130,7 @@ describe('Profile seed from auth.profile', () => {
             canOpenSettings: false
         });
         pushServiceMocks.openPushNotificationSettings.mockResolvedValue(undefined);
+        pushServiceMocks.runPushNotificationPrimer.mockResolvedValue(true);
         shellLayoutState.isDesktopWeb = false;
         shellLayoutState.isNative = false;
     });


### PR DESCRIPTION
## Summary
- add reusable push notification primer state and context copy before OS/browser prompts
- gate Profile Alerts push registration and game-day alerts behind the primer when permission is promptable
- preserve denied-permission settings recovery and add coverage for declined primer, prompt-granted, and prompt-denied paths

## Tests
- npx vitest run apps/app/src/lib/pushService.test.ts tests/unit/app-profile-invites.test.tsx --reporter=verbose
- npx vitest run tests/unit/app-profile-section-restore.test.tsx tests/unit/app-profile-seed-from-auth.test.tsx --reporter=verbose
- npm run app:build

Closes #2185