### PR TITLE
Typed adapter for legacy team-fees helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyTeamFees.ts
+++ b/apps/app/src/lib/adapters/legacyTeamFees.ts
@@ -1,0 +1,16 @@
+import { createTeamFeeBatch as legacyCreateTeamFeeBatch, getPlayers as legacyGetPlayers, getTeam as legacyGetTeam, listTeamFeeBatches as legacyListTeamFeeBatches, listTeamFeeRecipients as legacyListTeamFeeRecipients, updateTeamFeeRecipient as legacyUpdateTeamFeeRecipient } from '@legacy/db.js';
+import { initiateTeamFeeCheckout as legacyInitiateTeamFeeCheckout } from '@legacy/stripe-service.js';
+import { hasFullTeamAccess as legacyHasFullTeamAccess } from '@legacy/team-access.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ team-fees helpers (#2066).
+ * Bindings re-exported as-is so existing js/* test mocks apply via the @legacy alias.
+ */
+export const createTeamFeeBatch = legacyCreateTeamFeeBatch as (...args: any[]) => Promise<any>;
+export const getPlayers = legacyGetPlayers as (...args: any[]) => Promise<any>;
+export const getTeam = legacyGetTeam as (...args: any[]) => Promise<any>;
+export const listTeamFeeBatches = legacyListTeamFeeBatches as (...args: any[]) => Promise<any>;
+export const listTeamFeeRecipients = legacyListTeamFeeRecipients as (...args: any[]) => Promise<any>;
+export const updateTeamFeeRecipient = legacyUpdateTeamFeeRecipient as (...args: any[]) => Promise<any>;
+export const initiateTeamFeeCheckout = legacyInitiateTeamFeeCheckout as (...args: any[]) => Promise<any>;
+export const hasFullTeamAccess = legacyHasFullTeamAccess as (...args: any[]) => boolean;

--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -1,6 +1,4 @@
-import { createTeamFeeBatch, getPlayers, getTeam, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient } from '../../../../js/db.js';
-import { initiateTeamFeeCheckout } from '../../../../js/stripe-service.js';
-import { hasFullTeamAccess } from '../../../../js/team-access.js';
+import { createTeamFeeBatch, getPlayers, getTeam, hasFullTeamAccess, initiateTeamFeeCheckout, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient } from './adapters/legacyTeamFees';
 import type { AuthUser } from './types';
 
 export type TeamFeeBatchSummary = {


### PR DESCRIPTION
Part of #2066. Routes `teamFeesService` through a typed `adapters/legacyTeamFees` boundary instead of deep `js/db.js` + `js/stripe-service.js` + `js/team-access.js` imports. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)