### PR TITLE
Typed adapter for legacy practice-timeline helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyPracticeTimeline.ts
+++ b/apps/app/src/lib/adapters/legacyPracticeTimeline.ts
@@ -1,0 +1,16 @@
+import { getDrills as legacyGetDrills, getPracticeSessionByEvent as legacyGetPracticeSessionByEvent, getTeam as legacyGetTeam, getTeamDrills as legacyGetTeamDrills, updatePracticeSession as legacyUpdatePracticeSession, upsertPracticeSessionForEvent as legacyUpsertPracticeSessionForEvent } from '@legacy/db.js';
+import { appendLivePracticeNote as legacyAppendLivePracticeNote } from '@legacy/drills-live-practice-notes.js';
+import { hasFullTeamAccess as legacyHasFullTeamAccess } from '@legacy/team-access.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ practice-timeline helpers (#2066).
+ * Bindings re-exported as-is so existing js/* test mocks apply via the @legacy alias.
+ */
+export const getDrills = legacyGetDrills as (...args: any[]) => Promise<any>;
+export const getPracticeSessionByEvent = legacyGetPracticeSessionByEvent as (...args: any[]) => Promise<any>;
+export const getTeam = legacyGetTeam as (...args: any[]) => Promise<any>;
+export const getTeamDrills = legacyGetTeamDrills as (...args: any[]) => Promise<any>;
+export const updatePracticeSession = legacyUpdatePracticeSession as (...args: any[]) => Promise<any>;
+export const upsertPracticeSessionForEvent = legacyUpsertPracticeSessionForEvent as (...args: any[]) => Promise<any>;
+export const appendLivePracticeNote = legacyAppendLivePracticeNote as (...args: any[]) => any;
+export const hasFullTeamAccess = legacyHasFullTeamAccess as (...args: any[]) => boolean;

--- a/apps/app/src/lib/practiceTimelineService.ts
+++ b/apps/app/src/lib/practiceTimelineService.ts
@@ -1,6 +1,4 @@
-import { getDrills, getPracticeSessionByEvent, getTeam, getTeamDrills, updatePracticeSession, upsertPracticeSessionForEvent } from '../../../../js/db.js';
-import { appendLivePracticeNote } from '../../../../js/drills-live-practice-notes.js';
-import { hasFullTeamAccess } from '../../../../js/team-access.js';
+import { appendLivePracticeNote, getDrills, getPracticeSessionByEvent, getTeam, getTeamDrills, hasFullTeamAccess, updatePracticeSession, upsertPracticeSessionForEvent } from './adapters/legacyPracticeTimeline';
 import type { AuthUser } from './types';
 
 export type PracticeTimelineNote = {


### PR DESCRIPTION
Part of #2066. Routes `practiceTimelineService` through a typed `adapters/legacyPracticeTimeline` boundary instead of deep `js/db.js` + `js/drills-live-practice-notes.js` + `js/team-access.js` imports. Build + tests green (mocks apply via the `@legacy` alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)