### PR TITLE
Use legacy alias for availability adapter

### DIFF
--- a/apps/app/src/lib/adapters/legacyAvailability.ts
+++ b/apps/app/src/lib/adapters/legacyAvailability.ts
@@ -4,7 +4,7 @@ import {
     formatAvailabilityCutoff as legacyFormatAvailabilityCutoff,
     isAvailabilityLocked as legacyIsAvailabilityLocked,
     normalizeAvailabilityPreferences as legacyNormalizeAvailabilityPreferences
-} from '../../../../../js/availability-preferences.js';
+} from '@legacy/availability-preferences.js';
 
 export type LegacyAvailabilityPreferences = Record<string, unknown> & {
     noteVisibility?: string | null;

--- a/tests/unit/app-availability-adapter-boundary.test.js
+++ b/tests/unit/app-availability-adapter-boundary.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+
+function readRepoFile(filePath) {
+    return readFileSync(path.join(repoRoot, filePath), 'utf8');
+}
+
+describe('availability adapter boundary', () => {
+    it('imports legacy availability helpers through the app alias', () => {
+        const source = readRepoFile('apps/app/src/lib/adapters/legacyAvailability.ts');
+
+        expect(source).toContain("from '@legacy/availability-preferences.js'");
+        expect(source).not.toContain('../../../../../js/availability-preferences.js');
+    });
+});


### PR DESCRIPTION
## Summary
- migrate the app availability adapter from a deep relative legacy import to the shared `@legacy` alias
- add a source-level regression test so the adapter boundary does not drift back to `../../../../../js`

## Tests
- `npx vitest run tests/unit/app-availability-adapter-boundary.test.js --reporter=verbose`

Refs #2614