### PR TITLE
Cover fee reminder player key guard

### DIFF
--- a/tests/unit/fee-due-reminders-source.test.js
+++ b/tests/unit/fee-due-reminders-source.test.js
@@ -23,6 +23,12 @@ describe('fee due reminder helper logic', () => {
         expect(getFeeReminderPlayerKey({ playerKey: 'team-9::player-9', playerId: 'ignored' }, 'team-1')).toBe('team-9::player-9');
     });
 
+    it('does not invent player-linked lookup keys when team or player context is missing', () => {
+        expect(getFeeReminderPlayerKey({ playerId: 'player-1' }, '')).toBe('');
+        expect(getFeeReminderPlayerKey({ teamId: 'team-1' }, 'team-1')).toBe('');
+        expect(getFeeReminderPlayerKey({}, 'team-1')).toBe('');
+    });
+
     it('merges direct payer ids with player-linked owner ids and removes blanks or duplicates', () => {
         expect(buildFeeReminderCandidateUserIds({
             userId: 'user-1',


### PR DESCRIPTION
## Summary
- add helper coverage for due-reminder player key generation
- verify missing team or player context does not create broad parent lookup keys
- keep direct payer and player-linked owner dedupe coverage in place

## Tests
- npx vitest run tests/unit/fee-due-reminders-source.test.js --reporter=verbose

Refs #2664