### PR TITLE
[codex] Extract staff RSVP panels

### DIFF
--- a/apps/app/src/components/schedule/AvailabilityPanels.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.tsx
@@ -38,6 +38,11 @@ export function getAvailabilityNoteSaveState(rsvp: RsvpResponse, availabilityNot
   };
 }
 
+export function formatRsvpSummary(summary?: { going?: number; maybe?: number; notGoing?: number; notResponded?: number } | null) {
+  if (!summary) return 'No RSVPs yet';
+  return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} out · ${summary.notResponded || 0} missing`;
+}
+
 export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit }: {
   event: ParentScheduleEvent;
   rsvp: RsvpResponse;

--- a/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx
@@ -1,0 +1,79 @@
+import { StaffRsvpPlayerRow } from './StaffRsvpPlayerRow';
+import {
+  formatRsvpSummary,
+  rsvpBadgeClasses,
+  rsvpLabels
+} from './AvailabilityPanels';
+import { useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
+import type { StaffRsvpOverrideStatus } from '../../hooks/schedule/useStaffRsvpBreakdown';
+import type { StaffScheduleRsvpBreakdown, StaffScheduleRsvpRow } from '../../lib/scheduleService';
+import type { RsvpResponse } from '../../lib/scheduleLogic';
+
+export function StaffRsvpBreakdownPanel({ breakdown, loading, error, submittingPlayerId, status, onOverride }: {
+  breakdown: StaffScheduleRsvpBreakdown | null;
+  loading: boolean;
+  error: string | null;
+  submittingPlayerId: string | null;
+  status: StaffRsvpOverrideStatus | null;
+  onOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
+}) {
+  const { event } = useScheduleEventDetailContext();
+
+  if (!event.isTeamAdmin || !event.isDbGame) return null;
+  if (loading && !breakdown) {
+    return <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-sm font-semibold text-gray-600">Loading team RSVP breakdown…</div>;
+  }
+  if (error && !breakdown) {
+    return <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm font-semibold text-rose-700">{error}</div>;
+  }
+  if (!breakdown) return null;
+
+  return (
+    <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Staff RSVP overrides</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">Review every player, including no response, and update availability inline.</div>
+        </div>
+        <span className="inline-flex min-h-8 items-center rounded-full border border-primary-100 bg-primary-50 px-3 text-xs font-black text-primary-700">
+          {formatRsvpSummary(breakdown.counts)}
+        </span>
+      </div>
+      <div className="mt-3 space-y-3">
+        {(['not_responded', 'going', 'maybe', 'not_going'] as const).map((responseKey) => {
+          const rows = breakdown.grouped[responseKey];
+          if (!rows.length) return null;
+          return (
+            <div key={responseKey}>
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">{rsvpLabels[responseKey]}</div>
+                <span className={`rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[responseKey]}`}>
+                  {rows.length}
+                </span>
+              </div>
+              <div className="space-y-2">
+                {rows.map((player) => {
+                  const inlineStatus = status?.playerId === player.playerId ? status : null;
+                  const busy = submittingPlayerId === player.playerId;
+                  return (
+                    <StaffRsvpPlayerRow
+                      key={player.playerId}
+                      eventLocked={event.isCancelled || event.availabilityLocked === true}
+                      player={player}
+                      submitting={busy}
+                      status={inlineStatus}
+                      onOverride={onOverride}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {error && breakdown ? <div className="mt-3 text-xs font-bold text-rose-700">{error}</div> : null}
+      {event.isCancelled ? <div className="mt-3 text-xs font-semibold text-gray-500">Cancelled events cannot be updated.</div> : null}
+      {event.availabilityLocked ? <div className="mt-3 text-xs font-semibold text-amber-700">Availability is locked for this event.</div> : null}
+    </div>
+  );
+}

--- a/apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    loadStaffRsvpReminderPreview,
+    sendStaffRsvpReminder
+} from '../../lib/scheduleService';
+import { ScheduleEventDetailProvider } from '../../pages/schedule/ScheduleEventDetailContext';
+import { StaffRsvpReminderPanel } from './StaffRsvpReminderPanel';
+import type { AuthState } from '../../lib/types';
+
+vi.mock('../../lib/scheduleService', () => ({
+    loadStaffRsvpReminderPreview: vi.fn(),
+    sendStaffRsvpReminder: vi.fn()
+}));
+
+const auth: AuthState = {
+    user: {
+        uid: 'coach-1',
+        email: 'coach@example.com',
+        displayName: 'Coach One'
+    } as any,
+    profile: { displayName: 'Coach One' },
+    loading: false,
+    error: null,
+    roles: [],
+    isParent: false,
+    isCoach: true,
+    isAdmin: true,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn()
+};
+
+const preview = {
+    missingPlayerCount: 2,
+    eligibleEmailCount: 3,
+    players: [
+        { playerId: 'player-1', playerName: 'Avery Smith', parentEmails: ['one@example.com'] },
+        { playerId: 'player-2', playerName: 'Blake Jones', parentEmails: ['two@example.com'] }
+    ]
+} as any;
+
+function buildEvent(overrides: Record<string, unknown> = {}) {
+    return {
+        eventKey: 'team-1::game-1::player-1',
+        id: 'game-1',
+        teamId: 'team-1',
+        childId: 'player-1',
+        childName: 'Avery Smith',
+        isDbGame: true,
+        isCancelled: false,
+        isTeamRsvpReminderManager: true,
+        ...overrides
+    } as any;
+}
+
+function renderPanel(eventOverrides: Record<string, unknown> = {}) {
+    return render(
+        <ScheduleEventDetailProvider
+            value={{
+                auth,
+                event: buildEvent(eventOverrides),
+                childEvents: [buildEvent(eventOverrides)],
+                refreshEvent: vi.fn(),
+                updateEvents: vi.fn()
+            }}
+        >
+            <StaffRsvpReminderPanel />
+        </ScheduleEventDetailProvider>
+    );
+}
+
+describe('StaffRsvpReminderPanel', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+    });
+
+    it('loads reminder preview and sends a confirmed reminder', async () => {
+        vi.mocked(loadStaffRsvpReminderPreview).mockResolvedValue(preview);
+        vi.mocked(sendStaffRsvpReminder).mockResolvedValue({
+            ...preview,
+            emailSentCount: 3
+        });
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+        renderPanel();
+
+        await waitFor(() => {
+            expect(screen.getByText('Staff RSVP reminder')).toBeTruthy();
+        });
+        expect(screen.getByText('2 no-response players · 3 eligible parent/guardian emails.')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Send reminder' }));
+
+        await waitFor(() => {
+            expect(sendStaffRsvpReminder).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user, auth.profile);
+        });
+        expect(screen.getByText('RSVP reminder sent to team chat and 3 parent/guardian emails.')).toBeTruthy();
+    });
+
+    it('does not render when there are no missing player RSVPs', async () => {
+        vi.mocked(loadStaffRsvpReminderPreview).mockResolvedValue({
+            ...preview,
+            missingPlayerCount: 0
+        });
+
+        renderPanel();
+
+        await waitFor(() => {
+            expect(loadStaffRsvpReminderPreview).toHaveBeenCalled();
+        });
+        expect(screen.queryByText('Staff RSVP reminder')).toBeNull();
+    });
+});

--- a/apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  loadStaffRsvpReminderPreview,
+  sendStaffRsvpReminder,
+  type StaffRsvpReminderSendResult
+} from '../../lib/scheduleService';
+import { type StaffRsvpReminderPreview } from '../../lib/scheduleLogic';
+import { useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
+
+export function StaffRsvpReminderPanel({ refreshToken = 0 }: { refreshToken?: number }) {
+  const { auth, event } = useScheduleEventDetailContext();
+  const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);
+
+  const refreshPreview = useCallback(async () => {
+    if (!auth.user || !canLoad) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setPreview(await loadStaffRsvpReminderPreview(event, auth.user));
+    } catch (loadError: any) {
+      setError(loadError?.message || 'Unable to load RSVP reminder preview.');
+      setPreview(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [auth.user, canLoad, event.eventKey, event.teamId, event.id]);
+
+  useEffect(() => {
+    setStatus(null);
+    if (canLoad) {
+      refreshPreview();
+    } else {
+      setPreview(null);
+    }
+  }, [canLoad, refreshPreview, refreshToken]);
+
+  if (!event.isTeamRsvpReminderManager || !event.isDbGame || event.isCancelled) return null;
+  if (loading && !preview) {
+    return <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-sm font-semibold text-gray-600">Loading staff RSVP reminder preview…</div>;
+  }
+  if (!preview || preview.missingPlayerCount <= 0) return null;
+
+  const sendReminder = async () => {
+    if (!auth.user || sending) return;
+    const confirmed = window.confirm(`Send an RSVP reminder to ${preview.missingPlayerCount} no-response ${preview.missingPlayerCount === 1 ? 'player' : 'players'}? ${preview.eligibleEmailCount} eligible parent/guardian ${preview.eligibleEmailCount === 1 ? 'email' : 'emails'} will be targeted.`);
+    if (!confirmed) return;
+    setSending(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});
+      setPreview(result);
+      setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? 'email' : 'emails'}.`);
+    } catch (sendError: any) {
+      setError(sendError?.message || 'Unable to send RSVP reminder.');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 rounded-xl border border-primary-200 bg-primary-50 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Staff RSVP reminder</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">
+            {preview.missingPlayerCount} no-response {preview.missingPlayerCount === 1 ? 'player' : 'players'} · {preview.eligibleEmailCount} eligible parent/guardian {preview.eligibleEmailCount === 1 ? 'email' : 'emails'}.
+          </div>
+        </div>
+        <button
+          type="button"
+          className="primary-button min-h-9 flex-none px-3 text-xs"
+          disabled={sending || loading}
+          onClick={sendReminder}
+        >
+          {sending ? 'Sending…' : 'Send reminder'}
+        </button>
+      </div>
+      {status ? <div className="mt-2 text-xs font-bold text-emerald-700">{status}</div> : null}
+      {error ? <div className="mt-2 text-xs font-bold text-rose-700">{error}</div> : null}
+    </div>
+  );
+}

--- a/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx
+++ b/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import {
+    loadStaffScheduleRsvpBreakdown,
+    submitStaffScheduleRsvpOverride,
+    type StaffScheduleRsvpBreakdown,
+    type StaffScheduleRsvpRow
+} from '../../lib/scheduleService';
+import { ScheduleEventDetailProvider, useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
+import { useStaffRsvpBreakdown } from './useStaffRsvpBreakdown';
+import type { AuthState } from '../../lib/types';
+
+vi.mock('../../lib/scheduleService', () => ({
+    loadStaffScheduleRsvpBreakdown: vi.fn(),
+    submitStaffScheduleRsvpOverride: vi.fn()
+}));
+
+const auth: AuthState = {
+    user: {
+        uid: 'coach-1',
+        email: 'coach@example.com',
+        displayName: 'Coach One'
+    } as any,
+    profile: null,
+    loading: false,
+    error: null,
+    roles: [],
+    isParent: false,
+    isCoach: true,
+    isAdmin: true,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn()
+};
+
+const playerRow: StaffScheduleRsvpRow = {
+    playerId: 'player-1',
+    playerName: 'Avery Smith',
+    playerNumber: '7',
+    response: 'not_responded',
+    note: ''
+};
+
+function buildBreakdown(response: StaffScheduleRsvpRow['response'], counts: StaffScheduleRsvpBreakdown['counts']): StaffScheduleRsvpBreakdown {
+    const row = { ...playerRow, response };
+    return {
+        counts,
+        grouped: {
+            not_responded: response === 'not_responded' ? [row] : [],
+            going: response === 'going' ? [row] : [],
+            maybe: response === 'maybe' ? [row] : [],
+            not_going: response === 'not_going' ? [row] : []
+        }
+    };
+}
+
+function buildEvent(overrides: Record<string, unknown> = {}) {
+    return {
+        eventKey: 'team-1::game-1::player-1',
+        id: 'game-1',
+        teamId: 'team-1',
+        childId: 'player-1',
+        childName: 'Avery Smith',
+        isDbGame: true,
+        isCancelled: false,
+        isTeamAdmin: true,
+        availabilityLocked: false,
+        myRsvp: 'not_responded',
+        rsvpSummary: { going: 0, maybe: 0, notGoing: 0, notResponded: 1, total: 1 },
+        ...overrides
+    } as any;
+}
+
+function StaffRsvpProbe() {
+    const workflow = useStaffRsvpBreakdown();
+    const { event } = useScheduleEventDetailContext();
+
+    return (
+        <div>
+            <div data-testid="loading">{String(workflow.loading)}</div>
+            <div data-testid="row-count">{String(Object.values(workflow.breakdown?.grouped || {}).flat().length)}</div>
+            <div data-testid="current-rsvp">{String(event.myRsvp)}</div>
+            <div data-testid="summary-going">{String(event.rsvpSummary?.going || 0)}</div>
+            <div data-testid="submitting">{String(workflow.submittingPlayerId || '')}</div>
+            <div data-testid="refresh-token">{String(workflow.refreshToken)}</div>
+            <div>{workflow.status?.message || ''}</div>
+            <div>{workflow.error || ''}</div>
+            <button type="button" onClick={() => workflow.submitOverride(playerRow, 'going')}>Mark going</button>
+        </div>
+    );
+}
+
+function renderProbe(eventOverrides: Record<string, unknown> = {}) {
+    function Harness() {
+        const [events, setEvents] = useState([buildEvent(eventOverrides)]);
+
+        return (
+            <ScheduleEventDetailProvider
+                value={{
+                    auth,
+                    event: events[0],
+                    childEvents: events,
+                    refreshEvent: vi.fn(),
+                    updateEvents: (updater) => setEvents((current) => updater(current))
+                }}
+            >
+                <StaffRsvpProbe />
+            </ScheduleEventDetailProvider>
+        );
+    }
+
+    return render(<Harness />);
+}
+
+describe('useStaffRsvpBreakdown', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('loads the staff RSVP breakdown for team admins', async () => {
+        vi.mocked(loadStaffScheduleRsvpBreakdown).mockResolvedValue(buildBreakdown('not_responded', {
+            going: 0,
+            maybe: 0,
+            notGoing: 0,
+            notResponded: 1,
+            total: 1
+        }));
+
+        renderProbe();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('row-count').textContent).toBe('1');
+        });
+        expect(loadStaffScheduleRsvpBreakdown).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user);
+        expect(screen.getByTestId('loading').textContent).toBe('false');
+    });
+
+    it('submits an override, updates selected player state, and exposes reminder refresh status', async () => {
+        vi.mocked(loadStaffScheduleRsvpBreakdown)
+            .mockResolvedValueOnce(buildBreakdown('not_responded', {
+                going: 0,
+                maybe: 0,
+                notGoing: 0,
+                notResponded: 1,
+                total: 1
+            }))
+            .mockResolvedValue(buildBreakdown('going', {
+                going: 1,
+                maybe: 0,
+                notGoing: 0,
+                notResponded: 0,
+                total: 1
+            }));
+        vi.mocked(submitStaffScheduleRsvpOverride).mockResolvedValue({ going: 1, maybe: 0, notGoing: 0, notResponded: 0, total: 1 } as any);
+
+        renderProbe();
+
+        await waitFor(() => {
+            expect(screen.getByTestId('row-count').textContent).toBe('1');
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Mark going' }));
+
+        await waitFor(() => {
+            expect(submitStaffScheduleRsvpOverride).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user, 'player-1', 'going');
+        });
+        await waitFor(() => {
+            expect(screen.getByText('Avery Smith marked going.')).toBeTruthy();
+        });
+        expect(screen.getByTestId('current-rsvp').textContent).toBe('going');
+        expect(screen.getByTestId('summary-going').textContent).toBe('1');
+        expect(screen.getByTestId('refresh-token').textContent).toBe('1');
+        expect(screen.getByTestId('submitting').textContent).toBe('');
+    });
+
+    it('does not load staff RSVP data when the event is not staff manageable', async () => {
+        renderProbe({ isTeamAdmin: false });
+
+        await waitFor(() => {
+            expect(loadStaffScheduleRsvpBreakdown).not.toHaveBeenCalled();
+        });
+        expect(screen.getByTestId('row-count').textContent).toBe('0');
+    });
+});

--- a/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts
+++ b/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  loadStaffScheduleRsvpBreakdown,
+  submitStaffScheduleRsvpOverride,
+  type StaffScheduleRsvpBreakdown,
+  type StaffScheduleRsvpRow
+} from '../../lib/scheduleService';
+import { type RsvpResponse } from '../../lib/scheduleLogic';
+import { rsvpLabels } from '../../components/schedule/AvailabilityPanels';
+import { useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
+
+export type StaffRsvpOverrideStatus = {
+  tone: 'success' | 'error';
+  playerId: string;
+  message: string;
+};
+
+export function useStaffRsvpBreakdown() {
+  const { auth, event, updateEvents } = useScheduleEventDetailContext();
+  const [breakdown, setBreakdown] = useState<StaffScheduleRsvpBreakdown | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [submittingPlayerId, setSubmittingPlayerId] = useState<string | null>(null);
+  const [status, setStatus] = useState<StaffRsvpOverrideStatus | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  const refreshBreakdown = useCallback(async (showLoading = true) => {
+    if (!auth.user || !event.isTeamAdmin || !event.isDbGame) {
+      setBreakdown(null);
+      setError(null);
+      return null;
+    }
+    if (showLoading) setLoading(true);
+    setError(null);
+    try {
+      const nextBreakdown = await loadStaffScheduleRsvpBreakdown(event, auth.user);
+      setBreakdown(nextBreakdown);
+      return nextBreakdown;
+    } catch (loadError: any) {
+      setBreakdown(null);
+      setError(loadError?.message || 'Unable to load staff RSVP breakdown.');
+      return null;
+    } finally {
+      if (showLoading) setLoading(false);
+    }
+  }, [auth.user, event.eventKey, event.teamId, event.id, event.isTeamAdmin, event.isDbGame]);
+
+  useEffect(() => {
+    setStatus(null);
+    setSubmittingPlayerId(null);
+    if (!event.isTeamAdmin || !event.isDbGame) {
+      setBreakdown(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    refreshBreakdown();
+  }, [refreshBreakdown, event.eventKey]);
+
+  const submitOverride = async (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => {
+    if (!auth.user) return;
+    setSubmittingPlayerId(player.playerId);
+    setStatus(null);
+    setError(null);
+    try {
+      await submitStaffScheduleRsvpOverride(event, auth.user, player.playerId, response);
+      const nextBreakdown = await refreshBreakdown(false);
+      if (nextBreakdown) {
+        updateEvents((current) => current.map((currentEvent) => {
+          if (currentEvent.teamId !== event.teamId || currentEvent.id !== event.id) return currentEvent;
+          return {
+            ...currentEvent,
+            myRsvp: currentEvent.childId === player.playerId ? response : currentEvent.myRsvp,
+            rsvpSummary: nextBreakdown.counts
+          };
+        }));
+      }
+      setRefreshToken((current) => current + 1);
+      setStatus({ tone: 'success', playerId: player.playerId, message: `${player.playerName} marked ${rsvpLabels[response].toLowerCase()}.` });
+    } catch (submitError: any) {
+      setStatus({ tone: 'error', playerId: player.playerId, message: submitError?.message || 'Unable to update player RSVP.' });
+    } finally {
+      setSubmittingPlayerId(null);
+    }
+  };
+
+  return {
+    breakdown,
+    loading,
+    error,
+    submittingPlayerId,
+    status,
+    refreshToken,
+    submitOverride
+  };
+}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -20,14 +20,10 @@ import {
   loadParentScheduleEventDetail,
   resolveCachedParentScheduleEvents,
   loadParentScheduleAssignments,
-  loadStaffScheduleRsvpBreakdown,
-  loadStaffRsvpReminderPreview,
   loadAutoFilledLineupDraftPreviewForApp,
   markParentPracticePacketComplete,
   publishGamePlanForApp,
   releaseParentScheduleAssignmentClaim,
-  sendStaffRsvpReminder,
-  submitStaffScheduleRsvpOverride,
   loadHomeScoringPlayers,
   publishLiveScoreUpdateEvent,
   recordPlayerGameStat,
@@ -50,9 +46,6 @@ import {
   type StaffPracticePacketBlock,
   type ParentPracticePacket,
   type ParentPracticePacketChild,
-  type StaffScheduleRsvpBreakdown,
-  type StaffScheduleRsvpRow,
-  type StaffRsvpReminderSendResult,
   type ScheduleHomeScoringPlayer,
   type PlayerGameStatResult,
   type LineupDraftPreviewResult
@@ -96,11 +89,13 @@ import { DateTile } from '../components/schedule/DateTile';
 import { EventBrief } from '../components/schedule/EventBrief';
 import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';
 import { EventSectionNav } from '../components/schedule/EventSectionNav';
-import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';
+import { StaffRsvpBreakdownPanel } from '../components/schedule/StaffRsvpBreakdownPanel';
+import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';
 import {
   AttentionPanel,
   AvailabilityNotesList,
   QuickAvailabilityPanel,
+  formatRsvpSummary,
   getAvailabilityNoteSaveState,
   rsvpBadgeClasses,
   rsvpLabels,
@@ -128,7 +123,6 @@ import {
   type PracticePacketCompletion,
   type RsvpResponse,
   type ScheduleAssignment,
-  type StaffRsvpReminderPreview,
   type ScheduleRideOffer
 } from '../lib/scheduleLogic';
 // Type-only imports for deferred modules — runtime values loaded on demand below
@@ -159,6 +153,7 @@ function loadLiveGameReactionsModule() {
 import type { AuthState } from '../lib/types';
 import { ScheduleEventDetailProvider } from './schedule/ScheduleEventDetailContext';
 import { useScheduleEventRsvp } from '../hooks/schedule/useScheduleEventRsvp';
+import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';
 import { useScheduleRideOffers } from '../hooks/schedule/useScheduleRideOffers';
 
 export { getAvailabilityNoteSaveState } from '../components/schedule/AvailabilityPanels';
@@ -277,12 +272,6 @@ type ActiveLiveReaction = LiveGameReaction & {
   emoji: string;
 };
 
-type StaffRsvpOverrideStatus = {
-  tone: 'success' | 'error';
-  playerId: string;
-  message: string;
-};
-
 export function shouldPersistLineupDraft(user: AuthState['user'] | null | undefined, formationId: string, _lineups: Record<string, string>) {
   return Boolean(user?.uid && String(formationId || '').trim());
 }
@@ -304,12 +293,6 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const [activeSection, setActiveSection] = useState<EventDetailSectionId>(() => parseEventDetailSection(searchParams.get('section')));
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [availabilityNote, setAvailabilityNote] = useState('');
-  const [staffRsvpBreakdown, setStaffRsvpBreakdown] = useState<StaffScheduleRsvpBreakdown | null>(null);
-  const [staffRsvpLoading, setStaffRsvpLoading] = useState(false);
-  const [staffRsvpError, setStaffRsvpError] = useState<string | null>(null);
-  const [staffRsvpSubmittingPlayerId, setStaffRsvpSubmittingPlayerId] = useState<string | null>(null);
-  const [staffRsvpStatus, setStaffRsvpStatus] = useState<StaffRsvpOverrideStatus | null>(null);
-  const [staffRsvpRefreshToken, setStaffRsvpRefreshToken] = useState(0);
   const [initialLoadPending, setInitialLoadPending] = useState(true);
   const hasLoadedEventRef = useRef(false);
   const { loading, error, clearError, setError, run: runPrimaryLoad } = useAsyncOperation();
@@ -422,39 +405,6 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     setAvailabilityNote(selectedEvent?.myRsvpNote || '');
   }, [selectedEvent?.eventKey, selectedEvent?.myRsvpNote]);
 
-  const refreshStaffRsvpBreakdown = useCallback(async (showLoading = true) => {
-    if (!auth.user || !selectedEvent?.isTeamAdmin || !selectedEvent.isDbGame) {
-      setStaffRsvpBreakdown(null);
-      setStaffRsvpError(null);
-      return null;
-    }
-    if (showLoading) setStaffRsvpLoading(true);
-    setStaffRsvpError(null);
-    try {
-      const breakdown = await loadStaffScheduleRsvpBreakdown(selectedEvent, auth.user);
-      setStaffRsvpBreakdown(breakdown);
-      return breakdown;
-    } catch (loadError: any) {
-      setStaffRsvpBreakdown(null);
-      setStaffRsvpError(loadError?.message || 'Unable to load staff RSVP breakdown.');
-      return null;
-    } finally {
-      if (showLoading) setStaffRsvpLoading(false);
-    }
-  }, [auth.user, selectedEvent]);
-
-  useEffect(() => {
-    setStaffRsvpStatus(null);
-    setStaffRsvpSubmittingPlayerId(null);
-    if (!selectedEvent?.isTeamAdmin || !selectedEvent.isDbGame) {
-      setStaffRsvpBreakdown(null);
-      setStaffRsvpError(null);
-      setStaffRsvpLoading(false);
-      return;
-    }
-    refreshStaffRsvpBreakdown();
-  }, [refreshStaffRsvpBreakdown, selectedEvent?.eventKey]);
-
   const updateEvents = useCallback((updater: (current: ParentScheduleEvent[]) => ParentScheduleEvent[]) => {
     setEvents((current) => updater(current));
   }, []);
@@ -538,33 +488,6 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
         : event
     )));
   }, [decodedEventId, decodedTeamId]);
-
-  const submitStaffRsvpOverride = async (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => {
-    if (!auth.user || !selectedEvent) return;
-    setStaffRsvpSubmittingPlayerId(player.playerId);
-    setStaffRsvpStatus(null);
-    setStaffRsvpError(null);
-    try {
-      await submitStaffScheduleRsvpOverride(selectedEvent, auth.user, player.playerId, response);
-      const breakdown = await refreshStaffRsvpBreakdown(false);
-      if (breakdown) {
-        setEvents((current) => current.map((event) => {
-          if (event.teamId !== selectedEvent.teamId || event.id !== selectedEvent.id) return event;
-          return {
-            ...event,
-            myRsvp: event.childId === player.playerId ? response : event.myRsvp,
-            rsvpSummary: breakdown.counts
-          };
-        }));
-      }
-      setStaffRsvpRefreshToken((current) => current + 1);
-      setStaffRsvpStatus({ tone: 'success', playerId: player.playerId, message: `${player.playerName} marked ${rsvpLabels[response].toLowerCase()}.` });
-    } catch (submitError: any) {
-      setStaffRsvpStatus({ tone: 'error', playerId: player.playerId, message: submitError?.message || 'Unable to update player RSVP.' });
-    } finally {
-      setStaffRsvpSubmittingPlayerId(null);
-    }
-  };
 
   // Keep the full-page skeleton for cold loads only; once a cached or fetched
   // event is available, render it and let the background refresh reconcile (#2649).
@@ -719,18 +642,10 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
 
         {activeSection === 'availability' ? (
           <AvailabilitySection
-            auth={auth}
             event={selectedEvent}
             rsvp={rsvp}
             availabilityNote={availabilityNote}
             onAvailabilityNoteChange={setAvailabilityNote}
-            staffRsvpBreakdown={staffRsvpBreakdown}
-            staffRsvpLoading={staffRsvpLoading}
-            staffRsvpError={staffRsvpError}
-            staffRsvpSubmittingPlayerId={staffRsvpSubmittingPlayerId}
-            staffRsvpStatus={staffRsvpStatus}
-            staffRsvpRefreshToken={staffRsvpRefreshToken}
-            onStaffRsvpOverride={submitStaffRsvpOverride}
             attentionItems={attentionItems}
             onSelectSection={selectSection}
           />
@@ -1083,23 +998,16 @@ function PracticePacketPrompt({ event, onOpen }: { event: ParentScheduleEvent; o
   );
 }
 
-function AvailabilitySection({ auth, event, rsvp, availabilityNote, onAvailabilityNoteChange, staffRsvpBreakdown, staffRsvpLoading, staffRsvpError, staffRsvpSubmittingPlayerId, staffRsvpStatus, staffRsvpRefreshToken, onStaffRsvpOverride, attentionItems, onSelectSection }: {
-  auth: AuthState;
+function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNoteChange, attentionItems, onSelectSection }: {
   event: ParentScheduleEvent;
   rsvp: RsvpResponse;
   availabilityNote: string;
   onAvailabilityNoteChange: (note: string) => void;
-  staffRsvpBreakdown: StaffScheduleRsvpBreakdown | null;
-  staffRsvpLoading: boolean;
-  staffRsvpError: string | null;
-  staffRsvpSubmittingPlayerId: string | null;
-  staffRsvpStatus: StaffRsvpOverrideStatus | null;
-  staffRsvpRefreshToken: number;
-  onStaffRsvpOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
   attentionItems: AttentionItem[];
   onSelectSection: (sectionId: EventDetailSectionId) => void;
 }) {
   const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });
+  const staffRsvp = useStaffRsvpBreakdown();
 
   return (
     <section className="app-card overflow-hidden p-0">
@@ -1126,168 +1034,19 @@ function AvailabilitySection({ auth, event, rsvp, availabilityNote, onAvailabili
         {rsvpWorkflow.error ? <div className="mt-2"><Status tone="error" message={rsvpWorkflow.error} /></div> : null}
         <AttentionPanel items={attentionItems} onSelectSection={onSelectSection} />
         <StaffRsvpBreakdownPanel
-          event={event}
-          breakdown={staffRsvpBreakdown}
-          loading={staffRsvpLoading}
-          error={staffRsvpError}
-          submittingPlayerId={staffRsvpSubmittingPlayerId}
-          status={staffRsvpStatus}
-          onOverride={onStaffRsvpOverride}
+          breakdown={staffRsvp.breakdown}
+          loading={staffRsvp.loading}
+          error={staffRsvp.error}
+          submittingPlayerId={staffRsvp.submittingPlayerId}
+          status={staffRsvp.status}
+          onOverride={staffRsvp.submitOverride}
         />
-        <StaffRsvpReminderPanel auth={auth} event={event} refreshToken={staffRsvpRefreshToken} />
+        <StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />
         <AvailabilityNotesList event={event} />
         {!event.isDbGame ? <div className="mt-2 text-xs font-semibold text-gray-500">Availability opens after this event is tracked in the schedule.</div> : null}
         {event.availabilityLocked ? <div className="mt-2 text-xs font-semibold text-amber-700">Availability locked {String(event.availabilityCutoffLabel || '').toLowerCase()}.</div> : null}
       </div>
     </section>
-  );
-}
-
-function StaffRsvpBreakdownPanel({ event, breakdown, loading, error, submittingPlayerId, status, onOverride }: {
-  event: ParentScheduleEvent;
-  breakdown: StaffScheduleRsvpBreakdown | null;
-  loading: boolean;
-  error: string | null;
-  submittingPlayerId: string | null;
-  status: StaffRsvpOverrideStatus | null;
-  onOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
-}) {
-  if (!event.isTeamAdmin || !event.isDbGame) return null;
-  if (loading && !breakdown) {
-    return <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-sm font-semibold text-gray-600">Loading team RSVP breakdown…</div>;
-  }
-  if (error && !breakdown) {
-    return <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm font-semibold text-rose-700">{error}</div>;
-  }
-  if (!breakdown) return null;
-
-  return (
-    <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <div className="text-sm font-black text-gray-950">Staff RSVP overrides</div>
-          <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">Review every player, including no response, and update availability inline.</div>
-        </div>
-        <span className="inline-flex min-h-8 items-center rounded-full border border-primary-100 bg-primary-50 px-3 text-xs font-black text-primary-700">
-          {formatRsvpSummary(breakdown.counts)}
-        </span>
-      </div>
-      <div className="mt-3 space-y-3">
-        {(['not_responded', 'going', 'maybe', 'not_going'] as const).map((responseKey) => {
-          const rows = breakdown.grouped[responseKey];
-          if (!rows.length) return null;
-          return (
-            <div key={responseKey}>
-              <div className="mb-2 flex items-center justify-between gap-2">
-                <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">{rsvpLabels[responseKey]}</div>
-                <span className={`rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[responseKey]}`}>
-                  {rows.length}
-                </span>
-              </div>
-              <div className="space-y-2">
-                {rows.map((player) => {
-                  const inlineStatus = status?.playerId === player.playerId ? status : null;
-                  const busy = submittingPlayerId === player.playerId;
-                  return (
-                    <StaffRsvpPlayerRow
-                      key={player.playerId}
-                      eventLocked={event.isCancelled || event.availabilityLocked === true}
-                      player={player}
-                      submitting={busy}
-                      status={inlineStatus}
-                      onOverride={onOverride}
-                    />
-                  );
-                })}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      {error && breakdown ? <div className="mt-3 text-xs font-bold text-rose-700">{error}</div> : null}
-      {event.isCancelled ? <div className="mt-3 text-xs font-semibold text-gray-500">Cancelled events cannot be updated.</div> : null}
-      {event.availabilityLocked ? <div className="mt-3 text-xs font-semibold text-amber-700">Availability is locked for this event.</div> : null}
-    </div>
-  );
-}
-
-function StaffRsvpReminderPanel({ auth, event, refreshToken = 0 }: { auth: AuthState; event: ParentScheduleEvent; refreshToken?: number }) {
-  const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [sending, setSending] = useState(false);
-  const [status, setStatus] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);
-
-  const refreshPreview = useCallback(async () => {
-    if (!auth.user || !canLoad) return;
-    setLoading(true);
-    setError(null);
-    try {
-      setPreview(await loadStaffRsvpReminderPreview(event, auth.user));
-    } catch (loadError: any) {
-      setError(loadError?.message || 'Unable to load RSVP reminder preview.');
-      setPreview(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [auth.user, canLoad, event.eventKey, event.teamId, event.id]);
-
-  useEffect(() => {
-    setStatus(null);
-    if (canLoad) {
-      refreshPreview();
-    } else {
-      setPreview(null);
-    }
-  }, [canLoad, refreshPreview, refreshToken]);
-
-  if (!event.isTeamRsvpReminderManager || !event.isDbGame || event.isCancelled) return null;
-  if (loading && !preview) {
-    return <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-sm font-semibold text-gray-600">Loading staff RSVP reminder preview…</div>;
-  }
-  if (!preview || preview.missingPlayerCount <= 0) return null;
-
-  const sendReminder = async () => {
-    if (!auth.user || sending) return;
-    const confirmed = window.confirm(`Send an RSVP reminder to ${preview.missingPlayerCount} no-response ${preview.missingPlayerCount === 1 ? 'player' : 'players'}? ${preview.eligibleEmailCount} eligible parent/guardian ${preview.eligibleEmailCount === 1 ? 'email' : 'emails'} will be targeted.`);
-    if (!confirmed) return;
-    setSending(true);
-    setError(null);
-    setStatus(null);
-    try {
-      const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});
-      setPreview(result);
-      setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? 'email' : 'emails'}.`);
-    } catch (sendError: any) {
-      setError(sendError?.message || 'Unable to send RSVP reminder.');
-    } finally {
-      setSending(false);
-    }
-  };
-
-  return (
-    <div className="mt-3 rounded-xl border border-primary-200 bg-primary-50 p-3">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-sm font-black text-gray-950">Staff RSVP reminder</div>
-          <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">
-            {preview.missingPlayerCount} no-response {preview.missingPlayerCount === 1 ? 'player' : 'players'} · {preview.eligibleEmailCount} eligible parent/guardian {preview.eligibleEmailCount === 1 ? 'email' : 'emails'}.
-          </div>
-        </div>
-        <button
-          type="button"
-          className="primary-button min-h-9 flex-none px-3 text-xs"
-          disabled={sending || loading}
-          onClick={sendReminder}
-        >
-          {sending ? 'Sending…' : 'Send reminder'}
-        </button>
-      </div>
-      {status ? <div className="mt-2 text-xs font-bold text-emerald-700">{status}</div> : null}
-      {error ? <div className="mt-2 text-xs font-bold text-rose-700">{error}</div> : null}
-    </div>
   );
 }
 
@@ -5164,11 +4923,6 @@ function formatAssignment(assignment?: { role?: string; value?: string; claim?: 
   if (assignment.value) return `${assignment.role || 'Role'}: ${assignment.value}`;
   if (assignment.role) return `${assignment.role}: Open`;
   return 'None posted';
-}
-
-function formatRsvpSummary(summary?: { going?: number; maybe?: number; notGoing?: number; notResponded?: number } | null) {
-  if (!summary) return 'No RSVPs yet';
-  return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} out · ${summary.notResponded || 0} missing`;
 }
 
 function getAttentionItems(event: ParentScheduleEvent, rsvp: RsvpResponse): AttentionItem[] {

--- a/tests/unit/app-schedule-detail-decomposition.test.js
+++ b/tests/unit/app-schedule-detail-decomposition.test.js
@@ -14,11 +14,15 @@ describe('ScheduleEventDetail decomposition', () => {
 
         expect(source).toContain("from '../components/schedule/EventSectionNav'");
         expect(source).toContain("from '../components/schedule/AvailabilityPanels'");
+        expect(source).toContain("from '../components/schedule/StaffRsvpBreakdownPanel'");
+        expect(source).toContain("from '../components/schedule/StaffRsvpReminderPanel'");
         expect(source).toContain("from './schedule/ScheduleEventDetailContext'");
         expect(source).toContain("from '../hooks/schedule/useScheduleEventRsvp'");
+        expect(source).toContain("from '../hooks/schedule/useStaffRsvpBreakdown'");
         expect(source).toContain("from '../hooks/schedule/useScheduleRideOffers'");
         expect(source).toContain('<ScheduleEventDetailProvider value={{');
         expect(source).toContain('useScheduleEventRsvp({ availabilityNote })');
+        expect(source).toContain('useStaffRsvpBreakdown()');
         expect(source).toContain('useScheduleRideOffers()');
     });
 
@@ -27,6 +31,10 @@ describe('ScheduleEventDetail decomposition', () => {
             'apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx',
             'apps/app/src/hooks/schedule/useScheduleEventRsvp.ts',
             'apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx',
+            'apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts',
+            'apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx',
+            'apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx',
+            'apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx',
             'apps/app/src/hooks/schedule/useScheduleRideOffers.ts',
             'apps/app/src/hooks/schedule/useScheduleRideOffers.test.tsx'
         ].forEach((path) => {

--- a/tests/unit/issue-1966-schedule-rsvp-reminders-source.test.js
+++ b/tests/unit/issue-1966-schedule-rsvp-reminders-source.test.js
@@ -5,6 +5,7 @@ const scheduleLogicSource = readFileSync(new URL('../../apps/app/src/lib/schedul
 const scheduleServiceSource = readFileSync(new URL('../../apps/app/src/lib/scheduleService.ts', import.meta.url), 'utf8');
 const teamDetailSource = readFileSync(new URL('../../apps/app/src/pages/TeamDetail.tsx', import.meta.url), 'utf8');
 const scheduleEventDetailSource = readFileSync(new URL('../../apps/app/src/pages/ScheduleEventDetail.tsx', import.meta.url), 'utf8');
+const staffRsvpReminderPanelSource = readFileSync(new URL('../../apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx', import.meta.url), 'utf8');
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 const reminderTestSource = readFileSync(new URL('./schedule-rsvp-reminder.test.js', import.meta.url), 'utf8');
 const notificationContractTestSource = readFileSync(new URL('./schedule-rsvp-notification-contract.test.js', import.meta.url), 'utf8');
@@ -37,10 +38,12 @@ describe('issue 1966 schedule RSVP reminders source contract', () => {
     });
 
     it('keeps mobile schedule and team screens exposing the manager-only reminder action', () => {
-        expect(scheduleEventDetailSource).toContain('function StaffRsvpReminderPanel');
-        expect(scheduleEventDetailSource).toContain('event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled');
-        expect(scheduleEventDetailSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
-        expect(scheduleEventDetailSource).toContain('await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
+        expect(scheduleEventDetailSource).toContain("import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';");
+        expect(scheduleEventDetailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(staffRsvpReminderPanelSource).toContain('export function StaffRsvpReminderPanel');
+        expect(staffRsvpReminderPanelSource).toContain('event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled');
+        expect(staffRsvpReminderPanelSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
+        expect(staffRsvpReminderPanelSource).toContain('await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
         expect(teamDetailSource).toContain('function TeamEventReminderAction');
         expect(teamDetailSource).toContain('createStaffRsvpReminderPreviewLoader');
         expect(teamDetailSource).toContain('await reminderPreviewLoader.loadPreview(scheduleEvent, auth.user);');

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -11,8 +11,12 @@ const rsvpHookSource = readSource('apps/app/src/hooks/schedule/useScheduleEventR
 const ridesHookSource = readSource('apps/app/src/hooks/schedule/useScheduleRideOffers.ts');
 const availabilityPanelsSource = readSource('apps/app/src/components/schedule/AvailabilityPanels.tsx');
 const staffRsvpRowSource = readSource('apps/app/src/components/schedule/StaffRsvpPlayerRow.tsx');
+const staffRsvpBreakdownPanelSource = readSource('apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx');
+const staffRsvpReminderPanelSource = readSource('apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx');
+const staffRsvpBreakdownHookSource = readSource('apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts');
 const summaryComponentTestSource = readSource('apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx');
 const rsvpHookTestSource = readSource('apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx');
+const staffRsvpHookTestSource = readSource('apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx');
 const ridesHookTestSource = readSource('apps/app/src/hooks/schedule/useScheduleRideOffers.test.tsx');
 
 describe('ScheduleEventDetail decomposition initiative source contract', () => {
@@ -70,7 +74,8 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
             "import { DateTile } from '../components/schedule/DateTile';",
             "import { EventBrief } from '../components/schedule/EventBrief';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
-            "import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';",
+            "import { StaffRsvpBreakdownPanel } from '../components/schedule/StaffRsvpBreakdownPanel';",
+            "import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';",
             'QuickAvailabilityPanel',
             'AvailabilityNotesList',
             'AttentionPanel'
@@ -82,6 +87,8 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
             /^function DateTile\b/m,
             /^function EventBrief\b/m,
             /^function EventSectionNav\b/m,
+            /^function StaffRsvpBreakdownPanel\b/m,
+            /^function StaffRsvpReminderPanel\b/m,
             /^function QuickAvailabilityPanel\b/m,
             /^function AvailabilityNotesList\b/m,
             /^function AttentionPanel\b/m,
@@ -94,6 +101,27 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
         expect(availabilityPanelsSource).toContain('export function AvailabilityNotesList');
         expect(availabilityPanelsSource).toContain('export function AttentionPanel');
         expect(staffRsvpRowSource).toContain('export function StaffRsvpPlayerRow');
+        expect(staffRsvpBreakdownPanelSource).toContain('export function StaffRsvpBreakdownPanel');
+        expect(staffRsvpReminderPanelSource).toContain('export function StaffRsvpReminderPanel');
         expect(summaryComponentTestSource).toContain("describe('Schedule event summary components'");
+    });
+
+    it('keeps staff RSVP admin workflow behind extracted panel and hook modules', () => {
+        expect(detailSource).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
+        expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown();');
+        expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
+        expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(detailSource).not.toMatch(/const\s+\[staffRsvpBreakdown\b/);
+        expect(detailSource).not.toMatch(/^function StaffRsvpBreakdownPanel\b/m);
+        expect(detailSource).not.toMatch(/^function StaffRsvpReminderPanel\b/m);
+
+        expect(staffRsvpBreakdownHookSource).toContain('export function useStaffRsvpBreakdown');
+        expect(staffRsvpBreakdownHookSource).toContain('useScheduleEventDetailContext()');
+        expect(staffRsvpBreakdownHookSource).toContain('loadStaffScheduleRsvpBreakdown');
+        expect(staffRsvpBreakdownHookSource).toContain('submitStaffScheduleRsvpOverride');
+        expect(staffRsvpHookTestSource).toContain("describe('useStaffRsvpBreakdown'");
+        expect(staffRsvpBreakdownPanelSource).toContain('StaffRsvpPlayerRow');
+        expect(staffRsvpReminderPanelSource).toContain('loadStaffRsvpReminderPreview');
+        expect(staffRsvpReminderPanelSource).toContain('sendStaffRsvpReminder');
     });
 });

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -17,7 +17,8 @@ describe('ScheduleEventDetail decomposition contract', () => {
             "import { EventBrief } from '../components/schedule/EventBrief';",
             "import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
-            "import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';",
+            "import { StaffRsvpBreakdownPanel } from '../components/schedule/StaffRsvpBreakdownPanel';",
+            "import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';",
             'QuickAvailabilityPanel',
             'AvailabilityNotesList',
             'AttentionPanel'
@@ -31,6 +32,8 @@ describe('ScheduleEventDetail decomposition contract', () => {
             /^function EventBrief\b/m,
             /^function EventDetailsPanel\b/m,
             /^function EventSectionNav\b/m,
+            /^function StaffRsvpBreakdownPanel\b/m,
+            /^function StaffRsvpReminderPanel\b/m,
             /^function StaffRsvpPlayerRow\b/m,
             /^function QuickAvailabilityPanel\b/m,
             /^function AttentionPanel\b/m
@@ -47,9 +50,11 @@ describe('ScheduleEventDetail decomposition contract', () => {
 
         expect(page).toContain("import { ScheduleEventDetailProvider } from './schedule/ScheduleEventDetailContext';");
         expect(page).toContain("import { useScheduleEventRsvp } from '../hooks/schedule/useScheduleEventRsvp';");
+        expect(page).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
         expect(page).toContain("import { useScheduleRideOffers } from '../hooks/schedule/useScheduleRideOffers';");
         expect(page).toContain('<ScheduleEventDetailProvider value={{');
         expect(page).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });');
+        expect(page).toContain('const staffRsvp = useStaffRsvpBreakdown();');
         expect(page).toContain('const rideOffers = useScheduleRideOffers();');
 
         expect(rsvpHook).toContain('export function useScheduleEventRsvp');
@@ -60,6 +65,34 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(ridesHook).toContain('loadParentScheduleRideOffers');
         expect(context).toContain('export function ScheduleEventDetailProvider');
         expect(context).toContain('export function useScheduleEventDetailContext');
+    });
+
+    it('keeps staff RSVP breakdown and reminder workflow extracted from the detail page', () => {
+        const page = readRepoFile('apps/app/src/pages/ScheduleEventDetail.tsx');
+        const breakdownHook = readRepoFile('apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts');
+        const breakdownPanel = readRepoFile('apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx');
+        const reminderPanel = readRepoFile('apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx');
+
+        expect(page).toContain("import { StaffRsvpBreakdownPanel } from '../components/schedule/StaffRsvpBreakdownPanel';");
+        expect(page).toContain("import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';");
+        expect(page).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
+        expect(page).toContain('<StaffRsvpBreakdownPanel');
+        expect(page).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(page).not.toMatch(/^function StaffRsvpBreakdownPanel\b/m);
+        expect(page).not.toMatch(/^function StaffRsvpReminderPanel\b/m);
+        expect(page).not.toMatch(/const\s+\[staffRsvpBreakdown\b/);
+        expect(page).not.toMatch(/loadStaffScheduleRsvpBreakdown\(/);
+        expect(page).not.toMatch(/sendStaffRsvpReminder\(/);
+
+        expect(breakdownHook).toContain('export function useStaffRsvpBreakdown');
+        expect(breakdownHook).toContain('loadStaffScheduleRsvpBreakdown');
+        expect(breakdownHook).toContain('submitStaffScheduleRsvpOverride');
+        expect(breakdownHook).toContain('setRefreshToken((current) => current + 1)');
+        expect(breakdownPanel).toContain('export function StaffRsvpBreakdownPanel');
+        expect(breakdownPanel).toContain('StaffRsvpPlayerRow');
+        expect(reminderPanel).toContain('export function StaffRsvpReminderPanel');
+        expect(reminderPanel).toContain('loadStaffRsvpReminderPreview');
+        expect(reminderPanel).toContain('sendStaffRsvpReminder');
     });
 
     it('keeps staff RSVP player rows in the extracted schedule component', () => {

--- a/tests/unit/schedule-rsvp-reminder.test.js
+++ b/tests/unit/schedule-rsvp-reminder.test.js
@@ -120,12 +120,14 @@ describe('staff RSVP reminder service wiring', () => {
   it('gates reminders on backend-compatible managers instead of all team staff', () => {
     const serviceSource = readFileSync('apps/app/src/lib/scheduleService.ts', 'utf8');
     const detailSource = readFileSync('apps/app/src/pages/ScheduleEventDetail.tsx', 'utf8');
+    const reminderPanelSource = readFileSync('apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx', 'utf8');
 
     expect(serviceSource).toContain('function isPublicRsvpReminderManager');
     expect(serviceSource).toContain('if (!event.isTeamRsvpReminderManager)');
     expect(serviceSource).toContain('const { players, rsvps } = await getRsvpBreakdownByPlayer(event.teamId, event.id);');
-    expect(detailSource).toContain('event.isTeamRsvpReminderManager');
-    expect(detailSource).not.toContain('event.isTeamStaff && event.isDbGame');
+    expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+    expect(reminderPanelSource).toContain('event.isTeamRsvpReminderManager');
+    expect(reminderPanelSource).not.toContain('event.isTeamStaff && event.isDbGame');
   });
 
   it('persists Cloud Function RSVP push metrics from app reminder sends', () => {

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -2,20 +2,21 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const detailSource = readFileSync(new URL('../../apps/app/src/pages/ScheduleEventDetail.tsx', import.meta.url), 'utf8');
+const breakdownPanelSource = readFileSync(new URL('../../apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx', import.meta.url), 'utf8');
+const reminderPanelSource = readFileSync(new URL('../../apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx', import.meta.url), 'utf8');
 const playerRowSource = readFileSync(new URL('../../apps/app/src/components/schedule/StaffRsvpPlayerRow.tsx', import.meta.url), 'utf8');
 
 describe('staff RSVP panel decomposition contract', () => {
     it('keeps the availability section wired through named staff RSVP panels', () => {
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
-        expect(detailSource).toContain('<StaffRsvpReminderPanel auth={auth} event={event} refreshToken={staffRsvpRefreshToken} />');
-        expect(detailSource).toContain('onOverride={onStaffRsvpOverride}');
-        expect(detailSource).toContain('staffRsvpRefreshToken={staffRsvpRefreshToken}');
+        expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(detailSource).toContain('onOverride={staffRsvp.submitOverride}');
         expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });');
     });
 
     it('keeps staff override rows in the reusable schedule component', () => {
-        expect(detailSource).toContain("import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';");
-        expect(detailSource).toContain('<StaffRsvpPlayerRow');
+        expect(breakdownPanelSource).toContain("import { StaffRsvpPlayerRow } from './StaffRsvpPlayerRow';");
+        expect(breakdownPanelSource).toContain('<StaffRsvpPlayerRow');
         expect(playerRowSource).toContain('export function StaffRsvpPlayerRow');
         expect(playerRowSource).toContain('data-testid={`staff-rsvp-row-${player.playerId}`}');
         expect(playerRowSource).toContain("(['going', 'maybe', 'not_going'] as const).map");
@@ -23,10 +24,10 @@ describe('staff RSVP panel decomposition contract', () => {
     });
 
     it('preserves the reminder preview and send workflow behind the staff reminder panel', () => {
-        expect(detailSource).toContain('const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);');
-        expect(detailSource).toContain('const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);');
-        expect(detailSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
-        expect(detailSource).toContain('const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
-        expect(detailSource).toContain('setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? \'email\' : \'emails\'}.`);');
+        expect(reminderPanelSource).toContain('const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);');
+        expect(reminderPanelSource).toContain('const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);');
+        expect(reminderPanelSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
+        expect(reminderPanelSource).toContain('const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
+        expect(reminderPanelSource).toContain('setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? \'email\' : \'emails\'}.`);');
     });
 });

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -3,19 +3,23 @@ import { readFileSync } from 'node:fs';
 
 const detailSource = readFileSync(new URL('../../apps/app/src/pages/ScheduleEventDetail.tsx', import.meta.url), 'utf8');
 const playerRowSource = readFileSync(new URL('../../apps/app/src/components/schedule/StaffRsvpPlayerRow.tsx', import.meta.url), 'utf8');
+const breakdownPanelSource = readFileSync(new URL('../../apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx', import.meta.url), 'utf8');
+const reminderPanelSource = readFileSync(new URL('../../apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx', import.meta.url), 'utf8');
 
 describe('staff RSVP panel decomposition contract', () => {
     it('keeps the availability section wired through named staff RSVP panels', () => {
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
-        expect(detailSource).toContain('<StaffRsvpReminderPanel auth={auth} event={event} refreshToken={staffRsvpRefreshToken} />');
-        expect(detailSource).toContain('onOverride={onStaffRsvpOverride}');
-        expect(detailSource).toContain('staffRsvpRefreshToken={staffRsvpRefreshToken}');
+        expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(detailSource).toContain('onOverride={staffRsvp.submitOverride}');
+        expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown();');
         expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });');
     });
 
     it('keeps staff override rows in the reusable schedule component', () => {
-        expect(detailSource).toContain("import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';");
-        expect(detailSource).toContain('<StaffRsvpPlayerRow');
+        expect(detailSource).not.toContain("import { StaffRsvpPlayerRow } from '../components/schedule/StaffRsvpPlayerRow';");
+        expect(detailSource).not.toMatch(/^function StaffRsvpPlayerRow\b/m);
+        expect(breakdownPanelSource).toContain("import { StaffRsvpPlayerRow } from './StaffRsvpPlayerRow';");
+        expect(breakdownPanelSource).toContain('<StaffRsvpPlayerRow');
         expect(playerRowSource).toContain('export function StaffRsvpPlayerRow');
         expect(playerRowSource).toContain('data-testid={`staff-rsvp-row-${player.playerId}`}');
         expect(playerRowSource).toContain("(['going', 'maybe', 'not_going'] as const).map");
@@ -23,10 +27,12 @@ describe('staff RSVP panel decomposition contract', () => {
     });
 
     it('preserves the reminder preview and send workflow behind the staff reminder panel', () => {
-        expect(detailSource).toContain('const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);');
-        expect(detailSource).toContain('const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);');
-        expect(detailSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
-        expect(detailSource).toContain('const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
-        expect(detailSource).toContain('setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? \'email\' : \'emails\'}.`);');
+        expect(detailSource).not.toContain('const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);');
+        expect(reminderPanelSource).toContain('const { auth, event } = useScheduleEventDetailContext();');
+        expect(reminderPanelSource).toContain('const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);');
+        expect(reminderPanelSource).toContain('const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);');
+        expect(reminderPanelSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
+        expect(reminderPanelSource).toContain('const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
+        expect(reminderPanelSource).toContain('setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? \'email\' : \'emails\'}.`);');
     });
 });


### PR DESCRIPTION
## Summary
- Extract staff RSVP breakdown rendering into `StaffRsvpBreakdownPanel` and move override loading/submission state into `useStaffRsvpBreakdown`.
- Extract staff RSVP reminder preview/send UI into `StaffRsvpReminderPanel`.
- Update decomposition source contracts and add focused hook/component coverage for override and reminder behavior.

Closes #2653

## Validation
- `npx vitest run apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx tests/unit/app-schedule-detail-decomposition.test.js tests/unit/schedule-event-detail-decomposition-contract.test.js tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js --reporter=verbose`
- `npm run app:build`