### PR TITLE
Extract staff RSVP player row

### DIFF
--- a/apps/app/src/components/schedule/StaffRsvpPlayerRow.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpPlayerRow.tsx
@@ -1,0 +1,50 @@
+import {
+  rsvpBadgeClasses,
+  rsvpLabels
+} from './AvailabilityPanels';
+import type { StaffScheduleRsvpRow } from '../../lib/scheduleService';
+import type { RsvpResponse } from '../../lib/scheduleLogic';
+
+type StaffRsvpOverrideStatus = {
+  tone: 'success' | 'error';
+  playerId: string;
+  message: string;
+};
+
+export function StaffRsvpPlayerRow({ eventLocked, player, submitting, status, onOverride }: {
+  eventLocked: boolean;
+  player: StaffScheduleRsvpRow;
+  submitting: boolean;
+  status: StaffRsvpOverrideStatus | null;
+  onOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
+}) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 p-3" data-testid={`staff-rsvp-row-${player.playerId}`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="text-sm font-black text-gray-950">{player.playerNumber ? `#${player.playerNumber} ` : ''}{player.playerName}</div>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <span className={`rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[player.response]}`}>
+              {rsvpLabels[player.response]}
+            </span>
+            {player.note ? <span className="text-xs font-semibold text-gray-500">{player.note}</span> : null}
+          </div>
+        </div>
+        <div className="grid grid-cols-3 gap-1.5 sm:min-w-[220px]">
+          {(['going', 'maybe', 'not_going'] as const).map((response) => (
+            <button
+              key={response}
+              type="button"
+              className={`min-h-8 rounded-full border px-2 text-[11px] font-black transition ${player.response === response ? rsvpBadgeClasses[response] : 'border-gray-200 bg-white text-gray-600 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700'}`}
+              disabled={submitting || eventLocked}
+              onClick={() => onOverride(player, response)}
+            >
+              {submitting && player.response !== response ? 'Saving' : rsvpLabels[response]}
+            </button>
+          ))}
+        </div>
+      </div>
+      {status ? <div className={`mt-2 text-xs font-bold ${status.tone === 'success' ? 'text-emerald-700' : 'text-rose-700'}`}>{status.message}</div> : null}
+    </div>
+  );
+}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -94,6 +94,7 @@ import { EventDetailPageSkeleton } from '../components/PageSkeletons';
 import { DateTile } from '../components/schedule/DateTile';
 import { EventBrief } from '../components/schedule/EventBrief';
 import { EventSectionNav } from '../components/schedule/EventSectionNav';
+import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';
 import {
   AttentionPanel,
   AvailabilityNotesList,
@@ -1226,37 +1227,16 @@ function StaffRsvpBreakdownPanel({ event, breakdown, loading, error, submittingP
               <div className="space-y-2">
                 {rows.map((player) => {
                   const inlineStatus = status?.playerId === player.playerId ? status : null;
+                  const busy = submittingPlayerId === player.playerId;
                   return (
-                    <div key={player.playerId} className="rounded-xl border border-gray-200 bg-gray-50 p-3" data-testid={`staff-rsvp-row-${player.playerId}`}>
-                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="min-w-0">
-                          <div className="text-sm font-black text-gray-950">{player.playerNumber ? `#${player.playerNumber} ` : ''}{player.playerName}</div>
-                          <div className="mt-1 flex flex-wrap items-center gap-2">
-                            <span className={`rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[player.response]}`}>
-                              {rsvpLabels[player.response]}
-                            </span>
-                            {player.note ? <span className="text-xs font-semibold text-gray-500">{player.note}</span> : null}
-                          </div>
-                        </div>
-                        <div className="grid grid-cols-3 gap-1.5 sm:min-w-[220px]">
-                          {(['going', 'maybe', 'not_going'] as const).map((response) => {
-                            const busy = submittingPlayerId === player.playerId;
-                            return (
-                              <button
-                                key={response}
-                                type="button"
-                                className={`min-h-8 rounded-full border px-2 text-[11px] font-black transition ${player.response === response ? rsvpBadgeClasses[response] : 'border-gray-200 bg-white text-gray-600 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700'}`}
-                                disabled={busy || event.isCancelled || event.availabilityLocked}
-                                onClick={() => onOverride(player, response)}
-                              >
-                                {busy && player.response !== response ? 'Saving' : rsvpLabels[response]}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-                      {inlineStatus ? <div className={`mt-2 text-xs font-bold ${inlineStatus.tone === 'success' ? 'text-emerald-700' : 'text-rose-700'}`}>{inlineStatus.message}</div> : null}
-                    </div>
+                    <StaffRsvpPlayerRow
+                      key={player.playerId}
+                      eventLocked={event.isCancelled || event.availabilityLocked === true}
+                      player={player}
+                      submitting={busy}
+                      status={inlineStatus}
+                      onOverride={onOverride}
+                    />
                   );
                 })}
               </div>

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -15,6 +15,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
             "import { DateTile } from '../components/schedule/DateTile';",
             "import { EventBrief } from '../components/schedule/EventBrief';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
+            "import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';",
             'QuickAvailabilityPanel',
             'AvailabilityNotesList',
             'AttentionPanel'
@@ -26,6 +27,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
             /^function DateTile\b/m,
             /^function EventBrief\b/m,
             /^function EventSectionNav\b/m,
+            /^function StaffRsvpPlayerRow\b/m,
             /^function QuickAvailabilityPanel\b/m,
             /^function AttentionPanel\b/m
         ].forEach((inlineDefinition) => {
@@ -54,5 +56,15 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(ridesHook).toContain('loadParentScheduleRideOffers');
         expect(context).toContain('export function ScheduleEventDetailProvider');
         expect(context).toContain('export function useScheduleEventDetailContext');
+    });
+
+    it('keeps staff RSVP player rows in the extracted schedule component', () => {
+        const component = readRepoFile('apps/app/src/components/schedule/StaffRsvpPlayerRow.tsx');
+
+        expect(component).toContain('export function StaffRsvpPlayerRow');
+        expect(component).toContain('data-testid={`staff-rsvp-row-${player.playerId}`}');
+        expect(component).toContain("(['going', 'maybe', 'not_going'] as const).map");
+        expect(component).toContain("disabled={submitting || eventLocked}");
+        expect(component).toContain("{submitting && player.response !== response ? 'Saving' : rsvpLabels[response]}");
     });
 });


### PR DESCRIPTION
## Summary
- move the interactive staff RSVP player row out of ScheduleEventDetail
- preserve the existing override buttons, busy state, locked-event handling, and inline status copy
- extend the decomposition contract around the extracted staff RSVP row boundary

## Tests
- npx vitest run tests/unit/schedule-event-detail-decomposition-contract.test.js tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose

Refs #2653