### PR TITLE
Typed adapter for vendored Firebase auth SDK runtime (#2066)

### DIFF
--- a/apps/app/src/lib/adapters/legacyFirebaseAuthSdk.ts
+++ b/apps/app/src/lib/adapters/legacyFirebaseAuthSdk.ts
@@ -1,0 +1,52 @@
+import { getApp as legacyGetApp, getApps as legacyGetApps, initializeApp as legacyInitializeApp } from '@legacy/vendor/firebase-app.js';
+import {
+  applyActionCode as legacyApplyActionCode,
+  confirmPasswordReset as legacyConfirmPasswordReset,
+  createUserWithEmailAndPassword as legacyCreateUserWithEmailAndPassword,
+  getAuth as legacyGetAuth,
+  getRedirectResult as legacyGetRedirectResult,
+  GoogleAuthProvider as LegacyGoogleAuthProvider,
+  indexedDBLocalPersistence as legacyIndexedDBLocalPersistence,
+  initializeAuth as legacyInitializeAuth,
+  isSignInWithEmailLink as legacyIsSignInWithEmailLink,
+  onAuthStateChanged as legacyOnAuthStateChanged,
+  sendEmailVerification as legacySendEmailVerification,
+  sendPasswordResetEmail as legacySendPasswordResetEmail,
+  signInWithEmailAndPassword as legacySignInWithEmailAndPassword,
+  signInWithEmailLink as legacySignInWithEmailLink,
+  signInWithPopup as legacySignInWithPopup,
+  signInWithRedirect as legacySignInWithRedirect,
+  signOut as legacySignOut,
+  updatePassword as legacyUpdatePassword,
+  verifyPasswordResetCode as legacyVerifyPasswordResetCode
+} from '@legacy/vendor/firebase-auth.js';
+import { resolvePrimaryFirebaseConfig as legacyResolvePrimaryFirebaseConfig } from '@legacy/firebase-runtime-config.js';
+
+/**
+ * Typed adapter boundary for the vendored Firebase app/auth SDK + runtime config
+ * used by firebaseAuthRuntime (#2066). Bindings re-exported as-is (no behavior
+ * change to the auth boot path); SDK shapes stay loose.
+ */
+export const getApp = legacyGetApp as (...args: any[]) => any;
+export const getApps = legacyGetApps as () => any[];
+export const initializeApp = legacyInitializeApp as (...args: any[]) => any;
+export const applyActionCode = legacyApplyActionCode as (...args: any[]) => Promise<any>;
+export const confirmPasswordReset = legacyConfirmPasswordReset as (...args: any[]) => Promise<any>;
+export const createUserWithEmailAndPassword = legacyCreateUserWithEmailAndPassword as (...args: any[]) => Promise<any>;
+export const getAuth = legacyGetAuth as (...args: any[]) => any;
+export const getRedirectResult = legacyGetRedirectResult as (...args: any[]) => Promise<any>;
+export const GoogleAuthProvider = LegacyGoogleAuthProvider as any;
+export const indexedDBLocalPersistence = legacyIndexedDBLocalPersistence as any;
+export const initializeAuth = legacyInitializeAuth as (...args: any[]) => any;
+export const isSignInWithEmailLink = legacyIsSignInWithEmailLink as (...args: any[]) => boolean;
+export const onAuthStateChanged = legacyOnAuthStateChanged as (...args: any[]) => () => void;
+export const sendEmailVerification = legacySendEmailVerification as (...args: any[]) => Promise<any>;
+export const sendPasswordResetEmail = legacySendPasswordResetEmail as (...args: any[]) => Promise<any>;
+export const signInWithEmailAndPassword = legacySignInWithEmailAndPassword as (...args: any[]) => Promise<any>;
+export const signInWithEmailLink = legacySignInWithEmailLink as (...args: any[]) => Promise<any>;
+export const signInWithPopup = legacySignInWithPopup as (...args: any[]) => Promise<any>;
+export const signInWithRedirect = legacySignInWithRedirect as (...args: any[]) => Promise<any>;
+export const signOut = legacySignOut as (...args: any[]) => Promise<any>;
+export const updatePassword = legacyUpdatePassword as (...args: any[]) => Promise<any>;
+export const verifyPasswordResetCode = legacyVerifyPasswordResetCode as (...args: any[]) => Promise<any>;
+export const resolvePrimaryFirebaseConfig = legacyResolvePrimaryFirebaseConfig as (...args: any[]) => Promise<any>;

--- a/apps/app/src/lib/firebaseAuthRuntime.ts
+++ b/apps/app/src/lib/firebaseAuthRuntime.ts
@@ -1,15 +1,18 @@
-import { getApp, getApps, initializeApp } from '../../../../js/vendor/firebase-app.js';
 import {
   applyActionCode,
   confirmPasswordReset,
   createUserWithEmailAndPassword,
+  getApp,
+  getApps,
   getAuth,
   getRedirectResult,
   GoogleAuthProvider,
   indexedDBLocalPersistence,
+  initializeApp,
   initializeAuth,
   isSignInWithEmailLink,
   onAuthStateChanged,
+  resolvePrimaryFirebaseConfig,
   sendEmailVerification,
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
@@ -19,8 +22,7 @@ import {
   signOut,
   updatePassword,
   verifyPasswordResetCode
-} from '../../../../js/vendor/firebase-auth.js';
-import { resolvePrimaryFirebaseConfig } from '../../../../js/firebase-runtime-config.js';
+} from './adapters/legacyFirebaseAuthSdk';
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);


### PR DESCRIPTION
Part of #2066. Routes `firebaseAuthRuntime` through a typed `adapters/legacyFirebaseAuthSdk` boundary instead of deep `js/vendor/firebase-app.js` + `js/vendor/firebase-auth.js` + `js/firebase-runtime-config.js` imports. Direct re-exports keep the auth boot path identical. Build + `authService` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)