### PR TITLE
Add private secret scan guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,21 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_BASE_REF: ${{ github.base_ref }}
 
+  secret-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Scan app and legacy web code for private secrets
+        run: npm run ci:secret-scan
+
   unit-tests:
     runs-on: ubuntu-latest
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:smoke": "playwright test --config=playwright.smoke.config.js",
     "test:smoke:team-fallback": "playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --reporter=line",
+    "ci:secret-scan": "node scripts/check-no-private-secrets.mjs",
     "ci:firebase-rules": "node scripts/validate-firebase-rules-ci.mjs",
     "stage:pages": "node scripts/stage-pages-bundle.mjs",
     "app:build-help-index": "node scripts/build-app-help-knowledge-index.mjs",

--- a/scripts/check-no-private-secrets.mjs
+++ b/scripts/check-no-private-secrets.mjs
@@ -1,0 +1,157 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+export const DEFAULT_SCAN_ROOTS = ['apps/app/src', 'js'];
+const DEFAULT_IGNORED_DIRECTORIES = new Set([
+    '.git',
+    'node_modules',
+    'dist',
+    'build',
+    'coverage',
+    'vendor'
+]);
+const DEFAULT_SCANNED_EXTENSIONS = new Set([
+    '.cjs',
+    '.css',
+    '.html',
+    '.js',
+    '.json',
+    '.jsx',
+    '.mjs',
+    '.ts',
+    '.tsx'
+]);
+
+const SECRET_PATTERNS = [
+    {
+        name: 'private-key-block',
+        pattern: /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/
+    },
+    {
+        name: 'google-service-account-private-key',
+        pattern: /"private_key"\s*:\s*"[^"]*-----BEGIN PRIVATE KEY-----/
+    },
+    {
+        name: 'github-token',
+        pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{36,}\b|\bgithub_pat_[A-Za-z0-9_]{60,}\b/
+    },
+    {
+        name: 'slack-token',
+        pattern: /\bxox(?:b|p|a|r|s)-[A-Za-z0-9-]{20,}\b/
+    },
+    {
+        name: 'stripe-secret-key',
+        pattern: /\bsk_(?:live|test)_[A-Za-z0-9]{20,}\b/
+    },
+    {
+        name: 'openai-secret-key',
+        pattern: /\bsk-proj-[A-Za-z0-9_-]{20,}\b|\bsk-[A-Za-z0-9]{32,}\b/
+    },
+    {
+        name: 'google-oauth-client-secret',
+        pattern: /\bGOCSPX-[A-Za-z0-9_-]{20,}\b/
+    }
+];
+
+export function scanTextForPrivateSecrets(text, filePath = '<inline>') {
+    const findings = [];
+    const lines = text.split(/\r?\n/);
+
+    for (const { name, pattern } of SECRET_PATTERNS) {
+        for (const match of text.matchAll(new RegExp(pattern, pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`))) {
+            const line = countLinesBefore(text, match.index || 0);
+            findings.push({
+                filePath,
+                line,
+                pattern: name,
+                preview: lines[line - 1]?.trim() || ''
+            });
+        }
+    }
+
+    return findings;
+}
+
+export async function collectScannableFiles(rootDir, options = {}) {
+    const scanRoots = options.scanRoots || DEFAULT_SCAN_ROOTS;
+    const ignoredDirectories = options.ignoredDirectories || DEFAULT_IGNORED_DIRECTORIES;
+    const scannedExtensions = options.scannedExtensions || DEFAULT_SCANNED_EXTENSIONS;
+    const files = [];
+
+    for (const scanRoot of scanRoots) {
+        const absoluteRoot = path.resolve(rootDir, scanRoot);
+        await walkDirectory(absoluteRoot, {
+            files,
+            ignoredDirectories,
+            scannedExtensions
+        });
+    }
+
+    return files.sort();
+}
+
+export async function scanRepositoryForPrivateSecrets(rootDir = process.cwd(), options = {}) {
+    const files = await collectScannableFiles(rootDir, options);
+    const findings = [];
+
+    for (const filePath of files) {
+        const text = await readFile(filePath, 'utf8');
+        findings.push(...scanTextForPrivateSecrets(text, path.relative(rootDir, filePath)));
+    }
+
+    return findings;
+}
+
+async function walkDirectory(directory, context) {
+    const entries = await readdir(directory, { withFileTypes: true }).catch((error) => {
+        if (error.code === 'ENOENT') {
+            return [];
+        }
+
+        throw error;
+    });
+
+    for (const entry of entries) {
+        if (entry.isDirectory()) {
+            if (!context.ignoredDirectories.has(entry.name)) {
+                await walkDirectory(path.join(directory, entry.name), context);
+            }
+            continue;
+        }
+
+        if (entry.isFile() && context.scannedExtensions.has(path.extname(entry.name))) {
+            context.files.push(path.join(directory, entry.name));
+        }
+    }
+}
+
+function countLinesBefore(text, index) {
+    return text.slice(0, index).split(/\r?\n/).length;
+}
+
+function formatFinding(finding) {
+    return `${finding.filePath}:${finding.line} matched ${finding.pattern}`;
+}
+
+async function main() {
+    const findings = await scanRepositoryForPrivateSecrets(process.cwd());
+    if (findings.length > 0) {
+        console.error('Private secret scan failed:');
+        for (const finding of findings) {
+            console.error(`- ${formatFinding(finding)}`);
+        }
+        process.exit(1);
+    }
+
+    console.log('Private secret scan passed for apps/app/src and js.');
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+    main().catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });
+}

--- a/tests/unit/secret-scan.test.js
+++ b/tests/unit/secret-scan.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+    collectScannableFiles,
+    scanTextForPrivateSecrets
+} from '../../scripts/check-no-private-secrets.mjs';
+
+describe('private secret scan', () => {
+    it('allows public Firebase web config fields', () => {
+        const findings = scanTextForPrivateSecrets(`
+            export const config = {
+                apiKey: 'AIzaSyDoixIoKJuUVWdmImwjYRTthjKOv2mU0Jc',
+                authDomain: 'game-flow-c6311.firebaseapp.com',
+                projectId: 'game-flow-c6311',
+                messagingSenderId: '1030107289033',
+                appId: '1:1030107289033:web:7154238712942475143046'
+            };
+        `);
+
+        expect(findings).toEqual([]);
+    });
+
+    it('flags private key and token material', () => {
+        const privateKeyHeader = ['-----BEGIN', 'PRIVATE KEY-----'].join(' ');
+        const privateKeyFooter = ['-----END', 'PRIVATE KEY-----'].join(' ');
+        const githubToken = `ghp_${'1'.repeat(40)}`;
+        const findings = scanTextForPrivateSecrets(`
+            const serviceAccount = {
+                "private_key": "${privateKeyHeader}\\nabc\\n${privateKeyFooter}"
+            };
+            const token = '${githubToken}';
+        `, 'apps/app/src/bad.ts');
+
+        expect(findings.map((finding) => finding.pattern)).toEqual([
+            'private-key-block',
+            'google-service-account-private-key',
+            'github-token'
+        ]);
+        expect(findings[0]).toMatchObject({
+            filePath: 'apps/app/src/bad.ts',
+            line: 3
+        });
+    });
+
+    it('scans only app source and legacy web files by default', async () => {
+        const files = await collectScannableFiles(process.cwd());
+        const relativeFiles = files.map((file) => file.replace(`${process.cwd()}/`, ''));
+
+        expect(relativeFiles).toContain('js/firebase-runtime-config.js');
+        expect(relativeFiles.some((file) => file.startsWith('apps/app/src/'))).toBe(true);
+        expect(relativeFiles.some((file) => file.startsWith('tests/unit/'))).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #2061.

## Summary
- Add a focused private secret scanner for `apps/app/src` and `js`.
- Allow expected public Firebase web config while flagging private keys and common service tokens.
- Wire the scanner into npm scripts and CI.

## Validation
- `npm run ci:secret-scan`
- `npx vitest run tests/unit/secret-scan.test.js --reporter=verbose`