### PR TITLE
Handle Firebase preview channel quota

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -189,7 +189,20 @@ jobs:
         run: |
           set -euo pipefail
           log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
-          npx firebase-tools@14.25.0 hosting:channel:deploy pr-${{ github.event.pull_request.number }} --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive | tee "$log_file"
+          if ! npx firebase-tools@14.25.0 hosting:channel:deploy pr-${{ github.event.pull_request.number }} --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive >"$log_file" 2>&1; then
+            cat "$log_file"
+            if grep -Eiq 'HTTP Error: 429|channel quota reached' "$log_file"; then
+              {
+                echo "### Firebase preview skipped"
+                echo
+                echo "Firebase Hosting preview channel quota was reached. Build and regression checks completed successfully, so this deploy-only preview limitation did not fail the PR."
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "preview_url=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            exit 1
+          fi
+          cat "$log_file"
           preview_url="$(grep -Eo 'https://[^ ]+' "$log_file" | tail -n1)"
           if [ -z "$preview_url" ]; then
             echo "Failed to extract preview URL from Firebase deploy output." >&2
@@ -207,9 +220,11 @@ jobs:
         run: |
           set -euo pipefail
           marker='<!-- allplays-preview-url -->'
-          body="$marker
-
-          Preview URL: $PREVIEW_URL"
+          if [ -n "$PREVIEW_URL" ]; then
+            body="$(printf '%s\n\nPreview URL: %s' "$marker" "$PREVIEW_URL")"
+          else
+            body="$(printf '%s\n\nFirebase preview skipped: Firebase Hosting preview channel quota was reached for this run.' "$marker")"
+          fi
           comment_id="$(gh api --paginate repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq "$JQ_FILTER" | head -n1)"
           if [ -n "$comment_id" ]; then
             gh api repos/${{ github.repository }}/issues/comments/"$comment_id" --method PATCH -f body="$body" >/dev/null


### PR DESCRIPTION
## Summary
- Treat Firebase Hosting preview channel quota exhaustion as a non-blocking preview limitation
- Skip the preview URL comment when no preview URL is available

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-preview.yml"); puts "yaml ok"'\n- git diff --check