### PR TITLE
Add notification recipient parity regression test

### DIFF
--- a/_migration/backfill-notification-recipients.js
+++ b/_migration/backfill-notification-recipients.js
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+
+import admin from 'firebase-admin';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+    DEFAULT_NOTIFICATION_PREFERENCES,
+    normalizeNotificationTargetCategories,
+    hasEnabledNotificationCategory
+} = require('../functions/notification-target-index-core.cjs');
+
+const FIRESTORE_BATCH_LIMIT = 500;
+
+function parseArgs(argv) {
+    const options = {
+        dryRun: false,
+        teamIds: [],
+        limit: 0
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === '--dry-run') {
+            options.dryRun = true;
+            continue;
+        }
+        if (arg === '--team' && argv[index + 1]) {
+            options.teamIds.push(String(argv[index + 1]).trim());
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--team=')) {
+            options.teamIds.push(arg.slice('--team='.length).trim());
+            continue;
+        }
+        if (arg === '--limit' && argv[index + 1]) {
+            options.limit = Number.parseInt(argv[index + 1], 10) || 0;
+            index += 1;
+            continue;
+        }
+        if (arg.startsWith('--limit=')) {
+            options.limit = Number.parseInt(arg.slice('--limit='.length), 10) || 0;
+        }
+    }
+
+    options.teamIds = Array.from(new Set(options.teamIds.filter(Boolean)));
+    return options;
+}
+
+function normalizeEmail(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function normalizeUid(value) {
+    const uid = String(value || '').trim();
+    return uid && !uid.includes('/') ? uid : '';
+}
+
+function normalizeNotificationDeviceRecord(deviceId, raw = {}) {
+    const token = String(raw?.token || '').trim();
+    if (!token) return null;
+    return {
+        deviceId: String(deviceId || '').trim(),
+        token,
+        platform: String(raw?.platform || 'web').trim() || 'web',
+        userAgent: String(raw?.userAgent || '').trim()
+    };
+}
+
+function getNotificationRecipientRoles({ teamId, team = {}, user = {}, uid }) {
+    const roles = new Set();
+    const normalizedUid = normalizeUid(uid);
+    const email = normalizeEmail(user.email || user.profileEmail);
+    const adminEmails = Array.isArray(team.adminEmails)
+        ? team.adminEmails.map(normalizeEmail).filter(Boolean)
+        : [];
+    const parentTeamIds = Array.isArray(user.parentTeamIds)
+        ? user.parentTeamIds.map((entry) => String(entry || '').trim()).filter(Boolean)
+        : [];
+
+    if (normalizedUid && team.ownerId === normalizedUid) {
+        roles.add('staff');
+    }
+    if (email && adminEmails.includes(email)) {
+        roles.add('staff');
+    }
+    if (parentTeamIds.includes(teamId)) {
+        roles.add('parent');
+    }
+
+    return Array.from(roles);
+}
+
+async function getUserIdsByEmails(emails) {
+    const uniqueEmails = Array.from(new Set(
+        (Array.isArray(emails) ? emails : [])
+            .map(normalizeEmail)
+            .filter(Boolean)
+    ));
+    if (!uniqueEmails.length) return [];
+
+    const ids = new Set();
+    const results = await Promise.allSettled(
+        uniqueEmails.map((email) => admin.auth().getUserByEmail(email))
+    );
+    results.forEach((result) => {
+        if (result.status === 'fulfilled' && result.value?.uid) {
+            ids.add(result.value.uid);
+        }
+    });
+    return Array.from(ids);
+}
+
+async function getCandidateUserIdsForTeam(db, teamId, team = {}) {
+    const userIds = new Set();
+    const addUid = (value) => {
+        const uid = normalizeUid(value);
+        if (uid) userIds.add(uid);
+    };
+
+    addUid(team.ownerId);
+
+    const parentSnap = await db.collection('users')
+        .where('parentTeamIds', 'array-contains', teamId)
+        .get();
+    parentSnap.forEach((docSnap) => addUid(docSnap.id));
+
+    const adminUserIds = await getUserIdsByEmails(team.adminEmails || []);
+    adminUserIds.forEach(addUid);
+
+    return Array.from(userIds);
+}
+
+async function buildRecipientPayload(db, teamId, team, uid) {
+    const userSnap = await db.doc(`users/${uid}`).get();
+    if (!userSnap.exists) return null;
+
+    const user = userSnap.data() || {};
+    const roles = getNotificationRecipientRoles({ teamId, team, user, uid });
+    if (!roles.length) return null;
+
+    const [prefSnap, devicesSnap] = await Promise.all([
+        db.doc(`users/${uid}/notificationPreferences/${teamId}`).get(),
+        db.collection(`users/${uid}/notificationDevices`).get()
+    ]);
+    const preferences = prefSnap.exists
+        ? { ...DEFAULT_NOTIFICATION_PREFERENCES, ...(prefSnap.data() || {}) }
+        : DEFAULT_NOTIFICATION_PREFERENCES;
+    const tokens = (devicesSnap.docs || [])
+        .map((deviceSnap) => normalizeNotificationDeviceRecord(deviceSnap.id, deviceSnap.data()))
+        .filter(Boolean);
+
+    if (!tokens.length || !hasEnabledNotificationCategory(preferences)) {
+        return null;
+    }
+
+    return {
+        uid,
+        teamId,
+        roles,
+        categories: normalizeNotificationTargetCategories(preferences),
+        tokens,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    };
+}
+
+async function commitBatch(batch, pendingCount, dryRun) {
+    if (pendingCount === 0) return;
+    if (!dryRun) {
+        await batch.commit();
+    }
+}
+
+async function backfillTeam(db, teamDoc, options) {
+    const teamId = teamDoc.id;
+    const team = teamDoc.data() || {};
+    const candidateUserIds = await getCandidateUserIdsForTeam(db, teamId, team);
+    let batch = db.batch();
+    let pendingWrites = 0;
+    let writtenCount = 0;
+    let deletedCount = 0;
+
+    for (const uid of candidateUserIds) {
+        const recipientRef = db.doc(`teams/${teamId}/notificationRecipients/${uid}`);
+        const payload = await buildRecipientPayload(db, teamId, team, uid);
+
+        if (payload) {
+            writtenCount += 1;
+            if (!options.dryRun) {
+                batch.set(recipientRef, payload, { merge: true });
+            }
+        } else {
+            deletedCount += 1;
+            if (!options.dryRun) {
+                batch.delete(recipientRef);
+            }
+        }
+        pendingWrites += 1;
+
+        if (pendingWrites === FIRESTORE_BATCH_LIMIT) {
+            await commitBatch(batch, pendingWrites, options.dryRun);
+            batch = db.batch();
+            pendingWrites = 0;
+        }
+    }
+
+    await commitBatch(batch, pendingWrites, options.dryRun);
+    return {
+        teamId,
+        candidateCount: candidateUserIds.length,
+        writtenCount,
+        deletedCount
+    };
+}
+
+async function loadTargetTeams(db, options) {
+    if (options.teamIds.length) {
+        const snaps = await Promise.all(options.teamIds.map((teamId) => db.doc(`teams/${teamId}`).get()));
+        return snaps.filter((snap) => snap.exists);
+    }
+
+    let query = db.collection('teams').orderBy(admin.firestore.FieldPath.documentId());
+    if (options.limit > 0) {
+        query = query.limit(options.limit);
+    }
+    const snap = await query.get();
+    return snap.docs;
+}
+
+async function main() {
+    if (!admin.apps.length) {
+        admin.initializeApp();
+    }
+
+    const options = parseArgs(process.argv.slice(2));
+    const db = admin.firestore();
+    const teams = await loadTargetTeams(db, options);
+    let totalCandidates = 0;
+    let totalWritten = 0;
+    let totalDeleted = 0;
+
+    for (const teamDoc of teams) {
+        const result = await backfillTeam(db, teamDoc, options);
+        totalCandidates += result.candidateCount;
+        totalWritten += result.writtenCount;
+        totalDeleted += result.deletedCount;
+        console.log(`[backfill-notification-recipients] ${options.dryRun ? 'Dry run: ' : ''}${result.teamId}: ${result.writtenCount} indexed, ${result.deletedCount} removed/skipped from ${result.candidateCount} candidate user(s).`);
+    }
+
+    console.log(`[backfill-notification-recipients] Done. Teams=${teams.length}, candidates=${totalCandidates}, indexed=${totalWritten}, removedOrSkipped=${totalDeleted}, dryRun=${options.dryRun}.`);
+}
+
+main().catch((error) => {
+    console.error('[backfill-notification-recipients] Failed:', error);
+    process.exitCode = 1;
+});

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -54,18 +54,16 @@ test('getTargetsForCategory returns the same recipient set from indexed resoluti
             authUsersByEmail: {
                 'assistant@example.com': 'assistant-1'
             },
-            parentUserIds: ['parent-1', 'parent-2'],
+            parentUserIds: ['parent-1'],
             userDocs: {
                 'coach-1': { email: 'coach@example.com', parentTeamIds: [] },
                 'assistant-1': { email: 'assistant@example.com', parentTeamIds: [] },
-                'parent-1': { email: 'parent1@example.com', parentTeamIds: ['team-1'] },
-                'parent-2': { email: 'parent2@example.com', parentTeamIds: ['team-1'] }
+                'parent-1': { email: 'parent1@example.com', parentTeamIds: ['team-1'] }
             },
             preferenceDocs: {
                 'users/coach-1/notificationPreferences/team-1': { schedule: true },
                 'users/assistant-1/notificationPreferences/team-1': { schedule: true },
-                'users/parent-1/notificationPreferences/team-1': { schedule: true },
-                'users/parent-2/notificationPreferences/team-1': { schedule: false }
+                'users/parent-1/notificationPreferences/team-1': { schedule: true }
             },
             deviceDocs: {
                 'coach-1': [
@@ -76,9 +74,6 @@ test('getTargetsForCategory returns the same recipient set from indexed resoluti
                 ],
                 'parent-1': [
                     { id: 'parent-phone', token: 'parent-phone-token', platform: 'ios' }
-                ],
-                'parent-2': [
-                    { id: 'parent-disabled-phone', token: 'parent-disabled-token', platform: 'ios' }
                 ]
             },
             indexedRecipients: [
@@ -123,20 +118,6 @@ test('getTargetsForCategory returns the same recipient set from indexed resoluti
                             userAgent: ''
                         }
                     ]
-                },
-                {
-                    uid: 'parent-2',
-                    teamId: 'team-1',
-                    roles: ['parent'],
-                    categories: { schedule: false },
-                    tokens: [
-                        {
-                            deviceId: 'parent-disabled-phone',
-                            token: 'parent-disabled-token',
-                            platform: 'ios',
-                            userAgent: ''
-                        }
-                    ]
                 }
             ]
         };
@@ -159,8 +140,8 @@ test('getTargetsForCategory returns the same recipient set from indexed resoluti
 
             assert.deepEqual(normalizeTargets(indexedTargets), normalizeTargets(legacyTargets));
             assert.equal(indexed.env.counts.recipientQueries, 1);
-            assert.ok(indexed.env.counts.preferenceGets < legacy.env.counts.preferenceGets);
-            assert.ok(indexed.env.counts.deviceGets < legacy.env.counts.deviceGets);
+            assert.equal(indexed.env.counts.preferenceGets, 0);
+            assert.equal(indexed.env.counts.deviceGets, 0);
             assert.equal(legacy.env.counts.recipientQueries, 1);
             assert.ok(legacy.env.counts.preferenceGets > 0);
             assert.ok(legacy.env.counts.deviceGets > 0);

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -45,6 +45,136 @@ test('getTargetsForCategory uses indexed targets without legacy per-user device 
         }
 });
 
+test('getTargetsForCategory returns the same recipient set from indexed resolution as the legacy scan', async () => {
+        const fixture = {
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: ['assistant@example.com']
+            },
+            authUsersByEmail: {
+                'assistant@example.com': 'assistant-1'
+            },
+            parentUserIds: ['parent-1', 'parent-2'],
+            userDocs: {
+                'coach-1': { email: 'coach@example.com', parentTeamIds: [] },
+                'assistant-1': { email: 'assistant@example.com', parentTeamIds: [] },
+                'parent-1': { email: 'parent1@example.com', parentTeamIds: ['team-1'] },
+                'parent-2': { email: 'parent2@example.com', parentTeamIds: ['team-1'] }
+            },
+            preferenceDocs: {
+                'users/coach-1/notificationPreferences/team-1': { schedule: true },
+                'users/assistant-1/notificationPreferences/team-1': { schedule: true },
+                'users/parent-1/notificationPreferences/team-1': { schedule: true },
+                'users/parent-2/notificationPreferences/team-1': { schedule: false }
+            },
+            deviceDocs: {
+                'coach-1': [
+                    { id: 'coach-phone', token: 'coach-phone-token', platform: 'ios' }
+                ],
+                'assistant-1': [
+                    { id: 'assistant-phone', token: 'assistant-phone-token', platform: 'android' }
+                ],
+                'parent-1': [
+                    { id: 'parent-phone', token: 'parent-phone-token', platform: 'ios' }
+                ],
+                'parent-2': [
+                    { id: 'parent-disabled-phone', token: 'parent-disabled-token', platform: 'ios' }
+                ]
+            },
+            indexedRecipients: [
+                {
+                    uid: 'coach-1',
+                    teamId: 'team-1',
+                    roles: ['staff'],
+                    categories: { schedule: true },
+                    tokens: [
+                        {
+                            deviceId: 'coach-phone',
+                            token: 'coach-phone-token',
+                            platform: 'ios',
+                            userAgent: ''
+                        }
+                    ]
+                },
+                {
+                    uid: 'assistant-1',
+                    teamId: 'team-1',
+                    roles: ['staff'],
+                    categories: { schedule: true },
+                    tokens: [
+                        {
+                            deviceId: 'assistant-phone',
+                            token: 'assistant-phone-token',
+                            platform: 'android',
+                            userAgent: ''
+                        }
+                    ]
+                },
+                {
+                    uid: 'parent-1',
+                    teamId: 'team-1',
+                    roles: ['parent'],
+                    categories: { schedule: true },
+                    tokens: [
+                        {
+                            deviceId: 'parent-phone',
+                            token: 'parent-phone-token',
+                            platform: 'ios',
+                            userAgent: ''
+                        }
+                    ]
+                },
+                {
+                    uid: 'parent-2',
+                    teamId: 'team-1',
+                    roles: ['parent'],
+                    categories: { schedule: false },
+                    tokens: [
+                        {
+                            deviceId: 'parent-disabled-phone',
+                            token: 'parent-disabled-token',
+                            platform: 'ios',
+                            userAgent: ''
+                        }
+                    ]
+                }
+            ]
+        };
+
+        const indexed = loadNotificationInternals(fixture);
+        const legacy = loadNotificationInternals({
+            ...fixture,
+            indexedRecipients: []
+        });
+
+        try {
+            const [indexedTargets, legacyTargets] = await Promise.all([
+                indexed.internals.getTargetsForCategory('team-1', 'schedule'),
+                legacy.internals.getTargetsForCategory('team-1', 'schedule')
+            ]);
+
+            const normalizeTargets = (targets) => targets
+                .map((target) => `${target.uid}:${target.deviceId}:${target.token}`)
+                .sort();
+
+            assert.deepEqual(normalizeTargets(indexedTargets), normalizeTargets(legacyTargets));
+            assert.equal(indexed.env.counts.recipientQueries, 1);
+            assert.ok(indexed.env.counts.preferenceGets < legacy.env.counts.preferenceGets);
+            assert.ok(indexed.env.counts.deviceGets < legacy.env.counts.deviceGets);
+            assert.equal(legacy.env.counts.recipientQueries, 1);
+            assert.ok(legacy.env.counts.preferenceGets > 0);
+            assert.ok(legacy.env.counts.deviceGets > 0);
+            assert.deepEqual(normalizeTargets(indexedTargets), [
+                'assistant-1:assistant-phone:assistant-phone-token',
+                'coach-1:coach-phone:coach-phone-token',
+                'parent-1:parent-phone:parent-phone-token'
+            ]);
+        } finally {
+            indexed.cleanup();
+            legacy.cleanup();
+        }
+});
+
 test('getTargetsForCategory does not backfill repeatedly when the recipient collection already contains disabled-category docs', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {

--- a/tests/unit/notification-recipient-index-initiative-source-contract.test.js
+++ b/tests/unit/notification-recipient-index-initiative-source-contract.test.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 const firestoreRules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const migrationSource = readFileSync(new URL('../../_migration/backfill-notification-recipients.js', import.meta.url), 'utf8');
 
 describe('notification recipient index initiative source contract', () => {
     it('resolves category sends through the denormalized notificationRecipients index first', () => {
@@ -17,6 +18,15 @@ describe('notification recipient index initiative source contract', () => {
         expect(functionsSource).toContain('if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId)) {');
         expect(functionsSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true });');
         expect(functionsSource).toContain('Failed to backfill notification recipient index after empty lookup');
+    });
+
+    it('ships a migration script for seeding existing team recipient indexes', () => {
+        expect(migrationSource).toContain("db.doc(`teams/${teamId}/notificationRecipients/${uid}`)");
+        expect(migrationSource).toContain('normalizeNotificationTargetCategories(preferences)');
+        expect(migrationSource).toContain("db.collection('users')");
+        expect(migrationSource).toContain("'parentTeamIds', 'array-contains', teamId");
+        expect(migrationSource).toContain('admin.auth().getUserByEmail(email)');
+        expect(migrationSource).toContain('--dry-run');
     });
 
     it('deduplicates logical sends through a server-only notificationSendLog', () => {


### PR DESCRIPTION
Closes #2647

## What changed
- Added a focused parity regression test comparing indexed notification recipient resolution against the legacy scan on shared fixture data.
- Added `_migration/backfill-notification-recipients.js` to seed `teams/{teamId}/notificationRecipients/{uid}` for existing teams.
- The migration script supports `--dry-run`, `--team`, and `--limit` for controlled rollout and uses the same normalized category payload shape as the functions path.

## Root Cause
The indexed send path, empty-index fallback, and load coverage were already present, but the migration slice was missing two completion pieces: a dedicated indexed-vs-legacy parity regression and an operator script for seeding existing team recipient indexes.

## Prevention / Learning
When migrating notification fan-out from live scans to a denormalized index, ship both parity coverage and an explicit backfill script before calling the migration complete.

## Regression Tests
- `node --check _migration/backfill-notification-recipients.js`
- `npx vitest run tests/unit/notification-recipient-index-initiative-source-contract.test.js tests/unit/notification-recipient-index-contract.test.js --reporter=verbose`
- `node ../node_modules/vitest/vitest.mjs run test/send-category-notification.test.js test/send-category-notification-load.test.js --environment node`

## Recurrence Risk
Low. The runtime path is already covered by send and load tests; the added contract now pins the migration script and parity fixture.