### PR TITLE
Paginate Team Media album reads

### DIFF
--- a/apps/app/src/lib/adapters/legacyParentTools.ts
+++ b/apps/app/src/lib/adapters/legacyParentTools.ts
@@ -46,6 +46,7 @@ export const getTeamRegistrationForm = (...args: any[]) => callLegacyDb('getTeam
 export const getTeam = (...args: any[]) => callLegacyDb('getTeam', args);
 export const getTeamMediaFolders = (...args: any[]) => callLegacyDb('getTeamMediaFolders', args);
 export const getTeamMediaItems = (...args: any[]) => callLegacyDb('getTeamMediaItems', args);
+export const getTeamMediaItemsPage = (...args: any[]) => callLegacyDb('getTeamMediaItemsPage', args);
 export const canAccessTeamChat = (...args: any[]) => callLegacyDb('canAccessTeamChat', args);
 export const listCertificatesForPlayer = (...args: any[]) => callLegacyDb('listCertificatesForPlayer', args);
 export const listFamilyShareTokens = (...args: any[]) => callLegacyDb('listFamilyShareTokens', args);

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -34,7 +34,7 @@ import {
   getTeam,
   getTeamMediaFolders,
   getTeamMediaItemUrl,
-  getTeamMediaItems,
+  getTeamMediaItemsPage,
   getTeamRegistrationForm,
   hasOnlineRegistrationCheckout,
   initiateTeamFeeCheckout,
@@ -244,6 +244,8 @@ export type TeamMediaFolder = Record<string, any> & {
   itemCount: number;
   items: TeamMediaItem[];
   itemsLoaded?: boolean;
+  itemsHasMore?: boolean;
+  itemsNextCursor?: any;
 };
 
 export type TeamMediaItem = Record<string, any> & {
@@ -833,7 +835,7 @@ function getPublicRegistrationTeamName(form: Record<string, any>) {
 export async function loadTeamMediaForApp(
   user: AuthUser | null,
   teamId: string,
-  options: { initialFolderId?: string; folderIds?: string[] } = {}
+  options: { initialFolderId?: string; folderIds?: string[]; pageSize?: number; cursorsByFolderId?: Record<string, any> } = {}
 ): Promise<TeamMediaModel> {
   if (!teamId) throw new Error('Team is required.');
   const team = await Promise.resolve(getTeam(teamId));
@@ -859,6 +861,7 @@ export async function loadTeamMediaForApp(
 
   const itemSets = new Map<string, TeamMediaItem[]>();
   const fallbackCounts = new Map<string, number>();
+  const pageStateByFolderId = new Map<string, { hasMore: boolean; nextCursor: any }>();
   await Promise.all(visibleFolders.map(async (folder: any) => {
     const folderId = compactString(folder?.id);
     if (!folderId) return;
@@ -868,10 +871,19 @@ export async function loadTeamMediaForApp(
       if (storedCount !== null) fallbackCounts.set(folderId, storedCount);
       return;
     }
-    const items = sortByMediaOrder(await Promise.resolve(getTeamMediaItems(teamId, folderId)).catch(() => []))
+    const page = await Promise.resolve(getTeamMediaItemsPage(teamId, folderId, {
+      pageSize: options.pageSize || 24,
+      cursor: options.cursorsByFolderId?.[folderId] || null
+    })).catch(() => ({ items: [], hasMore: false, nextCursor: null }));
+    const pageItems = Array.isArray(page?.items) ? page.items : [];
+    const items = sortByMediaOrder(pageItems)
       .map(toTeamMediaItem)
       .filter((item: TeamMediaItem) => item.url && isSafeTeamMediaUrl(item.url));
-    fallbackCounts.set(folderId, items.length);
+    fallbackCounts.set(folderId, storedCount !== null ? Math.max(storedCount, items.length) : items.length);
+    pageStateByFolderId.set(folderId, {
+      hasMore: page?.hasMore === true,
+      nextCursor: page?.nextCursor || page?.lastDoc || null
+    });
     itemSets.set(folderId, items);
   }));
 
@@ -882,9 +894,11 @@ export async function loadTeamMediaForApp(
     return {
       ...folder,
       id: folderId,
-      itemCount: loadedItems ? loadedItems.length : Number.isFinite(fallbackCount) ? fallbackCount : 0,
+      itemCount: Number.isFinite(fallbackCount) ? fallbackCount : loadedItems ? loadedItems.length : 0,
       items: loadedItems || [],
-      itemsLoaded: Boolean(loadedItems)
+      itemsLoaded: Boolean(loadedItems),
+      itemsHasMore: pageStateByFolderId.get(folderId)?.hasMore || false,
+      itemsNextCursor: pageStateByFolderId.get(folderId)?.nextCursor || null
     };
   });
 

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -327,4 +327,62 @@ describe('TeamMedia bulk delete', () => {
     expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenCalledTimes(2);
     expect(await screen.findByText('Photo one')).toBeTruthy();
   });
+
+  it('loads the next album page with the stored cursor and appends it', async () => {
+    const cursor = { id: 'cursor-1' };
+    parentToolsServiceMocks.loadTeamMediaForApp
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        canManage: true,
+        canContribute: false,
+        canPostChat: false,
+        folders: [
+          {
+            id: 'album-1',
+            name: 'Game day',
+            visibility: 'team',
+            itemCount: 2,
+            itemsLoaded: true,
+            itemsHasMore: true,
+            itemsNextCursor: cursor,
+            items: [
+              { id: 'photo-1', title: 'Photo one', type: 'photo', url: 'https://example.com/photo-1.jpg', uploadedBy: 'coach-1' }
+            ]
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        canManage: true,
+        canContribute: false,
+        canPostChat: false,
+        folders: [
+          {
+            id: 'album-1',
+            name: 'Game day',
+            visibility: 'team',
+            itemCount: 2,
+            itemsLoaded: true,
+            itemsHasMore: false,
+            itemsNextCursor: null,
+            items: [
+              { id: 'photo-2', title: 'Photo two', type: 'photo', url: 'https://example.com/photo-2.jpg', uploadedBy: 'coach-1' }
+            ]
+          }
+        ]
+      });
+
+    renderTeamMedia();
+
+    await screen.findByText('Photo one');
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenNthCalledWith(2, auth.user, 'team-1', {
+      initialFolderId: 'album-1',
+      folderIds: ['album-1'],
+      cursorsByFolderId: { 'album-1': cursor }
+    });
+    expect(await screen.findByText('Photo two')).toBeTruthy();
+    expect(screen.getByText('Photo one')).toBeTruthy();
+  });
 });

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -63,38 +63,81 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [movingItemId, setMovingItemId] = useState('');
   const [coverItemId, setCoverItemId] = useState('');
   const [postingItemId, setPostingItemId] = useState('');
+  const [loadingMoreFolderId, setLoadingMoreFolderId] = useState('');
   const postingItemIdRef = useRef('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
-  const refresh = async ({ showLoading = model === null, preferredFolderId = '', folderIdsToLoad = [] }: { showLoading?: boolean; preferredFolderId?: string; folderIdsToLoad?: string[] } = {}) => {
+  const refresh = async ({
+    showLoading = model === null,
+    preferredFolderId = '',
+    folderIdsToLoad = [],
+    cursorsByFolderId = {},
+    append = false
+  }: {
+    showLoading?: boolean;
+    preferredFolderId?: string;
+    folderIdsToLoad?: string[];
+    cursorsByFolderId?: Record<string, any>;
+    append?: boolean;
+  } = {}) => {
     if (!teamId) return;
     if (showLoading) setLoading(true);
     setError('');
     try {
-      const nextModel = await loadTeamMediaForApp(auth.user, teamId, {
+      const loadOptions: { initialFolderId: string; folderIds: string[]; cursorsByFolderId?: Record<string, any> } = {
         initialFolderId: preferredFolderId || activeFolderId,
         folderIds: folderIdsToLoad
+      };
+      if (Object.keys(cursorsByFolderId).length) loadOptions.cursorsByFolderId = cursorsByFolderId;
+      const nextModel = await loadTeamMediaForApp(auth.user, teamId, loadOptions);
+      const mergedFolders = nextModel.folders.map((folder) => {
+        const cachedFolder = model?.folders.find((currentFolder) => currentFolder.id === folder.id && (currentFolder.itemsLoaded || currentFolder.items.length));
+        if (folder.itemsLoaded || folder.items.length) {
+          return mergeTeamMediaFolderItems(folder, cachedFolder, append && folderIdsToLoad.includes(folder.id));
+        }
+        return cachedFolder ? {
+          ...folder,
+          items: cachedFolder.items,
+          itemCount: cachedFolder.itemCount,
+          itemsLoaded: true,
+          itemsHasMore: cachedFolder.itemsHasMore,
+          itemsNextCursor: cachedFolder.itemsNextCursor
+        } : folder;
       });
-      setModel((currentModel) => ({
+      setModel({
         ...nextModel,
-        folders: nextModel.folders.map((folder) => {
-          if (folder.itemsLoaded || folder.items.length) return { ...folder, itemsLoaded: true };
-          const cachedFolder = currentModel?.folders.find((currentFolder) => currentFolder.id === folder.id && (currentFolder.itemsLoaded || currentFolder.items.length));
-          return cachedFolder ? { ...folder, items: cachedFolder.items, itemCount: cachedFolder.itemCount, itemsLoaded: true } : folder;
-        })
-      }));
+        folders: mergedFolders
+      });
       setActiveFolderId((current) => {
         if (preferredFolderId && nextModel.folders.some((folder) => folder.id === preferredFolderId)) return preferredFolderId;
         if (current && nextModel.folders.some((folder) => folder.id === current)) return current;
         return nextModel.folders[0]?.id || '';
       });
-      setSelectedIds((current) => current.filter((itemId) => nextModel.folders.some((folder) => folder.items.some((item) => item.id === itemId))));
+      setSelectedIds((current) => current.filter((itemId) => mergedFolders.some((folder) => folder.items.some((item) => item.id === itemId))));
     } catch (loadError: any) {
       setError(loadError?.message || 'Unable to load media.');
       if (showLoading) setModel(null);
     } finally {
       if (showLoading) setLoading(false);
+    }
+  };
+
+  const handleLoadMoreItems = async () => {
+    const folderToLoad = model?.folders.find((folder) => folder.id === activeFolderId) || model?.folders[0] || null;
+    if (!folderToLoad?.id || !folderToLoad.itemsHasMore || !folderToLoad.itemsNextCursor) return;
+
+    setLoadingMoreFolderId(folderToLoad.id);
+    try {
+      await refresh({
+        showLoading: false,
+        preferredFolderId: folderToLoad.id,
+        folderIdsToLoad: [folderToLoad.id],
+        cursorsByFolderId: { [folderToLoad.id]: folderToLoad.itemsNextCursor },
+        append: true
+      });
+    } finally {
+      setLoadingMoreFolderId('');
     }
   };
 
@@ -661,6 +704,20 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
         </div>
+        {activeFolder?.itemsHasMore ? (
+          <div className="mt-3 flex justify-center">
+            <button
+              type="button"
+              className="ghost-button justify-center disabled:opacity-60"
+              onClick={handleLoadMoreItems}
+              disabled={loadingMoreFolderId === activeFolder.id}
+              aria-disabled={loadingMoreFolderId === activeFolder.id}
+            >
+              {loadingMoreFolderId === activeFolder.id ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+              {loadingMoreFolderId === activeFolder.id ? 'Loading more' : 'Load more'}
+            </button>
+          </div>
+        ) : null}
       </section>
     </div>
   );
@@ -1058,4 +1115,25 @@ function getItemIcon(item: TeamMediaItem) {
   if (type === 'photo' || type.includes('image')) return ImageIcon;
   if (type.includes('link')) return LinkIcon;
   return File;
+}
+
+function mergeTeamMediaFolderItems(nextFolder: TeamMediaFolder, cachedFolder: TeamMediaFolder | undefined, append: boolean): TeamMediaFolder {
+  if (!append || !cachedFolder) {
+    return { ...nextFolder, itemsLoaded: true };
+  }
+
+  const seen = new Set<string>();
+  const items = [...cachedFolder.items, ...nextFolder.items].filter((item) => {
+    const itemId = String(item.id || '').trim();
+    if (!itemId || seen.has(itemId)) return false;
+    seen.add(itemId);
+    return true;
+  });
+
+  return {
+    ...nextFolder,
+    items,
+    itemCount: Math.max(Number(nextFolder.itemCount) || 0, Number(cachedFolder.itemCount) || 0, items.length),
+    itemsLoaded: true
+  };
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -310,6 +310,14 @@
       ]
     },
     {
+      "collectionGroup": "mediaItems",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "folderId", "order": "ASCENDING" },
+        { "fieldPath": "order", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "chatMessages",
       "queryScope": "COLLECTION",
       "fields": [

--- a/js/db.js
+++ b/js/db.js
@@ -982,6 +982,65 @@ export async function getTeamMediaItems(teamId, folderId = null) {
     return sortByMediaOrder(resolvedItems);
 }
 
+export async function getTeamMediaItemsPage(teamId, folderId, options = {}) {
+    if (!teamId) {
+        return { items: [], lastDoc: null, nextCursor: null, hasMore: false };
+    }
+
+    const cleanFolderId = String(folderId || '').trim();
+    if (!cleanFolderId) {
+        return { items: [], lastDoc: null, nextCursor: null, hasMore: false };
+    }
+
+    const requestedPageSize = Number(options.pageSize || 24);
+    const pageSize = Number.isFinite(requestedPageSize)
+        ? Math.min(Math.max(Math.floor(requestedPageSize), 1), 100)
+        : 24;
+    const cursor = options.cursor || options.afterDoc || null;
+    const constraints = [
+        where('folderId', '==', cleanFolderId),
+        orderBy('order', 'asc')
+    ];
+    if (cursor) constraints.push(startAfterQuery(cursor));
+    constraints.push(limitQuery(pageSize + 1));
+
+    const snapshot = await getDocs(query(getTeamMediaItemsRef(teamId), ...constraints));
+    const docs = snapshot.docs
+        .filter((itemDoc) => {
+            const item = itemDoc.data() || {};
+            return item.deleted !== true && item.folderId === cleanFolderId;
+        });
+    const pageDocs = docs.slice(0, pageSize);
+    const hasMore = docs.length > pageSize;
+    const items = pageDocs.map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }));
+    const resolvedItems = await Promise.all(items.map(async (item) => {
+        if (!['photo', 'file'].includes(String(item?.type || '').toLowerCase())) return item;
+        if (String(item.downloadUrl || item.url || item.src || '').trim()) return item;
+        if (!item.storagePath) return item;
+        try {
+            const downloadUrl = await getDownloadURL(ref(storage, item.storagePath));
+            updateDoc(doc(db, `teams/${teamId}/mediaItems`, item.id), {
+                downloadUrl,
+                updatedAt: serverTimestamp()
+            }).catch((error) => {
+                console.warn('Unable to backfill cached team media download URL:', error);
+            });
+            return { ...item, downloadUrl };
+        } catch (error) {
+            console.warn('Unable to resolve team media download URL:', error);
+            return item;
+        }
+    }));
+    const lastDoc = pageDocs[pageDocs.length - 1] || null;
+
+    return {
+        items: sortByMediaOrder(resolvedItems),
+        lastDoc,
+        nextCursor: hasMore ? lastDoc : null,
+        hasMore
+    };
+}
+
 export async function createTeamMediaFolder(teamId, draft = {}) {
     const folder = normalizeTeamMediaFolderDraft(typeof draft === 'string' ? { name: draft } : draft);
     if (!teamId) throw new Error('Team is required.');

--- a/js/db.js
+++ b/js/db.js
@@ -982,6 +982,27 @@ export async function getTeamMediaItems(teamId, folderId = null) {
     return sortByMediaOrder(resolvedItems);
 }
 
+function readTeamMediaPageOffset(cursor, folderId, sortedDocs = []) {
+    if (Number.isFinite(Number(cursor))) {
+        return Math.max(0, Math.floor(Number(cursor)));
+    }
+
+    if (cursor?.kind === 'team-media-items-page') {
+        const cursorFolderId = String(cursor.folderId || '').trim();
+        if (!cursorFolderId || cursorFolderId === folderId) {
+            const offset = Number(cursor.offset);
+            if (Number.isFinite(offset)) {
+                return Math.max(0, Math.floor(offset));
+            }
+        }
+    }
+
+    const cursorId = String(cursor?.id || '').trim();
+    if (!cursorId) return 0;
+    const cursorIndex = sortedDocs.findIndex((itemDoc) => itemDoc.id === cursorId);
+    return cursorIndex >= 0 ? cursorIndex + 1 : 0;
+}
+
 export async function getTeamMediaItemsPage(teamId, folderId, options = {}) {
     if (!teamId) {
         return { items: [], lastDoc: null, nextCursor: null, hasMore: false };
@@ -997,21 +1018,23 @@ export async function getTeamMediaItemsPage(teamId, folderId, options = {}) {
         ? Math.min(Math.max(Math.floor(requestedPageSize), 1), 100)
         : 24;
     const cursor = options.cursor || options.afterDoc || null;
-    const constraints = [
-        where('folderId', '==', cleanFolderId),
-        orderBy('order', 'asc')
-    ];
-    if (cursor) constraints.push(startAfterQuery(cursor));
-    constraints.push(limitQuery(pageSize + 1));
 
-    const snapshot = await getDocs(query(getTeamMediaItemsRef(teamId), ...constraints));
+    const snapshot = await getDocs(query(
+        getTeamMediaItemsRef(teamId),
+        where('folderId', '==', cleanFolderId)
+    ));
     const docs = snapshot.docs
         .filter((itemDoc) => {
             const item = itemDoc.data() || {};
             return item.deleted !== true && item.folderId === cleanFolderId;
         });
-    const pageDocs = docs.slice(0, pageSize);
-    const hasMore = docs.length > pageSize;
+    const docsById = new Map(docs.map((itemDoc) => [itemDoc.id, itemDoc]));
+    const sortedDocs = sortByMediaOrder(docs.map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() })))
+        .map((item) => docsById.get(item.id))
+        .filter(Boolean);
+    const startOffset = readTeamMediaPageOffset(cursor, cleanFolderId, sortedDocs);
+    const pageDocs = sortedDocs.slice(startOffset, startOffset + pageSize);
+    const hasMore = startOffset + pageSize < sortedDocs.length;
     const items = pageDocs.map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }));
     const resolvedItems = await Promise.all(items.map(async (item) => {
         if (!['photo', 'file'].includes(String(item?.type || '').toLowerCase())) return item;
@@ -1036,7 +1059,13 @@ export async function getTeamMediaItemsPage(teamId, folderId, options = {}) {
     return {
         items: sortByMediaOrder(resolvedItems),
         lastDoc,
-        nextCursor: hasMore ? lastDoc : null,
+        nextCursor: hasMore
+            ? {
+                kind: 'team-media-items-page',
+                folderId: cleanFolderId,
+                offset: startOffset + pageDocs.length
+            }
+            : null,
         hasMore
     };
 }

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -2,7 +2,7 @@ import { checkAuth } from './auth.js?v=32';
 import {
     getTeam,
     getTeamMediaFolders,
-    getTeamMediaItems,
+    getTeamMediaItemsPage,
     createTeamMediaFolder,
     updateTeamMediaFolder,
     deleteTeamMediaFolder,
@@ -15,8 +15,8 @@ import {
     moveTeamMediaItems,
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
-    updateTeamMediaItem // Add this new import
-} from './db.js?v=63';
+    updateTeamMediaItem
+} from './db.js?v=64';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,
@@ -40,11 +40,14 @@ const state = {
     canContribute: false,
     folders: [],
     items: [],
+    itemPageState: new Map(),
     selectedFolderId: '',
     selectedMediaType: 'all',
     selectedIds: new Set(),
     actionInFlight: false
 };
+
+const TEAM_MEDIA_PAGE_SIZE = 24;
 
 const els = {
     title: document.getElementById('team-media-title'),
@@ -117,6 +120,56 @@ function getItemsForFolder(folderId) {
     return sortByMediaOrder(state.items
         .filter((item) => item.folderId === folderId)
         .filter((item) => isSafeTeamMediaUrl(getTeamMediaItemUrl(item))));
+}
+
+function getFolderPageState(folderId) {
+    return state.itemPageState.get(folderId) || { loaded: false, hasMore: false, nextCursor: null };
+}
+
+function getStoredMediaCount(folder = {}) {
+    const count = Number(folder.itemCount ?? folder.mediaCount ?? folder.totalItems);
+    return Number.isFinite(count) && count >= 0 ? count : null;
+}
+
+function getFolderItemCount(folder = {}) {
+    const loadedCount = getItemsForFolder(folder.id).length;
+    const storedCount = getStoredMediaCount(folder);
+    return storedCount === null ? loadedCount : Math.max(storedCount, loadedCount);
+}
+
+function mergeFolderPageItems(folderId, items = [], append = false) {
+    const existingItems = append ? state.items.filter((item) => item.folderId === folderId) : [];
+    const seen = new Set();
+    const mergedFolderItems = [...existingItems, ...items].filter((item) => {
+        const itemId = String(item?.id || '').trim();
+        if (!itemId || seen.has(itemId)) return false;
+        seen.add(itemId);
+        return true;
+    });
+    state.items = [
+        ...state.items.filter((item) => item.folderId !== folderId),
+        ...mergedFolderItems
+    ];
+}
+
+async function loadFolderItemsPage(folderId, { append = false } = {}) {
+    const cleanFolderId = String(folderId || '').trim();
+    if (!cleanFolderId) return;
+    const currentPageState = getFolderPageState(cleanFolderId);
+    if (append && !currentPageState.nextCursor) return;
+
+    const page = await getTeamMediaItemsPage(state.teamId, cleanFolderId, {
+        pageSize: TEAM_MEDIA_PAGE_SIZE,
+        cursor: append ? currentPageState.nextCursor : null
+    });
+    mergeFolderPageItems(cleanFolderId, Array.isArray(page.items) ? page.items : [], append);
+    state.itemPageState.set(cleanFolderId, {
+        loaded: true,
+        hasMore: page.hasMore === true,
+        nextCursor: page.nextCursor || page.lastDoc || null
+    });
+    state.selectedIds = new Set([...state.selectedIds].filter((id) => state.items.some((item) => item.id === id)));
+    render();
 }
 
 const MEDIA_TYPE_FILTERS = [
@@ -207,8 +260,8 @@ function renderAlbumCards() {
     }
 
     els.foldersList.innerHTML = state.folders.map((folder, folderIndex) => {
-        const items = getItemsForFolder(folder.id);
         const isSelected = getSelectedFolder()?.id === folder.id;
+        const itemCount = getFolderItemCount(folder);
         const folderControls = state.canManage ? `
             <div class="flex flex-wrap gap-2">
                 <button type="button" data-folder-move="up" data-folder-id="${escapeHtml(folder.id)}" ${folderIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
@@ -225,7 +278,7 @@ function renderAlbumCards() {
                             ${coverUrl ? `<img src="${escapeHtml(coverUrl)}" alt="${escapeHtml(folder.coverPhotoTitle || folder.name || 'Album cover')}" class="h-16 w-16 rounded-xl object-cover">` : ''}
                             <div>
                                 <h2 class="text-xl font-bold">${escapeHtml(folder.name || 'Untitled album')}</h2>
-                                <p class="mt-1 text-sm text-gray-500">${items.length} item${items.length === 1 ? '' : 's'}</p>
+                                <p class="mt-1 text-sm text-gray-500">${itemCount} item${itemCount === 1 ? '' : 's'}</p>
                             </div>
                         </div>
                         <span class="rounded-full ${folder.visibility === 'private' ? 'bg-amber-100 text-amber-800' : 'bg-green-100 text-green-800'} px-3 py-1 text-xs font-semibold">${escapeHtml(getVisibilityLabel(folder))}</span>
@@ -245,6 +298,8 @@ function renderAlbumDetail() {
     }
 
     const items = getItemsForFolder(folder.id);
+    const pageState = getFolderPageState(folder.id);
+    const folderItemCount = getFolderItemCount(folder);
     const counts = getMediaTypeCounts(items);
     const filteredItems = getFilteredItems(items);
     const selectedMediaTypeLabel = getSelectedMediaTypeLabel();
@@ -293,6 +348,10 @@ function renderAlbumDetail() {
                     </div>
                 </div>`;
         }).join('')}</div>`;
+    const loadMoreRow = pageState.hasMore ? `
+        <div class="flex justify-center">
+            <button type="button" data-load-more-media="${escapeHtml(folder.id)}" class="rounded-lg border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-50">Load more</button>
+        </div>` : '';
 
     els.albumDetail.innerHTML = `
         <article class="mt-6 rounded-2xl border border-gray-200 bg-white shadow-sm">
@@ -300,12 +359,12 @@ function renderAlbumDetail() {
                 <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <div>
                         <h2 class="text-2xl font-bold">${escapeHtml(folder.name || 'Untitled album')}</h2>
-                        <p class="text-sm text-gray-500">${items.length} item${items.length === 1 ? '' : 's'} · ${escapeHtml(getVisibilityLabel(folder))}</p>
+                        <p class="text-sm text-gray-500">${items.length}${folderItemCount > items.length || pageState.hasMore ? ` of ${folderItemCount}` : ''} item${folderItemCount === 1 ? '' : 's'} · ${escapeHtml(getVisibilityLabel(folder))}</p>
                     </div>
                 </div>
                 <div class="mt-4 flex flex-wrap gap-2" aria-label="Media type filters">${filterTabs}</div>
             </header>
-            <div class="space-y-3 p-5">${itemRows}</div>
+            <div class="space-y-3 p-5">${itemRows}${loadMoreRow}</div>
         </article>`;
 }
 
@@ -340,14 +399,16 @@ export async function loadLibrary() {
         if (!state.canManage) {
             state.folders = state.folders.filter((folder) => canReadTeamMediaAlbum(folder, false));
         }
-        const itemSets = state.canManage
-            ? [await getTeamMediaItems(state.teamId)]
-            : await Promise.all(state.folders.map((folder) => getTeamMediaItems(state.teamId, folder.id)));
-        state.items = itemSets.flat();
         if (!state.folders.some((folder) => folder.id === state.selectedFolderId)) {
             state.selectedFolderId = state.folders[0]?.id || '';
         }
-        state.selectedIds = new Set([...state.selectedIds].filter((id) => state.items.some((item) => item.id === id)));
+        state.items = [];
+        state.itemPageState = new Map();
+        state.selectedIds.clear();
+        if (state.selectedFolderId) {
+            await loadFolderItemsPage(state.selectedFolderId);
+            return;
+        }
         render();
     } catch (error) {
         if (!isPermissionDenied(error)) {
@@ -356,6 +417,7 @@ export async function loadLibrary() {
         console.warn('Unable to load team media library; showing empty state:', error);
         state.folders = [];
         state.items = [];
+        state.itemPageState = new Map();
         state.selectedIds.clear();
         render();
         if (state.canManage) {
@@ -424,16 +486,22 @@ async function uploadSelectedFiles({ files, folderId, progressEl, validateFile, 
         }
     }
 
+    if (uploadedCount > 0) state.selectedFolderId = folderId;
     await loadLibrary();
     showAlert(`${uploadedCount} ${uploadedCount === 1 ? nounSingular : nounPlural} uploaded${failedCount ? `, ${failedCount} failed` : ''}.`, failedCount ? 'error' : 'success');
     return { uploadedCount, failedCount };
 }
 
-els.foldersList.addEventListener('click', (event) => {
+els.foldersList.addEventListener('click', async (event) => {
     const selectedButton = event.target.closest('[data-select-folder]');
     if (selectedButton) {
         state.selectedFolderId = selectedButton.dataset.selectFolder;
         state.selectedIds.clear();
+        if (!getFolderPageState(state.selectedFolderId).loaded) {
+            render();
+            await loadFolderItemsPage(state.selectedFolderId);
+            return;
+        }
         render();
         return;
     }
@@ -476,6 +544,12 @@ els.albumDetail.addEventListener('click', async (event) => {
         state.selectedMediaType = filterButton.dataset.mediaTypeFilter || 'all';
         state.selectedIds.clear();
         render();
+        return;
+    }
+
+    const loadMoreButton = event.target.closest('[data-load-more-media]');
+    if (loadMoreButton) {
+        await loadFolderItemsPage(loadMoreButton.dataset.loadMoreMedia, { append: true });
         return;
     }
 

--- a/team-media.html
+++ b/team-media.html
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=7"></script>
+    <script type="module" src="js/team-media.js?v=8"></script>
 </body>
 </html>

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -307,8 +307,8 @@ export async function getTeam(teamId) {
 export async function getTeamMediaFolders() {
     throw permissionDenied();
 }
-export async function getTeamMediaItems() {
-    throw permissionDenied();
+export async function getTeamMediaItemsPage() {
+    return { items: [], hasMore: false, nextCursor: null };
 }
 export async function createTeamMediaFolder() {}
 export async function updateTeamMediaFolder() {}
@@ -332,8 +332,8 @@ export async function getTeam(teamId) {
 export async function getTeamMediaFolders() {
     return [{ id: 'folder-1', name: 'Highlights', order: 0 }];
 }
-export async function getTeamMediaItems() {
-    return [];
+export async function getTeamMediaItemsPage() {
+    return { items: [], hasMore: false, nextCursor: null };
 }
 export async function createTeamMediaFolder() {}
 export async function updateTeamMediaFolder() {}

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -26,6 +26,7 @@ const dbMocks = vi.hoisted(() => ({
     getTeam: vi.fn(),
     getTeamMediaFolders: vi.fn(),
     getTeamMediaItems: vi.fn(),
+    getTeamMediaItemsPage: vi.fn(),
     canAccessTeamChat: vi.fn(() => true),
     listCertificatesForPlayer: vi.fn(),
     listFamilyShareTokens: vi.fn(),
@@ -1014,14 +1015,18 @@ describe('React app parent tools service', () => {
             { id: 'folder-3', name: 'Highlights', visibility: 'team', order: 4, itemCount: 2 },
             { id: 'folder-private', name: 'Private', visibility: 'private', order: 1, itemCount: 9 }
         ]);
-        dbMocks.getTeamMediaItems.mockImplementation(async (teamId, folderId) => (folderId === 'folder-1' ? [
-            { id: 'bad', title: 'Bad', type: 'photo', url: 'javascript:alert(1)', order: 1 },
-            { id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/photo.jpg', order: 0 }
-        ] : folderId === 'folder-2' ? [
-            { id: 'video-1', title: 'Replay', type: 'video_link', url: 'https://video.example.test/replay', order: 0 }
-        ] : folderId === 'folder-3' ? [
-            { id: 'highlight-1', title: 'Highlight', type: 'photo', url: 'https://img.example.test/highlight.jpg', order: 0 }
-        ] : []));
+        dbMocks.getTeamMediaItemsPage.mockImplementation(async (teamId, folderId, options = {}) => ({
+            items: folderId === 'folder-1' ? [
+                { id: 'bad', title: 'Bad', type: 'photo', url: 'javascript:alert(1)', order: 1 },
+                { id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/photo.jpg', order: 0 }
+            ] : folderId === 'folder-2' ? [
+                { id: 'video-1', title: 'Replay', type: 'video_link', url: 'https://video.example.test/replay', order: 0 }
+            ] : folderId === 'folder-3' ? [
+                { id: 'highlight-1', title: 'Highlight', type: 'photo', url: 'https://img.example.test/highlight.jpg', order: 0 }
+            ] : [],
+            hasMore: folderId === 'folder-1',
+            nextCursor: folderId === 'folder-1' ? { id: `cursor-${options.pageSize || 24}` } : null
+        }));
         dbMocks.uploadTeamMediaPhoto.mockResolvedValue('photo-2');
         dbMocks.uploadTeamMediaFile.mockResolvedValue('file-1');
         dbMocks.createTeamMediaLink.mockResolvedValue('link-1');
@@ -1035,8 +1040,9 @@ describe('React app parent tools service', () => {
             folders: [
                 {
                     id: 'folder-1',
-                    itemCount: 1,
+                    itemCount: 4,
                     itemsLoaded: true,
+                    itemsHasMore: true,
                     items: [{ id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/photo.jpg' }]
                 },
                 {
@@ -1053,8 +1059,8 @@ describe('React app parent tools service', () => {
                 }
             ]
         });
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(1);
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledWith('team-1', 'folder-1');
+        expect(dbMocks.getTeamMediaItemsPage).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getTeamMediaItemsPage).toHaveBeenCalledWith('team-1', 'folder-1', { pageSize: 24, cursor: null });
 
         await expect(loadTeamMediaForApp(user, 'team-1', { folderIds: ['folder-2'] })).resolves.toMatchObject({
             folders: [
@@ -1063,8 +1069,8 @@ describe('React app parent tools service', () => {
                 { id: 'folder-3', itemCount: 2, itemsLoaded: false, items: [] }
             ]
         });
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(2);
-        expect(dbMocks.getTeamMediaItems).toHaveBeenLastCalledWith('team-1', 'folder-2');
+        expect(dbMocks.getTeamMediaItemsPage).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getTeamMediaItemsPage).toHaveBeenLastCalledWith('team-1', 'folder-2', { pageSize: 24, cursor: null });
 
         await expect(createTeamMediaAlbumForApp('team-1', { name: '  Spring photos  ', visibility: 'private' })).resolves.toBe('folder-new');
         await uploadParentTeamMediaPhoto('team-1', 'folder-1', photoFile);
@@ -1075,6 +1081,40 @@ describe('React app parent tools service', () => {
         expect(dbMocks.uploadTeamMediaPhoto).toHaveBeenCalledWith('team-1', 'folder-1', photoFile);
         expect(dbMocks.uploadTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', docFile);
         expect(dbMocks.createTeamMediaLink).toHaveBeenCalledWith('team-1', 'folder-1', { title: 'Replay', url: 'https://video.example.test/replay' });
+    });
+
+    it('passes team media pagination cursors through the app media model', async () => {
+        const cursor = { id: 'cursor-1' };
+        const nextCursor = { id: 'cursor-2' };
+        dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears' });
+        dbMocks.getTeamMediaFolders.mockResolvedValue([
+            { id: 'folder-1', name: 'Game photos', visibility: 'team', order: 1, itemCount: 40 }
+        ]);
+        dbMocks.getTeamMediaItemsPage.mockResolvedValue({
+            items: [
+                { id: 'photo-25', title: 'Second page', type: 'photo', url: 'https://img.example.test/photo-25.jpg', order: 25 }
+            ],
+            hasMore: true,
+            nextCursor
+        });
+
+        await expect(loadTeamMediaForApp(user, 'team-1', {
+            folderIds: ['folder-1'],
+            pageSize: 1,
+            cursorsByFolderId: { 'folder-1': cursor }
+        })).resolves.toMatchObject({
+            folders: [
+                {
+                    id: 'folder-1',
+                    itemCount: 40,
+                    itemsLoaded: true,
+                    itemsHasMore: true,
+                    itemsNextCursor: nextCursor,
+                    items: [{ id: 'photo-25', title: 'Second page' }]
+                }
+            ]
+        });
+        expect(dbMocks.getTeamMediaItemsPage).toHaveBeenCalledWith('team-1', 'folder-1', { pageSize: 1, cursor });
     });
 
     it('initiates Stripe checkout for registration and returns URL', async () => {

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -222,7 +222,6 @@ describe('team media db ordering', () => {
     });
 
     it('returns bounded media item pages with stable folder order and cursor metadata', async () => {
-        const cursor = { id: 'media-cursor' };
         const docs = [
             {
                 id: 'media-1',
@@ -237,18 +236,73 @@ describe('team media db ordering', () => {
                 data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/3.jpg', order: 3, deleted: false })
             }
         ];
-        firebaseMocks.getDocs.mockResolvedValueOnce({ docs });
+        firebaseMocks.getDocs.mockResolvedValue({ docs });
 
         const { getTeamMediaItemsPage } = await import('../../js/db.js');
-        const page = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 2, cursor });
+        const firstPage = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 2 });
+        const secondPage = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 2, cursor: firstPage.nextCursor });
 
         expect(firebaseMocks.where).toHaveBeenCalledWith('folderId', '==', 'folder-1');
-        expect(firebaseMocks.orderBy).toHaveBeenNthCalledWith(1, 'order', 'asc');
-        expect(firebaseMocks.startAfter).toHaveBeenCalledWith(cursor);
-        expect(firebaseMocks.limit).toHaveBeenCalledWith(3);
-        expect(page.items.map((item) => item.id)).toEqual(['media-1', 'media-2']);
-        expect(page.hasMore).toBe(true);
-        expect(page.lastDoc).toBe(docs[1]);
-        expect(page.nextCursor).toBe(docs[1]);
+        expect(firstPage.items.map((item) => item.id)).toEqual(['media-1', 'media-2']);
+        expect(firstPage.hasMore).toBe(true);
+        expect(firstPage.lastDoc).toBe(docs[1]);
+        expect(firstPage.nextCursor).toEqual({ kind: 'team-media-items-page', folderId: 'folder-1', offset: 2 });
+        expect(secondPage.items.map((item) => item.id)).toEqual(['media-3']);
+        expect(secondPage.hasMore).toBe(false);
+        expect(secondPage.nextCursor).toBeNull();
+    });
+
+    it('keeps deleted items from truncating later live media pages', async () => {
+        const docs = [
+            {
+                id: 'media-1',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/1.jpg', order: 1, deleted: false })
+            },
+            {
+                id: 'media-deleted',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/deleted.jpg', order: 2, deleted: true })
+            },
+            {
+                id: 'media-2',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/2.jpg', order: 3, deleted: false })
+            },
+            {
+                id: 'media-3',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/3.jpg', order: 4, deleted: false })
+            }
+        ];
+        firebaseMocks.getDocs.mockResolvedValue({ docs });
+
+        const { getTeamMediaItemsPage } = await import('../../js/db.js');
+        const firstPage = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 2 });
+        const secondPage = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 2, cursor: firstPage.nextCursor });
+
+        expect(firstPage.items.map((item) => item.id)).toEqual(['media-1', 'media-2']);
+        expect(firstPage.hasMore).toBe(true);
+        expect(secondPage.items.map((item) => item.id)).toEqual(['media-3']);
+        expect(secondPage.hasMore).toBe(false);
+    });
+
+    it('preserves legacy media without order fields at the end of paginated reads', async () => {
+        const docs = [
+            {
+                id: 'media-ordered',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/ordered.jpg', order: 0, deleted: false, title: 'Ordered' })
+            },
+            {
+                id: 'media-legacy',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/legacy.jpg', deleted: false, title: 'Legacy' })
+            }
+        ];
+        firebaseMocks.getDocs.mockResolvedValue({ docs });
+
+        const { getTeamMediaItemsPage } = await import('../../js/db.js');
+        const firstPage = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 1 });
+        const secondPage = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 1, cursor: firstPage.nextCursor });
+
+        expect(firstPage.items.map((item) => item.id)).toEqual(['media-ordered']);
+        expect(firstPage.hasMore).toBe(true);
+        expect(secondPage.items.map((item) => item.id)).toEqual(['media-legacy']);
+        expect(secondPage.hasMore).toBe(false);
     });
 });

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -10,7 +10,8 @@ const firebaseMocks = vi.hoisted(() => ({
     getDocs: vi.fn(),
     getDownloadURL: vi.fn(async () => 'https://cdn.example.test/uploaded-file'),
     doc: vi.fn((_db, path, id) => ({ path: `${path}/${id}` })),
-    orderBy: vi.fn(),
+    limit: vi.fn((value) => ({ type: 'limit', value })),
+    orderBy: vi.fn((field, direction) => ({ type: 'orderBy', field, direction })),
     query: vi.fn((...parts) => parts),
     runTransaction: vi.fn(async (_db, callback) => callback({
         get: async () => ({
@@ -22,8 +23,9 @@ const firebaseMocks = vi.hoisted(() => ({
         }
     })),
     serverTimestamp: vi.fn(() => 'server-ts'),
+    startAfter: vi.fn((cursor) => ({ type: 'startAfter', cursor })),
     updateDoc: vi.fn(async () => undefined),
-    where: vi.fn(),
+    where: vi.fn((field, op, value) => ({ type: 'where', field, op, value })),
     writeBatch: vi.fn(),
 }));
 
@@ -50,8 +52,8 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     arrayUnion: vi.fn(),
     arrayRemove: vi.fn(),
     deleteField: vi.fn(),
-    limit: vi.fn(),
-    startAfter: vi.fn(),
+    limit: firebaseMocks.limit,
+    startAfter: firebaseMocks.startAfter,
     getCountFromServer: firebaseMocks.getCountFromServer,
     onSnapshot: vi.fn(),
     serverTimestamp: firebaseMocks.serverTimestamp,
@@ -217,5 +219,36 @@ describe('team media db ordering', () => {
                 downloadUrl: 'https://cdn.example.test/legacy.pdf'
             })
         ]);
+    });
+
+    it('returns bounded media item pages with stable folder order and cursor metadata', async () => {
+        const cursor = { id: 'media-cursor' };
+        const docs = [
+            {
+                id: 'media-1',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/1.jpg', order: 1, deleted: false })
+            },
+            {
+                id: 'media-2',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/2.jpg', order: 2, deleted: false })
+            },
+            {
+                id: 'media-3',
+                data: () => ({ folderId: 'folder-1', type: 'photo', downloadUrl: 'https://cdn.example.test/3.jpg', order: 3, deleted: false })
+            }
+        ];
+        firebaseMocks.getDocs.mockResolvedValueOnce({ docs });
+
+        const { getTeamMediaItemsPage } = await import('../../js/db.js');
+        const page = await getTeamMediaItemsPage('team-1', 'folder-1', { pageSize: 2, cursor });
+
+        expect(firebaseMocks.where).toHaveBeenCalledWith('folderId', '==', 'folder-1');
+        expect(firebaseMocks.orderBy).toHaveBeenNthCalledWith(1, 'order', 'asc');
+        expect(firebaseMocks.startAfter).toHaveBeenCalledWith(cursor);
+        expect(firebaseMocks.limit).toHaveBeenCalledWith(3);
+        expect(page.items.map((item) => item.id)).toEqual(['media-1', 'media-2']);
+        expect(page.hasMore).toBe(true);
+        expect(page.lastDoc).toBe(docs[1]);
+        expect(page.nextCursor).toBe(docs[1]);
     });
 });

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -10,17 +10,17 @@ const repoRoot = path.resolve(__dirname, '../..');
 
 const mocks = vi.hoisted(() => ({
     updateTeamMediaItem: vi.fn(),
-    getTeamMediaItems: vi.fn(),
+    getTeamMediaItemsPage: vi.fn(),
     getTeamMediaFolders: vi.fn(),
     getTeam: vi.fn(),
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=63', () => {
+vi.mock('../../js/db.js?v=64', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,
-        getTeamMediaItems: mocks.getTeamMediaItems,
+        getTeamMediaItemsPage: mocks.getTeamMediaItemsPage,
         createTeamMediaFolder: vi.fn(),
         updateTeamMediaFolder: vi.fn(),
         deleteTeamMediaFolder: vi.fn(),
@@ -67,9 +67,13 @@ describe('team media item renaming', () => {
 
         mocks.getTeam.mockResolvedValue({ id: 'team123', name: 'Test Team', adminEmails: ['admin@example.com'] });
         mocks.getTeamMediaFolders.mockResolvedValue([{ id: 'folderA', name: 'Album A', visibility: 'team' }]);
-        mocks.getTeamMediaItems.mockResolvedValue([
-            { id: 'item1', folderId: 'folderA', title: 'Original Photo', type: 'photo', url: 'https://example.com/photo1.jpg', uploadedBy: 'user123' },
-        ]);
+        mocks.getTeamMediaItemsPage.mockResolvedValue({
+            items: [
+                { id: 'item1', folderId: 'folderA', title: 'Original Photo', type: 'photo', url: 'https://example.com/photo1.jpg', uploadedBy: 'user123' },
+            ],
+            hasMore: false,
+            nextCursor: null
+        });
         mocks.checkAuth.mockImplementation((callback) => callback({ uid: 'user123', email: 'user@example.com' }));
         mocks.updateTeamMediaItem.mockResolvedValue(true);
     });
@@ -222,9 +226,13 @@ describe('team media item renaming', () => {
     });
 
     it('shows saved video-link items under the Videos filter', async () => {
-        mocks.getTeamMediaItems.mockResolvedValue([
-            { id: 'video1', folderId: 'folderA', title: 'Game Clip', type: 'video-link', url: 'https://youtu.be/abc123', uploadedBy: 'user123' }
-        ]);
+        mocks.getTeamMediaItemsPage.mockResolvedValue({
+            items: [
+                { id: 'video1', folderId: 'folderA', title: 'Game Clip', type: 'video-link', url: 'https://youtu.be/abc123', uploadedBy: 'user123' }
+            ],
+            hasMore: false,
+            nextCursor: null
+        });
 
         const module = await loadModule();
         await module.loadLibrary();

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -21,7 +21,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=7"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=8"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
@@ -33,7 +33,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toContain("from './db.js?v=63'");
+        expect(pageJs).toContain("from './db.js?v=64'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');
@@ -45,6 +45,10 @@ describe('team media entry point', () => {
         expect(pageJs).toContain('canReadTeamMediaAlbum');
         expect(pageJs).toContain('bulkDeleteTeamMediaItems');
         expect(pageJs).toContain('setTeamMediaAlbumCover');
+        expect(pageJs).toContain('getTeamMediaItemsPage');
+        expect(pageJs).toContain('TEAM_MEDIA_PAGE_SIZE');
+        expect(pageJs).toContain('data-load-more-media');
+        expect(pageJs).not.toContain('getTeamMediaItems(state.teamId)');
         expect(pageJs).toContain('MEDIA_TYPE_FILTERS');
         expect(pageJs).toContain("{ id: 'videos', label: 'Videos' }");
         expect(pageJs).toContain('data-media-type-filter');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -20,11 +20,11 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=7"');
+        expect(page).toContain('src="js/team-media.js?v=8"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=63'");
+        expect(source).toContain("from './db.js?v=64'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=32';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
@@ -34,6 +34,8 @@ describe('team media page wiring', () => {
         expect(source).toContain('actionInFlight: false');
         expect(source).toContain('if (state.actionInFlight) return;');
         expect(source).toContain('state.actionInFlight = false;');
+        expect(source).toContain('getTeamMediaItemsPage');
+        expect(source).toContain('data-load-more-media');
     });
 
     it('keeps media reads member-scoped and uploads explicitly approved', () => {


### PR DESCRIPTION
## Summary
- Adds a bounded `getTeamMediaItemsPage` API with folder/order cursor paging and a Firestore index.
- Updates the React Team Media service/page to load album pages, preserve cached album items, and append via Load more.
- Switches the legacy `team-media.html` flow to selected-folder page loading instead of eager whole-library reads, with cache-busted module versions.

Closes #2586

## Tests
- npx vitest run tests/unit/team-media-db-ordering.test.js tests/unit/app-parent-tools-service.test.js tests/unit/team-media-page.test.js tests/unit/team-media-wiring.test.js --reporter=verbose
- npm --prefix apps/app test -- --run src/pages/TeamMedia.test.tsx --reporter=verbose
- npm run ci:firebase-rules
- npm run app:build
- node --check js/team-media.js
- node --check js/db.js
- git diff --check