### PR TITLE
[codex] Cover chat message loading and sheets

### DIFF
--- a/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
+++ b/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
@@ -135,6 +135,19 @@ describe('useChatMessages', () => {
         expect(screen.getByTestId('has-more').textContent).toBe('false');
     });
 
+    it('skips older message loading when the live page has no older cursor', async () => {
+        render(<MessagesProbe conversationId="team" />);
+        act(() => {
+            liveCallback?.([message('latest', 20)], { cursor: 'latest' });
+        });
+
+        await waitFor(() => expect(screen.getByTestId('has-more').textContent).toBe('false'));
+        fireEvent.click(screen.getByRole('button', { name: 'Load older' }));
+
+        expect(loadOlderTeamChatMessages).not.toHaveBeenCalled();
+        expect(screen.getByTestId('loading-older').textContent).toBe('false');
+    });
+
     it('does not resubscribe when the user object changes identity but keeps the same uid', async () => {
         function MessagesProbeWithUser({ authUser }: { authUser: NonNullable<AuthState['user']> }) {
             useChatMessages({

--- a/apps/app/src/pages/messages/hooks/useChatSheets.test.tsx
+++ b/apps/app/src/pages/messages/hooks/useChatSheets.test.tsx
@@ -74,4 +74,17 @@ describe('useChatSheets', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Close email' }));
         expectSheetState('email', false);
     });
+
+    it('keeps unrelated sheet state intact when closing the email composer', () => {
+        render(<HookProbe />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Open conversation' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Open email' }));
+        expect(screen.getByTestId('conversation')).toHaveTextContent('true');
+        expect(screen.getByTestId('email')).toHaveTextContent('true');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close email' }));
+        expect(screen.getByTestId('conversation')).toHaveTextContent('true');
+        expect(screen.getByTestId('email')).toHaveTextContent('false');
+    });
 });


### PR DESCRIPTION
## Summary
- Add regression coverage for skipped older-message loading when no older page is available
- Verify extracted chat sheet state closes the email composer without disturbing other open sheets

Closes #2396

## Tests
- cd apps/app && npx vitest run src/pages/messages/hooks/__tests__/useChatMessages.test.tsx src/pages/messages/hooks/useChatSheets.test.tsx --reporter=verbose