### PR TITLE
Cover error tracking global runtime config

### DIFF
--- a/apps/app/src/lib/telemetry.test.ts
+++ b/apps/app/src/lib/telemetry.test.ts
@@ -26,6 +26,13 @@ describe('app telemetry bridge', () => {
     delete window.__ALLPLAYS_REPORT_REACT_ERROR__;
     delete window.__ALLPLAYS_CONFIG__;
     delete window.ALLPLAYS_ERROR_TRACKING_DSN;
+    delete window.ALLPLAYS_ERROR_TRACKING_ENVIRONMENT;
+    delete window.ALLPLAYS_ERROR_TRACKING_RELEASE;
+    delete window.ALLPLAYS_SENTRY_DSN;
+    delete window.ALLPLAYS_SENTRY_ENVIRONMENT;
+    delete window.ALLPLAYS_SENTRY_RELEASE;
+    delete window.ALLPLAYS_ENVIRONMENT;
+    delete window.ALLPLAYS_RELEASE;
     document.body.innerHTML = '<div id="root"></div>';
   });
 
@@ -176,6 +183,19 @@ describe('app telemetry bridge', () => {
     }));
     expect(addEventListenerSpy).not.toHaveBeenCalledWith('error', expect.any(Function));
     expect(addEventListenerSpy).not.toHaveBeenCalledWith('unhandledrejection', expect.any(Function));
+  });
+
+  it('does not leak global fallback environment or release values into later DSN-only initialization', async () => {
+    window.ALLPLAYS_ERROR_TRACKING_DSN = 'https://public@example.ingest.sentry.io/clean';
+
+    const telemetry = await import('./telemetry');
+
+    expect(telemetry.initializeAppErrorTracking({ isProduction: false })).toBe(true);
+    expect(sentryMocks.init).toHaveBeenCalledWith(expect.objectContaining({
+      dsn: 'https://public@example.ingest.sentry.io/clean',
+      environment: undefined,
+      release: undefined
+    }));
   });
 
   it('reports React boundary failures without misclassifying generic TypeErrors as network errors', async () => {

--- a/apps/app/src/lib/telemetry.test.ts
+++ b/apps/app/src/lib/telemetry.test.ts
@@ -160,6 +160,24 @@ describe('app telemetry bridge', () => {
     });
   });
 
+  it('accepts global runtime DSN fallbacks without installing production-only handlers in local mode', async () => {
+    window.ALLPLAYS_ERROR_TRACKING_DSN = 'https://public@example.ingest.sentry.io/global';
+    window.ALLPLAYS_ERROR_TRACKING_ENVIRONMENT = 'staging';
+    window.ALLPLAYS_ERROR_TRACKING_RELEASE = 'app@global';
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+    const telemetry = await import('./telemetry');
+
+    expect(telemetry.initializeAppErrorTracking({ isProduction: false })).toBe(true);
+    expect(sentryMocks.init).toHaveBeenCalledWith(expect.objectContaining({
+      dsn: 'https://public@example.ingest.sentry.io/global',
+      environment: 'staging',
+      release: 'app@global'
+    }));
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('error', expect.any(Function));
+    expect(addEventListenerSpy).not.toHaveBeenCalledWith('unhandledrejection', expect.any(Function));
+  });
+
   it('reports React boundary failures without misclassifying generic TypeErrors as network errors', async () => {
     const capture = vi.fn();
     window.AllPlaysTelemetry = { capture };


### PR DESCRIPTION
## Summary
- add telemetry coverage for global runtime error-tracking DSN/env/release fallbacks
- verify local-mode initialization does not install production-only window error handlers

## Tests
- npx vitest run apps/app/src/lib/telemetry.test.ts apps/app/src/main.test.tsx --reporter=verbose

Refs #2640