### PR TITLE
[codex] Add team fee installment previews

### DIFF
--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -83,6 +83,20 @@ export type OfflineTeamFeeRefundInput = {
   currentPaidCents?: string | number | null;
 };
 
+export type TeamFeeInstallmentScheduleInput = {
+  amount: string | number;
+  installmentCount: string | number;
+  firstDueDate: string;
+  intervalDays?: string | number | null;
+};
+
+export type TeamFeeInstallmentPreview = {
+  installmentNumber: number;
+  amountCents: number;
+  dueDate: string;
+  label: string;
+};
+
 const REFUND_METHOD_LABELS: Record<string, string> = {
   cash: 'Cash',
   check: 'Check'
@@ -96,6 +110,61 @@ export function toFeeCents(value: string | number | null | undefined) {
   const parsed = Number(normalized);
   if (!Number.isFinite(parsed) || parsed < 0) return null;
   return Math.round(parsed * 100);
+}
+
+function parseInstallmentDate(value: string) {
+  const normalized = normalizeString(value);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) return null;
+  const date = new Date(`${normalized}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10) === normalized ? date : null;
+}
+
+function addInstallmentDays(date: Date, days: number) {
+  const nextDate = new Date(date.getTime());
+  nextDate.setUTCDate(nextDate.getUTCDate() + days);
+  return nextDate.toISOString().slice(0, 10);
+}
+
+export function buildTeamFeeInstallmentSchedule({
+  amount,
+  installmentCount,
+  firstDueDate,
+  intervalDays = 30
+}: TeamFeeInstallmentScheduleInput) {
+  const totalAmountCents = toFeeCents(amount);
+  if (totalAmountCents === null || totalAmountCents <= 0) {
+    throw new Error('Enter an amount greater than $0 before creating a payment plan.');
+  }
+
+  const count = Number.parseInt(String(installmentCount ?? '').trim(), 10);
+  if (!Number.isInteger(count) || count < 2 || count > 12) {
+    throw new Error('Choose between 2 and 12 installments.');
+  }
+
+  const firstDate = parseInstallmentDate(firstDueDate);
+  if (!firstDate) throw new Error('Enter a valid first installment due date.');
+
+  const interval = Number.parseInt(String(intervalDays ?? '').trim(), 10);
+  if (!Number.isInteger(interval) || interval < 1 || interval > 366) {
+    throw new Error('Installment spacing must be between 1 and 366 days.');
+  }
+
+  const baseAmountCents = Math.floor(totalAmountCents / count);
+  const remainderCents = totalAmountCents % count;
+  const installments = Array.from({ length: count }, (_, index): TeamFeeInstallmentPreview => ({
+    installmentNumber: index + 1,
+    amountCents: baseAmountCents + (index < remainderCents ? 1 : 0),
+    dueDate: addInstallmentDays(firstDate, index * interval),
+    label: `Installment ${index + 1} of ${count}`
+  }));
+
+  return {
+    totalAmountCents,
+    installmentCount: count,
+    intervalDays: interval,
+    installments
+  };
 }
 
 function toSignedFeeCents(value: string | number | null | undefined) {

--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -145,7 +145,8 @@ export function buildTeamFeeInstallmentSchedule({
   const firstDate = parseInstallmentDate(firstDueDate);
   if (!firstDate) throw new Error('Enter a valid first installment due date.');
 
-  const interval = Number.parseInt(String(intervalDays ?? '').trim(), 10);
+  const normalizedIntervalDays = intervalDays == null ? '' : String(intervalDays).trim();
+  const interval = normalizedIntervalDays ? Number.parseInt(normalizedIntervalDays, 10) : 30;
   if (!Number.isInteger(interval) || interval < 1 || interval > 366) {
     throw new Error('Installment spacing must be between 1 and 366 days.');
   }

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -23,6 +23,7 @@ import {
     createTeamFeeBatchForApp,
     buildBalanceAdjustmentUpdate,
     buildOfflineTeamFeeRefundUpdate,
+    buildTeamFeeInstallmentSchedule,
     buildManualPaymentUpdate,
     initiateStaffTeamFeeCheckout,
     loadTeamFeeManagementModel,
@@ -257,6 +258,50 @@ describe('React app team fee offline payment service', () => {
             currentBalanceCents: 10000,
             currentPaidCents: 5000
         })).toThrow('admin note');
+    });
+
+    it('builds rounded installment previews for payment plan setup', () => {
+        const preview = buildTeamFeeInstallmentSchedule({
+            amount: '100.01',
+            installmentCount: 3,
+            firstDueDate: '2026-07-15',
+            intervalDays: 14
+        });
+
+        expect(preview).toEqual({
+            totalAmountCents: 10001,
+            installmentCount: 3,
+            intervalDays: 14,
+            installments: [
+                { installmentNumber: 1, amountCents: 3334, dueDate: '2026-07-15', label: 'Installment 1 of 3' },
+                { installmentNumber: 2, amountCents: 3334, dueDate: '2026-07-29', label: 'Installment 2 of 3' },
+                { installmentNumber: 3, amountCents: 3333, dueDate: '2026-08-12', label: 'Installment 3 of 3' }
+            ]
+        });
+    });
+
+    it('rejects invalid installment plan inputs', () => {
+        expect(() => buildTeamFeeInstallmentSchedule({
+            amount: '0',
+            installmentCount: 3,
+            firstDueDate: '2026-07-15'
+        })).toThrow('greater than $0');
+        expect(() => buildTeamFeeInstallmentSchedule({
+            amount: '100.00',
+            installmentCount: 1,
+            firstDueDate: '2026-07-15'
+        })).toThrow('between 2 and 12');
+        expect(() => buildTeamFeeInstallmentSchedule({
+            amount: '100.00',
+            installmentCount: 3,
+            firstDueDate: '2026-02-31'
+        })).toThrow('valid first installment due date');
+        expect(() => buildTeamFeeInstallmentSchedule({
+            amount: '100.00',
+            installmentCount: 3,
+            firstDueDate: '2026-07-15',
+            intervalDays: 0
+        })).toThrow('between 1 and 366 days');
     });
 
     it('loads batches and recipients only for fee managers', async () => {

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -280,6 +280,22 @@ describe('React app team fee offline payment service', () => {
         });
     });
 
+    it('defaults null installment spacing to 30 days', () => {
+        const preview = buildTeamFeeInstallmentSchedule({
+            amount: '90.00',
+            installmentCount: 3,
+            firstDueDate: '2026-07-15',
+            intervalDays: null
+        });
+
+        expect(preview.intervalDays).toBe(30);
+        expect(preview.installments.map((installment) => installment.dueDate)).toEqual([
+            '2026-07-15',
+            '2026-08-14',
+            '2026-09-13'
+        ]);
+    });
+
     it('rejects invalid installment plan inputs', () => {
         expect(() => buildTeamFeeInstallmentSchedule({
             amount: '0',


### PR DESCRIPTION
## Summary
- Add a reusable installment schedule preview helper for native team-fee payment-plan setup
- Cover cent rounding, due-date intervals, and validation for invalid plan inputs

Refs #1991

## Tests
- npx vitest run tests/unit/app-team-fees-service.test.ts --reporter=verbose