### PR TITLE
[codex] Cover opponent stat undo

### DIFF
--- a/apps/app/src/lib/statTrackingService.test.ts
+++ b/apps/app/src/lib/statTrackingService.test.ts
@@ -400,4 +400,42 @@ describe('statTrackingService', () => {
     });
     expect(service.getCurrentScore()).toEqual({ homeScore: 10, awayScore: 11 });
   });
+
+  it('undoes opponent scoring without writing player aggregates', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS'] },
+      initialScore: { homeScore: 10, awayScore: 8 },
+      dependencies
+    });
+    const user = { uid: 'coach-1' };
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: 'Opponent PTS +2',
+      clock: '00:45',
+      period: 'Q2',
+      undoData: {
+        type: 'stat',
+        playerId: 'opponent',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: true
+      }
+    }, user);
+
+    expect(dependencies.setDoc).toHaveBeenCalledTimes(1);
+    expect(service.getCurrentScore()).toEqual({ homeScore: 10, awayScore: 10 });
+
+    dependencies.setDoc.mockClear();
+    dependencies.updateGameScore.mockClear();
+    const undone = await service.undoLastEvent('team-1', 'game-1', user);
+
+    expect(undone?.isOpponent).toBe(true);
+    expect(dependencies.setDoc).not.toHaveBeenCalled();
+    expect(dependencies.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', {
+      homeScore: 10,
+      awayScore: 8
+    }, user);
+    expect(service.getCurrentScore()).toEqual({ homeScore: 10, awayScore: 8 });
+  });
 });


### PR DESCRIPTION
## Summary
- Add regression coverage for opponent scoring stat entry
- Verify undo restores the away score without writing player aggregate stats for opponent events

Refs #1974

## Tests
- cd apps/app && npx vitest run src/lib/statTrackingService.test.ts --reporter=verbose

Note: the test run still logs existing missing Firebase vendor source-map warnings, but the suite passes.