### PR TITLE
[codex] Add chat mention autocomplete

### DIFF
--- a/apps/app/src/lib/chatLogic.ts
+++ b/apps/app/src/lib/chatLogic.ts
@@ -57,6 +57,12 @@ export type ChatFormattedPart = {
   href?: string;
 };
 
+export type ChatMentionSuggestion = {
+  id: string;
+  label: string;
+  detail?: string;
+};
+
 export const chatReactions: Array<{ key: ChatReactionKey; emoji: string; label: string }> = [
   { key: 'thumbs_up', emoji: '👍', label: 'Like' },
   { key: 'heart', emoji: '❤️', label: 'Love' },
@@ -69,6 +75,8 @@ export const chatReactions: Array<{ key: ChatReactionKey; emoji: string; label: 
 export const chatReactionKeys = new Set(chatReactions.map((reaction) => reaction.key));
 
 const aiMentionRegex = /@all\s*plays/ig;
+const chatMentionTriggerRegex = /(^|\s)@([A-Za-z0-9 .'-]{0,40})$/;
+const chatMentionHighlightRegex = /(^|[\s([{"'])@([A-Za-z0-9][A-Za-z0-9.'-]*(?:\s+[A-Za-z0-9][A-Za-z0-9.'-]*){0,2})(?=$|[\s.,!?:;)\]}])/g;
 const urlRegex = /(\bhttps?:\/\/[^\s<]+[^\s<.,;:!?"'\])>]|\bwww\.[^\s<]+[^\s<.,;:!?"'\])>])/gi;
 const allowedChatHtmlTags = new Set(['strong', 'em', 'del', 'code', 'a', 'span']);
 const chatHtmlSanitizeConfig = {
@@ -322,6 +330,65 @@ export function extractAllPlaysQuestion(text: string) {
   return String(text || '').replace(aiMentionRegex, '').trim();
 }
 
+export function getChatMentionQuery(text: string) {
+  const match = String(text || '').match(chatMentionTriggerRegex);
+  if (!match) return null;
+  return String(match[2] || '').trim().toLowerCase();
+}
+
+export function hasChatMentionTrigger(text: string) {
+  return getChatMentionQuery(text) !== null;
+}
+
+export function buildChatMentionSuggestions(
+  recipientOptions: ChatRecipientOption[] = [],
+  text = '',
+  limit = 5
+): ChatMentionSuggestion[] {
+  const query = getChatMentionQuery(text);
+  if (query === null) return [];
+
+  const seen = new Set<string>();
+  const suggestions = recipientOptions.flatMap((option) => {
+    const label = String(option?.name || '').trim();
+    if (!label || isEmailLike(label)) return [];
+    const key = label.toLowerCase();
+    if (seen.has(key)) return [];
+    seen.add(key);
+    return [{
+      id: option.id || key,
+      label,
+      detail: option.detail
+    }];
+  });
+
+  return suggestions
+    .filter((suggestion) => {
+      if (!query) return true;
+      return suggestion.label.toLowerCase().includes(query)
+        || String(suggestion.detail || '').toLowerCase().includes(query);
+    })
+    .sort((a, b) => {
+      const aStarts = a.label.toLowerCase().startsWith(query) ? 0 : 1;
+      const bStarts = b.label.toLowerCase().startsWith(query) ? 0 : 1;
+      if (aStarts !== bStarts) return aStarts - bStarts;
+      return a.label.localeCompare(b.label);
+    })
+    .slice(0, limit);
+}
+
+export function insertChatMention(text: string, mentionLabel: string) {
+  const label = String(mentionLabel || '').replace(/^@+/, '').replace(/\s+/g, ' ').trim();
+  if (!label) return text;
+  const mention = `@${label} `;
+  const source = String(text || '');
+  if (chatMentionTriggerRegex.test(source)) {
+    return source.replace(chatMentionTriggerRegex, (_match, prefix) => `${prefix}${mention}`);
+  }
+  const spacer = source.trim() ? ' ' : '';
+  return `${source}${spacer}${mention}`;
+}
+
 export function getMessageSenderLabel(message: any, currentUserId = '') {
   if (message?.ai === true) return message.aiName || 'ALL PLAYS';
   if (message?.senderId && message.senderId === currentUserId) return 'You';
@@ -420,6 +487,10 @@ export function formatChatMessageHtml(text: string) {
   formatted = formatted.replace(
     /@all\s*plays/gi,
     '<span class="chat-mention">@ALL PLAYS</span>'
+  );
+  formatted = formatted.replace(
+    chatMentionHighlightRegex,
+    (_match, prefix, mentionLabel) => `${prefix}<span class="chat-mention">@${mentionLabel}</span>`
   );
   formatted = formatted.replace(urlRegex, (url) => {
     const href = url.startsWith('www.') ? `https://${url}` : url;

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -62,6 +62,7 @@ import {
   DEFAULT_TEAM_CONVERSATION_ID,
   MAX_CHAT_MEDIA_SIZE,
   buildChatAudienceMetadata,
+  buildChatMentionSuggestions,
   buildEmailAudienceMetadata,
   buildChatMediaShareDetails,
   chatReactions,
@@ -77,7 +78,9 @@ import {
   getMessageAttachments,
   getMessageSenderLabel,
   getReactionNames,
+  hasChatMentionTrigger,
   hasAllPlaysMention,
+  insertChatMention,
   isChatComposerLinkSafe,
   isDefaultTeamConversation,
   isStaffConversation,
@@ -85,6 +88,7 @@ import {
   normalizeChatReactions,
   shouldRetryChatLastReadOnViewReturn,
   shouldUpdateChatLastRead,
+  type ChatMentionSuggestion,
   type ChatRecipientOption,
   type ChatAudienceMetadata,
   type ChatTargetType
@@ -695,6 +699,10 @@ function ChatWindow({
     recipientOptions
   }), [recipientOptions, selectedConversation, selectedConversationId, selectedRecipientIds, selectedRecipientTarget]);
   const audienceSummary = useMemo(() => getAudienceSummaryText(audienceMetadata, recipientOptions), [audienceMetadata, recipientOptions]);
+  const mentionSuggestions = useMemo(
+    () => buildChatMentionSuggestions(recipientOptions, text),
+    [recipientOptions, text]
+  );
   const mediaEntries = useMemo(() => collectThreadMedia(messages), [messages]);
   const teamName = team?.name || inboxTeam?.name || 'Team chat';
 
@@ -747,6 +755,11 @@ function ChatWindow({
     recipientOptionsPromiseRef.current = request;
     return request;
   }, [canModerate, recipientOptions, recipientOptionsLoaded, teamId]);
+
+  useEffect(() => {
+    if (!hasChatMentionTrigger(text)) return;
+    void ensureRecipientOptionsLoaded().catch(() => undefined);
+  }, [ensureRecipientOptionsLoaded, text]);
 
   const setVoiceDraftTranscript = useCallback((transcript: string) => {
     const normalizedTranscript = String(transcript || '').trim();
@@ -1501,6 +1514,10 @@ function ChatWindow({
     });
   };
 
+  const insertRecipientMention = (mentionLabel: string) => {
+    setText((current) => insertChatMention(current, mentionLabel));
+  };
+
   const handleToggleReaction = useCallback(async (messageId: string, reactionKey: string) => {
     if (!auth.user) return;
     try {
@@ -1701,6 +1718,8 @@ function ChatWindow({
         voiceSupported={voiceSupported}
         canModerate={canModerate && isDefaultTeamConversation(selectedConversationId)}
         canSendTeamEmail={canModerate}
+        mentionSuggestions={mentionSuggestions}
+        mentionSuggestionsLoading={hasChatMentionTrigger(text) && recipientOptionsLoading}
         audienceSummary={audienceSummary}
         onTextChange={setText}
         onSubmit={handleSend}
@@ -1713,6 +1732,7 @@ function ChatWindow({
         }}
         onTeamEmail={openEmailSheet}
         onMention={insertAllPlaysMention}
+        onRecipientMention={insertRecipientMention}
       />
 
       <input ref={photoInputRef} type="file" className="chat-file-input" accept="image/*" multiple onChange={handleFiles} aria-hidden="true" tabIndex={-1} />
@@ -2662,6 +2682,8 @@ function Composer({
   voiceSupported,
   canModerate,
   canSendTeamEmail,
+  mentionSuggestions,
+  mentionSuggestionsLoading,
   audienceSummary,
   onTextChange,
   onSubmit,
@@ -2670,7 +2692,8 @@ function Composer({
   onVoice,
   onAudience,
   onTeamEmail,
-  onMention
+  onMention,
+  onRecipientMention
 }: {
   teamName: string;
   text: string;
@@ -2682,6 +2705,8 @@ function Composer({
   voiceSupported: boolean;
   canModerate: boolean;
   canSendTeamEmail: boolean;
+  mentionSuggestions: ChatMentionSuggestion[];
+  mentionSuggestionsLoading: boolean;
   audienceSummary: string;
   onTextChange: (value: string) => void;
   onSubmit: (event?: FormEvent) => void;
@@ -2691,9 +2716,11 @@ function Composer({
   onAudience: () => void;
   onTeamEmail: () => void;
   onMention: () => void;
+  onRecipientMention: (mentionLabel: string) => void;
 }) {
   const canSend = Boolean(text.trim() || filePreviews.length) && !sending && !aiThinking;
   const showMentionQuickAction = /(^|\s)@\w*$/i.test(text) && !hasAllPlaysMention(text);
+  const showMentionSuggestions = showMentionQuickAction && (mentionSuggestionsLoading || mentionSuggestions.length > 0);
   const placeholder = teamName.length > 16 ? 'Message' : `Message ${teamName}`;
   const attachmentSummary = filePreviews.length
     ? `${filePreviews.length} attachment${filePreviews.length === 1 ? '' : 's'} ready`
@@ -2724,6 +2751,30 @@ function Composer({
           <Bot className="h-4 w-4" aria-hidden="true" />
           @ALL PLAYS
         </button>
+      ) : null}
+
+      {showMentionSuggestions ? (
+        <div className="mb-2 rounded-xl border border-gray-200 bg-white p-1 shadow-sm" aria-label="Mention suggestions">
+          {mentionSuggestionsLoading && mentionSuggestions.length === 0 ? (
+            <div className="px-3 py-2 text-xs font-bold text-gray-500">Loading teammates...</div>
+          ) : mentionSuggestions.map((suggestion) => (
+            <button
+              key={suggestion.id}
+              type="button"
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left hover:bg-primary-50"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => onRecipientMention(suggestion.label)}
+            >
+              <span className="flex h-7 w-7 flex-none items-center justify-center rounded-full bg-primary-50 text-xs font-black text-primary-700">
+                {suggestion.label.slice(0, 1).toUpperCase()}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-black text-gray-950">@{suggestion.label}</span>
+                {suggestion.detail ? <span className="block truncate text-xs font-semibold text-gray-500">{suggestion.detail}</span> : null}
+              </span>
+            </button>
+          ))}
+        </div>
       ) : null}
 
       <div className="chat-composer-input-shell">

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -2720,7 +2720,7 @@ function Composer({
 }) {
   const canSend = Boolean(text.trim() || filePreviews.length) && !sending && !aiThinking;
   const showMentionQuickAction = /(^|\s)@\w*$/i.test(text) && !hasAllPlaysMention(text);
-  const showMentionSuggestions = showMentionQuickAction && (mentionSuggestionsLoading || mentionSuggestions.length > 0);
+  const showMentionSuggestions = hasChatMentionTrigger(text) && !hasAllPlaysMention(text) && (mentionSuggestionsLoading || mentionSuggestions.length > 0);
   const placeholder = teamName.length > 16 ? 'Message' : `Message ${teamName}`;
   const attachmentSummary = filePreviews.length
     ? `${filePreviews.length} attachment${filePreviews.length === 1 ? '' : 's'} ready`

--- a/tests/unit/app-chat-logic.test.js
+++ b/tests/unit/app-chat-logic.test.js
@@ -4,14 +4,17 @@ import {
     DEFAULT_TEAM_CONVERSATION_ID,
     buildChatAudienceMetadata,
     buildEmailAudienceMetadata,
+    buildChatMentionSuggestions,
     extractAllPlaysQuestion,
     formatChatMessageHtml,
+    getChatMentionQuery,
     getChatMemberDisplayName,
     getAudienceSummaryText,
     getMessageSenderLabel,
     getReactionNames,
     getMessagePreviewText,
     getSortedChatMessages,
+    insertChatMention,
     isChatComposerLinkSafe,
     mergeChatMessageLists,
     normalizeChatReactions
@@ -46,6 +49,32 @@ describe('React app chat logic', () => {
         expect(html).toContain('<span class="chat-mention">@ALL PLAYS</span>');
         expect(html).toContain('target="_blank"');
         expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('highlights teammate mentions while keeping hostile mention-like input escaped', () => {
+        const html = formatChatMessageHtml('Thanks @Coach Jamie <img src=x onerror=alert(1)> and parent@example.com');
+
+        expect(html).toContain('<span class="chat-mention">@Coach Jamie</span>');
+        expect(html).not.toContain('<img');
+        expect(html).not.toMatch(/<[^>]+\sonerror=/i);
+        expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+        expect(html).toContain('parent@example.com');
+        expect(html).not.toContain('<span class="chat-mention">@example</span>');
+    });
+
+    it('filters mention suggestions from recipient options and inserts the selected mention', () => {
+        const options = [
+            { id: 'user:coach-1', name: 'Coach Jamie', detail: 'Staff' },
+            { id: 'player:player-1', name: 'Pat Star', detail: '#9' },
+            { id: 'email:parent@example.com', name: 'parent@example.com', detail: 'Email' }
+        ];
+
+        expect(getChatMentionQuery('Can @co')).toBe('co');
+        expect(buildChatMentionSuggestions(options, 'Can @co')).toEqual([
+            { id: 'user:coach-1', label: 'Coach Jamie', detail: 'Staff' }
+        ]);
+        expect(insertChatMention('Can @co', 'Coach Jamie')).toBe('Can @Coach Jamie ');
+        expect(insertChatMention('No trigger', 'Pat Star')).toBe('No trigger @Pat Star ');
     });
 
     it('strips malformed or unsafe anchors in the fallback chat sanitizer', () => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -943,6 +943,20 @@ describe('React app messages integration', () => {
         expect(composer.value).toBe('Can @Coach Jamie ');
     });
 
+    it('keeps mention suggestions visible for multi-word full-name queries', async () => {
+        const { container } = await renderMessages('/messages/team-1');
+        const composer = container.querySelector('.chat-composer-textarea');
+
+        await setFieldValue(composer, 'Can @Coach J');
+
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledWith('team-1');
+        expect(container.textContent).toContain('@Coach Jamie');
+
+        await click(container, '@Coach Jamie');
+
+        expect(composer.value).toBe('Can @Coach Jamie ');
+    });
+
     it('does not recompute existing message html while the composer changes', async () => {
         const chatLogic = await import('../../apps/app/src/lib/chatLogic.ts');
         const formatSpy = vi.spyOn(chatLogic, 'formatChatMessageHtml');

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -929,6 +929,20 @@ describe('React app messages integration', () => {
         expect(chatMocks.deleteTeamChatMessage).toHaveBeenCalledWith('team-1', 'msg-2', 'team');
     });
 
+    it('suggests teammate mentions from recipient options and inserts the selected mention', async () => {
+        const { container } = await renderMessages('/messages/team-1');
+        const composer = container.querySelector('.chat-composer-textarea');
+
+        await setFieldValue(composer, 'Can @co');
+
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledWith('team-1');
+        expect(container.textContent).toContain('@Coach Jamie');
+
+        await click(container, '@Coach Jamie');
+
+        expect(composer.value).toBe('Can @Coach Jamie ');
+    });
+
     it('does not recompute existing message html while the composer changes', async () => {
         const chatLogic = await import('../../apps/app/src/lib/chatLogic.ts');
         const formatSpy = vi.spyOn(chatLogic, 'formatChatMessageHtml');


### PR DESCRIPTION
Closes #2412.

## Summary
- Add chat mention helper logic for filtering recipient options and inserting selected teammate mentions.
- Show teammate mention suggestions in the Messages composer when typing an @ trigger.
- Highlight teammate mentions in rendered chat content while preserving escaped/sanitized hostile input handling.

## Validation
- npx vitest run tests/unit/app-chat-logic.test.js --reporter=verbose
- npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose
- npm --prefix apps/app run lint -- --quiet
- npm run app:build