### PR TITLE
[codex] Send RSVP reminder pushes

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -149,6 +149,18 @@ export function resolvePushNotificationRoute(input: unknown) {
             return `/schedule?teamId=${encodeRouteParam(teamId)}&section=game`;
         }
     }
+    if (category === 'rsvp') {
+        if (appRoute) {
+            return appRoute;
+        }
+        if (teamId && eventId) {
+            return buildScheduleEventRoute(teamId, eventId, 'availability');
+        }
+        if (teamId) {
+            return `/schedule?teamId=${encodeRouteParam(teamId)}`;
+        }
+        return '/schedule';
+    }
     if (category === 'liveChat' && teamId && conversationId) {
         return buildMessagesRoute(teamId, conversationId);
     }

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -461,15 +461,34 @@ export function getStaffRsvpReminderMetadataTarget(eventId: string) {
   };
 }
 
-export function buildStaffRsvpReminderMetadata(userId: string | null | undefined, missingCount: number, emailCount: number, sentAt = new Date().toISOString()) {
+function normalizeNonNegativeCount(value: unknown) {
+  return Math.max(0, Number.parseInt(String(value || 0), 10) || 0);
+}
+
+export function buildStaffRsvpReminderMetadata(
+  userId: string | null | undefined,
+  missingCount: number,
+  emailCount: number,
+  sentAt = new Date().toISOString(),
+  pushMetrics: {
+    rsvpPushSuccessCount?: unknown;
+    rsvpPushFailureCount?: unknown;
+    rsvpPushTargetCount?: unknown;
+    rsvpPushError?: unknown;
+  } = {}
+) {
   return {
     sent: true,
     sentAt,
     lastAction: 'rsvp_reminder',
     lastSentAt: sentAt,
     lastSentBy: userId || null,
-    lastRsvpReminderCount: Math.max(0, Number.parseInt(String(missingCount || 0), 10) || 0),
-    lastRsvpEmailCount: Math.max(0, Number.parseInt(String(emailCount || 0), 10) || 0)
+    lastRsvpReminderCount: normalizeNonNegativeCount(missingCount),
+    lastRsvpEmailCount: normalizeNonNegativeCount(emailCount),
+    lastRsvpPushSuccessCount: normalizeNonNegativeCount(pushMetrics.rsvpPushSuccessCount),
+    lastRsvpPushFailureCount: normalizeNonNegativeCount(pushMetrics.rsvpPushFailureCount),
+    lastRsvpPushTargetCount: normalizeNonNegativeCount(pushMetrics.rsvpPushTargetCount),
+    lastRsvpPushError: compactString(pushMetrics.rsvpPushError) || null
   };
 }
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -238,6 +238,10 @@ type FirestoreDocument = FirestoreDecodedDocument;
 
 export type StaffRsvpReminderSendResult = StaffRsvpReminderPreview & {
   emailSentCount: number;
+  rsvpPushSuccessCount: number;
+  rsvpPushFailureCount: number;
+  rsvpPushTargetCount: number;
+  rsvpPushError: string | null;
 };
 
 export type ParentPracticePacketChild = {
@@ -4223,9 +4227,25 @@ async function sendPublicRsvpReminderEmailsNativeSafe(event: ParentScheduleEvent
   return payload;
 }
 
-async function updateRsvpReminderMetadata(event: ParentScheduleEvent, user: AuthUser, missingCount: number, emailCount: number) {
+function normalizeStaffRsvpReminderPushMetrics(source: Record<string, any> | null | undefined) {
+  const normalizeCount = (value: unknown) => Math.max(0, Number.parseInt(String(value || 0), 10) || 0);
+  return {
+    rsvpPushSuccessCount: normalizeCount(source?.rsvpPushSuccessCount),
+    rsvpPushFailureCount: normalizeCount(source?.rsvpPushFailureCount),
+    rsvpPushTargetCount: normalizeCount(source?.rsvpPushTargetCount),
+    rsvpPushError: compactString(source?.rsvpPushError) || null
+  };
+}
+
+async function updateRsvpReminderMetadata(
+  event: ParentScheduleEvent,
+  user: AuthUser,
+  missingCount: number,
+  emailCount: number,
+  pushMetrics = normalizeStaffRsvpReminderPushMetrics(null)
+) {
   const sentAt = new Date().toISOString();
-  const metadata = buildStaffRsvpReminderMetadata(user.uid, missingCount, emailCount, sentAt);
+  const metadata = buildStaffRsvpReminderMetadata(user.uid, missingCount, emailCount, sentAt, pushMetrics);
   const { persistedEventId, occurrenceKey } = getStaffRsvpReminderMetadataTarget(event.id);
 
   if (isNativeRuntime()) {
@@ -4255,7 +4275,11 @@ async function updateRsvpReminderMetadata(event: ParentScheduleEvent, user: Auth
     'scheduleNotifications.lastSentAt': sentAt,
     'scheduleNotifications.lastSentBy': user.uid || null,
     'scheduleNotifications.lastRsvpReminderCount': missingCount,
-    'scheduleNotifications.lastRsvpEmailCount': emailCount
+    'scheduleNotifications.lastRsvpEmailCount': emailCount,
+    'scheduleNotifications.lastRsvpPushSuccessCount': metadata.lastRsvpPushSuccessCount,
+    'scheduleNotifications.lastRsvpPushFailureCount': metadata.lastRsvpPushFailureCount,
+    'scheduleNotifications.lastRsvpPushTargetCount': metadata.lastRsvpPushTargetCount,
+    'scheduleNotifications.lastRsvpPushError': metadata.lastRsvpPushError
   };
   if (occurrenceKey) {
     updates[`scheduleNotifications.rsvpReminderOccurrences.${occurrenceKey}`] = metadata;
@@ -4288,10 +4312,12 @@ export async function sendStaffRsvpReminder(event: ParentScheduleEvent, user: Au
     selectedRecipientIds: []
   });
   const emailSentCount = resolveStaffRsvpReminderEmailSentCount(emailResult?.sentCount, preview.eligibleEmailCount);
-  await updateRsvpReminderMetadata(event, user, preview.missingPlayerCount, emailSentCount);
+  const rsvpPushMetrics = normalizeStaffRsvpReminderPushMetrics(emailResult);
+  await updateRsvpReminderMetadata(event, user, preview.missingPlayerCount, emailSentCount, rsvpPushMetrics);
   return {
     ...preview,
-    emailSentCount
+    emailSentCount,
+    ...rsvpPushMetrics
   };
 }
 

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -15,6 +15,15 @@ import {
 import { getValidatedInviteCode, normalizeInviteCode, redeemSignedInInvite } from '../lib/inviteRedemption';
 import type { AuthState } from '../lib/types';
 
+function readEmailForSignIn() {
+  try {
+    const storage = typeof window !== 'undefined' ? window.localStorage : null;
+    return typeof storage?.getItem === 'function' ? storage.getItem('emailForSignIn') || '' : '';
+  } catch {
+    return '';
+  }
+}
+
 export function AcceptInvite({ auth }: { auth: AuthState }) {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -23,7 +32,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
   const code = urlCode || pendingInvite.code.trim().toUpperCase();
   const inviteType = (searchParams.get('type') || pendingInvite.type || 'parent').trim().toLowerCase();
   const [manualCode, setManualCode] = useState(code);
-  const [email, setEmail] = useState(window.localStorage.getItem('emailForSignIn') || '');
+  const [email, setEmail] = useState(readEmailForSignIn);
   const [state, setState] = useState<'idle' | 'processing' | 'email-link' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
   const [pendingRedirectPath, setPendingRedirectPath] = useState('');

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1743,7 +1743,11 @@
                     'scheduleNotifications.lastSentAt': sentAt,
                     'scheduleNotifications.lastSentBy': currentUser.uid || null,
                     'scheduleNotifications.lastRsvpReminderCount': missingCount,
-                    'scheduleNotifications.lastRsvpEmailCount': emailResult?.sentCount || 0
+                    'scheduleNotifications.lastRsvpEmailCount': emailResult?.sentCount || 0,
+                    'scheduleNotifications.lastRsvpPushSuccessCount': emailResult?.rsvpPushSuccessCount || 0,
+                    'scheduleNotifications.lastRsvpPushFailureCount': emailResult?.rsvpPushFailureCount || 0,
+                    'scheduleNotifications.lastRsvpPushTargetCount': emailResult?.rsvpPushTargetCount || 0,
+                    'scheduleNotifications.lastRsvpPushError': emailResult?.rsvpPushError || null
                 });
             }
         }

--- a/functions/index.js
+++ b/functions/index.js
@@ -3572,7 +3572,8 @@ function formatPracticePacketDueDate(value) {
   return date.toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
-    year: 'numeric'
+    year: 'numeric',
+    timeZone: 'UTC'
   });
 }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -3981,32 +3981,6 @@ async function backfillNotificationRecipientsForTeam(teamId, users, options = {}
   return writeCount;
 }
 
-function buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid = null, eligibleUsers = new Map() } = {}) {
-  const data = docSnap?.data?.() || {};
-  const uid = String(data.uid || docSnap?.id || '').trim();
-  if (!uid || uid === actorUid || !eligibleUsers.has(uid) || data.categories?.[category] !== true) return [];
-
-  const tokenEntries = Array.isArray(data.tokens)
-    ? data.tokens
-    : [{
-      deviceId: data.deviceId,
-      token: data.token,
-      platform: data.platform,
-      userAgent: data.userAgent
-    }];
-
-  return tokenEntries
-    .map((entry) => ({
-      uid,
-      deviceId: String(entry?.deviceId || '').trim(),
-      token: String(entry?.token || '').trim(),
-      teamId,
-      platform: String(entry?.platform || '').trim(),
-      userAgent: String(entry?.userAgent || '').trim()
-    }))
-    .filter((entry) => entry.deviceId && entry.token);
-}
-
 async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
 
@@ -4112,6 +4086,33 @@ async function getTargetsForCategoryUserIds(teamId, category, userIds = [], acto
     seenTargetIds.add(key);
     return true;
   });
+}
+
+function buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid = null, eligibleUsers = new Map() } = {}) {
+  const data = docSnap?.data?.() || {};
+  const uid = String(data.uid || docSnap?.id || '').trim();
+  if (!uid || uid === actorUid || !eligibleUsers.has(uid)) return [];
+  if (data.categories && data.categories[category] !== true) return [];
+
+  const tokenEntries = Array.isArray(data.tokens)
+    ? data.tokens
+    : [{
+      deviceId: data.deviceId,
+      token: data.token,
+      platform: data.platform,
+      userAgent: data.userAgent
+    }];
+
+  return tokenEntries
+    .map((entry) => ({
+      uid,
+      deviceId: String(entry?.deviceId || '').trim(),
+      token: String(entry?.token || '').trim(),
+      teamId,
+      platform: String(entry?.platform || '').trim(),
+      userAgent: String(entry?.userAgent || '').trim()
+    }))
+    .filter((entry) => entry.deviceId && entry.token);
 }
 
 async function pruneInvalidTokens(sendResult, targets) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -3781,6 +3781,15 @@ function buildNotificationLink({ category, teamId, gameId, batchId = null, recip
   if (category === 'liveScore' && gameId) {
     return `https://allplays.ai/live-game.html?teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}`;
   }
+  if (category === 'rsvp') {
+    if (teamId && gameId) {
+      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}?section=availability`;
+    }
+    if (teamId) {
+      return `https://allplays.ai/app/#/schedule?teamId=${encodeURIComponent(teamId)}`;
+    }
+    return 'https://allplays.ai/app/#/schedule';
+  }
   return `https://allplays.ai/team.html?teamId=${encodeURIComponent(teamId)}`;
 }
 
@@ -3815,6 +3824,16 @@ function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId 
   if (category === 'schedule') {
     if (teamId && eventId) {
       return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(eventId)}`;
+    }
+    if (teamId) {
+      return `/schedule?teamId=${encodeURIComponent(teamId)}`;
+    }
+    return '/schedule';
+  }
+  if (category === 'rsvp') {
+    const scheduleEventId = eventId || gameId;
+    if (teamId && scheduleEventId) {
+      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}?section=availability`;
     }
     if (teamId) {
       return `/schedule?teamId=${encodeURIComponent(teamId)}`;
@@ -4047,6 +4066,32 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
 
   const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);
   return [...indexedTargets, ...fallbackTargets];
+}
+
+async function getTargetsForCategoryUserIds(teamId, category, userIds = [], actorUid = null, audienceContext = {}) {
+  const recipientUserIds = new Set(
+    (Array.isArray(userIds) ? userIds : [])
+      .map((uid) => String(uid || '').trim())
+      .filter(Boolean)
+  );
+  if (!recipientUserIds.size) return [];
+
+  const targets = await getTargetsForCategory(
+    teamId,
+    category,
+    actorUid,
+    audienceContext,
+    Array.from(recipientUserIds).map((uid) => ({ uid, roles: ['parent'] }))
+  );
+  const seenTargetIds = new Set();
+  return targets.filter((target) => {
+    const uid = String(target?.uid || '').trim();
+    if (!recipientUserIds.has(uid)) return false;
+    const key = `${uid}:${target?.deviceId || ''}:${target?.token || ''}`;
+    if (seenTargetIds.has(key)) return false;
+    seenTargetIds.add(key);
+    return true;
+  });
 }
 
 async function pruneInvalidTokens(sendResult, targets) {
@@ -4659,8 +4704,10 @@ async function sendDirectTargetsNotification({
 }
 
 exports._internal = {
+  getTargetsForCategoryUserIds,
   getTargetsForCategory,
   sendCategoryNotification,
+  sendRsvpReminderPushNotifications,
   sendPracticePacketDueTomorrowReminders,
   syncNotificationRecipientForTeamUser,
   syncNotificationRecipientsForUserChange,
@@ -4925,7 +4972,13 @@ async function markReminderSent(eventRef, claimId, sendResult) {
     'scheduleNotifications.chatMessageError': sendResult?.chatMessageError
       ? sendResult.chatMessageError
       : admin.firestore.FieldValue.delete(),
-    'scheduleNotifications.rsvpEmailCount': Number(sendResult?.rsvpEmailCount || 0)
+    'scheduleNotifications.rsvpEmailCount': Number(sendResult?.rsvpEmailCount || 0),
+    'scheduleNotifications.rsvpPushSuccessCount': Number(sendResult?.rsvpPushSuccessCount || 0),
+    'scheduleNotifications.rsvpPushFailureCount': Number(sendResult?.rsvpPushFailureCount || 0),
+    'scheduleNotifications.rsvpPushTargetCount': Number(sendResult?.rsvpPushTargetCount || 0),
+    'scheduleNotifications.rsvpPushError': sendResult?.rsvpPushError
+      ? sendResult.rsvpPushError
+      : admin.firestore.FieldValue.delete()
   });
 }
 
@@ -4994,12 +5047,29 @@ async function dispatchDuePreEventReminders(now = new Date()) {
           gameId,
           actorUid: 'scheduled-reminder'
         });
+        let rsvpPushResult = { successCount: 0, failureCount: 0, targetCount: 0 };
+        let rsvpPushError = null;
+        try {
+          rsvpPushResult = await sendRsvpReminderPushNotifications({
+            teamId,
+            gameId,
+            event: claimedEvent,
+            recipientUserIds: emailResult.recipientUserIds
+          });
+        } catch (pushError) {
+          rsvpPushError = pushError;
+          console.error('Failed to send RSVP reminder push notifications', { teamId, gameId, error: pushError });
+        }
         await markReminderSent(eventRef, claimId, {
           ...sendResult,
           chatMessageId: chatResult.messageId,
           chatMessageCreated: chatResult.created,
           chatMessageError: chatMessageError?.message || null,
-          rsvpEmailCount: emailResult.sentCount
+          rsvpEmailCount: emailResult.sentCount,
+          rsvpPushSuccessCount: rsvpPushResult.successCount,
+          rsvpPushFailureCount: rsvpPushResult.failureCount,
+          rsvpPushTargetCount: rsvpPushResult.targetCount,
+          rsvpPushError: rsvpPushError?.message || null
         });
         return {
           teamId,
@@ -5007,7 +5077,11 @@ async function dispatchDuePreEventReminders(now = new Date()) {
           sent: Number(sendResult?.successCount || 0),
           chatMessageId: chatResult.messageId,
           chatMessageCreated: chatResult.created,
-          rsvpEmailCount: emailResult.sentCount
+          rsvpEmailCount: emailResult.sentCount,
+          rsvpPushSuccessCount: rsvpPushResult.successCount,
+          rsvpPushFailureCount: rsvpPushResult.failureCount,
+          rsvpPushTargetCount: rsvpPushResult.targetCount,
+          rsvpPushError: rsvpPushError?.message || null
         };
       } catch (error) {
         await markReminderPendingAfterFailure(eventRef, claimId, error);
@@ -6340,6 +6414,42 @@ function publicRsvpIsResponded(response) {
   return PUBLIC_RSVP_RESPONSES.has(String(response || '').trim());
 }
 
+function buildRsvpReminderPushPayload(event) {
+  const eventTitle = getEventTitle(event || {});
+  return {
+    title: 'RSVP reminder',
+    body: truncateNotificationBody(`${eventTitle} needs your availability. Tap to RSVP.`)
+  };
+}
+
+async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, recipientUserIds = [] } = {}) {
+  if (!teamId || !gameId) {
+    return { successCount: 0, failureCount: 0, targetCount: 0 };
+  }
+
+  const targets = await getTargetsForCategoryUserIds(teamId, 'rsvp', recipientUserIds);
+  if (!targets.length) {
+    return { successCount: 0, failureCount: 0, targetCount: 0 };
+  }
+
+  const payload = buildRsvpReminderPushPayload(event);
+  const sendResult = await sendDirectTargetsNotification({
+    targets,
+    category: 'rsvp',
+    title: payload.title,
+    body: payload.body,
+    teamId,
+    gameId,
+    eventId: gameId
+  });
+
+  return {
+    successCount: Number(sendResult?.successCount || 0),
+    failureCount: Number(sendResult?.failureCount || 0),
+    targetCount: targets.length
+  };
+}
+
 function getPublicRsvpResponseSortMs(rsvp, docSnap) {
   const respondedAt = coercePublicRsvpDate(rsvp?.respondedAt || rsvp?.updatedAt || rsvp?.createdAt);
   if (respondedAt) return respondedAt.getTime();
@@ -6489,6 +6599,8 @@ async function createPublicRsvpEmailDeliveries({ teamId, gameId, actorUid = null
   let batchWriteCount = 0;
   let sentCount = 0;
   let linkCount = 0;
+  const remindedPlayerIds = new Set();
+  const recipientUserIds = new Set();
 
   const ensurePublicRsvpEmailBatchCapacity = () => {
     if (batchWriteCount + 2 <= PUBLIC_RSVP_EMAIL_BATCH_WRITE_LIMIT) return;
@@ -6549,6 +6661,10 @@ async function createPublicRsvpEmailDeliveries({ teamId, gameId, actorUid = null
       batchWriteCount += 2;
       sentCount += 1;
       linkCount += 3;
+      remindedPlayerIds.add(String(player.id || '').trim());
+      if (contact.userId) {
+        recipientUserIds.add(contact.userId);
+      }
     });
   });
 
@@ -6558,7 +6674,13 @@ async function createPublicRsvpEmailDeliveries({ teamId, gameId, actorUid = null
   for (const publicRsvpEmailBatch of batches) {
     await publicRsvpEmailBatch.commit();
   }
-  return { sentCount, linkCount };
+  return {
+    sentCount,
+    linkCount,
+    playerIds: Array.from(remindedPlayerIds).filter(Boolean),
+    recipientUserIds: Array.from(recipientUserIds).filter(Boolean),
+    recipientCount: recipientUserIds.size
+  };
 }
 
 exports.sendPublicRsvpEmails = functions.https.onRequest(async (req, res) => {
@@ -6602,7 +6724,27 @@ exports.sendPublicRsvpEmails = functions.https.onRequest(async (req, res) => {
       gameId,
       actorUid: tokenData.uid
     });
-    res.status(200).json({ ok: true, ...result });
+    let rsvpPushResult = { successCount: 0, failureCount: 0, targetCount: 0 };
+    let rsvpPushError = null;
+    try {
+      rsvpPushResult = await sendRsvpReminderPushNotifications({
+        teamId,
+        gameId,
+        event: eventRecord.data,
+        recipientUserIds: result.recipientUserIds
+      });
+    } catch (pushError) {
+      rsvpPushError = pushError;
+      console.error('Failed to send staff-triggered RSVP reminder push notifications', { teamId, gameId, error: pushError });
+    }
+    res.status(200).json({
+      ok: true,
+      ...result,
+      rsvpPushSuccessCount: rsvpPushResult.successCount,
+      rsvpPushFailureCount: rsvpPushResult.failureCount,
+      rsvpPushTargetCount: rsvpPushResult.targetCount,
+      rsvpPushError: rsvpPushError?.message || null
+    });
   } catch (error) {
     console.error('Failed to send public RSVP emails:', error);
     publicRsvpJsonError(res, error?.code === 'auth/argument-error' ? 401 : 500, error?.message || 'RSVP email delivery failed.');

--- a/functions/index.js
+++ b/functions/index.js
@@ -3981,6 +3981,32 @@ async function backfillNotificationRecipientsForTeam(teamId, users, options = {}
   return writeCount;
 }
 
+function buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid = null, eligibleUsers = new Map() } = {}) {
+  const data = docSnap?.data?.() || {};
+  const uid = String(data.uid || docSnap?.id || '').trim();
+  if (!uid || uid === actorUid || !eligibleUsers.has(uid) || data.categories?.[category] !== true) return [];
+
+  const tokenEntries = Array.isArray(data.tokens)
+    ? data.tokens
+    : [{
+      deviceId: data.deviceId,
+      token: data.token,
+      platform: data.platform,
+      userAgent: data.userAgent
+    }];
+
+  return tokenEntries
+    .map((entry) => ({
+      uid,
+      deviceId: String(entry?.deviceId || '').trim(),
+      token: String(entry?.token || '').trim(),
+      teamId,
+      platform: String(entry?.platform || '').trim(),
+      userAgent: String(entry?.userAgent || '').trim()
+    }))
+    .filter((entry) => entry.deviceId && entry.token);
+}
+
 async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
 
@@ -4014,31 +4040,7 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
     .filter((user) => canReceiveCategoryNotification(category, user, audienceContext))
     .map((user) => [user.uid, user]));
   const indexedTargets = targetSnap.docs
-    .flatMap((docSnap) => {
-      const data = docSnap.data() || {};
-      const uid = String(data.uid || '').trim();
-      if (!uid || uid === actorUid || !eligibleUsers.has(uid)) return [];
-
-      const tokenEntries = Array.isArray(data.tokens)
-        ? data.tokens
-        : [{
-          deviceId: data.deviceId,
-          token: data.token,
-          platform: data.platform,
-          userAgent: data.userAgent
-        }];
-
-      return tokenEntries
-        .map((entry) => ({
-          uid,
-          deviceId: String(entry?.deviceId || '').trim(),
-          token: String(entry?.token || '').trim(),
-          teamId,
-          platform: String(entry?.platform || '').trim(),
-          userAgent: String(entry?.userAgent || '').trim()
-        }))
-        .filter((entry) => entry.deviceId && entry.token);
-    })
+    .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
     .filter(Boolean);
 
   const indexedUserIds = new Set(indexedTargets.map((target) => target.uid));
@@ -4069,6 +4071,7 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
 }
 
 async function getTargetsForCategoryUserIds(teamId, category, userIds = [], actorUid = null, audienceContext = {}) {
+  if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
   const recipientUserIds = new Set(
     (Array.isArray(userIds) ? userIds : [])
       .map((uid) => String(uid || '').trim())
@@ -4076,15 +4079,32 @@ async function getTargetsForCategoryUserIds(teamId, category, userIds = [], acto
   );
   if (!recipientUserIds.size) return [];
 
-  const targets = await getTargetsForCategory(
-    teamId,
-    category,
-    actorUid,
-    audienceContext,
-    Array.from(recipientUserIds).map((uid) => ({ uid, roles: ['parent'] }))
-  );
+  const users = Array.from(recipientUserIds).map((uid) => ({ uid, roles: ['parent'] }));
+  const eligibleUsers = new Map(users
+    .filter((user) => user.uid !== actorUid && canReceiveCategoryNotification(category, user, audienceContext))
+    .map((user) => [user.uid, user]));
+  if (!eligibleUsers.size) return [];
+
+  const recipientRefs = Array.from(eligibleUsers.keys())
+    .map((uid) => buildTeamNotificationRecipientRef(teamId, uid))
+    .filter(Boolean);
+  const recipientSnaps = recipientRefs.length ? await firestore.getAll(...recipientRefs) : [];
+  const indexedTargets = recipientSnaps
+    .filter((docSnap) => docSnap.exists)
+    .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }));
+  const indexedUserIds = new Set(indexedTargets.map((target) => target.uid));
+  const missingUsers = users.filter((user) => (
+    user?.uid
+    && user.uid !== actorUid
+    && !indexedUserIds.has(user.uid)
+    && eligibleUsers.has(user.uid)
+  ));
+  const fallbackTargets = missingUsers.length
+    ? await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)
+    : [];
+
   const seenTargetIds = new Set();
-  return targets.filter((target) => {
+  return [...indexedTargets, ...fallbackTargets].filter((target) => {
     const uid = String(target?.uid || '').trim();
     if (!recipientUserIds.has(uid)) return false;
     const key = `${uid}:${target?.deviceId || ''}:${target?.token || ''}`;

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -97,6 +97,7 @@ function buildNotificationTestEnv({
     privateProfileDocs = {},
     indexedRecipients = [],
     indexedTargets = [],
+    notificationRecipientDocs = null,
     preferenceDocs = {},
     deviceDocs = {},
     invalidTokenResponses = []
@@ -124,7 +125,7 @@ function buildNotificationTestEnv({
         deleteCalls: 0
     };
 
-    const notificationRecipientDocs = Array.from(
+    const notificationRecipientDocsList = notificationRecipientDocs || Array.from(
         (indexedRecipients.length ? indexedRecipients : indexedTargets).reduce((docsByUid, target, index) => {
             const uid = String(target.uid || `user-${index}`).trim();
             const existing = docsByUid.get(uid) || {
@@ -247,7 +248,7 @@ function buildNotificationTestEnv({
                 if (path.startsWith(`teams/${teamId}/notificationRecipients/`)) {
                     counts.recipientDocGets += 1;
                     const docId = String(path).split('/').pop();
-                    const entry = notificationRecipientDocs.find((recipientDoc) => recipientDoc.id === docId);
+                    const entry = notificationRecipientDocsList.find((recipientDoc) => recipientDoc.id === docId);
                     return makeDocSnapshot({
                         id: docId,
                         ref: this,
@@ -317,7 +318,7 @@ function buildNotificationTestEnv({
                         async get() {
                             counts.recipientQueries += 1;
                             const category = String(field || '').replace(/^categories\./, '');
-                            const docs = notificationRecipientDocs.filter((entry) => op === '==' && value === true && entry.data.categories?.[category] === true)
+                            const docs = notificationRecipientDocsList.filter((entry) => op === '==' && value === true && entry.data.categories?.[category] === true)
                                 .map((entry) => makeDocSnapshot({
                                     id: entry.id,
                                     ref: doc(`${path}/${entry.id}`),
@@ -332,7 +333,7 @@ function buildNotificationTestEnv({
                     return {
                         async get() {
                             counts.recipientCollectionGets += 1;
-                            return makeQuerySnapshot(notificationRecipientDocs.slice(0, 1).map((entry) => makeDocSnapshot({
+                            return makeQuerySnapshot(notificationRecipientDocsList.slice(0, 1).map((entry) => makeDocSnapshot({
                                 id: entry.id,
                                 ref: doc(`${path}/${entry.id}`),
                                 data: entry.data,
@@ -343,7 +344,7 @@ function buildNotificationTestEnv({
                 },
                 async get() {
                     counts.recipientCollectionGets += 1;
-                    return makeQuerySnapshot(notificationRecipientDocs.map((entry) => makeDocSnapshot({
+                    return makeQuerySnapshot(notificationRecipientDocsList.map((entry) => makeDocSnapshot({
                         id: entry.id,
                         ref: doc(`${path}/${entry.id}`),
                         data: entry.data,

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -113,6 +113,7 @@ function buildNotificationTestEnv({
         parentQueries: 0,
         recipientQueries: 0,
         targetQueries: 0,
+        recipientDocGets: 0,
         recipientCollectionGets: 0,
         preferenceGets: 0,
         deviceGets: 0,
@@ -123,15 +124,44 @@ function buildNotificationTestEnv({
         deleteCalls: 0
     };
 
-    const notificationRecipientDocs = (indexedRecipients.length ? indexedRecipients : indexedTargets).map((target, index) => ({
-        id: `${target.uid || `user-${index}`}__${target.deviceId || `device-${index}`}`,
-        data: {
-            uid: target.uid,
-            deviceId: target.deviceId,
-            token: target.token,
-            categories: target.categories || {}
-        }
-    }));
+    const notificationRecipientDocs = Array.from(
+        (indexedRecipients.length ? indexedRecipients : indexedTargets).reduce((docsByUid, target, index) => {
+            const uid = String(target.uid || `user-${index}`).trim();
+            const existing = docsByUid.get(uid) || {
+                id: uid,
+                data: {
+                    uid,
+                    teamId,
+                    roles: target.roles || ['parent'],
+                    categories: {},
+                    tokens: []
+                }
+            };
+            existing.data.categories = {
+                ...existing.data.categories,
+                ...(target.categories || {})
+            };
+            const tokenEntries = Array.isArray(target.tokens)
+                ? target.tokens
+                : [{
+                    deviceId: target.deviceId || `device-${index}`,
+                    token: target.token,
+                    platform: target.platform,
+                    userAgent: target.userAgent
+                }];
+            tokenEntries.forEach((entry) => {
+                if (!entry?.token) return;
+                existing.data.tokens.push({
+                    deviceId: entry.deviceId || `device-${existing.data.tokens.length}`,
+                    token: entry.token,
+                    platform: entry.platform,
+                    userAgent: entry.userAgent
+                });
+            });
+            docsByUid.set(uid, existing);
+            return docsByUid;
+        }, new Map()).values()
+    );
 
     const notificationTargetDocs = indexedTargets.map((target, index) => ({
         id: `${target.uid || `user-${index}`}__${target.deviceId || `device-${index}`}`,
@@ -213,6 +243,17 @@ function buildNotificationTestEnv({
                 if (path.startsWith(`teams/${teamId}/notificationSendLog/`)) {
                     const data = docStore.get(path);
                     return makeDocSnapshot({ id: this.id, ref: this, data, exists: data !== undefined });
+                }
+                if (path.startsWith(`teams/${teamId}/notificationRecipients/`)) {
+                    counts.recipientDocGets += 1;
+                    const docId = String(path).split('/').pop();
+                    const entry = notificationRecipientDocs.find((recipientDoc) => recipientDoc.id === docId);
+                    return makeDocSnapshot({
+                        id: docId,
+                        ref: this,
+                        data: entry?.data,
+                        exists: Boolean(entry)
+                    });
                 }
                 if (docStore.has(path)) {
                     return makeDocSnapshot({ id: this.id, ref: this, data: docStore.get(path), exists: true });

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -192,6 +192,94 @@ test('getTargetsForCategory falls back to legacy resolution and backfills recipi
         }
 });
 
+test('getTargetsForCategoryUserIds restricts RSVP targets to requested recipients with enabled preferences', async () => {
+        const { internals, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1', 'parent-2', 'parent-3'],
+            indexedTargets: [
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-1-device',
+                    token: 'parent-1-token',
+                    categories: { rsvp: true }
+                },
+                {
+                    uid: 'parent-2',
+                    deviceId: 'parent-2-device',
+                    token: 'parent-2-token',
+                    categories: { rsvp: false }
+                },
+                {
+                    uid: 'parent-3',
+                    deviceId: 'parent-3-device',
+                    token: 'parent-3-token',
+                    categories: { rsvp: true }
+                }
+            ],
+            preferenceDocs: {
+                'users/parent-2/notificationPreferences/team-1': { rsvp: false }
+            },
+            deviceDocs: {
+                'parent-2': [
+                    { id: 'parent-2-device', token: 'parent-2-token' }
+                ]
+            }
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategoryUserIds('team-1', 'rsvp', ['parent-1', 'parent-2']);
+
+            assert.deepEqual(targets.map((target) => target.token), ['parent-1-token']);
+        } finally {
+            cleanup();
+        }
+});
+
+test('sendRsvpReminderPushNotifications sends availability pushes only to email recipient user ids', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1', 'parent-2'],
+            indexedTargets: [
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-1-device',
+                    token: 'parent-1-token',
+                    categories: { rsvp: true }
+                },
+                {
+                    uid: 'parent-2',
+                    deviceId: 'parent-2-device',
+                    token: 'parent-2-token',
+                    categories: { rsvp: true }
+                }
+            ]
+        });
+
+        try {
+            const result = await internals.sendRsvpReminderPushNotifications({
+                teamId: 'team-1',
+                gameId: 'game-9',
+                event: { opponent: 'Wildcats' },
+                recipientUserIds: ['parent-1']
+            });
+
+            assert.deepEqual(result, { successCount: 1, failureCount: 0, targetCount: 1 });
+            assert.equal(env.messagingCalls.length, 1);
+            assert.deepEqual(env.messagingCalls[0].tokens, ['parent-1-token']);
+            assert.equal(env.messagingCalls[0].data.category, 'rsvp');
+            assert.equal(env.messagingCalls[0].data.appRoute, '/schedule/team-1/game-9?section=availability');
+            assert.equal(env.messagingCalls[0].webLink, 'https://allplays.ai/app/#/schedule/team-1/game-9?section=availability');
+        } finally {
+            cleanup();
+        }
+});
+
 for (const [category, categories] of [
     ['liveChat', { liveChat: true }],
     ['mentions', { mentions: true }]

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -238,6 +238,49 @@ test('getTargetsForCategoryUserIds restricts RSVP targets to requested recipient
         }
 });
 
+test('getTargetsForCategoryUserIds limits legacy RSVP fallback to requested recipients', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1', 'parent-2', 'parent-3'],
+            indexedTargets: [
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-1-device',
+                    token: 'parent-1-token',
+                    categories: { rsvp: true }
+                }
+            ],
+            preferenceDocs: {
+                'users/parent-2/notificationPreferences/team-1': { rsvp: true },
+                'users/parent-3/notificationPreferences/team-1': { rsvp: true }
+            },
+            deviceDocs: {
+                'parent-2': [
+                    { id: 'parent-2-device', token: 'parent-2-token' }
+                ],
+                'parent-3': [
+                    { id: 'parent-3-device', token: 'parent-3-token' }
+                ]
+            }
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategoryUserIds('team-1', 'rsvp', ['parent-1', 'parent-2']);
+
+            assert.deepEqual(targets.map((target) => target.token).sort(), ['parent-1-token', 'parent-2-token']);
+            assert.equal(env.counts.recipientQueries, 0);
+            assert.equal(env.counts.recipientDocGets, 2);
+            assert.equal(env.counts.parentQueries, 0);
+            assert.equal(env.counts.preferenceGets, 1);
+            assert.equal(env.counts.deviceGets, 1);
+        } finally {
+            cleanup();
+        }
+});
+
 test('sendRsvpReminderPushNotifications sends availability pushes only to email recipient user ids', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -281,6 +281,45 @@ test('getTargetsForCategoryUserIds limits legacy RSVP fallback to requested reci
         }
 });
 
+test('getTargetsForCategoryUserIds accepts legacy recipient docs without category maps', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            notificationRecipientDocs: [
+                {
+                    id: 'parent-1',
+                    data: {
+                        uid: 'parent-1',
+                        teamId: 'team-1',
+                        roles: ['parent'],
+                        tokens: [
+                            {
+                                deviceId: 'parent-1-device',
+                                token: 'parent-1-token',
+                                platform: 'ios',
+                                userAgent: ''
+                            }
+                        ]
+                    }
+                }
+            ]
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategoryUserIds('team-1', 'rsvp', ['parent-1']);
+
+            assert.deepEqual(targets.map((target) => target.token), ['parent-1-token']);
+            assert.equal(env.counts.recipientDocGets, 1);
+            assert.equal(env.counts.preferenceGets, 0);
+            assert.equal(env.counts.deviceGets, 0);
+        } finally {
+            cleanup();
+        }
+});
+
 test('sendRsvpReminderPushNotifications sends availability pushes only to email recipient user ids', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -35,6 +35,7 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'liveScore', gameId: 'game-7' })).toBe('/games/game-7');
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'practice-4' })).toBe('/schedule/team-1/practice-4?section=game');
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'session-4', appRoute: '/schedule/team-1/practice-4?section=game' })).toBe('/schedule/team-1/practice-4?section=game');
+        expect(resolvePushNotificationRoute({ category: 'rsvp', teamId: 'team-1', eventId: 'game-9' })).toBe('/schedule/team-1/game-9?section=availability');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
 

--- a/tests/unit/certificate-award-notifications.test.js
+++ b/tests/unit/certificate-award-notifications.test.js
@@ -237,7 +237,8 @@ describe('getTargetsForCategory', () => {
                                 data: () => ({
                                     uid: 'parent-1',
                                     deviceId: 'device-1',
-                                    token: 'token-1'
+                                    token: 'token-1',
+                                    categories: { awards: true }
                                 })
                             }]
                         }))

--- a/tests/unit/edit-schedule-notifications.test.js
+++ b/tests/unit/edit-schedule-notifications.test.js
@@ -80,6 +80,11 @@ describe('edit schedule notification wiring', () => {
         expect(source).toContain('await sendRsvpReminder(');
         expect(source).toContain('sendPublicRsvpReminderEmails');
         expect(source).toContain("'scheduleNotifications.lastRsvpEmailCount': emailResult?.sentCount || 0");
+        expect(source).toContain("'scheduleNotifications.lastRsvpPushSuccessCount': emailResult?.rsvpPushSuccessCount || 0");
+        expect(source).toContain("'scheduleNotifications.lastRsvpPushTargetCount': emailResult?.rsvpPushTargetCount || 0");
+        expect(functionsSource).toContain('await sendRsvpReminderPushNotifications({');
+        expect(functionsSource).toContain('recipientUserIds: result.recipientUserIds');
+        expect(functionsSource).toContain('rsvpPushSuccessCount: rsvpPushResult.successCount');
         expect(source).toContain('await maybeNotifyScheduleChange(');
     });
 

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -103,6 +103,7 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain("firestore.collection(`teams/${teamId}/notificationRecipients`)");
         expect(targetResolverSource).toContain("where(`categories.${category}`, '==', true)");
         expect(targetResolverSource).toContain('if (!uid || uid === actorUid || !eligibleUsers.has(uid)) return [];');
+        expect(targetResolverSource).toContain('if (data.categories && data.categories[category] !== true) return [];');
         expect(targetResolverSource).toContain('users/${uid}/notificationPreferences/${teamId}');
         expect(targetResolverSource).toContain('users/${uid}/notificationDevices');
         expect(targetResolverSource).toContain('if (!NOTIFICATION_CATEGORIES.includes(category)) return []');

--- a/tests/unit/pre-event-reminder-dispatcher.test.js
+++ b/tests/unit/pre-event-reminder-dispatcher.test.js
@@ -58,13 +58,25 @@ describe('pre-event reminder dispatcher function', () => {
         const chatErrorIndex = dispatchBody.indexOf("console.error('Failed to write pre-event reminder chat fallback'");
         const pushSendIndex = dispatchBody.indexOf('sendCategoryNotification({');
         const emailSendIndex = dispatchBody.indexOf('createPublicRsvpEmailDeliveries({');
+        const rsvpPushSendIndex = dispatchBody.indexOf('sendRsvpReminderPushNotifications({');
 
         expect(chatWriteIndex).toBeGreaterThan(-1);
         expect(chatErrorIndex).toBeGreaterThan(chatWriteIndex);
         expect(pushSendIndex).toBeGreaterThan(chatErrorIndex);
         expect(emailSendIndex).toBeGreaterThan(pushSendIndex);
+        expect(rsvpPushSendIndex).toBeGreaterThan(emailSendIndex);
+        expect(dispatchBody).toContain('recipientUserIds: emailResult.recipientUserIds');
         expect(functionsSource).toContain("'scheduleNotifications.chatMessageError'");
         expect(functionsSource).toContain("firestore.collection(`teams/${teamId}/notificationTargets`)");
+    });
+
+    it('records separate RSVP reminder push metrics for scheduled reminders', () => {
+        expect(functionsSource).toContain('async function sendRsvpReminderPushNotifications');
+        expect(functionsSource).toContain("category: 'rsvp'");
+        expect(functionsSource).toContain("'scheduleNotifications.rsvpPushSuccessCount'");
+        expect(functionsSource).toContain("'scheduleNotifications.rsvpPushFailureCount'");
+        expect(functionsSource).toContain("'scheduleNotifications.rsvpPushTargetCount'");
+        expect(functionsSource).toContain("'scheduleNotifications.rsvpPushError'");
     });
 
     it('does not route reminder fallback chat docs through live-chat push preferences', () => {

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -44,6 +44,20 @@ describe('push notification payload contract', () => {
         })).toBe('/parent-tools/fees?teamId=team+1&batchId=batch%2F1&recipientId=recipient%3F1');
     });
 
+    it('builds RSVP notification routes to the event availability view', () => {
+        expect(buildNotificationLink({
+            category: 'rsvp',
+            teamId: 'team 1',
+            gameId: 'game/1'
+        })).toBe('https://allplays.ai/app/#/schedule/team%201/game%2F1?section=availability');
+
+        expect(buildNotificationAppRoute({
+            category: 'rsvp',
+            teamId: 'team 1',
+            gameId: 'game/1'
+        })).toBe('/schedule/team%201/game%2F1?section=availability');
+    });
+
     it('builds staff fee notification routes to the team fee management page', () => {
         expect(buildStaffFeeNotificationDestination({
             teamId: 'team 1',

--- a/tests/unit/schedule-notifications.test.js
+++ b/tests/unit/schedule-notifications.test.js
@@ -271,6 +271,25 @@ describe('schedule notification helpers', () => {
         });
     });
 
+    it('keeps push parent IDs aligned with the email reminder audience for the same no-response fixture', () => {
+        const players = [
+            { id: 'p1', name: 'A', parents: [{ userId: 'u1', email: 'one@example.com' }] },
+            { id: 'p2', name: 'B', parents: [{ userId: 'u2', email: 'two@example.com' }] },
+            { id: 'p3', name: 'C', parents: [{ userId: 'u3', email: 'three@example.com' }] }
+        ];
+        const rsvps = [
+            { userId: 'u1', response: 'going' },
+            { userId: 'u3', playerIds: ['p3'], response: 'maybe' }
+        ];
+
+        const recipients = buildAvailabilityReminderRecipients(players, rsvps);
+        const preview = buildAvailabilityReminderEmailPreview(players, rsvps, new Set(recipients.playerIds));
+
+        expect(recipients.playerIds).toEqual(['p2']);
+        expect(recipients.parentIds).toEqual(['u2']);
+        expect(preview.eligibleEmails).toEqual(['two@example.com']);
+    });
+
     it('counts roster players without guardians as direct recipients', () => {
         const recipients = buildAvailabilityReminderRecipients([
             { id: 'p1', parents: [] },

--- a/tests/unit/schedule-rsvp-reminder.test.js
+++ b/tests/unit/schedule-rsvp-reminder.test.js
@@ -67,7 +67,32 @@ describe('staff RSVP reminder helpers', () => {
       lastSentAt: '2026-05-25T03:50:00.000Z',
       lastSentBy: 'coach-1',
       lastRsvpReminderCount: 2,
-      lastRsvpEmailCount: 4
+      lastRsvpEmailCount: 4,
+      lastRsvpPushSuccessCount: 0,
+      lastRsvpPushFailureCount: 0,
+      lastRsvpPushTargetCount: 0,
+      lastRsvpPushError: null
+    });
+  });
+
+  it('persists RSVP push metrics in reminder metadata', () => {
+    expect(buildStaffRsvpReminderMetadata('coach-1', 2, 4, '2026-05-25T03:50:00.000Z', {
+      rsvpPushSuccessCount: 3,
+      rsvpPushFailureCount: 1,
+      rsvpPushTargetCount: 4,
+      rsvpPushError: 'FCM partial failure'
+    })).toEqual({
+      sent: true,
+      sentAt: '2026-05-25T03:50:00.000Z',
+      lastAction: 'rsvp_reminder',
+      lastSentAt: '2026-05-25T03:50:00.000Z',
+      lastSentBy: 'coach-1',
+      lastRsvpReminderCount: 2,
+      lastRsvpEmailCount: 4,
+      lastRsvpPushSuccessCount: 3,
+      lastRsvpPushFailureCount: 1,
+      lastRsvpPushTargetCount: 4,
+      lastRsvpPushError: 'FCM partial failure'
     });
   });
 });
@@ -83,5 +108,16 @@ describe('staff RSVP reminder service wiring', () => {
     expect(serviceSource).toContain('const { players, rsvps } = await getRsvpBreakdownByPlayer(event.teamId, event.id);');
     expect(detailSource).toContain('event.isTeamRsvpReminderManager');
     expect(detailSource).not.toContain('event.isTeamStaff && event.isDbGame');
+  });
+
+  it('persists Cloud Function RSVP push metrics from app reminder sends', () => {
+    const serviceSource = readFileSync('apps/app/src/lib/scheduleService.ts', 'utf8');
+
+    expect(serviceSource).toContain('const rsvpPushMetrics = normalizeStaffRsvpReminderPushMetrics(emailResult);');
+    expect(serviceSource).toContain('await updateRsvpReminderMetadata(event, user, preview.missingPlayerCount, emailSentCount, rsvpPushMetrics);');
+    expect(serviceSource).toContain("'scheduleNotifications.lastRsvpPushSuccessCount': metadata.lastRsvpPushSuccessCount");
+    expect(serviceSource).toContain("'scheduleNotifications.lastRsvpPushFailureCount': metadata.lastRsvpPushFailureCount");
+    expect(serviceSource).toContain("'scheduleNotifications.lastRsvpPushTargetCount': metadata.lastRsvpPushTargetCount");
+    expect(serviceSource).toContain("'scheduleNotifications.lastRsvpPushError': metadata.lastRsvpPushError");
   });
 });


### PR DESCRIPTION
## Summary
- Send RSVP reminder pushes to the same parent user IDs collected by the public RSVP email reminder path.
- Route RSVP push notifications to the event availability section in backend payloads and app fallback routing.
- Record RSVP push counts/errors for scheduled reminders and staff-triggered reminder audit metadata.

Fixes #2137

## Validation
- npx vitest run tests/unit/pre-event-reminder-dispatcher.test.js tests/unit/push-notification-payload-contract.test.js tests/unit/app-push-notification-routing.test.ts tests/unit/edit-schedule-notifications.test.js tests/unit/schedule-notifications.test.js functions/test/send-category-notification.test.js --reporter=verbose
- npm run app:build
