### PR TITLE
Use parent team summaries in search bootstrap

### DIFF
--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -667,11 +667,7 @@ function buildParentHomeSearchTeam(homeTeam: any, baseTeam?: AppSearchTeam): App
     city: baseTeam?.city || '',
     state: baseTeam?.state || '',
     location: baseTeam?.location || cleanString(homeTeam?.location),
-    isPublic: typeof homeTeam?.isPublic === 'boolean'
-      ? homeTeam.isPublic
-      : typeof homeTeam?.public === 'boolean'
-        ? homeTeam.public
-        : baseTeam?.isPublic,
+    isPublic: resolveParentHomeTeamIsPublic(homeTeam, baseTeam?.isPublic),
     active: homeTeam?.active ?? baseTeam?.active,
     archived: homeTeam?.archived ?? baseTeam?.archived,
     status: cleanString(homeTeam?.status) || baseTeam?.status,
@@ -688,14 +684,18 @@ function buildParentHomeSearchTeam(homeTeam: any, baseTeam?: AppSearchTeam): App
 function hasSearchSafeParentHomeTeamMetadata(team: any) {
   return cleanString(team?.teamName || team?.name) !== ''
     && isTeamActive(team)
-    && (
-      typeof team?.isPublic === 'boolean'
-      || typeof team?.public === 'boolean'
-      || team?.fromAppAccess === true
-      || team?.appAccess === true
-      || cleanString(team?.visibility) !== ''
-      || cleanString(team?.searchVisibility) !== ''
-    );
+    && typeof resolveParentHomeTeamIsPublic(team) === 'boolean';
+}
+
+function resolveParentHomeTeamIsPublic(team: any, fallbackIsPublic?: boolean) {
+  if (typeof team?.isPublic === 'boolean') return team.isPublic;
+  if (typeof team?.public === 'boolean') return team.public;
+
+  const visibility = cleanString(team?.searchVisibility || team?.visibility).toLowerCase();
+  if (visibility === 'private') return false;
+  if (visibility === 'public') return true;
+
+  return fallbackIsPublic;
 }
 
 function normalizePublicTeamSearchResults(teams: any[]): AppSearchTeam[] {

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -590,6 +590,14 @@ async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>,
       return;
     }
 
+    if (hasSearchSafeParentHomeTeamMetadata(team)) {
+      const searchTeam = buildParentHomeSearchTeam(team);
+      if (canUserDiscoverTeamInAppSearch(searchTeam, user)) {
+        teamsById.set(searchTeam.id, searchTeam);
+      }
+      return;
+    }
+
     fallbackTeams.push({ ...team, teamId });
   });
 
@@ -659,7 +667,11 @@ function buildParentHomeSearchTeam(homeTeam: any, baseTeam?: AppSearchTeam): App
     city: baseTeam?.city || '',
     state: baseTeam?.state || '',
     location: baseTeam?.location || cleanString(homeTeam?.location),
-    isPublic: baseTeam?.isPublic,
+    isPublic: typeof homeTeam?.isPublic === 'boolean'
+      ? homeTeam.isPublic
+      : typeof homeTeam?.public === 'boolean'
+        ? homeTeam.public
+        : baseTeam?.isPublic,
     active: homeTeam?.active ?? baseTeam?.active,
     archived: homeTeam?.archived ?? baseTeam?.archived,
     status: cleanString(homeTeam?.status) || baseTeam?.status,
@@ -671,6 +683,19 @@ function buildParentHomeSearchTeam(homeTeam: any, baseTeam?: AppSearchTeam): App
     streamVolunteerEmails: baseTeam?.streamVolunteerEmails || [],
     teamPermissions: baseTeam?.teamPermissions || null
   };
+}
+
+function hasSearchSafeParentHomeTeamMetadata(team: any) {
+  return cleanString(team?.teamName || team?.name) !== ''
+    && isTeamActive(team)
+    && (
+      typeof team?.isPublic === 'boolean'
+      || typeof team?.public === 'boolean'
+      || team?.fromAppAccess === true
+      || team?.appAccess === true
+      || cleanString(team?.visibility) !== ''
+      || cleanString(team?.searchVisibility) !== ''
+    );
 }
 
 function normalizePublicTeamSearchResults(teams: any[]): AppSearchTeam[] {

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -133,11 +133,49 @@ function buildAccessibleTeamsCacheKey(user) {
     });
 }
 
-function getParentTeamIds(user) {
-    return Array.from(new Set([
-        ...(Array.isArray(user?.parentOf) ? user.parentOf.map((link) => String(link?.teamId || '').trim()) : []),
-        ...(Array.isArray(user?.parentPlayerKeys) ? user.parentPlayerKeys.map((key) => String(key || '').split('::')[0] || '') : [])
-    ].filter(Boolean)));
+function getParentTeamLinks(user) {
+    const byId = new Map();
+    (Array.isArray(user?.parentOf) ? user.parentOf : []).forEach((link) => {
+        const teamId = String(link?.teamId || link?.id || '').trim();
+        if (!teamId) return;
+        byId.set(teamId, { ...link, teamId });
+    });
+    (Array.isArray(user?.parentPlayerKeys) ? user.parentPlayerKeys : []).forEach((key) => {
+        const teamId = String(key || '').split('::')[0] || '';
+        if (teamId && !byId.has(teamId)) byId.set(teamId, { teamId });
+    });
+    return Array.from(byId.values());
+}
+
+function hasSearchSafeParentTeamLinkMetadata(team) {
+    return String(team?.teamName || team?.name || '').trim() !== ''
+        && isTeamActive(team)
+        && (
+            typeof team?.isPublic === 'boolean'
+            || typeof team?.public === 'boolean'
+            || team?.fromAppAccess === true
+            || team?.appAccess === true
+            || String(team?.visibility || '').trim() !== ''
+            || String(team?.searchVisibility || '').trim() !== ''
+        );
+}
+
+function buildParentTeamLinkSearchTeam(team) {
+    return {
+        id: String(team?.teamId || team?.id || '').trim(),
+        name: String(team?.teamName || team?.name || 'Team').trim(),
+        sport: String(team?.sport || '').trim(),
+        zip: String(team?.zip || '').trim(),
+        city: String(team?.city || '').trim(),
+        state: String(team?.state || '').trim(),
+        location: String(team?.location || '').trim(),
+        isPublic: typeof team?.isPublic === 'boolean' ? team.isPublic : team?.public,
+        active: team?.active,
+        archived: team?.archived,
+        status: String(team?.status || '').trim(),
+        photoUrl: team?.photoUrl || team?.teamPhotoUrl || team?.logoUrl || team?.imageUrl || '',
+        fromAppAccess: true
+    };
 }
 
 function normalizeAccessibleTeams(teams) {
@@ -160,9 +198,12 @@ async function loadAccessibleTeams(user) {
         teamQueries.push(getDocs(query(teamsRef, where('adminEmails', 'array-contains', email))));
     }
 
+    const parentTeamLinks = getParentTeamLinks(user).filter(isTeamActive);
+    const fallbackParentTeamLinks = parentTeamLinks.filter((team) => !hasSearchSafeParentTeamLinkMetadata(team));
+
     const [queryResults, parentTeamResults] = await Promise.all([
         Promise.allSettled(teamQueries),
-        Promise.allSettled(getParentTeamIds(user).map((teamId) => getDoc(doc(db, 'teams', teamId))))
+        Promise.allSettled(fallbackParentTeamLinks.map((team) => getDoc(doc(db, 'teams', team.teamId))))
     ]);
 
     const teamsById = new Map();
@@ -172,11 +213,17 @@ async function loadAccessibleTeams(user) {
             teamsById.set(teamDoc.id, { id: teamDoc.id, ...(teamDoc.data() || {}) });
         });
     });
+    parentTeamLinks
+        .filter(hasSearchSafeParentTeamLinkMetadata)
+        .forEach((team) => {
+            const searchTeam = buildParentTeamLinkSearchTeam(team);
+            if (searchTeam.id) teamsById.set(searchTeam.id, searchTeam);
+        });
     parentTeamResults.forEach((result, index) => {
         if (result.status !== 'fulfilled') return;
         const teamDoc = result.value;
         if (!teamDoc?.exists?.()) return;
-        const teamId = getParentTeamIds(user)[index];
+        const teamId = fallbackParentTeamLinks[index]?.teamId;
         teamsById.set(teamDoc.id || teamId, { id: teamDoc.id || teamId, ...(teamDoc.data() || {}) });
     });
 

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -150,14 +150,7 @@ function getParentTeamLinks(user) {
 function hasSearchSafeParentTeamLinkMetadata(team) {
     return String(team?.teamName || team?.name || '').trim() !== ''
         && isTeamActive(team)
-        && (
-            typeof team?.isPublic === 'boolean'
-            || typeof team?.public === 'boolean'
-            || team?.fromAppAccess === true
-            || team?.appAccess === true
-            || String(team?.visibility || '').trim() !== ''
-            || String(team?.searchVisibility || '').trim() !== ''
-        );
+        && typeof resolveParentTeamLinkIsPublic(team) === 'boolean';
 }
 
 function buildParentTeamLinkSearchTeam(team) {
@@ -169,13 +162,24 @@ function buildParentTeamLinkSearchTeam(team) {
         city: String(team?.city || '').trim(),
         state: String(team?.state || '').trim(),
         location: String(team?.location || '').trim(),
-        isPublic: typeof team?.isPublic === 'boolean' ? team.isPublic : team?.public,
+        isPublic: resolveParentTeamLinkIsPublic(team),
         active: team?.active,
         archived: team?.archived,
         status: String(team?.status || '').trim(),
         photoUrl: team?.photoUrl || team?.teamPhotoUrl || team?.logoUrl || team?.imageUrl || '',
         fromAppAccess: true
     };
+}
+
+function resolveParentTeamLinkIsPublic(team) {
+    if (typeof team?.isPublic === 'boolean') return team.isPublic;
+    if (typeof team?.public === 'boolean') return team.public;
+
+    const visibility = String(team?.searchVisibility || team?.visibility || '').trim().toLowerCase();
+    if (visibility === 'private') return false;
+    if (visibility === 'public') return true;
+
+    return undefined;
 }
 
 function normalizeAccessibleTeams(teams) {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -603,7 +603,14 @@ describe('React app search service', () => {
                     teamId: 'team-summary-public',
                     teamName: 'Summary Public',
                     sport: 'Soccer',
-                    isPublic: true,
+                    searchVisibility: 'public',
+                    active: true
+                },
+                {
+                    teamId: 'team-summary-visibility-private',
+                    teamName: 'Visibility Private',
+                    sport: 'Volleyball',
+                    visibility: 'private',
                     active: true
                 },
                 {
@@ -624,12 +631,51 @@ describe('React app search service', () => {
         const teams = await loadAppSearchTeams(auth.user);
 
         expect(firebaseMocks.getDoc).not.toHaveBeenCalled();
-        expect(teams.map((team) => team.id)).toEqual(['team-summary-private', 'team-summary-public']);
+        expect(teams.map((team) => team.id)).toEqual(['team-summary-private', 'team-summary-public', 'team-summary-visibility-private']);
         expect(teams.find((team) => team.id === 'team-summary-private')).toMatchObject({
             isPublic: false,
             fromAppAccess: true,
             photoUrl: 'https://img.example.test/summary.png'
         });
+        expect(teams.find((team) => team.id === 'team-summary-visibility-private')).toMatchObject({
+            isPublic: false,
+            fromAppAccess: true
+        });
+    });
+
+    it('falls back to Firestore when parent home summaries only say app access without visibility', async () => {
+        homeMocks.loadParentHome.mockResolvedValue({
+            teams: [
+                {
+                    teamId: 'team-app-access-only',
+                    teamName: 'App Access Only',
+                    sport: 'Basketball',
+                    appAccess: true,
+                    active: true
+                }
+            ]
+        });
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({ docs: [] });
+        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDocument('team-app-access-only', {
+            name: 'Stored App Access Only',
+            sport: 'Basketball',
+            isPublic: false,
+            active: true
+        }));
+
+        const teams = await loadAppSearchTeams(auth.user);
+
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-app-access-only');
+        expect(teams).toEqual([expect.objectContaining({
+            id: 'team-app-access-only',
+            name: 'App Access Only',
+            isPublic: false,
+            fromAppAccess: true
+        })]);
     });
 
     it('loads private selected stream-volunteer teams before checking search access', async () => {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -586,6 +586,52 @@ describe('React app search service', () => {
         });
     });
 
+    it('uses parent home team visibility summaries without per-team Firestore fallback reads', async () => {
+        homeMocks.loadParentHome.mockResolvedValue({
+            teams: [
+                {
+                    teamId: 'team-summary-private',
+                    teamName: 'Summary Private',
+                    sport: 'Basketball',
+                    isPublic: false,
+                    active: true,
+                    archived: false,
+                    status: 'active',
+                    photoUrl: 'https://img.example.test/summary.png'
+                },
+                {
+                    teamId: 'team-summary-public',
+                    teamName: 'Summary Public',
+                    sport: 'Soccer',
+                    isPublic: true,
+                    active: true
+                },
+                {
+                    teamId: 'team-summary-archived',
+                    teamName: 'Archived Summary',
+                    sport: 'Baseball',
+                    isPublic: false,
+                    status: 'archived'
+                }
+            ]
+        });
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({ docs: [] });
+
+        const teams = await loadAppSearchTeams(auth.user);
+
+        expect(firebaseMocks.getDoc).not.toHaveBeenCalled();
+        expect(teams.map((team) => team.id)).toEqual(['team-summary-private', 'team-summary-public']);
+        expect(teams.find((team) => team.id === 'team-summary-private')).toMatchObject({
+            isPublic: false,
+            fromAppAccess: true,
+            photoUrl: 'https://img.example.test/summary.png'
+        });
+    });
+
     it('loads private selected stream-volunteer teams before checking search access', async () => {
         homeMocks.loadParentHome.mockResolvedValue({ teams: [] });
         firebaseMocks.getDocs

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -118,6 +118,14 @@ describe('legacy global search modal', () => {
                         status: 'active'
                     },
                     {
+                        teamId: 'team-private-visibility',
+                        teamName: 'Visibility Rockets',
+                        sport: 'Soccer',
+                        visibility: 'private',
+                        active: true,
+                        status: 'active'
+                    },
+                    {
                         teamId: 'team-archived',
                         teamName: 'Archived Rockets',
                         sport: 'Soccer',
@@ -135,6 +143,42 @@ describe('legacy global search modal', () => {
 
         expect(firebaseMocks.getDoc).not.toHaveBeenCalled();
         expect(document.body.textContent).toContain('Summary Rockets');
+        expect(document.body.textContent).toContain('Visibility Rockets');
         expect(document.body.textContent).not.toContain('Archived Rockets');
+    });
+
+    it('falls back to Firestore when parent links only mark app access without visibility', async () => {
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=8');
+
+        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDoc('team-app-access-only', {
+            name: 'Stored Access Rockets',
+            sport: 'Basketball',
+            isPublic: false,
+            active: true
+        }));
+
+        setupHeaderSearch({
+            user: {
+                uid: 'parent-1',
+                email: 'parent@example.com',
+                parentOf: [
+                    {
+                        teamId: 'team-app-access-only',
+                        teamName: 'Access Rockets',
+                        sport: 'Basketball',
+                        appAccess: true,
+                        active: true
+                    }
+                ]
+            },
+            headerContainer: null
+        });
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        await flushAsyncWork();
+
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-app-access-only');
+        expect(document.body.textContent).toContain('Stored Access Rockets');
     });
 });

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -100,4 +100,41 @@ describe('legacy global search modal', () => {
         expect(document.body.textContent).toContain('Bearcats');
         expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-access');
     });
+
+    it('uses parent team link visibility summaries without per-team fallback reads', async () => {
+        const { setupHeaderSearch } = await import('../../js/global-search.js?v=8');
+
+        setupHeaderSearch({
+            user: {
+                uid: 'parent-1',
+                email: 'parent@example.com',
+                parentOf: [
+                    {
+                        teamId: 'team-summary',
+                        teamName: 'Summary Rockets',
+                        sport: 'Basketball',
+                        isPublic: false,
+                        active: true,
+                        status: 'active'
+                    },
+                    {
+                        teamId: 'team-archived',
+                        teamName: 'Archived Rockets',
+                        sport: 'Soccer',
+                        isPublic: false,
+                        status: 'archived'
+                    }
+                ]
+            },
+            headerContainer: null
+        });
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true, bubbles: true }));
+        await flushAsyncWork();
+        await flushAsyncWork();
+
+        expect(firebaseMocks.getDoc).not.toHaveBeenCalled();
+        expect(document.body.textContent).toContain('Summary Rockets');
+        expect(document.body.textContent).not.toContain('Archived Rockets');
+    });
 });


### PR DESCRIPTION
## Summary
- use parent-home and parent-link team visibility summaries directly during app and legacy search bootstrap
- keep per-team Firestore fallback reads only for linked teams missing search-safe metadata
- filter inactive/archived summary teams without revalidating each one

Fixes #2716

## Tests
- npx vitest run tests/unit/app-search-service.test.js tests/unit/global-search-modal-integration.test.js --reporter=verbose