### PR TITLE
[codex] Add practice AI coach prompt builder

### DIFF
--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildPracticeAiCoachPrompt, filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite } from './teamDrillsService';
 
@@ -143,6 +144,17 @@ describe('teamDrillsService', () => {
     expect(prompt.user).toContain('- Half field only');
     expect(prompt.user).toContain('- Rondo 4v2 (Technical; 15 min, 8-10 players, 20x20). Skills: passing, support.');
     expect(prompt.user).toContain('minute-by-minute practice plan');
+  });
+
+  it('keeps practice prompt section headers on their own source line so prompts stay readable', () => {
+    const source = readFileSync(new URL('./teamDrillsService.ts', import.meta.url), 'utf8');
+
+    expect(source).toContain("`Practice goals:\n${goalLines.map((goal) => `- ${goal}`).join('\\n')}`");
+    expect(source).toContain("`Focus skills:\n${skillLines.map((skill) => `- ${skill}`).join('\\n')}`");
+    expect(source).toContain("`Constraints:\n${constraintLines.map((constraint) => `- ${constraint}`).join('\\n')}`");
+    expect(source).toContain("`Favorite drills to prefer when they fit:\n${drillLines.length ? drillLines.join('\\n') : '- No favorites supplied.'}`");
+    expect(source).not.toContain("`Practice goals:\\n${goalLines.map((goal) => `- ${goal}`).join('\\n')}`");
+    expect(source).not.toContain("`Favorite drills to prefer when they fit:\\n${drillLines.length ? drillLines.join('\\n') : '- No favorites supplied.'}`");
   });
 
   it('loads a bounded community drill page and merges team-published drills for staff users', async () => {

--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildPracticeAiCoachPrompt, filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite } from './teamDrillsService';
 
@@ -147,7 +148,7 @@ describe('teamDrillsService', () => {
   });
 
   it('keeps practice prompt section headers on their own source line so prompts stay readable', () => {
-    const source = readFileSync(new URL('./teamDrillsService.ts', import.meta.url), 'utf8');
+    const source = readFileSync(resolve(process.cwd(), 'src/lib/teamDrillsService.ts'), 'utf8');
 
     expect(source).toContain("`Practice goals:\n${goalLines.map((goal) => `- ${goal}`).join('\\n')}`");
     expect(source).toContain("`Focus skills:\n${skillLines.map((skill) => `- ${skill}`).join('\\n')}`");

--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildPracticeAiCoachPrompt, filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite } from './teamDrillsService';
 
@@ -148,7 +147,7 @@ describe('teamDrillsService', () => {
   });
 
   it('keeps practice prompt section headers on their own source line so prompts stay readable', () => {
-    const source = readFileSync(resolve(process.cwd(), 'src/lib/teamDrillsService.ts'), 'utf8');
+    const source = readFileSync(new URL('./teamDrillsService.ts', import.meta.url), 'utf8');
 
     expect(source).toContain("`Practice goals:\n${goalLines.map((goal) => `- ${goal}`).join('\\n')}`");
     expect(source).toContain("`Focus skills:\n${skillLines.map((skill) => `- ${skill}`).join('\\n')}`");

--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite } from './teamDrillsService';
+import { buildPracticeAiCoachPrompt, filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite } from './teamDrillsService';
 
 const dbMocks = vi.hoisted(() => ({
   addDrillFavorite: vi.fn(),
@@ -106,6 +106,43 @@ describe('teamDrillsService', () => {
     expect(filterDrillSummaries(drills, { searchText: 'finish' }).map((drill) => drill.id)).toEqual(['drill-3']);
     expect(filterDrillSummaries(drills, { type: 'Technical', level: 'Intermediate' }).map((drill) => drill.id)).toEqual(['drill-1']);
     expect(filterDrillSummaries(drills, { type: 'Warm-up' }).map((drill) => drill.id)).toEqual(['drill-2']);
+  });
+
+  it('builds a practice AI coach prompt from team goals and favorite drills', () => {
+    const prompt = buildPracticeAiCoachPrompt({
+      teamName: 'Bears',
+      sport: 'Soccer',
+      ageGroup: 'U12',
+      availableMinutes: 75,
+      rosterSize: 14,
+      goals: ['Press after turnovers', 'Finish from wide service'],
+      focusSkills: ['first touch', 'finishing'],
+      constraints: ['Half field only', 'Two keepers unavailable'],
+      favoriteDrills: [{
+        id: 'drill-1',
+        title: 'Rondo 4v2',
+        sport: 'Soccer',
+        type: 'Technical',
+        level: 'Intermediate',
+        ageGroup: 'U12',
+        skills: ['passing', 'support'],
+        description: 'Keep the ball moving.',
+        instructions: 'Two-touch max.',
+        youtubeUrl: '',
+        diagramUrls: [],
+        attribution: null,
+        setup: { duration: 15, players: '8-10', cones: 6, balls: '2', area: '20x20', pinnies: '4' }
+      }]
+    });
+
+    expect(prompt.system).toContain('Soccer practices');
+    expect(prompt.user).toContain('Team: Bears');
+    expect(prompt.user).toContain('Available time: 75 minutes');
+    expect(prompt.user).toContain('- Press after turnovers');
+    expect(prompt.user).toContain('- first touch');
+    expect(prompt.user).toContain('- Half field only');
+    expect(prompt.user).toContain('- Rondo 4v2 (Technical; 15 min, 8-10 players, 20x20). Skills: passing, support.');
+    expect(prompt.user).toContain('minute-by-minute practice plan');
   });
 
   it('loads a bounded community drill page and merges team-published drills for staff users', async () => {

--- a/apps/app/src/lib/teamDrillsService.ts
+++ b/apps/app/src/lib/teamDrillsService.ts
@@ -64,6 +64,23 @@ export type TeamFavoriteDrillsModel = {
   drills: TeamDrillSummary[];
 };
 
+export type PracticeAiCoachPromptInput = {
+  teamName?: string | null;
+  sport?: string | null;
+  ageGroup?: string | null;
+  availableMinutes?: string | number | null;
+  rosterSize?: string | number | null;
+  goals?: unknown[];
+  focusSkills?: unknown[];
+  constraints?: unknown[];
+  favoriteDrills?: TeamDrillSummary[];
+};
+
+export type PracticeAiCoachPrompt = {
+  system: string;
+  user: string;
+};
+
 type TeamDrillLibraryCursor = {
   communityCursor: unknown | null;
   pendingDrills: any[];
@@ -154,6 +171,59 @@ export function filterDrillSummaries(drills: TeamDrillSummary[], filters: TeamDr
       || drill.instructions.toLowerCase().includes(searchText)
       || drill.skills.some((skill) => skill.toLowerCase().includes(searchText));
   });
+}
+
+function normalizeCoachPromptList(values: unknown[] | undefined, fallback: string[]) {
+  const normalized = Array.from(new Set((Array.isArray(values) ? values : [])
+    .map((value) => normalizeString(value))
+    .filter(Boolean)));
+  return normalized.length ? normalized : fallback;
+}
+
+export function buildPracticeAiCoachPrompt({
+  teamName,
+  sport,
+  ageGroup,
+  availableMinutes,
+  rosterSize,
+  goals,
+  focusSkills,
+  constraints,
+  favoriteDrills
+}: PracticeAiCoachPromptInput): PracticeAiCoachPrompt {
+  const normalizedSport = normalizeString(sport) || 'youth sports';
+  const minutes = normalizeWholeNumber(availableMinutes, 60);
+  const playerCount = normalizeWholeNumber(rosterSize, 10);
+  const goalLines = normalizeCoachPromptList(goals, ['Build a balanced practice with warm-up, skill work, game-like reps, and a short wrap-up.']);
+  const skillLines = normalizeCoachPromptList(focusSkills, ['fundamentals', 'teamwork']);
+  const constraintLines = normalizeCoachPromptList(constraints, ['Keep instructions concise and age-appropriate.']);
+  const drillLines = (Array.isArray(favoriteDrills) ? favoriteDrills : [])
+    .slice(0, 5)
+    .map((drill) => {
+      const setupParts = [
+        drill.setup?.duration ? `${drill.setup.duration} min` : '',
+        drill.setup?.players ? `${drill.setup.players} players` : '',
+        drill.setup?.area ? drill.setup.area : ''
+      ].filter(Boolean).join(', ');
+      const skillsText = drill.skills.length ? ` Skills: ${drill.skills.join(', ')}.` : '';
+      return `- ${drill.title} (${drill.type || 'Drill'}${setupParts ? `; ${setupParts}` : ''}).${skillsText}`;
+    });
+
+  return {
+    system: `You are an assistant coach helping plan ${normalizedSport} practices. Return practical, safety-aware plans with clear timing, setup, and coaching cues.`,
+    user: [
+      `Team: ${normalizeString(teamName) || 'Team'}`,
+      `Sport: ${normalizedSport}`,
+      `Age group: ${normalizeString(ageGroup) || 'Not specified'}`,
+      `Available time: ${minutes} minutes`,
+      `Roster size: ${playerCount}`,
+      `Practice goals:\n${goalLines.map((goal) => `- ${goal}`).join('\n')}`,
+      `Focus skills:\n${skillLines.map((skill) => `- ${skill}`).join('\n')}`,
+      `Constraints:\n${constraintLines.map((constraint) => `- ${constraint}`).join('\n')}`,
+      `Favorite drills to prefer when they fit:\n${drillLines.length ? drillLines.join('\n') : '- No favorites supplied.'}`,
+      'Create a minute-by-minute practice plan with drill names, setup notes, coaching cues, and an adjustment for fewer players.'
+    ].join('\n\n')
+  };
 }
 
 export async function loadTeamDrillLibraryPage(

--- a/apps/app/src/lib/teamDrillsService.ts
+++ b/apps/app/src/lib/teamDrillsService.ts
@@ -217,10 +217,14 @@ export function buildPracticeAiCoachPrompt({
       `Age group: ${normalizeString(ageGroup) || 'Not specified'}`,
       `Available time: ${minutes} minutes`,
       `Roster size: ${playerCount}`,
-      `Practice goals:\n${goalLines.map((goal) => `- ${goal}`).join('\n')}`,
-      `Focus skills:\n${skillLines.map((skill) => `- ${skill}`).join('\n')}`,
-      `Constraints:\n${constraintLines.map((constraint) => `- ${constraint}`).join('\n')}`,
-      `Favorite drills to prefer when they fit:\n${drillLines.length ? drillLines.join('\n') : '- No favorites supplied.'}`,
+      `Practice goals:
+${goalLines.map((goal) => `- ${goal}`).join('\n')}`,
+      `Focus skills:
+${skillLines.map((skill) => `- ${skill}`).join('\n')}`,
+      `Constraints:
+${constraintLines.map((constraint) => `- ${constraint}`).join('\n')}`,
+      `Favorite drills to prefer when they fit:
+${drillLines.length ? drillLines.join('\n') : '- No favorites supplied.'}`,
       'Create a minute-by-minute practice plan with drill names, setup notes, coaching cues, and an adjustment for fewer players.'
     ].join('\n\n')
   };


### PR DESCRIPTION
## Summary
- Add a deterministic practice AI coach prompt builder for team goals, constraints, and favorite drills
- Cover prompt content so future AI wiring has stable practice-plan context

Refs #1986

## Tests
- cd apps/app && npx vitest run src/lib/teamDrillsService.test.ts --reporter=verbose