### PR TITLE
Use legacy alias in app adapters

### DIFF
--- a/apps/app/src/lib/adapters/legacyPlayerDb.ts
+++ b/apps/app/src/lib/adapters/legacyPlayerDb.ts
@@ -17,7 +17,7 @@ import {
     updatePlayerProfile as legacyUpdatePlayerProfile,
     uploadAthleteProfileMedia as legacyUploadAthleteProfileMedia,
     uploadPlayerPhoto as legacyUploadPlayerPhoto
-} from '../../../../../js/db.js';
+} from '@legacy/db.js';
 
 export type LegacyTeamRecord = {
     id?: string;

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -41,7 +41,7 @@ import {
     upsertPracticeSessionForEvent as legacyUpsertPracticeSessionForEvent,
     upsertPracticePacketCompletion as legacyUpsertPracticePacketCompletion,
     listRideOffersForEvent as legacyListRideOffersForEvent
-} from '../../../../../js/db.js';
+} from '@legacy/db.js';
 import {
     collection as legacyFirebaseCollection,
     collectionGroup as legacyFirebaseCollectionGroup,
@@ -56,7 +56,7 @@ import {
     serverTimestamp as legacyFirebaseServerTimestamp,
     Timestamp as legacyFirebaseTimestamp,
     where as legacyFirebaseWhere
-} from '../../../../../js/firebase.js';
+} from '@legacy/firebase.js';
 
 export const db = legacyFirebaseDb;
 export const doc = legacyFirebaseDoc;

--- a/tests/unit/app-legacy-adapter-boundary.test.js
+++ b/tests/unit/app-legacy-adapter-boundary.test.js
@@ -26,7 +26,10 @@ describe('app legacy adapter boundary', () => {
 
         expect(scheduleServiceSource).toContain("from './adapters/legacyScheduleDb'");
         expect(playerServiceSource).toContain("from './adapters/legacyPlayerDb'");
-        expect(scheduleAdapterSource).toContain("from '../../../../../js/db.js'");
-        expect(playerAdapterSource).toContain("from '../../../../../js/db.js'");
+        expect(scheduleAdapterSource).toContain("from '@legacy/db.js'");
+        expect(scheduleAdapterSource).toContain("from '@legacy/firebase.js'");
+        expect(playerAdapterSource).toContain("from '@legacy/db.js'");
+        expect(scheduleAdapterSource).not.toMatch(directLegacyImportPattern);
+        expect(playerAdapterSource).not.toMatch(directLegacyImportPattern);
     });
 });

--- a/tests/unit/app-vite-config.test.ts
+++ b/tests/unit/app-vite-config.test.ts
@@ -19,6 +19,12 @@ describe('app Vite config', () => {
         expect(manualChunks?.(scopedModule)).toBe('vendor-@capacitor-core');
     });
 
+    it('exposes the legacy JS directory through the @legacy alias', () => {
+        expect(appViteConfig.resolve?.alias).toEqual(expect.objectContaining({
+            '@legacy': expect.stringContaining('/js')
+        }));
+    });
+
     it('enables app coverage reports across source files', () => {
         expect(appViteConfig.test?.coverage).toEqual(expect.objectContaining({
             provider: 'v8',


### PR DESCRIPTION
## Summary
- switch schedule and player legacy adapters from deep relative js imports to @legacy aliases
- add Vite alias guard coverage
- update the adapter boundary test to reject deep legacy imports in these adapters

Fixes #2613

## Tests
- npx vitest run tests/unit/app-legacy-adapter-boundary.test.js tests/unit/app-vite-config.test.ts --reporter=verbose