### PR TITLE
Cover muted photo chat notification suppression

### DIFF
--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -349,6 +349,33 @@ describe('buildTeamChatNotificationPlan', () => {
         expect(plan.liveChatTargets).toHaveLength(1);
     });
 
+    it('suppresses muted conversation participants from generic photo-only chat pushes', () => {
+        const plan = buildTeamChatNotificationPlan({
+            text: '',
+            actorUid: 'coach-1',
+            recipientContext: {
+                members: [
+                    { uid: 'coach-1', displayName: 'Coach Kim', roles: ['staff'] },
+                    { uid: 'muted-parent', displayName: 'Muted Parent', roles: ['parent'] },
+                    { uid: 'active-parent', displayName: 'Active Parent', roles: ['parent'] }
+                ],
+                mutedUids: ['muted-parent'],
+                targetsByCategory: {
+                    mentions: [],
+                    liveChat: [
+                        { uid: 'coach-1', deviceId: 'phone', token: 'coach-chat' },
+                        { uid: 'muted-parent', deviceId: 'phone', token: 'muted-chat' },
+                        { uid: 'active-parent', deviceId: 'phone', token: 'active-chat' }
+                    ]
+                }
+            }
+        });
+
+        expect(plan.mentionedUids).toEqual([]);
+        expect(plan.mentionTargets).toEqual([]);
+        expect(plan.liveChatTargets.map((target) => target.uid)).toEqual(['active-parent']);
+    });
+
     it('handles a large mixed team fixture from one preloaded recipient context', () => {
         const mentionedUserIds = ['user-12', 'user-87', 'user-301'];
         const members = Array.from({ length: 500 }, (_, index) => ({


### PR DESCRIPTION
## Summary
- add regression coverage for generic live-chat pushes when mention parsing is skipped
- verify muted conversation participants are excluded from photo-only chat notifications
- keep actor exclusion and mention-target handling covered through the shared chat notification plan

## Tests
- npx vitest run tests/unit/functions-chat-mention-detection.test.js --reporter=verbose

Refs #2590