### PR TITLE
Typed adapter for legacy notification-inbox Firestore primitives (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyNotificationInboxDb.ts
+++ b/apps/app/src/lib/adapters/legacyNotificationInboxDb.ts
@@ -1,0 +1,30 @@
+import {
+  collection as legacyCollection,
+  db as legacyDb,
+  doc as legacyDoc,
+  functions as legacyFunctions,
+  httpsCallable as legacyHttpsCallable,
+  limit as legacyLimit,
+  onSnapshot as legacyOnSnapshot,
+  orderBy as legacyOrderBy,
+  query as legacyQuery,
+  updateDoc as legacyUpdateDoc,
+  serverTimestamp as legacyServerTimestamp
+} from '@legacy/firebase.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ Firestore primitives used by
+ * notificationInboxService (#2066). SDK shapes stay loose; bindings re-exported
+ * as-is so existing js/* test mocks apply via the @legacy alias.
+ */
+export const collection = legacyCollection as (...args: any[]) => any;
+export const db: unknown = legacyDb;
+export const doc = legacyDoc as (...args: any[]) => any;
+export const functions: unknown = legacyFunctions;
+export const httpsCallable = legacyHttpsCallable as (...args: any[]) => (...callArgs: any[]) => Promise<any>;
+export const limit = legacyLimit as (...args: any[]) => any;
+export const onSnapshot = legacyOnSnapshot as (...args: any[]) => () => void;
+export const orderBy = legacyOrderBy as (...args: any[]) => any;
+export const query = legacyQuery as (...args: any[]) => any;
+export const updateDoc = legacyUpdateDoc as (...args: any[]) => Promise<any>;
+export const serverTimestamp = legacyServerTimestamp as (...args: any[]) => any;

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -1,17 +1,17 @@
 import type { QuerySnapshot, DocumentData } from 'firebase/firestore';
 import {
-    collection,
-    db,
-    doc,
-    functions,
-    httpsCallable,
-    limit,
-    onSnapshot,
-    orderBy,
-    query,
-    updateDoc,
-    serverTimestamp
-} from '../../../../js/firebase.js';
+  collection,
+  db,
+  doc,
+  functions,
+  httpsCallable,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  updateDoc
+} from './adapters/legacyNotificationInboxDb';
 
 export type NotificationInboxItem = {
     id: string;


### PR DESCRIPTION
Part of #2066. Routes `notificationInboxService` through a typed `adapters/legacyNotificationInboxDb` boundary instead of a deep `js/firebase.js` import of 11 Firestore/Functions primitives. Build + notification-bell tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)