### PR TITLE
[codex] Cover Messages decomposition contracts

### DIFF
--- a/apps/app/src/pages/messages/hooks/useChatSheets.test.tsx
+++ b/apps/app/src/pages/messages/hooks/useChatSheets.test.tsx
@@ -31,43 +31,47 @@ function HookProbe() {
     );
 }
 
+function expectSheetState(testId: string, state: boolean) {
+    expect(screen.getByTestId(testId).textContent).toBe(String(state));
+}
+
 describe('useChatSheets', () => {
     it('opens and closes each extracted sheet without leaking state', () => {
         render(<HookProbe />);
 
-        expect(screen.getByTestId('conversation')).toHaveTextContent('false');
-        expect(screen.getByTestId('audience')).toHaveTextContent('false');
-        expect(screen.getByTestId('media')).toHaveTextContent('false');
-        expect(screen.getByTestId('attach')).toHaveTextContent('false');
-        expect(screen.getByTestId('link')).toHaveTextContent('false');
-        expect(screen.getByTestId('email')).toHaveTextContent('false');
+        expectSheetState('conversation', false);
+        expectSheetState('audience', false);
+        expectSheetState('media', false);
+        expectSheetState('attach', false);
+        expectSheetState('link', false);
+        expectSheetState('email', false);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open conversation' }));
-        expect(screen.getByTestId('conversation')).toHaveTextContent('true');
+        expectSheetState('conversation', true);
         fireEvent.click(screen.getByRole('button', { name: 'Close conversation' }));
-        expect(screen.getByTestId('conversation')).toHaveTextContent('false');
+        expectSheetState('conversation', false);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open audience' }));
-        expect(screen.getByTestId('audience')).toHaveTextContent('true');
+        expectSheetState('audience', true);
         fireEvent.click(screen.getByRole('button', { name: 'Close audience' }));
-        expect(screen.getByTestId('audience')).toHaveTextContent('false');
+        expectSheetState('audience', false);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open media' }));
-        expect(screen.getByTestId('media')).toHaveTextContent('true');
+        expectSheetState('media', true);
         fireEvent.click(screen.getByRole('button', { name: 'Close media' }));
-        expect(screen.getByTestId('media')).toHaveTextContent('false');
+        expectSheetState('media', false);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open attach' }));
-        expect(screen.getByTestId('attach')).toHaveTextContent('true');
+        expectSheetState('attach', true);
         fireEvent.click(screen.getByRole('button', { name: 'Open link' }));
-        expect(screen.getByTestId('attach')).toHaveTextContent('false');
-        expect(screen.getByTestId('link')).toHaveTextContent('true');
+        expectSheetState('attach', false);
+        expectSheetState('link', true);
         fireEvent.click(screen.getByRole('button', { name: 'Close link' }));
-        expect(screen.getByTestId('link')).toHaveTextContent('false');
+        expectSheetState('link', false);
 
         fireEvent.click(screen.getByRole('button', { name: 'Open email' }));
-        expect(screen.getByTestId('email')).toHaveTextContent('true');
+        expectSheetState('email', true);
         fireEvent.click(screen.getByRole('button', { name: 'Close email' }));
-        expect(screen.getByTestId('email')).toHaveTextContent('false');
+        expectSheetState('email', false);
     });
 });

--- a/tests/unit/messages-decomposition-contract.test.js
+++ b/tests/unit/messages-decomposition-contract.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = new URL('../../', import.meta.url);
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(relativePath, repoRoot), 'utf8');
+}
+
+describe('Messages decomposition contract', () => {
+    it('keeps chat state domains in extracted hooks', () => {
+        const messages = readRepoFile('apps/app/src/pages/Messages.tsx');
+
+        expect(messages).toContain("import { useChatSheets } from './messages/hooks/useChatSheets';");
+        expect(messages).toContain("import { useChatTeam } from './messages/hooks/useChatTeam';");
+        expect(messages).toContain("import { useChatMessages } from './messages/hooks/useChatMessages';");
+        expect(messages).toContain('} = useChatSheets();');
+        expect(messages).toContain('} = useChatTeam({');
+        expect(messages).toContain('} = useChatMessages({');
+
+        const useStateCount = (messages.match(/\buseState(?:<|\()/g) || []).length;
+        expect(useStateCount).toBeLessThan(40);
+    });
+
+    it('keeps email composer transitions in the reducer instead of separate page state', () => {
+        const messages = readRepoFile('apps/app/src/pages/Messages.tsx');
+        const reducer = readRepoFile('apps/app/src/pages/messages/state/emailReducer.ts');
+
+        expect(messages).toContain("import { emailReducer, initialEmailComposerState } from './messages/state/emailReducer';");
+        expect(messages).toMatch(/const\s+\[emailState,\s*emailDispatch\]\s*=\s*useReducer\(emailReducer,\s*initialEmailComposerState\);/);
+        expect(messages).not.toMatch(/const\s+\[emailSubject\b/);
+        expect(messages).not.toMatch(/const\s+\[emailBody\b/);
+        expect(messages).not.toMatch(/const\s+\[emailDrafts\b/);
+        expect(messages).not.toMatch(/const\s+\[selectedEmailDraftId\b/);
+
+        [
+            "type: 'setDrafts'",
+            "type: 'selectDraft'",
+            "type: 'saveDraft'",
+            "type: 'deleteDraft'",
+            "type: 'clearComposer'"
+        ].forEach((action) => {
+            expect(reducer).toContain(action);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add a source-level contract test that keeps Messages wired to the extracted chat hooks and email reducer
- guard against reintroducing separate email draft subject/body/selection state in the page component
- make the extracted useChatSheets test use plain Vitest text assertions so the focused hook suite runs cleanly

## Tests
- npx vitest run tests/unit/messages-decomposition-contract.test.js apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts apps/app/src/pages/messages/hooks/useChatSheets.test.tsx apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx --reporter=verbose

Refs #2064
