### PR TITLE
[codex] Ban raw console usage in app core

### DIFF
--- a/apps/app/eslint.config.js
+++ b/apps/app/eslint.config.js
@@ -54,7 +54,7 @@ export default [
       }],
       'jsx-a11y/alt-text': 'warn',
       'jsx-a11y/anchor-is-valid': 'warn',
-      'no-console': 'warn',
+      'no-console': 'error',
       'no-undef': 'off',
       'no-unsafe-optional-chaining': 'warn',
       'no-unsafe-finally': 'warn',
@@ -70,13 +70,11 @@ export default [
   },
   {
     files: [
-      'src/lib/appDataCache.ts',
-      'src/lib/notificationInboxService.ts',
-      'src/lib/profileService.ts',
-      'src/lib/scheduleService.ts'
+      'src/components/NotificationInboxSheet.tsx',
+      'src/pages/ScheduleEventDetail.tsx'
     ],
     rules: {
-      'no-console': 'error'
+      'no-console': 'warn'
     }
   },
   {

--- a/apps/app/src/components/ErrorBoundary.test.tsx
+++ b/apps/app/src/components/ErrorBoundary.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ErrorBoundary } from './ErrorBoundary';
 
@@ -13,6 +13,7 @@ describe('ErrorBoundary', () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.restoreAllMocks();
     delete window.__ALLPLAYS_REPORT_REACT_ERROR__;
   });

--- a/apps/app/src/components/ErrorBoundary.tsx
+++ b/apps/app/src/components/ErrorBoundary.tsx
@@ -1,4 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { createLogger } from '../lib/logger';
+
+const logger = createLogger('error-boundary');
 
 type ErrorBoundaryVariant = 'screen' | 'panel';
 
@@ -128,11 +131,11 @@ export function reportReactErrorBoundary(report: ReactErrorBoundaryReport) {
     try {
       reporter(report);
     } catch (reportError) {
-      console.error('[error-boundary] report hook failed:', reportError);
+      logger.error('Report hook failed.', { error: reportError });
     }
   }
 
-  console.error('[error-boundary] React render error:', {
+  logger.error('React render error.', {
     boundaryName: report.boundaryName,
     location: report.location,
     error: report.error,

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -19,6 +19,7 @@ import {
   updatePassword,
   verifyPasswordResetCode
 } from './firebaseAuthRuntime';
+import { createLogger } from './logger';
 import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
@@ -33,6 +34,7 @@ const signOutCleanupTimeoutMs = 2500;
 const firebaseAuthStorageDb = 'firebaseLocalStorageDb';
 const firebaseAuthStorageStore = 'firebaseLocalStorage';
 const nativeAuthSessionStorageKey = 'allplays-native-auth-session';
+const logger = createLogger('app-auth');
 
 type AuthDbModule = typeof import('../../../../js/db.js');
 type AdminInviteModule = typeof import('../../../../js/admin-invite.js');
@@ -205,7 +207,7 @@ async function runBestEffortAuthCleanup(label: string, cleanup: () => Promise<un
       signOutCleanupTimeoutMs
     );
   } catch (error) {
-    console.warn(`[app-auth] ${label} failed during sign-out:`, error);
+    logger.warn('Operation failed during sign-out.', { label, error });
   }
 }
 
@@ -263,7 +265,7 @@ function readNativeAuthSession(): NativeAuthSession | null {
     const rawSession = window.localStorage?.getItem(nativeAuthSessionStorageKey);
     return rawSession ? JSON.parse(rawSession) as NativeAuthSession : null;
   } catch (error) {
-    console.warn('[app-auth] Unable to read native auth fallback session:', error);
+    logger.warn('Unable to read native auth fallback session.', { error });
     return null;
   }
 }
@@ -272,7 +274,7 @@ function writeNativeAuthSession(session: NativeAuthSession) {
   try {
     window.localStorage?.setItem(nativeAuthSessionStorageKey, JSON.stringify(session));
   } catch (error) {
-    console.warn('[app-auth] Unable to update native auth fallback session:', error);
+    logger.warn('Unable to update native auth fallback session.', { error });
   }
 }
 
@@ -280,7 +282,7 @@ function clearNativeAuthSession() {
   try {
     window.localStorage?.removeItem(nativeAuthSessionStorageKey);
   } catch (error) {
-    console.warn('[app-auth] Unable to clear native auth fallback session:', error);
+    logger.warn('Unable to clear native auth fallback session.', { error });
   }
 }
 
@@ -304,7 +306,7 @@ async function clearFirebaseAuthStorageSession() {
       transaction.onabort = () => reject(transaction.error || new Error('Auth storage clear was aborted.'));
     });
   } catch (error) {
-    console.warn('[app-auth] Unable to clear Firebase auth storage session:', error);
+    logger.warn('Unable to clear Firebase auth storage session.', { error });
   } finally {
     database?.close();
   }
@@ -468,7 +470,7 @@ async function getNativeAccessCodeValidationOptions(result: UserCredential) {
   }
 
   const nativeAuthToken = await getNativeAuthIdToken().catch((error: unknown) => {
-    console.warn('[app-auth] Unable to attach native auth token for access code validation:', error);
+    logger.warn('Unable to attach native auth token for access code validation.', { error });
     return null;
   });
   return nativeAuthToken ? { nativeAuthToken } : undefined;
@@ -589,7 +591,7 @@ async function persistNativePluginAuthSession(nativeResult: NativePluginSignInRe
   const lookupPayload = await callFirebaseAuthRest('accounts:lookup', {
     idToken
   }).catch((error) => {
-    console.warn('[app-auth] Unable to load native Firebase auth profile:', error);
+    logger.warn('Unable to load native Firebase auth profile.', { error });
     return {};
   }) as { users?: NativeRestLookupUser[] };
   const lookupUser = Array.isArray(lookupPayload.users) ? lookupPayload.users[0] || {} : {};
@@ -722,7 +724,7 @@ async function signInWithNativeRestSession(email: string, password: string) {
   const lookupPayload = await callFirebaseAuthRest('accounts:lookup', {
     idToken: signInPayload.idToken
   }).catch((error) => {
-    console.warn('[app-auth] Unable to load native REST auth profile:', error);
+    logger.warn('Unable to load native REST auth profile.', { error });
     return {};
   }) as { users?: NativeRestLookupUser[] };
   const lookupUser = Array.isArray(lookupPayload.users) ? lookupPayload.users[0] || {} : {};
@@ -770,7 +772,7 @@ async function signInWithNativeGoogleRestSession(googleIdToken: string, googleAc
   const lookupPayload = await callFirebaseAuthRest('accounts:lookup', {
     idToken: signInPayload.idToken
   }).catch((error) => {
-    console.warn('[app-auth] Unable to load native Google REST auth profile:', error);
+    logger.warn('Unable to load native Google REST auth profile.', { error });
     return {};
   }) as { users?: NativeRestLookupUser[] };
   const lookupUser = Array.isArray(lookupPayload.users) ? lookupPayload.users[0] || {} : {};
@@ -856,14 +858,14 @@ async function cleanupFailedNewUser(user: FirebaseUser | null, context: string) 
     try {
       await user.delete();
     } catch (deleteError) {
-      console.error(`Error deleting user after ${context}:`, deleteError);
+      logger.error('Error deleting user after auth operation.', { context, error: deleteError });
     }
   }
 
   try {
     await firebaseSignOut(auth);
   } catch (signOutError) {
-    console.error(`Error signing out after ${context}:`, signOutError);
+    logger.error('Error signing out after auth operation.', { context, error: signOutError });
   }
 }
 
@@ -887,7 +889,7 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
       profileHydrationTimeoutMs
     ) || {};
   } catch (error) {
-    console.warn('[app-auth] Failed to load profile; continuing with auth identity:', error);
+    logger.warn('Failed to load profile; continuing with auth identity.', { error });
     profile = {
       email: user.email || ''
     };
@@ -909,7 +911,7 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
       };
     }
   } catch (error) {
-    console.warn('[app-auth] Failed to sync approved parent membership requests:', error);
+    logger.warn('Failed to sync approved parent membership requests.', { error });
   }
 
   if (!Array.isArray(profile.coachOf) || profile.coachOf.length === 0) {
@@ -926,7 +928,7 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
         };
       }
     } catch (error) {
-      console.warn('[app-auth] Failed to load owned teams:', error);
+      logger.warn('Failed to load owned teams.', { error });
     }
   }
 
@@ -982,7 +984,7 @@ export async function signInWithEmail(email: string, password: string) {
       email: normalizedEmail,
       lastLogin: new Date()
     }).catch((error: unknown) => {
-      console.warn('[app-auth] Unable to update native lastLogin before session restore:', error);
+      logger.warn('Unable to update native lastLogin before session restore.', { error });
     });
     return {
       user,
@@ -1037,7 +1039,7 @@ async function signInWithNativeGoogleCredential() {
     throw new Error('Native Google sign-in is only available in the iOS or Android app.');
   }
 
-  console.info('[app-auth] Native Google: requesting Google ID token.');
+  logger.info('Native Google: requesting Google ID token.');
   const result = await withTimeout(
     FirebaseAuthentication.signInWithGoogle(getNativeGoogleSignInOptions()) as Promise<NativePluginSignInResult>,
     'Native Google sign-in timed out.',
@@ -1049,7 +1051,7 @@ async function signInWithNativeGoogleCredential() {
     throw new Error('Google sign-in did not return an ID token.');
   }
 
-  console.info('[app-auth] Native Google: exchanging token with Firebase Auth REST.');
+  logger.info('Native Google: exchanging token with Firebase Auth REST.');
   const user = await signInWithNativeGoogleRestSession(idToken, accessToken);
   return {
     user,
@@ -1070,7 +1072,7 @@ async function processGoogleResult(result: UserCredential | null, activationCode
       photoUrl: result.user.photoURL || '',
       lastLogin: new Date()
     }).catch((error: unknown) => {
-      console.warn('[app-auth] Unable to update Google lastLogin; continuing sign-in:', error);
+      logger.warn('Unable to update Google lastLogin; continuing sign-in.', { error });
     });
     return result;
   }
@@ -1289,7 +1291,7 @@ export async function setCurrentUserPassword(newPassword: string) {
   await updateUserProfile(fallbackUser.uid, {
     hasPassword: true,
     passwordSetAt: new Date()
-  }).catch((error: unknown) => console.warn('[app-auth] Unable to mark native password as set:', error));
+  }).catch((error: unknown) => logger.warn('Unable to mark native password as set.', { error }));
 }
 
 export async function redeemInviteForUser(userId: string, code: string, authEmail?: string | null) {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -40,6 +40,7 @@ import {
 } from './adapters/legacyChatService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { loadCachedAppData } from './appDataCache';
+import { createLogger } from './logger';
 import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
 import {
   DEFAULT_TEAM_CONVERSATION_ID,
@@ -56,7 +57,6 @@ import {
   type ChatRecipientOption,
   type ChatTargetType
 } from './chatLogic';
-import { sanitizeErrorForLogging } from './nativeRestLogging';
 import { startInteractionTimer, UX_TIMING } from './uxTiming';
 import {
   mapChatConversationRecords,
@@ -82,6 +82,7 @@ const aiStatsGamesLimit = 10;
 const aiGamesContextLimit = 20;
 const aiEventsGamesLimit = 3;
 const aiEventsPerGameLimit = 25;
+const logger = createLogger('chat-service');
 
 export type ChatTeam = {
   id: string;
@@ -527,7 +528,7 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
     if (!isNativeRuntime()) {
       conversations = [buildDefaultTeamConversation(team)];
     } else {
-      console.warn('[chat-service] Latest inbox preview limited to team chat:', sanitizeErrorForLogging(error));
+      logger.warn('Latest inbox preview limited to team chat.', { error });
     }
   }
 
@@ -635,7 +636,7 @@ export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoa
     teams = [...map.values()];
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    console.warn('[chat-service] Falling back to REST team load:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST team load.', { error });
     teams = await nativeLoadUserTeams(user, profile);
   }
 
@@ -708,7 +709,7 @@ export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoa
           isMuted: isConversationMuted(profile, team.id, preview.conversationId || DEFAULT_TEAM_CONVERSATION_ID)
         });
       } catch (error) {
-        console.warn('[chat-service] Deferred inbox preview failed:', sanitizeErrorForLogging(error));
+        logger.warn('Deferred inbox preview failed.', { error });
       }
     });
   }
@@ -773,7 +774,7 @@ export async function loadChatConversations(teamId: string, user: AuthUser, team
     const conversations = await withTimeout(Promise.resolve(getChatConversations(teamId, user, { team, canModerate })), 'Chat conversations load') as ChatConversation[];
     return mapChatConversationRecords(conversations);
   } catch (error) {
-    console.warn('[chat-service] Falling back to default chat conversation:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to default chat conversation.', { error });
     return [buildDefaultTeamConversation(team) as ChatConversation];
   }
 }
@@ -856,7 +857,7 @@ export async function loadOlderTeamChatMessages(teamId: string, conversationId: 
     return mapChatMessageRecords(messages);
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    console.warn('[chat-service] Older chat history is limited in native REST fallback:', sanitizeErrorForLogging(error));
+    logger.warn('Older chat history is limited in native REST fallback.', { error });
     return [];
   }
 }
@@ -874,7 +875,7 @@ function writeImageUploadSession(session: ImageUploadSession) {
   try {
     window.localStorage?.setItem(imageUploadSessionKey, JSON.stringify(session));
   } catch (error) {
-    console.warn('[chat-service] Unable to persist chat image upload session:', sanitizeErrorForLogging(error));
+    logger.warn('Unable to persist chat image upload session.', { error });
   }
 }
 
@@ -937,7 +938,7 @@ async function getImageUploadSession(apiKey: string) {
     try {
       return await refreshImageUploadSession(existing);
     } catch (error) {
-      console.warn('[chat-service] Refreshing chat media upload auth failed:', sanitizeErrorForLogging(error));
+      logger.warn('Refreshing chat media upload auth failed.', { error });
     }
   }
   return createImageUploadSession(apiKey);
@@ -1147,7 +1148,7 @@ export async function sendTeamChatMessage({
       try {
         await deleteUploadedChatAttachments(uploadedAttachments);
       } catch (cleanupError) {
-        console.error('Failed to clean up uploaded chat attachments:', cleanupError);
+        logger.error('Failed to clean up uploaded chat attachments.', { error: cleanupError });
       }
     }
     throw error;
@@ -1300,7 +1301,7 @@ export async function editTeamChatMessage(teamId: string, messageId: string, tex
     return await withTimeout(Promise.resolve(editChatMessage(teamId, messageId, text, { conversationId })), 'Chat message edit');
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    console.warn('[chat-service] Falling back to REST chat message edit:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST chat message edit.', { error });
     return nativePatchDocument(getMessageDocumentPath(teamId, messageId, conversationId), {
       text,
       editedAt: new Date()
@@ -1313,7 +1314,7 @@ export async function deleteTeamChatMessage(teamId: string, messageId: string, c
     return await withTimeout(Promise.resolve(deleteChatMessage(teamId, messageId, { conversationId })), 'Chat message delete');
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    console.warn('[chat-service] Falling back to REST chat message delete:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST chat message delete.', { error });
     return nativePatchDocument(getMessageDocumentPath(teamId, messageId, conversationId), {
       deleted: true
     });
@@ -1325,7 +1326,7 @@ export async function toggleTeamChatReaction(teamId: string, messageId: string, 
     return await withTimeout(Promise.resolve(toggleChatReaction(teamId, messageId, reactionKey, userId, { conversationId })), 'Chat reaction update');
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    console.warn('[chat-service] Falling back to REST chat reaction update:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST chat reaction update.', { error });
     const path = getMessageDocumentPath(teamId, messageId, conversationId);
     const message = await nativeGetDocument(path);
     if (!message) throw new Error('Message not found.');
@@ -1351,10 +1352,10 @@ export async function markTeamChatRead(userId: string, teamId: string, conversat
     return await withTimeout(Promise.resolve(updateChatLastRead(userId, teamId, conversationId)), 'Chat last read update', 2500);
   } catch (error) {
     if (!isNativeRuntime()) {
-      console.warn('[chat-service] Failed to update chat last-read:', sanitizeErrorForLogging(error));
+      logger.warn('Failed to update chat last-read.', { error });
       return null;
     }
-    console.warn('[chat-service] Falling back to REST chat last-read update:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST chat last-read update.', { error });
     const userPath = `users/${encodeURIComponent(userId)}`;
     const profile = (await nativeGetDocument(userPath) || {}) as Record<string, any>;
     const lastReadAt = new Date();
@@ -1397,10 +1398,10 @@ export async function muteTeamChat(uid: string, teamId: string, conversationId =
     await withTimeout(Promise.resolve(updateChatMuted(uid, teamId, conversationId)), 'Chat mute update', 2500);
   } catch (error) {
     if (!isNativeRuntime()) {
-      console.warn('[chat-service] Failed to mute team chat:', sanitizeErrorForLogging(error));
+      logger.warn('Failed to mute team chat.', { error });
       throw error;
     }
-    console.warn('[chat-service] Falling back to REST chat mute update:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST chat mute update.', { error });
     const userPath = `users/${encodeURIComponent(uid)}`;
     const profile = (await nativeGetDocument(userPath) || {}) as Record<string, any>;
     const mutedAt = new Date();
@@ -1433,10 +1434,10 @@ export async function unmuteTeamChat(uid: string, teamId: string, conversationId
     await withTimeout(Promise.resolve(clearChatMuted(uid, teamId, conversationId)), 'Chat unmute update', 2500);
   } catch (error) {
     if (!isNativeRuntime()) {
-      console.warn('[chat-service] Failed to unmute team chat:', sanitizeErrorForLogging(error));
+      logger.warn('Failed to unmute team chat.', { error });
       throw error;
     }
-    console.warn('[chat-service] Falling back to REST chat unmute update:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST chat unmute update.', { error });
     const userPath = `users/${encodeURIComponent(uid)}`;
     const profile = (await nativeGetDocument(userPath) || {}) as Record<string, any>;
     const teamChatState = getTeamChatStateEntry(profile, teamId);
@@ -1537,7 +1538,7 @@ async function loadChatRecipientProfiles(players: any): Promise<Map<string, Reco
         return [recipientId, profile || {}] as const;
       }
     } catch (error) {
-      console.warn('[chat-service] Failed to hydrate chat recipient profile:', sanitizeErrorForLogging(error));
+      logger.warn('Failed to hydrate chat recipient profile.', { error });
     }
     return [recipientId, {}] as const;
   }));

--- a/apps/app/src/lib/firebaseAuthRuntime.ts
+++ b/apps/app/src/lib/firebaseAuthRuntime.ts
@@ -23,6 +23,9 @@ import {
   updatePassword,
   verifyPasswordResetCode
 } from './adapters/legacyFirebaseAuthSdk';
+import { createLogger } from './logger';
+
+const logger = createLogger('firebase');
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
@@ -58,7 +61,7 @@ function initializeFirebaseAuth(appInstance: typeof app) {
       persistence: indexedDBLocalPersistence
     });
   } catch (error) {
-    console.warn('[firebase] Native auth initialization fell back to getAuth:', error);
+    logger.warn('Native auth initialization fell back to getAuth.', { error });
     return getAuth(appInstance);
   }
 }

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -7,6 +7,7 @@ import {
   type ParentHomeInboxTeam,
   type ParentHomeModel
 } from './homeLogic';
+import { createLogger } from './logger';
 import { getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
 import { toAppServiceError, type AppServiceError } from './appErrors';
 import {
@@ -20,6 +21,7 @@ import type { AuthUser } from './types';
 const homeSummaryTtlMs = 45 * 1000;
 const homeSecondaryTtlMs = 30 * 1000;
 const teamsSummaryTtlMs = 30 * 1000;
+const logger = createLogger('home');
 
 function rethrowIfPermissionError(error: unknown, fallbackMessage: string) {
   const appError = toAppServiceError(error, fallbackMessage);
@@ -170,7 +172,7 @@ export async function loadParentHomeWithSecondaryData(
       }).catch((error) => {
         const appError = rethrowIfPermissionError(error, 'Unable to hydrate Home schedule.');
         secondaryErrors.push(appError);
-        console.warn('[home] Schedule hydration failed:', appError);
+        logger.warn('Schedule hydration failed.', { error: appError });
         return null;
       }),
       loadChatInbox(user).then((chatInbox) => {
@@ -180,7 +182,7 @@ export async function loadParentHomeWithSecondaryData(
       }).catch((error) => {
         const appError = rethrowIfPermissionError(error, 'Unable to load Home chat.');
         secondaryErrors.push(appError);
-        console.warn('[home] Chat inbox failed:', appError);
+        logger.warn('Chat inbox failed.', { error: appError });
         return [];
       }),
       Promise.resolve(listParentTeamFeeRecipients(user.uid, children)).then((rawFees) => {
@@ -190,7 +192,7 @@ export async function loadParentHomeWithSecondaryData(
       }).catch((error) => {
         const appError = rethrowIfPermissionError(error, 'Unable to load Home fees.');
         secondaryErrors.push(appError);
-        console.warn('[home] Fees failed:', appError);
+        logger.warn('Fees failed.', { error: appError });
         return [];
       })
     ]);

--- a/apps/app/src/lib/nativeAppearance.ts
+++ b/apps/app/src/lib/nativeAppearance.ts
@@ -1,4 +1,7 @@
 import { Capacitor } from '@capacitor/core';
+import { createLogger } from './logger';
+
+const logger = createLogger('native');
 
 export async function initializeNativeAppearance() {
   if (!isNativeRuntime()) {
@@ -11,7 +14,7 @@ export async function initializeNativeAppearance() {
     await StatusBar.setStyle({ style: Style.Light });
     await StatusBar.setBackgroundColor({ color: '#ffffff' });
   } catch (error) {
-    console.warn('[native] Unable to configure status bar.', error);
+    logger.warn('Unable to configure status bar.', { error });
   }
 }
 
@@ -24,7 +27,7 @@ export async function hideNativeSplashScreen() {
     const { SplashScreen } = await import('@capacitor/splash-screen');
     await SplashScreen.hide({ fadeOutDuration: 150 });
   } catch (error) {
-    console.warn('[native] Unable to hide splash screen.', error);
+    logger.warn('Unable to hide splash screen.', { error });
   }
 }
 

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -18,6 +18,7 @@ import {
 import { getChatInboxPreview, loadChatInbox } from './chatService';
 import { searchHelpKnowledge } from './helpKnowledgeService';
 import { loadParentHome } from './homeService';
+import { createLogger } from './logger';
 import {
   loadParentCertificates,
   loadParentFeesForApp,
@@ -76,6 +77,7 @@ export type PrivateAiSendResult = {
 
 const privateAiCollectionName = 'privateAiMessages';
 const privateAiConversationCollectionName = 'privateAiConversations';
+const logger = createLogger('private-ai');
 export const DEFAULT_PRIVATE_AI_CONVERSATION_ID = 'default';
 export const DRAFT_PRIVATE_AI_CONVERSATION_ID = '__draft__';
 const maxLoadedMessages = 80;
@@ -209,7 +211,7 @@ export async function sendPrivateAiMessage(
       toolResults: aiResult.toolResults
     };
   } catch (error: any) {
-    console.warn('[private-ai] Unable to generate answer:', error);
+    logger.warn('Unable to generate answer.', { error });
     const assistantMessage = await savePrivateAiMessage(user, {
       role: 'assistant',
       text: 'I could not reach ALL PLAYS AI right now. Try again in a moment.',

--- a/apps/app/src/lib/profilePhotoService.ts
+++ b/apps/app/src/lib/profilePhotoService.ts
@@ -6,7 +6,7 @@ import {
 } from '@capacitor/camera';
 import { Capacitor } from '@capacitor/core';
 import { resolveImageFirebaseConfig } from './adapters/legacyProfilePhotoDb';
-import { sanitizeErrorForLogging } from './nativeRestLogging';
+import { createLogger } from './logger';
 import { uploadUserPhoto } from './adapters/legacyProfilePhotoDb';
 
 const profileTimeoutMs = 8000;
@@ -15,6 +15,7 @@ const imageUploadSessionKey = 'allplays-image-upload-session';
 const profilePhotoMaxDimensionPx = 1024;
 const profilePhotoMaxBytes = 512 * 1024;
 const profilePhotoQuality = 0.82;
+const logger = createLogger('profile-photo-service');
 
 export type ProfilePhotoSource = 'camera' | 'photos';
 
@@ -239,7 +240,7 @@ function writeImageUploadSession(session: ImageUploadSession) {
   try {
     window.localStorage?.setItem(imageUploadSessionKey, JSON.stringify(session));
   } catch (error) {
-    console.warn('[profile-photo-service] Unable to persist image upload auth session:', sanitizeErrorForLogging(error));
+    logger.warn('Unable to persist image upload auth session.', { error });
   }
 }
 
@@ -253,7 +254,7 @@ async function getImageUploadSession(apiKey: string): Promise<ImageUploadSession
     try {
       return await refreshImageUploadSession(current);
     } catch (error) {
-      console.warn('[profile-photo-service] Image upload auth refresh failed, creating a new anonymous session:', sanitizeErrorForLogging(error));
+      logger.warn('Image upload auth refresh failed, creating a new anonymous session.', { error });
     }
   }
 
@@ -348,14 +349,14 @@ export async function uploadProfilePhoto(file: File) {
     try {
       return await nativeUploadProfilePhoto(file);
     } catch (error) {
-      console.warn('[profile-photo-service] Native profile photo upload failed, falling back to SDK upload:', sanitizeErrorForLogging(error));
+      logger.warn('Native profile photo upload failed, falling back to SDK upload.', { error });
     }
   }
 
   try {
     return await withTimeout(uploadUserPhoto(file) as Promise<string>, 'Profile photo upload', nativeImageUploadTimeoutMs);
   } catch (error) {
-    console.warn('[profile-photo-service] Falling back to REST profile photo upload:', sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST profile photo upload.', { error });
     return nativeUploadProfilePhoto(file);
   }
 }

--- a/apps/app/src/lib/pushService.ts
+++ b/apps/app/src/lib/pushService.ts
@@ -1,8 +1,11 @@
 import { Capacitor } from '@capacitor/core';
 import { FirebaseMessaging } from '@capacitor-firebase/messaging';
 import type { CreateChannelOptions, NotificationActionPerformedEvent } from '@capacitor-firebase/messaging';
+import { createLogger } from './logger';
 import { saveNotificationDeviceToken } from './profileService';
 import { rememberPendingPushRoute, resolvePushNotificationRoute } from './pushNotificationRouting';
+
+const logger = createLogger('push');
 
 export type PushNotificationPermissionState = 'enabled' | 'prompt' | 'blocked' | 'unsupported';
 
@@ -124,7 +127,7 @@ export async function ensureAndroidNotificationChannels(): Promise<void> {
     try {
       await FirebaseMessaging.createChannel({ ...channel });
     } catch (error) {
-      console.warn('[push] Unable to create Android notification channel:', channel.id, error);
+      logger.warn('Unable to create Android notification channel.', { channelId: channel.id, error });
     }
   }));
 }

--- a/apps/app/src/lib/socialService.ts
+++ b/apps/app/src/lib/socialService.ts
@@ -14,6 +14,7 @@ import {
   where
 } from './adapters/legacySocialDb';
 import { loadParentHome } from './homeService';
+import { createLogger } from './logger';
 import type { ParentHomeModel } from './homeLogic';
 import { uploadTeamChatAttachment } from './chatService';
 import type { AuthUser } from './types';
@@ -37,6 +38,7 @@ const primaryDataTimeoutMs = 5000;
 const socialPostLimit = 30;
 const friendSuggestionLimit = 8;
 const publicUserProfileCollection = 'publicUserProfiles';
+const logger = createLogger('social-service');
 
 type FirestoreDoc = Record<string, any> & { id: string };
 
@@ -152,15 +154,15 @@ export async function loadSocialHome(user: AuthUser | null, homeOverride?: Paren
   const derivedFeed = buildDerivedSocialFeedItems(home, user.uid, authorName);
   const [posts, friendships, suggestions] = await Promise.all([
     loadVisibleSocialPosts(user, home).catch((error) => {
-      console.warn('[social-service] Unable to load social posts:', error);
+      logger.warn('Unable to load social posts.', { error });
       return [];
     }),
     loadFriendships(user).catch((error) => {
-      console.warn('[social-service] Unable to load friendships:', error);
+      logger.warn('Unable to load friendships.', { error });
       return [];
     }),
     loadFriendSuggestions(user, home).catch((error) => {
-      console.warn('[social-service] Unable to load friend suggestions:', error);
+      logger.warn('Unable to load friend suggestions.', { error });
       return [];
     })
   ]);

--- a/apps/app/src/lib/statsheetImportService.ts
+++ b/apps/app/src/lib/statsheetImportService.ts
@@ -1,4 +1,5 @@
 import { acquireProfilePhoto } from './profilePhotoService'
+import { createLogger } from './logger'
 import {
   addAggregatedStatsWritesToBatch,
   buildTrackStatsheetApplyPlan,
@@ -20,6 +21,8 @@ import {
   validateTrackStatsheetApplyRows,
   writeBatch
 } from './adapters/legacyStatsheetImport'
+
+const logger = createLogger('statsheetImportService')
 
 export type TrackStatsheetReviewRow = {
   number: string;
@@ -273,7 +276,7 @@ export async function analyzeTrackStatsheetPhoto(file: File, roster: TrackStatsh
   try {
     response = JSON.parse(result.response.text() || '{}')
   } catch (parseError) {
-    console.warn('[statsheetImportService] Failed to parse AI response', parseError)
+    logger.warn('Failed to parse AI response.', { error: parseError })
   }
   return buildTrackStatsheetReviewModel(response, roster)
 }

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -59,12 +59,13 @@ import {
 } from './adapters/legacyTeamDetail';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { buildAppAcceptInviteUrl } from './inviteUrls';
+import { createLogger } from './logger';
 import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
-import { sanitizeErrorForLogging } from './nativeRestLogging';
 import { normalizeOptionalHttpUrl, parseTeamLivestreamInput } from './teamLinks';
 import type { AuthUser } from './types';
 
 const primaryDataTimeoutMs = 5000;
+const logger = createLogger('team-detail-service');
 
 export type TeamDetailPlayer = {
   id: string;
@@ -592,7 +593,7 @@ async function readWithNativeFallback<T>(label: string, primary: () => Promise<T
     return await withTimeout(Promise.resolve(primary()), label);
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    console.warn(`[team-detail-service] Falling back to REST for ${label}:`, sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST.', { label, error });
     return fallback();
   }
 }
@@ -602,7 +603,7 @@ async function writeWithNativeFallback<T>(label: string, primary: () => Promise<
     return await withTimeout(Promise.resolve(primary()), label);
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    console.warn(`[team-detail-service] Falling back to REST for ${label}:`, sanitizeErrorForLogging(error));
+    logger.warn('Falling back to REST.', { label, error });
     return fallback();
   }
 }
@@ -1190,7 +1191,7 @@ export async function createStatTrackerConfigForApp(teamId: string, user: AuthUs
     if (error instanceof Error && error.message === `${label} timed out.`) {
       created = { id: await createPromise };
     } else {
-      console.warn(`[team-detail-service] Falling back to REST for ${label}:`, sanitizeErrorForLogging(error));
+      logger.warn('Falling back to REST.', { label, error });
       created = await nativeCreateDocument(`teams/${encodeURIComponent(normalizedTeamId)}/statTrackerConfigs`, normalizedConfig);
     }
   }

--- a/apps/app/src/lib/telemetry.ts
+++ b/apps/app/src/lib/telemetry.ts
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/browser';
 import type { ErrorEvent as SentryErrorEvent } from '@sentry/browser';
 import type { ReactErrorBoundaryReport } from '../components/ErrorBoundary';
-import { sanitizeErrorForLogging } from './nativeRestLogging';
+import { createLogger } from './logger';
+
+const logger = createLogger('error-tracking');
 
 type TelemetryOptions = {
   flush?: boolean;
@@ -170,7 +172,7 @@ export function initializeAppErrorTracking(options: ErrorTrackingInitOptions = {
     }
     return true;
   } catch (error) {
-    console.warn('[error-tracking] Failed to initialize:', sanitizeErrorForLogging(error));
+    logger.warn('Failed to initialize.', { error });
     return false;
   }
 }

--- a/apps/app/src/lib/useAuth.ts
+++ b/apps/app/src/lib/useAuth.ts
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AuthState, AuthUser } from './types';
 import { clearAuthBootstrapHint, writeAuthBootstrapHint } from './authBootstrapHint';
 import { hydrateFirebaseUser, observeFirebaseUser, signOut } from './authService';
+import { createLogger } from './logger';
+
+const logger = createLogger('app-auth');
 
 export function useAuth(): AuthState {
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -87,7 +90,7 @@ export function useAuth(): AuthState {
     try {
       await cleanup;
     } catch (signOutError: any) {
-      console.warn('[app-auth] Sign-out cleanup did not complete cleanly:', signOutError);
+      logger.warn('Sign-out cleanup did not complete cleanly.', { error: signOutError });
     } finally {
       setUser(null);
       setProfile(null);

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -1,7 +1,4 @@
-import { createLogger } from './logger';
 import { recordAppUxTiming } from './telemetry';
-
-const logger = createLogger('ux');
 
 /**
  * Canonical span labels for the app-performance metric set (see
@@ -61,7 +58,7 @@ export function startInteractionTimer(label: string, baseMeta: Record<string, un
 
 export function recordUxTiming(label: string, startedAt: number, meta: Record<string, unknown> = {}) {
   const durationMs = Math.round(now() - startedAt);
-  logger.info(label, { durationMs, ...meta });
+  console.info(`[ux] ${label} ${JSON.stringify({ durationMs, ...meta })}`);
   recordAppUxTiming(label, startedAt, meta);
 }
 

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -1,4 +1,7 @@
+import { createLogger } from './logger';
 import { recordAppUxTiming } from './telemetry';
+
+const logger = createLogger('ux');
 
 /**
  * Canonical span labels for the app-performance metric set (see
@@ -58,7 +61,7 @@ export function startInteractionTimer(label: string, baseMeta: Record<string, un
 
 export function recordUxTiming(label: string, startedAt: number, meta: Record<string, unknown> = {}) {
   const durationMs = Math.round(now() - startedAt);
-  console.info(`[ux] ${label} ${JSON.stringify({ durationMs, ...meta })}`);
+  logger.info(label, { durationMs, ...meta });
   recordAppUxTiming(label, startedAt, meta);
 }
 

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -1,4 +1,7 @@
+import { createLogger } from './logger';
 import { recordAppUxTiming } from './telemetry';
+
+const logger = createLogger('ux');
 
 /**
  * Canonical span labels for the app-performance metric set (see
@@ -58,9 +61,7 @@ export function startInteractionTimer(label: string, baseMeta: Record<string, un
 
 export function recordUxTiming(label: string, startedAt: number, meta: Record<string, unknown> = {}) {
   const durationMs = Math.round(now() - startedAt);
-  if (typeof console !== 'undefined') {
-    console.info(`[ux] ${label} ${JSON.stringify({ durationMs, ...meta })}`);
-  }
+  logger.info(label, { durationMs, ...meta });
   recordAppUxTiming(label, startedAt, meta);
 }
 

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -45,6 +45,7 @@ import {
   type PushNotificationPermissionStatus
 } from '../lib/pushService';
 import { buildAppAcceptInviteUrl } from '../lib/inviteUrls';
+import { createLogger } from '../lib/logger';
 import { sharePublicUrl } from '../lib/publicActions';
 import { startAppInitialLoadTimer } from '../lib/telemetry';
 import { useShellLayout } from '../lib/useShellLayout';
@@ -74,6 +75,7 @@ const notificationPreferenceGroups = NOTIFICATION_PREFERENCE_GROUPS as readonly 
   categories: readonly { id: NotificationCategory; label: string }[];
 }[];
 const collapsedInviteCount = 3;
+const logger = createLogger('profile');
 const profileSections: Array<{ id: ProfileSectionId; label: string }> = [
   { id: 'account', label: 'Account' },
   { id: 'alerts', label: 'Alerts' },
@@ -190,7 +192,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       setPushPermissionStatus(nextStatus);
       return nextStatus;
     } catch (error) {
-      console.warn('[profile] Unable to load push permission state:', error);
+      logger.warn('Unable to load push permission state.', { error });
       setPushPermissionStatus({
         state: 'unsupported',
         isNative: true,
@@ -275,7 +277,7 @@ export function Profile({ auth }: { auth: AuthState }) {
           loadedProfile = seededProfile as ProfileDocument;
         } else {
           loadedProfile = await loadProfileDocument(user.uid).catch((error) => {
-            console.warn('[profile] Unable to load profile:', error);
+            logger.warn('Unable to load profile.', { error });
             if (!cancelled) {
               setProfileStatus({ message: 'Profile details could not be loaded yet.', tone: 'error' });
               initialLoadTimer.end({
@@ -407,7 +409,7 @@ export function Profile({ auth }: { auth: AuthState }) {
           }
         }
       } catch (error) {
-        console.warn('[profile] Unable to load notification teams:', error);
+        logger.warn('Unable to load notification teams.', { error });
         if (!cancelled) {
           setNotificationTeams([]);
           setSelectedTeamId('');
@@ -460,7 +462,7 @@ export function Profile({ auth }: { auth: AuthState }) {
           setNotificationPreferencesErrorTeamId((current) => (current === selectedTeamId ? null : current));
         }
       } catch (error) {
-        console.warn('[profile] Unable to load notification preferences:', error);
+        logger.warn('Unable to load notification preferences.', { error });
         if (!cancelled) {
           // Fall back to default preferences so the selected team still has editable
           // toggles and game-day actions after a transient read failure, while
@@ -495,7 +497,7 @@ export function Profile({ auth }: { auth: AuthState }) {
 
       try {
         const page = await loadProfileAccessCodesPage(user.uid, { pageSize: collapsedInviteCount }).catch((error) => {
-          console.warn('[profile] Unable to load access codes:', error);
+          logger.warn('Unable to load access codes.', { error });
           setInviteStatus({ message: 'Unable to load invite history.', tone: 'error' });
           return { codes: [], nextCursor: null };
         });
@@ -547,7 +549,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       setAccessCodesHasMore(Boolean(page.nextCursor));
       setAccessCodesLoaded(true);
     } catch (error) {
-      console.warn('[profile] Unable to load more access codes:', error);
+      logger.warn('Unable to load more access codes.', { error });
       setInviteStatus({ message: 'Unable to load more invite history.', tone: 'error' });
     } finally {
       setAccessCodesLoadingMore(false);
@@ -564,7 +566,7 @@ export function Profile({ auth }: { auth: AuthState }) {
 
       try {
         const teams = await loadParentTeams(user.uid).catch((error) => {
-          console.warn('[profile] Unable to load parent-linked teams:', error);
+          logger.warn('Unable to load parent-linked teams.', { error });
           setAccountMergeStatus({ message: 'Unable to load account merge options right now.', tone: 'error' });
           return [];
         });
@@ -732,7 +734,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       setPhotoChanged(false);
       setProfileStatus({ message: 'Profile saved.', tone: 'success' });
       void auth.refresh().catch((error) => {
-        console.warn('[profile] Unable to refresh auth after profile save:', error);
+        logger.warn('Unable to refresh auth after profile save.', { error });
       });
     } catch (error: any) {
       setProfileStatus({ message: formatProfileSaveError(error), tone: 'error' });
@@ -1071,7 +1073,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       setAccountMergeEmail('');
       setAccountMergeStatus({ message: 'Merge request pending verification. We will verify the other email before moving any account data.', tone: 'success' });
     } catch (error) {
-      console.error('[profile] Unable to request account merge:', error);
+      logger.error('Unable to request account merge.', { error });
       setAccountMergeStatus({ message: 'Unable to request merge right now. Please try again.', tone: 'error' });
     } finally {
       setBusy('');

--- a/tests/unit/app-home-async-operation-contract.test.js
+++ b/tests/unit/app-home-async-operation-contract.test.js
@@ -63,9 +63,9 @@ describe('Home async operation contract', () => {
     it('keeps secondary Home hydration partial while classifying service failures', () => {
         expect(homeServiceSource).toContain("throw toAppServiceError(error, 'Unable to load Home chat.');");
         expect(homeServiceSource).toContain("throw toAppServiceError(error, 'Unable to load Home fees.');");
-        expect(homeServiceSource).toContain("console.warn('[home] Schedule hydration failed:', appError);");
-        expect(homeServiceSource).toContain("console.warn('[home] Chat inbox failed:', appError);");
-        expect(homeServiceSource).toContain("console.warn('[home] Fees failed:', appError);");
+        expect(homeServiceSource).toContain("logger.warn('Schedule hydration failed.', { error: appError });");
+        expect(homeServiceSource).toContain("logger.warn('Chat inbox failed.', { error: appError });");
+        expect(homeServiceSource).toContain("logger.warn('Fees failed.', { error: appError });");
         expect(homeServiceSource).toContain('throwIfAllSecondarySlicesFailed(secondaryErrors);');
         expect(homeServiceSource).toContain('onPartial?.(buildParentHomeModel(partialState));');
     });

--- a/tests/unit/app-performance-measurement-initiative-source-contract.test.js
+++ b/tests/unit/app-performance-measurement-initiative-source-contract.test.js
@@ -66,7 +66,7 @@ describe('app performance measurement initiative source contract', () => {
         });
 
         expect(uxTimingSource).toContain('recordAppUxTiming(label, startedAt, meta);');
-        expect(uxTimingSource).toContain('console.info(`[ux] ${label} ${JSON.stringify({ durationMs, ...meta })}`);');
+        expect(uxTimingSource).toContain('logger.info(label, { durationMs, ...meta });');
         expect(telemetrySource).toContain("captureAppTelemetryEvent('app_ux_timing', {");
         expect(telemetrySource).toContain('durationMs,');
         expect(telemetrySource).toContain('outcome,');


### PR DESCRIPTION
## Summary
- Make `no-console` an error for app `src` while keeping the shared logger implementation as the console escape hatch.
- Migrate remaining core app `console.warn` / `console.error` / `console.info` calls to scoped structured loggers with redacted context.
- Add ErrorBoundary test cleanup so the focused component spec does not leak rendered DOM between cases.

## Validation
- `npm --prefix apps/app run lint -- --quiet`
- `npx --prefix apps/app vitest run src/lib/logger.test.ts src/lib/uxTiming.test.ts src/components/ErrorBoundary.test.tsx --reporter=verbose`
- `npm --prefix apps/app run build`

Closes #2639