### PR TITLE
Typed adapter for legacy team-chat logic helpers (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyChatLogic.ts
+++ b/apps/app/src/lib/adapters/legacyChatLogic.ts
@@ -1,0 +1,21 @@
+import { DEFAULT_TEAM_CONVERSATION_ID as legacyDefaultTeamConversationId, buildDefaultTeamConversation as legacyBuildDefaultTeamConversation, getConversationDisplayName as legacyGetConversationDisplayName, isDefaultTeamConversation as legacyIsDefaultTeamConversation } from '@legacy/team-chat-conversations.js';
+import { MAX_CHAT_MEDIA_SIZE as legacyMaxChatMediaSize, buildChatMediaShareDetails as legacyBuildChatMediaShareDetails, collectThreadMedia as legacyCollectThreadMedia, getChatMediaActionState as legacyGetChatMediaActionState, getChatMediaDownloadName as legacyGetChatMediaDownloadName, getMessageAttachments as legacyGetMessageAttachments, isSafeChatMediaUrl as legacyIsSafeChatMediaUrl } from '@legacy/team-chat-media.js';
+import { shouldRetryChatLastReadOnViewReturn as legacyShouldRetryChatLastReadOnViewReturn, shouldUpdateChatLastRead as legacyShouldUpdateChatLastRead } from '@legacy/team-chat-last-read.js';
+
+/**
+ * Typed adapter boundary for the legacy js/ team-chat helpers (#2066). Bindings
+ * re-exported as-is so existing js/* test mocks apply via the @legacy alias.
+ */
+export const DEFAULT_TEAM_CONVERSATION_ID = legacyDefaultTeamConversationId as string;
+export const buildDefaultTeamConversation = legacyBuildDefaultTeamConversation as (...args: any[]) => any;
+export const getConversationDisplayName = legacyGetConversationDisplayName as (...args: any[]) => string;
+export const isDefaultTeamConversation = legacyIsDefaultTeamConversation as (...args: any[]) => boolean;
+export const MAX_CHAT_MEDIA_SIZE = legacyMaxChatMediaSize as number;
+export const buildChatMediaShareDetails = legacyBuildChatMediaShareDetails as (...args: any[]) => any;
+export const collectThreadMedia = legacyCollectThreadMedia as (...args: any[]) => any;
+export const getChatMediaActionState = legacyGetChatMediaActionState as (...args: any[]) => any;
+export const getChatMediaDownloadName = legacyGetChatMediaDownloadName as (...args: any[]) => string;
+export const getMessageAttachments = legacyGetMessageAttachments as (...args: any[]) => any;
+export const isSafeChatMediaUrl = legacyIsSafeChatMediaUrl as (...args: any[]) => boolean;
+export const shouldRetryChatLastReadOnViewReturn = legacyShouldRetryChatLastReadOnViewReturn as (...args: any[]) => boolean;
+export const shouldUpdateChatLastRead = legacyShouldUpdateChatLastRead as (...args: any[]) => boolean;

--- a/apps/app/src/lib/chatLogic.ts
+++ b/apps/app/src/lib/chatLogic.ts
@@ -1,23 +1,19 @@
 import DOMPurifyModule from 'dompurify';
 import {
-  DEFAULT_TEAM_CONVERSATION_ID,
-  buildDefaultTeamConversation,
-  getConversationDisplayName,
-  isDefaultTeamConversation
-} from '../../../../js/team-chat-conversations.js';
-import {
-  MAX_CHAT_MEDIA_SIZE,
   buildChatMediaShareDetails,
+  buildDefaultTeamConversation,
   collectThreadMedia,
+  DEFAULT_TEAM_CONVERSATION_ID,
   getChatMediaActionState,
   getChatMediaDownloadName,
+  getConversationDisplayName,
   getMessageAttachments,
-  isSafeChatMediaUrl
-} from '../../../../js/team-chat-media.js';
-import {
+  isDefaultTeamConversation,
+  isSafeChatMediaUrl,
+  MAX_CHAT_MEDIA_SIZE,
   shouldRetryChatLastReadOnViewReturn,
   shouldUpdateChatLastRead
-} from '../../../../js/team-chat-last-read.js';
+} from './adapters/legacyChatLogic';
 
 export {
   DEFAULT_TEAM_CONVERSATION_ID,


### PR DESCRIPTION
Part of #2066. Routes `chatLogic` through a typed `adapters/legacyChatLogic` boundary, replacing deep `js/team-chat-conversations.js` + `team-chat-media.js` + `team-chat-last-read.js` imports. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)