### PR TITLE
[codex] Map parent schedule reads through event mapper

### DIFF
--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -94,6 +94,15 @@ function asObject(value: unknown): Record<string, unknown> | null {
     return value as Record<string, unknown>;
 }
 
+function asScheduleSourceMetadata(value: unknown): ScheduleEventFirestoreRecord['sourceMetadata'] {
+    const source = asObject(value);
+    if (!source) return null;
+    return {
+        ...source,
+        sourceType: asTrimmedString(source.sourceType)
+    };
+}
+
 function asTemporalValue(value: unknown): unknown {
     return asOptionalDate(value);
 }
@@ -314,9 +323,10 @@ export function mapGameReportTeamStatsRecord(value: unknown): GameReportTeamStat
     return asGameReportStatsRecord(value);
 }
 
-export function mapScheduleEventDocument(document: FirestoreDocument | null | undefined): ScheduleEventFirestoreRecord | null {
-    const decoded = mapFirestoreDocument(document);
-    if (!decoded?.id) return null;
+export function mapScheduleEventRecord(value: unknown, fallbackId = ''): ScheduleEventFirestoreRecord | null {
+    const decoded = asLooseObject(value);
+    const id = asTrimmedString(decoded.id) || fallbackId;
+    if (!id) return null;
 
     const type = asTrimmedString(decoded.type) || 'game';
     const date = asOptionalDate(decoded.date);
@@ -325,7 +335,7 @@ export function mapScheduleEventDocument(document: FirestoreDocument | null | un
     }
 
     return {
-        id: decoded.id,
+        id,
         type,
         date,
         calendarEventUid: asTrimmedString(decoded.calendarEventUid),
@@ -340,6 +350,7 @@ export function mapScheduleEventDocument(document: FirestoreDocument | null | un
         awayTeamName: asTrimmedString(decoded.awayTeamName),
         opponentTeamPhoto: asTrimmedString(decoded.opponentTeamPhoto),
         sharedScheduleOpponentTeamId: asTrimmedString(decoded.sharedScheduleOpponentTeamId),
+        gameId: asTrimmedString(decoded.gameId),
         status: asTrimmedString(decoded.status),
         liveStatus: asTrimmedString(decoded.liveStatus),
         liveClockMs: asOptionalNumber(decoded.liveClockMs),
@@ -358,8 +369,10 @@ export function mapScheduleEventDocument(document: FirestoreDocument | null | un
         seasonLabel: asTrimmedString(decoded.seasonLabel),
         competitionType: asTrimmedString(decoded.competitionType),
         countsTowardSeasonRecord: asOptionalBoolean(decoded.countsTowardSeasonRecord),
+        tournament: asObject(decoded.tournament),
+        statTrackerConfigId: asTrimmedString(decoded.statTrackerConfigId),
         source: asTrimmedString(decoded.source),
-        sourceMetadata: asObject(decoded.sourceMetadata),
+        sourceMetadata: asScheduleSourceMetadata(decoded.sourceMetadata),
         visibility: asTrimmedString(decoded.visibility),
         assignments: asObjectArray(decoded.assignments),
         rsvpSummary: asObject(decoded.rsvpSummary),
@@ -370,6 +383,20 @@ export function mapScheduleEventDocument(document: FirestoreDocument | null | un
         isSeriesMaster: decoded.isSeriesMaster === true,
         recurrence: asObject(decoded.recurrence)
     };
+}
+
+export function mapScheduleEventRecords(values: unknown): ScheduleEventFirestoreRecord[] {
+    return Array.isArray(values)
+        ? values.map((value) => {
+            const source = asLooseObject(value);
+            return mapScheduleEventRecord(source, asTrimmedString(source.id) || '');
+        }).filter((document): document is ScheduleEventFirestoreRecord => Boolean(document))
+        : [];
+}
+
+export function mapScheduleEventDocument(document: FirestoreDocument | null | undefined): ScheduleEventFirestoreRecord | null {
+    const decoded = mapFirestoreDocument(document);
+    return decoded ? mapScheduleEventRecord(decoded, decoded.id) : null;
 }
 
 export function mapScheduleEventDocuments(documents: FirestoreDocument[] | null | undefined): ScheduleEventFirestoreRecord[] {

--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -381,7 +381,11 @@ export function mapScheduleEventRecord(value: unknown, fallbackId = ''): Schedul
         rotationActual: asObject(decoded.rotationActual),
         coachingNotes: asObjectArray(decoded.coachingNotes),
         isSeriesMaster: decoded.isSeriesMaster === true,
-        recurrence: asObject(decoded.recurrence)
+        recurrence: asObject(decoded.recurrence),
+        startTime: asTrimmedString(decoded.startTime),
+        endDayOffset: asOptionalNumber(decoded.endDayOffset),
+        exDates: asUniqueStringArray(decoded.exDates),
+        overrides: asObject(decoded.overrides) as Record<string, Record<string, unknown>> | null
     };
 }
 

--- a/apps/app/src/lib/firestore/types.ts
+++ b/apps/app/src/lib/firestore/types.ts
@@ -135,6 +135,10 @@ export type ScheduleEventFirestoreRecord = {
     coachingNotes?: Array<Record<string, unknown>>;
     isSeriesMaster?: boolean;
     recurrence?: Record<string, unknown> | null;
+    startTime?: string | null;
+    endDayOffset?: number | null;
+    exDates?: string[];
+    overrides?: Record<string, Record<string, unknown>> | null;
 };
 
 export type GameReportStatValue = string | number | boolean | null;

--- a/apps/app/src/lib/firestore/types.ts
+++ b/apps/app/src/lib/firestore/types.ts
@@ -103,6 +103,7 @@ export type ScheduleEventFirestoreRecord = {
     awayTeamName?: string | null;
     opponentTeamPhoto?: string | null;
     sharedScheduleOpponentTeamId?: string | null;
+    gameId?: string | null;
     status?: string | null;
     liveStatus?: string | null;
     liveClockMs?: number | null;
@@ -121,8 +122,10 @@ export type ScheduleEventFirestoreRecord = {
     seasonLabel?: string | null;
     competitionType?: string | null;
     countsTowardSeasonRecord?: boolean | null;
+    tournament?: Record<string, unknown> | null;
+    statTrackerConfigId?: string | null;
     source?: string | null;
-    sourceMetadata?: Record<string, unknown> | null;
+    sourceMetadata?: (Record<string, unknown> & { sourceType?: string | null }) | null;
     visibility?: string | null;
     assignments?: Array<Record<string, unknown>>;
     rsvpSummary?: Record<string, unknown> | null;

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -164,6 +164,7 @@ import { addPractice, broadcastLiveEvent, claimOpenOfficiatingSlot, clearOccurre
 import { getNativeAuthIdToken } from './authService';
 import { expandRecurrence, fetchAndParseCalendar, isTeamActive } from './adapters/legacyScheduleHelpers';
 import { getCachedAppData, loadCachedAppData } from './appDataCache';
+import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
 import { buildPlayerScoringLiveEvent, claimOfficialAssignmentItem, createScheduledPracticeForApp, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
@@ -1990,5 +1991,40 @@ describe('team schedule game windowing (#2034)', () => {
         location: 'North Field'
       })
     ]));
+  });
+
+  it('preserves recurrence exception fields when mapping legacy recurring practice masters', () => {
+    const mapped = mapScheduleEventRecord({
+      id: 'practice-master',
+      type: 'practice',
+      isSeriesMaster: true,
+      recurrence: { freq: 'weekly', interval: 1, byDays: ['WE'] },
+      date: new Date('2025-01-08T18:00:00.000Z'),
+      end: new Date('2025-01-08T19:30:00.000Z'),
+      location: 'North Field',
+      title: 'Weekly Practice',
+      startTime: '18:00',
+      endDayOffset: 1,
+      exDates: ['2026-06-17'],
+      overrides: {
+        '2026-06-24': {
+          title: 'Adjusted Practice',
+          location: 'South Field'
+        }
+      }
+    });
+
+    expect(mapped).toMatchObject({
+      id: 'practice-master',
+      startTime: '18:00',
+      endDayOffset: 1,
+      exDates: ['2026-06-17'],
+      overrides: {
+        '2026-06-24': {
+          title: 'Adjusted Practice',
+          location: 'South Field'
+        }
+      }
+    });
   });
 });

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -527,7 +527,7 @@ describe('parent game route resolution', () => {
     });
     vi.mocked(getGame).mockImplementation(async (teamId: string, gameId: string) => {
       if (teamId === 'team-bravo' && gameId === 'game-7') {
-        return { id: 'game-7', type: 'game' } as any;
+        return { id: 'game-7', type: 'game', date: new Date('2026-06-25T18:00:00.000Z') } as any;
       }
       return null as any;
     });
@@ -1916,6 +1916,36 @@ describe('team schedule game windowing (#2034)', () => {
     expect(getGames).toHaveBeenCalledTimes(1);
     const [, options] = vi.mocked(getGames).mock.calls[0] as [string, any];
     expect(options?.startDate ?? null).toBeNull();
+  });
+
+  it('maps legacy game reads through the schedule event mapper before building parent rows', async () => {
+    vi.mocked(getGames).mockResolvedValue([
+      {
+        id: 'game-1',
+        type: 'game',
+        date: new Date('2026-06-25T18:00:00.000Z'),
+        opponent: 'Tigers',
+        liveClockMs: '90000',
+        liveClockRunning: 'yes',
+        assignments: [{ role: 'Clock', value: 'Open' }]
+      },
+      {
+        id: 'bad-game',
+        type: 'game',
+        date: 'not-a-date',
+        opponent: 'Should drop'
+      }
+    ] as any);
+
+    const result = await loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(result.events.map((event) => event.id)).toEqual(['game-1']);
+    expect(result.events[0]).toMatchObject({
+      opponent: 'Tigers',
+      liveClockMs: 90000,
+      liveClockRunning: null,
+      assignments: [{ role: 'Clock', value: 'Open' }]
+    });
   });
 
   it('keeps recurring practice masters available during windowed schedule loads', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -131,7 +131,7 @@ import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData }
 import { toAppServiceError } from './appErrors';
 import { createLogger } from './logger';
 import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
-import { mapFirestoreDocument, mapScheduleEventDocument, mapScheduleEventDocuments } from './firestore/mappers';
+import { mapFirestoreDocument, mapScheduleEventDocument, mapScheduleEventDocuments, mapScheduleEventRecord, mapScheduleEventRecords } from './firestore/mappers';
 import type { FirestoreDecodedDocument, FirestoreDocument as NativeFirestoreDocument } from './firestore/types';
 import type { AuthUser } from './types';
 
@@ -2192,7 +2192,7 @@ function isEventWithinRange(game: any, range: ScheduleDateRange) {
 async function loadGames(teamId: string, range: ScheduleDateRange = {}) {
   return readWithNativeFallback(
     `games ${teamId}`,
-    () => Promise.resolve(getGames(teamId, range)),
+    async () => mapScheduleEventRecords(await getGames(teamId, range)),
     async () => {
       const docs = await nativeListScheduleEventDocuments(`teams/${encodeURIComponent(teamId)}/games`);
       const windowed = (range.startDate || range.endDate)
@@ -2206,7 +2206,7 @@ async function loadGames(teamId: string, range: ScheduleDateRange = {}) {
 async function loadGameById(teamId: string, gameId: string) {
   return readWithNativeFallback(
     `game ${teamId}/${gameId}`,
-    () => Promise.resolve(getGame(teamId, gameId)),
+    async () => mapScheduleEventRecord(await getGame(teamId, gameId), gameId),
     () => nativeGetScheduleEventDocument(`teams/${encodeURIComponent(teamId)}/games/${encodeURIComponent(gameId)}`)
   );
 }

--- a/tests/unit/schedule-date-range-source.test.js
+++ b/tests/unit/schedule-date-range-source.test.js
@@ -20,7 +20,7 @@ describe('schedule date range source contracts', () => {
         expect(dbSource).toContain('function recurringPracticeMasterMayOverlapDateRange');
         expect(getGamesSource).toContain('getRecurringPracticeMastersForDateRange(gamesRef, startDate, endDate)');
         expect(getGamesSource).toContain('teamGames = mergeGamesById(teamGames, recurringMasters);');
-        expect(appLoadGamesSource).toContain('() => Promise.resolve(getGames(teamId, range))');
-        expect(appSource).not.toContain('async function loadRecurringPracticeMasters');
+        expect(appLoadGamesSource).toContain('mapScheduleEventRecords(await getGames(teamId, range))');
+        expect(appLoadGamesSource).not.toContain('loadRecurringPracticeMasters');
     });
 });


### PR DESCRIPTION
Refs #2618

## Summary
- route legacy web parent schedule game reads through the typed schedule event mapper
- share schedule event normalization between REST/native documents and legacy getGames/getGame results
- preserve expected schedule fields like gameId, tournament metadata, stat tracker config, and source metadata while rejecting malformed events

## Tests
- cd apps/app && npx vitest run src/lib/scheduleService.test.ts --reporter=verbose
- npm run app:build