### PR TITLE
Typed adapter for legacy game-report helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyGameReport.ts
+++ b/apps/app/src/lib/adapters/legacyGameReport.ts
@@ -1,0 +1,38 @@
+import {
+  getConfigs as legacyGetConfigs,
+  getGame as legacyGetGame,
+  getGameEvents as legacyGetGameEvents,
+  getPlayers as legacyGetPlayers,
+  getTeam as legacyGetTeam,
+  getTeamStatsForGame as legacyGetTeamStatsForGame
+} from '@legacy/db.js';
+import { collection as legacyCollection, db as legacyDb, getDocs as legacyGetDocs } from '@legacy/firebase.js';
+import { resolveReportStatColumns as legacyResolveReportStatColumns, resolveOpponentReportStatColumns as legacyResolveOpponentReportStatColumns } from '@legacy/game-report-stats.js';
+import { buildHighlightShareUrl as legacyBuildHighlightShareUrl, normalizeGameRecapHighlightClips as legacyNormalizeGameRecapHighlightClips } from '@legacy/live-game-video.js';
+import { resolveLiveStatConfig as legacyResolveLiveStatConfig } from '@legacy/live-game-state.js';
+import { generateGameInsights as legacyGenerateGameInsights } from '@legacy/post-game-insights.js';
+import { hasPlayerProfileParticipation as legacyHasPlayerProfileParticipation } from '@legacy/player-profile-stats.js';
+import { resolvePostGameTeamStatFields as legacyResolvePostGameTeamStatFields } from '@legacy/post-game-stat-editor.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ game-report helpers (#2066). Bindings
+ * re-exported as-is so existing js/* test mocks apply via the @legacy alias;
+ * legacy shapes stay loose.
+ */
+export const getConfigs = legacyGetConfigs as (...args: any[]) => Promise<any>;
+export const getGame = legacyGetGame as (...args: any[]) => Promise<any>;
+export const getGameEvents = legacyGetGameEvents as (...args: any[]) => Promise<any>;
+export const getPlayers = legacyGetPlayers as (...args: any[]) => Promise<any>;
+export const getTeam = legacyGetTeam as (...args: any[]) => Promise<any>;
+export const getTeamStatsForGame = legacyGetTeamStatsForGame as (...args: any[]) => Promise<any>;
+export const collection = legacyCollection as (...args: any[]) => any;
+export const getDocs = legacyGetDocs as (...args: any[]) => Promise<any>;
+export const db: unknown = legacyDb;
+export const resolveReportStatColumns = legacyResolveReportStatColumns as (...args: any[]) => any;
+export const resolveOpponentReportStatColumns = legacyResolveOpponentReportStatColumns as (...args: any[]) => any;
+export const buildHighlightShareUrl = legacyBuildHighlightShareUrl as (...args: any[]) => any;
+export const normalizeGameRecapHighlightClips = legacyNormalizeGameRecapHighlightClips as (...args: any[]) => any;
+export const resolveLiveStatConfig = legacyResolveLiveStatConfig as (...args: any[]) => any;
+export const generateGameInsights = legacyGenerateGameInsights as (...args: any[]) => any;
+export const hasPlayerProfileParticipation = legacyHasPlayerProfileParticipation as (...args: any[]) => boolean;
+export const resolvePostGameTeamStatFields = legacyResolvePostGameTeamStatFields as (...args: any[]) => any;

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -1,19 +1,22 @@
 import {
+  buildHighlightShareUrl,
+  collection,
+  db,
+  generateGameInsights,
   getConfigs,
+  getDocs,
   getGame,
   getGameEvents,
   getPlayers,
   getTeam,
-  getTeamStatsForGame
-} from '../../../../js/db.js';
-import { collection, getDocs } from '../../../../js/firebase.js';
-import { db } from '../../../../js/firebase.js';
-import { resolveReportStatColumns, resolveOpponentReportStatColumns } from '../../../../js/game-report-stats.js';
-import { buildHighlightShareUrl, normalizeGameRecapHighlightClips } from '../../../../js/live-game-video.js';
-import { resolveLiveStatConfig } from '../../../../js/live-game-state.js';
-import { generateGameInsights } from '../../../../js/post-game-insights.js';
-import { hasPlayerProfileParticipation } from '../../../../js/player-profile-stats.js';
-import { resolvePostGameTeamStatFields } from '../../../../js/post-game-stat-editor.js';
+  getTeamStatsForGame,
+  hasPlayerProfileParticipation,
+  normalizeGameRecapHighlightClips,
+  resolveLiveStatConfig,
+  resolveOpponentReportStatColumns,
+  resolvePostGameTeamStatFields,
+  resolveReportStatColumns
+} from './adapters/legacyGameReport';
 import {
   mapGameReportAggregatedStatsRecord,
   mapGameReportGameRecord,


### PR DESCRIPTION
Part of #2066. Routes `gameReportService` through a typed `adapters/legacyGameReport` boundary, replacing 8 deep `js/*` imports. Build + tests green (existing mocks apply via the `@legacy` alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)