### PR TITLE
Reject live play-by-play on long-past games (stuck-live guard) (#2022)

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -771,6 +771,20 @@ describe('live game clock state', () => {
     }));
   });
 
+  it('rejects live clock updates for games whose scheduled date is long past (#2022)', async () => {
+    await expect(updateLiveGameClockState('team-1', 'game-1', {
+      liveClockMs: 135432,
+      liveClockRunning: true,
+      liveClockPeriod: 'Q2',
+      currentGame: {
+        liveStatus: 'scheduled',
+        date: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000)
+      }
+    }, { uid: 'coach-1', email: 'coach@example.com' } as any)).rejects.toThrow('past games');
+
+    expect(updateGame).not.toHaveBeenCalled();
+  });
+
   it('stamps live score events with the resumed running game clock', async () => {
     (globalThis as any).window = { location: { protocol: 'https:' }, setTimeout, clearTimeout } as any;
     vi.useFakeTimers();

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -890,6 +890,29 @@ describe('live score publishing', () => {
     await expect(publishLiveScoreUpdateEvent('team-1', 'game-1', { homeScore: 12, awayScore: 8 }, user)).rejects.toThrow('game is final');
     expect(mocks.transactionSet).not.toHaveBeenCalled();
   });
+
+  it('rejects live score broadcasts for games whose scheduled date is long past (#2022)', async () => {
+    mocks.transactionGet.mockReset();
+    const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    mocks.transactionGet.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ id: 'game-1', status: 'scheduled', liveStatus: 'scheduled', date: fiveDaysAgo })
+    });
+
+    await expect(publishLiveScoreUpdateEvent('team-1', 'game-1', { homeScore: 12, awayScore: 8 }, user)).rejects.toThrow('past games');
+    expect(mocks.transactionSet).not.toHaveBeenCalled();
+  });
+
+  it('allows live score broadcasts for a game scheduled today', async () => {
+    mocks.transactionGet.mockReset();
+    mocks.transactionGet.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ id: 'game-1', status: 'scheduled', liveStatus: 'scheduled', date: new Date(), liveHasData: false, period: 'Q1' })
+    });
+
+    await expect(publishLiveScoreUpdateEvent('team-1', 'game-1', { homeScore: 5, awayScore: 3 }, user)).resolves.toBeDefined();
+    expect(mocks.transactionSet).toHaveBeenCalled();
+  });
 });
 
 describe('native live publishing fallbacks', () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3236,9 +3236,21 @@ function isFinalLiveTrackingStatus(value: unknown) {
   return normalized === 'completed' || normalized === 'final';
 }
 
+// Games are only ever live for a few hours; reject live publishing once a game's
+// scheduled date is well past so a stray late score update can't flip a stale game
+// to liveStatus: 'live' and leave it stuck there (#2022). Finalizing still happens
+// through Game Wrapup (completeGameWrapupForApp writes liveStatus: 'completed').
+const liveTrackingMaxStalenessMs = 3 * 24 * 60 * 60 * 1000;
+
 function assertGameAllowsLivePublishing(game: Record<string, any> | null | undefined) {
   if (isFinalLiveTrackingStatus(game?.status) || isFinalLiveTrackingStatus(game?.liveStatus)) {
     throw new Error('Live play-by-play is unavailable after the game is final.');
+  }
+  if (game?.date) {
+    const scheduledDate = toEventDate(game.date);
+    if (!Number.isNaN(scheduledDate.getTime()) && Date.now() - scheduledDate.getTime() > liveTrackingMaxStalenessMs) {
+      throw new Error('Live play-by-play is unavailable for past games. Use Game Wrapup to set the final score.');
+    }
   }
 }
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3193,6 +3193,7 @@ export async function updateLiveGameClockState(teamId: string, gameId: string, c
     throw new Error('Sign in before updating the live clock.');
   }
 
+  assertGameAllowsLivePublishing(clock.currentGame);
   const now = new Date();
   const periods = buildLiveGameClockPeriods({ ...(clock.currentGame || {}), liveClockPeriod: clock.liveClockPeriod });
   const requestedPeriod = compactString(clock.liveClockPeriod) || compactString(clock.currentGame?.liveClockPeriod) || compactString(clock.currentGame?.period) || periods[0] || 'H1';
@@ -3204,12 +3205,8 @@ export async function updateLiveGameClockState(teamId: string, gameId: string, c
     liveClockUpdatedAt: now,
     liveClockUpdatedBy: user.uid,
     period,
-    liveStatus: 'live',
-    liveHasData: true
+    ...buildLiveTrackingGamePatch(clock.currentGame, user, now)
   };
-  if (!clock.currentGame?.liveStartedAt) {
-    payload.liveStartedAt = now;
-  }
 
   try {
     await withTimeout(Promise.resolve(updateGame(teamId, gameId, payload)), 'Live clock update');


### PR DESCRIPTION
Closes #2022.

## Findings
The issue's core premise — "no code path ever transitions a game out of `live`" — is **already mitigated on `master`**: the **Game Wrapup** panel finalizes a game via `completeGameWrapupForApp`, which writes the legacy finish payload (`status: 'completed'`, `liveStatus: 'completed'` from `buildFinishGamePayload`). That's the finish handler (consistent with the issue's `not-reproducible` label).

The genuine remaining gap is the **safety** the issue explicitly suggests: nothing stops a stray late score update from flipping a *stale* game back to `liveStatus: 'live'` and leaving it stuck.

## Fix
Add a staleness guard to `assertGameAllowsLivePublishing` (the shared gate for all live publishing — score, clock, play-by-play): reject live publishing once a game's **scheduled date is more than ~3 days past**. A real game never runs that long, so this can't interrupt legitimate live tracking; late final scores go through Game Wrapup instead. Undated games and final games behave exactly as before.

## Tests
- New `scheduleService.test.ts` cases: a game scheduled 5 days ago rejects live score broadcasts (`past games`) and writes nothing; a game scheduled today still publishes normally.
- `tsc --noEmit` (via build) clean; full `scheduleService.test.ts` (54) passes.

## Manual test
Try a live score update on a game dated several days ago → blocked with guidance to use Game Wrapup; a current game tracks live normally; Game Wrapup sets the final score and clears the live state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)