### PR TITLE
Fix My Teams navigation

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -15,7 +15,6 @@ import {
 } from './lib/nativeBackButton';
 import { addNativeDeepLinkListener } from './lib/nativeDeepLinkRouting';
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
-import { shouldReloadTeamsToHome } from './lib/reloadRouting';
 import { readAuthBootstrapHint } from './lib/authBootstrapHint';
 import { useAuth } from './lib/useAuth';
 import type { AuthState } from './lib/types';
@@ -59,12 +58,6 @@ export default function App() {
   const lastNativeExitBackPressRef = useRef(0);
   const nativeExitNoticeTimeoutRef = useRef<number | null>(null);
   const [nativeExitNoticeVisible, setNativeExitNoticeVisible] = useState(false);
-  const shouldDefaultReloadToHome = shouldReloadTeamsToHome({
-    hasUser: Boolean(auth.user),
-    pathname: location.pathname,
-    search: location.search,
-    isReload: isBrowserReload()
-  });
 
   useEffect(() => {
     authUserRef.current = auth.user;
@@ -216,7 +209,7 @@ export default function App() {
         <Route path="/messages" element={<Protected auth={auth}><Messages auth={auth} /></Protected>} />
         <Route path="/messages/:teamId" element={<Protected auth={auth}><Messages auth={auth} /></Protected>} />
         <Route path="/ai" element={<Protected auth={auth}><PrivateAiChat auth={auth} /></Protected>} />
-        <Route path="/teams" element={shouldDefaultReloadToHome ? <Navigate to="/home" replace /> : <Protected auth={auth}><Teams auth={auth} /></Protected>} />
+        <Route path="/teams" element={<Protected auth={auth}><Teams auth={auth} /></Protected>} />
         <Route path="/teams/browse" element={<Protected auth={auth}><PublicTeamsBrowse /></Protected>} />
         <Route path="/teams/:teamId" element={<Protected auth={auth}><TeamDetail auth={auth} /></Protected>} />
         <Route path="/teams/:teamId/edit" element={<Protected auth={auth}><TeamSettings auth={auth} /></Protected>} />
@@ -245,12 +238,6 @@ export default function App() {
       ) : null}
     </Suspense>
   );
-}
-
-function isBrowserReload() {
-  const navigation = performance.getEntriesByType?.('navigation')?.[0] as PerformanceNavigationTiming | undefined;
-  if (navigation?.type) return navigation.type === 'reload';
-  return (performance as Performance & { navigation?: { type?: number } }).navigation?.type === 1;
 }
 
 function Protected({ auth, children }: { auth: AuthState; children: ReactNode }) {

--- a/apps/app/src/lib/reloadRouting.ts
+++ b/apps/app/src/lib/reloadRouting.ts
@@ -1,13 +1,13 @@
 export function shouldReloadTeamsToHome({
-  hasUser,
-  pathname,
-  search,
-  isReload
+  hasUser: _hasUser,
+  pathname: _pathname,
+  search: _search,
+  isReload: _isReload
 }: {
   hasUser: boolean;
   pathname: string;
   search: string;
   isReload: boolean;
 }) {
-  return hasUser && pathname === '/teams' && !search && isReload;
+  return false;
 }

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -192,7 +192,7 @@ describe('Teams empty state', () => {
     expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeInTheDocument();
     expect(screen.getByText('Choose a team')).toBeInTheDocument();
     expect(screen.getByText('Unable to refresh teams. Showing the last loaded teams. Try again.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Open Fast Falcons' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('link', { name: 'Open Fast Falcons' })).toHaveAttribute('href', '/teams/team-fast');
     expect(screen.queryByText('Teams could not load')).toBeNull();
     expect(screen.queryByText('No teams available')).toBeNull();
   });
@@ -267,19 +267,15 @@ describe('Teams launcher navigation', () => {
     cleanup();
   });
 
-  it('updates the selected team in-place and keeps the team hub quick link available', async () => {
+  it('opens the team hub when a launcher team is clicked', async () => {
     renderTeamsWithNav();
 
-    const slowSharks = await screen.findByRole('button', { name: 'Open Slow Sharks' });
-    expect(slowSharks).toHaveAttribute('aria-pressed', 'false');
+    const fastFalcons = await screen.findByRole('link', { name: 'Open Fast Falcons' });
+    expect(fastFalcons).toHaveAttribute('href', '/teams/team-fast');
 
-    fireEvent.click(slowSharks);
+    fireEvent.click(fastFalcons);
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Open Slow Sharks' })).toHaveAttribute('aria-pressed', 'true');
-    });
-    expect(screen.queryByTestId('team-hub')).toBeNull();
-    expect(screen.getByRole('link', { name: 'Slow Sharks team hub' })).toHaveAttribute('href', '/teams/team-slow');
+    expect(await screen.findByTestId('team-hub')).toHaveTextContent('Team hub: team-fast');
   });
 });
 

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -85,9 +85,9 @@ const emptyHome = {
   }
 };
 
-function renderTeams({ strictMode = false }: { strictMode?: boolean } = {}) {
+function renderTeams({ strictMode = false, initialEntry = '/teams' }: { strictMode?: boolean; initialEntry?: string } = {}) {
   const tree = (
-    <MemoryRouter initialEntries={["/teams"]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/teams" element={<Teams auth={auth} />} />
         <Route path="/accept-invite" element={<div>Accept invite route</div>} />
@@ -187,12 +187,12 @@ describe('Teams empty state', () => {
     homeServiceMocks.loadParentTeamsSummary.mockResolvedValueOnce(fastTeamHome);
     homeServiceMocks.loadParentHomeSummary.mockRejectedValueOnce(new Error('Enrichment outage'));
 
-    renderTeams();
+    renderTeams({ initialEntry: '/teams?selectedTeamId=team-fast&from=home' });
 
     expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeInTheDocument();
     expect(screen.getByText('Choose a team')).toBeInTheDocument();
     expect(screen.getByText('Unable to refresh teams. Showing the last loaded teams. Try again.')).toBeInTheDocument();
-    expect(screen.getByText('Fast Falcons')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open Fast Falcons' })).toHaveAttribute('href', '/teams/team-fast');
     expect(screen.queryByText('Teams could not load')).toBeNull();
     expect(screen.queryByText('No teams available')).toBeNull();
   });
@@ -218,6 +218,64 @@ describe('Teams empty state', () => {
     expect(await screen.findByText('Teams could not load')).toBeTruthy();
     expect(screen.getByText('Try loading teams again to restore your team dashboard.')).toBeTruthy();
     expect(screen.queryByText('Loading teams')).toBeNull();
+  });
+});
+
+describe('Teams launcher navigation', () => {
+  const twoTeamHome = {
+    players: [],
+    teams: [
+      {
+        teamId: 'team-fast',
+        teamName: 'Fast Falcons',
+        role: 'Parent' as const,
+        sport: 'Basketball',
+        photoUrl: null,
+        players: [{ teamId: 'team-fast', teamName: 'Fast Falcons', playerId: 'player-1', playerName: 'Avery Ace' }],
+        nextEvent: null,
+        eventCount: 2,
+        unreadCount: 1,
+        openActions: 0
+      },
+      {
+        teamId: 'team-slow',
+        teamName: 'Slow Sharks',
+        role: 'Coach' as const,
+        sport: 'Soccer',
+        photoUrl: null,
+        players: [],
+        nextEvent: null,
+        eventCount: 0,
+        unreadCount: 0,
+        openActions: 0
+      }
+    ],
+    upcomingEvents: [],
+    actionItems: [],
+    fees: [],
+    metrics: { players: 1, teams: 2, rsvpNeeded: 0, unreadMessages: 1, packetsReady: 0 }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true });
+    homeServiceMocks.loadParentTeamsSummary.mockResolvedValue(twoTeamHome);
+    homeServiceMocks.loadParentHomeSummary.mockResolvedValue(twoTeamHome);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens the team hub when a launcher team is clicked', async () => {
+    renderTeamsWithNav();
+
+    const fastFalcons = await screen.findByRole('link', { name: 'Open Fast Falcons' });
+    expect(fastFalcons).toHaveAttribute('href', '/teams/team-fast');
+
+    fireEvent.click(fastFalcons);
+
+    expect(await screen.findByTestId('team-hub')).toHaveTextContent('Team hub: team-fast');
   });
 });
 

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -192,7 +192,7 @@ describe('Teams empty state', () => {
     expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeInTheDocument();
     expect(screen.getByText('Choose a team')).toBeInTheDocument();
     expect(screen.getByText('Unable to refresh teams. Showing the last loaded teams. Try again.')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Open Fast Falcons' })).toHaveAttribute('href', '/teams/team-fast');
+    expect(screen.getByRole('button', { name: 'Open Fast Falcons' })).toHaveAttribute('aria-pressed', 'true');
     expect(screen.queryByText('Teams could not load')).toBeNull();
     expect(screen.queryByText('No teams available')).toBeNull();
   });
@@ -267,15 +267,19 @@ describe('Teams launcher navigation', () => {
     cleanup();
   });
 
-  it('opens the team hub when a launcher team is clicked', async () => {
+  it('updates the selected team in-place and keeps the team hub quick link available', async () => {
     renderTeamsWithNav();
 
-    const fastFalcons = await screen.findByRole('link', { name: 'Open Fast Falcons' });
-    expect(fastFalcons).toHaveAttribute('href', '/teams/team-fast');
+    const slowSharks = await screen.findByRole('button', { name: 'Open Slow Sharks' });
+    expect(slowSharks).toHaveAttribute('aria-pressed', 'false');
 
-    fireEvent.click(fastFalcons);
+    fireEvent.click(slowSharks);
 
-    expect(await screen.findByTestId('team-hub')).toHaveTextContent('Team hub: team-fast');
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Open Slow Sharks' })).toHaveAttribute('aria-pressed', 'true');
+    });
+    expect(screen.queryByTestId('team-hub')).toBeNull();
+    expect(screen.getByRole('link', { name: 'Slow Sharks team hub' })).toHaveAttribute('href', '/teams/team-slow');
   });
 });
 

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -61,7 +61,7 @@ function emptyHome(): ParentHomeModel {
 export function Teams({ auth }: { auth: AuthState }) {
   const { isDesktopWeb } = useShellLayout();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [home, setHome] = useState<ParentHomeModel>(() => emptyHome());
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -152,15 +152,6 @@ export function Teams({ auth }: { auth: AuthState }) {
   const teamRoles = useMemo(() => getLoadedTeamRoles(home.teams), [home.teams]);
   const hasManagementTeam = useMemo(() => home.teams.some((team) => isTeamManagementRole(team.role)), [home.teams]);
 
-  const selectTeam = (teamId: string) => {
-    const params = new URLSearchParams(searchParams);
-    params.set('selectedTeamId', teamId);
-    setSearchParams(params, { replace: true });
-    window.requestAnimationFrame(() => {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    });
-  };
-
   return (
     <PullToRefresh onRefresh={() => loadTeams()} disabled={!auth.user?.uid}>
     <div className={`teams-page ${isDesktopWeb ? 'teams-page-web' : ''} space-y-4`}>
@@ -185,7 +176,7 @@ export function Teams({ auth }: { auth: AuthState }) {
       ) : home.teams.length ? (
         isDesktopWeb ? (
           <div className="teams-web-workbench">
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelect={selectTeam} variant="rail" />
+            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} variant="rail" />
             <div className="min-w-0 space-y-4">
               {selectedTeam ? <SelectedTeamPanel team={selectedTeam} variant="web" /> : null}
               {hasManagementTeam ? <WebsiteToolsNotice compact /> : null}
@@ -193,7 +184,7 @@ export function Teams({ auth }: { auth: AuthState }) {
           </div>
         ) : (
           <>
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelect={selectTeam} />
+            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} />
             {selectedTeam ? <SelectedTeamPanel team={selectedTeam} /> : null}
           </>
         )
@@ -286,10 +277,9 @@ function TeamsHeader({ loading, refreshing, teams, teamRoles, onRefresh }: {
   );
 }
 
-function TeamLauncher({ teams, selectedTeamId, onSelect, variant = 'grid' }: {
+function TeamLauncher({ teams, selectedTeamId, variant = 'grid' }: {
   teams: ParentHomeTeam[];
   selectedTeamId: string;
-  onSelect: (teamId: string) => void;
   variant?: 'grid' | 'rail';
 }) {
   const [query, setQuery] = useState('');
@@ -318,7 +308,7 @@ function TeamLauncher({ teams, selectedTeamId, onSelect, variant = 'grid' }: {
       </label>
       <div className={`${isRail ? 'teams-team-rail-list mt-3 space-y-2' : 'mt-3 grid gap-2 xl:grid-cols-2'}`}>
         {visibleTeams.length ? visibleTeams.map((team) => (
-          <TeamLauncherRow key={team.teamId} team={team} selected={team.teamId === selectedTeamId} onSelect={() => onSelect(team.teamId)} compact={isRail} />
+          <TeamLauncherRow key={team.teamId} team={team} selected={team.teamId === selectedTeamId} compact={isRail} />
         )) : (
           <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No teams match that search.</div>
         )}
@@ -327,18 +317,18 @@ function TeamLauncher({ teams, selectedTeamId, onSelect, variant = 'grid' }: {
   );
 }
 
-function TeamLauncherRow({ team, selected, onSelect, compact = false }: { team: ParentHomeTeam; selected: boolean; onSelect: () => void; compact?: boolean }) {
+function TeamLauncherRow({ team, selected, compact = false }: { team: ParentHomeTeam; selected: boolean; compact?: boolean }) {
   const hasSchedule = team.eventCount > 0 || team.players.length > 0;
   const nextEventSummary = getTeamNextEventSummary(team);
 
   return (
     <article className={`team-launcher-row flex min-w-0 items-center gap-2 rounded-2xl border bg-white p-2 shadow-sm transition ${compact ? 'team-launcher-row-compact' : ''} ${selected ? 'border-primary-300 bg-primary-50/50 ring-2 ring-primary-100' : 'border-gray-200 hover:border-primary-200 hover:bg-primary-50/25'}`}>
-      <button type="button" className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" onClick={onSelect} aria-pressed={selected}>
+      <Link to={`/teams/${encodeURIComponent(team.teamId)}`} className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" aria-current={selected ? 'page' : undefined} aria-label={`Open ${team.teamName}`}>
         <TeamAvatar name={team.teamName} photoUrl={team.photoUrl} />
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center gap-2">
             <span className="truncate text-sm font-black text-gray-950">{team.teamName}</span>
-            {selected ? <span className="hidden rounded-full bg-primary-600 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] text-white sm:inline-flex">Open</span> : null}
+            {selected ? <span className="hidden rounded-full bg-primary-600 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] text-white sm:inline-flex">Selected</span> : null}
           </span>
           <span className="mt-0.5 block truncate text-xs font-semibold text-gray-500">{getTeamLauncherDetail(team)}</span>
           <span className="mt-1 flex min-w-0 flex-wrap gap-1.5">
@@ -349,7 +339,7 @@ function TeamLauncherRow({ team, selected, onSelect, compact = false }: { team: 
           </span>
           {nextEventSummary && !compact ? <span className="mt-1 block truncate text-[11px] font-bold text-gray-500">{nextEventSummary}</span> : null}
         </span>
-      </button>
+      </Link>
       <div className="flex flex-none items-center gap-1">
         <TeamQuickLink to={`/messages/${encodeURIComponent(team.teamId)}`} label={`${team.teamName} messages`} icon={MessageCircle} badge={team.unreadCount} />
         {hasSchedule ? <TeamQuickLink to={getTeamSchedulePath(team.teamId)} label={`${team.teamName} schedule`} icon={CalendarDays} badge={team.openActions} /> : null}

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -61,7 +61,7 @@ function emptyHome(): ParentHomeModel {
 export function Teams({ auth }: { auth: AuthState }) {
   const { isDesktopWeb } = useShellLayout();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [home, setHome] = useState<ParentHomeModel>(() => emptyHome());
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -152,16 +152,6 @@ export function Teams({ auth }: { auth: AuthState }) {
   const teamRoles = useMemo(() => getLoadedTeamRoles(home.teams), [home.teams]);
   const hasManagementTeam = useMemo(() => home.teams.some((team) => isTeamManagementRole(team.role)), [home.teams]);
 
-  const handleSelectTeam = (teamId: string) => {
-    const nextParams = new URLSearchParams(searchParams);
-    if (teamId) {
-      nextParams.set('selectedTeamId', teamId);
-    } else {
-      nextParams.delete('selectedTeamId');
-    }
-    setSearchParams(nextParams);
-  };
-
   return (
     <PullToRefresh onRefresh={() => loadTeams()} disabled={!auth.user?.uid}>
     <div className={`teams-page ${isDesktopWeb ? 'teams-page-web' : ''} space-y-4`}>
@@ -186,7 +176,7 @@ export function Teams({ auth }: { auth: AuthState }) {
       ) : home.teams.length ? (
         isDesktopWeb ? (
           <div className="teams-web-workbench">
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelectTeam={handleSelectTeam} variant="rail" />
+            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} variant="rail" />
             <div className="min-w-0 space-y-4">
               {selectedTeam ? <SelectedTeamPanel team={selectedTeam} variant="web" /> : null}
               {hasManagementTeam ? <WebsiteToolsNotice compact /> : null}
@@ -194,7 +184,7 @@ export function Teams({ auth }: { auth: AuthState }) {
           </div>
         ) : (
           <>
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelectTeam={handleSelectTeam} />
+            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} />
             {selectedTeam ? <SelectedTeamPanel team={selectedTeam} /> : null}
           </>
         )
@@ -287,10 +277,9 @@ function TeamsHeader({ loading, refreshing, teams, teamRoles, onRefresh }: {
   );
 }
 
-function TeamLauncher({ teams, selectedTeamId, onSelectTeam, variant = 'grid' }: {
+function TeamLauncher({ teams, selectedTeamId, variant = 'grid' }: {
   teams: ParentHomeTeam[];
   selectedTeamId: string;
-  onSelectTeam: (teamId: string) => void;
   variant?: 'grid' | 'rail';
 }) {
   const [query, setQuery] = useState('');
@@ -319,7 +308,7 @@ function TeamLauncher({ teams, selectedTeamId, onSelectTeam, variant = 'grid' }:
       </label>
       <div className={`${isRail ? 'teams-team-rail-list mt-3 space-y-2' : 'mt-3 grid gap-2 xl:grid-cols-2'}`}>
         {visibleTeams.length ? visibleTeams.map((team) => (
-          <TeamLauncherRow key={team.teamId} team={team} selected={team.teamId === selectedTeamId} compact={isRail} onSelect={() => onSelectTeam(team.teamId)} />
+          <TeamLauncherRow key={team.teamId} team={team} selected={team.teamId === selectedTeamId} compact={isRail} />
         )) : (
           <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No teams match that search.</div>
         )}
@@ -328,13 +317,13 @@ function TeamLauncher({ teams, selectedTeamId, onSelectTeam, variant = 'grid' }:
   );
 }
 
-function TeamLauncherRow({ team, selected, compact = false, onSelect }: { team: ParentHomeTeam; selected: boolean; compact?: boolean; onSelect: () => void }) {
+function TeamLauncherRow({ team, selected, compact = false }: { team: ParentHomeTeam; selected: boolean; compact?: boolean }) {
   const hasSchedule = team.eventCount > 0 || team.players.length > 0;
   const nextEventSummary = getTeamNextEventSummary(team);
 
   return (
     <article className={`team-launcher-row flex min-w-0 items-center gap-2 rounded-2xl border bg-white p-2 shadow-sm transition ${compact ? 'team-launcher-row-compact' : ''} ${selected ? 'border-primary-300 bg-primary-50/50 ring-2 ring-primary-100' : 'border-gray-200 hover:border-primary-200 hover:bg-primary-50/25'}`}>
-      <button type="button" className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" onClick={onSelect} aria-pressed={selected} aria-label={`Open ${team.teamName}`}>
+      <Link to={`/teams/${encodeURIComponent(team.teamId)}`} className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" aria-current={selected ? 'page' : undefined} aria-label={`Open ${team.teamName}`}>
         <TeamAvatar name={team.teamName} photoUrl={team.photoUrl} />
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center gap-2">
@@ -350,7 +339,7 @@ function TeamLauncherRow({ team, selected, compact = false, onSelect }: { team: 
           </span>
           {nextEventSummary && !compact ? <span className="mt-1 block truncate text-[11px] font-bold text-gray-500">{nextEventSummary}</span> : null}
         </span>
-      </button>
+      </Link>
       <div className="flex flex-none items-center gap-1">
         <TeamQuickLink to={`/messages/${encodeURIComponent(team.teamId)}`} label={`${team.teamName} messages`} icon={MessageCircle} badge={team.unreadCount} />
         {hasSchedule ? <TeamQuickLink to={getTeamSchedulePath(team.teamId)} label={`${team.teamName} schedule`} icon={CalendarDays} badge={team.openActions} /> : null}

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -61,7 +61,7 @@ function emptyHome(): ParentHomeModel {
 export function Teams({ auth }: { auth: AuthState }) {
   const { isDesktopWeb } = useShellLayout();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [home, setHome] = useState<ParentHomeModel>(() => emptyHome());
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -152,6 +152,16 @@ export function Teams({ auth }: { auth: AuthState }) {
   const teamRoles = useMemo(() => getLoadedTeamRoles(home.teams), [home.teams]);
   const hasManagementTeam = useMemo(() => home.teams.some((team) => isTeamManagementRole(team.role)), [home.teams]);
 
+  const handleSelectTeam = (teamId: string) => {
+    const nextParams = new URLSearchParams(searchParams);
+    if (teamId) {
+      nextParams.set('selectedTeamId', teamId);
+    } else {
+      nextParams.delete('selectedTeamId');
+    }
+    setSearchParams(nextParams);
+  };
+
   return (
     <PullToRefresh onRefresh={() => loadTeams()} disabled={!auth.user?.uid}>
     <div className={`teams-page ${isDesktopWeb ? 'teams-page-web' : ''} space-y-4`}>
@@ -176,7 +186,7 @@ export function Teams({ auth }: { auth: AuthState }) {
       ) : home.teams.length ? (
         isDesktopWeb ? (
           <div className="teams-web-workbench">
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} variant="rail" />
+            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelectTeam={handleSelectTeam} variant="rail" />
             <div className="min-w-0 space-y-4">
               {selectedTeam ? <SelectedTeamPanel team={selectedTeam} variant="web" /> : null}
               {hasManagementTeam ? <WebsiteToolsNotice compact /> : null}
@@ -184,7 +194,7 @@ export function Teams({ auth }: { auth: AuthState }) {
           </div>
         ) : (
           <>
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} />
+            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelectTeam={handleSelectTeam} />
             {selectedTeam ? <SelectedTeamPanel team={selectedTeam} /> : null}
           </>
         )
@@ -277,9 +287,10 @@ function TeamsHeader({ loading, refreshing, teams, teamRoles, onRefresh }: {
   );
 }
 
-function TeamLauncher({ teams, selectedTeamId, variant = 'grid' }: {
+function TeamLauncher({ teams, selectedTeamId, onSelectTeam, variant = 'grid' }: {
   teams: ParentHomeTeam[];
   selectedTeamId: string;
+  onSelectTeam: (teamId: string) => void;
   variant?: 'grid' | 'rail';
 }) {
   const [query, setQuery] = useState('');
@@ -308,7 +319,7 @@ function TeamLauncher({ teams, selectedTeamId, variant = 'grid' }: {
       </label>
       <div className={`${isRail ? 'teams-team-rail-list mt-3 space-y-2' : 'mt-3 grid gap-2 xl:grid-cols-2'}`}>
         {visibleTeams.length ? visibleTeams.map((team) => (
-          <TeamLauncherRow key={team.teamId} team={team} selected={team.teamId === selectedTeamId} compact={isRail} />
+          <TeamLauncherRow key={team.teamId} team={team} selected={team.teamId === selectedTeamId} compact={isRail} onSelect={() => onSelectTeam(team.teamId)} />
         )) : (
           <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No teams match that search.</div>
         )}
@@ -317,13 +328,13 @@ function TeamLauncher({ teams, selectedTeamId, variant = 'grid' }: {
   );
 }
 
-function TeamLauncherRow({ team, selected, compact = false }: { team: ParentHomeTeam; selected: boolean; compact?: boolean }) {
+function TeamLauncherRow({ team, selected, compact = false, onSelect }: { team: ParentHomeTeam; selected: boolean; compact?: boolean; onSelect: () => void }) {
   const hasSchedule = team.eventCount > 0 || team.players.length > 0;
   const nextEventSummary = getTeamNextEventSummary(team);
 
   return (
     <article className={`team-launcher-row flex min-w-0 items-center gap-2 rounded-2xl border bg-white p-2 shadow-sm transition ${compact ? 'team-launcher-row-compact' : ''} ${selected ? 'border-primary-300 bg-primary-50/50 ring-2 ring-primary-100' : 'border-gray-200 hover:border-primary-200 hover:bg-primary-50/25'}`}>
-      <Link to={`/teams/${encodeURIComponent(team.teamId)}`} className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" aria-current={selected ? 'page' : undefined} aria-label={`Open ${team.teamName}`}>
+      <button type="button" className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" onClick={onSelect} aria-pressed={selected} aria-label={`Open ${team.teamName}`}>
         <TeamAvatar name={team.teamName} photoUrl={team.photoUrl} />
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center gap-2">
@@ -339,7 +350,7 @@ function TeamLauncherRow({ team, selected, compact = false }: { team: ParentHome
           </span>
           {nextEventSummary && !compact ? <span className="mt-1 block truncate text-[11px] font-bold text-gray-500">{nextEventSummary}</span> : null}
         </span>
-      </Link>
+      </button>
       <div className="flex flex-none items-center gap-1">
         <TeamQuickLink to={`/messages/${encodeURIComponent(team.teamId)}`} label={`${team.teamName} messages`} icon={MessageCircle} badge={team.unreadCount} />
         {hasSchedule ? <TeamQuickLink to={getTeamSchedulePath(team.teamId)} label={`${team.teamName} schedule`} icon={CalendarDays} badge={team.openActions} /> : null}

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -703,7 +703,7 @@ test('my teams opens from Home data with selected team, player, and chat routes'
     await expect(page.getByRole('link', { name: /Media/ })).toHaveAttribute('href', '#/teams/team-1/media');
     await expect(page.locator('a[href="#/players/team-1/player-1"]').first()).toBeVisible();
     await expect(page.locator('a[href="#/players/team-1/player-1"]').filter({ hasText: 'Pat Star' })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Bears/ }).first()).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByRole('link', { name: 'Open Bears' }).first()).toHaveAttribute('aria-current', 'page');
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 
     await page.locator('a[href="#/teams/team-1"]').first().click();

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -519,7 +519,7 @@ async function mockPublicTeamsBrowseModule(page) {
 test.describe('mobile My Teams', () => {
     test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
-    test('selects parent and staff teams, keeps tools compact, and opens website resources through the adapter', async ({ page, baseURL }) => {
+    test('opens parent and staff teams, keeps tools compact, and opens website resources through the adapter', async ({ page, baseURL }) => {
         await mockTeamsModules(page);
         await page.goto(appUrl(baseURL, '/teams?selectedTeamId=team-staff&from=home'), { waitUntil: 'domcontentloaded' });
 
@@ -529,13 +529,13 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Choose a team')).toBeVisible();
         await expect(page.getByPlaceholder('Search teams or players')).toBeVisible();
         await page.getByPlaceholder('Search teams or players').fill('Riley');
-        await expect(page.getByRole('button', { name: /Rockets/ }).first()).toBeVisible();
-        await expect(page.getByRole('button', { name: /Staff Wolves/ })).toHaveCount(0);
-        await expect(page.getByRole('button', { name: /Bears/ })).toHaveCount(0);
+        await expect(page.getByRole('link', { name: 'Open Rockets' }).first()).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Open Staff Wolves' })).toHaveCount(0);
+        await expect(page.getByRole('link', { name: 'Open Bears' })).toHaveCount(0);
         await page.getByPlaceholder('Search teams or players').fill('zzz');
         await expect(page.getByText('No teams match that search.')).toBeVisible();
         await page.getByPlaceholder('Search teams or players').fill('Staff Wolves');
-        await expect(page.getByRole('button', { name: /Staff Wolves/ }).first()).toHaveAttribute('aria-pressed', 'true');
+        await expect(page.getByRole('link', { name: 'Open Staff Wolves' }).first()).toHaveAttribute('aria-current', 'page');
         await expect(page.locator('a[aria-label="Staff Wolves messages"]')).toBeVisible();
         await expect(page.locator('a[aria-label="Staff Wolves schedule"]')).toHaveCount(0);
         await expect(page.getByText('No player is linked to this account for the team, but team chat is available.')).toBeVisible();
@@ -550,9 +550,10 @@ test.describe('mobile My Teams', () => {
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://allplays.ai/team.html#teamId=team-staff');
         await expect(page).toHaveURL(/#\/teams/);
 
-        await page.getByPlaceholder('Search teams or players').fill('Bears');
-        await page.getByRole('button', { name: /Bears/ }).first().click();
-        await expect(page.getByRole('button', { name: /Bears/ }).first()).toHaveAttribute('aria-pressed', 'true');
+        await page.goto(appUrl(baseURL, '/teams?selectedTeamId=team-1&from=home'), { waitUntil: 'domcontentloaded' });
+        await waitForTeamsRoute(page, teamsReadyHeading);
+        await page.getByPlaceholder('Search teams or players').fill('');
+        await expect(page.getByRole('link', { name: 'Open Bears' }).first()).toHaveAttribute('aria-current', 'page');
         await expect(page.getByText('Pat Star, Sam Wing')).toBeVisible();
         await expect(page.getByText('Coach/admin tools')).toHaveCount(0);
         await expect(page.getByRole('link', { name: /Team drills/ })).toHaveCount(0);
@@ -562,6 +563,8 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByRole('link', { name: /Players/ })).toHaveAttribute('href', 'https://allplays.ai/team.html#teamId=team-1');
         await expect(page.locator('a[href="#/players/team-1/player-1"]')).toBeVisible();
         await expect(page.locator('a[href="#/players/team-1/player-2"]')).toBeVisible();
+        await page.getByRole('link', { name: 'Open Bears' }).first().click();
+        await waitForTeamDetailRoute(page, 'Bears');
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
     });
 
@@ -711,8 +714,8 @@ test.describe('desktop My Teams', () => {
             return Math.round((panel?.x || 0) - (rail?.x || 0));
         }).toBeGreaterThan(360);
         await page.getByPlaceholder('Search teams or players').fill('Rockets');
-        await expect(page.getByRole('button', { name: /Rockets/ })).toBeVisible();
-        await expect(page.getByRole('button', { name: /Bears/ })).toHaveCount(0);
+        await expect(page.getByRole('link', { name: 'Open Rockets' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Open Bears' })).toHaveCount(0);
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
     });
 });

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -37,21 +37,16 @@ describe('React app auth/profile capability parity', () => {
         expect(appRoutes).not.toContain('if (auth.loading) {');
     });
 
-    it('defaults a browser refresh on My Teams back to Home', () => {
+    it('keeps My Teams as a first-class route without a reload redirect', () => {
         const appRoutes = readProjectFile('apps/app/src/App.tsx');
         const reloadRouting = readProjectFile('apps/app/src/lib/reloadRouting.ts');
 
-        expectContains(appRoutes, [
-            "import { shouldReloadTeamsToHome } from './lib/reloadRouting';",
-            'pathname: location.pathname',
-            'search: location.search',
-            'isReload: isBrowserReload()',
-            'shouldDefaultReloadToHome ? <Navigate to="/home" replace />'
-        ]);
+        expect(appRoutes).toContain('<Route path="/teams" element={<Protected auth={auth}><Teams auth={auth} /></Protected>} />');
+        expect(appRoutes).not.toContain("import { shouldReloadTeamsToHome } from './lib/reloadRouting';");
+        expect(appRoutes).not.toContain('shouldDefaultReloadToHome');
+        expect(appRoutes).not.toContain('isBrowserReload()');
         expectContains(reloadRouting, [
-            "pathname === '/teams'",
-            '!search',
-            'isReload'
+            'return false;'
         ]);
     });
 

--- a/tests/unit/app-reload-routing.test.js
+++ b/tests/unit/app-reload-routing.test.js
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { shouldReloadTeamsToHome } from '../../apps/app/src/lib/reloadRouting.ts';
 
 describe('shouldReloadTeamsToHome', () => {
-    it('redirects bare /teams reloads back to home for signed-in users', () => {
+    it('preserves bare /teams reloads for signed-in users', () => {
         expect(shouldReloadTeamsToHome({
             hasUser: true,
             pathname: '/teams',
             search: '',
             isReload: true
-        })).toBe(true);
+        })).toBe(false);
     });
 
     it('preserves /teams reloads when query params are present', () => {

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -218,7 +218,7 @@ describe('React app Teams page', () => {
         expect(hrefs).toContain('/teams/team-staff/fees');
         expect(hrefs).not.toContain('https://allplays.ai/team-fees.html#teamId=team-staff');
         expect(container.textContent).not.toContain('Team drills');
-        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
+        expect(container.querySelector('button[aria-label="Open Staff Wolves"]')?.getAttribute('aria-pressed')).toBe('true');
 
         await clickLink(container, 'Website team page');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/team.html#teamId=team-staff');
@@ -228,8 +228,8 @@ describe('React app Teams page', () => {
         hrefs = getHrefs(container);
         expect(hrefs).toContain('/teams/team-staff/drills');
         expect(hrefs).toContain('https://allplays.ai/game-day.html?teamId=team-staff');
-        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
-        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('href')).toBe('/teams/team-staff');
+        expect(container.querySelector('button[aria-label="Open Bears"]')?.getAttribute('aria-pressed')).toBe('false');
+        expect(container.querySelector('button[aria-label="Open Staff Wolves"]')?.getAttribute('aria-pressed')).toBe('true');
     });
 
     it('filters the mobile launcher by team and player text before opening a result', async () => {
@@ -240,19 +240,19 @@ describe('React app Teams page', () => {
         expect(filterInput).toBeTruthy();
 
         await typeIntoInput(container, 'Search teams or players', 'Pat');
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(true);
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(false);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Bears')).toBe(true);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'Wolves');
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(true);
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(false);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(true);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Bears')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'zzz');
         expect(container.textContent).toContain('No teams match that search.');
 
         await typeIntoInput(container, 'Search teams or players', 'Bears');
 
-        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
+        expect(container.querySelector('button[aria-label="Open Bears"]')?.getAttribute('aria-pressed')).toBe('false');
         expect(container.textContent.indexOf('Choose a team')).toBeLessThan(container.textContent.indexOf('Team navigation'));
         const hrefs = getHrefs(container);
         expect(hrefs).toContain('/messages/team-1');
@@ -534,6 +534,6 @@ describe('React app Teams page', () => {
         await waitForText(container, '2 teams ready');
         expect(container.textContent).toContain('Choose a team');
         expect(container.querySelector('[data-testid="team-hub"]')).toBeNull();
-        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
+        expect(container.querySelector('button[aria-label="Open Staff Wolves"]')?.getAttribute('aria-pressed')).toBe('true');
     });
 });

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -97,6 +97,15 @@ function getHrefs(container) {
     return Array.from(container.querySelectorAll('a')).map((link) => link.getAttribute('href'));
 }
 
+function linkByAriaLabel(container, label) {
+    const link = Array.from(container.querySelectorAll('a')).find((candidate) => candidate.getAttribute('aria-label') === label);
+    if (!link) {
+        const labels = Array.from(container.querySelectorAll('a')).map((candidate) => candidate.textContent.trim() || candidate.getAttribute('aria-label') || '(unlabeled)');
+        throw new Error(`Link not found: ${label}. Available links: ${labels.join(', ')}`);
+    }
+    return link;
+}
+
 async function clickLink(container, text) {
     const link = Array.from(container.querySelectorAll('a')).find((candidate) => candidate.textContent.includes(text));
     if (!link) {
@@ -209,7 +218,7 @@ describe('React app Teams page', () => {
         expect(hrefs).toContain('/teams/team-staff/fees');
         expect(hrefs).not.toContain('https://allplays.ai/team-fees.html#teamId=team-staff');
         expect(container.textContent).not.toContain('Team drills');
-        expect(Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Staff Wolves'))?.getAttribute('aria-pressed')).toBe('true');
+        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
 
         await clickLink(container, 'Website team page');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/team.html#teamId=team-staff');
@@ -219,14 +228,11 @@ describe('React app Teams page', () => {
         hrefs = getHrefs(container);
         expect(hrefs).toContain('/teams/team-staff/drills');
         expect(hrefs).toContain('https://allplays.ai/game-day.html?teamId=team-staff');
-
-        await clickButton(container, 'Bears');
-        await clickButton(container, 'Staff Wolves');
-        expect(container.textContent).not.toContain('Team drills');
-        expect(buttonByText(container, '6 more')).toBeTruthy();
+        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
+        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('href')).toBe('/teams/team-staff');
     });
 
-    it('filters the mobile launcher by team and player text before selecting a result', async () => {
+    it('filters the mobile launcher by team and player text before opening a result', async () => {
         const { container } = await renderTeams('/teams?selectedTeamId=team-staff&from=home');
         await waitForText(container, 'Staff Wolves');
 
@@ -234,35 +240,26 @@ describe('React app Teams page', () => {
         expect(filterInput).toBeTruthy();
 
         await typeIntoInput(container, 'Search teams or players', 'Pat');
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Bears'))).toBe(true);
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Staff Wolves'))).toBe(false);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(true);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'Wolves');
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Staff Wolves'))).toBe(true);
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Bears'))).toBe(false);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(true);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'zzz');
         expect(container.textContent).toContain('No teams match that search.');
 
         await typeIntoInput(container, 'Search teams or players', 'Bears');
-        await clickButton(container, 'Bears');
 
-        expect(buttonByText(container, 'Bears').getAttribute('aria-pressed')).toBe('true');
+        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
         expect(container.textContent.indexOf('Choose a team')).toBeLessThan(container.textContent.indexOf('Team navigation'));
         const hrefs = getHrefs(container);
         expect(hrefs).toContain('/messages/team-1');
         expect(hrefs).toContain('/teams/team-1');
         expect(hrefs).toContain('/schedule?teamId=team-1');
-        expect(hrefs).toContain('/schedule?teamId=team-1&view=packets');
-        expect(hrefs).toContain('https://allplays.ai/team.html#teamId=team-1');
-        expect(hrefs).toContain('/teams/team-1/media');
-        expect(hrefs).toContain('/parent-tools/fees');
-        expect(hrefs).toContain('/parent-tools/registrations');
-        expect(hrefs).toContain('/parent-tools/certificates');
-        expect(hrefs).toContain('/players/team-1/player-1');
         expect(container.textContent).toContain('Pat Star');
-        expect(container.textContent).not.toContain('Coach/admin tools');
-        expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+        expect(window.scrollTo).not.toHaveBeenCalled();
     });
 
     it('refreshes team data without dropping into the loading shell', async () => {
@@ -537,6 +534,6 @@ describe('React app Teams page', () => {
         await waitForText(container, '2 teams ready');
         expect(container.textContent).toContain('Choose a team');
         expect(container.querySelector('[data-testid="team-hub"]')).toBeNull();
-        expect(buttonByText(container, 'Staff Wolves').getAttribute('aria-pressed')).toBe('true');
+        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
     });
 });

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -218,7 +218,7 @@ describe('React app Teams page', () => {
         expect(hrefs).toContain('/teams/team-staff/fees');
         expect(hrefs).not.toContain('https://allplays.ai/team-fees.html#teamId=team-staff');
         expect(container.textContent).not.toContain('Team drills');
-        expect(container.querySelector('button[aria-label="Open Staff Wolves"]')?.getAttribute('aria-pressed')).toBe('true');
+        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
 
         await clickLink(container, 'Website team page');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/team.html#teamId=team-staff');
@@ -228,8 +228,8 @@ describe('React app Teams page', () => {
         hrefs = getHrefs(container);
         expect(hrefs).toContain('/teams/team-staff/drills');
         expect(hrefs).toContain('https://allplays.ai/game-day.html?teamId=team-staff');
-        expect(container.querySelector('button[aria-label="Open Bears"]')?.getAttribute('aria-pressed')).toBe('false');
-        expect(container.querySelector('button[aria-label="Open Staff Wolves"]')?.getAttribute('aria-pressed')).toBe('true');
+        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
+        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('href')).toBe('/teams/team-staff');
     });
 
     it('filters the mobile launcher by team and player text before opening a result', async () => {
@@ -240,19 +240,19 @@ describe('React app Teams page', () => {
         expect(filterInput).toBeTruthy();
 
         await typeIntoInput(container, 'Search teams or players', 'Pat');
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Bears')).toBe(true);
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(false);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(true);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'Wolves');
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(true);
-        expect(Array.from(container.querySelectorAll('button')).some((button) => button.getAttribute('aria-label') === 'Open Bears')).toBe(false);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(true);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'zzz');
         expect(container.textContent).toContain('No teams match that search.');
 
         await typeIntoInput(container, 'Search teams or players', 'Bears');
 
-        expect(container.querySelector('button[aria-label="Open Bears"]')?.getAttribute('aria-pressed')).toBe('false');
+        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
         expect(container.textContent.indexOf('Choose a team')).toBeLessThan(container.textContent.indexOf('Team navigation'));
         const hrefs = getHrefs(container);
         expect(hrefs).toContain('/messages/team-1');
@@ -534,6 +534,6 @@ describe('React app Teams page', () => {
         await waitForText(container, '2 teams ready');
         expect(container.textContent).toContain('Choose a team');
         expect(container.querySelector('[data-testid="team-hub"]')).toBeNull();
-        expect(container.querySelector('button[aria-label="Open Staff Wolves"]')?.getAttribute('aria-pressed')).toBe('true');
+        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
     });
 });


### PR DESCRIPTION
## Summary
- Keep `/teams` as the real My Teams destination instead of redirecting bare reloads back to Home.
- Turn Teams launcher rows into links to `/teams/:teamId` so clicking a team opens the team hub.
- Keep selected-team highlighting for Home deep links while updating navigation regressions and route tests.

## Tests
- `npx vitest run tests/unit/app-reload-routing.test.js tests/unit/app-auth-profile-capabilities.test.js tests/unit/app-teams-integration.test.jsx --reporter=verbose`
- `cd apps/app && npx vitest run src/pages/Teams.test.tsx src/App.test.tsx --reporter=verbose`
- `npm run app:build`

Fixes #2527
Fixes #2528