### PR TITLE
Cover startup telemetry timing

### DIFF
--- a/apps/app/src/lib/telemetry.test.ts
+++ b/apps/app/src/lib/telemetry.test.ts
@@ -88,6 +88,33 @@ describe('app telemetry bridge', () => {
     expect(sentryMocks.captureException).toHaveBeenCalledWith(expect.any(TypeError));
   });
 
+  it('records app startup timing with the canonical startup stage', async () => {
+    const capture = vi.fn();
+    window.AllPlaysTelemetry = { capture };
+    const telemetry = await import('./telemetry');
+
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(25)
+      .mockReturnValueOnce(125);
+
+    const timer = telemetry.startAppStartupTimer();
+    timer.end({ phase: 'initial-render' });
+
+    await Promise.resolve();
+
+    expect(capture).toHaveBeenCalledWith(
+      'app_ux_timing',
+      expect.objectContaining({
+        label: 'app startup',
+        stage: 'startup',
+        phase: 'initial-render',
+        durationMs: 100,
+        outcome: 'success'
+      }),
+      {}
+    );
+  });
+
   it('initializes only when runtime config provides a DSN, redacts sensitive payload fields, and preserves stack frames', async () => {
     const telemetry = await import('./telemetry');
 


### PR DESCRIPTION
## Summary
- add regression coverage for startAppStartupTimer
- assert the canonical app startup label, startup stage, initial-render phase, duration, and success outcome reach telemetry

Refs #2641

## Tests
- npx vitest run apps/app/src/lib/telemetry.test.ts --reporter=verbose