### PR TITLE
Cover email template reducer application

### DIFF
--- a/tests/unit/app-email-reducer.test.ts
+++ b/tests/unit/app-email-reducer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { emailReducer, initialEmailComposerState } from '../../apps/app/src/pages/messages/state/emailReducer.ts';
-import type { TeamEmailDraft } from '../../apps/app/src/lib/chatService.ts';
+import type { TeamEmailDraft, TeamEmailTemplate } from '../../apps/app/src/lib/chatService.ts';
 
 function draft(overrides: Partial<TeamEmailDraft> = {}): TeamEmailDraft {
     return {
@@ -9,6 +9,16 @@ function draft(overrides: Partial<TeamEmailDraft> = {}): TeamEmailDraft {
         body: 'Bring shoes and water.',
         recipientIds: ['player-1'],
         recipients: [],
+        ...overrides
+    };
+}
+
+function template(overrides: Partial<TeamEmailTemplate> = {}): TeamEmailTemplate {
+    return {
+        id: 'template-1',
+        name: 'Game day',
+        subject: 'Game tomorrow',
+        body: 'Bring both uniforms.',
         ...overrides
     };
 }
@@ -25,6 +35,23 @@ describe('emailReducer', () => {
             selectedDraftId: '',
             subject: '',
             body: ''
+        });
+    });
+
+    it('applies email templates through the reducer without clearing the selected draft', () => {
+        const selected = emailReducer(
+            emailReducer(
+                emailReducer(initialEmailComposerState, { type: 'setDrafts', drafts: [draft()] }),
+                { type: 'setTemplates', templates: [template()] }
+            ),
+            { type: 'selectDraft', draftId: 'draft-1' }
+        );
+
+        expect(emailReducer(selected, { type: 'applyTemplate', templateId: 'template-1' })).toMatchObject({
+            selectedDraftId: 'draft-1',
+            subject: 'Game tomorrow',
+            body: 'Bring both uniforms.',
+            templates: [template()]
         });
     });
 });


### PR DESCRIPTION
## Summary
- add reducer coverage for applying saved email templates
- verify template application updates subject and body through emailReducer
- verify applying a template does not clear the selected draft or template state

## Tests
- npx vitest run tests/unit/app-email-reducer.test.ts --reporter=verbose

Refs #2652