### PR TITLE
Cover game report mapper boundary

### DIFF
--- a/tests/unit/app-game-report-mapper-boundary-contract.test.js
+++ b/tests/unit/app-game-report-mapper-boundary-contract.test.js
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const serviceSource = readFileSync(new URL('../../apps/app/src/lib/gameReportService.ts', import.meta.url), 'utf8');
+const mapperSource = readFileSync(new URL('../../apps/app/src/lib/firestore/mappers.ts', import.meta.url), 'utf8');
+const typeSource = readFileSync(new URL('../../apps/app/src/lib/firestore/types.ts', import.meta.url), 'utf8');
+
+describe('game report Firestore mapper boundary', () => {
+    it('routes report assembly through typed Firestore mappers instead of raw records', () => {
+        expect(serviceSource).toContain("from './firestore/mappers'");
+        [
+            'mapGameReportTeamRecord',
+            'mapGameReportGameRecord',
+            'mapGameReportPlayerRecords',
+            'mapGameReportAggregatedStatsRecord',
+            'mapGameReportTeamStatsRecord',
+            'mapGameReportEventRecords'
+        ].forEach((mapperName) => {
+            expect(serviceSource).toContain(mapperName);
+            expect(mapperSource).toContain(`export function ${mapperName}`);
+        });
+    });
+
+    it('keeps the report service typed to normalized mapper records', () => {
+        [
+            'GameReportTeamFirestoreRecord',
+            'GameReportGameFirestoreRecord',
+            'GameReportPlayerFirestoreRecord',
+            'GameReportStatsRecord',
+            'GameReportTeamStatsFirestoreRecord',
+            'GameReportEventFirestoreRecord'
+        ].forEach((typeName) => {
+            expect(serviceSource).toContain(typeName);
+            expect(typeSource).toContain(`export type ${typeName}`);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add a source contract for the game report Firestore mapper boundary
- verify report assembly imports and uses the typed mapper layer
- verify report service types stay aligned with normalized Firestore record types

## Tests
- npx vitest run tests/unit/app-game-report-mapper-boundary-contract.test.js --reporter=verbose

Refs #2684