### PR TITLE
Typed adapter for vendored Firebase AI (schedule import) (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyGenerativeAi.ts
+++ b/apps/app/src/lib/adapters/legacyGenerativeAi.ts
@@ -1,0 +1,15 @@
+import { getApp as legacyGetApp } from '@legacy/vendor/firebase-app.js';
+import { getAI as legacyGetAI, getGenerativeModel as legacyGetGenerativeModel, GoogleAIBackend as LegacyGoogleAIBackend, Schema as LegacySchema } from '@legacy/vendor/firebase-ai.js';
+
+/**
+ * Typed adapter boundary for the vendored Firebase AI SDK (#2066), so app
+ * services import a single typed surface instead of deep js/vendor/* imports.
+ * SDK object shapes stay loose.
+ */
+export const getApp = legacyGetApp as (name?: string) => unknown;
+export const getAI = legacyGetAI as (app: unknown, options?: Record<string, unknown>) => unknown;
+export const getGenerativeModel = legacyGetGenerativeModel as (ai: unknown, options: Record<string, unknown>) => {
+  generateContent: (...args: any[]) => Promise<any>;
+};
+export const GoogleAIBackend = LegacyGoogleAIBackend as new (...args: any[]) => unknown;
+export const Schema = LegacySchema as any;

--- a/apps/app/src/lib/scheduleAiImport.test.ts
+++ b/apps/app/src/lib/scheduleAiImport.test.ts
@@ -16,11 +16,8 @@ const aiMocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('../../../../js/vendor/firebase-app.js', () => ({
-  getApp: vi.fn(() => ({}))
-}));
-
-vi.mock('../../../../js/vendor/firebase-ai.js', () => ({
+vi.mock('./adapters/legacyGenerativeAi', () => ({
+  getApp: vi.fn(() => ({})),
   getAI: vi.fn(() => ({})),
   getGenerativeModel: aiMocks.getGenerativeModel,
   GoogleAIBackend: vi.fn(),

--- a/apps/app/src/lib/scheduleAiImport.ts
+++ b/apps/app/src/lib/scheduleAiImport.ts
@@ -1,5 +1,4 @@
-import { getApp } from '../../../../js/vendor/firebase-app.js';
-import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from '../../../../js/vendor/firebase-ai.js';
+import { getAI, getApp, getGenerativeModel, GoogleAIBackend, Schema } from './adapters/legacyGenerativeAi';
 import { normalizeScheduleImportDraft, type ScheduleCsvImportPreviewRow } from './scheduleCsvImport';
 
 export type ScheduleAiImportCurrentGame = {


### PR DESCRIPTION
Part of #2066. Adds `adapters/legacyGenerativeAi` wrapping the vendored `js/vendor/firebase-app` + `firebase-ai` imports, and routes `scheduleAiImport` through it. Test mocks the adapter. Build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)