### PR TITLE
Typed adapter for legacy live-stream URL helper (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyLiveStreamUtils.ts
+++ b/apps/app/src/lib/adapters/legacyLiveStreamUtils.ts
@@ -1,0 +1,8 @@
+import { normalizeYouTubeEmbedUrl as legacyNormalizeYouTubeEmbedUrl } from '@legacy/live-stream-utils.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ live-stream URL helpers (#2066).
+ */
+export function normalizeYouTubeEmbedUrl(url: string): string | null {
+  return legacyNormalizeYouTubeEmbedUrl(url) ?? null;
+}

--- a/apps/app/src/lib/teamLinks.ts
+++ b/apps/app/src/lib/teamLinks.ts
@@ -1,4 +1,4 @@
-import { normalizeYouTubeEmbedUrl } from '../../../../js/live-stream-utils.js';
+import { normalizeYouTubeEmbedUrl } from './adapters/legacyLiveStreamUtils';
 
 const YOUTUBE_HOST_RE = /(^|\.)youtube\.com$/i;
 const YOUTU_BE_HOST_RE = /(^|\.)youtu\.be$/i;


### PR DESCRIPTION
Part of #2066. Routes `teamLinks` through a typed `adapters/legacyLiveStreamUtils` boundary instead of a deep `../../../../js/live-stream-utils.js` import. Build + teamLinks tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)