### PR TITLE
[codex] Cover email reducer field state

### DIFF
--- a/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
+++ b/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
@@ -24,6 +24,34 @@ function template(overrides: Partial<TeamEmailTemplate> = {}): TeamEmailTemplate
 }
 
 describe('emailReducer', () => {
+  it('starts with empty composer fields and applies direct subject and body edits', () => {
+    expect(initialEmailComposerState).toMatchObject({
+      drafts: [],
+      templates: [],
+      selectedDraftId: '',
+      subject: '',
+      body: '',
+      templateName: ''
+    });
+
+    const editedSubject = emailReducer(initialEmailComposerState, {
+      type: 'updateSubject',
+      subject: 'Saturday schedule'
+    });
+    const editedBody = emailReducer(editedSubject, {
+      type: 'updateBody',
+      body: 'Arrive 30 minutes early.'
+    });
+
+    expect(editedBody).toMatchObject({
+      drafts: [],
+      templates: [],
+      selectedDraftId: '',
+      subject: 'Saturday schedule',
+      body: 'Arrive 30 minutes early.'
+    });
+  });
+
   it('selects a draft and updates selection, subject, and body together', () => {
     const state = emailReducer(initialEmailComposerState, {
       type: 'setDrafts',

--- a/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
+++ b/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
@@ -162,6 +162,20 @@ describe('emailReducer', () => {
     });
   });
 
+  it('clears stale composer content when refreshed drafts no longer include the selected draft', () => {
+    const selected = emailReducer(
+      emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+      { type: 'selectDraft', draftId: 'draft-1' }
+    );
+
+    expect(emailReducer(selected, { type: 'setDrafts', drafts: [] })).toMatchObject({
+      drafts: [],
+      selectedDraftId: '',
+      subject: '',
+      body: ''
+    });
+  });
+
   it('applies templates and clears the composer through reducer actions', () => {
     const withTemplate = emailReducer(initialEmailComposerState, { type: 'setTemplates', templates: [template()] });
     const applied = emailReducer(withTemplate, { type: 'applyTemplate', templateId: 'template-1' });

--- a/tests/unit/app-chat-email-reducer.test.ts
+++ b/tests/unit/app-chat-email-reducer.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { emailReducer, initialEmailComposerState } from '../../apps/app/src/pages/messages/state/emailReducer';
+import type { TeamEmailDraft, TeamEmailTemplate } from '../../apps/app/src/lib/chatService';
+
+function draft(overrides: Partial<TeamEmailDraft> = {}): TeamEmailDraft {
+    return {
+        id: 'draft-1',
+        subject: 'Practice reminder',
+        body: 'Bring shoes and water.',
+        recipientIds: ['player-1'],
+        recipients: [],
+        ...overrides
+    };
+}
+
+function template(overrides: Partial<TeamEmailTemplate> = {}): TeamEmailTemplate {
+    return {
+        id: 'template-1',
+        name: 'Weekly update',
+        subject: 'Week ahead',
+        body: 'Here is the plan.',
+        ...overrides
+    };
+}
+
+describe('emailReducer', () => {
+    it('starts with empty composer fields and applies direct subject and body edits', () => {
+        expect(initialEmailComposerState).toMatchObject({
+            drafts: [],
+            templates: [],
+            selectedDraftId: '',
+            subject: '',
+            body: '',
+            templateName: ''
+        });
+
+        const editedSubject = emailReducer(initialEmailComposerState, {
+            type: 'updateSubject',
+            subject: 'Saturday schedule'
+        });
+        const editedBody = emailReducer(editedSubject, {
+            type: 'updateBody',
+            body: 'Arrive 30 minutes early.'
+        });
+
+        expect(editedBody).toMatchObject({
+            drafts: [],
+            templates: [],
+            selectedDraftId: '',
+            subject: 'Saturday schedule',
+            body: 'Arrive 30 minutes early.'
+        });
+    });
+
+    it('selects a draft and updates selection, subject, and body together', () => {
+        const state = emailReducer(initialEmailComposerState, {
+            type: 'setDrafts',
+            drafts: [draft({ id: 'draft-1', subject: 'Old', body: 'Old body' }), draft({ id: 'draft-2', subject: 'New', body: 'New body' })]
+        });
+
+        expect(emailReducer(state, { type: 'selectDraft', draftId: 'draft-2' })).toMatchObject({
+            selectedDraftId: 'draft-2',
+            subject: 'New',
+            body: 'New body'
+        });
+    });
+
+    it('preserves edited subject and body while switching between drafts', () => {
+        const withDrafts = emailReducer(initialEmailComposerState, {
+            type: 'setDrafts',
+            drafts: [draft({ id: 'draft-1', subject: 'Alpha', body: 'Alpha body' }), draft({ id: 'draft-2', subject: 'Beta', body: 'Beta body' })]
+        });
+        const edited = emailReducer(
+            emailReducer(
+                emailReducer(withDrafts, { type: 'selectDraft', draftId: 'draft-1' }),
+                { type: 'updateSubject', subject: 'Alpha edited' }
+            ),
+            { type: 'updateBody', body: 'Alpha edited body' }
+        );
+        const saved = emailReducer(edited, {
+            type: 'saveDraft',
+            draft: draft({ id: 'draft-1', subject: 'Alpha edited', body: 'Alpha edited body' })
+        });
+        const switched = emailReducer(saved, { type: 'selectDraft', draftId: 'draft-2' });
+
+        expect(switched).toMatchObject({ selectedDraftId: 'draft-2', subject: 'Beta', body: 'Beta body' });
+        expect(emailReducer(switched, { type: 'selectDraft', draftId: 'draft-1' })).toMatchObject({
+            selectedDraftId: 'draft-1',
+            subject: 'Alpha edited',
+            body: 'Alpha edited body'
+        });
+    });
+
+    it('clears the selected draft and composer fields when the selected draft is deleted', () => {
+        const selected = emailReducer(
+            emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+            { type: 'selectDraft', draftId: 'draft-1' }
+        );
+
+        expect(emailReducer(selected, { type: 'deleteDraft', draftId: 'draft-1' })).toMatchObject({
+            drafts: [],
+            selectedDraftId: '',
+            subject: '',
+            body: ''
+        });
+    });
+
+    it('preserves unsaved draft edits when refreshed drafts still include the selected draft', () => {
+        const selected = emailReducer(
+            emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+            { type: 'selectDraft', draftId: 'draft-1' }
+        );
+        const edited = emailReducer(
+            emailReducer(selected, { type: 'updateSubject', subject: 'Edited subject' }),
+            { type: 'updateBody', body: 'Edited body' }
+        );
+
+        expect(emailReducer(edited, {
+            type: 'setDrafts',
+            drafts: [draft({ subject: 'Server subject', body: 'Server body' })]
+        })).toMatchObject({
+            drafts: [draft({ subject: 'Server subject', body: 'Server body' })],
+            selectedDraftId: 'draft-1',
+            subject: 'Edited subject',
+            body: 'Edited body'
+        });
+    });
+
+    it('refreshes selected draft content when there are no unsaved edits', () => {
+        const selected = emailReducer(
+            emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+            { type: 'selectDraft', draftId: 'draft-1' }
+        );
+
+        expect(emailReducer(selected, {
+            type: 'setDrafts',
+            drafts: [draft({ subject: 'Server subject', body: 'Server body' })]
+        })).toMatchObject({
+            selectedDraftId: 'draft-1',
+            subject: 'Server subject',
+            body: 'Server body'
+        });
+    });
+
+    it('clears stale composer content when refreshed drafts no longer include the selected draft', () => {
+        const selected = emailReducer(
+            emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+            { type: 'selectDraft', draftId: 'draft-1' }
+        );
+
+        expect(emailReducer(selected, { type: 'setDrafts', drafts: [] })).toMatchObject({
+            drafts: [],
+            selectedDraftId: '',
+            subject: '',
+            body: ''
+        });
+    });
+
+    it('applies templates and clears the composer through reducer actions', () => {
+        const withTemplate = emailReducer(initialEmailComposerState, { type: 'setTemplates', templates: [template()] });
+        const applied = emailReducer(withTemplate, { type: 'applyTemplate', templateId: 'template-1' });
+
+        expect(applied).toMatchObject({ subject: 'Week ahead', body: 'Here is the plan.' });
+        expect(emailReducer(applied, { type: 'clearComposer' })).toMatchObject({
+            selectedDraftId: '',
+            subject: '',
+            body: ''
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add regression coverage for the email composer reducer initial state
- Verify direct subject and body edits stay inside reducer-managed state

Closes #2400

## Tests
- cd apps/app && npx vitest run src/pages/messages/state/__tests__/emailReducer.test.ts --reporter=verbose