### PR TITLE
Defer full inbox subscription until Notifications opens

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -44,6 +44,23 @@ vi.mock('./AppSearchDialog', () => ({
   AppSearchDialog: ({ open }: { open: boolean }) => (open ? <div role="dialog" aria-label="Search teams, players, actions, and help" /> : null),
 }));
 
+vi.mock('./NotificationInboxSheet', () => ({
+  NotificationInboxSheet: ({
+    items,
+    inboxState,
+  }: {
+    items: Array<{ id: string; text: string }>;
+    inboxState: 'loading' | 'ready' | 'error';
+  }) => (
+    <div role="dialog" aria-label="Notifications">
+      <div data-testid="notification-inbox-sheet-state">{inboxState}</div>
+      {items.map((item) => (
+        <div key={item.id}>{item.text}</div>
+      ))}
+    </div>
+  ),
+}));
+
 const auth: AuthState = {
   user: null,
   profile: null,
@@ -173,6 +190,59 @@ describe('AppShell', () => {
         expect.any(Function)
       );
     });
+  });
+
+  it('clears cached inbox items when the signed-in uid changes while the sheet is closed', async () => {
+    subscribeToNotificationInboxMock.mockImplementation((uid, onItems) => {
+      onItems([
+        {
+          id: `notif-${uid}`,
+          category: 'team_message',
+          type: 'team_message',
+          title: 'Notification',
+          body: '',
+          text: `Notification for ${uid}`,
+          appRoute: '/messages',
+          conversationId: '',
+          createdAt: null,
+          readAt: null,
+        },
+      ]);
+      return vi.fn();
+    });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+    await waitFor(() => {
+      expect(screen.getByText('Notification for user-123')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+
+    rerender(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route
+            path="/home"
+            element={<AppShell auth={{ ...signedInAuth, user: { ...signedInAuth.user!, uid: 'user-456' } }}><div>Home</div></AppShell>}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-inbox-sheet-state').textContent).toBe('loading');
+    });
+    expect(screen.queryByText('Notification for user-123')).toBeNull();
   });
 
   it('keeps the mobile search trigger discoverable with a stable selector', () => {

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -13,9 +13,16 @@ type SubscribeToNotificationInbox = (
   onError?: (error: unknown) => void
 ) => () => void;
 
-const { useShellLayoutMock, subscribeToNotificationInboxMock } = vi.hoisted(() => ({
+type SubscribeToUnreadNotificationCount = (
+  uid: string,
+  onCount: (count: number) => void,
+  onError?: (error: unknown) => void
+) => () => void;
+
+const { useShellLayoutMock, subscribeToNotificationInboxMock, subscribeToUnreadNotificationCountMock } = vi.hoisted(() => ({
   useShellLayoutMock: vi.fn(() => ({ isDesktopWeb: true })),
   subscribeToNotificationInboxMock: vi.fn<SubscribeToNotificationInbox>(() => vi.fn()),
+  subscribeToUnreadNotificationCountMock: vi.fn<SubscribeToUnreadNotificationCount>(() => vi.fn()),
 }));
 
 vi.mock('../lib/useShellLayout', () => ({
@@ -30,6 +37,7 @@ vi.mock('../lib/notificationInboxService', () => ({
   countUnread: (items: Array<{ readAt: unknown | null }>) => items.filter((item) => !item.readAt).length,
   markNotificationRead: vi.fn(),
   subscribeToNotificationInbox: subscribeToNotificationInboxMock,
+  subscribeToUnreadNotificationCount: subscribeToUnreadNotificationCountMock,
 }));
 
 vi.mock('./AppSearchDialog', () => ({
@@ -70,6 +78,8 @@ describe('AppShell', () => {
     useShellLayoutMock.mockReturnValue({ isDesktopWeb: true });
     subscribeToNotificationInboxMock.mockReset();
     subscribeToNotificationInboxMock.mockReturnValue(vi.fn());
+    subscribeToUnreadNotificationCountMock.mockReset();
+    subscribeToUnreadNotificationCountMock.mockReturnValue(vi.fn());
   });
 
   afterEach(() => {
@@ -117,8 +127,8 @@ describe('AppShell', () => {
     expect(screen.getByTestId('app-shell-notification-status').textContent).toBe('Loading notifications…');
   });
 
-  it('announces load failures instead of a false empty inbox state', () => {
-    subscribeToNotificationInboxMock.mockImplementation((_uid, _onItems, onError) => {
+  it('announces load failures instead of a false empty inbox state', async () => {
+    subscribeToUnreadNotificationCountMock.mockImplementation((_uid, _onCount, onError) => {
       onError?.(new Error('offline'));
       return vi.fn();
     });
@@ -131,7 +141,38 @@ describe('AppShell', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByTestId('app-shell-notification-status').textContent).toBe('Could not load notifications');
+    await waitFor(() => {
+      expect(screen.getByTestId('app-shell-notification-status').textContent).toBe('Could not load notifications');
+    });
+  });
+
+  it('does not subscribe to the full inbox until notifications are opened', async () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(subscribeToUnreadNotificationCountMock).toHaveBeenCalledWith(
+        'user-123',
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
+    expect(subscribeToNotificationInboxMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+
+    await waitFor(() => {
+      expect(subscribeToNotificationInboxMock).toHaveBeenCalledWith(
+        'user-123',
+        expect.any(Function),
+        expect.any(Function)
+      );
+    });
   });
 
   it('keeps the mobile search trigger discoverable with a stable selector', () => {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -75,6 +75,7 @@ export function AppShell({ auth, children }: AppShellProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const routeStartedAtRef = useRef(typeof performance !== 'undefined' ? performance.now() : Date.now());
+  const lastInboxUidRef = useRef<string | null>(auth.user?.uid ?? null);
   const isAiRoute = location.pathname === '/ai';
   const isMobileChatDetail = !isDesktopWeb && location.pathname.startsWith('/messages/') && location.pathname !== '/messages';
   const isDesktopMessages = isDesktopWeb && (location.pathname.startsWith('/messages') || isAiRoute);
@@ -167,6 +168,11 @@ export function AppShell({ auth, children }: AppShellProps) {
 
   useEffect(() => {
     const uid = auth.user?.uid;
+    if (lastInboxUidRef.current !== (uid ?? null)) {
+      lastInboxUidRef.current = uid ?? null;
+      setInboxItems([]);
+      setInboxState('idle');
+    }
     if (!uid) {
       setInboxItems([]);
       setInboxState('idle');

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -68,7 +68,9 @@ export function AppShell({ auth, children }: AppShellProps) {
   const [addTeamOpen, setAddTeamOpen] = useState(false);
   const [inboxOpen, setInboxOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<NotificationInboxItem[]>([]);
-  const [inboxState, setInboxState] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [inboxState, setInboxState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [unreadState, setUnreadState] = useState<'loading' | 'ready' | 'error'>('loading');
   const { isDesktopWeb } = useShellLayout();
   const navigate = useNavigate();
   const location = useLocation();
@@ -76,14 +78,10 @@ export function AppShell({ auth, children }: AppShellProps) {
   const isAiRoute = location.pathname === '/ai';
   const isMobileChatDetail = !isDesktopWeb && location.pathname.startsWith('/messages/') && location.pathname !== '/messages';
   const isDesktopMessages = isDesktopWeb && (location.pathname.startsWith('/messages') || isAiRoute);
-  // Inlined from notificationInboxService.countUnread so this boot-path component
-  // does not statically import the module (which pulls the vendored Firestore SDK
-  // into the entry chunk). The module is dynamically imported on subscribe below.
-  const unreadCount = inboxItems.filter((item) => !item.readAt).length;
   const unreadNotificationStatus = auth.user
-    ? inboxState === 'loading' && inboxItems.length === 0
+    ? unreadState === 'loading'
       ? 'Loading notifications…'
-      : inboxState === 'error' && inboxItems.length === 0
+      : unreadState === 'error'
         ? 'Could not load notifications'
         : unreadCount > 0
           ? `${unreadCount} unread notification${unreadCount === 1 ? '' : 's'}`
@@ -136,12 +134,49 @@ export function AppShell({ auth, children }: AppShellProps) {
 
   useEffect(() => {
     const uid = auth.user?.uid;
-    if (!uid) return;
+    if (!uid) {
+      setUnreadCount(0);
+      setUnreadState('ready');
+      return;
+    }
+    setUnreadState('loading');
+    let active = true;
+    let unsubscribe = () => {};
+    void loadNotificationInboxService()
+      .then((mod) => {
+        if (!active) return;
+        unsubscribe = mod.subscribeToUnreadNotificationCount(
+          uid,
+          (count) => {
+            setUnreadCount(count);
+            setUnreadState('ready');
+          },
+          () => {
+            setUnreadState('error');
+          }
+        );
+      })
+      .catch(() => {
+        if (active) setUnreadState('error');
+      });
+    return () => {
+      active = false;
+      unsubscribe();
+    };
+  }, [auth.user?.uid]);
+
+  useEffect(() => {
+    const uid = auth.user?.uid;
+    if (!uid) {
+      setInboxItems([]);
+      setInboxState('idle');
+      return;
+    }
+    if (!inboxOpen) return;
+
     setInboxState('loading');
     let active = true;
     let unsubscribe = () => {};
-    // Lazy-import the inbox service (and its Firestore dependency) so it stays out
-    // of the entry chunk and loads after first paint.
     void loadNotificationInboxService()
       .then((mod) => {
         if (!active) return;
@@ -159,11 +194,12 @@ export function AppShell({ auth, children }: AppShellProps) {
       .catch(() => {
         if (active) setInboxState('error');
       });
+
     return () => {
       active = false;
       unsubscribe();
     };
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, inboxOpen]);
 
   const handleMarkNotificationRead = async (uid: string, itemId: string) => {
     const mod = await loadNotificationInboxService();
@@ -407,7 +443,7 @@ export function AppShell({ auth, children }: AppShellProps) {
         <Suspense fallback={null}>
           <NotificationInboxSheet
             items={inboxItems}
-            inboxState={inboxState}
+            inboxState={inboxState === 'idle' ? 'loading' : inboxState}
             uid={auth.user?.uid ?? ''}
             onClose={() => setInboxOpen(false)}
             onMarkRead={handleMarkNotificationRead}

--- a/apps/app/src/lib/adapters/legacyNotificationInboxDb.ts
+++ b/apps/app/src/lib/adapters/legacyNotificationInboxDb.ts
@@ -8,6 +8,7 @@ import {
   onSnapshot as legacyOnSnapshot,
   orderBy as legacyOrderBy,
   query as legacyQuery,
+  where as legacyWhere,
   updateDoc as legacyUpdateDoc,
   serverTimestamp as legacyServerTimestamp
 } from '@legacy/firebase.js';
@@ -26,5 +27,6 @@ export const limit = legacyLimit as (...args: any[]) => any;
 export const onSnapshot = legacyOnSnapshot as (...args: any[]) => () => void;
 export const orderBy = legacyOrderBy as (...args: any[]) => any;
 export const query = legacyQuery as (...args: any[]) => any;
+export const where = legacyWhere as (...args: any[]) => any;
 export const updateDoc = legacyUpdateDoc as (...args: any[]) => Promise<any>;
 export const serverTimestamp = legacyServerTimestamp as (...args: any[]) => any;

--- a/apps/app/src/lib/notificationInboxService.test.ts
+++ b/apps/app/src/lib/notificationInboxService.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const adapterMocks = vi.hoisted(() => ({
+    collection: vi.fn(),
+    db: { kind: 'db' },
+    doc: vi.fn(),
+    functions: { kind: 'functions' },
+    httpsCallable: vi.fn(),
+    limit: vi.fn(),
+    onSnapshot: vi.fn(),
+    orderBy: vi.fn(),
+    query: vi.fn(),
+    serverTimestamp: vi.fn(),
+    updateDoc: vi.fn(),
+    where: vi.fn()
+}));
+
+vi.mock('./adapters/legacyNotificationInboxDb', () => adapterMocks);
+
+import {
+    collection,
+    db,
+    onSnapshot,
+    query,
+    where
+} from './adapters/legacyNotificationInboxDb';
+import { subscribeToUnreadNotificationCount } from './notificationInboxService';
+
+describe('notificationInboxService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(collection).mockReturnValue({ kind: 'collection' } as never);
+        vi.mocked(where).mockReturnValue({ kind: 'where' } as never);
+        vi.mocked(query).mockReturnValue({ kind: 'query' } as never);
+        vi.mocked(onSnapshot).mockReturnValue(vi.fn());
+    });
+
+    it('subscribes to unread notifications without hydrating inbox items', () => {
+        const callback = vi.fn();
+        vi.mocked(onSnapshot).mockImplementation((_query, onNext) => {
+            onNext({ size: 3 } as never);
+            return vi.fn();
+        });
+
+        subscribeToUnreadNotificationCount('user-123', callback);
+
+        expect(collection).toHaveBeenCalledWith(db, 'users/user-123/notificationInbox');
+        expect(where).toHaveBeenCalledWith('readAt', '==', null);
+        expect(query).toHaveBeenCalledWith({ kind: 'collection' }, { kind: 'where' });
+        expect(callback).toHaveBeenCalledWith(3);
+    });
+});

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -9,6 +9,7 @@ import {
     onSnapshot,
     orderBy,
     query,
+    where,
     serverTimestamp,
     updateDoc
 } from './adapters/legacyNotificationInboxDb';
@@ -37,6 +38,35 @@ function getStringField(data: DocumentData, key: string): string {
 function buildNotificationText(title: string, body: string, legacyText: string): string {
     if (title && body) return `${title}: ${body}`;
     return title || body || legacyText;
+}
+
+/**
+ * Subscribe to the unread notification count only.
+ * Returns an unsubscribe function.
+ */
+export function subscribeToUnreadNotificationCount(
+    uid: string,
+    callback: (count: number) => void,
+    onError?: (error: unknown) => void
+): () => void {
+    const q = query(
+        collection(db, `users/${uid}/notificationInbox`),
+        where('readAt', '==', null)
+    );
+
+    return onSnapshot(
+        q,
+        (snapshot: QuerySnapshot<DocumentData>) => {
+            callback(snapshot.size);
+        },
+        (error: unknown) => {
+            if (onError) {
+                onError(error);
+            } else {
+                logger.error('Failed to subscribe to unread notification count.', { error });
+            }
+        }
+    );
 }
 
 /**

--- a/tests/unit/app-notification-bell.test.tsx
+++ b/tests/unit/app-notification-bell.test.tsx
@@ -14,6 +14,7 @@ const { useShellLayoutMock } = vi.hoisted(() => ({
 
 const inboxServiceMocks = vi.hoisted(() => ({
     subscribeToNotificationInbox: vi.fn(() => vi.fn()),
+    subscribeToUnreadNotificationCount: vi.fn(() => vi.fn()),
     countUnread: vi.fn((items: Array<{ readAt: unknown }>) => items.filter((i) => !i.readAt).length),
     markNotificationRead: vi.fn(() => Promise.resolve()),
 }));
@@ -144,6 +145,7 @@ describe('Notification bell in AppShell', () => {
         });
         vi.stubGlobal('cancelAnimationFrame', vi.fn());
         inboxServiceMocks.subscribeToNotificationInbox.mockReturnValue(vi.fn());
+        inboxServiceMocks.subscribeToUnreadNotificationCount.mockReturnValue(vi.fn());
         inboxServiceMocks.markNotificationRead.mockResolvedValue(undefined);
         loadNotificationInboxServiceMock.mockResolvedValue(inboxServiceMocks);
     });
@@ -166,8 +168,19 @@ describe('Notification bell in AppShell', () => {
         expect(bellButton.getAttribute('aria-label')).toBe('Notifications');
     });
 
-    it('subscribes to the notification inbox for the signed-in user', async () => {
+    it('subscribes to unread counts on mount and defers the full inbox until opened', async () => {
         renderShell(true);
+        await waitFor(() => {
+            expect(inboxServiceMocks.subscribeToUnreadNotificationCount).toHaveBeenCalledWith(
+                'user-1',
+                expect.any(Function),
+                expect.any(Function)
+            );
+        });
+        expect(inboxServiceMocks.subscribeToNotificationInbox).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+
         await waitFor(() => {
             expect(inboxServiceMocks.subscribeToNotificationInbox).toHaveBeenCalledWith(
                 'user-1',
@@ -184,13 +197,9 @@ describe('Notification bell in AppShell', () => {
     });
 
     it('shows the unread badge with the correct count when there are unread notifications', async () => {
-        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
-            (_uid: string, callback: (items: Array<{ id: string; text: string; appRoute: string; readAt: unknown }>) => void) => {
-                callback([
-                    { id: 'n1', text: 'Game tonight', appRoute: '/schedule', readAt: null },
-                    { id: 'n2', text: 'Practice update', appRoute: '/schedule', readAt: 'some-ts' },
-                    { id: 'n3', text: 'New message', appRoute: '/messages', readAt: null },
-                ]);
+        inboxServiceMocks.subscribeToUnreadNotificationCount.mockImplementation(
+            (_uid: string, callback: (count: number) => void) => {
+                callback(2);
                 return vi.fn();
             }
         );
@@ -294,16 +303,9 @@ describe('Notification bell in AppShell', () => {
     });
 
     it('caps the badge display at 99+ for very large unread counts', async () => {
-        const manyItems = Array.from({ length: 105 }, (_, i) => ({
-            id: `n${i}`,
-            text: `Notification ${i}`,
-            appRoute: '/home',
-            readAt: null,
-        }));
-
-        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
-            (_uid: string, callback: (items: typeof manyItems) => void) => {
-                callback(manyItems);
+        inboxServiceMocks.subscribeToUnreadNotificationCount.mockImplementation(
+            (_uid: string, callback: (count: number) => void) => {
+                callback(105);
                 return vi.fn();
             }
         );
@@ -331,27 +333,24 @@ describe('Notification bell in AppShell', () => {
     });
 
     it('shows error state when the onError callback is invoked before any items load', async () => {
-        let capturedOnError: ((error: unknown) => void) | undefined;
-
-        inboxServiceMocks.subscribeToNotificationInbox.mockImplementation(
-            (_uid: string, _callback: unknown, onError: (error: unknown) => void) => {
-                capturedOnError = onError;
-                return vi.fn();
-            }
-        );
-
         renderShell(true);
 
-        await waitFor(() => {
-            expect(capturedOnError).toBeTypeOf('function');
-        });
-
-        // Trigger the error callback before any items arrive
-        act(() => {
-            capturedOnError?.(new Error('Firestore unavailable'));
-        });
-
         fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+
+        await waitFor(() => {
+            expect(inboxServiceMocks.subscribeToNotificationInbox).toHaveBeenCalledWith(
+                'user-1',
+                expect.any(Function),
+                expect.any(Function)
+            );
+        });
+
+        const onError = inboxServiceMocks.subscribeToNotificationInbox.mock.calls[0]?.[2] as ((error: unknown) => void) | undefined;
+        expect(onError).toBeTypeOf('function');
+
+        act(() => {
+            onError?.(new Error('Firestore unavailable'));
+        });
 
         await waitFor(() => {
             expect(screen.getByTestId('inbox-error-state')).toBeTruthy();

--- a/tests/unit/app-notification-inbox-review.test.tsx
+++ b/tests/unit/app-notification-inbox-review.test.tsx
@@ -24,6 +24,7 @@ const firebaseMocks = vi.hoisted(() => ({
     onSnapshot: vi.fn(() => vi.fn()),
     orderBy: vi.fn((field: string, direction: string) => ({ type: 'orderBy', field, direction })),
     query: vi.fn((...args: unknown[]) => ({ args })),
+    where: vi.fn((field: string, operator: string, value: unknown) => ({ type: 'where', field, operator, value })),
     serverTimestamp: vi.fn(),
     updateDoc: vi.fn(),
     writeBatch: vi.fn(),


### PR DESCRIPTION
Closes #2714

## What changed
- split AppShell notification state so the shell mounts an unread-count listener on sign-in instead of hydrating the full 50-item inbox snapshot
- deferred `subscribeToNotificationInbox()` until the Notifications sheet is actually opened, while preserving cached inbox items across close/reopen
- added a focused unread-count service helper and regression coverage for deferred inbox loading, unread badge updates, and inbox error/loading behavior

## Root Cause
AppShell used the full inbox snapshot for two different jobs: the always-visible unread badge and the on-demand notifications sheet. Because that listener lived in a mount-time effect keyed only on `auth.user?.uid`, every signed-in shell mount opened the heavyweight 50-item Firestore subscription even when the sheet was never opened.

## Prevention / Learning
Do not couple shell-level badges or counters to hidden modal/list data sources. Keep always-visible shell state on the lightest possible live query, and lazy-load full collection snapshots only when the user opens the dependent surface.

## Regression Tests
- `npx vitest run apps/app/src/components/AppShell.test.tsx apps/app/src/lib/notificationInboxService.test.ts tests/unit/app-notification-bell.test.tsx --reporter=verbose`
- `apps/app/src/components/AppShell.test.tsx` now proves the unread path initializes on mount and the full inbox listener does not start until the notifications trigger is clicked
- `apps/app/src/lib/notificationInboxService.test.ts` now proves unread counts come from a `readAt == null` query without hydrating inbox items
- `tests/unit/app-notification-bell.test.tsx` now covers badge updates and deferred full inbox loading through the higher-level bell flow

## Recurrence Risk
low: the mount-time/full-inbox coupling is now covered at both the AppShell behavior layer and the unread-query service layer.