### PR TITLE
Keep bundle visualizer tooltips visible

### DIFF
--- a/apps/app/build/fixBundleVisualizerTooltip.js
+++ b/apps/app/build/fixBundleVisualizerTooltip.js
@@ -1,0 +1,40 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const BROKEN_TOOLTIP_HANDLER = `          const handleMouseOut = () => {
+              setShowTooltip(false);
+          };
+          document.addEventListener("mouseover", handleMouseOut);
+          return () => {
+              document.removeEventListener("mouseover", handleMouseOut);
+          };`;
+
+const FIXED_TOOLTIP_HANDLER = `          const handleMouseOut = (event) => {
+              const target = event.target;
+              if (target instanceof Element && (target.closest(".node") || target.closest(".tooltip"))) {
+                  return;
+              }
+              setShowTooltip(false);
+          };
+          document.addEventListener("mouseover", handleMouseOut);
+          return () => {
+              document.removeEventListener("mouseover", handleMouseOut);
+          };`;
+
+export function fixBundleVisualizerTooltip(html) {
+    if (!html.includes(BROKEN_TOOLTIP_HANDLER)) {
+        return html;
+    }
+
+    return html.replace(BROKEN_TOOLTIP_HANDLER, FIXED_TOOLTIP_HANDLER);
+}
+
+export function patchBundleVisualizerTooltipFile(filePath) {
+    const html = readFileSync(filePath, 'utf8');
+    const patchedHtml = fixBundleVisualizerTooltip(html);
+
+    if (patchedHtml !== html) {
+        writeFileSync(filePath, patchedHtml);
+    }
+
+    return patchedHtml !== html;
+}

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -2,8 +2,17 @@ import path from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
+import { patchBundleVisualizerTooltipFile } from './build/fixBundleVisualizerTooltip.js';
 
 // https://vitejs.dev/config/
+const bundleVisualizerTooltipFixPlugin = {
+  name: 'bundle-visualizer-tooltip-fix',
+  apply: 'build',
+  writeBundle() {
+    patchBundleVisualizerTooltipFile(path.resolve(__dirname, 'bundle-visualizer.html'));
+  }
+};
+
 export default defineConfig({
   base: './',
   resolve: {
@@ -19,7 +28,8 @@ export default defineConfig({
       gzipSize: true,
       brotliSize: true,
       open: false
-    })
+    }),
+    bundleVisualizerTooltipFixPlugin
   ],
   server: {
     port: 5174,

--- a/tests/unit/app-bundle-visualizer-tooltip.test.js
+++ b/tests/unit/app-bundle-visualizer-tooltip.test.js
@@ -1,18 +1,20 @@
-import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import { fixBundleVisualizerTooltip } from '../../apps/app/build/fixBundleVisualizerTooltip.js';
 
-const repoRoot = new URL('../../', import.meta.url);
-
-function readRepoFile(relativePath) {
-    return readFileSync(new URL(relativePath, repoRoot), 'utf8');
-}
+const brokenVisualizerHtml = `  y(() => {
+          const handleMouseOut = () => {
+              setShowTooltip(false);
+          };
+          document.addEventListener("mouseover", handleMouseOut);
+          return () => {
+              document.removeEventListener("mouseover", handleMouseOut);
+          };
+  }, []);`;
 
 describe('bundle visualizer tooltip patch', () => {
     it('replaces the document-level hover hide handler with a guarded version', () => {
-        const visualizerHtml = readRepoFile('apps/app/bundle-visualizer.html');
-        const patchedHtml = fixBundleVisualizerTooltip(visualizerHtml);
+        const patchedHtml = fixBundleVisualizerTooltip(brokenVisualizerHtml);
 
         expect(patchedHtml).not.toContain('const handleMouseOut = () => {');
         expect(patchedHtml).toContain('const handleMouseOut = (event) => {');

--- a/tests/unit/app-bundle-visualizer-tooltip.test.js
+++ b/tests/unit/app-bundle-visualizer-tooltip.test.js
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { fixBundleVisualizerTooltip } from '../../apps/app/build/fixBundleVisualizerTooltip.js';
+
+const repoRoot = new URL('../../', import.meta.url);
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(relativePath, repoRoot), 'utf8');
+}
+
+describe('bundle visualizer tooltip patch', () => {
+    it('replaces the document-level hover hide handler with a guarded version', () => {
+        const visualizerHtml = readRepoFile('apps/app/bundle-visualizer.html');
+        const patchedHtml = fixBundleVisualizerTooltip(visualizerHtml);
+
+        expect(patchedHtml).not.toContain('const handleMouseOut = () => {');
+        expect(patchedHtml).toContain('const handleMouseOut = (event) => {');
+        expect(patchedHtml).toContain('target.closest(".node") || target.closest(".tooltip")');
+        expect(patchedHtml).toContain('document.addEventListener("mouseover", handleMouseOut);');
+    });
+
+    it('leaves already-patched reports unchanged', () => {
+        const patchedHtml = `  y(() => {
+      const handleMouseOut = (event) => {
+          const target = event.target;
+          if (target instanceof Element && (target.closest(".node") || target.closest(".tooltip"))) {
+              return;
+          }
+          setShowTooltip(false);
+      };
+      document.addEventListener("mouseover", handleMouseOut);
+      return () => {
+          document.removeEventListener("mouseover", handleMouseOut);
+      };
+  }, []);`;
+
+        expect(fixBundleVisualizerTooltip(patchedHtml)).toBe(patchedHtml);
+    });
+});


### PR DESCRIPTION
Closes #2706

## What changed
- added a small build-time patch that rewrites the generated `apps/app/bundle-visualizer.html` hover hide handler after `rollup-plugin-visualizer` emits the treemap report
- changed the tooltip hide logic so document-level `mouseover` events do not hide the tooltip when the pointer is still over a treemap node or the tooltip itself
- added a focused unit regression test that fails if the generated report ever reverts to the unguarded hide handler

## Root Cause
`rollup-plugin-visualizer` generated a treemap report whose node hover handler showed the tooltip, but the same hover event bubbled into a document-level `mouseover` listener that always called `setShowTooltip(false)`. That made tooltip visibility self-cancel during the same interaction.

## Prevention / Learning
For generated UI artifacts that we ship for direct use, treat them like product code when they contain interactive behavior. If an upstream generator emits broken event wiring, add a deterministic post-build patch plus a regression test that asserts the exact invariant we need instead of relying on manual inspection.

## Regression Tests
- `npx vitest run tests/unit/app-bundle-visualizer-tooltip.test.js --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Medium. The fix is narrow and covered, but it depends on a stable upstream generated code shape from `rollup-plugin-visualizer`, so a future plugin upgrade could require updating the patch matcher.