### PR TITLE
Use structured logger for resume refresh failures

### DIFF
--- a/apps/app/src/lib/useRefreshOnResume.ts
+++ b/apps/app/src/lib/useRefreshOnResume.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { App as CapacitorApp } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
+import { createLogger } from './logger';
 
 export type RefreshOnResumeFn = () => void | Promise<void>;
 
@@ -20,6 +21,7 @@ export type RefreshOnResumeDeps = {
 };
 
 const defaultStaleAfterMs = 5 * 60_000;
+const logger = createLogger('refresh-on-resume');
 
 /**
  * Refreshes a page when the app returns to the foreground (Capacitor `App.appStateChange`)
@@ -55,7 +57,7 @@ export function useRefreshOnResume(
       if (elapsed < staleAfterMs) return;
       lastRefreshAtRef.current = now();
       void Promise.resolve(refreshRef.current()).catch((error) => {
-        console.warn('[refresh-on-resume] Refresh failed:', error);
+        logger.warn('Refresh failed.', { error });
       });
     };
 

--- a/tests/unit/app-refresh-on-resume.test.tsx
+++ b/tests/unit/app-refresh-on-resume.test.tsx
@@ -172,4 +172,37 @@ describe('useRefreshOnResume', () => {
         view.unmount();
         expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function));
     });
+
+    it('logs failed resume refreshes through the structured logger', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const doc = makeFakeDoc('visible');
+        let clock = 0;
+        const refresh = vi.fn(async () => {
+            throw Object.assign(new Error('Refresh failed with Bearer unsafe-token'), {
+                headers: { Authorization: 'Bearer header-token' }
+            });
+        });
+        mountUseRefreshOnResume(refresh, { staleAfterMs: 1_000 }, {
+            doc: doc as unknown as Document,
+            isNativePlatform: () => false,
+            now: () => clock
+        });
+
+        clock = 2_000;
+        doc.fire('visibilitychange');
+        await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled());
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[refresh-on-resume] Refresh failed.',
+            {
+                error: {
+                    name: 'Error',
+                    message: 'Refresh failed with Bearer [REDACTED]',
+                    headers: {
+                        Authorization: '[REDACTED]'
+                    }
+                }
+            }
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- migrate the refresh-on-resume helper from raw console.warn to createLogger
- log resume refresh failures with sanitized structured context
- add regression coverage for redacted error logging

Refs #2639

## Tests
- npx vitest run tests/unit/app-refresh-on-resume.test.tsx apps/app/src/lib/logger.test.ts --reporter=verbose

Note: the refresh-on-resume test file still emits its existing React act environment warnings, but all assertions pass.