### PR TITLE
Centralize app date and money formatting

### DIFF
--- a/apps/app/src/components/schedule/DateTile.tsx
+++ b/apps/app/src/components/schedule/DateTile.tsx
@@ -1,13 +1,17 @@
+import { formatDateTileParts } from '../../lib/datetime';
+
 interface DateTileProps {
   date: Date;
 }
 
 export function DateTile({ date }: DateTileProps) {
+  const { month, day, weekday } = formatDateTileParts(date);
+
   return (
     <div className="flex h-12 w-12 flex-none flex-col items-center justify-center rounded-xl bg-gray-50 shadow-inner ring-1 ring-gray-200 sm:h-16 sm:w-16 sm:rounded-2xl">
-      <div className="text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500 sm:text-[11px]">{date.toLocaleDateString('en-US', { month: 'short' })}</div>
-      <div className="mt-0.5 text-lg font-black leading-none text-gray-950 sm:text-2xl">{date.getDate()}</div>
-      <div className="mt-0.5 text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500 sm:mt-1 sm:tracking-[0.08em]">{date.toLocaleDateString('en-US', { weekday: 'short' })}</div>
+      <div className="text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500 sm:text-[11px]">{month}</div>
+      <div className="mt-0.5 text-lg font-black leading-none text-gray-950 sm:text-2xl">{day}</div>
+      <div className="mt-0.5 text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500 sm:mt-1 sm:tracking-[0.08em]">{weekday}</div>
     </div>
   );
 }

--- a/apps/app/src/lib/datetime.ts
+++ b/apps/app/src/lib/datetime.ts
@@ -1,0 +1,109 @@
+export const DEFAULT_APP_LOCALE = 'en-US';
+
+export type DateTimeFormatOptions = {
+  locale?: string | null;
+  timeZone?: string | null;
+};
+
+export function getViewerTimeZone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+}
+
+export function resolveDateTimeLocale(locale?: string | null) {
+  return String(locale || '').trim() || DEFAULT_APP_LOCALE;
+}
+
+export function resolveEventTimeZone(timeZone?: string | null) {
+  const candidate = String(timeZone || '').trim();
+  if (candidate && isSupportedTimeZone(candidate)) {
+    return candidate;
+  }
+
+  const viewerTimeZone = getViewerTimeZone();
+  return isSupportedTimeZone(viewerTimeZone) ? viewerTimeZone : 'UTC';
+}
+
+export function formatDateTime(
+  date: Date,
+  formatOptions: Intl.DateTimeFormatOptions,
+  options: DateTimeFormatOptions = {}
+) {
+  return new Intl.DateTimeFormat(resolveDateTimeLocale(options.locale), {
+    ...formatOptions,
+    timeZone: resolveEventTimeZone(options.timeZone)
+  }).format(date);
+}
+
+export function formatEventDate(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatDateTime(date, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  }, options);
+}
+
+export function formatEventTime(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatDateTime(date, {
+    hour: 'numeric',
+    minute: '2-digit'
+  }, options);
+}
+
+export function formatLongEventDate(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatDateTime(date, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric'
+  }, options);
+}
+
+export function formatMonthYear(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatDateTime(date, {
+    month: 'long',
+    year: 'numeric'
+  }, options);
+}
+
+export function formatLongMonthDay(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatDateTime(date, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric'
+  }, options);
+}
+
+export function formatShortMonthDay(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatDateTime(date, {
+    month: 'short',
+    day: 'numeric'
+  }, options);
+}
+
+export function formatDateTileParts(date: Date, options: DateTimeFormatOptions = {}) {
+  const formatter = new Intl.DateTimeFormat(resolveDateTimeLocale(options.locale), {
+    month: 'short',
+    day: 'numeric',
+    weekday: 'short',
+    timeZone: resolveEventTimeZone(options.timeZone)
+  });
+  const parts = formatter.formatToParts(date);
+  return {
+    month: getPart(parts, 'month'),
+    day: getPart(parts, 'day'),
+    weekday: getPart(parts, 'weekday')
+  };
+}
+
+function isSupportedTimeZone(timeZone: string) {
+  try {
+    new Intl.DateTimeFormat(DEFAULT_APP_LOCALE, { timeZone }).format(new Date(0));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getPart(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPartTypes) {
+  return parts.find((part) => part.type === type)?.value || '';
+}

--- a/apps/app/src/lib/homeLogic.ts
+++ b/apps/app/src/lib/homeLogic.ts
@@ -4,6 +4,8 @@ import {
   normalizeRsvpResponse,
   type ParentScheduleEvent
 } from './scheduleLogic';
+import { formatEventDate } from './datetime';
+import { formatMoneyFromCents } from './money';
 import type { ParentScheduleChild } from './scheduleService';
 
 export type HomeActionKind = 'rsvp' | 'packet' | 'assignment' | 'rideshare' | 'fee' | 'message';
@@ -519,11 +521,11 @@ function toDate(value: unknown) {
 }
 
 function formatHomeActionDate(date: Date) {
-  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  return formatEventDate(date);
 }
 
 function formatHomeCurrency(value: number | string) {
   const cents = Number(value);
   if (!Number.isFinite(cents)) return 'Balance';
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+  return formatMoneyFromCents(cents);
 }

--- a/apps/app/src/lib/money.ts
+++ b/apps/app/src/lib/money.ts
@@ -1,0 +1,19 @@
+export type MoneyFormatOptions = {
+  locale?: string | null;
+  currency?: string | null;
+  signDisplay?: Intl.NumberFormatOptions['signDisplay'];
+  absolute?: boolean;
+};
+
+export function formatMoneyFromCents(cents: number, options: MoneyFormatOptions = {}) {
+  const safeCents = Number.isFinite(Number(cents)) ? Number(cents) : 0;
+  const amount = (options.absolute ? Math.abs(safeCents) : safeCents) / 100;
+  const locale = String(options.locale || '').trim() || 'en-US';
+  const currency = String(options.currency || '').trim() || 'USD';
+
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    signDisplay: options.signDisplay || 'auto'
+  }).format(amount);
+}

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -68,6 +68,7 @@ import {
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { loadParentScheduleSummary } from './homeService';
 import { formatEventDateLabel, formatEventTimeLabel, getScheduleTitle, type ParentScheduleEvent } from './scheduleLogic';
+import { formatMoneyFromCents } from './money';
 import type { AuthUser } from './types';
 
 const legacyOrigin = 'https://allplays.ai';
@@ -1141,10 +1142,7 @@ function getArrayField(source: any, keys: string[]) {
 }
 
 function formatCurrency(cents: number, currency = 'USD') {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: currency || 'USD'
-  }).format((Number(cents) || 0) / 100);
+  return formatMoneyFromCents(cents, { currency });
 }
 
 function escapeIcs(value: unknown) {

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -1,3 +1,5 @@
+import { formatEventDate, formatEventTime, formatLongEventDate, type DateTimeFormatOptions } from './datetime';
+
 export type ParentScheduleFilter = 'upcoming-all' | 'upcoming-games' | 'upcoming-practices' | 'availability' | 'recent-results' | 'past-all';
 export type ScheduleViewMode = 'list' | 'compact' | 'calendar' | 'packets';
 export type ScheduleTimeRange = 'week' | 'month' | 'quarter' | 'all';
@@ -319,12 +321,12 @@ export function getLiveClockViewModel(event: Pick<ParentScheduleEvent, 'type' | 
   };
 }
 
-export function formatEventDateLabel(date: Date) {
-  return date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+export function formatEventDateLabel(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatEventDate(date, options);
 }
 
-export function formatEventTimeLabel(date: Date) {
-  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+export function formatEventTimeLabel(date: Date, options: DateTimeFormatOptions = {}) {
+  return formatEventTime(date, options);
 }
 
 export function getScheduleTitle(event: Pick<ParentScheduleEvent, 'type' | 'title' | 'opponent'>) {
@@ -949,7 +951,7 @@ export function getScheduleForecastHref(location: string | null | undefined, dat
 
   let query = `weather in ${normalizedLocation}`;
   if (date) {
-    const formattedDate = date.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+    const formattedDate = formatLongEventDate(date);
     query += ` on ${formattedDate}`;
   }
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -90,6 +90,8 @@ import {
   normalizeRideRequestStatus,
   normalizeRsvpResponse,
   normalizeScheduleDate,
+  formatEventDateLabel,
+  formatEventTimeLabel,
   validateExternalCalendarUrl,
   buildStaffRsvpReminderMetadata,
   buildStaffRsvpReminderMessage,
@@ -1189,11 +1191,7 @@ export function normalizeGameScoreValue(value: unknown) {
 function formatCancelledGameDate(value: unknown) {
   const eventDate = normalizeScheduleDate(value);
   if (!eventDate) return 'date TBD';
-  return eventDate.toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric'
-  });
+  return formatEventDateLabel(eventDate);
 }
 
 export function buildCancelScheduledGameChatMessage(event: Pick<ParentScheduleEvent, 'opponent' | 'title' | 'date'>, titleOverride?: string | null) {
@@ -4332,7 +4330,7 @@ export async function sendStaffRsvpReminder(event: ParentScheduleEvent, user: Au
     text: buildStaffRsvpReminderMessage({
       eventType: event.type,
       title: getScheduleTitle(event),
-      dateLabel: `${event.date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })} at ${event.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}`,
+      dateLabel: `${formatEventDateLabel(event.date)} at ${formatEventTimeLabel(event.date)}`,
       missingCount: preview.missingPlayerCount
     }),
     files: [],

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -64,6 +64,7 @@ import {
   type ParentScheduleEvent,
   type RsvpResponse
 } from '../lib/scheduleLogic';
+import { formatDateTileParts, formatShortMonthDay } from '../lib/datetime';
 import { loadOfficialAssignmentsAccess } from '../lib/scheduleService';
 import { recordFirstMeaningfulRender, startScreenMountTimer } from '../lib/uxTiming';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
@@ -297,6 +298,7 @@ export function Home({ auth }: { auth: AuthState }) {
   const displayName = auth.user?.displayName || auth.user?.email || 'ALL PLAYS User';
   const openCount = home.metrics.rsvpNeeded + home.metrics.packetsReady + home.metrics.unreadMessages + home.fees.length + social.metrics.incomingRequests;
   const today = new Date();
+  const todayTile = formatDateTileParts(today);
   const selectedComposerType = (searchParams.get('type') || 'manual_post') as SocialPostType;
 
   const openComposer = (type: SocialPostType = 'manual_post') => {
@@ -365,8 +367,8 @@ export function Home({ auth }: { auth: AuthState }) {
       <section className="home-hero app-card overflow-hidden">
         <div className="flex items-center gap-3 px-3 py-3 sm:px-4">
           <div className="flex h-12 w-12 flex-none flex-col items-center justify-center rounded-2xl bg-gray-950 text-white shadow-sm">
-            <div className="text-[10px] font-black uppercase leading-none tracking-[0.08em] text-gray-300">{today.toLocaleDateString('en-US', { month: 'short' })}</div>
-            <div className="mt-0.5 text-xl font-black leading-none">{today.getDate()}</div>
+            <div className="text-[10px] font-black uppercase leading-none tracking-[0.08em] text-gray-300">{todayTile.month}</div>
+            <div className="mt-0.5 text-xl font-black leading-none">{todayTile.day}</div>
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
@@ -1744,7 +1746,7 @@ function formatSocialDate(date: Date) {
   if (diffMinutes < 60) return `${diffMinutes}m`;
   const diffHours = Math.round(diffMinutes / 60);
   if (diffHours < 24) return `${diffHours}h`;
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return formatShortMonthDay(date);
 }
 
 function PulseChip({ icon: Icon, label, value, urgent = false }: { icon: LucideIcon; label: string; value: string; urgent?: boolean }) {
@@ -1852,11 +1854,13 @@ function HomeEventCard({ event }: { event: ParentScheduleEvent }) {
 }
 
 function DateTile({ date }: { date: Date }) {
+  const { month, day, weekday } = formatDateTileParts(date);
+
   return (
     <div className="flex h-12 w-12 flex-none flex-col items-center justify-center rounded-xl bg-gray-50 shadow-inner ring-1 ring-gray-200">
-      <div className="text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{date.toLocaleDateString('en-US', { month: 'short' })}</div>
-      <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{date.getDate()}</div>
-      <div className="mt-0.5 text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{date.toLocaleDateString('en-US', { weekday: 'short' })}</div>
+      <div className="text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{month}</div>
+      <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{day}</div>
+      <div className="mt-0.5 text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{weekday}</div>
     </div>
   );
 }

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -55,6 +55,7 @@ import {
 } from '../lib/parentToolsService';
 import { getCalendarEventShareText } from '../lib/parentToolsService';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
+import { formatMoneyFromCents } from '../lib/money';
 import type { ParentScheduleEvent } from '../lib/scheduleLogic';
 import type { AuthState } from '../lib/types';
 
@@ -1487,7 +1488,7 @@ function splitLines(value: string) {
 }
 
 function formatMoney(cents: number) {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((Number(cents) || 0) / 100);
+  return formatMoneyFromCents(cents);
 }
 
 function formatDetailAmount(row: Record<string, any>) {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -45,6 +45,8 @@ import {
 import { DetailLoadErrorState } from '../components/DetailLoadErrorState';
 import { getEventDetailPath } from '../lib/homeLogic';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
+import { formatDateTileParts } from '../lib/datetime';
+import { formatMoneyFromCents } from '../lib/money';
 import {
   formatEventDateLabel,
   formatEventTimeLabel,
@@ -1883,11 +1885,13 @@ function EmptyCard({ icon: Icon, title, detail }: { icon: LucideIcon; title: str
 }
 
 function DateTile({ date }: { date: Date }) {
+  const { month, day, weekday } = formatDateTileParts(date);
+
   return (
     <div className="flex h-12 w-12 flex-none flex-col items-center justify-center rounded-xl bg-gray-50 shadow-inner ring-1 ring-gray-200">
-      <div className="text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{date.toLocaleDateString('en-US', { month: 'short' })}</div>
-      <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{date.getDate()}</div>
-      <div className="mt-0.5 text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{date.toLocaleDateString('en-US', { weekday: 'short' })}</div>
+      <div className="text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{month}</div>
+      <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{day}</div>
+      <div className="mt-0.5 text-[10px] font-black uppercase leading-none tracking-[0.06em] text-gray-500">{weekday}</div>
     </div>
   );
 }
@@ -1954,10 +1958,10 @@ function formatAverage(value: number) {
 }
 
 function formatMoney(cents: number, sign = true) {
-  const safeCents = Number.isFinite(Number(cents)) ? Number(cents) : 0;
-  const dollars = `$${(Math.abs(safeCents) / 100).toFixed(2)}`;
-  if (!sign) return dollars;
-  return safeCents >= 0 ? `+${dollars}` : `-${dollars}`;
+  return formatMoneyFromCents(cents, {
+    absolute: !sign,
+    signDisplay: sign ? 'always' : 'auto'
+  });
 }
 
 function getIncentiveStatLabel(statOptions: Array<{ key: string; label: string }>, statKey: string) {

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -17,6 +17,7 @@ import {
   requiresRegistrationOption,
   hasQuantityDiscountRule
 } from '../lib/adapters/legacyRegistration';
+import { formatMoneyFromCents } from '../lib/money';
 import type { AuthState } from '../lib/types';
 
 type FieldErrors = Record<string, string>;
@@ -823,7 +824,7 @@ function formatOptionAvailability(option: any, counts: Record<string, any>) {
 }
 
 function formatMoney(cents: number, currency = 'USD') {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency || 'USD' }).format((Number(cents) || 0) / 100);
+  return formatMoneyFromCents(cents, { currency });
 }
 
 function StatusPill({ value }: { value: string }) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -35,6 +35,7 @@ import {
   type ScheduleTimeRange,
   type ScheduleViewMode
 } from '../lib/scheduleLogic';
+import { formatDateTileParts, formatLongMonthDay, formatMonthYear } from '../lib/datetime';
 import type { AuthState } from '../lib/types';
 
 const filterOptions: Array<{ value: ParentScheduleFilter; label: string }> = [
@@ -2006,14 +2007,15 @@ function ScheduleEventCard({ event }: {
   const mapHref = getScheduleMapHref(event.location);
   const forecastHref = getScheduleForecastHref(event.location, event.date);
   const childLabel = getScheduleChildLabel(event);
+  const dateTile = formatDateTileParts(event.date);
 
   return (
     <>
       <Link to={detailPath} className={`block border-b border-gray-100 px-3 py-2 transition last:border-b-0 hover:bg-gray-50 sm:hidden ${event.isCancelled ? 'opacity-65' : ''}`}>
         <div className="flex items-center gap-2.5">
           <div className="flex h-12 w-11 flex-none flex-col items-center justify-center rounded-lg bg-gray-50 ring-1 ring-gray-100">
-            <div className="text-[10px] font-black uppercase leading-none tracking-[0.04em] text-gray-500">{event.date.toLocaleDateString('en-US', { month: 'short' })}</div>
-            <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{event.date.getDate()}</div>
+            <div className="text-[10px] font-black uppercase leading-none tracking-[0.04em] text-gray-500">{dateTile.month}</div>
+            <div className="mt-0.5 text-lg font-black leading-none text-gray-950">{dateTile.day}</div>
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-1.5">
@@ -2039,8 +2041,8 @@ function ScheduleEventCard({ event }: {
       <article className={`app-card schedule-event-card hidden p-4 transition sm:block ${event.isCancelled ? 'opacity-65' : ''}`}>
         <div className="flex items-start gap-3">
           <div className="schedule-card-date flex h-16 w-16 flex-none flex-col items-center justify-center rounded-2xl bg-gray-50 shadow-inner ring-1 ring-gray-200">
-            <div className="text-2xl font-black leading-none text-gray-950">{event.date.getDate()}</div>
-            <div className="mt-1 text-[10px] font-black uppercase tracking-[0.08em] text-gray-500">{event.date.toLocaleDateString('en-US', { weekday: 'short' })}</div>
+            <div className="text-2xl font-black leading-none text-gray-950">{dateTile.day}</div>
+            <div className="mt-1 text-[10px] font-black uppercase tracking-[0.08em] text-gray-500">{dateTile.weekday}</div>
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
@@ -2177,7 +2179,7 @@ function CalendarSchedule({ month, entries, selectedDay, selectedDayEntries, onM
   onDaySelect: (day: Date) => void;
   onDayClose: () => void;
 }) {
-  const monthLabel = month.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  const monthLabel = formatMonthYear(month);
   const monthStart = new Date(month.getFullYear(), month.getMonth(), 1);
   const daysInMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate();
   const startDow = monthStart.getDay();
@@ -2257,7 +2259,7 @@ function CalendarEventPicker({ day, entries, onClose }: {
 }) {
   if (!day) return null;
 
-  const dayLabel = day.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+  const dayLabel = formatLongMonthDay(day);
   const eventCountLabel = `${entries.length} ${entries.length === 1 ? 'event' : 'events'}`;
 
   return (

--- a/apps/app/src/pages/TeamFees.tsx
+++ b/apps/app/src/pages/TeamFees.tsx
@@ -12,6 +12,7 @@ import {
   type TeamFeeRecipientSummary
 } from '../lib/teamFeesService';
 import { copyPublicText, sharePublicUrl } from '../lib/publicActions';
+import { formatMoneyFromCents } from '../lib/money';
 import type { AuthState } from '../lib/types';
 
 type RecipientFormState = {
@@ -32,7 +33,7 @@ type RecipientFormState = {
 };
 
 function formatMoney(cents: number) {
-  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((Number(cents) || 0) / 100);
+  return formatMoneyFromCents(cents);
 }
 
 function todayIsoDate() {

--- a/tests/unit/app-intl-formatters.test.ts
+++ b/tests/unit/app-intl-formatters.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  formatDateTileParts,
+  formatEventDate,
+  formatEventTime,
+  formatLongEventDate,
+  formatLongMonthDay,
+  formatMonthYear,
+  formatShortMonthDay,
+  resolveEventTimeZone
+} from '../../apps/app/src/lib/datetime';
+import { formatMoneyFromCents } from '../../apps/app/src/lib/money';
+import { formatEventDateLabel, formatEventTimeLabel, getScheduleForecastHref } from '../../apps/app/src/lib/scheduleLogic';
+
+describe('app Intl formatters', () => {
+  it('formats schedule dates and times with an explicit event timezone', () => {
+    const date = new Date('2026-07-20T23:30:00.000Z');
+
+    expect(formatEventDate(date, { timeZone: 'America/New_York' })).toBe('Mon, Jul 20');
+    expect(formatEventTime(date, { timeZone: 'America/New_York' })).toBe('7:30 PM');
+    expect(formatLongEventDate(date, { timeZone: 'America/New_York' })).toBe('Monday, July 20, 2026');
+    expect(formatLongMonthDay(date, { timeZone: 'America/New_York' })).toBe('Monday, July 20');
+    expect(formatMonthYear(date, { timeZone: 'America/New_York' })).toBe('July 2026');
+    expect(formatShortMonthDay(date, { timeZone: 'America/New_York' })).toBe('Jul 20');
+    expect(formatDateTileParts(date, { timeZone: 'America/New_York' })).toEqual({
+      month: 'Jul',
+      day: '20',
+      weekday: 'Mon'
+    });
+  });
+
+  it('keeps scheduleLogic labels on the shared formatter path', () => {
+    const date = new Date('2026-07-20T23:30:00.000Z');
+
+    expect(formatEventDateLabel(date, { timeZone: 'America/Los_Angeles' })).toBe('Mon, Jul 20');
+    expect(formatEventTimeLabel(date, { timeZone: 'America/Los_Angeles' })).toBe('4:30 PM');
+  });
+
+  it('uses timezone-aware dates for forecast search links', () => {
+    const href = getScheduleForecastHref('Central Park, New York', new Date('2026-07-20T23:30:00.000Z'));
+    const url = new URL(href);
+
+    expect(url.searchParams.get('q')).toMatch(/weather in Central Park, New York on /);
+  });
+
+  it('falls back to the viewer timezone when an event timezone is absent or invalid', () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
+      locale: 'en-US',
+      calendar: 'gregory',
+      numberingSystem: 'latn',
+      timeZone: 'America/Chicago'
+    });
+
+    expect(resolveEventTimeZone()).toBe('America/Chicago');
+    expect(resolveEventTimeZone('Not/AZone')).toBe('America/Chicago');
+  });
+
+  it('formats currency and signed incentive amounts through Intl.NumberFormat', () => {
+    expect(formatMoneyFromCents(123456)).toBe('$1,234.56');
+    expect(formatMoneyFromCents(-2500, { signDisplay: 'always' })).toBe('-$25.00');
+    expect(formatMoneyFromCents(2500, { signDisplay: 'always' })).toBe('+$25.00');
+    expect(formatMoneyFromCents(-2500, { absolute: true })).toBe('$25.00');
+    expect(formatMoneyFromCents(123456, { locale: 'en-GB', currency: 'GBP' })).toBe('£1,234.56');
+  });
+});


### PR DESCRIPTION
Closes #2073.

## Summary
- Add shared `datetime` and `money` helpers backed by `Intl` with explicit locale/timezone options.
- Route schedule labels, calendar tiles, RSVP reminder labels, home action dates, and parent/team fee currency through the shared helpers.
- Add formatter regression tests for explicit timezone behavior, fallback timezone policy, and signed/unsigned money output.

## Validation
- `npx vitest run tests/unit/app-intl-formatters.test.ts tests/unit/app-schedule-logic.test.js tests/unit/app-schedule-service-contracts.test.js --reporter=verbose`
- `npm --prefix apps/app run lint -- --quiet`
- `npm run app:build`