### PR TITLE
Typed adapter for legacy schedule CSV import helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleCsv.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleCsv.ts
@@ -1,0 +1,21 @@
+import {
+  SCHEDULE_CSV_IMPORT_FIELDS as legacyFields,
+  buildScheduleImportPreview as legacyBuildScheduleImportPreview,
+  inferScheduleCsvMapping as legacyInferScheduleCsvMapping,
+  normalizeScheduleImportDraft as legacyNormalizeScheduleImportDraft,
+  parseCsvText as legacyParseCsvText,
+  validateScheduleCsvMapping as legacyValidateScheduleCsvMapping
+} from '@legacy/schedule-csv-import.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ schedule CSV import helpers (#2066).
+ * Shapes stay loose (the legacy module is untyped); scheduleCsvImport layers its
+ * own exported types on top.
+ */
+export const SCHEDULE_CSV_IMPORT_FIELDS = legacyFields as ReadonlyArray<{ key: string; label: string; [key: string]: unknown }>;
+
+export const buildScheduleImportPreview = legacyBuildScheduleImportPreview as (...args: any[]) => any;
+export const inferScheduleCsvMapping = legacyInferScheduleCsvMapping as (...args: any[]) => any;
+export const normalizeScheduleImportDraft = legacyNormalizeScheduleImportDraft as (...args: any[]) => any;
+export const parseCsvText = legacyParseCsvText as (text: string) => any;
+export const validateScheduleCsvMapping = legacyValidateScheduleCsvMapping as (...args: any[]) => any;

--- a/apps/app/src/lib/scheduleCsvImport.ts
+++ b/apps/app/src/lib/scheduleCsvImport.ts
@@ -5,7 +5,7 @@ import {
   normalizeScheduleImportDraft,
   parseCsvText,
   validateScheduleCsvMapping
-} from '../../../../js/schedule-csv-import.js';
+} from './adapters/legacyScheduleCsv';
 
 export type ScheduleCsvImportFieldKey = 'startDateTime' | 'date' | 'startTime' | 'endTime' | 'eventType' | 'opponent' | 'title' | 'location' | 'arrivalTime' | 'isHome' | 'notes';
 export type ScheduleCsvImportMapping = Partial<Record<ScheduleCsvImportFieldKey, string>>;


### PR DESCRIPTION
Part of #2066. Routes `scheduleCsvImport` through a typed `adapters/legacyScheduleCsv` boundary instead of a deep `js/schedule-csv-import.js` import. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)