### PR TITLE
Typed adapter for legacy home parent-fee helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyHomeFees.ts
+++ b/apps/app/src/lib/adapters/legacyHomeFees.ts
@@ -1,0 +1,10 @@
+import { listParentTeamFeeRecipients as legacyListParentTeamFeeRecipients } from '@legacy/db.js';
+import { normalizeParentFeeRecord as legacyNormalizeParentFeeRecord } from '@legacy/parent-dashboard-fees.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ parent-fee helpers used by
+ * homeService (#2066). Bindings re-exported as-is so existing js/* test mocks
+ * apply via the @legacy alias.
+ */
+export const listParentTeamFeeRecipients = legacyListParentTeamFeeRecipients as (...args: any[]) => any;
+export const normalizeParentFeeRecord = legacyNormalizeParentFeeRecord as (...args: any[]) => any;

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -1,5 +1,5 @@
-import { listParentTeamFeeRecipients } from '../../../../js/db.js';
-import { normalizeParentFeeRecord } from '../../../../js/parent-dashboard-fees.js';
+import { listParentTeamFeeRecipients } from './adapters/legacyHomeFees';
+import { normalizeParentFeeRecord } from './adapters/legacyHomeFees';
 import { loadChatInbox } from './chatService';
 import { startUxTimer } from './uxTiming';
 import {


### PR DESCRIPTION
Part of #2066. Routes `homeService` through a typed `adapters/legacyHomeFees` boundary instead of deep `js/db.js` + `js/parent-dashboard-fees.js` imports. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)