### PR TITLE
[codex] Cover visible media notification eligibility

### DIFF
--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -124,7 +124,8 @@ describe('team media notification recipients', () => {
         expect(functionsSource).toContain("firestore.collection('teamMediaNotificationBatches')");
         expect(functionsSource).toContain("category: 'media'");
         expect(functionsSource).toContain('dedupKey: `team-media:${batch.id}`');
-        expect(functionsSource).toContain("audienceContext: { albumVisibility }");
+        expect(functionsSource).toContain('const audienceContext = buildTeamMediaNotificationAudienceContext({');
+        expect(functionsSource).toMatch(/sendCategoryNotification\(\{[\s\S]*dedupKey: `team-media:\$\{batch\.id\}`,[\s\S]*audienceContext[\s\S]*\}\)/);
         expect(functionsSource).toContain("['sent', 'sending', 'skipped'].includes(currentStatus)");
         expect(firestoreIndexes).toContain('"collectionGroup": "teamMediaNotificationBatches"');
         expect(firestoreIndexes).toContain('"fieldPath": "dueAt"');

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -124,7 +124,7 @@ describe('team media notification recipients', () => {
         expect(functionsSource).toContain("firestore.collection('teamMediaNotificationBatches')");
         expect(functionsSource).toContain("category: 'media'");
         expect(functionsSource).toContain('dedupKey: `team-media:${batch.id}`');
-        expect(functionsSource).toContain('audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility }');
+        expect(functionsSource).toContain("audienceContext: { albumVisibility }");
         expect(functionsSource).toContain("['sent', 'sending', 'skipped'].includes(currentStatus)");
         expect(firestoreIndexes).toContain('"collectionGroup": "teamMediaNotificationBatches"');
         expect(firestoreIndexes).toContain('"fieldPath": "dueAt"');
@@ -194,6 +194,38 @@ describe('team media notification recipients', () => {
         ]);
     });
 
+    it('keeps indexed parent and staff targets for standard visible albums', async () => {
+        const harness = createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'parent-disabled', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            indexedTargets: [
+                { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { media: true } },
+                { uid: 'parent-disabled', deviceId: 'disabled-device', token: 'disabled-token', categories: { media: false } },
+                { uid: 'staff-1', deviceId: 'staff-device', token: 'staff-token', categories: { media: true } }
+            ]
+        });
+
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, { albumVisibility: 'team' });
+
+        expect(normalizeTargets(targets)).toEqual([
+            {
+                uid: 'parent-1',
+                deviceId: 'parent-device',
+                token: 'parent-token',
+                teamId: 'team-1'
+            },
+            {
+                uid: 'staff-1',
+                deviceId: 'staff-device',
+                token: 'staff-token',
+                teamId: 'team-1'
+            }
+        ]);
+    });
+
     it('filters indexed team-visible media recipients by explicit allowed user ids', async () => {
         const harness = createHarness({
             candidateUsers: [
@@ -227,6 +259,25 @@ describe('team media notification recipients', () => {
                 teamId: 'team-1'
             }
         ]);
+    });
+
+    it('distinguishes visible and restricted album eligibility with the same candidate users', async () => {
+        const createSharedHarness = () => createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            indexedTargets: [
+                { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token' },
+                { uid: 'staff-1', deviceId: 'staff-device', token: 'staff-token' }
+            ]
+        });
+
+        const visibleTargets = await createSharedHarness().getTargetsForCategory('team-1', 'media', null, { albumVisibility: 'team' });
+        const restrictedTargets = await createSharedHarness().getTargetsForCategory('team-1', 'media', null, { albumVisibility: 'private' });
+
+        expect(normalizeTargets(visibleTargets).map((target) => target.uid)).toEqual(['parent-1', 'staff-1']);
+        expect(normalizeTargets(restrictedTargets).map((target) => target.uid)).toEqual(['staff-1']);
     });
 
     it('filters fallback team-visible media recipients by explicit audience roles', async () => {


### PR DESCRIPTION
Refs #2658

## Summary
- add indexed-recipient coverage proving standard team-visible media albums still notify eligible parents and staff
- add a same-candidate regression check contrasting visible and restricted album eligibility

## Tests
- npx vitest run tests/unit/team-media-notification-recipients.test.js tests/unit/team-media-visibility-notification-contract.test.js --reporter=verbose