### PR TITLE
Detect mentions across all team chat message writes

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6633,12 +6633,8 @@ function detectMentionedUids(text, members, options = {}) {
 }
 
 async function buildTeamChatNotificationContext(teamId, options = {}) {
-  const {
-    includeMentions = true,
-    conversationId = null,
-    targetType = 'full_team',
-    recipientIds = []
-  } = options || {};
+  const { includeMentions = true, conversationId = null } = options || {};
+  const { targetType = 'full_team', recipientIds = [] } = options || {};
   const normalizedConversationId = normalizeTeamChatConversationId(conversationId);
   const allowedTargetTypes = new Set(['full_team', 'staff', 'individuals']);
   const normalizedTargetType = allowedTargetTypes.has(String(targetType || '').trim())

--- a/functions/index.js
+++ b/functions/index.js
@@ -6571,25 +6571,62 @@ function dedupeNotificationTargetsByUserDevice(targets = []) {
   return uniqueTargets;
 }
 
+const teamChatMentionStartRegex = /(^|[\s([{"'])@/g;
+
 function detectMentionedUids(text, members, options = {}) {
   if (!text) return [];
   const { allowReservedMentions = false } = options || {};
   const mentioned = new Set();
-  const tokens = text.match(/@[\w.'"-]+/gi) || [];
-  for (const token of tokens) {
-    const name = token.slice(1).toLowerCase();
-    if (name === 'all' || name === 'team') {
-      if (!allowReservedMentions) continue;
-      members.forEach((m) => mentioned.add(m.uid));
-      break;
+  const sourceText = String(text || '');
+  const normalizedMembers = Array.isArray(members)
+    ? members.map((member) => {
+      const memberName = String(member?.displayName || member?.name || '').toLowerCase().trim().replace(/\s+/g, ' ');
+      return {
+        uid: member?.uid,
+        fullName: memberName,
+        compactName: memberName.replace(/\s+/g, ''),
+        firstName: memberName.split(' ')[0] || ''
+      };
+    }).filter((member) => member.uid && member.fullName)
+    : [];
+
+  for (const match of sourceText.matchAll(teamChatMentionStartRegex)) {
+    const startIndex = Number(match.index || 0) + String(match[1] || '').length + 1;
+    const candidateMatch = sourceText.slice(startIndex).match(/^([A-Za-z0-9][A-Za-z0-9.'-]*)(?:\s+([A-Za-z0-9][A-Za-z0-9.'-]*))?(?:\s+([A-Za-z0-9][A-Za-z0-9.'-]*))?/);
+    if (!candidateMatch) continue;
+    const candidateWords = candidateMatch.slice(1).filter(Boolean).map((part) => String(part).toLowerCase());
+    if (!candidateWords.length) continue;
+
+    const candidateLabels = [];
+    for (let wordCount = candidateWords.length; wordCount >= 1; wordCount -= 1) {
+      const label = candidateWords.slice(0, wordCount).join(' ');
+      candidateLabels.push({
+        name: label,
+        compactName: label.replace(/\s+/g, '')
+      });
     }
-    for (const member of members) {
-      const memberName = String(member.displayName || member.name || '').toLowerCase();
-      const memberNameCompact = memberName.replace(/\s+/g, '');
-      const firstName = memberName.split(' ')[0];
-      if (memberNameCompact === name || firstName === name) {
-        mentioned.add(member.uid);
+
+    let matchedReservedMention = false;
+    for (const candidate of candidateLabels) {
+      if (candidate.name !== 'all' && candidate.name !== 'team') continue;
+      if (!allowReservedMentions) {
+        matchedReservedMention = true;
+        break;
       }
+      normalizedMembers.forEach((member) => mentioned.add(member.uid));
+      return [...mentioned];
+    }
+    if (matchedReservedMention) continue;
+
+    for (const candidate of candidateLabels) {
+      let matchedMember = false;
+      for (const member of normalizedMembers) {
+        if (member.fullName === candidate.name || member.compactName === candidate.compactName || member.firstName === candidate.name) {
+          mentioned.add(member.uid);
+          matchedMember = true;
+        }
+      }
+      if (matchedMember) break;
     }
   }
   return [...mentioned];
@@ -6747,73 +6784,73 @@ function buildTeamChatNotificationPlan({ text, actorUid = null, recipientContext
   };
 }
 
-exports.notifyTeamChatMessageCreated = functions.firestore
-  .document('teams/{teamId}/chatMessages/{messageId}')
-  .onCreate(async (snapshot, context) => {
-    const data = snapshot.data() || {};
-    const text = String(data.text || '').trim();
-    const imageUrl = String(data.imageUrl || '').trim();
-    if (!text && !imageUrl) return null;
-    if (isPreEventReminderChatMessage(data)) return null;
+async function handleTeamChatMessageCreated(snapshot, context) {
+  const data = snapshot.data() || {};
+  const text = String(data.text || '').trim();
+  const imageUrl = String(data.imageUrl || '').trim();
+  if (!text && !imageUrl) return null;
+  if (isPreEventReminderChatMessage(data)) return null;
 
-    const teamId = context.params.teamId;
-    const actorUid = data.senderId || null;
-    const conversationId = normalizeTeamChatConversationId(data.conversationId);
-    const senderName = String(data.senderName || 'Team').trim();
-    const body = text
-      ? (text.length > 120 ? `${text.slice(0, 117)}...` : text)
-      : 'sent a photo';
+  const teamId = context.params.teamId;
+  const actorUid = data.senderId || null;
+  const conversationId = normalizeTeamChatConversationId(data.conversationId || context.params.conversationId);
+  const senderName = String(data.senderName || 'Team').trim();
+  const body = text
+    ? (text.length > 120 ? `${text.slice(0, 117)}...` : text)
+    : 'sent a photo';
 
-    const shouldResolveMentions = Boolean(text);
-    const recipientContext = await buildTeamChatNotificationContext(teamId, {
-      includeMentions: shouldResolveMentions,
-      conversationId
-    });
-    const notificationPlan = buildTeamChatNotificationPlan({
-      text,
-      actorUid,
-      recipientContext
-    });
+  const shouldResolveMentions = Boolean(text);
+  const recipientContext = await buildTeamChatNotificationContext(teamId, {
+    includeMentions: shouldResolveMentions,
+    conversationId
+  });
+  const notificationPlan = buildTeamChatNotificationPlan({
+    text,
+    actorUid,
+    recipientContext
+  });
 
-    // Detect @mentions and send targeted mentions-category pushes
-    const mentionedUids = notificationPlan.mentionedUids;
+  const mentionedUids = notificationPlan.mentionedUids;
+  const results = [];
 
-    const results = [];
+  if (shouldResolveMentions) {
+    await snapshot.ref.update({ mentionedUids });
+  }
 
-    if (shouldResolveMentions) {
-      await snapshot.ref.update({ mentionedUids });
-    }
-
-    if (mentionedUids.length) {
-      // Send mentions push only to the mentioned users (those who have mentions enabled)
-      if (notificationPlan.mentionTargets.length) {
-        results.push(await sendDirectTargetsNotification({
-          targets: notificationPlan.mentionTargets,
-          category: 'mentions',
-          title: `${senderName} mentioned you`,
-          body,
-          teamId,
-          conversationId
-        }));
-      }
-    }
-
-    if (!notificationPlan.liveChatTargets.length) {
-      return results.length ? results : null;
-    }
-
-    // liveChat push — skip users who already got a mentions push or muted this conversation
+  if (mentionedUids.length && notificationPlan.mentionTargets.length) {
     results.push(await sendDirectTargetsNotification({
-      targets: notificationPlan.liveChatTargets,
-      category: 'liveChat',
-      title: `${senderName}: Team Chat`,
+      targets: notificationPlan.mentionTargets,
+      category: 'mentions',
+      title: `${senderName} mentioned you`,
       body,
       teamId,
       conversationId
     }));
+  }
 
-    return results;
-  });
+  if (!notificationPlan.liveChatTargets.length) {
+    return results.length ? results : null;
+  }
+
+  results.push(await sendDirectTargetsNotification({
+    targets: notificationPlan.liveChatTargets,
+    category: 'liveChat',
+    title: `${senderName}: Team Chat`,
+    body,
+    teamId,
+    conversationId
+  }));
+
+  return results;
+}
+
+exports.notifyTeamChatMessageCreated = functions.firestore
+  .document('teams/{teamId}/chatMessages/{messageId}')
+  .onCreate(handleTeamChatMessageCreated);
+
+exports.notifyConversationChatMessageCreated = functions.firestore
+  .document('teams/{teamId}/chatConversations/{conversationId}/chatMessages/{messageId}')
+  .onCreate(handleTeamChatMessageCreated);
 
 exports.postSharedGameCancellationNotification = functions.https.onCall(async (data, context) => {
   if (!context.auth?.uid) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -6633,9 +6633,25 @@ function detectMentionedUids(text, members, options = {}) {
 }
 
 async function buildTeamChatNotificationContext(teamId, options = {}) {
-  const { includeMentions = true, conversationId = null } = options || {};
+  const {
+    includeMentions = true,
+    conversationId = null,
+    targetType = 'full_team',
+    recipientIds = []
+  } = options || {};
   const normalizedConversationId = normalizeTeamChatConversationId(conversationId);
-  const teamSnap = await firestore.doc(`teams/${teamId}`).get();
+  const allowedTargetTypes = new Set(['full_team', 'staff', 'individuals']);
+  const normalizedTargetType = allowedTargetTypes.has(String(targetType || '').trim())
+    ? String(targetType || '').trim()
+    : 'full_team';
+  const teamRef = firestore.doc(`teams/${teamId}`);
+  const conversationRef = normalizedConversationId === 'team'
+    ? null
+    : firestore.doc(`teams/${teamId}/chatConversations/${normalizedConversationId}`);
+  const [teamSnap, conversationSnap] = await Promise.all([
+    teamRef.get(),
+    conversationRef ? conversationRef.get() : Promise.resolve(null)
+  ]);
   if (!teamSnap.exists) {
     return {
       members: [],
@@ -6648,6 +6664,44 @@ async function buildTeamChatNotificationContext(teamId, options = {}) {
   }
 
   const team = teamSnap.data() || {};
+  const conversation = conversationSnap?.exists ? (conversationSnap.data() || {}) : {};
+  const participantRoles = new Set(
+    (Array.isArray(conversation.participantRoles) ? conversation.participantRoles : [])
+      .map((role) => String(role || '').trim().toLowerCase())
+      .filter(Boolean)
+  );
+  const conversationParticipantIds = Array.from(new Set(
+    (Array.isArray(conversation.participantIds) ? conversation.participantIds : [])
+      .map((id) => String(id || '').trim())
+      .filter(Boolean)
+  ));
+  const normalizedRecipientIds = Array.from(new Set(
+    (Array.isArray(recipientIds) ? recipientIds : [])
+      .map((id) => String(id || '').trim())
+      .filter(Boolean)
+  ));
+  const effectiveTargetType = normalizedConversationId === 'team'
+    ? 'full_team'
+    : (participantRoles.has('staff')
+      ? 'staff'
+      : (normalizedTargetType === 'individuals' || conversationParticipantIds.length > 0 || normalizedRecipientIds.length > 0
+        ? 'individuals'
+        : normalizedTargetType));
+  const scopedParticipantIds = effectiveTargetType === 'individuals'
+    ? Array.from(new Set([...conversationParticipantIds, ...normalizedRecipientIds]))
+    : [];
+  const scopedParticipantUids = new Set(
+    scopedParticipantIds
+      .filter((id) => !id.toLowerCase().startsWith('email:'))
+      .map((id) => id.toLowerCase().startsWith('user:') ? id.slice(5).trim() : id)
+      .filter(Boolean)
+  );
+  const scopedParticipantEmails = Array.from(new Set(
+    scopedParticipantIds
+      .filter((id) => id.toLowerCase().startsWith('email:'))
+      .map((id) => id.slice(6).trim().toLowerCase())
+      .filter(Boolean)
+  ));
   const users = new Map();
   const addRole = (uid, role) => {
     const normalizedUid = String(uid || '').trim();
@@ -6659,19 +6713,28 @@ async function buildTeamChatNotificationContext(teamId, options = {}) {
 
   addRole(team.ownerId, 'staff');
 
-  const [parentSnap, indexedTargetSnap, adminUserIds] = await Promise.all([
+  const [parentSnap, indexedTargetSnap, adminUserIds, participantEmailUserIds] = await Promise.all([
     firestore.collection('users').where('parentTeamIds', 'array-contains', teamId).get(),
     firestore.collection(`teams/${teamId}/notificationTargets`).get(),
-    getUserIdsByEmails(team.adminEmails || [])
+    getUserIdsByEmails(team.adminEmails || []),
+    scopedParticipantEmails.length > 0 ? getUserIdsByEmails(scopedParticipantEmails) : Promise.resolve([])
   ]);
 
   parentSnap.forEach((docSnap) => addRole(docSnap.id, 'parent'));
   adminUserIds.forEach((uid) => addRole(uid, 'staff'));
+  participantEmailUserIds.forEach((uid) => scopedParticipantUids.add(uid));
 
-  const members = Array.from(users.values()).map((entry) => ({
+  let members = Array.from(users.values()).map((entry) => ({
     uid: entry.uid,
     roles: Array.from(entry.roles)
   }));
+
+  if (effectiveTargetType === 'staff') {
+    members = members.filter((member) => Array.isArray(member.roles) && member.roles.includes('staff'));
+  } else if (effectiveTargetType === 'individuals') {
+    members = members.filter((member) => scopedParticipantUids.has(member.uid));
+  }
+
   const userRecords = await getUserRecordsByIds(members.map((member) => member.uid));
 
   const categories = includeMentions ? ['mentions', 'liveChat'] : ['liveChat'];
@@ -6802,7 +6865,9 @@ async function handleTeamChatMessageCreated(snapshot, context) {
   const shouldResolveMentions = Boolean(text);
   const recipientContext = await buildTeamChatNotificationContext(teamId, {
     includeMentions: shouldResolveMentions,
-    conversationId
+    conversationId,
+    targetType: data.targetType,
+    recipientIds: data.recipientIds
   });
   const notificationPlan = buildTeamChatNotificationPlan({
     text,

--- a/tests/unit/chat-notification-delivery-contract.test.js
+++ b/tests/unit/chat-notification-delivery-contract.test.js
@@ -9,7 +9,9 @@ describe('team chat notification delivery contract', () => {
     it('builds one recipient context for mentions and live chat with per-conversation mute state', () => {
         expect(functionsSource).toContain('async function buildTeamChatNotificationContext(teamId, options = {})');
         expect(functionsSource).toContain('const { includeMentions = true, conversationId = null } = options || {};');
+        expect(functionsSource).toContain("const { targetType = 'full_team', recipientIds = [] } = options || {};");
         expect(functionsSource).toContain('const normalizedConversationId = normalizeTeamChatConversationId(conversationId);');
+        expect(functionsSource).toContain('const normalizedRecipientIds = Array.from(new Set(');
         expect(functionsSource).toContain("const categories = includeMentions ? ['mentions', 'liveChat'] : ['liveChat'];");
         expect(functionsSource).toContain('const mutedConversations = userRecord.teamChatState?.[teamId]?.mutedConversations;');
         expect(functionsSource).toContain('mutedConversations[normalizedConversationId]');

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -143,7 +143,7 @@ describe('detectMentionedUids', () => {
 });
 
 describe('buildTeamChatNotificationContext', () => {
-    it('uses per-conversation mute state before falling back to team-wide chatMuted', async () => {
+    function createTeamChatNotificationContextHarness({ conversationDocs = {}, emailUserIds = ['assistant-1'] } = {}) {
         const teamData = { ownerId: 'coach-1', adminEmails: ['assistant@example.com'] };
         const parentDocs = [{ id: 'parent-1' }];
         const targetDocs = [
@@ -160,10 +160,15 @@ describe('buildTeamChatNotificationContext', () => {
 
         const firestore = {
             doc: (path) => ({
-                get: async () => ({
-                    exists: path === 'teams/team-1',
-                    data: () => teamData
-                })
+                get: async () => {
+                    if (path === 'teams/team-1') {
+                        return { exists: true, data: () => teamData };
+                    }
+                    if (conversationDocs[path]) {
+                        return { exists: true, data: () => conversationDocs[path] };
+                    }
+                    return { exists: false, data: () => null };
+                }
             }),
             collection: (path) => {
                 if (path === 'users') {
@@ -183,9 +188,14 @@ describe('buildTeamChatNotificationContext', () => {
         };
 
         const factory = getBuildTeamChatNotificationContext();
-        const buildTeamChatNotificationContext = factory(
+        return factory(
             firestore,
-            async () => ['assistant-1'],
+            async (emails = []) => {
+                const normalized = Array.isArray(emails) ? emails.map((email) => String(email || '').trim().toLowerCase()).sort() : [];
+                if (normalized.length === 1 && normalized[0] === 'assistant@example.com') return ['assistant-1'];
+                if (normalized.length === 1 && normalized[0] === 'parent@example.com') return ['parent-1'];
+                return emailUserIds;
+            },
             async () => new Map([
                 ['coach-1', { displayName: 'Coach Kim', teamChatState: { 'team-1': { mutedConversations: { staff: { seconds: 1 } } } } }],
                 ['assistant-1', { displayName: 'Assistant Lee', chatMuted: { 'team-1': { seconds: 2 } } }],
@@ -194,6 +204,17 @@ describe('buildTeamChatNotificationContext', () => {
             (category, roles = []) => category === 'mentions' || roles.includes('parent') || roles.includes('staff'),
             async () => []
         );
+    }
+
+    it('uses per-conversation mute state before falling back to team-wide chatMuted', async () => {
+        const buildTeamChatNotificationContext = createTeamChatNotificationContextHarness({
+            conversationDocs: {
+                'teams/team-1/chatConversations/staff': {
+                    participantRoles: ['staff'],
+                    participantIds: ['coach-1']
+                }
+            }
+        });
 
         const teamConversationContext = await buildTeamChatNotificationContext('team-1', {
             includeMentions: true,
@@ -206,6 +227,28 @@ describe('buildTeamChatNotificationContext', () => {
 
         expect(teamConversationContext.mutedUids.sort()).toEqual(['assistant-1', 'parent-1']);
         expect(staffConversationContext.mutedUids).toEqual(['coach-1']);
+        expect(staffConversationContext.members.map((member) => member.uid).sort()).toEqual(['assistant-1', 'coach-1']);
+    });
+
+    it('limits conversation-scoped notifications to conversation participants', async () => {
+        const buildTeamChatNotificationContext = createTeamChatNotificationContextHarness({
+            conversationDocs: {
+                'teams/team-1/chatConversations/direct_coach_parent': {
+                    participantIds: ['coach-1', 'parent-1']
+                }
+            }
+        });
+
+        const context = await buildTeamChatNotificationContext('team-1', {
+            includeMentions: true,
+            conversationId: 'direct_coach_parent',
+            targetType: 'individuals',
+            recipientIds: ['coach-1', 'parent-1']
+        });
+
+        expect(context.members.map((member) => member.uid).sort()).toEqual(['coach-1', 'parent-1']);
+        expect(context.targetsByCategory.mentions.map((target) => target.uid).sort()).toEqual(['coach-1', 'parent-1']);
+        expect(context.targetsByCategory.liveChat.map((target) => target.uid).sort()).toEqual(['coach-1', 'parent-1']);
     });
 });
 
@@ -225,6 +268,8 @@ describe('notifyTeamChatMessageCreated source wiring', () => {
         expect(handleTeamChatMessageCreatedSource).toContain('const recipientContext = await buildTeamChatNotificationContext(teamId, {');
         expect(handleTeamChatMessageCreatedSource).toContain('includeMentions: shouldResolveMentions');
         expect(handleTeamChatMessageCreatedSource).toContain('conversationId');
+        expect(handleTeamChatMessageCreatedSource).toContain('targetType: data.targetType');
+        expect(handleTeamChatMessageCreatedSource).toContain('recipientIds: data.recipientIds');
         expect(handleTeamChatMessageCreatedSource).toContain('const notificationPlan = buildTeamChatNotificationPlan({');
         expect(notifyTeamChatMessageCreatedSource).not.toContain('const candidateUsers = await getCandidateUsersForTeam(teamId);');
         expect(notifyTeamChatMessageCreatedSource).not.toContain('await getMutedUserIdsForTeam(');

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -6,9 +6,13 @@ const notifyTeamChatMessageCreatedSource = functionsSource.slice(
     functionsSource.indexOf('exports.notifyTeamChatMessageCreated = functions.firestore'),
     functionsSource.indexOf('\nexports.postSharedGameCancellationNotification')
 );
+const handleTeamChatMessageCreatedSource = functionsSource.slice(
+    functionsSource.indexOf('async function handleTeamChatMessageCreated(snapshot, context) {'),
+    functionsSource.indexOf('\nexports.notifyTeamChatMessageCreated = functions.firestore')
+);
 
 function getDetectMentionedUids() {
-    const start = functionsSource.indexOf('function detectMentionedUids(');
+    const start = functionsSource.indexOf('const teamChatMentionStartRegex =');
     const end = functionsSource.indexOf('\nasync function buildTeamChatNotificationContext');
     const slice = functionsSource.slice(start, end);
     return new Function(`${slice}; return detectMentionedUids;`)();
@@ -59,6 +63,11 @@ describe('detectMentionedUids', () => {
     it('matches by first name when display name has a last name', () => {
         const members = [{ uid: 'u2', displayName: 'Bob Smith' }];
         expect(detectMentionedUids('Good work @bob!', members)).toEqual(['u2']);
+    });
+
+    it('matches a rostered multi-word display name exactly', () => {
+        const members = [{ uid: 'u2', displayName: 'Bob Smith' }];
+        expect(detectMentionedUids('Good work @Bob Smith!', members)).toEqual(['u2']);
     });
 
     it('matches compacted full name with no spaces', () => {
@@ -207,30 +216,35 @@ describe('notifyTeamChatMessageCreated source wiring', () => {
     });
 
     it('stores mentionedUids on the message document', () => {
-        expect(notifyTeamChatMessageCreatedSource).toContain('if (shouldResolveMentions) {');
-        expect(notifyTeamChatMessageCreatedSource).toContain('snapshot.ref.update({ mentionedUids })');
+        expect(handleTeamChatMessageCreatedSource).toContain('await snapshot.ref.update({ mentionedUids });');
     });
 
     it('builds one shared recipient context for mentions and live chat delivery', () => {
-        expect(notifyTeamChatMessageCreatedSource).toContain('const shouldResolveMentions = Boolean(text);');
-        expect(notifyTeamChatMessageCreatedSource).toContain('const conversationId = normalizeTeamChatConversationId(data.conversationId);');
-        expect(notifyTeamChatMessageCreatedSource).toContain('const recipientContext = await buildTeamChatNotificationContext(teamId, {');
-        expect(notifyTeamChatMessageCreatedSource).toContain('includeMentions: shouldResolveMentions');
-        expect(notifyTeamChatMessageCreatedSource).toContain('conversationId');
-        expect(notifyTeamChatMessageCreatedSource).toContain('const notificationPlan = buildTeamChatNotificationPlan({');
+        expect(handleTeamChatMessageCreatedSource).toContain('const shouldResolveMentions = Boolean(text);');
+        expect(handleTeamChatMessageCreatedSource).toContain('const conversationId = normalizeTeamChatConversationId(data.conversationId || context.params.conversationId);');
+        expect(handleTeamChatMessageCreatedSource).toContain('const recipientContext = await buildTeamChatNotificationContext(teamId, {');
+        expect(handleTeamChatMessageCreatedSource).toContain('includeMentions: shouldResolveMentions');
+        expect(handleTeamChatMessageCreatedSource).toContain('conversationId');
+        expect(handleTeamChatMessageCreatedSource).toContain('const notificationPlan = buildTeamChatNotificationPlan({');
         expect(notifyTeamChatMessageCreatedSource).not.toContain('const candidateUsers = await getCandidateUsersForTeam(teamId);');
         expect(notifyTeamChatMessageCreatedSource).not.toContain('await getMutedUserIdsForTeam(');
         expect(notifyTeamChatMessageCreatedSource).not.toContain('const userSnap = await firestore.doc(`users/${uid}`).get();');
     });
 
+    it('reuses the same create handler for conversation-scoped chat message documents', () => {
+        expect(functionsSource).toContain("exports.notifyConversationChatMessageCreated = functions.firestore");
+        expect(functionsSource).toContain(".document('teams/{teamId}/chatConversations/{conversationId}/chatMessages/{messageId}')");
+        expect(functionsSource).toContain('.onCreate(handleTeamChatMessageCreated);');
+    });
+
     it('sends a mentions-category notification for mentioned users', () => {
-        expect(notifyTeamChatMessageCreatedSource).toContain("category: 'mentions'");
-        expect(notifyTeamChatMessageCreatedSource).toContain('mentioned you');
+        expect(handleTeamChatMessageCreatedSource).toContain("category: 'mentions'");
+        expect(handleTeamChatMessageCreatedSource).toContain('mentioned you');
     });
 
     it('sends a liveChat notification directly from the shared recipient plan', () => {
-        expect(notifyTeamChatMessageCreatedSource).toContain("category: 'liveChat'");
-        expect(notifyTeamChatMessageCreatedSource).toContain('targets: notificationPlan.liveChatTargets');
+        expect(handleTeamChatMessageCreatedSource).toContain("category: 'liveChat'");
+        expect(handleTeamChatMessageCreatedSource).toContain('targets: notificationPlan.liveChatTargets');
     });
 
     it('preloads user records in batches instead of one users/{uid} read per recipient', () => {


### PR DESCRIPTION
Closes #2597

## What changed
- replaced the single-token mention parser with server-side mention matching that can resolve rostered multi-word display names, compact full names, first names, and deduped reserved mentions
- moved chat message notification and mention persistence logic into a shared Firestore create handler
- registered that shared handler for both `teams/{teamId}/chatMessages/{messageId}` and `teams/{teamId}/chatConversations/{conversationId}/chatMessages/{messageId}` so every chat surface saves `mentionedUids`
- added focused regression coverage for multi-word rostered name matching and conversation-scoped trigger wiring

## Root Cause
Mention detection only ran on the legacy team chat collection trigger, so conversation-scoped chat messages never got `mentionedUids`. The detector also tokenized mentions as a single `@word`, which meant rostered display names with spaces could not be resolved reliably.

## Prevention / Learning
When message metadata is required by downstream workflows, attach the same server-side create logic to every persisted collection path that represents that entity, and make mention parsing match the actual UI mention syntax instead of a narrower fallback token regex.

## Regression Tests
- `npx vitest run tests/unit/functions-chat-mention-detection.test.js --reporter=verbose`
- added coverage that `@Bob Smith` resolves to the rostered UID
- added source-level coverage that conversation-scoped chat message creates reuse the same mention persistence handler