### PR TITLE
Cover notification dedup category scope

### DIFF
--- a/tests/unit/notification-send-dedup.test.js
+++ b/tests/unit/notification-send-dedup.test.js
@@ -237,6 +237,19 @@ describe('notification send dedup guard — checkAndSetNotificationDedup', () =>
 
         expect(first.mockFirestore.doc.mock.calls[0][0]).not.toBe(second.mockFirestore.doc.mock.calls[0][0]);
     });
+
+    it('uses a different Firestore dedup document for different notification categories', async () => {
+        const now = Date.now();
+        const first = createDedupHarness({ nowMs: now });
+        const second = createDedupHarness({ nowMs: now });
+
+        await first.fn('team-1', 'schedule', 'game-1');
+        await second.fn('team-1', 'practice', 'game-1');
+
+        expect(first.mockFirestore.doc.mock.calls[0][0]).not.toBe(second.mockFirestore.doc.mock.calls[0][0]);
+        expect([...first.store.values()][0]).toMatchObject({ category: 'schedule', gameId: 'game-1' });
+        expect([...second.store.values()][0]).toMatchObject({ category: 'practice', gameId: 'game-1' });
+    });
 });
 
 describe('notification send dedup guard — sendCategoryNotification', () => {


### PR DESCRIPTION
## Summary
- add regression coverage for category-scoped notification dedup records
- verify two categories sharing a game ID use different Firestore send-log documents
- assert saved dedup metadata keeps the expected category and game identity

## Tests
- npx vitest run tests/unit/notification-send-dedup.test.js --reporter=verbose

Refs #2648