### PR TITLE
Cover chat mention notification dedup

### DIFF
--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -349,6 +349,37 @@ describe('buildTeamChatNotificationPlan', () => {
         expect(plan.liveChatTargets).toHaveLength(1);
     });
 
+    it('deduplicates mentioned users out of generic live chat pushes across devices', () => {
+        const plan = buildTeamChatNotificationPlan({
+            text: '@Alice check the jersey note',
+            actorUid: 'coach-1',
+            recipientContext: {
+                members: [
+                    { uid: 'coach-1', displayName: 'Coach Kim', roles: ['staff'] },
+                    { uid: 'u1', displayName: 'Alice Parent', roles: ['parent'] },
+                    { uid: 'u2', displayName: 'Blair Parent', roles: ['parent'] }
+                ],
+                mutedUids: [],
+                targetsByCategory: {
+                    mentions: [
+                        { uid: 'u1', deviceId: 'ios', token: 'mention-ios' },
+                        { uid: 'u1', deviceId: 'web', token: 'mention-web' },
+                        { uid: 'u1', deviceId: 'web', token: 'mention-web' }
+                    ],
+                    liveChat: [
+                        { uid: 'u1', deviceId: 'ios', token: 'chat-ios' },
+                        { uid: 'u1', deviceId: 'web', token: 'chat-web' },
+                        { uid: 'u2', deviceId: 'ios', token: 'chat-u2' }
+                    ]
+                }
+            }
+        });
+
+        expect(plan.mentionedUids).toEqual(['u1']);
+        expect(plan.mentionTargets.map((target) => `${target.uid}:${target.deviceId}`).sort()).toEqual(['u1:ios', 'u1:web']);
+        expect(plan.liveChatTargets.map((target) => target.uid)).toEqual(['u2']);
+    });
+
     it('handles a large mixed team fixture from one preloaded recipient context', () => {
         const mentionedUserIds = ['user-12', 'user-87', 'user-301'];
         const members = Array.from({ length: 500 }, (_, index) => ({


### PR DESCRIPTION
## Summary
- add regression coverage for mentioned users being removed from generic live-chat pushes
- verify mention-category targets remain deduped across duplicate device rows
- guard multi-device overlap so a mentioned user does not receive both mention and generic chat pushes

## Tests
- npx vitest run tests/unit/functions-chat-mention-detection.test.js --reporter=verbose

Refs #2599