### PR TITLE
[codex] Add rideshare notification deep links

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4014,6 +4014,15 @@ function buildNotificationLink({ category, teamId, gameId, batchId = null, recip
     }
     return 'https://allplays.ai/app/#/schedule';
   }
+  if (category === 'rideshare') {
+    if (teamId && gameId) {
+      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}?section=rideshare`;
+    }
+    if (teamId) {
+      return `https://allplays.ai/app/#/schedule?teamId=${encodeURIComponent(teamId)}&section=rideshare`;
+    }
+    return 'https://allplays.ai/app/#/schedule?section=rideshare';
+  }
   if (category === 'media') {
     if (teamId) {
       return `https://allplays.ai/app/#/teams/${encodeURIComponent(teamId)}/media`;
@@ -4075,6 +4084,16 @@ function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId 
       return `/schedule?teamId=${encodeURIComponent(teamId)}`;
     }
     return '/schedule';
+  }
+  if (category === 'rideshare') {
+    const scheduleEventId = eventId || gameId;
+    if (teamId && scheduleEventId) {
+      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}?section=rideshare`;
+    }
+    if (teamId) {
+      return `/schedule?teamId=${encodeURIComponent(teamId)}&section=rideshare`;
+    }
+    return '/schedule?section=rideshare';
   }
   if (category === 'media') {
     if (teamId) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -3975,7 +3975,7 @@ async function practicePacketAssignedNotification(beforeData = null, afterData =
   return null;
 }
 
-function buildNotificationLink({ category, teamId, gameId, batchId = null, recipientId = null, conversationId = null }) {
+function buildNotificationLink({ category, teamId, gameId, eventId = null, batchId = null, recipientId = null, conversationId = null }) {
   if (category === 'officiating') {
     return teamId
       ? `https://allplays.ai/officials.html?teamId=${encodeURIComponent(teamId)}`
@@ -4015,8 +4015,9 @@ function buildNotificationLink({ category, teamId, gameId, batchId = null, recip
     return 'https://allplays.ai/app/#/schedule';
   }
   if (category === 'rideshare') {
-    if (teamId && gameId) {
-      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}?section=rideshare`;
+    const scheduleEventId = eventId || gameId;
+    if (teamId && scheduleEventId) {
+      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}?section=rideshare`;
     }
     if (teamId) {
       return `https://allplays.ai/app/#/schedule?teamId=${encodeURIComponent(teamId)}&section=rideshare`;
@@ -5003,7 +5004,7 @@ async function sendCategoryNotification({
     : allTargets;
   if (!targets.length) return null;
 
-  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, conversationId });
+  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
@@ -5257,7 +5258,7 @@ async function sendDirectTargetsNotification({
 }) {
   if (!targets.length) return null;
 
-  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, batchId, recipientId, conversationId });
+  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId });
   const appRoute = appRouteOverride || buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -398,6 +398,51 @@ test('sendRsvpReminderPushNotifications sends availability pushes only to email 
         }
 });
 
+test('sendCategoryNotification deep links rideshare notifications to the rideshare event section', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            indexedTargets: [
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-device',
+                    token: 'parent-token',
+                    categories: { rideshare: true }
+                }
+            ]
+        });
+
+        try {
+            const result = await internals.sendCategoryNotification({
+                teamId: 'team-1',
+                gameId: 'game-9',
+                category: 'rideshare',
+                title: 'Ride request claimed',
+                body: 'Avery has a confirmed ride.'
+            });
+
+            assert.equal(result?.successCount, 1);
+            assert.equal(env.messagingCalls.length, 1);
+            assert.deepEqual(env.messagingCalls[0].data, {
+                category: 'rideshare',
+                teamId: 'team-1',
+                gameId: 'game-9',
+                eventId: 'game-9',
+                conversationId: '',
+                appRoute: '/schedule/team-1/game-9?section=rideshare',
+                link: 'https://allplays.ai/app/#/schedule/team-1/game-9?section=rideshare'
+            });
+            assert.equal(env.messagingCalls[0].webLink, 'https://allplays.ai/app/#/schedule/team-1/game-9?section=rideshare');
+            assert.equal(env.inboxWrites[0].value.appRoute, '/schedule/team-1/game-9?section=rideshare');
+            assert.equal(env.auditWrites[0].value.category, 'rideshare');
+        } finally {
+            cleanup();
+        }
+});
+
 for (const [category, categories] of [
     ['liveChat', { liveChat: true }],
     ['mentions', { mentions: true }]

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -443,6 +443,51 @@ test('sendCategoryNotification deep links rideshare notifications to the ridesha
         }
 });
 
+test('sendCategoryNotification uses eventId for rideshare deep links when no gameId is provided', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            indexedTargets: [
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-device',
+                    token: 'parent-token',
+                    categories: { rideshare: true }
+                }
+            ]
+        });
+
+        try {
+            const result = await internals.sendCategoryNotification({
+                teamId: 'team-1',
+                eventId: 'event-9',
+                category: 'rideshare',
+                title: 'Ride request claimed',
+                body: 'Avery has a confirmed ride.'
+            });
+
+            assert.equal(result?.successCount, 1);
+            assert.equal(env.messagingCalls.length, 1);
+            assert.deepEqual(env.messagingCalls[0].data, {
+                category: 'rideshare',
+                teamId: 'team-1',
+                gameId: '',
+                eventId: 'event-9',
+                conversationId: '',
+                appRoute: '/schedule/team-1/event-9?section=rideshare',
+                link: 'https://allplays.ai/app/#/schedule/team-1/event-9?section=rideshare'
+            });
+            assert.equal(env.messagingCalls[0].webLink, 'https://allplays.ai/app/#/schedule/team-1/event-9?section=rideshare');
+            assert.equal(env.inboxWrites[0].value.appRoute, '/schedule/team-1/event-9?section=rideshare');
+            assert.equal(env.auditWrites[0].value.link, 'https://allplays.ai/app/#/schedule/team-1/event-9?section=rideshare');
+        } finally {
+            cleanup();
+        }
+});
+
 for (const [category, categories] of [
     ['liveChat', { liveChat: true }],
     ['mentions', { mentions: true }]


### PR DESCRIPTION
## Summary
- Route rideshare notification web links to the schedule detail rideshare section
- Route native app notification payloads to the same rideshare section
- Add sendCategoryNotification coverage for rideshare category deep links and inbox/audit payloads

Refs #2109

## Tests
- npx vitest run functions/test/send-category-notification.test.js --reporter=verbose