### PR TITLE
Notify parents for assigned team fees

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -5922,6 +5922,91 @@ function formatMoneyFromCents(amountCents, currency = 'USD') {
   }
 }
 
+function resolveFeeRecipientPlayerId(teamId, recipient = {}) {
+  const explicitPlayerId = String(recipient.playerId || recipient.childId || '').trim();
+  if (explicitPlayerId) return explicitPlayerId;
+
+  const playerKey = String(recipient.playerKey || '').trim();
+  const prefix = `${String(teamId || recipient.teamId || '').trim()}::`;
+  if (prefix.length > 2 && playerKey.startsWith(prefix)) {
+    return playerKey.slice(prefix.length).trim();
+  }
+  return '';
+}
+
+function formatFeeAssignmentDueDate(value) {
+  const dueDate = coerceDate(value);
+  if (!dueDate) return '';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric'
+  }).format(dueDate);
+}
+
+function buildFeeAssignmentNotificationBody(recipient = {}, amountDisplay = '') {
+  const dueDateDisplay = formatFeeAssignmentDueDate(recipient.dueDate || recipient.dueAt || recipient.deadline);
+  const parts = [];
+  if (amountDisplay) {
+    parts.push(`${amountDisplay} has been assigned`);
+  } else {
+    parts.push('A new team fee has been assigned');
+  }
+  if (dueDateDisplay) {
+    parts.push(`due ${dueDateDisplay}`);
+  }
+  return `${parts.join(', ')}.`;
+}
+
+async function resolveFeeAssignmentPayerUserIds(teamId, recipient = {}) {
+  const playerId = resolveFeeRecipientPlayerId(teamId, recipient);
+  const playerRef = playerId ? firestore.doc(`teams/${teamId}/players/${playerId}`) : null;
+  const [playerSnap, privateProfileSnap] = playerRef
+    ? await Promise.all([
+      playerRef.get(),
+      playerRef.collection('private').doc('profile').get()
+    ])
+    : [null, null];
+  const playerData = playerSnap?.exists ? { id: playerSnap.id, ...(playerSnap.data() || {}) } : {};
+  const privateProfileData = privateProfileSnap?.exists ? (privateProfileSnap.data() || {}) : {};
+  const userIds = new Set(getTeamFeeRecipientTargetUserIds({
+    ...recipient,
+    playerId: playerId || recipient.playerId || recipient.childId
+  }, playerData, privateProfileData));
+  const playerKey = getFeeReminderPlayerKey({
+    ...recipient,
+    playerId: playerId || recipient.playerId || recipient.childId
+  }, teamId);
+  if (playerKey) {
+    const parentSnap = await firestore.collection('users')
+      .where('parentPlayerKeys', 'array-contains', playerKey)
+      .get();
+    parentSnap.docs
+      .map((docSnap) => String(docSnap.id || '').trim())
+      .filter(Boolean)
+      .forEach((uid) => userIds.add(uid));
+  }
+  return Array.from(userIds);
+}
+
+async function claimFeeAssignmentNotificationUser({ teamId, batchId, recipientId, uid }) {
+  const normalizedUid = String(uid || '').trim();
+  if (!teamId || !batchId || !normalizedUid) return false;
+  const claimRef = firestore.doc(`teams/${teamId}/feeBatches/${batchId}/assignmentNotificationClaims/${normalizedUid}`);
+  return firestore.runTransaction(async (transaction) => {
+    const claimSnap = await transaction.get(claimRef);
+    if (claimSnap.exists) return false;
+    transaction.set(claimRef, {
+      uid: normalizedUid,
+      teamId,
+      batchId,
+      firstRecipientId: recipientId || null,
+      createdAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+    return true;
+  });
+}
+
 function getFeePaymentAmountCents(before = {}, after = {}) {
   const explicitAmount = Number(
     after.stripePaymentAmountCents
@@ -6878,36 +6963,34 @@ exports.notifyFeeAssigned = functions.firestore
       return null;
     }
 
-    const { teamId } = context.params;
-    const playerId = String(data.playerId || '').trim();
-    const playerRef = playerId ? firestore.doc(`teams/${teamId}/players/${playerId}`) : null;
-    const playerSnap = playerRef ? await playerRef.get() : null;
-    const playerData = playerSnap?.exists ? { id: playerSnap.id, ...(playerSnap.data() || {}) } : {};
-    let privateProfileData = {};
-    if (playerRef) {
-      const privateProfileSnap = await playerRef.collection('private').doc('profile').get();
-      privateProfileData = privateProfileSnap.exists ? (privateProfileSnap.data() || {}) : {};
-    }
-
-    const payerUserIds = getTeamFeeRecipientTargetUserIds(data, playerData, privateProfileData);
+    const { teamId, batchId, recipientId } = context.params;
+    const payerUserIds = await resolveFeeAssignmentPayerUserIds(teamId, data);
     if (!payerUserIds.length) return null;
 
-    const payerTargets = (await getTargetsForCategory(teamId, 'fees', null))
-      .filter((target) => payerUserIds.includes(target.uid));
+    const payerTargets = await getTargetsForCategoryUserIds(teamId, 'fees', payerUserIds, null);
     if (!payerTargets.length) return null;
 
+    const targetUserIds = Array.from(new Set(payerTargets.map((target) => String(target.uid || '').trim()).filter(Boolean)));
+    const claimResults = await Promise.all(targetUserIds.map(async (uid) => ({
+      uid,
+      claimed: await claimFeeAssignmentNotificationUser({ teamId, batchId, recipientId, uid })
+    })));
+    const claimedUserIds = new Set(claimResults.filter((result) => result.claimed).map((result) => result.uid));
+    if (!claimedUserIds.size) return null;
+    const claimedTargets = payerTargets.filter((target) => claimedUserIds.has(target.uid));
+
     const title = String(data.feeTitle || data.title || 'Team fee').trim();
-    const amountCents = Number(data.amountCents || data.feeAmountCents || 0);
+    const amountCents = getTeamFeeBalanceCents(data) || Number(data.amountCents || data.feeAmountCents || 0);
     const amountDisplay = amountCents > 0 ? ` (${formatMoneyFromCents(amountCents, data.currency || 'USD')})` : '';
 
-    await sendDirectTargetsNotification({
-      targets: payerTargets,
+    return sendDirectTargetsNotification({
+      targets: claimedTargets,
       category: 'fees',
       title: `New fee assigned: ${title}${amountDisplay}`,
-      body: 'A new team fee has been assigned to your account.',
+      body: buildFeeAssignmentNotificationBody(data, amountDisplay ? amountDisplay.slice(2, -1) : ''),
       teamId,
+      batchId
     });
-    return null;
   });
 
 exports.notifyPracticePacketCompleted = functions.firestore

--- a/functions/index.js
+++ b/functions/index.js
@@ -5989,10 +5989,16 @@ async function resolveFeeAssignmentPayerUserIds(teamId, recipient = {}) {
   return Array.from(userIds);
 }
 
+function buildFeeAssignmentNotificationClaimRef({ teamId, batchId, uid }) {
+  const normalizedUid = String(uid || '').trim();
+  if (!teamId || !batchId || !normalizedUid) return null;
+  return firestore.doc(`teams/${teamId}/feeBatches/${batchId}/assignmentNotificationClaims/${normalizedUid}`);
+}
+
 async function claimFeeAssignmentNotificationUser({ teamId, batchId, recipientId, uid }) {
   const normalizedUid = String(uid || '').trim();
-  if (!teamId || !batchId || !normalizedUid) return false;
-  const claimRef = firestore.doc(`teams/${teamId}/feeBatches/${batchId}/assignmentNotificationClaims/${normalizedUid}`);
+  const claimRef = buildFeeAssignmentNotificationClaimRef({ teamId, batchId, uid: normalizedUid });
+  if (!claimRef) return false;
   return firestore.runTransaction(async (transaction) => {
     const claimSnap = await transaction.get(claimRef);
     if (claimSnap.exists) return false;
@@ -6005,6 +6011,21 @@ async function claimFeeAssignmentNotificationUser({ teamId, batchId, recipientId
     });
     return true;
   });
+}
+
+async function releaseFeeAssignmentNotificationClaims({ teamId, batchId, userIds = [] }) {
+  const uniqueUserIds = Array.from(new Set(
+    (Array.isArray(userIds) ? userIds : [])
+      .map((uid) => String(uid || '').trim())
+      .filter(Boolean)
+  ));
+  if (!teamId || !batchId || !uniqueUserIds.length) return;
+  const batch = firestore.batch();
+  uniqueUserIds.forEach((uid) => {
+    const claimRef = buildFeeAssignmentNotificationClaimRef({ teamId, batchId, uid });
+    if (claimRef) batch.delete(claimRef);
+  });
+  await batch.commit();
 }
 
 function getFeePaymentAmountCents(before = {}, after = {}) {
@@ -6983,14 +7004,23 @@ exports.notifyFeeAssigned = functions.firestore
     const amountCents = getTeamFeeBalanceCents(data) || Number(data.amountCents || data.feeAmountCents || 0);
     const amountDisplay = amountCents > 0 ? ` (${formatMoneyFromCents(amountCents, data.currency || 'USD')})` : '';
 
-    return sendDirectTargetsNotification({
-      targets: claimedTargets,
-      category: 'fees',
-      title: `New fee assigned: ${title}${amountDisplay}`,
-      body: buildFeeAssignmentNotificationBody(data, amountDisplay ? amountDisplay.slice(2, -1) : ''),
-      teamId,
-      batchId
-    });
+    try {
+      return await sendDirectTargetsNotification({
+        targets: claimedTargets,
+        category: 'fees',
+        title: `New fee assigned: ${title}${amountDisplay}`,
+        body: buildFeeAssignmentNotificationBody(data, amountDisplay ? amountDisplay.slice(2, -1) : ''),
+        teamId,
+        batchId
+      });
+    } catch (error) {
+      await releaseFeeAssignmentNotificationClaims({
+        teamId,
+        batchId,
+        userIds: Array.from(claimedUserIds)
+      });
+      throw error;
+    }
   });
 
 exports.notifyPracticePacketCompleted = functions.firestore

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -210,17 +210,116 @@ test('notifyFeeAssigned sends fees notifications only to opted-in payer targets'
         const snapshot = makeSnapshot(ref, {
             playerId: 'player-1',
             feeTitle: 'Tournament dues',
-            amountCents: 4500
+            amountCents: 4500,
+            dueDate: '2026-07-01T12:00:00.000Z'
         });
         const context = { params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' } };
 
         const result = await moduleExports.notifyFeeAssigned(snapshot, context);
 
-        assert.equal(result, null);
+        assert.equal(result?.successCount, 1);
         assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].title, 'New fee assigned: Tournament dues ($45.00)');
+        assert.equal(env.messagingCalls[0].body, '$45.00 has been assigned, due Jul 1, 2026.');
         assert.equal(env.messagingCalls[0].data.category, 'fees');
+        assert.equal(env.messagingCalls[0].data.appRoute, '/parent-tools/fees?teamId=team-1&batchId=batch-1');
         assert.equal(env.auditWrites.length, 1);
         assert.equal(env.auditWrites[0].value.category, 'fees');
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyFeeAssigned resolves app-created child fee recipients through parentPlayerKeys', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-2': { parentPlayerKeys: ['team-1::player-2'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-2', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/feeBatches/batch-2/feeRecipients/recipient-2');
+        const snapshot = makeSnapshot(ref, {
+            childId: 'player-2',
+            playerKey: 'team-1::player-2',
+            feeTitle: 'Winter dues',
+            balanceDueCents: 8000
+        });
+        const context = { params: { teamId: 'team-1', batchId: 'batch-2', recipientId: 'recipient-2' } };
+
+        const result = await moduleExports.notifyFeeAssigned(snapshot, context);
+
+        assert.equal(result?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
+        assert.equal(env.messagingCalls[0].title, 'New fee assigned: Winter dues ($80.00)');
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyFeeAssigned sends one batch assignment push when a parent has multiple recipients', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-1': { parentPlayerKeys: ['team-1::player-1', 'team-1::player-2'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } }
+        ]
+    });
+
+    try {
+        const contextA = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-a' } };
+        const contextB = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-b' } };
+
+        const firstResult = await moduleExports.notifyFeeAssigned(makeSnapshot(
+            env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-a'),
+            { playerKey: 'team-1::player-1', feeTitle: 'Spring dues', amountCents: 2500 }
+        ), contextA);
+        const secondResult = await moduleExports.notifyFeeAssigned(makeSnapshot(
+            env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-b'),
+            { playerKey: 'team-1::player-2', feeTitle: 'Spring dues', amountCents: 2500 }
+        ), contextB);
+
+        assert.equal(firstResult?.successCount, 1);
+        assert.equal(secondResult, null);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyFeeAssigned stays silent when the payer disabled fee notifications', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-3': { parentPlayerKeys: ['team-1::player-3'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-3', deviceId: 'parent-device', token: 'parent-token', categories: { fees: false } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/feeBatches/batch-4/feeRecipients/recipient-4');
+        const snapshot = makeSnapshot(ref, {
+            playerKey: 'team-1::player-3',
+            feeTitle: 'Silent dues',
+            amountCents: 2500
+        });
+        const context = { params: { teamId: 'team-1', batchId: 'batch-4', recipientId: 'recipient-4' } };
+
+        const result = await moduleExports.notifyFeeAssigned(snapshot, context);
+
+        assert.equal(result, null);
+        assert.equal(env.messagingCalls.length, 0);
+        assert.equal(env.auditWrites.length, 0);
     } finally {
         cleanup();
     }

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -295,6 +295,39 @@ test('notifyFeeAssigned sends one batch assignment push when a parent has multip
     }
 });
 
+test('notifyFeeAssigned releases assignment claims when delivery fails so retries can resend', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-1': { parentPlayerKeys: ['team-1::player-1'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } }
+        ],
+        sendEachErrors: [new Error('temporary FCM outage')]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/feeBatches/batch-5/feeRecipients/recipient-5');
+        const snapshot = makeSnapshot(ref, {
+            playerKey: 'team-1::player-1',
+            feeTitle: 'Retry dues',
+            amountCents: 2500
+        });
+        const context = { params: { teamId: 'team-1', batchId: 'batch-5', recipientId: 'recipient-5' } };
+
+        await assert.rejects(() => moduleExports.notifyFeeAssigned(snapshot, context), /temporary FCM outage/);
+        const retryResult = await moduleExports.notifyFeeAssigned(snapshot, context);
+
+        assert.equal(retryResult?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 2);
+        assert.equal(env.deletedPaths.includes('teams/team-1/feeBatches/batch-5/assignmentNotificationClaims/parent-1'), true);
+        assert.equal(env.auditWrites.length, 1);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyFeeAssigned stays silent when the payer disabled fee notifications', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -296,15 +296,29 @@ function buildNotificationTestEnv({
                     return {
                         async get() {
                             counts.parentQueries += 1;
-                            if (field !== 'parentTeamIds' || op !== 'array-contains' || value !== teamId) {
+                            if (op !== 'array-contains') {
                                 return makeQuerySnapshot([]);
                             }
-                            return makeQuerySnapshot(parentUserIds.map((uid) => makeDocSnapshot({
-                                id: uid,
-                                ref: doc(`users/${uid}`),
-                                data: { parentTeamIds: [teamId] },
-                                exists: true
-                            })));
+                            if (field === 'parentTeamIds' && value === teamId) {
+                                return makeQuerySnapshot(parentUserIds.map((uid) => makeDocSnapshot({
+                                    id: uid,
+                                    ref: doc(`users/${uid}`),
+                                    data: { parentTeamIds: [teamId] },
+                                    exists: true
+                                })));
+                            }
+                            if (field === 'parentPlayerKeys') {
+                                const docs = Object.entries(userDocs)
+                                    .filter(([, user]) => Array.isArray(user?.parentPlayerKeys) && user.parentPlayerKeys.includes(value))
+                                    .map(([uid, user]) => makeDocSnapshot({
+                                        id: uid,
+                                        ref: doc(`users/${uid}`),
+                                        data: user,
+                                        exists: true
+                                    }));
+                                return makeQuerySnapshot(docs);
+                            }
+                            return makeQuerySnapshot([]);
                         }
                     };
                 }

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -100,7 +100,8 @@ function buildNotificationTestEnv({
     notificationRecipientDocs = null,
     preferenceDocs = {},
     deviceDocs = {},
-    invalidTokenResponses = []
+    invalidTokenResponses = [],
+    sendEachErrors = []
 } = {}) {
     const dedupWrites = [];
     const inboxWrites = [];
@@ -470,6 +471,8 @@ function buildNotificationTestEnv({
                     dedupWrites.push({ path: ref.path, value });
                 },
                 delete(ref) {
+                    counts.deleteCalls += 1;
+                    docStore.delete(ref.path);
                     deletedPaths.push(ref.path);
                 },
                 update() {},
@@ -511,6 +514,10 @@ function buildNotificationTestEnv({
                     data: { ...(message.data || {}) },
                     webLink: message.webpush?.fcmOptions?.link || ''
                 });
+                const sendError = sendEachErrors.length ? sendEachErrors.shift() : null;
+                if (sendError) {
+                    throw sendError;
+                }
                 const responses = message.tokens.map((token, index) => invalidTokenResponses[index] || { success: true, token });
                 const failureCount = responses.filter((response) => response?.success === false).length;
                 return {


### PR DESCRIPTION
Closes #2193.\n\n## Summary\n- Resolve assigned fee parent audiences from recipient fields, roster/private profile parent links, and parentPlayerKeys\n- Send fee assignment pushes with amount, due date, and parent fee route metadata\n- Add per-parent batch claims so a parent linked to multiple fee recipients in one batch gets one assignment push\n\n## Tests\n- npx vitest run functions/test/notification-triggers.test.js --reporter=verbose\n- npm run test:notifications --prefix functions\n\nNote: npm test --prefix functions was not used for this PR because the broad package runner currently fails an unrelated checkout-capability test before this suite.