### PR TITLE
Cover email reducer draft edits

### DIFF
--- a/tests/unit/app-email-reducer.test.ts
+++ b/tests/unit/app-email-reducer.test.ts
@@ -14,6 +14,22 @@ function draft(overrides: Partial<TeamEmailDraft> = {}): TeamEmailDraft {
 }
 
 describe('emailReducer', () => {
+    it('keeps draft selection while direct composer edits update subject and body', () => {
+        const selected = emailReducer(
+            emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+            { type: 'selectDraft', draftId: 'draft-1' }
+        );
+        const editedSubject = emailReducer(selected, { type: 'updateSubject', subject: 'Updated practice reminder' });
+        const editedBody = emailReducer(editedSubject, { type: 'updateBody', body: 'Bring cleats, water, and a jacket.' });
+
+        expect(editedBody).toMatchObject({
+            selectedDraftId: 'draft-1',
+            subject: 'Updated practice reminder',
+            body: 'Bring cleats, water, and a jacket.',
+            drafts: [draft()]
+        });
+    });
+
     it('clears stale composer content when refreshed drafts no longer include the selected draft', () => {
         const selected = emailReducer(
             emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),


### PR DESCRIPTION
## Summary
- add reducer coverage for selecting an email draft and then editing subject/body
- verify direct composer edits preserve selected draft state and draft list ownership in emailReducer

## Tests
- npx vitest run tests/unit/app-email-reducer.test.ts tests/unit/app-chat-email-reducer.test.ts tests/unit/messages-decomposition-contract.test.js --reporter=verbose

Refs #2650