### PR TITLE
[codex] Store empty chat mention arrays

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6700,8 +6700,11 @@ exports.notifyTeamChatMessageCreated = functions.firestore
 
     const results = [];
 
-    if (mentionedUids.length) {
+    if (shouldResolveMentions) {
       await snapshot.ref.update({ mentionedUids });
+    }
+
+    if (mentionedUids.length) {
       // Send mentions push only to the mentioned users (those who have mentions enabled)
       if (notificationPlan.mentionTargets.length) {
         results.push(await sendDirectTargetsNotification({

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -207,6 +207,7 @@ describe('notifyTeamChatMessageCreated source wiring', () => {
     });
 
     it('stores mentionedUids on the message document', () => {
+        expect(notifyTeamChatMessageCreatedSource).toContain('if (shouldResolveMentions) {');
         expect(notifyTeamChatMessageCreatedSource).toContain('snapshot.ref.update({ mentionedUids })');
     });
 


### PR DESCRIPTION
## Summary
- Store `mentionedUids` for every text chat message, including an empty array when no mention matched
- Keep mention-category delivery gated to non-empty mention targets
- Add regression coverage for the deterministic write path

Refs #2597

## Tests
- npx vitest run tests/unit/functions-chat-mention-detection.test.js --reporter=verbose