### PR TITLE
Add native app game scheduling

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -9,6 +9,7 @@ import {
     claimOpenOfficiatingSlot as legacyClaimOpenOfficiatingSlot,
     closeRideOffer as legacyCloseRideOffer,
     createRideOffer as legacyCreateRideOffer,
+    getConfigs as legacyGetConfigs,
     getAssignmentClaims as legacyGetAssignmentClaims,
     getGame as legacyGetGame,
     getGames as legacyGetGames,
@@ -87,6 +88,10 @@ export type GamesQueryOptions = { startDate?: Date | null; endDate?: Date | null
 
 export async function getGames(teamId: string, options: GamesQueryOptions = {}) {
     return await Promise.resolve(legacyGetGames(teamId, options));
+}
+
+export async function getConfigs(teamId: string) {
+    return await Promise.resolve(legacyGetConfigs(teamId));
 }
 
 export async function getPracticePacketCompletions(teamId: string, sessionId: string) {

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -155,6 +155,7 @@ export type ParentScheduleEvent = {
   seasonLabel?: string | null;
   competitionType?: string | null;
   countsTowardSeasonRecord?: boolean | null;
+  statTrackerConfigId?: string | null;
   sourceType?: ScheduleSourceType | string | null;
   sourceLabel?: string | null;
   isImported?: boolean;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1,6 +1,7 @@
 import {
   getAssignmentClaims,
   claimOpenOfficiatingSlot,
+  getConfigs,
   getGame,
   getGames,
   getPracticePacketCompletions,
@@ -1313,6 +1314,29 @@ export type ScheduleImportNormalizedRow = {
   } | null;
 };
 
+export type ScheduleGameFormInput = {
+  opponent: string;
+  startDate: Date;
+  endDate?: Date | null;
+  location?: string | null;
+  arrivalTime?: Date | null;
+  isHome?: boolean | null;
+  notes?: string | null;
+  statTrackerConfigId?: string | null;
+  competitionType?: string | null;
+  countsTowardSeasonRecord?: boolean;
+  opponentTeamId?: string | null;
+  opponentTeamName?: string | null;
+  opponentTeamPhoto?: string | null;
+};
+
+export type ScheduleStatTrackerConfigOption = {
+  id: string;
+  name: string;
+  baseType?: string | null;
+  isBasketball?: boolean;
+};
+
 function normalizeScheduleImportBatch(input: ScheduleImportNormalizedRow['importBatch']) {
   const batchId = compactString(input?.batchId);
   const totalCount = Math.max(0, Number.parseInt(String(input?.totalCount ?? 0), 10) || 0);
@@ -1375,6 +1399,60 @@ function buildScheduleImportGamePayload(row: ScheduleImportNormalizedRow, user: 
   };
 }
 
+function parseScheduleGameFormDate(value: Date | string | number | null | undefined, label: string) {
+  const date = value instanceof Date ? new Date(value) : new Date(value || '');
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${label} is invalid.`);
+  }
+  return date;
+}
+
+function buildScheduledGamePayload(input: ScheduleGameFormInput, user: AuthUser) {
+  const opponent = compactString(input.opponent);
+  if (!opponent) throw new Error('Games require an opponent.');
+  const startDate = parseScheduleGameFormDate(input.startDate, 'Game start time');
+  const endDate = input.endDate ? parseScheduleGameFormDate(input.endDate, 'Game end time') : null;
+  const arrivalTime = input.arrivalTime ? parseScheduleGameFormDate(input.arrivalTime, 'Arrival time') : null;
+  if (endDate && endDate.getTime() <= startDate.getTime()) {
+    throw new Error('Game end time must be after the start time.');
+  }
+  return {
+    type: 'game',
+    date: startDate,
+    end: endDate,
+    opponent,
+    title: null,
+    location: compactString(input.location),
+    isHome: input.isHome === null || input.isHome === undefined ? null : input.isHome === true,
+    arrivalTime,
+    notes: compactString(input.notes),
+    assignments: [],
+    status: 'scheduled',
+    homeScore: 0,
+    awayScore: 0,
+    competitionType: compactString(input.competitionType) || 'league',
+    countsTowardSeasonRecord: input.countsTowardSeasonRecord === false ? false : true,
+    statTrackerConfigId: compactString(input.statTrackerConfigId) || null,
+    opponentTeamId: compactString(input.opponentTeamId) || null,
+    opponentTeamName: compactString(input.opponentTeamName) || null,
+    opponentTeamPhoto: compactString(input.opponentTeamPhoto) || null,
+    createdBy: user.uid
+  };
+}
+
+function buildScheduledGameUpdatePayload(input: ScheduleGameFormInput, user: AuthUser) {
+  const { assignments, homeScore, awayScore, createdBy, ...payload } = buildScheduledGamePayload(input, user) as Record<string, unknown>;
+  void assignments;
+  void homeScore;
+  void awayScore;
+  void createdBy;
+  return {
+    ...payload,
+    updatedAt: new Date(),
+    updatedBy: user.uid
+  };
+}
+
 function buildScheduleImportPracticePayload(row: ScheduleImportNormalizedRow, user: AuthUser) {
   const startDate = parseScheduleImportDate(row.startsAt, 'Start time');
   const importBatch = normalizeScheduleImportBatch(row.importBatch);
@@ -1424,6 +1502,63 @@ export type UpdateScheduledPracticeOptions = {
   scope?: SchedulePracticeEditScope;
   instanceDate?: string | null;
 };
+
+export async function loadScheduleStatTrackerConfigsForApp(teamId: string, user: AuthUser | null): Promise<ScheduleStatTrackerConfigOption[]> {
+  const normalizedTeamId = compactString(teamId);
+  if (!normalizedTeamId) throw new Error('Team is required.');
+  await requireScheduleImportStaff(normalizedTeamId, user);
+  const configs = await readWithNativeFallback(
+    `schedule stat tracker configs ${normalizedTeamId}`,
+    () => Promise.resolve(getConfigs(normalizedTeamId)),
+    () => nativeListCollection(`teams/${encodeURIComponent(normalizedTeamId)}/statTrackerConfigs`)
+  ).catch(() => []);
+  return (Array.isArray(configs) ? configs : [])
+    .map((config: any) => ({
+      id: compactString(config?.id),
+      name: compactString(config?.name) || compactString(config?.label) || compactString(config?.baseType) || 'Tracker config',
+      baseType: compactString(config?.baseType) || null,
+      isBasketball: config?.isBasketball === true || compactString(config?.baseType).toLowerCase() === 'basketball'
+    }))
+    .filter((config) => config.id)
+    .sort((first, second) => first.name.localeCompare(second.name));
+}
+
+export async function createScheduledGameForApp(teamId: string, input: ScheduleGameFormInput, user: AuthUser | null) {
+  const normalizedTeamId = compactString(teamId);
+  if (!normalizedTeamId) throw new Error('Team is required.');
+  await requireScheduleImportStaff(normalizedTeamId, user);
+  const payload = buildScheduledGamePayload(input, user as AuthUser);
+
+  try {
+    return await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Scheduled game create');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    logScheduleWarning('Falling back to REST scheduled game create.', 'scheduled-game-create', error, { fallback: 'rest', teamId: normalizedTeamId });
+    const doc = await nativeCreateDocument(`teams/${encodeURIComponent(normalizedTeamId)}/games`, {
+      ...payload,
+      createdAt: new Date()
+    });
+    return doc?.id || '';
+  }
+}
+
+export async function updateScheduledGameForApp(teamId: string, gameId: string, input: ScheduleGameFormInput, user: AuthUser | null) {
+  const normalizedTeamId = compactString(teamId);
+  const normalizedGameId = compactString(gameId);
+  if (!normalizedTeamId) throw new Error('Team is required.');
+  if (!normalizedGameId) throw new Error('Game is required.');
+  await requireScheduleImportStaff(normalizedTeamId, user);
+  const payload = buildScheduledGameUpdatePayload(input, user as AuthUser);
+
+  try {
+    await withTimeout(Promise.resolve(updateGame(normalizedTeamId, normalizedGameId, payload)), 'Scheduled game update');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    logScheduleWarning('Falling back to REST scheduled game update.', 'scheduled-game-update', error, { fallback: 'rest', teamId: normalizedTeamId, gameId: normalizedGameId });
+    await nativePatchDocument(`teams/${encodeURIComponent(normalizedTeamId)}/games/${encodeURIComponent(normalizedGameId)}`, payload);
+  }
+  return { updated: true, eventId: normalizedGameId };
+}
 
 function sanitizePracticeRecurrenceInput(input?: PracticeRecurrenceFormInput | null) {
   const byDays = Array.isArray(input?.byDays) ? input?.byDays.map((value) => compactString(value).toUpperCase()).filter(Boolean) : [];
@@ -2283,6 +2418,7 @@ function createScheduleEvent(input: {
   seasonLabel?: string | null;
   competitionType?: string | null;
   countsTowardSeasonRecord?: boolean | null;
+  statTrackerConfigId?: string | null;
   sourceType?: string | null;
   sourceLabel?: string | null;
   isImported?: boolean;
@@ -2349,6 +2485,7 @@ function createScheduleEvent(input: {
     seasonLabel: input.seasonLabel || null,
     competitionType: input.competitionType || null,
     countsTowardSeasonRecord: input.countsTowardSeasonRecord ?? null,
+    statTrackerConfigId: input.statTrackerConfigId || null,
     sourceType: input.sourceType || (input.isDbGame ? 'db' : 'calendar'),
     sourceLabel: input.sourceLabel || (input.isDbGame ? 'ALL PLAYS schedule' : 'Team calendar'),
     isImported: input.isImported === true || !input.isDbGame,
@@ -2688,6 +2825,7 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
     seasonLabel: game.seasonLabel || null,
     competitionType: game.competitionType || null,
     countsTowardSeasonRecord: game.countsTowardSeasonRecord ?? null,
+    statTrackerConfigId: game.statTrackerConfigId || null,
     sourceType: game.sourceMetadata?.sourceType || game.source || 'db',
     sourceLabel: getScheduleSourceLabel(game),
     isImported: Boolean(game.sourceMetadata || game.source === 'calendar' || game.source === 'registration'),

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1441,8 +1441,9 @@ function buildScheduledGamePayload(input: ScheduleGameFormInput, user: AuthUser)
 }
 
 function buildScheduledGameUpdatePayload(input: ScheduleGameFormInput, user: AuthUser) {
-  const { assignments, homeScore, awayScore, createdBy, ...payload } = buildScheduledGamePayload(input, user) as Record<string, unknown>;
+  const { assignments, status, homeScore, awayScore, createdBy, ...payload } = buildScheduledGamePayload(input, user) as Record<string, unknown>;
   void assignments;
+  void status;
   void homeScore;
   void awayScore;
   void createdBy;

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { Modal } from '../components/Modal';
 import { SchedulePageSkeleton } from '../components/PageSkeletons';
 import { PullToRefresh } from '../components/PullToRefresh';
-import { addTeamCalendarUrl, createScheduledPracticeForApp, createScheduleImportGame, createScheduleImportPractice, finalizeScheduleImportBatch, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild, type SchedulePracticeFormInput, type PracticeRecurrenceFormInput } from '../lib/scheduleService';
+import { addTeamCalendarUrl, createScheduledGameForApp, createScheduledPracticeForApp, createScheduleImportGame, createScheduleImportPractice, finalizeScheduleImportBatch, loadParentSchedule, loadScheduleStatTrackerConfigsForApp, removeTeamCalendarUrl, type ParentScheduleChild, type ScheduleGameFormInput, type SchedulePracticeFormInput, type PracticeRecurrenceFormInput, type ScheduleStatTrackerConfigOption } from '../lib/scheduleService';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from '../lib/appDataCache';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { recordFirstMeaningfulRender, startScreenMountTimer } from '../lib/uxTiming';
@@ -167,6 +167,11 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [importingCsv, setImportingCsv] = useState(false);
   const [removingCalendarUrl, setRemovingCalendarUrl] = useState<string | null>(null);
   const [mobileStaffToolsOpen, setMobileStaffToolsOpen] = useState(false);
+  const [gameForm, setGameForm] = useState<ScheduleGameFormInput>(() => getDefaultScheduleGameForm());
+  const [savingGame, setSavingGame] = useState(false);
+  const [gameFormError, setGameFormError] = useState<string | null>(null);
+  const [gameTrackerConfigs, setGameTrackerConfigs] = useState<ScheduleStatTrackerConfigOption[]>([]);
+  const [gameTrackerConfigError, setGameTrackerConfigError] = useState<string | null>(null);
   const [practiceForm, setPracticeForm] = useState<SchedulePracticeFormInput>(() => getDefaultSchedulePracticeForm());
   const [savingPractice, setSavingPractice] = useState(false);
   const [practiceFormError, setPracticeFormError] = useState<string | null>(null);
@@ -360,6 +365,42 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
   }, [isDesktopWeb, selectedCalendarTeam]);
 
+
+  useEffect(() => {
+    let cancelled = false;
+    setGameTrackerConfigs([]);
+    setGameTrackerConfigError(null);
+    if (!selectedCalendarTeam || !auth.user) return;
+    loadScheduleStatTrackerConfigsForApp(selectedCalendarTeam.teamId, auth.user)
+      .then((configs) => {
+        if (!cancelled) setGameTrackerConfigs(configs);
+      })
+      .catch((configError: any) => {
+        if (!cancelled) setGameTrackerConfigError(configError?.message || 'Unable to load tracker configs.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.user, selectedCalendarTeam]);
+
+  const handleCreateGame = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedCalendarTeam || !auth.user || savingGame) return;
+    setSavingGame(true);
+    setGameFormError(null);
+    setStatusMessage(null);
+    clearError();
+    try {
+      await createScheduledGameForApp(selectedCalendarTeam.teamId, gameForm, auth.user);
+      setGameForm(getDefaultScheduleGameForm());
+      await refreshSchedule(true);
+      setStatusMessage('Game created and schedule refreshed.');
+    } catch (gameError: any) {
+      setGameFormError(gameError?.message || 'Unable to create game.');
+    } finally {
+      setSavingGame(false);
+    }
+  };
 
   const handleCreatePractice = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -888,6 +929,19 @@ export function Schedule({ auth }: { auth: AuthState }) {
 
           {isDesktopWeb && selectedCalendarTeam ? (
             <>
+              <ScheduleGameCreatePanel
+                teamName={selectedCalendarTeam.teamName}
+                form={gameForm}
+                configs={gameTrackerConfigs}
+                saving={savingGame}
+                error={gameFormError}
+                configError={gameTrackerConfigError}
+                onChange={(nextForm) => {
+                  setGameForm(nextForm);
+                  if (gameFormError) setGameFormError(null);
+                }}
+                onSubmit={handleCreateGame}
+              />
               <SchedulePracticeCreatePanel
                 teamName={selectedCalendarTeam.teamName}
                 form={practiceForm}
@@ -979,6 +1033,19 @@ export function Schedule({ auth }: { auth: AuthState }) {
               teamName={selectedCalendarTeam.teamName}
               onToggle={() => setMobileStaffToolsOpen((current) => !current)}
             >
+              <ScheduleGameCreatePanel
+                teamName={selectedCalendarTeam.teamName}
+                form={gameForm}
+                configs={gameTrackerConfigs}
+                saving={savingGame}
+                error={gameFormError}
+                configError={gameTrackerConfigError}
+                onChange={(nextForm) => {
+                  setGameForm(nextForm);
+                  if (gameFormError) setGameFormError(null);
+                }}
+                onSubmit={handleCreateGame}
+              />
               <SchedulePracticeCreatePanel
                 teamName={selectedCalendarTeam.teamName}
                 form={practiceForm}
@@ -1043,9 +1110,28 @@ function padDatePart(value: number) {
 }
 
 function toDatetimeLocalInputValue(value: Date | string | number | null | undefined) {
+  if (value === null || value === undefined || value === '') return '';
   const date = value instanceof Date ? value : new Date(value || Date.now());
   if (Number.isNaN(date.getTime())) return '';
   return `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}T${padDatePart(date.getHours())}:${padDatePart(date.getMinutes())}`;
+}
+
+function getDefaultScheduleGameForm(): ScheduleGameFormInput {
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() + 1);
+  startDate.setHours(18, 30, 0, 0);
+  return {
+    opponent: '',
+    startDate,
+    endDate: new Date(startDate.getTime() + 90 * 60000),
+    location: '',
+    arrivalTime: new Date(startDate.getTime() - 30 * 60000),
+    isHome: true,
+    notes: '',
+    statTrackerConfigId: '',
+    competitionType: 'league',
+    countsTowardSeasonRecord: true
+  };
 }
 
 function getDefaultSchedulePracticeForm(): SchedulePracticeFormInput {
@@ -1062,6 +1148,33 @@ function getDefaultSchedulePracticeForm(): SchedulePracticeFormInput {
     notes: '',
     recurrence: { isRecurring: false, freq: 'weekly', interval: 1, byDays: [dayCodes[startDate.getDay()]], endType: 'never', countValue: 10 }
   };
+}
+
+function ScheduleGameCreatePanel({ teamName, form, configs, saving, error, configError, onChange, onSubmit }: { teamName: string; form: ScheduleGameFormInput; configs: ScheduleStatTrackerConfigOption[]; saving: boolean; error: string | null; configError: string | null; onChange: (form: ScheduleGameFormInput) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {
+  const updateField = (field: keyof ScheduleGameFormInput, value: string | Date | boolean | null) => onChange({ ...form, [field]: value });
+  return (
+    <section className="app-card p-3 sm:p-4" aria-label="Create game">
+      <div className="app-label">Game scheduling</div>
+      <h2 className="mt-1 text-base font-black text-gray-950">Add game for {teamName}</h2>
+      <form className="mt-3 space-y-3" onSubmit={onSubmit}>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Opponent<input className="auth-input mt-1" value={form.opponent} onChange={(event) => updateField('opponent', event.target.value)} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Location<input className="auth-input mt-1" value={form.location || ''} onChange={(event) => updateField('location', event.target.value)} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Starts<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.startDate)} onChange={(event) => updateField('startDate', new Date(event.target.value))} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Ends<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.endDate)} onChange={(event) => updateField('endDate', event.target.value ? new Date(event.target.value) : null)} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Arrival<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.arrivalTime)} onChange={(event) => updateField('arrivalTime', event.target.value ? new Date(event.target.value) : null)} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Home / away<select className="auth-input mt-1" value={form.isHome === false ? 'away' : form.isHome === true ? 'home' : 'neutral'} onChange={(event) => updateField('isHome', event.target.value === 'neutral' ? null : event.target.value === 'home')}><option value="home">Home</option><option value="away">Away</option><option value="neutral">Neutral</option></select></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tracker config<select className="auth-input mt-1" value={form.statTrackerConfigId || ''} onChange={(event) => updateField('statTrackerConfigId', event.target.value)}><option value="">No tracker config</option>{configs.map((config) => <option key={config.id} value={config.id}>{config.name}</option>)}</select></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Competition<select className="auth-input mt-1" value={form.competitionType || 'league'} onChange={(event) => updateField('competitionType', event.target.value)}><option value="league">League</option><option value="tournament">Tournament</option><option value="scrimmage">Scrimmage</option><option value="friendly">Friendly</option></select></label>
+        </div>
+        <label className="flex items-center gap-2 text-sm font-black text-gray-800"><input type="checkbox" checked={form.countsTowardSeasonRecord !== false} onChange={(event) => updateField('countsTowardSeasonRecord', event.target.checked)} /> Counts toward season record</label>
+        <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Notes<textarea className="auth-input mt-1 min-h-20" value={form.notes || ''} onChange={(event) => updateField('notes', event.target.value)} /></label>
+        <button type="submit" className="primary-button" disabled={saving}>{saving ? 'Creating game' : 'Create game'}</button>
+        {configError ? <div className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-bold text-amber-700">{configError}</div> : null}
+        {error ? <div className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">{error}</div> : null}
+      </form>
+    </section>
+  );
 }
 
 function SchedulePracticeCreatePanel({ teamName, form, saving, error, onChange, onSubmit }: { teamName: string; form: SchedulePracticeFormInput; saving: boolean; error: string | null; onChange: (form: SchedulePracticeFormInput) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -383,6 +383,18 @@ export function Schedule({ auth }: { auth: AuthState }) {
     };
   }, [auth.user, selectedCalendarTeam]);
 
+  useEffect(() => {
+    setGameForm((current) => {
+      if (!current.statTrackerConfigId) return current;
+      const hasMatchingConfig = gameTrackerConfigs.some((config) => config.id === current.statTrackerConfigId);
+      if (hasMatchingConfig) return current;
+      return {
+        ...current,
+        statTrackerConfigId: ''
+      };
+    });
+  }, [gameTrackerConfigs]);
+
   const handleCreateGame = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!selectedCalendarTeam || !auth.user || savingGame) return;

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -10,6 +10,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   cancelScheduledGameForApp: vi.fn(),
   claimParentScheduleAssignmentSlot: vi.fn(),
   createParentScheduleRideOffer: vi.fn(),
+  loadScheduleStatTrackerConfigsForApp: vi.fn<(...args: any[]) => Promise<any[]>>(() => Promise.resolve([{ id: 'cfg-basketball', name: 'Basketball' }])),
   loadParentPracticePacket: vi.fn(),
   loadStaffPracticePacket: vi.fn<(...args: any[]) => Promise<any>>(() => Promise.resolve({
     sessionId: 'session-1',
@@ -66,6 +67,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   loadGameDayLiveEventsForApp: vi.fn<(...args: any[]) => Promise<any[]>>(() => Promise.resolve([] as any[])),
   saveGameDaySubstitutionForApp: vi.fn((_teamId, _gameId, _user, payload) => Promise.resolve(payload)),
   updateGameScore: vi.fn(),
+  updateScheduledGameForApp: vi.fn<(...args: any[]) => Promise<any>>(() => Promise.resolve({ updated: true, eventId: 'game-1' })),
   updateLiveGameClockState: vi.fn(),
   buildLiveGameClockPeriods: vi.fn((game: any) => game?.gamePlan?.numPeriods === 4 ? ['Q1', 'Q2', 'Q3', 'Q4'] : ['H1', 'H2']),
   resolveLiveGameClockSnapshot: vi.fn((game: any, now = new Date()) => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -4,11 +4,15 @@ import { AlertCircle, CalendarDays, Car, CheckCircle2, ChevronDown, ChevronLeft,
 import {
   cancelPracticeOccurrenceForApp,
   cancelScheduledGameForApp,
+  loadScheduleStatTrackerConfigsForApp,
   loadScheduledPracticeSeriesForEdit,
+  updateScheduledGameForApp,
   updateScheduledPracticeForApp,
   revertScheduledPracticeOccurrenceForApp,
+  type ScheduleGameFormInput,
   type SchedulePracticeFormInput,
   type PracticeRecurrenceFormInput,
+  type ScheduleStatTrackerConfigOption,
   claimParentScheduleAssignmentSlot,
   loadParentPracticePacket,
   loadStaffPracticePacket,
@@ -775,6 +779,7 @@ function padDatePart(value: number) {
 }
 
 function toDatetimeLocalInputValue(value: Date | string | number | null | undefined) {
+  if (value === null || value === undefined || value === '') return '';
   const date = value instanceof Date ? value : new Date(value || Date.now());
   if (Number.isNaN(date.getTime())) return '';
   return `${date.getFullYear()}-${padDatePart(date.getMonth() + 1)}-${padDatePart(date.getDate())}T${padDatePart(date.getHours())}:${padDatePart(date.getMinutes())}`;
@@ -794,6 +799,108 @@ function buildPracticeFormFromEvent(event: ParentScheduleEvent): SchedulePractic
     notes: event.notes || '',
     recurrence: { isRecurring: event.id.includes('__') }
   };
+}
+
+function buildGameFormFromEvent(event: ParentScheduleEvent): ScheduleGameFormInput {
+  const startDate = event.date instanceof Date ? event.date : new Date(event.date);
+  const endDate = event.endDate instanceof Date ? event.endDate : (event.endDate ? new Date(event.endDate) : null);
+  const arrivalTime = event.arrivalTime instanceof Date ? event.arrivalTime : (event.arrivalTime ? new Date(event.arrivalTime) : null);
+  return {
+    opponent: event.opponent || event.title || '',
+    startDate,
+    endDate,
+    location: event.location || '',
+    arrivalTime,
+    isHome: event.isHome === false ? false : event.isHome === true ? true : null,
+    notes: event.notes || '',
+    statTrackerConfigId: event.statTrackerConfigId || '',
+    competitionType: event.competitionType || 'league',
+    countsTowardSeasonRecord: event.countsTowardSeasonRecord !== false,
+    opponentTeamId: event.opponentTeamId || null,
+    opponentTeamName: event.opponentTeamName || null,
+    opponentTeamPhoto: event.opponentTeamPhoto || null
+  };
+}
+
+function GameScheduleEditPanel({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState<ScheduleGameFormInput>(() => buildGameFormFromEvent(event));
+  const [configs, setConfigs] = useState<ScheduleStatTrackerConfigOption[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const [configError, setConfigError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setForm(buildGameFormFromEvent(event));
+    setStatus(null);
+  }, [event.eventKey]);
+
+  useEffect(() => {
+    if (!open || !auth.user) return;
+    let cancelled = false;
+    setConfigError(null);
+    loadScheduleStatTrackerConfigsForApp(event.teamId, auth.user)
+      .then((nextConfigs) => {
+        if (!cancelled) setConfigs(nextConfigs);
+      })
+      .catch((error: any) => {
+        if (!cancelled) setConfigError(error?.message || 'Unable to load tracker configs.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth.user, event.teamId, open]);
+
+  const updateField = (field: keyof ScheduleGameFormInput, value: string | Date | boolean | null) => {
+    setForm((current) => ({ ...current, [field]: value }));
+  };
+
+  const saveGame = async (submitEvent: FormEvent<HTMLFormElement>) => {
+    submitEvent.preventDefault();
+    if (!auth.user) return;
+    setSaving(true);
+    setStatus(null);
+    try {
+      await updateScheduledGameForApp(event.teamId, event.id, form, auth.user);
+      setStatus({ tone: 'success', message: 'Game schedule was updated.' });
+    } catch (error: any) {
+      setStatus({ tone: 'error', message: error?.message || 'Unable to update game.' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="app-card p-3 sm:p-4" aria-label="Edit game schedule">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="text-xs font-black uppercase tracking-[0.04em] text-primary-700">Schedule management</div>
+          <h2 className="mt-1 text-base font-black text-gray-950">Edit game</h2>
+          <p className="mt-1 text-sm font-semibold text-gray-500">Update opponent, timing, location, home/away, and tracker config without touching score data.</p>
+        </div>
+        <button type="button" className="secondary-button" onClick={() => setOpen((current) => !current)}>{open ? 'Hide editor' : 'Edit game'}</button>
+      </div>
+      {open ? (
+        <form className="mt-3 space-y-3" onSubmit={saveGame}>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Opponent<input className="auth-input mt-1" value={form.opponent} onChange={(e) => updateField('opponent', e.target.value)} /></label>
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Location<input className="auth-input mt-1" value={form.location || ''} onChange={(e) => updateField('location', e.target.value)} /></label>
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Starts<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.startDate)} onChange={(e) => updateField('startDate', new Date(e.target.value))} /></label>
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Ends<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.endDate)} onChange={(e) => updateField('endDate', e.target.value ? new Date(e.target.value) : null)} /></label>
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Arrival<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.arrivalTime)} onChange={(e) => updateField('arrivalTime', e.target.value ? new Date(e.target.value) : null)} /></label>
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Home / away<select className="auth-input mt-1" value={form.isHome === false ? 'away' : form.isHome === true ? 'home' : 'neutral'} onChange={(e) => updateField('isHome', e.target.value === 'neutral' ? null : e.target.value === 'home')}><option value="home">Home</option><option value="away">Away</option><option value="neutral">Neutral</option></select></label>
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tracker config<select className="auth-input mt-1" value={form.statTrackerConfigId || ''} onChange={(e) => updateField('statTrackerConfigId', e.target.value)}><option value="">No tracker config</option>{configs.map((config) => <option key={config.id} value={config.id}>{config.name}</option>)}</select></label>
+            <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Competition<select className="auth-input mt-1" value={form.competitionType || 'league'} onChange={(e) => updateField('competitionType', e.target.value)}><option value="league">League</option><option value="tournament">Tournament</option><option value="scrimmage">Scrimmage</option><option value="friendly">Friendly</option></select></label>
+          </div>
+          <label className="flex items-center gap-2 text-sm font-black text-gray-800"><input type="checkbox" checked={form.countsTowardSeasonRecord !== false} onChange={(e) => updateField('countsTowardSeasonRecord', e.target.checked)} /> Counts toward season record</label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Notes<textarea className="auth-input mt-1 min-h-20" value={form.notes || ''} onChange={(e) => updateField('notes', e.target.value)} /></label>
+          <button type="submit" className="primary-button" disabled={saving}>{saving ? 'Saving' : 'Save game'}</button>
+          {configError ? <div className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-bold text-amber-700">{configError}</div> : null}
+        </form>
+      ) : null}
+      {status ? <div className={`mt-3 rounded-2xl border px-3 py-2 text-sm font-bold ${status.tone === 'success' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-rose-200 bg-rose-50 text-rose-700'}`}>{status.message}</div> : null}
+    </section>
+  );
 }
 
 function PracticeScheduleEditPanel({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
@@ -2101,6 +2208,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
     <section className="space-y-3">
       {showNonAdminPracticePacketFirst ? <PracticePacketSection auth={auth} event={event} childEvents={childEvents} /> : null}
       {showAdminPracticeTimeline ? <PracticeTimelineSection auth={auth} event={event} /> : null}
+      {!isPractice && event.isTeamAdmin && event.isDbGame && !event.isCancelled ? <GameScheduleEditPanel auth={auth} event={event} /> : null}
       {isPractice && event.isTeamAdmin && event.isDbGame && !event.isCancelled ? <PracticeScheduleEditPanel auth={auth} event={event} /> : null}
       {isPractice && event.isTeamAdmin && event.isDbGame && !event.isCancelled ? <StaffPracticePacketEditor auth={auth} event={event} childEvents={childEvents} /> : null}
       {isPractice && !showNonAdminPracticePacketFirst ? <PracticePacketSection auth={auth} event={event} childEvents={childEvents} /> : null}

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -298,9 +298,20 @@ async function mockScheduleModules(page, options = {}) {
                     return { ok: true };
                 }
 
+                export async function createScheduledGameForApp(teamId, form, user) {
+                    window.__scheduleCalls.gameCreates = (window.__scheduleCalls.gameCreates || []).concat({ teamId, form, userId: user?.uid || null });
+                    return { id: 'game-created' };
+                }
+
                 export async function createScheduledPracticeForApp(teamId, form, user) {
                     window.__scheduleCalls.practiceCreates = (window.__scheduleCalls.practiceCreates || []).concat({ teamId, form, userId: user?.uid || null });
                     return { id: 'practice-created' };
+                }
+
+                export async function loadScheduleStatTrackerConfigsForApp() {
+                    return [
+                        { id: 'tracker-config-1', label: 'Basketball Standard', sport: 'basketball', defaultGameTitle: 'Game' }
+                    ];
                 }
 
                 export async function loadScheduledPracticeSeriesForEdit(teamId, eventId, user) {
@@ -317,6 +328,11 @@ async function mockScheduleModules(page, options = {}) {
                             recurrence: { isRecurring: true, byDays: ['WE'], interval: 1, endType: 'never' }
                         }
                     };
+                }
+
+                export async function updateScheduledGameForApp(teamId, gameId, input, user) {
+                    window.__scheduleCalls.gameUpdates = (window.__scheduleCalls.gameUpdates || []).concat({ teamId, gameId, input, userId: user?.uid || null });
+                    return { success: true };
                 }
 
                 export async function updateScheduledPracticeForApp(teamId, input, user, options) {

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -6,10 +6,13 @@ import { MemoryRouter } from 'react-router-dom';
 
 const scheduleMocks = vi.hoisted(() => ({
     addTeamCalendarUrl: vi.fn(),
+    createScheduledGameForApp: vi.fn(),
+    createScheduledPracticeForApp: vi.fn(),
     createScheduleImportGame: vi.fn(),
     createScheduleImportPractice: vi.fn(),
     finalizeScheduleImportBatch: vi.fn(),
     loadParentSchedule: vi.fn(),
+    loadScheduleStatTrackerConfigsForApp: vi.fn(),
     removeTeamCalendarUrl: vi.fn(),
     generateScheduleAiImportRows: vi.fn(),
     aiModuleLoads: 0,
@@ -168,9 +171,12 @@ beforeEach(() => {
     layoutState.isNative = false;
     layoutState.isMobileWeb = false;
     scheduleMocks.addTeamCalendarUrl.mockResolvedValue({ added: true, calendarUrls: ['https://example.com/team.ics'] });
+    scheduleMocks.createScheduledGameForApp.mockResolvedValue('game-new');
+    scheduleMocks.createScheduledPracticeForApp.mockResolvedValue('practice-new');
     scheduleMocks.createScheduleImportGame.mockResolvedValue('game-new');
     scheduleMocks.createScheduleImportPractice.mockResolvedValue('practice-new');
     scheduleMocks.finalizeScheduleImportBatch.mockResolvedValue(undefined);
+    scheduleMocks.loadScheduleStatTrackerConfigsForApp.mockResolvedValue([{ id: 'cfg-basketball', name: 'Basketball' }]);
     scheduleMocks.removeTeamCalendarUrl.mockResolvedValue({ removed: true, calendarUrls: [] });
     scheduleMocks.generateScheduleAiImportRows.mockResolvedValue({ rows: [], errors: [] });
     vi.spyOn(window, 'confirm').mockReturnValue(true);

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -25,6 +25,10 @@ const layoutState = vi.hoisted(() => ({
 }));
 
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
+vi.mock('../../apps/app/src/lib/uxTiming.ts', () => ({
+    recordFirstMeaningfulRender: vi.fn(),
+    startScreenMountTimer: vi.fn(() => ({ end: vi.fn() }))
+}));
 vi.mock('../../apps/app/src/lib/scheduleAiImport.ts', async () => {
     scheduleMocks.aiModuleLoads += 1;
     return {
@@ -741,6 +745,52 @@ describe('React app desktop Schedule controls', () => {
 
         await waitForText(container, 'Imported 3 row(s); 1 row(s) failed and remain below for retry.');
         expect(scheduleMocks.finalizeScheduleImportBatch).toHaveBeenCalledWith('team-1', expect.any(String), 3, auth.user);
+    });
+
+    it('clears stale tracker config selections when staff switch teams before creating a game', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
+                { playerId: 'player-2', playerName: 'Sam', teamId: 'team-2', teamName: 'Wolves' }
+            ],
+            events: [
+                event({ teamId: 'team-1', teamName: 'Bears', isTeamStaff: true }),
+                event({ eventKey: 'team-2::game-2::player-2', id: 'game-2', teamId: 'team-2', teamName: 'Wolves', childId: 'player-2', childName: 'Sam', isTeamStaff: true })
+            ]
+        });
+        scheduleMocks.loadScheduleStatTrackerConfigsForApp.mockImplementation(async (teamId) => {
+            if (teamId === 'team-1') {
+                return [{ id: 'cfg-team-1', name: 'Bears Tracker' }];
+            }
+            if (teamId === 'team-2') {
+                return [{ id: 'cfg-team-2', name: 'Wolves Tracker' }];
+            }
+            return [];
+        });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Main Gym');
+        await clickButton(container, 'Filters and views');
+        await changeSelect(selectByLabel(container, 'Team'), 'team-1');
+        await waitForText(container, 'Add game for Bears');
+
+        const teamOnePanel = container.querySelector('section[aria-label="Create game"]');
+        const teamOneSelects = teamOnePanel.querySelectorAll('select');
+        await changeSelect(teamOneSelects[1], 'cfg-team-1');
+        expect(teamOneSelects[1].value).toBe('cfg-team-1');
+
+        await changeSelect(selectByLabel(container, 'Team'), 'team-2');
+        await waitForText(container, 'Add game for Wolves');
+
+        const teamTwoPanel = container.querySelector('section[aria-label="Create game"]');
+        const teamTwoSelects = teamTwoPanel.querySelectorAll('select');
+        expect(teamTwoSelects[1].value).toBe('');
+
+        await clickButton(container, 'Create game');
+
+        expect(scheduleMocks.createScheduledGameForApp).toHaveBeenCalledWith('team-2', expect.objectContaining({
+            statTrackerConfigId: ''
+        }), auth.user);
     });
 
 });

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -8,6 +8,7 @@ const scheduleMocks = vi.hoisted(() => ({
     cancelParentScheduleRideRequest: vi.fn(),
     claimParentScheduleAssignmentSlot: vi.fn(),
     createParentScheduleRideOffer: vi.fn(),
+    loadScheduleStatTrackerConfigsForApp: vi.fn(),
     loadParentPracticePacket: vi.fn(),
     loadStaffPracticePacket: vi.fn(),
     loadParentSchedule: vi.fn(),
@@ -47,6 +48,7 @@ const scheduleMocks = vi.hoisted(() => ({
     saveScheduledGameLineupDraftForApp: vi.fn(),
     saveStaffPracticePacket: vi.fn(),
     updateGameScore: vi.fn(),
+    updateScheduledGameForApp: vi.fn(),
     updateParentScheduleRideRequestStatus: vi.fn()
 }));
 
@@ -187,6 +189,7 @@ beforeEach(() => {
     vi.clearAllMocks();
     scheduleMocks.loadParentSchedule.mockResolvedValue({ events: [] });
     scheduleMocks.loadParentScheduleEventDetail.mockImplementation(async () => scheduleMocks.loadParentSchedule());
+    scheduleMocks.loadScheduleStatTrackerConfigsForApp.mockResolvedValue([{ id: 'cfg-basketball', name: 'Basketball' }]);
     scheduleMocks.loadParentPracticePacket.mockResolvedValue(null);
     scheduleMocks.loadStaffPracticePacket.mockResolvedValue({
         sessionId: 'session-1',
@@ -254,6 +257,7 @@ beforeEach(() => {
         children: [{ id: 'player-1', name: 'Pat' }]
     });
     scheduleMocks.updateGameScore.mockResolvedValue({ homeScore: 5, awayScore: 2, scoreUpdatedAt: new Date('2026-05-25T08:00:00Z'), scoreUpdatedBy: 'user-1' });
+    scheduleMocks.updateScheduledGameForApp.mockResolvedValue({ updated: true, eventId: 'game-1' });
     scheduleMocks.publishLiveScoreUpdateEvent.mockResolvedValue({ type: 'score_update', homeScore: 5, awayScore: 2 });
     scheduleMocks.markParentPracticePacketComplete.mockResolvedValue({
         id: 'user-1__player-1',

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -142,6 +142,11 @@ vi.mock('../../js/db.js', () => dbMocks);
 vi.mock('../../js/firebase.js', () => firebaseMocks);
 vi.mock('../../apps/app/src/lib/profileService.ts', () => profileMocks);
 vi.mock('../../apps/app/src/lib/authService.ts', () => authMocks);
+vi.mock('../../apps/app/src/lib/uxTiming.ts', () => ({
+    UX_TIMING: { rsvpTap: 'rsvpTap' },
+    startInteractionTimer: vi.fn(() => ({ end: vi.fn() })),
+    startUxTimer: vi.fn(() => ({ end: vi.fn() }))
+}));
 vi.mock('../../apps/app/src/lib/chatService.ts', () => ({
     sendTeamChatMessage: vi.fn()
 }));
@@ -983,6 +988,7 @@ describe('React app schedule service contract integration', () => {
             statTrackerConfigId: null,
             updatedBy: 'coach-1'
         }));
+        expect(updatePayload.status).toBeUndefined();
         expect(updatePayload.homeScore).toBeUndefined();
         expect(updatePayload.awayScore).toBeUndefined();
         expect(updatePayload.assignments).toBeUndefined();

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const dbMocks = vi.hoisted(() => ({
     getAssignmentClaims: vi.fn(),
+    getConfigs: vi.fn(),
     getGame: vi.fn(),
     getGames: vi.fn(),
     getPlayers: vi.fn(),
@@ -210,7 +211,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     }))
 }));
 
-import { addTeamCalendarUrl, cancelPracticeOccurrenceForApp, createScheduleImportGame, createScheduleImportPractice, createStaffRsvpReminderPreviewLoader, loadParentPlayerSchedule, loadParentSchedule, loadParentScheduleEventDetail, parseRecurringPracticeOccurrenceId, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
+import { addTeamCalendarUrl, cancelPracticeOccurrenceForApp, createScheduledGameForApp, createScheduleImportGame, createScheduleImportPractice, createStaffRsvpReminderPreviewLoader, loadParentPlayerSchedule, loadParentSchedule, loadParentScheduleEventDetail, loadScheduleStatTrackerConfigsForApp, parseRecurringPracticeOccurrenceId, removeTeamCalendarUrl, updateScheduledGameForApp } from '../../apps/app/src/lib/scheduleService.ts';
 import { clearAppDataCache } from '../../apps/app/src/lib/appDataCache.ts';
 import { getScheduleForecastHref, getScheduleMapHref } from '../../apps/app/src/lib/scheduleLogic.ts';
 
@@ -917,6 +918,94 @@ describe('React app schedule service contract integration', () => {
             startsAt: '2026-04-02T18:30',
             opponent: 'Tigers'
         }, { uid: 'parent-1', email: 'parent@example.com' })).rejects.toThrow('permission');
+    });
+
+    it('creates and updates one native app game without resetting existing score data', async () => {
+        dbMocks.getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            adminEmails: []
+        });
+        dbMocks.addGame.mockResolvedValue('game-new');
+        dbMocks.updateGame.mockResolvedValue(undefined);
+        const coach = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach' };
+
+        await expect(createScheduledGameForApp('team-1', {
+            opponent: 'Tigers',
+            startDate: new Date('2026-04-02T18:30:00Z'),
+            endDate: new Date('2026-04-02T20:00:00Z'),
+            location: 'Field 1',
+            arrivalTime: new Date('2026-04-02T17:45:00Z'),
+            isHome: false,
+            notes: 'Bring white kit',
+            statTrackerConfigId: 'cfg-basketball',
+            competitionType: 'tournament',
+            countsTowardSeasonRecord: false
+        }, coach)).resolves.toBe('game-new');
+
+        expect(dbMocks.addGame).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            type: 'game',
+            opponent: 'Tigers',
+            location: 'Field 1',
+            isHome: false,
+            status: 'scheduled',
+            homeScore: 0,
+            awayScore: 0,
+            statTrackerConfigId: 'cfg-basketball',
+            competitionType: 'tournament',
+            countsTowardSeasonRecord: false,
+            createdBy: 'coach-1'
+        }));
+        expect(dbMocks.addGame.mock.calls[0][1].date).toBeInstanceOf(Date);
+        expect(dbMocks.addGame.mock.calls[0][1].end).toBeInstanceOf(Date);
+        expect(dbMocks.addGame.mock.calls[0][1].arrivalTime).toBeInstanceOf(Date);
+
+        await expect(updateScheduledGameForApp('team-1', 'game-1', {
+            opponent: 'Hawks',
+            startDate: new Date('2026-04-09T18:30:00Z'),
+            endDate: null,
+            location: 'Field 2',
+            arrivalTime: null,
+            isHome: true,
+            notes: 'Moved fields',
+            statTrackerConfigId: '',
+            competitionType: 'league',
+            countsTowardSeasonRecord: true
+        }, coach)).resolves.toEqual({ updated: true, eventId: 'game-1' });
+
+        const updatePayload = dbMocks.updateGame.mock.calls[0][2];
+        expect(updatePayload).toEqual(expect.objectContaining({
+            type: 'game',
+            opponent: 'Hawks',
+            location: 'Field 2',
+            isHome: true,
+            statTrackerConfigId: null,
+            updatedBy: 'coach-1'
+        }));
+        expect(updatePayload.homeScore).toBeUndefined();
+        expect(updatePayload.awayScore).toBeUndefined();
+        expect(updatePayload.assignments).toBeUndefined();
+        expect(updatePayload.createdBy).toBeUndefined();
+    });
+
+    it('loads schedule tracker configs for staff game forms', async () => {
+        dbMocks.getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            adminEmails: []
+        });
+        dbMocks.getConfigs.mockResolvedValue([
+            { id: 'cfg-z', name: 'Zone Tracker', baseType: 'Soccer' },
+            { id: 'cfg-b', baseType: 'Basketball' }
+        ]);
+
+        await expect(loadScheduleStatTrackerConfigsForApp('team-1', { uid: 'coach-1', email: 'coach@example.com' }))
+            .resolves.toEqual([
+                { id: 'cfg-b', name: 'Basketball', baseType: 'Basketball', isBasketball: true },
+                { id: 'cfg-z', name: 'Zone Tracker', baseType: 'Soccer', isBasketball: false }
+            ]);
     });
 
     it('redacts bearer tokens from native REST fallback warning logs', async () => {


### PR DESCRIPTION
## Summary
- add app schedule service helpers for one-off game create/edit plus tracker config loading
- add a native Add game panel on Schedule and an Edit game panel in the game hub
- preserve existing score/assignment fields on game edits and cover the service contract with regressions

Closes #1964

## Tests
- npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=verbose
- npx vitest run tests/unit/app-schedule-desktop-controls.test.jsx --reporter=verbose
- npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx --reporter=verbose
- npm --prefix apps/app run lint -- --quiet
- npm run app:build