### PR TITLE
Fix merged review findings

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -904,13 +904,13 @@
                 team?.teamCalendarToken;
             if (!token || !team?.id) return '';
 
-            const configuredUrl = window.__ALLPLAYS_CONFIG__?.privateTeamCalendarIcsFunctionUrl || window.ALLPLAYS_PRIVATE_TEAM_CALENDAR_ICS_URL;
+            const configuredUrl = window.__ALLPLAYS_CONFIG__?.teamCalendarFeedFunctionUrl || window.ALLPLAYS_TEAM_CALENDAR_FEED_URL;
             const fallbackUrl = window.__ALLPLAYS_CONFIG__?.calendarFetchFunctionUrl || window.ALLPLAYS_CALENDAR_FUNCTION_URL;
             const baseUrl = (typeof configuredUrl === 'string' && configuredUrl.trim())
                 ? configuredUrl.trim()
                 : (typeof fallbackUrl === 'string' && fallbackUrl.includes('fetchCalendarIcs')
-                    ? fallbackUrl.replace('fetchCalendarIcs', 'privateTeamCalendarIcs')
-                    : 'https://us-central1-all-plays-prod.cloudfunctions.net/privateTeamCalendarIcs');
+                    ? fallbackUrl.replace('fetchCalendarIcs', 'teamCalendarFeed')
+                    : 'https://us-central1-all-plays-prod.cloudfunctions.net/teamCalendarFeed');
             const separator = baseUrl.includes('?') ? '&' : '?';
             return `${baseUrl}${separator}teamId=${encodeURIComponent(team.id)}&token=${encodeURIComponent(token)}`;
         }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1929,8 +1929,7 @@ service cloud.firestore {
 
         // Manager-only player stats subcollection for private player-scoped metrics.
         match /privatePlayerStats/{statId} {
-          allow read, create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);
-          allow delete: if isTeamOwnerOrAdmin(teamId);
+          allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);
         }
 
         // Live Events subcollection - for real-time game broadcasting

--- a/tests/unit/calendar-sync-action.test.js
+++ b/tests/unit/calendar-sync-action.test.js
@@ -28,7 +28,10 @@ describe('calendar page live sync controls', () => {
         expect(source).toContain('function getPrivateCalendarFeedUrl(team)');
         expect(source).toContain('team?.calendarSubscriptionUrl');
         expect(source).toContain('team?.calendarSubscriptionToken');
-        expect(source).toContain('privateTeamCalendarIcs');
+        expect(source).toContain('teamCalendarFeedFunctionUrl');
+        expect(source).toContain('ALLPLAYS_TEAM_CALENDAR_FEED_URL');
+        expect(source).toContain('teamCalendarFeed');
+        expect(source).not.toContain('privateTeamCalendarIcs');
         expect(source).toContain("return feedUrl.replace(/^https?:\\/\\//i, 'webcal://');");
         expect(source).toContain("https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedUrl)}");
         expect(source).toContain("navigator.clipboard.writeText(feedUrl)");

--- a/tests/unit/scorekeeping-access-wiring.test.js
+++ b/tests/unit/scorekeeping-access-wiring.test.js
@@ -36,6 +36,8 @@ describe('scorekeeping access wiring', () => {
         expect(rules).toContain('function canScorekeepGame(teamId, gameId)');
         expect(rules).toMatch(/allow update: if isTeamOwnerOrAdmin\(teamId\) \|\|\s+\(isOfficialForGame\(\) && isOfficialGameUpdate\(\)\) \|\|\s+isScorekeepingGameUpdate\(teamId, gameId\) \|\|\s+isVideographyGameUpdate\(teamId, gameId\);/);
         expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);');
+        expect(rules).toContain('match /privatePlayerStats/{statId}');
+        expect(rules).toContain('allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);');
         expect(rules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
     });
 });


### PR DESCRIPTION
## Summary
- Allows delegated scorekeepers to delete stale `privatePlayerStats` docs created by the Track Finish cleanup path
- Points Calendar page token feed fallback URLs at the exported `teamCalendarFeed` function
- Updates regression coverage for both review findings

Follow-up for review comments on #2702 and #2703.

## Tests
- npx vitest run tests/unit/calendar-sync-action.test.js tests/unit/scorekeeping-access-wiring.test.js tests/unit/track-finish-batch-limit.test.js --reporter=verbose