### PR TITLE
Link paid fee payer notifications to recipient

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -456,6 +456,53 @@ describe('ParentTools access', () => {
         expect(openPublicUrl).not.toHaveBeenCalledWith('https://pay.example.test/stale');
     });
 
+    it('shows deep-linked paid fees from notification query params', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
+            {
+                id: 'fee-open',
+                title: 'Open fee',
+                teamId: 'team-1',
+                batchId: 'batch-open',
+                recipientId: 'recipient-open',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'open',
+                amountLabel: '$50',
+                dueLabel: 'Tomorrow',
+                statusLabel: 'Open',
+                balanceDueCents: 5000,
+                canPay: true,
+                lineItems: [],
+                installments: [],
+                ledgerEntries: []
+            },
+            {
+                id: 'fee-paid',
+                title: 'Paid fee',
+                teamId: 'team-1',
+                batchId: 'batch-1',
+                recipientId: 'recipient-1',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'paid',
+                amountLabel: '$100',
+                dueLabel: 'Paid today',
+                statusLabel: 'Paid',
+                balanceDueCents: 0,
+                canPay: false,
+                lineItems: [],
+                installments: [],
+                ledgerEntries: []
+            }
+        ]);
+
+        renderParentTools(['/parent-tools/fees?teamId=team-1&batchId=batch-1&recipientId=recipient-1']);
+
+        expect(await screen.findByText('Paid fee')).toBeTruthy();
+        expect(screen.queryByText('Open fee')).toBeNull();
+        expect(screen.getByRole('button', { name: /all/i }).getAttribute('aria-pressed')).toBe('true');
+    });
+
     it('redirects invalid tabs without triggering a hook order violation', async () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
-import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
+import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 import {
   AlertCircle,
@@ -566,12 +566,17 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
 }
 
 function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
+  const [searchParams] = useSearchParams();
   const [fees, setFees] = useState<ParentFeeAppRecord[]>([]);
   const [filter, setFilter] = useState<'open' | 'all' | 'paid'>('open');
   const [payingFeeId, setPayingFeeId] = useState('');
   const [feeErrors, setFeeErrors] = useState<Record<string, string>>({});
   const { loading, error, run: runLoad } = useParentToolAsyncOperation();
   const payOperation = useAsyncOperation();
+  const requestedTeamId = String(searchParams.get('teamId') || '').trim();
+  const requestedBatchId = String(searchParams.get('batchId') || '').trim();
+  const requestedRecipientId = String(searchParams.get('recipientId') || '').trim();
+  const hasRequestedFee = Boolean(requestedTeamId || requestedBatchId || requestedRecipientId);
 
   const refresh = useCallback(async () => {
     return runLoad(
@@ -590,11 +595,31 @@ function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: n
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, refreshVersion]);
 
-  const visibleFees = useMemo(() => fees.filter((fee) => {
-    if (filter === 'all') return true;
-    if (filter === 'paid') return fee.status === 'paid';
-    return !['paid', 'canceled', 'cancelled'].includes(String(fee.status || '').toLowerCase());
-  }), [fees, filter]);
+  useEffect(() => {
+    if (!hasRequestedFee) return;
+    setFilter((current) => (current === 'open' ? 'all' : current));
+  }, [hasRequestedFee, requestedBatchId, requestedRecipientId, requestedTeamId]);
+
+  const visibleFees = useMemo(() => {
+    const filteredFees = fees.filter((fee) => {
+      if (filter === 'all') return true;
+      if (filter === 'paid') return fee.status === 'paid';
+      return !['paid', 'canceled', 'cancelled'].includes(String(fee.status || '').toLowerCase());
+    });
+
+    if (!hasRequestedFee) {
+      return filteredFees;
+    }
+
+    const matchingFees = filteredFees.filter((fee) => {
+      if (requestedTeamId && String(fee.teamId || '') !== requestedTeamId) return false;
+      if (requestedBatchId && String(fee.batchId || '') !== requestedBatchId) return false;
+      if (requestedRecipientId && String(fee.recipientId || '') !== requestedRecipientId) return false;
+      return true;
+    });
+
+    return matchingFees.length ? matchingFees : filteredFees;
+  }, [fees, filter, hasRequestedFee, requestedBatchId, requestedRecipientId, requestedTeamId]);
 
   const openCount = fees.filter((fee) => !['paid', 'canceled', 'cancelled'].includes(String(fee.status || '').toLowerCase())).length;
   const balanceCents = visibleFees.reduce((sum, fee) => sum + Number(fee.balanceDueCents ?? fee.amountDueCents ?? 0), 0);

--- a/functions/index.js
+++ b/functions/index.js
@@ -7475,7 +7475,9 @@ exports.notifyFeeMarkedPaid = functions.firestore
           body: wasPaymentRecorded
             ? `We received your ${paymentAmountDisplay} payment. Thank you!`
             : 'Your fee balance is now marked as paid.',
-          teamId
+          teamId,
+          batchId,
+          recipientId
         }));
       }
     }

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -674,14 +674,14 @@ test('notifyFeeMarkedPaid sends fees notifications to payer and staff and record
         const staffNotification = env.messagingCalls.find((call) => call.tokens.includes('coach-token'));
         assert.equal(payerNotification.title, 'Payment received: Tournament dues');
         assert.equal(payerNotification.body, 'We received your $25.00 payment. Thank you!');
-        assert.equal(payerNotification.data.appRoute, '/parent-tools/fees?teamId=team-1');
+        assert.equal(payerNotification.data.appRoute, '/parent-tools/fees?teamId=team-1&batchId=batch-1&recipientId=recipient-2');
         assert.equal(staffNotification.title, 'Fee paid: Tournament dues');
         assert.equal(staffNotification.body, 'Pat Parent paid $25.00.');
         assert.equal(staffNotification.data.appRoute, '/teams/team-1/fees/batch-1?recipientId=recipient-2');
         assert.equal(env.auditWrites.length, 2);
         assert.deepEqual(env.auditWrites.map((entry) => entry.value.category), ['fees', 'fees']);
         assert.deepEqual(env.auditWrites.map((entry) => entry.value.appRoute).sort(), [
-            '/parent-tools/fees?teamId=team-1',
+            '/parent-tools/fees?teamId=team-1&batchId=batch-1&recipientId=recipient-2',
             '/teams/team-1/fees/batch-1?recipientId=recipient-2'
         ]);
     } finally {

--- a/tests/unit/fee-notification-contract.test.js
+++ b/tests/unit/fee-notification-contract.test.js
@@ -78,6 +78,7 @@ describe('fee notification contract', () => {
         expect(functionsSource).toContain('const staffFeeDestination = buildStaffFeeNotificationDestination({ teamId, batchId, recipientId });');
         expect(functionsSource).toContain('const paymentAmountCents = getFeePaymentAmountCents(before, after);');
         expect(functionsSource).toContain("title: wasPaymentRecorded ? `Payment received: ${title}` : `Fee paid: ${title}`");
+        expect(functionsSource).toContain("body: wasPaymentRecorded\n            ? `We received your ${paymentAmountDisplay} payment. Thank you!`\n            : 'Your fee balance is now marked as paid.',\n          teamId,\n          batchId,\n          recipientId");
         expect(functionsSource).toContain('const staffTargets = allFeeTargets.filter((target) => staffUserIds.has(target.uid) && target.uid !== payerUserId);');
         expect(functionsSource).toContain("title: `Fee paid: ${title}`");
         expect(functionsSource).toContain('appRouteOverride: staffFeeDestination.appRoute');

--- a/tests/unit/team-fee-paid-notifications.test.js
+++ b/tests/unit/team-fee-paid-notifications.test.js
@@ -97,7 +97,9 @@ describe('notifyFeeMarkedPaid trigger', () => {
         expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(1, expect.objectContaining({
             targets: [{ uid: 'parent-1', token: 'parent-token', teamId: 'team-1' }],
             title: 'Payment received: Spring dues',
-            body: 'We received your $100.00 payment. Thank you!'
+            body: 'We received your $100.00 payment. Thank you!',
+            batchId: 'batch-1',
+            recipientId: 'recipient-1'
         }));
         expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(2, expect.objectContaining({
             targets: [
@@ -142,7 +144,9 @@ describe('notifyFeeMarkedPaid trigger', () => {
         expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(2);
         expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(1, expect.objectContaining({
             title: 'Fee paid: Spring dues',
-            body: 'Your fee balance is now marked as paid.'
+            body: 'Your fee balance is now marked as paid.',
+            batchId: 'batch-1',
+            recipientId: 'recipient-1'
         }));
         expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(2, expect.objectContaining({
             title: 'Fee paid: Spring dues',


### PR DESCRIPTION
## Summary
- include `batchId` and `recipientId` on payer paid-fee notifications
- update unit and trigger fixtures so payer receipts route to the exact fee record, matching staff deep links

## Tests
- `npx vitest run tests/unit/team-fee-paid-notifications.test.js tests/unit/fee-notification-contract.test.js --reporter=verbose`
- `npx vitest run functions/test/notification-triggers.test.js --testNamePattern "notifyFeeMarkedPaid" --reporter=verbose`

Fixes #2665