### PR TITLE
Clear stale private stats on finish

### DIFF
--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -186,21 +186,23 @@ export async function commitStandardTrackerFinishData({
     }
 
     for (const { playerId, publicData, privateData } of aggregatedStatsWrites) {
-        const writeCount = privateData ? 2 : 1;
+        const writeCount = 2;
         if (statsBatchWriteCount > 0 && statsBatchWriteCount + writeCount > maxAggregatedStatsBatchWrites) {
             await commitStatsBatch();
         }
 
         ensureStatsBatch();
         const statsRef = doc(db, `teams/${teamId}/games/${gameId}/aggregatedStats`, playerId);
+        const privateStatsRef = doc(db, `teams/${teamId}/games/${gameId}/privatePlayerStats`, playerId);
         statsBatch.set(statsRef, publicData);
         statsBatchWriteCount += 1;
 
         if (privateData) {
-            const privateStatsRef = doc(db, `teams/${teamId}/games/${gameId}/privatePlayerStats`, playerId);
             statsBatch.set(privateStatsRef, privateData);
-            statsBatchWriteCount += 1;
+        } else {
+            statsBatch.delete(privateStatsRef);
         }
+        statsBatchWriteCount += 1;
     }
     await commitStatsBatch();
 

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -21,6 +21,9 @@ function createFirestoreHarness({ commitFailuresByBatchIndex = {} } = {}) {
                 update(ref, data) {
                     this.operations.push({ type: 'update', ref, data });
                 },
+                delete(ref) {
+                    this.operations.push({ type: 'delete', ref });
+                },
                 async commit() {
                     this.commitCount += 1;
                     if (commitFailuresByBatchIndex[batchIndex]) {
@@ -103,9 +106,9 @@ describe('standard tracker finish batch limits', () => {
         });
 
         expect(result.eventBatchSizes).toEqual([499]);
-        expect(result.aggregatedStatsBatchSizes).toEqual([450, 450, 5]);
+        expect(result.aggregatedStatsBatchSizes).toEqual([450, 450, 450, 450, 10]);
         expect(result.gameUpdateBatchSize).toBe(1);
-        expect(harness.batches).toHaveLength(5);
+        expect(harness.batches).toHaveLength(7);
 
         const [eventBatch, ...secondaryBatches] = harness.batches;
         const gameUpdateBatch = secondaryBatches.pop();
@@ -113,11 +116,15 @@ describe('standard tracker finish batch limits', () => {
         expect(eventBatch.operations).toHaveLength(499);
         expect(eventBatch.operations.every((op) => op.type === 'set')).toBe(true);
 
-        expect(secondaryBatches.map((batch) => batch.operations.length)).toEqual([450, 450, 5]);
+        expect(secondaryBatches.map((batch) => batch.operations.length)).toEqual([450, 450, 450, 450, 10]);
         secondaryBatches.forEach((batch) => {
             expect(batch.commitCount).toBe(1);
-            expect(batch.operations.every((op) => op.type === 'set')).toBe(true);
+            expect(batch.operations.every((op) => op.type === 'set' || op.type === 'delete')).toBe(true);
         });
+        expect(secondaryBatches[0].operations.slice(0, 2)).toEqual([
+            expect.objectContaining({ type: 'set', ref: { path: 'teams/team-1/games/game-1/aggregatedStats/player-1' } }),
+            expect.objectContaining({ type: 'delete', ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/player-1' } })
+        ]);
         expect(gameUpdateBatch.operations).toEqual([
             expect.objectContaining({ type: 'update', ref: { path: 'teams/team-1/games/game-1' } })
         ]);
@@ -218,6 +225,47 @@ describe('standard tracker finish batch limits', () => {
         ]);
     });
 
+    it('deletes stale private player stats when the current finish has no private payload', async () => {
+        const harness = createFirestoreHarness();
+
+        await commitStandardTrackerFinishData({
+            db: harness.db,
+            writeBatch: harness.writeBatch,
+            doc: harness.doc,
+            collection: harness.collection,
+            teamId: 'team-1',
+            gameId: 'game-1',
+            currentUserUid: 'coach-1',
+            gameLog: [],
+            players: [{ id: 'p1', name: 'Ava', number: '3' }],
+            playerStatsByPlayerId: { p1: { pts: 8 } },
+            columns: ['PTS'],
+            statTrackerConfig: {
+                columns: ['PTS'],
+                statDefinitions: [
+                    { label: 'PTS', acronym: 'PTS' }
+                ]
+            },
+            finalHome: 8,
+            finalAway: 6,
+            summary: 'Finished cleanly.',
+            opponentStats: {}
+        });
+
+        expect(harness.batches[0].operations).toEqual([
+            expect.objectContaining({
+                type: 'set',
+                ref: { path: 'teams/team-1/games/game-1/aggregatedStats/p1' },
+                data: expect.objectContaining({ stats: { pts: 8 } })
+            }),
+            {
+                type: 'delete',
+                ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/p1' }
+            }
+        ]);
+    });
+
+
     it('chunks more than 500 game logs instead of rejecting the finish', async () => {
         const { harness, result } = await runFinishSave({
             eventCount: 1001,
@@ -225,8 +273,8 @@ describe('standard tracker finish batch limits', () => {
         });
 
         expect(result.eventBatchSizes).toEqual([500, 500, 1]);
-        expect(result.aggregatedStatsBatchSizes).toEqual([12]);
-        expect(harness.batches.map((batch) => batch.operations.length)).toEqual([500, 500, 1, 12, 1]);
+        expect(result.aggregatedStatsBatchSizes).toEqual([24]);
+        expect(harness.batches.map((batch) => batch.operations.length)).toEqual([500, 500, 1, 24, 1]);
         expect(harness.batches[0].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000001');
         expect(harness.batches[0].operations[499].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000500');
         expect(harness.batches[1].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000501');
@@ -276,7 +324,11 @@ describe('standard tracker finish batch limits', () => {
             timeMs: 123000,
             stats: expect.objectContaining({ pts: 2, fouls: 1 })
         });
-        expect(harness.batches[1].operations[1].data).toMatchObject({
+        expect(harness.batches[1].operations[1]).toEqual({
+            type: 'delete',
+            ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/p1' }
+        });
+        expect(harness.batches[1].operations[2].data).toMatchObject({
             playerName: 'Ben',
             playerNumber: '12',
             participated: false,
@@ -285,7 +337,11 @@ describe('standard tracker finish batch limits', () => {
             timeMs: 0,
             stats: { pts: 0, fouls: 0 }
         });
-        expect(hasPlayerProfileParticipation(harness.batches[1].operations[1].data)).toBe(false);
+        expect(harness.batches[1].operations[3]).toEqual({
+            type: 'delete',
+            ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/p2' }
+        });
+        expect(hasPlayerProfileParticipation(harness.batches[1].operations[2].data)).toBe(false);
     });
 
     it('rejects when a secondary aggregated stats batch fails after primary commit', async () => {


### PR DESCRIPTION
## Summary
- Deletes `privatePlayerStats/{playerId}` when the current finish payload has no private stats for that player
- Keeps public aggregated stats and private stat cleanup in the same replacement batch path
- Updates batch-size coverage and adds a stale private doc regression

Fixes #2645

## Tests
- npx vitest run tests/unit/track-finish-batch-limit.test.js --reporter=verbose