### PR TITLE
[codex] Cover Messages decomposition wiring

### DIFF
--- a/tests/unit/app-messages-decomposition.test.js
+++ b/tests/unit/app-messages-decomposition.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(path) {
+    return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+describe('Messages page decomposition', () => {
+    it('keeps chat data loading and email composer state in focused modules', () => {
+        const source = readRepoFile('apps/app/src/pages/Messages.tsx');
+
+        expect(source).toContain("from './messages/hooks/useChatSheets'");
+        expect(source).toContain("from './messages/hooks/useChatTeam'");
+        expect(source).toContain("from './messages/hooks/useChatMessages'");
+        expect(source).toContain("from './messages/state/emailReducer'");
+        expect(source).toContain('useReducer(emailReducer, initialEmailComposerState)');
+    });
+
+    it('keeps split Messages modules covered by focused unit tests', () => {
+        [
+            'apps/app/src/pages/messages/hooks/useChatSheets.test.tsx',
+            'apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx',
+            'apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx',
+            'apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts'
+        ].forEach((path) => {
+            expect(readRepoFile(path).length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/tests/unit/app-messages-decomposition.test.js
+++ b/tests/unit/app-messages-decomposition.test.js
@@ -26,7 +26,7 @@ describe('Messages page decomposition', () => {
             'apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx',
             'apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts'
         ].forEach((path) => {
-            expect(readRepoFile(path).length).toBeGreaterThan(0);
+            expect(readRepoFile(path)).toMatch(/\b(describe|it|test)\s*\(/);
         });
     });
 });


### PR DESCRIPTION
## Summary
- Add a static unit test that pins Messages.tsx to the split chat hooks and email reducer.
- Verify the extracted hooks/reducer keep focused test coverage in place.

Refs #2064

## Tests
- npx vitest run tests/unit/app-messages-decomposition.test.js --reporter=verbose