### PR TITLE
[codex] Extract schedule availability panels

### DIFF
--- a/apps/app/src/components/schedule/AvailabilityPanels.test.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ParentScheduleEvent } from '../../lib/scheduleLogic';
+import {
+  AttentionPanel,
+  AvailabilityNotesList,
+  QuickAvailabilityPanel,
+  getAvailabilityNoteSaveState,
+  type AttentionItem
+} from './AvailabilityPanels';
+
+afterEach(() => {
+  cleanup();
+});
+
+function buildEvent(overrides: Partial<ParentScheduleEvent> = {}): ParentScheduleEvent {
+  return {
+    eventKey: 'event-1',
+    id: 'event-1',
+    teamId: 'team-1',
+    teamName: 'Tigers',
+    type: 'practice',
+    date: new Date('2026-06-20T18:00:00.000Z'),
+    location: 'North Field',
+    childId: 'child-1',
+    childName: 'Avery Smith',
+    isDbGame: false,
+    isCancelled: false,
+    assignments: [],
+    availabilityNotesVisible: false,
+    availabilityNotes: [],
+    ...overrides
+  };
+}
+
+describe('availability schedule panels', () => {
+  it('tracks trimmed availability note save state', () => {
+    expect(getAvailabilityNoteSaveState('going', '  carpool after practice  ', 'carpool after practice')).toEqual({
+      isDirty: false,
+      canSaveNote: false,
+      trimmedAvailabilityNote: 'carpool after practice',
+      trimmedSavedAvailabilityNote: 'carpool after practice'
+    });
+
+    expect(getAvailabilityNoteSaveState('maybe', 'Needs a ride', '')).toMatchObject({
+      isDirty: true,
+      canSaveNote: true
+    });
+
+    expect(getAvailabilityNoteSaveState('not_responded', 'Needs a ride', '')).toMatchObject({
+      isDirty: true,
+      canSaveNote: false
+    });
+  });
+
+  it('renders a dirty saved RSVP note and submits the current RSVP when saving the note', () => {
+    const onAvailabilityNoteChange = vi.fn();
+    const onSubmit = vi.fn(() => Promise.resolve());
+
+    render(
+      <QuickAvailabilityPanel
+        event={buildEvent({ myRsvpNote: 'Arriving at 5:00', availabilityNotesVisible: true })}
+        rsvp="going"
+        canSubmitRsvp
+        submitting={null}
+        availabilityNote="Arriving at 5:15"
+        onAvailabilityNoteChange={onAvailabilityNoteChange}
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.getByText('Unsaved note changes')).toBeTruthy();
+    expect(screen.getByText('Team note sharing is on for this team.')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Availability note'), { target: { value: 'Arriving after school' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save note' }));
+
+    expect(onAvailabilityNoteChange).toHaveBeenCalledWith('Arriving after school');
+    expect(onSubmit).toHaveBeenCalledWith('going');
+  });
+
+  it('renders needed and locked availability states without changing async behavior', () => {
+    const onSubmit = vi.fn(() => Promise.resolve());
+
+    const { rerender } = render(
+      <QuickAvailabilityPanel
+        event={buildEvent()}
+        rsvp="not_responded"
+        canSubmitRsvp
+        submitting={null}
+        availabilityNote=""
+        onAvailabilityNoteChange={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.getByText('Availability needed')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Going' }));
+    expect(onSubmit).toHaveBeenCalledWith('going');
+
+    rerender(
+      <QuickAvailabilityPanel
+        event={buildEvent()}
+        rsvp="maybe"
+        canSubmitRsvp={false}
+        submitting={null}
+        availabilityNote=""
+        onAvailabilityNoteChange={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.getByText('Availability is not open for this event.')).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Going' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('renders no availability notes when sharing is hidden or the list is empty', () => {
+    const { container, rerender } = render(
+      <AvailabilityNotesList
+        event={buildEvent({
+          availabilityNotesVisible: false,
+          availabilityNotes: [{ displayName: 'Avery', response: 'going', note: 'Can drive.' }]
+        })}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+
+    rerender(<AvailabilityNotesList event={buildEvent({ availabilityNotesVisible: true, availabilityNotes: [] })} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders shared availability notes with normalized RSVP badges', () => {
+    render(
+      <AvailabilityNotesList
+        event={buildEvent({
+          availabilityNotesVisible: true,
+          availabilityNotes: [
+            { displayName: 'Avery', response: 'going', note: 'Can drive two players.' },
+            { displayName: 'Jordan', response: 'not_going', note: 'Out of town.' }
+          ]
+        })}
+      />
+    );
+
+    expect(screen.getByText('Availability notes')).toBeTruthy();
+    expect(screen.getByText('Avery')).toBeTruthy();
+    expect(screen.getByText('Can drive two players.')).toBeTruthy();
+    expect(screen.getByText('Jordan')).toBeTruthy();
+    expect(screen.getByText("Can't go")).toBeTruthy();
+  });
+
+  it('renders caught-up attention state and routes attention item clicks', () => {
+    const onSelectSection = vi.fn();
+    const items: AttentionItem[] = [
+      { title: 'Claim snack duty', detail: 'One assignment still needs a helper.', section: 'assignments' },
+      { title: 'Ride request waiting', detail: 'Someone needs a seat.', section: 'rideshare' }
+    ];
+
+    const { rerender } = render(<AttentionPanel items={[]} onSelectSection={onSelectSection} />);
+
+    expect(screen.getByText('All caught up')).toBeTruthy();
+    expect(screen.getByText('No parent actions need attention right now.')).toBeTruthy();
+
+    rerender(<AttentionPanel items={items} onSelectSection={onSelectSection} />);
+
+    expect(screen.getByText('Needs attention')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Claim snack duty/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Ride request waiting' }));
+
+    expect(onSelectSection).toHaveBeenNthCalledWith(1, 'assignments');
+    expect(onSelectSection).toHaveBeenNthCalledWith(2, 'rideshare');
+  });
+});

--- a/apps/app/src/components/schedule/AvailabilityPanels.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.tsx
@@ -1,0 +1,188 @@
+import { AlertCircle, CheckCircle2 } from 'lucide-react';
+import { normalizeRsvpResponse, type ParentScheduleEvent, type RsvpResponse } from '../../lib/scheduleLogic';
+import { PlayerInitials } from './PlayerInitials';
+
+export type ScheduleEventDetailSectionId = 'availability' | 'rideshare' | 'assignments' | 'game';
+
+export type AttentionItem = {
+  title: string;
+  detail: string;
+  section: ScheduleEventDetailSectionId;
+};
+
+export const rsvpLabels: Record<RsvpResponse, string> = {
+  going: 'Going',
+  maybe: 'Maybe',
+  not_going: "Can't go",
+  not_responded: 'RSVP needed'
+};
+
+export const rsvpBadgeClasses: Record<RsvpResponse, string> = {
+  going: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  maybe: 'border-amber-200 bg-amber-50 text-amber-700',
+  not_going: 'border-rose-200 bg-rose-50 text-rose-700',
+  not_responded: 'border-primary-200 bg-primary-50 text-primary-700'
+};
+
+export function getAvailabilityNoteSaveState(rsvp: RsvpResponse, availabilityNote: string, savedAvailabilityNote: string) {
+  const trimmedAvailabilityNote = String(availabilityNote || '').trim();
+  const trimmedSavedAvailabilityNote = String(savedAvailabilityNote || '').trim();
+  const isDirty = trimmedAvailabilityNote !== trimmedSavedAvailabilityNote;
+  const canSaveNote = rsvp !== 'not_responded' && isDirty;
+
+  return {
+    isDirty,
+    canSaveNote,
+    trimmedAvailabilityNote,
+    trimmedSavedAvailabilityNote
+  };
+}
+
+export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit }: {
+  event: ParentScheduleEvent;
+  rsvp: RsvpResponse;
+  canSubmitRsvp: boolean;
+  submitting: RsvpResponse | null;
+  availabilityNote: string;
+  onAvailabilityNoteChange: (note: string) => void;
+  onSubmit: (response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
+}) {
+  const needsResponse = rsvp === 'not_responded';
+  const noteSaveState = getAvailabilityNoteSaveState(rsvp, availabilityNote, event.myRsvpNote || '');
+  const showDirtyState = rsvp !== 'not_responded' && noteSaveState.isDirty;
+  return (
+    <div className={`border-b px-3 py-2.5 sm:px-4 sm:py-3 ${needsResponse ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
+      <div className="flex items-center gap-2.5 sm:items-start sm:gap-3">
+        <PlayerInitials name={event.childName} />
+        <div className="min-w-0 flex-1">
+          <div className={`text-[11px] font-black uppercase tracking-[0.06em] ${needsResponse ? 'text-amber-800' : showDirtyState ? 'text-amber-800' : 'text-gray-500'}`}>
+            {needsResponse ? 'Availability needed' : showDirtyState ? 'Unsaved note changes' : 'Availability saved'}
+          </div>
+          <div className="mt-0.5 text-sm font-black leading-tight text-gray-950 sm:mt-1 sm:text-base">Is {event.childName} going?</div>
+          <div className="mt-2 grid grid-cols-3 gap-1.5">
+            {(['going', 'maybe', 'not_going'] as const).map((response) => (
+              <button
+                key={response}
+                type="button"
+                className={`min-h-8 rounded-full border px-2 text-[11px] font-black transition sm:min-h-9 ${
+                  rsvp === response ? rsvpBadgeClasses[response] : 'border-gray-200 bg-white text-gray-600 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700'
+                } ${!canSubmitRsvp ? 'cursor-not-allowed opacity-60' : ''}`}
+                disabled={!canSubmitRsvp || submitting === response}
+                onClick={() => onSubmit(response)}
+              >
+                {submitting === response ? 'Saving' : rsvpLabels[response]}
+              </button>
+            ))}
+          </div>
+          <label className="mt-2 block">
+            <span className="sr-only">Availability note</span>
+            <textarea
+              aria-label="Availability note"
+              className="auth-input min-h-16 resize-none !px-3 !py-2 text-xs font-semibold"
+              value={availabilityNote}
+              onChange={(changeEvent) => onAvailabilityNoteChange(changeEvent.target.value)}
+              disabled={!canSubmitRsvp}
+              placeholder="Optional note for coaches, rides, or arrival details"
+              rows={2}
+              maxLength={280}
+            />
+          </label>
+          <div className="mt-1 text-[11px] font-semibold text-gray-500">
+            {event.availabilityNotesVisible ? 'Team note sharing is on for this team.' : 'Notes are visible to team staff unless sharing is enabled.'}
+          </div>
+          {noteSaveState.canSaveNote ? (
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
+              <div className="text-xs font-black text-amber-900">Note edited but not saved yet.</div>
+              <button
+                type="button"
+                className="min-h-8 rounded-full border border-primary-200 bg-white px-3 text-xs font-black text-primary-700 transition hover:border-primary-300 hover:bg-primary-50"
+                disabled={!canSubmitRsvp || submitting === rsvp}
+                onClick={() => onSubmit(rsvp as Exclude<RsvpResponse, 'not_responded'>)}
+              >
+                {submitting === rsvp ? 'Saving' : 'Save note'}
+              </button>
+            </div>
+          ) : null}
+          {!canSubmitRsvp ? <div className="mt-2 text-xs font-semibold text-gray-500">Availability is not open for this event.</div> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AvailabilityNotesList({ event }: { event: ParentScheduleEvent }) {
+  const notes = Array.isArray(event.availabilityNotes) ? event.availabilityNotes : [];
+  if (!event.availabilityNotesVisible || !notes.length) return null;
+
+  return (
+    <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3">
+      <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Availability notes</div>
+      <div className="mt-2 space-y-2">
+        {notes.map((note, index) => {
+          const response = normalizeRsvpResponse(note.response);
+          return (
+            <div key={`${note.displayName}-${index}`} className="rounded-lg bg-gray-50 p-2">
+              <div className="flex items-center justify-between gap-2">
+                <div className="truncate text-sm font-black text-gray-950">{note.displayName}</div>
+                <span className={`flex-none rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[response]}`}>
+                  {rsvpLabels[response]}
+                </span>
+              </div>
+              <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{note.note}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function AttentionPanel({ items, onSelectSection }: { items: AttentionItem[]; onSelectSection: (sectionId: ScheduleEventDetailSectionId) => void }) {
+  if (!items.length) {
+    return (
+      <div className="mt-3 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm font-semibold text-emerald-800">
+        <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
+        <div>
+          <div className="font-black">All caught up</div>
+          <div className="mt-0.5 text-xs font-semibold text-emerald-700">No parent actions need attention right now.</div>
+        </div>
+      </div>
+    );
+  }
+
+  const [primary, ...secondary] = items;
+
+  return (
+    <div className="mt-2 rounded-xl border border-amber-200 bg-amber-50 p-2.5 sm:mt-3 sm:p-3">
+      <div className="flex items-center gap-2 text-sm font-black text-amber-900">
+        <AlertCircle className="h-4 w-4 flex-none" aria-hidden="true" />
+        Needs attention
+      </div>
+      <button
+        type="button"
+        className="mt-2 flex w-full items-start justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-1.5 text-left transition hover:border-amber-300 hover:bg-amber-50 sm:py-2"
+        onClick={() => onSelectSection(primary.section)}
+      >
+        <span>
+          <span className="block text-sm font-black text-gray-950">{primary.title}</span>
+          <span className="mt-0.5 block text-xs font-semibold leading-4 text-gray-600 sm:leading-5">{primary.detail}</span>
+        </span>
+        <span className="mt-0.5 flex-none text-xs font-black text-primary-700">Go</span>
+      </button>
+      {secondary.length ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {secondary.map((item) => (
+            <button
+              key={`${item.section}-${item.title}`}
+              type="button"
+              className="min-h-8 rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-900"
+              onClick={() => onSelectSection(item.section)}
+            >
+              {item.title}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -85,7 +85,16 @@ import { EventDetailPageSkeleton } from '../components/PageSkeletons';
 import { DateTile } from '../components/schedule/DateTile';
 import { EventBrief } from '../components/schedule/EventBrief';
 import { EventSectionNav } from '../components/schedule/EventSectionNav';
-import { PlayerInitials } from '../components/schedule/PlayerInitials';
+import {
+  AttentionPanel,
+  AvailabilityNotesList,
+  QuickAvailabilityPanel,
+  getAvailabilityNoteSaveState,
+  rsvpBadgeClasses,
+  rsvpLabels,
+  type AttentionItem,
+  type ScheduleEventDetailSectionId
+} from '../components/schedule/AvailabilityPanels';
 import {
   canRequestScheduleRide,
   findScheduleRideRequestForChild,
@@ -141,7 +150,9 @@ import { ScheduleEventDetailProvider } from './schedule/ScheduleEventDetailConte
 import { useScheduleEventRsvp } from '../hooks/schedule/useScheduleEventRsvp';
 import { useScheduleRideOffers } from '../hooks/schedule/useScheduleRideOffers';
 
-type EventDetailSectionId = 'availability' | 'rideshare' | 'assignments' | 'game';
+export { getAvailabilityNoteSaveState } from '../components/schedule/AvailabilityPanels';
+
+type EventDetailSectionId = ScheduleEventDetailSectionId;
 type GameReportSectionId = 'summary' | 'players' | 'plays' | 'opponent' | 'insights' | 'media';
 
 const eventDetailSectionIds = new Set<EventDetailSectionId>(['availability', 'rideshare', 'assignments', 'game']);
@@ -235,34 +246,6 @@ function getEventDetailSections(event?: ParentScheduleEvent | null): Array<{ id:
   ];
 }
 
-const rsvpLabels: Record<RsvpResponse, string> = {
-  going: 'Going',
-  maybe: 'Maybe',
-  not_going: "Can't go",
-  not_responded: 'RSVP needed'
-};
-
-const rsvpBadgeClasses: Record<RsvpResponse, string> = {
-  going: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  maybe: 'border-amber-200 bg-amber-50 text-amber-700',
-  not_going: 'border-rose-200 bg-rose-50 text-rose-700',
-  not_responded: 'border-primary-200 bg-primary-50 text-primary-700'
-};
-
-export function getAvailabilityNoteSaveState(rsvp: RsvpResponse, availabilityNote: string, savedAvailabilityNote: string) {
-  const trimmedAvailabilityNote = String(availabilityNote || '').trim();
-  const trimmedSavedAvailabilityNote = String(savedAvailabilityNote || '').trim();
-  const isDirty = trimmedAvailabilityNote !== trimmedSavedAvailabilityNote;
-  const canSaveNote = rsvp !== 'not_responded' && isDirty;
-
-  return {
-    isDirty,
-    canSaveNote,
-    trimmedAvailabilityNote,
-    trimmedSavedAvailabilityNote
-  };
-}
-
 function getScheduleEventDetailLoadErrorMessage(error: AppServiceError, hasExistingEvent: boolean) {
   if (hasExistingEvent) {
     if (error.type === 'network') return 'Unable to refresh this event while offline. Showing the last loaded details.';
@@ -277,12 +260,6 @@ function getScheduleEventDetailLoadErrorMessage(error: AppServiceError, hasExist
   if (error.type === 'validation') return error.message;
   return error.message || 'Unable to load event details.';
 }
-
-type AttentionItem = {
-  title: string;
-  detail: string;
-  section: EventDetailSectionId;
-};
 
 type ActiveLiveReaction = LiveGameReaction & {
   localId: string;
@@ -748,160 +725,11 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   );
 }
 
-function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit }: {
-  event: ParentScheduleEvent;
-  rsvp: RsvpResponse;
-  canSubmitRsvp: boolean;
-  submitting: RsvpResponse | null;
-  availabilityNote: string;
-  onAvailabilityNoteChange: (note: string) => void;
-  onSubmit: (response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
-}) {
-  const needsResponse = rsvp === 'not_responded';
-  const noteSaveState = getAvailabilityNoteSaveState(rsvp, availabilityNote, event.myRsvpNote || '');
-  const showDirtyState = rsvp !== 'not_responded' && noteSaveState.isDirty;
-  return (
-    <div className={`border-b px-3 py-2.5 sm:px-4 sm:py-3 ${needsResponse ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
-      <div className="flex items-center gap-2.5 sm:items-start sm:gap-3">
-        <PlayerInitials name={event.childName} />
-        <div className="min-w-0 flex-1">
-          <div className={`text-[11px] font-black uppercase tracking-[0.06em] ${needsResponse ? 'text-amber-800' : showDirtyState ? 'text-amber-800' : 'text-gray-500'}`}>
-            {needsResponse ? 'Availability needed' : showDirtyState ? 'Unsaved note changes' : 'Availability saved'}
-          </div>
-          <div className="mt-0.5 text-sm font-black leading-tight text-gray-950 sm:mt-1 sm:text-base">Is {event.childName} going?</div>
-          <div className="mt-2 grid grid-cols-3 gap-1.5">
-            {(['going', 'maybe', 'not_going'] as const).map((response) => (
-              <button
-                key={response}
-                type="button"
-                className={`min-h-8 rounded-full border px-2 text-[11px] font-black transition sm:min-h-9 ${
-                  rsvp === response ? rsvpBadgeClasses[response] : 'border-gray-200 bg-white text-gray-600 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700'
-                } ${!canSubmitRsvp ? 'cursor-not-allowed opacity-60' : ''}`}
-                disabled={!canSubmitRsvp || submitting === response}
-                onClick={() => onSubmit(response)}
-              >
-                {submitting === response ? 'Saving' : rsvpLabels[response]}
-              </button>
-            ))}
-          </div>
-          <label className="mt-2 block">
-            <span className="sr-only">Availability note</span>
-            <textarea
-              aria-label="Availability note"
-              className="auth-input min-h-16 resize-none !px-3 !py-2 text-xs font-semibold"
-              value={availabilityNote}
-              onChange={(changeEvent) => onAvailabilityNoteChange(changeEvent.target.value)}
-              disabled={!canSubmitRsvp}
-              placeholder="Optional note for coaches, rides, or arrival details"
-              rows={2}
-              maxLength={280}
-            />
-          </label>
-          <div className="mt-1 text-[11px] font-semibold text-gray-500">
-            {event.availabilityNotesVisible ? 'Team note sharing is on for this team.' : 'Notes are visible to team staff unless sharing is enabled.'}
-          </div>
-          {noteSaveState.canSaveNote ? (
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
-              <div className="text-xs font-black text-amber-900">Note edited but not saved yet.</div>
-              <button
-                type="button"
-                className="min-h-8 rounded-full border border-primary-200 bg-white px-3 text-xs font-black text-primary-700 transition hover:border-primary-300 hover:bg-primary-50"
-                disabled={!canSubmitRsvp || submitting === rsvp}
-                onClick={() => onSubmit(rsvp as Exclude<RsvpResponse, 'not_responded'>)}
-              >
-                {submitting === rsvp ? 'Saving' : 'Save note'}
-              </button>
-            </div>
-          ) : null}
-          {!canSubmitRsvp ? <div className="mt-2 text-xs font-semibold text-gray-500">Availability is not open for this event.</div> : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function AvailabilityNotesList({ event }: { event: ParentScheduleEvent }) {
-  const notes = Array.isArray(event.availabilityNotes) ? event.availabilityNotes : [];
-  if (!event.availabilityNotesVisible || !notes.length) return null;
-
-  return (
-    <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3">
-      <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Availability notes</div>
-      <div className="mt-2 space-y-2">
-        {notes.map((note, index) => {
-          const response = normalizeRsvpResponse(note.response);
-          return (
-            <div key={`${note.displayName}-${index}`} className="rounded-lg bg-gray-50 p-2">
-              <div className="flex items-center justify-between gap-2">
-                <div className="truncate text-sm font-black text-gray-950">{note.displayName}</div>
-                <span className={`flex-none rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[response]}`}>
-                  {rsvpLabels[response]}
-                </span>
-              </div>
-              <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{note.note}</div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
 function CompactMeta({ icon: Icon, value }: { icon: LucideIcon; value: string }) {
   return (
     <div className="flex min-w-0 items-center gap-2 text-sm font-bold text-gray-800">
       <Icon className="h-4 w-4 flex-none text-primary-600" aria-hidden="true" />
       <span className="min-w-0 truncate">{value}</span>
-    </div>
-  );
-}
-
-function AttentionPanel({ items, onSelectSection }: { items: AttentionItem[]; onSelectSection: (sectionId: EventDetailSectionId) => void }) {
-  if (!items.length) {
-    return (
-      <div className="mt-3 flex items-start gap-2 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm font-semibold text-emerald-800">
-        <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
-        <div>
-          <div className="font-black">All caught up</div>
-          <div className="mt-0.5 text-xs font-semibold text-emerald-700">No parent actions need attention right now.</div>
-        </div>
-      </div>
-    );
-  }
-
-  const [primary, ...secondary] = items;
-
-  return (
-    <div className="mt-2 rounded-xl border border-amber-200 bg-amber-50 p-2.5 sm:mt-3 sm:p-3">
-      <div className="flex items-center gap-2 text-sm font-black text-amber-900">
-        <AlertCircle className="h-4 w-4 flex-none" aria-hidden="true" />
-        Needs attention
-      </div>
-      <button
-        type="button"
-        className="mt-2 flex w-full items-start justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-1.5 text-left transition hover:border-amber-300 hover:bg-amber-50 sm:py-2"
-        onClick={() => onSelectSection(primary.section)}
-      >
-        <span>
-          <span className="block text-sm font-black text-gray-950">{primary.title}</span>
-          <span className="mt-0.5 block text-xs font-semibold leading-4 text-gray-600 sm:leading-5">{primary.detail}</span>
-        </span>
-        <span className="mt-0.5 flex-none text-xs font-black text-primary-700">Go</span>
-      </button>
-      {secondary.length ? (
-        <div className="mt-2 flex flex-wrap gap-2">
-          {secondary.map((item) => (
-            <button
-              key={`${item.section}-${item.title}`}
-              type="button"
-              className="min-h-8 rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-900"
-              onClick={() => onSelectSection(item.section)}
-            >
-              {item.title}
-            </button>
-          ))}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/tests/unit/app-schedule-availability-panels.test.tsx
+++ b/tests/unit/app-schedule-availability-panels.test.tsx
@@ -1,15 +1,16 @@
 // @vitest-environment jsdom
 
+import React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ParentScheduleEvent } from '../../lib/scheduleLogic';
+import type { ParentScheduleEvent } from '../../apps/app/src/lib/scheduleLogic';
 import {
   AttentionPanel,
   AvailabilityNotesList,
   QuickAvailabilityPanel,
   getAvailabilityNoteSaveState,
   type AttentionItem
-} from './AvailabilityPanels';
+} from '../../apps/app/src/components/schedule/AvailabilityPanels';
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary
- Extract ScheduleEventDetail availability and attention panels into reusable schedule components
- Keep RSVP note save-state and badge labels shared without moving async event workflows
- Add focused component coverage for empty, locked, dirty, populated, and click-routing states

## Tests
- npx vitest run apps/app/src/components/schedule/AvailabilityPanels.test.tsx apps/app/src/pages/ScheduleEventDetail.test.tsx --reporter=verbose
- npm run app:build
- git diff --check

Closes #2284