### PR TITLE
[codex] Add team name to schedule import summary pushes

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -5295,17 +5295,46 @@ function normalizeScheduleImportBatch(batch = {}) {
   return { batchId, totalCount, rowNumber };
 }
 
-function buildScheduleImportSummaryPayload({ totalCount, gameCount, practiceCount }) {
+function normalizeScheduleImportTeamName(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+async function resolveScheduleImportTeamName(teamId, batch = {}) {
+  const batchTeamName = normalizeScheduleImportTeamName(
+    batch.teamName
+    || batch.team?.name
+    || batch.teamDisplayName
+  );
+  if (batchTeamName) return batchTeamName;
+
+  try {
+    const teamSnap = await firestore.doc(`teams/${teamId}`).get();
+    if (!teamSnap.exists) return '';
+    const team = teamSnap.data() || {};
+    return normalizeScheduleImportTeamName(team.name || team.teamName || team.displayName);
+  } catch (error) {
+    functions.logger.warn('Failed to resolve schedule import team name for notification summary', {
+      teamId,
+      batchId: batch.batchId || null,
+      error: error?.message || String(error || 'Unknown error')
+    });
+    return '';
+  }
+}
+
+function buildScheduleImportSummaryPayload({ totalCount, gameCount, practiceCount, teamName = '' }) {
   const safeTotalCount = Math.max(0, Number(totalCount || 0));
   const safeGameCount = Math.max(0, Number(gameCount || 0));
   const safePracticeCount = Math.max(0, Number(practiceCount || 0));
+  const teamLabel = normalizeScheduleImportTeamName(teamName);
   const parts = [];
   if (safeGameCount > 0) parts.push(`${safeGameCount} game${safeGameCount === 1 ? '' : 's'}`);
   if (safePracticeCount > 0) parts.push(`${safePracticeCount} practice${safePracticeCount === 1 ? '' : 's'}`);
+  const teamDetail = teamLabel ? ` for ${teamLabel}` : '';
   const detail = parts.length ? ` (${parts.join(', ')})` : '';
   return {
     title: 'Schedule import complete',
-    body: `Imported ${safeTotalCount} schedule events${detail}.`
+    body: `Imported ${safeTotalCount} schedule events${teamDetail}${detail}.`
   };
 }
 
@@ -5345,7 +5374,8 @@ async function sendScheduleImportBatchNotifications({ teamId, batchId, batch }) 
   }
 
   if (totalCount > 3) {
-    const payload = buildScheduleImportSummaryPayload({ totalCount, gameCount, practiceCount });
+    const teamName = await resolveScheduleImportTeamName(teamId, batch);
+    const payload = buildScheduleImportSummaryPayload({ totalCount, gameCount, practiceCount, teamName });
     await sendCategoryNotification({
       teamId,
       category: 'schedule',

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -60,6 +60,129 @@ test('notifyGameCreated sends a schedule notification once and records audit out
     }
 });
 
+test('notifyGameCreated sends one team summary for schedule import batches over three events', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', name: 'Team Bears', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'coach-1', deviceId: 'coach-device', token: 'coach-token', categories: { schedule: true } },
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { schedule: true } }
+        ]
+    });
+
+    try {
+        const importBatchId = 'schedule-import-1';
+        const importedEvents = [
+            { id: 'import-game-1', type: 'game', title: 'Game at Lions' },
+            { id: 'import-practice-1', type: 'practice', title: 'Tuesday practice' },
+            { id: 'import-game-2', type: 'game', title: 'Game vs Tigers' },
+            { id: 'import-practice-2', type: 'practice', title: 'Thursday practice' }
+        ];
+        let finalResult = null;
+
+        for (const [index, event] of importedEvents.entries()) {
+            const ref = env.firestoreState.doc(`teams/team-1/games/${event.id}`);
+            const snapshot = makeSnapshot(ref, {
+                title: event.title,
+                type: event.type,
+                date: `2026-06-2${index}T16:00:00.000Z`,
+                createdBy: 'coach-1',
+                importBatch: {
+                    batchId: importBatchId,
+                    totalCount: importedEvents.length,
+                    rowNumber: index + 1,
+                    importedBy: 'coach-1'
+                }
+            });
+            const context = { params: { teamId: 'team-1', gameId: event.id } };
+            const result = await moduleExports.notifyGameCreated(snapshot, context);
+
+            if (index < importedEvents.length - 1) {
+                assert.equal(result, null);
+            } else {
+                finalResult = result;
+            }
+        }
+
+        assert.deepEqual(finalResult, {
+            title: 'Schedule import complete',
+            body: 'Imported 4 schedule events for Team Bears (2 games, 2 practices).'
+        });
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
+        assert.equal(env.messagingCalls[0].title, 'Schedule import complete');
+        assert.equal(env.messagingCalls[0].body, 'Imported 4 schedule events for Team Bears (2 games, 2 practices).');
+        assert.equal(env.messagingCalls[0].data.category, 'schedule');
+        assert.equal(env.messagingCalls[0].data.appRoute, '/schedule?teamId=team-1');
+        assert.equal(env.auditWrites.length, 1);
+        assert.equal(env.auditWrites[0].value.body, 'Imported 4 schedule events for Team Bears (2 games, 2 practices).');
+
+        const scheduleDedupWrites = env.dedupWrites.filter((write) => (
+            write.path.startsWith('teams/team-1/notificationSendLog/')
+            && write.value?.category === 'schedule'
+        ));
+        assert.equal(scheduleDedupWrites.length, 5);
+        assert.equal(scheduleDedupWrites.some((write) => write.value.dedupKey === `import-batch:${importBatchId}`), true);
+        assert.deepEqual(
+            scheduleDedupWrites
+                .filter((write) => !write.value.dedupKey)
+                .map((write) => write.value.gameId)
+                .sort(),
+            importedEvents.map((event) => event.id).sort()
+        );
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyGameUpdated does not double-push an imported event after its batch summary', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', name: 'Team Bears', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { schedule: true } }
+        ]
+    });
+
+    try {
+        const importBatchId = 'schedule-import-2';
+        for (let index = 0; index < 4; index += 1) {
+            const gameId = `imported-event-${index + 1}`;
+            const ref = env.firestoreState.doc(`teams/team-1/games/${gameId}`);
+            const snapshot = makeSnapshot(ref, {
+                title: `Imported event ${index + 1}`,
+                type: 'game',
+                date: `2026-07-0${index + 1}T18:00:00.000Z`,
+                createdBy: 'coach-1',
+                importBatch: {
+                    batchId: importBatchId,
+                    totalCount: 4,
+                    rowNumber: index + 1,
+                    importedBy: 'coach-1'
+                }
+            });
+            await moduleExports.notifyGameCreated(snapshot, { params: { teamId: 'team-1', gameId } });
+        }
+
+        const updateRef = env.firestoreState.doc('teams/team-1/games/imported-event-1');
+        const updateResult = await moduleExports.notifyGameUpdated(
+            makeChange(
+                updateRef,
+                { title: 'Imported event 1', date: '2026-07-01T18:00:00.000Z', location: 'Field 1' },
+                { title: 'Imported event 1', date: '2026-07-01T19:00:00.000Z', location: 'Field 1', updatedBy: 'coach-1' }
+            ),
+            { params: { teamId: 'team-1', gameId: 'imported-event-1' } }
+        );
+
+        assert.equal(updateResult, null);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].title, 'Schedule import complete');
+        assert.equal(env.auditWrites.length, 1);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyGameCreated respects practice preferences and skips sends when the category is off', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },

--- a/tests/unit/schedule-rsvp-notification-contract.test.js
+++ b/tests/unit/schedule-rsvp-notification-contract.test.js
@@ -50,7 +50,7 @@ describe('schedule and RSVP notification contract', () => {
     it('summarizes large schedule imports and deduplicates the individual event ids', () => {
         expect(functionsSource).toContain('async function sendScheduleImportBatchNotifications({ teamId, batchId, batch })');
         expect(functionsSource).toContain('if (totalCount > 3) {');
-        expect(functionsSource).toContain('const payload = buildScheduleImportSummaryPayload({ totalCount, gameCount, practiceCount });');
+        expect(functionsSource).toContain('const payload = buildScheduleImportSummaryPayload({ totalCount, gameCount, practiceCount, teamName });');
         expect(functionsSource).toContain("dedupKey: `import-batch:${batchId}`");
         expect(functionsSource).toContain("eventIds.map((eventId) => markNotificationDedupSent(teamId, 'schedule', eventId))");
         expect(functionsSource).toContain('exports.notifyScheduleImportBatchCompleted = notifyScheduleImportBatchCompleted;');


### PR DESCRIPTION
## Summary
- Include the team name in large schedule import summary push bodies.
- Keep large import batches to one schedule summary push while marking imported events as deduped.
- Add focused trigger coverage for >3-event imports and create-then-update dedup behavior.

## Tests
- `node node_modules/vitest/vitest.mjs run functions/test/notification-triggers.test.js --environment node --root /Users/paulsnider/.codex/worktrees/5d53f003-ad8e-4f99-99e6-bdce364fa745/allplays-2643 --config /Users/paulsnider/.codex/worktrees/5d53f003-ad8e-4f99-99e6-bdce364fa745/allplays/vitest.config.ts`
- `node node_modules/vitest/vitest.mjs run functions/test/send-category-notification.test.js functions/test/send-category-notification-load.test.js functions/test/notification-triggers.test.js --environment node --root /Users/paulsnider/.codex/worktrees/5d53f003-ad8e-4f99-99e6-bdce364fa745/allplays-2643 --config /Users/paulsnider/.codex/worktrees/5d53f003-ad8e-4f99-99e6-bdce364fa745/allplays/vitest.config.ts`

Closes #2643