### PR TITLE
[codex] Cover chat notification delivery contracts

### DIFF
--- a/tests/unit/chat-notification-delivery-contract.test.js
+++ b/tests/unit/chat-notification-delivery-contract.test.js
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+const chatServiceSource = readFileSync(new URL('../../apps/app/src/lib/chatService.ts', import.meta.url), 'utf8');
+const messagesSource = readFileSync(new URL('../../apps/app/src/pages/Messages.tsx', import.meta.url), 'utf8');
+
+describe('team chat notification delivery contract', () => {
+    it('builds one recipient context for mentions and live chat with per-conversation mute state', () => {
+        expect(functionsSource).toContain('async function buildTeamChatNotificationContext(teamId, options = {})');
+        expect(functionsSource).toContain('const { includeMentions = true, conversationId = null } = options || {};');
+        expect(functionsSource).toContain('const normalizedConversationId = normalizeTeamChatConversationId(conversationId);');
+        expect(functionsSource).toContain("const categories = includeMentions ? ['mentions', 'liveChat'] : ['liveChat'];");
+        expect(functionsSource).toContain('const mutedConversations = userRecord.teamChatState?.[teamId]?.mutedConversations;');
+        expect(functionsSource).toContain('mutedConversations[normalizedConversationId]');
+        expect(functionsSource).toContain("Boolean(normalizedConversationId === 'team' && chatMuted && chatMuted[teamId])");
+        expect(functionsSource).toContain('mutedUids: hydratedMembers.filter((member) => member.muted).map((member) => member.uid)');
+    });
+
+    it('sends mention pushes only to mentioned users and live chat pushes only to non-muted non-mentioned users', () => {
+        expect(functionsSource).toContain('function buildTeamChatNotificationPlan({ text, actorUid = null, recipientContext })');
+        expect(functionsSource).toContain('const mentionedUids = text');
+        expect(functionsSource).toContain('detectMentionedUids(text, mentionMembers, { allowReservedMentions: actorIsStaff }).filter((uid) => uid !== actorUid)');
+        expect(functionsSource).toContain("category: 'mentions'");
+        expect(functionsSource).toContain('targets: notificationPlan.mentionTargets');
+        expect(functionsSource).toContain("category: 'liveChat'");
+        expect(functionsSource).toContain('targets: notificationPlan.liveChatTargets');
+        expect(functionsSource).toContain('!mentionedSet.has(target.uid)');
+        expect(functionsSource).toContain('!mutedSet.has(target.uid)');
+    });
+
+    it('routes chat notification links to the matching app conversation', () => {
+        expect(functionsSource).toContain("if (category === 'liveChat' || category === 'mentions') {");
+        expect(functionsSource).toContain('params.push(`conversationId=${encodeURIComponent(conversationId)}`);');
+        expect(functionsSource).toContain("if ((category === 'liveChat' || category === 'mentions') && teamId) {");
+        expect(functionsSource).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
+        expect(functionsSource).toContain('conversationId: String(conversationId || \'\')');
+    });
+
+    it('lets the app toggle the same conversation mute keys the function reads', () => {
+        expect(chatServiceSource).toContain('export async function muteTeamChat(uid: string, teamId: string, conversationId = DEFAULT_TEAM_CONVERSATION_ID)');
+        expect(chatServiceSource).toContain('export async function unmuteTeamChat(uid: string, teamId: string, conversationId = DEFAULT_TEAM_CONVERSATION_ID)');
+        expect(chatServiceSource).toContain('updateChatMuted(uid, teamId, conversationId)');
+        expect(chatServiceSource).toContain('clearChatMuted(uid, teamId, conversationId)');
+        expect(chatServiceSource).toContain('mutedConversations = {');
+        expect(chatServiceSource).toContain('[conversationId]: mutedAt');
+        expect(chatServiceSource).toContain('delete mutedConversations[conversationId]');
+        expect(messagesSource).toContain('await muteTeamChat(auth.user.uid, teamId, conversationId);');
+        expect(messagesSource).toContain('await unmuteTeamChat(auth.user.uid, teamId, conversationId);');
+        expect(messagesSource).toContain('resolveMutedState(teamId, effectiveConversationId, inboxTeam, profile)');
+    });
+});


### PR DESCRIPTION
## Summary
- Add coverage for team chat mention and live-chat notification planning.
- Lock in per-conversation mute handling across Cloud Functions and the app chat service.
- Cover notification links/routes for deep-linked chat conversations.

## Tests
- npx vitest run tests/unit/chat-notification-delivery-contract.test.js --reporter=verbose

Refs #2103