### PR TITLE
Typed adapter for legacy profile helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyProfileDb.ts
+++ b/apps/app/src/lib/adapters/legacyProfileDb.ts
@@ -1,0 +1,35 @@
+import {
+  createAccessCode as legacyCreateAccessCode,
+  createAccountMergeRequest as legacyCreateAccountMergeRequest,
+  generateAccessCode as legacyGenerateAccessCode,
+  getNotificationPreferencesForTeam as legacyGetNotificationPreferencesForTeam,
+  getParentTeams as legacyGetParentTeams,
+  getUserAccessCodes as legacyGetUserAccessCodes,
+  getUserAccessCodesPage as legacyGetUserAccessCodesPage,
+  getUserProfile as legacyGetUserProfile,
+  getUserTeamsWithAccess as legacyGetUserTeamsWithAccess,
+  saveNotificationPreferencesForTeam as legacySaveNotificationPreferencesForTeam,
+  updateUserProfile as legacyUpdateUserProfile,
+  upsertNotificationDeviceToken as legacyUpsertNotificationDeviceToken
+} from '@legacy/db.js';
+import { normalizeTeamNotificationPreferences as legacyNormalizeTeamNotificationPreferences } from '@legacy/notification-preferences.js';
+import { isTeamActive as legacyIsTeamActive } from '@legacy/team-visibility.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ profile helpers (#2066). Bindings
+ * re-exported as-is so existing js/* test mocks apply via the @legacy alias.
+ */
+export const createAccessCode = legacyCreateAccessCode as (...args: any[]) => Promise<any>;
+export const createAccountMergeRequest = legacyCreateAccountMergeRequest as (...args: any[]) => Promise<any>;
+export const generateAccessCode = legacyGenerateAccessCode as (...args: any[]) => any;
+export const getNotificationPreferencesForTeam = legacyGetNotificationPreferencesForTeam as (...args: any[]) => Promise<any>;
+export const getParentTeams = legacyGetParentTeams as (...args: any[]) => Promise<any>;
+export const getUserAccessCodes = legacyGetUserAccessCodes as (...args: any[]) => Promise<any>;
+export const getUserAccessCodesPage = legacyGetUserAccessCodesPage as (...args: any[]) => Promise<any>;
+export const getUserProfile = legacyGetUserProfile as (...args: any[]) => Promise<any>;
+export const getUserTeamsWithAccess = legacyGetUserTeamsWithAccess as (...args: any[]) => Promise<any>;
+export const saveNotificationPreferencesForTeam = legacySaveNotificationPreferencesForTeam as (...args: any[]) => Promise<any>;
+export const updateUserProfile = legacyUpdateUserProfile as (...args: any[]) => Promise<any>;
+export const upsertNotificationDeviceToken = legacyUpsertNotificationDeviceToken as (...args: any[]) => Promise<any>;
+export const normalizeTeamNotificationPreferences = legacyNormalizeTeamNotificationPreferences as (...args: any[]) => any;
+export const isTeamActive = legacyIsTeamActive as (team: unknown) => boolean;

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -8,15 +8,15 @@ import {
   getUserAccessCodesPage,
   getUserProfile,
   getUserTeamsWithAccess,
+  isTeamActive,
+  normalizeTeamNotificationPreferences,
   saveNotificationPreferencesForTeam,
   updateUserProfile,
   upsertNotificationDeviceToken
-} from '../../../../js/db.js';
-import { normalizeTeamNotificationPreferences } from '../../../../js/notification-preferences.js';
+} from './adapters/legacyProfileDb';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { createLogger } from './logger';
 import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
-import { isTeamActive } from '../../../../js/team-visibility.js';
 
 export {
   acquireProfilePhoto,


### PR DESCRIPTION
Part of #2066. Routes `profileService` through a typed `adapters/legacyProfileDb` boundary, replacing deep `js/db.js` + `js/notification-preferences.js` + `js/team-visibility.js` imports. Build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)