### PR TITLE
[codex] Batch team media push notifications

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -149,6 +149,15 @@ export function resolvePushNotificationRoute(input: unknown) {
             return `/schedule?teamId=${encodeRouteParam(teamId)}&section=game`;
         }
     }
+    if (category === 'media') {
+        if (appRoute) {
+            return appRoute;
+        }
+        if (teamId) {
+            return `/teams/${encodeRouteParam(teamId)}/media`;
+        }
+        return '/teams';
+    }
     if (category === 'liveChat' && teamId && conversationId) {
         return buildMessagesRoute(teamId, conversationId);
     }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -302,6 +302,14 @@
       ]
     },
     {
+      "collectionGroup": "teamMediaNotificationBatches",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "dueAt", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "chatMessages",
       "queryScope": "COLLECTION",
       "fields": [

--- a/functions/index.js
+++ b/functions/index.js
@@ -3909,6 +3909,40 @@ function buildTeamMediaNotificationPayload(batch = {}) {
   };
 }
 
+function buildTeamMediaNotificationBatchWrite(batch = {}, metadata = {}) {
+  const existingItemIds = Array.from(new Set(
+    (Array.isArray(batch.itemIds) ? batch.itemIds : [])
+      .map((itemId) => normalizeTeamMediaNotificationText(itemId))
+      .filter(Boolean)
+  ));
+  const existingItemTypes = Array.from(new Set(
+    (Array.isArray(batch.itemTypes) ? batch.itemTypes : [])
+      .map((itemType) => normalizeTeamMediaNotificationItemType(itemType))
+      .filter(Boolean)
+  ));
+  const nextItemIds = existingItemIds.includes(metadata.itemId)
+    ? existingItemIds
+    : [...existingItemIds, metadata.itemId];
+  const nextItemTypes = metadata.itemType && !existingItemTypes.includes(metadata.itemType)
+    ? [...existingItemTypes, metadata.itemType]
+    : existingItemTypes;
+
+  return {
+    teamId: metadata.teamId,
+    folderId: metadata.folderId,
+    albumName: metadata.albumName,
+    albumVisibility: metadata.albumVisibility,
+    windowStartAt: admin.firestore.Timestamp.fromDate(metadata.windowStartAt),
+    dueAt: admin.firestore.Timestamp.fromDate(metadata.dueAt),
+    status: 'pending',
+    itemCount: nextItemIds.length,
+    itemIds: nextItemIds,
+    itemTypes: nextItemTypes,
+    latestItemTitle: metadata.itemTitle || null,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp()
+  };
+}
+
 async function queueTeamMediaNotificationBatch({ teamId, itemId, item, now = new Date() } = {}) {
   const folderId = normalizeTeamMediaNotificationText(item?.folderId);
   if (!teamId || !itemId || !folderId || item?.deleted === true) return null;
@@ -3929,23 +3963,11 @@ async function queueTeamMediaNotificationBatch({ teamId, itemId, item, now = new
   const batchRef = firestore.doc(`teamMediaNotificationBatches/${metadata.batchId}`);
   await firestore.runTransaction(async (transaction) => {
     const batchSnap = await transaction.get(batchRef);
-    const currentStatus = batchSnap.exists ? String(batchSnap.data()?.status || '') : '';
+    const batch = batchSnap.exists ? (batchSnap.data() || {}) : {};
+    const currentStatus = batchSnap.exists ? String(batch.status || '') : '';
     if (['sent', 'sending', 'skipped'].includes(currentStatus)) return;
 
-    transaction.set(batchRef, {
-      teamId: metadata.teamId,
-      folderId: metadata.folderId,
-      albumName: metadata.albumName,
-      albumVisibility: metadata.albumVisibility,
-      windowStartAt: admin.firestore.Timestamp.fromDate(metadata.windowStartAt),
-      dueAt: admin.firestore.Timestamp.fromDate(metadata.dueAt),
-      status: 'pending',
-      itemCount: admin.firestore.FieldValue.increment(1),
-      itemIds: admin.firestore.FieldValue.arrayUnion(metadata.itemId),
-      itemTypes: admin.firestore.FieldValue.arrayUnion(metadata.itemType),
-      latestItemTitle: metadata.itemTitle || null,
-      updatedAt: admin.firestore.FieldValue.serverTimestamp()
-    }, { merge: true });
+    transaction.set(batchRef, buildTeamMediaNotificationBatchWrite(batch, metadata), { merge: true });
   });
 
   return metadata;
@@ -4889,6 +4911,7 @@ async function sendDirectTargetsNotification({
 exports._internal = {
   buildTeamMediaNotificationBatchId,
   buildTeamMediaNotificationBatchMetadata,
+  buildTeamMediaNotificationBatchWrite,
   buildTeamMediaNotificationPayload,
   dispatchDueTeamMediaNotificationBatches,
   getTargetsForCategory,

--- a/functions/index.js
+++ b/functions/index.js
@@ -107,6 +107,8 @@ if (admin.apps.length === 0) {
 }
 
 const firestore = admin.firestore();
+const TEAM_MEDIA_NOTIFICATION_BATCH_WINDOW_MS = 60 * 60 * 1000;
+const TEAM_MEDIA_NOTIFICATION_DISPATCH_LIMIT = 50;
 const checkStripeWebhookRateLimit = createInMemoryRateLimiter({
   windowMs: 60_000,
   maxRequests: 120,
@@ -3781,6 +3783,12 @@ function buildNotificationLink({ category, teamId, gameId, batchId = null, recip
   if (category === 'liveScore' && gameId) {
     return `https://allplays.ai/live-game.html?teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}`;
   }
+  if (category === 'media') {
+    if (teamId) {
+      return `https://allplays.ai/app/#/teams/${encodeURIComponent(teamId)}/media`;
+    }
+    return 'https://allplays.ai/app/#/teams';
+  }
   return `https://allplays.ai/team.html?teamId=${encodeURIComponent(teamId)}`;
 }
 
@@ -3821,10 +3829,230 @@ function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId 
     }
     return '/schedule';
   }
+  if (category === 'media') {
+    if (teamId) {
+      return `/teams/${encodeURIComponent(teamId)}/media`;
+    }
+    return '/teams';
+  }
   if (category === 'practice') {
     return buildPracticePacketNotificationDestination({ teamId, eventId }).appRoute;
   }
   return '/home';
+}
+
+function normalizeTeamMediaNotificationText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeTeamMediaNotificationVisibility(value) {
+  return normalizeNotificationAlbumVisibility(value);
+}
+
+function normalizeTeamMediaNotificationItemType(value) {
+  const normalized = String(value || '').trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (['photo', 'image', 'team_photo'].includes(normalized)) return 'photo';
+  if (['file', 'document', 'doc'].includes(normalized)) return 'file';
+  if (['video', 'video_link', 'link'].includes(normalized)) return 'video';
+  return 'item';
+}
+
+function getTeamMediaNotificationWindowStart(date) {
+  const timestamp = date instanceof Date && !Number.isNaN(date.getTime()) ? date.getTime() : Date.now();
+  return new Date(Math.floor(timestamp / TEAM_MEDIA_NOTIFICATION_BATCH_WINDOW_MS) * TEAM_MEDIA_NOTIFICATION_BATCH_WINDOW_MS);
+}
+
+function buildTeamMediaNotificationBatchId(teamId, folderId, windowStartAt) {
+  const startedAt = windowStartAt instanceof Date && !Number.isNaN(windowStartAt.getTime())
+    ? windowStartAt
+    : getTeamMediaNotificationWindowStart(new Date());
+  return [teamId, folderId, startedAt.toISOString()]
+    .map((part) => String(part || '').trim().replace(/[^A-Za-z0-9_-]+/g, '_').replace(/^_+|_+$/g, ''))
+    .filter(Boolean)
+    .join('__')
+    .slice(0, 220);
+}
+
+function buildTeamMediaNotificationBatchMetadata({ teamId, itemId, item = {}, folder = {}, now = new Date() } = {}) {
+  const normalizedTeamId = normalizeTeamMediaNotificationText(teamId);
+  const normalizedItemId = normalizeTeamMediaNotificationText(itemId);
+  const folderId = normalizeTeamMediaNotificationText(item.folderId || folder.id);
+  if (!normalizedTeamId || !normalizedItemId || !folderId || item.deleted === true) return null;
+
+  const albumVisibility = normalizeTeamMediaNotificationVisibility(folder.visibility);
+  if (albumVisibility !== 'team') return null;
+
+  const createdAt = coerceDate(item.createdAt) || (now instanceof Date ? now : new Date(now));
+  const windowStartAt = getTeamMediaNotificationWindowStart(createdAt);
+  const dueAt = new Date(windowStartAt.getTime() + TEAM_MEDIA_NOTIFICATION_BATCH_WINDOW_MS);
+  return {
+    batchId: buildTeamMediaNotificationBatchId(normalizedTeamId, folderId, windowStartAt),
+    teamId: normalizedTeamId,
+    folderId,
+    albumName: normalizeTeamMediaNotificationText(folder.name) || 'Team media',
+    albumVisibility,
+    itemId: normalizedItemId,
+    itemType: normalizeTeamMediaNotificationItemType(item.type || item.mediaType),
+    itemTitle: normalizeTeamMediaNotificationText(item.title || item.fileName || item.name),
+    windowStartAt,
+    dueAt
+  };
+}
+
+function buildTeamMediaNotificationPayload(batch = {}) {
+  const itemCount = Math.max(1, Number(batch.itemCount || 0));
+  const albumName = normalizeTeamMediaNotificationText(batch.albumName) || 'Team media';
+  const itemLabel = `${itemCount} new media item${itemCount === 1 ? '' : 's'}`;
+  return {
+    title: 'New team media',
+    body: truncateNotificationBody(`${albumName} has ${itemLabel}.`)
+  };
+}
+
+async function queueTeamMediaNotificationBatch({ teamId, itemId, item, now = new Date() } = {}) {
+  const folderId = normalizeTeamMediaNotificationText(item?.folderId);
+  if (!teamId || !itemId || !folderId || item?.deleted === true) return null;
+
+  const folderRef = firestore.doc(`teams/${teamId}/mediaFolders/${folderId}`);
+  const folderSnap = await folderRef.get();
+  if (!folderSnap.exists) return null;
+
+  const metadata = buildTeamMediaNotificationBatchMetadata({
+    teamId,
+    itemId,
+    item,
+    folder: { id: folderId, ...(folderSnap.data() || {}) },
+    now
+  });
+  if (!metadata) return null;
+
+  const batchRef = firestore.doc(`teamMediaNotificationBatches/${metadata.batchId}`);
+  await firestore.runTransaction(async (transaction) => {
+    const batchSnap = await transaction.get(batchRef);
+    const currentStatus = batchSnap.exists ? String(batchSnap.data()?.status || '') : '';
+    if (['sent', 'sending', 'skipped'].includes(currentStatus)) return;
+
+    transaction.set(batchRef, {
+      teamId: metadata.teamId,
+      folderId: metadata.folderId,
+      albumName: metadata.albumName,
+      albumVisibility: metadata.albumVisibility,
+      windowStartAt: admin.firestore.Timestamp.fromDate(metadata.windowStartAt),
+      dueAt: admin.firestore.Timestamp.fromDate(metadata.dueAt),
+      status: 'pending',
+      itemCount: admin.firestore.FieldValue.increment(1),
+      itemIds: admin.firestore.FieldValue.arrayUnion(metadata.itemId),
+      itemTypes: admin.firestore.FieldValue.arrayUnion(metadata.itemType),
+      latestItemTitle: metadata.itemTitle || null,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+  });
+
+  return metadata;
+}
+
+async function claimTeamMediaNotificationBatch(batchRef, claimId, now = new Date()) {
+  return firestore.runTransaction(async (transaction) => {
+    const snap = await transaction.get(batchRef);
+    if (!snap.exists) return null;
+    const batch = snap.data() || {};
+    const dueAt = coerceDate(batch.dueAt);
+    if (batch.status !== 'pending' || (dueAt && dueAt > now)) return null;
+
+    transaction.update(batchRef, {
+      status: 'sending',
+      claimId,
+      lastAttemptAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+    return { id: snap.id, ...batch };
+  });
+}
+
+async function markTeamMediaNotificationBatchSkipped(batchRef, claimId, reason) {
+  await batchRef.update({
+    status: 'skipped',
+    claimId,
+    skippedReason: reason || null,
+    finishedAt: admin.firestore.FieldValue.serverTimestamp()
+  });
+}
+
+async function markTeamMediaNotificationBatchSent(batchRef, claimId, sendResult) {
+  await batchRef.update({
+    status: 'sent',
+    claimId,
+    sentAt: admin.firestore.FieldValue.serverTimestamp(),
+    successCount: Number(sendResult?.successCount || 0),
+    failureCount: Number(sendResult?.failureCount || 0),
+    inboxWriteCount: Number(sendResult?.inboxWriteCount || 0)
+  });
+}
+
+async function releaseTeamMediaNotificationBatchAfterFailure(batchRef, claimId, error) {
+  await batchRef.update({
+    status: 'pending',
+    claimId,
+    lastError: error?.message || 'Unknown team media notification error',
+    lastAttemptAt: admin.firestore.FieldValue.serverTimestamp()
+  });
+}
+
+async function dispatchDueTeamMediaNotificationBatches(now = new Date()) {
+  const dueSnap = await firestore.collection('teamMediaNotificationBatches')
+    .where('status', '==', 'pending')
+    .where('dueAt', '<=', admin.firestore.Timestamp.fromDate(now))
+    .limit(TEAM_MEDIA_NOTIFICATION_DISPATCH_LIMIT)
+    .get();
+  const results = [];
+
+  for (const docSnap of dueSnap.docs) {
+    const batchRef = docSnap.ref;
+    const claimId = `team-media-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const batch = await claimTeamMediaNotificationBatch(batchRef, claimId, now);
+    if (!batch) continue;
+
+    try {
+      const folderSnap = await firestore.doc(`teams/${batch.teamId}/mediaFolders/${batch.folderId}`).get();
+      if (!folderSnap.exists) {
+        await markTeamMediaNotificationBatchSkipped(batchRef, claimId, 'album_not_found');
+        continue;
+      }
+
+      const folder = folderSnap.data() || {};
+      const albumVisibility = normalizeTeamMediaNotificationVisibility(folder.visibility || batch.albumVisibility);
+      if (albumVisibility !== 'team') {
+        await markTeamMediaNotificationBatchSkipped(batchRef, claimId, 'album_not_team_visible');
+        continue;
+      }
+
+      const payload = buildTeamMediaNotificationPayload({
+        ...batch,
+        albumName: normalizeTeamMediaNotificationText(folder.name || batch.albumName),
+        albumVisibility
+      });
+      const sendResult = await sendCategoryNotification({
+        teamId: batch.teamId,
+        category: 'media',
+        title: payload.title,
+        body: payload.body,
+        dedupKey: `team-media:${batch.id}`,
+        audienceContext: { albumVisibility }
+      });
+      await markTeamMediaNotificationBatchSent(batchRef, claimId, sendResult);
+      results.push({
+        teamId: batch.teamId,
+        folderId: batch.folderId,
+        itemCount: Number(batch.itemCount || 0),
+        successCount: Number(sendResult?.successCount || 0),
+        failureCount: Number(sendResult?.failureCount || 0)
+      });
+    } catch (error) {
+      await releaseTeamMediaNotificationBatchAfterFailure(batchRef, claimId, error);
+      console.error('Failed to dispatch team media notification batch', { batchId: batch.id, error });
+    }
+  }
+
+  return results;
 }
 
 async function getUserIdsByEmails(emails) {
@@ -4659,6 +4887,10 @@ async function sendDirectTargetsNotification({
 }
 
 exports._internal = {
+  buildTeamMediaNotificationBatchId,
+  buildTeamMediaNotificationBatchMetadata,
+  buildTeamMediaNotificationPayload,
+  dispatchDueTeamMediaNotificationBatches,
   getTargetsForCategory,
   sendCategoryNotification,
   sendPracticePacketDueTomorrowReminders,
@@ -4666,6 +4898,26 @@ exports._internal = {
   syncNotificationRecipientsForUserChange,
   syncNotificationRecipientsForTeamChange
 };
+
+exports.queueTeamMediaNotificationBatch = functions.firestore
+  .document('teams/{teamId}/mediaItems/{itemId}')
+  .onCreate(async (snap, context) => {
+    const teamId = String(context.params.teamId || '').trim();
+    const itemId = String(context.params.itemId || '').trim();
+    const timestamp = context.timestamp ? new Date(context.timestamp) : new Date();
+    await queueTeamMediaNotificationBatch({
+      teamId,
+      itemId,
+      item: snap.data() || {},
+      now: timestamp
+    });
+    return null;
+  });
+
+exports.dispatchDueTeamMediaNotificationBatches = functions.pubsub
+  .schedule('every 15 minutes')
+  .timeZone('America/Chicago')
+  .onRun(() => dispatchDueTeamMediaNotificationBatches());
 
 exports.markNotificationInboxItemRead = functions.https.onCall(async (data, context) => {
   if (!context.auth?.uid) {

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -426,6 +426,12 @@ function buildNotificationTestEnv({
         FieldValue: {
             serverTimestamp: () => ({ __serverTimestamp: true }),
             increment: (amount) => ({ __increment: amount })
+        },
+        Timestamp: {
+            fromDate: (date) => ({
+                toDate: () => new Date(date),
+                toMillis: () => new Date(date).getTime()
+            })
         }
     });
 

--- a/functions/test/team-media-notification-batches.test.js
+++ b/functions/test/team-media-notification-batches.test.js
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { loadNotificationInternals } = require('./send-category-notification-test-helpers');
+
+test('team media notification batch metadata groups album uploads into hourly windows', () => {
+        const { internals, cleanup } = loadNotificationInternals();
+
+        try {
+            const metadata = internals.buildTeamMediaNotificationBatchMetadata({
+                teamId: 'team 1',
+                itemId: 'photo-1',
+                item: {
+                    folderId: 'folder 1',
+                    title: 'Warmups',
+                    type: 'photo',
+                    createdAt: '2026-06-20T15:42:12.000Z'
+                },
+                folder: {
+                    id: 'folder 1',
+                    name: 'Game Highlights',
+                    visibility: 'team'
+                },
+                now: new Date('2026-06-20T15:45:00.000Z')
+            });
+
+            assert.equal(metadata.batchId, 'team_1__folder_1__2026-06-20T15_00_00_000Z');
+            assert.equal(metadata.albumName, 'Game Highlights');
+            assert.equal(metadata.itemType, 'photo');
+            assert.equal(metadata.windowStartAt.toISOString(), '2026-06-20T15:00:00.000Z');
+            assert.equal(metadata.dueAt.toISOString(), '2026-06-20T16:00:00.000Z');
+        } finally {
+            cleanup();
+        }
+});
+
+test('team media notification batch metadata skips private albums and deleted items', () => {
+        const { internals, cleanup } = loadNotificationInternals();
+
+        try {
+            assert.equal(internals.buildTeamMediaNotificationBatchMetadata({
+                teamId: 'team-1',
+                itemId: 'photo-1',
+                item: { folderId: 'folder-1', type: 'photo' },
+                folder: { id: 'folder-1', name: 'Private film', visibility: 'private' }
+            }), null);
+            assert.equal(internals.buildTeamMediaNotificationBatchMetadata({
+                teamId: 'team-1',
+                itemId: 'photo-2',
+                item: { folderId: 'folder-1', type: 'photo', deleted: true },
+                folder: { id: 'folder-1', name: 'Highlights', visibility: 'team' }
+            }), null);
+        } finally {
+            cleanup();
+        }
+});
+
+test('team media notification payload summarizes the album and total batch count', () => {
+        const { internals, cleanup } = loadNotificationInternals();
+
+        try {
+            assert.deepEqual(internals.buildTeamMediaNotificationPayload({
+                albumName: 'Game Highlights',
+                itemCount: 3
+            }), {
+                title: 'New team media',
+                body: 'Game Highlights has 3 new media items.'
+            });
+        } finally {
+            cleanup();
+        }
+});

--- a/functions/test/team-media-notification-batches.test.js
+++ b/functions/test/team-media-notification-batches.test.js
@@ -72,3 +72,38 @@ test('team media notification payload summarizes the album and total batch count
             cleanup();
         }
 });
+
+test('team media notification batch writes keep itemCount aligned with unique item ids', () => {
+        const { internals, cleanup } = loadNotificationInternals();
+
+        try {
+            const metadata = internals.buildTeamMediaNotificationBatchMetadata({
+                teamId: 'team-1',
+                itemId: 'photo-1',
+                item: {
+                    folderId: 'folder-1',
+                    title: 'Warmups',
+                    type: 'photo',
+                    createdAt: '2026-06-20T15:42:12.000Z'
+                },
+                folder: {
+                    id: 'folder-1',
+                    name: 'Game Highlights',
+                    visibility: 'team'
+                },
+                now: new Date('2026-06-20T15:45:00.000Z')
+            });
+
+            const nextBatch = internals.buildTeamMediaNotificationBatchWrite({
+                itemCount: 2,
+                itemIds: ['photo-1'],
+                itemTypes: ['photo']
+            }, metadata);
+
+            assert.equal(nextBatch.itemCount, 1);
+            assert.deepEqual(nextBatch.itemIds, ['photo-1']);
+            assert.deepEqual(nextBatch.itemTypes, ['photo']);
+        } finally {
+            cleanup();
+        }
+});

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -7,22 +7,22 @@ import {
     resolvePushNotificationRoute
 } from '../../apps/app/src/lib/pushNotificationRouting.ts';
 
-function installLocalStorageMock() {
-    const store = new Map<string, string>();
+function installMemoryLocalStorage() {
+    const values = new Map<string, string>();
     Object.defineProperty(window, 'localStorage', {
         configurable: true,
         value: {
-            getItem: (key: string) => store.get(key) ?? null,
-            setItem: (key: string, value: string) => store.set(key, String(value)),
-            removeItem: (key: string) => store.delete(key),
-            clear: () => store.clear()
+            clear: () => values.clear(),
+            getItem: (key: string) => values.get(String(key)) ?? null,
+            removeItem: (key: string) => values.delete(String(key)),
+            setItem: (key: string, value: string) => values.set(String(key), String(value))
         }
     });
 }
 
 describe('app push notification routing', () => {
     beforeEach(() => {
-        installLocalStorageMock();
+        installMemoryLocalStorage();
         window.localStorage.clear();
     });
 
@@ -35,6 +35,7 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'liveScore', gameId: 'game-7' })).toBe('/games/game-7');
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'practice-4' })).toBe('/schedule/team-1/practice-4?section=game');
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'session-4', appRoute: '/schedule/team-1/practice-4?section=game' })).toBe('/schedule/team-1/practice-4?section=game');
+        expect(resolvePushNotificationRoute({ category: 'media', teamId: 'team-1' })).toBe('/teams/team-1/media');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
 

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -44,6 +44,18 @@ describe('push notification payload contract', () => {
         })).toBe('/parent-tools/fees?teamId=team+1&batchId=batch%2F1&recipientId=recipient%3F1');
     });
 
+    it('builds media notification routes to the team media page', () => {
+        expect(buildNotificationLink({
+            category: 'media',
+            teamId: 'team 1'
+        })).toBe('https://allplays.ai/app/#/teams/team%201/media');
+
+        expect(buildNotificationAppRoute({
+            category: 'media',
+            teamId: 'team 1'
+        })).toBe('/teams/team%201/media');
+    });
+
     it('builds staff fee notification routes to the team fee management page', () => {
         expect(buildStaffFeeNotificationDestination({
             teamId: 'team 1',

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+const firestoreIndexes = readFileSync(new URL('../../firestore.indexes.json', import.meta.url), 'utf8');
 
 function getSourceSlice(startMarker, endMarker) {
     const start = functionsSource.indexOf(startMarker);
@@ -116,6 +117,19 @@ function createHarness({ candidateUsers = [], indexedTargets = [], preferences =
 }
 
 describe('team media notification recipients', () => {
+    it('registers batched team media push notification queue and dispatcher functions', () => {
+        expect(functionsSource).toContain('exports.queueTeamMediaNotificationBatch = functions.firestore');
+        expect(functionsSource).toContain(".document('teams/{teamId}/mediaItems/{itemId}')");
+        expect(functionsSource).toContain('exports.dispatchDueTeamMediaNotificationBatches = functions.pubsub');
+        expect(functionsSource).toContain("firestore.collection('teamMediaNotificationBatches')");
+        expect(functionsSource).toContain("category: 'media'");
+        expect(functionsSource).toContain('dedupKey: `team-media:${batch.id}`');
+        expect(functionsSource).toContain("audienceContext: { albumVisibility }");
+        expect(functionsSource).toContain("['sent', 'sending', 'skipped'].includes(currentStatus)");
+        expect(firestoreIndexes).toContain('"collectionGroup": "teamMediaNotificationBatches"');
+        expect(firestoreIndexes).toContain('"fieldPath": "dueAt"');
+    });
+
     it.each([
         { albumVisibility: 'private' },
         { albumVisibility: 'staff-only' },


### PR DESCRIPTION
## Summary
- Queue team media item creates into one hourly batch per team album.
- Dispatch due media batches with a summary push that routes to the native team media page and honors media notification preferences/album visibility.
- Add the Firestore index and route fallback coverage needed by the scheduled dispatcher.

Fixes #2159

## Validation
- npx vitest run functions/test/team-media-notification-batches.test.js tests/unit/team-media-notification-recipients.test.js tests/unit/push-notification-payload-contract.test.js tests/unit/app-push-notification-routing.test.ts --reporter=verbose
- npm run app:build
