### PR TITLE
Cover user-id recipient index fallback

### DIFF
--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -121,4 +121,22 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
         expect(functionsSource).toContain('buildTeamNotificationTargetRef(target.teamId, target.uid, target.deviceId)');
     });
+
+    it('uses indexed recipient docs before fallback reads for explicit user-id target resolution', () => {
+        const userIdResolverSource = functionsSource.slice(
+            functionsSource.indexOf('async function getTargetsForCategoryUserIds'),
+            functionsSource.indexOf('function buildTargetsFromNotificationRecipientDoc')
+        );
+
+        expect(userIdResolverSource).toContain('Array.from(eligibleUsers.keys())');
+        expect(userIdResolverSource).toContain('buildTeamNotificationRecipientRef(teamId, uid)');
+        expect(userIdResolverSource).toContain('firestore.getAll(...recipientRefs)');
+        expect(userIdResolverSource).toContain('buildTargetsFromNotificationRecipientDoc(docSnap');
+        expect(userIdResolverSource).toContain('const indexedUserIds = new Set(indexedTargets.map((target) => target.uid));');
+        expect(userIdResolverSource).toContain('!indexedUserIds.has(user.uid)');
+        expect(userIdResolverSource).toContain('eligibleUsers.has(user.uid)');
+        expect(userIdResolverSource).toContain('? await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
+        expect(userIdResolverSource).toContain('return [...indexedTargets, ...fallbackTargets].filter');
+        expect(userIdResolverSource).toContain('if (!recipientUserIds.has(uid)) return false;');
+    });
 });


### PR DESCRIPTION
## Summary
- add source coverage for explicit user-id notification recipient resolution
- verify user-id sends consult the team recipient index before legacy fallback reads
- verify missing indexed users still fall back through the legacy preference/device path

## Tests
- npx vitest run tests/unit/notification-target-index-core.test.js --reporter=verbose

Refs #2647