### PR TITLE
Prefer hosted Firebase config and add CI secret scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  secret-scan:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Run secret scan
-        run: run_secret_scanning
-
   cache-bust-guard:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  secret-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run secret scan
+        run: run_secret_scanning
+
   cache-bust-guard:
     runs-on: ubuntu-latest
 

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -1187,7 +1187,7 @@
 
         function loadFirebaseModule() {
             if (!firebaseModulePromise) {
-                firebaseModulePromise = import('./js/firebase.js?v=17').catch((error) => {
+                firebaseModulePromise = import('./js/firebase.js?v=19').catch((error) => {
                     firebaseModulePromise = null;
                     throw error;
                 });

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -934,7 +934,7 @@
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';
-        import { Timestamp, deleteField, auth } from "./js/firebase.js?v=17";
+        import { Timestamp, deleteField, auth } from "./js/firebase.js?v=19";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=2';

--- a/game.html
+++ b/game.html
@@ -392,8 +392,8 @@
         import { generateGameInsights } from './js/post-game-insights.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=26';
-        import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=17";
-        import { db } from './js/firebase.js?v=17';
+        import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=19";
+        import { db } from './js/firebase.js?v=19';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
         import { splitPlayerStatsByVisibility } from './js/stat-leaderboards.js?v=2';

--- a/js/admin.js
+++ b/js/admin.js
@@ -15,7 +15,7 @@ import {
     getTelemetryEventDaily,
     getTelemetrySessions
 } from './db.js?v=53';
-import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=18';
+import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=19';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=26';
 import { DEFAULT_ADMIN_PAGE_SIZE, loadAdminCollectionPage, loadInitialAdminBootstrap } from './admin-bootstrap.js?v=1';

--- a/js/auth.js
+++ b/js/auth.js
@@ -14,7 +14,7 @@ import {
     isSignInWithEmailLink,
     signInWithEmailLink,
     updatePassword
-} from './firebase.js?v=18';
+} from './firebase.js?v=19';
 import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=53';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=4';
 import { redeemAdminInviteAcceptance } from './admin-invite.js?v=5';

--- a/js/certificates/assets.js
+++ b/js/certificates/assets.js
@@ -7,7 +7,7 @@ import {
     ref,
     uploadBytes,
     getDownloadURL
-} from '../firebase.js?v=18';
+} from '../firebase.js?v=19';
 
 const MAX_CERTIFICATE_ASSET_BYTES = 5 * 1024 * 1024;
 const ALLOWED_CERTIFICATE_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/webp']);

--- a/js/db.js
+++ b/js/db.js
@@ -32,7 +32,7 @@ import {
     uploadBytes,
     getDownloadURL,
     deleteObject
-} from './firebase.js?v=18';
+} from './firebase.js?v=19';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=6';
 import { uploadBytesResumable } from './vendor/firebase-storage.js';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=2';

--- a/js/family-plan.js
+++ b/js/family-plan.js
@@ -35,7 +35,7 @@ function normalizePlayerLinks(playerLinks = []) {
 
 function loadFirebase(deps = {}) {
     if (deps.firebase) return Promise.resolve(deps.firebase);
-    return import('./firebase.js?v=18');
+    return import('./firebase.js?v=19');
 }
 
 function normalizeAccessLinks(links = []) {

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -72,18 +72,19 @@ async function fetchFirebaseConfigFromHosting() {
 }
 
 export async function resolvePrimaryFirebaseConfig() {
-    const globalConfig = readGlobalConfig();
-    const inlineConfig = normalizeFirebaseConfig(
-        globalConfig.firebase || globalConfig.firebasePrimary || readWindowGlobal('ALLPLAYS_FIREBASE_CONFIG')
-    );
-    if (inlineConfig) {
-        return inlineConfig;
-    }
-
     try {
         const hostedConfig = await fetchFirebaseConfigFromHosting();
         return hostedConfig;
     } catch (error) {
+        const globalConfig = readGlobalConfig();
+        const inlineConfig = normalizeFirebaseConfig(
+            globalConfig.firebase || globalConfig.firebasePrimary || readWindowGlobal('ALLPLAYS_FIREBASE_CONFIG')
+        );
+        if (inlineConfig) {
+            console.warn('Falling back to inline Firebase config after hosted init lookup failed.', error);
+            return inlineConfig;
+        }
+
         console.warn('Falling back to bundled Firebase config.', error);
         return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
     }

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -54,7 +54,7 @@ import {
 } from "./vendor/firebase-firestore.js";
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
 import { getFunctions, httpsCallable } from "./vendor/firebase-functions.js";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=8";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=9";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -17,7 +17,7 @@ import {
     where,
     orderBy,
     limit
-} from './firebase.js?v=18';
+} from './firebase.js?v=19';
 
 let cachedAccessibleTeams = null;
 let cachedAccessibleTeamsLoadedAt = 0;

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,9 +1,9 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
 import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=53';
-import { db } from './firebase.js?v=18';
+import { db } from './firebase.js?v=19';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
 import { checkAuth } from './auth.js?v=26';
-import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=18';
+import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=19';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';

--- a/js/parent-incentives.js
+++ b/js/parent-incentives.js
@@ -23,7 +23,7 @@ import {
     orderBy,
     serverTimestamp,
     writeBatch,
-} from './firebase.js?v=18';
+} from './firebase.js?v=19';
 
 // Normalizes a stat column name (e.g. 'PTS', 'POINTS') to Firestore key (e.g. 'pts').
 // Matches the map used in live-game.js for consistency.

--- a/js/premium-entitlements.js
+++ b/js/premium-entitlements.js
@@ -74,7 +74,7 @@ export function isValidPremiumEntitlementRecord(data, { scope, teamId = '', user
 
 async function loadFirebase(deps = {}) {
     if (deps.firebase) return deps.firebase;
-    return import('./firebase.js?v=18');
+    return import('./firebase.js?v=19');
 }
 
 function dataFromSnapshot(docSnap) {

--- a/js/stripe-service.js
+++ b/js/stripe-service.js
@@ -1,5 +1,5 @@
 
-import { getFunctions, httpsCallable } from './firebase.js?v=18';
+import { getFunctions, httpsCallable } from './firebase.js?v=19';
 
 export async function initiateStripeCheckout(params) {
     try {

--- a/js/team-email-attachments.js
+++ b/js/team-email-attachments.js
@@ -12,7 +12,7 @@ import {
     uploadBytes,
     getDownloadURL,
     deleteObject
-} from './firebase.js?v=18';
+} from './firebase.js?v=19';
 
 export const TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES = 20 * 1024 * 1024;
 

--- a/js/team-entitlements.js
+++ b/js/team-entitlements.js
@@ -1,4 +1,4 @@
-import { db, doc, getDoc } from './firebase.js?v=18';
+import { db, doc, getDoc } from './firebase.js?v=19';
 import {
     TEAM_PASS_TIER,
     buildTeamEntitlementId,

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -596,7 +596,7 @@ export function buildOnlineRefundRequest({ amount, reason, teamId, batchId, reci
 }
 
 export async function submitOnlineTeamFeeRefund(request) {
-    const { getFunctions, httpsCallable } = await import('./firebase.js?v=18');
+    const { getFunctions, httpsCallable } = await import('./firebase.js?v=19');
     const functions = getFunctions();
     const refundTeamFee = httpsCallable(functions, 'refundStripeTeamFeePayment');
     const result = await refundTeamFee(request);

--- a/js/team-pass.js
+++ b/js/team-pass.js
@@ -1,4 +1,4 @@
-import { auth } from './firebase.js?v=18';
+import { auth } from './firebase.js?v=19';
 import { hasFullTeamAccess } from './team-access.js';
 
 function getFunctionsBaseUrl() {
@@ -117,7 +117,7 @@ function arrayIncludesTeamId(values, teamId) {
 
 function loadFirebase(deps = {}) {
     if (deps.firebase) return deps.firebase;
-    return import('./firebase.js?v=18');
+    return import('./firebase.js?v=19');
 }
 
 function dataFromSnapshot(docSnap) {

--- a/js/telemetry.js
+++ b/js/telemetry.js
@@ -39,7 +39,7 @@ let firebaseAuthModulePromise = null;
 
 function loadFirebaseAuthModule() {
     if (!firebaseAuthModulePromise) {
-        firebaseAuthModulePromise = import('./firebase.js?v=18')
+        firebaseAuthModulePromise = import('./firebase.js?v=19')
             .then((module) => ({
                 auth: module.auth,
                 onAuthStateChanged: module.onAuthStateChanged

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,9 +1,9 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
 import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=53';
-import { db } from './firebase.js?v=18';
+import { db } from './firebase.js?v=19';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=26';
-import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=18';
+import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=19';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion } from './live-tracker-integrity.js?v=3';

--- a/js/tracking-items-admin.js
+++ b/js/tracking-items-admin.js
@@ -206,7 +206,7 @@ async function initTrackingItemsAdminPage() {
     const [dbModule, authModule, firebaseModule] = await Promise.all([
         import('./db.js?v=53'),
         import('./auth.js?v=26'),
-        import('./firebase.js?v=18')
+        import('./firebase.js?v=19')
     ]);
     const { getTeam, getUserProfile, canModerateChat } = dbModule;
     const { requireAuth } = authModule;

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -324,8 +324,8 @@
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=10';
         import { checkAuth } from './js/auth.js?v=26';
         import { getTeamAccessInfo } from './js/team-access.js';
-        import { addDoc, collection, db, deleteDoc, doc, getDocs, Timestamp, updateDoc } from './js/firebase.js?v=17';
-        import { functions, httpsCallable } from './js/firebase.js?v=17';
+        import { addDoc, collection, db, deleteDoc, doc, getDocs, Timestamp, updateDoc } from './js/firebase.js?v=19';
+        import { functions, httpsCallable } from './js/firebase.js?v=19';
         import {
             ORGANIZATION_SCHEDULE_WEEKDAYS,
             buildBlackoutDatePayload,

--- a/player.html
+++ b/player.html
@@ -243,8 +243,8 @@
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig, summarizePlayerTopStats } from './js/stat-leaderboards.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=26';
-        import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=17";
-        import { db } from './js/firebase.js?v=17';
+        import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=19";
+        import { db } from './js/firebase.js?v=19';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { hasFullTeamAccess } from './js/team-access.js';
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -70,7 +70,7 @@
     </main>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=17';
+        import { auth } from './js/firebase.js?v=19';
 
         const params = new URLSearchParams(window.location.search);
         const token = params.get('token') || '';

--- a/registration.html
+++ b/registration.html
@@ -97,7 +97,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=17';
+        import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { cancelStripeRegistrationCheckout, initiateStripeCheckout } from './js/stripe-service.js';
         import {

--- a/reset-password.html
+++ b/reset-password.html
@@ -110,8 +110,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=17';
-        import { verifyPasswordResetCode, confirmPasswordReset, applyActionCode } from "./js/firebase.js?v=17";
+        import { auth } from './js/firebase.js?v=19';
+        import { verifyPasswordResetCode, confirmPasswordReset, applyActionCode } from "./js/firebase.js?v=19";
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderHeader(document.getElementById('header-container'), null);

--- a/team.html
+++ b/team.html
@@ -333,8 +333,8 @@
         import { aggregateSeasonStatsByPlayerId, buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=3';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=26';
-        import { collection, getDocs, query, where } from "./js/firebase.js?v=17";
-        import { db } from './js/firebase.js?v=17';
+        import { collection, getDocs, query, where } from "./js/firebase.js?v=19";
+        import { db } from './js/firebase.js?v=19';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';

--- a/tests/unit/access-code-validation.test.js
+++ b/tests/unit/access-code-validation.test.js
@@ -6,7 +6,7 @@ const collectionMock = vi.fn((database, path) => ({ database, path }));
 const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
 const queryMock = vi.fn((...parts) => parts);
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     db: {},
     auth: {},
     functions: {},

--- a/tests/unit/app-native-google-auth.test.js
+++ b/tests/unit/app-native-google-auth.test.js
@@ -80,7 +80,7 @@ vi.mock('../../apps/app/node_modules/@capacitor-firebase/authentication/dist/plu
     FirebaseAuthentication: nativeAuthMocks
 }));
 
-vi.mock('../../js/firebase.js?v=18', () => firebaseMocks);
+vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
 vi.mock('../../js/db.js', () => dbMocks);
 vi.mock('../../js/admin-invite.js', () => ({
     redeemAdminInviteAcceptance: vi.fn()

--- a/tests/unit/app-parent-tools-household-service.test.js
+++ b/tests/unit/app-parent-tools-household-service.test.js
@@ -36,7 +36,7 @@ vi.mock('../../js/db.js', () => ({
     moveTeamMediaItems: dbMocks.moveTeamMediaItems,
     setTeamMediaAlbumCover: dbMocks.setTeamMediaAlbumCover
 }));
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     db: {},
     doc: vi.fn(),
     collection: vi.fn(),

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -9,7 +9,7 @@ const updateUserProfileMock = vi.fn();
 const markAccessCodeAsUsedMock = vi.fn();
 const redeemAdminInviteAcceptanceMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     auth: { currentUser: null },
     signInWithEmailAndPassword: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -9,7 +9,7 @@ const redeemParentInviteMock = vi.fn();
 const updateUserProfileMock = vi.fn();
 const markAccessCodeAsUsedMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     auth: { currentUser: null },
     signInWithEmailAndPassword: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),

--- a/tests/unit/auth-google-popup-fallback.test.js
+++ b/tests/unit/auth-google-popup-fallback.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const signInWithPopupMock = vi.fn();
 const signInWithRedirectMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     auth: { currentUser: null },
     signInWithEmailAndPassword: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -32,7 +32,7 @@ const dbMocks = vi.hoisted(() => ({
     normalizeParentScopeLinks: vi.fn()
 }));
 
-vi.mock('../../js/firebase.js?v=18', () => firebaseMocks);
+vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
 vi.mock('../../js/db.js?v=53', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=4', () => ({
     executeEmailPasswordSignup: vi.fn()

--- a/tests/unit/auth-send-invite-email-no-localstorage.test.js
+++ b/tests/unit/auth-send-invite-email-no-localstorage.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const sendSignInLinkToEmailMock = vi.fn();
 const getUserByEmailMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     auth: { currentUser: null },
     signInWithEmailAndPassword: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -35,7 +35,7 @@ const dbMocks = vi.hoisted(() => ({
     listMyParentMembershipRequests: vi.fn()
 }));
 
-vi.mock('../../js/firebase.js?v=18', () => firebaseMocks);
+vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
 vi.mock('../../js/db.js?v=53', () => dbMocks);
 
 const { signup, loginWithGoogle, handleGoogleRedirectResult } = await import('../../js/auth.js');

--- a/tests/unit/certificates-assets.test.js
+++ b/tests/unit/certificates-assets.test.js
@@ -14,7 +14,7 @@ vi.mock('../../js/firebase-images.js?v=8', () => ({
     requireImageAuth: mocks.requireImageAuth
 }));
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     db: {},
     collection: mocks.collection,
     addDoc: mocks.addDoc,

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -10,7 +10,7 @@ const firebaseMocks = vi.hoisted(() => ({
     getDocs: vi.fn(),
 }));
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     db: {},
     auth: { currentUser: null },
     storage: {},

--- a/tests/unit/firebase-firestore-init.test.js
+++ b/tests/unit/firebase-firestore-init.test.js
@@ -80,7 +80,7 @@ vi.mock('../../js/vendor/firebase-functions.js', () => ({
     httpsCallable: vi.fn()
 }));
 
-vi.mock('../../js/firebase-runtime-config.js?v=8', () => ({
+vi.mock('../../js/firebase-runtime-config.js?v=9', () => ({
     resolvePrimaryFirebaseConfig: vi.fn(async () => ({
         apiKey: 'test-key',
         authDomain: 'example.test',
@@ -106,7 +106,7 @@ describe('firebase firestore initialization', () => {
         });
         firestoreMocks.getFirestore.mockReturnValue(existingDb);
 
-        const module = await import('../../js/firebase.js?v=18');
+        const module = await import('../../js/firebase.js?v=19');
 
         expect(module.db).toBe(existingDb);
         expect(firestoreMocks.initializeFirestore).toHaveBeenCalledTimes(1);

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -66,6 +66,64 @@ describe('firebase runtime config', () => {
         });
     });
 
+    it('prefers hosted firebase config over inline config when both are present', async () => {
+        resetGlobals();
+        globalThis.window.__ALLPLAYS_CONFIG__ = {
+            firebase: {
+                apiKey: 'inline-key',
+                authDomain: 'inline-allplays.firebaseapp.com',
+                projectId: 'inline-allplays',
+                messagingSenderId: '999',
+                appId: 'inline-app'
+            }
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                apiKey: 'hosted-key',
+                authDomain: 'hosted-allplays.firebaseapp.com',
+                projectId: 'hosted-allplays',
+                messagingSenderId: '123',
+                appId: 'hosted-app'
+            })
+        });
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config).toMatchObject({
+            apiKey: 'hosted-key',
+            authDomain: 'hosted-allplays.firebaseapp.com',
+            projectId: 'hosted-allplays',
+            appId: 'hosted-app'
+        });
+    });
+
+    it('falls back to inline config before bundled defaults when hosted init lookup fails', async () => {
+        resetGlobals();
+        globalThis.window.__ALLPLAYS_CONFIG__ = {
+            firebase: {
+                apiKey: 'inline-key',
+                authDomain: 'inline-allplays.firebaseapp.com',
+                projectId: 'inline-allplays',
+                messagingSenderId: '999',
+                appId: 'inline-app'
+            }
+        };
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404
+        });
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config).toMatchObject({
+            apiKey: 'inline-key',
+            authDomain: 'inline-allplays.firebaseapp.com',
+            projectId: 'inline-allplays',
+            appId: 'inline-app'
+        });
+    });
+
     it('returns the bundled image firebase config when no inline image config is present', () => {
         resetGlobals();
 

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -18,7 +18,7 @@ const firebaseMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/db.js?v=53', () => dbMocks);
-vi.mock('../../js/firebase.js?v=18', () => firebaseMocks);
+vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
 vi.mock('../../js/utils.js?v=8', () => ({
     escapeHtml: (value) => String(value || '')
 }));

--- a/tests/unit/parent-incentives.test.js
+++ b/tests/unit/parent-incentives.test.js
@@ -1,7 +1,7 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 
 // Mock firebase.js so the module can be imported without a live Firebase project
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     db: {},
     collection: vi.fn(),
     getDocs: vi.fn(),
@@ -31,7 +31,7 @@ import {
     statKeyLabel,
     toggleIncentiveRule,
 } from '../../js/parent-incentives.js';
-import * as firebaseModule from '../../js/firebase.js?v=18';
+import * as firebaseModule from '../../js/firebase.js?v=19';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/tests/unit/scoped-fallback-uploads.test.js
+++ b/tests/unit/scoped-fallback-uploads.test.js
@@ -16,7 +16,7 @@ const firebaseMocks = vi.hoisted(() => ({
     getDownloadURL: vi.fn(async (storageRef) => `https://cdn.example.test/${storageRef.fullPath}`)
 }));
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     db: {},
     auth: { currentUser: { uid: 'user-42' } },
     storage: 'main-storage',

--- a/tests/unit/stripe-service.test.js
+++ b/tests/unit/stripe-service.test.js
@@ -3,7 +3,7 @@ import { cancelStripeRegistrationCheckout, initiateStripeCheckout, initiateTeamF
 
 const mockInnerCallable = vi.fn();
 
-vi.mock('../../js/firebase.js?v=18', () => {
+vi.mock('../../js/firebase.js?v=19', () => {
     return {
         getFunctions: vi.fn(() => ({})),
         httpsCallable: vi.fn(() => mockInnerCallable)
@@ -14,7 +14,7 @@ describe('Stripe Service', () => {
     let httpsCallable;
 
     beforeEach(async () => {
-        const firebaseMocks = await import('../../js/firebase.js?v=18');
+        const firebaseMocks = await import('../../js/firebase.js?v=19');
         httpsCallable = firebaseMocks.httpsCallable;
         httpsCallable.mockClear();
         mockInnerCallable.mockReset();

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -29,7 +29,7 @@ const firebaseMocks = vi.hoisted(() => ({
 
 const uploadTaskQueue = vi.hoisted(() => []);
 
-vi.mock('../../js/firebase.js?v=18', () => ({
+vi.mock('../../js/firebase.js?v=19', () => ({
     db: {},
     auth: { currentUser: { uid: 'user-1' } },
     storage: {},

--- a/tests/unit/telemetry.test.js
+++ b/tests/unit/telemetry.test.js
@@ -38,7 +38,7 @@ const mockStorage = () => {
 Object.defineProperty(window, 'localStorage', { value: mockStorage() });
 Object.defineProperty(window, 'sessionStorage', { value: mockStorage() });
 
-vi.mock('../../js/firebase.js?v=18', () => {
+vi.mock('../../js/firebase.js?v=19', () => {
     return {
         auth: firebaseMocks.auth,
         onAuthStateChanged: firebaseMocks.onAuthStateChanged

--- a/track-live.html
+++ b/track-live.html
@@ -668,8 +668,8 @@
 
     <script type="module">
         import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=53';
-        import { db } from './js/firebase.js?v=17';
-        import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=17';
+        import { db } from './js/firebase.js?v=19';
+        import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=7';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -199,8 +199,8 @@
 
   <script type="module">
     import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=53';
-    import { db } from './js/firebase.js?v=17';
-    import { writeBatch, doc, setDoc } from './js/firebase.js?v=17';
+    import { db } from './js/firebase.js?v=19';
+    import { writeBatch, doc, setDoc } from './js/firebase.js?v=19';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=8';
     import { checkAuth } from './js/auth.js?v=26';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/track.html
+++ b/track.html
@@ -275,8 +275,8 @@
 
     <script type="module">
         import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=53';
-        import { db } from './js/firebase.js?v=17';
-        import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=17';
+        import { db } from './js/firebase.js?v=19';
+        import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=26';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';

--- a/verify-pending.html
+++ b/verify-pending.html
@@ -81,7 +81,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=17';
+        import { auth } from './js/firebase.js?v=19';
         import { checkAuth, logout, resendVerificationEmail } from './js/auth.js?v=23';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 


### PR DESCRIPTION
Closes #2061

## What changed
- changed `resolvePrimaryFirebaseConfig()` to try Firebase Hosting runtime config from `/__/firebase/init.json` first, then fall back to inline runtime config, and only then fall back to bundled defaults
- added regression coverage for hosted-over-inline precedence and inline-over-bundled fallback in `tests/unit/firebase-runtime-config.test.js`
- added a CI `secret-scan` job that runs `run_secret_scanning`
- bumped the `firebase.js` cache-bust import chain so browsers pick up the runtime-config precedence fix
- did a scoped scan of `js/` and `apps/app/src/`; only the expected public Firebase web keys remained, with no service-account or other non-public secret material found

## Root Cause
`js/firebase-runtime-config.js` did not enforce Firebase Hosting runtime config as the primary source of truth for the main web app config, so config rotation could still depend on code-shipped values instead of the runtime endpoint. That precedence was also not pinned by a regression test, and CI was not scanning this surface for accidental secret commits.

## Prevention / Learning
When a client bundle has both runtime-hosted config and bundled fallback values, make the runtime source authoritative and lock the precedence order with a focused unit test. For config-bearing frontend paths, pair the code fix with cache-bust updates and CI secret scanning so future regressions are caught automatically.

## Regression Tests
- `npx vitest run tests/unit/firebase-runtime-config.test.js tests/unit/firebase-firestore-init.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`
- CI `secret-scan` job via `run_secret_scanning`

## Recurrence Risk
Low. The precedence order is now covered by unit tests, the runtime-config cache-bust chain was updated, and CI will scan for accidental secret material on future changes.