### PR TITLE
[codex] Map game report event records

### DIFF
--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -6,6 +6,7 @@ import type {
     FirestoreDocument,
     FirestoreValue,
     GameReportAggregatedStatsFirestoreRecord,
+    GameReportEventFirestoreRecord,
     GameReportGameFirestoreRecord,
     GameReportOpponentFirestoreRecord,
     GameReportPlayerFirestoreRecord,
@@ -321,6 +322,30 @@ export function mapGameReportAggregatedStatsRecord(id: string, value: unknown): 
 
 export function mapGameReportTeamStatsRecord(value: unknown): GameReportTeamStatsFirestoreRecord {
     return asGameReportStatsRecord(value);
+}
+
+export function mapGameReportEventRecord(value: unknown, fallbackId = ''): GameReportEventFirestoreRecord | null {
+    const source = asLooseObject(value);
+    const id = asTrimmedString(source.id) || fallbackId;
+    if (!id) return null;
+
+    return {
+        ...source,
+        id,
+        text: asTrimmedString(source.text) || asTrimmedString(source.message) || 'Event logged',
+        period: asTrimmedString(source.period) || 'Q1',
+        clock: asTrimmedString(source.clock) || asTrimmedString(source.gameTime) || '',
+        timestamp: asTemporalValue(source.timestamp)
+    };
+}
+
+export function mapGameReportEventRecords(value: unknown): GameReportEventFirestoreRecord[] {
+    return Array.isArray(value)
+        ? value.map((entry) => {
+            const source = asLooseObject(entry);
+            return mapGameReportEventRecord(source, asTrimmedString(source.id) || '');
+        }).filter((entry): entry is GameReportEventFirestoreRecord => Boolean(entry))
+        : [];
 }
 
 export function mapScheduleEventRecord(value: unknown, fallbackId = ''): ScheduleEventFirestoreRecord | null {

--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -108,6 +108,13 @@ function asTemporalValue(value: unknown): unknown {
     return asOptionalDate(value);
 }
 
+function asEventTimestamp(value: unknown): unknown {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+    return asTemporalValue(value);
+}
+
 function asLooseObject(value: unknown): Record<string, unknown> {
     return asObject(value) || {};
 }
@@ -335,7 +342,7 @@ export function mapGameReportEventRecord(value: unknown, fallbackId = ''): GameR
         text: asTrimmedString(source.text) || asTrimmedString(source.message) || 'Event logged',
         period: asTrimmedString(source.period) || 'Q1',
         clock: asTrimmedString(source.clock) || asTrimmedString(source.gameTime) || '',
-        timestamp: asTemporalValue(source.timestamp)
+        timestamp: asEventTimestamp(source.timestamp)
     };
 }
 

--- a/apps/app/src/lib/firestore/types.ts
+++ b/apps/app/src/lib/firestore/types.ts
@@ -187,3 +187,12 @@ export type GameReportAggregatedStatsFirestoreRecord = {
 };
 
 export type GameReportTeamStatsFirestoreRecord = GameReportStatsRecord;
+
+export type GameReportEventFirestoreRecord = {
+    id: string;
+    text: string;
+    period: string;
+    clock: string;
+    timestamp?: unknown;
+    [key: string]: unknown;
+};

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -91,6 +91,11 @@ describe('gameReportService', () => {
       }
     });
     dbMocks.getTeamStatsForGame.mockResolvedValue({ turnovers: 7, assists: '11', nested: { invalid: true } });
+    dbMocks.getGameEvents.mockResolvedValue([
+      { id: 'event-late', message: 'Late bucket', period: '', gameTime: '0:12', timestamp: { seconds: 1717200060 } },
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: { seconds: 1717200000 } },
+      { id: '', text: 'Missing id' }
+    ]);
     firebaseMocks.getDocs.mockResolvedValue({
       forEach(callback: (docSnap: any) => void) {
         callback({
@@ -137,5 +142,21 @@ describe('gameReportService', () => {
       }
     ]);
     expect(report.teamStats).toEqual({ turnovers: 7, assists: '11' });
+    expect(report.plays).toEqual([
+      {
+        id: 'event-early',
+        text: 'Opening tip',
+        period: 'Q1',
+        clock: '8:00',
+        timestamp: new Date(1717200000 * 1000)
+      },
+      {
+        id: 'event-late',
+        text: 'Late bucket',
+        period: 'Q1',
+        clock: '0:12',
+        timestamp: new Date(1717200060 * 1000)
+      }
+    ]);
   });
 });

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -93,7 +93,7 @@ describe('gameReportService', () => {
     dbMocks.getTeamStatsForGame.mockResolvedValue({ turnovers: 7, assists: '11', nested: { invalid: true } });
     dbMocks.getGameEvents.mockResolvedValue([
       { id: 'event-late', message: 'Late bucket', period: '', gameTime: '0:12', timestamp: { seconds: 1717200060 } },
-      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: { seconds: 1717200000 } },
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: 1717200000000 },
       { id: '', text: 'Missing id' }
     ]);
     firebaseMocks.getDocs.mockResolvedValue({

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -19,6 +19,7 @@ import {
 } from './adapters/legacyGameReport';
 import {
   mapGameReportAggregatedStatsRecord,
+  mapGameReportEventRecords,
   mapGameReportGameRecord,
   mapGameReportPlayerRecords,
   mapGameReportTeamRecord,
@@ -26,6 +27,7 @@ import {
 } from './firestore/mappers';
 import type {
   GameReportGameFirestoreRecord,
+  GameReportEventFirestoreRecord,
   GameReportPlayerFirestoreRecord,
   GameReportStatsRecord,
   GameReportTeamFirestoreRecord,
@@ -160,12 +162,12 @@ async function loadAggregatedStats(teamId: string, gameId: string): Promise<Aggr
   return { statsMap, timeMap, didNotPlayMap, participatedMap, participationStatusMap, participationSourceMap, recordedPlayerIds };
 }
 
-function normalizePlay(entry: any): GameReportPlay {
+function normalizePlay(entry: GameReportEventFirestoreRecord): GameReportPlay {
   return {
     id: String(entry?.id || ''),
-    text: String(entry?.text || entry?.message || 'Event logged'),
+    text: String(entry?.text || 'Event logged'),
     period: String(entry?.period || 'Q1'),
-    clock: String(entry?.clock || entry?.gameTime || ''),
+    clock: String(entry?.clock || ''),
     timestamp: normalizeDate(entry?.timestamp)
   };
 }
@@ -267,11 +269,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
     String(field.fieldName || '').trim(),
     String(field.label || field.fieldName || '').trim()
   ]));
-  const insightEvents = (Array.isArray(rawEvents) ? rawEvents : [])
-    .map((entry: any) => ({
-      ...entry,
-      clock: entry?.clock || entry?.gameTime || ''
-    }))
+  const insightEvents = mapGameReportEventRecords(rawEvents)
     .sort((a, b) => (normalizeDate(a.timestamp)?.getTime() || 0) - (normalizeDate(b.timestamp)?.getTime() || 0));
   const plays = insightEvents.map(normalizePlay);
   const insights = generateGameInsights({


### PR DESCRIPTION
## Summary
- Add typed Firestore event records for game report reads
- Route game event/play normalization through the shared mapper boundary
- Cover malformed event payloads, gameTime fallback, and timestamp ordering

Refs #2617

## Tests
- cd apps/app && npx vitest run src/lib/gameReportService.test.ts --reporter=verbose
- npm run app:build