### PR TITLE
Cover one-slot officiating self assignment

### DIFF
--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -136,6 +136,8 @@ describe('officiating slots', () => {
         expect(dbSource).toContain("throw new Error('Only team owners, admins, or parents can claim open officiating slots.');");
         expect(dbSource).toContain('officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds)');
         expect(dbSource).toContain('officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)');
+        expect(dbSource).toContain('const officiatingSlots = claimOfficiatingSlot(game.officiatingSlots || [], slotId, {');
+        expect(dbSource).toContain('officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots)');
         expect(rules).toContain('function canClaimOpenOfficiatingSlot(teamId)');
         expect(rules).toContain('isParentForTeam(teamId)');
         expect(rules).not.toContain('playerTeamIds');

--- a/tests/unit/officiating-utils.test.js
+++ b/tests/unit/officiating-utils.test.js
@@ -103,6 +103,44 @@ describe('officiating assignment helpers', () => {
       status: 'accepted',
       selfAssigned: true
     });
+    expect(claimed[1]).toMatchObject({
+      id: 'slot-2',
+      officialEmail: 'taken@example.com',
+      status: 'pending',
+      selfAssigned: false
+    });
+    expect(claimed.filter((slot) => slot.selfAssigned === true)).toHaveLength(1);
+  });
+
+  it('keeps self-assignment updates scoped to one claimant-owned open slot', () => {
+    const claimed = claimOfficiatingSlot([
+      { id: 'slot-1', position: 'Referee', status: 'open' },
+      { id: 'slot-2', position: 'AR1', officialUserId: 'official-2', officialEmail: 'taken@example.com', officialName: 'Taken Official', status: 'accepted' },
+      { id: 'slot-3', position: 'AR2', status: 'open' }
+    ], 'slot-3', {
+      uid: 'claimant-1',
+      email: 'Claimant@Example.com',
+      displayName: 'Casey Claimant'
+    });
+
+    expect(claimed[0]).toMatchObject({ id: 'slot-1', position: 'Referee', status: 'open', selfAssigned: false });
+    expect(claimed[1]).toMatchObject({
+      id: 'slot-2',
+      position: 'AR1',
+      officialUserId: 'official-2',
+      officialEmail: 'taken@example.com',
+      officialName: 'Taken Official',
+      status: 'accepted',
+      selfAssigned: false
+    });
+    expect(claimed[2]).toMatchObject({
+      id: 'slot-3',
+      officialUserId: 'claimant-1',
+      officialEmail: 'claimant@example.com',
+      officialName: 'Casey Claimant',
+      status: 'accepted',
+      selfAssigned: true
+    });
   });
 
   it('prevents claiming a filled slot', () => {


### PR DESCRIPTION
## Summary
- add regression coverage that open-slot self-assignment only marks one claimed slot
- assert unrelated officiating slots keep their assignment/status fields
- strengthen source coverage for the transaction path that writes computed coverage and auth fields

Refs #2591

## Tests
- npx vitest run tests/unit/officiating-utils.test.js tests/unit/officiating-slots.test.js --reporter=verbose