### PR TITLE
[codex] Cover team media visibility notification filters

### DIFF
--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -41,7 +41,7 @@ describe('team media visibility notification contract', () => {
         expect(functionsSource).toContain("return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';");
         expect(functionsSource).toContain('function canReceiveCategoryNotification(category, user, audienceContext = {}) {');
         expect(functionsSource).toContain("if (category !== 'media') return true;");
-        expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true");
+        expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true\n    ? 'private'\n    : normalizeNotificationAlbumVisibility(audienceContext.albumVisibility);");
         expect(functionsSource).toContain("if (albumVisibility !== 'private') return true;");
         expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
     });
@@ -49,7 +49,7 @@ describe('team media visibility notification contract', () => {
     it('passes media audience context through indexed and legacy target lookups', () => {
         expect(functionsSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
         expect(functionsSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
-        expect(functionsSource).toContain('getTargetsForCategory(teamId, category, actorUid, audienceContext');
+        expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {');
         expect(functionsSource).toContain('const eligibleUsers = new Map(users');
         expect(functionsSource).toContain('eligibleUsers.has(user.uid)');
         expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);');

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+    canReadTeamMediaAlbum,
+    canViewTeamMediaFolder,
+    normalizeAlbumVisibility,
+    normalizeTeamMediaFolderDraft
+} from '../../js/team-media-utils.js';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+describe('team media visibility notification contract', () => {
+    it('keeps member-facing album reads limited to team-visible albums', () => {
+        expect(normalizeAlbumVisibility('private')).toBe('private');
+        expect(normalizeAlbumVisibility('staff-only')).toBe('team');
+        expect(normalizeAlbumVisibility('')).toBe('team');
+
+        expect(canReadTeamMediaAlbum({ visibility: 'team' }, false)).toBe(true);
+        expect(canReadTeamMediaAlbum({ visibility: 'private' }, false)).toBe(false);
+        expect(canReadTeamMediaAlbum({ visibility: 'private' }, true)).toBe(true);
+
+        expect(canViewTeamMediaFolder({ visibility: 'private' }, 'parent')).toBe(false);
+        expect(canViewTeamMediaFolder({ visibility: 'team' }, 'parent')).toBe(true);
+        expect(canViewTeamMediaFolder({ visibility: 'private' }, 'full')).toBe(true);
+    });
+
+    it('normalizes album drafts through the same visibility vocabulary the gallery reads', () => {
+        expect(normalizeTeamMediaFolderDraft({ name: 'Game photos', visibility: 'private' })).toEqual({
+            name: 'Game photos',
+            visibility: 'private'
+        });
+        expect(normalizeTeamMediaFolderDraft({ name: 'Highlights', visibility: 'staff-only' })).toEqual({
+            name: 'Highlights',
+            visibility: 'team'
+        });
+        expect(() => normalizeTeamMediaFolderDraft({ name: ' ', visibility: 'team' })).toThrow('Album name is required.');
+    });
+
+    it('normalizes notification album visibility defensively before selecting recipients', () => {
+        expect(functionsSource).toContain('function normalizeNotificationAlbumVisibility(value) {');
+        expect(functionsSource).toContain("return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';");
+        expect(functionsSource).toContain('function canReceiveCategoryNotification(category, user, audienceContext = {}) {');
+        expect(functionsSource).toContain("if (category !== 'media') return true;");
+        expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true");
+        expect(functionsSource).toContain("if (albumVisibility !== 'private') return true;");
+        expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
+    });
+
+    it('passes media audience context through indexed and legacy target lookups', () => {
+        expect(functionsSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
+        expect(functionsSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
+        expect(functionsSource).toContain('getTargetsForCategory(teamId, category, actorUid, audienceContext');
+        expect(functionsSource).toContain('const eligibleUsers = new Map(users');
+        expect(functionsSource).toContain('eligibleUsers.has(user.uid)');
+        expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);');
+    });
+});


### PR DESCRIPTION
## Summary
- Add helper coverage for team media album visibility and parent/full access checks.
- Lock in album draft normalization for gallery visibility values.
- Cover Cloud Function media notification audience filtering for private/staff-only albums through indexed and legacy targets.

## Tests
- npx vitest run tests/unit/team-media-visibility-notification-contract.test.js --reporter=verbose

Refs #2160