### PR TITLE
Route already-redeemed invite links to the dashboard, not a dead-end (#1808)

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -157,7 +157,7 @@
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=27';
         import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=53';
-        import { createInviteProcessor } from './js/accept-invite-flow.js?v=6';
+        import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));
@@ -313,7 +313,13 @@
                             }
                         } catch (error) {
                             console.error('Error processing invite:', error);
-                            showError(error.message);
+                            if (isInviteAlreadyRedeemedError(error)) {
+                                // Returning user re-opening an already-redeemed invite link (#1808):
+                                // behave like a normal login and route to their dashboard.
+                                showSuccess('You’re already set up — taking you to your dashboard.', getInviteDashboardUrl(inviteType));
+                            } else {
+                                showError(error.message);
+                            }
                         }
                     } else if (user) {
                         // User is logged in but no invite code
@@ -353,8 +359,17 @@
 
                 // Process the invite code
                 if (inviteCode) {
-                    const inviteResult = await processInvite(userId, inviteCode, result?.user?.email || email);
-                    showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                    try {
+                        const inviteResult = await processInvite(userId, inviteCode, result?.user?.email || email);
+                        showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                    } catch (error) {
+                        if (isInviteAlreadyRedeemedError(error)) {
+                            // Already redeemed on a prior visit (#1808) — route to dashboard.
+                            showSuccess('You’re already set up — taking you to your dashboard.', getInviteDashboardUrl(inviteType));
+                        } else {
+                            throw error;
+                        }
+                    }
                 } else {
                     const profile = await getUserProfile(userId);
                     const redirectUrl = getRedirectUrl({ ...result.user, ...profile });

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -279,9 +279,19 @@
 
                     // Process the invite code
                     if (inviteCode) {
-                        const inviteResult = await processInviteOnce(userId, inviteCode, result?.user?.email || email);
-                        if (inviteResult) {
-                            showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                        try {
+                            const inviteResult = await processInviteOnce(userId, inviteCode, result?.user?.email || email);
+                            if (inviteResult) {
+                                showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                            }
+                        } catch (error) {
+                            if (isInviteAlreadyRedeemedError(error)) {
+                                // Returning user re-opening an already-redeemed invite link (#1808):
+                                // behave like a normal login and route to their dashboard.
+                                showSuccess('You’re already set up — taking you to your dashboard.', getInviteDashboardUrl(inviteType));
+                            } else {
+                                throw error;
+                            }
                         }
                     } else {
                         // No invite code - just redirect to dashboard

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -432,6 +432,11 @@
                     }
                 } catch (error) {
                     console.error('Error:', error);
+                    if (isInviteAlreadyRedeemedError(error)) {
+                        // Already redeemed previously (#1808) — route to dashboard like a normal login.
+                        showSuccess('You’re already set up — taking you to your dashboard.', getInviteDashboardUrl(inviteType));
+                        return;
+                    }
                     errorDiv.textContent = error.message || 'Invalid or expired code';
                     errorDiv.classList.remove('hidden');
                     btn.disabled = false;

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -1,5 +1,32 @@
 import { hasFullTeamAccess } from './team-access.js?v=1';
 
+/**
+ * True when an invite failed only because the code was already redeemed/used (#1808).
+ * A returning user who already accepted an invite and opens the same link again
+ * should be treated like a normal login, not dead-ended on a used-code error.
+ */
+export function isInviteAlreadyRedeemedError(error) {
+    const message = String(error?.message || '').toLowerCase();
+    if (!message) return false;
+    return (
+        message.includes('already used')
+        || message.includes('already been used')
+        || message.includes('already redeemed')
+        || message.includes('already a member')
+        || message.includes('already an admin')
+    );
+}
+
+/** Dashboard a successful redemption of this invite type would land on. */
+export function getInviteDashboardUrl(inviteType) {
+    const normalized = String(inviteType || '').trim().toLowerCase();
+    if (normalized === 'admin' || normalized === 'admin_invite') {
+        return 'dashboard.html';
+    }
+    // parent, household, and unknown types all land on the parent dashboard.
+    return 'parent-dashboard.html';
+}
+
 function normalizeInviteEmail(email) {
     return String(email || '').trim().toLowerCase();
 }

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -1,6 +1,30 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createInviteProcessor } from '../../js/accept-invite-flow.js';
+import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from '../../js/accept-invite-flow.js';
 import { hasFullTeamAccess } from '../../js/team-access.js';
+
+describe('already-redeemed invite handling (#1808)', () => {
+    it('recognizes already-used / already-member errors', () => {
+        expect(isInviteAlreadyRedeemedError(new Error('Code already used'))).toBe(true);
+        expect(isInviteAlreadyRedeemedError(new Error('This invite has already been used.'))).toBe(true);
+        expect(isInviteAlreadyRedeemedError(new Error('You are already a member of this team'))).toBe(true);
+        expect(isInviteAlreadyRedeemedError(new Error('You are already an admin'))).toBe(true);
+    });
+
+    it('does not treat other errors as already-redeemed', () => {
+        expect(isInviteAlreadyRedeemedError(new Error('Invalid or expired invite code'))).toBe(false);
+        expect(isInviteAlreadyRedeemedError(new Error('This invite was sent to a@b.com.'))).toBe(false);
+        expect(isInviteAlreadyRedeemedError(null)).toBe(false);
+        expect(isInviteAlreadyRedeemedError({})).toBe(false);
+    });
+
+    it('routes invite types to the dashboard a successful redemption would use', () => {
+        expect(getInviteDashboardUrl('parent')).toBe('parent-dashboard.html');
+        expect(getInviteDashboardUrl('household')).toBe('parent-dashboard.html');
+        expect(getInviteDashboardUrl('admin')).toBe('dashboard.html');
+        expect(getInviteDashboardUrl('admin_invite')).toBe('dashboard.html');
+        expect(getInviteDashboardUrl(undefined)).toBe('parent-dashboard.html');
+    });
+});
 
 describe('accept invite flow', () => {
     it('redeems admin invite codes via atomic redemption when available', async () => {

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { createInviteProcessor } from '../../js/accept-invite-flow.js';
+import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from '../../js/accept-invite-flow.js';
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=53';";
@@ -112,8 +112,8 @@ const setTimeout = deps.setTimeout;
             'const { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } = deps.db;'
         )
         .replace(
-            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=6';",
-            'const { createInviteProcessor } = deps.acceptInviteFlow;'
+            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';",
+            'const { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } = deps.acceptInviteFlow;'
         )
         .replace(
             "import { renderHeader, renderFooter } from './js/utils.js?v=8';",
@@ -265,7 +265,9 @@ async function bootAcceptInvite({
                 renderFooter: vi.fn()
             },
             acceptInviteFlow: {
-                createInviteProcessor
+                createInviteProcessor,
+                getInviteDashboardUrl,
+                isInviteAlreadyRedeemedError
             }
         });
         await auth.pendingCheckAuth;
@@ -305,6 +307,21 @@ describe('accept-invite page parent flow', () => {
         expect(elements.get('success-state').classList.contains('hidden')).toBe(false);
         expect(elements.get('success-message').textContent).toContain("#22");
         expect(elements.get('success-message').textContent).toContain('Tigers');
+        expect(window.location.href).toBe('http://example.com/parent-dashboard.html');
+    });
+
+    it('routes an already-redeemed invite link to the dashboard instead of dead-ending (#1808)', async () => {
+        const { elements, window } = await bootAcceptInvite({
+            href: 'http://example.com/accept-invite.html?code=ab12cd34&type=parent',
+            authUser: { uid: 'parent-1', email: 'parent@example.com' },
+            authCallbackCount: 2,
+            dbOverrides: {
+                validateAccessCode: vi.fn().mockResolvedValue({ valid: false, message: 'Code already used' })
+            }
+        });
+
+        expect(elements.get('error-state').classList.contains('hidden')).toBe(true);
+        expect(elements.get('success-state').classList.contains('hidden')).toBe(false);
         expect(window.location.href).toBe('http://example.com/parent-dashboard.html');
     });
 

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -461,6 +461,37 @@ describe('accept-invite page admin flow', () => {
         expect(loggedOut.window.location.href).toBe('http://example.com/login.html?code=NEW11122&type=admin');
     });
 
+    it('routes same-device email-link reopen with an already-used invite code to the dashboard', async () => {
+        const { elements, window, auth, db } = await bootAcceptInvite({
+            href: 'http://example.com/accept-invite.html?code=exist111&type=admin',
+            authUser: null,
+            storageEntries: {
+                emailForSignIn: 'coach@example.com'
+            },
+            authOverrides: {
+                isEmailSignInLink: vi.fn(() => true),
+                completeEmailLinkSignIn: vi.fn().mockResolvedValue({
+                    user: {
+                        uid: 'admin-1',
+                        email: 'coach@example.com'
+                    }
+                })
+            },
+            dbOverrides: {
+                validateAccessCode: vi.fn().mockResolvedValue({
+                    valid: false,
+                    message: 'Code already used'
+                })
+            }
+        });
+
+        expect(auth.completeEmailLinkSignIn).toHaveBeenCalledWith('coach@example.com');
+        expect(db.validateAccessCode).toHaveBeenCalledWith('exist111');
+        expect(elements.get('error-state').classList.contains('hidden')).toBe(true);
+        expect(elements.get('success-state').classList.contains('hidden')).toBe(false);
+        expect(window.location.href).toBe('http://example.com/dashboard.html');
+    });
+
     it('completes cross-device email-link admin redemption after the user confirms their email', async () => {
         const { elements, window, auth, db } = await bootAcceptInvite({
             href: 'http://example.com/accept-invite.html?code=exist111&type=admin',

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -18,7 +18,7 @@ describe('admin invite signup cache busting', () => {
             "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=53';"
         );
         expect(acceptInviteSource).toContain(
-            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=6';"
+            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';"
         );
     });
 


### PR DESCRIPTION
Closes #1808.

## Problem
A returning parent/admin who opens their **original invite URL** again (email, bookmark, copied message) and logs in was redirected back into `accept-invite.html`, where the now-already-used code failed with **"Code already used"** — a dead-end error for a perfectly valid account.

## Fix
- Add two small, tested helpers to `js/accept-invite-flow.js`:
  - `isInviteAlreadyRedeemedError(error)` — detects already-used / already-member / already-admin failures.
  - `getInviteDashboardUrl(inviteType)` — the dashboard a successful redemption would land on (`parent-dashboard.html`, `dashboard.html` for admin).
- In `accept-invite.html`, when a **signed-in** user's redemption fails **only** because the code is already redeemed, route them to their dashboard like a normal login instead of showing the error. Other errors (invalid/expired code, email mismatch) still surface. Applied to both the already-authenticated path and the email-link sign-in path.

This is safe even if the code was someone else's: redemption already failed, so no access is granted — the user just lands on their own dashboard.

## Tests
- `accept-invite-flow.test.js`: helper unit tests (already-used detection, negative cases, type→dashboard mapping).
- `accept-invite-page.test.js`: new behavior test — an authenticated user hitting an already-used invite link lands on `parent-dashboard.html` with no error state.
- Bumped `accept-invite-flow.js?v=6`→`?v=7` and updated the cache-busting + page-harness expectations. 27 invite tests pass.

## Manual test
1. Redeem a parent invite link once.
2. Open the same link again while logged in → lands on the dashboard (no "Code already used" error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)