### PR TITLE
[codex] Dedupe chat notification targets

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6471,6 +6471,22 @@ function normalizeTeamChatConversationId(value) {
   return conversationId || 'team';
 }
 
+function dedupeNotificationTargetsByUserDevice(targets = []) {
+  const seen = new Set();
+  const uniqueTargets = [];
+  for (const target of Array.isArray(targets) ? targets : []) {
+    const uid = String(target?.uid || '').trim();
+    const deviceId = String(target?.deviceId || target?.token || '').trim();
+    const token = String(target?.token || '').trim();
+    if (!uid || !token) continue;
+    const key = `${uid}::${deviceId || token}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    uniqueTargets.push({ ...target, uid, token });
+  }
+  return uniqueTargets;
+}
+
 function detectMentionedUids(text, members, options = {}) {
   if (!text) return [];
   const { allowReservedMentions = false } = options || {};
@@ -6619,12 +6635,8 @@ function buildTeamChatNotificationPlan({ text, actorUid = null, recipientContext
     mutedUids: [],
     targetsByCategory: { mentions: [], liveChat: [] }
   };
-  const mentionTargets = Array.isArray(context.targetsByCategory?.mentions)
-    ? context.targetsByCategory.mentions
-    : [];
-  const liveChatTargets = Array.isArray(context.targetsByCategory?.liveChat)
-    ? context.targetsByCategory.liveChat
-    : [];
+  const mentionTargets = dedupeNotificationTargetsByUserDevice(context.targetsByCategory?.mentions);
+  const liveChatTargets = dedupeNotificationTargetsByUserDevice(context.targetsByCategory?.liveChat);
   const mentionEligibleUids = new Set(mentionTargets.map((target) => target.uid));
   const mentionMembers = Array.isArray(context.members)
     ? context.members.filter((member) => mentionEligibleUids.has(member.uid))

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -29,7 +29,7 @@ function getBuildTeamChatNotificationContext() {
 }
 
 function getBuildTeamChatNotificationPlan() {
-    const start = functionsSource.indexOf('function buildTeamChatNotificationPlan(');
+    const start = functionsSource.indexOf('function dedupeNotificationTargetsByUserDevice(');
     const end = functionsSource.indexOf('\nexports.notifyTeamChatMessageCreated');
     const slice = functionsSource.slice(start, end);
     return new Function('detectMentionedUids', `${slice}; return buildTeamChatNotificationPlan;`)(detectMentionedUids);
@@ -266,6 +266,7 @@ describe('buildTeamChatNotificationPlan', () => {
                 targetsByCategory: {
                     mentions: [
                         { uid: 'u1', token: 'mention-1' },
+                        { uid: 'u1', token: 'mention-1' },
                         { uid: 'u2', token: 'mention-2' },
                         { uid: 'u3', token: 'mention-3' }
                     ],
@@ -274,6 +275,7 @@ describe('buildTeamChatNotificationPlan', () => {
                         { uid: 'u1', token: 'chat-1' },
                         { uid: 'u2', token: 'chat-2' },
                         { uid: 'u3', token: 'chat-3' },
+                        { uid: 'u4', token: 'chat-4' },
                         { uid: 'u4', token: 'chat-4' }
                     ]
                 }
@@ -283,6 +285,8 @@ describe('buildTeamChatNotificationPlan', () => {
         expect(plan.mentionedUids.sort()).toEqual(['u1', 'u2']);
         expect(plan.mentionTargets.map((target) => target.uid).sort()).toEqual(['u1', 'u2']);
         expect(plan.liveChatTargets.map((target) => target.uid)).toEqual(['u4']);
+        expect(plan.mentionTargets).toHaveLength(2);
+        expect(plan.liveChatTargets).toHaveLength(1);
     });
 
     it('handles a large mixed team fixture from one preloaded recipient context', () => {


### PR DESCRIPTION
## Summary
- Deduplicate chat notification targets by user/device before mention and live-chat filtering
- Preserve the existing mentioned-user exclusion from generic live-chat pushes
- Extend the chat notification plan test with overlapping target records

Refs #2599

## Tests
- npx vitest run tests/unit/functions-chat-mention-detection.test.js --reporter=verbose