### PR TITLE
Cover fee assignment payer notification contract

### DIFF
--- a/tests/unit/fee-notification-contract.test.js
+++ b/tests/unit/fee-notification-contract.test.js
@@ -44,6 +44,17 @@ describe('fee notification contract', () => {
         expect(buildFeeAssignmentNotificationBody({}, '')).toBe('A new team fee has been assigned.');
     });
 
+    it('resolves app-created child fee recipients and collapses each batch to one payer push', () => {
+        expect(functionsSource).toContain('async function resolveFeeAssignmentPayerUserIds(teamId, recipient = {})');
+        expect(functionsSource).toContain('playerId: playerId || recipient.playerId || recipient.childId');
+        expect(functionsSource).toContain("const playerKey = getFeeReminderPlayerKey({");
+        expect(functionsSource).toContain(".where('parentPlayerKeys', 'array-contains', playerKey)");
+        expect(functionsSource).toContain('function buildFeeAssignmentNotificationClaimRef({ teamId, batchId, uid })');
+        expect(functionsSource).toContain("assignmentNotificationClaims/${normalizedUid}");
+        expect(functionsSource).toContain('firstRecipientId: recipientId || null');
+        expect(functionsSource).toContain('if (claimSnap.exists) return false;');
+    });
+
     it('sends due-soon reminders only to linked payers with remaining balances and marks sent after targets exist', () => {
         expect(functionsSource).toContain('function getFeeReminderPlayerKey(recipient = {}, teamId = \'\')');
         expect(functionsSource).toContain("return `${resolvedTeamId}::${playerId}`;");


### PR DESCRIPTION
## Summary
- add fast contract coverage for app-created child fee recipient resolution through `parentPlayerKeys`
- guard the per-user fee assignment claim path that collapses multiple recipients in one batch to one payer push

## Tests
- `npx vitest run tests/unit/fee-notification-contract.test.js --reporter=verbose`
- `npx vitest run functions/test/notification-triggers.test.js --testNamePattern "notifyFeeAssigned" --reporter=verbose`

Refs #2663