### PR TITLE
Filter media notifications by album visibility

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4609,10 +4609,12 @@ function canReceiveCategoryNotification(category, user, audienceContext = {}) {
     ? 'private'
     : normalizeNotificationAlbumVisibility(audienceContext.albumVisibility);
   if (albumVisibility === 'private') {
+    const isStaffUser = Array.isArray(user.roles) && user.roles.includes('staff');
+    if (!isStaffUser) return false;
     if (hasMediaAudienceConstraints(audienceContext)) {
       return mediaAudienceAllowsUser(user, audienceContext);
     }
-    return Array.isArray(user.roles) && user.roles.includes('staff');
+    return true;
   }
   return mediaAudienceAllowsUser(user, audienceContext);
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -4282,7 +4282,6 @@ function buildTeamMediaNotificationBatchMetadata({ teamId, itemId, item = {}, fo
 
   const audienceContext = buildTeamMediaNotificationAudienceContext(folder);
   const albumVisibility = audienceContext.albumVisibility;
-  if (albumVisibility !== 'team') return null;
 
   const createdAt = coerceDate(item.createdAt) || (now instanceof Date ? now : new Date(now));
   const windowStartAt = getTeamMediaNotificationWindowStart(createdAt);
@@ -4450,10 +4449,6 @@ async function dispatchDueTeamMediaNotificationBatches(now = new Date()) {
         visibility: folder.visibility || batch.albumVisibility
       });
       const albumVisibility = audienceContext.albumVisibility;
-      if (albumVisibility !== 'team') {
-        await markTeamMediaNotificationBatchSkipped(batchRef, claimId, 'album_not_team_visible');
-        continue;
-      }
 
       const payload = buildTeamMediaNotificationPayload({
         ...batch,

--- a/functions/test/team-media-notification-batches.test.js
+++ b/functions/test/team-media-notification-batches.test.js
@@ -66,16 +66,26 @@ test('team media notification batch writes preserve restricted album audience co
         }
 });
 
-test('team media notification batch metadata skips private albums and deleted items', () => {
+test('team media notification batch metadata preserves private album audience rules and skips deleted items', () => {
         const { internals, cleanup } = loadNotificationInternals();
 
         try {
-            assert.equal(internals.buildTeamMediaNotificationBatchMetadata({
+            assert.deepEqual(internals.buildTeamMediaNotificationBatchMetadata({
                 teamId: 'team-1',
                 itemId: 'photo-1',
                 item: { folderId: 'folder-1', type: 'photo' },
-                folder: { id: 'folder-1', name: 'Private film', visibility: 'private' }
-            }), null);
+                folder: {
+                    id: 'folder-1',
+                    name: 'Private film',
+                    visibility: 'private',
+                    allowedUserIds: ['parent-2'],
+                    allowedRoles: ['staff']
+                }
+            })?.audienceContext, {
+                albumVisibility: 'private',
+                allowedUserIds: ['parent-2'],
+                allowedRoles: ['staff']
+            });
             assert.equal(internals.buildTeamMediaNotificationBatchMetadata({
                 teamId: 'team-1',
                 itemId: 'photo-2',

--- a/tests/unit/media-award-notification-contract.test.js
+++ b/tests/unit/media-award-notification-contract.test.js
@@ -5,11 +5,11 @@ const functionsSource = readFileSync(new URL('../../functions/index.js', import.
 const firestoreIndexes = readFileSync(new URL('../../firestore.indexes.json', import.meta.url), 'utf8');
 
 describe('media and award notification contract', () => {
-    it('queues team-visible media items into hourly notification batches', () => {
+    it('queues visible and restricted media items into hourly notification batches', () => {
         expect(functionsSource).toContain('const TEAM_MEDIA_NOTIFICATION_BATCH_WINDOW_MS = 60 * 60 * 1000;');
         expect(functionsSource).toContain('function buildTeamMediaNotificationBatchMetadata({ teamId, itemId, item = {}, folder = {}, now = new Date() } = {})');
         expect(functionsSource).toContain("if (!normalizedTeamId || !normalizedItemId || !folderId || item.deleted === true) return null;");
-        expect(functionsSource).toContain("if (albumVisibility !== 'team') return null;");
+        expect(functionsSource).not.toContain("if (albumVisibility !== 'team') return null;");
         expect(functionsSource).toContain('batchId: buildTeamMediaNotificationBatchId(normalizedTeamId, folderId, windowStartAt)');
         expect(functionsSource).toContain('windowStartAt,');
         expect(functionsSource).toContain('dueAt');
@@ -25,7 +25,7 @@ describe('media and award notification contract', () => {
         expect(functionsSource).toContain(".where('dueAt', '<=', admin.firestore.Timestamp.fromDate(now))");
         expect(functionsSource).toContain('const batch = await claimTeamMediaNotificationBatch(batchRef, claimId, now);');
         expect(functionsSource).toContain('await markTeamMediaNotificationBatchSkipped(batchRef, claimId, \'album_not_found\');');
-        expect(functionsSource).toContain('await markTeamMediaNotificationBatchSkipped(batchRef, claimId, \'album_not_team_visible\');');
+        expect(functionsSource).not.toContain('await markTeamMediaNotificationBatchSkipped(batchRef, claimId, \'album_not_team_visible\');');
         expect(functionsSource).toContain("category: 'media'");
         expect(functionsSource).toContain('dedupKey: `team-media:${batch.id}`');
         expect(functionsSource).toContain('audienceContext');

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -113,7 +113,7 @@ describe('notification target index core helpers', () => {
         expect(functionsSource).toContain("return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';");
         expect(functionsSource).toContain('if (hasMediaAudienceConstraints(audienceContext))');
         expect(functionsSource).toContain('return mediaAudienceAllowsUser(user, audienceContext);');
-        expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
+        expect(functionsSource).toContain("const isStaffUser = Array.isArray(user.roles) && user.roles.includes('staff');");
         expect(targetResolverSource).toContain('const missingUsers = users.filter');
         expect(targetResolverSource).toContain('teamNotificationRecipientIndexIsEmpty(teamId)');
         expect(targetResolverSource).toContain('if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId))');

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -339,4 +339,40 @@ describe('team media notification recipients', () => {
             }
         ]);
     });
+
+    it('filters private album recipients by explicit visibility audience before send fanout', async () => {
+        const harness = createHarness({
+            candidateUsers: [
+                { uid: 'parent-1', roles: ['parent'] },
+                { uid: 'parent-2', roles: ['parent'] },
+                { uid: 'staff-1', roles: ['staff'] }
+            ],
+            indexedTargets: [
+                { uid: 'parent-1', deviceId: 'parent-1-device', token: 'parent-1-token' },
+                { uid: 'parent-2', deviceId: 'parent-2-device', token: 'parent-2-token' },
+                { uid: 'staff-1', deviceId: 'staff-device', token: 'staff-token' }
+            ]
+        });
+
+        const targets = await harness.getTargetsForCategory('team-1', 'media', null, {
+            albumVisibility: 'private',
+            allowedUserIds: ['parent-2'],
+            allowedRoles: ['staff']
+        });
+
+        expect(normalizeTargets(targets)).toEqual([
+            {
+                uid: 'parent-2',
+                deviceId: 'parent-2-device',
+                token: 'parent-2-token',
+                teamId: 'team-1'
+            },
+            {
+                uid: 'staff-1',
+                deviceId: 'staff-device',
+                token: 'staff-token',
+                teamId: 'team-1'
+            }
+        ]);
+    });
 });

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -340,7 +340,7 @@ describe('team media notification recipients', () => {
         ]);
     });
 
-    it('filters private album recipients by explicit visibility audience before send fanout', async () => {
+    it('keeps private album fanout staff-only even when explicit audience lists include parents', async () => {
         const harness = createHarness({
             candidateUsers: [
                 { uid: 'parent-1', roles: ['parent'] },
@@ -361,12 +361,6 @@ describe('team media notification recipients', () => {
         });
 
         expect(normalizeTargets(targets)).toEqual([
-            {
-                uid: 'parent-2',
-                deviceId: 'parent-2-device',
-                token: 'parent-2-token',
-                teamId: 'team-1'
-            },
             {
                 uid: 'staff-1',
                 deviceId: 'staff-device',

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -46,8 +46,10 @@ describe('team media visibility notification contract', () => {
         expect(functionsSource).toContain('function normalizeNotificationAudienceRoles(value) {');
         expect(functionsSource).toContain('function mediaAudienceAllowsUser(user, audienceContext = {}) {');
         expect(functionsSource).toContain('function hasMediaAudienceConstraints(audienceContext = {}) {');
+        expect(functionsSource).toContain("const isStaffUser = Array.isArray(user.roles) && user.roles.includes('staff');");
+        expect(functionsSource).toContain("if (!isStaffUser) return false;");
         expect(functionsSource).toContain("if (hasMediaAudienceConstraints(audienceContext)) {\n      return mediaAudienceAllowsUser(user, audienceContext);\n    }");
-        expect(functionsSource).toContain("return Array.isArray(user.roles) && user.roles.includes('staff');");
+        expect(functionsSource).toContain('return true;');
     });
 
     it('passes media audience context through indexed and legacy target lookups', () => {

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -59,5 +59,7 @@ describe('team media visibility notification contract', () => {
         expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);');
         expect(functionsSource).toContain('audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility }');
         expect(functionsSource).toContain('const audienceContext = buildTeamMediaNotificationAudienceContext({');
+        expect(functionsSource).not.toContain("if (albumVisibility !== 'team') return null;");
+        expect(functionsSource).not.toContain("await markTeamMediaNotificationBatchSkipped(batchRef, claimId, 'album_not_team_visible');");
     });
 });


### PR DESCRIPTION
Closes #2657

## What changed
- Removed the team-only gate when queuing team media notification batches so visibility-restricted albums still reach notification fanout.
- Removed the dispatcher skip that dropped non-`team` albums before recipient filtering ran.
- Added regression coverage proving private/restricted album notifications preserve audience context and only fan out to users explicitly allowed by the album visibility model.

## Root Cause
The media notification pipeline captured album audience context, but `buildTeamMediaNotificationBatchMetadata()` and `dispatchDueTeamMediaNotificationBatches()` both short-circuited any album whose normalized visibility was not `team`. That meant visibility-restricted albums were excluded before `canReceiveCategoryNotification(...)` could apply the TeamMedia audience rules at send time.

## Prevention / Learning
When notification fanout depends on a richer visibility model, do not pre-filter whole batches on a coarse visibility enum if the downstream recipient selector already enforces per-user eligibility. Queue the work, preserve the audience context, and let send-time recipient filtering enforce the final authorization boundary.

## Regression Tests
- `functions/test/team-media-notification-batches.test.js`
- `tests/unit/team-media-notification-recipients.test.js`
- `tests/unit/team-media-visibility-notification-contract.test.js`
- `tests/unit/media-award-notification-contract.test.js`

Validated with:
- `npx vitest run functions/test/team-media-notification-batches.test.js tests/unit/team-media-notification-recipients.test.js --reporter=verbose`
- `npx vitest run tests/unit/team-media-visibility-notification-contract.test.js tests/unit/media-award-notification-contract.test.js --reporter=verbose`