### PR TITLE
[codex] Cover schedule detail decomposition wiring

### DIFF
--- a/tests/unit/app-schedule-detail-decomposition.test.js
+++ b/tests/unit/app-schedule-detail-decomposition.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(path) {
+    return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+describe('ScheduleEventDetail decomposition', () => {
+    it('keeps extracted navigation, availability, RSVP, and rideshare pieces wired in', () => {
+        const source = readRepoFile('apps/app/src/pages/ScheduleEventDetail.tsx');
+
+        expect(source).toContain("from '../components/schedule/EventSectionNav'");
+        expect(source).toContain("from '../components/schedule/AvailabilityPanels'");
+        expect(source).toContain("from './schedule/ScheduleEventDetailContext'");
+        expect(source).toContain("from '../hooks/schedule/useScheduleEventRsvp'");
+        expect(source).toContain("from '../hooks/schedule/useScheduleRideOffers'");
+        expect(source).toContain('<ScheduleEventDetailProvider value={{');
+        expect(source).toContain('useScheduleEventRsvp({ availabilityNote })');
+        expect(source).toContain('useScheduleRideOffers()');
+    });
+
+    it('keeps extracted schedule detail modules under focused tests', () => {
+        [
+            'apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx',
+            'apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx',
+            'apps/app/src/hooks/schedule/useScheduleRideOffers.test.tsx'
+        ].forEach((path) => {
+            expect(readRepoFile(path).length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/tests/unit/app-schedule-detail-decomposition.test.js
+++ b/tests/unit/app-schedule-detail-decomposition.test.js
@@ -22,10 +22,12 @@ describe('ScheduleEventDetail decomposition', () => {
         expect(source).toContain('useScheduleRideOffers()');
     });
 
-    it('keeps extracted schedule detail modules under focused tests', () => {
+    it('keeps extracted schedule detail modules and focused coverage files in the repo', () => {
         [
             'apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx',
+            'apps/app/src/hooks/schedule/useScheduleEventRsvp.ts',
             'apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx',
+            'apps/app/src/hooks/schedule/useScheduleRideOffers.ts',
             'apps/app/src/hooks/schedule/useScheduleRideOffers.test.tsx'
         ].forEach((path) => {
             expect(readRepoFile(path).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Add a static guard that pins ScheduleEventDetail to extracted nav, availability, context, RSVP, and rideshare modules.
- Verify those extracted schedule detail modules remain covered by focused tests.

Refs #2063

## Tests
- npx vitest run tests/unit/app-schedule-detail-decomposition.test.js --reporter=verbose