### PR TITLE
Standardize Home secondary service errors

### DIFF
--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -8,7 +8,7 @@ import {
   type ParentHomeModel
 } from './homeLogic';
 import { getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
-import { toAppServiceError } from './appErrors';
+import { AppServiceError, toAppServiceError } from './appErrors';
 import {
   hydrateParentScheduleDetails,
   loadParentScheduleChildren,
@@ -27,6 +27,12 @@ function rethrowIfPermissionError(error: unknown, fallbackMessage: string) {
     throw appError;
   }
   return appError;
+}
+
+function throwIfAllSecondarySlicesFailed(errors: AppServiceError[]) {
+  if (errors.length >= 3) {
+    throw errors[0];
+  }
 }
 
 export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeModel> {
@@ -151,6 +157,7 @@ export async function loadParentHomeWithSecondaryData(
     // immediately and fills in chat badges / fee items / hydrated RSVP states as
     // each arrives, instead of blocking on all of them before any update (#2037).
     // A per-slice failure degrades that card rather than gating the whole page.
+    const secondaryErrors: AppServiceError[] = [];
     const results = await Promise.allSettled([
       hydrateParentScheduleDetails(schedule, user).then((hydratedSchedule) => {
         const nextSchedule = hydratedSchedule || schedule;
@@ -161,7 +168,9 @@ export async function loadParentHomeWithSecondaryData(
         emit(patch);
         return patch;
       }).catch((error) => {
-        console.warn('[home] Schedule hydration failed:', rethrowIfPermissionError(error, 'Unable to hydrate Home schedule.'));
+        const appError = rethrowIfPermissionError(error, 'Unable to hydrate Home schedule.');
+        secondaryErrors.push(appError);
+        console.warn('[home] Schedule hydration failed:', appError);
         return null;
       }),
       loadChatInbox(user).then((chatInbox) => {
@@ -169,7 +178,9 @@ export async function loadParentHomeWithSecondaryData(
         emit({ inboxTeams: nextInboxTeams });
         return nextInboxTeams;
       }).catch((error) => {
-        console.warn('[home] Chat inbox failed:', rethrowIfPermissionError(error, 'Unable to load Home chat.'));
+        const appError = rethrowIfPermissionError(error, 'Unable to load Home chat.');
+        secondaryErrors.push(appError);
+        console.warn('[home] Chat inbox failed:', appError);
         return [];
       }),
       Promise.resolve(listParentTeamFeeRecipients(user.uid, children)).then((rawFees) => {
@@ -177,7 +188,9 @@ export async function loadParentHomeWithSecondaryData(
         emit({ fees: nextFees });
         return nextFees;
       }).catch((error) => {
-        console.warn('[home] Fees failed:', rethrowIfPermissionError(error, 'Unable to load Home fees.'));
+        const appError = rethrowIfPermissionError(error, 'Unable to load Home fees.');
+        secondaryErrors.push(appError);
+        console.warn('[home] Fees failed:', appError);
         return [];
       })
     ]);
@@ -186,6 +199,7 @@ export async function loadParentHomeWithSecondaryData(
     if (permissionFailure?.status === 'rejected') {
       throw permissionFailure.reason;
     }
+    throwIfAllSecondarySlicesFailed(secondaryErrors);
 
     const [scheduleResult, chatResult, feesResult] = results;
     return buildParentHomeModel({

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3026,12 +3026,21 @@ function loadCachedEventHydrationDetails(teamId: string, gameId: string) {
   return loadCachedAppData(
     `event-details:${teamId}:${gameId}`,
     async () => {
-      const [rsvps, offers, claims] = await Promise.all([
-        loadRsvps(teamId, gameId).catch(() => []),
-        loadRideOffers(teamId, gameId).catch(() => []),
-        loadAssignmentClaims(teamId, gameId).catch(() => ({}))
+      const results = await Promise.allSettled([
+        loadRsvps(teamId, gameId),
+        loadRideOffers(teamId, gameId),
+        loadAssignmentClaims(teamId, gameId)
       ]);
-      return { rsvps, offers, claims };
+      const firstRejected = results.find((result) => result.status === 'rejected');
+      if (firstRejected && results.every((result) => result.status === 'rejected')) {
+        throw firstRejected.reason;
+      }
+      const [rsvpsResult, offersResult, claimsResult] = results;
+      return {
+        rsvps: rsvpsResult.status === 'fulfilled' ? rsvpsResult.value : [],
+        offers: offersResult.status === 'fulfilled' ? offersResult.value : [],
+        claims: claimsResult.status === 'fulfilled' ? claimsResult.value : {}
+      };
     },
     {
       ttlMs: scheduleHydrationCacheTtlMs,

--- a/js/db.js
+++ b/js/db.js
@@ -4718,6 +4718,9 @@ export async function listParentTeamFeeRecipients(userId, children = []) {
     ];
 
     const results = await Promise.allSettled(queries.map((feeQuery) => getDocs(feeQuery)));
+    if (results.length > 0 && results.every((result) => result.status === 'rejected')) {
+        throw results[0].reason;
+    }
     const feesByPath = new Map();
 
     results.forEach((result) => {

--- a/tests/unit/app-home-async-operation-contract.test.js
+++ b/tests/unit/app-home-async-operation-contract.test.js
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 
 const homeSource = readFileSync(new URL('../../apps/app/src/pages/Home.tsx', import.meta.url), 'utf8');
 const homeServiceSource = readFileSync(new URL('../../apps/app/src/lib/homeService.ts', import.meta.url), 'utf8');
+const scheduleServiceSource = readFileSync(new URL('../../apps/app/src/lib/scheduleService.ts', import.meta.url), 'utf8');
+const legacyDbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
 
 function getRefreshHomeSource() {
     const start = homeSource.indexOf('  const refreshHome = async');
@@ -46,5 +48,13 @@ describe('Home async operation contract', () => {
         expect(homeServiceSource).toContain("console.warn('[home] Fees failed:', appError);");
         expect(homeServiceSource).toContain('throwIfAllSecondarySlicesFailed(secondaryErrors);');
         expect(homeServiceSource).toContain('onPartial?.(buildParentHomeModel(partialState));');
+    });
+
+    it('treats fully swallowed schedule and fee loader failures as real secondary failures', () => {
+        expect(scheduleServiceSource).toContain('const results = await Promise.allSettled([');
+        expect(scheduleServiceSource).toContain("if (firstRejected && results.every((result) => result.status === 'rejected')) {");
+        expect(scheduleServiceSource).toContain('throw firstRejected.reason;');
+        expect(legacyDbSource).toContain("if (results.length > 0 && results.every((result) => result.status === 'rejected')) {");
+        expect(legacyDbSource).toContain('throw results[0].reason;');
     });
 });

--- a/tests/unit/app-home-async-operation-contract.test.js
+++ b/tests/unit/app-home-async-operation-contract.test.js
@@ -41,9 +41,10 @@ describe('Home async operation contract', () => {
     it('keeps secondary Home hydration partial while classifying service failures', () => {
         expect(homeServiceSource).toContain("throw toAppServiceError(error, 'Unable to load Home chat.');");
         expect(homeServiceSource).toContain("throw toAppServiceError(error, 'Unable to load Home fees.');");
-        expect(homeServiceSource).toContain("console.warn('[home] Schedule hydration failed:', rethrowIfPermissionError(error, 'Unable to hydrate Home schedule.'));");
-        expect(homeServiceSource).toContain("console.warn('[home] Chat inbox failed:', rethrowIfPermissionError(error, 'Unable to load Home chat.'));");
-        expect(homeServiceSource).toContain("console.warn('[home] Fees failed:', rethrowIfPermissionError(error, 'Unable to load Home fees.'));");
+        expect(homeServiceSource).toContain("console.warn('[home] Schedule hydration failed:', appError);");
+        expect(homeServiceSource).toContain("console.warn('[home] Chat inbox failed:', appError);");
+        expect(homeServiceSource).toContain("console.warn('[home] Fees failed:', appError);");
+        expect(homeServiceSource).toContain('throwIfAllSecondarySlicesFailed(secondaryErrors);');
         expect(homeServiceSource).toContain('onPartial?.(buildParentHomeModel(partialState));');
     });
 });

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -259,6 +259,31 @@ describe('React app Home service', () => {
         ]));
     });
 
+    it('throws a typed secondary error when every Home detail slice fails', async () => {
+        scheduleMocks.hydrateParentScheduleDetails.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        chatMocks.loadChatInbox.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        dbMocks.listParentTeamFeeRecipients.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+        const { loadParentHomeWithSecondaryData } = await import('../../apps/app/src/lib/homeService.ts');
+
+        await expect(loadParentHomeWithSecondaryData(user, {
+            schedule: {
+                children: [
+                    {
+                        teamId: 'team-1',
+                        teamName: 'Bears',
+                        playerId: 'player-1',
+                        playerName: 'Pat Star'
+                    }
+                ],
+                events: [event()]
+            }
+        })).rejects.toMatchObject({
+            name: 'AppServiceError',
+            type: 'network',
+            message: 'Failed to fetch'
+        });
+    });
+
     it('preserves every completed secondary slice in the final progressive Home model', async () => {
         let resolveChat;
         let resolveFees;


### PR DESCRIPTION
Closes #2622

## What changed
- kept Home secondary hydration progressive, but now aggregate per-slice typed `AppServiceError` instances during schedule, chat, and fee loads
- throw a typed secondary error when every Home secondary slice fails, so the shared Home async/retry UI can surface network and permission failures consistently
- added focused regression coverage for the all-slices-failed case and updated the async-operation contract test to lock in the shared error path

## Root Cause
Home secondary loaders were catching slice-level failures, logging them, and returning empty fallbacks. That meant a full secondary-load outage could be silently downgraded into partial defaults instead of surfacing a typed service error back to the shared Home async operation.

## Prevention / Learning
When a page intentionally supports partial secondary hydration, do not choose between resilience and typed errors. Keep per-slice fallbacks for single-slice failures, but aggregate failures and throw a typed error when every secondary slice fails so retry/error UI remains reachable.

## Regression Tests
- `npx vitest run tests/unit/app-home-service.test.js tests/unit/app-home-async-operation-contract.test.js apps/app/src/pages/Home.test.tsx --reporter=verbose`
- added a regression in `tests/unit/app-home-service.test.js` covering the all-secondary-slices-fail path
- updated `tests/unit/app-home-async-operation-contract.test.js` to assert the aggregated typed-error path remains in source

## Recurrence Risk
Medium. Other progressive loaders can still swallow total secondary failure unless they explicitly aggregate slice errors before returning fallbacks.