### PR TITLE
[codex] Filter media notifications by album audience

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4225,6 +4225,21 @@ function normalizeTeamMediaNotificationVisibility(value) {
   return normalizeNotificationAlbumVisibility(value);
 }
 
+function buildTeamMediaNotificationAudienceContext(folder = {}) {
+  const albumVisibility = normalizeTeamMediaNotificationVisibility(folder.visibility);
+  const allowedUserIds = normalizeNotificationAudienceUserIds(
+    folder.allowedUserIds || folder.audienceUserIds || folder.visibleToUserIds || folder.userIds
+  );
+  const allowedRoles = normalizeNotificationAudienceRoles(
+    folder.allowedRoles || folder.audienceRoles || folder.visibleToRoles || folder.roles
+  );
+  return {
+    albumVisibility,
+    ...(allowedUserIds.length ? { allowedUserIds } : {}),
+    ...(allowedRoles.length ? { allowedRoles } : {})
+  };
+}
+
 function normalizeTeamMediaNotificationItemType(value) {
   const normalized = String(value || '').trim().toLowerCase().replace(/[\s-]+/g, '_');
   if (['photo', 'image', 'team_photo'].includes(normalized)) return 'photo';
@@ -4255,7 +4270,8 @@ function buildTeamMediaNotificationBatchMetadata({ teamId, itemId, item = {}, fo
   const folderId = normalizeTeamMediaNotificationText(item.folderId || folder.id);
   if (!normalizedTeamId || !normalizedItemId || !folderId || item.deleted === true) return null;
 
-  const albumVisibility = normalizeTeamMediaNotificationVisibility(folder.visibility);
+  const audienceContext = buildTeamMediaNotificationAudienceContext(folder);
+  const albumVisibility = audienceContext.albumVisibility;
   if (albumVisibility !== 'team') return null;
 
   const createdAt = coerceDate(item.createdAt) || (now instanceof Date ? now : new Date(now));
@@ -4267,6 +4283,7 @@ function buildTeamMediaNotificationBatchMetadata({ teamId, itemId, item = {}, fo
     folderId,
     albumName: normalizeTeamMediaNotificationText(folder.name) || 'Team media',
     albumVisibility,
+    audienceContext,
     itemId: normalizedItemId,
     itemType: normalizeTeamMediaNotificationItemType(item.type || item.mediaType),
     itemTitle: normalizeTeamMediaNotificationText(item.title || item.fileName || item.name),
@@ -4308,6 +4325,7 @@ function buildTeamMediaNotificationBatchWrite(batch = {}, metadata = {}) {
     folderId: metadata.folderId,
     albumName: metadata.albumName,
     albumVisibility: metadata.albumVisibility,
+    audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility },
     windowStartAt: admin.firestore.Timestamp.fromDate(metadata.windowStartAt),
     dueAt: admin.firestore.Timestamp.fromDate(metadata.dueAt),
     status: 'pending',
@@ -4417,7 +4435,11 @@ async function dispatchDueTeamMediaNotificationBatches(now = new Date()) {
       }
 
       const folder = folderSnap.data() || {};
-      const albumVisibility = normalizeTeamMediaNotificationVisibility(folder.visibility || batch.albumVisibility);
+      const audienceContext = buildTeamMediaNotificationAudienceContext({
+        ...folder,
+        visibility: folder.visibility || batch.albumVisibility
+      });
+      const albumVisibility = audienceContext.albumVisibility;
       if (albumVisibility !== 'team') {
         await markTeamMediaNotificationBatchSkipped(batchRef, claimId, 'album_not_team_visible');
         continue;
@@ -4434,7 +4456,7 @@ async function dispatchDueTeamMediaNotificationBatches(now = new Date()) {
         title: payload.title,
         body: payload.body,
         dedupKey: `team-media:${batch.id}`,
-        audienceContext: { albumVisibility }
+        audienceContext
       });
       await markTeamMediaNotificationBatchSent(batchRef, claimId, sendResult);
       results.push({
@@ -4529,14 +4551,65 @@ function normalizeNotificationAlbumVisibility(value) {
   return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';
 }
 
+function normalizeNotificationAudienceList(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (value instanceof Set) {
+    return Array.from(value);
+  }
+  if (typeof value === 'string') {
+    return value.split(',');
+  }
+  return [];
+}
+
+function normalizeNotificationAudienceUserIds(value) {
+  return Array.from(new Set(
+    normalizeNotificationAudienceList(value)
+      .map((entry) => String(entry || '').trim())
+      .filter(Boolean)
+  ));
+}
+
+function normalizeNotificationAudienceRoles(value) {
+  return Array.from(new Set(
+    normalizeNotificationAudienceList(value)
+      .map((entry) => String(entry || '').trim().toLowerCase().replace(/[\s_]+/g, '-'))
+      .map((role) => (['admin', 'coach', 'manager', 'owner'].includes(role) ? 'staff' : role))
+      .filter((role) => ['parent', 'staff'].includes(role))
+  ));
+}
+
+function mediaAudienceAllowsUser(user, audienceContext = {}) {
+  const allowedUserIds = normalizeNotificationAudienceUserIds(audienceContext.allowedUserIds);
+  const allowedRoles = normalizeNotificationAudienceRoles(audienceContext.allowedRoles);
+  if (!allowedUserIds.length && !allowedRoles.length) return true;
+
+  const uid = String(user?.uid || '').trim();
+  const roles = normalizeNotificationAudienceRoles(user?.roles || []);
+  if (allowedUserIds.includes(uid)) return true;
+  return roles.some((role) => allowedRoles.includes(role));
+}
+
+function hasMediaAudienceConstraints(audienceContext = {}) {
+  return normalizeNotificationAudienceUserIds(audienceContext.allowedUserIds).length > 0
+    || normalizeNotificationAudienceRoles(audienceContext.allowedRoles).length > 0;
+}
+
 function canReceiveCategoryNotification(category, user, audienceContext = {}) {
   if (!user?.uid || !notificationAudienceAllowsRoles(category, user.roles)) return false;
   if (category !== 'media') return true;
   const albumVisibility = audienceContext?.staffOnly === true
     ? 'private'
     : normalizeNotificationAlbumVisibility(audienceContext.albumVisibility);
-  if (albumVisibility !== 'private') return true;
-  return Array.isArray(user.roles) && user.roles.includes('staff');
+  if (albumVisibility === 'private') {
+    if (hasMediaAudienceConstraints(audienceContext)) {
+      return mediaAudienceAllowsUser(user, audienceContext);
+    }
+    return Array.isArray(user.roles) && user.roles.includes('staff');
+  }
+  return mediaAudienceAllowsUser(user, audienceContext);
 }
 
 async function getLegacyTargetsForCategory(teamId, category, users, actorUid = null, audienceContext = {}) {

--- a/functions/test/team-media-notification-batches.test.js
+++ b/functions/test/team-media-notification-batches.test.js
@@ -28,9 +28,39 @@ test('team media notification batch metadata groups album uploads into hourly wi
 
             assert.equal(metadata.batchId, 'team_1__folder_1__2026-06-20T15_00_00_000Z');
             assert.equal(metadata.albumName, 'Game Highlights');
+            assert.deepEqual(metadata.audienceContext, { albumVisibility: 'team' });
             assert.equal(metadata.itemType, 'photo');
             assert.equal(metadata.windowStartAt.toISOString(), '2026-06-20T15:00:00.000Z');
             assert.equal(metadata.dueAt.toISOString(), '2026-06-20T16:00:00.000Z');
+        } finally {
+            cleanup();
+        }
+});
+
+test('team media notification batch writes preserve restricted album audience context', () => {
+        const { internals, cleanup } = loadNotificationInternals();
+
+        try {
+            const metadata = internals.buildTeamMediaNotificationBatchMetadata({
+                teamId: 'team-1',
+                itemId: 'photo-1',
+                item: { folderId: 'folder-1', type: 'photo' },
+                folder: {
+                    id: 'folder-1',
+                    name: 'Player gallery',
+                    visibility: 'team',
+                    allowedUserIds: ['parent-2', 'staff-1'],
+                    allowedRoles: ['parent']
+                }
+            });
+
+            const nextBatch = internals.buildTeamMediaNotificationBatchWrite({}, metadata);
+
+            assert.deepEqual(nextBatch.audienceContext, {
+                albumVisibility: 'team',
+                allowedUserIds: ['parent-2', 'staff-1'],
+                allowedRoles: ['parent']
+            });
         } finally {
             cleanup();
         }

--- a/tests/unit/media-award-notification-contract.test.js
+++ b/tests/unit/media-award-notification-contract.test.js
@@ -28,7 +28,7 @@ describe('media and award notification contract', () => {
         expect(functionsSource).toContain('await markTeamMediaNotificationBatchSkipped(batchRef, claimId, \'album_not_team_visible\');');
         expect(functionsSource).toContain("category: 'media'");
         expect(functionsSource).toContain('dedupKey: `team-media:${batch.id}`');
-        expect(functionsSource).toContain('audienceContext: { albumVisibility }');
+        expect(functionsSource).toContain('audienceContext');
         expect(functionsSource).toContain('exports.dispatchDueTeamMediaNotificationBatches = functions.pubsub');
         expect(firestoreIndexes).toContain('"collectionGroup": "teamMediaNotificationBatches"');
         expect(firestoreIndexes).toContain('"fieldPath": "status"');

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -111,7 +111,8 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
         expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true");
         expect(functionsSource).toContain("return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';");
-        expect(functionsSource).toContain("if (albumVisibility !== 'private') return true;");
+        expect(functionsSource).toContain('if (hasMediaAudienceConstraints(audienceContext))');
+        expect(functionsSource).toContain('return mediaAudienceAllowsUser(user, audienceContext);');
         expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
         expect(targetResolverSource).toContain('const missingUsers = users.filter');
         expect(targetResolverSource).toContain('teamNotificationRecipientIndexIsEmpty(teamId)');

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -124,7 +124,7 @@ describe('team media notification recipients', () => {
         expect(functionsSource).toContain("firestore.collection('teamMediaNotificationBatches')");
         expect(functionsSource).toContain("category: 'media'");
         expect(functionsSource).toContain('dedupKey: `team-media:${batch.id}`');
-        expect(functionsSource).toContain("audienceContext: { albumVisibility }");
+        expect(functionsSource).toContain('audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility }');
         expect(functionsSource).toContain("['sent', 'sending', 'skipped'].includes(currentStatus)");
         expect(firestoreIndexes).toContain('"collectionGroup": "teamMediaNotificationBatches"');
         expect(firestoreIndexes).toContain('"fieldPath": "dueAt"');
@@ -189,6 +189,72 @@ describe('team media notification recipients', () => {
                 uid: 'staff-1',
                 deviceId: 'staff-device',
                 token: 'staff-token',
+                teamId: 'team-1'
+            }
+        ]);
+    });
+
+    it('filters indexed team-visible media recipients by explicit allowed user ids', async () => {
+        const harness = createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'parent-2', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            indexedTargets: [
+                { uid: 'parent-1', deviceId: 'parent-1-device', token: 'parent-1-token' },
+                { uid: 'parent-2', deviceId: 'parent-2-device', token: 'parent-2-token' },
+                { uid: 'staff-1', deviceId: 'staff-device', token: 'staff-token' }
+            ]
+        });
+
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, {
+            albumVisibility: 'team',
+            allowedUserIds: ['parent-2', 'staff-1']
+        });
+
+        expect(normalizeTargets(targets)).toEqual([
+            {
+                uid: 'parent-2',
+                deviceId: 'parent-2-device',
+                token: 'parent-2-token',
+                teamId: 'team-1'
+            },
+            {
+                uid: 'staff-1',
+                deviceId: 'staff-device',
+                token: 'staff-token',
+                teamId: 'team-1'
+            }
+        ]);
+    });
+
+    it('filters fallback team-visible media recipients by explicit audience roles', async () => {
+        const harness = createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            preferences: {
+                'parent-1': { 'team-1': { media: true } },
+                'staff-1': { 'team-1': { media: true } }
+            },
+            devices: {
+                'parent-1': [{ deviceId: 'parent-device', token: 'parent-token' }],
+                'staff-1': [{ deviceId: 'staff-device', token: 'staff-token' }]
+            }
+        });
+
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, {
+            albumVisibility: 'team',
+            allowedRoles: ['parent']
+        });
+
+        expect(normalizeTargets(targets)).toEqual([
+            {
+                uid: 'parent-1',
+                deviceId: 'parent-device',
+                token: 'parent-token',
                 teamId: 'team-1'
             }
         ]);

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -42,7 +42,11 @@ describe('team media visibility notification contract', () => {
         expect(functionsSource).toContain('function canReceiveCategoryNotification(category, user, audienceContext = {}) {');
         expect(functionsSource).toContain("if (category !== 'media') return true;");
         expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true\n    ? 'private'\n    : normalizeNotificationAlbumVisibility(audienceContext.albumVisibility);");
-        expect(functionsSource).toContain("if (albumVisibility !== 'private') return true;");
+        expect(functionsSource).toContain('function normalizeNotificationAudienceUserIds(value) {');
+        expect(functionsSource).toContain('function normalizeNotificationAudienceRoles(value) {');
+        expect(functionsSource).toContain('function mediaAudienceAllowsUser(user, audienceContext = {}) {');
+        expect(functionsSource).toContain('function hasMediaAudienceConstraints(audienceContext = {}) {');
+        expect(functionsSource).toContain("if (hasMediaAudienceConstraints(audienceContext)) {\n      return mediaAudienceAllowsUser(user, audienceContext);\n    }");
         expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
     });
 
@@ -53,5 +57,7 @@ describe('team media visibility notification contract', () => {
         expect(functionsSource).toContain('const eligibleUsers = new Map(users');
         expect(functionsSource).toContain('eligibleUsers.has(user.uid)');
         expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);');
+        expect(functionsSource).toContain('audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility }');
+        expect(functionsSource).toContain('const audienceContext = buildTeamMediaNotificationAudienceContext({');
     });
 });


### PR DESCRIPTION
Refs #2657

## Summary
- carry team media album audience constraints into queued notification batches
- enforce allowed user IDs and allowed roles for both indexed and legacy media notification targets before fanout
- keep private/staff-only album behavior staff-limited unless an explicit audience is provided

## Tests
- npx vitest run tests/unit/team-media-notification-recipients.test.js tests/unit/team-media-visibility-notification-contract.test.js tests/unit/media-award-notification-contract.test.js --reporter=verbose
- cd functions && npx vitest run test/team-media-notification-batches.test.js --reporter=verbose