### PR TITLE
[codex] Disable Sports Connect dead-end sync actions

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -950,7 +950,7 @@
                 ? 'Preview players and guardian/contact records from the latest stored registration snapshot before importing. This uses saved provider data only and does not fetch Sports Connect live.'
                 : (hasConfiguredMetadata
                     ? 'Sports Connect metadata is saved for this team, but roster import is unavailable until a provider connector stores a roster snapshot. This page does not fetch provider data live.'
-                    : 'Roster import works from a stored registration snapshot. Connect a provider and save provider data before importing here.');
+                    : 'Roster import works from a stored registration snapshot. Connect a provider and save or load a registration roster snapshot for this team before importing here.');
 
             previewButton.classList.toggle('hidden', !hasImportableSnapshot);
             importButton.classList.toggle('hidden', !hasImportableSnapshot);

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -949,7 +949,7 @@
             description.textContent = hasImportableSnapshot
                 ? 'Preview players and guardian/contact records from the latest stored registration snapshot before importing. This uses saved provider data only and does not fetch Sports Connect live.'
                 : (hasConfiguredMetadata
-                    ? 'Sports Connect metadata is saved for this team, but roster import only works after a registration roster snapshot has been stored. This page does not fetch provider data live.'
+                    ? 'Sports Connect metadata is saved for this team, but roster import is unavailable until a provider connector stores a roster snapshot. This page does not fetch provider data live.'
                     : 'Roster import works from a stored registration snapshot. Connect a provider and save provider data before importing here.');
 
             previewButton.classList.toggle('hidden', !hasImportableSnapshot);
@@ -963,7 +963,7 @@
             status.textContent = hasImportableSnapshot
                 ? `${sourcePlayers.length} player${sourcePlayers.length === 1 ? '' : 's'} available in the latest stored roster snapshot. Preview before importing.`
                 : (hasConfiguredMetadata
-                    ? 'Required next step: save or load a registration roster snapshot for this team, then return here to preview and import the stored data.'
+                    ? 'Import unavailable: Sports Connect has metadata only. A live connector must create a stored roster snapshot before this page can preview or import players.'
                     : 'No registration provider data is available yet. Connect a provider and save a registration roster snapshot before importing.');
         }
 
@@ -975,7 +975,7 @@
             const sourcePlayers = getRegistrationRosterPlayers(currentTeam);
             if (sourcePlayers.length === 0) {
                 status.textContent = hasConfiguredRegistrationProviderMetadata(currentTeam)
-                    ? 'No stored registration roster snapshot is available yet. Save or load provider data for this team before previewing import.'
+                    ? 'No stored registration roster snapshot is available yet. Sports Connect live import requires a provider connector before preview is possible.'
                     : 'No registration provider data is available yet. Connect a provider and save a registration roster snapshot before previewing import.';
                 return;
             }

--- a/edit-team.html
+++ b/edit-team.html
@@ -454,7 +454,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Connection</h3>
-                            <p class="text-xs text-blue-700 mt-1">Store registration metadata for this team. Saved Sports Connect mappings can run a backend manual sync that fetches a roster snapshot for import.</p>
+                            <p class="text-xs text-blue-700 mt-1">Store registration metadata for this team. Sports Connect live sync is unavailable until a connector is added.</p>
                         </div>
                         <button id="clear-registration-provider-btn" type="button" class="shrink-0 px-3 py-1.5 bg-white border border-blue-200 text-blue-700 text-xs font-semibold rounded-lg hover:bg-blue-100 transition">
                             Clear
@@ -470,7 +470,7 @@
                                 <option value="League Apps">League Apps</option>
                                 <option value="Other">Other documented source</option>
                             </select>
-                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect enables a backend manual sync after this team is saved.</p>
+                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect saves metadata only; it does not fetch live provider data today.</p>
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700">Sports Connect Team ID / External Mapping</label>
@@ -509,9 +509,9 @@
                             </div>
                         </div>
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <p id="registration-connection-help" class="text-xs text-blue-700">Save a Sports Connect provider mapping, then sync a roster snapshot for import.</p>
+                            <p id="registration-connection-help" class="text-xs text-blue-700">Save a Sports Connect provider mapping as metadata. A future connector is required before roster snapshots can be synced.</p>
                             <button id="registration-refresh-btn" type="button" disabled aria-disabled="true" class="shrink-0 cursor-not-allowed rounded-lg border border-slate-200 bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500">
-                                Sync now
+                                Sync unavailable
                             </button>
                         </div>
                     </div>
@@ -795,15 +795,7 @@
                 return 'Metadata incomplete. Add provider mapping.';
             }
             if (isSportsConnectProvider(provider)) {
-                const source = currentRegistrationSource || {};
-                if (source.lastSyncStatus === 'success') {
-                    const count = Number(source.playerCount || 0);
-                    return `Last sync successful${count ? ` (${count} players)` : ''}`;
-                }
-                if (source.lastSyncStatus === 'error') {
-                    return 'Last sync failed';
-                }
-                return 'Ready for manual sync';
+                return 'Metadata saved; live sync unavailable';
             }
             return 'Registration metadata only. No live sync.';
         }
@@ -832,22 +824,18 @@
             const lastSyncTime = getRegistrationLastSyncTime(source);
             const refreshButton = document.getElementById('registration-refresh-btn');
             const hasUnsavedSyncChanges = hasUnsavedRegistrationSyncChanges(provider, externalTeamId);
-            const canSyncSportsConnect = Boolean(currentTeamId && isSportsConnectProvider(provider) && externalTeamId && !hasUnsavedSyncChanges);
+            const canSyncSportsConnect = false;
             let helpText = 'Choose a provider and team mapping to save registration metadata.';
 
             if (provider && externalTeamId) {
                 helpText = isSportsConnectProvider(provider)
-                    ? (currentTeamId
-                        ? (hasUnsavedSyncChanges
-                            ? 'Save the updated Sports Connect mapping before running backend sync.'
-                            : 'Sync now fetches Sports Connect data through the backend and stores the roster snapshot for import.')
-                        : 'Save the team before running a Sports Connect sync.')
+                    ? 'Sports Connect metadata is saved for reference only. Live refresh and re-import require a future provider connector.'
                     : 'This provider mapping is saved as metadata only. Manual refresh stays unavailable until a live connector exists.';
             } else if (provider) {
                 helpText = 'Add the provider team ID or mapping to finish setup.';
             }
 
-            if (!hasUnsavedSyncChanges && source.lastSyncStatus === 'error' && source.lastSyncError) {
+            if (!isSportsConnectProvider(provider) && !hasUnsavedSyncChanges && source.lastSyncStatus === 'error' && source.lastSyncError) {
                 helpText = `Last sync error: ${source.lastSyncError}`;
             }
 
@@ -894,6 +882,12 @@
         async function handleRegistrationProviderSync() {
             const button = document.getElementById('registration-refresh-btn');
             if (!currentTeamId || button.disabled) return;
+            const provider = document.getElementById('registrationProviderName').value.trim();
+            if (isSportsConnectProvider(provider)) {
+                renderRegistrationConnectionStatus(currentRegistrationSource || {});
+                document.getElementById('registration-connection-help').textContent = 'Sports Connect live refresh is unavailable until a provider connector exists.';
+                return;
+            }
 
             const originalText = button.textContent;
             let finalHelpText = '';
@@ -947,7 +941,7 @@
                 externalTeamId,
                 teamId: currentTeamId || null,
                 connectionStatus: provider && externalTeamId ? 'metadata_configured' : 'metadata_incomplete',
-                syncEnabled: isSportsConnectProvider(provider) && !!externalTeamId,
+                syncEnabled: false,
                 lastSyncStatus: metadataStatus
             };
         }

--- a/edit-team.html
+++ b/edit-team.html
@@ -470,7 +470,7 @@
                                 <option value="League Apps">League Apps</option>
                                 <option value="Other">Other documented source</option>
                             </select>
-                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect saves metadata only; it does not fetch live provider data today.</p>
+                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect enables a backend manual sync after this team is saved.</p>
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700">Sports Connect Team ID / External Mapping</label>
@@ -509,7 +509,7 @@
                             </div>
                         </div>
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <p id="registration-connection-help" class="text-xs text-blue-700">Save a Sports Connect provider mapping as metadata. A future connector is required before roster snapshots can be synced.</p>
+                            <p id="registration-connection-help" class="text-xs text-blue-700">Save a Sports Connect provider mapping, then sync a roster snapshot for import.</p>
                             <button id="registration-refresh-btn" type="button" disabled aria-disabled="true" class="shrink-0 cursor-not-allowed rounded-lg border border-slate-200 bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500">
                                 Sync unavailable
                             </button>

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -438,6 +438,9 @@ describe('registration roster import wiring', () => {
         expect(source).toContain('hasConfiguredRegistrationProviderMetadata(team)');
         expect(source).toContain('Registration provider metadata saved');
         expect(source).toContain('This page does not fetch provider data live.');
+        expect(source).toContain('Sports Connect metadata is saved for this team, but roster import is unavailable until a provider connector stores a roster snapshot.');
+        expect(source).toContain('Import unavailable: Sports Connect has metadata only. A live connector must create a stored roster snapshot before this page can preview or import players.');
+        expect(source).toContain('No stored registration roster snapshot is available yet. Sports Connect live import requires a provider connector before preview is possible.');
         expect(source).toContain('save or load a registration roster snapshot for this team');
         expect(source).toContain('previewButton.setAttribute(\'aria-disabled\', String(previewButton.disabled));');
         expect(source).toContain('importButton.setAttribute(\'aria-disabled\', \'true\');');

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -630,7 +630,8 @@ describe('edit team admin access persistence', () => {
         expect(html.indexOf('id="teamColorPrimary"')).toBeGreaterThan(advancedIndex);
         expect(html.indexOf('id="registrationProviderName"')).toBeGreaterThan(advancedIndex);
         expect(html).toContain('Registration Provider Connection');
-        expect(html).toContain('Saved Sports Connect mappings can run a backend manual sync that fetches a roster snapshot for import.');
+        expect(html).toContain('Sports Connect live sync is unavailable until a connector is added.');
+        expect(html).toContain('Sync unavailable');
         expect(html).toContain('id="team-create-mode-registration"');
         expect(html).toContain('No registration sources are configured yet. Start with a blank team or load provider data before using this import path.');
         expect(html).toContain('registrationMode.setAttribute(\'aria-disabled\', String(registrationMode.disabled));');
@@ -646,6 +647,16 @@ describe('edit team admin access persistence', () => {
         } finally {
             createEnv.cleanup();
         }
+    });
+
+    it('blocks Sports Connect roster import until a stored provider snapshot exists', () => {
+        const html = readFileSync(new URL('../../edit-roster.html', import.meta.url), 'utf8');
+
+        expect(html).toContain('Sports Connect metadata is saved for this team, but roster import is unavailable until a provider connector stores a roster snapshot.');
+        expect(html).toContain('Import unavailable: Sports Connect has metadata only. A live connector must create a stored roster snapshot before this page can preview or import players.');
+        expect(html).toContain('No stored registration roster snapshot is available yet. Sports Connect live import requires a provider connector before preview is possible.');
+        expect(html).toContain("previewButton.disabled = !hasImportableSnapshot;");
+        expect(html).toContain("importButton.disabled = true;");
     });
 
     it('saves the simple create path with safe advanced defaults', async () => {
@@ -1111,11 +1122,11 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('registrationProviderName').value).toBe('Sports Connect');
             expect(env.elements.get('registrationExternalTeamId').value).toBe('SC-123');
             expect(env.elements.get('registrationCopiedTeamId').value).toBe('team-1');
-            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Ready for manual sync');
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Ready for manual sync');
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Ready for manual sync');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Metadata saved; live sync unavailable');
             expect(env.elements.get('registration-sync-time').textContent).toContain('2026');
-            expect(env.elements.get('registration-refresh-btn').disabled).toBe(false);
+            expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
 
             env.elements.get('registrationProviderName').value = 'League Apps';
             env.elements.get('registrationExternalTeamId').value = 'LA-456';
@@ -1167,17 +1178,27 @@ describe('edit team admin access persistence', () => {
             updateCalls: []
         };
 
-        const env = await bootEditTeam(initialState);
+        let syncCalls = 0;
+        const env = await bootEditTeam(initialState, undefined, {
+            db: {
+                async syncRegistrationProvider() {
+                    syncCalls += 1;
+                    throw new Error('sync should stay unavailable');
+                }
+            }
+        });
         try {
             env.elements.get('registrationProviderName').value = 'sports-connect';
             env.elements.get('registrationExternalTeamId').value = 'SC-987';
             await env.elements.get('registrationProviderName').dispatchEvent(new MockEvent('change'));
 
-            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Ready for manual sync');
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Ready for manual sync');
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Ready for manual sync');
-            expect(env.elements.get('registration-connection-help').textContent).toContain('backend');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registration-connection-help').textContent).toContain('future provider connector');
             expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
+            await env.elements.get('registration-refresh-btn').click();
+            expect(syncCalls).toBe(0);
 
             await env.elements.get('team-form').requestSubmit();
 
@@ -1187,8 +1208,8 @@ describe('edit team admin access persistence', () => {
                 externalTeamId: 'SC-987',
                 teamId: 'team-1',
                 connectionStatus: 'metadata_configured',
-                syncEnabled: true,
-                lastSyncStatus: 'Ready for manual sync'
+                syncEnabled: false,
+                lastSyncStatus: 'Metadata saved; live sync unavailable'
             });
         } finally {
             env.cleanup();

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -1216,6 +1216,44 @@ describe('edit team admin access persistence', () => {
         }
     });
 
+    it('keeps Sports Connect connector guidance visible even when prior sync metadata contains an error', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: [],
+                registrationSource: {
+                    provider: 'sports-connect',
+                    externalTeamId: 'SC-987',
+                    teamId: 'team-1',
+                    connectionStatus: 'metadata_configured',
+                    syncEnabled: false,
+                    lastSyncStatus: 'error',
+                    lastSyncError: 'Connector failed upstream'
+                }
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registration-connection-help').textContent).toContain('future provider connector');
+            expect(env.elements.get('registration-connection-help').textContent).not.toContain('Connector failed upstream');
+        } finally {
+            env.cleanup();
+        }
+    });
+
     it('round-trips the archived replay Team Pass gate setting', async () => {
         const initialState = {
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },

--- a/tests/unit/edit-team-registration-sync.test.js
+++ b/tests/unit/edit-team-registration-sync.test.js
@@ -18,7 +18,7 @@ function readSportsConnectSyncCore() {
 }
 
 describe('edit team Sports Connect registration sync wiring', () => {
-    it('enables manual sync for saved Sports Connect mappings through a callable wrapper', () => {
+    it('keeps Sports Connect metadata wiring while manual sync remains disabled', () => {
         const source = readEditTeam();
         const dbSource = readDb();
         const functionsSource = readFunctions();
@@ -29,9 +29,9 @@ describe('edit team Sports Connect registration sync wiring', () => {
         expect(source).toContain('function handleRegistrationProviderSync()');
         expect(source).toContain('await syncRegistrationProvider(currentTeamId)');
         expect(source).toContain('function hasUnsavedRegistrationSyncChanges(provider, externalTeamId)');
-        expect(source).toContain('Save the updated Sports Connect mapping before running backend sync.');
-        expect(source).toContain('const canSyncSportsConnect = Boolean(currentTeamId && isSportsConnectProvider(provider) && externalTeamId && !hasUnsavedSyncChanges);');
-        expect(source).toContain('syncEnabled: isSportsConnectProvider(provider) && !!externalTeamId');
+        expect(source).toContain('Sports Connect live sync is unavailable until a connector is added.');
+        expect(source).toContain('const canSyncSportsConnect = false;');
+        expect(source).toContain('syncEnabled: false');
         expect(source).toContain('Open roster import to preview changes.');
         expect(source).not.toContain('Manual refresh unavailable');
 


### PR DESCRIPTION
Refs #2633

## Summary
- mark Sports Connect registration provider setup as metadata-only while no live connector exists
- keep the team refresh action disabled and prevent the old sync dependency from running
- clarify roster import messaging when only provider metadata exists and no stored snapshot is available

## Tests
- npx vitest run tests/unit/edit-team-admin-access-persistence.test.js --reporter=verbose