### PR TITLE
Mark app live scores final

### DIFF
--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3101,6 +3101,38 @@ export async function updateGameScore(teamId: string, gameId: string, score: Gam
   return payload;
 }
 
+export async function markLiveGameFinalForApp(teamId: string, gameId: string, score: GameScoreInput, user: AuthUser) {
+  if (!teamId || !gameId) {
+    throw new Error('A scheduled game is required before marking a final score.');
+  }
+  if (!user?.uid) {
+    throw new Error('Sign in before marking a final score.');
+  }
+
+  const finalizedAt = new Date();
+  const payload: Record<string, unknown> = {
+    homeScore: normalizeGameScoreValue(score.homeScore),
+    awayScore: normalizeGameScoreValue(score.awayScore),
+    status: 'completed',
+    liveStatus: 'completed',
+    liveClockRunning: false,
+    scoreUpdatedAt: finalizedAt,
+    scoreUpdatedBy: user.uid,
+    liveEndedAt: finalizedAt,
+    liveEndedBy: user.uid
+  };
+
+  try {
+    await withTimeout(Promise.resolve(updateGame(teamId, gameId, payload)), 'Final score save');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    logScheduleWarning('Falling back to REST final score save.', 'game-final-score-save', error, { fallback: 'rest', teamId, gameId });
+    await nativePatchDocument(`teams/${encodeURIComponent(teamId)}/games/${encodeURIComponent(gameId)}`, payload);
+  }
+
+  return payload;
+}
+
 export async function completeGameWrapupForApp(teamId: string, gameId: string, payload: Record<string, unknown>, user: AuthUser) {
   if (!teamId || !gameId) {
     throw new Error('A scheduled game is required before completing wrap-up.');

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -18,6 +18,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   loadStaffScheduleRsvpBreakdown: vi.fn(),
   loadStaffRsvpReminderPreview: vi.fn(),
   loadAutoFilledLineupDraftPreviewForApp: vi.fn<(...args: any[]) => Promise<any>>(() => Promise.resolve({ availablePlayers: [] as any[], goingPlayers: [] as any[], gamePlan: null as any })),
+  markLiveGameFinalForApp: vi.fn(),
   markParentPracticePacketComplete: vi.fn(),
   publishGamePlanForApp: vi.fn(),
   releaseParentScheduleAssignmentClaim: vi.fn(),

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -23,6 +23,7 @@ import {
   sendStaffRsvpReminder,
   submitStaffScheduleRsvpOverride,
   loadHomeScoringPlayers,
+  markLiveGameFinalForApp,
   publishLiveScoreUpdateEvent,
   recordPlayerGameStat,
   recordPlayerScoringStat,
@@ -154,6 +155,7 @@ export { getAvailabilityNoteSaveState } from '../components/schedule/Availabilit
 
 type EventDetailSectionId = ScheduleEventDetailSectionId;
 type GameReportSectionId = 'summary' | 'players' | 'plays' | 'opponent' | 'insights' | 'media';
+type ScoreUpdateMetadata = Partial<Pick<ParentScheduleEvent, 'status' | 'liveStatus' | 'liveClockRunning'>>;
 
 const eventDetailSectionIds = new Set<EventDetailSectionId>(['availability', 'rideshare', 'assignments', 'game']);
 
@@ -439,10 +441,10 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     )));
   }, [decodedEventId, decodedTeamId]);
 
-  const handleScoreUpdated = useCallback((homeScore: number, awayScore: number) => {
+  const handleScoreUpdated = useCallback((homeScore: number, awayScore: number, metadata: ScoreUpdateMetadata = {}) => {
     setEvents((current) => current.map((event) => (
       event.teamId === decodedTeamId && event.id === decodedEventId
-        ? { ...event, homeScore, awayScore }
+        ? { ...event, homeScore, awayScore, ...metadata }
         : event
     )));
   }, [decodedEventId, decodedTeamId]);
@@ -1997,7 +1999,7 @@ function LazyGameHubPanel({
   );
 }
 
-function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockUpdated, onWrapupCompleted, onStatsheetImported, onGameCancelled, onPracticeOccurrenceCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onLiveClockUpdated: (payload: Partial<ParentScheduleEvent> & { period?: string | null }) => void; onWrapupCompleted: (payload: { homeScore: number; awayScore: number; postGameNotes: string; summary: string; practiceFeedItems: PracticeFeedItem[] }) => void; onStatsheetImported: (payload: { homeScore: number; awayScore: number; statSheetPhotoUrl?: string | null }) => void; onGameCancelled: () => void; onPracticeOccurrenceCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
+function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockUpdated, onWrapupCompleted, onStatsheetImported, onGameCancelled, onPracticeOccurrenceCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number, metadata?: ScoreUpdateMetadata) => void; onLiveClockUpdated: (payload: Partial<ParentScheduleEvent> & { period?: string | null }) => void; onWrapupCompleted: (payload: { homeScore: number; awayScore: number; postGameNotes: string; summary: string; practiceFeedItems: PracticeFeedItem[] }) => void; onStatsheetImported: (payload: { homeScore: number; awayScore: number; statSheetPhotoUrl?: string | null }) => void; onGameCancelled: () => void; onPracticeOccurrenceCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
@@ -3453,7 +3455,7 @@ function getBonusState(teamFouls: number) {
   };
 }
 
-function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; event: ParentScheduleEvent; onScoreUpdated: (homeScore: number, awayScore: number) => void }) {
+function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; event: ParentScheduleEvent; onScoreUpdated: (homeScore: number, awayScore: number, metadata?: ScoreUpdateMetadata) => void }) {
   const savedHomeScore = Math.max(0, Number(event.homeScore ?? 0));
   const savedAwayScore = Math.max(0, Number(event.awayScore ?? 0));
   const [homeScore, setHomeScore] = useState(savedHomeScore);
@@ -3506,8 +3508,10 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
     };
   }, [event.teamId, event.id, event.eventKey]);
 
+  const isCompleted = String(event.liveStatus || event.status || '').trim().toLowerCase() === 'completed';
   const dirty = homeScore !== savedHomeScore || awayScore !== savedAwayScore;
   const adjust = (side: 'home' | 'away', delta: number) => {
+    if (isCompleted) return;
     const nextHomeScore = side === 'home' ? Math.max(0, homeScore + delta) : homeScore;
     const nextAwayScore = side === 'away' ? Math.max(0, awayScore + delta) : awayScore;
     if (nextHomeScore === homeScore && nextAwayScore === awayScore) return;
@@ -3557,8 +3561,48 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
     }
   };
 
+  const markFinalScore = async () => {
+    if (!auth.user) return;
+    const previousScore = { homeScore: savedHomeScore, awayScore: savedAwayScore };
+    setSaving(true);
+    setStatus(null);
+    let livePublishFailed = false;
+    try {
+      if (homeScore !== previousScore.homeScore || awayScore !== previousScore.awayScore) {
+        try {
+          await publishLiveScoreUpdateEvent(event.teamId, event.id, { homeScore, awayScore }, auth.user, previousScore);
+        } catch (publishError) {
+          livePublishFailed = true;
+          console.warn('[schedule-event-detail] Final score saved but live play-by-play posting failed:', publishError);
+        }
+      }
+      const payload = await markLiveGameFinalForApp(event.teamId, event.id, { homeScore, awayScore }, auth.user);
+      const nextHomeScore = Number(payload.homeScore ?? homeScore);
+      const nextAwayScore = Number(payload.awayScore ?? awayScore);
+      pendingLocalSaveRef.current = { homeScore: nextHomeScore, awayScore: nextAwayScore };
+      setHomeScore(nextHomeScore);
+      setAwayScore(nextAwayScore);
+      setPreviousScoreSnapshots([]);
+      onScoreUpdated(nextHomeScore, nextAwayScore, {
+        status: 'completed',
+        liveStatus: 'completed',
+        liveClockRunning: false
+      });
+      setStatus({
+        tone: 'success',
+        message: livePublishFailed
+          ? 'Final score saved. Live play-by-play post failed.'
+          : 'Final score saved and game marked complete.'
+      });
+    } catch (error: any) {
+      setStatus({ tone: 'error', message: error?.message || 'Unable to mark final score.' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
   const recordPlayerTwo = async (player: ScheduleHomeScoringPlayer) => {
-    if (!auth.user || saving || playerScoringId || dirty) return;
+    if (!auth.user || saving || playerScoringId || dirty || isCompleted) return;
     setPlayerScoringId(player.id);
     setStatus(null);
     try {
@@ -3595,8 +3639,8 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
         <div className="rounded-full bg-white px-3 py-1 text-xl font-black tabular-nums text-gray-950 shadow-sm">{homeScore}-{awayScore}</div>
       </div>
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
-        <ScoreStepper label="Home" value={homeScore} onDecrease={() => adjust('home', -1)} onIncrease={() => adjust('home', 1)} disabled={saving || Boolean(playerScoringId)} />
-        <ScoreStepper label="Away" value={awayScore} onDecrease={() => adjust('away', -1)} onIncrease={() => adjust('away', 1)} disabled={saving || Boolean(playerScoringId)} />
+        <ScoreStepper label="Home" value={homeScore} onDecrease={() => adjust('home', -1)} onIncrease={() => adjust('home', 1)} disabled={saving || Boolean(playerScoringId) || isCompleted} />
+        <ScoreStepper label="Away" value={awayScore} onDecrease={() => adjust('away', -1)} onIncrease={() => adjust('away', 1)} disabled={saving || Boolean(playerScoringId) || isCompleted} />
       </div>
       <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3">
         <div className="flex items-center justify-between gap-2">
@@ -3617,7 +3661,7 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
                   type="button"
                   className="flex min-h-11 items-center justify-between gap-2 rounded-xl border border-gray-200 px-3 text-left text-sm font-black text-gray-900 disabled:opacity-50"
                   onClick={() => recordPlayerTwo(player)}
-                  disabled={saving || Boolean(playerScoringId) || dirty}
+                  disabled={saving || Boolean(playerScoringId) || dirty || isCompleted}
                   aria-label={`${label} plus 2 points`}
                 >
                   <span className="min-w-0 truncate">{label}</span>
@@ -3635,9 +3679,17 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
             type="button"
             className="primary-button min-h-11 px-4 text-sm"
             onClick={saveScore}
-            disabled={saving || Boolean(playerScoringId) || !dirty}
+            disabled={saving || Boolean(playerScoringId) || !dirty || isCompleted}
           >
             {saving ? 'Saving score' : 'Save score'}
+          </button>
+          <button
+            type="button"
+            className="secondary-button min-h-11 px-4 text-sm"
+            onClick={markFinalScore}
+            disabled={saving || Boolean(playerScoringId) || isCompleted}
+          >
+            {isCompleted ? 'Final' : saving ? 'Saving final' : 'Mark final'}
           </button>
           {previousScoreSnapshots.length ? (
             <button

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -473,6 +473,18 @@ async function mockScheduleModules(page, options = {}) {
                     return { type: 'score_update', ...payload };
                 }
 
+                export async function markLiveGameFinalForApp(teamId, gameId, score, user) {
+                    const payload = {
+                        homeScore: Number(score?.homeScore ?? 0),
+                        awayScore: Number(score?.awayScore ?? 0),
+                        status: 'completed',
+                        liveStatus: 'completed',
+                        finalizedBy: user?.uid || null
+                    };
+                    window.__scheduleCalls.finalScoreUpdates = (window.__scheduleCalls.finalScoreUpdates || []).concat({ teamId, gameId, payload });
+                    return payload;
+                }
+
                 export function buildLiveGameClockPeriods(game = {}) {
                     const requested = String(game?.liveClockPeriod || game?.period || '').trim();
                     return requested ? [requested, 'H2'].filter((period, index, list) => list.indexOf(period) === index) : ['H1', 'H2'];

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -16,6 +16,7 @@ const scheduleMocks = vi.hoisted(() => ({
     loadHomeScoringPlayers: vi.fn().mockResolvedValue([]),
     loadAutoFilledLineupDraftPreviewForApp: vi.fn(),
     loadGameDayLiveEventsForApp: vi.fn().mockResolvedValue([]),
+    markLiveGameFinalForApp: vi.fn(),
     buildLiveGameClockPeriods: vi.fn((game) => {
         const activePeriod = String(game?.liveClockPeriod || game?.period || '').trim();
         return activePeriod ? [activePeriod] : ['H1', 'H2'];
@@ -225,6 +226,7 @@ beforeEach(() => {
     });
     scheduleMocks.updateGameScore.mockResolvedValue({ homeScore: 5, awayScore: 2, scoreUpdatedAt: new Date('2026-05-25T08:00:00Z'), scoreUpdatedBy: 'user-1' });
     scheduleMocks.publishLiveScoreUpdateEvent.mockResolvedValue({ type: 'score_update', homeScore: 5, awayScore: 2 });
+    scheduleMocks.markLiveGameFinalForApp.mockResolvedValue({ homeScore: 5, awayScore: 2, status: 'completed', liveStatus: 'completed', liveClockRunning: false });
     scheduleMocks.markParentPracticePacketComplete.mockResolvedValue({
         id: 'user-1__player-1',
         parentUserId: 'user-1',
@@ -824,6 +826,37 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'Score saved. Live play-by-play post failed.');
         expect(container.textContent).toContain('4-3');
         expect(container.textContent).toContain('Saved score controls');
+    });
+
+    it('marks a live score final from the quick score controls', async () => {
+        scheduleMocks.markLiveGameFinalForApp.mockResolvedValue({ homeScore: 5, awayScore: 2, status: 'completed', liveStatus: 'completed', liveClockRunning: false });
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ homeScore: 4, awayScore: 2, liveStatus: 'live', status: 'live', canUpdateScore: true })]
+        });
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Live score');
+
+        await clickButton(container, 'Home score up');
+        await clickButton(container, 'Mark final');
+
+        expect(scheduleMocks.publishLiveScoreUpdateEvent).toHaveBeenCalledWith(
+            'team-1',
+            'game-1',
+            { homeScore: 5, awayScore: 2 },
+            auth.user,
+            { homeScore: 4, awayScore: 2 }
+        );
+        expect(scheduleMocks.markLiveGameFinalForApp).toHaveBeenCalledWith(
+            'team-1',
+            'game-1',
+            { homeScore: 5, awayScore: 2 },
+            auth.user
+        );
+        await waitForText(container, 'Final score saved and game marked complete.');
+        expect(buttonByText(container, 'Final').disabled).toBe(true);
     });
 
     it('disables undo while a live score save is in flight', async () => {

--- a/tests/unit/app-schedule-score-update.test.js
+++ b/tests/unit/app-schedule-score-update.test.js
@@ -104,7 +104,7 @@ vi.mock('../../apps/app/src/lib/chatLogic.ts', () => ({
     DEFAULT_TEAM_CONVERSATION_ID: 'team'
 }));
 
-import { buildCancelScheduledGameChatMessage, cancelScheduledGameForApp, normalizeGameScoreValue, publishLiveScoreUpdateEvent, updateGameScore } from '../../apps/app/src/lib/scheduleService.ts';
+import { buildCancelScheduledGameChatMessage, cancelScheduledGameForApp, markLiveGameFinalForApp, normalizeGameScoreValue, publishLiveScoreUpdateEvent, updateGameScore } from '../../apps/app/src/lib/scheduleService.ts';
 
 const user = {
     uid: 'user-1',
@@ -202,6 +202,28 @@ describe('React app schedule score updates', () => {
             createdBy: 'user-1',
             createdByName: 'Coach Pat'
         });
+    });
+
+    it('marks a live score final so app-updated games do not stay live forever', async () => {
+        dbMocks.updateGame.mockResolvedValue(undefined);
+
+        const payload = await markLiveGameFinalForApp('team-1', 'game-1', {
+            homeScore: 8,
+            awayScore: 6
+        }, user);
+
+        expect(dbMocks.updateGame).toHaveBeenCalledWith('team-1', 'game-1', expect.objectContaining({
+            homeScore: 8,
+            awayScore: 6,
+            status: 'completed',
+            liveStatus: 'completed',
+            liveClockRunning: false,
+            scoreUpdatedBy: 'user-1',
+            liveEndedBy: 'user-1'
+        }));
+        expect(dbMocks.updateGame.mock.calls[0][2].scoreUpdatedAt).toBeInstanceOf(Date);
+        expect(dbMocks.updateGame.mock.calls[0][2].liveEndedAt).toBeInstanceOf(Date);
+        expect(payload).toEqual(dbMocks.updateGame.mock.calls[0][2]);
     });
 
     it('writes cancellation metadata and posts the legacy-style team chat notice', async () => {


### PR DESCRIPTION
## Summary
- add an app schedule service helper that marks quick-score games completed with final score metadata
- add a Mark final action to the live score controls and lock the controls once completed
- cover the service payload and quick-score final flow with regression tests

Closes #2022

## Tests
- npx vitest run tests/unit/app-schedule-score-update.test.js tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose
- npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx --reporter=verbose
- npm --prefix apps/app run lint -- --quiet
- npm run app:build