### PR TITLE
[codex] Cover uxTiming interaction spans

### DIFF
--- a/apps/app/src/lib/uxTiming.test.ts
+++ b/apps/app/src/lib/uxTiming.test.ts
@@ -26,6 +26,15 @@ describe('uxTiming', () => {
     vi.restoreAllMocks();
   });
 
+  it('declares stable app-start and core interaction spans', () => {
+    expect(UX_TIMING).toMatchObject({
+      appStartup: 'app startup',
+      firstMeaningfulRender: 'first meaningful render',
+      rsvpTap: 'rsvp tap latency',
+      chatSend: 'chat send latency'
+    });
+  });
+
   it('startUxTimer merges base meta and recorded meta', () => {
     const timer = startUxTimer('schedule load', { route: 'schedule' });
     timer.end({ eventRows: 12 });


### PR DESCRIPTION
## Summary
- Add regression coverage for the stable app startup, first meaningful render, RSVP tap, and chat send UX timing labels.
- Keep the performance metric names pinned to the issue acceptance surface.

Refs #2281

## Tests
- npm --prefix apps/app exec vitest run src/lib/uxTiming.test.ts --reporter=verbose