### PR TITLE
Add pull to refresh across app screens

### DIFF
--- a/apps/app/src/components/PullToRefresh.test.tsx
+++ b/apps/app/src/components/PullToRefresh.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PullToRefresh } from './PullToRefresh';
+
+describe('PullToRefresh', () => {
+  it('merges custom layout classes onto the root container', () => {
+    const { container } = render(
+      <PullToRefresh className="h-full min-h-0" onRefresh={vi.fn()}>
+        <div>Child</div>
+      </PullToRefresh>
+    );
+
+    const root = container.firstElementChild;
+    expect(root?.className).toContain('pull-to-refresh-root');
+    expect(root?.className).toContain('h-full');
+    expect(root?.className).toContain('min-h-0');
+  });
+});

--- a/apps/app/src/components/PullToRefresh.tsx
+++ b/apps/app/src/components/PullToRefresh.tsx
@@ -12,13 +12,15 @@ type PullToRefreshProps = {
   onRefresh: () => Promise<unknown> | unknown;
   disabled?: boolean;
   threshold?: number;
+  className?: string;
 };
 
 export function PullToRefresh({
   children,
   onRefresh,
   disabled = false,
-  threshold = PULL_TO_REFRESH_THRESHOLD_PX
+  threshold = PULL_TO_REFRESH_THRESHOLD_PX,
+  className = ''
 }: PullToRefreshProps) {
   const startYRef = useRef<number | null>(null);
   const hapticTickedRef = useRef(false);
@@ -82,7 +84,7 @@ export function PullToRefresh({
 
   return (
     <div
-      className="pull-to-refresh-root"
+      className={`pull-to-refresh-root ${className}`.trim()}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}

--- a/apps/app/src/components/PullToRefresh.tsx
+++ b/apps/app/src/components/PullToRefresh.tsx
@@ -1,0 +1,121 @@
+import { type ReactNode, useRef, useState, type TouchEvent } from 'react';
+import { RefreshCw } from 'lucide-react';
+import {
+  PULL_TO_REFRESH_THRESHOLD_PX,
+  getPullToRefreshDistance,
+  getPullToRefreshIndicatorHeight,
+  isPullToRefreshReady
+} from '../lib/pullToRefresh';
+
+type PullToRefreshProps = {
+  children: ReactNode;
+  onRefresh: () => Promise<unknown> | unknown;
+  disabled?: boolean;
+  threshold?: number;
+};
+
+export function PullToRefresh({
+  children,
+  onRefresh,
+  disabled = false,
+  threshold = PULL_TO_REFRESH_THRESHOLD_PX
+}: PullToRefreshProps) {
+  const startYRef = useRef<number | null>(null);
+  const hapticTickedRef = useRef(false);
+  const [distance, setDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+  const ready = isPullToRefreshReady(distance, threshold);
+  const indicatorHeight = getPullToRefreshIndicatorHeight(distance, refreshing);
+  const isActive = indicatorHeight > 0;
+
+  const resetPull = () => {
+    startYRef.current = null;
+    hapticTickedRef.current = false;
+    setDistance(0);
+  };
+
+  const handleTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    if (disabled || refreshing || getPageScrollTop() > 0) {
+      startYRef.current = null;
+      return;
+    }
+    startYRef.current = event.touches[0]?.clientY ?? null;
+    hapticTickedRef.current = false;
+  };
+
+  const handleTouchMove = (event: TouchEvent<HTMLDivElement>) => {
+    if (disabled || refreshing || startYRef.current === null) return;
+    const nextDistance = getPullToRefreshDistance(startYRef.current, event.touches[0]?.clientY ?? startYRef.current, getPageScrollTop());
+    if (nextDistance <= 0) {
+      setDistance(0);
+      return;
+    }
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    setDistance(nextDistance);
+    if (!hapticTickedRef.current && isPullToRefreshReady(nextDistance, threshold)) {
+      hapticTickedRef.current = true;
+      navigator.vibrate?.(10);
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (disabled || refreshing || startYRef.current === null) {
+      resetPull();
+      return;
+    }
+
+    const shouldRefresh = isPullToRefreshReady(distance, threshold);
+    resetPull();
+    if (!shouldRefresh) return;
+
+    setRefreshing(true);
+    Promise.resolve(onRefresh())
+      .catch(() => {
+        // The owning page already renders its refresh error state.
+      })
+      .finally(() => {
+        setRefreshing(false);
+      });
+  };
+
+  return (
+    <div
+      className="pull-to-refresh-root"
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+      onTouchCancel={resetPull}
+    >
+      <div
+        className="pointer-events-none fixed left-0 right-0 z-[90] flex justify-center transition-opacity duration-150"
+        style={{
+          top: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)',
+          opacity: isActive ? 1 : 0,
+          transform: `translateY(${isActive ? 0 : -12}px)`
+        }}
+        aria-hidden={!isActive}
+      >
+        <div
+          role="status"
+          aria-live="polite"
+          className={`flex h-10 w-10 items-center justify-center rounded-full border border-gray-200 bg-white shadow-lg transition-transform ${ready || refreshing ? 'text-primary-700' : 'text-gray-500'}`}
+          style={{
+            transform: `scale(${isActive ? 1 : 0.85})`,
+            marginTop: `${Math.min(indicatorHeight, 48) - 48}px`
+          }}
+        >
+          <RefreshCw className={`h-4 w-4 ${refreshing ? 'animate-spin' : ''}`} aria-hidden="true" />
+          <span className="sr-only">{refreshing ? 'Refreshing' : 'Pull refresh ready'}</span>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function getPageScrollTop() {
+  if (typeof window === 'undefined') return 0;
+  return window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0;
+}

--- a/apps/app/src/lib/pullToRefresh.ts
+++ b/apps/app/src/lib/pullToRefresh.ts
@@ -1,0 +1,18 @@
+export const PULL_TO_REFRESH_THRESHOLD_PX = 72;
+export const PULL_TO_REFRESH_MAX_DISTANCE_PX = 112;
+
+export function getPullToRefreshDistance(startY: number, currentY: number, scrollTop: number) {
+  if (scrollTop > 0) return 0;
+  const delta = currentY - startY;
+  if (delta <= 0) return 0;
+  return Math.min(PULL_TO_REFRESH_MAX_DISTANCE_PX, delta * 0.55);
+}
+
+export function isPullToRefreshReady(distance: number, threshold = PULL_TO_REFRESH_THRESHOLD_PX) {
+  return distance >= threshold;
+}
+
+export function getPullToRefreshIndicatorHeight(distance: number, refreshing: boolean) {
+  if (refreshing) return 48;
+  return Math.round(Math.max(0, distance));
+}

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -28,6 +28,7 @@ import {
 } from 'lucide-react';
 import { Modal } from '../components/Modal';
 import { HomePageSkeleton } from '../components/PageSkeletons';
+import { PullToRefresh } from '../components/PullToRefresh';
 import { loadParentHomeSummaryBootstrap, loadParentHomeWithSecondaryData } from '../lib/homeService';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import {
@@ -361,7 +362,8 @@ export function Home({ auth }: { auth: AuthState }) {
   };
 
   return (
-    <div className="home-page home-page-live home-page-social space-y-3">
+    <PullToRefresh onRefresh={() => refreshHome({ force: true })} disabled={!auth.user?.uid}>
+      <div className="home-page home-page-live home-page-social space-y-3">
       <section className="home-hero app-card overflow-hidden">
         <div className="flex items-center gap-3 px-3 py-3 sm:px-4">
           <div className="flex h-12 w-12 flex-none flex-col items-center justify-center rounded-2xl bg-gray-950 text-white shadow-sm">
@@ -467,7 +469,8 @@ export function Home({ auth }: { auth: AuthState }) {
           onSubmit={handleCreatePost}
         />
       ) : null}
-    </div>
+      </div>
+    </PullToRefresh>
   );
 }
 

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -58,6 +58,7 @@ import {
   type ChatTeam
 } from '../lib/chatService';
 import { MessagesPageSkeleton } from '../components/PageSkeletons';
+import { PullToRefresh } from '../components/PullToRefresh';
 import {
   DEFAULT_TEAM_CONVERSATION_ID,
   MAX_CHAT_MEDIA_SIZE,
@@ -128,6 +129,7 @@ export function Messages({ auth }: { auth: AuthState }) {
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [selectedDesktopTeamId, setSelectedDesktopTeamId] = useState<string | undefined>(undefined);
+  const [threadRefreshVersion, setThreadRefreshVersion] = useState(0);
   const shouldLoadInbox = isDesktopWeb || !teamId;
   const inboxLoadRouteKey = getMessagesInboxLoadRouteKey(shouldLoadInbox, teamId);
   const inboxRequestIdRef = useRef(0);
@@ -181,6 +183,13 @@ export function Messages({ auth }: { auth: AuthState }) {
       }
     }
   }, [auth.user, teamId]);
+
+  const refreshMessages = useCallback(async () => {
+    if (shouldLoadInbox) {
+      await refreshInbox();
+    }
+    setThreadRefreshVersion((current) => current + 1);
+  }, [refreshInbox, shouldLoadInbox]);
 
   useEffect(() => {
     if (!shouldLoadInbox) {
@@ -257,74 +266,82 @@ export function Messages({ auth }: { auth: AuthState }) {
 
   if (isDesktopWeb) {
     return (
-      <div className="messages-page messages-page-web">
-        <MessagesHeader teams={teams} loading={loading} onRefresh={refreshInbox} />
-        <section className="messages-two-pane mt-4">
-          <aside className="messages-list-pane">
-            <InboxSearch query={query} onChange={setQuery} />
-            <div className="messages-list-scroll">
-              <InboxList
-                teams={filteredTeams}
-                loading={loading}
-                error={error}
-                activeTeamId={activeTeamId || ''}
-                searchQuery={query}
-                totalTeamsCount={teams.length}
-                onClearSearch={() => setQuery('')}
-                onSelect={setSelectedDesktopTeamId}
-                compact
-              />
+      <PullToRefresh onRefresh={refreshMessages} disabled={!auth.user?.uid}>
+        <div className="messages-page messages-page-web">
+          <MessagesHeader teams={teams} loading={loading} onRefresh={refreshMessages} />
+          <section className="messages-two-pane mt-4">
+            <aside className="messages-list-pane">
+              <InboxSearch query={query} onChange={setQuery} />
+              <div className="messages-list-scroll">
+                <InboxList
+                  teams={filteredTeams}
+                  loading={loading}
+                  error={error}
+                  activeTeamId={activeTeamId || ''}
+                  searchQuery={query}
+                  totalTeamsCount={teams.length}
+                  onClearSearch={() => setQuery('')}
+                  onSelect={setSelectedDesktopTeamId}
+                  compact
+                />
+              </div>
+            </aside>
+            <div className="messages-chat-pane min-w-0">
+              {activeTeamId ? (
+                <ChatWindow
+                  auth={auth}
+                  teamId={activeTeamId}
+                  inboxTeam={teams.find((team) => team.id === activeTeamId)}
+                  preferredConversationId={teamId === activeTeamId ? preferredConversationId : ''}
+                  refreshVersion={threadRefreshVersion}
+                  onInboxMuteChange={(nextConversationId, nextIsMuted) => {
+                    setTeams((current) => updateInboxTeamMuteState(current, activeTeamId, nextConversationId, nextIsMuted));
+                  }}
+                  embedded
+                />
+              ) : (
+                <EmptyChatSelection />
+              )}
             </div>
-          </aside>
-          <div className="messages-chat-pane min-w-0">
-            {activeTeamId ? (
-              <ChatWindow
-                auth={auth}
-                teamId={activeTeamId}
-                inboxTeam={teams.find((team) => team.id === activeTeamId)}
-                preferredConversationId={teamId === activeTeamId ? preferredConversationId : ''}
-                onInboxMuteChange={(nextConversationId, nextIsMuted) => {
-                  setTeams((current) => updateInboxTeamMuteState(current, activeTeamId, nextConversationId, nextIsMuted));
-                }}
-                embedded
-              />
-            ) : (
-              <EmptyChatSelection />
-            )}
-          </div>
-        </section>
-      </div>
+          </section>
+        </div>
+      </PullToRefresh>
     );
   }
 
   if (activeTeamId) {
     return (
-      <ChatWindow
-        auth={auth}
-        teamId={activeTeamId}
-        inboxTeam={teams.find((team) => team.id === activeTeamId)}
-        preferredConversationId={preferredConversationId}
-        onInboxMuteChange={(nextConversationId, nextIsMuted) => {
-          setTeams((current) => updateInboxTeamMuteState(current, activeTeamId, nextConversationId, nextIsMuted));
-        }}
-      />
+      <PullToRefresh onRefresh={refreshMessages} disabled={!auth.user?.uid}>
+        <ChatWindow
+          auth={auth}
+          teamId={activeTeamId}
+          inboxTeam={teams.find((team) => team.id === activeTeamId)}
+          preferredConversationId={preferredConversationId}
+          refreshVersion={threadRefreshVersion}
+          onInboxMuteChange={(nextConversationId, nextIsMuted) => {
+            setTeams((current) => updateInboxTeamMuteState(current, activeTeamId, nextConversationId, nextIsMuted));
+          }}
+        />
+      </PullToRefresh>
     );
   }
 
   return (
-    <div className="messages-page space-y-4">
-      <MessagesHeader teams={teams} loading={loading} onRefresh={refreshInbox} />
-      <InboxSearch query={query} onChange={setQuery} />
-      <InboxList
-        teams={filteredTeams}
-        loading={loading}
-        error={error}
-        activeTeamId=""
-        searchQuery={query}
-        totalTeamsCount={teams.length}
-        onClearSearch={() => setQuery('')}
-      />
-    </div>
+    <PullToRefresh onRefresh={refreshMessages} disabled={!auth.user?.uid}>
+      <div className="messages-page space-y-4">
+        <MessagesHeader teams={teams} loading={loading} onRefresh={refreshMessages} />
+        <InboxSearch query={query} onChange={setQuery} />
+        <InboxList
+          teams={filteredTeams}
+          loading={loading}
+          error={error}
+          activeTeamId=""
+          searchQuery={query}
+          totalTeamsCount={teams.length}
+          onClearSearch={() => setQuery('')}
+        />
+      </div>
+    </PullToRefresh>
   );
 }
 
@@ -516,6 +533,7 @@ function ChatWindow({
   teamId,
   inboxTeam,
   preferredConversationId = '',
+  refreshVersion = 0,
   onInboxMuteChange,
   embedded = false
 }: {
@@ -523,6 +541,7 @@ function ChatWindow({
   teamId: string;
   inboxTeam?: ChatTeam;
   preferredConversationId?: string;
+  refreshVersion?: number;
   onInboxMuteChange?: (conversationId: string, isMuted: boolean) => void;
   embedded?: boolean;
 }) {
@@ -674,7 +693,8 @@ function ChatWindow({
     onBeforeLiveUpdate: handleBeforeLiveUpdate,
     onLiveUpdateState: handleLiveUpdateState,
     onMessagesReset: handleMessagesReset,
-    onMarkRead: handleMarkRead
+    onMarkRead: handleMarkRead,
+    refreshVersion
   });
   const error = teamError || messagesError;
 

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -266,7 +266,7 @@ export function Messages({ auth }: { auth: AuthState }) {
 
   if (isDesktopWeb) {
     return (
-      <PullToRefresh onRefresh={refreshMessages} disabled={!auth.user?.uid}>
+      <PullToRefresh className="h-full min-h-0" onRefresh={refreshMessages} disabled={!auth.user?.uid}>
         <div className="messages-page messages-page-web">
           <MessagesHeader teams={teams} loading={loading} onRefresh={refreshMessages} />
           <section className="messages-two-pane mt-4">

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, CalendarDays, CheckCircle2, ChevronDown, ChevronLeft, Chev
 import { Link } from 'react-router-dom';
 import { Modal } from '../components/Modal';
 import { SchedulePageSkeleton } from '../components/PageSkeletons';
+import { PullToRefresh } from '../components/PullToRefresh';
 import { addTeamCalendarUrl, createScheduledPracticeForApp, createScheduleImportGame, createScheduleImportPractice, finalizeScheduleImportBatch, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild, type SchedulePracticeFormInput, type PracticeRecurrenceFormInput } from '../lib/scheduleService';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from '../lib/appDataCache';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
@@ -671,7 +672,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
   };
 
   return (
-    <div className="schedule-page space-y-4">
+    <PullToRefresh onRefresh={() => refreshSchedule(true)} disabled={!auth.user?.uid}>
+      <div className="schedule-page space-y-4">
       <section className="schedule-header app-card p-3 sm:hidden">
         <div className="flex items-center justify-between gap-2">
           <div className="min-w-0">
@@ -1030,7 +1032,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
           ) : null}
         </div>
       </div>
-    </div>
+      </div>
+    </PullToRefresh>
   );
 }
 

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 import { TeamDetailPageSkeleton } from '../components/PageSkeletons';
 import { DetailLoadErrorState } from '../components/DetailLoadErrorState';
+import { PullToRefresh } from '../components/PullToRefresh';
 import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { getEventDetailPath } from '../lib/homeLogic';
@@ -365,7 +366,8 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   }
 
   return (
-    <div className="team-detail-page space-y-4">
+    <PullToRefresh onRefresh={refreshTeamDetail} disabled={!auth.user?.uid}>
+      <div className="team-detail-page space-y-4">
       <TeamHero model={model} />
 
       <section className="app-card p-2">
@@ -398,7 +400,8 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       {activeTab === 'roster' ? <RosterTab model={model} authUser={auth.user} onRefresh={refreshTeamDetail} rosterInviteLoading={rosterInviteLoading} rosterInviteError={rosterInviteError} rosterInviteSummaries={rosterInviteSummaries} onInviteCreated={refreshRosterInvites} trackingLoading={trackingLoading} trackingError={trackingError} trackingItems={trackingItems} onTrackingChanged={refreshTrackingItems} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} loading={insightsLoading} error={insightsError} /> : null}
       {activeTab === 'more' ? <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} sponsorsLoading={sponsorsLoading} sponsorsError={sponsorsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
-    </div>
+      </div>
+    </PullToRefresh>
   );
 }
 

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -25,6 +25,7 @@ import {
   WalletCards
 } from 'lucide-react';
 import { RoleBadge } from '../components/Badges';
+import { PullToRefresh } from '../components/PullToRefresh';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { getEventDetailPath, getPlayerDetailPath, type ParentHomeModel, type ParentHomeTeam } from '../lib/homeLogic';
 import { loadParentHomeSummary, loadParentTeamsSummary } from '../lib/homeService';
@@ -161,7 +162,8 @@ export function Teams({ auth }: { auth: AuthState }) {
   };
 
   return (
-    <div className={`teams-page ${isDesktopWeb ? 'teams-page-web' : ''} space-y-4`}>
+    <PullToRefresh onRefresh={() => loadTeams()} disabled={!auth.user?.uid}>
+      <div className={`teams-page ${isDesktopWeb ? 'teams-page-web' : ''} space-y-4`}>
       <TeamsHeader
         loading={loading}
         refreshing={refreshing}
@@ -212,7 +214,8 @@ export function Teams({ auth }: { auth: AuthState }) {
           </Link>
         </div>
       </section>
-    </div>
+      </div>
+    </PullToRefresh>
   );
 }
 

--- a/apps/app/src/pages/messages/hooks/useChatMessages.ts
+++ b/apps/app/src/pages/messages/hooks/useChatMessages.ts
@@ -16,6 +16,7 @@ type UseChatMessagesParams = {
   onLiveUpdateState?: (state: { isInitialSnapshot: boolean; wasNearBottom: boolean }) => void;
   onMessagesReset?: () => void;
   onMarkRead?: () => void;
+  refreshVersion?: number;
 };
 
 export function useChatMessages({
@@ -26,7 +27,8 @@ export function useChatMessages({
   onBeforeLiveUpdate,
   onLiveUpdateState,
   onMessagesReset,
-  onMarkRead
+  onMarkRead,
+  refreshVersion = 0
 }: UseChatMessagesParams) {
   const [liveMessages, setLiveMessages] = useState<ChatMessage[]>([]);
   const [olderMessages, setOlderMessages] = useState<ChatMessage[]>([]);
@@ -74,7 +76,7 @@ export function useChatMessages({
     return () => {
       subscription.unsubscribe();
     };
-  }, [onBeforeLiveUpdate, onLiveUpdateState, onMarkRead, onMessagesReset, selectedConversationId, team?.id, teamId, user?.uid]);
+  }, [onBeforeLiveUpdate, onLiveUpdateState, onMarkRead, onMessagesReset, refreshVersion, selectedConversationId, team?.id, teamId, user?.uid]);
 
   const loadOlderMessages = useCallback(async () => {
     if (loadingOlder || !hasMoreMessages) return;

--- a/tests/unit/app-pull-to-refresh.test.tsx
+++ b/tests/unit/app-pull-to-refresh.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PullToRefresh } from '../../apps/app/src/components/PullToRefresh';
+import {
+  PULL_TO_REFRESH_MAX_DISTANCE_PX,
+  getPullToRefreshDistance,
+  getPullToRefreshIndicatorHeight,
+  isPullToRefreshReady
+} from '../../apps/app/src/lib/pullToRefresh';
+
+describe('pull to refresh', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('calculates pull distance only when the page is at the top', () => {
+    expect(getPullToRefreshDistance(100, 260, 0)).toBe(88);
+    expect(getPullToRefreshDistance(100, 400, 0)).toBe(PULL_TO_REFRESH_MAX_DISTANCE_PX);
+    expect(getPullToRefreshDistance(100, 80, 0)).toBe(0);
+    expect(getPullToRefreshDistance(100, 260, 12)).toBe(0);
+  });
+
+  it('reports readiness and indicator height from the shared threshold', () => {
+    expect(isPullToRefreshReady(71)).toBe(false);
+    expect(isPullToRefreshReady(72)).toBe(true);
+    expect(getPullToRefreshIndicatorHeight(22.4, false)).toBe(22);
+    expect(getPullToRefreshIndicatorHeight(0, true)).toBe(48);
+  });
+
+  it('calls onRefresh after a threshold pull gesture', async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    const { getByTestId } = render(
+      <PullToRefresh onRefresh={onRefresh}>
+        <div data-testid="surface">content</div>
+      </PullToRefresh>
+    );
+    const surface = getByTestId('surface').parentElement as HTMLElement;
+
+    fireEvent.touchStart(surface, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(surface, { touches: [{ clientY: 160 }], cancelable: true });
+    fireEvent.touchEnd(surface);
+
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+  });
+
+  it('ignores short pulls', () => {
+    const onRefresh = vi.fn();
+    const { getByTestId } = render(
+      <PullToRefresh onRefresh={onRefresh}>
+        <div data-testid="surface">content</div>
+      </PullToRefresh>
+    );
+    const surface = getByTestId('surface').parentElement as HTMLElement;
+
+    fireEvent.touchStart(surface, { touches: [{ clientY: 0 }] });
+    fireEvent.touchMove(surface, { touches: [{ clientY: 40 }], cancelable: true });
+    fireEvent.touchEnd(surface);
+
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #2044.

## Summary
- Add a reusable pull-to-refresh wrapper with threshold handling, haptic tick, and a visible refresh indicator.
- Wire pull-to-refresh into Home, Schedule, Messages inbox/thread, Teams, and TeamDetail using their existing forced refresh paths.
- Let Messages bump the chat subscription refresh version so an open thread resubscribes on pull refresh.

## Validation
- `npx vitest run tests/unit/app-pull-to-refresh.test.tsx tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- `npx vitest run tests/unit/app-home-logic.test.js tests/unit/app-schedule-logic.test.js tests/unit/app-teams-integration.test.jsx tests/unit/app-team-detail-integration.test.jsx --reporter=verbose`
- `npm --prefix apps/app run lint -- --quiet`
- `npm run app:build`