### PR TITLE
[codex] Cover award published notifications

### DIFF
--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -656,6 +656,52 @@ test('notifyFeeMarkedPaid avoids payment wording when a credit marks the fee as 
     }
 });
 
+test('notifyPublishedCertificateAward sends awards notifications to linked parents', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-1': { parentPlayerKeys: ['team-1::player-1'] },
+            'parent-2': { parentPlayerKeys: ['team-1::player-2'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { awards: true } },
+            { uid: 'parent-2', deviceId: 'other-parent-device', token: 'other-parent-token', categories: { awards: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/certificates/certificate-1');
+        const publishedCertificate = {
+            status: 'published',
+            playerId: 'player-1',
+            recipientName: 'Jordan B.',
+            awardTitle: 'Player of the Match'
+        };
+        await ref.set(publishedCertificate);
+
+        await moduleExports.notifyPublishedCertificateAward(
+            makeChange(ref, { status: 'draft', playerId: 'player-1' }, publishedCertificate),
+            { params: { teamId: 'team-1', certificateId: 'certificate-1' }, eventId: 'event-award-1' }
+        );
+
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
+        assert.equal(env.messagingCalls[0].title, 'Award published for Jordan B.');
+        assert.equal(env.messagingCalls[0].body, 'Player of the Match is ready to view in ParentTools.');
+        assert.equal(env.messagingCalls[0].data.category, 'awards');
+        assert.equal(env.messagingCalls[0].data.appRoute, '/parent-tools/certificates?teamId=team-1&certificateId=certificate-1');
+        assert.equal(env.messagingCalls[0].webLink, 'https://allplays.ai/app/#/parent-tools/certificates?teamId=team-1&certificateId=certificate-1');
+        assert.equal(env.auditWrites.length, 1);
+        assert.equal(env.auditWrites[0].value.category, 'awards');
+        assert.equal(env.updatedDocs.some((write) => (
+            write.path === 'teams/team-1/certificates/certificate-1'
+            && write.value.awardNotificationProcessedEventId === 'event-award-1'
+        )), true);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyParentMembershipRequestCreated sends access notifications only to staff reviewers', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: ['assistant@example.com'] },

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -697,6 +697,11 @@ test('notifyPublishedCertificateAward sends awards notifications to linked paren
             write.path === 'teams/team-1/certificates/certificate-1'
             && write.value.awardNotificationProcessedEventId === 'event-award-1'
         )), true);
+
+        const storedCertificate = (await ref.get()).data();
+        assert.equal(storedCertificate.awardNotificationProcessedEventId, 'event-award-1');
+        assert.equal('awardNotificationProcessingEventId' in storedCertificate, false);
+        assert.equal('awardNotificationProcessingStartedAt' in storedCertificate, false);
     } finally {
         cleanup();
     }

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -505,7 +505,8 @@ function buildNotificationTestEnv({
             counts.dedupTransactions += 1;
             return handler({
                 get: (ref) => ref.get(),
-                set: (ref, value) => ref.set(value)
+                set: (ref, value) => ref.set(value),
+                update: (ref, value) => ref.update(value)
             });
         },
         batch() {
@@ -527,7 +528,8 @@ function buildNotificationTestEnv({
     const firestoreFactory = Object.assign(() => firestoreState, {
         FieldValue: {
             serverTimestamp: () => ({ __serverTimestamp: true }),
-            increment: (amount) => ({ __increment: amount })
+            increment: (amount) => ({ __increment: amount }),
+            delete: () => ({ __delete: true })
         },
         Timestamp: {
             fromDate: (date) => ({

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -182,16 +182,53 @@ function buildNotificationTestEnv({
         return value == null ? value : JSON.parse(JSON.stringify(value));
     }
 
+    function isDeleteSentinel(value) {
+        return Boolean(value && typeof value === 'object' && value.__delete === true);
+    }
+
+    function setValueAtPath(target, pathSegments, value) {
+        let cursor = target;
+        for (let index = 0; index < pathSegments.length - 1; index += 1) {
+            const segment = pathSegments[index];
+            if (!cursor[segment] || typeof cursor[segment] !== 'object' || Array.isArray(cursor[segment])) {
+                cursor[segment] = {};
+            }
+            cursor = cursor[segment];
+        }
+        cursor[pathSegments[pathSegments.length - 1]] = value;
+    }
+
+    function deleteValueAtPath(target, pathSegments) {
+        let cursor = target;
+        for (let index = 0; index < pathSegments.length - 1; index += 1) {
+            cursor = cursor?.[pathSegments[index]];
+            if (!cursor || typeof cursor !== 'object') {
+                return;
+            }
+        }
+        if (cursor && typeof cursor === 'object') {
+            delete cursor[pathSegments[pathSegments.length - 1]];
+        }
+    }
+
     function writeStoredDoc(path, value) {
         docStore.set(path, clone(value));
     }
 
     function mergeStoredDoc(path, value) {
-        const current = docStore.get(path) || {};
-        docStore.set(path, {
-            ...clone(current),
-            ...clone(value)
+        const current = clone(docStore.get(path) || {});
+        const incoming = clone(value) || {};
+
+        Object.entries(incoming).forEach(([key, entryValue]) => {
+            const pathSegments = key.split('.');
+            if (isDeleteSentinel(entryValue)) {
+                deleteValueAtPath(current, pathSegments);
+                return;
+            }
+            setValueAtPath(current, pathSegments, entryValue);
         });
+
+        docStore.set(path, current);
     }
 
     function doc(path) {


### PR DESCRIPTION
## Summary
- Add trigger coverage for published certificate award notifications to linked parents.
- Verify award push title/body, category, ParentTools certificates route, web link, audit, and processed marker.
- Extend the notification test Firestore stub with transaction update/delete sentinel support needed by the award claim path.

Refs #2110

## Tests
- npx vitest run functions/test/notification-triggers.test.js --reporter=verbose