### PR TITLE
[codex] Centralize awards studio handoff URLs

### DIFF
--- a/apps/app/src/lib/certificateDraftService.test.ts
+++ b/apps/app/src/lib/certificateDraftService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildCertificatePayloadForApp,
+  getCertificateStudioUrl,
   loadCertificateDraftComposer,
   saveCertificateDraftsForApp,
   type CertificateDraftSharedState
@@ -192,6 +193,11 @@ describe('certificateDraftService', () => {
       certificateIds: ['cert-1', 'cert-2'],
       webUrl: 'https://allplays.ai/certificates.html#teamId=team-1&batchId=batch-1'
     });
+  });
+
+  it('builds team-only and batch continuation URLs for the web awards studio', () => {
+    expect(getCertificateStudioUrl('team 1')).toBe('https://allplays.ai/certificates.html#teamId=team+1');
+    expect(getCertificateStudioUrl('team 1', 'batch/1')).toBe('https://allplays.ai/certificates.html#teamId=team+1&batchId=batch%2F1');
   });
 
   it('builds a draft payload that matches the saved web studio shape', () => {

--- a/apps/app/src/lib/certificateDraftService.ts
+++ b/apps/app/src/lib/certificateDraftService.ts
@@ -232,9 +232,11 @@ export function buildCertificatePayloadForApp({
   };
 }
 
-export function getCertificateStudioUrl(teamId: string, batchId: string) {
+export function getCertificateStudioUrl(teamId: string, batchId = '') {
   const url = new URL('certificates.html', 'https://allplays.ai');
-  url.hash = new URLSearchParams({ teamId, batchId }).toString();
+  const params = new URLSearchParams({ teamId });
+  if (batchId) params.set('batchId', batchId);
+  url.hash = params.toString();
   return url.toString();
 }
 

--- a/apps/app/src/pages/TeamCertificates.test.tsx
+++ b/apps/app/src/pages/TeamCertificates.test.tsx
@@ -6,6 +6,13 @@ import { TeamCertificates } from './TeamCertificates';
 import type { AuthState } from '../lib/types';
 
 const certificateDraftServiceMocks = vi.hoisted(() => ({
+  getCertificateStudioUrl: vi.fn((teamId: string, batchId = '') => {
+    const url = new URL('certificates.html', 'https://allplays.ai');
+    const params = new URLSearchParams({ teamId });
+    if (batchId) params.set('batchId', batchId);
+    url.hash = params.toString();
+    return url.toString();
+  }),
   loadCertificateDraftComposer: vi.fn(),
   saveCertificateDraftsForApp: vi.fn()
 }));
@@ -150,6 +157,24 @@ describe('TeamCertificates', () => {
 
     expect(await screen.findByText('Unable to create certificate drafts.')).toBeTruthy();
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it('opens the awards web studio for AI narratives, publish, and print continuation', async () => {
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1/certificates']}>
+        <Routes>
+          <Route path="/teams/:teamId/certificates" element={<TeamCertificates auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Awards drafts' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open website' }));
+
+    await waitFor(() => {
+      expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/certificates.html#teamId=team-1');
+    });
   });
 
   it('ignores stale certificate loads after navigating to a different team', async () => {

--- a/apps/app/src/pages/TeamCertificates.tsx
+++ b/apps/app/src/pages/TeamCertificates.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, Navigate, useParams } from 'react-router-dom';
 import { Award, ExternalLink, Loader2, RefreshCw, Sparkles } from 'lucide-react';
 import { renderCertificate } from '../lib/adapters/legacyCertificates';
-import { loadCertificateDraftComposer, saveCertificateDraftsForApp, type CertificateDraftComposerModel, type CertificateDraftPlayer, type CertificateDraftSharedState } from '../lib/certificateDraftService';
+import { getCertificateStudioUrl, loadCertificateDraftComposer, saveCertificateDraftsForApp, type CertificateDraftComposerModel, type CertificateDraftPlayer, type CertificateDraftSharedState } from '../lib/certificateDraftService';
 import { openPublicUrl } from '../lib/publicActions';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
 import type { AuthState } from '../lib/types';
@@ -113,9 +113,7 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
 
   const onOpenWebsite = async () => {
     if (!teamId) return;
-    const url = new URL('certificates.html', 'https://allplays.ai');
-    url.hash = new URLSearchParams({ teamId }).toString();
-    await openPublicUrl(url.toString());
+    await openPublicUrl(getCertificateStudioUrl(teamId));
   };
 
   const onSaveDrafts = async () => {


### PR DESCRIPTION
## Summary
- Extend the certificate studio URL helper for team-only native-to-web awards handoffs
- Use the helper from the native awards draft screen
- Add coverage for team-only and batch continuation URLs plus the Open website action for AI narratives, publish, and print continuation

Refs #1997

## Tests
- cd apps/app && npx vitest run src/lib/certificateDraftService.test.ts src/pages/TeamCertificates.test.tsx --reporter=verbose