### PR TITLE
[codex] Carry chat conversation ids into inbox

### DIFF
--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -21,6 +21,7 @@ export type NotificationInboxItem = {
     body: string;
     text: string;
     appRoute: string;
+    conversationId: string;
     createdAt: unknown;
     readAt: unknown | null;
 };
@@ -67,6 +68,7 @@ export function subscribeToNotificationInbox(
                     body,
                     text: buildNotificationText(title, body, legacyText),
                     appRoute: getStringField(data, 'appRoute'),
+                    conversationId: getStringField(data, 'conversationId'),
                     createdAt: data['createdAt'] ?? null,
                     readAt: data['readAt'] ?? null
                 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -4819,7 +4819,8 @@ async function writeNotificationInboxRecords({
   appRoute,
   teamId,
   gameId = null,
-  eventId = null
+  eventId = null,
+  conversationId = null
 }) {
   const uniqueTargets = getUniqueNotificationInboxTargets(targets);
   if (!uniqueTargets.length) {
@@ -4838,6 +4839,7 @@ async function writeNotificationInboxRecords({
       teamId,
       gameId,
       eventId,
+      conversationId,
       createdAt,
       readAt
     }));
@@ -5080,7 +5082,8 @@ async function sendCategoryNotification({
     appRoute,
     teamId,
     gameId,
-    eventId: eventId || gameId
+    eventId: eventId || gameId,
+    conversationId
   });
 
   await writeNotificationAuditRecord({
@@ -5337,7 +5340,8 @@ async function sendDirectTargetsNotification({
     appRoute,
     teamId,
     gameId,
-    eventId: eventId || gameId
+    eventId: eventId || gameId,
+    conversationId
   });
 
   await writeNotificationAuditRecord({

--- a/functions/notification-inbox-core.cjs
+++ b/functions/notification-inbox-core.cjs
@@ -30,6 +30,7 @@ function buildNotificationInboxPayload({
   teamId,
   gameId = null,
   eventId = null,
+  conversationId = null,
   createdAt = null,
   readAt = null
 } = {}) {
@@ -41,6 +42,7 @@ function buildNotificationInboxPayload({
     teamId: normalizeInboxId(teamId),
     gameId: gameId ? normalizeInboxId(gameId) : null,
     eventId: eventId ? normalizeInboxId(eventId) : null,
+    conversationId: conversationId ? normalizeInboxId(conversationId) : null,
     createdAt,
     readAt
   };

--- a/tests/unit/notification-inbox.test.js
+++ b/tests/unit/notification-inbox.test.js
@@ -22,6 +22,7 @@ describe('notification inbox pipeline', () => {
             appRoute: '/schedule/team-1/game-1',
             teamId: 'team-1',
             gameId: 'game-1',
+            conversationId: 'staff',
             createdAt: 'server-time',
             readAt: null
         });
@@ -34,6 +35,7 @@ describe('notification inbox pipeline', () => {
             teamId: 'team-1',
             gameId: 'game-1',
             eventId: null,
+            conversationId: 'staff',
             createdAt: 'server-time',
             readAt: null
         });
@@ -56,6 +58,7 @@ describe('notification inbox pipeline', () => {
         expect(NOTIFICATION_INBOX_MAX_ITEMS).toBe(50);
         expect(functionsSource).toContain('async function writeNotificationInboxRecords');
         expect(functionsSource).toContain("firestore.collection(`users/${target.uid}/notificationInbox`)");
+        expect(functionsSource).toContain('conversationId,');
         expect(functionsSource).toContain('.offset(NOTIFICATION_INBOX_MAX_ITEMS)');
         expect(functionsSource.match(/const inboxResult = await writeNotificationInboxRecords\(\{/g)).toHaveLength(2);
         expect(functionsSource.match(/inboxWriteCount: inboxResult.writeCount/g)).toHaveLength(2);
@@ -72,6 +75,7 @@ describe('notification inbox pipeline', () => {
         expect(functionsSource).toContain(".where('readAt', '==', null)");
         expect(functionsSource).toContain('.limit(NOTIFICATION_INBOX_MAX_ITEMS)');
         expect(appNotificationInboxServiceSource).toContain("httpsCallable(functions, 'markAllNotificationInboxRead')");
+        expect(appNotificationInboxServiceSource).toContain("conversationId: getStringField(data, 'conversationId')");
         expect(appNotificationInboxServiceSource).not.toContain('writeBatch(db)');
     });
 


### PR DESCRIPTION
## Summary
- Store `conversationId` on notification inbox records
- Pass chat conversation metadata through category and direct-target notification send paths
- Read the field in the app inbox service so mention inbox records retain their conversation context

Refs #2598

## Tests
- npx vitest run tests/unit/notification-inbox.test.js tests/unit/app-push-notification-routing.test.ts tests/unit/app-notification-open-routing.test.jsx --reporter=verbose
- npx vitest run tests/unit/functions-chat-mention-detection.test.js --reporter=verbose
- npm run app:build