### PR TITLE
Scope chat attachment fallback storage

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -982,7 +982,7 @@ async function nativeUploadChatMedia(teamId: string, file: File): Promise<ChatAt
   };
 }
 
-export async function uploadTeamChatAttachment(teamId: string, file: File): Promise<ChatAttachment> {
+export async function uploadTeamChatAttachment(teamId: string, file: File, conversationId = DEFAULT_TEAM_CONVERSATION_ID): Promise<ChatAttachment> {
   if (!file.type.startsWith('image/') && !file.type.startsWith('video/')) {
     throw new Error('Choose image or video files only.');
   }
@@ -993,7 +993,7 @@ export async function uploadTeamChatAttachment(teamId: string, file: File): Prom
     return nativeUploadChatMedia(teamId, file);
   }
   try {
-    return await withTimeout(Promise.resolve(uploadChatImage(teamId, file)), 'Chat media upload', chatUploadTimeoutMs) as ChatAttachment;
+    return await withTimeout(Promise.resolve(uploadChatImage(teamId, file, conversationId)), 'Chat media upload', chatUploadTimeoutMs) as ChatAttachment;
   } catch (error) {
     throw error;
   }
@@ -1085,7 +1085,7 @@ export async function sendTeamChatMessage({
   try {
     for (const file of files) {
       onProgress?.('uploading');
-      uploadedAttachments.push(await uploadTeamChatAttachment(teamId, file));
+      uploadedAttachments.push(await uploadTeamChatAttachment(teamId, file, selectedConversationId || DEFAULT_TEAM_CONVERSATION_ID));
     }
     onProgress?.('posting');
 

--- a/js/db.js
+++ b/js/db.js
@@ -469,7 +469,7 @@ function getRequiredSignedInUserId() {
     return userId;
 }
 
-export async function uploadChatImage(teamId, file) {
+export async function uploadChatImage(teamId, file, conversationId = 'team') {
     await requireImageAuth();
 
     const ts = Date.now();
@@ -495,7 +495,7 @@ export async function uploadChatImage(teamId, file) {
         const code = error?.code || '';
         if (code === 'storage/unauthorized' || code === 'storage/unauthenticated') {
             console.warn('Image storage denied chat upload, falling back to main storage:', error?.message || error);
-            const fallbackPath = buildChatAttachmentFallbackPath(teamId, userId, file.name, ts);
+            const fallbackPath = buildChatAttachmentFallbackPath(teamId, userId, file.name, ts, conversationId);
             const fallbackRef = ref(storage, fallbackPath);
             const fallbackSnapshot = await uploadBytes(fallbackRef, file);
             const fallbackUrl = await getDownloadURL(fallbackSnapshot.ref);

--- a/js/fallback-media-paths.js
+++ b/js/fallback-media-paths.js
@@ -6,12 +6,13 @@ function sanitizePathSegment(value, fallback) {
     return sanitized || fallback;
 }
 
-export function buildChatAttachmentFallbackPath(teamId, userId, fileName, ts = Date.now()) {
+export function buildChatAttachmentFallbackPath(teamId, userId, fileName, ts = Date.now(), conversationId = 'team') {
     const safeTeamId = sanitizePathSegment(teamId, 'unknown-team');
+    const safeConversationId = sanitizePathSegment(conversationId, 'team');
     const safeUserId = sanitizePathSegment(userId, 'unknown-user');
     const safeName = sanitizePathSegment(fileName, 'attachment');
 
-    return `stat-sheets/team-chat/${safeTeamId}/${safeUserId}/${ts}_${safeName}`;
+    return `stat-sheets/team-chat/${safeTeamId}/conversations/${safeConversationId}/${safeUserId}/${ts}_${safeName}`;
 }
 
 export function buildStatSheetFallbackPath(teamId, userId, fileName, ts = Date.now()) {

--- a/storage.rules
+++ b/storage.rules
@@ -30,6 +30,26 @@ service firebase.storage {
       return isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
     }
 
+    function canAccessTeamChatConversation(teamId, conversationId) {
+      let conversationPath = /databases/(default)/documents/teams/$(teamId)/chatConversations/$(conversationId);
+      let participantIds = firestore.exists(conversationPath)
+        ? firestore.get(conversationPath).data.get('participantIds', [])
+        : [];
+      return canAccessTeamMedia(teamId) &&
+        (
+          conversationId == 'team' ||
+          isTeamOwnerOrAdmin(teamId) ||
+          (firestore.exists(conversationPath) &&
+           (
+             firestore.get(conversationPath).data.get('type', '') == 'team' ||
+             request.auth.uid in participantIds ||
+             ('user:' + request.auth.uid) in participantIds ||
+             (request.auth.token.email != null &&
+              ('email:' + request.auth.token.email.lower()) in participantIds)
+           ))
+        );
+    }
+
     function hasTeamMediaUploadGrant(teamId) {
       let userPath = /databases/(default)/documents/users/$(request.auth.uid);
       return isSignedIn() &&
@@ -106,6 +126,17 @@ service firebase.storage {
         request.resource.size > 0 &&
         request.resource.size <= 20 * 1024 * 1024;
       allow delete: if isTeamOwnerOrAdmin(teamId);
+      allow update: if false;
+    }
+
+    match /stat-sheets/team-chat/{teamId}/conversations/{conversationId}/{userId}/{fileName} {
+      allow get: if canAccessTeamChatConversation(teamId, conversationId);
+      allow list: if false;
+      allow create: if canAccessTeamChatConversation(teamId, conversationId) &&
+        request.auth.uid == userId &&
+        request.resource.size > 0 &&
+        request.resource.size <= 20 * 1024 * 1024;
+      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
       allow update: if false;
     }
 

--- a/team-chat.html
+++ b/team-chat.html
@@ -2889,7 +2889,7 @@
             try {
                 if (imageFiles.length > 0) {
                     for (const file of imageFiles) {
-                        mediaPayloads.push(await uploadChatImage(teamId, file));
+                        mediaPayloads.push(await uploadChatImage(teamId, file, conversationId));
                     }
                 }
                 pendingScrollToBottom = true;

--- a/tests/unit/fallback-media-storage.test.js
+++ b/tests/unit/fallback-media-storage.test.js
@@ -12,7 +12,8 @@ function extractRuleBlock(startMarker) {
     return rules.slice(start, end === -1 ? undefined : end);
 }
 
-const chatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/{userId}/{fileName}');
+const scopedChatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/conversations/{conversationId}/{userId}/{fileName}');
+const legacyChatFallbackRules = extractRuleBlock('match /stat-sheets/team-chat/{teamId}/{userId}/{fileName}');
 const statSheetFallbackRules = extractRuleBlock('match /stat-sheets/team-games/{teamId}/{userId}/{fileName}');
 const drillFallbackRules = extractRuleBlock('match /stat-sheets/drills/{teamId}/{drillId}/{userId}/{fileName}');
 const clipFallbackRules = extractRuleBlock('match /game-clips/{teamId}/{gameId}/{userId}/{fileName}');
@@ -37,24 +38,29 @@ function canAccessLegacyGameClipFallback({ authUid }) {
 
 describe('fallback media paths and Storage rules', () => {
     it('builds team-scoped fallback paths with uploader context', () => {
-        expect(buildChatAttachmentFallbackPath('team/alpha', 'user 42', 'my photo (1).png', 1700000000000))
-            .toBe('stat-sheets/team-chat/team_alpha/user_42/1700000000000_my_photo_1_.png');
+        expect(buildChatAttachmentFallbackPath('team/alpha', 'user 42', 'my photo (1).png', 1700000000000, 'staff room'))
+            .toBe('stat-sheets/team-chat/team_alpha/conversations/staff_room/user_42/1700000000000_my_photo_1_.png');
         expect(buildStatSheetFallbackPath('team/alpha', 'user 42', 'box score (1).png', 1700000000001))
             .toBe('stat-sheets/team-games/team_alpha/user_42/1700000000001_box_score_1_.png');
         expect(buildDrillDiagramFallbackPath('team/alpha', 'drill 7', 'user 42', 'diagram #1.png', 1700000000002))
             .toBe('stat-sheets/drills/team_alpha/drill_7/user_42/1700000000002_diagram_1.png');
         expect(buildGameClipFallbackPath('team/alpha', 'game 7', 'user 42', 'clip #1.mp4', 1700000000001))
             .toBe('game-clips/team_alpha/game_7/user_42/1700000000001_clip_1.mp4');
-        expect(dbSource).toContain('buildChatAttachmentFallbackPath(teamId, userId, file.name, ts)');
+        expect(dbSource).toContain('buildChatAttachmentFallbackPath(teamId, userId, file.name, ts, conversationId)');
         expect(dbSource).toContain('buildStatSheetFallbackPath(teamId, userId, file.name, Date.now())');
         expect(dbSource).toContain('buildDrillDiagramUploadPaths(teamId, drillId, userId, file?.name, Date.now())');
         expect(dbSource).toContain('buildGameClipFallbackPath(teamId, gameId, userId, file.name, ts)');
     });
 
-    it('limits fallback chat media access to the same team audience and uploader/admin delete rights', () => {
-        expect(chatFallbackRules).toContain('allow get: if canAccessTeamMedia(teamId);');
-        expect(chatFallbackRules).toContain('request.auth.uid == userId');
-        expect(chatFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+    it('limits fallback chat media access to conversation participants and uploader/admin delete rights', () => {
+        expect(rules).toContain('function canAccessTeamChatConversation(teamId, conversationId)');
+        expect(rules).toContain("conversationId == 'team'");
+        expect(rules).toContain("('user:' + request.auth.uid) in participantIds");
+        expect(rules).toContain("('email:' + request.auth.token.email.lower()) in participantIds");
+        expect(scopedChatFallbackRules).toContain('allow get: if canAccessTeamChatConversation(teamId, conversationId);');
+        expect(scopedChatFallbackRules).toContain('request.auth.uid == userId');
+        expect(scopedChatFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(legacyChatFallbackRules).toContain('match /stat-sheets/team-chat/{teamId}/{userId}/{fileName}');
 
         expect(canAccessTeamMedia({ authUid: 'coach-1', isTeamAdmin: true })).toBe(true);
         expect(canAccessTeamMedia({ authUid: 'parent-1', isTeamParent: true })).toBe(true);

--- a/tests/unit/team-chat-send-media-cleanup.test.js
+++ b/tests/unit/team-chat-send-media-cleanup.test.js
@@ -16,7 +16,7 @@ describe('team chat multi-file send cleanup', () => {
         const html = readRepoFile('team-chat.html');
 
         expect(html).toContain('for (const file of imageFiles)');
-        expect(html).toContain('mediaPayloads.push(await uploadChatImage(teamId, file));');
+        expect(html).toContain('mediaPayloads.push(await uploadChatImage(teamId, file, conversationId));');
         expect(html).not.toContain('Promise.all(imageFiles.map((file) => uploadChatImage(teamId, file)))');
     });
 


### PR DESCRIPTION
## Summary
- add conversation-scoped fallback Storage paths for team chat attachments
- restrict new chat attachment fallback reads/writes to conversation participants or team admins
- pass conversation ids through legacy web and React app chat upload calls while preserving legacy object rules

## Tests
- npx vitest run tests/unit/fallback-media-storage.test.js tests/unit/team-chat-send-media-cleanup.test.js --reporter=verbose
- npm run ci:firebase-rules

Refs #2596