### PR TITLE
Defer advanced app search UI until real queries

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -40,10 +40,13 @@ const {
 }));
 
 vi.mock('../lib/searchService', () => ({
-  computeAppSearchResults: ({ teams, players }: {
+  computeAppSearchResults: ({ queryText, players, helpRoleFilter, teams }: {
+    queryText: string;
     teams: Array<{ id: string; name: string; sport?: string; zip?: string }>;
     players: Array<{ id: string; title: string; subtitle?: string; route?: string }>;
+    helpRoleFilter: 'all' | 'parent' | 'coach' | 'admin' | 'member';
   }) => {
+    const normalizedQuery = queryText.trim().toLowerCase();
     const actionItems = [{ id: 'browse-teams', kind: 'action', title: 'Browse Teams', subtitle: 'Explore public teams', route: '/teams' }];
     const teamItems = teams.map((team) => ({
       id: `team:${team.id}`,
@@ -52,12 +55,25 @@ vi.mock('../lib/searchService', () => ({
       subtitle: [team.sport, team.zip].filter(Boolean).join(' • '),
       route: `/teams/${team.id}`,
     }));
+    const allHelpItems = normalizedQuery.length >= 2
+      ? [{
+          id: 'help:coach-search',
+          kind: 'help',
+          title: 'Search like a coach',
+          subtitle: 'Use filters to find coaching answers fast',
+          route: '/help/coach-search',
+          roles: ['coach']
+        }]
+      : [];
+    const helpItems = helpRoleFilter === 'all'
+      ? allHelpItems
+      : allHelpItems.filter((item) => item.roles?.includes(helpRoleFilter));
     return {
       actions: actionItems,
       teams: teamItems,
-      help: [],
+      help: helpItems,
       players,
-      flat: [...actionItems, ...teamItems, ...players],
+      flat: [...actionItems, ...teamItems, ...helpItems, ...players],
     };
   },
   getKnownAppSearchTeams: getKnownAppSearchTeamsMock,
@@ -94,6 +110,52 @@ describe('AppSearchDialog', () => {
     searchAppTeamsMock.mockImplementation(async (_query, teams) => teams);
     searchAppPlayersMock.mockResolvedValue([]);
     preloadSearchRouteMock.mockImplementation(async () => true);
+  });
+
+  it('hides help role filters and the players section until search has a real query', async () => {
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByLabelText('Filter help by role')).toBeNull();
+    expect(screen.queryByText('Players')).toBeNull();
+    expect(screen.queryByText('Type at least 2 characters to search players')).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: ' r ' } });
+
+    await waitFor(() => expect(screen.queryByLabelText('Filter help by role')).toBeNull());
+    expect(screen.queryByText('Players')).toBeNull();
+    expect(screen.queryByText('Type at least 2 characters to search players')).toBeNull();
+  });
+
+  it('shows help role filters and player results once the query reaches two characters', async () => {
+    const onClose = vi.fn();
+    searchAppPlayersMock.mockResolvedValueOnce([{
+      id: 'player:team-2:player-2',
+      kind: 'player',
+      title: '#10 Rocket Kid',
+      subtitle: 'Rockets',
+      route: '/players/team-2/player-2',
+      teamId: 'team-2',
+      playerId: 'player-2',
+    }]);
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+
+    expect(await screen.findByLabelText('Filter help by role')).not.toBeNull();
+    expect(await screen.findByText('Players')).not.toBeNull();
+    expect(await screen.findByRole('button', { name: /#10 Rocket Kid/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /Search like a coach/i })).not.toBeNull();
   });
 
   it('keeps the opening tap guard active long enough for slower mobile pointer sequences', async () => {

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -112,7 +112,7 @@ describe('AppSearchDialog', () => {
     preloadSearchRouteMock.mockImplementation(async () => true);
   });
 
-  it('hides help role filters and the players section until search has a real query', async () => {
+  it('shows player guidance while keeping player results hidden until search has a real query', async () => {
     const onClose = vi.fn();
 
     render(
@@ -122,14 +122,14 @@ describe('AppSearchDialog', () => {
     );
 
     expect(screen.queryByLabelText('Filter help by role')).toBeNull();
-    expect(screen.queryByText('Players')).toBeNull();
-    expect(screen.queryByText('Type at least 2 characters to search players')).toBeNull();
+    expect(screen.getByText('Players')).not.toBeNull();
+    expect(screen.getByText('Type at least 2 characters to search players')).not.toBeNull();
 
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: ' r ' } });
 
     await waitFor(() => expect(screen.queryByLabelText('Filter help by role')).toBeNull());
-    expect(screen.queryByText('Players')).toBeNull();
-    expect(screen.queryByText('Type at least 2 characters to search players')).toBeNull();
+    expect(screen.getByText('Players')).not.toBeNull();
+    expect(screen.getByText('Type at least 2 characters to search players')).not.toBeNull();
   });
 
   it('shows help role filters and player results once the query reaches two characters', async () => {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -277,7 +277,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       : `No ${getHelpRoleLabel(helpRoleFilter)} help articles match this search`
     : '';
   const playersStatus = !hasRealQuery
-    ? ''
+    ? 'Type at least 2 characters to search players'
     : playersLoading
       ? 'Searching players...'
       : playersError
@@ -363,18 +363,16 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               onHover={setActiveResultIndex}
             />
 
-            {hasRealQuery ? (
-              <SearchSection
-                title="Players"
-                items={results.players}
-                activeIndex={activeIndex}
-                offset={results.actions.length + results.teams.length + helpResults.length}
-                status={playersStatus}
-                statusTone={playersError ? 'error' : 'neutral'}
-                onOpen={openResult}
-                onHover={setActiveResultIndex}
-              />
-            ) : null}
+            <SearchSection
+              title="Players"
+              items={results.players}
+              activeIndex={activeIndex}
+              offset={results.actions.length + results.teams.length + helpResults.length}
+              status={playersStatus}
+              statusTone={playersError ? 'error' : 'neutral'}
+              onOpen={openResult}
+              onHover={setActiveResultIndex}
+            />
 
             {!teamsLoading && !playersLoading && flatResults.length === 0 ? (
               <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm font-semibold text-gray-500">

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -261,7 +261,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     }
   };
 
-  const teamsStatus = query.trim().length >= 2
+  const hasRealQuery = query.trim().length >= 2;
+  const teamsStatus = hasRealQuery
     ? teamsLoading
       ? 'Searching teams...'
       : teamsError
@@ -270,17 +271,17 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
           ? 'No matching teams'
           : ''
     : teamsError;
-  const helpStatus = query.trim().length >= 2 && helpResults.length === 0
+  const helpStatus = hasRealQuery && helpResults.length === 0
     ? helpRoleFilter === 'all'
       ? 'No matching help articles'
       : `No ${getHelpRoleLabel(helpRoleFilter)} help articles match this search`
     : '';
-  const playersStatus = playersLoading
-    ? 'Searching players...'
-    : playersError
-      ? playersError
-      : query.trim().length < 2
-        ? 'Type at least 2 characters to search players'
+  const playersStatus = !hasRealQuery
+    ? ''
+    : playersLoading
+      ? 'Searching players...'
+      : playersError
+        ? playersError
         : results.players.length === 0
           ? 'No matching players'
           : '';
@@ -317,7 +318,6 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               <div className="mt-2 hidden text-xs font-semibold text-gray-500 sm:block">
                 Use arrow keys to move, Enter to open, Esc to close.
               </div>
-              <HelpRoleFilter value={helpRoleFilter} onChange={setHelpRoleFilter} />
             </div>
             <button
               type="button"
@@ -358,20 +358,23 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               activeIndex={activeIndex}
               offset={results.actions.length + results.teams.length}
               status={helpStatus}
+              headerAccessory={hasRealQuery ? <HelpRoleFilter value={helpRoleFilter} onChange={setHelpRoleFilter} /> : null}
               onOpen={openResult}
               onHover={setActiveResultIndex}
             />
 
-            <SearchSection
-              title="Players"
-              items={results.players}
-              activeIndex={activeIndex}
-              offset={results.actions.length + results.teams.length + helpResults.length}
-              status={playersStatus}
-              statusTone={playersError ? 'error' : 'neutral'}
-              onOpen={openResult}
-              onHover={setActiveResultIndex}
-            />
+            {hasRealQuery ? (
+              <SearchSection
+                title="Players"
+                items={results.players}
+                activeIndex={activeIndex}
+                offset={results.actions.length + results.teams.length + helpResults.length}
+                status={playersStatus}
+                statusTone={playersError ? 'error' : 'neutral'}
+                onOpen={openResult}
+                onHover={setActiveResultIndex}
+              />
+            ) : null}
 
             {!teamsLoading && !playersLoading && flatResults.length === 0 ? (
               <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-6 text-center text-sm font-semibold text-gray-500">
@@ -398,8 +401,8 @@ function HelpRoleFilter({ value, onChange }: {
   onChange: (value: AppSearchHelpRoleFilter) => void;
 }) {
   return (
-    <div className="mt-3" aria-label="Filter help by role">
-      <div className="mb-1 text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Help role</div>
+    <div className="flex flex-wrap items-center justify-end gap-1.5" aria-label="Filter help by role">
+      <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Help role</div>
       <div className="flex flex-wrap gap-1.5">
         {helpRoleOptions.map((option) => (
           <button


### PR DESCRIPTION
Closes #2709

## What changed
- gated the advanced app search UI behind the existing 2-character normalized query threshold
- moved the Help role filter out of the always-visible dialog header and into the Help section header
- hid the Players section entirely for empty and sub-2-character queries instead of showing the instructional short-query status
- added focused `AppSearchDialog` regression coverage for both the hidden-on-open state and the visible-after-query state

## Root Cause
`AppSearchDialog` rendered the Help role filter and Players section unconditionally, while `playersStatus` also injected a short-query instructional message. That let advanced search chrome appear even when the underlying search flow intentionally treats sub-2-character input as the lightweight actions-and-teams path.

## Prevention / Learning
When a search workflow has a minimum-query threshold, gate the entire advanced section and its empty-state messaging on the same normalized-query predicate. Do not render section shells or helper text unconditionally when the backing search service has not entered that mode yet.

## Regression Tests
- `npx vitest run apps/app/src/components/AppSearchDialog.test.tsx --reporter=verbose`
- added coverage that empty and 1-character queries do not render the Help role filter or Players section
- added coverage that a 2-character query restores the Help role filter, Help results, and Players section behavior

## Recurrence Risk
Low. The dialog now uses a shared `hasRealQuery` gate for both advanced sections, and the focused tests cover both sides of the threshold.