### PR TITLE
Lock in bounded Home schedule hydration fan-out (#2033)

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -1829,3 +1829,48 @@ describe('team schedule game windowing (#2034)', () => {
     ]));
   });
 });
+
+describe('home schedule hydration bounding (#2033)', () => {
+  const user = { uid: 'parent-1', email: 'parent@example.com' } as any;
+  const day = 24 * 60 * 60 * 1000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getRsvps).mockResolvedValue([] as any);
+    vi.mocked(getRsvpSummaries).mockResolvedValue(new Map() as any);
+    vi.mocked(listRideOffersForEvent).mockResolvedValue([] as any);
+    vi.mocked(getAssignmentClaims).mockResolvedValue({} as any);
+  });
+
+  function makeEvent(id: string, offsetMs: number) {
+    return {
+      teamId: 'team-1',
+      id,
+      childId: 'p1',
+      isDbGame: true,
+      isCancelled: false,
+      date: new Date(Date.now() + offsetMs),
+      assignments: [],
+      availabilityPreferences: {}
+    } as any;
+  }
+
+  it('only hydrates events inside the look-ahead/look-behind window', async () => {
+    const events = [
+      makeEvent('soon', 2 * day), // within 14d ahead
+      makeEvent('far-future', 40 * day), // beyond the look-ahead window
+      makeEvent('old', -5 * day) // beyond the 12h look-behind window
+    ];
+
+    await hydrateParentScheduleDetails({ children: [], events }, user);
+
+    const hydratedGameIds = vi.mocked(getRsvps).mock.calls.map((call) => call[1]);
+    expect(hydratedGameIds).toContain('soon');
+    expect(hydratedGameIds).not.toContain('far-future');
+    expect(hydratedGameIds).not.toContain('old');
+
+    expect(events.find((event) => event.id === 'soon')?.rsvpSummary).toBeDefined();
+    expect(events.find((event) => event.id === 'far-future')?.rsvpSummary).toBeUndefined();
+    expect(events.find((event) => event.id === 'old')?.rsvpSummary).toBeUndefined();
+  });
+});

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2661,6 +2661,12 @@ function loadCachedEventHydrationDetails(teamId: string, gameId: string) {
   );
 }
 
+// Home mount hydrates RSVP/rideshare/assignment subcollections per event, which
+// fanned out to ~180 reads for a 3-team x 20-event parent (#2033). Hydration is
+// bounded to events inside the look-ahead/look-behind window (the only ones whose
+// affordances render up front); the rest hydrate on demand when opened. Each
+// event's details are also cached (loadCachedEventHydrationDetails) so Home ->
+// Schedule -> detail doesn't repeat the same subcollection reads.
 export async function hydrateParentScheduleDetails(schedule: ParentScheduleLoadResult, user: AuthUser | null): Promise<ParentScheduleLoadResult> {
   if (!user?.uid || !schedule.events.length) {
     return schedule;


### PR DESCRIPTION
Closes #2033. (Recreated after rebasing onto current master; supersedes the earlier closed PR #2476.)

## Findings
The largest read-count finding is already mitigated on `master`:
- `hydrateParentScheduleDetails` only hydrates events inside the look-ahead (14d) / look-behind (12h) window via `shouldEagerlyHydrateParentHomeEvent`.
- Per-event details are cached via `loadCachedEventHydrationDetails` (`event-details:{teamId}:{gameId}`).

So a 3-team × 20-event parent no longer pays ~180 reads on Home mount.

## Changes
- **Regression test** asserting only in-window events are hydrated (a 40-day-out and a 5-day-past event issue no RSVP/rideshare/assignment reads and stay un-hydrated; a 2-day-out event is hydrated).
- A comment documenting the bounding + caching contract.

## Tests
Hydration-bounding test passes; `tsc --noEmit` clean. Rebased cleanly onto current master (resolved a test-file append conflict with the merged #2034 windowing tests — both blocks kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)