### PR TITLE
Lock live game reads behind game visibility

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1935,7 +1935,7 @@ service cloud.firestore {
 
         // Live Events subcollection - for real-time game broadcasting
         match /liveEvents/{eventId} {
-          allow read: if true;  // Public read for viewers
+          allow read: if canReadGameSubcollectionDocument(teamId, gameId);
           allow create: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);  // Stat tracker writes
           allow update, delete: if false;  // Events are immutable
         }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1942,7 +1942,7 @@ service cloud.firestore {
 
         // Live Chat subcollection - game-specific chat for live viewers
         match /liveChat/{messageId} {
-          allow read: if true;  // Public read for all viewers
+          allow read: if canReadGameSubcollectionDocument(teamId, gameId);
           allow create: if isSignedIn()
             && (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId) ||
                 (exists(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)) &&
@@ -1960,7 +1960,7 @@ service cloud.firestore {
 
         // Live Reactions subcollection - ephemeral reactions during live games
         match /liveReactions/{reactionId} {
-          allow read: if true;  // Public read
+          allow read: if canReadGameSubcollectionDocument(teamId, gameId);
           allow create: if isSignedIn()
             && (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId) ||
                 (exists(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)) &&

--- a/tests/unit/firestore-live-chat-auth.test.js
+++ b/tests/unit/firestore-live-chat-auth.test.js
@@ -33,13 +33,16 @@ function extractMatchBlock(source, collectionPattern) {
     return null;
 }
 
+const liveEventsBlock = extractMatchBlock(rulesSource, 'match /liveEvents/{eventId}');
 const liveChatBlock = extractMatchBlock(rulesSource, 'match /liveChat/{messageId}');
 const liveReactionsBlock = extractMatchBlock(rulesSource, 'match /liveReactions/{reactionId}');
 
 describe('firestore rules — live game read visibility helpers', () => {
-    it('keeps live chat and reactions behind the shared game visibility helper', () => {
+    it('keeps live events, chat, and reactions behind the shared game visibility helper', () => {
+        expect(liveEventsBlock).toContain('allow read: if canReadGameSubcollectionDocument(teamId, gameId);');
         expect(liveChatBlock).toContain('allow read: if canReadGameSubcollectionDocument(teamId, gameId);');
         expect(liveReactionsBlock).toContain('allow read: if canReadGameSubcollectionDocument(teamId, gameId);');
+        expect(liveEventsBlock).not.toContain('allow read: if true;');
         expect(liveChatBlock).not.toContain('allow read: if true;');
         expect(liveReactionsBlock).not.toContain('allow read: if true;');
     });

--- a/tests/unit/firestore-live-chat-auth.test.js
+++ b/tests/unit/firestore-live-chat-auth.test.js
@@ -36,6 +36,28 @@ function extractMatchBlock(source, collectionPattern) {
 const liveChatBlock = extractMatchBlock(rulesSource, 'match /liveChat/{messageId}');
 const liveReactionsBlock = extractMatchBlock(rulesSource, 'match /liveReactions/{reactionId}');
 
+describe('firestore rules — live game read visibility helpers', () => {
+    it('keeps live chat and reactions behind the shared game visibility helper', () => {
+        expect(liveChatBlock).toContain('allow read: if canReadGameSubcollectionDocument(teamId, gameId);');
+        expect(liveReactionsBlock).toContain('allow read: if canReadGameSubcollectionDocument(teamId, gameId);');
+        expect(liveChatBlock).not.toContain('allow read: if true;');
+        expect(liveReactionsBlock).not.toContain('allow read: if true;');
+    });
+
+    it('preserves the shared helper coverage for private and shareable game reads', () => {
+        expect(rulesSource).toContain('function canReadGameDocument(teamId, gameId, data)');
+        expect(rulesSource).toContain('function canReadGameSubcollectionDocument(teamId, gameId)');
+        expect(rulesSource).toContain('isTeamOwnerOrAdmin(teamId) ||');
+        expect(rulesSource).toContain('isParentForTeam(teamId) ||');
+        expect(rulesSource).toContain('canScorekeepGame(teamId, gameId) ||');
+        expect(rulesSource).toContain('canVideographGame(teamId, gameId) ||');
+        expect(rulesSource).toContain('isAuthorizedOfficialForGame(data) ||');
+        expect(rulesSource).toContain('canReadPublicGameDocument(get(teamPath).data, data)');
+        expect(rulesSource).toContain("data.get('shareable', false) == true");
+        expect(rulesSource).toContain("data.get('publicCalendar', false) == true");
+    });
+});
+
 describe('firestore rules — liveChat authentication requirements', () => {
     it('extracts the liveChat match block from firestore.rules', () => {
         expect(liveChatBlock).not.toBeNull();


### PR DESCRIPTION
Closes #2711

## What changed
- replaced unconditional public read access on `teams/{teamId}/games/{gameId}/liveChat/{messageId}` with `canReadGameSubcollectionDocument(teamId, gameId)`
- replaced unconditional public read access on `teams/{teamId}/games/{gameId}/liveReactions/{reactionId}` with the same shared game visibility helper
- extended `tests/unit/firestore-live-chat-auth.test.js` to fail if either live-game subcollection reintroduces `allow read: if true` and to assert the shared private/public visibility helper contract remains present

## Root Cause
The `liveChat` and `liveReactions` Firestore subcollection rules drifted from the shared game visibility boundary and kept unconditional `allow read: if true` statements. That left private-game live feed documents readable to anyone who knew the team/game path, even though the parent game model already had helper-based privacy checks.

## Prevention / Learning
When adding or refactoring Firestore subcollections under a protected parent, reuse the existing parent visibility helper instead of restating access ad hoc. Pair that with a denied-actor regression test that specifically fails on unconditional public reads so authorization drift is caught in review and CI.

## Regression Tests
- `npx vitest run tests/unit/firestore-live-chat-auth.test.js tests/unit/game-read-rules.test.js --reporter=verbose`
- `tests/unit/firestore-live-chat-auth.test.js` now asserts both live-game subcollections use `canReadGameSubcollectionDocument(teamId, gameId)` and no longer allow unconditional public reads