### PR TITLE
Fix native badge to follow notification inbox

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -19,10 +19,11 @@ type SubscribeToUnreadNotificationCount = (
   onError?: (error: unknown) => void
 ) => () => void;
 
-const { useShellLayoutMock, subscribeToNotificationInboxMock, subscribeToUnreadNotificationCountMock } = vi.hoisted(() => ({
+const { useShellLayoutMock, subscribeToNotificationInboxMock, subscribeToUnreadNotificationCountMock, updateAppIconBadgeMock } = vi.hoisted(() => ({
   useShellLayoutMock: vi.fn(() => ({ isDesktopWeb: true })),
   subscribeToNotificationInboxMock: vi.fn<SubscribeToNotificationInbox>(() => vi.fn()),
   subscribeToUnreadNotificationCountMock: vi.fn<SubscribeToUnreadNotificationCount>(() => vi.fn()),
+  updateAppIconBadgeMock: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('../lib/useShellLayout', () => ({
@@ -33,11 +34,24 @@ vi.mock('../lib/uxTiming', () => ({
   recordUxTiming: vi.fn(),
 }));
 
+vi.mock('../lib/badgeService', () => ({
+  updateAppIconBadge: updateAppIconBadgeMock,
+}));
+
 vi.mock('../lib/notificationInboxService', () => ({
   countUnread: (items: Array<{ readAt: unknown | null }>) => items.filter((item) => !item.readAt).length,
   markNotificationRead: vi.fn(),
   subscribeToNotificationInbox: subscribeToNotificationInboxMock,
   subscribeToUnreadNotificationCount: subscribeToUnreadNotificationCountMock,
+}));
+
+vi.mock('../lib/notificationInboxServiceLoader', () => ({
+  loadNotificationInboxService: () => Promise.resolve({
+    subscribeToNotificationInbox: subscribeToNotificationInboxMock,
+    subscribeToUnreadNotificationCount: subscribeToUnreadNotificationCountMock,
+    markNotificationRead: vi.fn(),
+    markAllNotificationsRead: vi.fn(),
+  }),
 }));
 
 vi.mock('./AppSearchDialog', () => ({
@@ -48,11 +62,14 @@ vi.mock('./NotificationInboxSheet', () => ({
   NotificationInboxSheet: ({
     items,
     inboxState,
+    onClose,
   }: {
     items: Array<{ id: string; text: string }>;
     inboxState: 'loading' | 'ready' | 'error';
+    onClose: () => void;
   }) => (
     <div role="dialog" aria-label="Notifications">
+      <button type="button" aria-label="Close notifications" onClick={onClose}>Close</button>
       <div data-testid="notification-inbox-sheet-state">{inboxState}</div>
       {items.map((item) => (
         <div key={item.id}>{item.text}</div>
@@ -97,6 +114,7 @@ describe('AppShell', () => {
     subscribeToNotificationInboxMock.mockReturnValue(vi.fn());
     subscribeToUnreadNotificationCountMock.mockReset();
     subscribeToUnreadNotificationCountMock.mockReturnValue(vi.fn());
+    updateAppIconBadgeMock.mockClear();
   });
 
   afterEach(() => {
@@ -163,6 +181,47 @@ describe('AppShell', () => {
     });
   });
 
+  it('syncs the native app badge from unread notification counts', async () => {
+    subscribeToUnreadNotificationCountMock.mockImplementation((_uid, onCount) => {
+      onCount(3);
+      return vi.fn();
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(updateAppIconBadgeMock).toHaveBeenCalledWith(3);
+    });
+  });
+
+  it('clears the native app badge after sign-out', async () => {
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    rerender(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={auth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(updateAppIconBadgeMock).toHaveBeenLastCalledWith(0);
+    });
+  });
+
   it('does not subscribe to the full inbox until notifications are opened', async () => {
     render(
       <MemoryRouter initialEntries={['/home']}>
@@ -224,7 +283,7 @@ describe('AppShell', () => {
       expect(screen.getByText('Notification for user-123')).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+    fireEvent.click(screen.getByRole('button', { name: 'Close notifications' }));
 
     rerender(
       <MemoryRouter initialEntries={['/home']}>

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -200,6 +200,21 @@ describe('AppShell', () => {
     });
   });
 
+  it('does not clear the native app badge while auth is still bootstrapping', async () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={{ ...auth, loading: true }}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(subscribeToUnreadNotificationCountMock).not.toHaveBeenCalled();
+    });
+    expect(updateAppIconBadgeMock).not.toHaveBeenCalled();
+  });
+
   it('clears the native app badge after sign-out', async () => {
     const { rerender } = render(
       <MemoryRouter initialEntries={['/home']}>

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -30,6 +30,7 @@ import { useShellLayout } from '../lib/useShellLayout';
 import { recordUxTiming } from '../lib/uxTiming';
 import { openPublicUrl } from '../lib/publicActions';
 import { APP_BACK_DISMISS_EVENT } from '../lib/nativeBackButton';
+import { updateAppIconBadge } from '../lib/badgeService';
 import type { NotificationInboxItem } from '../lib/notificationInboxService';
 import { loadNotificationInboxService } from '../lib/notificationInboxServiceLoader';
 import type { AuthState, NavItem } from '../lib/types';
@@ -165,6 +166,17 @@ export function AppShell({ auth, children }: AppShellProps) {
       unsubscribe();
     };
   }, [auth.user?.uid]);
+
+  useEffect(() => {
+    if (!auth.user?.uid) {
+      void updateAppIconBadge(0);
+      return;
+    }
+    if (unreadState !== 'ready') {
+      return;
+    }
+    void updateAppIconBadge(unreadCount);
+  }, [auth.user?.uid, unreadCount, unreadState]);
 
   useEffect(() => {
     const uid = auth.user?.uid;

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -169,6 +169,9 @@ export function AppShell({ auth, children }: AppShellProps) {
 
   useEffect(() => {
     if (!auth.user?.uid) {
+      if (auth.loading) {
+        return;
+      }
       void updateAppIconBadge(0);
       return;
     }
@@ -176,7 +179,7 @@ export function AppShell({ auth, children }: AppShellProps) {
       return;
     }
     void updateAppIconBadge(unreadCount);
-  }, [auth.user?.uid, unreadCount, unreadState]);
+  }, [auth.loading, auth.user?.uid, unreadCount, unreadState]);
 
   useEffect(() => {
     const uid = auth.user?.uid;

--- a/apps/app/src/lib/badgeService.test.ts
+++ b/apps/app/src/lib/badgeService.test.ts
@@ -11,16 +11,9 @@ const capacitorCoreMock = vi.hoisted(() => ({
     isNativePlatform: vi.fn(() => true)
 }));
 
-const chatServiceMocks = vi.hoisted(() => ({
-    loadChatInbox: vi.fn().mockResolvedValue({ teams: [] }),
-    markTeamChatRead: vi.fn().mockResolvedValue(undefined)
-}));
-
 vi.mock('@capacitor/core', () => ({
     Capacitor: capacitorCoreMock
 }));
-
-vi.mock('./chatService', () => chatServiceMocks);
 
 // @capawesome/capacitor-badge is dynamically imported inside updateAppIconBadge, so we
 // mock the module so the dynamic import resolves to our stub.
@@ -29,9 +22,9 @@ vi.mock('@capawesome/capacitor-badge', () => ({
 }));
 
 import {
-    markTeamChatReadAndRefreshBadge,
+    countUnreadNotificationInboxItems,
     normalizeAppIconBadgeCount,
-    refreshUnreadChatBadge,
+    syncAppIconBadgeToNotificationInbox,
     updateAppIconBadge
 } from './badgeService';
 
@@ -56,8 +49,6 @@ describe('normalizeAppIconBadgeCount', () => {
 describe('updateAppIconBadge', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: [] });
-        chatServiceMocks.markTeamChatRead.mockResolvedValue(undefined);
         // Default: native platform.
         capacitorCoreMock.isNativePlatform.mockReturnValue(true);
         // Ensure protocol appears non-capacitor so only isNativePlatform governs.
@@ -114,33 +105,30 @@ describe('updateAppIconBadge', () => {
         await expect(updateAppIconBadge(7)).resolves.toBeUndefined();
     });
 
-    it('refreshes the badge count from the unread inbox total on native', async () => {
-        chatServiceMocks.loadChatInbox.mockResolvedValue({
-            teams: [
-                { id: 'team-1', unreadCount: 2.9 },
-                { id: 'team-2', unreadCount: 3 },
-                { id: 'team-3', unreadCount: -4 }
-            ]
-        });
-
-        await refreshUnreadChatBadge({ uid: 'user-1' } as any);
-
-        expect(chatServiceMocks.loadChatInbox).toHaveBeenCalledWith({ uid: 'user-1' }, { includeLastMessages: false });
-        expect(badgeMocks.set).toHaveBeenCalledWith({ count: 5 });
+    it('counts unread notification inbox items from mixed read states', () => {
+        expect(countUnreadNotificationInboxItems([
+            { id: 'notif-1', readAt: null } as any,
+            { id: 'notif-2', readAt: { seconds: 1 } } as any,
+            { id: 'notif-3', readAt: null } as any,
+        ])).toBe(2);
     });
 
-    it('marks the direct chat read and then refreshes the unread badge total', async () => {
-        chatServiceMocks.loadChatInbox.mockResolvedValue({
-            teams: [
-                { id: 'team-1', unreadCount: 0 },
-                { id: 'team-2', unreadCount: 1 }
-            ]
-        });
+    it('syncs the native badge from notification inbox unread items', async () => {
+        await syncAppIconBadgeToNotificationInbox([
+            { id: 'notif-1', readAt: null } as any,
+            { id: 'notif-2', readAt: { seconds: 1 } } as any,
+            { id: 'notif-3', readAt: null } as any,
+        ]);
 
-        await markTeamChatReadAndRefreshBadge({ uid: 'user-1' } as any, 'team-1');
+        expect(badgeMocks.set).toHaveBeenCalledWith({ count: 2 });
+    });
 
-        expect(chatServiceMocks.markTeamChatRead).toHaveBeenCalledWith('user-1', 'team-1');
-        expect(chatServiceMocks.loadChatInbox).toHaveBeenCalledWith({ uid: 'user-1' }, { includeLastMessages: false });
-        expect(badgeMocks.set).toHaveBeenCalledWith({ count: 1 });
+    it('clears the native badge when every notification inbox item is read', async () => {
+        await syncAppIconBadgeToNotificationInbox([
+            { id: 'notif-1', readAt: { seconds: 1 } } as any,
+            { id: 'notif-2', readAt: new Date() } as any,
+        ]);
+
+        expect(badgeMocks.clear).toHaveBeenCalled();
     });
 });

--- a/apps/app/src/lib/badgeService.ts
+++ b/apps/app/src/lib/badgeService.ts
@@ -1,6 +1,5 @@
 import { Capacitor } from '@capacitor/core';
-import { loadChatInbox, markTeamChatRead } from './chatService';
-import type { AuthUser } from './types';
+import type { NotificationInboxItem } from './notificationInboxService';
 
 function isNativeRuntime(): boolean {
     const protocol = typeof window === 'undefined' ? '' : window.location.protocol;
@@ -16,7 +15,7 @@ export function normalizeAppIconBadgeCount(count: unknown): number {
 }
 
 /**
- * Update the native app icon badge count to reflect unread chat messages.
+ * Update the native app icon badge count.
  * On web/non-native platforms this is a no-op.
  * Uses a dynamic import so the web build is unaffected if @capawesome/capacitor-badge
  * is not installed.
@@ -36,19 +35,12 @@ export async function updateAppIconBadge(count: number): Promise<void> {
     }
 }
 
-export async function refreshUnreadChatBadge(user: AuthUser | null): Promise<void> {
-    if (!user?.uid || !isNativeRuntime()) return;
-    const result = await loadChatInbox(user, { includeLastMessages: false });
-    const totalUnread = result.teams.reduce((sum, team) => sum + normalizeAppIconBadgeCount(team.unreadCount), 0);
-    await updateAppIconBadge(totalUnread);
+export function countUnreadNotificationInboxItems(items: NotificationInboxItem[]): number {
+    return (Array.isArray(items) ? items : []).reduce((count, item) => {
+        return item && !item.readAt ? count + 1 : count;
+    }, 0);
 }
 
-export async function markTeamChatReadAndRefreshBadge(user: AuthUser | null, teamId: string): Promise<void> {
-    if (!user?.uid || !teamId) return;
-    await markTeamChatRead(user.uid, teamId);
-    try {
-        await refreshUnreadChatBadge(user);
-    } catch {
-        // The chat read succeeded. Ignore badge refresh failures.
-    }
+export async function syncAppIconBadgeToNotificationInbox(items: NotificationInboxItem[]): Promise<void> {
+    await updateAppIconBadge(countUnreadNotificationInboxItems(items));
 }

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -96,7 +96,6 @@ import {
   type ChatTargetType
 } from '../lib/chatLogic';
 import { sharePublicUrl } from '../lib/publicActions';
-import { markTeamChatReadAndRefreshBadge, updateAppIconBadge } from '../lib/badgeService';
 import { useShellLayout } from '../lib/useShellLayout';
 import { useRefreshOnResume } from '../lib/useRefreshOnResume';
 import { startScreenMountTimer } from '../lib/uxTiming';
@@ -246,7 +245,6 @@ export function Messages({ auth }: { auth: AuthState }) {
       if (inboxRequestIdRef.current !== requestId) return;
       setTeams(mergeInboxTeams(result.teams, previewUpdates));
       const totalUnread = result.teams.reduce((sum, team) => sum + team.unreadCount, 0);
-      void updateAppIconBadge(totalUnread);
       timer.end({
         teamCount: result.teams.length,
         unreadCount: totalUnread,
@@ -295,7 +293,6 @@ export function Messages({ auth }: { auth: AuthState }) {
     }
     directThreadMountRecordedTeamIdRef.current = null;
     if (!auth.user) {
-      void updateAppIconBadge(0);
       return;
     }
     refreshInbox();
@@ -750,8 +747,8 @@ function ChatWindow({
     setShowJumpToLatest(false);
   }, []);
   const handleMarkRead = useCallback(() => {
-    maybeMarkRead(auth.user, teamId, true, !isDesktopWeb && !embedded);
-  }, [auth.user, embedded, isDesktopWeb, teamId]);
+    maybeMarkRead(auth.user, teamId, true);
+  }, [auth.user, teamId]);
 
   const {
     messages,
@@ -1075,7 +1072,7 @@ function ChatWindow({
         hasMessages: messages.length > 0,
         hasLoadedSnapshot: initialSnapshotLoadedRef.current
       })) {
-        maybeMarkRead(auth.user, teamId, true, !isDesktopWeb && !embedded);
+        maybeMarkRead(auth.user, teamId, true);
       }
     };
     document.addEventListener('visibilitychange', handleReturn);
@@ -2127,7 +2124,7 @@ function resolveMutedState(
   return false;
 }
 
-function maybeMarkRead(user: AuthState['user'] | null | undefined, teamId: string, hasTeamId: boolean, shouldRefreshBadge = false) {
+function maybeMarkRead(user: AuthState['user'] | null | undefined, teamId: string, hasTeamId: boolean) {
   const isPageVisible = document.visibilityState === 'visible' && !document.hidden;
   const isWindowFocused = document.hasFocus();
   if (shouldUpdateChatLastRead({
@@ -2136,10 +2133,6 @@ function maybeMarkRead(user: AuthState['user'] | null | undefined, teamId: strin
     isPageVisible,
     isWindowFocused
   })) {
-    if (shouldRefreshBadge) {
-      void markTeamChatReadAndRefreshBadge(user || null, teamId);
-      return;
-    }
     if (user?.uid) {
       void markTeamChatRead(user.uid, teamId);
     }


### PR DESCRIPTION
Closes #2712

## What changed
- made `AppShell` push the native app icon badge from the same unread `notificationInbox` count that drives the in-app bell
- removed chat inbox badge writes from `Messages` so opening chat can no longer overwrite the native badge with chat-only totals
- added a focused badge helper for notification inbox unread items and updated tests around native badge sync and clear behavior

## Root Cause
The native app badge and the in-app notification bell were reading different sources of truth. `AppShell` used `notificationInbox` unread state for the bell, but `Messages` still wrote the native badge from chat thread unread totals, so opening or refreshing Messages could replace the broader notification count with a stale or zero chat-only count.

## Prevention / Learning
When the same unread indicator appears in native UI and in-app UI, define one source of truth and route all badge writes through it. Do not let feature-local refresh paths write their own badge counts if another surface already owns the canonical unread state.

## Regression Tests
- `cd apps/app && npx vitest run src/lib/badgeService.test.ts src/components/AppShell.test.tsx --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Low. The native badge now updates from the notification inbox subscription path, and focused tests cover both syncing unread counts and clearing the badge on read/sign-out flows.