### PR TITLE
Cover media notification visibility eligibility

### DIFF
--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -228,6 +228,63 @@ test('getTargetsForCategory limits staff-only media notifications to staff recip
         }
 });
 
+test('getTargetsForCategory preserves eligible recipients for visible media albums while honoring restrictions', async () => {
+        const { internals, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1', 'parent-2'],
+            indexedTargets: [
+                {
+                    uid: 'coach-1',
+                    deviceId: 'coach-device',
+                    token: 'coach-token',
+                    categories: { media: true }
+                },
+                {
+                    uid: 'parent-1',
+                    deviceId: 'parent-1-device',
+                    token: 'parent-1-token',
+                    categories: { media: true }
+                },
+                {
+                    uid: 'parent-2',
+                    deviceId: 'parent-2-device',
+                    token: 'parent-2-token',
+                    categories: { media: true }
+                }
+            ]
+        });
+
+        try {
+            const visibleTargets = await internals.getTargetsForCategory('team-1', 'media', null, {
+                albumVisibility: 'team'
+            });
+            const restrictedTargets = await internals.getTargetsForCategory('team-1', 'media', null, {
+                albumVisibility: 'team',
+                allowedUserIds: ['parent-2'],
+                allowedRoles: ['staff']
+            });
+            const staffOnlyTargets = await internals.getTargetsForCategory('team-1', 'media', null, {
+                albumVisibility: 'staff-only'
+            });
+
+            assert.deepEqual(visibleTargets.map((target) => target.token).sort(), [
+                'coach-token',
+                'parent-1-token',
+                'parent-2-token'
+            ]);
+            assert.deepEqual(restrictedTargets.map((target) => target.token).sort(), [
+                'coach-token',
+                'parent-2-token'
+            ]);
+            assert.deepEqual(staffOnlyTargets.map((target) => target.token), ['coach-token']);
+        } finally {
+            cleanup();
+        }
+});
+
 test('getTargetsForCategoryUserIds restricts RSVP targets to requested recipients with enabled preferences', async () => {
         const { internals, cleanup } = loadNotificationInternals({
             teamDoc: {


### PR DESCRIPTION
## Summary
- Adds regression coverage for standard team-visible media albums still notifying eligible recipients
- Verifies restricted media audiences only notify allowed users/roles
- Keeps staff-only album coverage distinct from standard visible album behavior

Fixes #2658

## Tests
- npx vitest run functions/test/send-category-notification.test.js --reporter=verbose