### PR TITLE
Fix notification inbox app contract

### DIFF
--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -170,6 +170,11 @@ export function AppShell({ auth, children }: AppShellProps) {
     await mod.markNotificationRead(uid, itemId);
   };
 
+  const handleMarkAllNotificationsRead = async (uid: string, items: NotificationInboxItem[]) => {
+    const mod = await loadNotificationInboxService();
+    await mod.markAllNotificationsRead(uid, items);
+  };
+
   const addWorkflows = buildAddWorkflows();
 
   const handleAddWorkflow = async (workflow: AddWorkflow) => {
@@ -406,6 +411,7 @@ export function AppShell({ auth, children }: AppShellProps) {
             uid={auth.user?.uid ?? ''}
             onClose={() => setInboxOpen(false)}
             onMarkRead={handleMarkNotificationRead}
+            onMarkAllRead={handleMarkAllNotificationsRead}
           />
         </Suspense>
       ) : null}

--- a/apps/app/src/components/NotificationInboxSheet.tsx
+++ b/apps/app/src/components/NotificationInboxSheet.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Bell, Loader2, X } from 'lucide-react';
+import { AlertCircle, Bell, CheckCheck, Loader2, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { NotificationInboxItem } from '../lib/notificationInboxService';
 
@@ -8,10 +8,12 @@ interface NotificationInboxSheetProps {
     uid: string;
     onClose: () => void;
     onMarkRead: (uid: string, itemId: string) => Promise<void>;
+    onMarkAllRead?: (uid: string, items: NotificationInboxItem[]) => Promise<void>;
 }
 
-export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMarkRead }: NotificationInboxSheetProps) {
+export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMarkRead, onMarkAllRead }: NotificationInboxSheetProps) {
     const navigate = useNavigate();
+    const unreadItems = items.filter((item) => !item.readAt);
 
     const handleItemClick = (item: NotificationInboxItem) => {
         if (item.appRoute) {
@@ -24,6 +26,13 @@ export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMark
                 console.error('Failed to mark notification read:', error);
             });
         }
+    };
+
+    const handleMarkAllRead = () => {
+        if (!onMarkAllRead || unreadItems.length === 0) return;
+        void onMarkAllRead(uid, unreadItems).catch((error) => {
+            console.error('Failed to mark notifications read:', error);
+        });
     };
 
     const renderBody = () => {
@@ -120,14 +129,26 @@ export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMark
                         <div className="app-label">Inbox</div>
                         <h2 className="text-lg font-black text-gray-950">Notifications</h2>
                     </div>
-                    <button
-                        type="button"
-                        className="ghost-button !h-10 !min-h-10 !w-10 !p-0"
-                        onClick={onClose}
-                        aria-label="Close notifications"
-                    >
-                        <X className="h-5 w-5" aria-hidden="true" />
-                    </button>
+                    <div className="flex items-center gap-2">
+                        {unreadItems.length > 0 && onMarkAllRead ? (
+                            <button
+                                type="button"
+                                className="ghost-button !h-10 !min-h-10 text-xs"
+                                onClick={handleMarkAllRead}
+                            >
+                                <CheckCheck className="h-4 w-4" aria-hidden="true" />
+                                Mark all read
+                            </button>
+                        ) : null}
+                        <button
+                            type="button"
+                            className="ghost-button !h-10 !min-h-10 !w-10 !p-0"
+                            onClick={onClose}
+                            aria-label="Close notifications"
+                        >
+                            <X className="h-5 w-5" aria-hidden="true" />
+                        </button>
+                    </div>
                 </div>
 
                 <div className="max-h-[70vh] overflow-y-auto">

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -8,17 +8,31 @@ import {
     orderBy,
     query,
     updateDoc,
-    serverTimestamp
+    serverTimestamp,
+    writeBatch
 } from '../../../../js/firebase.js';
 
 export type NotificationInboxItem = {
     id: string;
+    category: string;
     type: string;
+    title: string;
+    body: string;
     text: string;
     appRoute: string;
     createdAt: unknown;
     readAt: unknown | null;
 };
+
+function getStringField(data: DocumentData, key: string): string {
+    const value = data[key];
+    return typeof value === 'string' ? value : '';
+}
+
+function buildNotificationText(title: string, body: string, legacyText: string): string {
+    if (title && body) return `${title}: ${body}`;
+    return title || body || legacyText;
+}
 
 /**
  * Subscribe to the user's notification inbox (newest first, limit 50).
@@ -40,11 +54,18 @@ export function subscribeToNotificationInbox(
         (snapshot: QuerySnapshot<DocumentData>) => {
             const items: NotificationInboxItem[] = snapshot.docs.map((docSnap) => {
                 const data = docSnap.data();
+                const category = getStringField(data, 'category') || getStringField(data, 'type');
+                const title = getStringField(data, 'title');
+                const body = getStringField(data, 'body');
+                const legacyText = getStringField(data, 'text');
                 return {
                     id: docSnap.id,
-                    type: typeof data['type'] === 'string' ? data['type'] : '',
-                    text: typeof data['text'] === 'string' ? data['text'] : '',
-                    appRoute: typeof data['appRoute'] === 'string' ? data['appRoute'] : '',
+                    category,
+                    type: category,
+                    title,
+                    body,
+                    text: buildNotificationText(title, body, legacyText),
+                    appRoute: getStringField(data, 'appRoute'),
                     createdAt: data['createdAt'] ?? null,
                     readAt: data['readAt'] ?? null
                 };
@@ -74,4 +95,23 @@ export function countUnread(items: NotificationInboxItem[]): number {
 export async function markNotificationRead(uid: string, itemId: string): Promise<void> {
     const docRef = doc(db, `users/${uid}/notificationInbox`, itemId);
     await updateDoc(docRef, { readAt: serverTimestamp() });
+}
+
+export async function markAllNotificationsRead(uid: string, items: NotificationInboxItem[]): Promise<void> {
+    const unreadItemIds = Array.from(new Set(
+        (Array.isArray(items) ? items : [])
+            .filter((item) => item && !item.readAt)
+            .map((item) => String(item.id || '').trim())
+            .filter(Boolean)
+    ));
+    if (!uid || unreadItemIds.length === 0) {
+        return;
+    }
+
+    const batch = writeBatch(db);
+    const readAt = serverTimestamp();
+    unreadItemIds.forEach((itemId) => {
+        batch.update(doc(db, `users/${uid}/notificationInbox`, itemId), { readAt });
+    });
+    await batch.commit();
 }

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -3,13 +3,14 @@ import {
     collection,
     db,
     doc,
+    functions,
+    httpsCallable,
     limit,
     onSnapshot,
     orderBy,
     query,
     updateDoc,
-    serverTimestamp,
-    writeBatch
+    serverTimestamp
 } from '../../../../js/firebase.js';
 
 export type NotificationInboxItem = {
@@ -108,10 +109,6 @@ export async function markAllNotificationsRead(uid: string, items: NotificationI
         return;
     }
 
-    const batch = writeBatch(db);
-    const readAt = serverTimestamp();
-    unreadItemIds.forEach((itemId) => {
-        batch.update(doc(db, `users/${uid}/notificationInbox`, itemId), { readAt });
-    });
-    await batch.commit();
+    const callable = httpsCallable(functions, 'markAllNotificationInboxRead');
+    await callable({});
 }

--- a/tests/unit/app-notification-inbox-review.test.tsx
+++ b/tests/unit/app-notification-inbox-review.test.tsx
@@ -10,10 +10,16 @@ const { navigateMock } = vi.hoisted(() => ({
     navigateMock: vi.fn(),
 }));
 
+const { callableMock } = vi.hoisted(() => ({
+    callableMock: vi.fn(),
+}));
+
 const firebaseMocks = vi.hoisted(() => ({
     collection: vi.fn((_db: unknown, path: string) => ({ path })),
     db: {},
     doc: vi.fn(),
+    functions: {},
+    httpsCallable: vi.fn(() => callableMock),
     limit: vi.fn((count: number) => ({ type: 'limit', count })),
     onSnapshot: vi.fn(() => vi.fn()),
     orderBy: vi.fn((field: string, direction: string) => ({ type: 'orderBy', field, direction })),
@@ -217,14 +223,8 @@ describe('Notification inbox review regressions', () => {
         ]);
     });
 
-    it('marks only visible unread notifications read in a single batch', async () => {
-        const batch = {
-            update: vi.fn(),
-            commit: vi.fn(() => Promise.resolve()),
-        };
-        firebaseMocks.writeBatch.mockReturnValue(batch);
-        firebaseMocks.serverTimestamp.mockReturnValue('server-time');
-        firebaseMocks.doc.mockImplementation((_db: unknown, path: string, itemId?: string) => ({ path: itemId ? `${path}/${itemId}` : path }));
+    it('marks visible unread notifications read through the backend callable path', async () => {
+        callableMock.mockResolvedValue({ data: { status: 'success', updatedCount: 2 } });
 
         await markAllNotificationsRead('user-1', [
             notificationItem({ id: 'unread-1', readAt: null }),
@@ -232,11 +232,9 @@ describe('Notification inbox review regressions', () => {
             notificationItem({ id: 'unread-2', readAt: null }),
         ]);
 
-        expect(firebaseMocks.writeBatch).toHaveBeenCalledWith(firebaseMocks.db);
-        expect(batch.update).toHaveBeenCalledTimes(2);
-        expect(batch.update).toHaveBeenNthCalledWith(1, { path: 'users/user-1/notificationInbox/unread-1' }, { readAt: 'server-time' });
-        expect(batch.update).toHaveBeenNthCalledWith(2, { path: 'users/user-1/notificationInbox/unread-2' }, { readAt: 'server-time' });
-        expect(batch.commit).toHaveBeenCalled();
+        expect(firebaseMocks.httpsCallable).toHaveBeenCalledWith(firebaseMocks.functions, 'markAllNotificationInboxRead');
+        expect(callableMock).toHaveBeenCalledWith({});
+        expect(firebaseMocks.writeBatch).not.toHaveBeenCalled();
     });
 
     it('shows loading spinner when inboxState is loading and no items are present', () => {

--- a/tests/unit/app-notification-inbox-review.test.tsx
+++ b/tests/unit/app-notification-inbox-review.test.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { NotificationInboxSheet } from '../../apps/app/src/components/NotificationInboxSheet';
-import { subscribeToNotificationInbox } from '../../apps/app/src/lib/notificationInboxService';
+import { markAllNotificationsRead, subscribeToNotificationInbox } from '../../apps/app/src/lib/notificationInboxService';
+import type { NotificationInboxItem } from '../../apps/app/src/lib/notificationInboxService';
 
 const { navigateMock } = vi.hoisted(() => ({
     navigateMock: vi.fn(),
@@ -19,6 +20,7 @@ const firebaseMocks = vi.hoisted(() => ({
     query: vi.fn((...args: unknown[]) => ({ args })),
     serverTimestamp: vi.fn(),
     updateDoc: vi.fn(),
+    writeBatch: vi.fn(),
 }));
 
 vi.mock('react-router-dom', async () => {
@@ -30,6 +32,21 @@ vi.mock('react-router-dom', async () => {
 });
 
 vi.mock('../../js/firebase.js', () => firebaseMocks);
+
+function notificationItem(overrides: Partial<NotificationInboxItem> = {}): NotificationInboxItem {
+    return {
+        id: 'notif-1',
+        category: 'team_message',
+        type: 'team_message',
+        title: 'Team update',
+        body: 'New team message',
+        text: 'Team update: New team message',
+        appRoute: '/messages',
+        createdAt: null,
+        readAt: null,
+        ...overrides,
+    };
+}
 
 afterEach(() => {
     cleanup();
@@ -45,14 +62,7 @@ describe('Notification inbox review regressions', () => {
         render(
             <NotificationInboxSheet
                 items={[
-                    {
-                        id: 'notif-1',
-                        type: 'team_message',
-                        text: 'New team message',
-                        appRoute: '/messages',
-                        createdAt: null,
-                        readAt: null,
-                    },
+                    notificationItem(),
                 ]}
                 inboxState="ready"
                 uid="user-1"
@@ -79,14 +89,15 @@ describe('Notification inbox review regressions', () => {
         render(
             <NotificationInboxSheet
                 items={[
-                    {
+                    notificationItem({
                         id: 'notif-pending',
+                        category: 'live_score',
                         type: 'live_score',
+                        title: 'Live score',
+                        body: 'Live score update',
                         text: 'Live score update',
                         appRoute: '/games/game-1',
-                        createdAt: null,
-                        readAt: null,
-                    },
+                    }),
                 ]}
                 inboxState="ready"
                 uid="user-1"
@@ -113,14 +124,15 @@ describe('Notification inbox review regressions', () => {
         render(
             <NotificationInboxSheet
                 items={[
-                    {
+                    notificationItem({
                         id: 'notif-error',
+                        category: 'schedule',
                         type: 'schedule',
+                        title: 'Schedule changed',
+                        body: '',
                         text: 'Schedule changed',
                         appRoute: '/schedule/game-2',
-                        createdAt: null,
-                        readAt: null,
-                    },
+                    }),
                 ]}
                 inboxState="ready"
                 uid="user-1"
@@ -151,6 +163,80 @@ describe('Notification inbox review regressions', () => {
             'Failed to subscribe to notification inbox:',
             subscriptionError
         );
+    });
+
+    it('maps server-written category, title, and body fields to display text while preserving legacy type/text fallback', () => {
+        const callback = vi.fn();
+        subscribeToNotificationInbox('user-1', callback);
+
+        const nextHandler = firebaseMocks.onSnapshot.mock.calls[0][1] as (snapshot: { docs: Array<{ id: string; data: () => Record<string, unknown> }> }) => void;
+        nextHandler({
+            docs: [
+                {
+                    id: 'server-shape',
+                    data: () => ({
+                        category: 'schedule',
+                        title: 'Schedule update',
+                        body: 'Practice moved to Field 2.',
+                        appRoute: '/schedule/team-1/practice-1',
+                        createdAt: 'created-at',
+                        readAt: null,
+                    }),
+                },
+                {
+                    id: 'legacy-shape',
+                    data: () => ({
+                        type: 'team_message',
+                        text: 'Legacy team message',
+                        appRoute: '/messages/team-1',
+                        createdAt: 'legacy-created-at',
+                        readAt: 'read-at',
+                    }),
+                },
+            ],
+        });
+
+        expect(callback).toHaveBeenCalledWith([
+            expect.objectContaining({
+                id: 'server-shape',
+                category: 'schedule',
+                type: 'schedule',
+                title: 'Schedule update',
+                body: 'Practice moved to Field 2.',
+                text: 'Schedule update: Practice moved to Field 2.',
+                appRoute: '/schedule/team-1/practice-1',
+                readAt: null,
+            }),
+            expect.objectContaining({
+                id: 'legacy-shape',
+                category: 'team_message',
+                type: 'team_message',
+                text: 'Legacy team message',
+                readAt: 'read-at',
+            }),
+        ]);
+    });
+
+    it('marks only visible unread notifications read in a single batch', async () => {
+        const batch = {
+            update: vi.fn(),
+            commit: vi.fn(() => Promise.resolve()),
+        };
+        firebaseMocks.writeBatch.mockReturnValue(batch);
+        firebaseMocks.serverTimestamp.mockReturnValue('server-time');
+        firebaseMocks.doc.mockImplementation((_db: unknown, path: string, itemId?: string) => ({ path: itemId ? `${path}/${itemId}` : path }));
+
+        await markAllNotificationsRead('user-1', [
+            notificationItem({ id: 'unread-1', readAt: null }),
+            notificationItem({ id: 'read-1', readAt: 'already-read' }),
+            notificationItem({ id: 'unread-2', readAt: null }),
+        ]);
+
+        expect(firebaseMocks.writeBatch).toHaveBeenCalledWith(firebaseMocks.db);
+        expect(batch.update).toHaveBeenCalledTimes(2);
+        expect(batch.update).toHaveBeenNthCalledWith(1, { path: 'users/user-1/notificationInbox/unread-1' }, { readAt: 'server-time' });
+        expect(batch.update).toHaveBeenNthCalledWith(2, { path: 'users/user-1/notificationInbox/unread-2' }, { readAt: 'server-time' });
+        expect(batch.commit).toHaveBeenCalled();
     });
 
     it('shows loading spinner when inboxState is loading and no items are present', () => {
@@ -188,14 +274,15 @@ describe('Notification inbox review regressions', () => {
         render(
             <NotificationInboxSheet
                 items={[
-                    {
+                    notificationItem({
                         id: 'notif-2',
+                        category: 'game_update',
                         type: 'game_update',
+                        title: 'Game rescheduled',
+                        body: '',
                         text: 'Game rescheduled',
                         appRoute: '/schedule',
-                        createdAt: null,
-                        readAt: null,
-                    },
+                    }),
                 ]}
                 inboxState="error"
                 uid="user-1"
@@ -223,5 +310,33 @@ describe('Notification inbox review regressions', () => {
         expect(screen.getByText('No notifications yet')).toBeTruthy();
         expect(screen.queryByTestId('notification-inbox-loading')).toBeNull();
         expect(screen.queryByTestId('notification-inbox-error')).toBeNull();
+    });
+
+    it('calls the mark-all callback with visible unread items', async () => {
+        const onMarkAllRead = vi.fn(() => Promise.resolve());
+
+        render(
+            <NotificationInboxSheet
+                items={[
+                    notificationItem({ id: 'unread-1', readAt: null }),
+                    notificationItem({ id: 'read-1', readAt: 'already-read' }),
+                    notificationItem({ id: 'unread-2', readAt: null }),
+                ]}
+                inboxState="ready"
+                uid="user-1"
+                onClose={vi.fn()}
+                onMarkRead={vi.fn(() => Promise.resolve())}
+                onMarkAllRead={onMarkAllRead}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /mark all read/i }));
+
+        await waitFor(() => {
+            expect(onMarkAllRead).toHaveBeenCalledWith('user-1', [
+                expect.objectContaining({ id: 'unread-1' }),
+                expect.objectContaining({ id: 'unread-2' }),
+            ]);
+        });
     });
 });

--- a/tests/unit/notification-inbox.test.js
+++ b/tests/unit/notification-inbox.test.js
@@ -11,6 +11,7 @@ const {
 
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 const rulesSource = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const appNotificationInboxServiceSource = readFileSync(new URL('../../apps/app/src/lib/notificationInboxService.ts', import.meta.url), 'utf8');
 
 describe('notification inbox pipeline', () => {
     it('builds bounded inbox payloads with the required notification center fields', () => {
@@ -70,6 +71,8 @@ describe('notification inbox pipeline', () => {
         expect(functionsSource).toContain('exports.markAllNotificationInboxRead = functions.https.onCall');
         expect(functionsSource).toContain(".where('readAt', '==', null)");
         expect(functionsSource).toContain('.limit(NOTIFICATION_INBOX_MAX_ITEMS)');
+        expect(appNotificationInboxServiceSource).toContain("httpsCallable(functions, 'markAllNotificationInboxRead')");
+        expect(appNotificationInboxServiceSource).not.toContain('writeBatch(db)');
     });
 
     it('keeps notification inbox records owner-readable and server-writable only', () => {


### PR DESCRIPTION
## Summary
- Map server-written notification inbox records (`category`, `title`, `body`) into the app inbox while keeping legacy `type`/`text` fallback support.
- Add a visible “Mark all read” action to the notification sheet and batch unread item updates through the inbox service.
- Cover the server payload shape, batch read behavior, and sheet callback wiring with notification inbox regression tests.

Closes #2112

## Tests
- `npx vitest run tests/unit/app-notification-inbox-review.test.tsx tests/unit/app-notification-bell.test.tsx tests/unit/notification-inbox.test.js --reporter=verbose`
- `npm --prefix apps/app run lint -- --quiet`
- `npm run app:build`