### PR TITLE
Lock in throttled inbox preview hydration

### DIFF
--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -581,6 +581,86 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Coach Jamie: Practice packet posted.');
     });
 
+    it('applies deferred preview updates incrementally without losing inbox ordering', async () => {
+        let onPreview;
+        chatMocks.loadChatInbox.mockImplementationOnce(async (_user, options = {}) => {
+            onPreview = options.onPreview;
+            return {
+                teams: [
+                    {
+                        id: 'team-1',
+                        name: 'Bears',
+                        sport: 'Basketball',
+                        role: 'Admin',
+                        canModerate: true,
+                        unreadCount: 0,
+                        lastMessage: null,
+                        preferredConversationId: null
+                    },
+                    {
+                        id: 'team-2',
+                        name: 'Thunder',
+                        sport: 'Soccer',
+                        role: 'Parent',
+                        canModerate: false,
+                        unreadCount: 1,
+                        lastMessage: null,
+                        preferredConversationId: null
+                    }
+                ]
+            };
+        });
+
+        const { container } = await renderMessages('/messages');
+
+        expect(Array.from(container.querySelectorAll('.message-row')).map((row) => row.textContent || '')).toEqual([
+            expect.stringContaining('Bears'),
+            expect.stringContaining('Thunder')
+        ]);
+        expect(container.textContent).toContain('No messages yet');
+
+        await act(async () => {
+            onPreview?.({
+                teamId: 'team-2',
+                lastMessage: chatMessage({
+                    id: 'last-2',
+                    text: 'Tournament schedule changed.',
+                    senderName: 'Morgan',
+                    createdAt: new Date('2026-05-21T15:00:00Z')
+                }),
+                preferredConversationId: null,
+                isMuted: false
+            });
+        });
+        await flush();
+
+        let rows = Array.from(container.querySelectorAll('.message-row')).map((row) => row.textContent || '');
+        expect(rows[0]).toContain('Thunder');
+        expect(rows[0]).toContain('Morgan: Tournament schedule changed.');
+        expect(rows[1]).toContain('Bears');
+        expect(rows[1]).toContain('No messages yet');
+
+        await act(async () => {
+            onPreview?.({
+                teamId: 'team-1',
+                lastMessage: chatMessage({
+                    id: 'last-1',
+                    text: 'Practice packet posted.',
+                    createdAt: new Date('2026-05-21T14:00:00Z')
+                }),
+                preferredConversationId: null,
+                isMuted: false
+            });
+        });
+        await flush();
+
+        rows = Array.from(container.querySelectorAll('.message-row')).map((row) => row.textContent || '');
+        expect(rows[0]).toContain('Thunder');
+        expect(rows[1]).toContain('Bears');
+        expect(container.textContent).toContain('Morgan: Tournament schedule changed.');
+        expect(container.textContent).toContain('Coach Jamie: Practice packet posted.');
+    });
+
     it('refreshes the inbox and keeps the latest preview copy visible', async () => {
         chatMocks.loadChatInbox
             .mockResolvedValueOnce({


### PR DESCRIPTION
Closes #2637

## What changed
- added an inbox integration regression that starts `/messages` with deferred previews, applies preview callbacks one team at a time, and verifies the rows update progressively
- asserted that preview hydration preserves inbox ordering as newer previews arrive while older rows continue to render and later fill in
- kept the existing focused unit coverage for the bounded deferred preview queue as the guard on in-flight concurrency

## Root Cause
`loadChatInbox()` originally deferred preview hydration with an unbounded `Promise.allSettled(previewInputs.map(...))`, so opening the inbox for users with many teams launched every per-team preview job at once. Because each team preview can fan out into multiple conversation and message reads, first paint was followed by a burst of background work that could contend with scrolling and input on mobile.

## Prevention / Learning
When a route intentionally defers secondary data after first paint, the deferred path still needs an explicit concurrency bound and regression coverage for progressive UI updates. Future inbox-style hydration work should test both invariants: capped background fan-out and stable incremental rendering as callbacks resolve.

## Regression Tests
- `tests/unit/app-chat-service-recipients.test.js` proves deferred team preview work stays capped and later jobs do not start until a slot frees up
- `tests/unit/app-chat-messages-integration.test.jsx` now proves `/messages` renders rows immediately, applies deferred preview text incrementally, and preserves sort order while previews hydrate
- ran: `npx vitest run tests/unit/app-chat-messages-integration.test.jsx tests/unit/app-chat-service-recipients.test.js --reporter=dot`