### PR TITLE
[codex] Use typed chat Firestore record lists

### DIFF
--- a/apps/app/src/lib/chatService.test.ts
+++ b/apps/app/src/lib/chatService.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { mapChatConversationDocument, mapChatMessageDocument, mapChatMessageRecord } from './firestore/mappers';
+import { mapChatConversationDocument, mapChatMessageDocument, mapChatMessageRecord, mapChatMessageRecords } from './firestore/mappers';
 import type { FirestoreDocument } from './firestore/types';
 
 describe('chat Firestore mappers', () => {
@@ -58,6 +58,7 @@ describe('chat Firestore mappers', () => {
 
     expect(mapChatMessageDocument(document)).toEqual({
       id: 'message-1',
+      clientMessageId: null,
       text: 'Great pass',
       senderId: 'user-1',
       senderName: 'Coach Kim',
@@ -92,6 +93,7 @@ describe('chat Firestore mappers', () => {
       },
       targetType: 'individuals',
       recipientIds: ['user-2', 'user-3'],
+      mentionedUids: [],
       targetRole: null,
       conversationId: null,
       _doc: undefined
@@ -111,6 +113,7 @@ describe('chat Firestore mappers', () => {
       recipientIds: [' user-4 ', '', 'user-4']
     })).toEqual({
       id: 'message-2',
+      clientMessageId: null,
       text: null,
       senderId: null,
       senderName: null,
@@ -145,10 +148,56 @@ describe('chat Firestore mappers', () => {
       },
       targetType: 'full_team',
       recipientIds: ['user-4'],
+      mentionedUids: [],
       targetRole: null,
       conversationId: null,
       _doc: undefined
     });
+  });
+
+  it('maps chat message record lists and drops malformed entries at the boundary', () => {
+    expect(mapChatMessageRecords([
+      {
+        text: 'missing id',
+        createdAt: { seconds: Date.parse('2026-06-19T19:02:00.000Z') / 1000 }
+      },
+      {
+        id: 'message-3',
+        text: '  Tagged update ',
+        attachments: [
+          {
+            url: 'https://example.com/photo.jpg',
+            mimeType: 'image/jpeg',
+            uploadedAt: { toMillis: () => Date.parse('2026-06-19T19:01:30.000Z') }
+          }
+        ],
+        reactions: {
+          heart: ['user-2', 'user-2', ''],
+          clap: [' user-3 ']
+        },
+        mentionedUids: [' user-4 ', 'user-4', 'user-5'],
+        createdAt: { toDate: () => new Date('2026-06-19T19:02:00.000Z') },
+        editedAt: { seconds: Date.parse('2026-06-19T19:03:00.000Z') / 1000, nanoseconds: 123000000 }
+      }
+    ])).toEqual([
+      expect.objectContaining({
+        id: 'message-3',
+        text: 'Tagged update',
+        attachments: [
+          expect.objectContaining({
+            url: 'https://example.com/photo.jpg',
+            uploadedAt: new Date('2026-06-19T19:01:30.000Z')
+          })
+        ],
+        reactions: {
+          heart: ['user-2'],
+          clap: ['user-3']
+        },
+        mentionedUids: ['user-4', 'user-5'],
+        createdAt: new Date('2026-06-19T19:02:00.000Z'),
+        editedAt: new Date('2026-06-19T19:03:00.123Z')
+      })
+    ]);
   });
 
   it('maps conversation preview metadata from partial Firestore documents', () => {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -56,7 +56,12 @@ import {
 } from './chatLogic';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
 import { startInteractionTimer, UX_TIMING } from './uxTiming';
-import { mapChatConversationRecord, mapChatMessageRecord, mapFirestoreDocument } from './firestore/mappers';
+import {
+  mapChatConversationRecords,
+  mapChatMessageRecord,
+  mapChatMessageRecords,
+  mapFirestoreDocument
+} from './firestore/mappers';
 import type {
   ChatAttachmentFirestoreRecord,
   ChatConversationFirestoreRecord,
@@ -503,11 +508,7 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
       `latest chat conversations ${teamId}`,
       2500
     ) as ChatConversation[];
-    const mappedConversations = Array.isArray(loadedConversations)
-      ? loadedConversations
-        .map((conversation) => mapChatConversationRecord(conversation, conversation?.id || ''))
-        .filter((conversation): conversation is ChatConversation => Boolean(conversation))
-      : [];
+    const mappedConversations = mapChatConversationRecords(loadedConversations);
     conversations = mappedConversations.length
       ? mappedConversations
       : [buildDefaultTeamConversation(team)];
@@ -717,9 +718,7 @@ export async function loadChatTeamContext(teamId: string, user: AuthUser | null)
 export async function loadChatConversations(teamId: string, user: AuthUser, team: Record<string, any>, canModerate: boolean): Promise<ChatConversation[]> {
   try {
     const conversations = await withTimeout(Promise.resolve(getChatConversations(teamId, user, { team, canModerate })), 'Chat conversations load') as ChatConversation[];
-    return (Array.isArray(conversations) ? conversations : [])
-      .map((conversation) => mapChatConversationRecord(conversation, conversation?.id || ''))
-      .filter((conversation): conversation is ChatConversation => Boolean(conversation));
+    return mapChatConversationRecords(conversations);
   } catch (error) {
     console.warn('[chat-service] Falling back to default chat conversation:', sanitizeErrorForLogging(error));
     return [buildDefaultTeamConversation(team) as ChatConversation];
@@ -757,9 +756,7 @@ export function subscribeToTeamChatMessages(
           orderBy: 'createdAt desc',
           pageSize: 50
         });
-        const mappedMessages = messages
-          .map((message) => mapChatMessageRecord(message, message?.id || ''))
-          .filter((message): message is ChatMessage => Boolean(message));
+        const mappedMessages = mapChatMessageRecords(messages);
         onMessages(mappedMessages, mappedMessages[mappedMessages.length - 1]?._doc || null);
       } catch (error: any) {
         onError?.(error);
@@ -774,9 +771,7 @@ export function subscribeToTeamChatMessages(
   try {
     unsubscribe = subscribeToChatMessages(teamId, { limit: 50, conversationId }, (messages: ChatMessage[], oldestDoc: unknown | null) => {
       if (!cancelled) {
-        const mappedMessages = (Array.isArray(messages) ? messages : [])
-          .map((message) => mapChatMessageRecord(message, message?.id || ''))
-          .filter((message): message is ChatMessage => Boolean(message));
+        const mappedMessages = mapChatMessageRecords(messages);
         onMessages(mappedMessages, oldestDoc);
       }
     });
@@ -805,9 +800,7 @@ export async function loadOlderTeamChatMessages(teamId: string, conversationId: 
       startAfterDoc,
       conversationId
     })), 'Older chat messages load') as ChatMessage[];
-    return (Array.isArray(messages) ? messages : [])
-      .map((message) => mapChatMessageRecord(message, message?.id || ''))
-      .filter((message): message is ChatMessage => Boolean(message));
+    return mapChatMessageRecords(messages);
   } catch (error) {
     if (!isNativeRuntime()) throw error;
     console.warn('[chat-service] Older chat history is limited in native REST fallback:', sanitizeErrorForLogging(error));

--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -59,6 +59,20 @@ function asOptionalDate(value: unknown): Date | null {
     if (value instanceof Date) {
         return Number.isNaN(value.getTime()) ? null : value;
     }
+    if (value && typeof (value as { toDate?: unknown }).toDate === 'function') {
+        const date = (value as { toDate: () => unknown }).toDate();
+        return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+    }
+    if (value && typeof (value as { toMillis?: unknown }).toMillis === 'function') {
+        const date = new Date((value as { toMillis: () => number }).toMillis());
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+    if (value && typeof (value as { seconds?: unknown }).seconds === 'number') {
+        const { seconds, nanoseconds } = value as { seconds: number; nanoseconds?: unknown };
+        const millis = (seconds * 1000) + Math.floor(Number(nanoseconds || 0) / 1000000);
+        const date = new Date(millis);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
     const stringValue = asTrimmedString(value);
     if (!stringValue) return null;
     const parsed = new Date(stringValue);
@@ -81,15 +95,6 @@ function asObject(value: unknown): Record<string, unknown> | null {
 }
 
 function asTemporalValue(value: unknown): unknown {
-    if (value instanceof Date) {
-        return Number.isNaN(value.getTime()) ? null : value;
-    }
-    if (value && typeof (value as { toDate?: unknown }).toDate === 'function') {
-        return value;
-    }
-    if (typeof (value as { seconds?: unknown })?.seconds === 'number') {
-        return value;
-    }
     return asOptionalDate(value);
 }
 
@@ -171,6 +176,15 @@ export function mapChatConversationDocument(document: FirestoreDocument | null |
     return decoded ? mapChatConversationRecord(decoded, decoded.id) : null;
 }
 
+export function mapChatConversationRecords(values: unknown): ChatConversationFirestoreRecord[] {
+    return Array.isArray(values)
+        ? values.map((value) => {
+            const source = asLooseObject(value);
+            return mapChatConversationRecord(source, asTrimmedString(source.id) || '');
+        }).filter((conversation): conversation is ChatConversationFirestoreRecord => Boolean(conversation))
+        : [];
+}
+
 export function mapChatMessageRecord(value: unknown, fallbackId = ''): ChatMessageFirestoreRecord | null {
     const source = asLooseObject(value);
     const id = asTrimmedString(source.id) || fallbackId;
@@ -202,10 +216,20 @@ export function mapChatMessageRecord(value: unknown, fallbackId = ''): ChatMessa
         reactions: asReactionMap(source.reactions),
         targetType: asChatTargetType(source.targetType),
         recipientIds: asUniqueStringArray(source.recipientIds),
+        mentionedUids: asUniqueStringArray(source.mentionedUids),
         targetRole: asTrimmedString(source.targetRole),
         conversationId: asTrimmedString(source.conversationId),
         _doc: source._doc
     };
+}
+
+export function mapChatMessageRecords(values: unknown): ChatMessageFirestoreRecord[] {
+    return Array.isArray(values)
+        ? values.map((value) => {
+            const source = asLooseObject(value);
+            return mapChatMessageRecord(source, asTrimmedString(source.id) || '');
+        }).filter((message): message is ChatMessageFirestoreRecord => Boolean(message))
+        : [];
 }
 
 export function mapChatMessageDocument(document: FirestoreDocument | null | undefined): ChatMessageFirestoreRecord | null {

--- a/apps/app/src/lib/firestore/types.ts
+++ b/apps/app/src/lib/firestore/types.ts
@@ -78,6 +78,7 @@ export type ChatMessageFirestoreRecord = {
     reactions?: Record<string, string[]>;
     targetType?: 'full_team' | 'staff' | 'individuals';
     recipientIds?: string[];
+    mentionedUids?: string[];
     targetRole?: string | null;
     conversationId?: string | null;
     sendStatus?: 'pending' | 'failed';

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -495,6 +495,64 @@ describe('React app chat recipient service', () => {
         expect(dbMocks.getUserTeamsWithAccess).not.toHaveBeenCalled();
     });
 
+    it('normalizes chat conversations and older message pages through typed mappers', async () => {
+        dbMocks.getChatConversations.mockResolvedValue([
+            { name: 'Missing id', type: 'direct' },
+            {
+                id: 'conversation-1',
+                type: 'unsupported',
+                participantIds: [' user-1 ', 'user-1', 'coach-1'],
+                mutedBy: [' coach-1 ', 'coach-1'],
+                updatedAt: { seconds: Date.parse('2026-06-19T19:00:00.000Z') / 1000 }
+            }
+        ]);
+        dbMocks.getChatMessages.mockResolvedValue([
+            {
+                text: 'missing id',
+                createdAt: new Date('2026-06-19T19:01:00.000Z')
+            },
+            {
+                id: 'message-1',
+                text: '  Bring water ',
+                reactions: {
+                    heart: [' user-2 ', 'user-2', '']
+                },
+                mentionedUids: [' user-3 ', 'user-3'],
+                createdAt: { toDate: () => new Date('2026-06-19T19:02:00.000Z') }
+            }
+        ]);
+
+        const { loadChatConversations, loadOlderTeamChatMessages } = await import('../../apps/app/src/lib/chatService.ts');
+        const conversations = await loadChatConversations(
+            'team-1',
+            { uid: 'user-1', email: 'parent@example.com', roles: [] },
+            { id: 'team-1', name: 'Bears' },
+            true
+        );
+        const messages = await loadOlderTeamChatMessages('team-1', 'conversation-1', { id: 'cursor' });
+
+        expect(conversations).toEqual([
+            expect.objectContaining({
+                id: 'conversation-1',
+                type: 'group',
+                participantIds: ['user-1', 'coach-1'],
+                mutedBy: ['coach-1'],
+                updatedAt: new Date('2026-06-19T19:00:00.000Z')
+            })
+        ]);
+        expect(messages).toEqual([
+            expect.objectContaining({
+                id: 'message-1',
+                text: 'Bring water',
+                reactions: {
+                    heart: ['user-2']
+                },
+                mentionedUids: ['user-3'],
+                createdAt: new Date('2026-06-19T19:02:00.000Z')
+            })
+        ]);
+    });
+
     it('routes selected-member messages into a non-default conversation before posting', async () => {
         const photo = new File(['photo'], 'arrival.jpg', { type: 'image/jpeg' });
         const video = new File(['clip'], 'warmups.mp4', { type: 'video/mp4' });


### PR DESCRIPTION
Refs #2619

## Summary
- add typed list mappers for chat conversations and messages
- normalize Firestore timestamp-like values and mentionedUids in chat message records
- route inbox preview, conversation, subscription, and older-message reads through the typed list helpers

## Tests
- cd apps/app && npx vitest run src/lib/chatService.test.ts --reporter=verbose
- npx vitest run tests/unit/app-chat-service-recipients.test.js --reporter=verbose
- npm run app:build