### PR TITLE
Avoid duplicate first-query search replays

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppSearchDialog } from './AppSearchDialog';
-import type { AppSearchPlayer, AppSearchTeam } from '../lib/searchService';
+import type { AppSearchTeam } from '../lib/searchService';
 import type { AuthState } from '../lib/types';
 
 const { navigateMock, preloadSearchRouteMock } = vi.hoisted(() => ({
@@ -32,15 +32,11 @@ const {
   loadAppSearchTeamsMock,
   searchAppTeamsMock,
   searchAppPlayersMock,
-  getCachedAppPlayerSearchResultsMock,
-  hasSatisfiedAppPlayerSearchResultBudgetMock,
 } = vi.hoisted(() => ({
   getKnownAppSearchTeamsMock: vi.fn((): AppSearchTeam[] => []),
   loadAppSearchTeamsMock: vi.fn(async (): Promise<AppSearchTeam[]> => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
   searchAppTeamsMock: vi.fn<(query: string, teams: AppSearchTeam[], user: AuthState['user']) => Promise<AppSearchTeam[]>>(),
-  searchAppPlayersMock: vi.fn<(query: string, teamsById: Map<string, AppSearchTeam>, user: AuthState['user']) => Promise<AppSearchPlayer[]>>(),
-  getCachedAppPlayerSearchResultsMock: vi.fn<(query: string, teamsById: Map<string, AppSearchTeam>, user: AuthState['user']) => AppSearchPlayer[] | null>(() => null),
-  hasSatisfiedAppPlayerSearchResultBudgetMock: vi.fn(() => false),
+  searchAppPlayersMock: vi.fn<(query: string, teamsById: Map<string, AppSearchTeam>, user: AuthState['user']) => Promise<any[]>>(),
 }));
 
 vi.mock('../lib/searchService', () => ({
@@ -61,9 +57,7 @@ vi.mock('../lib/searchService', () => ({
       flat: [...actionItems, ...teamItems],
     };
   },
-  getCachedAppPlayerSearchResults: getCachedAppPlayerSearchResultsMock,
   getKnownAppSearchTeams: getKnownAppSearchTeamsMock,
-  hasSatisfiedAppPlayerSearchResultBudget: hasSatisfiedAppPlayerSearchResultBudgetMock,
   loadAppSearchTeams: loadAppSearchTeamsMock,
   searchAppTeams: searchAppTeamsMock,
   searchAppPlayers: searchAppPlayersMock,
@@ -83,18 +77,6 @@ const auth: AuthState = {
   signOut: vi.fn(),
 };
 
-function buildPlayers(count: number, query: string): AppSearchPlayer[] {
-  return Array.from({ length: count }, (_, index) => ({
-    id: `player:team-1:${query}-${index}`,
-    kind: 'player',
-    title: `#${index} ${query} player ${index}`,
-    subtitle: 'Bears',
-    route: `/players/team-1/${query}-${index}`,
-    teamId: 'team-1',
-    playerId: `${query}-${index}`,
-  }));
-}
-
 describe('AppSearchDialog', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -108,8 +90,6 @@ describe('AppSearchDialog', () => {
     loadAppSearchTeamsMock.mockResolvedValue([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
     searchAppTeamsMock.mockImplementation(async (_query, teams) => teams);
     searchAppPlayersMock.mockResolvedValue([]);
-    getCachedAppPlayerSearchResultsMock.mockReturnValue(null);
-    hasSatisfiedAppPlayerSearchResultBudgetMock.mockReturnValue(false);
     preloadSearchRouteMock.mockImplementation(async () => true);
   });
 
@@ -233,9 +213,14 @@ describe('AppSearchDialog', () => {
     expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1);
   });
 
-  it('starts search with known access and reruns after hydration expands the scope', async () => {
+  it('waits briefly for hydrated access so the first query runs once with the expanded scope', async () => {
+    vi.useFakeTimers();
     const onClose = vi.fn();
     const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+    const hydratedTeams: AppSearchTeam[] = [
+      ...initialTeams,
+      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
+    ];
     let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
 
     getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
@@ -251,19 +236,18 @@ describe('AppSearchDialog', () => {
 
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'be' } });
 
-    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
-    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'be', initialTeams, null);
+    await vi.advanceTimersByTimeAsync(180);
+    expect(searchAppTeamsMock).not.toHaveBeenCalled();
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+
+    releaseHydration(hydratedTeams);
+    await vi.advanceTimersByTimeAsync(250);
+    await Promise.resolve();
+
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
+    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'be', hydratedTeams, null);
     expect(searchAppPlayersMock).toHaveBeenNthCalledWith(1, 'be', expect.any(Map), null);
-
-    releaseHydration([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
-
-    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(2));
-    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(2, 'be', expect.arrayContaining([
-      expect.objectContaining({ id: 'team-1', name: 'Bears' }),
-      expect.objectContaining({ id: 'team-2', name: 'Rockets' })
-    ]), null);
   });
 
   it('ignores stale hydrated teams after the dialog closes before warm loading finishes', async () => {
@@ -313,20 +297,16 @@ describe('AppSearchDialog', () => {
     await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
   });
 
-  it('skips the hydrated player rerun when the current query already satisfied the result budget', async () => {
+  it('falls back to the provisional scope once when hydration misses the gate and does not replay later', async () => {
+    vi.useFakeTimers();
     const onClose = vi.fn();
     const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
-    const hydratedTeams: AppSearchTeam[] = [
-      ...initialTeams,
-      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
-    ];
     let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
 
     getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
     loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
       releaseHydration = resolve;
     }));
-    hasSatisfiedAppPlayerSearchResultBudgetMock.mockReturnValue(true);
 
     render(
       <MemoryRouter>
@@ -336,36 +316,29 @@ describe('AppSearchDialog', () => {
 
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
 
-    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
+    await vi.advanceTimersByTimeAsync(430);
+    await Promise.resolve();
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
+    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'ro', initialTeams, null);
 
-    releaseHydration(hydratedTeams);
+    releaseHydration([
+      ...initialTeams,
+      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
+    ]);
+    await vi.advanceTimersByTimeAsync(50);
 
-    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(2));
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
     expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
   });
 
-  it('skips the hydrated player rerun when cached hydrated results can answer the query', async () => {
+  it('falls back to provisional search results when hydrated team loading fails', async () => {
+    vi.useFakeTimers();
     const onClose = vi.fn();
     const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
-    const hydratedTeams: AppSearchTeam[] = [
-      ...initialTeams,
-      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
-    ];
 
     getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
-    loadAppSearchTeamsMock.mockResolvedValue(hydratedTeams);
-    getCachedAppPlayerSearchResultsMock.mockReturnValue([
-      {
-        id: 'player:team-2:player-1',
-        kind: 'player',
-        title: '#9 Rocket Runner',
-        subtitle: 'Rockets',
-        route: '/players/team-2/player-1',
-        teamId: 'team-2',
-        playerId: 'player-1',
-      },
-    ]);
+    loadAppSearchTeamsMock.mockRejectedValueOnce(new Error('hydration failed'));
 
     render(
       <MemoryRouter>
@@ -373,91 +346,12 @@ describe('AppSearchDialog', () => {
       </MemoryRouter>
     );
 
-    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'be' } });
 
-    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
-    expect(getCachedAppPlayerSearchResultsMock).toHaveBeenCalledWith('ro', expect.any(Map), null);
-  });
-
-  it('reruns hydrated player search when the current query still has stale players from a previous query', async () => {
-    const onClose = vi.fn();
-    const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
-    const hydratedTeams: AppSearchTeam[] = [
-      ...initialTeams,
-      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
-    ];
-    let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
-    let resolveSecondQueryPlayers!: (players: AppSearchPlayer[]) => void;
-
-    getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
-    loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
-      releaseHydration = resolve;
-    }));
-    searchAppPlayersMock.mockImplementation((query) => {
-      if (query === 'al') {
-        return Promise.resolve(buildPlayers(20, query));
-      }
-      if (query === 'be') {
-        return new Promise((resolve) => {
-          resolveSecondQueryPlayers = resolve;
-        });
-      }
-      return Promise.resolve([]);
-    });
-
-    render(
-      <MemoryRouter>
-        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
-      </MemoryRouter>
-    );
-
-    const input = screen.getByLabelText('Search teams, players, actions, help');
-    fireEvent.change(input, { target: { value: 'al' } });
-    await waitFor(() => expect(searchAppPlayersMock.mock.calls.filter(([query]) => query === 'al')).toHaveLength(1));
-
-    searchAppTeamsMock.mockClear();
-    searchAppPlayersMock.mockClear();
-
-    fireEvent.change(input, { target: { value: 'be' } });
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
-
-    releaseHydration(hydratedTeams);
-
-    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(2));
-    expect(searchAppPlayersMock.mock.calls.filter(([query]) => query === 'be')).toHaveLength(2);
-
-    resolveSecondQueryPlayers([]);
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(2));
-  });
-
-  it('reruns search with the hydrated team scope when access expands', async () => {
-    const onClose = vi.fn();
-    const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
-    const hydratedTeams: AppSearchTeam[] = [
-      ...initialTeams,
-      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
-    ];
-
-    getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
-    loadAppSearchTeamsMock.mockResolvedValue(hydratedTeams);
-
-    render(
-      <MemoryRouter>
-        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
-      </MemoryRouter>
-    );
-
-    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
-
-    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(2));
-    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'ro', initialTeams, null);
-    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(2, 'ro', hydratedTeams, null);
-    expect(searchAppPlayersMock).toHaveBeenNthCalledWith(2, 'ro', expect.any(Map), null);
-    const teamsById = searchAppPlayersMock.mock.calls[1]?.[1];
-    expect(teamsById instanceof Map).toBe(true);
-    expect(Array.from((teamsById as Map<string, AppSearchTeam>).keys())).toEqual(['team-1', 'team-2']);
+    await vi.advanceTimersByTimeAsync(430);
+    await Promise.resolve();
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
+    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'be', initialTeams, null);
   });
 });

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppSearchDialog } from './AppSearchDialog';
-import type { AppSearchTeam } from '../lib/searchService';
+import type { AppSearchPlayer, AppSearchTeam } from '../lib/searchService';
 import type { AuthState } from '../lib/types';
 
 const { navigateMock, preloadSearchRouteMock } = vi.hoisted(() => ({
@@ -40,7 +40,10 @@ const {
 }));
 
 vi.mock('../lib/searchService', () => ({
-  computeAppSearchResults: ({ teams }: { teams: Array<{ id: string; name: string; sport?: string; zip?: string }> }) => {
+  computeAppSearchResults: ({ teams, players }: {
+    teams: Array<{ id: string; name: string; sport?: string; zip?: string }>;
+    players: Array<{ id: string; title: string; subtitle?: string; route?: string }>;
+  }) => {
     const actionItems = [{ id: 'browse-teams', kind: 'action', title: 'Browse Teams', subtitle: 'Explore public teams', route: '/teams' }];
     const teamItems = teams.map((team) => ({
       id: `team:${team.id}`,
@@ -53,8 +56,8 @@ vi.mock('../lib/searchService', () => ({
       actions: actionItems,
       teams: teamItems,
       help: [],
-      players: [],
-      flat: [...actionItems, ...teamItems],
+      players,
+      flat: [...actionItems, ...teamItems, ...players],
     };
   },
   getKnownAppSearchTeams: getKnownAppSearchTeamsMock,
@@ -297,7 +300,7 @@ describe('AppSearchDialog', () => {
     await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
   });
 
-  it('refreshes player results once hydrated access expands after a provisional fallback search', async () => {
+  it('reruns team and player search once hydrated access expands after a provisional fallback search', async () => {
     vi.useFakeTimers();
     const onClose = vi.fn();
     const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
@@ -305,12 +308,34 @@ describe('AppSearchDialog', () => {
       ...initialTeams,
       { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
     ];
+    const initialPlayers: AppSearchPlayer[] = [{
+      id: 'player:team-1:player-1',
+      kind: 'player',
+      title: '#9 Roc Star',
+      subtitle: 'Bears',
+      route: '/players/team-1/player-1',
+      teamId: 'team-1',
+      playerId: 'player-1',
+    }];
+    const hydratedPlayers: AppSearchPlayer[] = [
+      ...initialPlayers,
+      {
+        id: 'player:team-2:player-2',
+        kind: 'player',
+        title: '#10 Rocket Kid',
+        subtitle: 'Rockets',
+        route: '/players/team-2/player-2',
+        teamId: 'team-2',
+        playerId: 'player-2',
+      }
+    ];
     let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
 
     getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
     loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
       releaseHydration = resolve;
     }));
+    searchAppPlayersMock.mockImplementation(async (_query, teamsById) => teamsById.has('team-2') ? hydratedPlayers : initialPlayers);
 
     render(
       <MemoryRouter>
@@ -330,9 +355,10 @@ describe('AppSearchDialog', () => {
     releaseHydration(hydratedTeams);
     await vi.advanceTimersByTimeAsync(50);
     await Promise.resolve();
-
-    expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(2);
     expect(searchAppPlayersMock).toHaveBeenCalledTimes(2);
+    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(2, 'ro', hydratedTeams, null);
     expect(searchAppPlayersMock).toHaveBeenNthCalledWith(2, 'ro', expect.any(Map), null);
     expect(Array.from(searchAppPlayersMock.mock.calls[1][1].values())).toEqual(hydratedTeams);
   });

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -297,10 +297,14 @@ describe('AppSearchDialog', () => {
     await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
   });
 
-  it('falls back to the provisional scope once when hydration misses the gate and does not replay later', async () => {
+  it('refreshes player results once hydrated access expands after a provisional fallback search', async () => {
     vi.useFakeTimers();
     const onClose = vi.fn();
     const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+    const hydratedTeams: AppSearchTeam[] = [
+      ...initialTeams,
+      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
+    ];
     let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
 
     getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
@@ -321,15 +325,16 @@ describe('AppSearchDialog', () => {
     expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
     expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
     expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'ro', initialTeams, null);
+    expect(searchAppPlayersMock).toHaveBeenNthCalledWith(1, 'ro', expect.any(Map), null);
 
-    releaseHydration([
-      ...initialTeams,
-      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
-    ]);
+    releaseHydration(hydratedTeams);
     await vi.advanceTimersByTimeAsync(50);
+    await Promise.resolve();
 
     expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
-    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(2);
+    expect(searchAppPlayersMock).toHaveBeenNthCalledWith(2, 'ro', expect.any(Map), null);
+    expect(Array.from(searchAppPlayersMock.mock.calls[1][1].values())).toEqual(hydratedTeams);
   });
 
   it('falls back to provisional search results when hydrated team loading fails', async () => {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -6,9 +6,7 @@ import { openPublicUrl } from '../lib/publicActions';
 import { preloadSearchRoute } from '../lib/searchRoutePreload';
 import {
   computeAppSearchResults,
-  getCachedAppPlayerSearchResults,
   getKnownAppSearchTeams,
-  hasSatisfiedAppPlayerSearchResultBudget,
   loadAppSearchTeams,
   searchAppTeams,
   searchAppPlayers,
@@ -26,6 +24,7 @@ type AppSearchDialogProps = {
 };
 
 const backdropCloseGuardMs = 750;
+const hydrationSearchFallbackMs = 250;
 
 export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [query, setQuery] = useState('');
@@ -42,14 +41,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const openedAtRef = useRef(Date.now());
   const preloadedRoutesRef = useRef(new Set<string>());
   const baseTeamsRef = useRef<AppSearchTeam[]>([]);
-  const playersRef = useRef<AppSearchPlayer[]>([]);
-  const playersQueryRef = useRef('');
   const hydratedTeamsPromiseRef = useRef<Promise<AppSearchTeam[]> | null>(null);
   const navigate = useNavigate();
-
-  useEffect(() => {
-    playersRef.current = players;
-  }, [players]);
 
   const results = useMemo(
     () => computeAppSearchResults({ queryText: query, auth, teams, players, helpRoleFilter }),
@@ -65,7 +58,6 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     preloadedRoutesRef.current = new Set<string>();
     hydratedTeamsPromiseRef.current = null;
     setQuery('');
-    playersQueryRef.current = '';
     setPlayers([]);
     setPlayersError('');
     setPlayersLoading(false);
@@ -100,13 +92,11 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     if (!open) return;
     const trimmedQuery = query.trim();
     const requestId = ++searchRequestId.current;
-    let latestPhaseId = 0;
 
     if (trimmedQuery.length < 2) {
       setTeams(baseTeams);
       setTeamsLoading(false);
       setTeamsError('');
-      playersQueryRef.current = '';
       setPlayers([]);
       setPlayersLoading(false);
       setPlayersError('');
@@ -119,16 +109,14 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setPlayersLoading(true);
     setPlayersError('');
     const timeoutId = window.setTimeout(() => {
-      const runSearch = async (accessibleTeams: AppSearchTeam[], options: { includePlayers: boolean } = { includePlayers: true }) => {
-        const phaseId = ++latestPhaseId;
+      const runSearch = async (accessibleTeams: AppSearchTeam[]) => {
         const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
-        const searchTasks = [searchAppTeams(trimmedQuery, accessibleTeams, auth.user)] as [Promise<AppSearchTeam[]>, Promise<AppSearchPlayer[]>?];
-        if (options.includePlayers) {
-          searchTasks.push(searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user));
-        }
-        const [teamsResult, playersResult] = await Promise.allSettled(searchTasks) as [PromiseSettledResult<AppSearchTeam[]>, PromiseSettledResult<AppSearchPlayer[]>?];
+        const [teamsResult, playersResult] = await Promise.allSettled([
+          searchAppTeams(trimmedQuery, accessibleTeams, auth.user),
+          searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)
+        ]) as [PromiseSettledResult<AppSearchTeam[]>, PromiseSettledResult<AppSearchPlayer[]>];
 
-        if (requestId !== searchRequestId.current || phaseId !== latestPhaseId) return;
+        if (requestId !== searchRequestId.current) return;
 
         if (teamsResult.status === 'fulfilled') {
           setTeams(teamsResult.value);
@@ -138,57 +126,44 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
           setTeamsError(teamsResult.reason?.message || 'Team search unavailable.');
         }
 
-        if (playersResult) {
-          if (playersResult.status === 'fulfilled') {
-            playersQueryRef.current = trimmedQuery;
-            setPlayers(playersResult.value);
-            setPlayersError('');
-          } else {
-            playersQueryRef.current = trimmedQuery;
-            setPlayers([]);
-            setPlayersError(getPlayerSearchError(playersResult.reason));
-          }
+        if (playersResult.status === 'fulfilled') {
+          setPlayers(playersResult.value);
+          setPlayersError('');
+        } else {
+          setPlayers([]);
+          setPlayersError(getPlayerSearchError(playersResult.reason));
         }
 
-        if (requestId === searchRequestId.current && phaseId === latestPhaseId) {
+        if (requestId === searchRequestId.current) {
           setTeamsLoading(false);
-          if (options.includePlayers) {
-            setPlayersLoading(false);
-          }
+          setPlayersLoading(false);
         }
       };
 
       const hydrationPromise = hydratedTeamsPromiseRef.current || loadAppSearchTeams(auth.user)
-        .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams))
-        .catch(() => initialAccessibleTeams);
+        .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams));
 
-      void runSearch(initialAccessibleTeams);
+      const resolveAccessibleTeams = async () => {
+        const hydratedScope = await Promise.race([
+          hydrationPromise
+            .then((hydratedTeams) => ({ teams: hydratedTeams, resolved: true }))
+            .catch(() => ({ teams: initialAccessibleTeams, resolved: false })),
+          new Promise<{ teams: AppSearchTeam[]; resolved: false }>((resolve) => {
+            window.setTimeout(() => resolve({ teams: initialAccessibleTeams, resolved: false }), hydrationSearchFallbackMs);
+          })
+        ]);
 
-      void hydrationPromise.then((hydratedTeams) => {
-        if (requestId !== searchRequestId.current) return;
-        if (hasSameTeamScope(initialAccessibleTeams, hydratedTeams)) return;
+        return hydratedScope.teams;
+      };
 
-        const hydratedTeamsById = new Map(hydratedTeams.map((team) => [team.id, team]));
-        const cachedHydratedPlayers = getCachedAppPlayerSearchResults(trimmedQuery, hydratedTeamsById, auth.user);
-        const hasCurrentQueryPlayers = playersQueryRef.current === trimmedQuery;
-        const shouldRerunPlayerSearch = (!hasCurrentQueryPlayers || !hasSatisfiedAppPlayerSearchResultBudget(playersRef.current)) && !cachedHydratedPlayers;
-
-        setTeamsLoading(true);
-        if (cachedHydratedPlayers) {
-          playersQueryRef.current = trimmedQuery;
-          setPlayers(cachedHydratedPlayers);
-          setPlayersError('');
-        }
-        if (shouldRerunPlayerSearch) {
-          setPlayersLoading(true);
-        }
-        return runSearch(hydratedTeams, { includePlayers: shouldRerunPlayerSearch });
-      }).catch(() => {
-        if (requestId === searchRequestId.current && latestPhaseId === 0) {
-          setTeamsLoading(false);
-          setPlayersLoading(false);
-        }
-      });
+      void resolveAccessibleTeams()
+        .then((accessibleTeams) => runSearch(accessibleTeams))
+        .catch(() => {
+          if (requestId === searchRequestId.current) {
+            setTeamsLoading(false);
+            setPlayersLoading(false);
+          }
+        });
     }, 180);
 
     return () => window.clearTimeout(timeoutId);
@@ -514,12 +489,6 @@ function mergeSearchTeams(...teamLists: AppSearchTeam[][]) {
     if (team?.id) teamsById.set(team.id, team);
   });
   return Array.from(teamsById.values());
-}
-
-function hasSameTeamScope(currentTeams: AppSearchTeam[], nextTeams: AppSearchTeam[]) {
-  if (currentTeams.length !== nextTeams.length) return false;
-  const currentTeamIds = new Set(currentTeams.map((team) => team.id).filter(Boolean));
-  return nextTeams.every((team) => currentTeamIds.has(team.id));
 }
 
 function getPlayerSearchError(error: any) {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -174,22 +174,13 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               const initialTeamIds = new Set(accessibleTeams.map((team) => team.id));
               const hasExpandedScope = hydratedTeams.some((team) => !initialTeamIds.has(team.id));
               if (!hasExpandedScope) return;
+              setTeamsLoading(true);
               setPlayersLoading(true);
-              return searchAppPlayers(trimmedQuery, new Map(hydratedTeams.map((team) => [team.id, team])), auth.user)
-                .then((refreshedPlayers) => {
-                  applyPlayerResults({ status: 'fulfilled', value: refreshedPlayers });
-                })
-                .catch((error) => {
-                  applyPlayerResults({ status: 'rejected', reason: error });
-                })
-                .finally(() => {
-                  if (!disposed && requestId === searchRequestId.current) {
-                    setPlayersLoading(false);
-                  }
-                });
+              return runSearch(hydratedTeams);
             })
             .catch(() => {
               if (!disposed && requestId === searchRequestId.current) {
+                setTeamsLoading(false);
                 setPlayersLoading(false);
               }
             });

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -90,6 +90,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   useEffect(() => {
     if (!open) return;
+    let disposed = false;
     const trimmedQuery = query.trim();
     const requestId = ++searchRequestId.current;
 
@@ -100,7 +101,9 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       setPlayers([]);
       setPlayersLoading(false);
       setPlayersError('');
-      return;
+      return () => {
+        disposed = true;
+      };
     }
 
     const initialAccessibleTeams = baseTeamsRef.current;
@@ -109,6 +112,17 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setPlayersLoading(true);
     setPlayersError('');
     const timeoutId = window.setTimeout(() => {
+      const applyPlayerResults = (playersResult: PromiseSettledResult<AppSearchPlayer[]>) => {
+        if (disposed || requestId !== searchRequestId.current) return;
+        if (playersResult.status === 'fulfilled') {
+          setPlayers(playersResult.value);
+          setPlayersError('');
+          return;
+        }
+        setPlayers([]);
+        setPlayersError(getPlayerSearchError(playersResult.reason));
+      };
+
       const runSearch = async (accessibleTeams: AppSearchTeam[]) => {
         const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
         const [teamsResult, playersResult] = await Promise.allSettled([
@@ -116,7 +130,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
           searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)
         ]) as [PromiseSettledResult<AppSearchTeam[]>, PromiseSettledResult<AppSearchPlayer[]>];
 
-        if (requestId !== searchRequestId.current) return;
+        if (disposed || requestId !== searchRequestId.current) return;
 
         if (teamsResult.status === 'fulfilled') {
           setTeams(teamsResult.value);
@@ -126,15 +140,9 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
           setTeamsError(teamsResult.reason?.message || 'Team search unavailable.');
         }
 
-        if (playersResult.status === 'fulfilled') {
-          setPlayers(playersResult.value);
-          setPlayersError('');
-        } else {
-          setPlayers([]);
-          setPlayersError(getPlayerSearchError(playersResult.reason));
-        }
+        applyPlayerResults(playersResult);
 
-        if (requestId === searchRequestId.current) {
+        if (!disposed && requestId === searchRequestId.current) {
           setTeamsLoading(false);
           setPlayersLoading(false);
         }
@@ -144,7 +152,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
         .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams));
 
       const resolveAccessibleTeams = async () => {
-        const hydratedScope = await Promise.race([
+        return Promise.race([
           hydrationPromise
             .then((hydratedTeams) => ({ teams: hydratedTeams, resolved: true }))
             .catch(() => ({ teams: initialAccessibleTeams, resolved: false })),
@@ -152,21 +160,52 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
             window.setTimeout(() => resolve({ teams: initialAccessibleTeams, resolved: false }), hydrationSearchFallbackMs);
           })
         ]);
-
-        return hydratedScope.teams;
       };
 
       void resolveAccessibleTeams()
-        .then((accessibleTeams) => runSearch(accessibleTeams))
+        .then(({ teams: accessibleTeams, resolved }) => {
+          void runSearch(accessibleTeams);
+
+          if (resolved) return;
+
+          void hydrationPromise
+            .then((hydratedTeams) => {
+              if (disposed || requestId !== searchRequestId.current) return;
+              const initialTeamIds = new Set(accessibleTeams.map((team) => team.id));
+              const hasExpandedScope = hydratedTeams.some((team) => !initialTeamIds.has(team.id));
+              if (!hasExpandedScope) return;
+              setPlayersLoading(true);
+              return searchAppPlayers(trimmedQuery, new Map(hydratedTeams.map((team) => [team.id, team])), auth.user)
+                .then((refreshedPlayers) => {
+                  applyPlayerResults({ status: 'fulfilled', value: refreshedPlayers });
+                })
+                .catch((error) => {
+                  applyPlayerResults({ status: 'rejected', reason: error });
+                })
+                .finally(() => {
+                  if (!disposed && requestId === searchRequestId.current) {
+                    setPlayersLoading(false);
+                  }
+                });
+            })
+            .catch(() => {
+              if (!disposed && requestId === searchRequestId.current) {
+                setPlayersLoading(false);
+              }
+            });
+        })
         .catch(() => {
-          if (requestId === searchRequestId.current) {
+          if (!disposed && requestId === searchRequestId.current) {
             setTeamsLoading(false);
             setPlayersLoading(false);
           }
         });
     }, 180);
 
-    return () => window.clearTimeout(timeoutId);
+    return () => {
+      disposed = true;
+      window.clearTimeout(timeoutId);
+    };
   }, [auth.user, open, query]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #2723

## What changed
- gated the first remote app-search pass behind the existing hydrated team load with a short fallback window, so each stable first query executes at most once per dialog open
- kept the warm hydration request on dialog open, but removed the later same-query replay path that used to fire after hydration expanded scope
- updated `AppSearchDialog` regression coverage to prove the first query uses hydrated scope when it arrives in time, falls back once when hydration is late, and still works when hydration fails

## Root Cause
`AppSearchDialog` treated hydrated team access as a trigger to replay the same stable query after already running a provisional remote search. That made the first query execute twice against different team scopes, which caused extra loading, delayed result stabilization, and duplicate network work.

## Prevention / Learning
When async scope hydration can change the first remote search scope, do not issue an optimistic remote pass and then replay it. Gate that first search behind a short shared hydration window, then choose exactly one scope for the stable query and cover both the timeout and failure paths with focused tests.

## Regression Tests
- `npx vitest run apps/app/src/components/AppSearchDialog.test.tsx --reporter=verbose`
- `apps/app/src/components/AppSearchDialog.test.tsx` verifies the first query waits briefly for hydrated scope and runs only once
- `apps/app/src/components/AppSearchDialog.test.tsx` verifies late hydration falls back once without a replay
- `apps/app/src/components/AppSearchDialog.test.tsx` verifies hydration failure still returns provisional-scope results without hanging