### PR TITLE
Typed adapter for legacy registration form-admin helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyRegistrationFormAdmin.ts
+++ b/apps/app/src/lib/adapters/legacyRegistrationFormAdmin.ts
@@ -1,0 +1,15 @@
+import { buildAdminRegistrationFormPayload as legacyBuildAdminRegistrationFormPayload, formatFieldLabels as legacyFormatFieldLabels, normalizeBackgroundCheckSettings as legacyNormalizeBackgroundCheckSettings, validateAdminRegistrationFormPayload as legacyValidateAdminRegistrationFormPayload } from '@legacy/admin-registration-forms.js';
+import { calculateRegistrationFeeSnapshot as legacyCalculateRegistrationFeeSnapshot, getPaymentPlanChoices as legacyGetPaymentPlanChoices, normalizeRegistrationForm as legacyNormalizeRegistrationForm } from '@legacy/registration-flow.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ registration form-admin helpers
+ * (#2066). Bindings re-exported as-is so existing js/* test mocks apply via the
+ * @legacy alias; legacy shapes stay loose.
+ */
+export const buildAdminRegistrationFormPayload = legacyBuildAdminRegistrationFormPayload as (...args: any[]) => any;
+export const formatFieldLabels = legacyFormatFieldLabels as (...args: any[]) => any;
+export const normalizeBackgroundCheckSettings = legacyNormalizeBackgroundCheckSettings as (...args: any[]) => any;
+export const validateAdminRegistrationFormPayload = legacyValidateAdminRegistrationFormPayload as (...args: any[]) => any;
+export const calculateRegistrationFeeSnapshot = legacyCalculateRegistrationFeeSnapshot as (...args: any[]) => any;
+export const getPaymentPlanChoices = legacyGetPaymentPlanChoices as (...args: any[]) => any;
+export const normalizeRegistrationForm = legacyNormalizeRegistrationForm as (...args: any[]) => any;

--- a/apps/app/src/lib/registrationFormAdmin.ts
+++ b/apps/app/src/lib/registrationFormAdmin.ts
@@ -1,14 +1,12 @@
 import {
   buildAdminRegistrationFormPayload,
-  formatFieldLabels,
-  normalizeBackgroundCheckSettings,
-  validateAdminRegistrationFormPayload
-} from '../../../../js/admin-registration-forms.js';
-import {
   calculateRegistrationFeeSnapshot,
+  formatFieldLabels,
   getPaymentPlanChoices,
-  normalizeRegistrationForm
-} from '../../../../js/registration-flow.js';
+  normalizeBackgroundCheckSettings,
+  normalizeRegistrationForm,
+  validateAdminRegistrationFormPayload
+} from './adapters/legacyRegistrationFormAdmin';
 
 export type RegistrationFormEditorDraft = {
   teamId?: string;


### PR DESCRIPTION
Part of #2066. Routes `registrationFormAdmin` through a typed `adapters/legacyRegistrationFormAdmin` boundary instead of deep `js/admin-registration-forms.js` + `js/registration-flow.js` imports. Build green. (Two pre-existing date-sensitive discount tests fail on `master` too — unrelated to this direct-re-export change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)