### PR TITLE
[codex] Add native schedule tournament info helper

### DIFF
--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -155,6 +155,7 @@ export type ParentScheduleEvent = {
   seasonLabel?: string | null;
   competitionType?: string | null;
   countsTowardSeasonRecord?: boolean | null;
+  tournament?: Record<string, any> | null;
   statTrackerConfigId?: string | null;
   sourceType?: ScheduleSourceType | string | null;
   sourceLabel?: string | null;
@@ -542,6 +543,47 @@ export function getScheduleEventDetailPath(
   if (section) params.set('section', section);
   const query = params.toString();
   return `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}${query ? `?${query}` : ''}`;
+}
+
+export function getScheduleTournamentInfo(
+  event: Pick<ParentScheduleEvent, 'competitionType' | 'tournament'> & Record<string, any>
+) {
+  const tournament = event?.tournament && typeof event.tournament === 'object' ? event.tournament : {};
+  const isTournament = String(event?.competitionType || '').trim().toLowerCase() === 'tournament'
+    || Object.keys(tournament).length > 0;
+
+  if (!isTournament) {
+    return {
+      isTournament: false,
+      label: '',
+      details: '',
+      divisionName: '',
+      bracketName: '',
+      roundName: '',
+      poolName: ''
+    };
+  }
+
+  const divisionName = compactString(tournament.divisionName || event.divisionName);
+  const bracketName = compactString(tournament.bracketName || event.bracketName);
+  const roundName = compactString(tournament.roundName || event.roundName);
+  const poolName = compactString(tournament.poolName || event.poolName);
+  const labelParts = [divisionName, bracketName, roundName || poolName].filter(Boolean);
+  const detailParts = [
+    poolName && roundName ? `Pool: ${poolName}` : poolName,
+    tournament.gameLabel,
+    tournament.seedLabel
+  ].map(compactString).filter(Boolean);
+
+  return {
+    isTournament: true,
+    label: labelParts.join(' / ') || 'Tournament',
+    details: detailParts.join(' - '),
+    divisionName,
+    bracketName,
+    roundName,
+    poolName
+  };
 }
 
 export function getScheduleAssignmentStatus(assignment: Partial<ScheduleAssignment>, userId = '') {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2419,6 +2419,7 @@ function createScheduleEvent(input: {
   seasonLabel?: string | null;
   competitionType?: string | null;
   countsTowardSeasonRecord?: boolean | null;
+  tournament?: Record<string, any> | null;
   statTrackerConfigId?: string | null;
   sourceType?: string | null;
   sourceLabel?: string | null;
@@ -2486,6 +2487,7 @@ function createScheduleEvent(input: {
     seasonLabel: input.seasonLabel || null,
     competitionType: input.competitionType || null,
     countsTowardSeasonRecord: input.countsTowardSeasonRecord ?? null,
+    tournament: input.tournament && typeof input.tournament === 'object' ? input.tournament : null,
     statTrackerConfigId: input.statTrackerConfigId || null,
     sourceType: input.sourceType || (input.isDbGame ? 'db' : 'calendar'),
     sourceLabel: input.sourceLabel || (input.isDbGame ? 'ALL PLAYS schedule' : 'Team calendar'),
@@ -2592,6 +2594,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
             seasonLabel: game.seasonLabel || null,
             competitionType: game.competitionType || null,
             countsTowardSeasonRecord: game.countsTowardSeasonRecord ?? null,
+            tournament: game.tournament || null,
             sourceType: game.sourceMetadata?.sourceType || game.source || 'db',
             sourceLabel: getScheduleSourceLabel(game),
             isImported: Boolean(game.sourceMetadata || game.source === 'calendar' || game.source === 'registration'),
@@ -2655,6 +2658,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
           seasonLabel: game.seasonLabel || null,
           competitionType: game.competitionType || null,
           countsTowardSeasonRecord: game.countsTowardSeasonRecord ?? null,
+          tournament: game.tournament || null,
           sourceType: game.sourceMetadata?.sourceType || game.source || 'db',
           sourceLabel: getScheduleSourceLabel(game),
           isImported: Boolean(game.sourceMetadata || game.source === 'calendar' || game.source === 'registration'),
@@ -2826,6 +2830,7 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
     seasonLabel: game.seasonLabel || null,
     competitionType: game.competitionType || null,
     countsTowardSeasonRecord: game.countsTowardSeasonRecord ?? null,
+    tournament: game.tournament || null,
     statTrackerConfigId: game.statTrackerConfigId || null,
     sourceType: game.sourceMetadata?.sourceType || game.source || 'db',
     sourceLabel: getScheduleSourceLabel(game),

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -278,7 +278,15 @@ beforeEach(() => {
             sharedScheduleOpponentTeamId: 'team-2',
             status: 'scheduled',
             seasonLabel: 'Spring 2026',
-            competitionType: 'league',
+            competitionType: 'tournament',
+            tournament: {
+                divisionName: '10U Gold',
+                bracketName: 'Championship',
+                roundName: 'Semifinal',
+                poolName: 'Pool A',
+                gameLabel: 'Game 12',
+                seedLabel: 'A1 vs B2'
+            },
             assignments: [
                 { role: 'Snacks', value: '', claimable: true },
                 { role: 'Scorebook', value: 'Jamie', claimable: false }
@@ -443,6 +451,15 @@ describe('React app schedule service contract integration', () => {
             opponentTeamId: 'team-2',
             sharedScheduleOpponentTeamId: 'team-2',
             counterpartTitle: 'vs. Bears',
+            competitionType: 'tournament',
+            tournament: {
+                divisionName: '10U Gold',
+                bracketName: 'Championship',
+                roundName: 'Semifinal',
+                poolName: 'Pool A',
+                gameLabel: 'Game 12',
+                seedLabel: 'A1 vs B2'
+            },
             myRsvp: 'going',
             myRsvpNote: 'Needs a ride home',
             rsvpSummary: { going: 1, maybe: 1, notGoing: 0, notResponded: 0, total: 2 },
@@ -574,7 +591,15 @@ describe('React app schedule service contract integration', () => {
             sharedScheduleOpponentTeamId: 'team-2',
             status: 'scheduled',
             seasonLabel: 'Spring 2026',
-            competitionType: 'league',
+            competitionType: 'tournament',
+            tournament: {
+                divisionName: '10U Gold',
+                bracketName: 'Championship',
+                roundName: 'Semifinal',
+                poolName: 'Pool A',
+                gameLabel: 'Game 12',
+                seedLabel: 'A1 vs B2'
+            },
             assignments: [
                 { role: 'Snacks', value: '', claimable: true },
                 { role: 'Scorebook', value: 'Jamie', claimable: false }
@@ -600,6 +625,15 @@ describe('React app schedule service contract integration', () => {
         expect(result.events).toHaveLength(2);
         expect(result.events.every((event) => event.id === 'game-1')).toBe(true);
         expect(result.events.find((event) => event.childId === 'player-1')).toMatchObject({
+            competitionType: 'tournament',
+            tournament: {
+                divisionName: '10U Gold',
+                bracketName: 'Championship',
+                roundName: 'Semifinal',
+                poolName: 'Pool A',
+                gameLabel: 'Game 12',
+                seedLabel: 'A1 vs B2'
+            },
             myRsvp: 'going',
             myRsvpNote: 'Needs a ride home',
             teamNotificationEmail: 'team-notify@example.com',

--- a/tests/unit/app-schedule-tournament-info.test.ts
+++ b/tests/unit/app-schedule-tournament-info.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { getScheduleTournamentInfo } from '../../apps/app/src/lib/scheduleLogic.ts';
+
+describe('native schedule tournament info', () => {
+  it('builds a concise label and details from tournament bracket metadata', () => {
+    expect(getScheduleTournamentInfo({
+      competitionType: 'tournament',
+      tournament: {
+        divisionName: '10U Gold',
+        bracketName: 'Championship',
+        roundName: 'Semifinal',
+        poolName: 'Pool A',
+        gameLabel: 'Game 12',
+        seedLabel: 'A1 vs B2'
+      }
+    } as any)).toEqual({
+      isTournament: true,
+      label: '10U Gold / Championship / Semifinal',
+      details: 'Pool: Pool A - Game 12 - A1 vs B2',
+      divisionName: '10U Gold',
+      bracketName: 'Championship',
+      roundName: 'Semifinal',
+      poolName: 'Pool A'
+    });
+  });
+
+  it('falls back to pool labels and hides info for non-tournament events', () => {
+    expect(getScheduleTournamentInfo({
+      competitionType: 'league',
+      tournament: {
+        poolName: 'Pool B'
+      }
+    } as any)).toMatchObject({
+      isTournament: true,
+      label: 'Pool B',
+      details: 'Pool B'
+    });
+
+    expect(getScheduleTournamentInfo({ competitionType: 'league', tournament: null } as any)).toEqual({
+      isTournament: false,
+      label: '',
+      details: '',
+      divisionName: '',
+      bracketName: '',
+      roundName: '',
+      poolName: ''
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a schedule helper that normalizes tournament bracket, round, pool, and division metadata for native display
- Cover bracket labels, detail text, and non-tournament fallback behavior

Refs #1967

## Tests
- npx vitest run tests/unit/app-schedule-tournament-info.test.ts --reporter=verbose