### PR TITLE
[codex] Warn when deactivating linked players

### DIFF
--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -233,7 +233,7 @@ describe('TeamDetail', () => {
         ]
       })
       .mockResolvedValueOnce(managedModel);
-    vi.spyOn(window, 'confirm')
+    const confirmSpy = vi.spyOn(window, 'confirm')
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(true);
 
@@ -250,6 +250,7 @@ describe('TeamDetail', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Deactivate' }));
 
+    expect(confirmSpy).toHaveBeenCalledWith('Deactivate Pat Star?\n\nLinked parents may lose access to this team, including history, until the player is reactivated or parent scope is repaired.');
     await waitFor(() => expect(teamDetailServiceMocks.deactivateRosterPlayerForApp).toHaveBeenCalledWith('team-1', 'player-1'));
     expect(await screen.findByText('Pat Star deactivated.')).toBeTruthy();
     expect(await screen.findByText('Inactive roster')).toBeTruthy();
@@ -257,6 +258,7 @@ describe('TeamDetail', () => {
     const reactivateButtons = await screen.findAllByRole('button', { name: 'Reactivate' });
     fireEvent.click(reactivateButtons[0]);
 
+    expect(confirmSpy).toHaveBeenCalledWith('Reactivate Sam Bench?');
     await waitFor(() => expect(teamDetailServiceMocks.reactivateRosterPlayerForApp).toHaveBeenCalledWith('team-1', 'player-2'));
     expect(await screen.findByText('Sam Bench reactivated.')).toBeTruthy();
   });

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -526,7 +526,10 @@ function RosterTab({
 
   async function togglePlayerActiveState(player: TeamDetailPlayer) {
     const action = player.active ? 'deactivate' : 'reactivate';
-    const confirmed = window.confirm(`${action === 'deactivate' ? 'Deactivate' : 'Reactivate'} ${player.name}?`);
+    const confirmationMessage = player.active
+      ? `Deactivate ${player.name}?\n\nLinked parents may lose access to this team, including history, until the player is reactivated or parent scope is repaired.`
+      : `Reactivate ${player.name}?`;
+    const confirmed = window.confirm(confirmationMessage);
     if (!confirmed) return;
     setPendingPlayerId(player.id);
     setStatus(null);

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -1663,7 +1663,7 @@
 
             document.querySelectorAll('.deactivate-btn').forEach(btn => {
                 btn.addEventListener('click', async (e) => {
-                    if (confirm('Deactivate this player? This keeps all historical stats and reports.')) {
+                    if (confirm('Deactivate this player? This keeps historical stats and reports, but linked parents may lose team access, including history, until the player is reactivated or parent scope is repaired.')) {
                         await deactivatePlayer(currentTeamId, e.target.dataset.id);
                         loadRoster();
                     }

--- a/tests/unit/player-soft-delete-policy.test.js
+++ b/tests/unit/player-soft-delete-policy.test.js
@@ -57,4 +57,11 @@ describe('player soft-delete policy', () => {
         expect(liveGame).toContain(': getPlayers(state.teamId)');
         expect(teamChat).toContain('getPlayers(teamId, { includeInactive: true })');
     });
+
+    it('warns staff that deactivation can affect linked parent team access', () => {
+        const legacyRoster = readFile('edit-roster.html');
+
+        expect(legacyRoster).toContain('linked parents may lose team access, including history');
+        expect(legacyRoster).toContain('until the player is reactivated or parent scope is repaired');
+    });
 });


### PR DESCRIPTION
## Summary
- Add app and legacy roster confirmation copy warning staff that deactivating a player can affect linked parent team/history access.
- Keep reactivation confirmation unchanged.
- Add regression coverage for the app confirm text and legacy roster warning copy.

Refs #2028

## Tests
- npm --prefix apps/app exec -- vitest run src/pages/TeamDetail.test.tsx --reporter=verbose
- npx vitest run tests/unit/player-soft-delete-policy.test.js --reporter=verbose