### PR TITLE
Cover award notification destinations

### DIFF
--- a/tests/unit/certificate-award-notifications.test.js
+++ b/tests/unit/certificate-award-notifications.test.js
@@ -169,6 +169,24 @@ describe('published certificate award helpers', () => {
         });
     });
 
+    it('builds encoded award notification destinations and falls back to the certificates view', () => {
+        const firestore = buildFirestoreForParentLookup();
+        const admin = { firestore: { FieldValue: { serverTimestamp: vi.fn(() => 'SERVER_TIMESTAMP') } } };
+        const helpers = getAwardHelpers()(firestore, admin);
+
+        expect(helpers.buildAwardNotificationDestination({
+            teamId: 'team 1',
+            certificateId: 'cert/1'
+        })).toEqual({
+            link: 'https://allplays.ai/app/#/parent-tools/certificates?teamId=team+1&certificateId=cert%2F1',
+            appRoute: '/parent-tools/certificates?teamId=team+1&certificateId=cert%2F1'
+        });
+        expect(helpers.buildAwardNotificationDestination({ teamId: 'team 1' })).toEqual({
+            link: 'https://allplays.ai/app/#/parent-tools/certificates?teamId=team+1',
+            appRoute: '/parent-tools/certificates?teamId=team+1'
+        });
+    });
+
     it('claims the first published notification send with a retry-safe transaction guard and marks it processed after send', async () => {
         const certificateRef = {
             path: 'teams/team-1/certificates/cert-1',


### PR DESCRIPTION
## Summary
- add executable coverage for encoded award notification destinations
- verify certificate deep links preserve team and certificate IDs
- verify award pushes fall back to the certificates view when no certificate ID is provided

## Tests
- npx vitest run tests/unit/certificate-award-notifications.test.js --reporter=verbose

Refs #2110