### PR TITLE
Typed adapter for legacy stat-tracking Firestore helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyStatTrackingDb.ts
+++ b/apps/app/src/lib/adapters/legacyStatTrackingDb.ts
@@ -1,0 +1,18 @@
+import { db as legacyDb, deleteDoc as legacyDeleteDoc, doc as legacyDoc, increment as legacyIncrement, setDoc as legacySetDoc } from '@legacy/firebase.js';
+import { splitPlayerStatsByVisibility as legacySplitPlayerStatsByVisibility } from '@legacy/stat-leaderboards.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ Firestore primitives + stat helper
+ * used by statTrackingService (#2066). The Firestore SDK shapes stay loose; the
+ * service injects these via its dependencies object.
+ */
+export const db: unknown = legacyDb;
+export const doc = legacyDoc as (db: unknown, ...segments: string[]) => unknown;
+export const setDoc = legacySetDoc as (ref: unknown, data: Record<string, unknown>, options?: { merge?: boolean }) => Promise<unknown>;
+export const deleteDoc = legacyDeleteDoc as (ref: unknown) => Promise<unknown>;
+export const increment = legacyIncrement as (delta: number) => unknown;
+
+export const splitPlayerStatsByVisibility = legacySplitPlayerStatsByVisibility as (
+  statConfig: Record<string, unknown>,
+  stats: Record<string, unknown>
+) => { publicStats: Record<string, unknown>; privateStats: Record<string, unknown> };

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -183,6 +183,8 @@ it('keeps schedule workflows behind typed legacy adapters', () => {
   expect(scheduleServiceSource).toContain("./adapters/legacyScheduleDb");
   expect(scheduleServiceSource).toContain("./adapters/legacyScheduleHelpers");
   expect(scheduleServiceSource).toContain("./adapters/legacyAvailability");
+  expect(scheduleServiceSource).toContain("./statTrackingEvent");
+  expect(scheduleServiceSource).not.toContain("from './statTrackingService'");
   expect(scheduleServiceSource).toContain("./logger");
   expect(scheduleServiceSource).toContain("createLogger('schedule-service')");
   expect(scheduleServiceSource).not.toContain('console.');

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -80,7 +80,7 @@ import {
   isTeamActive
 } from './adapters/legacyScheduleHelpers';
 import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './adapters/legacyAvailability';
-import { buildTrackerEventDocument } from './statTrackingService';
+import { buildTrackerEventDocument } from './statTrackingEvent';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { startInteractionTimer, startUxTimer, UX_TIMING } from './uxTiming';

--- a/apps/app/src/lib/statTrackingEvent.ts
+++ b/apps/app/src/lib/statTrackingEvent.ts
@@ -1,0 +1,75 @@
+export type TrackerUser = {
+    uid: string;
+    displayName?: string | null;
+    email?: string | null;
+};
+
+export type TrackerUndoData = {
+    type?: string | null;
+    playerId?: string | null;
+    statKey?: string | null;
+    value?: number | null;
+    isOpponent?: boolean;
+};
+
+export type TrackerEventInput = {
+    text: string;
+    clock?: string | null;
+    gameTime?: string | null;
+    period?: string | null;
+    timestamp?: number | Date | null;
+    undoData?: TrackerUndoData | null;
+    playerName?: string | null;
+    playerNumber?: string | null;
+    teamSide?: 'home' | 'away';
+};
+
+export type TrackerEventDocument = {
+    text: string;
+    gameTime: string;
+    period: string;
+    timestamp: number;
+    type: string;
+    playerId: string | null;
+    statKey: string | null;
+    value: number | null;
+    isOpponent: boolean;
+    createdBy: string;
+};
+
+const BASE_TRACKER_PERIOD = 'Q1';
+
+function normalizeText(value: unknown) {
+    return String(value || '').trim();
+}
+
+function normalizeStatKey(value: unknown) {
+    return normalizeText(value).toLowerCase();
+}
+
+function normalizeTimestamp(value: unknown) {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? Date.now() : value.getTime();
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+export function buildTrackerEventDocument(input: TrackerEventInput, user: TrackerUser): TrackerEventDocument {
+    const undoData = input.undoData || {};
+    const statKey = normalizeStatKey(undoData.statKey);
+    const value = Number(undoData.value);
+
+    return {
+        text: String(input.text || ''),
+        gameTime: String(input.gameTime || input.clock || ''),
+        period: String(input.period || BASE_TRACKER_PERIOD),
+        timestamp: normalizeTimestamp(input.timestamp),
+        type: String(undoData.type || 'game_log'),
+        playerId: normalizeText(undoData.playerId) || null,
+        statKey: statKey || null,
+        value: Number.isFinite(value) ? value : null,
+        isOpponent: undoData.isOpponent === true,
+        createdBy: String(user.uid || '')
+    };
+}

--- a/apps/app/src/lib/statTrackingService.test.ts
+++ b/apps/app/src/lib/statTrackingService.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
-import { buildTrackerEventDocument, createStatTrackingService } from './statTrackingService';
+import { buildTrackerEventDocument } from './statTrackingEvent';
+import { createStatTrackingService } from './statTrackingService';
 
 function createDependencies() {
   return {
@@ -13,6 +15,14 @@ function createDependencies() {
 }
 
 describe('statTrackingService', () => {
+  it('keeps stat tracking helpers behind typed adapters and the extracted tracker event builder', () => {
+    const statTrackingServiceSource = readFileSync('src/lib/statTrackingService.ts', 'utf8');
+
+    expect(statTrackingServiceSource).not.toContain("../../../../js/");
+    expect(statTrackingServiceSource).toContain("./adapters/legacyStatTrackingDb");
+    expect(statTrackingServiceSource).toContain("./statTrackingEvent");
+  });
+
   it('builds legacy-compatible tracker event documents', () => {
     const event = buildTrackerEventDocument({
       text: '#4 Alex PTS +2',

--- a/apps/app/src/lib/statTrackingService.ts
+++ b/apps/app/src/lib/statTrackingService.ts
@@ -1,3 +1,4 @@
+import { buildTrackerEventDocument, type TrackerEventDocument, type TrackerEventInput, type TrackerUndoData, type TrackerUser } from './statTrackingEvent';
 import { db, deleteDoc, doc, increment, setDoc, splitPlayerStatsByVisibility } from './adapters/legacyStatTrackingDb';
 
 export type TrackerScoreState = {
@@ -5,48 +6,9 @@ export type TrackerScoreState = {
   awayScore: number;
 };
 
-export type TrackerUser = {
-  uid: string;
-  displayName?: string | null;
-  email?: string | null;
-};
-
 export type TrackerStatConfig = {
   columns?: string[];
   statDefinitions?: Array<{ id?: string; scope?: string; visibility?: string }>;
-};
-
-export type TrackerUndoData = {
-  type?: string | null;
-  playerId?: string | null;
-  statKey?: string | null;
-  value?: number | null;
-  isOpponent?: boolean;
-};
-
-export type TrackerEventInput = {
-  text: string;
-  clock?: string | null;
-  gameTime?: string | null;
-  period?: string | null;
-  timestamp?: number | Date | null;
-  undoData?: TrackerUndoData | null;
-  playerName?: string | null;
-  playerNumber?: string | null;
-  teamSide?: 'home' | 'away';
-};
-
-export type TrackerEventDocument = {
-  text: string;
-  gameTime: string;
-  period: string;
-  timestamp: number;
-  type: string;
-  playerId: string | null;
-  statKey: string | null;
-  value: number | null;
-  isOpponent: boolean;
-  createdBy: string;
 };
 
 export type TrackerLogEntry = {
@@ -72,7 +34,6 @@ type StatTrackingDependencies = {
 };
 
 const DEFAULT_SCORE: TrackerScoreState = { homeScore: 0, awayScore: 0 };
-const BASE_TRACKER_PERIOD = 'Q1';
 const BASE_PARTICIPATION_SOURCE = 'app-stat-tracker';
 
 function normalizeScoreValue(value: unknown) {
@@ -93,14 +54,6 @@ function normalizeText(value: unknown) {
 
 function normalizeStatKey(value: unknown) {
   return normalizeText(value).toLowerCase();
-}
-
-function normalizeTimestamp(value: unknown) {
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? Date.now() : value.getTime();
-  }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : Date.now();
 }
 
 function isScoringStatKey(statKey: string) {
@@ -127,25 +80,6 @@ function collectAllowedStatKeys(config: TrackerStatConfig = {}) {
   });
 
   return keys;
-}
-
-function buildTrackerEventDocument(input: TrackerEventInput, user: TrackerUser): TrackerEventDocument {
-  const undoData = input.undoData || {};
-  const statKey = normalizeStatKey(undoData.statKey);
-  const value = Number(undoData.value);
-
-  return {
-    text: String(input.text || ''),
-    gameTime: String(input.gameTime || input.clock || ''),
-    period: String(input.period || BASE_TRACKER_PERIOD),
-    timestamp: normalizeTimestamp(input.timestamp),
-    type: String(undoData.type || 'game_log'),
-    playerId: normalizeText(undoData.playerId) || null,
-    statKey: statKey || null,
-    value: Number.isFinite(value) ? value : null,
-    isOpponent: undoData.isOpponent === true,
-    createdBy: String(user.uid || '')
-  };
 }
 
 function buildParticipationPayload(playerName: string, playerNumber: string) {
@@ -430,3 +364,4 @@ export function createDefaultStatTrackingService(options: {
 }
 
 export { buildTrackerEventDocument };
+export type { TrackerEventDocument, TrackerEventInput, TrackerUndoData, TrackerUser };

--- a/apps/app/src/lib/statTrackingService.ts
+++ b/apps/app/src/lib/statTrackingService.ts
@@ -1,5 +1,4 @@
-import { db, deleteDoc, doc, increment, setDoc } from '../../../../js/firebase.js';
-import { splitPlayerStatsByVisibility } from '../../../../js/stat-leaderboards.js';
+import { db, deleteDoc, doc, increment, setDoc, splitPlayerStatsByVisibility } from './adapters/legacyStatTrackingDb';
 
 export type TrackerScoreState = {
   homeScore: number;


### PR DESCRIPTION
Part of #2066. Routes `statTrackingService` through a typed `adapters/legacyStatTrackingDb` boundary instead of deep `js/firebase.js` + `js/stat-leaderboards.js` imports. Build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)