### PR TITLE
Typed adapter for legacy search helpers + Firestore primitives (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacySearchDb.ts
+++ b/apps/app/src/lib/adapters/legacySearchDb.ts
@@ -1,0 +1,32 @@
+import { isTeamActive as legacyIsTeamActive } from '@legacy/team-visibility.js';
+import { executeBoundedPlayerSearch as legacyExecuteBoundedPlayerSearch, playerSearchFirestoreQueryBudget as legacyPlayerSearchFirestoreQueryBudget, playerSearchResultLimit as legacyPlayerSearchResultLimit } from '@legacy/player-search-budget.js';
+import {
+  db as legacyDb,
+  collection as legacyCollection,
+  doc as legacyDoc,
+  getDoc as legacyGetDoc,
+  getDocs as legacyGetDocs,
+  query as legacyQuery,
+  where as legacyWhere,
+  orderBy as legacyOrderBy,
+  limit as legacyLimit
+} from '@legacy/firebase.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ search helpers + Firestore primitives
+ * (#2066). Bindings re-exported as-is so existing js/* test mocks apply via the
+ * @legacy alias; legacy shapes stay loose.
+ */
+export const isTeamActive = legacyIsTeamActive as (team: unknown) => boolean;
+export const executeBoundedPlayerSearch = legacyExecuteBoundedPlayerSearch as (...args: any[]) => Promise<any>;
+export const playerSearchFirestoreQueryBudget = legacyPlayerSearchFirestoreQueryBudget as number;
+export const playerSearchResultLimit = legacyPlayerSearchResultLimit as number;
+export const db: unknown = legacyDb;
+export const collection = legacyCollection as (...args: any[]) => any;
+export const doc = legacyDoc as (...args: any[]) => any;
+export const getDoc = legacyGetDoc as (...args: any[]) => Promise<any>;
+export const getDocs = legacyGetDocs as (...args: any[]) => Promise<any>;
+export const query = legacyQuery as (...args: any[]) => any;
+export const where = legacyWhere as (...args: any[]) => any;
+export const orderBy = legacyOrderBy as (...args: any[]) => any;
+export const limit = legacyLimit as (...args: any[]) => any;

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -1,20 +1,18 @@
-import { isTeamActive } from '../../../../js/team-visibility.js';
 import {
-  executeBoundedPlayerSearch,
-  playerSearchFirestoreQueryBudget,
-  playerSearchResultLimit
-} from '../../../../js/player-search-budget.js';
-import {
-  db,
   collection,
+  db,
   doc,
+  executeBoundedPlayerSearch,
   getDoc,
   getDocs,
-  query,
-  where,
+  isTeamActive,
+  limit,
   orderBy,
-  limit
-} from '../../../../js/firebase.js';
+  playerSearchFirestoreQueryBudget,
+  playerSearchResultLimit,
+  query,
+  where
+} from './adapters/legacySearchDb';
 import { loadParentHomeSummary } from './homeService';
 import { searchHelpKnowledge } from './helpKnowledgeService';
 import { getPublicTeamsPage } from './publicTeamsService';


### PR DESCRIPTION
Part of #2066. Routes `searchService` through a typed `adapters/legacySearchDb` boundary, replacing deep `js/team-visibility.js` + `js/player-search-budget.js` + `js/firebase.js` imports. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)