### PR TITLE
Typed adapter for legacy game-day lineup builder imports (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyGameDayLineup.ts
+++ b/apps/app/src/lib/adapters/legacyGameDayLineup.ts
@@ -1,0 +1,19 @@
+import { getApp as legacyGetApp } from '@legacy/vendor/firebase-app.js';
+import { getAI as legacyGetAI, getGenerativeModel as legacyGetGenerativeModel, GoogleAIBackend as LegacyGoogleAIBackend } from '@legacy/vendor/firebase-ai.js';
+import { buildRotationPlanFromGamePlan as legacyBuildRotationPlanFromGamePlan, normalizeLineupsForGamePlanPlanner as legacyNormalizeLineupsForGamePlanPlanner } from '@legacy/game-plan-interop.js';
+import { buildGamePlanIntervals as legacyBuildGamePlanIntervals } from '@legacy/game-plan-intervals.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ + vendored Firebase AI imports used
+ * by gameDayLineupBuilder (#2066). Bindings re-exported as-is so existing js/*
+ * test mocks apply via the @legacy alias; SDK shapes stay loose.
+ */
+export const getApp = legacyGetApp as (name?: string) => unknown;
+export const getAI = legacyGetAI as (app: unknown, options?: Record<string, unknown>) => unknown;
+export const getGenerativeModel = legacyGetGenerativeModel as (ai: unknown, options: Record<string, unknown>) => {
+  generateContent: (...args: any[]) => Promise<any>;
+};
+export const GoogleAIBackend = LegacyGoogleAIBackend as new (...args: any[]) => unknown;
+export const buildRotationPlanFromGamePlan = legacyBuildRotationPlanFromGamePlan as (...args: any[]) => any;
+export const normalizeLineupsForGamePlanPlanner = legacyNormalizeLineupsForGamePlanPlanner as (...args: any[]) => any;
+export const buildGamePlanIntervals = legacyBuildGamePlanIntervals as (...args: any[]) => any;

--- a/apps/app/src/lib/gameDayLineupBuilder.ts
+++ b/apps/app/src/lib/gameDayLineupBuilder.ts
@@ -1,7 +1,12 @@
-import { getApp } from '../../../../js/vendor/firebase-app.js';
-import { getAI, getGenerativeModel, GoogleAIBackend } from '../../../../js/vendor/firebase-ai.js';
-import { buildRotationPlanFromGamePlan, normalizeLineupsForGamePlanPlanner } from '../../../../js/game-plan-interop.js';
-import { buildGamePlanIntervals } from '../../../../js/game-plan-intervals.js';
+import {
+  buildGamePlanIntervals,
+  buildRotationPlanFromGamePlan,
+  getAI,
+  getApp,
+  getGenerativeModel,
+  GoogleAIBackend,
+  normalizeLineupsForGamePlanPlanner
+} from './adapters/legacyGameDayLineup';
 import { getLineupFormation, getLineupPeriodsForFormation, type AutoFilledLineupPlayer, type LineupFormationPosition } from './gameDayLineupPublish';
 
 export type LineupEditorPlayer = AutoFilledLineupPlayer & {


### PR DESCRIPTION
Part of #2066. Routes `gameDayLineupBuilder` through a typed `adapters/legacyGameDayLineup` boundary, replacing 4 deep `js/*` imports (vendored firebase-app/firebase-ai + game-plan-interop/intervals). Build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)