### PR TITLE
Scope chat attachment fallback storage

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -943,7 +943,7 @@ async function getImageUploadSession(apiKey: string) {
   return createImageUploadSession(apiKey);
 }
 
-async function nativeUploadChatMedia(teamId: string, file: File): Promise<ChatAttachment> {
+async function nativeUploadChatMedia(teamId: string, file: File, conversationId = DEFAULT_TEAM_CONVERSATION_ID): Promise<ChatAttachment> {
   const imageConfig = resolveImageFirebaseConfig();
   const bucket = imageConfig.storageBucket;
   if (!imageConfig.apiKey || !bucket) {
@@ -953,7 +953,8 @@ async function nativeUploadChatMedia(teamId: string, file: File): Promise<ChatAt
   const safeName = String(file.name || 'media').replace(/[^\w.-]+/g, '_');
   const isVideo = String(file.type || '').toLowerCase().startsWith('video/');
   const mediaFolder = isVideo ? 'team-videos' : 'team-photos';
-  const path = `${mediaFolder}/${Date.now()}_chat_${teamId}_${safeName}`;
+  const safeConversationId = String(conversationId || DEFAULT_TEAM_CONVERSATION_ID).replace(/[^\w.-]+/g, '_') || DEFAULT_TEAM_CONVERSATION_ID;
+  const path = `${mediaFolder}/${Date.now()}_chat_${teamId}_${safeConversationId}_${safeName}`;
   const response = await withTimeout(fetch(`https://firebasestorage.googleapis.com/v0/b/${encodeURIComponent(bucket)}/o?uploadType=media&name=${encodeURIComponent(path)}`, {
     method: 'POST',
     headers: {
@@ -982,7 +983,7 @@ async function nativeUploadChatMedia(teamId: string, file: File): Promise<ChatAt
   };
 }
 
-export async function uploadTeamChatAttachment(teamId: string, file: File): Promise<ChatAttachment> {
+export async function uploadTeamChatAttachment(teamId: string, file: File, conversationId = DEFAULT_TEAM_CONVERSATION_ID): Promise<ChatAttachment> {
   if (!file.type.startsWith('image/') && !file.type.startsWith('video/')) {
     throw new Error('Choose image or video files only.');
   }
@@ -990,10 +991,10 @@ export async function uploadTeamChatAttachment(teamId: string, file: File): Prom
     throw new Error('Photos and videos must be 5MB or smaller each.');
   }
   if (isNativeRuntime()) {
-    return nativeUploadChatMedia(teamId, file);
+    return nativeUploadChatMedia(teamId, file, conversationId);
   }
   try {
-    return await withTimeout(Promise.resolve(uploadChatImage(teamId, file)), 'Chat media upload', chatUploadTimeoutMs) as ChatAttachment;
+    return await withTimeout(Promise.resolve(uploadChatImage(teamId, file, { conversationId })), 'Chat media upload', chatUploadTimeoutMs) as ChatAttachment;
   } catch (error) {
     throw error;
   }
@@ -1083,14 +1084,6 @@ export async function sendTeamChatMessage({
   });
   const uploadedAttachments: ChatAttachment[] = [];
   try {
-    for (const file of files) {
-      onProgress?.('uploading');
-      uploadedAttachments.push(await uploadTeamChatAttachment(teamId, file));
-    }
-    onProgress?.('posting');
-
-    const attachments = [...sharedAttachments, ...uploadedAttachments];
-
     const targetMetadata = buildChatAudienceMetadata({
       selectedConversation,
       selectedConversationId,
@@ -1114,6 +1107,14 @@ export async function sendTeamChatMessage({
       })), 'Chat conversation create') as ChatConversation;
       conversationId = createdConversation.id;
     }
+
+    for (const file of files) {
+      onProgress?.('uploading');
+      uploadedAttachments.push(await uploadTeamChatAttachment(teamId, file, conversationId));
+    }
+    onProgress?.('posting');
+
+    const attachments = [...sharedAttachments, ...uploadedAttachments];
 
     const payload = {
       clientMessageId: clientMessageId || null,

--- a/js/db.js
+++ b/js/db.js
@@ -469,7 +469,7 @@ function getRequiredSignedInUserId() {
     return userId;
 }
 
-export async function uploadChatImage(teamId, file) {
+export async function uploadChatImage(teamId, file, { conversationId = DEFAULT_TEAM_CONVERSATION_ID } = {}) {
     await requireImageAuth();
 
     const ts = Date.now();
@@ -495,7 +495,7 @@ export async function uploadChatImage(teamId, file) {
         const code = error?.code || '';
         if (code === 'storage/unauthorized' || code === 'storage/unauthenticated') {
             console.warn('Image storage denied chat upload, falling back to main storage:', error?.message || error);
-            const fallbackPath = buildChatAttachmentFallbackPath(teamId, userId, file.name, ts);
+            const fallbackPath = buildChatAttachmentFallbackPath(teamId, conversationId, userId, file.name, ts);
             const fallbackRef = ref(storage, fallbackPath);
             const fallbackSnapshot = await uploadBytes(fallbackRef, file);
             const fallbackUrl = await getDownloadURL(fallbackSnapshot.ref);

--- a/js/fallback-media-paths.js
+++ b/js/fallback-media-paths.js
@@ -6,12 +6,13 @@ function sanitizePathSegment(value, fallback) {
     return sanitized || fallback;
 }
 
-export function buildChatAttachmentFallbackPath(teamId, userId, fileName, ts = Date.now()) {
+export function buildChatAttachmentFallbackPath(teamId, conversationId, userId, fileName, ts = Date.now()) {
     const safeTeamId = sanitizePathSegment(teamId, 'unknown-team');
+    const safeConversationId = sanitizePathSegment(conversationId, 'team');
     const safeUserId = sanitizePathSegment(userId, 'unknown-user');
     const safeName = sanitizePathSegment(fileName, 'attachment');
 
-    return `stat-sheets/team-chat/${safeTeamId}/${safeUserId}/${ts}_${safeName}`;
+    return `stat-sheets/team-chat/${safeTeamId}/${safeConversationId}/${safeUserId}/${ts}_${safeName}`;
 }
 
 export function buildStatSheetFallbackPath(teamId, userId, fileName, ts = Date.now()) {

--- a/js/fallback-media-paths.js
+++ b/js/fallback-media-paths.js
@@ -1,14 +1,15 @@
-function sanitizePathSegment(value, fallback) {
+function sanitizePathSegment(value, fallback, { allowPercent = false } = {}) {
+    const pattern = allowPercent ? /[^%\w.\-]+/g : /[^\w.\-]+/g;
     const sanitized = String(value || fallback || '')
         .trim()
-        .replace(/[^\w.\-]+/g, '_')
+        .replace(pattern, '_')
         .replace(/^_+|_+$/g, '');
     return sanitized || fallback;
 }
 
 export function buildChatAttachmentFallbackPath(teamId, conversationId, userId, fileName, ts = Date.now()) {
     const safeTeamId = sanitizePathSegment(teamId, 'unknown-team');
-    const safeConversationId = sanitizePathSegment(conversationId, 'team');
+    const safeConversationId = sanitizePathSegment(conversationId, 'team', { allowPercent: true });
     const safeUserId = sanitizePathSegment(userId, 'unknown-user');
     const safeName = sanitizePathSegment(fileName, 'attachment');
 

--- a/storage.rules
+++ b/storage.rules
@@ -30,6 +30,30 @@ service firebase.storage {
       return isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
     }
 
+    function chatConversationPath(teamId, conversationId) {
+      return /databases/(default)/documents/teams/$(teamId)/chatConversations/$(conversationId);
+    }
+
+    function isChatConversationParticipant(teamId, conversationId) {
+      let conversationPath = chatConversationPath(teamId, conversationId);
+      let conversation = firestore.get(conversationPath).data;
+      let participantIds = conversation.get('participantIds', []);
+      return conversationId.size() > 0 &&
+        firestore.exists(conversationPath) &&
+        (conversation.get('type', '') == 'team' ||
+         request.auth.uid in participantIds ||
+         ('user:' + request.auth.uid) in participantIds ||
+         (request.auth.token.email != null &&
+          ('email:' + request.auth.token.email.lower()) in participantIds));
+    }
+
+    function canAccessChatAttachment(teamId, conversationId) {
+      return canAccessTeamMedia(teamId) &&
+        (conversationId == 'team' ||
+         isTeamOwnerOrAdmin(teamId) ||
+         isChatConversationParticipant(teamId, conversationId));
+    }
+
     function hasTeamMediaUploadGrant(teamId) {
       let userPath = /databases/(default)/documents/users/$(request.auth.uid);
       return isSignedIn() &&
@@ -109,13 +133,21 @@ service firebase.storage {
       allow update: if false;
     }
 
-    match /stat-sheets/team-chat/{teamId}/{userId}/{fileName} {
-      allow get: if canAccessTeamMedia(teamId);
+    match /stat-sheets/team-chat/{teamId}/{conversationId}/{userId}/{fileName} {
+      allow get: if canAccessChatAttachment(teamId, conversationId);
       allow list: if false;
-      allow create: if canAccessTeamMedia(teamId) &&
+      allow create: if canAccessChatAttachment(teamId, conversationId) &&
         request.auth.uid == userId &&
         request.resource.size > 0 &&
         request.resource.size <= 20 * 1024 * 1024;
+      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow update: if false;
+    }
+
+    match /stat-sheets/team-chat/{teamId}/{userId}/{fileName} {
+      allow get: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow list: if false;
+      allow create: if false;
       allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
       allow update: if false;
     }

--- a/team-chat.html
+++ b/team-chat.html
@@ -2887,12 +2887,6 @@
 
             let mediaPayloads = [];
             try {
-                if (imageFiles.length > 0) {
-                    for (const file of imageFiles) {
-                        mediaPayloads.push(await uploadChatImage(teamId, file));
-                    }
-                }
-                pendingScrollToBottom = true;
                 const targetMetadata = buildRecipientTargetMetadata();
                 let conversationId = selectedConversationId;
                 if (isDefaultTeamConversation(conversationId) && targetMetadata.targetType !== 'full_team') {
@@ -2911,6 +2905,12 @@
                     selectedConversationId = conversationId;
                     await loadConversations();
                 }
+                if (imageFiles.length > 0) {
+                    for (const file of imageFiles) {
+                        mediaPayloads.push(await uploadChatImage(teamId, file, { conversationId }));
+                    }
+                }
+                pendingScrollToBottom = true;
                 await postChatMessage(teamId, {
                     text,
                     senderId: currentUser.uid,

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,7 +344,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=32';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=63';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=64';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -764,8 +764,8 @@ describe('React app chat recipient service', () => {
         });
 
         expect(progress).toEqual(['uploading', 'uploading', 'posting']);
-        expect(dbMocks.uploadChatImage).toHaveBeenNthCalledWith(1, 'team-1', photo);
-        expect(dbMocks.uploadChatImage).toHaveBeenNthCalledWith(2, 'team-1', video);
+        expect(dbMocks.uploadChatImage).toHaveBeenNthCalledWith(1, 'team-1', photo, { conversationId: 'group-player-coach' });
+        expect(dbMocks.uploadChatImage).toHaveBeenNthCalledWith(2, 'team-1', video, { conversationId: 'group-player-coach' });
         expect(dbMocks.upsertChatConversation).toHaveBeenCalledWith('team-1', expect.objectContaining({
             type: 'group',
             participantIds: ['user-1', 'player:player-1', 'user:coach-1'],

--- a/tests/unit/fallback-media-storage.test.js
+++ b/tests/unit/fallback-media-storage.test.js
@@ -12,7 +12,8 @@ function extractRuleBlock(startMarker) {
     return rules.slice(start, end === -1 ? undefined : end);
 }
 
-const chatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/{userId}/{fileName}');
+const chatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/{conversationId}/{userId}/{fileName}');
+const legacyChatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/{userId}/{fileName}');
 const statSheetFallbackRules = extractRuleBlock('match /stat-sheets/team-games/{teamId}/{userId}/{fileName}');
 const drillFallbackRules = extractRuleBlock('match /stat-sheets/drills/{teamId}/{drillId}/{userId}/{fileName}');
 const clipFallbackRules = extractRuleBlock('match /game-clips/{teamId}/{gameId}/{userId}/{fileName}');
@@ -23,8 +24,13 @@ function canAccessTeamMedia({ authUid, isTeamAdmin = false, isTeamParent = false
     return authUid !== null && (isTeamAdmin || isTeamParent);
 }
 
-function canCreateScopedFallback({ authUid, pathUserId, isTeamAdmin = false, isTeamParent = false }) {
-    return canAccessTeamMedia({ authUid, isTeamAdmin, isTeamParent }) && authUid === pathUserId;
+function canAccessChatAttachment({ authUid, conversationId = 'team', isTeamAdmin = false, isTeamParent = false, isParticipant = false }) {
+    return canAccessTeamMedia({ authUid, isTeamAdmin, isTeamParent }) &&
+        (conversationId === 'team' || isTeamAdmin || isParticipant);
+}
+
+function canCreateScopedFallback({ authUid, pathUserId, conversationId = 'team', isTeamAdmin = false, isTeamParent = false, isParticipant = false }) {
+    return canAccessChatAttachment({ authUid, conversationId, isTeamAdmin, isTeamParent, isParticipant }) && authUid === pathUserId;
 }
 
 function canDeleteScopedFallback({ authUid, pathUserId, isTeamAdmin = false }) {
@@ -37,30 +43,38 @@ function canAccessLegacyGameClipFallback({ authUid }) {
 
 describe('fallback media paths and Storage rules', () => {
     it('builds team-scoped fallback paths with uploader context', () => {
-        expect(buildChatAttachmentFallbackPath('team/alpha', 'user 42', 'my photo (1).png', 1700000000000))
-            .toBe('stat-sheets/team-chat/team_alpha/user_42/1700000000000_my_photo_1_.png');
+        expect(buildChatAttachmentFallbackPath('team/alpha', 'group user 42', 'user 42', 'my photo (1).png', 1700000000000))
+            .toBe('stat-sheets/team-chat/team_alpha/group_user_42/user_42/1700000000000_my_photo_1_.png');
         expect(buildStatSheetFallbackPath('team/alpha', 'user 42', 'box score (1).png', 1700000000001))
             .toBe('stat-sheets/team-games/team_alpha/user_42/1700000000001_box_score_1_.png');
         expect(buildDrillDiagramFallbackPath('team/alpha', 'drill 7', 'user 42', 'diagram #1.png', 1700000000002))
             .toBe('stat-sheets/drills/team_alpha/drill_7/user_42/1700000000002_diagram_1.png');
         expect(buildGameClipFallbackPath('team/alpha', 'game 7', 'user 42', 'clip #1.mp4', 1700000000001))
             .toBe('game-clips/team_alpha/game_7/user_42/1700000000001_clip_1.mp4');
-        expect(dbSource).toContain('buildChatAttachmentFallbackPath(teamId, userId, file.name, ts)');
+        expect(dbSource).toContain('buildChatAttachmentFallbackPath(teamId, conversationId, userId, file.name, ts)');
         expect(dbSource).toContain('buildStatSheetFallbackPath(teamId, userId, file.name, Date.now())');
         expect(dbSource).toContain('buildDrillDiagramUploadPaths(teamId, drillId, userId, file?.name, Date.now())');
         expect(dbSource).toContain('buildGameClipFallbackPath(teamId, gameId, userId, file.name, ts)');
     });
 
     it('limits fallback chat media access to the same team audience and uploader/admin delete rights', () => {
-        expect(chatFallbackRules).toContain('allow get: if canAccessTeamMedia(teamId);');
+        expect(chatFallbackRules).toContain('allow get: if canAccessChatAttachment(teamId, conversationId);');
+        expect(rules).toContain("('user:' + request.auth.uid) in participantIds");
+        expect(rules).toContain("('email:' + request.auth.token.email.lower()) in participantIds");
         expect(chatFallbackRules).toContain('request.auth.uid == userId');
         expect(chatFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(legacyChatFallbackRules).toContain('allow get: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(legacyChatFallbackRules).toContain('allow create: if false;');
 
         expect(canAccessTeamMedia({ authUid: 'coach-1', isTeamAdmin: true })).toBe(true);
         expect(canAccessTeamMedia({ authUid: 'parent-1', isTeamParent: true })).toBe(true);
         expect(canAccessTeamMedia({ authUid: 'parent-2', isTeamParent: false })).toBe(false);
+        expect(canAccessChatAttachment({ authUid: 'parent-1', conversationId: 'direct-1', isTeamParent: true, isParticipant: true })).toBe(true);
+        expect(canAccessChatAttachment({ authUid: 'parent-2', conversationId: 'direct-1', isTeamParent: true, isParticipant: false })).toBe(false);
 
         expect(canCreateScopedFallback({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: true })).toBe(true);
+        expect(canCreateScopedFallback({ authUid: 'parent-1', pathUserId: 'parent-1', conversationId: 'direct-1', isTeamParent: true, isParticipant: true })).toBe(true);
+        expect(canCreateScopedFallback({ authUid: 'parent-1', pathUserId: 'parent-1', conversationId: 'direct-1', isTeamParent: true })).toBe(false);
         expect(canCreateScopedFallback({ authUid: 'parent-2', pathUserId: 'parent-1', isTeamParent: true })).toBe(false);
         expect(canDeleteScopedFallback({ authUid: 'coach-1', pathUserId: 'parent-1', isTeamAdmin: true })).toBe(true);
         expect(canDeleteScopedFallback({ authUid: 'parent-2', pathUserId: 'parent-1' })).toBe(false);

--- a/tests/unit/fallback-media-storage.test.js
+++ b/tests/unit/fallback-media-storage.test.js
@@ -45,6 +45,8 @@ describe('fallback media paths and Storage rules', () => {
     it('builds team-scoped fallback paths with uploader context', () => {
         expect(buildChatAttachmentFallbackPath('team/alpha', 'group user 42', 'user 42', 'my photo (1).png', 1700000000000))
             .toBe('stat-sheets/team-chat/team_alpha/group_user_42/user_42/1700000000000_my_photo_1_.png');
+        expect(buildChatAttachmentFallbackPath('team/alpha', 'group_user%3Acoach-1', 'user 42', 'my photo (1).png', 1700000000000))
+            .toBe('stat-sheets/team-chat/team_alpha/group_user%3Acoach-1/user_42/1700000000000_my_photo_1_.png');
         expect(buildStatSheetFallbackPath('team/alpha', 'user 42', 'box score (1).png', 1700000000001))
             .toBe('stat-sheets/team-games/team_alpha/user_42/1700000000001_box_score_1_.png');
         expect(buildDrillDiagramFallbackPath('team/alpha', 'drill 7', 'user 42', 'diagram #1.png', 1700000000002))

--- a/tests/unit/team-chat-send-media-cleanup.test.js
+++ b/tests/unit/team-chat-send-media-cleanup.test.js
@@ -16,7 +16,7 @@ describe('team chat multi-file send cleanup', () => {
         const html = readRepoFile('team-chat.html');
 
         expect(html).toContain('for (const file of imageFiles)');
-        expect(html).toContain('mediaPayloads.push(await uploadChatImage(teamId, file));');
+        expect(html).toContain('mediaPayloads.push(await uploadChatImage(teamId, file, { conversationId }));');
         expect(html).not.toContain('Promise.all(imageFiles.map((file) => uploadChatImage(teamId, file)))');
     });
 

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=63';");
+        expect(html).toContain("from './js/db.js?v=64';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {


### PR DESCRIPTION
## Summary
- move chat attachment fallback uploads onto a conversation-scoped Storage path
- create or resolve targeted conversations before uploading attachments in the React app and legacy chat page
- tighten Storage rules so new fallback attachments use conversation participant checks, while legacy unscoped objects are uploader/admin only

## Tests
- `npx vitest run tests/unit/fallback-media-storage.test.js tests/unit/team-chat-send-media-cleanup.test.js apps/app/src/lib/chatService.test.ts --reporter=verbose`

Fixes #2596