### PR TITLE
Typed adapter for legacy team-drills helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyTeamDrills.ts
+++ b/apps/app/src/lib/adapters/legacyTeamDrills.ts
@@ -1,0 +1,18 @@
+import { addDrillFavorite as legacyAddDrillFavorite, getDrill as legacyGetDrill, getDrillFavorites as legacyGetDrillFavorites, getDrills as legacyGetDrills, getPublishedDrills as legacyGetPublishedDrills, getTeam as legacyGetTeam, removeDrillFavorite as legacyRemoveDrillFavorite } from '@legacy/db.js';
+import { DRILL_LEVELS as legacyDrillLevels, DRILL_TYPES as legacyDrillTypes } from '@legacy/drill-constants.js';
+import { hasFullTeamAccess as legacyHasFullTeamAccess } from '@legacy/team-access.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ team-drills helpers (#2066).
+ * Bindings re-exported as-is so existing js/* test mocks apply via the @legacy alias.
+ */
+export const addDrillFavorite = legacyAddDrillFavorite as (...args: any[]) => Promise<any>;
+export const getDrill = legacyGetDrill as (...args: any[]) => Promise<any>;
+export const getDrillFavorites = legacyGetDrillFavorites as (...args: any[]) => Promise<any>;
+export const getDrills = legacyGetDrills as (...args: any[]) => Promise<any>;
+export const getPublishedDrills = legacyGetPublishedDrills as (...args: any[]) => Promise<any>;
+export const getTeam = legacyGetTeam as (...args: any[]) => Promise<any>;
+export const removeDrillFavorite = legacyRemoveDrillFavorite as (...args: any[]) => Promise<any>;
+export const DRILL_LEVELS = legacyDrillLevels as readonly string[];
+export const DRILL_TYPES = legacyDrillTypes as readonly string[];
+export const hasFullTeamAccess = legacyHasFullTeamAccess as (...args: any[]) => boolean;

--- a/apps/app/src/lib/teamDrillsService.ts
+++ b/apps/app/src/lib/teamDrillsService.ts
@@ -1,6 +1,4 @@
-import { addDrillFavorite, getDrill, getDrillFavorites, getDrills, getPublishedDrills, getTeam, removeDrillFavorite } from '../../../../js/db.js';
-import { DRILL_LEVELS, DRILL_TYPES } from '../../../../js/drill-constants.js';
-import { hasFullTeamAccess } from '../../../../js/team-access.js';
+import { addDrillFavorite, DRILL_LEVELS, DRILL_TYPES, getDrill, getDrillFavorites, getDrills, getPublishedDrills, getTeam, hasFullTeamAccess, removeDrillFavorite } from './adapters/legacyTeamDrills';
 import type { AuthUser } from './types';
 
 const drillLibraryPageSize = 12;


### PR DESCRIPTION
Part of #2066. Routes `teamDrillsService` through a typed `adapters/legacyTeamDrills` boundary instead of deep `js/db.js` + `js/drill-constants.js` + `js/team-access.js` imports. Build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)