### PR TITLE
Add dependency hygiene gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/app"
+    schedule:
+      interval: "weekly"
+    groups:
+      app-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Install app dependencies
         run: npm ci --prefix apps/app
 
+      - name: Audit app dependencies
+        run: npm --prefix apps/app audit --audit-level=moderate
+
       - name: Typecheck app
         run: npm --prefix apps/app run typecheck
 

--- a/apps/app/package-lock.json
+++ b/apps/app/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "allplays-app",
       "version": "0.1.0",
+      "engines": {
+        "node": ">=22",
+        "npm": ">=10"
+      },
       "dependencies": {
         "@capacitor-firebase/authentication": "^8.2.0",
         "@capacitor-firebase/messaging": "^8.2.0",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "engines": {
+    "node": ">=22",
+    "npm": ">=10"
+  },
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc --noEmit && vite build",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,10 @@
   "packages": {
     "": {
       "name": "allplays",
+      "engines": {
+        "node": ">=22",
+        "npm": ">=10"
+      },
       "dependencies": {
         "@capacitor-firebase/authentication": "^8.2.0",
         "@capacitor-firebase/messaging": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "allplays",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22",
+    "npm": ">=10"
+  },
   "scripts": {
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",


### PR DESCRIPTION
## Summary
- add Node/npm engine constraints to root and app manifests
- add a moderate-threshold app npm audit gate to CI
- add weekly grouped Dependabot updates for root and app npm dependencies

Fixes #2075

## Tests
- npm --prefix apps/app audit --audit-level=moderate (passes; reports one low esbuild advisory below the gate)
- node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('apps/app/package.json','utf8')); JSON.parse(require('fs').readFileSync('package-lock.json','utf8')); JSON.parse(require('fs').readFileSync('apps/app/package-lock.json','utf8')); console.log('json ok')"
- npx --yes yaml@2.7.0 valid < .github/dependabot.yml
- npx --yes yaml@2.7.0 valid < .github/workflows/ci.yml