### PR TITLE
Add regression coverage for child-aware push deep links

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -506,19 +506,6 @@ describe('ScheduleEventDetail route state', () => {
     expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-2&section=assignments');
   });
 
-  it('falls back safely when the route childId does not match an event', async () => {
-    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=missing-player&section=availability');
-
-    await waitFor(() => {
-      expect(screen.getAllByText(/Avery Smith/).length).toBeGreaterThan(0);
-    });
-
-    const switcher = screen.getByTestId('event-player-switcher');
-    expect(within(switcher).getByRole('button', { name: 'Avery Smith' }).getAttribute('aria-pressed')).toBe('true');
-    expect(within(switcher).getByRole('button', { name: 'Sam Lee' }).getAttribute('aria-pressed')).toBe('false');
-    expect(screen.getAllByRole('button', { name: 'Availability' })[0].className).toContain('bg-primary-600');
-    expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=missing-player&section=availability');
-  });
 });
 
 describe('ScheduleEventDetail rideshare permissions', () => {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -505,6 +505,20 @@ describe('ScheduleEventDetail route state', () => {
     expect(screen.getAllByRole('button', { name: 'Assignments' })[0].className).toContain('bg-primary-600');
     expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-2&section=assignments');
   });
+
+  it('falls back safely when the route childId does not match an event', async () => {
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=missing-player&section=availability');
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/Avery Smith/).length).toBeGreaterThan(0);
+    });
+
+    const switcher = screen.getByTestId('event-player-switcher');
+    expect(within(switcher).getByRole('button', { name: 'Avery Smith' }).getAttribute('aria-pressed')).toBe('true');
+    expect(within(switcher).getByRole('button', { name: 'Sam Lee' }).getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getAllByRole('button', { name: 'Availability' })[0].className).toContain('bg-primary-600');
+    expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=missing-player&section=availability');
+  });
 });
 
 describe('ScheduleEventDetail rideshare permissions', () => {

--- a/tests/unit/app-notification-open-routing.test.jsx
+++ b/tests/unit/app-notification-open-routing.test.jsx
@@ -117,7 +117,9 @@ describe('app notification open routing', () => {
         [{ category: 'liveScore', gameId: 'game-7' }, '/games/game-7'],
         [{ category: 'schedule', teamId: 'team-1', eventId: 'event-9' }, '/schedule/team-1/event-9'],
         [{ category: 'fees', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }, '/teams/team-1/fees/batch-1?recipientId=recipient-1'],
+        [{ category: 'rsvp', teamId: 'team-1', eventId: 'game-7', childId: 'player-2' }, '/schedule/team-1/game-7?childId=player-2&section=availability'],
         [{ category: 'rideshare', teamId: 'team-1', eventId: 'game-7' }, '/schedule/team-1/game-7?section=rideshare'],
+        [{ category: 'rideshare', teamId: 'team-1', eventId: 'game-7', childId: 'player-2' }, '/schedule/team-1/game-7?childId=player-2&section=rideshare'],
         [{ category: 'awards', teamId: 'team-1', certificateId: 'cert-1' }, '/parent-tools/certificates?teamId=team-1&certificateId=cert-1'],
         [{ category: 'officiating', teamId: 'team-1' }, '/officials?teamId=team-1']
     ])('navigates to the expected route when a notification is opened: %o', async (payload, expectedRoute) => {

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -2,7 +2,7 @@
 import React, { act } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 
 const scheduleMocks = vi.hoisted(() => ({
     cancelParentScheduleRideRequest: vi.fn(),
@@ -129,6 +129,11 @@ function report(overrides = {}) {
     };
 }
 
+function LocationProbe() {
+    const location = useLocation();
+    return React.createElement('div', { 'data-testid': 'location' }, `${location.pathname}${location.search}`);
+}
+
 async function renderDetail(initialEntry) {
     const container = document.createElement('div');
     document.body.appendChild(container);
@@ -138,13 +143,16 @@ async function renderDetail(initialEntry) {
         root.render(React.createElement(
             MemoryRouter,
             { initialEntries: [initialEntry] },
-            React.createElement(
-                Routes,
-                null,
-                React.createElement(Route, {
-                    path: '/schedule/:teamId/:eventId',
-                    element: React.createElement(ScheduleEventDetail, { auth })
-                })
+            React.createElement(React.Fragment, null,
+                React.createElement(LocationProbe),
+                React.createElement(
+                    Routes,
+                    null,
+                    React.createElement(Route, {
+                        path: '/schedule/:teamId/:eventId',
+                        element: React.createElement(ScheduleEventDetail, { auth })
+                    })
+                )
             )
         ));
     });
@@ -465,6 +473,24 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'Is Pat going?');
 
         expect(container.textContent).not.toContain('Game hub');
+    });
+
+    it('keeps the requested section while falling back to the first event when the route childId is unknown', async () => {
+        scheduleMocks.loadParentScheduleEventDetail.mockResolvedValue({
+            events: [
+                event({ childId: 'player-1', childName: 'Pat' }),
+                event({ eventKey: 'team-1::game-1::player-2', childId: 'player-2', childName: 'Sam', myRsvp: 'maybe' })
+            ]
+        });
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=missing-player&section=availability');
+        await waitForText(container, 'Is Pat going?');
+
+        const switcher = container.querySelector('[data-testid="event-player-switcher"]');
+        expect(switcher).not.toBeNull();
+        expect(buttonByText(switcher, 'Pat').getAttribute('aria-pressed')).toBe('true');
+        expect(buttonByText(switcher, 'Sam').getAttribute('aria-pressed')).toBe('false');
+        expect(container.querySelector('[data-testid="location"]')?.textContent).toBe('/schedule/team-1/game-1?childId=missing-player&section=availability');
     });
 
     it('renders the completed game More tab with replay and report actions wired to public URLs', async () => {


### PR DESCRIPTION
Closes #2595

## What changed
- added notification-open routing coverage for RSVP and rideshare pushes that include `childId`, so the app navigation contract stays pinned to the child-scoped schedule route
- added a ScheduleEventDetail route-state regression that proves an invalid `childId` still falls back safely to the first available child while preserving the route query
- kept the change set focused on the nearest regression tests because the child-aware payload and route plumbing is already present in the current code path

## Root Cause
The original defect was a contract gap: game-day RSVP and rideshare push payloads were event-scoped but not player-scoped, so notification opens dropped `childId` before ScheduleEventDetail rendered and the page fell back to the first child in the family.

## Prevention / Learning
For multi-actor deep links, treat the notification payload builder, app route parser, and first-paint page selection as one contract. Any route parameter that drives initial UI state needs end-to-end regression coverage across payload generation, notification open handling, and route hydration.

## Regression Tests
- `tests/unit/app-notification-open-routing.test.jsx`
  - verifies RSVP and rideshare notification opens preserve `childId` in the resolved schedule route
- `apps/app/src/pages/ScheduleEventDetail.test.tsx`
  - verifies route hydration selects the intended child from `childId`
  - verifies invalid `childId` values still fall back safely without breaking the event detail view
- validated adjacent contract tests remain green:
  - `tests/unit/push-notification-payload-contract.test.js`
  - `tests/unit/app-push-notification-routing.test.ts`

## Recurrence Risk
Medium. This bug class is easy to reintroduce whenever push payload schemas or deep-link builders change unless route parameters are asserted end to end.