### PR TITLE
Cover chat mention notification split

### DIFF
--- a/tests/unit/issue-2589-chat-mention-notification-source.test.js
+++ b/tests/unit/issue-2589-chat-mention-notification-source.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+const mentionDetectionTestSource = readFileSync(new URL('./functions-chat-mention-detection.test.js', import.meta.url), 'utf8');
+const deliveryContractSource = readFileSync(new URL('./chat-notification-delivery-contract.test.js', import.meta.url), 'utf8');
+
+describe('issue 2589 chat mention notification source contract', () => {
+    it('keeps server mention detection scoped to eligible conversation members', () => {
+        expect(functionsSource).toContain('const teamChatMentionStartRegex =');
+        expect(functionsSource).toContain('function detectMentionedUids(text, members, options = {})');
+        expect(functionsSource).toContain('const { allowReservedMentions = false } = options || {};');
+        expect(functionsSource).toContain('const mentionEligibleUids = new Set(mentionTargets.map((target) => target.uid));');
+        expect(functionsSource).toContain('const mentionMembers = Array.isArray(context.members)');
+        expect(functionsSource).toContain('detectMentionedUids(text, mentionMembers, { allowReservedMentions: actorIsStaff }).filter((uid) => uid !== actorUid)');
+    });
+
+    it('keeps mention pushes separate from regular live-chat pushes', () => {
+        expect(functionsSource).toContain('await snapshot.ref.update({ mentionedUids });');
+        expect(functionsSource).toContain("category: 'mentions'");
+        expect(functionsSource).toContain('targets: notificationPlan.mentionTargets');
+        expect(functionsSource).toContain("category: 'liveChat'");
+        expect(functionsSource).toContain('targets: notificationPlan.liveChatTargets');
+        expect(functionsSource).toContain('&& !mentionedSet.has(target.uid)');
+        expect(functionsSource).toContain('&& !mutedSet.has(target.uid)');
+    });
+
+    it('keeps tests for mention matching and notification delivery split', () => {
+        expect(mentionDetectionTestSource).toContain('matches a rostered multi-word display name exactly');
+        expect(mentionDetectionTestSource).toContain('ignores reserved tokens unless the caller explicitly allows them');
+        expect(mentionDetectionTestSource).toContain('uses per-conversation mute state before falling back to team-wide chatMuted');
+        expect(deliveryContractSource).toContain('sends mention pushes only to mentioned users and live chat pushes only to non-muted non-mentioned users');
+    });
+});


### PR DESCRIPTION
## Summary
- add source coverage for backend chat mention detection
- verify mention pushes stay separate from regular live chat pushes
- guard existing mention matching and notification delivery split regression tests

Refs #2589

## Tests
- npx vitest run tests/unit/issue-2589-chat-mention-notification-source.test.js --reporter=verbose