### PR TITLE
Extract schedule event details panel

### DIFF
--- a/apps/app/src/components/schedule/EventDetailsPanel.tsx
+++ b/apps/app/src/components/schedule/EventDetailsPanel.tsx
@@ -1,0 +1,77 @@
+import { CalendarDays, Clock, ClipboardCheck, ExternalLink, FileText, MapPin, Users, type LucideIcon } from 'lucide-react';
+import {
+  formatEventDateLabel,
+  formatEventTimeLabel,
+  getScheduleForecastHref,
+  getScheduleMapHref,
+  type ParentScheduleEvent
+} from '../../lib/scheduleLogic';
+
+export function EventDetailsPanel({ event, open }: { event: ParentScheduleEvent; open: boolean }) {
+  if (!open) return null;
+  const rows = getEventDetailRows(event);
+  const mapHref = getScheduleMapHref(event.location);
+  const forecastHref = getScheduleForecastHref(event.location);
+
+  return (
+    <div className="mt-3 rounded-xl border border-gray-200 bg-white">
+      <dl className="divide-y divide-gray-200 px-3">
+        {rows.map((row) => (
+          <div key={row.label} className="flex items-start gap-3 py-3">
+            <div className="mt-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-full bg-primary-50 text-primary-600">
+              <row.icon className="h-4 w-4" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <dt className="text-sm font-black text-gray-950">{row.value}</dt>
+              <dd className="mt-0.5 text-xs font-semibold text-gray-500">{row.label}</dd>
+            </div>
+          </div>
+        ))}
+      </dl>
+      {(mapHref || forecastHref) ? (
+        <div className="flex flex-wrap gap-2 border-t border-gray-100 p-3">
+          {mapHref ? (
+            <a href={mapHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">
+              <MapPin className="h-4 w-4" aria-hidden="true" />
+              Directions
+            </a>
+          ) : null}
+          {forecastHref ? (
+            <a href={forecastHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+              Forecast
+            </a>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function getEventDetailRows(event: ParentScheduleEvent) {
+  return [
+    { label: 'Date', value: formatEventDateLabel(event.date), icon: CalendarDays },
+    { label: 'Start time', value: formatEventTimeLabel(event.date), icon: Clock },
+    event.endDate ? { label: 'End time', value: formatEventTimeLabel(event.endDate), icon: Clock } : null,
+    event.arrivalTime ? { label: 'Arrival time', value: formatEventTimeLabel(event.arrivalTime), icon: Clock } : null,
+    { label: 'Location', value: event.location || 'TBD', icon: MapPin },
+    { label: 'Game info', value: formatGameInfo(event), icon: ClipboardCheck },
+    event.seasonLabel ? { label: 'Season', value: event.seasonLabel, icon: CalendarDays } : null,
+    event.competitionType ? { label: 'Competition', value: event.competitionType, icon: ClipboardCheck } : null,
+    event.sourceLabel ? { label: 'Source', value: event.sourceLabel, icon: ExternalLink } : null,
+    event.kitColor ? { label: 'Kit', value: event.kitColor, icon: Users } : null,
+    event.practiceAttendanceSummary ? { label: 'Practice', value: event.practiceAttendanceSummary, icon: ClipboardCheck } : null,
+    event.practiceHomePacketSummary ? { label: 'Home packet', value: event.practiceHomePacketSummary, icon: FileText } : null,
+    event.notes ? { label: 'Notes', value: event.notes, icon: FileText } : null
+  ].filter((row): row is { label: string; value: string; icon: LucideIcon } => Boolean(row));
+}
+
+function formatGameInfo(event: ParentScheduleEvent) {
+  const pieces = [
+    event.isHome === true ? 'Home' : event.isHome === false ? 'Away' : '',
+    event.kitColor ? `${event.kitColor} kit` : '',
+    event.countsTowardSeasonRecord === false ? 'Exhibition' : '',
+    event.isCancelled ? 'Cancelled' : ''
+  ].filter(Boolean);
+  return pieces.length ? pieces.join(' · ') : 'Game-day details';
+}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1,6 +1,6 @@
 import { createContext, Fragment, useCallback, useContext, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { AlertCircle, CalendarDays, Car, CheckCircle2, ChevronDown, ChevronLeft, ClipboardCheck, Clock, ExternalLink, FileText, MapPin, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
+import { AlertCircle, CalendarDays, Car, CheckCircle2, ChevronDown, ChevronLeft, ClipboardCheck, ExternalLink, FileText, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
 import {
   cancelPracticeOccurrenceForApp,
   cancelScheduledGameForApp,
@@ -93,6 +93,7 @@ import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { EventDetailPageSkeleton } from '../components/PageSkeletons';
 import { DateTile } from '../components/schedule/DateTile';
 import { EventBrief } from '../components/schedule/EventBrief';
+import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';
 import { EventSectionNav } from '../components/schedule/EventSectionNav';
 import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';
 import {
@@ -111,8 +112,6 @@ import {
   formatRideDirection,
   formatEventDateLabel,
   formatEventTimeLabel,
-  getScheduleMapHref,
-  getScheduleForecastHref,
   getScheduleAssignmentStatus,
   getScheduleRideRequestCounts,
   getScheduleRideSeatInfo,
@@ -1079,47 +1078,6 @@ function PracticePacketPrompt({ event, onOpen }: { event: ParentScheduleEvent; o
       </span>
       <span className="flex-none rounded-full bg-white px-3 py-1 text-xs font-black text-blue-700">Review</span>
     </button>
-  );
-}
-
-function EventDetailsPanel({ event, open }: { event: ParentScheduleEvent; open: boolean }) {
-  if (!open) return null;
-  const rows = getEventDetailRows(event);
-  const mapHref = getScheduleMapHref(event.location);
-  const forecastHref = getScheduleForecastHref(event.location);
-
-  return (
-    <div className="mt-3 rounded-xl border border-gray-200 bg-white">
-      <dl className="divide-y divide-gray-200 px-3">
-        {rows.map((row) => (
-          <div key={row.label} className="flex items-start gap-3 py-3">
-            <div className="mt-0.5 flex h-8 w-8 flex-none items-center justify-center rounded-full bg-primary-50 text-primary-600">
-              <row.icon className="h-4 w-4" aria-hidden="true" />
-            </div>
-            <div className="min-w-0 flex-1">
-              <dt className="text-sm font-black text-gray-950">{row.value}</dt>
-              <dd className="mt-0.5 text-xs font-semibold text-gray-500">{row.label}</dd>
-            </div>
-          </div>
-        ))}
-      </dl>
-      {(mapHref || forecastHref) ? (
-        <div className="flex flex-wrap gap-2 border-t border-gray-100 p-3">
-          {mapHref ? (
-            <a href={mapHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">
-              <MapPin className="h-4 w-4" aria-hidden="true" />
-              Directions
-            </a>
-          ) : null}
-          {forecastHref ? (
-            <a href={forecastHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">
-              <ExternalLink className="h-4 w-4" aria-hidden="true" />
-              Forecast
-            </a>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
   );
 }
 
@@ -5312,39 +5270,11 @@ function getEventBriefPieces(event: ParentScheduleEvent) {
   ].filter(Boolean).slice(0, 6);
 }
 
-function getEventDetailRows(event: ParentScheduleEvent) {
-  return [
-    { label: 'Date', value: formatEventDateLabel(event.date), icon: CalendarDays },
-    { label: 'Start time', value: formatEventTimeLabel(event.date), icon: Clock },
-    event.endDate ? { label: 'End time', value: formatEventTimeLabel(event.endDate), icon: Clock } : null,
-    event.arrivalTime ? { label: 'Arrival time', value: formatEventTimeLabel(event.arrivalTime), icon: Clock } : null,
-    { label: 'Location', value: event.location || 'TBD', icon: MapPin },
-    { label: 'Game info', value: formatGameInfo(event), icon: ClipboardCheck },
-    event.seasonLabel ? { label: 'Season', value: event.seasonLabel, icon: CalendarDays } : null,
-    event.competitionType ? { label: 'Competition', value: event.competitionType, icon: ClipboardCheck } : null,
-    event.sourceLabel ? { label: 'Source', value: event.sourceLabel, icon: ExternalLink } : null,
-    event.kitColor ? { label: 'Kit', value: event.kitColor, icon: Users } : null,
-    event.practiceAttendanceSummary ? { label: 'Practice', value: event.practiceAttendanceSummary, icon: ClipboardCheck } : null,
-    event.practiceHomePacketSummary ? { label: 'Home packet', value: event.practiceHomePacketSummary, icon: FileText } : null,
-    event.notes ? { label: 'Notes', value: event.notes, icon: FileText } : null
-  ].filter((row): row is { label: string; value: string; icon: LucideIcon } => Boolean(row));
-}
-
 function formatHeroTime(event: ParentScheduleEvent) {
   if (event.arrivalTime) {
     return `Arrive ${formatEventTimeLabel(event.arrivalTime)} · Starts ${formatEventTimeLabel(event.date)}`;
   }
   return `Starts ${formatEventTimeLabel(event.date)}`;
-}
-
-function formatGameInfo(event: ParentScheduleEvent) {
-  const pieces = [
-    event.isHome === true ? 'Home' : event.isHome === false ? 'Away' : '',
-    event.kitColor ? `${event.kitColor} kit` : '',
-    event.countsTowardSeasonRecord === false ? 'Exhibition' : '',
-    event.isCancelled ? 'Cancelled' : ''
-  ].filter(Boolean);
-  return pieces.length ? pieces.join(' · ') : 'Game-day details';
 }
 
 function getReportScoreLabel(game: Record<string, any>) {

--- a/tests/unit/app-schedule-event-detail-cancel.test.js
+++ b/tests/unit/app-schedule-event-detail-cancel.test.js
@@ -5,6 +5,10 @@ function readDetailSource() {
     return readFileSync(new URL('../../apps/app/src/pages/ScheduleEventDetail.tsx', import.meta.url), 'utf8');
 }
 
+function readDetailsPanelSource() {
+    return readFileSync(new URL('../../apps/app/src/components/schedule/EventDetailsPanel.tsx', import.meta.url), 'utf8');
+}
+
 describe('React app schedule event detail cancellation action', () => {
     it('wires a staff-only non-cancelled DB game action through the cancellation service', () => {
         const source = readDetailSource();
@@ -32,15 +36,18 @@ describe('React app schedule event detail cancellation action', () => {
     });
 
     it('includes Forecast link logic when a location is present', () => {
-        const source = readDetailSource();
-        expect(source).toContain('  getScheduleMapHref,');
-        expect(source).toContain('  getScheduleForecastHref,');
-        expect(source).toContain('const mapHref = getScheduleMapHref(event.location);');
-        expect(source).toContain('const forecastHref = getScheduleForecastHref(event.location);');
-        expect(source).toContain('{(mapHref || forecastHref) ? (');
-        expect(source).toContain('<a href={mapHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">');
-        expect(source).toContain('Directions');
-        expect(source).toContain('<a href={forecastHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">');
-        expect(source).toContain('Forecast');
+        const pageSource = readDetailSource();
+        const panelSource = readDetailsPanelSource();
+
+        expect(pageSource).toContain("import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';");
+        expect(panelSource).toContain('  getScheduleMapHref,');
+        expect(panelSource).toContain('  getScheduleForecastHref,');
+        expect(panelSource).toContain('const mapHref = getScheduleMapHref(event.location);');
+        expect(panelSource).toContain('const forecastHref = getScheduleForecastHref(event.location);');
+        expect(panelSource).toContain('{(mapHref || forecastHref) ? (');
+        expect(panelSource).toContain('<a href={mapHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">');
+        expect(panelSource).toContain('Directions');
+        expect(panelSource).toContain('<a href={forecastHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">');
+        expect(panelSource).toContain('Forecast');
     });
 });

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -14,6 +14,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
         [
             "import { DateTile } from '../components/schedule/DateTile';",
             "import { EventBrief } from '../components/schedule/EventBrief';",
+            "import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
             "import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';",
             'QuickAvailabilityPanel',
@@ -26,6 +27,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
         [
             /^function DateTile\b/m,
             /^function EventBrief\b/m,
+            /^function EventDetailsPanel\b/m,
             /^function EventSectionNav\b/m,
             /^function StaffRsvpPlayerRow\b/m,
             /^function QuickAvailabilityPanel\b/m,
@@ -66,5 +68,16 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(component).toContain("(['going', 'maybe', 'not_going'] as const).map");
         expect(component).toContain("disabled={submitting || eventLocked}");
         expect(component).toContain("{submitting && player.response !== response ? 'Saving' : rsvpLabels[response]}");
+    });
+
+    it('keeps event detail metadata rendering in the extracted schedule component', () => {
+        const component = readRepoFile('apps/app/src/components/schedule/EventDetailsPanel.tsx');
+
+        expect(component).toContain('export function EventDetailsPanel');
+        expect(component).toContain('function getEventDetailRows(event: ParentScheduleEvent)');
+        expect(component).toContain('const mapHref = getScheduleMapHref(event.location);');
+        expect(component).toContain('const forecastHref = getScheduleForecastHref(event.location);');
+        expect(component).toContain("{ label: 'Game info', value: formatGameInfo(event), icon: ClipboardCheck }");
+        expect(component).toContain("{ label: 'Home packet', value: event.practiceHomePacketSummary, icon: FileText }");
     });
 });


### PR DESCRIPTION
## Summary
- move the read-only ScheduleEventDetail event metadata panel into a reusable schedule component
- move the event detail row builder and game-info formatter with that component
- extend the ScheduleEventDetail decomposition contract to guard the extracted boundary

## Tests
- npx vitest run tests/unit/schedule-event-detail-decomposition-contract.test.js tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose
- npm run app:build

Refs #2655