### PR TITLE
Typed adapter for legacy live-game chat imports (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyLiveGameChat.ts
+++ b/apps/app/src/lib/adapters/legacyLiveGameChat.ts
@@ -1,0 +1,37 @@
+import { postLiveChatMessage as legacyPostLiveChatMessage, subscribeLiveChat as legacySubscribeLiveChat } from '@legacy/db.js';
+import { isViewerChatEnabled as legacyIsViewerChatEnabled } from '@legacy/live-game-chat.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ live-game chat helpers (#2066), so
+ * liveGameChatService imports a typed surface instead of deep `../../../../js/*`.
+ */
+export type LegacyLiveChatPayload = {
+  text: string;
+  senderId: string | null;
+  senderName: string;
+  senderPhotoUrl: string | null;
+  isAnonymous: boolean;
+};
+
+export type LegacyViewerChatOptions = {
+  isReplay?: boolean;
+  now?: Date;
+};
+
+export function postLiveChatMessage(teamId: string, gameId: string, payload: LegacyLiveChatPayload): Promise<unknown> {
+  return Promise.resolve(legacyPostLiveChatMessage(teamId, gameId, payload));
+}
+
+export function subscribeLiveChat<T>(
+  teamId: string,
+  gameId: string,
+  options: { limit?: number },
+  callback: (messages: T) => void,
+  onError?: (error: unknown) => void
+): () => void {
+  return legacySubscribeLiveChat(teamId, gameId, options, callback, onError);
+}
+
+export function isViewerChatEnabled(game: unknown, options?: LegacyViewerChatOptions): boolean {
+  return legacyIsViewerChatEnabled(game, options) === true;
+}

--- a/apps/app/src/lib/liveGameChatService.test.ts
+++ b/apps/app/src/lib/liveGameChatService.test.ts
@@ -1,23 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 
-const dbMocks = vi.hoisted(() => ({
+const adapterMocks = vi.hoisted(() => ({
     postLiveChatMessage: vi.fn(),
-    subscribeLiveChat: vi.fn(() => vi.fn())
-}));
-
-const legacyChatMocks = vi.hoisted(() => ({
+    subscribeLiveChat: vi.fn(() => vi.fn()),
     isViewerChatEnabled: vi.fn()
 }));
 
-vi.mock('../../../../js/db.js', () => dbMocks);
-vi.mock('../../../../js/live-game-chat.js', () => legacyChatMocks);
+vi.mock('./adapters/legacyLiveGameChat', () => adapterMocks);
 
-import { postLiveChatMessage, subscribeLiveChat } from '../../../../js/db.js';
+import { postLiveChatMessage, subscribeLiveChat } from './adapters/legacyLiveGameChat';
 import { buildLiveGameChatPayload, canUseLiveGameChat, sendLiveGameChatMessage, subscribeToLiveGameChat } from './liveGameChatService';
 
 describe('liveGameChatService', () => {
     it('uses the legacy viewer chat gate for live, same-day, and replay decisions', () => {
-        vi.mocked(legacyChatMocks.isViewerChatEnabled)
+        vi.mocked(adapterMocks.isViewerChatEnabled)
             .mockReturnValueOnce(true)
             .mockReturnValueOnce(true)
             .mockReturnValueOnce(false);
@@ -26,9 +22,9 @@ describe('liveGameChatService', () => {
         expect(canUseLiveGameChat({ date: '2026-06-03T09:00:00Z' }, { now: new Date('2026-06-03T12:00:00Z') })).toBe(true);
         expect(canUseLiveGameChat({ date: '2026-06-03T09:00:00Z' }, { isReplay: true, now: new Date('2026-06-03T12:00:00Z') })).toBe(false);
 
-        expect(legacyChatMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(1, { status: 'live', liveStatus: 'live' }, { now: new Date('2026-06-03T12:00:00Z') });
-        expect(legacyChatMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(2, { date: '2026-06-03T09:00:00Z', liveStatus: null }, { now: new Date('2026-06-03T12:00:00Z') });
-        expect(legacyChatMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(3, { date: '2026-06-03T09:00:00Z', liveStatus: null }, { isReplay: true, now: new Date('2026-06-03T12:00:00Z') });
+        expect(adapterMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(1, { status: 'live', liveStatus: 'live' }, { now: new Date('2026-06-03T12:00:00Z') });
+        expect(adapterMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(2, { date: '2026-06-03T09:00:00Z', liveStatus: null }, { now: new Date('2026-06-03T12:00:00Z') });
+        expect(adapterMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(3, { date: '2026-06-03T09:00:00Z', liveStatus: null }, { isReplay: true, now: new Date('2026-06-03T12:00:00Z') });
     });
 
     it('builds signed-in and anonymous live chat payloads', () => {

--- a/apps/app/src/lib/liveGameChatService.ts
+++ b/apps/app/src/lib/liveGameChatService.ts
@@ -1,5 +1,4 @@
-import { postLiveChatMessage, subscribeLiveChat } from '../../../../js/db.js';
-import { isViewerChatEnabled } from '../../../../js/live-game-chat.js';
+import { isViewerChatEnabled, postLiveChatMessage, subscribeLiveChat } from './adapters/legacyLiveGameChat';
 import type { AuthUser } from './types';
 
 export type LiveGameChatMessage = {


### PR DESCRIPTION
Part of #2066. Routes `liveGameChatService` through a typed `adapters/legacyLiveGameChat` boundary (typed `postLiveChatMessage`/`subscribeLiveChat`/`isViewerChatEnabled` via `@legacy`) instead of deep `../../../../js/*` imports. Test mocks the adapter. Build + service test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)