### PR TITLE
Cover notification dedup multi-device sends

### DIFF
--- a/tests/unit/notification-send-dedup.test.js
+++ b/tests/unit/notification-send-dedup.test.js
@@ -273,6 +273,42 @@ describe('notification send dedup guard — sendCategoryNotification', () => {
         );
     });
 
+    it('keeps an allowed deduped send scoped to the logical event while preserving all device tokens', async () => {
+        const harness = buildSendCategoryNotificationHarness({
+            canSend: true,
+            targets: [
+                { uid: 'parent-1', deviceId: 'ios-1', token: 'token-1' },
+                { uid: 'parent-1', deviceId: 'web-1', token: 'token-2' }
+            ]
+        });
+
+        const result = await harness.fn({
+            teamId: 'team-1',
+            category: 'schedule',
+            gameId: 'game-1',
+            dedupKey: 'schedule-import:batch-1',
+            title: 'Schedule imported',
+            body: 'Two new events were added.'
+        });
+
+        expect(harness.checkAndSetNotificationDedup).toHaveBeenCalledWith(
+            'team-1',
+            'schedule',
+            'game-1',
+            'schedule-import:batch-1'
+        );
+        expect(harness.sendEachForMulticast).toHaveBeenCalledWith(expect.objectContaining({
+            tokens: ['token-1', 'token-2']
+        }));
+        expect(harness.writeNotificationInboxRecords).toHaveBeenCalledWith(expect.objectContaining({
+            targets: [
+                { uid: 'parent-1', deviceId: 'ios-1', token: 'token-1' },
+                { uid: 'parent-1', deviceId: 'web-1', token: 'token-2' }
+            ]
+        }));
+        expect(result).toMatchObject({ successCount: 2, failureCount: 0 });
+    });
+
     it('does not run the dedup guard for liveChat sends', async () => {
         const harness = buildSendCategoryNotificationHarness({ canSend: false });
 


### PR DESCRIPTION
## Summary
- add send-path coverage for custom logical dedup keys
- verify an allowed deduped send still delivers every target device token and writes inbox records for those targets

## Tests
- npx vitest run tests/unit/notification-send-dedup.test.js --reporter=verbose

Refs #2648