### PR TITLE
Batch inbox unread count queries

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -486,6 +486,13 @@ function getConversationActivityTime(conversation: ChatConversation | null | und
   return conversationTime ? conversationTime.getTime() : null;
 }
 
+function getTeamLatestMessageTime(team: Record<string, any>) {
+  return team?.lastMessageAt
+    || team?.chatLastMessageAt
+    || team?.lastChatMessageAt
+    || null;
+}
+
 async function getLatestConversationMessage(teamId: string, conversationId: string): Promise<ChatMessage | null> {
   try {
     const [message] = await withTimeout(Promise.resolve(getChatMessages(teamId, { limit: 1, conversationId })), `latest chat ${teamId}/${conversationId}`, 2500);
@@ -633,8 +640,26 @@ export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoa
 
   const userWithProfile = mapUserWithProfile(user, profile);
   const accessibleTeams = teams.filter((team) => isTeamActive(team) && canAccessTeamChat(userWithProfile, { ...team, id: team.id }));
+  const latestMessageAtByTeam = accessibleTeams.reduce<Record<string, unknown>>((acc, team) => {
+    const latestMessageAt = getTeamLatestMessageTime(team);
+    if (latestMessageAt) {
+      acc[team.id] = latestMessageAt;
+    }
+    return acc;
+  }, {});
+  const unreadCandidateTeamIds = accessibleTeams
+    .filter((team) => {
+      const latestMessageAt = latestMessageAtByTeam[team.id];
+      if (!latestMessageAt) return true;
+      const lastReadAt = getTeamChatStateEntry(profile, team.id).lastReadAt || profile?.chatLastRead?.[team.id] || null;
+      if (!lastReadAt) return true;
+      const latestTime = toDate(latestMessageAt)?.getTime() || 0;
+      const lastReadTime = toDate(lastReadAt)?.getTime() || 0;
+      return latestTime === 0 || latestTime > lastReadTime;
+    })
+    .map((team) => team.id);
   const unreadCounts = await withTimeout(
-    Promise.resolve(getUnreadChatCounts(user.uid, accessibleTeams.map((team) => team.id))),
+    Promise.resolve(getUnreadChatCounts(user.uid, unreadCandidateTeamIds, { latestMessageAtByTeam })),
     'Chat unread counts',
     3000
   ).catch(() => ({} as Record<string, number>));

--- a/dashboard.html
+++ b/dashboard.html
@@ -88,7 +88,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=60';
+        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=61';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=31';
 

--- a/js/db.js
+++ b/js/db.js
@@ -6334,11 +6334,35 @@ export async function clearChatMuted(userId, teamId, conversationId = DEFAULT_TE
  * @param {string} teamId - The team ID
  * @returns {Promise<number>} Number of unread messages
  */
-export async function getUnreadChatCount(userId, teamId) {
-    const userDoc = await getDoc(doc(db, 'users', userId));
-    const userData = userDoc.data();
+export async function getUnreadChatCount(userId, teamId, options = {}) {
+    const userData = options.userData || (await getDoc(doc(db, 'users', userId))).data();
     const lastRead = userData?.teamChatState?.[teamId]?.lastReadAt || userData?.chatLastRead?.[teamId] || null;
     const messagesRef = collection(db, 'teams', teamId, 'chatMessages');
+    const toMillis = (value) => {
+        if (!value) return 0;
+        if (typeof value?.toMillis === 'function') return value.toMillis();
+        if (value instanceof Date) return value.getTime();
+        if (typeof value?.seconds === 'number') {
+            return (value.seconds * 1000) + Math.floor(Number(value.nanoseconds || 0) / 1000000);
+        }
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+    };
+    let latestMessageAt = options.latestMessageAt;
+
+    if (latestMessageAt === undefined) {
+        const latestMessageSnapshot = await getDocs(query(messagesRef, orderBy('createdAt', 'desc'), limit(1)));
+        latestMessageAt = latestMessageSnapshot.docs[0]?.data?.()?.createdAt || null;
+    }
+
+    if (!latestMessageAt) {
+        return 0;
+    }
+
+    if (lastRead && toMillis(latestMessageAt) <= toMillis(lastRead)) {
+        return 0;
+    }
+
     const unreadConstraints = [];
 
     if (lastRead) {
@@ -6364,11 +6388,19 @@ export async function getUnreadChatCount(userId, teamId) {
  * @param {string[]} teamIds - Array of team IDs
  * @returns {Promise<Object>} Map of teamId to unread count
  */
-export async function getUnreadChatCounts(userId, teamIds) {
+export async function getUnreadChatCounts(userId, teamIds, options = {}) {
     const counts = {};
+    const userDoc = await getDoc(doc(db, 'users', userId));
+    const userData = userDoc.data() || {};
+    const latestMessageAtByTeam = options?.latestMessageAtByTeam || {};
     await Promise.all(teamIds.map(async (teamId) => {
         try {
-            counts[teamId] = await getUnreadChatCount(userId, teamId);
+            counts[teamId] = await getUnreadChatCount(userId, teamId, {
+                userData,
+                latestMessageAt: Object.prototype.hasOwnProperty.call(latestMessageAtByTeam, teamId)
+                    ? latestMessageAtByTeam[teamId]
+                    : undefined
+            });
         } catch (err) {
             console.warn(`Failed to get unread count for team ${teamId}:`, err);
             counts[teamId] = 0;

--- a/js/db.js
+++ b/js/db.js
@@ -6390,9 +6390,20 @@ export async function getUnreadChatCount(userId, teamId, options = {}) {
  */
 export async function getUnreadChatCounts(userId, teamIds, options = {}) {
     const counts = {};
-    const userDoc = await getDoc(doc(db, 'users', userId));
-    const userData = userDoc.data() || {};
     const latestMessageAtByTeam = options?.latestMessageAtByTeam || {};
+    let userData = {};
+
+    try {
+        const userDoc = await getDoc(doc(db, 'users', userId));
+        userData = userDoc.data() || {};
+    } catch (err) {
+        console.warn(`Failed to load chat state for user ${userId}:`, err);
+        teamIds.forEach((teamId) => {
+            counts[teamId] = 0;
+        });
+        return counts;
+    }
+
     await Promise.all(teamIds.map(async (teamId) => {
         try {
             counts[teamId] = await getUnreadChatCount(userId, teamId, {

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -173,7 +173,9 @@ describe('React app chat recipient service', () => {
 
         expect(dbMocks.getUserTeamsWithAccess).toHaveBeenCalledWith('user-1', 'parent@example.com');
         expect(dbMocks.getParentTeams).toHaveBeenCalledWith('user-1');
-        expect(dbMocks.getUnreadChatCounts).toHaveBeenCalledWith('user-1', ['team-coach', 'team-parent']);
+        expect(dbMocks.getUnreadChatCounts).toHaveBeenCalledWith('user-1', ['team-coach', 'team-parent'], {
+            latestMessageAtByTeam: {}
+        });
         expect(dbMocks.canAccessTeamChat).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ id: 'team-inactive-admin' }));
         expect(dbMocks.canAccessTeamChat).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ id: 'team-inactive-parent' }));
         expect(dbMocks.canAccessTeamChat).toHaveBeenCalledWith(expect.objectContaining({
@@ -195,6 +197,65 @@ describe('React app chat recipient service', () => {
             unreadCount: 0,
             lastMessage: expect.objectContaining({ text: 'Staff note' })
         }));
+    });
+
+    it('only requests exact unread counts for teams whose known latest message is newer than last read', async () => {
+        dbMocks.getUserProfile.mockResolvedValue({
+            email: 'parent@example.com',
+            chatLastRead: {
+                'team-read': new Date('2026-05-21T13:00:00Z')
+            },
+            teamChatState: {
+                'team-read': {
+                    lastReadAt: new Date('2026-05-21T13:00:00Z')
+                }
+            }
+        });
+        dbMocks.getUserTeamsWithAccess.mockResolvedValue([
+            {
+                id: 'team-read',
+                name: 'Already Read',
+                sport: 'Soccer',
+                lastMessageAt: new Date('2026-05-21T12:00:00Z')
+            },
+            {
+                id: 'team-unread',
+                name: 'Needs Attention',
+                sport: 'Basketball',
+                lastMessageAt: new Date('2026-05-21T14:00:00Z')
+            },
+            {
+                id: 'team-unknown',
+                name: 'Unknown Timestamp',
+                sport: 'Baseball'
+            }
+        ]);
+        dbMocks.getParentTeams.mockResolvedValue([]);
+        dbMocks.getUnreadChatCounts.mockResolvedValue({
+            'team-unread': 4,
+            'team-unknown': 1
+        });
+        dbMocks.getChatMessages.mockResolvedValue([]);
+
+        const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
+        const inbox = await loadChatInbox({
+            uid: 'user-1',
+            email: 'parent@example.com',
+            displayName: 'Pat Parent',
+            roles: ['parent']
+        });
+
+        expect(dbMocks.getUnreadChatCounts).toHaveBeenCalledWith('user-1', ['team-unread', 'team-unknown'], {
+            latestMessageAtByTeam: {
+                'team-read': new Date('2026-05-21T12:00:00Z'),
+                'team-unread': new Date('2026-05-21T14:00:00Z')
+            }
+        });
+        expect(inbox.teams).toEqual(expect.arrayContaining([
+            expect.objectContaining({ id: 'team-read', unreadCount: 0 }),
+            expect.objectContaining({ id: 'team-unread', unreadCount: 4 }),
+            expect.objectContaining({ id: 'team-unknown', unreadCount: 1 })
+        ]));
     });
 
     it('uses only the newest conversation lookup per team when timestamps are usable', async () => {

--- a/tests/unit/dashboard-parent-membership-sync.test.js
+++ b/tests/unit/dashboard-parent-membership-sync.test.js
@@ -21,7 +21,7 @@ describe('dashboard parent membership sync', () => {
     const html = readRepoFile('dashboard.html');
 
     it('uses the rich auth path before loading parent-linked teams', () => {
-        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=60';");
+        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=61';");
         expect(html).toContain("import { checkAuth } from './js/auth.js?v=31';");
         expect(html).toContain('function requireSyncedAuth()');
         expect(html).toContain('const user = await requireSyncedAuth();');

--- a/tests/unit/db-unread-chat-counts.test.js
+++ b/tests/unit/db-unread-chat-counts.test.js
@@ -268,6 +268,27 @@ describe('chat unread count helpers', () => {
         }));
         expect(warn).toHaveBeenCalledWith('Failed to get unread count for team team-b:', expect.any(Error));
     });
+
+    it('returns zero counts when the shared user profile read fails', async () => {
+        const getUnreadChatCount = vi.fn();
+        const getDoc = vi.fn().mockRejectedValue(new Error('permission denied'));
+        const doc = vi.fn(() => ({ path: 'users/user-4' }));
+        const warn = vi.fn();
+        const getUnreadChatCounts = buildGetUnreadChatCounts({
+            db: {},
+            getDoc,
+            doc,
+            getUnreadChatCount,
+            console: { warn }
+        });
+
+        await expect(getUnreadChatCounts('user-4', ['team-a', 'team-b'])).resolves.toEqual({
+            'team-a': 0,
+            'team-b': 0
+        });
+        expect(getUnreadChatCount).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalledWith('Failed to load chat state for user user-4:', expect.any(Error));
+    });
 });
 
 describe('chat user state persistence helpers', () => {

--- a/tests/unit/db-unread-chat-counts.test.js
+++ b/tests/unit/db-unread-chat-counts.test.js
@@ -13,7 +13,7 @@ function getFunctionSource(functionName) {
     return dbSource.slice(start, end);
 }
 
-function buildGetUnreadChatCount({ db, getDoc, doc, collection, query, where, getCountFromServer }) {
+function buildGetUnreadChatCount({ db, getDoc, doc, collection, query, where, orderBy, limit, getDocs, getCountFromServer }) {
     const functionSource = getFunctionSource('getUnreadChatCount')
         .replace('export async function getUnreadChatCount', 'return async function getUnreadChatCount');
 
@@ -24,6 +24,9 @@ function buildGetUnreadChatCount({ db, getDoc, doc, collection, query, where, ge
         'collection',
         'query',
         'where',
+        'orderBy',
+        'limit',
+        'getDocs',
         'getCountFromServer',
         functionSource
     )(
@@ -33,19 +36,28 @@ function buildGetUnreadChatCount({ db, getDoc, doc, collection, query, where, ge
         collection,
         query,
         where,
+        orderBy,
+        limit,
+        getDocs,
         getCountFromServer
     );
 }
 
-function buildGetUnreadChatCounts({ getUnreadChatCount, console }) {
+function buildGetUnreadChatCounts({ db, getDoc, doc, getUnreadChatCount, console }) {
     const functionSource = getFunctionSource('getUnreadChatCounts')
         .replace('export async function getUnreadChatCounts', 'return async function getUnreadChatCounts');
 
     return new Function(
+        'db',
+        'getDoc',
+        'doc',
         'getUnreadChatCount',
         'console',
         functionSource
     )(
+        db,
+        getDoc,
+        doc,
         getUnreadChatCount,
         console
     );
@@ -97,7 +109,12 @@ describe('chat unread count helpers', () => {
         const messagesRef = { path: 'teams/team-1/chatMessages' };
         const collection = vi.fn(() => messagesRef);
         const where = vi.fn((field, op, value) => ({ field, op, value }));
+        const orderBy = vi.fn((field, direction) => ({ field, direction }));
+        const limit = vi.fn((value) => ({ limit: value }));
         const query = vi.fn((ref, ...constraints) => ({ ref, constraints }));
+        const getDocs = vi.fn().mockResolvedValue({
+            docs: [{ data: () => ({ createdAt: { seconds: 200 } }) }]
+        });
         const getCountFromServer = vi.fn()
             .mockResolvedValueOnce(makeCountSnapshot(7))
             .mockResolvedValueOnce(makeCountSnapshot(2));
@@ -109,15 +126,22 @@ describe('chat unread count helpers', () => {
             collection,
             query,
             where,
+            orderBy,
+            limit,
+            getDocs,
             getCountFromServer
         });
 
         await expect(getUnreadChatCount('user-1', 'team-1')).resolves.toBe(5);
         expect(getCountFromServer).toHaveBeenCalledTimes(2);
         expect(query).toHaveBeenNthCalledWith(1, messagesRef,
-            { field: 'createdAt', op: '>', value: lastRead }
+            { field: 'createdAt', direction: 'desc' },
+            { limit: 1 }
         );
         expect(query).toHaveBeenNthCalledWith(2, messagesRef,
+            { field: 'createdAt', op: '>', value: lastRead }
+        );
+        expect(query).toHaveBeenNthCalledWith(3, messagesRef,
             { field: 'createdAt', op: '>', value: lastRead },
             { field: 'senderId', op: '==', value: 'user-1' }
         );
@@ -131,7 +155,12 @@ describe('chat unread count helpers', () => {
         const messagesRef = { path: 'teams/team-9/chatMessages' };
         const collection = vi.fn(() => messagesRef);
         const where = vi.fn((field, op, value) => ({ field, op, value }));
+        const orderBy = vi.fn((field, direction) => ({ field, direction }));
+        const limit = vi.fn((value) => ({ limit: value }));
         const query = vi.fn((ref, ...constraints) => ({ ref, constraints }));
+        const getDocs = vi.fn().mockResolvedValue({
+            docs: [{ data: () => ({ createdAt: { seconds: 200 } }) }]
+        });
         const getCountFromServer = vi.fn()
             .mockResolvedValueOnce(makeCountSnapshot(4))
             .mockResolvedValueOnce(makeCountSnapshot(1));
@@ -143,34 +172,100 @@ describe('chat unread count helpers', () => {
             collection,
             query,
             where,
+            orderBy,
+            limit,
+            getDocs,
             getCountFromServer
         });
 
         await expect(getUnreadChatCount('user-2', 'team-9')).resolves.toBe(3);
-        expect(query).toHaveBeenNthCalledWith(1, messagesRef);
-        expect(query).toHaveBeenNthCalledWith(2, messagesRef,
+        expect(query).toHaveBeenNthCalledWith(1, messagesRef,
+            { field: 'createdAt', direction: 'desc' },
+            { limit: 1 }
+        );
+        expect(query).toHaveBeenNthCalledWith(2, messagesRef);
+        expect(query).toHaveBeenNthCalledWith(3, messagesRef,
             { field: 'senderId', op: '==', value: 'user-2' }
         );
         expect(getCountFromServer).toHaveBeenCalledTimes(2);
     });
 
-    it('keeps multi-team unread counts on the aggregate helper path', async () => {
+    it('skips count queries when the latest team message is already read', async () => {
+        const lastRead = { seconds: 300 };
+        const getDoc = vi.fn();
+        const doc = vi.fn();
+        const messagesRef = { path: 'teams/team-1/chatMessages' };
+        const collection = vi.fn(() => messagesRef);
+        const where = vi.fn((field, op, value) => ({ field, op, value }));
+        const orderBy = vi.fn((field, direction) => ({ field, direction }));
+        const limit = vi.fn((value) => ({ limit: value }));
+        const query = vi.fn((ref, ...constraints) => ({ ref, constraints }));
+        const getDocs = vi.fn().mockResolvedValue({
+            docs: [{ data: () => ({ createdAt: { seconds: 200 } }) }]
+        });
+        const getCountFromServer = vi.fn();
+
+        const getUnreadChatCount = buildGetUnreadChatCount({
+            db: {},
+            getDoc,
+            doc,
+            collection,
+            query,
+            where,
+            orderBy,
+            limit,
+            getDocs,
+            getCountFromServer
+        });
+
+        await expect(getUnreadChatCount('user-1', 'team-1', {
+            userData: {
+                teamChatState: {
+                    'team-1': {
+                        lastReadAt: lastRead
+                    }
+                }
+            }
+        })).resolves.toBe(0);
+        expect(getCountFromServer).not.toHaveBeenCalled();
+    });
+
+    it('reuses one user profile read and passes latest-message hints across teams', async () => {
         const getUnreadChatCount = vi.fn()
             .mockResolvedValueOnce(3)
             .mockRejectedValueOnce(new Error('index pending'));
+        const getDoc = vi.fn().mockResolvedValue({
+            data: () => ({ teamChatState: { 'team-a': { lastReadAt: { seconds: 100 } } } })
+        });
+        const doc = vi.fn(() => ({ path: 'users/user-3' }));
         const warn = vi.fn();
         const getUnreadChatCounts = buildGetUnreadChatCounts({
+            db: {},
+            getDoc,
+            doc,
             getUnreadChatCount,
             console: { warn }
         });
 
-        await expect(getUnreadChatCounts('user-3', ['team-a', 'team-b'])).resolves.toEqual({
+        await expect(getUnreadChatCounts('user-3', ['team-a', 'team-b'], {
+            latestMessageAtByTeam: {
+                'team-a': { seconds: 150 },
+                'team-b': { seconds: 250 }
+            }
+        })).resolves.toEqual({
             'team-a': 3,
             'team-b': 0
         });
+        expect(getDoc).toHaveBeenCalledTimes(1);
         expect(getUnreadChatCount).toHaveBeenCalledTimes(2);
-        expect(getUnreadChatCount).toHaveBeenNthCalledWith(1, 'user-3', 'team-a');
-        expect(getUnreadChatCount).toHaveBeenNthCalledWith(2, 'user-3', 'team-b');
+        expect(getUnreadChatCount).toHaveBeenNthCalledWith(1, 'user-3', 'team-a', expect.objectContaining({
+            userData: { teamChatState: { 'team-a': { lastReadAt: { seconds: 100 } } } },
+            latestMessageAt: { seconds: 150 }
+        }));
+        expect(getUnreadChatCount).toHaveBeenNthCalledWith(2, 'user-3', 'team-b', expect.objectContaining({
+            userData: { teamChatState: { 'team-a': { lastReadAt: { seconds: 100 } } } },
+            latestMessageAt: { seconds: 250 }
+        }));
         expect(warn).toHaveBeenCalledWith('Failed to get unread count for team team-b:', expect.any(Error));
     });
 });


### PR DESCRIPTION
Closes #2713

## What changed
- changed `js/db.js` unread helpers to load the user chat state once per inbox unread calculation instead of once per team
- added a latest-message guard so teams with no messages, or teams whose newest known message is not newer than `lastReadAt`, return `0` without running aggregate unread count queries
- updated `apps/app/src/lib/chatService.ts` to skip exact unread count requests for teams whose known `lastMessageAt` is already at or before the user’s last-read timestamp when that metadata is available
- added focused regression coverage for both the Firestore helper path and the app inbox integration path

## Root Cause
The inbox unread flow fanned out per team in two ways: `getUnreadChatCounts()` reloaded `users/{userId}` for every team through `getUnreadChatCount()`, and it immediately ran aggregate count queries for every accessible team without first checking whether each team had any message newer than the user's `lastReadAt`.

## Prevention / Learning
For per-entity unread badges, fetch shared user state once, compare each entity's newest-known activity timestamp against last-read state before counting, and only run exact unread queries for entities that are still candidates for unread work.

## Regression Tests
- `npx vitest run tests/unit/db-unread-chat-counts.test.js tests/unit/app-chat-service-recipients.test.js --reporter=verbose`
- `tests/unit/db-unread-chat-counts.test.js` now proves one user-profile read is reused across teams and count queries are skipped when the latest message is already read
- `tests/unit/app-chat-service-recipients.test.js` now proves inbox loading only requests exact unread counts for teams whose known latest message is newer than the saved last-read timestamp while preserving returned unread badges