### PR TITLE
Typed adapter for legacy certificate helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyCertificateDraft.ts
+++ b/apps/app/src/lib/adapters/legacyCertificateDraft.ts
@@ -1,0 +1,35 @@
+import {
+  createCertificate as legacyCreateCertificate,
+  createCertificateBatch as legacyCreateCertificateBatch,
+  getCertificateDefaults as legacyGetCertificateDefaults,
+  getPlayers as legacyGetPlayers,
+  getTeam as legacyGetTeam,
+  getUserByEmail as legacyGetUserByEmail,
+  getUserProfile as legacyGetUserProfile,
+  setCertificateDefaults as legacySetCertificateDefaults,
+  updateCertificateBatch as legacyUpdateCertificateBatch
+} from '@legacy/db.js';
+import { buildDefaultSigners as legacyBuildDefaultSigners, normalizeSigners as legacyNormalizeSigners } from '@legacy/certificates/signers.js';
+import { resolveColors as legacyResolveColors } from '@legacy/certificates/renderer.js';
+import { TEMPLATES as legacyTemplates } from '@legacy/certificates/templates.js';
+import { hasFullTeamAccess as legacyHasFullTeamAccess } from '@legacy/team-access.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ certificate helpers (#2066). Bindings
+ * are re-exported as-is (no runtime wrapping) so existing js/* test mocks still
+ * apply through the @legacy alias; legacy shapes stay loose.
+ */
+export const createCertificate = legacyCreateCertificate as (...args: any[]) => Promise<any>;
+export const createCertificateBatch = legacyCreateCertificateBatch as (...args: any[]) => Promise<any>;
+export const getCertificateDefaults = legacyGetCertificateDefaults as (...args: any[]) => Promise<any>;
+export const getPlayers = legacyGetPlayers as (...args: any[]) => Promise<any>;
+export const getTeam = legacyGetTeam as (...args: any[]) => Promise<any>;
+export const getUserByEmail = legacyGetUserByEmail as (...args: any[]) => Promise<any>;
+export const getUserProfile = legacyGetUserProfile as (...args: any[]) => Promise<any>;
+export const setCertificateDefaults = legacySetCertificateDefaults as (...args: any[]) => Promise<any>;
+export const updateCertificateBatch = legacyUpdateCertificateBatch as (...args: any[]) => Promise<any>;
+export const buildDefaultSigners = legacyBuildDefaultSigners as (...args: any[]) => any;
+export const normalizeSigners = legacyNormalizeSigners as (...args: any[]) => any;
+export const resolveColors = legacyResolveColors as (...args: any[]) => any;
+export const TEMPLATES = legacyTemplates as Record<string, unknown>;
+export const hasFullTeamAccess = legacyHasFullTeamAccess as (...args: any[]) => boolean;

--- a/apps/app/src/lib/certificateDraftService.ts
+++ b/apps/app/src/lib/certificateDraftService.ts
@@ -1,4 +1,6 @@
 import {
+  TEMPLATES,
+  buildDefaultSigners,
   createCertificate,
   createCertificateBatch,
   getCertificateDefaults,
@@ -6,13 +8,12 @@ import {
   getTeam,
   getUserByEmail,
   getUserProfile,
+  hasFullTeamAccess,
+  normalizeSigners,
+  resolveColors,
   setCertificateDefaults,
   updateCertificateBatch
-} from '../../../../js/db.js';
-import { buildDefaultSigners, normalizeSigners } from '../../../../js/certificates/signers.js';
-import { resolveColors } from '../../../../js/certificates/renderer.js';
-import { TEMPLATES } from '../../../../js/certificates/templates.js';
-import { hasFullTeamAccess } from '../../../../js/team-access.js';
+} from './adapters/legacyCertificateDraft';
 import type { AuthUser } from './types';
 
 export type CertificateDraftTemplateOption = {


### PR DESCRIPTION
Part of #2066. Routes `certificateDraftService` through a typed `adapters/legacyCertificateDraft` boundary (db, certificates/signers, certificates/renderer, certificates/templates, team-access). Build + tests green (existing mocks apply via the `@legacy` alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)