### PR TITLE
Harden notification badge and channel wiring

### DIFF
--- a/apps/app/src/lib/badgeService.test.ts
+++ b/apps/app/src/lib/badgeService.test.ts
@@ -28,7 +28,30 @@ vi.mock('@capawesome/capacitor-badge', () => ({
     Badge: badgeMocks
 }));
 
-import { markTeamChatReadAndRefreshBadge, refreshUnreadChatBadge, updateAppIconBadge } from './badgeService';
+import {
+    markTeamChatReadAndRefreshBadge,
+    normalizeAppIconBadgeCount,
+    refreshUnreadChatBadge,
+    updateAppIconBadge
+} from './badgeService';
+
+describe('normalizeAppIconBadgeCount', () => {
+    it('keeps positive integer counts unchanged', () => {
+        expect(normalizeAppIconBadgeCount(12)).toBe(12);
+    });
+
+    it('floors fractional unread counts before writing to native badge APIs', () => {
+        expect(normalizeAppIconBadgeCount(4.9)).toBe(4);
+    });
+
+    it('coerces numeric values and clamps invalid or negative counts to zero', () => {
+        expect(normalizeAppIconBadgeCount('7')).toBe(7);
+        expect(normalizeAppIconBadgeCount(Number.NaN)).toBe(0);
+        expect(normalizeAppIconBadgeCount(Number.POSITIVE_INFINITY)).toBe(0);
+        expect(normalizeAppIconBadgeCount(-3)).toBe(0);
+        expect(normalizeAppIconBadgeCount(undefined)).toBe(0);
+    });
+});
 
 describe('updateAppIconBadge', () => {
     beforeEach(() => {
@@ -50,7 +73,7 @@ describe('updateAppIconBadge', () => {
     });
 
     it('calls Badge.set with the total unread count when count > 0 on native', async () => {
-        await updateAppIconBadge(5);
+        await updateAppIconBadge(5.7);
 
         expect(badgeMocks.set).toHaveBeenCalledWith({ count: 5 });
         expect(badgeMocks.clear).not.toHaveBeenCalled();
@@ -94,8 +117,9 @@ describe('updateAppIconBadge', () => {
     it('refreshes the badge count from the unread inbox total on native', async () => {
         chatServiceMocks.loadChatInbox.mockResolvedValue({
             teams: [
-                { id: 'team-1', unreadCount: 2 },
-                { id: 'team-2', unreadCount: 3 }
+                { id: 'team-1', unreadCount: 2.9 },
+                { id: 'team-2', unreadCount: 3 },
+                { id: 'team-3', unreadCount: -4 }
             ]
         });
 

--- a/apps/app/src/lib/badgeService.ts
+++ b/apps/app/src/lib/badgeService.ts
@@ -3,7 +3,16 @@ import { loadChatInbox, markTeamChatRead } from './chatService';
 import type { AuthUser } from './types';
 
 function isNativeRuntime(): boolean {
-    return Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:';
+    const protocol = typeof window === 'undefined' ? '' : window.location.protocol;
+    return Capacitor.isNativePlatform() || protocol === 'capacitor:';
+}
+
+export function normalizeAppIconBadgeCount(count: unknown): number {
+    const numericCount = typeof count === 'number' ? count : Number(count);
+    if (!Number.isFinite(numericCount) || numericCount <= 0) {
+        return 0;
+    }
+    return Math.floor(numericCount);
 }
 
 /**
@@ -16,8 +25,9 @@ export async function updateAppIconBadge(count: number): Promise<void> {
     if (!isNativeRuntime()) return;
     try {
         const { Badge } = await import('@capawesome/capacitor-badge');
-        if (count > 0) {
-            await Badge.set({ count });
+        const normalizedCount = normalizeAppIconBadgeCount(count);
+        if (normalizedCount > 0) {
+            await Badge.set({ count: normalizedCount });
         } else {
             await Badge.clear();
         }
@@ -29,7 +39,7 @@ export async function updateAppIconBadge(count: number): Promise<void> {
 export async function refreshUnreadChatBadge(user: AuthUser | null): Promise<void> {
     if (!user?.uid || !isNativeRuntime()) return;
     const result = await loadChatInbox(user, { includeLastMessages: false });
-    const totalUnread = result.teams.reduce((sum, team) => sum + team.unreadCount, 0);
+    const totalUnread = result.teams.reduce((sum, team) => sum + normalizeAppIconBadgeCount(team.unreadCount), 0);
     await updateAppIconBadge(totalUnread);
 }
 

--- a/tests/unit/app-push-notification-wiring.test.js
+++ b/tests/unit/app-push-notification-wiring.test.js
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { ANDROID_NOTIFICATION_CHANNELS } = require('../../functions/notification-delivery-metadata.cjs');
+
+function extractAppAndroidChannelIds(source) {
+    return [...source.matchAll(/id: '([^']+)'/g)].map((match) => match[1]);
+}
 
 describe('app push notification wiring', () => {
     it('registers native notification-open listeners and consumes pending routes after auth bootstrap', () => {
@@ -15,9 +23,7 @@ describe('app push notification wiring', () => {
 
     it('keeps Android channel metadata local to the app so Vite does not try to import the Functions CommonJS bundle in the browser', () => {
         const source = readFileSync(new URL('../../apps/app/src/lib/pushService.ts', import.meta.url), 'utf8');
-        expect(source).toContain("id: 'allplays_messages'");
-        expect(source).toContain("id: 'allplays_game_day'");
-        expect(source).toContain("id: 'allplays_schedule'");
+        expect(extractAppAndroidChannelIds(source)).toEqual(ANDROID_NOTIFICATION_CHANNELS.map((channel) => channel.id));
         expect(source).not.toContain('notification-delivery-metadata.cjs');
     });
 });


### PR DESCRIPTION
## Summary
- Normalize native app badge counts before calling the badge plugin so invalid, negative, and fractional unread counts cannot leak into OS APIs.
- Keep badge refresh totals using the same normalization path used by direct badge updates.
- Add a regression check that the app Android channel IDs stay in parity with Functions notification delivery metadata without importing the CJS bundle in Vite.

Closes #2102

## Tests
- `npx vitest run apps/app/src/lib/badgeService.test.ts apps/app/src/lib/pushService.test.ts --reporter=verbose`
- `npx vitest run tests/unit/notification-delivery-metadata.test.js tests/unit/app-push-notification-wiring.test.js --reporter=verbose`
- `npm --prefix apps/app run lint -- --quiet`
- `npm run app:build`