### PR TITLE
Restrict open officiating self-assignment claims

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -877,43 +877,6 @@ service cloud.firestore {
       );
     }
 
-    function isOnlyAddingCurrentOfficialAuthorization() {
-      let previousUserIds = resource.data.get('officiatingAuthorizedUserIds', []);
-      let nextUserIds = request.resource.data.get('officiatingAuthorizedUserIds', []);
-      let previousEmails = resource.data.get('officiatingAuthorizedEmails', []);
-      let nextEmails = request.resource.data.get('officiatingAuthorizedEmails', []);
-      let callerEmail = request.auth.token.email != null ? request.auth.token.email.lower() : '';
-      return nextUserIds.hasAll(previousUserIds) &&
-             nextUserIds.hasOnly(previousUserIds + [request.auth.uid]) &&
-             request.auth.uid in nextUserIds &&
-             nextEmails.hasAll(previousEmails) &&
-             (
-               (callerEmail == '' && nextEmails.hasOnly(previousEmails)) ||
-               (callerEmail != '' &&
-                nextEmails.hasOnly(previousEmails + [callerEmail]) &&
-                callerEmail in nextEmails)
-             );
-    }
-
-    function canClaimOpenOfficiatingSlot(teamId) {
-      return isTeamOwnerOrAdmin(teamId) ||
-             isParentForTeam(teamId);
-    }
-
-    function isOpenOfficiatingSelfAssignmentUpdate(teamId) {
-      return canClaimOpenOfficiatingSlot(teamId) &&
-             resource.data.get('officiatingSelfAssignmentEnabled', false) == true &&
-             request.resource.data.get('officiatingSelfAssignmentEnabled', false) == true &&
-             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
-               'officiatingSlots',
-               'officiatingCoverageStatus',
-               'officiatingUpdatedAt',
-               'officiatingAuthorizedUserIds',
-               'officiatingAuthorizedEmails'
-             ]) &&
-             isOnlyAddingCurrentOfficialAuthorization();
-    }
-
     function canAccessTeamChat(teamId) {
       let team = get(/databases/$(database)/documents/teams/$(teamId)).data;
 
@@ -1904,7 +1867,6 @@ service cloud.firestore {
                         (isOfficialForGame() && isOfficialGameUpdate()) ||
                         isScorekeepingGameUpdate(teamId, gameId) ||
                         isVideographyGameUpdate(teamId, gameId);
-        allow update: if isOpenOfficiatingSelfAssignmentUpdate(teamId);
 
         // Events subcollection
         match /events/{eventId} {

--- a/functions/index.js
+++ b/functions/index.js
@@ -110,6 +110,8 @@ const {
 const {
   normalizeOpenOfficiatingSlotClaimInput,
   isEligibleOpenOfficiatingSlotParticipant,
+  resolveOfficiatingGamePath,
+  isTeamLinkedToSharedGame,
   buildOpenOfficiatingSlotClaimUpdate,
   buildOfficiatingSelfAssignmentNotificationRecord
 } = require('./officiating-self-assignment-core.cjs');
@@ -977,7 +979,7 @@ exports.claimOpenOfficiatingSlot = functions.https.onCall(async (data, context) 
     throw new functions.https.HttpsError('permission-denied', 'Only team owners, admins, or parents can claim open officiating slots.');
   }
 
-  const gameRef = firestore.doc(`teams/${input.teamId}/games/${input.gameId}`);
+  const gameRef = firestore.doc(resolveOfficiatingGamePath(input.teamId, input.gameId));
   const notificationRef = firestore.collection(`teams/${input.teamId}/officiatingNotifications`).doc();
   const now = admin.firestore.FieldValue.serverTimestamp();
 
@@ -989,6 +991,10 @@ exports.claimOpenOfficiatingSlot = functions.https.onCall(async (data, context) 
       }
 
       const game = { id: input.gameId, ...(gameSnap.data() || {}) };
+      if (!gameRef.path.startsWith(`teams/${input.teamId}/games/`) && !isTeamLinkedToSharedGame(game, input.teamId)) {
+        throw new functions.https.HttpsError('permission-denied', 'Game is not available to this team.');
+      }
+
       const { update, claimedSlot } = buildOpenOfficiatingSlotClaimUpdate({
         game,
         slotId: input.slotId,

--- a/functions/index.js
+++ b/functions/index.js
@@ -108,6 +108,12 @@ const {
   formatScheduleUpdateDate
 } = require('./schedule-notification-utils.cjs');
 const {
+  normalizeOpenOfficiatingSlotClaimInput,
+  isEligibleOpenOfficiatingSlotParticipant,
+  buildOpenOfficiatingSlotClaimUpdate,
+  buildOfficiatingSelfAssignmentNotificationRecord
+} = require('./officiating-self-assignment-core.cjs');
+const {
   assertSportsConnectSyncConfig,
   buildSportsConnectRegistrationSnapshot,
   buildSportsConnectSyncErrorUpdate,
@@ -939,6 +945,86 @@ exports.syncRegistrationProvider = functions.https.onCall(async (data, context) 
       });
     });
     throw toHttpsError(error, 'unavailable');
+  }
+});
+
+exports.claimOpenOfficiatingSlot = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in before claiming an officiating slot.');
+  }
+
+  let input;
+  try {
+    input = normalizeOpenOfficiatingSlotClaimInput(data || {});
+  } catch (error) {
+    throw toHttpsError(error, 'invalid-argument');
+  }
+
+  const uid = context.auth.uid;
+  const callerEmail = String(context.auth.token?.email || '').trim().toLowerCase();
+  const displayName = String(context.auth.token?.name || data?.displayName || callerEmail || 'Official').trim();
+  const [teamSnap, userSnap] = await Promise.all([
+    firestore.doc(`teams/${input.teamId}`).get(),
+    firestore.doc(`users/${uid}`).get()
+  ]);
+  if (!teamSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Team not found.');
+  }
+
+  const team = { id: input.teamId, ...(teamSnap.data() || {}) };
+  const user = userSnap.exists ? userSnap.data() || {} : {};
+  if (!isEligibleOpenOfficiatingSlotParticipant({ team, user, uid, email: callerEmail, teamId: input.teamId })) {
+    throw new functions.https.HttpsError('permission-denied', 'Only team owners, admins, or parents can claim open officiating slots.');
+  }
+
+  const gameRef = firestore.doc(`teams/${input.teamId}/games/${input.gameId}`);
+  const notificationRef = firestore.collection(`teams/${input.teamId}/officiatingNotifications`).doc();
+  const now = admin.firestore.FieldValue.serverTimestamp();
+
+  try {
+    const result = await firestore.runTransaction(async (transaction) => {
+      const gameSnap = await transaction.get(gameRef);
+      if (!gameSnap.exists) {
+        throw new functions.https.HttpsError('not-found', 'Game not found.');
+      }
+
+      const game = { id: input.gameId, ...(gameSnap.data() || {}) };
+      const { update, claimedSlot } = buildOpenOfficiatingSlotClaimUpdate({
+        game,
+        slotId: input.slotId,
+        official: { uid, email: callerEmail, displayName },
+        now
+      });
+      const notificationRecord = buildOfficiatingSelfAssignmentNotificationRecord({
+        teamId: input.teamId,
+        gameId: input.gameId,
+        game,
+        slot: claimedSlot,
+        actor: { uid, email: callerEmail, displayName },
+        timestamp: now
+      });
+
+      transaction.update(gameRef, update);
+      transaction.set(notificationRef, {
+        ...notificationRecord,
+        createdAt: now
+      });
+
+      return {
+        claimedSlot,
+        notificationId: notificationRef.id
+      };
+    });
+
+    return {
+      success: true,
+      teamId: input.teamId,
+      gameId: input.gameId,
+      slotId: input.slotId,
+      ...result
+    };
+  } catch (error) {
+    throw toHttpsError(error, error?.code || 'internal');
   }
 });
 

--- a/functions/officiating-self-assignment-core.cjs
+++ b/functions/officiating-self-assignment-core.cjs
@@ -1,0 +1,237 @@
+const OFFICIATING_ASSIGNMENT_STATUSES = new Set(['pending', 'accepted', 'declined', 'cant_make', 'needs_review', 'open']);
+
+function normalizeString(value) {
+    return String(value || '').trim();
+}
+
+function normalizeEmail(value) {
+    return normalizeString(value).toLowerCase();
+}
+
+function createClaimError(code, message) {
+    const error = new Error(message);
+    error.code = code;
+    return error;
+}
+
+function normalizeDocId(value, label) {
+    const normalized = normalizeString(value);
+    if (!normalized || normalized.includes('/')) {
+        throw createClaimError('invalid-argument', `${label} is required.`);
+    }
+    return normalized;
+}
+
+function normalizeOpenOfficiatingSlotClaimInput(data = {}) {
+    return {
+        teamId: normalizeDocId(data.teamId, 'Team ID'),
+        gameId: normalizeDocId(data.gameId, 'Game ID'),
+        slotId: normalizeDocId(data.slotId, 'Officiating slot ID'),
+        displayName: normalizeString(data.displayName || data.name)
+    };
+}
+
+function normalizeOfficiatingResult(result = null) {
+    if (!result || typeof result !== 'object') return null;
+
+    const homeScore = Number(result.homeScore);
+    const awayScore = Number(result.awayScore);
+    if (!Number.isInteger(homeScore) || homeScore < 0 || !Number.isInteger(awayScore) || awayScore < 0) {
+        return null;
+    }
+
+    return {
+        homeScore,
+        awayScore,
+        notes: normalizeString(result.notes),
+        submittedAt: result.submittedAt || null,
+        submittedByUserId: normalizeString(result.submittedByUserId),
+        submittedByEmail: normalizeEmail(result.submittedByEmail),
+        submittedByName: normalizeString(result.submittedByName)
+    };
+}
+
+function normalizeOfficiatingSlots(slots = []) {
+    if (!Array.isArray(slots)) return [];
+
+    return slots.map((slot, index) => {
+        const position = normalizeString(slot?.position || slot?.role);
+        if (!position) return null;
+
+        const officialId = normalizeString(slot?.officialId);
+        const officialUserId = normalizeString(slot?.officialUserId);
+        const officialEmail = normalizeEmail(slot?.officialEmail || slot?.email);
+        const officialName = normalizeString(slot?.officialName || slot?.name);
+        const hasOfficial = Boolean(officialId || officialUserId || officialEmail || officialName);
+        const requestedStatus = normalizeString(slot?.status);
+        const status = OFFICIATING_ASSIGNMENT_STATUSES.has(requestedStatus)
+            ? requestedStatus
+            : (hasOfficial ? 'pending' : 'open');
+        const scheduleReviewRequired = slot?.scheduleReviewRequired === true ||
+            slot?.needsReview === true ||
+            slot?.rescheduled === true ||
+            status === 'needs_review';
+
+        return {
+            id: normalizeString(slot?.id || `slot-${index + 1}`),
+            position,
+            officialId,
+            officialUserId,
+            officialName,
+            officialEmail,
+            status: hasOfficial ? (status === 'open' ? 'pending' : status) : 'open',
+            selfAssigned: slot?.selfAssigned === true,
+            scheduleReviewRequired,
+            scheduleReviewReason: scheduleReviewRequired ? normalizeString(slot?.scheduleReviewReason || 'Game schedule changed') : '',
+            scheduleReviewMarkedAt: scheduleReviewRequired ? (slot?.scheduleReviewMarkedAt || null) : null,
+            submittedResult: normalizeOfficiatingResult(slot?.submittedResult || null)
+        };
+    }).filter(Boolean);
+}
+
+function computeOfficiatingCoverageStatus(slots = []) {
+    const normalized = normalizeOfficiatingSlots(slots);
+    if (!normalized.length) return 'none';
+    return normalized.every((slot) => slot.status === 'accepted') ? 'covered' : 'needs_attention';
+}
+
+function isEligibleOpenOfficiatingSlotParticipant({ team = {}, user = {}, uid = '', email = '', teamId = '' } = {}) {
+    const normalizedUid = normalizeString(uid);
+    if (!normalizedUid) return false;
+
+    const normalizedTeamId = normalizeString(teamId || team.id);
+    const normalizedEmail = normalizeEmail(email || user.email || user.profileEmail);
+    if (team.ownerId === normalizedUid) return true;
+    if (user.isAdmin === true) return true;
+
+    const adminEmails = Array.isArray(team.adminEmails)
+        ? team.adminEmails.map(normalizeEmail).filter(Boolean)
+        : [];
+    if (normalizedEmail && adminEmails.includes(normalizedEmail)) return true;
+
+    const parentTeamIds = Array.isArray(user.parentTeamIds)
+        ? user.parentTeamIds.map(normalizeString).filter(Boolean)
+        : [];
+    return Boolean(normalizedTeamId && parentTeamIds.includes(normalizedTeamId));
+}
+
+function claimOpenOfficiatingSlotForOfficial(slots = [], slotId, official = {}) {
+    const normalizedSlotId = normalizeString(slotId);
+    const officialUserId = normalizeString(official.uid || official.userId);
+    const officialEmail = normalizeEmail(official.email);
+    const officialName = normalizeString(official.displayName || official.name || officialEmail || 'Official');
+    if (!officialUserId && !officialEmail) {
+        throw createClaimError('unauthenticated', 'Sign in before claiming an officiating slot.');
+    }
+
+    let claimed = false;
+    const nextSlots = normalizeOfficiatingSlots(slots).map((slot) => {
+        if (slot.id !== normalizedSlotId) return slot;
+        if (slot.officialUserId || slot.officialEmail || slot.officialName || slot.status !== 'open') {
+            throw createClaimError('failed-precondition', 'This officiating slot is already filled.');
+        }
+        claimed = true;
+        return {
+            ...slot,
+            officialUserId,
+            officialEmail,
+            officialName,
+            status: 'accepted',
+            selfAssigned: true
+        };
+    });
+
+    if (!claimed) {
+        throw createClaimError('not-found', 'Officiating slot not found.');
+    }
+    return nextSlots;
+}
+
+function uniqueStrings(values = []) {
+    return Array.from(new Set((Array.isArray(values) ? values : []).map(normalizeString).filter(Boolean)));
+}
+
+function buildOpenOfficiatingSlotClaimUpdate({ game = {}, slotId, official = {}, now = null } = {}) {
+    if (game.officiatingSelfAssignmentEnabled !== true) {
+        throw createClaimError('failed-precondition', 'Self-assignment is not enabled for this game.');
+    }
+
+    const officiatingSlots = claimOpenOfficiatingSlotForOfficial(game.officiatingSlots || [], slotId, official);
+    const claimedSlot = officiatingSlots.find((slot) => slot.id === normalizeString(slotId)) || null;
+    const officialUserId = normalizeString(official.uid || official.userId);
+    const officialEmail = normalizeEmail(official.email);
+    const officiatingAuthorizedUserIds = uniqueStrings([
+        ...uniqueStrings(game.officiatingAuthorizedUserIds),
+        officialUserId
+    ]);
+    const officiatingAuthorizedEmails = uniqueStrings([
+        ...uniqueStrings(game.officiatingAuthorizedEmails).map(normalizeEmail),
+        officialEmail
+    ]);
+
+    return {
+        update: {
+            officiatingSlots,
+            officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots),
+            officiatingUpdatedAt: now,
+            officiatingAuthorizedUserIds,
+            officiatingAuthorizedEmails
+        },
+        claimedSlot
+    };
+}
+
+function buildOfficiatingSelfAssignmentNotificationRecord({
+    teamId,
+    gameId,
+    game = {},
+    slot = {},
+    actor = {},
+    timestamp = null
+} = {}) {
+    const normalizedSlot = normalizeOfficiatingSlots([slot])[0] || slot;
+    const actorUserId = normalizeString(actor.uid || actor.userId);
+    const actorEmail = normalizeEmail(actor.email);
+    const actorName = normalizeString(actor.displayName || actor.name);
+
+    return {
+        type: 'officiating_assignment',
+        assignmentType: normalizedSlot.position || null,
+        event: 'self_assigned',
+        gameReference: {
+            teamId: normalizeString(teamId),
+            gameId: normalizeString(gameId || game.id),
+            opponent: normalizeString(game.opponent) || null,
+            location: normalizeString(game.location) || null,
+            date: game.date || null
+        },
+        gameId: normalizeString(gameId || game.id),
+        slotId: normalizedSlot.id || null,
+        position: normalizedSlot.position || null,
+        status: normalizedSlot.status || null,
+        timestamp,
+        actor: {
+            userId: actorUserId,
+            name: actorName,
+            email: actorEmail
+        },
+        actorUserId: actorUserId || null,
+        actorEmail: actorEmail || null,
+        recipientType: 'assigner',
+        recipientOfficialId: normalizedSlot.officialId || null,
+        recipientOfficialUserId: normalizedSlot.officialUserId || null,
+        recipientOfficialName: normalizedSlot.officialName || null,
+        recipientOfficialEmail: normalizedSlot.officialEmail || null,
+        read: false
+    };
+}
+
+module.exports = {
+    normalizeOpenOfficiatingSlotClaimInput,
+    normalizeOfficiatingSlots,
+    computeOfficiatingCoverageStatus,
+    isEligibleOpenOfficiatingSlotParticipant,
+    claimOpenOfficiatingSlotForOfficial,
+    buildOpenOfficiatingSlotClaimUpdate,
+    buildOfficiatingSelfAssignmentNotificationRecord
+};

--- a/functions/officiating-self-assignment-core.cjs
+++ b/functions/officiating-self-assignment-core.cjs
@@ -1,4 +1,6 @@
 const OFFICIATING_ASSIGNMENT_STATUSES = new Set(['pending', 'accepted', 'declined', 'cant_make', 'needs_review', 'open']);
+const SHARED_GAME_ID_PREFIX = 'shared_';
+const LEGACY_SHARED_GAME_ID_PREFIX = 'shared::';
 
 function normalizeString(value) {
     return String(value || '').trim();
@@ -20,6 +22,36 @@ function normalizeDocId(value, label) {
         throw createClaimError('invalid-argument', `${label} is required.`);
     }
     return normalized;
+}
+
+function isSharedGameSyntheticId(gameId) {
+    return typeof gameId === 'string'
+        && (gameId.startsWith(SHARED_GAME_ID_PREFIX) || gameId.startsWith(LEGACY_SHARED_GAME_ID_PREFIX));
+}
+
+function decodeSharedGameSyntheticId(gameId) {
+    if (!isSharedGameSyntheticId(gameId)) return null;
+    const prefix = gameId.startsWith(SHARED_GAME_ID_PREFIX)
+        ? SHARED_GAME_ID_PREFIX
+        : LEGACY_SHARED_GAME_ID_PREFIX;
+    return decodeURIComponent(gameId.slice(prefix.length));
+}
+
+function resolveOfficiatingGamePath(teamId, gameId) {
+    const sharedPath = decodeSharedGameSyntheticId(gameId);
+    return sharedPath || `teams/${teamId}/games/${gameId}`;
+}
+
+function isTeamLinkedToSharedGame(game = {}, teamId = '') {
+    const normalizedTeamId = normalizeString(teamId);
+    if (!normalizedTeamId) return false;
+
+    if (normalizeString(game.homeTeamId) === normalizedTeamId) return true;
+    if (normalizeString(game.awayTeamId) === normalizedTeamId) return true;
+    const teamIds = Array.isArray(game.teamIds)
+        ? game.teamIds.map(normalizeString).filter(Boolean)
+        : [];
+    return teamIds.includes(normalizedTeamId);
 }
 
 function normalizeOpenOfficiatingSlotClaimInput(data = {}) {
@@ -231,6 +263,10 @@ module.exports = {
     normalizeOfficiatingSlots,
     computeOfficiatingCoverageStatus,
     isEligibleOpenOfficiatingSlotParticipant,
+    isSharedGameSyntheticId,
+    decodeSharedGameSyntheticId,
+    resolveOfficiatingGamePath,
+    isTeamLinkedToSharedGame,
     claimOpenOfficiatingSlotForOfficial,
     buildOpenOfficiatingSlotClaimUpdate,
     buildOfficiatingSelfAssignmentNotificationRecord

--- a/functions/test/officiating-self-assignment-core.test.cjs
+++ b/functions/test/officiating-self-assignment-core.test.cjs
@@ -3,6 +3,9 @@ const assert = require('node:assert/strict');
 const {
     normalizeOpenOfficiatingSlotClaimInput,
     isEligibleOpenOfficiatingSlotParticipant,
+    decodeSharedGameSyntheticId,
+    resolveOfficiatingGamePath,
+    isTeamLinkedToSharedGame,
     buildOpenOfficiatingSlotClaimUpdate,
     buildOfficiatingSelfAssignmentNotificationRecord
 } = require('../officiating-self-assignment-core.cjs');
@@ -25,6 +28,21 @@ test('normalizeOpenOfficiatingSlotClaimInput requires document-safe IDs', () => 
         gameId: 'games/game-1',
         slotId: 'line-judge'
     }), /Game ID is required/);
+});
+
+test('resolveOfficiatingGamePath decodes shared synthetic game ids', () => {
+    const syntheticId = 'shared_organizations%2Forg-1%2FsharedGames%2Fgame-1';
+
+    assert.equal(decodeSharedGameSyntheticId(syntheticId), 'organizations/org-1/sharedGames/game-1');
+    assert.equal(resolveOfficiatingGamePath('team-1', syntheticId), 'organizations/org-1/sharedGames/game-1');
+    assert.equal(resolveOfficiatingGamePath('team-1', 'game-1'), 'teams/team-1/games/game-1');
+});
+
+test('isTeamLinkedToSharedGame only accepts participating teams', () => {
+    assert.equal(isTeamLinkedToSharedGame({ homeTeamId: 'team-1' }, 'team-1'), true);
+    assert.equal(isTeamLinkedToSharedGame({ awayTeamId: 'team-2' }, 'team-2'), true);
+    assert.equal(isTeamLinkedToSharedGame({ teamIds: ['team-3', 'team-4'] }, 'team-4'), true);
+    assert.equal(isTeamLinkedToSharedGame({ homeTeamId: 'team-1', awayTeamId: 'team-2' }, 'team-9'), false);
 });
 
 test('isEligibleOpenOfficiatingSlotParticipant accepts staff and linked parents only', () => {

--- a/functions/test/officiating-self-assignment-core.test.cjs
+++ b/functions/test/officiating-self-assignment-core.test.cjs
@@ -1,0 +1,145 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+    normalizeOpenOfficiatingSlotClaimInput,
+    isEligibleOpenOfficiatingSlotParticipant,
+    buildOpenOfficiatingSlotClaimUpdate,
+    buildOfficiatingSelfAssignmentNotificationRecord
+} = require('../officiating-self-assignment-core.cjs');
+
+test('normalizeOpenOfficiatingSlotClaimInput requires document-safe IDs', () => {
+    assert.deepEqual(normalizeOpenOfficiatingSlotClaimInput({
+        teamId: ' team-1 ',
+        gameId: 'game-1',
+        slotId: 'line-judge',
+        displayName: ' Casey '
+    }), {
+        teamId: 'team-1',
+        gameId: 'game-1',
+        slotId: 'line-judge',
+        displayName: 'Casey'
+    });
+
+    assert.throws(() => normalizeOpenOfficiatingSlotClaimInput({
+        teamId: 'team-1',
+        gameId: 'games/game-1',
+        slotId: 'line-judge'
+    }), /Game ID is required/);
+});
+
+test('isEligibleOpenOfficiatingSlotParticipant accepts staff and linked parents only', () => {
+    const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: ['assistant@example.com'] };
+
+    assert.equal(isEligibleOpenOfficiatingSlotParticipant({ team, uid: 'coach-1', teamId: 'team-1' }), true);
+    assert.equal(isEligibleOpenOfficiatingSlotParticipant({
+        team,
+        user: { email: 'assistant@example.com' },
+        uid: 'assistant-1',
+        email: 'assistant@example.com',
+        teamId: 'team-1'
+    }), true);
+    assert.equal(isEligibleOpenOfficiatingSlotParticipant({
+        team,
+        user: { parentTeamIds: ['team-1'] },
+        uid: 'parent-1',
+        email: 'parent@example.com',
+        teamId: 'team-1'
+    }), true);
+    assert.equal(isEligibleOpenOfficiatingSlotParticipant({
+        team,
+        user: { parentTeamIds: ['other-team'] },
+        uid: 'parent-2',
+        email: 'parent2@example.com',
+        teamId: 'team-1'
+    }), false);
+});
+
+test('buildOpenOfficiatingSlotClaimUpdate changes exactly the requested open slot', () => {
+    const result = buildOpenOfficiatingSlotClaimUpdate({
+        game: {
+            officiatingSelfAssignmentEnabled: true,
+            officiatingSlots: [
+                { id: 'center', position: 'Center Referee', status: 'open' },
+                { id: 'line', position: 'Line Judge', officialUserId: 'official-2', officialEmail: 'taken@example.com', officialName: 'Taken Official', status: 'accepted' }
+            ],
+            officiatingAuthorizedUserIds: ['coach-1'],
+            officiatingAuthorizedEmails: ['coach@example.com']
+        },
+        slotId: 'center',
+        official: {
+            uid: 'parent-1',
+            email: 'Parent@Example.com',
+            displayName: 'Pat Parent'
+        },
+        now: 'server-now'
+    });
+
+    assert.equal(result.claimedSlot.id, 'center');
+    assert.equal(result.claimedSlot.officialUserId, 'parent-1');
+    assert.equal(result.claimedSlot.officialEmail, 'parent@example.com');
+    assert.equal(result.claimedSlot.selfAssigned, true);
+    assert.deepEqual(result.update.officiatingSlots[1], {
+        id: 'line',
+        position: 'Line Judge',
+        officialId: '',
+        officialUserId: 'official-2',
+        officialName: 'Taken Official',
+        officialEmail: 'taken@example.com',
+        status: 'accepted',
+        selfAssigned: false,
+        scheduleReviewRequired: false,
+        scheduleReviewReason: '',
+        scheduleReviewMarkedAt: null,
+        submittedResult: null
+    });
+    assert.equal(result.update.officiatingCoverageStatus, 'covered');
+    assert.equal(result.update.officiatingUpdatedAt, 'server-now');
+    assert.deepEqual(result.update.officiatingAuthorizedUserIds, ['coach-1', 'parent-1']);
+    assert.deepEqual(result.update.officiatingAuthorizedEmails, ['coach@example.com', 'parent@example.com']);
+});
+
+test('buildOpenOfficiatingSlotClaimUpdate rejects filled or disabled slots', () => {
+    assert.throws(() => buildOpenOfficiatingSlotClaimUpdate({
+        game: {
+            officiatingSelfAssignmentEnabled: false,
+            officiatingSlots: [{ id: 'center', position: 'Center Referee', status: 'open' }]
+        },
+        slotId: 'center',
+        official: { uid: 'parent-1' }
+    }), /Self-assignment is not enabled/);
+
+    assert.throws(() => buildOpenOfficiatingSlotClaimUpdate({
+        game: {
+            officiatingSelfAssignmentEnabled: true,
+            officiatingSlots: [{ id: 'center', position: 'Center Referee', officialUserId: 'official-1', status: 'accepted' }]
+        },
+        slotId: 'center',
+        official: { uid: 'parent-1' }
+    }), /already filled/);
+});
+
+test('buildOfficiatingSelfAssignmentNotificationRecord targets assigners for audit visibility', () => {
+    const record = buildOfficiatingSelfAssignmentNotificationRecord({
+        teamId: 'team-1',
+        gameId: 'game-1',
+        game: { opponent: 'Lions', location: 'Field 2', date: '2026-06-01T12:00:00.000Z' },
+        slot: { id: 'center', position: 'Center Referee', officialUserId: 'parent-1', officialEmail: 'Parent@Example.com', status: 'accepted' },
+        actor: { uid: 'parent-1', email: 'Parent@Example.com', displayName: 'Pat Parent' },
+        timestamp: 'server-now'
+    });
+
+    assert.equal(record.type, 'officiating_assignment');
+    assert.equal(record.event, 'self_assigned');
+    assert.equal(record.recipientType, 'assigner');
+    assert.equal(record.actorUserId, 'parent-1');
+    assert.equal(record.actorEmail, 'parent@example.com');
+    assert.equal(record.recipientOfficialUserId, 'parent-1');
+    assert.equal(record.recipientOfficialEmail, 'parent@example.com');
+    assert.deepEqual(record.gameReference, {
+        teamId: 'team-1',
+        gameId: 'game-1',
+        opponent: 'Lions',
+        location: 'Field 2',
+        date: '2026-06-01T12:00:00.000Z'
+    });
+});

--- a/js/db.js
+++ b/js/db.js
@@ -199,7 +199,6 @@ import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
 import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=3';
 import { getApp } from './vendor/firebase-app.js';
 import {
-    claimOfficiatingSlot,
     computeOfficiatingCoverageStatus,
     updateOfficiatingSlotResponse,
     updateOfficiatingSlotResult
@@ -7524,49 +7523,13 @@ export async function claimOpenOfficiatingSlot(teamId, gameId, slotId, official 
         throw new Error('Only team owners, admins, or parents can claim open officiating slots.');
     }
 
-    const docRef = getGameDocRef(teamId, gameId);
-    let notificationRecord = null;
-    await runTransaction(db, async (transaction) => {
-        const snap = await transaction.get(docRef);
-        if (!snap.exists()) throw new Error('Game not found');
-        const game = snap.data() || {};
-        if (game.officiatingSelfAssignmentEnabled !== true) {
-            throw new Error('Self-assignment is not enabled for this game');
-        }
-        const officiatingSlots = claimOfficiatingSlot(game.officiatingSlots || [], slotId, {
-            uid: official?.uid || '',
-            email: official?.email || '',
-            displayName: official?.displayName || official?.email || 'Official'
-        });
-        const updatedSlot = officiatingSlots.find((slot) => slot.id === slotId) || null;
-        if (updatedSlot) {
-            notificationRecord = buildOfficiatingNotificationRecord({
-                teamId,
-                gameId,
-                game: { ...game, officiatingSlots },
-                slot: updatedSlot,
-                event: 'self_assigned',
-                status: updatedSlot.status,
-                recipientType: 'assigner',
-                actor: official || {},
-                timestamp: Timestamp.now()
-            });
-        }
-        const officiatingAuthorizedUserIds = new Set(game.officiatingAuthorizedUserIds || []);
-        const officiatingAuthorizedEmails = new Set(game.officiatingAuthorizedEmails || []);
-        if (official?.uid) officiatingAuthorizedUserIds.add(official.uid);
-        if (official?.email) officiatingAuthorizedEmails.add(String(official.email).trim().toLowerCase());
-
-        transaction.update(docRef, {
-            officiatingSlots,
-            officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots),
-            officiatingUpdatedAt: Timestamp.now(),
-            officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds),
-            officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)
-        });
+    const callable = httpsCallable(functions, 'claimOpenOfficiatingSlot');
+    await callable({
+        teamId,
+        gameId,
+        slotId,
+        displayName: official?.displayName || official?.email || 'Official'
     });
-
-    await tryCreateOfficiatingAssignmentNotificationRecords(teamId, notificationRecord ? [notificationRecord] : []);
 }
 
 export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser) {

--- a/officials.html
+++ b/officials.html
@@ -43,7 +43,7 @@
 
     <script type="module">
         import { checkAuth } from './js/auth.js?v=32';
-        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=63';
+        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=64';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
         import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots, hasSubmittedOfficiatingResult, validateOfficiatingResultSubmission } from './js/officiating-utils.js?v=4';
 

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -22,6 +22,10 @@ function readFirestoreRules() {
     return readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 }
 
+function readFunctionsSource() {
+    return readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+}
+
 describe('officiating slots', () => {
     it('normalizes officials and fills slot display names from the directory', () => {
         const officials = normalizeOfficialsDirectory([
@@ -125,6 +129,7 @@ describe('officiating slots', () => {
         const officialsSource = readOfficialsPage();
         const dbSource = readDbSource();
         const rules = readFirestoreRules();
+        const functionsSource = readFunctionsSource();
 
         expect(officialsSource).toContain('canClaimOpenSlots = isEligibleOpenSlotParticipant(currentUser, currentUserProfile, currentTeam);');
         expect(officialsSource).toContain("section.classList.add('hidden');");
@@ -134,18 +139,16 @@ describe('officiating slots', () => {
         expect(officialsSource).not.toContain('Open self-assignment slots are only available to team owners, admins, or parents.');
         expect(dbSource).toContain('function isEligibleOpenOfficiatingSlotParticipant(team = {}, userProfile = {}, user = {})');
         expect(dbSource).toContain("throw new Error('Only team owners, admins, or parents can claim open officiating slots.');");
-        expect(dbSource).toContain('officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds)');
-        expect(dbSource).toContain('officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)');
-        expect(dbSource).toContain('const officiatingSlots = claimOfficiatingSlot(game.officiatingSlots || [], slotId, {');
-        expect(dbSource).toContain('officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots)');
-        expect(rules).toContain('function canClaimOpenOfficiatingSlot(teamId)');
-        expect(rules).toContain('isParentForTeam(teamId)');
+        expect(dbSource).toContain("const callable = httpsCallable(functions, 'claimOpenOfficiatingSlot');");
+        expect(dbSource).toContain("displayName: official?.displayName || official?.email || 'Official'");
+        expect(dbSource).not.toContain('const officiatingSlots = claimOfficiatingSlot(game.officiatingSlots || [], slotId, {');
+        expect(functionsSource).toContain('exports.claimOpenOfficiatingSlot = functions.https.onCall');
+        expect(functionsSource).toContain('isEligibleOpenOfficiatingSlotParticipant({ team, user, uid, email: callerEmail, teamId: input.teamId })');
+        expect(functionsSource).toContain('buildOpenOfficiatingSlotClaimUpdate({');
+        expect(functionsSource).toContain('buildOfficiatingSelfAssignmentNotificationRecord({');
+        expect(functionsSource).toContain('transaction.set(notificationRef, {');
         expect(rules).not.toContain('playerTeamIds');
-        expect(rules).toContain('function isOpenOfficiatingSelfAssignmentUpdate(teamId)');
-        expect(rules).toContain('return canClaimOpenOfficiatingSlot(teamId) &&');
-        expect(rules).toContain('function isOnlyAddingCurrentOfficialAuthorization()');
-        expect(rules).toContain("nextUserIds.hasOnly(previousUserIds + [request.auth.uid])");
-        expect(rules).toContain("nextEmails.hasOnly(previousEmails + [callerEmail])");
-        expect(rules).toContain('allow update: if isOpenOfficiatingSelfAssignmentUpdate(teamId);');
+        expect(rules).not.toContain('function isOpenOfficiatingSelfAssignmentUpdate(teamId)');
+        expect(rules).not.toContain('allow update: if isOpenOfficiatingSelfAssignmentUpdate(teamId);');
     });
 });

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -107,8 +107,8 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain('Result submitted');
         expect(officialsSource).toContain("slot.status !== 'accepted' || !hasGameStarted(game) || isCancelled(game)");
         expect(officialsSource).toContain("document.getElementById('officials-status').textContent = 'Result saved.';");
-        expect(officialsSource).toContain("'./js/db.js?v=63'");
-        expect(officialsSource).not.toContain("'./js/db.js?v=41'");
+        expect(officialsSource).toContain("'./js/db.js?v=64'");
+        expect(officialsSource).not.toContain("'./js/db.js?v=42'");
         expect(dbSource).toContain('export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser)');
         expect(dbSource).toContain("throw new Error('Cancelled games cannot accept final results.');");
         expect(dbSource).toContain('homeScore: submittedResult.homeScore');

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -144,6 +144,8 @@ describe('officiating slots', () => {
         expect(dbSource).not.toContain('const officiatingSlots = claimOfficiatingSlot(game.officiatingSlots || [], slotId, {');
         expect(functionsSource).toContain('exports.claimOpenOfficiatingSlot = functions.https.onCall');
         expect(functionsSource).toContain('isEligibleOpenOfficiatingSlotParticipant({ team, user, uid, email: callerEmail, teamId: input.teamId })');
+        expect(functionsSource).toContain('const gameRef = firestore.doc(resolveOfficiatingGamePath(input.teamId, input.gameId));');
+        expect(functionsSource).toContain('!gameRef.path.startsWith(`teams/${input.teamId}/games/`) && !isTeamLinkedToSharedGame(game, input.teamId)');
         expect(functionsSource).toContain('buildOpenOfficiatingSlotClaimUpdate({');
         expect(functionsSource).toContain('buildOfficiatingSelfAssignmentNotificationRecord({');
         expect(functionsSource).toContain('transaction.set(notificationRef, {');

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -108,7 +108,7 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain("slot.status !== 'accepted' || !hasGameStarted(game) || isCancelled(game)");
         expect(officialsSource).toContain("document.getElementById('officials-status').textContent = 'Result saved.';");
         expect(officialsSource).toContain("'./js/db.js?v=64'");
-        expect(officialsSource).not.toContain("'./js/db.js?v=42'");
+        expect(officialsSource).not.toContain("'./js/db.js?v=63'");
         expect(dbSource).toContain('export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser)');
         expect(dbSource).toContain("throw new Error('Cancelled games cannot accept final results.');");
         expect(dbSource).toContain('homeScore: submittedResult.homeScore');


### PR DESCRIPTION
## Summary
- Moves open officiating self-assignment writes behind a callable Cloud Function that enforces eligible claimant access server-side.
- Builds the one-slot claim update on the server, writes the assigner audit notification as Admin, and removes the direct Firestore self-assignment update rule.
- Adds pure Functions core coverage plus source/rules regression coverage for the legacy app entry point.

Closes #2591

## Tests
- npx vitest run tests/unit/officiating-slots.test.js tests/unit/officiating-utils.test.js --reporter=verbose
- node --test functions/test/officiating-self-assignment-core.test.cjs
- npm run ci:firebase-rules
- node --check functions/index.js
- node --check functions/officiating-self-assignment-core.cjs
- git diff --check

Note: `npm --prefix functions test -- --test-name-pattern="officiating"` still ran unrelated registration checkout tests and failed in `registration-checkout-retry-capacity.test.js` with `Public checkout capability is required`; the new officiating core test passes directly.