### PR TITLE
Redact logger URL secrets

### DIFF
--- a/apps/app/src/lib/logger.test.ts
+++ b/apps/app/src/lib/logger.test.ts
@@ -118,4 +118,15 @@ describe('logger', () => {
             }
         );
     });
+
+    it('redacts secrets from free-form log messages before writing to console', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        const logger = createLogger('schedule-service');
+
+        logger.warn('Fetch failed for https://example.test/callback?access_token=abc123&teamId=team-1#id_token=jwt456');
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[schedule-service] Fetch failed for https://example.test/callback?access_token=[REDACTED]&teamId=team-1#id_token=[REDACTED]'
+        );
+    });
 });

--- a/apps/app/src/lib/logger.test.ts
+++ b/apps/app/src/lib/logger.test.ts
@@ -33,6 +33,26 @@ describe('logger', () => {
         });
     });
 
+    it('redacts secret URL parameters inside free-form strings', () => {
+        const sanitized = sanitizeForLogging({
+            message: 'Fetch failed for https://example.test/callback?access_token=abc123&teamId=team-1#id_token=jwt456',
+            retryUrl: 'https://example.test/retry?client_secret=client-secret&status=pending',
+            nested: [
+                'https://example.test/session?auth-token=native-secret&view=home',
+                'Bearer message-token'
+            ]
+        });
+
+        expect(sanitized).toEqual({
+            message: 'Fetch failed for https://example.test/callback?access_token=[REDACTED]&teamId=team-1#id_token=[REDACTED]',
+            retryUrl: 'https://example.test/retry?client_secret=[REDACTED]&status=pending',
+            nested: [
+                'https://example.test/session?auth-token=[REDACTED]&view=home',
+                'Bearer [REDACTED]'
+            ]
+        });
+    });
+
     it('sanitizes Error objects with nested headers and circular request context', () => {
         const request: Record<string, unknown> = {
             headers: new Headers({

--- a/apps/app/src/lib/logger.ts
+++ b/apps/app/src/lib/logger.ts
@@ -107,7 +107,7 @@ function getConsoleMethod(level: LogLevel) {
 
 function writeLog(scope: string, level: LogLevel, message: string, context?: LogContext) {
     const method = getConsoleMethod(level);
-    const prefix = `[${scope}] ${message}`;
+    const prefix = `[${scope}] ${sanitizeForLogging(message)}`;
     if (!context || !Object.keys(context).length) {
         method(prefix);
         return;

--- a/apps/app/src/lib/logger.ts
+++ b/apps/app/src/lib/logger.ts
@@ -31,6 +31,13 @@ function redactBearerTokens(value: string) {
     return value.replace(/Bearer\s+[^\s"',}]+/gi, `Bearer ${redactedValue}`);
 }
 
+function redactSensitiveQueryParams(value: string) {
+    return value.replace(
+        /([?&#](?:access[_-]?token|id[_-]?token|refresh[_-]?token|auth[_-]?token|api[_-]?key|client[_-]?secret|token|password|secret)=)[^&#\s"',}]+/gi,
+        `$1${redactedValue}`
+    );
+}
+
 function isHeadersLike(value: unknown): value is Headers {
     return typeof Headers !== 'undefined' && value instanceof Headers;
 }
@@ -39,7 +46,7 @@ function sanitizeValue(value: unknown, seen: WeakSet<object>, depth: number, key
     if (value == null) return value;
 
     if (typeof value === 'string') {
-        return isSensitiveKey(keyHint) ? redactedValue : redactBearerTokens(value);
+        return isSensitiveKey(keyHint) ? redactedValue : redactSensitiveQueryParams(redactBearerTokens(value));
     }
 
     if (typeof value !== 'object') {


### PR DESCRIPTION
## Summary
- redact token-like URL query and fragment parameters in free-form log strings
- preserve non-sensitive URL parameters so logs stay useful
- add logger unit coverage for URL-secret redaction alongside existing structured redaction

## Tests
- npx vitest run apps/app/src/lib/logger.test.ts --reporter=verbose

Refs #2639