### PR TITLE
Combine fee assignment pushes by parent

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7828,8 +7828,9 @@ exports.notifyFeeAssigned = functions.firestore
     try {
       const sendResults = [];
       for (const uid of claimedUserIds) {
-        const claimedTargets = claimedPayerTargets.filter((target) => String(target.uid || '').trim() === uid);
-        if (!claimedTargets.length) continue;
+        const claimedTargets = claimedPayerTargets;
+        const targetsForUser = claimedTargets.filter((target) => String(target.uid || '').trim() === uid);
+        if (!targetsForUser.length) continue;
         const recipientsForUser = await filterFeeAssignmentRecipientsForUser({
           teamId,
           uid,
@@ -7842,7 +7843,7 @@ exports.notifyFeeAssigned = functions.firestore
           const amountCents = getTeamFeeBalanceCents(data) || Number(data.amountCents || data.feeAmountCents || 0);
           const amountDisplay = amountCents > 0 ? ` (${formatMoneyFromCents(amountCents, data.currency || 'USD')})` : '';
           sendResults.push(await sendDirectTargetsNotification({
-            targets: claimedTargets,
+            targets: targetsForUser,
             category: 'fees',
             title: `New fee assigned: ${title}${amountDisplay}`,
             body: buildFeeAssignmentNotificationBody(data, amountDisplay ? amountDisplay.slice(2, -1) : ''),
@@ -7853,7 +7854,7 @@ exports.notifyFeeAssigned = functions.firestore
         }
         const payload = buildCombinedFeeAssignmentNotificationPayload(recipientsForUser);
         sendResults.push(await sendDirectTargetsNotification({
-          targets: claimedTargets,
+          targets: targetsForUser,
           category: 'fees',
           title: payload.title,
           body: payload.body,

--- a/functions/index.js
+++ b/functions/index.js
@@ -6626,17 +6626,49 @@ async function listFeeAssignmentBatchRecipients({ teamId, batchId, recipientId, 
   return recipients;
 }
 
+function getFeeAssignmentRecipientPlayerKey(teamId, recipient = {}) {
+  const playerId = resolveFeeRecipientPlayerId(teamId, recipient);
+  return getFeeReminderPlayerKey({
+    ...recipient,
+    playerId: playerId || recipient.playerId || recipient.childId
+  }, teamId);
+}
+
+async function loadFeeAssignmentUserParentPlayerKeys(uid) {
+  const normalizedUid = String(uid || '').trim();
+  if (!normalizedUid) return new Set();
+  try {
+    const userSnap = await firestore.doc(`users/${normalizedUid}`).get();
+    const user = userSnap.exists ? (userSnap.data() || {}) : {};
+    return new Set(
+      (Array.isArray(user.parentPlayerKeys) ? user.parentPlayerKeys : [])
+        .map((key) => String(key || '').trim())
+        .filter(Boolean)
+    );
+  } catch (error) {
+    functions.logger.warn('Failed to read fee assignment payer parent keys; falling back to current recipient.', {
+      uid: normalizedUid,
+      error: error?.message || error
+    });
+    return new Set();
+  }
+}
+
 async function filterFeeAssignmentRecipientsForUser({ teamId, uid, recipients, fallbackRecipient }) {
   const normalizedUid = String(uid || '').trim();
   if (!normalizedUid) return fallbackRecipient ? [fallbackRecipient] : [];
-  const matchedRecipients = [];
-  for (const recipient of Array.isArray(recipients) ? recipients : []) {
-    const payerUserIds = await resolveFeeAssignmentPayerUserIds(teamId, recipient);
-    if (payerUserIds.includes(normalizedUid)) {
-      matchedRecipients.push(recipient);
+  const parentPlayerKeys = await loadFeeAssignmentUserParentPlayerKeys(normalizedUid);
+  if (parentPlayerKeys.size) {
+    const fallbackPlayerKey = getFeeAssignmentRecipientPlayerKey(teamId, fallbackRecipient || {});
+    if (!fallbackPlayerKey || parentPlayerKeys.has(fallbackPlayerKey)) {
+      const matchedRecipients = (Array.isArray(recipients) ? recipients : [])
+        .filter((recipient) => parentPlayerKeys.has(getFeeAssignmentRecipientPlayerKey(teamId, recipient)));
+      if (matchedRecipients.length) {
+        return matchedRecipients;
+      }
     }
   }
-  return matchedRecipients.length ? matchedRecipients : (fallbackRecipient ? [fallbackRecipient] : []);
+  return fallbackRecipient ? [fallbackRecipient] : [];
 }
 
 function combineDirectNotificationResults(results = []) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -6564,10 +6564,10 @@ function buildCombinedFeeAssignmentNotificationPayload(recipients = []) {
     const recipient = normalizedRecipients[0] || {};
     const title = String(recipient.feeTitle || recipient.title || 'Team fee').trim();
     const amountCents = getTeamFeeBalanceCents(recipient) || Number(recipient.amountCents || recipient.feeAmountCents || 0);
-    const amountDisplay = amountCents > 0 ? formatMoneyFromCents(amountCents, recipient.currency || 'USD') : '';
+    const amountDisplay = amountCents > 0 ? ` (${formatMoneyFromCents(amountCents, recipient.currency || 'USD')})` : '';
     return {
-      title: `New fee assigned: ${title}${amountDisplay ? ` (${amountDisplay})` : ''}`,
-      body: buildFeeAssignmentNotificationBody(recipient, amountDisplay)
+      title: `New fee assigned: ${title}${amountDisplay}`,
+      body: buildFeeAssignmentNotificationBody(recipient, amountDisplay ? amountDisplay.slice(2, -1) : '')
     };
   }
 
@@ -7817,7 +7817,7 @@ exports.notifyFeeAssigned = functions.firestore
     })));
     const claimedUserIds = new Set(claimResults.filter((result) => result.claimed).map((result) => result.uid));
     if (!claimedUserIds.size) return null;
-    const claimedTargets = payerTargets.filter((target) => claimedUserIds.has(target.uid));
+    const claimedPayerTargets = payerTargets.filter((target) => claimedUserIds.has(target.uid));
     const batchRecipients = await listFeeAssignmentBatchRecipients({
       teamId,
       batchId,
@@ -7828,17 +7828,32 @@ exports.notifyFeeAssigned = functions.firestore
     try {
       const sendResults = [];
       for (const uid of claimedUserIds) {
-        const targetsForUser = claimedTargets.filter((target) => String(target.uid || '').trim() === uid);
-        if (!targetsForUser.length) continue;
+        const claimedTargets = claimedPayerTargets.filter((target) => String(target.uid || '').trim() === uid);
+        if (!claimedTargets.length) continue;
         const recipientsForUser = await filterFeeAssignmentRecipientsForUser({
           teamId,
           uid,
           recipients: batchRecipients,
           fallbackRecipient: data
         });
+        if (recipientsForUser.length <= 1) {
+          const data = recipientsForUser[0] || {};
+          const title = String(data.feeTitle || data.title || 'Team fee').trim();
+          const amountCents = getTeamFeeBalanceCents(data) || Number(data.amountCents || data.feeAmountCents || 0);
+          const amountDisplay = amountCents > 0 ? ` (${formatMoneyFromCents(amountCents, data.currency || 'USD')})` : '';
+          sendResults.push(await sendDirectTargetsNotification({
+            targets: claimedTargets,
+            category: 'fees',
+            title: `New fee assigned: ${title}${amountDisplay}`,
+            body: buildFeeAssignmentNotificationBody(data, amountDisplay ? amountDisplay.slice(2, -1) : ''),
+            teamId,
+            batchId
+          }));
+          continue;
+        }
         const payload = buildCombinedFeeAssignmentNotificationPayload(recipientsForUser);
         sendResults.push(await sendDirectTargetsNotification({
-          targets: targetsForUser,
+          targets: claimedTargets,
           category: 'fees',
           title: payload.title,
           body: payload.body,

--- a/functions/index.js
+++ b/functions/index.js
@@ -6537,6 +6537,131 @@ function buildFeeAssignmentNotificationBody(recipient = {}, amountDisplay = '') 
   return `${parts.join(', ')}.`;
 }
 
+function getFeeAssignmentRecipientName(recipient = {}) {
+  return String(
+    recipient.playerName ||
+    recipient.childName ||
+    recipient.participantName ||
+    recipient.athleteName ||
+    recipient.name ||
+    ''
+  ).trim();
+}
+
+function joinDisplayValues(values = []) {
+  const uniqueValues = Array.from(new Set(
+    values.map((value) => String(value || '').trim()).filter(Boolean)
+  ));
+  if (uniqueValues.length <= 1) return uniqueValues[0] || '';
+  if (uniqueValues.length === 2) return `${uniqueValues[0]} and ${uniqueValues[1]}`;
+  return `${uniqueValues.slice(0, -1).join(', ')}, and ${uniqueValues[uniqueValues.length - 1]}`;
+}
+
+function buildCombinedFeeAssignmentNotificationPayload(recipients = []) {
+  const normalizedRecipients = (Array.isArray(recipients) ? recipients : [])
+    .filter((recipient) => recipient && typeof recipient === 'object');
+  if (normalizedRecipients.length <= 1) {
+    const recipient = normalizedRecipients[0] || {};
+    const title = String(recipient.feeTitle || recipient.title || 'Team fee').trim();
+    const amountCents = getTeamFeeBalanceCents(recipient) || Number(recipient.amountCents || recipient.feeAmountCents || 0);
+    const amountDisplay = amountCents > 0 ? formatMoneyFromCents(amountCents, recipient.currency || 'USD') : '';
+    return {
+      title: `New fee assigned: ${title}${amountDisplay ? ` (${amountDisplay})` : ''}`,
+      body: buildFeeAssignmentNotificationBody(recipient, amountDisplay)
+    };
+  }
+
+  const titles = Array.from(new Set(
+    normalizedRecipients
+      .map((recipient) => String(recipient.feeTitle || recipient.title || '').trim())
+      .filter(Boolean)
+  ));
+  const title = titles.length === 1 ? titles[0] : `${normalizedRecipients.length} team fees`;
+  const currency = normalizedRecipients.find((recipient) => recipient.currency)?.currency || 'USD';
+  const totalAmountCents = normalizedRecipients.reduce((total, recipient) => {
+    return total + (getTeamFeeBalanceCents(recipient) || Number(recipient.amountCents || recipient.feeAmountCents || 0));
+  }, 0);
+  const amountDisplay = totalAmountCents > 0 ? formatMoneyFromCents(totalAmountCents, currency) : '';
+  const names = normalizedRecipients.map(getFeeAssignmentRecipientName).filter(Boolean);
+  const dueDateDisplay = joinDisplayValues(
+    normalizedRecipients.map((recipient) => formatFeeAssignmentDueDate(recipient.dueDate || recipient.dueAt || recipient.deadline))
+  );
+  const childDisplay = names.length ? joinDisplayValues(names) : `${normalizedRecipients.length} children`;
+  const bodyParts = [
+    amountDisplay
+      ? `${amountDisplay} has been assigned for ${childDisplay}`
+      : `${normalizedRecipients.length} fees have been assigned for ${childDisplay}`
+  ];
+  if (dueDateDisplay) {
+    bodyParts.push(`due ${dueDateDisplay}`);
+  }
+  return {
+    title: `New fees assigned: ${title}${amountDisplay ? ` (${amountDisplay} total)` : ''}`,
+    body: `${bodyParts.join(', ')}.`
+  };
+}
+
+async function listFeeAssignmentBatchRecipients({ teamId, batchId, recipientId, recipient }) {
+  let recipients = [];
+  try {
+    const snap = await firestore.collection(`teams/${teamId}/feeBatches/${batchId}/feeRecipients`).get();
+    recipients = snap.docs
+      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
+      .filter((entry) => entry && typeof entry === 'object');
+  } catch (error) {
+    functions.logger.warn('Failed to read fee assignment batch recipients; falling back to current recipient.', {
+      teamId,
+      batchId,
+      recipientId,
+      error: error?.message || error
+    });
+  }
+
+  if (recipientId && !recipients.some((entry) => String(entry.id || '') === String(recipientId))) {
+    recipients.push({ id: recipientId, ...(recipient || {}) });
+  }
+  if (!recipients.length && recipient) {
+    recipients.push({ id: recipientId || null, ...recipient });
+  }
+  return recipients;
+}
+
+async function filterFeeAssignmentRecipientsForUser({ teamId, uid, recipients, fallbackRecipient }) {
+  const normalizedUid = String(uid || '').trim();
+  if (!normalizedUid) return fallbackRecipient ? [fallbackRecipient] : [];
+  const matchedRecipients = [];
+  for (const recipient of Array.isArray(recipients) ? recipients : []) {
+    const payerUserIds = await resolveFeeAssignmentPayerUserIds(teamId, recipient);
+    if (payerUserIds.includes(normalizedUid)) {
+      matchedRecipients.push(recipient);
+    }
+  }
+  return matchedRecipients.length ? matchedRecipients : (fallbackRecipient ? [fallbackRecipient] : []);
+}
+
+function combineDirectNotificationResults(results = []) {
+  const deliveredResults = (Array.isArray(results) ? results : []).filter(Boolean);
+  if (!deliveredResults.length) return null;
+  return deliveredResults.reduce((combined, result) => ({
+    responses: [
+      ...(combined.responses || []),
+      ...(Array.isArray(result.responses) ? result.responses : [])
+    ],
+    successCount: Number(combined.successCount || 0) + Number(result.successCount || 0),
+    failureCount: Number(combined.failureCount || 0) + Number(result.failureCount || 0),
+    inboxWriteCount: Number(combined.inboxWriteCount || 0) + Number(result.inboxWriteCount || 0),
+    inboxCleanupCount: Number(combined.inboxCleanupCount || 0) + Number(result.inboxCleanupCount || 0),
+    inboxFailureCount: Number(combined.inboxFailureCount || 0) + Number(result.inboxFailureCount || 0)
+  }), {
+    responses: [],
+    successCount: 0,
+    failureCount: 0,
+    inboxWriteCount: 0,
+    inboxCleanupCount: 0,
+    inboxFailureCount: 0
+  });
+}
+
 async function resolveFeeAssignmentPayerUserIds(teamId, recipient = {}) {
   const playerId = resolveFeeRecipientPlayerId(teamId, recipient);
   const playerRef = playerId ? firestore.doc(`teams/${teamId}/players/${playerId}`) : null;
@@ -7693,20 +7818,35 @@ exports.notifyFeeAssigned = functions.firestore
     const claimedUserIds = new Set(claimResults.filter((result) => result.claimed).map((result) => result.uid));
     if (!claimedUserIds.size) return null;
     const claimedTargets = payerTargets.filter((target) => claimedUserIds.has(target.uid));
-
-    const title = String(data.feeTitle || data.title || 'Team fee').trim();
-    const amountCents = getTeamFeeBalanceCents(data) || Number(data.amountCents || data.feeAmountCents || 0);
-    const amountDisplay = amountCents > 0 ? ` (${formatMoneyFromCents(amountCents, data.currency || 'USD')})` : '';
+    const batchRecipients = await listFeeAssignmentBatchRecipients({
+      teamId,
+      batchId,
+      recipientId,
+      recipient: data
+    });
 
     try {
-      return await sendDirectTargetsNotification({
-        targets: claimedTargets,
-        category: 'fees',
-        title: `New fee assigned: ${title}${amountDisplay}`,
-        body: buildFeeAssignmentNotificationBody(data, amountDisplay ? amountDisplay.slice(2, -1) : ''),
-        teamId,
-        batchId
-      });
+      const sendResults = [];
+      for (const uid of claimedUserIds) {
+        const targetsForUser = claimedTargets.filter((target) => String(target.uid || '').trim() === uid);
+        if (!targetsForUser.length) continue;
+        const recipientsForUser = await filterFeeAssignmentRecipientsForUser({
+          teamId,
+          uid,
+          recipients: batchRecipients,
+          fallbackRecipient: data
+        });
+        const payload = buildCombinedFeeAssignmentNotificationPayload(recipientsForUser);
+        sendResults.push(await sendDirectTargetsNotification({
+          targets: targetsForUser,
+          category: 'fees',
+          title: payload.title,
+          body: payload.body,
+          teamId,
+          batchId
+        }));
+      }
+      return combineDirectNotificationResults(sendResults);
     } catch (error) {
       await releaseFeeAssignmentNotificationClaims({
         teamId,

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -545,7 +545,7 @@ test('notifyFeeAssigned resolves app-created child fee recipients through parent
     }
 });
 
-test('notifyFeeAssigned sends one batch assignment push when a parent has multiple recipients', async () => {
+test('notifyFeeAssigned sends one combined batch assignment push when a parent has multiple recipients', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },
         userDocs: {
@@ -557,22 +557,36 @@ test('notifyFeeAssigned sends one batch assignment push when a parent has multip
     });
 
     try {
+        const recipientA = {
+            playerKey: 'team-1::player-1',
+            childName: 'Avery',
+            feeTitle: 'Spring dues',
+            amountCents: 2500,
+            dueDate: '2026-07-01T12:00:00.000Z'
+        };
+        const recipientB = {
+            playerKey: 'team-1::player-2',
+            childName: 'Blake',
+            feeTitle: 'Spring dues',
+            amountCents: 2500,
+            dueDate: '2026-07-01T12:00:00.000Z'
+        };
+        const refA = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-a');
+        const refB = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-b');
+        await refA.set(recipientA);
+        await refB.set(recipientB);
         const contextA = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-a' } };
         const contextB = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-b' } };
 
-        const firstResult = await moduleExports.notifyFeeAssigned(makeSnapshot(
-            env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-a'),
-            { playerKey: 'team-1::player-1', feeTitle: 'Spring dues', amountCents: 2500 }
-        ), contextA);
-        const secondResult = await moduleExports.notifyFeeAssigned(makeSnapshot(
-            env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-b'),
-            { playerKey: 'team-1::player-2', feeTitle: 'Spring dues', amountCents: 2500 }
-        ), contextB);
+        const firstResult = await moduleExports.notifyFeeAssigned(makeSnapshot(refA, recipientA), contextA);
+        const secondResult = await moduleExports.notifyFeeAssigned(makeSnapshot(refB, recipientB), contextB);
 
         assert.equal(firstResult?.successCount, 1);
         assert.equal(secondResult, null);
         assert.equal(env.messagingCalls.length, 1);
         assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
+        assert.equal(env.messagingCalls[0].title, 'New fees assigned: Spring dues ($50.00 total)');
+        assert.equal(env.messagingCalls[0].body, '$50.00 has been assigned for Avery and Blake, due Jul 1, 2026.');
     } finally {
         cleanup();
     }

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -587,6 +587,8 @@ test('notifyFeeAssigned sends one combined batch assignment push when a parent h
         assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
         assert.equal(env.messagingCalls[0].title, 'New fees assigned: Spring dues ($50.00 total)');
         assert.equal(env.messagingCalls[0].body, '$50.00 has been assigned for Avery and Blake, due Jul 1, 2026.');
+        assert.equal(env.counts.parentQueries, 2);
+        assert.equal(env.counts.userRecordGets, 1);
     } finally {
         cleanup();
     }

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -473,6 +473,24 @@ function buildNotificationTestEnv({
             };
         }
 
+        const feeRecipientsMatch = path.match(/^teams\/([^/]+)\/feeBatches\/([^/]+)\/feeRecipients$/);
+        if (feeRecipientsMatch) {
+            return {
+                async get() {
+                    const prefix = `${path}/`;
+                    const docs = Array.from(docStore.entries())
+                        .filter(([docPath]) => docPath.startsWith(prefix) && !docPath.slice(prefix.length).includes('/'))
+                        .map(([docPath, data]) => makeDocSnapshot({
+                            id: docPath.slice(prefix.length),
+                            ref: doc(docPath),
+                            data,
+                            exists: true
+                        }));
+                    return makeQuerySnapshot(docs);
+                }
+            };
+        }
+
         const inboxMatch = path.match(/^users\/([^/]+)\/notificationInbox$/);
         if (inboxMatch) {
             return {

--- a/tests/unit/fee-assignment-notification-source-contract.test.js
+++ b/tests/unit/fee-assignment-notification-source-contract.test.js
@@ -9,9 +9,15 @@ describe('fee assignment notification source contract', () => {
         expect(functionsSource).toContain(".document('teams/{teamId}/feeBatches/{batchId}/feeRecipients/{recipientId}')");
         expect(functionsSource).toContain('const payerUserIds = await resolveFeeAssignmentPayerUserIds(teamId, data);');
         expect(functionsSource).toContain("const payerTargets = await getTargetsForCategoryUserIds(teamId, 'fees', payerUserIds, null);");
-        expect(functionsSource).toContain('targets: claimedTargets,');
+        expect(functionsSource).toContain('const batchRecipients = await listFeeAssignmentBatchRecipients({');
+        expect(functionsSource).toContain('for (const uid of claimedUserIds)');
+        expect(functionsSource).toContain('const targetsForUser = claimedTargets.filter');
+        expect(functionsSource).toContain('const recipientsForUser = await filterFeeAssignmentRecipientsForUser({');
+        expect(functionsSource).toContain('const payload = buildCombinedFeeAssignmentNotificationPayload(recipientsForUser);');
+        expect(functionsSource).toContain('targets: targetsForUser,');
         expect(functionsSource).toContain("category: 'fees',");
-        expect(functionsSource).toContain('title: `New fee assigned: ${title}${amountDisplay}`');
+        expect(functionsSource).toContain('title: payload.title');
+        expect(functionsSource).toContain('body: payload.body');
     });
 
     it('deduplicates assignment notifications by parent within a fee batch', () => {

--- a/tests/unit/fee-notification-contract.test.js
+++ b/tests/unit/fee-notification-contract.test.js
@@ -80,6 +80,28 @@ describe('fee notification contract', () => {
         });
     });
 
+    it('builds a combined assignment summary when one parent owes multiple distinct fees', () => {
+        const { buildCombinedFeeAssignmentNotificationPayload } = getFeeAssignmentNotificationHelpers();
+
+        expect(buildCombinedFeeAssignmentNotificationPayload([
+            {
+                childName: 'Avery',
+                feeTitle: 'Spring dues',
+                amountCents: 2500,
+                dueDate: '2026-07-01T12:00:00.000Z'
+            },
+            {
+                childName: 'Blake',
+                feeTitle: 'Tournament hotel',
+                amountCents: 4000,
+                dueDate: '2026-07-15T12:00:00.000Z'
+            }
+        ])).toEqual({
+            title: 'New fees assigned: 2 team fees ($65.00 total)',
+            body: '$65.00 has been assigned for Avery and Blake, due Jul 1, 2026 and Jul 15, 2026.'
+        });
+    });
+
     it('resolves app-created child fee recipients and collapses each batch to one payer push', () => {
         expect(functionsSource).toContain('async function resolveFeeAssignmentPayerUserIds(teamId, recipient = {})');
         expect(functionsSource).toContain('playerId: playerId || recipient.playerId || recipient.childId');

--- a/tests/unit/fee-notification-contract.test.js
+++ b/tests/unit/fee-notification-contract.test.js
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 const teamFeesCoreSource = readFileSync(new URL('../../functions/team-fees-core.cjs', import.meta.url), 'utf8');
 
-function getFeeAssignmentNotificationBodyHelper() {
+function getFeeAssignmentNotificationHelpers() {
     const start = functionsSource.indexOf('function formatFeeAssignmentDueDate(');
     const end = functionsSource.indexOf('\nasync function resolveFeeAssignmentPayerUserIds', start);
     const slice = functionsSource.slice(start, end);
@@ -16,9 +16,17 @@ function getFeeAssignmentNotificationBodyHelper() {
             });
         }
     };
-    return new Function('coerceDate', 'Intl', `${slice}; return buildFeeAssignmentNotificationBody;`)(
+    return new Function(
+        'coerceDate',
+        'Intl',
+        'getTeamFeeBalanceCents',
+        'formatMoneyFromCents',
+        `${slice}; return { buildFeeAssignmentNotificationBody, buildCombinedFeeAssignmentNotificationPayload };`
+    )(
         (value) => (value ? new Date(value) : null),
-        utcIntl
+        utcIntl,
+        (recipient = {}) => Number(recipient.balanceDueCents ?? recipient.remainingBalanceCents ?? recipient.amountCents ?? recipient.feeAmountCents ?? 0),
+        (cents) => `$${(Number(cents || 0) / 100).toFixed(2)}`
     );
 }
 
@@ -30,18 +38,46 @@ describe('fee notification contract', () => {
         expect(functionsSource).toContain('const payerUserIds = await resolveFeeAssignmentPayerUserIds(teamId, data);');
         expect(functionsSource).toContain("const payerTargets = await getTargetsForCategoryUserIds(teamId, 'fees', payerUserIds, null);");
         expect(functionsSource).toContain('claimFeeAssignmentNotificationUser({ teamId, batchId, recipientId, uid })');
-        expect(functionsSource).toContain("title: `New fee assigned: ${title}${amountDisplay}`");
-        expect(functionsSource).toContain('body: buildFeeAssignmentNotificationBody(data, amountDisplay ? amountDisplay.slice(2, -1) : \'\')');
+        expect(functionsSource).toContain('const batchRecipients = await listFeeAssignmentBatchRecipients({');
+        expect(functionsSource).toContain('for (const uid of claimedUserIds)');
+        expect(functionsSource).toContain('const recipientsForUser = await filterFeeAssignmentRecipientsForUser({');
+        expect(functionsSource).toContain('const payload = buildCombinedFeeAssignmentNotificationPayload(recipientsForUser);');
+        expect(functionsSource).toContain('targets: targetsForUser,');
+        expect(functionsSource).toContain('title: payload.title');
+        expect(functionsSource).toContain('body: payload.body');
+        expect(functionsSource).toContain('return combineDirectNotificationResults(sendResults);');
         expect(functionsSource).toContain('await releaseFeeAssignmentNotificationClaims({');
     });
 
     it('builds assigned-fee push copy with amount and due-date context', () => {
-        const buildFeeAssignmentNotificationBody = getFeeAssignmentNotificationBodyHelper();
+        const { buildFeeAssignmentNotificationBody } = getFeeAssignmentNotificationHelpers();
 
         expect(buildFeeAssignmentNotificationBody({
             dueDate: '2026-08-15T12:00:00.000Z'
         }, '$45.00')).toBe('$45.00 has been assigned, due Aug 15, 2026.');
         expect(buildFeeAssignmentNotificationBody({}, '')).toBe('A new team fee has been assigned.');
+    });
+
+    it('builds one combined assigned-fee push per parent for sibling recipients', () => {
+        const { buildCombinedFeeAssignmentNotificationPayload } = getFeeAssignmentNotificationHelpers();
+
+        expect(buildCombinedFeeAssignmentNotificationPayload([
+            {
+                childName: 'Avery',
+                feeTitle: 'Spring dues',
+                amountCents: 2500,
+                dueDate: '2026-07-01T12:00:00.000Z'
+            },
+            {
+                childName: 'Blake',
+                feeTitle: 'Spring dues',
+                amountCents: 2500,
+                dueDate: '2026-07-01T12:00:00.000Z'
+            }
+        ])).toEqual({
+            title: 'New fees assigned: Spring dues ($50.00 total)',
+            body: '$50.00 has been assigned for Avery and Blake, due Jul 1, 2026.'
+        });
     });
 
     it('resolves app-created child fee recipients and collapses each batch to one payer push', () => {


### PR DESCRIPTION
## Summary
- Build parent-specific fee assignment notification summaries from all recipient docs in the created batch
- Keep one assignment claim per parent so later recipient triggers do not duplicate the push
- Extend notification trigger tests to cover combined copy for one parent with multiple children

Closes #2663

## Tests
- npm run test:notifications --prefix functions