### PR TITLE
Cover notification recipient index initiative

### DIFF
--- a/tests/unit/notification-recipient-index-initiative-source-contract.test.js
+++ b/tests/unit/notification-recipient-index-initiative-source-contract.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+const firestoreRules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+describe('notification recipient index initiative source contract', () => {
+    it('resolves category sends through the denormalized notificationRecipients index first', () => {
+        expect(functionsSource).toContain('function buildTeamNotificationRecipientRef(teamId, uid, deviceId)');
+        expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = [])');
+        expect(functionsSource).toContain('firestore.collection(`teams/${teamId}/notificationRecipients`)');
+        expect(functionsSource).toContain(".where(`categories.${category}`, '==', true)");
+    });
+
+    it('keeps a migration fallback that backfills the index when a team has no indexed recipients yet', () => {
+        expect(functionsSource).toContain('async function backfillNotificationRecipientsForTeam(teamId, users, options = {})');
+        expect(functionsSource).toContain('if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId)) {');
+        expect(functionsSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true });');
+        expect(functionsSource).toContain('Failed to backfill notification recipient index after empty lookup');
+    });
+
+    it('deduplicates logical sends through a server-only notificationSendLog', () => {
+        expect(functionsSource).toContain('function buildNotificationDedupRef(teamId, category, dedupIdentity = \'\')');
+        expect(functionsSource).toContain('teams/${teamId}/notificationSendLog/${hash}');
+        expect(functionsSource).toContain('async function checkAndSetNotificationDedup(teamId, category, gameId, dedupKey = null)');
+        expect(functionsSource).toContain('Notification dedup: skipping duplicate send');
+    });
+
+    it('denies client reads and writes to recipient index and dedup log collections', () => {
+        expect(firestoreRules).toMatch(/match \/notificationRecipients\/\{uid\} \{[\s\S]*allow read, write: if false;/);
+        expect(firestoreRules).toMatch(/match \/notificationSendLog\/\{docId\} \{[\s\S]*allow read, write: if false;/);
+    });
+});


### PR DESCRIPTION
## Summary
- add parent-issue source coverage for notificationRecipients index resolution and fallback backfill
- guard notification send dedup log wiring
- verify Firestore rules deny client access to recipient index and dedup log collections

Refs #2099

## Tests
- npx vitest run tests/unit/notification-recipient-index-initiative-source-contract.test.js --reporter=verbose