### PR TITLE
[codex] Preserve child ids in schedule push routes

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -5,6 +5,7 @@ type PushPayload = {
     category?: string;
     teamId?: string;
     conversationId?: string;
+    childId?: string;
     gameId?: string;
     eventId?: string;
     batchId?: string;
@@ -34,7 +35,7 @@ function buildMessagesRoute(teamId: string, conversationId?: string) {
     return `${route}?conversationId=${encodeRouteParam(normalizedConversationId)}`;
 }
 
-function buildScheduleEventRoute(teamId: string, eventId: string, section?: string) {
+function buildScheduleEventRoute(teamId: string, eventId: string, section?: string, childId?: string) {
     const normalizedTeamId = normalizeValue(teamId);
     const normalizedEventId = normalizeValue(eventId);
     if (!normalizedTeamId || !normalizedEventId) {
@@ -42,7 +43,10 @@ function buildScheduleEventRoute(teamId: string, eventId: string, section?: stri
     }
     const route = `/schedule/${encodeRouteParam(normalizedTeamId)}/${encodeRouteParam(normalizedEventId)}`;
     const normalizedSection = normalizeValue(section);
-    return normalizedSection ? `${route}?section=${encodeRouteParam(normalizedSection)}` : route;
+    return appendQuery(route, {
+        childId: normalizeValue(childId),
+        section: normalizedSection
+    });
 }
 
 function appendQuery(route: string, params: Record<string, string>) {
@@ -123,6 +127,7 @@ export function resolvePushNotificationRoute(input: unknown) {
     const conversationId = normalizeValue(payload.conversationId);
     const gameId = normalizeValue(payload.gameId);
     const eventId = normalizeValue(payload.eventId) || gameId;
+    const childId = normalizeValue(payload.childId);
     const batchId = normalizeValue(payload.batchId);
     const recipientId = normalizeValue(payload.recipientId);
     const certificateId = normalizeValue(payload.certificateId);
@@ -154,7 +159,7 @@ export function resolvePushNotificationRoute(input: unknown) {
             return appRoute;
         }
         if (teamId && eventId) {
-            return buildScheduleEventRoute(teamId, eventId, 'availability');
+            return buildScheduleEventRoute(teamId, eventId, 'availability', childId);
         }
         if (teamId) {
             return `/schedule?teamId=${encodeRouteParam(teamId)}`;
@@ -188,7 +193,7 @@ export function resolvePushNotificationRoute(input: unknown) {
     }
     if (category === 'rideshare') {
         if (teamId && eventId) {
-            return buildScheduleEventRoute(teamId, eventId, 'rideshare');
+            return buildScheduleEventRoute(teamId, eventId, 'rideshare', childId);
         }
         return teamId ? `/schedule?teamId=${encodeRouteParam(teamId)}&section=rideshare` : '/schedule?section=rideshare';
     }

--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -18,6 +18,17 @@ function normalizeValue(value: unknown) {
     return String(value || '').trim();
 }
 
+function getPushPayload(input: unknown) {
+    if (!input || typeof input !== 'object') {
+        return null;
+    }
+    const candidate = input as PushPayload & { data?: unknown };
+    if (candidate.data && typeof candidate.data === 'object') {
+        return candidate.data as PushPayload;
+    }
+    return candidate;
+}
+
 function encodeRouteParam(value: string) {
     return encodeURIComponent(value);
 }
@@ -112,11 +123,11 @@ function buildLegacyLinkFallback(link: string) {
 }
 
 export function resolvePushNotificationRoute(input: unknown) {
-    if (!input || typeof input !== 'object') {
+    const payload = getPushPayload(input);
+    if (!payload) {
         return '/home';
     }
 
-    const payload = input as PushPayload;
     const appRoute = normalizeAppRoute(payload.appRoute);
     if (appRoute) {
         return appRoute;

--- a/functions/index.js
+++ b/functions/index.js
@@ -5943,6 +5943,7 @@ async function dispatchDuePreEventReminders(now = new Date()) {
             teamId,
             gameId,
             event: claimedEvent,
+            recipientTargets: emailResult.recipientTargets,
             recipientUserIds: emailResult.recipientUserIds
           });
         } catch (pushError) {
@@ -7626,9 +7627,48 @@ function getScheduleNotificationChildId(event = {}) {
   return String(event.childId || event.playerId || event.recipientId || '').trim() || null;
 }
 
-async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, recipientUserIds = [] } = {}) {
+async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, recipientUserIds = [], recipientTargets = [] } = {}) {
   if (!teamId || !gameId) {
     return { successCount: 0, failureCount: 0, targetCount: 0 };
+  }
+
+  const payload = buildRsvpReminderPushPayload(event);
+  const childIdByRecipientGroup = new Map();
+  (Array.isArray(recipientTargets) ? recipientTargets : []).forEach((target) => {
+    const userId = String(target?.userId || '').trim();
+    const childId = String(target?.childId || '').trim();
+    if (!userId || !childId) return;
+    const groupUserIds = childIdByRecipientGroup.get(childId) || [];
+    if (!groupUserIds.includes(userId)) {
+      groupUserIds.push(userId);
+      childIdByRecipientGroup.set(childId, groupUserIds);
+    }
+  });
+
+  if (childIdByRecipientGroup.size > 0) {
+    let successCount = 0;
+    let failureCount = 0;
+    let targetCount = 0;
+
+    for (const [childId, userIds] of childIdByRecipientGroup.entries()) {
+      const targets = await getTargetsForCategoryUserIds(teamId, 'rsvp', userIds);
+      if (!targets.length) continue;
+      const sendResult = await sendDirectTargetsNotification({
+        targets,
+        category: 'rsvp',
+        title: payload.title,
+        body: payload.body,
+        teamId,
+        gameId,
+        eventId: gameId,
+        childId
+      });
+      successCount += Number(sendResult?.successCount || 0);
+      failureCount += Number(sendResult?.failureCount || 0);
+      targetCount += targets.length;
+    }
+
+    return { successCount, failureCount, targetCount };
   }
 
   const targets = await getTargetsForCategoryUserIds(teamId, 'rsvp', recipientUserIds);
@@ -7636,7 +7676,6 @@ async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, r
     return { successCount: 0, failureCount: 0, targetCount: 0 };
   }
 
-  const payload = buildRsvpReminderPushPayload(event);
   const sendResult = await sendDirectTargetsNotification({
     targets,
     category: 'rsvp',
@@ -7806,6 +7845,7 @@ async function createPublicRsvpEmailDeliveries({ teamId, gameId, actorUid = null
   let linkCount = 0;
   const remindedPlayerIds = new Set();
   const recipientUserIds = new Set();
+  const recipientTargets = [];
 
   const ensurePublicRsvpEmailBatchCapacity = () => {
     if (batchWriteCount + 2 <= PUBLIC_RSVP_EMAIL_BATCH_WRITE_LIMIT) return;
@@ -7869,6 +7909,10 @@ async function createPublicRsvpEmailDeliveries({ teamId, gameId, actorUid = null
       remindedPlayerIds.add(String(player.id || '').trim());
       if (contact.userId) {
         recipientUserIds.add(contact.userId);
+        recipientTargets.push({
+          userId: contact.userId,
+          childId: player.id
+        });
       }
     });
   });
@@ -7884,6 +7928,7 @@ async function createPublicRsvpEmailDeliveries({ teamId, gameId, actorUid = null
     linkCount,
     playerIds: Array.from(remindedPlayerIds).filter(Boolean),
     recipientUserIds: Array.from(recipientUserIds).filter(Boolean),
+    recipientTargets,
     recipientCount: recipientUserIds.size
   };
 }
@@ -7936,6 +7981,7 @@ exports.sendPublicRsvpEmails = functions.https.onRequest(async (req, res) => {
         teamId,
         gameId,
         event: eventRecord.data,
+        recipientTargets: result.recipientTargets,
         recipientUserIds: result.recipientUserIds
       });
     } catch (pushError) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -5055,6 +5055,7 @@ async function sendCategoryNotification({
         eventId: String(eventId || gameId || ''),
         conversationId: String(conversationId || ''),
         childId: String(childId || ''),
+        rsvpId: String(childId || ''),
         category: String(category),
         appRoute,
         link
@@ -5311,6 +5312,7 @@ async function sendDirectTargetsNotification({
         eventId: String(eventId || gameId || ''),
         conversationId: String(conversationId || ''),
         childId: String(childId || ''),
+        rsvpId: String(childId || ''),
         category: String(category),
         appRoute,
         link

--- a/functions/index.js
+++ b/functions/index.js
@@ -3975,7 +3975,19 @@ async function practicePacketAssignedNotification(beforeData = null, afterData =
   return null;
 }
 
-function buildNotificationLink({ category, teamId, gameId, eventId = null, batchId = null, recipientId = null, conversationId = null }) {
+function buildScheduleSectionQuery(section, childId = null) {
+  const params = new URLSearchParams();
+  if (childId) {
+    params.set('childId', childId);
+  }
+  if (section) {
+    params.set('section', section);
+  }
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+function buildNotificationLink({ category, teamId, gameId, eventId = null, batchId = null, recipientId = null, conversationId = null, childId = null }) {
   if (category === 'officiating') {
     return teamId
       ? `https://allplays.ai/officials.html?teamId=${encodeURIComponent(teamId)}`
@@ -4007,7 +4019,7 @@ function buildNotificationLink({ category, teamId, gameId, eventId = null, batch
   }
   if (category === 'rsvp') {
     if (teamId && gameId) {
-      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}?section=availability`;
+      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}${buildScheduleSectionQuery('availability', childId)}`;
     }
     if (teamId) {
       return `https://allplays.ai/app/#/schedule?teamId=${encodeURIComponent(teamId)}`;
@@ -4017,7 +4029,7 @@ function buildNotificationLink({ category, teamId, gameId, eventId = null, batch
   if (category === 'rideshare') {
     const scheduleEventId = eventId || gameId;
     if (teamId && scheduleEventId) {
-      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}?section=rideshare`;
+      return `https://allplays.ai/app/#/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}${buildScheduleSectionQuery('rideshare', childId)}`;
     }
     if (teamId) {
       return `https://allplays.ai/app/#/schedule?teamId=${encodeURIComponent(teamId)}&section=rideshare`;
@@ -4036,7 +4048,7 @@ function buildNotificationLink({ category, teamId, gameId, eventId = null, batch
   return `https://allplays.ai/team.html?teamId=${encodeURIComponent(teamId)}`;
 }
 
-function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId = null, recipientId = null, conversationId = null }) {
+function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId = null, recipientId = null, conversationId = null, childId = null }) {
   if (category === 'officiating') {
     return teamId ? `/officials?teamId=${encodeURIComponent(teamId)}` : '/officials';
   }
@@ -4079,7 +4091,7 @@ function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId 
   if (category === 'rsvp') {
     const scheduleEventId = eventId || gameId;
     if (teamId && scheduleEventId) {
-      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}?section=availability`;
+      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}${buildScheduleSectionQuery('availability', childId)}`;
     }
     if (teamId) {
       return `/schedule?teamId=${encodeURIComponent(teamId)}`;
@@ -4089,7 +4101,7 @@ function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId 
   if (category === 'rideshare') {
     const scheduleEventId = eventId || gameId;
     if (teamId && scheduleEventId) {
-      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}?section=rideshare`;
+      return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}${buildScheduleSectionQuery('rideshare', childId)}`;
     }
     if (teamId) {
       return `/schedule?teamId=${encodeURIComponent(teamId)}&section=rideshare`;
@@ -4977,6 +4989,7 @@ async function sendCategoryNotification({
   gameId = null,
   eventId = null,
   conversationId = null,
+  childId = null,
   category,
   title,
   body,
@@ -5004,8 +5017,8 @@ async function sendCategoryNotification({
     : allTargets;
   if (!targets.length) return null;
 
-  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
-  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId });
+  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, eventId: eventId || gameId, conversationId, childId });
+  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, conversationId, childId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
@@ -5041,6 +5054,7 @@ async function sendCategoryNotification({
         gameId: String(gameId || ''),
         eventId: String(eventId || gameId || ''),
         conversationId: String(conversationId || ''),
+        childId: String(childId || ''),
         category: String(category),
         appRoute,
         link
@@ -5253,13 +5267,14 @@ async function sendDirectTargetsNotification({
   batchId = null,
   recipientId = null,
   conversationId = null,
+  childId = null,
   linkOverride = null,
   appRouteOverride = null
 }) {
   if (!targets.length) return null;
 
-  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId });
-  const appRoute = appRouteOverride || buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId });
+  const link = linkOverride || buildNotificationLink({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId, childId });
+  const appRoute = appRouteOverride || buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId, batchId, recipientId, conversationId, childId });
   const deliveryOptions = typeof buildNotificationDeliveryOptions === 'function'
     ? buildNotificationDeliveryOptions({ category, teamId, gameId, eventId: eventId || gameId })
     : {};
@@ -5295,6 +5310,7 @@ async function sendDirectTargetsNotification({
         gameId: String(gameId || ''),
         eventId: String(eventId || gameId || ''),
         conversationId: String(conversationId || ''),
+        childId: String(childId || ''),
         category: String(category),
         appRoute,
         link
@@ -7604,6 +7620,10 @@ function buildRsvpReminderPushPayload(event) {
   };
 }
 
+function getScheduleNotificationChildId(event = {}) {
+  return String(event.childId || event.playerId || event.recipientId || '').trim() || null;
+}
+
 async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, recipientUserIds = [] } = {}) {
   if (!teamId || !gameId) {
     return { successCount: 0, failureCount: 0, targetCount: 0 };
@@ -7622,7 +7642,8 @@ async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, r
     body: payload.body,
     teamId,
     gameId,
-    eventId: gameId
+    eventId: gameId,
+    childId: getScheduleNotificationChildId(event)
   });
 
   return {

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -432,6 +432,7 @@ test('sendCategoryNotification deep links rideshare notifications to the ridesha
                 gameId: 'game-9',
                 eventId: 'game-9',
                 conversationId: '',
+                childId: '',
                 appRoute: '/schedule/team-1/game-9?section=rideshare',
                 link: 'https://allplays.ai/app/#/schedule/team-1/game-9?section=rideshare'
             });
@@ -477,6 +478,7 @@ test('sendCategoryNotification uses eventId for rideshare deep links when no gam
                 gameId: '',
                 eventId: 'event-9',
                 conversationId: '',
+                childId: '',
                 appRoute: '/schedule/team-1/event-9?section=rideshare',
                 link: 'https://allplays.ai/app/#/schedule/team-1/event-9?section=rideshare'
             });
@@ -525,6 +527,7 @@ for (const [category, categories] of [
                 gameId: '',
                 eventId: '',
                 conversationId: 'staff room',
+                childId: '',
                 appRoute: '/messages/team-1?conversationId=staff%20room',
                 link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff%20room'
             });

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -398,6 +398,56 @@ test('sendRsvpReminderPushNotifications sends availability pushes only to email 
         }
 });
 
+test('sendRsvpReminderPushNotifications sends per-recipient child routes when player ids are available', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1', 'parent-2'],
+            indexedTargets: [
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-1-device',
+                    token: 'parent-1-token',
+                    categories: { rsvp: true }
+                },
+                {
+                    uid: 'parent-2',
+                    deviceId: 'parent-2-device',
+                    token: 'parent-2-token',
+                    categories: { rsvp: true }
+                }
+            ]
+        });
+
+        try {
+            const result = await internals.sendRsvpReminderPushNotifications({
+                teamId: 'team-1',
+                gameId: 'game-9',
+                event: { opponent: 'Wildcats' },
+                recipientTargets: [
+                    { userId: 'parent-1', childId: 'player-1' },
+                    { userId: 'parent-2', childId: 'player-2' }
+                ]
+            });
+
+            assert.deepEqual(result, { successCount: 2, failureCount: 0, targetCount: 2 });
+            assert.equal(env.messagingCalls.length, 2);
+            assert.deepEqual(env.messagingCalls.map((call) => call.tokens), [['parent-1-token'], ['parent-2-token']]);
+            assert.deepEqual(env.messagingCalls.map((call) => call.data.appRoute), [
+                '/schedule/team-1/game-9?childId=player-1&section=availability',
+                '/schedule/team-1/game-9?childId=player-2&section=availability'
+            ]);
+            assert.deepEqual(env.messagingCalls.map((call) => call.webLink), [
+                'https://allplays.ai/app/#/schedule/team-1/game-9?childId=player-1&section=availability',
+                'https://allplays.ai/app/#/schedule/team-1/game-9?childId=player-2&section=availability'
+            ]);
+        } finally {
+            cleanup();
+        }
+});
+
 test('sendCategoryNotification deep links rideshare notifications to the rideshare event section', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -433,6 +433,7 @@ test('sendCategoryNotification deep links rideshare notifications to the ridesha
                 eventId: 'game-9',
                 conversationId: '',
                 childId: '',
+                rsvpId: '',
                 appRoute: '/schedule/team-1/game-9?section=rideshare',
                 link: 'https://allplays.ai/app/#/schedule/team-1/game-9?section=rideshare'
             });
@@ -479,6 +480,7 @@ test('sendCategoryNotification uses eventId for rideshare deep links when no gam
                 eventId: 'event-9',
                 conversationId: '',
                 childId: '',
+                rsvpId: '',
                 appRoute: '/schedule/team-1/event-9?section=rideshare',
                 link: 'https://allplays.ai/app/#/schedule/team-1/event-9?section=rideshare'
             });
@@ -528,6 +530,7 @@ for (const [category, categories] of [
                 eventId: '',
                 conversationId: 'staff room',
                 childId: '',
+                rsvpId: '',
                 appRoute: '/messages/team-1?conversationId=staff%20room',
                 link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff%20room'
             });

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -70,6 +70,11 @@ describe('app push notification routing', () => {
     it('returns the home route when notification data is missing', () => {
         expect(resolvePushNotificationRoute(undefined)).toBe('/home');
         expect(resolvePushNotificationRoute(null)).toBe('/home');
+        expect(resolvePushNotificationRoute({ data: undefined })).toBe('/home');
+    });
+
+    it('accepts Capacitor notification wrappers without requiring data to be dereferenced first', () => {
+        expect(resolvePushNotificationRoute({ data: { category: 'rsvp', teamId: 'team-1', eventId: 'game-9', childId: 'player-2' } })).toBe('/schedule/team-1/game-9?childId=player-2&section=availability');
     });
 
     it('keeps and clears pending notification routes for delayed auth hydration', () => {

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -36,6 +36,7 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'practice-4' })).toBe('/schedule/team-1/practice-4?section=game');
         expect(resolvePushNotificationRoute({ category: 'practice', teamId: 'team-1', eventId: 'session-4', appRoute: '/schedule/team-1/practice-4?section=game' })).toBe('/schedule/team-1/practice-4?section=game');
         expect(resolvePushNotificationRoute({ category: 'rsvp', teamId: 'team-1', eventId: 'game-9' })).toBe('/schedule/team-1/game-9?section=availability');
+        expect(resolvePushNotificationRoute({ category: 'rsvp', teamId: 'team-1', eventId: 'game-9', childId: 'player-2' })).toBe('/schedule/team-1/game-9?childId=player-2&section=availability');
         expect(resolvePushNotificationRoute({ category: 'media', teamId: 'team-1' })).toBe('/teams/team-1/media');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
@@ -51,6 +52,7 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'fees', teamId: 'team 1' })).toBe('/parent-tools/fees?teamId=team+1');
         expect(resolvePushNotificationRoute({ category: 'access', teamId: 'team 1' })).toBe('/parent-tools/access?teamId=team+1');
         expect(resolvePushNotificationRoute({ category: 'rideshare', teamId: 'team-1', eventId: 'game-7' })).toBe('/schedule/team-1/game-7?section=rideshare');
+        expect(resolvePushNotificationRoute({ category: 'rideshare', teamId: 'team-1', eventId: 'game-7', childId: 'player-2' })).toBe('/schedule/team-1/game-7?childId=player-2&section=rideshare');
         expect(resolvePushNotificationRoute({ category: 'media', teamId: 'team-1' })).toBe('/teams/team-1/media');
         expect(resolvePushNotificationRoute({ category: 'awards', teamId: 'team-1', certificateId: 'cert-9' })).toBe('/parent-tools/certificates?teamId=team-1&certificateId=cert-9');
         expect(resolvePushNotificationRoute({ category: 'mentions', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -28,6 +28,7 @@ describe('push notification payload contract', () => {
         expect(source).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(gameId)}?section=game`;");
         expect(source).toContain('eventId: String(eventId || gameId || \'\')');
         expect(source).toContain('conversationId: String(conversationId || \'\')');
+        expect(source).toContain('rsvpId: String(childId || \'\')');
         expect(source).toContain("if (category === 'liveChat' || category === 'mentions') {");
         expect(source).toContain("if ((category === 'liveChat' || category === 'mentions') && teamId) {");
         expect(source).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -11,8 +11,15 @@ function getHelper(name, nextMarker) {
 }
 
 const buildStaffFeeNotificationDestination = getHelper('buildStaffFeeNotificationDestination', 'function buildNotificationLink');
-const buildNotificationLink = getHelper('buildNotificationLink', 'function buildNotificationAppRoute');
-const buildNotificationAppRoute = getHelper('buildNotificationAppRoute', 'async function getUserIdsByEmails');
+function getNotificationRouteHelper(name) {
+    const start = source.indexOf('function buildScheduleSectionQuery(');
+    const end = source.indexOf('\nasync function getUserIdsByEmails', start);
+    const slice = source.slice(start, end);
+    return new Function(`${slice}; return ${name};`)();
+}
+
+const buildNotificationLink = getNotificationRouteHelper('buildNotificationLink');
+const buildNotificationAppRoute = getNotificationRouteHelper('buildNotificationAppRoute');
 
 describe('push notification payload contract', () => {
     it('includes native app routing fields alongside the legacy web link', () => {
@@ -48,14 +55,32 @@ describe('push notification payload contract', () => {
         expect(buildNotificationLink({
             category: 'rsvp',
             teamId: 'team 1',
-            gameId: 'game/1'
-        })).toBe('https://allplays.ai/app/#/schedule/team%201/game%2F1?section=availability');
+            gameId: 'game/1',
+            childId: 'child?1'
+        })).toBe('https://allplays.ai/app/#/schedule/team%201/game%2F1?childId=child%3F1&section=availability');
 
         expect(buildNotificationAppRoute({
             category: 'rsvp',
             teamId: 'team 1',
-            gameId: 'game/1'
-        })).toBe('/schedule/team%201/game%2F1?section=availability');
+            gameId: 'game/1',
+            childId: 'child?1'
+        })).toBe('/schedule/team%201/game%2F1?childId=child%3F1&section=availability');
+    });
+
+    it('builds rideshare notification routes with child context', () => {
+        expect(buildNotificationLink({
+            category: 'rideshare',
+            teamId: 'team 1',
+            eventId: 'game/1',
+            childId: 'child?1'
+        })).toBe('https://allplays.ai/app/#/schedule/team%201/game%2F1?childId=child%3F1&section=rideshare');
+
+        expect(buildNotificationAppRoute({
+            category: 'rideshare',
+            teamId: 'team 1',
+            eventId: 'game/1',
+            childId: 'child?1'
+        })).toBe('/schedule/team%201/game%2F1?childId=child%3F1&section=rideshare');
     });
 
     it('builds media notification routes to the team media page', () => {

--- a/tests/unit/schedule-rsvp-notification-contract.test.js
+++ b/tests/unit/schedule-rsvp-notification-contract.test.js
@@ -36,19 +36,22 @@ describe('schedule and RSVP notification contract', () => {
         expect(functionsSource).toContain("category: 'schedule'");
         expect(functionsSource).toContain('const emailResult = await createPublicRsvpEmailDeliveries({');
         expect(functionsSource).toContain('rsvpPushResult = await sendRsvpReminderPushNotifications({');
+        expect(functionsSource).toContain('recipientTargets: emailResult.recipientTargets');
         expect(functionsSource).toContain('recipientUserIds: emailResult.recipientUserIds');
         expect(functionsSource).toContain('rsvpPushSuccessCount: rsvpPushResult.successCount');
         expect(functionsSource).toContain('rsvpPushTargetCount: rsvpPushResult.targetCount');
     });
 
-    it('sends RSVP reminder pushes through the rsvp category with event deep links', () => {
-        expect(functionsSource).toContain('async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, recipientUserIds = [] } = {})');
-        expect(functionsSource).toContain("const targets = await getTargetsForCategoryUserIds(teamId, 'rsvp', recipientUserIds);");
+    it('sends RSVP reminder pushes through the rsvp category with per-recipient child deep links', () => {
+        expect(functionsSource).toContain('async function sendRsvpReminderPushNotifications({ teamId, gameId, event = {}, recipientUserIds = [], recipientTargets = [] } = {})');
+        expect(functionsSource).toContain('const childIdByRecipientGroup = new Map();');
+        expect(functionsSource).toContain('const groupUserIds = childIdByRecipientGroup.get(childId) || [];');
+        expect(functionsSource).toContain("const targets = await getTargetsForCategoryUserIds(teamId, 'rsvp', userIds);");
         expect(functionsSource).toContain("category: 'rsvp'");
         expect(functionsSource).toContain('eventId: gameId');
         expect(functionsSource).toContain('childId: getScheduleNotificationChildId(event)');
         expect(functionsSource).toContain("childId: String(childId || '')");
-        expect(functionsSource).toContain('targetCount: targets.length');
+        expect(functionsSource).toContain('targetCount += targets.length');
         expect(functionsSource).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}${buildScheduleSectionQuery('availability', childId)}`;");
     });
 

--- a/tests/unit/schedule-rsvp-notification-contract.test.js
+++ b/tests/unit/schedule-rsvp-notification-contract.test.js
@@ -46,8 +46,10 @@ describe('schedule and RSVP notification contract', () => {
         expect(functionsSource).toContain("const targets = await getTargetsForCategoryUserIds(teamId, 'rsvp', recipientUserIds);");
         expect(functionsSource).toContain("category: 'rsvp'");
         expect(functionsSource).toContain('eventId: gameId');
+        expect(functionsSource).toContain('childId: getScheduleNotificationChildId(event)');
+        expect(functionsSource).toContain("childId: String(childId || '')");
         expect(functionsSource).toContain('targetCount: targets.length');
-        expect(functionsSource).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}?section=availability`;");
+        expect(functionsSource).toContain("return `/schedule/${encodeURIComponent(teamId)}/${encodeURIComponent(scheduleEventId)}${buildScheduleSectionQuery('availability', childId)}`;");
     });
 
     it('persists app-initiated RSVP reminder push metrics in schedule notification metadata', () => {


### PR DESCRIPTION
## Summary
- Add childId-aware RSVP and rideshare notification route construction
- Include childId in push data payloads and RSVP reminder direct sends
- Preserve child context in app-side RSVP/rideshare push route fallbacks

Refs #2595

## Tests
- npx vitest run tests/unit/push-notification-payload-contract.test.js tests/unit/schedule-rsvp-notification-contract.test.js tests/unit/app-push-notification-routing.test.ts tests/unit/app-notification-open-routing.test.jsx --reporter=verbose
- npm run app:build