### PR TITLE
Typed adapter for legacy social Firestore primitives (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacySocialDb.ts
+++ b/apps/app/src/lib/adapters/legacySocialDb.ts
@@ -1,0 +1,33 @@
+import {
+  db as legacyDb,
+  collection as legacyCollection,
+  getDocs as legacyGetDocs,
+  doc as legacyDoc,
+  getDoc as legacyGetDoc,
+  setDoc as legacySetDoc,
+  addDoc as legacyAddDoc,
+  updateDoc as legacyUpdateDoc,
+  query as legacyQuery,
+  where as legacyWhere,
+  limit as legacyLimit,
+  Timestamp as LegacyTimestamp,
+  serverTimestamp as legacyServerTimestamp
+} from '@legacy/firebase.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ Firestore primitives used by
+ * socialService (#2066). SDK shapes stay loose; bindings re-exported as-is.
+ */
+export const db: unknown = legacyDb;
+export const collection = legacyCollection as (...args: any[]) => any;
+export const getDocs = legacyGetDocs as (...args: any[]) => Promise<any>;
+export const doc = legacyDoc as (...args: any[]) => any;
+export const getDoc = legacyGetDoc as (...args: any[]) => Promise<any>;
+export const setDoc = legacySetDoc as (...args: any[]) => Promise<any>;
+export const addDoc = legacyAddDoc as (...args: any[]) => Promise<any>;
+export const updateDoc = legacyUpdateDoc as (...args: any[]) => Promise<any>;
+export const query = legacyQuery as (...args: any[]) => any;
+export const where = legacyWhere as (...args: any[]) => any;
+export const limit = legacyLimit as (...args: any[]) => any;
+export const Timestamp = LegacyTimestamp as any;
+export const serverTimestamp = legacyServerTimestamp as (...args: any[]) => any;

--- a/apps/app/src/lib/socialService.ts
+++ b/apps/app/src/lib/socialService.ts
@@ -1,18 +1,18 @@
 import {
-  db,
+  addDoc,
   collection,
-  getDocs,
+  db,
   doc,
   getDoc,
-  setDoc,
-  addDoc,
-  updateDoc,
-  query,
-  where,
+  getDocs,
   limit,
+  query,
+  serverTimestamp,
+  setDoc,
   Timestamp,
-  serverTimestamp
-} from '../../../../js/firebase.js';
+  updateDoc,
+  where
+} from './adapters/legacySocialDb';
 import { loadParentHome } from './homeService';
 import type { ParentHomeModel } from './homeLogic';
 import { uploadTeamChatAttachment } from './chatService';


### PR DESCRIPTION
Part of #2066. Routes `socialService` through a typed `adapters/legacySocialDb` boundary instead of a deep `js/firebase.js` import of 13 Firestore primitives. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)