### PR TITLE
Cover fee paid staff payer dedupe

### DIFF
--- a/tests/unit/team-fee-paid-notifications.test.js
+++ b/tests/unit/team-fee-paid-notifications.test.js
@@ -150,6 +150,45 @@ describe('notifyFeeMarkedPaid trigger', () => {
         }));
     });
 
+    it('does not duplicate the staff notification to a staff member who paid their own fee', async () => {
+        const harness = buildTriggerHarness({
+            targets: [
+                { uid: 'staff-payer', token: 'payer-token', teamId: 'team-1' },
+                { uid: 'staff-2', token: 'staff-2-token', teamId: 'team-1' }
+            ],
+            users: [
+                { uid: 'staff-payer', roles: ['staff', 'parent'] },
+                { uid: 'staff-2', roles: ['staff'] }
+            ]
+        });
+
+        await harness.trigger({
+            before: { exists: true, data: () => ({ status: 'unpaid', amountPaidCents: 0 }) },
+            after: {
+                exists: true,
+                data: () => ({
+                    status: 'paid',
+                    feeTitle: 'Tournament fee',
+                    userId: 'staff-payer',
+                    parentName: 'Coach Parent',
+                    manualPayment: { amountPaidCents: 7500 }
+                })
+            }
+        }, {
+            params: { teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
+        });
+
+        expect(harness.sendDirectTargetsNotification).toHaveBeenCalledTimes(2);
+        expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(1, expect.objectContaining({
+            targets: [{ uid: 'staff-payer', token: 'payer-token', teamId: 'team-1' }],
+            title: 'Payment received: Tournament fee'
+        }));
+        expect(harness.sendDirectTargetsNotification).toHaveBeenNthCalledWith(2, expect.objectContaining({
+            targets: [{ uid: 'staff-2', token: 'staff-2-token', teamId: 'team-1' }],
+            title: 'Fee paid: Tournament fee'
+        }));
+    });
+
     it('does not send when an already-paid recipient gets an unrelated update', async () => {
         const harness = buildTriggerHarness({
             targets: [{ uid: 'staff-1', token: 'staff-token', teamId: 'team-1' }],


### PR DESCRIPTION
## Summary
- add regression coverage for staff members paying their own team fee
- verify the payer still receives the payment receipt
- verify staff notification targets exclude that same payer to avoid duplicate pushes

## Tests
- npx vitest run tests/unit/team-fee-paid-notifications.test.js --reporter=verbose

Refs #2665