### PR TITLE
[codex] Cover schedule detail decomposition contracts

### DIFF
--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const repoRoot = new URL('../../', import.meta.url);
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(relativePath, repoRoot), 'utf8');
+}
+
+describe('ScheduleEventDetail decomposition contract', () => {
+    it('keeps reusable event summary UI in schedule components', () => {
+        const page = readRepoFile('apps/app/src/pages/ScheduleEventDetail.tsx');
+
+        [
+            "import { DateTile } from '../components/schedule/DateTile';",
+            "import { EventBrief } from '../components/schedule/EventBrief';",
+            "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
+            'QuickAvailabilityPanel',
+            'AvailabilityNotesList',
+            'AttentionPanel'
+        ].forEach((snippet) => {
+            expect(page).toContain(snippet);
+        });
+
+        [
+            /^function DateTile\b/m,
+            /^function EventBrief\b/m,
+            /^function EventSectionNav\b/m,
+            /^function QuickAvailabilityPanel\b/m,
+            /^function AttentionPanel\b/m
+        ].forEach((inlineDefinition) => {
+            expect(page).not.toMatch(inlineDefinition);
+        });
+    });
+
+    it('keeps RSVP and rideshare workflows behind extracted hooks and page context', () => {
+        const page = readRepoFile('apps/app/src/pages/ScheduleEventDetail.tsx');
+        const rsvpHook = readRepoFile('apps/app/src/hooks/schedule/useScheduleEventRsvp.ts');
+        const ridesHook = readRepoFile('apps/app/src/hooks/schedule/useScheduleRideOffers.ts');
+        const context = readRepoFile('apps/app/src/pages/schedule/ScheduleEventDetailContext.tsx');
+
+        expect(page).toContain("import { ScheduleEventDetailProvider } from './schedule/ScheduleEventDetailContext';");
+        expect(page).toContain("import { useScheduleEventRsvp } from '../hooks/schedule/useScheduleEventRsvp';");
+        expect(page).toContain("import { useScheduleRideOffers } from '../hooks/schedule/useScheduleRideOffers';");
+        expect(page).toContain('<ScheduleEventDetailProvider value={{');
+        expect(page).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });');
+        expect(page).toContain('const rideOffers = useScheduleRideOffers();');
+
+        expect(rsvpHook).toContain('export function useScheduleEventRsvp');
+        expect(rsvpHook).toContain('useScheduleEventDetailContext()');
+        expect(rsvpHook).toContain('submitParentScheduleRsvp');
+        expect(ridesHook).toContain('export function useScheduleRideOffers');
+        expect(ridesHook).toContain('useScheduleEventDetailContext()');
+        expect(ridesHook).toContain('loadParentScheduleRideOffers');
+        expect(context).toContain('export function ScheduleEventDetailProvider');
+        expect(context).toContain('export function useScheduleEventDetailContext');
+    });
+});


### PR DESCRIPTION
## Summary
- add a ScheduleEventDetail decomposition contract covering extracted summary components, workflow hooks, and page context
- guard against moving key summary components back inline into the page file
- verify RSVP and rideshare workflows continue to use the extracted context-backed hooks

## Tests
- npx vitest run tests/unit/schedule-event-detail-decomposition-contract.test.js apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx apps/app/src/hooks/schedule/useScheduleRideOffers.test.tsx --reporter=verbose

Refs #2063
