### PR TITLE
Stop search parent team fallback reads

### DIFF
--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -577,6 +577,8 @@ export function resetAppSearchCacheForTests() {
 }
 
 async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>, homeTeams: any[], user: AuthUser | null) {
+  const fallbackTeams: any[] = [];
+
   (Array.isArray(homeTeams) ? homeTeams : []).forEach((team: any) => {
     const teamId = cleanString(team?.teamId || team?.id);
     if (!teamId) return;
@@ -588,7 +590,25 @@ async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>,
       return;
     }
 
-    const searchTeam = buildParentHomeSearchTeam({ ...team, teamId });
+    fallbackTeams.push({ ...team, teamId });
+  });
+
+  if (!fallbackTeams.length) return;
+
+  const snapshots = await Promise.allSettled(
+    fallbackTeams.map((team) => getDoc(doc(db, 'teams', team.teamId)))
+  );
+
+  fallbackTeams.forEach((homeTeam, index) => {
+    const snapshot: any = snapshots[index];
+    const teamDoc = snapshot?.status === 'fulfilled' ? snapshot.value : null;
+    const [firestoreTeam] = teamDoc?.exists?.()
+      ? normalizeTeams([{ id: homeTeam.teamId, ...(typeof teamDoc.data === 'function' ? teamDoc.data() || {} : {}) }])
+      : [];
+
+    if (firestoreTeam && !isTeamActive(firestoreTeam)) return;
+
+    const searchTeam = buildParentHomeSearchTeam(homeTeam, firestoreTeam);
     if (canUserDiscoverTeamInAppSearch(searchTeam, user)) {
       teamsById.set(searchTeam.id, searchTeam);
     }

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -577,8 +577,6 @@ export function resetAppSearchCacheForTests() {
 }
 
 async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>, homeTeams: any[], user: AuthUser | null) {
-  const fallbackTeams: any[] = [];
-
   (Array.isArray(homeTeams) ? homeTeams : []).forEach((team: any) => {
     const teamId = cleanString(team?.teamId || team?.id);
     if (!teamId) return;
@@ -590,25 +588,7 @@ async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>,
       return;
     }
 
-    fallbackTeams.push({ ...team, teamId });
-  });
-
-  if (!fallbackTeams.length) return;
-
-  const snapshots = await Promise.allSettled(
-    fallbackTeams.map((team) => getDoc(doc(db, 'teams', team.teamId)))
-  );
-
-  snapshots.forEach((snapshot: any, index) => {
-    if (snapshot.status !== 'fulfilled') return;
-    const teamDoc = snapshot.value;
-    if (!teamDoc?.exists?.()) return;
-
-    const homeTeam = fallbackTeams[index];
-    const [firestoreTeam] = normalizeTeams([{ id: homeTeam.teamId, ...(typeof teamDoc.data === 'function' ? teamDoc.data() || {} : {}) }]);
-    if (!firestoreTeam || !isTeamActive(firestoreTeam)) return;
-
-    const searchTeam = buildParentHomeSearchTeam(homeTeam, firestoreTeam);
+    const searchTeam = buildParentHomeSearchTeam({ ...team, teamId });
     if (canUserDiscoverTeamInAppSearch(searchTeam, user)) {
       teamsById.set(searchTeam.id, searchTeam);
     }

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -533,7 +533,7 @@ describe('React app search service', () => {
         expect(dbMocks.getTeams).not.toHaveBeenCalled();
     });
 
-    it('uses parent home summary teams without per-team Firestore fallback reads', async () => {
+    it('hydrates parent home summary teams with Firestore metadata when direct access queries miss them', async () => {
         homeMocks.loadParentHome.mockResolvedValue({
             teams: [
                 { teamId: 'team-home', teamName: 'Home Rockets', sport: 'Basketball', location: 'Kansas City, MO' },
@@ -542,15 +542,28 @@ describe('React app search service', () => {
                 { teamId: 'team-status-archived-summary', teamName: 'Status Archived Summary', sport: 'Softball', status: 'archived' }
             ]
         });
+        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDocument('team-home', {
+            name: 'Stored Home Rockets',
+            sport: 'Basketball',
+            isPublic: false,
+            city: 'Kansas City',
+            state: 'MO',
+            zip: '64111',
+            active: true
+        }));
 
         const teams = await loadAppSearchTeams(auth.user);
 
-        expect(firebaseMocks.getDoc).not.toHaveBeenCalled();
-        expect(firebaseMocks.doc).not.toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-home');
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-home');
         expect(teams.map((team) => team.id)).toEqual(['team-home']);
         expect(teams[0]).toMatchObject({
             id: 'team-home',
             name: 'Home Rockets',
+            sport: 'Basketball',
+            city: 'Kansas City',
+            state: 'MO',
+            zip: '64111',
+            isPublic: false,
             location: 'Kansas City, MO',
             fromAppAccess: true
         });

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -519,12 +519,6 @@ describe('React app search service', () => {
             .mockResolvedValueOnce({ docs: [firestoreTeam('team-admin', { name: 'Admin Lions', sport: 'Soccer', isPublic: false, adminEmails: ['parent@example.com'] })] })
             .mockResolvedValueOnce({ docs: [] })
             .mockResolvedValueOnce({ docs: [] });
-        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDocument('team-home', {
-            name: 'Home Rockets',
-            sport: 'Basketball',
-            isPublic: false,
-            active: true
-        }));
         const teams = await loadAppSearchTeams(auth.user);
 
         expect(teams.map((team) => team.id)).toEqual(['team-admin', 'team-home', 'team-owner']);
@@ -539,49 +533,25 @@ describe('React app search service', () => {
         expect(dbMocks.getTeams).not.toHaveBeenCalled();
     });
 
-    it('validates parent home fallback teams against Firestore visibility before adding them', async () => {
+    it('uses parent home summary teams without per-team Firestore fallback reads', async () => {
         homeMocks.loadParentHome.mockResolvedValue({
             teams: [
-                { teamId: 'team-active-private', teamName: 'Active Private', sport: 'Basketball' },
-                { teamId: 'team-archived-doc', teamName: 'Archived Doc', sport: 'Soccer' },
-                { teamId: 'team-inactive-doc', teamName: 'Inactive Doc', sport: 'Baseball' },
-                { teamId: 'team-missing-doc', teamName: 'Missing Doc', sport: 'Softball' }
+                { teamId: 'team-home', teamName: 'Home Rockets', sport: 'Basketball', location: 'Kansas City, MO' },
+                { teamId: 'team-archived-summary', teamName: 'Archived Summary', sport: 'Soccer', archived: true },
+                { teamId: 'team-inactive-summary', teamName: 'Inactive Summary', sport: 'Baseball', active: false },
+                { teamId: 'team-status-archived-summary', teamName: 'Status Archived Summary', sport: 'Softball', status: 'archived' }
             ]
         });
-        firebaseMocks.getDoc
-            .mockResolvedValueOnce(firestoreDocument('team-active-private', {
-                name: 'Stored Active Private',
-                sport: 'Basketball',
-                isPublic: false,
-                active: true,
-                archived: false,
-                status: 'active'
-            }))
-            .mockResolvedValueOnce(firestoreDocument('team-archived-doc', {
-                name: 'Stored Archived',
-                sport: 'Soccer',
-                isPublic: false,
-                archived: true
-            }))
-            .mockResolvedValueOnce(firestoreDocument('team-inactive-doc', {
-                name: 'Stored Inactive',
-                sport: 'Baseball',
-                isPublic: false,
-                active: false
-            }))
-            .mockResolvedValueOnce(firestoreDocument('team-missing-doc', {}, false));
 
         const teams = await loadAppSearchTeams(auth.user);
 
-        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-active-private');
-        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-archived-doc');
-        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-inactive-doc');
-        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-missing-doc');
-        expect(teams.map((team) => team.id)).toEqual(['team-active-private']);
+        expect(firebaseMocks.getDoc).not.toHaveBeenCalled();
+        expect(firebaseMocks.doc).not.toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-home');
+        expect(teams.map((team) => team.id)).toEqual(['team-home']);
         expect(teams[0]).toMatchObject({
-            id: 'team-active-private',
-            name: 'Active Private',
-            isPublic: false,
+            id: 'team-home',
+            name: 'Home Rockets',
+            location: 'Kansas City, MO',
             fromAppAccess: true
         });
     });
@@ -671,12 +641,6 @@ describe('React app search service', () => {
             .mockResolvedValueOnce({ docs: [] })
             .mockResolvedValueOnce({ docs: [] })
             .mockResolvedValueOnce({ docs: [] });
-        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDocument('team-home', {
-            name: 'Home Rockets',
-            sport: 'Basketball',
-            isPublic: false,
-            active: true
-        }));
 
         const first = await loadAppSearchTeams(auth.user);
         const second = await loadAppSearchTeams(auth.user);
@@ -694,12 +658,6 @@ describe('React app search service', () => {
         homeMocks.loadParentHome.mockResolvedValueOnce({
             teams: [{ teamId: 'team-private-access', teamName: 'Private Access', sport: 'Soccer' }]
         });
-        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDocument('team-private-access', {
-            name: 'Private Access',
-            sport: 'Soccer',
-            isPublic: false,
-            active: true
-        }));
 
         await expect(loadAppSearchTeams(auth.user)).resolves.toMatchObject([
             { id: 'team-private-access', name: 'Private Access', fromAppAccess: true }


### PR DESCRIPTION
## Summary
- stop app search bootstrapping from reading teams/{id} once per parent-home team
- rely on the parent-home summary payload for parent-linked team search entries
- update regression coverage to assert no per-team getDoc fallback reads occur

## Tests
- npx vitest run tests/unit/app-search-service.test.js --reporter=verbose

Refs #2716