### PR TITLE
Fix fee due reminder threshold and parent targeting

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6406,11 +6406,28 @@ function getFeeReminderPlayerKey(recipient = {}, teamId = '') {
 
 function buildFeeReminderCandidateUserIds(recipient = {}, playerOwnerIds = []) {
   return Array.from(new Set([
-    recipient.userId,
-    recipient.accountUserId,
     recipient.parentUserId,
     ...playerOwnerIds
   ].map((value) => String(value || '').trim()).filter(Boolean)));
+}
+
+function resolveFeeReminderThresholdHours(team = {}) {
+  const reminderHours = Number.parseInt(team?.scheduleNotifications?.reminderHours, 10);
+  return [24, 48, 72].includes(reminderHours) ? reminderHours : 72;
+}
+
+function wasFeeReminderSentForThreshold(recipient = {}, reminderThresholdHours = 72) {
+  if (!recipient?.reminderSentAt) return false;
+  const sentThresholdHours = Number.parseInt(recipient?.reminderThresholdHours, 10);
+  if ([24, 48, 72].includes(sentThresholdHours)) {
+    return sentThresholdHours === reminderThresholdHours;
+  }
+  return reminderThresholdHours === 72;
+}
+
+function formatFeeReminderWindowLabel(reminderThresholdHours = 72) {
+  const reminderThresholdDays = Math.max(1, Math.round(reminderThresholdHours / 24));
+  return `${reminderThresholdDays} day${reminderThresholdDays === 1 ? '' : 's'} or less`;
 }
 
 async function resolveFeeReminderCandidateUserIds(teamId, recipient = {}) {
@@ -6429,27 +6446,44 @@ async function resolveFeeReminderCandidateUserIds(teamId, recipient = {}) {
 
 async function sendFeeUnpaidDueReminders() {
   const now = admin.firestore.Timestamp.now();
-  const threeDaysLater = admin.firestore.Timestamp.fromMillis(now.toMillis() + 3 * 24 * 60 * 60 * 1000);
+  const maxReminderThresholdLater = admin.firestore.Timestamp.fromMillis(now.toMillis() + 72 * 60 * 60 * 1000);
+  const teamReminderThresholdHours = new Map();
 
   // Use 'in' filter instead of '!=' to avoid Firestore inequality-on-different-field restriction
   const snap = await firestore.collectionGroup('feeRecipients')
     .where('status', 'in', ['unpaid', 'pending'])
     .where('dueDate', '>=', now)
-    .where('dueDate', '<=', threeDaysLater)
+    .where('dueDate', '<=', maxReminderThresholdLater)
     .get();
 
   const promises = snap.docs.map(async (doc) => {
     const data = doc.data();
-    // Skip if reminder already sent (deduplication guard)
-    if (data.reminderSentAt) return null;
     const pathParts = doc.ref.path.split('/');
     // Path structure: teams/{teamId}/feeBatches/{batchId}/feeRecipients/{recipientId}
     const teamId = pathParts[1];
     const batchId = pathParts[3];
     const recipientId = pathParts[5];
     if (!teamId) return null;
+
+    let reminderThresholdHours = teamReminderThresholdHours.get(teamId);
+    if (!reminderThresholdHours) {
+      const teamSnap = await firestore.collection('teams').doc(teamId).get();
+      reminderThresholdHours = resolveFeeReminderThresholdHours(teamSnap.exists ? teamSnap.data() : {});
+      teamReminderThresholdHours.set(teamId, reminderThresholdHours);
+    }
+
+    const dueDateMillis = typeof data?.dueDate?.toMillis === 'function'
+      ? data.dueDate.toMillis()
+      : coerceDate(data?.dueDate)?.getTime();
+    if (!Number.isFinite(dueDateMillis)) return null;
+
+    const reminderThresholdMillis = reminderThresholdHours * 60 * 60 * 1000;
+    if (dueDateMillis > now.toMillis() + reminderThresholdMillis) return null;
+    if (wasFeeReminderSentForThreshold(data, reminderThresholdHours)) return null;
+
     const title = data.feeTitle || data.title || 'Team fee due soon';
     const amountLabel = formatMoneyFromCents(getTeamFeeBalanceCents(data), data.currency || 'USD');
+    const reminderWindowLabel = formatFeeReminderWindowLabel(reminderThresholdHours);
 
     try {
       const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, data);
@@ -6461,13 +6495,16 @@ async function sendFeeUnpaidDueReminders() {
       if (!payerTargets.length) return null;
 
       // Mark reminderSentAt only when targets exist, to prevent duplicate sends if function retries
-      await doc.ref.update({ reminderSentAt: admin.firestore.FieldValue.serverTimestamp() });
+      await doc.ref.update({
+        reminderSentAt: admin.firestore.FieldValue.serverTimestamp(),
+        reminderThresholdHours
+      });
 
       await sendDirectTargetsNotification({
         targets: payerTargets,
         category: 'fees',
         title: `Reminder: ${title} is due soon`,
-        body: `${amountLabel} is due in 3 days or less.`,
+        body: `${amountLabel} is due in ${reminderWindowLabel}.`,
         teamId,
         batchId,
         recipientId,

--- a/tests/unit/fee-due-reminders-source.test.js
+++ b/tests/unit/fee-due-reminders-source.test.js
@@ -11,7 +11,10 @@ function getHelper(name, nextMarker) {
 }
 
 const getFeeReminderPlayerKey = getHelper('getFeeReminderPlayerKey', 'function buildFeeReminderCandidateUserIds');
-const buildFeeReminderCandidateUserIds = getHelper('buildFeeReminderCandidateUserIds', 'async function resolveFeeReminderCandidateUserIds');
+const buildFeeReminderCandidateUserIds = getHelper('buildFeeReminderCandidateUserIds', 'function resolveFeeReminderThresholdHours');
+const resolveFeeReminderThresholdHours = getHelper('resolveFeeReminderThresholdHours', 'function wasFeeReminderSentForThreshold');
+const wasFeeReminderSentForThreshold = getHelper('wasFeeReminderSentForThreshold', 'function formatFeeReminderWindowLabel');
+const formatFeeReminderWindowLabel = getHelper('formatFeeReminderWindowLabel', 'async function resolveFeeReminderCandidateUserIds');
 
 describe('fee due reminder helper logic', () => {
     it('builds a player key from team and player ids when the recipient does not store one', () => {
@@ -29,12 +32,31 @@ describe('fee due reminder helper logic', () => {
         expect(getFeeReminderPlayerKey({}, 'team-1')).toBe('');
     });
 
-    it('merges direct payer ids with player-linked owner ids and removes blanks or duplicates', () => {
+    it('merges only parent-linked ids and removes blanks or duplicates', () => {
         expect(buildFeeReminderCandidateUserIds({
-            userId: 'user-1',
-            accountUserId: 'user-2',
             parentUserId: 'user-1'
-        }, ['user-3', '', 'user-2'])).toEqual(['user-1', 'user-2', 'user-3']);
+        }, ['user-3', '', 'user-1'])).toEqual(['user-1', 'user-3']);
+    });
+
+    it('uses team reminder defaults when configured and falls back to the existing three-day threshold', () => {
+        expect(resolveFeeReminderThresholdHours({ scheduleNotifications: { reminderHours: 48 } })).toBe(48);
+        expect(resolveFeeReminderThresholdHours({ scheduleNotifications: { reminderHours: 24 } })).toBe(24);
+        expect(resolveFeeReminderThresholdHours({ scheduleNotifications: { reminderHours: 12 } })).toBe(72);
+        expect(resolveFeeReminderThresholdHours({})).toBe(72);
+    });
+
+    it('deduplicates reminders by threshold and treats legacy sent flags as the default three-day send', () => {
+        expect(wasFeeReminderSentForThreshold({ reminderSentAt: { seconds: 1 }, reminderThresholdHours: 48 }, 48)).toBe(true);
+        expect(wasFeeReminderSentForThreshold({ reminderSentAt: { seconds: 1 }, reminderThresholdHours: 48 }, 72)).toBe(false);
+        expect(wasFeeReminderSentForThreshold({ reminderSentAt: { seconds: 1 } }, 72)).toBe(true);
+        expect(wasFeeReminderSentForThreshold({ reminderSentAt: { seconds: 1 } }, 24)).toBe(false);
+        expect(wasFeeReminderSentForThreshold({}, 72)).toBe(false);
+    });
+
+    it('formats reminder copy from the configured day window', () => {
+        expect(formatFeeReminderWindowLabel(24)).toBe('1 day or less');
+        expect(formatFeeReminderWindowLabel(48)).toBe('2 days or less');
+        expect(formatFeeReminderWindowLabel(72)).toBe('3 days or less');
     });
 });
 
@@ -42,20 +64,23 @@ describe('fee due reminder source wiring', () => {
     it('queries fee recipients using the stored status and dueDate fields', () => {
         expect(functionsSource).toContain(".where('status', 'in', ['unpaid', 'pending'])");
         expect(functionsSource).toContain(".where('dueDate', '>=', now)");
-        expect(functionsSource).toContain(".where('dueDate', '<=', threeDaysLater)");
+        expect(functionsSource).toContain(".where('dueDate', '<=', maxReminderThresholdLater)");
     });
 
-    it('resolves player-linked parents before deciding whether to mark the reminder as sent', () => {
+    it('resolves player-linked parents and team reminder thresholds before deciding whether to mark the reminder as sent', () => {
         expect(functionsSource).toContain(".where('parentPlayerKeys', 'array-contains', playerKey)");
+        expect(functionsSource).toContain("const teamSnap = await firestore.collection('teams').doc(teamId).get();");
+        expect(functionsSource).toContain('reminderThresholdHours = resolveFeeReminderThresholdHours(teamSnap.exists ? teamSnap.data() : {});');
         expect(functionsSource).toContain('const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, data);');
         expect(functionsSource).toContain('const candidateUserIdSet = new Set(candidateUserIds);');
-        expect(functionsSource).toContain('await doc.ref.update({ reminderSentAt: admin.firestore.FieldValue.serverTimestamp() });');
+        expect(functionsSource).toContain('if (wasFeeReminderSentForThreshold(data, reminderThresholdHours)) return null;');
+        expect(functionsSource).toContain('reminderThresholdHours');
     });
 
     it('leaves reminders unmarked when no payer targets can receive them', () => {
         const candidateGuardIndex = functionsSource.indexOf('if (!candidateUserIds.length) return null;');
         const targetGuardIndex = functionsSource.indexOf('if (!payerTargets.length) return null;');
-        const markSentIndex = functionsSource.indexOf('await doc.ref.update({ reminderSentAt: admin.firestore.FieldValue.serverTimestamp() });');
+        const markSentIndex = functionsSource.indexOf('await doc.ref.update({');
 
         expect(candidateGuardIndex).toBeGreaterThan(-1);
         expect(targetGuardIndex).toBeGreaterThan(candidateGuardIndex);
@@ -66,7 +91,8 @@ describe('fee due reminder source wiring', () => {
         expect(functionsSource).toContain("const batchId = pathParts[3];");
         expect(functionsSource).toContain("const recipientId = pathParts[5];");
         expect(functionsSource).toContain("const amountLabel = formatMoneyFromCents(getTeamFeeBalanceCents(data), data.currency || 'USD');");
-        expect(functionsSource).toContain('body: `${amountLabel} is due in 3 days or less.`,');
+        expect(functionsSource).toContain('const reminderWindowLabel = formatFeeReminderWindowLabel(reminderThresholdHours);');
+        expect(functionsSource).toContain('body: `${amountLabel} is due in ${reminderWindowLabel}.`,');
         expect(functionsSource).toContain('batchId,');
         expect(functionsSource).toContain('recipientId,');
     });

--- a/tests/unit/fee-notification-contract.test.js
+++ b/tests/unit/fee-notification-contract.test.js
@@ -121,11 +121,12 @@ describe('fee notification contract', () => {
         expect(functionsSource).toContain("firestore.collectionGroup('feeRecipients')");
         expect(functionsSource).toContain(".where('status', 'in', ['unpaid', 'pending'])");
         expect(functionsSource).toContain(".where('dueDate', '>=', now)");
-        expect(functionsSource).toContain(".where('dueDate', '<=', threeDaysLater)");
-        expect(functionsSource).toContain('if (data.reminderSentAt) return null;');
+        expect(functionsSource).toContain(".where('dueDate', '<=', maxReminderThresholdLater)");
+        expect(functionsSource).toContain('if (wasFeeReminderSentForThreshold(data, reminderThresholdHours)) return null;');
         expect(functionsSource).toContain('const allTargets = await getTargetsForCategory(teamId, \'fees\', null);');
         expect(functionsSource).toContain('const payerTargets = allTargets.filter((t) => candidateUserIdSet.has(t.uid));');
-        expect(functionsSource).toContain('await doc.ref.update({ reminderSentAt: admin.firestore.FieldValue.serverTimestamp() });');
+        expect(functionsSource).toContain('reminderThresholdHours');
+        expect(functionsSource).toContain('const reminderWindowLabel = formatFeeReminderWindowLabel(reminderThresholdHours);');
         expect(functionsSource).toContain("title: `Reminder: ${title} is due soon`");
     });
 

--- a/tests/unit/fee-notification-initiative-source-contract.test.js
+++ b/tests/unit/fee-notification-initiative-source-contract.test.js
@@ -28,7 +28,7 @@ describe('fees notification initiative source contract', () => {
 
     it('marks due reminders sent only after opted-in payer targets exist', () => {
         const reminderTargetIndex = functionsSource.indexOf('const payerTargets = allTargets.filter((t) => candidateUserIdSet.has(t.uid));');
-        const markSentIndex = functionsSource.indexOf('await doc.ref.update({ reminderSentAt: admin.firestore.FieldValue.serverTimestamp() });');
+        const markSentIndex = functionsSource.indexOf('await doc.ref.update({');
 
         expect(reminderTargetIndex).toBeGreaterThan(-1);
         expect(markSentIndex).toBeGreaterThan(reminderTargetIndex);


### PR DESCRIPTION
Closes #2664

## What changed
- Use the team-configured fee reminder threshold, with the existing 72-hour default as fallback.
- Limit unpaid fee due reminder recipients to parent-linked users.
- Store reminderThresholdHours with reminderSentAt so reruns dedupe per resolved threshold.
- Keep shared fee amount formatting, fees-category routing, and parent fee destinations intact.

## Root Cause
The scheduled fee reminder path hardcoded a 72-hour window, mixed direct payer ids into the reminder audience, and used a threshold-agnostic reminderSentAt guard. That made the job ignore team timing configuration, risk non-parent delivery, and lose threshold context for reruns.

## Prevention / Learning
Scheduled notifications that depend on configurable timing should resolve the effective threshold first and persist that resolved value with send markers. Parent-scoped notifications should derive audiences from parent linkage sources instead of generic payer ids.

## Regression Tests
- npx vitest run tests/unit/fee-due-reminders-source.test.js tests/unit/fee-notification-contract.test.js tests/unit/fee-notification-initiative-source-contract.test.js --reporter=verbose
- npm run test:notifications --prefix functions