### PR TITLE
Typed adapter for legacy stat-config helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyStatConfig.ts
+++ b/apps/app/src/lib/adapters/legacyStatConfig.ts
@@ -1,0 +1,18 @@
+import { getStatConfigPresetById as legacyGetStatConfigPresetById, getStatConfigPresetOptions as legacyGetStatConfigPresetOptions } from '@legacy/stat-config-presets.js';
+import { normalizeStatTrackerConfig as legacyNormalizeStatTrackerConfig } from '@legacy/stat-leaderboards.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ stat-tracker config helpers (#2066).
+ * Returns `unknown` because the legacy shapes are untyped; callers narrow/cast.
+ */
+export function getStatConfigPresetById(presetId: string): unknown {
+  return legacyGetStatConfigPresetById(presetId);
+}
+
+export function getStatConfigPresetOptions(): unknown[] {
+  return legacyGetStatConfigPresetOptions() as unknown[];
+}
+
+export function normalizeStatTrackerConfig(config: unknown): unknown {
+  return legacyNormalizeStatTrackerConfig(config);
+}

--- a/apps/app/src/lib/statTrackerConfigEditor.ts
+++ b/apps/app/src/lib/statTrackerConfigEditor.ts
@@ -1,5 +1,4 @@
-import { getStatConfigPresetById, getStatConfigPresetOptions } from '../../../../js/stat-config-presets.js';
-import { normalizeStatTrackerConfig } from '../../../../js/stat-leaderboards.js';
+import { getStatConfigPresetById, getStatConfigPresetOptions, normalizeStatTrackerConfig } from './adapters/legacyStatConfig';
 
 type LegacyStatTrackerConfig = {
   id?: string;


### PR DESCRIPTION
Part of #2066. Routes `statTrackerConfigEditor` through a typed `adapters/legacyStatConfig` boundary instead of deep `js/stat-config-presets.js` + `js/stat-leaderboards.js` imports. Build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)