### PR TITLE
Typed adapter for legacy profile-photo helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyProfilePhotoDb.ts
+++ b/apps/app/src/lib/adapters/legacyProfilePhotoDb.ts
@@ -1,0 +1,13 @@
+import { resolveImageFirebaseConfig as legacyResolveImageFirebaseConfig } from '@legacy/firebase-runtime-config.js';
+import { uploadUserPhoto as legacyUploadUserPhoto } from '@legacy/db.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ profile-photo upload helpers (#2066).
+ */
+export function resolveImageFirebaseConfig(): any {
+  return legacyResolveImageFirebaseConfig() ?? {};
+}
+
+export function uploadUserPhoto(file: File): Promise<string> {
+  return Promise.resolve(legacyUploadUserPhoto(file)) as Promise<string>;
+}

--- a/apps/app/src/lib/profilePhotoService.ts
+++ b/apps/app/src/lib/profilePhotoService.ts
@@ -5,9 +5,9 @@ import {
   type CameraPhoto
 } from '@capacitor/camera';
 import { Capacitor } from '@capacitor/core';
-import { resolveImageFirebaseConfig } from '../../../../js/firebase-runtime-config.js';
+import { resolveImageFirebaseConfig } from './adapters/legacyProfilePhotoDb';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
-import { uploadUserPhoto } from '../../../../js/db.js';
+import { uploadUserPhoto } from './adapters/legacyProfilePhotoDb';
 
 const profileTimeoutMs = 8000;
 const nativeImageUploadTimeoutMs = 20000;


### PR DESCRIPTION
Part of #2066. Routes `profilePhotoService` through a typed `adapters/legacyProfilePhotoDb` boundary instead of deep `js/firebase-runtime-config.js` + `js/db.js` imports. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)