### PR TITLE
Send officiating assignment notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3813,6 +3813,11 @@ async function practicePacketAssignedNotification(beforeData = null, afterData =
 }
 
 function buildNotificationLink({ category, teamId, gameId, batchId = null, recipientId = null, conversationId = null }) {
+  if (category === 'officiating') {
+    return teamId
+      ? `https://allplays.ai/officials.html?teamId=${encodeURIComponent(teamId)}`
+      : 'https://allplays.ai/officials.html';
+  }
   if (category === 'fees') {
     const params = new URLSearchParams();
     if (teamId) {
@@ -3859,6 +3864,9 @@ function buildNotificationLink({ category, teamId, gameId, batchId = null, recip
 }
 
 function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId = null, recipientId = null, conversationId = null }) {
+  if (category === 'officiating') {
+    return teamId ? `/officials?teamId=${encodeURIComponent(teamId)}` : '/officials';
+  }
   if (category === 'fees') {
     const params = new URLSearchParams();
     if (teamId) {
@@ -5160,6 +5168,125 @@ async function sendDirectTargetsNotification({
   };
 }
 
+function getOfficiatingPositionLabel(record = {}) {
+  return String(record.position || record.assignmentType || 'Officiating assignment').trim() || 'Officiating assignment';
+}
+
+function getOfficiatingGameLabel(game = {}) {
+  return getEventTitle(game || {}) || 'the event';
+}
+
+function getOfficiatingDateLabel(game = {}) {
+  const date = coerceDate(game.date || game.startAt || game.startTime);
+  if (!date) return '';
+  const timeZone = String(game.timeZone || game.timezone || '').trim() || 'America/Chicago';
+  return formatScheduleUpdateDate(date, timeZone);
+}
+
+function getOfficiatingNotificationCopy(record = {}) {
+  const position = getOfficiatingPositionLabel(record);
+  const game = record.gameReference || {};
+  const gameLabel = getOfficiatingGameLabel(game);
+  const dateLabel = getOfficiatingDateLabel(game);
+  const suffix = dateLabel ? ` on ${dateLabel}` : '';
+  const event = String(record.event || '').trim().toLowerCase();
+
+  if (event === 'rescheduled') {
+    return {
+      title: `Officiating assignment updated: ${position}`,
+      body: `${gameLabel}${suffix} was rescheduled.`
+    };
+  }
+  if (event === 'cancelled' || event === 'canceled') {
+    return {
+      title: `Officiating assignment cancelled: ${position}`,
+      body: `${gameLabel}${suffix} was cancelled.`
+    };
+  }
+  if (event === 'declined') {
+    return {
+      title: `Officiating assignment declined: ${position}`,
+      body: `${gameLabel}${suffix} needs coverage.`
+    };
+  }
+  return {
+    title: `Officiating assignment: ${position}`,
+    body: `${gameLabel}${suffix} is ready for your response.`
+  };
+}
+
+async function resolveOfficiatingRecordRecipientUserIds(record = {}) {
+  const userIds = new Set([
+    record.recipientOfficialUserId,
+    record.officialUserId,
+    record.userId
+  ].map((value) => String(value || '').trim()).filter(Boolean));
+
+  const email = String(record.recipientOfficialEmail || record.officialEmail || '').trim().toLowerCase();
+  if (email) {
+    const emailUserIds = await getUserIdsByEmails([email]);
+    emailUserIds.forEach((uid) => userIds.add(uid));
+  }
+  return Array.from(userIds);
+}
+
+function buildOfficiatingDestination(teamId) {
+  return {
+    link: buildNotificationLink({ category: 'officiating', teamId }),
+    appRoute: buildNotificationAppRoute({ category: 'officiating', teamId })
+  };
+}
+
+async function sendOfficiatingTargetsNotification({ teamId, gameId = null, targets, title, body }) {
+  if (!targets.length) return null;
+  const destination = buildOfficiatingDestination(teamId);
+  return sendDirectTargetsNotification({
+    targets,
+    category: 'officiating',
+    title,
+    body,
+    teamId,
+    gameId,
+    eventId: gameId,
+    linkOverride: destination.link,
+    appRouteOverride: destination.appRoute
+  });
+}
+
+function normalizeOfficiatingSlotForNotification(slot = {}) {
+  const id = String(slot?.id || slot?.slotId || slot?.position || '').trim();
+  const status = String(slot?.status || '').trim().toLowerCase() || 'open';
+  return {
+    id,
+    position: String(slot?.position || slot?.role || 'Official').trim() || 'Official',
+    status,
+    officialUserId: String(slot?.officialUserId || '').trim(),
+    officialEmail: String(slot?.officialEmail || slot?.email || '').trim().toLowerCase(),
+    officialName: String(slot?.officialName || slot?.name || '').trim()
+  };
+}
+
+function isOpenOfficiatingSlotForNotification(slot = {}) {
+  const normalized = normalizeOfficiatingSlotForNotification(slot);
+  return normalized.status === 'open'
+    && !normalized.officialUserId
+    && !normalized.officialEmail
+    && !normalized.officialName;
+}
+
+function getNewOpenOfficiatingSlots(beforeGame = {}, afterGame = {}) {
+  if (afterGame.officiatingSelfAssignmentEnabled !== true) return [];
+  const beforeOpenIds = new Set(
+    (Array.isArray(beforeGame.officiatingSlots) ? beforeGame.officiatingSlots : [])
+      .filter(isOpenOfficiatingSlotForNotification)
+      .map((slot) => normalizeOfficiatingSlotForNotification(slot).id)
+      .filter(Boolean)
+  );
+  return (Array.isArray(afterGame.officiatingSlots) ? afterGame.officiatingSlots : [])
+    .map(normalizeOfficiatingSlotForNotification)
+    .filter((slot) => slot.id && isOpenOfficiatingSlotForNotification(slot) && !beforeOpenIds.has(slot.id));
+}
+
 exports._internal = {
   getTargetsForCategoryUserIds,
   buildTeamMediaNotificationBatchId,
@@ -5180,6 +5307,58 @@ exports._internal = {
 exports.sweepStaleNotificationDeviceTokens = functions.pubsub
   .schedule('every 24 hours')
   .onRun(() => sweepStaleNotificationDeviceTokens());
+
+exports.notifyOfficiatingNotificationCreated = functions.firestore
+  .document('teams/{teamId}/officiatingNotifications/{notificationId}')
+  .onCreate(async (snapshot, context) => {
+    const record = snapshot.data() || {};
+    if (record.type && record.type !== 'officiating_assignment') return null;
+
+    const { teamId } = context.params;
+    const recipientUserIds = await resolveOfficiatingRecordRecipientUserIds(record);
+    if (!recipientUserIds.length) return null;
+
+    const actorUid = String(record.actorUserId || record.actor?.userId || '').trim() || null;
+    const targets = await getTargetsForCategoryUserIds(teamId, 'officiating', recipientUserIds, actorUid);
+    if (!targets.length) return null;
+
+    const copy = getOfficiatingNotificationCopy(record);
+    return sendOfficiatingTargetsNotification({
+      teamId,
+      gameId: record.gameId || record.gameReference?.gameId || null,
+      targets,
+      title: copy.title,
+      body: copy.body
+    });
+  });
+
+exports.notifyOpenOfficiatingSlots = functions.firestore
+  .document('teams/{teamId}/games/{gameId}')
+  .onUpdate(async (change, context) => {
+    const beforeGame = change.before.data() || {};
+    const afterGame = change.after.data() || {};
+    const openSlots = getNewOpenOfficiatingSlots(beforeGame, afterGame);
+    if (!openSlots.length) return null;
+
+    const { teamId, gameId } = context.params;
+    const actorUid = String(afterGame.updatedBy || afterGame.createdBy || '').trim() || null;
+    const targets = await getTargetsForCategory(teamId, 'officiating', actorUid);
+    if (!targets.length) return null;
+
+    const gameLabel = getOfficiatingGameLabel(afterGame);
+    const dateLabel = getOfficiatingDateLabel(afterGame);
+    const position = openSlots.length === 1
+      ? openSlots[0].position
+      : `${openSlots.length} open assignments`;
+
+    return sendOfficiatingTargetsNotification({
+      teamId,
+      gameId,
+      targets,
+      title: `Open assignment: ${position}`,
+      body: `${gameLabel}${dateLabel ? ` on ${dateLabel}` : ''} needs an official. Claim it before someone else does.`
+    });
+  });
 
 exports.queueTeamMediaNotificationBatch = functions.firestore
   .document('teams/{teamId}/mediaItems/{itemId}')

--- a/functions/index.js
+++ b/functions/index.js
@@ -5215,7 +5215,25 @@ function getOfficiatingNotificationCopy(record = {}) {
   };
 }
 
-async function resolveOfficiatingRecordRecipientUserIds(record = {}) {
+async function getOfficiatingAssignerRecipientUserIds(teamId) {
+  const normalizedTeamId = String(teamId || '').trim();
+  if (!normalizedTeamId) return [];
+
+  const teamSnap = await firestore.doc(`teams/${normalizedTeamId}`).get();
+  if (!teamSnap.exists) return [];
+
+  const team = teamSnap.data() || {};
+  const userIds = new Set([String(team.ownerId || '').trim()].filter(Boolean));
+  const adminUserIds = await getUserIdsByEmails(team.adminEmails || []);
+  adminUserIds.forEach((uid) => userIds.add(uid));
+  return Array.from(userIds);
+}
+
+async function resolveOfficiatingRecordRecipientUserIds(teamId, record = {}) {
+  if (String(record.recipientType || '').trim().toLowerCase() === 'assigner') {
+    return getOfficiatingAssignerRecipientUserIds(teamId);
+  }
+
   const userIds = new Set([
     record.recipientOfficialUserId,
     record.officialUserId,
@@ -5276,12 +5294,14 @@ function isOpenOfficiatingSlotForNotification(slot = {}) {
 
 function getNewOpenOfficiatingSlots(beforeGame = {}, afterGame = {}) {
   if (afterGame.officiatingSelfAssignmentEnabled !== true) return [];
-  const beforeOpenIds = new Set(
-    (Array.isArray(beforeGame.officiatingSlots) ? beforeGame.officiatingSlots : [])
-      .filter(isOpenOfficiatingSlotForNotification)
-      .map((slot) => normalizeOfficiatingSlotForNotification(slot).id)
-      .filter(Boolean)
-  );
+  const beforeOpenIds = beforeGame.officiatingSelfAssignmentEnabled === true
+    ? new Set(
+      (Array.isArray(beforeGame.officiatingSlots) ? beforeGame.officiatingSlots : [])
+        .filter(isOpenOfficiatingSlotForNotification)
+        .map((slot) => normalizeOfficiatingSlotForNotification(slot).id)
+        .filter(Boolean)
+    )
+    : new Set();
   return (Array.isArray(afterGame.officiatingSlots) ? afterGame.officiatingSlots : [])
     .map(normalizeOfficiatingSlotForNotification)
     .filter((slot) => slot.id && isOpenOfficiatingSlotForNotification(slot) && !beforeOpenIds.has(slot.id));
@@ -5315,7 +5335,7 @@ exports.notifyOfficiatingNotificationCreated = functions.firestore
     if (record.type && record.type !== 'officiating_assignment') return null;
 
     const { teamId } = context.params;
-    const recipientUserIds = await resolveOfficiatingRecordRecipientUserIds(record);
+    const recipientUserIds = await resolveOfficiatingRecordRecipientUserIds(teamId, record);
     if (!recipientUserIds.length) return null;
 
     const actorUid = String(record.actorUserId || record.actor?.userId || '').trim() || null;
@@ -5334,8 +5354,10 @@ exports.notifyOfficiatingNotificationCreated = functions.firestore
 
 exports.notifyOpenOfficiatingSlots = functions.firestore
   .document('teams/{teamId}/games/{gameId}')
-  .onUpdate(async (change, context) => {
-    const beforeGame = change.before.data() || {};
+  .onWrite(async (change, context) => {
+    if (!change.after?.exists) return null;
+
+    const beforeGame = change.before?.exists ? (change.before.data() || {}) : {};
     const afterGame = change.after.data() || {};
     const openSlots = getNewOpenOfficiatingSlots(beforeGame, afterGame);
     if (!openSlots.length) return null;

--- a/functions/notification-target-index-core.cjs
+++ b/functions/notification-target-index-core.cjs
@@ -43,7 +43,7 @@ const NOTIFICATION_CATEGORY_AUDIENCES = Object.freeze({
   rideshare: Object.freeze(['parent', 'staff']),
   media: Object.freeze(['parent', 'staff']),
   awards: Object.freeze(['parent', 'staff']),
-  officiating: Object.freeze(['staff'])
+  officiating: Object.freeze(['parent', 'staff'])
 });
 
 function sanitizeNotificationTargetSegment(value) {

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -190,6 +190,116 @@ test('notifyTeamChatMessageCreated sends mentions and liveChat only to enabled r
     }
 });
 
+test('notifyOfficiatingNotificationCreated mirrors assignment records to the linked official', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        indexedTargets: [
+            { uid: 'official-1', deviceId: 'official-device', token: 'official-token', categories: { officiating: true } },
+            { uid: 'other-official', deviceId: 'other-device', token: 'other-token', categories: { officiating: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/officiatingNotifications/notification-1');
+        const snapshot = makeSnapshot(ref, {
+            type: 'officiating_assignment',
+            event: 'assigned',
+            position: 'Center Referee',
+            gameId: 'game-1',
+            gameReference: { gameId: 'game-1', opponent: 'Tigers' },
+            recipientOfficialUserId: 'official-1',
+            actorUserId: 'coach-1'
+        });
+        const context = { params: { teamId: 'team-1', notificationId: 'notification-1' } };
+
+        const result = await moduleExports.notifyOfficiatingNotificationCreated(snapshot, context);
+
+        assert.equal(result?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['official-token']);
+        assert.equal(env.messagingCalls[0].title, 'Officiating assignment: Center Referee');
+        assert.equal(env.messagingCalls[0].body, 'vs. Tigers is ready for your response.');
+        assert.equal(env.messagingCalls[0].data.category, 'officiating');
+        assert.equal(env.messagingCalls[0].data.appRoute, '/officials?teamId=team-1');
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyOfficiatingNotificationCreated resolves official recipients by email', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        authUsersByEmail: { 'ref@example.com': 'official-2' },
+        indexedTargets: [
+            { uid: 'official-2', deviceId: 'official-device', token: 'official-token', categories: { officiating: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/officiatingNotifications/notification-2');
+        const snapshot = makeSnapshot(ref, {
+            type: 'officiating_assignment',
+            event: 'rescheduled',
+            position: 'Line Judge',
+            gameId: 'game-2',
+            gameReference: { gameId: 'game-2', title: 'Cup semifinal' },
+            recipientOfficialEmail: 'REF@example.com',
+            actorUserId: 'coach-1'
+        });
+        const context = { params: { teamId: 'team-1', notificationId: 'notification-2' } };
+
+        await moduleExports.notifyOfficiatingNotificationCreated(snapshot, context);
+
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['official-token']);
+        assert.equal(env.messagingCalls[0].title, 'Officiating assignment updated: Line Judge');
+        assert.equal(env.messagingCalls[0].body, 'Cup semifinal was rescheduled.');
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyOpenOfficiatingSlots sends open-slot pushes only for newly posted slots', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['official-1'],
+        indexedTargets: [
+            { uid: 'official-1', deviceId: 'official-device', token: 'official-token', categories: { officiating: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/games/game-3');
+        const context = { params: { teamId: 'team-1', gameId: 'game-3' } };
+        const change = makeChange(ref, {
+            title: 'Cup final',
+            officiatingSelfAssignmentEnabled: true,
+            officiatingSlots: [
+                { id: 'center', position: 'Center Referee', status: 'open' }
+            ]
+        }, {
+            title: 'Cup final',
+            updatedBy: 'coach-1',
+            officiatingSelfAssignmentEnabled: true,
+            officiatingSlots: [
+                { id: 'center', position: 'Center Referee', status: 'open' },
+                { id: 'line', position: 'Line Judge', status: 'open' },
+                { id: 'claimed', position: 'Assistant Referee', status: 'accepted', officialUserId: 'official-2' }
+            ]
+        });
+
+        const result = await moduleExports.notifyOpenOfficiatingSlots(change, context);
+
+        assert.equal(result?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['official-token']);
+        assert.equal(env.messagingCalls[0].title, 'Open assignment: Line Judge');
+        assert.equal(env.messagingCalls[0].body, 'Cup final needs an official. Claim it before someone else does.');
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyFeeAssigned sends fees notifications only to opted-in payer targets', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -259,6 +259,43 @@ test('notifyOfficiatingNotificationCreated resolves official recipients by email
     }
 });
 
+test('notifyOfficiatingNotificationCreated routes assigner records to staff recipients', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: ['assistant@example.com'] },
+        authUsersByEmail: { 'assistant@example.com': 'coach-2' },
+        indexedTargets: [
+            { uid: 'coach-1', deviceId: 'coach-device', token: 'coach-token', categories: { officiating: true } },
+            { uid: 'coach-2', deviceId: 'assistant-device', token: 'assistant-token', categories: { officiating: true } },
+            { uid: 'official-1', deviceId: 'official-device', token: 'official-token', categories: { officiating: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/officiatingNotifications/notification-assigner');
+        const snapshot = makeSnapshot(ref, {
+            type: 'officiating_assignment',
+            event: 'declined',
+            position: 'Line Judge',
+            gameId: 'game-2',
+            gameReference: { gameId: 'game-2', title: 'Cup semifinal' },
+            recipientType: 'assigner',
+            recipientOfficialUserId: 'official-1',
+            actorUserId: 'official-1'
+        });
+        const context = { params: { teamId: 'team-1', notificationId: 'notification-assigner' } };
+
+        const result = await moduleExports.notifyOfficiatingNotificationCreated(snapshot, context);
+
+        assert.equal(result?.successCount, 2);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens.sort(), ['assistant-token', 'coach-token']);
+        assert.equal(env.messagingCalls[0].title, 'Officiating assignment declined: Line Judge');
+        assert.equal(env.messagingCalls[0].body, 'Cup semifinal needs coverage.');
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyOpenOfficiatingSlots sends open-slot pushes only for newly posted slots', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },
@@ -295,6 +332,75 @@ test('notifyOpenOfficiatingSlots sends open-slot pushes only for newly posted sl
         assert.deepEqual(env.messagingCalls[0].tokens, ['official-token']);
         assert.equal(env.messagingCalls[0].title, 'Open assignment: Line Judge');
         assert.equal(env.messagingCalls[0].body, 'Cup final needs an official. Claim it before someone else does.');
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyOpenOfficiatingSlots sends notifications when self-assignment is enabled for existing open slots', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['official-1'],
+        indexedTargets: [
+            { uid: 'official-1', deviceId: 'official-device', token: 'official-token', categories: { officiating: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/games/game-4');
+        const context = { params: { teamId: 'team-1', gameId: 'game-4' } };
+        const change = makeChange(ref, {
+            title: 'Semifinal',
+            officiatingSelfAssignmentEnabled: false,
+            officiatingSlots: [
+                { id: 'center', position: 'Center Referee', status: 'open' }
+            ]
+        }, {
+            title: 'Semifinal',
+            updatedBy: 'coach-1',
+            officiatingSelfAssignmentEnabled: true,
+            officiatingSlots: [
+                { id: 'center', position: 'Center Referee', status: 'open' }
+            ]
+        });
+
+        const result = await moduleExports.notifyOpenOfficiatingSlots(change, context);
+
+        assert.equal(result?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].title, 'Open assignment: Center Referee');
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyOpenOfficiatingSlots sends notifications when a game is created with open self-assignment slots', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['official-1'],
+        indexedTargets: [
+            { uid: 'official-1', deviceId: 'official-device', token: 'official-token', categories: { officiating: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/games/game-5');
+        const context = { params: { teamId: 'team-1', gameId: 'game-5' } };
+        const change = makeChange(ref, null, {
+            title: 'Championship',
+            createdBy: 'coach-1',
+            officiatingSelfAssignmentEnabled: true,
+            officiatingSlots: [
+                { id: 'line', position: 'Line Judge', status: 'open' }
+            ]
+        });
+
+        const result = await moduleExports.notifyOpenOfficiatingSlots(change, context);
+
+        assert.equal(result?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].title, 'Open assignment: Line Judge');
+        assert.equal(env.messagingCalls[0].body, 'Championship needs an official. Claim it before someone else does.');
     } finally {
         cleanup();
     }

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -73,10 +73,11 @@ describe('notification target index core helpers', () => {
         });
     });
 
-    it('keeps access available to parents and staff while preserving staff-only categories', () => {
+    it('keeps access and officiating available to parents and staff', () => {
         expect(notificationAudienceAllowsRoles('access', ['parent'])).toBe(true);
         expect(notificationAudienceAllowsRoles('access', ['staff'])).toBe(true);
-        expect(notificationAudienceAllowsRoles('officiating', ['parent'])).toBe(false);
+        expect(notificationAudienceAllowsRoles('officiating', ['parent'])).toBe(true);
+        expect(notificationAudienceAllowsRoles('officiating', ['staff'])).toBe(true);
         expect(notificationAudienceAllowsRoles('fees', ['parent'])).toBe(true);
     });
 


### PR DESCRIPTION
Closes #2111.\n\n## Summary\n- Mirrored new officiating assignment notification records into targeted officiating pushes\n- Added open-slot push delivery when a game posts new claimable officiating slots\n- Routed officiating pushes to the officials surface and allowed parent-linked officials to receive targeted officiating alerts\n\n## Tests\n- npx vitest run functions/test/notification-triggers.test.js --reporter=verbose\n- npx vitest run tests/unit/notification-target-index-core.test.js --reporter=verbose\n- npm run test:notifications --prefix functions