### PR TITLE
Cover schedule import summary metadata

### DIFF
--- a/tests/unit/import-batch-schedule-push.test.js
+++ b/tests/unit/import-batch-schedule-push.test.js
@@ -49,6 +49,14 @@ describe('schedule import batch push notifications', () => {
                 title: 'Schedule import complete',
                 body: 'Imported 4 schedule events (2 games, 2 practices).'
             });
+            const batchSnapshot = await harness.env.firestoreState
+                .doc('teams/team-1/scheduleImportNotificationBatches/batch-large')
+                .get();
+            expect(batchSnapshot.data()).toMatchObject({
+                sentAt: { __serverTimestamp: true },
+                summaryTitle: 'Schedule import complete',
+                summaryBody: 'Imported 4 schedule events (2 games, 2 practices).'
+            });
 
             const duplicateUpdate = await harness.internals.sendCategoryNotification({
                 teamId: 'team-1',


### PR DESCRIPTION
## Summary
- extend the large schedule import notification test to assert persisted summary audit fields
- keep one-summary-send behavior tied to both delivery and batch metadata

## Tests
- `npx vitest run tests/unit/import-batch-schedule-push.test.js tests/unit/schedule-rsvp-notification-contract.test.js --reporter=verbose`

Refs #2643