### PR TITLE
Typed adapter for legacy public-team discovery (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyPublicTeamsDb.ts
+++ b/apps/app/src/lib/adapters/legacyPublicTeamsDb.ts
@@ -1,0 +1,8 @@
+import { discoverPublicTeams as legacyDiscoverPublicTeams } from '@legacy/db.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ public-team discovery helper (#2066).
+ */
+export function discoverPublicTeams(options?: { searchText?: string; cursor?: unknown; pageSize?: number }): Promise<any> {
+  return Promise.resolve(legacyDiscoverPublicTeams(options));
+}

--- a/apps/app/src/lib/adapters/legacyPublicTeamsDb.ts
+++ b/apps/app/src/lib/adapters/legacyPublicTeamsDb.ts
@@ -4,5 +4,5 @@ import { discoverPublicTeams as legacyDiscoverPublicTeams } from '@legacy/db.js'
  * Typed adapter boundary for the legacy js/ public-team discovery helper (#2066).
  */
 export function discoverPublicTeams(options?: { searchText?: string; cursor?: unknown; pageSize?: number }): Promise<any> {
-  return Promise.resolve(legacyDiscoverPublicTeams(options));
+  return legacyDiscoverPublicTeams(options);
 }

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -4,7 +4,7 @@ const dbMocks = vi.hoisted(() => ({
     discoverPublicTeams: vi.fn()
 }));
 
-vi.mock('../../../../js/db.js', () => dbMocks);
+vi.mock('./adapters/legacyPublicTeamsDb', () => dbMocks);
 
 import { getPublicTeamsByLocation, getPublicTeamsPage } from './publicTeamsService';
 

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -1,4 +1,4 @@
-import { discoverPublicTeams } from '../../../../js/db.js';
+import { discoverPublicTeams } from './adapters/legacyPublicTeamsDb';
 import { type ParentHomeTeam } from './homeLogic';
 
 export type PublicTeamsPage = {


### PR DESCRIPTION
Part of #2066. Routes `publicTeamsService` through a typed `adapters/legacyPublicTeamsDb` boundary instead of a deep `js/db.js` import. Test mocks the adapter. Build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)