### PR TITLE
Add notification token hygiene sweep

### DIFF
--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -3,7 +3,9 @@
 importScripts('https://www.gstatic.com/firebasejs/12.6.0/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/12.6.0/firebase-messaging-compat.js');
 
-const CONFIG_CACHE_NAME = 'allplays-push-config-v1';
+const CONFIG_CACHE_VERSION = 'v2';
+const CONFIG_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const CONFIG_CACHE_NAME = `allplays-push-config-${CONFIG_CACHE_VERSION}`;
 const CONFIG_CACHE_KEY = '/__allplays/push/firebase-config.json';
 const FIREBASE_INIT_JSON_URL = '/__/firebase/init.json';
 const WEB_PUSH_NOTIFICATION_ICON = '/img/logo_small.png';
@@ -28,8 +30,10 @@ async function readCachedFirebaseConfig() {
         const cache = await caches.open(CONFIG_CACHE_NAME);
         const response = await cache.match(CONFIG_CACHE_KEY);
         if (!response) return null;
-        const config = await response.json();
-        return isValidFirebaseConfig(config) ? config : null;
+        const cached = await response.json();
+        if (cached?.version !== CONFIG_CACHE_VERSION) return null;
+        if (!Number.isFinite(cached?.cachedAt) || Date.now() - cached.cachedAt > CONFIG_CACHE_TTL_MS) return null;
+        return isValidFirebaseConfig(cached.config) ? cached.config : null;
     } catch {
         return null;
     }
@@ -39,7 +43,11 @@ async function writeCachedFirebaseConfig(config) {
     if (typeof caches === 'undefined' || !isValidFirebaseConfig(config)) return;
     try {
         const cache = await caches.open(CONFIG_CACHE_NAME);
-        await cache.put(CONFIG_CACHE_KEY, new Response(JSON.stringify(config), {
+        await cache.put(CONFIG_CACHE_KEY, new Response(JSON.stringify({
+            version: CONFIG_CACHE_VERSION,
+            cachedAt: Date.now(),
+            config
+        }), {
             headers: { 'Content-Type': 'application/json' }
         }));
     } catch {

--- a/functions/index.js
+++ b/functions/index.js
@@ -97,6 +97,9 @@ const {
   buildNotificationDeliveryOptions
 } = require('./notification-delivery-metadata.cjs');
 const {
+  getStaleNotificationTokenCutoffMillis
+} = require('./notification-token-sweep-core.cjs');
+const {
   coerceDate,
   getEventTitle,
   formatScheduleUpdateDate
@@ -4544,6 +4547,38 @@ async function pruneInvalidTokens(sendResult, targets) {
   }
 }
 
+async function sweepStaleNotificationDeviceTokens(nowMillis = Date.now()) {
+  const cutoff = admin.firestore.Timestamp.fromMillis(getStaleNotificationTokenCutoffMillis(nowMillis));
+  const pageSize = 400;
+  let deletedCount = 0;
+  let pageCount = 0;
+
+  while (pageCount < 20) {
+    pageCount += 1;
+    const snapshot = await firestore.collectionGroup('notificationDevices')
+      .where('updatedAt', '<', cutoff)
+      .limit(pageSize)
+      .get();
+    if (snapshot.empty) break;
+
+    const batch = firestore.batch();
+    snapshot.docs.forEach((docSnap) => {
+      batch.delete(docSnap.ref);
+      deletedCount += 1;
+    });
+    await batch.commit();
+
+    if (snapshot.docs.length < pageSize) break;
+  }
+
+  functions.logger.info('Swept stale notification device tokens.', {
+    deletedCount,
+    pageCount,
+    cutoffMillis: cutoff.toMillis?.() || null
+  });
+  return { deletedCount, pageCount };
+}
+
 async function cleanupNotificationInbox(inboxRef) {
   const oldItemsSnap = await inboxRef
     .orderBy('createdAt', 'desc')
@@ -5134,12 +5169,17 @@ exports._internal = {
   dispatchDueTeamMediaNotificationBatches,
   getTargetsForCategory,
   sendCategoryNotification,
+  sweepStaleNotificationDeviceTokens,
   sendRsvpReminderPushNotifications,
   sendPracticePacketDueTomorrowReminders,
   syncNotificationRecipientForTeamUser,
   syncNotificationRecipientsForUserChange,
   syncNotificationRecipientsForTeamChange
 };
+
+exports.sweepStaleNotificationDeviceTokens = functions.pubsub
+  .schedule('every 24 hours')
+  .onRun(() => sweepStaleNotificationDeviceTokens());
 
 exports.queueTeamMediaNotificationBatch = functions.firestore
   .document('teams/{teamId}/mediaItems/{itemId}')

--- a/functions/notification-token-sweep-core.cjs
+++ b/functions/notification-token-sweep-core.cjs
@@ -1,0 +1,40 @@
+const STALE_NOTIFICATION_DEVICE_TOKEN_DAYS = 90;
+const STALE_NOTIFICATION_DEVICE_TOKEN_MS = STALE_NOTIFICATION_DEVICE_TOKEN_DAYS * 24 * 60 * 60 * 1000;
+
+function getStaleNotificationTokenCutoffMillis(nowMillis = Date.now(), maxAgeMs = STALE_NOTIFICATION_DEVICE_TOKEN_MS) {
+  const now = Number(nowMillis);
+  const age = Number(maxAgeMs);
+  return Math.max(0, (Number.isFinite(now) ? now : Date.now()) - (Number.isFinite(age) ? age : STALE_NOTIFICATION_DEVICE_TOKEN_MS));
+}
+
+function getNotificationDeviceUpdatedAtMillis(device = {}) {
+  const value = device?.updatedAt || device?.createdAt || device?.lastSeenAt || null;
+  if (!value) return 0;
+  if (typeof value.toMillis === 'function') {
+    const millis = value.toMillis();
+    return Number.isFinite(millis) ? millis : 0;
+  }
+  if (typeof value.toDate === 'function') {
+    const date = value.toDate();
+    return date instanceof Date && !Number.isNaN(date.getTime()) ? date.getTime() : 0;
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? 0 : value.getTime();
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+}
+
+function isStaleNotificationDeviceRecord(device = {}, nowMillis = Date.now(), maxAgeMs = STALE_NOTIFICATION_DEVICE_TOKEN_MS) {
+  const updatedAtMillis = getNotificationDeviceUpdatedAtMillis(device);
+  if (!updatedAtMillis) return true;
+  return updatedAtMillis < getStaleNotificationTokenCutoffMillis(nowMillis, maxAgeMs);
+}
+
+module.exports = {
+  STALE_NOTIFICATION_DEVICE_TOKEN_DAYS,
+  STALE_NOTIFICATION_DEVICE_TOKEN_MS,
+  getNotificationDeviceUpdatedAtMillis,
+  getStaleNotificationTokenCutoffMillis,
+  isStaleNotificationDeviceRecord
+};

--- a/tests/unit/notification-delivery-metadata.test.js
+++ b/tests/unit/notification-delivery-metadata.test.js
@@ -145,4 +145,12 @@ describe('notification delivery metadata', () => {
         expect(serviceWorkerSource).toContain('payload?.fcmOptions?.link');
         expect(serviceWorkerSource).toContain('event.waitUntil(clients.openWindow(link));');
     });
+
+    it('versions and expires cached Firebase service worker config', () => {
+        expect(serviceWorkerSource).toContain("const CONFIG_CACHE_VERSION = 'v2';");
+        expect(serviceWorkerSource).toContain('const CONFIG_CACHE_TTL_MS = 24 * 60 * 60 * 1000;');
+        expect(serviceWorkerSource).toContain('cached?.version !== CONFIG_CACHE_VERSION');
+        expect(serviceWorkerSource).toContain('Date.now() - cached.cachedAt > CONFIG_CACHE_TTL_MS');
+        expect(serviceWorkerSource).toContain('cachedAt: Date.now()');
+    });
 });

--- a/tests/unit/notification-token-sweep-core.test.js
+++ b/tests/unit/notification-token-sweep-core.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const {
+    STALE_NOTIFICATION_DEVICE_TOKEN_MS,
+    getNotificationDeviceUpdatedAtMillis,
+    getStaleNotificationTokenCutoffMillis,
+    isStaleNotificationDeviceRecord
+} = require('../../functions/notification-token-sweep-core.cjs');
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+describe('notification token sweep helpers', () => {
+    it('computes the 90 day stale token cutoff', () => {
+        const now = Date.parse('2026-06-20T12:00:00.000Z');
+        expect(getStaleNotificationTokenCutoffMillis(now)).toBe(now - STALE_NOTIFICATION_DEVICE_TOKEN_MS);
+    });
+
+    it('normalizes Firestore, Date, and string token timestamps', () => {
+        expect(getNotificationDeviceUpdatedAtMillis({ updatedAt: { toMillis: () => 1234 } })).toBe(1234);
+        expect(getNotificationDeviceUpdatedAtMillis({ updatedAt: { toDate: () => new Date('2026-01-01T00:00:00.000Z') } })).toBe(Date.parse('2026-01-01T00:00:00.000Z'));
+        expect(getNotificationDeviceUpdatedAtMillis({ updatedAt: new Date('2026-02-01T00:00:00.000Z') })).toBe(Date.parse('2026-02-01T00:00:00.000Z'));
+        expect(getNotificationDeviceUpdatedAtMillis({ updatedAt: '2026-03-01T00:00:00.000Z' })).toBe(Date.parse('2026-03-01T00:00:00.000Z'));
+    });
+
+    it('treats missing or older token timestamps as stale', () => {
+        const now = Date.parse('2026-06-20T12:00:00.000Z');
+        expect(isStaleNotificationDeviceRecord({}, now)).toBe(true);
+        expect(isStaleNotificationDeviceRecord({ updatedAt: '2026-02-01T00:00:00.000Z' }, now)).toBe(true);
+        expect(isStaleNotificationDeviceRecord({ updatedAt: '2026-06-01T00:00:00.000Z' }, now)).toBe(false);
+    });
+
+    it('wires a scheduled collectionGroup sweep into Cloud Functions', () => {
+        expect(functionsSource).toContain("firestore.collectionGroup('notificationDevices')");
+        expect(functionsSource).toContain(".where('updatedAt', '<', cutoff)");
+        expect(functionsSource).toContain('exports.sweepStaleNotificationDeviceTokens = functions.pubsub');
+        expect(functionsSource).toContain(".schedule('every 24 hours')");
+    });
+});


### PR DESCRIPTION
Closes #2100.\n\n## Summary\n- Added a scheduled Cloud Function to sweep notification device tokens older than 90 days\n- Added core timestamp/cutoff helpers with regression coverage\n- Versioned and time-limited the Firebase config cache used by the web messaging service worker\n\n## Tests\n- npx vitest run tests/unit/notification-token-sweep-core.test.js tests/unit/notification-delivery-metadata.test.js --reporter=verbose\n- npm run test:notifications --prefix functions