### PR TITLE
Typed adapter for vendored Firebase AI (roster import) (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyRosterAi.ts
+++ b/apps/app/src/lib/adapters/legacyRosterAi.ts
@@ -1,0 +1,15 @@
+import { getApp as legacyGetApp } from '@legacy/vendor/firebase-app.js';
+import { getAI as legacyGetAI, getGenerativeModel as legacyGetGenerativeModel, GoogleAIBackend as LegacyGoogleAIBackend, Schema as LegacySchema } from '@legacy/vendor/firebase-ai.js';
+
+/**
+ * Typed adapter boundary for the vendored Firebase AI SDK used by rosterAiImport
+ * (#2066). Bindings re-exported as-is so existing js/vendor test mocks apply via
+ * the @legacy alias; SDK shapes stay loose.
+ */
+export const getApp = legacyGetApp as (name?: string) => unknown;
+export const getAI = legacyGetAI as (app: unknown, options?: Record<string, unknown>) => unknown;
+export const getGenerativeModel = legacyGetGenerativeModel as (ai: unknown, options: Record<string, unknown>) => {
+  generateContent: (...args: any[]) => Promise<any>;
+};
+export const GoogleAIBackend = LegacyGoogleAIBackend as new (...args: any[]) => unknown;
+export const Schema = LegacySchema as any;

--- a/apps/app/src/lib/rosterAiImport.ts
+++ b/apps/app/src/lib/rosterAiImport.ts
@@ -1,5 +1,4 @@
-import { getApp } from '../../../../js/vendor/firebase-app.js';
-import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from '../../../../js/vendor/firebase-ai.js';
+import { getAI, getApp, getGenerativeModel, GoogleAIBackend, Schema } from './adapters/legacyRosterAi';
 
 export type RosterAiImportCurrentPlayer = {
   id?: string;


### PR DESCRIPTION
Part of #2066. Routes `rosterAiImport` through a typed `adapters/legacyRosterAi` boundary instead of deep `js/vendor/firebase-app.js` + `firebase-ai.js` imports. Build + tests green (mocks apply via the `@legacy` alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)