### PR TITLE
Extract schedule assignment card

### DIFF
--- a/apps/app/src/components/schedule/AssignmentCard.tsx
+++ b/apps/app/src/components/schedule/AssignmentCard.tsx
@@ -1,0 +1,55 @@
+import {
+  getScheduleAssignmentStatus,
+  isScheduleAssignmentClaimedByUser,
+  isScheduleAssignmentOpen,
+  type ScheduleAssignment
+} from '../../lib/scheduleLogic';
+
+export function AssignmentCard({ assignment, userId, busy, disabled, onClaim, onRelease }: {
+  assignment: ScheduleAssignment;
+  userId: string;
+  busy: boolean;
+  disabled: boolean;
+  onClaim: () => void | Promise<void>;
+  onRelease: () => void | Promise<void>;
+}) {
+  const role = String(assignment.role || 'Assignment').trim();
+  const myOwn = isScheduleAssignmentClaimedByUser(assignment, userId);
+  const open = isScheduleAssignmentOpen(assignment);
+  const status = getScheduleAssignmentStatus(assignment, userId);
+
+  return (
+    <article className={`rounded-xl border p-3 ${myOwn ? 'border-emerald-200 bg-emerald-50' : open ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-gray-50'}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-black text-gray-950">{role}</div>
+          <div className={`mt-1 text-xs font-black ${myOwn ? 'text-emerald-700' : open ? 'text-amber-800' : 'text-gray-600'}`}>
+            {assignment.claimable ? status : `${role}: ${status}`}
+          </div>
+          {assignment.claimable ? (
+            <div className="mt-1 text-[11px] font-semibold text-gray-500">Parent sign-up slot</div>
+          ) : null}
+        </div>
+        {myOwn ? (
+          <button
+            type="button"
+            className="min-h-8 flex-none rounded-full border border-emerald-200 bg-white px-3 text-xs font-black text-emerald-700"
+            onClick={onRelease}
+            disabled={disabled}
+          >
+            {busy ? 'Releasing' : 'Release'}
+          </button>
+        ) : open ? (
+          <button
+            type="button"
+            className="min-h-8 flex-none rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-800"
+            onClick={onClaim}
+            disabled={disabled}
+          >
+            {busy ? 'Signing up' : 'Sign up'}
+          </button>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -91,6 +91,7 @@ import {
 import { type AppServiceError, toAppServiceError } from '../lib/appErrors';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { EventDetailPageSkeleton } from '../components/PageSkeletons';
+import { AssignmentCard } from '../components/schedule/AssignmentCard';
 import { DateTile } from '../components/schedule/DateTile';
 import { EventBrief } from '../components/schedule/EventBrief';
 import { EventSectionNav } from '../components/schedule/EventSectionNav';
@@ -113,10 +114,8 @@ import {
   formatEventTimeLabel,
   getScheduleMapHref,
   getScheduleForecastHref,
-  getScheduleAssignmentStatus,
   getScheduleRideRequestCounts,
   getScheduleRideSeatInfo,
-  isScheduleAssignmentClaimedByUser,
   isScheduleAssignmentOpen,
   getScheduleTitle,
   getLiveClockViewModel,
@@ -1761,55 +1760,6 @@ function AssignmentsSection({ auth, event, onAssignmentsChanged }: {
         ) : null}
       </div>
     </section>
-  );
-}
-
-function AssignmentCard({ assignment, userId, busy, disabled, onClaim, onRelease }: {
-  assignment: ScheduleAssignment;
-  userId: string;
-  busy: boolean;
-  disabled: boolean;
-  onClaim: () => void | Promise<void>;
-  onRelease: () => void | Promise<void>;
-}) {
-  const role = String(assignment.role || 'Assignment').trim();
-  const myOwn = isScheduleAssignmentClaimedByUser(assignment, userId);
-  const open = isScheduleAssignmentOpen(assignment);
-  const status = getScheduleAssignmentStatus(assignment, userId);
-
-  return (
-    <article className={`rounded-xl border p-3 ${myOwn ? 'border-emerald-200 bg-emerald-50' : open ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-gray-50'}`}>
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="text-sm font-black text-gray-950">{role}</div>
-          <div className={`mt-1 text-xs font-black ${myOwn ? 'text-emerald-700' : open ? 'text-amber-800' : 'text-gray-600'}`}>
-            {assignment.claimable ? status : `${role}: ${status}`}
-          </div>
-          {assignment.claimable ? (
-            <div className="mt-1 text-[11px] font-semibold text-gray-500">Parent sign-up slot</div>
-          ) : null}
-        </div>
-        {myOwn ? (
-          <button
-            type="button"
-            className="min-h-8 flex-none rounded-full border border-emerald-200 bg-white px-3 text-xs font-black text-emerald-700"
-            onClick={onRelease}
-            disabled={disabled}
-          >
-            {busy ? 'Releasing' : 'Release'}
-          </button>
-        ) : open ? (
-          <button
-            type="button"
-            className="min-h-8 flex-none rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-800"
-            onClick={onClaim}
-            disabled={disabled}
-          >
-            {busy ? 'Signing up' : 'Sign up'}
-          </button>
-        ) : null}
-      </div>
-    </article>
   );
 }
 

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -12,6 +12,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
         const page = readRepoFile('apps/app/src/pages/ScheduleEventDetail.tsx');
 
         [
+            "import { AssignmentCard } from '../components/schedule/AssignmentCard';",
             "import { DateTile } from '../components/schedule/DateTile';",
             "import { EventBrief } from '../components/schedule/EventBrief';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
@@ -24,6 +25,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
         });
 
         [
+            /^function AssignmentCard\b/m,
             /^function DateTile\b/m,
             /^function EventBrief\b/m,
             /^function EventSectionNav\b/m,
@@ -66,5 +68,16 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(component).toContain("(['going', 'maybe', 'not_going'] as const).map");
         expect(component).toContain("disabled={submitting || eventLocked}");
         expect(component).toContain("{submitting && player.response !== response ? 'Saving' : rsvpLabels[response]}");
+    });
+
+    it('keeps assignment row rendering in the extracted schedule component', () => {
+        const component = readRepoFile('apps/app/src/components/schedule/AssignmentCard.tsx');
+
+        expect(component).toContain('export function AssignmentCard');
+        expect(component).toContain('isScheduleAssignmentClaimedByUser(assignment, userId)');
+        expect(component).toContain('isScheduleAssignmentOpen(assignment)');
+        expect(component).toContain('getScheduleAssignmentStatus(assignment, userId)');
+        expect(component).toContain("{busy ? 'Signing up' : 'Sign up'}");
+        expect(component).toContain("{busy ? 'Releasing' : 'Release'}");
     });
 });


### PR DESCRIPTION
## Summary
- move the ScheduleEventDetail assignment row UI into a reusable schedule component
- keep the assignment load/claim/release state machine unchanged in the page
- extend the decomposition contract around the extracted assignment boundary

## Tests
- npx vitest run tests/unit/schedule-event-detail-decomposition-contract.test.js tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose

Refs #2654