### PR TITLE
Add Sports Connect registration sync

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -770,6 +770,23 @@
             return isSportsConnectProvider(provider) ? 'sports-connect' : '';
         }
 
+        function getSavedRegistrationProvider() {
+            return String(
+                currentRegistrationSource?.provider ||
+                currentRegistrationSource?.providerName ||
+                currentRegistrationSource?.providerId ||
+                ''
+            ).trim();
+        }
+
+        function hasUnsavedRegistrationSyncChanges(provider, externalTeamId) {
+            if (!currentTeamId || !isSportsConnectProvider(provider)) {
+                return false;
+            }
+            return normalizeRegistrationProviderKey(provider) !== normalizeRegistrationProviderKey(getSavedRegistrationProvider())
+                || externalTeamId !== getRegistrationSourceValue({ registrationSource: currentRegistrationSource || {} }, 'externalTeamId');
+        }
+
         function getRegistrationMetadataStatus(provider, externalTeamId) {
             if (!provider) {
                 return 'Not configured';
@@ -814,20 +831,23 @@
             const metadataStatus = getRegistrationMetadataStatus(provider, externalTeamId);
             const lastSyncTime = getRegistrationLastSyncTime(source);
             const refreshButton = document.getElementById('registration-refresh-btn');
-            const canSyncSportsConnect = Boolean(currentTeamId && isSportsConnectProvider(provider) && externalTeamId);
+            const hasUnsavedSyncChanges = hasUnsavedRegistrationSyncChanges(provider, externalTeamId);
+            const canSyncSportsConnect = Boolean(currentTeamId && isSportsConnectProvider(provider) && externalTeamId && !hasUnsavedSyncChanges);
             let helpText = 'Choose a provider and team mapping to save registration metadata.';
 
             if (provider && externalTeamId) {
                 helpText = isSportsConnectProvider(provider)
                     ? (currentTeamId
-                        ? 'Sync now fetches Sports Connect data through the backend and stores the roster snapshot for import.'
+                        ? (hasUnsavedSyncChanges
+                            ? 'Save the updated Sports Connect mapping before running sync.'
+                            : 'Sync now fetches Sports Connect data through the backend and stores the roster snapshot for import.')
                         : 'Save the team before running a Sports Connect sync.')
                     : 'This provider mapping is saved as metadata only. Manual refresh stays unavailable until a live connector exists.';
             } else if (provider) {
                 helpText = 'Add the provider team ID or mapping to finish setup.';
             }
 
-            if (source.lastSyncStatus === 'error' && source.lastSyncError) {
+            if (!hasUnsavedSyncChanges && source.lastSyncStatus === 'error' && source.lastSyncError) {
                 helpText = `Last sync error: ${source.lastSyncError}`;
             }
 

--- a/edit-team.html
+++ b/edit-team.html
@@ -454,7 +454,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Connection</h3>
-                            <p class="text-xs text-blue-700 mt-1">Store registration metadata for this team. Sports Connect details are saved for reference only until a live connector exists. No provider login, sync job, or network call runs from these fields.</p>
+                            <p class="text-xs text-blue-700 mt-1">Store registration metadata for this team. Saved Sports Connect mappings can run a backend manual sync that fetches a roster snapshot for import.</p>
                         </div>
                         <button id="clear-registration-provider-btn" type="button" class="shrink-0 px-3 py-1.5 bg-white border border-blue-200 text-blue-700 text-xs font-semibold rounded-lg hover:bg-blue-100 transition">
                             Clear
@@ -470,7 +470,7 @@
                                 <option value="League Apps">League Apps</option>
                                 <option value="Other">Other documented source</option>
                             </select>
-                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect stores metadata only. ALL PLAYS does not fetch live provider data yet.</p>
+                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect enables a backend manual sync after this team is saved.</p>
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700">Sports Connect Team ID / External Mapping</label>
@@ -509,9 +509,9 @@
                             </div>
                         </div>
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <p id="registration-connection-help" class="text-xs text-blue-700">This section stores provider references only. Manual refresh stays unavailable until a real Sports Connect connector is implemented.</p>
+                            <p id="registration-connection-help" class="text-xs text-blue-700">Save a Sports Connect provider mapping, then sync a roster snapshot for import.</p>
                             <button id="registration-refresh-btn" type="button" disabled aria-disabled="true" class="shrink-0 cursor-not-allowed rounded-lg border border-slate-200 bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500">
-                                Manual refresh unavailable
+                                Sync now
                             </button>
                         </div>
                     </div>
@@ -555,7 +555,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources } from './js/db.js?v=53';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=53';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
@@ -778,7 +778,15 @@
                 return 'Metadata incomplete. Add provider mapping.';
             }
             if (isSportsConnectProvider(provider)) {
-                return 'Sports Connect metadata only. No live sync.';
+                const source = currentRegistrationSource || {};
+                if (source.lastSyncStatus === 'success') {
+                    const count = Number(source.playerCount || 0);
+                    return `Last sync successful${count ? ` (${count} players)` : ''}`;
+                }
+                if (source.lastSyncStatus === 'error') {
+                    return 'Last sync failed';
+                }
+                return 'Ready for manual sync';
             }
             return 'Registration metadata only. No live sync.';
         }
@@ -805,14 +813,22 @@
             const externalTeamId = document.getElementById('registrationExternalTeamId').value.trim();
             const metadataStatus = getRegistrationMetadataStatus(provider, externalTeamId);
             const lastSyncTime = getRegistrationLastSyncTime(source);
-            let helpText = 'Choose a provider and team mapping to save metadata only. No live Sports Connect fetch runs yet.';
+            const refreshButton = document.getElementById('registration-refresh-btn');
+            const canSyncSportsConnect = Boolean(currentTeamId && isSportsConnectProvider(provider) && externalTeamId);
+            let helpText = 'Choose a provider and team mapping to save registration metadata.';
 
             if (provider && externalTeamId) {
                 helpText = isSportsConnectProvider(provider)
-                    ? 'Sports Connect is saved as metadata only for this team. Manual refresh stays unavailable until a live connector exists.'
+                    ? (currentTeamId
+                        ? 'Sync now fetches Sports Connect data through the backend and stores the roster snapshot for import.'
+                        : 'Save the team before running a Sports Connect sync.')
                     : 'This provider mapping is saved as metadata only. Manual refresh stays unavailable until a live connector exists.';
             } else if (provider) {
-                helpText = 'Add the provider team ID or mapping to finish saving metadata. No live provider fetch runs yet.';
+                helpText = 'Add the provider team ID or mapping to finish setup.';
+            }
+
+            if (source.lastSyncStatus === 'error' && source.lastSyncError) {
+                helpText = `Last sync error: ${source.lastSyncError}`;
             }
 
             document.getElementById('registrationLastSyncStatus').value = metadataStatus;
@@ -820,6 +836,15 @@
             document.getElementById('registration-sync-status').textContent = metadataStatus;
             document.getElementById('registration-sync-time').textContent = formatRegistrationSyncTime(lastSyncTime);
             document.getElementById('registration-connection-help').textContent = helpText;
+            refreshButton.disabled = !canSyncSportsConnect;
+            refreshButton.setAttribute('aria-disabled', String(refreshButton.disabled));
+            refreshButton.classList.toggle('cursor-not-allowed', refreshButton.disabled);
+            refreshButton.classList.toggle('border-slate-200', refreshButton.disabled);
+            refreshButton.classList.toggle('bg-slate-100', refreshButton.disabled);
+            refreshButton.classList.toggle('text-slate-500', refreshButton.disabled);
+            refreshButton.classList.toggle('border-blue-300', !refreshButton.disabled);
+            refreshButton.classList.toggle('bg-blue-600', !refreshButton.disabled);
+            refreshButton.classList.toggle('text-white', !refreshButton.disabled);
         }
 
         function populateRegistrationProviderFields(team = {}) {
@@ -842,7 +867,50 @@
             document.getElementById('registrationProviderName').value = '';
             document.getElementById('registrationExternalTeamId').value = '';
             document.getElementById('registrationLastSyncStatus').value = '';
+            currentRegistrationSource = null;
             renderRegistrationConnectionStatus({});
+        }
+
+        async function handleRegistrationProviderSync() {
+            const button = document.getElementById('registration-refresh-btn');
+            if (!currentTeamId || button.disabled) return;
+
+            const originalText = button.textContent;
+            let finalHelpText = '';
+            button.disabled = true;
+            button.setAttribute('aria-disabled', 'true');
+            button.textContent = 'Syncing...';
+            document.getElementById('registration-connection-help').textContent = 'Fetching Sports Connect registration snapshot...';
+
+            try {
+                const result = await syncRegistrationProvider(currentTeamId);
+                const refreshedTeam = await getTeam(currentTeamId);
+                if (refreshedTeam?.registrationSource) {
+                    currentRegistrationSource = { ...refreshedTeam.registrationSource };
+                } else {
+                    currentRegistrationSource = {
+                        ...(currentRegistrationSource || {}),
+                        lastSyncStatus: 'success',
+                        lastSyncAt: result?.fetchedAt || new Date().toISOString(),
+                        playerCount: result?.playerCount || 0
+                    };
+                }
+                finalHelpText = `Synced ${Number(result?.playerCount || 0)} Sports Connect player${Number(result?.playerCount || 0) === 1 ? '' : 's'}. Open roster import to preview changes.`;
+            } catch (error) {
+                currentRegistrationSource = {
+                    ...(currentRegistrationSource || {}),
+                    lastSyncStatus: 'error',
+                    lastSyncAt: new Date().toISOString(),
+                    lastSyncError: error?.message || 'Sports Connect sync failed.'
+                };
+                renderRegistrationConnectionStatus(currentRegistrationSource || {});
+            } finally {
+                button.textContent = originalText;
+                renderRegistrationConnectionStatus(currentRegistrationSource || {});
+                if (finalHelpText) {
+                    document.getElementById('registration-connection-help').textContent = finalHelpText;
+                }
+            }
         }
 
         function buildRegistrationSourcePayload() {
@@ -859,7 +927,7 @@
                 externalTeamId,
                 teamId: currentTeamId || null,
                 connectionStatus: provider && externalTeamId ? 'metadata_configured' : 'metadata_incomplete',
-                syncEnabled: false,
+                syncEnabled: isSportsConnectProvider(provider) && !!externalTeamId,
                 lastSyncStatus: metadataStatus
             };
         }
@@ -1438,7 +1506,7 @@
         });
 
         document.getElementById('clear-registration-provider-btn').addEventListener('click', clearRegistrationProviderFields);
-        document.getElementById('registration-refresh-btn').disabled = true;
+        document.getElementById('registration-refresh-btn').addEventListener('click', handleRegistrationProviderSync);
         ['registrationProviderName', 'registrationExternalTeamId'].forEach((id) => {
             document.getElementById(id).addEventListener('input', () => renderRegistrationConnectionStatus(currentRegistrationSource || {}));
             document.getElementById(id).addEventListener('change', () => renderRegistrationConnectionStatus(currentRegistrationSource || {}));

--- a/edit-team.html
+++ b/edit-team.html
@@ -839,7 +839,7 @@
                 helpText = isSportsConnectProvider(provider)
                     ? (currentTeamId
                         ? (hasUnsavedSyncChanges
-                            ? 'Save the updated Sports Connect mapping before running sync.'
+                            ? 'Save the updated Sports Connect mapping before running backend sync.'
                             : 'Sync now fetches Sports Connect data through the backend and stores the roster snapshot for import.')
                         : 'Save the team before running a Sports Connect sync.')
                     : 'This provider mapping is saved as metadata only. Manual refresh stays unavailable until a live connector exists.';

--- a/functions/index.js
+++ b/functions/index.js
@@ -104,6 +104,15 @@ const {
   getEventTitle,
   formatScheduleUpdateDate
 } = require('./schedule-notification-utils.cjs');
+const {
+  assertSportsConnectSyncConfig,
+  buildSportsConnectRegistrationSnapshot,
+  buildSportsConnectSyncErrorUpdate,
+  buildSportsConnectTeamUpdate,
+  fetchSportsConnectRegistrationPayload,
+  getRegistrationSource,
+  getTeamSportsConnectConfig
+} = require('./sports-connect-registration-sync.cjs');
 
 if (admin.apps.length === 0) {
   admin.initializeApp();
@@ -845,6 +854,90 @@ function hasTeamAdminAccess({ team, user = {}, uid, email }) {
   const adminEmails = Array.isArray(team?.adminEmails) ? team.adminEmails.map((entry) => String(entry || '').trim().toLowerCase()) : [];
   return Boolean(uid && team?.ownerId === uid) || Boolean(normalizedEmail && adminEmails.includes(normalizedEmail));
 }
+
+function getSportsConnectFunctionsConfig() {
+  const sportsConnectConfig = functions.config()?.sports_connect || {};
+  return {
+    endpointTemplate: process.env.SPORTS_CONNECT_REGISTRATION_SNAPSHOT_URL ||
+      process.env.SPORTS_CONNECT_REGISTRATION_BASE_URL ||
+      sportsConnectConfig.registration_snapshot_url ||
+      sportsConnectConfig.registration_base_url,
+    accessToken: process.env.SPORTS_CONNECT_API_TOKEN ||
+      sportsConnectConfig.api_token ||
+      sportsConnectConfig.token
+  };
+}
+
+function toHttpsError(error, fallbackCode = 'internal') {
+  if (error instanceof functions.https.HttpsError) return error;
+  const code = error?.code && typeof error.code === 'string' ? error.code : fallbackCode;
+  return new functions.https.HttpsError(code, error?.message || 'Request failed.');
+}
+
+exports.syncRegistrationProvider = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in to sync registration data.');
+  }
+
+  const teamId = String(data?.teamId || '').trim();
+  if (!teamId) {
+    throw new functions.https.HttpsError('invalid-argument', 'Team ID is required.');
+  }
+
+  const teamRef = firestore.doc(`teams/${teamId}`);
+  const [teamSnap, userSnap] = await Promise.all([
+    teamRef.get(),
+    firestore.doc(`users/${context.auth.uid}`).get()
+  ]);
+  if (!teamSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Team not found.');
+  }
+
+  const team = teamSnap.data() || {};
+  const user = userSnap.exists ? userSnap.data() || {} : {};
+  const callerEmail = String(context.auth.token?.email || '').trim().toLowerCase();
+  if (!hasTeamAdminAccess({ team, user, uid: context.auth.uid, email: callerEmail })) {
+    throw new functions.https.HttpsError('permission-denied', 'Only team owners and admins can sync registration data.');
+  }
+
+  const existingSource = getRegistrationSource(team);
+  const syncConfig = getTeamSportsConnectConfig(team, getSportsConnectFunctionsConfig());
+  try {
+    assertSportsConnectSyncConfig(syncConfig);
+    const payload = await fetchSportsConnectRegistrationPayload(syncConfig);
+    const nowIso = new Date().toISOString();
+    const snapshot = buildSportsConnectRegistrationSnapshot(payload, {
+      externalTeamId: syncConfig.externalTeamId,
+      fetchedAt: nowIso
+    });
+    const update = buildSportsConnectTeamUpdate({
+      existingSource,
+      snapshot,
+      nowIso
+    });
+    update.registrationSource.teamId = teamId;
+    update.registrationSource.lastSyncBy = context.auth.uid;
+    update.registrationSource.lastSyncByEmail = callerEmail || null;
+    await teamRef.set(update, { merge: true });
+    return {
+      success: true,
+      teamId,
+      provider: 'Sports Connect',
+      externalTeamId: snapshot.externalTeamId,
+      playerCount: snapshot.playerCount,
+      fetchedAt: snapshot.fetchedAt
+    };
+  } catch (error) {
+    const nowIso = new Date().toISOString();
+    await teamRef.set(buildSportsConnectSyncErrorUpdate(existingSource, error?.message, nowIso), { merge: true }).catch((writeError) => {
+      functions.logger.warn('Failed to record Sports Connect sync error state.', {
+        teamId,
+        error: writeError?.message || String(writeError)
+      });
+    });
+    throw toHttpsError(error, 'unavailable');
+  }
+});
 
 function normalizeOrganizationDraftSlot(slot = {}) {
   const homeTeamId = String(slot.homeTeamId || '').trim();

--- a/functions/sports-connect-registration-sync.cjs
+++ b/functions/sports-connect-registration-sync.cjs
@@ -1,0 +1,296 @@
+const DEFAULT_TIMEOUT_MS = 12000;
+
+function compactString(value) {
+  return String(value || '').trim();
+}
+
+function normalizeProviderKey(value) {
+  return compactString(value).toLowerCase().replace(/[\s_]+/g, '-');
+}
+
+function isSportsConnectProvider(value) {
+  return normalizeProviderKey(value) === 'sports-connect';
+}
+
+function getRegistrationSource(team = {}) {
+  const source = team.registrationSource && typeof team.registrationSource === 'object' ? team.registrationSource : {};
+  const legacyProvider = team.registrationProvider && typeof team.registrationProvider === 'object' ? team.registrationProvider : {};
+  return {
+    ...legacyProvider,
+    ...source
+  };
+}
+
+function getTeamSportsConnectConfig(team = {}, config = {}) {
+  const source = getRegistrationSource(team);
+  const provider = compactString(source.provider || source.providerName || source.providerId || team.registrationSourceId);
+  const externalTeamId = compactString(
+    source.externalTeamId ||
+    source.teamId ||
+    team.externalRegistrationTeamId ||
+    team.registrationExternalTeamId
+  );
+  const endpointTemplate = compactString(
+    config.endpointTemplate ||
+    config.registrationSnapshotUrl ||
+    config.baseUrl ||
+    source.registrationSnapshotUrl ||
+    source.syncUrl
+  );
+  const accessToken = compactString(config.accessToken || config.token);
+
+  return {
+    provider,
+    providerId: isSportsConnectProvider(provider) ? 'sports-connect' : normalizeProviderKey(provider),
+    externalTeamId,
+    endpointTemplate,
+    accessToken
+  };
+}
+
+function assertSportsConnectSyncConfig(syncConfig = {}) {
+  if (!isSportsConnectProvider(syncConfig.provider)) {
+    const error = new Error('Sports Connect must be selected before syncing registration data.');
+    error.code = 'failed-precondition';
+    throw error;
+  }
+  if (!syncConfig.externalTeamId) {
+    const error = new Error('Add a Sports Connect team ID before syncing registration data.');
+    error.code = 'failed-precondition';
+    throw error;
+  }
+  if (!syncConfig.endpointTemplate) {
+    const error = new Error('Sports Connect registration sync endpoint is not configured.');
+    error.code = 'failed-precondition';
+    throw error;
+  }
+  if (!syncConfig.accessToken) {
+    const error = new Error('Sports Connect registration sync credentials are not configured.');
+    error.code = 'failed-precondition';
+    throw error;
+  }
+}
+
+function buildSportsConnectRegistrationUrl(endpointTemplate, externalTeamId) {
+  const endpoint = compactString(endpointTemplate);
+  const encodedTeamId = encodeURIComponent(compactString(externalTeamId));
+  if (!endpoint) return '';
+  if (endpoint.includes('{externalTeamId}')) {
+    return endpoint.replace(/\{externalTeamId\}/g, encodedTeamId);
+  }
+  if (endpoint.includes('{teamId}')) {
+    return endpoint.replace(/\{teamId\}/g, encodedTeamId);
+  }
+
+  const parsed = new URL(endpoint);
+  parsed.pathname = `${parsed.pathname.replace(/\/$/, '')}/teams/${encodedTeamId}/registration-snapshot`;
+  return parsed.toString();
+}
+
+function createTimeoutSignal(timeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), Math.max(1000, Number(timeoutMs || DEFAULT_TIMEOUT_MS)));
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timeout)
+  };
+}
+
+async function fetchSportsConnectRegistrationPayload({
+  endpointTemplate,
+  externalTeamId,
+  accessToken,
+  fetchImpl = globalThis.fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+} = {}) {
+  if (typeof fetchImpl !== 'function') {
+    const error = new Error('A fetch implementation is required for Sports Connect sync.');
+    error.code = 'internal';
+    throw error;
+  }
+  const url = buildSportsConnectRegistrationUrl(endpointTemplate, externalTeamId);
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:') {
+    const error = new Error('Sports Connect registration sync endpoint must use https.');
+    error.code = 'failed-precondition';
+    throw error;
+  }
+
+  const timeout = createTimeoutSignal(timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        'User-Agent': 'allplays-sports-connect-sync/1.0'
+      },
+      signal: timeout.signal
+    });
+    if (!response?.ok) {
+      const errorText = typeof response?.text === 'function'
+        ? await response.text().catch(() => '')
+        : '';
+      const error = new Error(`Sports Connect sync failed with HTTP ${response?.status || 'unknown'}${errorText ? `: ${errorText.slice(0, 160)}` : ''}`);
+      error.code = 'unavailable';
+      throw error;
+    }
+    return await response.json();
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      const timeoutError = new Error('Sports Connect sync timed out.');
+      timeoutError.code = 'deadline-exceeded';
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    timeout.clear();
+  }
+}
+
+function getCandidateArray(payload = {}) {
+  const candidates = [
+    payload.players,
+    payload.rosterPlayers,
+    payload.roster,
+    payload.athletes,
+    payload.registrations,
+    payload.data?.players,
+    payload.data?.rosterPlayers,
+    payload.data?.roster,
+    payload.data?.athletes,
+    payload.data?.registrations
+  ];
+  return candidates.find(Array.isArray) || [];
+}
+
+function getName(record = {}) {
+  const directName = compactString(record.name || record.fullName || record.displayName || record.playerName || record.athleteName);
+  if (directName) return directName;
+  const firstName = compactString(record.firstName || record.givenName || record.player?.firstName || record.athlete?.firstName);
+  const lastName = compactString(record.lastName || record.familyName || record.player?.lastName || record.athlete?.lastName);
+  return [firstName, lastName].filter(Boolean).join(' ');
+}
+
+function getExternalPlayerId(record = {}) {
+  return compactString(
+    record.externalPlayerId ||
+    record.playerId ||
+    record.athleteId ||
+    record.personId ||
+    record.id ||
+    record.player?.id ||
+    record.athlete?.id ||
+    record.registrationId
+  );
+}
+
+function normalizeContacts(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((contact) => ({
+      name: compactString(contact.name || contact.fullName || contact.displayName),
+      email: compactString(contact.email || contact.emailAddress).toLowerCase(),
+      phone: compactString(contact.phone || contact.phoneNumber || contact.mobilePhone),
+      relation: compactString(contact.relation || contact.relationship || contact.type)
+    }))
+    .filter((contact) => contact.name || contact.email || contact.phone || contact.relation);
+}
+
+function normalizeSportsConnectPlayer(record = {}) {
+  const player = record.player && typeof record.player === 'object' ? record.player : {};
+  const athlete = record.athlete && typeof record.athlete === 'object' ? record.athlete : {};
+  const merged = { ...record, ...player, ...athlete };
+  const externalPlayerId = getExternalPlayerId(merged);
+  const name = getName(merged);
+  if (!externalPlayerId || !name) return null;
+
+  const output = {
+    externalPlayerId,
+    name,
+    number: compactString(merged.number || merged.jerseyNumber || merged.jersey || merged.uniformNumber),
+    active: merged.active === false ? false : true
+  };
+  const guardians = normalizeContacts(merged.guardians || merged.parents || merged.familyContacts);
+  const contacts = normalizeContacts(merged.contacts || merged.contactFields);
+  if (guardians.length) output.guardians = guardians;
+  if (contacts.length) output.contacts = contacts;
+
+  const answers = merged.answers || merged.customFields || merged.profileFields || merged.formData || merged.submittedData;
+  if (answers && typeof answers === 'object' && !Array.isArray(answers)) {
+    output.answers = answers;
+  }
+  return output;
+}
+
+function buildSportsConnectRegistrationSnapshot(payload = {}, { externalTeamId, fetchedAt = new Date().toISOString() } = {}) {
+  const players = getCandidateArray(payload)
+    .map(normalizeSportsConnectPlayer)
+    .filter(Boolean);
+  return {
+    provider: 'Sports Connect',
+    providerId: 'sports-connect',
+    sourceType: 'sports-connect',
+    sourceId: compactString(payload.sourceId || payload.id || externalTeamId || 'sports-connect'),
+    externalTeamId: compactString(payload.externalTeamId || payload.teamId || externalTeamId),
+    externalTeamName: compactString(payload.teamName || payload.name || payload.externalTeamName),
+    fetchedAt,
+    rosterPlayers: players,
+    players,
+    playerCount: players.length
+  };
+}
+
+function buildSportsConnectTeamUpdate({
+  existingSource = {},
+  snapshot,
+  nowIso = new Date().toISOString()
+} = {}) {
+  const playerCount = Number(snapshot?.playerCount || snapshot?.players?.length || 0);
+  const registrationSource = {
+    ...existingSource,
+    provider: 'Sports Connect',
+    providerId: 'sports-connect',
+    externalTeamId: snapshot.externalTeamId,
+    teamId: existingSource.teamId || null,
+    connectionStatus: 'sync_success',
+    syncEnabled: true,
+    lastSyncStatus: 'success',
+    lastSyncAt: nowIso,
+    lastSyncError: null,
+    playerCount
+  };
+  return {
+    registrationSource,
+    registrationSourceSnapshot: {
+      ...snapshot,
+      rosterPlayers: snapshot.players
+    },
+    registrationRosterSnapshot: snapshot
+  };
+}
+
+function buildSportsConnectSyncErrorUpdate(existingSource = {}, message, nowIso = new Date().toISOString()) {
+  return {
+    registrationSource: {
+      ...existingSource,
+      connectionStatus: 'sync_error',
+      syncEnabled: true,
+      lastSyncStatus: 'error',
+      lastSyncAt: nowIso,
+      lastSyncError: compactString(message).slice(0, 500) || 'Sports Connect sync failed.'
+    }
+  };
+}
+
+module.exports = {
+  buildSportsConnectRegistrationSnapshot,
+  buildSportsConnectRegistrationUrl,
+  buildSportsConnectSyncErrorUpdate,
+  buildSportsConnectTeamUpdate,
+  fetchSportsConnectRegistrationPayload,
+  getRegistrationSource,
+  getTeamSportsConnectConfig,
+  isSportsConnectProvider,
+  assertSportsConnectSyncConfig
+};

--- a/functions/sports-connect-registration-sync.cjs
+++ b/functions/sports-connect-registration-sync.cjs
@@ -148,59 +148,75 @@ async function fetchSportsConnectRegistrationPayload({
   }
 }
 
+function normalizeRecord(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
 function getCandidateArray(payload = {}) {
+  const source = normalizeRecord(payload);
+  const data = normalizeRecord(source.data);
   const candidates = [
-    payload.players,
-    payload.rosterPlayers,
-    payload.roster,
-    payload.athletes,
-    payload.registrations,
-    payload.data?.players,
-    payload.data?.rosterPlayers,
-    payload.data?.roster,
-    payload.data?.athletes,
-    payload.data?.registrations
+    source.players,
+    source.rosterPlayers,
+    source.roster,
+    source.athletes,
+    source.registrations,
+    data.players,
+    data.rosterPlayers,
+    data.roster,
+    data.athletes,
+    data.registrations
   ];
   return candidates.find(Array.isArray) || [];
 }
 
 function getName(record = {}) {
-  const directName = compactString(record.name || record.fullName || record.displayName || record.playerName || record.athleteName);
+  const source = normalizeRecord(record);
+  const player = normalizeRecord(source.player);
+  const athlete = normalizeRecord(source.athlete);
+  const directName = compactString(source.name || source.fullName || source.displayName || source.playerName || source.athleteName);
   if (directName) return directName;
-  const firstName = compactString(record.firstName || record.givenName || record.player?.firstName || record.athlete?.firstName);
-  const lastName = compactString(record.lastName || record.familyName || record.player?.lastName || record.athlete?.lastName);
+  const firstName = compactString(source.firstName || source.givenName || player.firstName || athlete.firstName);
+  const lastName = compactString(source.lastName || source.familyName || player.lastName || athlete.lastName);
   return [firstName, lastName].filter(Boolean).join(' ');
 }
 
 function getExternalPlayerId(record = {}) {
+  const source = normalizeRecord(record);
+  const player = normalizeRecord(source.player);
+  const athlete = normalizeRecord(source.athlete);
   return compactString(
-    record.externalPlayerId ||
-    record.playerId ||
-    record.athleteId ||
-    record.personId ||
-    record.id ||
-    record.player?.id ||
-    record.athlete?.id ||
-    record.registrationId
+    source.externalPlayerId ||
+    source.playerId ||
+    source.athleteId ||
+    source.personId ||
+    source.id ||
+    player.id ||
+    athlete.id ||
+    source.registrationId
   );
 }
 
 function normalizeContacts(value) {
   if (!Array.isArray(value)) return [];
   return value
-    .map((contact) => ({
-      name: compactString(contact.name || contact.fullName || contact.displayName),
-      email: compactString(contact.email || contact.emailAddress).toLowerCase(),
-      phone: compactString(contact.phone || contact.phoneNumber || contact.mobilePhone),
-      relation: compactString(contact.relation || contact.relationship || contact.type)
-    }))
+    .map((contact) => {
+      const source = normalizeRecord(contact);
+      return {
+        name: compactString(source.name || source.fullName || source.displayName),
+        email: compactString(source.email || source.emailAddress).toLowerCase(),
+        phone: compactString(source.phone || source.phoneNumber || source.mobilePhone),
+        relation: compactString(source.relation || source.relationship || source.type)
+      };
+    })
     .filter((contact) => contact.name || contact.email || contact.phone || contact.relation);
 }
 
 function normalizeSportsConnectPlayer(record = {}) {
-  const player = record.player && typeof record.player === 'object' ? record.player : {};
-  const athlete = record.athlete && typeof record.athlete === 'object' ? record.athlete : {};
-  const merged = { ...record, ...player, ...athlete };
+  const source = normalizeRecord(record);
+  const player = normalizeRecord(source.player);
+  const athlete = normalizeRecord(source.athlete);
+  const merged = { ...source, ...player, ...athlete };
   const externalPlayerId = getExternalPlayerId(merged);
   const name = getName(merged);
   if (!externalPlayerId || !name) return null;
@@ -224,16 +240,17 @@ function normalizeSportsConnectPlayer(record = {}) {
 }
 
 function buildSportsConnectRegistrationSnapshot(payload = {}, { externalTeamId, fetchedAt = new Date().toISOString() } = {}) {
-  const players = getCandidateArray(payload)
+  const source = normalizeRecord(payload);
+  const players = getCandidateArray(source)
     .map(normalizeSportsConnectPlayer)
     .filter(Boolean);
   return {
     provider: 'Sports Connect',
     providerId: 'sports-connect',
     sourceType: 'sports-connect',
-    sourceId: compactString(payload.sourceId || payload.id || externalTeamId || 'sports-connect'),
-    externalTeamId: compactString(payload.externalTeamId || payload.teamId || externalTeamId),
-    externalTeamName: compactString(payload.teamName || payload.name || payload.externalTeamName),
+    sourceId: compactString(source.sourceId || source.id || externalTeamId || 'sports-connect'),
+    externalTeamId: compactString(source.externalTeamId || source.teamId || externalTeamId),
+    externalTeamName: compactString(source.teamName || source.name || source.externalTeamName),
     fetchedAt,
     rosterPlayers: players,
     players,

--- a/functions/sports-connect-registration-sync.cjs
+++ b/functions/sports-connect-registration-sync.cjs
@@ -33,9 +33,7 @@ function getTeamSportsConnectConfig(team = {}, config = {}) {
   const endpointTemplate = compactString(
     config.endpointTemplate ||
     config.registrationSnapshotUrl ||
-    config.baseUrl ||
-    source.registrationSnapshotUrl ||
-    source.syncUrl
+    config.baseUrl
   );
   const accessToken = compactString(config.accessToken || config.token);
 
@@ -221,22 +219,12 @@ function normalizeSportsConnectPlayer(record = {}) {
   const name = getName(merged);
   if (!externalPlayerId || !name) return null;
 
-  const output = {
+  return {
     externalPlayerId,
     name,
     number: compactString(merged.number || merged.jerseyNumber || merged.jersey || merged.uniformNumber),
     active: merged.active === false ? false : true
   };
-  const guardians = normalizeContacts(merged.guardians || merged.parents || merged.familyContacts);
-  const contacts = normalizeContacts(merged.contacts || merged.contactFields);
-  if (guardians.length) output.guardians = guardians;
-  if (contacts.length) output.contacts = contacts;
-
-  const answers = merged.answers || merged.customFields || merged.profileFields || merged.formData || merged.submittedData;
-  if (answers && typeof answers === 'object' && !Array.isArray(answers)) {
-    output.answers = answers;
-  }
-  return output;
 }
 
 function buildSportsConnectRegistrationSnapshot(payload = {}, { externalTeamId, fetchedAt = new Date().toISOString() } = {}) {

--- a/js/db.js
+++ b/js/db.js
@@ -6004,6 +6004,12 @@ export async function sendTeamEmail(teamId, {
     return result.data;
 }
 
+export async function syncRegistrationProvider(teamId) {
+    const callable = httpsCallable(functions, 'syncRegistrationProvider');
+    const result = await callable({ teamId });
+    return result.data;
+}
+
 export async function postSharedGameCancellationNotification({
     teamId,
     gameId,

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -78,6 +78,14 @@ export async function getRegistrationSources() {
     return [];
 }
 
+export async function syncRegistrationProvider() {
+    return {
+        importedCount: 0,
+        players: [],
+        registrationSource: null
+    };
+}
+
 export async function inviteAdmin(teamId, email) {
     window.__lastAdminInvite = { teamId, email };
     return {

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -1177,7 +1177,7 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('registration-connection-status').textContent).toBe('Ready for manual sync');
             expect(env.elements.get('registration-sync-status').textContent).toBe('Ready for manual sync');
             expect(env.elements.get('registration-connection-help').textContent).toContain('backend');
-            expect(env.elements.get('registration-refresh-btn').disabled).toBe(false);
+            expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
 
             await env.elements.get('team-form').requestSubmit();
 

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -351,8 +351,8 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getAllUsers,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?(?:,\s*getRegistrationSources)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
-            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources } = deps.db;'
+            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getAllUsers,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?(?:,\s*getRegistrationSources)?(?:,\s*syncRegistrationProvider)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
+            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } = deps.db;'
         )
         .replace(
             "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';",
@@ -481,6 +481,9 @@ async function bootEditTeam(initialState, overrides = {}, dependencyOverrides = 
             },
             async getRegistrationSources() {
                 return [];
+            },
+            async syncRegistrationProvider() {
+                return { synced: false };
             }
         },
         utils: {
@@ -627,7 +630,7 @@ describe('edit team admin access persistence', () => {
         expect(html.indexOf('id="teamColorPrimary"')).toBeGreaterThan(advancedIndex);
         expect(html.indexOf('id="registrationProviderName"')).toBeGreaterThan(advancedIndex);
         expect(html).toContain('Registration Provider Connection');
-        expect(html).toContain('No provider login, sync job, or network call runs from these fields.');
+        expect(html).toContain('Saved Sports Connect mappings can run a backend manual sync that fetches a roster snapshot for import.');
         expect(html).toContain('id="team-create-mode-registration"');
         expect(html).toContain('No registration sources are configured yet. Start with a blank team or load provider data before using this import path.');
         expect(html).toContain('registrationMode.setAttribute(\'aria-disabled\', String(registrationMode.disabled));');
@@ -1108,11 +1111,11 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('registrationProviderName').value).toBe('Sports Connect');
             expect(env.elements.get('registrationExternalTeamId').value).toBe('SC-123');
             expect(env.elements.get('registrationCopiedTeamId').value).toBe('team-1');
-            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Sports Connect metadata only. No live sync.');
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata only. No live sync.');
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Sports Connect metadata only. No live sync.');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Ready for manual sync');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Ready for manual sync');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Ready for manual sync');
             expect(env.elements.get('registration-sync-time').textContent).toContain('2026');
-            expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
+            expect(env.elements.get('registration-refresh-btn').disabled).toBe(false);
 
             env.elements.get('registrationProviderName').value = 'League Apps';
             env.elements.get('registrationExternalTeamId').value = 'LA-456';
@@ -1170,11 +1173,11 @@ describe('edit team admin access persistence', () => {
             env.elements.get('registrationExternalTeamId').value = 'SC-987';
             await env.elements.get('registrationProviderName').dispatchEvent(new MockEvent('change'));
 
-            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Sports Connect metadata only. No live sync.');
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata only. No live sync.');
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Sports Connect metadata only. No live sync.');
-            expect(env.elements.get('registration-connection-help').textContent).toContain('metadata only');
-            expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Ready for manual sync');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Ready for manual sync');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Ready for manual sync');
+            expect(env.elements.get('registration-connection-help').textContent).toContain('backend');
+            expect(env.elements.get('registration-refresh-btn').disabled).toBe(false);
 
             await env.elements.get('team-form').requestSubmit();
 
@@ -1184,8 +1187,8 @@ describe('edit team admin access persistence', () => {
                 externalTeamId: 'SC-987',
                 teamId: 'team-1',
                 connectionStatus: 'metadata_configured',
-                syncEnabled: false,
-                lastSyncStatus: 'Sports Connect metadata only. No live sync.'
+                syncEnabled: true,
+                lastSyncStatus: 'Ready for manual sync'
             });
         } finally {
             env.cleanup();

--- a/tests/unit/edit-team-registration-import.test.js
+++ b/tests/unit/edit-team-registration-import.test.js
@@ -30,7 +30,7 @@ describe('edit team registration import', () => {
         expect(source).toContain('externalTeamName: selectedRegistrationTeam.externalTeamName');
     });
 
-    it('adds editable registration provider fields without live provider calls', () => {
+    it('adds editable registration provider fields and documents manual sync behavior', () => {
         const source = readRepoFile('edit-team.html');
 
         expect(source).toContain('Registration Provider Connection');
@@ -38,7 +38,8 @@ describe('edit team registration import', () => {
         expect(source).toContain('registrationExternalTeamId');
         expect(source).toContain('registrationCopiedTeamId');
         expect(source).toContain('registrationLastSyncStatus');
-        expect(source).toContain('No provider login, sync job, or network call runs from these fields');
+        expect(source).toContain('Selecting Sports Connect enables a backend manual sync after this team is saved.');
+        expect(source).toContain('Save a Sports Connect provider mapping, then sync a roster snapshot for import.');
     });
 
     it('renders registration provider metadata on the team page', () => {

--- a/tests/unit/edit-team-registration-sync.test.js
+++ b/tests/unit/edit-team-registration-sync.test.js
@@ -28,7 +28,9 @@ describe('edit team Sports Connect registration sync wiring', () => {
         expect(source).toContain('id="registration-refresh-btn"');
         expect(source).toContain('function handleRegistrationProviderSync()');
         expect(source).toContain('await syncRegistrationProvider(currentTeamId)');
-        expect(source).toContain('Sync now fetches Sports Connect data through the backend');
+        expect(source).toContain('function hasUnsavedRegistrationSyncChanges(provider, externalTeamId)');
+        expect(source).toContain('Save the updated Sports Connect mapping before running sync.');
+        expect(source).toContain('const canSyncSportsConnect = Boolean(currentTeamId && isSportsConnectProvider(provider) && externalTeamId && !hasUnsavedSyncChanges);');
         expect(source).toContain('syncEnabled: isSportsConnectProvider(provider) && !!externalTeamId');
         expect(source).toContain('Open roster import to preview changes.');
         expect(source).not.toContain('Manual refresh unavailable');
@@ -37,5 +39,6 @@ describe('edit team Sports Connect registration sync wiring', () => {
         expect(functionsSource).toContain('exports.syncRegistrationProvider = functions.https.onCall');
         expect(functionsSource).toContain('buildSportsConnectTeamUpdate');
         expect(coreSource).toContain('registrationRosterSnapshot');
+        expect(coreSource).not.toContain('source.syncUrl');
     });
 });

--- a/tests/unit/edit-team-registration-sync.test.js
+++ b/tests/unit/edit-team-registration-sync.test.js
@@ -29,7 +29,7 @@ describe('edit team Sports Connect registration sync wiring', () => {
         expect(source).toContain('function handleRegistrationProviderSync()');
         expect(source).toContain('await syncRegistrationProvider(currentTeamId)');
         expect(source).toContain('function hasUnsavedRegistrationSyncChanges(provider, externalTeamId)');
-        expect(source).toContain('Save the updated Sports Connect mapping before running sync.');
+        expect(source).toContain('Save the updated Sports Connect mapping before running backend sync.');
         expect(source).toContain('const canSyncSportsConnect = Boolean(currentTeamId && isSportsConnectProvider(provider) && externalTeamId && !hasUnsavedSyncChanges);');
         expect(source).toContain('syncEnabled: isSportsConnectProvider(provider) && !!externalTeamId');
         expect(source).toContain('Open roster import to preview changes.');

--- a/tests/unit/edit-team-registration-sync.test.js
+++ b/tests/unit/edit-team-registration-sync.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readEditTeam() {
+    return readFileSync(new URL('../../edit-team.html', import.meta.url), 'utf8');
+}
+
+function readDb() {
+    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+}
+
+function readFunctions() {
+    return readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+}
+
+function readSportsConnectSyncCore() {
+    return readFileSync(new URL('../../functions/sports-connect-registration-sync.cjs', import.meta.url), 'utf8');
+}
+
+describe('edit team Sports Connect registration sync wiring', () => {
+    it('enables manual sync for saved Sports Connect mappings through a callable wrapper', () => {
+        const source = readEditTeam();
+        const dbSource = readDb();
+        const functionsSource = readFunctions();
+        const coreSource = readSportsConnectSyncCore();
+
+        expect(source).toContain('syncRegistrationProvider } from');
+        expect(source).toContain('id="registration-refresh-btn"');
+        expect(source).toContain('function handleRegistrationProviderSync()');
+        expect(source).toContain('await syncRegistrationProvider(currentTeamId)');
+        expect(source).toContain('Sync now fetches Sports Connect data through the backend');
+        expect(source).toContain('syncEnabled: isSportsConnectProvider(provider) && !!externalTeamId');
+        expect(source).toContain('Open roster import to preview changes.');
+        expect(source).not.toContain('Manual refresh unavailable');
+
+        expect(dbSource).toContain("httpsCallable(functions, 'syncRegistrationProvider')");
+        expect(functionsSource).toContain('exports.syncRegistrationProvider = functions.https.onCall');
+        expect(functionsSource).toContain('buildSportsConnectTeamUpdate');
+        expect(coreSource).toContain('registrationRosterSnapshot');
+    });
+});

--- a/tests/unit/sports-connect-registration-sync.test.js
+++ b/tests/unit/sports-connect-registration-sync.test.js
@@ -1,0 +1,140 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+    assertSportsConnectSyncConfig,
+    buildSportsConnectRegistrationSnapshot,
+    buildSportsConnectRegistrationUrl,
+    buildSportsConnectSyncErrorUpdate,
+    buildSportsConnectTeamUpdate,
+    fetchSportsConnectRegistrationPayload,
+    getTeamSportsConnectConfig
+} = require('../../functions/sports-connect-registration-sync.cjs');
+
+describe('Sports Connect registration sync core', () => {
+    it('builds a configured endpoint URL and fetches a registration snapshot with credentials', async () => {
+        const fetchImpl = vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                externalTeamId: 'sc-team-1',
+                teamName: 'Bears 12U',
+                players: [
+                    {
+                        id: 'athlete-1',
+                        firstName: 'Avery',
+                        lastName: 'Lee',
+                        jerseyNumber: '4',
+                        guardians: [{ name: 'Pat Lee', email: 'PAT@example.com', relation: 'Parent' }],
+                        customFields: { Grade: '6' }
+                    }
+                ]
+            })
+        });
+
+        const payload = await fetchSportsConnectRegistrationPayload({
+            endpointTemplate: 'https://sports.example.test/api/{externalTeamId}/snapshot',
+            externalTeamId: 'sc-team-1',
+            accessToken: 'secret-token',
+            fetchImpl
+        });
+        const snapshot = buildSportsConnectRegistrationSnapshot(payload, {
+            externalTeamId: 'sc-team-1',
+            fetchedAt: '2026-06-20T12:00:00.000Z'
+        });
+        const update = buildSportsConnectTeamUpdate({
+            existingSource: { provider: 'Sports Connect', externalTeamId: 'sc-team-1' },
+            snapshot,
+            nowIso: '2026-06-20T12:00:00.000Z'
+        });
+
+        expect(fetchImpl).toHaveBeenCalledWith('https://sports.example.test/api/sc-team-1/snapshot', expect.objectContaining({
+            method: 'GET',
+            headers: expect.objectContaining({
+                Authorization: 'Bearer secret-token',
+                Accept: 'application/json'
+            })
+        }));
+        expect(snapshot).toMatchObject({
+            provider: 'Sports Connect',
+            providerId: 'sports-connect',
+            externalTeamId: 'sc-team-1',
+            externalTeamName: 'Bears 12U',
+            playerCount: 1,
+            players: [
+                {
+                    externalPlayerId: 'athlete-1',
+                    name: 'Avery Lee',
+                    number: '4',
+                    guardians: [{ name: 'Pat Lee', email: 'pat@example.com', phone: '', relation: 'Parent' }],
+                    answers: { Grade: '6' }
+                }
+            ]
+        });
+        expect(update).toMatchObject({
+            registrationSource: {
+                provider: 'Sports Connect',
+                providerId: 'sports-connect',
+                externalTeamId: 'sc-team-1',
+                syncEnabled: true,
+                lastSyncStatus: 'success',
+                playerCount: 1
+            },
+            registrationRosterSnapshot: {
+                players: [{ externalPlayerId: 'athlete-1' }]
+            },
+            registrationSourceSnapshot: {
+                rosterPlayers: [{ externalPlayerId: 'athlete-1' }]
+            }
+        });
+    });
+
+    it('derives team config from saved Sports Connect metadata and requires backend credentials', () => {
+        const config = getTeamSportsConnectConfig(
+            { registrationSource: { provider: 'Sports Connect', externalTeamId: 'league-team-9' } },
+            { baseUrl: 'https://sports.example.test/export', accessToken: '' }
+        );
+
+        expect(config).toMatchObject({
+            provider: 'Sports Connect',
+            providerId: 'sports-connect',
+            externalTeamId: 'league-team-9',
+            endpointTemplate: 'https://sports.example.test/export',
+            accessToken: ''
+        });
+        expect(() => assertSportsConnectSyncConfig(config)).toThrow('credentials are not configured');
+    });
+
+    it('rejects invalid teams, failed network responses, and records concise error state', async () => {
+        expect(() => assertSportsConnectSyncConfig({
+            provider: 'League Apps',
+            externalTeamId: 'team-1',
+            endpointTemplate: 'https://sports.example.test/export',
+            accessToken: 'token'
+        })).toThrow('Sports Connect must be selected');
+
+        await expect(fetchSportsConnectRegistrationPayload({
+            endpointTemplate: 'https://sports.example.test/export',
+            externalTeamId: 'team-1',
+            accessToken: 'token',
+            fetchImpl: vi.fn().mockResolvedValue({
+                ok: false,
+                status: 503,
+                text: async () => 'maintenance'
+            })
+        })).rejects.toThrow('HTTP 503');
+
+        expect(buildSportsConnectRegistrationUrl('https://sports.example.test/export', 'team 1'))
+            .toBe('https://sports.example.test/export/teams/team%201/registration-snapshot');
+        expect(buildSportsConnectSyncErrorUpdate({ provider: 'Sports Connect' }, 'Provider unavailable', '2026-06-20T12:00:00.000Z'))
+            .toMatchObject({
+                registrationSource: {
+                    provider: 'Sports Connect',
+                    syncEnabled: true,
+                    lastSyncStatus: 'error',
+                    lastSyncError: 'Provider unavailable'
+                }
+            });
+    });
+});

--- a/tests/unit/sports-connect-registration-sync.test.js
+++ b/tests/unit/sports-connect-registration-sync.test.js
@@ -137,4 +137,41 @@ describe('Sports Connect registration sync core', () => {
                 }
             });
     });
+
+    it('ignores malformed payload and contact entries instead of crashing the sync snapshot builder', () => {
+        expect(buildSportsConnectRegistrationSnapshot(null, {
+            externalTeamId: 'sc-team-1',
+            fetchedAt: '2026-06-20T12:00:00.000Z'
+        })).toMatchObject({
+            externalTeamId: 'sc-team-1',
+            playerCount: 0,
+            players: []
+        });
+
+        expect(buildSportsConnectRegistrationSnapshot({
+            externalTeamId: 'sc-team-2',
+            players: [
+                null,
+                {
+                    id: 'athlete-2',
+                    firstName: 'Jamie',
+                    lastName: 'Fox',
+                    guardians: [null, { emailAddress: 'guardian@example.com' }]
+                }
+            ]
+        }, {
+            externalTeamId: 'sc-team-2',
+            fetchedAt: '2026-06-20T12:00:00.000Z'
+        })).toMatchObject({
+            externalTeamId: 'sc-team-2',
+            playerCount: 1,
+            players: [
+                {
+                    externalPlayerId: 'athlete-2',
+                    name: 'Jamie Fox',
+                    guardians: [{ name: '', email: 'guardian@example.com', phone: '', relation: '' }]
+                }
+            ]
+        });
+    });
 });

--- a/tests/unit/sports-connect-registration-sync.test.js
+++ b/tests/unit/sports-connect-registration-sync.test.js
@@ -66,12 +66,13 @@ describe('Sports Connect registration sync core', () => {
                 {
                     externalPlayerId: 'athlete-1',
                     name: 'Avery Lee',
-                    number: '4',
-                    guardians: [{ name: 'Pat Lee', email: 'pat@example.com', phone: '', relation: 'Parent' }],
-                    answers: { Grade: '6' }
+                    number: '4'
                 }
             ]
         });
+        expect(snapshot.players[0]).not.toHaveProperty('guardians');
+        expect(snapshot.players[0]).not.toHaveProperty('contacts');
+        expect(snapshot.players[0]).not.toHaveProperty('answers');
         expect(update).toMatchObject({
             registrationSource: {
                 provider: 'Sports Connect',
@@ -92,7 +93,13 @@ describe('Sports Connect registration sync core', () => {
 
     it('derives team config from saved Sports Connect metadata and requires backend credentials', () => {
         const config = getTeamSportsConnectConfig(
-            { registrationSource: { provider: 'Sports Connect', externalTeamId: 'league-team-9' } },
+            {
+                registrationSource: {
+                    provider: 'Sports Connect',
+                    externalTeamId: 'league-team-9',
+                    syncUrl: 'https://attacker.example.test/steal-token'
+                }
+            },
             { baseUrl: 'https://sports.example.test/export', accessToken: '' }
         );
 
@@ -103,6 +110,7 @@ describe('Sports Connect registration sync core', () => {
             endpointTemplate: 'https://sports.example.test/export',
             accessToken: ''
         });
+        expect(config.endpointTemplate).not.toContain('attacker.example.test');
         expect(() => assertSportsConnectSyncConfig(config)).toThrow('credentials are not configured');
     });
 
@@ -138,7 +146,7 @@ describe('Sports Connect registration sync core', () => {
             });
     });
 
-    it('ignores malformed payload and contact entries instead of crashing the sync snapshot builder', () => {
+    it('ignores malformed payload instead of crashing the sync snapshot builder', () => {
         expect(buildSportsConnectRegistrationSnapshot(null, {
             externalTeamId: 'sc-team-1',
             fetchedAt: '2026-06-20T12:00:00.000Z'
@@ -168,8 +176,7 @@ describe('Sports Connect registration sync core', () => {
             players: [
                 {
                     externalPlayerId: 'athlete-2',
-                    name: 'Jamie Fox',
-                    guardians: [{ name: '', email: 'guardian@example.com', phone: '', relation: '' }]
+                    name: 'Jamie Fox'
                 }
             ]
         });


### PR DESCRIPTION
## Summary
- add a callable Sports Connect registration sync endpoint for team admins
- fetch and normalize roster snapshots into registrationRosterSnapshot/registrationSourceSnapshot for the existing roster importer
- enable edit-team manual sync state, success/error display, and a db.js callable wrapper

Closes #2246

## Tests
- npx vitest run tests/unit/sports-connect-registration-sync.test.js tests/unit/edit-team-registration-sync.test.js tests/unit/edit-roster-registration-import.test.js --reporter=verbose
- node --check functions/index.js
- node --check functions/sports-connect-registration-sync.cjs