### PR TITLE
[codex] Fix mention notification conversation links

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -4,6 +4,7 @@ type PushPayload = {
     appRoute?: string;
     category?: string;
     teamId?: string;
+    conversation?: string;
     conversationId?: string;
     childId?: string;
     gameId?: string;
@@ -33,7 +34,7 @@ function encodeRouteParam(value: string) {
     return encodeURIComponent(value);
 }
 
-function buildMessagesRoute(teamId: string, conversationId?: string) {
+function buildMessagesRoute(teamId: string, conversationId?: string, conversationParam = 'conversationId') {
     const normalizedTeamId = normalizeValue(teamId);
     if (!normalizedTeamId) {
         return '';
@@ -43,7 +44,7 @@ function buildMessagesRoute(teamId: string, conversationId?: string) {
     if (!normalizedConversationId) {
         return route;
     }
-    return `${route}?conversationId=${encodeRouteParam(normalizedConversationId)}`;
+    return `${route}?${conversationParam}=${encodeRouteParam(normalizedConversationId)}`;
 }
 
 function buildScheduleEventRoute(teamId: string, eventId: string, section?: string, childId?: string) {
@@ -88,12 +89,13 @@ function buildLegacyLinkFallback(link: string) {
     try {
         const url = new URL(link);
         const teamId = normalizeValue(url.searchParams.get('teamId'));
-        const conversationId = normalizeValue(url.searchParams.get('conversationId'));
+        const conversation = normalizeValue(url.searchParams.get('conversation'));
+        const conversationId = normalizeValue(url.searchParams.get('conversationId')) || conversation;
         const gameId = normalizeValue(url.searchParams.get('gameId'));
         const path = url.pathname.toLowerCase();
 
         if (path.endsWith('/team-chat.html') && teamId) {
-            return buildMessagesRoute(teamId, conversationId);
+            return buildMessagesRoute(teamId, conversationId, conversation ? 'conversation' : 'conversationId');
         }
         if (path.endsWith('/officials.html')) {
             return teamId ? `/officials?teamId=${encodeRouteParam(teamId)}` : '/officials';
@@ -135,7 +137,8 @@ export function resolvePushNotificationRoute(input: unknown) {
 
     const category = normalizeValue(payload.category);
     const teamId = normalizeValue(payload.teamId);
-    const conversationId = normalizeValue(payload.conversationId);
+    const conversation = normalizeValue(payload.conversation);
+    const conversationId = normalizeValue(payload.conversationId) || conversation;
     const gameId = normalizeValue(payload.gameId);
     const eventId = normalizeValue(payload.eventId) || gameId;
     const childId = normalizeValue(payload.childId);
@@ -190,7 +193,7 @@ export function resolvePushNotificationRoute(input: unknown) {
         return buildMessagesRoute(teamId, conversationId);
     }
     if (category === 'mentions' && teamId) {
-        return buildMessagesRoute(teamId, conversationId);
+        return buildMessagesRoute(teamId, conversationId, 'conversation');
     }
     if (category === 'fees') {
         if (teamId && batchId) {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -2009,7 +2009,7 @@ export function buildChatViewportSignature(scrollHeight: number, clientHeight: n
 
 function getPreferredConversationIdFromSearch(search: string) {
   const params = new URLSearchParams(search || '');
-  return String(params.get('conversationId') || '').trim();
+  return String(params.get('conversation') || params.get('conversationId') || '').trim();
 }
 
 function buildMessagesRoute(teamId: string, preferredConversationId?: string | null) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -4168,7 +4168,14 @@ function buildNotificationAppRoute({ category, teamId, gameId, eventId, batchId 
     const query = params.toString();
     return `/parent-tools/fees${query ? `?${query}` : ''}`;
   }
-  if ((category === 'liveChat' || category === 'mentions') && teamId) {
+  if (category === 'mentions' && teamId) {
+    const route = `/messages/${encodeURIComponent(teamId)}`;
+    if (!conversationId) {
+      return route;
+    }
+    return `${route}?conversation=${encodeURIComponent(conversationId)}`;
+  }
+  if (category === 'liveChat' && teamId) {
     const route = `/messages/${encodeURIComponent(teamId)}`;
     if (!conversationId) {
       return route;

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -710,9 +710,9 @@ test('sendCategoryNotification uses eventId for rideshare deep links when no gam
         }
 });
 
-for (const [category, categories] of [
-    ['liveChat', { liveChat: true }],
-    ['mentions', { mentions: true }]
+for (const [category, categories, expectedAppRoute] of [
+    ['liveChat', { liveChat: true }, '/messages/team-1?conversationId=staff%20room'],
+    ['mentions', { mentions: true }, '/messages/team-1?conversation=staff%20room']
 ]) {
     test(`sendCategoryNotification includes conversation deep links for ${category} notifications`, async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
@@ -749,12 +749,12 @@ for (const [category, categories] of [
                 conversationId: 'staff room',
                 childId: '',
                 rsvpId: '',
-                appRoute: '/messages/team-1?conversationId=staff%20room',
+                appRoute: expectedAppRoute,
                 link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff%20room'
             });
             assert.equal(env.messagingCalls[0].webLink, 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff%20room');
             assert.equal(env.inboxWrites.length, 1);
-            assert.equal(env.inboxWrites[0].value.appRoute, '/messages/team-1?conversationId=staff%20room');
+            assert.equal(env.inboxWrites[0].value.appRoute, expectedAppRoute);
             assert.equal(env.auditWrites.length, 1);
             assert.equal(env.auditWrites[0].value.category, category);
         } finally {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -464,7 +464,7 @@ describe('React app messages integration', () => {
             { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
         ]);
 
-        const { container } = await renderMessages('/messages/team-1?conversationId=staff-conversation');
+        const { container } = await renderMessages('/messages/team-1?conversation=staff-conversation');
 
         expect(chatMocks.loadChatInbox).not.toHaveBeenCalled();
         expect(chatMocks.loadChatTeamContext).toHaveBeenCalledWith('team-1', auth.user);

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -55,7 +55,8 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'rideshare', teamId: 'team-1', eventId: 'game-7', childId: 'player-2' })).toBe('/schedule/team-1/game-7?childId=player-2&section=rideshare');
         expect(resolvePushNotificationRoute({ category: 'media', teamId: 'team-1' })).toBe('/teams/team-1/media');
         expect(resolvePushNotificationRoute({ category: 'awards', teamId: 'team-1', certificateId: 'cert-9' })).toBe('/parent-tools/certificates?teamId=team-1&certificateId=cert-9');
-        expect(resolvePushNotificationRoute({ category: 'mentions', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
+        expect(resolvePushNotificationRoute({ category: 'mentions', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversation=staff-2');
+        expect(resolvePushNotificationRoute({ category: 'mentions', teamId: 'team-1', conversation: 'staff-2' })).toBe('/messages/team-1?conversation=staff-2');
         expect(resolvePushNotificationRoute({ category: 'gameDay', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7?section=game');
         expect(resolvePushNotificationRoute({ category: 'officiating', teamId: 'team-1' })).toBe('/officials?teamId=team-1');
     });
@@ -63,6 +64,7 @@ describe('app push notification routing', () => {
     it('falls back to legacy web links when an explicit app route is absent', () => {
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1' })).toBe('/messages/team-1');
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
+        expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversation=staff-2' })).toBe('/messages/team-1?conversation=staff-2');
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7?section=game');
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/game-day.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7?section=game');
     });

--- a/tests/unit/chat-notification-delivery-contract.test.js
+++ b/tests/unit/chat-notification-delivery-contract.test.js
@@ -34,7 +34,9 @@ describe('team chat notification delivery contract', () => {
     it('routes chat notification links to the matching app conversation', () => {
         expect(functionsSource).toContain("if (category === 'liveChat' || category === 'mentions') {");
         expect(functionsSource).toContain('params.push(`conversationId=${encodeURIComponent(conversationId)}`);');
-        expect(functionsSource).toContain("if ((category === 'liveChat' || category === 'mentions') && teamId) {");
+        expect(functionsSource).toContain("if (category === 'mentions' && teamId) {");
+        expect(functionsSource).toContain('return `${route}?conversation=${encodeURIComponent(conversationId)}`;');
+        expect(functionsSource).toContain("if (category === 'liveChat' && teamId) {");
         expect(functionsSource).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
         expect(functionsSource).toContain('conversationId: String(conversationId || \'\')');
     });

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -313,6 +313,7 @@ describe('notifyTeamChatMessageCreated source wiring', () => {
     it('includes the conversation deep-link target in both mention and live chat payloads', () => {
         expect(notifyTeamChatMessageCreatedSource).toContain('conversationId');
         expect(functionsSource).toContain('conversationId: String(conversationId || \'\')');
+        expect(functionsSource).toContain('return `${route}?conversation=${encodeURIComponent(conversationId)}`;');
         expect(functionsSource).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
     });
 });
@@ -328,7 +329,7 @@ describe('chat mention notification destinations', () => {
             category: 'mentions',
             teamId: 'team 1',
             conversationId: 'direct/user?2'
-        })).toBe('/messages/team%201?conversationId=direct%2Fuser%3F2');
+        })).toBe('/messages/team%201?conversation=direct%2Fuser%3F2');
     });
 
     it('keeps team-wide mention notifications on the default message route', () => {

--- a/tests/unit/notification-delivery-metadata.test.js
+++ b/tests/unit/notification-delivery-metadata.test.js
@@ -64,7 +64,7 @@ describe('notification delivery metadata', () => {
         });
 
         expect(mentionLink).toBe('https://allplays.ai/team-chat.html?teamId=team%201&conversationId=parents%2Fthread%202');
-        expect(appRoute).toBe('/messages/team%201?conversationId=parents%2Fthread%202');
+        expect(appRoute).toBe('/messages/team%201?conversation=parents%2Fthread%202');
     });
 
     it('collapses rapid live score notifications by game on iOS', () => {

--- a/tests/unit/push-notification-payload-contract.test.js
+++ b/tests/unit/push-notification-payload-contract.test.js
@@ -30,7 +30,9 @@ describe('push notification payload contract', () => {
         expect(source).toContain('conversationId: String(conversationId || \'\')');
         expect(source).toContain('rsvpId: String(childId || \'\')');
         expect(source).toContain("if (category === 'liveChat' || category === 'mentions') {");
-        expect(source).toContain("if ((category === 'liveChat' || category === 'mentions') && teamId) {");
+        expect(source).toContain("if (category === 'mentions' && teamId) {");
+        expect(source).toContain('return `${route}?conversation=${encodeURIComponent(conversationId)}`;');
+        expect(source).toContain("if (category === 'liveChat' && teamId) {");
         expect(source).toContain('return `${route}?conversationId=${encodeURIComponent(conversationId)}`;');
         expect(source).toContain('params.push(`conversationId=${encodeURIComponent(conversationId)}`);');
         expect(source).toContain('fcmOptions: { link }');


### PR DESCRIPTION
## Summary
- Change mention-category notification app routes to use `/messages/{teamId}?conversation={id}` while keeping generic live chat routes on the existing `conversationId` parameter.
- Teach app push routing and the Messages page to accept the new `conversation` parameter, with fallback support for existing `conversationId` links.
- Update focused mention notification and push-routing tests for the new mention deep-link contract.

Closes #2598

## Tests
- `npx vitest run tests/unit/notification-delivery-metadata.test.js tests/unit/functions-chat-mention-detection.test.js tests/unit/chat-notification-delivery-contract.test.js tests/unit/push-notification-payload-contract.test.js tests/unit/app-push-notification-routing.test.ts tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- `npx vitest run tests/unit/issue-2589-chat-mention-notification-source.test.js tests/unit/chat-mention-server-source-contract.test.js tests/unit/chat-notification-initiative-source-contract.test.js --reporter=verbose`
- `npx vitest run tests/unit/app-notification-open-routing.test.jsx --reporter=verbose`