### PR TITLE
[codex] Add app registration form admin helper

### DIFF
--- a/apps/app/src/lib/registrationFormAdmin.test.ts
+++ b/apps/app/src/lib/registrationFormAdmin.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAppRegistrationFormAdminPayload,
+  buildRegistrationFormEditorDraft
+} from './registrationFormAdmin';
+
+describe('registrationFormAdmin', () => {
+  it('hydrates an existing registration form into app-editable draft state', () => {
+    const draft = buildRegistrationFormEditorDraft({
+      id: 'form-1',
+      teamId: 'team-1',
+      programName: 'Spring Soccer',
+      description: 'Season signup',
+      season: 'Spring 2026',
+      feeAmountCents: 12550,
+      participantFields: [
+        { id: 'participant_1', label: 'Player name', type: 'text', required: true },
+        { id: 'participant_2', label: 'Birthdate', type: 'date', required: true }
+      ],
+      guardianFields: [
+        { id: 'guardian_1', label: 'Guardian name', type: 'text', required: true },
+        { id: 'guardian_2', label: 'Guardian email', type: 'email', required: true }
+      ],
+      registrationOptions: [
+        { id: 'travel', title: 'Travel Team', capacityLimit: 12, waitlistEnabled: true },
+        { id: 'academy', title: 'Academy', capacityLimit: null, active: false }
+      ],
+      paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: false },
+      installmentPlan: { enabled: true, title: 'Three payments', installmentCount: 3, firstDueDate: '2026-05-01', intervalDays: 30 },
+      waiverText: 'I accept the risk.',
+      status: 'published'
+    });
+
+    expect(draft).toMatchObject({
+      teamId: 'team-1',
+      formId: 'form-1',
+      title: 'Spring Soccer',
+      feeAmount: '125.50',
+      participantFieldsText: 'Player name\nBirthdate',
+      guardianFieldsText: 'Guardian name\nGuardian email',
+      paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: false },
+      installmentPlan: { enabled: true, title: 'Three payments', installmentCount: 3, firstDueDate: '2026-05-01', intervalDays: 30 },
+      waiverText: 'I accept the risk.',
+      status: 'published'
+    });
+    expect(draft.registrationOptions).toEqual([
+      { id: 'travel', label: 'Travel Team', description: '', capacityLimit: '12', active: true, waitlistEnabled: true },
+      { id: 'academy', label: 'Academy', description: '', capacityLimit: '', active: false, waitlistEnabled: false }
+    ]);
+  });
+
+  it('builds legacy-compatible app setup payloads with options, fees, waivers, payment plans, and waitlists', () => {
+    const result = buildAppRegistrationFormAdminPayload({
+      title: 'Summer Hoops',
+      description: 'June camp',
+      programType: 'camp',
+      season: 'Summer 2026',
+      feeAmount: '200',
+      participantFieldsText: 'Player name\nBirthdate',
+      guardianFieldsText: 'Guardian name\nGuardian email\nGuardian phone',
+      registrationOptions: [
+        { id: 'full-day', label: 'Full day', capacityLimit: '20', active: true, waitlistEnabled: true },
+        { id: 'half-day', label: 'Half day', capacityLimit: '', active: false, waitlistEnabled: false }
+      ],
+      paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+      installmentPlan: { enabled: true, installmentCount: '4', firstDueDate: '2026-06-01', intervalDays: '14' },
+      waiverText: 'Guardian accepts camp waiver.',
+      status: 'published'
+    }, {
+      teamId: 'team-1',
+      now: new Date('2026-05-15T12:00:00Z')
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.payload).toMatchObject({
+      teamId: 'team-1',
+      programType: 'camp',
+      programName: 'Summer Hoops',
+      feeAmountCents: 20000,
+      waiverText: 'Guardian accepts camp waiver.',
+      status: 'published',
+      published: true
+    });
+    expect(result.payload.registrationOptions).toEqual([
+      { id: 'full-day', label: 'Full day', capacityLimit: 20, active: true, waitlistEnabled: true, sortOrder: 0 },
+      { id: 'half-day', label: 'Half day', capacityLimit: null, active: false, waitlistEnabled: false, sortOrder: 1 }
+    ]);
+    expect(result.normalizedForm.registrationOptions[0]).toMatchObject({
+      id: 'full-day',
+      title: 'Full day',
+      capacityLimit: 20,
+      waitlistEnabled: true,
+      active: true
+    });
+    expect(result.paymentPlans.map((plan) => plan.id)).toEqual(['pay_full', 'installments']);
+    expect(result.feeSnapshot).toMatchObject({
+      originalFeeAmountCents: 20000,
+      finalAmountDueCents: 20000
+    });
+  });
+
+  it('returns validation errors without throwing so the app editor can show inline setup problems', () => {
+    const result = buildAppRegistrationFormAdminPayload({
+      title: '',
+      waiverText: '',
+      participantFieldsText: 'Player name',
+      guardianFieldsText: 'Guardian email',
+      registrationOptions: []
+    }, { teamId: 'team-1' });
+
+    expect(result.errors).toEqual([
+      'Title is required.',
+      'Waiver text is required.'
+    ]);
+    expect(result.normalizedForm.published).toBe(false);
+  });
+});

--- a/apps/app/src/lib/registrationFormAdmin.test.ts
+++ b/apps/app/src/lib/registrationFormAdmin.test.ts
@@ -27,6 +27,16 @@ describe('registrationFormAdmin', () => {
       ],
       paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: false },
       installmentPlan: { enabled: true, title: 'Three payments', installmentCount: 3, firstDueDate: '2026-05-01', intervalDays: 30 },
+      discountRules: [
+        { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 2500, minimumQuantity: 2, active: true }
+      ],
+      backgroundCheck: {
+        enabled: true,
+        required: true,
+        instructions: 'Bring a photo ID.',
+        initialScreeningStatus: 'submitted',
+        providerName: 'Checkr'
+      },
       waiverText: 'I accept the risk.',
       status: 'published'
     });
@@ -40,6 +50,13 @@ describe('registrationFormAdmin', () => {
       guardianFieldsText: 'Guardian name\nGuardian email',
       paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: false },
       installmentPlan: { enabled: true, title: 'Three payments', installmentCount: 3, firstDueDate: '2026-05-01', intervalDays: 30 },
+      backgroundCheck: {
+        enabled: true,
+        required: true,
+        instructions: 'Bring a photo ID.',
+        initialScreeningStatus: 'submitted',
+        providerName: 'Checkr'
+      },
       waiverText: 'I accept the risk.',
       status: 'published'
     });
@@ -47,9 +64,12 @@ describe('registrationFormAdmin', () => {
       { id: 'travel', label: 'Travel Team', description: '', capacityLimit: '12', active: true, waitlistEnabled: true },
       { id: 'academy', label: 'Academy', description: '', capacityLimit: '', active: false, waitlistEnabled: false }
     ]);
+    expect(draft.discountRules).toEqual([
+      { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 25, minimumQuantity: 2, active: true }
+    ]);
   });
 
-  it('builds legacy-compatible app setup payloads with options, fees, waivers, payment plans, and waitlists', () => {
+  it('builds legacy-compatible app setup payloads with options, fees, waivers, payment plans, waitlists, and editable fixed discounts', () => {
     const result = buildAppRegistrationFormAdminPayload({
       title: 'Summer Hoops',
       description: 'June camp',
@@ -64,6 +84,9 @@ describe('registrationFormAdmin', () => {
       ],
       paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
       installmentPlan: { enabled: true, installmentCount: '4', firstDueDate: '2026-06-01', intervalDays: '14' },
+      discountRules: [
+        { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 25, minimumQuantity: 2, active: true }
+      ],
       waiverText: 'Guardian accepts camp waiver.',
       status: 'published'
     }, {
@@ -84,6 +107,9 @@ describe('registrationFormAdmin', () => {
     expect(result.payload.registrationOptions).toEqual([
       { id: 'full-day', label: 'Full day', capacityLimit: 20, active: true, waitlistEnabled: true, sortOrder: 0 },
       { id: 'half-day', label: 'Half day', capacityLimit: null, active: false, waitlistEnabled: false, sortOrder: 1 }
+    ]);
+    expect(result.payload.discountRules).toEqual([
+      { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 2500, minimumQuantity: 2, active: true, sortOrder: 0 }
     ]);
     expect(result.normalizedForm.registrationOptions[0]).toMatchObject({
       id: 'full-day',

--- a/apps/app/src/lib/registrationFormAdmin.ts
+++ b/apps/app/src/lib/registrationFormAdmin.ts
@@ -1,0 +1,100 @@
+import {
+  buildAdminRegistrationFormPayload,
+  formatFieldLabels,
+  validateAdminRegistrationFormPayload
+} from '../../../../js/admin-registration-forms.js';
+import {
+  calculateRegistrationFeeSnapshot,
+  getPaymentPlanChoices,
+  normalizeRegistrationForm
+} from '../../../../js/registration-flow.js';
+
+export type RegistrationFormEditorDraft = {
+  teamId?: string;
+  formId?: string;
+  title: string;
+  description: string;
+  programType: string;
+  season: string;
+  feeAmount: string;
+  participantFieldsText: string;
+  guardianFieldsText: string;
+  registrationOptions: Array<Record<string, unknown>>;
+  paymentSettings: Record<string, unknown>;
+  installmentPlan: Record<string, unknown>;
+  discountRules: Array<Record<string, unknown>>;
+  backgroundCheck: Record<string, unknown>;
+  waiverText: string;
+  status: 'draft' | 'published';
+};
+
+export type RegistrationFormAdminPayloadResult = {
+  payload: Record<string, unknown>;
+  normalizedForm: Record<string, any>;
+  errors: string[];
+  paymentPlans: Array<Record<string, unknown>>;
+  feeSnapshot: Record<string, unknown>;
+};
+
+export function buildRegistrationFormEditorDraft(form: Record<string, any> = {}, context: { teamId?: string; formId?: string } = {}): RegistrationFormEditorDraft {
+  const normalizedForm = normalizeRegistrationForm(form, context);
+  const installmentPlan = normalizedForm.installmentPlan || {};
+
+  return {
+    teamId: normalizedForm.teamId,
+    formId: normalizedForm.id,
+    title: normalizedForm.programName,
+    description: normalizedForm.description,
+    programType: String(form.programType || 'season').trim() || 'season',
+    season: normalizedForm.season,
+    feeAmount: formatFeeInput(normalizedForm.feeAmountCents),
+    participantFieldsText: formatFieldLabels(normalizedForm.participantFields),
+    guardianFieldsText: formatFieldLabels(normalizedForm.guardianFields),
+    registrationOptions: normalizedForm.registrationOptions.map((option: Record<string, any>) => ({
+      id: option.id,
+      label: option.title,
+      description: option.description || '',
+      capacityLimit: option.capacityLimit === null || option.capacityLimit === undefined ? '' : String(option.capacityLimit),
+      active: option.active !== false,
+      waitlistEnabled: option.waitlistEnabled === true
+    })),
+    paymentSettings: { ...normalizedForm.paymentSettings },
+    installmentPlan: {
+      enabled: installmentPlan.enabled === true,
+      title: installmentPlan.title || 'Installment plan',
+      installmentCount: installmentPlan.installmentCount || 3,
+      firstDueDate: installmentPlan.firstDueDate || '',
+      intervalDays: installmentPlan.intervalDays || 30
+    },
+    discountRules: [...(normalizedForm.discountRules || [])],
+    backgroundCheck: { ...(normalizedForm.backgroundCheck || {}) },
+    waiverText: normalizedForm.waiverText,
+    status: normalizedForm.published ? 'published' : 'draft'
+  };
+}
+
+export function buildAppRegistrationFormAdminPayload(
+  draft: Partial<RegistrationFormEditorDraft> = {},
+  context: { teamId?: string; now?: Date } = {}
+): RegistrationFormAdminPayloadResult {
+  const payload = buildAdminRegistrationFormPayload(draft, { teamId: context.teamId || draft.teamId || '' });
+  const normalizedForm = normalizeRegistrationForm(payload, {
+    teamId: String(payload.teamId || ''),
+    formId: String(draft.formId || '')
+  });
+  const errors = validateAdminRegistrationFormPayload(payload);
+
+  return {
+    payload,
+    normalizedForm,
+    errors,
+    paymentPlans: getPaymentPlanChoices(normalizedForm),
+    feeSnapshot: calculateRegistrationFeeSnapshot(normalizedForm, { now: context.now || new Date() })
+  };
+}
+
+function formatFeeInput(feeAmountCents: number) {
+  const cents = Math.max(0, Math.round(Number(feeAmountCents) || 0));
+  if (!cents) return '';
+  return (cents / 100).toFixed(2);
+}

--- a/apps/app/src/lib/registrationFormAdmin.ts
+++ b/apps/app/src/lib/registrationFormAdmin.ts
@@ -1,6 +1,7 @@
 import {
   buildAdminRegistrationFormPayload,
   formatFieldLabels,
+  normalizeBackgroundCheckSettings,
   validateAdminRegistrationFormPayload
 } from '../../../../js/admin-registration-forms.js';
 import {
@@ -39,6 +40,7 @@ export type RegistrationFormAdminPayloadResult = {
 export function buildRegistrationFormEditorDraft(form: Record<string, any> = {}, context: { teamId?: string; formId?: string } = {}): RegistrationFormEditorDraft {
   const normalizedForm = normalizeRegistrationForm(form, context);
   const installmentPlan = normalizedForm.installmentPlan || {};
+  const backgroundCheck = normalizeBackgroundCheckSettings(form.backgroundCheck || normalizedForm.backgroundCheck || {});
 
   return {
     teamId: normalizedForm.teamId,
@@ -66,8 +68,8 @@ export function buildRegistrationFormEditorDraft(form: Record<string, any> = {},
       firstDueDate: installmentPlan.firstDueDate || '',
       intervalDays: installmentPlan.intervalDays || 30
     },
-    discountRules: [...(normalizedForm.discountRules || [])],
-    backgroundCheck: { ...(normalizedForm.backgroundCheck || {}) },
+    discountRules: denormalizeDraftDiscountRules(normalizedForm.discountRules || []),
+    backgroundCheck,
     waiverText: normalizedForm.waiverText,
     status: normalizedForm.published ? 'published' : 'draft'
   };
@@ -97,4 +99,13 @@ function formatFeeInput(feeAmountCents: number) {
   const cents = Math.max(0, Math.round(Number(feeAmountCents) || 0));
   if (!cents) return '';
   return (cents / 100).toFixed(2);
+}
+
+function denormalizeDraftDiscountRules(rules: Array<Record<string, any>> = []) {
+  return rules.map((rule) => ({
+    ...rule,
+    amountValue: rule?.amountType === 'fixed'
+      ? Number((Math.max(0, Number(rule?.amountValue || 0)) / 100).toFixed(2))
+      : Math.max(0, Number(rule?.amountValue || 0))
+  }));
 }


### PR DESCRIPTION
## Summary
- add an app-side registration form admin helper that reuses the legacy authoritative form payload shape
- support hydrating existing forms into editable app draft state for options, fees, waiver text, payment settings, installment plans, and waitlists
- return validation errors plus normalized preview/payment metadata for app setup screens without breaking public registration consumers

## Tests
- npx vitest run apps/app/src/lib/registrationFormAdmin.test.ts tests/unit/admin-registration-forms.test.js tests/unit/app-registration-detail.test.jsx --reporter=verbose

Refs #1995
