### PR TITLE
Target assigned practice packet parents

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3749,6 +3749,70 @@ function hasPracticePacketContent(packet = null) {
   return Array.isArray(packet?.blocks) && packet.blocks.length > 0;
 }
 
+function collectPracticePacketAssignedPlayerIds(packet = {}, session = {}) {
+  const playerIds = new Set();
+  const collectValue = (value) => {
+    if (!value) return;
+    if (Array.isArray(value)) {
+      value.forEach(collectValue);
+      return;
+    }
+    if (typeof value === 'object') {
+      collectValue(value.playerId || value.childId || value.id);
+      return;
+    }
+    const normalized = String(value || '').trim();
+    if (normalized) {
+      playerIds.add(normalized);
+    }
+  };
+
+  [
+    packet.playerIds,
+    packet.assignedPlayerIds,
+    packet.targetPlayerIds,
+    packet.childIds,
+    packet.players,
+    packet.assignedPlayers,
+    session.playerIds,
+    session.assignedPlayerIds,
+    session.targetPlayerIds
+  ].forEach(collectValue);
+
+  return Array.from(playerIds);
+}
+
+async function resolvePracticePacketAssignedParentUserIds(teamId, packet = {}, session = {}) {
+  const directParentUserIds = [
+    packet.parentUserIds,
+    packet.recipientUserIds,
+    packet.assignedParentUserIds
+  ].flatMap((value) => (Array.isArray(value) ? value : [value]))
+    .map((value) => String(value || '').trim())
+    .filter(Boolean);
+  const assignedPlayerIds = collectPracticePacketAssignedPlayerIds(packet, session);
+
+  if (!directParentUserIds.length && !assignedPlayerIds.length) {
+    return null;
+  }
+
+  const userIds = new Set(directParentUserIds);
+  const parentLookups = await Promise.allSettled(
+    assignedPlayerIds.map((playerId) => firestore.collection('users')
+      .where('parentPlayerKeys', 'array-contains', `${teamId}::${playerId}`)
+      .get())
+  );
+  parentLookups.forEach((result) => {
+    if (result.status !== 'fulfilled') return;
+    (result.value.docs || []).forEach((docSnap) => {
+      const uid = String(docSnap.id || '').trim();
+      if (uid) userIds.add(uid);
+    });
+  });
+
+  return Array.from(userIds);
+}
+
 function getCertificateNotificationPlayerKey(certificate = {}, teamId = '') {
   const resolvedTeamId = String(certificate.teamId || teamId || '').trim();
   const playerId = String(certificate.playerId || certificate.childId || '').trim();
@@ -3868,23 +3932,29 @@ async function practicePacketAssignedNotification(beforeData = null, afterData =
   }
 
   const { teamId, sessionId } = context.params || {};
-  const [allPracticeTargets, candidateUsers] = await Promise.all([
+  const [allPracticeTargets, candidateUsers, assignedParentUserIds] = await Promise.all([
     getTargetsForCategory(teamId, 'practice', null),
-    getCandidateUsersForTeam(teamId)
+    getCandidateUsersForTeam(teamId),
+    resolvePracticePacketAssignedParentUserIds(teamId, afterPacket, afterData)
   ]);
   const parentUserIds = new Set(
     candidateUsers
       .filter((user) => Array.isArray(user?.roles) && user.roles.includes('parent'))
       .map((user) => user.uid)
   );
-  const parentTargets = allPracticeTargets.filter((target) => parentUserIds.has(target.uid));
+  const assignedParentUserIdSet = Array.isArray(assignedParentUserIds) ? new Set(assignedParentUserIds) : null;
+  const parentTargets = allPracticeTargets.filter((target) => (
+    parentUserIds.has(target.uid)
+    && (!assignedParentUserIdSet || assignedParentUserIdSet.has(target.uid))
+  ));
 
   if (!parentTargets.length) {
     functions.logger.warn('notifyPracticePacketAssigned found no practice-enabled parent targets.', {
       teamId,
       sessionId,
       totalPracticeTargets: allPracticeTargets.length,
-      parentUserCount: parentUserIds.size
+      parentUserCount: parentUserIds.size,
+      assignedParentUserCount: assignedParentUserIdSet ? assignedParentUserIdSet.size : null
     });
     return null;
   }

--- a/tests/unit/practice-packet-assigned-notifications.test.js
+++ b/tests/unit/practice-packet-assigned-notifications.test.js
@@ -31,12 +31,21 @@ function buildHarness({
     categories = ['practice', 'schedule'],
     targets = [],
     users = [],
+    parentUserIdsByPlayerKey = {},
     sendResult = null
 } = {}) {
     const sendDirectTargetsNotification = vi.fn(() => sendResult || Promise.resolve({ successCount: 1, failureCount: 0 }));
     const getTargetsForCategory = vi.fn(async () => targets);
     const getCandidateUsersForTeam = vi.fn(async () => users);
-    const firestore = {};
+    const firestore = {
+        collection: vi.fn((_path) => ({
+            where: vi.fn((_field, _op, playerKey) => ({
+                get: vi.fn(async () => ({
+                    docs: (parentUserIdsByPlayerKey[playerKey] || []).map((uid) => ({ id: uid }))
+                }))
+            }))
+        }))
+    };
     const functions = {
         firestore: {
             document: vi.fn(() => ({
@@ -72,6 +81,7 @@ function buildHarness({
     return {
         trigger,
         functions,
+        firestore,
         getTargetsForCategory,
         getCandidateUsersForTeam,
         sendDirectTargetsNotification
@@ -79,7 +89,7 @@ function buildHarness({
 }
 
 describe('notifyPracticePacketAssigned trigger', () => {
-    it('fires from the practice session write and targets only parent devices', async () => {
+    it('fires from the practice session write and targets only parents linked to assigned players', async () => {
         const harness = buildHarness({
             targets: [
                 { uid: 'parent-1', token: 'parent-1-token', teamId: 'team-1' },
@@ -90,7 +100,10 @@ describe('notifyPracticePacketAssigned trigger', () => {
                 { uid: 'parent-1', roles: ['parent'] },
                 { uid: 'parent-2', roles: ['parent'] },
                 { uid: 'staff-1', roles: ['staff'] }
-            ]
+            ],
+            parentUserIdsByPlayerKey: {
+                'team-1::player-1': ['parent-1']
+            }
         });
 
         await harness.trigger({
@@ -105,6 +118,7 @@ describe('notifyPracticePacketAssigned trigger', () => {
                     eventId: 'practice-44',
                     date: '2026-06-21',
                     homePacketContent: {
+                        assignedPlayerIds: ['player-1'],
                         blocks: [{ id: 'block-1', title: 'Ball handling' }],
                         totalMinutes: 20,
                         updatedAt: '2026-06-19T20:15:00.000Z'
@@ -117,10 +131,10 @@ describe('notifyPracticePacketAssigned trigger', () => {
 
         expect(harness.getTargetsForCategory).toHaveBeenCalledWith('team-1', 'practice', null);
         expect(harness.getCandidateUsersForTeam).toHaveBeenCalledWith('team-1');
+        expect(harness.firestore.collection).toHaveBeenCalledWith('users');
         expect(harness.sendDirectTargetsNotification).toHaveBeenCalledWith(expect.objectContaining({
             targets: [
-                { uid: 'parent-1', token: 'parent-1-token', teamId: 'team-1' },
-                { uid: 'parent-2', token: 'parent-2-token', teamId: 'team-1' }
+                { uid: 'parent-1', token: 'parent-1-token', teamId: 'team-1' }
             ],
             category: 'practice',
             title: 'Practice packet ready',


### PR DESCRIPTION
## Summary
- Resolve explicit practice packet player/parent assignments before sending packet-ready notifications.
- Filter packet assignment push targets to parents linked to assigned players, while keeping whole-team packet behavior when no explicit assignment exists.
- Extend the packet assignment trigger regression to prove unrelated parent devices are excluded.

Closes #2107

## Tests
- `npx vitest run tests/unit/practice-packet-assigned-notifications.test.js tests/unit/practice-packet-due-reminders.test.js tests/unit/practice-packet-completion-notifications.test.js --reporter=verbose`
- `node --check functions/index.js`
- `npm run test:notifications --prefix functions`