### PR TITLE
[codex] Cover email template reducer actions

### DIFF
--- a/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
+++ b/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
@@ -139,4 +139,17 @@ describe('emailReducer', () => {
       body: ''
     });
   });
+
+  it('keeps composer state unchanged when applying an unknown template id', () => {
+    const withTemplate = emailReducer(initialEmailComposerState, {
+      type: 'setTemplates',
+      templates: [template()]
+    });
+    const edited = emailReducer(
+      emailReducer(withTemplate, { type: 'updateSubject', subject: 'Manual subject' }),
+      { type: 'updateBody', body: 'Manual body' }
+    );
+
+    expect(emailReducer(edited, { type: 'applyTemplate', templateId: 'missing-template' })).toEqual(edited);
+  });
 });

--- a/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
+++ b/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
@@ -114,20 +114,6 @@ describe('emailReducer', () => {
     });
   });
 
-  it('clears stale composer content when refreshed drafts no longer include the selected draft', () => {
-    const selected = emailReducer(
-      emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
-      { type: 'selectDraft', draftId: 'draft-1' }
-    );
-
-    expect(emailReducer(selected, { type: 'setDrafts', drafts: [] })).toMatchObject({
-      drafts: [],
-      selectedDraftId: '',
-      subject: '',
-      body: ''
-    });
-  });
-
   it('applies templates and clears the composer through reducer actions', () => {
     const withTemplate = emailReducer(initialEmailComposerState, { type: 'setTemplates', templates: [template()] });
     const applied = emailReducer(withTemplate, { type: 'applyTemplate', templateId: 'template-1' });

--- a/tests/unit/app-email-reducer.test.ts
+++ b/tests/unit/app-email-reducer.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { emailReducer, initialEmailComposerState } from '../../apps/app/src/pages/messages/state/emailReducer.ts';
+import type { TeamEmailDraft } from '../../apps/app/src/lib/chatService.ts';
+
+function draft(overrides: Partial<TeamEmailDraft> = {}): TeamEmailDraft {
+    return {
+        id: 'draft-1',
+        subject: 'Practice reminder',
+        body: 'Bring shoes and water.',
+        recipientIds: ['player-1'],
+        recipients: [],
+        ...overrides
+    };
+}
+
+describe('emailReducer', () => {
+    it('clears stale composer content when refreshed drafts no longer include the selected draft', () => {
+        const selected = emailReducer(
+            emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+            { type: 'selectDraft', draftId: 'draft-1' }
+        );
+
+        expect(emailReducer(selected, { type: 'setDrafts', drafts: [] })).toMatchObject({
+            drafts: [],
+            selectedDraftId: '',
+            subject: '',
+            body: ''
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add regression coverage for reducer-backed email template application
- Verify unknown template ids leave manual composer content unchanged

Closes #2402

## Tests
- cd apps/app && npx vitest run src/pages/messages/state/__tests__/emailReducer.test.ts --reporter=verbose