### PR TITLE
Cover registration provider capability states

### DIFF
--- a/tests/unit/edit-team-registration-sync.test.js
+++ b/tests/unit/edit-team-registration-sync.test.js
@@ -51,4 +51,36 @@ describe('edit team Sports Connect registration sync wiring', () => {
         expect(coreSource).toContain('registrationRosterSnapshot');
         expect(coreSource).not.toContain('source.syncUrl');
     });
+
+    it('keeps registration provider capability states explicit for metadata-only providers', () => {
+        const source = readEditTeam();
+        const capabilitySource = source.slice(
+            source.indexOf('function getRegistrationProviderCapability'),
+            source.indexOf('function ensureRegistrationProviderOption')
+        );
+
+        [
+            "state: 'not_configured'",
+            "connectionStatus: 'not_configured'",
+            "helpText: 'Choose a provider and team mapping to save registration metadata.'",
+            "state: 'metadata_incomplete'",
+            "connectionStatus: 'metadata_incomplete'",
+            "helpText: 'Add the provider team ID or mapping to finish setup.'",
+            "state: 'metadata_configured'",
+            "connectionStatus: 'metadata_configured'",
+            "label: isSportsConnect ? 'Metadata saved; live sync unavailable' : 'Registration metadata only. No live sync.'",
+            "? 'Sports Connect metadata is saved for reference only. Live refresh and re-import require a future provider connector.'",
+            "state: 'live_connected'",
+            "connectionStatus: 'live_connected'",
+            "canRefresh: true",
+            "syncEnabled: true"
+        ].forEach((snippet) => {
+            expect(capabilitySource).toContain(snippet);
+        });
+
+        expect(capabilitySource).toContain("const hasLiveConnection = ['live_connected', 'sync_success'].includes(source?.connectionStatus) && source?.syncEnabled === true;");
+        expect(capabilitySource).toContain("if (hasProvider && hasLiveConnection) {");
+        expect(capabilitySource).toContain('canRefresh: false');
+        expect(capabilitySource).toContain('syncEnabled: false');
+    });
 });


### PR DESCRIPTION
## Summary
- add regression coverage for explicit registration provider capability states
- guard metadata-only Sports Connect setup from enabling refresh/sync prematurely
- verify live connections require both live status and syncEnabled before refresh is available

## Tests
- npx vitest run tests/unit/edit-team-registration-sync.test.js --reporter=verbose

Refs #2634