### PR TITLE
[codex] Add app AI practice coach

### DIFF
--- a/apps/app/src/lib/practiceAiCoachService.test.ts
+++ b/apps/app/src/lib/practiceAiCoachService.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildPracticeAiCoachPrompt, generatePracticeAiCoachPlan, parsePracticeAiCoachPlanResponse } from './practiceAiCoachService';
+
+const genAiMocks = vi.hoisted(() => ({
+  generateContent: vi.fn(),
+  getAI: vi.fn(() => ({ ai: true })),
+  getApp: vi.fn(() => ({ app: true })),
+  getGenerativeModel: vi.fn()
+}));
+
+vi.mock('./adapters/legacyGenerativeAi', () => ({
+  getAI: genAiMocks.getAI,
+  getApp: genAiMocks.getApp,
+  getGenerativeModel: genAiMocks.getGenerativeModel,
+  GoogleAIBackend: class GoogleAIBackend {}
+}));
+
+const drillOptions = [
+  {
+    id: 'drill-1',
+    title: 'Rondo 4v2',
+    type: 'Technical',
+    duration: 15,
+    description: 'Keep the ball moving.',
+    source: 'community' as const
+  },
+  {
+    id: 'drill-2',
+    title: 'Finishing ladder',
+    type: 'Technical',
+    duration: 12,
+    description: 'Close-range finishing.',
+    source: 'team' as const
+  }
+];
+
+describe('practiceAiCoachService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    genAiMocks.getGenerativeModel.mockReturnValue({
+      generateContent: genAiMocks.generateContent
+    });
+  });
+
+  it('builds the legacy-style JSON practice-plan prompt with timeline and drill context', () => {
+    const prompt = buildPracticeAiCoachPrompt({
+      teamName: 'Bears',
+      sport: 'Soccer',
+      ageGroup: 'U12',
+      skillLevel: 'Intermediate',
+      targetMinutes: 60,
+      coachRequest: 'Focus on shooting from wide service.',
+      focusSkills: ['finishing', 'first touch'],
+      currentBlocks: [{
+        order: 0,
+        drillId: 'drill-1',
+        drillTitle: 'Rondo 4v2',
+        type: 'Technical',
+        duration: 15,
+        description: 'Keep the ball moving.',
+        notes: 'Current warm-up',
+        notesLog: []
+      }],
+      drillOptions
+    });
+
+    expect(prompt.system).toContain('ALL PLAYS AI coach');
+    expect(prompt.user).toContain('Return ONLY valid JSON in this shape');
+    expect(prompt.user).toContain('"coreBlocks"');
+    expect(prompt.user).toContain('The total planned drill durations must equal exactly 60 minutes');
+    expect(prompt.user).toContain('"skillLevel":"Intermediate"');
+    expect(prompt.user).toContain('"currentTimeline":[{"order":0,"drillId":"drill-1"');
+    expect(prompt.user).toContain('"drillLibraryCatalog":[{"id":"drill-1","title":"Rondo 4v2"');
+    expect(prompt.user).toContain('Focus on shooting from wide service.');
+  });
+
+  it('parses a well-formed AI fixture into native practice timeline blocks', () => {
+    const result = parsePracticeAiCoachPlanResponse(`
+      \`\`\`json
+      {
+        "assistantMessage": "Use touch quality before finishing.",
+        "coreBlocks": [
+          { "drillId": "drill-1", "title": "Rondo 4v2", "type": "Technical", "duration": 15, "notes": "Two-touch max" },
+          { "title": "Free finishing wave", "type": "Game", "duration": 20, "description": "Unmapped free-text block" },
+          { "blockType": "structure", "title": "Stations", "duration": 10, "children": [
+            { "title": "Finishing ladder", "type": "Technical", "duration": 10, "notes": "Rotate lines" }
+          ]}
+        ]
+      }
+      \`\`\`
+    `, { drillOptions });
+
+    expect(result.errors).toEqual([]);
+    expect(result.assistantMessage).toBe('Use touch quality before finishing.');
+    expect(result.blocks).toEqual([
+      expect.objectContaining({ order: 0, drillId: 'drill-1', drillTitle: 'Rondo 4v2', duration: 15 }),
+      expect.objectContaining({ order: 1, drillId: null, drillTitle: 'Free finishing wave', type: 'Game', duration: 20 }),
+      expect.objectContaining({ order: 2, drillId: 'drill-2', drillTitle: 'Finishing ladder', notes: 'Phase: Stations\nRotate lines' })
+    ]);
+  });
+
+  it('returns a safe error with no partial timeline for malformed blocks', () => {
+    const result = parsePracticeAiCoachPlanResponse(JSON.stringify({
+      assistantMessage: 'Partial plan',
+      coreBlocks: [
+        { title: 'Warm-up', type: 'Warm-up', duration: 10 },
+        { title: 'Missing duration', type: 'Technical' }
+      ]
+    }), { drillOptions });
+
+    expect(result.blocks).toEqual([]);
+    expect(result.errors).toEqual(['AI response included an incomplete timeline block.']);
+  });
+
+  it('lazy-loads GenAI at generation time and returns a retry-safe error on model failure', async () => {
+    genAiMocks.generateContent.mockRejectedValue(new Error('network down'));
+
+    const result = await generatePracticeAiCoachPlan({
+      teamName: 'Bears',
+      sport: 'Soccer',
+      targetMinutes: 45,
+      coachRequest: 'Shooting plan',
+      drillOptions
+    });
+
+    expect(genAiMocks.getApp).toHaveBeenCalled();
+    expect(genAiMocks.getGenerativeModel).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      model: 'gemini-2.5-flash',
+      generationConfig: { responseMimeType: 'application/json' }
+    }));
+    expect(result.blocks).toEqual([]);
+    expect(result.errors[0]).toContain('network down');
+  });
+});

--- a/apps/app/src/lib/practiceAiCoachService.ts
+++ b/apps/app/src/lib/practiceAiCoachService.ts
@@ -1,0 +1,302 @@
+import { DRILL_TYPES } from './adapters/legacyDrills';
+import type { PracticeTimelineBlock, PracticeTimelineDrillOption } from './practiceTimelineService';
+import type { TeamDrillSummary } from './teamDrillsService';
+
+export type PracticeAiCoachPlanScope = 'full-session' | 'append' | 'gap-fill';
+
+export type PracticeAiCoachPromptInput = {
+  teamName?: string | null;
+  sport?: string | null;
+  ageGroup?: string | null;
+  skillLevel?: string | null;
+  targetMinutes?: string | number | null;
+  availableMinutes?: string | number | null;
+  rosterSize?: string | number | null;
+  coachRequest?: string | null;
+  goals?: unknown[];
+  focusSkills?: unknown[];
+  constraints?: unknown[];
+  currentBlocks?: PracticeTimelineBlock[];
+  drillOptions?: PracticeTimelineDrillOption[];
+  favoriteDrills?: TeamDrillSummary[];
+  planScope?: PracticeAiCoachPlanScope;
+};
+
+export type PracticeAiCoachPrompt = {
+  system: string;
+  user: string;
+};
+
+export type PracticeAiCoachPlanResult = {
+  assistantMessage: string;
+  blocks: PracticeTimelineBlock[];
+  errors: string[];
+  rawText?: string;
+};
+
+const maxPromptDrills = 80;
+const allowedDrillTypes = new Set(DRILL_TYPES as string[]);
+
+function normalizeString(value: unknown) {
+  return String(value ?? '').trim();
+}
+
+function normalizeWholeNumber(value: unknown, fallback: number) {
+  const parsed = Number.parseInt(String(value ?? '').trim(), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, parsed);
+}
+
+function parsePositiveWholeNumber(value: unknown) {
+  const parsed = Number.parseInt(String(value ?? '').trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function normalizeList(values: unknown[] | undefined, fallback: string[]) {
+  const normalized = Array.from(new Set((Array.isArray(values) ? values : [])
+    .map((value) => normalizeString(value))
+    .filter(Boolean)));
+  return normalized.length ? normalized : fallback;
+}
+
+function normalizeDrillType(value: unknown) {
+  const normalized = normalizeString(value);
+  return allowedDrillTypes.has(normalized) ? normalized : 'Technical';
+}
+
+function compactDrillForPrompt(drill: PracticeTimelineDrillOption | TeamDrillSummary) {
+  const summary = drill as TeamDrillSummary;
+  return {
+    id: normalizeString(drill.id),
+    title: normalizeString(drill.title),
+    type: normalizeDrillType(drill.type),
+    duration: normalizeWholeNumber((drill as PracticeTimelineDrillOption).duration ?? summary.setup?.duration, 10),
+    description: normalizeString((drill as PracticeTimelineDrillOption).description ?? summary.description),
+    source: normalizeString((drill as PracticeTimelineDrillOption).source || summary.attribution?.source || 'library'),
+    skills: Array.isArray(summary.skills) ? summary.skills.slice(0, 6).map(normalizeString).filter(Boolean) : []
+  };
+}
+
+function buildPromptContext(input: PracticeAiCoachPromptInput) {
+  const drillOptions = Array.isArray(input.drillOptions) ? input.drillOptions : [];
+  const favoriteDrills = Array.isArray(input.favoriteDrills) ? input.favoriteDrills : [];
+  const currentBlocks = Array.isArray(input.currentBlocks) ? input.currentBlocks : [];
+  const drillCatalog = [
+    ...favoriteDrills.map(compactDrillForPrompt),
+    ...drillOptions.map(compactDrillForPrompt)
+  ].filter((drill) => drill.id && drill.title);
+  const dedupedCatalog = Array.from(new Map(drillCatalog.map((drill) => [drill.id, drill])).values()).slice(0, maxPromptDrills);
+
+  return {
+    team: {
+      name: normalizeString(input.teamName) || 'Team',
+      sport: normalizeString(input.sport) || 'Soccer',
+      ageGroup: normalizeString(input.ageGroup) || 'Not specified',
+      skillLevel: normalizeString(input.skillLevel) || 'All'
+    },
+    targetPlanMinutes: normalizeWholeNumber(input.targetMinutes ?? input.availableMinutes, 60),
+    planScope: input.planScope || 'full-session',
+    rosterSize: normalizeWholeNumber(input.rosterSize, 10),
+    practiceGoals: normalizeList(input.goals, ['Build a balanced practice with warm-up, skill work, game-like reps, and a short wrap-up.']),
+    focusSkills: normalizeList(input.focusSkills, ['fundamentals', 'teamwork']),
+    constraints: normalizeList(input.constraints, ['Keep instructions concise and age-appropriate.']),
+    currentTimeline: currentBlocks.map((block, index) => ({
+      order: index,
+      drillId: block.drillId || null,
+      title: normalizeString(block.drillTitle),
+      type: normalizeDrillType(block.type),
+      duration: normalizeWholeNumber(block.duration, 10),
+      notes: normalizeString(block.notes)
+    })),
+    drillLibraryCatalog: dedupedCatalog
+  };
+}
+
+export function buildPracticeAiCoachPrompt(input: PracticeAiCoachPromptInput): PracticeAiCoachPrompt {
+  const sport = normalizeString(input.sport) || 'Soccer';
+  const targetMinutes = normalizeWholeNumber(input.targetMinutes ?? input.availableMinutes, 60);
+  const context = buildPromptContext(input);
+  const coachRequest = normalizeString(input.coachRequest) || 'Build a balanced practice plan.';
+
+  return {
+    system: `You are ALL PLAYS AI coach. Build a ${sport} practice plan from the provided context.`,
+    user: `
+You are ALL PLAYS AI coach. Build a ${sport} practice plan from the provided context.
+
+Hard constraints:
+- Use the drillLibraryCatalog ids when a proposed block matches a real drill.
+- Use drillId null only for free-text blocks that do not map to a real catalog drill.
+- Return at most 3 core drill blocks in "coreBlocks".
+- The total planned drill durations must equal exactly ${targetMinutes} minutes.
+- Keep durations practical for the configured target duration.
+- Plan scope is "${context.planScope}".
+- If plan scope is "full-session", include warm-up and cool-down considerations.
+
+You may optionally wrap drill blocks in structure containers (warmup, stations, scrimmage, cooldown, custom).
+Structure blocks group drills into logical practice phases. The app will flatten them into the native practice timeline.
+
+Return ONLY valid JSON in this shape:
+{
+  "assistantMessage": "short coaching rationale",
+  "coreBlocks": [
+    { "drillId": "catalog-drill-id-or-null", "title": "string", "type": "Technical|Tactical|Physical|Game|Warm-up", "duration": 12, "description": "string", "notes": "string" },
+    { "blockType": "structure", "structureType": "warmup|stations|scrimmage|cooldown|custom", "title": "string", "duration": 15, "notes": "string", "children": [
+      { "drillId": "catalog-drill-id-or-null", "title": "string", "type": "Technical", "duration": 5, "description": "string", "notes": "string" }
+    ]}
+  ]
+}
+
+Context JSON:
+${JSON.stringify(context)}
+
+Coach request:
+${coachRequest}
+    `.trim()
+  };
+}
+
+export function parsePracticeAiCoachPlanResponse(rawText: unknown, input: PracticeAiCoachPromptInput = {}): PracticeAiCoachPlanResult {
+  const raw = normalizeString(rawText);
+  if (!raw) {
+    return { assistantMessage: '', blocks: [], errors: ['AI response was empty.'] };
+  }
+
+  let parsed: any;
+  try {
+    parsed = parseAiJson(raw);
+  } catch (error: any) {
+    return { assistantMessage: '', blocks: [], errors: [error?.message || 'AI response was not valid JSON.'], rawText: raw };
+  }
+
+  if (!parsed || !Array.isArray(parsed.coreBlocks)) {
+    return { assistantMessage: '', blocks: [], errors: ['AI response did not include a coreBlocks array.'], rawText: raw };
+  }
+
+  const drillLookup = buildDrillLookup(input);
+  const normalizedBlocks: PracticeTimelineBlock[] = [];
+  for (const candidate of parsed.coreBlocks) {
+    const nextBlocks = normalizeAiBlock(candidate, drillLookup);
+    if (!nextBlocks) {
+      return { assistantMessage: '', blocks: [], errors: ['AI response included an incomplete timeline block.'], rawText: raw };
+    }
+    normalizedBlocks.push(...nextBlocks);
+  }
+
+  if (!normalizedBlocks.length) {
+    return { assistantMessage: '', blocks: [], errors: ['AI response did not include any timeline blocks.'], rawText: raw };
+  }
+
+  return {
+    assistantMessage: normalizeString(parsed.assistantMessage) || 'Review the proposed practice plan before accepting it into the timeline.',
+    blocks: normalizedBlocks.map((block, index) => ({ ...block, order: index })),
+    errors: [],
+    rawText: raw
+  };
+}
+
+export async function generatePracticeAiCoachPlan(input: PracticeAiCoachPromptInput): Promise<PracticeAiCoachPlanResult> {
+  const prompt = buildPracticeAiCoachPrompt(input);
+
+  try {
+    const { getAI, getApp, getGenerativeModel, GoogleAIBackend } = await import('./adapters/legacyGenerativeAi');
+    const app = getApp();
+    const ai = getAI(app, { backend: new GoogleAIBackend() });
+    const model = getGenerativeModel(ai, {
+      model: 'gemini-2.5-flash',
+      generationConfig: {
+        responseMimeType: 'application/json'
+      }
+    });
+    const result = await model.generateContent(prompt.user);
+    const raw = normalizeString(result?.response?.text?.());
+    const parsed = parsePracticeAiCoachPlanResponse(raw, input);
+    if (parsed.errors.length) return parsed;
+    return parsed;
+  } catch (error: any) {
+    const message = normalizeString(error?.message);
+    return {
+      assistantMessage: '',
+      blocks: [],
+      errors: [message ? `AI practice coach could not generate a plan: ${message}` : 'AI practice coach could not generate a plan. Try again.']
+    };
+  }
+}
+
+function parseAiJson(raw: string) {
+  const cleaned = raw.trim().replace(/^```json\s*/i, '').replace(/^```\s*/i, '').replace(/\s*```$/, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch (jsonError) {
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (!match) throw jsonError;
+    return JSON.parse(match[0]);
+  }
+}
+
+type DrillLookup = {
+  byId: Map<string, PracticeTimelineDrillOption | TeamDrillSummary>;
+  byTitle: Map<string, PracticeTimelineDrillOption | TeamDrillSummary>;
+};
+
+function buildDrillLookup(input: PracticeAiCoachPromptInput): DrillLookup {
+  const drills = [
+    ...(Array.isArray(input.favoriteDrills) ? input.favoriteDrills : []),
+    ...(Array.isArray(input.drillOptions) ? input.drillOptions : [])
+  ];
+  const byId = new Map<string, PracticeTimelineDrillOption | TeamDrillSummary>();
+  const byTitle = new Map<string, PracticeTimelineDrillOption | TeamDrillSummary>();
+  drills.forEach((drill) => {
+    const id = normalizeString(drill.id);
+    const title = normalizeString(drill.title);
+    if (id) byId.set(id, drill);
+    if (title) byTitle.set(title.toLowerCase(), drill);
+  });
+  return { byId, byTitle };
+}
+
+function normalizeAiBlock(candidate: any, lookup: DrillLookup): PracticeTimelineBlock[] | null {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+
+  if (candidate.blockType === 'structure' && Array.isArray(candidate.children) && candidate.children.length) {
+    const children: PracticeTimelineBlock[] = [];
+    for (const child of candidate.children) {
+      const normalizedChild = normalizeLeafBlock(child, lookup, normalizeString(candidate.title));
+      if (!normalizedChild) return null;
+      children.push(normalizedChild);
+    }
+    return children;
+  }
+
+  const leaf = normalizeLeafBlock(candidate, lookup);
+  return leaf ? [leaf] : null;
+}
+
+function normalizeLeafBlock(candidate: any, lookup: DrillLookup, parentTitle = ''): PracticeTimelineBlock | null {
+  const title = normalizeString(candidate?.drillTitle || candidate?.title);
+  const duration = parsePositiveWholeNumber(candidate?.duration);
+  if (!title || !duration) return null;
+
+  const drill = resolveDrill(candidate?.drillId, title, lookup);
+  const drillSummary = drill ? compactDrillForPrompt(drill) : null;
+  const notes = [parentTitle ? `Phase: ${parentTitle}` : '', normalizeString(candidate?.notes || candidate?.customInstructions)].filter(Boolean).join('\n');
+
+  return {
+    order: 0,
+    drillId: drillSummary?.id || null,
+    drillTitle: drillSummary?.title || title,
+    type: normalizeDrillType(candidate?.type || drillSummary?.type),
+    duration,
+    description: normalizeString(candidate?.description) || drillSummary?.description || '',
+    notes,
+    notesLog: []
+  };
+}
+
+function resolveDrill(drillId: unknown, title: string, lookup: DrillLookup) {
+  const normalizedId = normalizeString(drillId);
+  if (normalizedId && lookup.byId.has(normalizedId)) return lookup.byId.get(normalizedId);
+  const normalizedTitle = normalizeString(title).toLowerCase();
+  if (normalizedTitle && lookup.byTitle.has(normalizedTitle)) return lookup.byTitle.get(normalizedTitle);
+  return null;
+}

--- a/apps/app/src/lib/practiceTimelineService.test.ts
+++ b/apps/app/src/lib/practiceTimelineService.test.ts
@@ -35,6 +35,8 @@ describe('practiceTimelineService', () => {
   it('loads sorted timeline blocks plus community and team drill options', async () => {
     dbMocks.getPracticeSessionByEvent.mockResolvedValue({
       id: 'session-1',
+      date: { toDate: () => new Date('2026-06-11T18:00:00Z') },
+      location: 'Main Field',
       blocks: [
         { order: 2, drillId: 'drill-3', drillTitle: 'Scrimmage', duration: 20, type: 'Game' },
         { order: 0, drillId: 'drill-1', drillTitle: 'Warm-up', duration: 10, type: 'Warm-up' }
@@ -55,6 +57,8 @@ describe('practiceTimelineService', () => {
     const result = await loadPracticeTimelineModel('team-1', 'practice-1', user);
 
     expect(result.sessionId).toBe('session-1');
+    expect(result.date?.toISOString()).toBe('2026-06-11T18:00:00.000Z');
+    expect(result.location).toBe('Main Field');
     expect(result.blocks.map((block) => block.drillTitle)).toEqual(['Warm-up', 'Scrimmage']);
     expect(result.drillOptions.map((option) => `${option.source}:${option.title}`)).toEqual(['community:Warm-up', 'team:Pattern play']);
   });

--- a/apps/app/src/lib/practiceTimelineService.ts
+++ b/apps/app/src/lib/practiceTimelineService.ts
@@ -33,6 +33,8 @@ export type PracticeTimelineModel = {
   eventId: string;
   teamName: string;
   teamSport: string;
+  date: Date | null;
+  location: string | null;
   blocks: PracticeTimelineBlock[];
   drillOptions: PracticeTimelineDrillOption[];
 };
@@ -56,6 +58,15 @@ function normalizeDuration(value: unknown, fallback = 10) {
   const parsed = Number.parseInt(String(value ?? '').trim(), 10);
   if (!Number.isFinite(parsed)) return fallback;
   return Math.max(1, parsed);
+}
+
+function normalizeDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const timestampDate = typeof (value as any)?.toDate === 'function' ? (value as any).toDate() : null;
+  if (timestampDate instanceof Date && !Number.isNaN(timestampDate.getTime())) return timestampDate;
+  const parsed = new Date(String(value));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 function normalizeNotesLog(value: unknown): PracticeTimelineNote[] {
@@ -153,6 +164,8 @@ export async function loadPracticeTimelineModel(teamId: string, eventId: string,
     eventId,
     teamName: normalizeString(team?.name) || 'Team',
     teamSport,
+    date: normalizeDate(session?.date),
+    location: normalizeString(session?.location) || null,
     blocks,
     drillOptions
   };

--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -114,7 +114,7 @@ describe('teamDrillsService', () => {
       teamName: 'Bears',
       sport: 'Soccer',
       ageGroup: 'U12',
-      availableMinutes: 75,
+      targetMinutes: 75,
       rosterSize: 14,
       goals: ['Press after turnovers', 'Finish from wide service'],
       focusSkills: ['first touch', 'finishing'],
@@ -136,25 +136,23 @@ describe('teamDrillsService', () => {
       }]
     });
 
-    expect(prompt.system).toContain('Soccer practices');
-    expect(prompt.user).toContain('Team: Bears');
-    expect(prompt.user).toContain('Available time: 75 minutes');
-    expect(prompt.user).toContain('- Press after turnovers');
-    expect(prompt.user).toContain('- first touch');
-    expect(prompt.user).toContain('- Half field only');
-    expect(prompt.user).toContain('- Rondo 4v2 (Technical; 15 min, 8-10 players, 20x20). Skills: passing, support.');
-    expect(prompt.user).toContain('minute-by-minute practice plan');
+    expect(prompt.system).toContain('ALL PLAYS AI coach');
+    expect(prompt.user).toContain('Return ONLY valid JSON in this shape');
+    expect(prompt.user).toContain('"coreBlocks"');
+    expect(prompt.user).toContain('The total planned drill durations must equal exactly 75 minutes');
+    expect(prompt.user).toContain('"practiceGoals":["Press after turnovers","Finish from wide service"]');
+    expect(prompt.user).toContain('"focusSkills":["first touch","finishing"]');
+    expect(prompt.user).toContain('"constraints":["Half field only","Two keepers unavailable"]');
+    expect(prompt.user).toContain('"drillLibraryCatalog":[{"id":"drill-1","title":"Rondo 4v2"');
   });
 
-  it('keeps practice prompt section headers on their own source line so prompts stay readable', () => {
-    const source = readFileSync(new URL('./teamDrillsService.ts', import.meta.url), 'utf8');
+  it('keeps the app drills prompt shared on the legacy-style JSON response contract', () => {
+    const source = readFileSync('src/lib/practiceAiCoachService.ts', 'utf8');
 
-    expect(source).toContain("`Practice goals:\n${goalLines.map((goal) => `- ${goal}`).join('\\n')}`");
-    expect(source).toContain("`Focus skills:\n${skillLines.map((skill) => `- ${skill}`).join('\\n')}`");
-    expect(source).toContain("`Constraints:\n${constraintLines.map((constraint) => `- ${constraint}`).join('\\n')}`");
-    expect(source).toContain("`Favorite drills to prefer when they fit:\n${drillLines.length ? drillLines.join('\\n') : '- No favorites supplied.'}`");
-    expect(source).not.toContain("`Practice goals:\\n${goalLines.map((goal) => `- ${goal}`).join('\\n')}`");
-    expect(source).not.toContain("`Favorite drills to prefer when they fit:\\n${drillLines.length ? drillLines.join('\\n') : '- No favorites supplied.'}`");
+    expect(source).toContain('You are ALL PLAYS AI coach. Build a ${sport} practice plan from the provided context.');
+    expect(source).toContain('Return ONLY valid JSON in this shape:');
+    expect(source).toContain('"coreBlocks": [');
+    expect(source).toContain('Use drillId null only for free-text blocks that do not map to a real catalog drill.');
   });
 
   it('loads a bounded community drill page and merges team-published drills for staff users', async () => {

--- a/apps/app/src/lib/teamDrillsService.ts
+++ b/apps/app/src/lib/teamDrillsService.ts
@@ -1,6 +1,9 @@
 import { addDrillFavorite, DRILL_LEVELS, DRILL_TYPES, getDrill, getDrillFavorites, getDrills, getPublishedDrills, getTeam, hasFullTeamAccess, removeDrillFavorite } from './adapters/legacyTeamDrills';
 import type { AuthUser } from './types';
 
+export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';
+export type { PracticeAiCoachPrompt, PracticeAiCoachPromptInput } from './practiceAiCoachService';
+
 const drillLibraryPageSize = 12;
 
 export type TeamDrillSummary = {
@@ -62,23 +65,6 @@ export type TeamFavoriteDrillsModel = {
   canManageDrills: boolean;
   favoriteIds: string[];
   drills: TeamDrillSummary[];
-};
-
-export type PracticeAiCoachPromptInput = {
-  teamName?: string | null;
-  sport?: string | null;
-  ageGroup?: string | null;
-  availableMinutes?: string | number | null;
-  rosterSize?: string | number | null;
-  goals?: unknown[];
-  focusSkills?: unknown[];
-  constraints?: unknown[];
-  favoriteDrills?: TeamDrillSummary[];
-};
-
-export type PracticeAiCoachPrompt = {
-  system: string;
-  user: string;
 };
 
 type TeamDrillLibraryCursor = {
@@ -171,63 +157,6 @@ export function filterDrillSummaries(drills: TeamDrillSummary[], filters: TeamDr
       || drill.instructions.toLowerCase().includes(searchText)
       || drill.skills.some((skill) => skill.toLowerCase().includes(searchText));
   });
-}
-
-function normalizeCoachPromptList(values: unknown[] | undefined, fallback: string[]) {
-  const normalized = Array.from(new Set((Array.isArray(values) ? values : [])
-    .map((value) => normalizeString(value))
-    .filter(Boolean)));
-  return normalized.length ? normalized : fallback;
-}
-
-export function buildPracticeAiCoachPrompt({
-  teamName,
-  sport,
-  ageGroup,
-  availableMinutes,
-  rosterSize,
-  goals,
-  focusSkills,
-  constraints,
-  favoriteDrills
-}: PracticeAiCoachPromptInput): PracticeAiCoachPrompt {
-  const normalizedSport = normalizeString(sport) || 'youth sports';
-  const minutes = normalizeWholeNumber(availableMinutes, 60);
-  const playerCount = normalizeWholeNumber(rosterSize, 10);
-  const goalLines = normalizeCoachPromptList(goals, ['Build a balanced practice with warm-up, skill work, game-like reps, and a short wrap-up.']);
-  const skillLines = normalizeCoachPromptList(focusSkills, ['fundamentals', 'teamwork']);
-  const constraintLines = normalizeCoachPromptList(constraints, ['Keep instructions concise and age-appropriate.']);
-  const drillLines = (Array.isArray(favoriteDrills) ? favoriteDrills : [])
-    .slice(0, 5)
-    .map((drill) => {
-      const setupParts = [
-        drill.setup?.duration ? `${drill.setup.duration} min` : '',
-        drill.setup?.players ? `${drill.setup.players} players` : '',
-        drill.setup?.area ? drill.setup.area : ''
-      ].filter(Boolean).join(', ');
-      const skillsText = drill.skills.length ? ` Skills: ${drill.skills.join(', ')}.` : '';
-      return `- ${drill.title} (${drill.type || 'Drill'}${setupParts ? `; ${setupParts}` : ''}).${skillsText}`;
-    });
-
-  return {
-    system: `You are an assistant coach helping plan ${normalizedSport} practices. Return practical, safety-aware plans with clear timing, setup, and coaching cues.`,
-    user: [
-      `Team: ${normalizeString(teamName) || 'Team'}`,
-      `Sport: ${normalizedSport}`,
-      `Age group: ${normalizeString(ageGroup) || 'Not specified'}`,
-      `Available time: ${minutes} minutes`,
-      `Roster size: ${playerCount}`,
-      `Practice goals:
-${goalLines.map((goal) => `- ${goal}`).join('\n')}`,
-      `Focus skills:
-${skillLines.map((skill) => `- ${skill}`).join('\n')}`,
-      `Constraints:
-${constraintLines.map((constraint) => `- ${constraint}`).join('\n')}`,
-      `Favorite drills to prefer when they fit:
-${drillLines.length ? drillLines.join('\n') : '- No favorites supplied.'}`,
-      'Create a minute-by-minute practice plan with drill names, setup notes, coaching cues, and an adjustment for fewer players.'
-    ].join('\n\n')
-  };
 }
 
 export async function loadTeamDrillLibraryPage(

--- a/apps/app/src/pages/TeamDrills.test.tsx
+++ b/apps/app/src/pages/TeamDrills.test.tsx
@@ -126,6 +126,8 @@ describe('TeamDrills', () => {
       eventId: 'practice-1',
       teamName: 'Bears',
       teamSport: 'Soccer',
+      date: new Date('2026-06-11T18:00:00Z'),
+      location: 'Main Field',
       blocks: [{
         order: 0,
         drillId: 'drill-1',
@@ -244,6 +246,8 @@ describe('TeamDrills', () => {
       eventId: 'practice-1',
       sessionId: 'session-1',
       user: auth.user,
+      date: new Date('2026-06-11T18:00:00Z'),
+      location: 'Main Field',
       blocks: [
         expect.objectContaining({ order: 0, drillTitle: 'Warm-up lanes', duration: 10 }),
         expect.objectContaining({ order: 1, drillTitle: 'Finishing ladder', duration: 18 })

--- a/apps/app/src/pages/TeamDrills.test.tsx
+++ b/apps/app/src/pages/TeamDrills.test.tsx
@@ -23,11 +23,23 @@ const teamDrillsServiceMocks = vi.hoisted(() => ({
   setTeamDrillFavorite: vi.fn()
 }));
 
+const practiceAiCoachServiceMocks = vi.hoisted(() => ({
+  generatePracticeAiCoachPlan: vi.fn()
+}));
+
+const practiceTimelineServiceMocks = vi.hoisted(() => ({
+  getPracticeTimelineTotalMinutes: vi.fn((blocks) => (Array.isArray(blocks) ? blocks : []).reduce((sum, block) => sum + (Number.parseInt(String(block?.duration ?? 0), 10) || 0), 0)),
+  loadPracticeTimelineModel: vi.fn(),
+  savePracticeTimelineForApp: vi.fn()
+}));
+
 const publicActionsMocks = vi.hoisted(() => ({
   openPublicUrl: vi.fn()
 }));
 
 vi.mock('../lib/teamDrillsService', () => teamDrillsServiceMocks);
+vi.mock('../lib/practiceAiCoachService', () => practiceAiCoachServiceMocks);
+vi.mock('../lib/practiceTimelineService', () => practiceTimelineServiceMocks);
 vi.mock('../lib/publicActions', () => publicActionsMocks);
 
 const auth: AuthState = {
@@ -108,10 +120,52 @@ describe('TeamDrills', () => {
       drills: [createDrill({ id: 'drill-2', title: 'Finishing ladder', type: 'Technical', level: 'Advanced', skills: ['finishing'], description: 'Close-range finishing.' })]
     });
     teamDrillsServiceMocks.setTeamDrillFavorite.mockResolvedValue(undefined);
+    practiceTimelineServiceMocks.loadPracticeTimelineModel.mockResolvedValue({
+      sessionId: 'session-1',
+      teamId: 'team-1',
+      eventId: 'practice-1',
+      teamName: 'Bears',
+      teamSport: 'Soccer',
+      blocks: [{
+        order: 0,
+        drillId: 'drill-1',
+        drillTitle: 'Warm-up lanes',
+        type: 'Warm-up',
+        duration: 10,
+        description: 'Start clean.',
+        notes: '',
+        notesLog: []
+      }],
+      drillOptions: [{
+        id: 'drill-2',
+        title: 'Finishing ladder',
+        type: 'Technical',
+        duration: 12,
+        description: 'Close-range finishing.',
+        source: 'team'
+      }]
+    });
+    practiceTimelineServiceMocks.savePracticeTimelineForApp.mockResolvedValue('session-1');
+    practiceAiCoachServiceMocks.generatePracticeAiCoachPlan.mockResolvedValue({
+      assistantMessage: 'Use quality touches before finishing.',
+      errors: [],
+      blocks: [{
+        order: 0,
+        drillId: 'drill-2',
+        drillTitle: 'Finishing ladder',
+        type: 'Technical',
+        duration: 12,
+        description: 'Close-range finishing.',
+        notes: 'Rotate every two reps.',
+        notesLog: []
+      }]
+    });
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
   });
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it('passes search and filter selections into the bounded community drill query', async () => {
@@ -120,7 +174,7 @@ describe('TeamDrills', () => {
     expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
     fireEvent.change(screen.getByLabelText('Search drills'), { target: { value: 'finish' } });
     fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'Technical' } });
-    fireEvent.change(screen.getByLabelText('Skill level'), { target: { value: 'Advanced' } });
+    fireEvent.change(screen.getByLabelText(/^Skill level$/i), { target: { value: 'Advanced' } });
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
     await waitFor(() => expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenLastCalledWith('team-1', auth.user, {
@@ -155,6 +209,48 @@ describe('TeamDrills', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
     expect(await screen.findByText('No team favorites match the current search and filter combination.')).toBeTruthy();
+  });
+
+  it('generates an editable AI coach proposal and waits for acceptance before saving the timeline', async () => {
+    renderTeamDrills();
+
+    expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Practice event ID'), { target: { value: 'practice-1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Load practice' }));
+
+    await waitFor(() => expect(practiceTimelineServiceMocks.loadPracticeTimelineModel).toHaveBeenCalledWith('team-1', 'practice-1', auth.user));
+    expect(await screen.findByText('Current timeline: 1 block · 10 min')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Practice focus'), { target: { value: '60 minute shooting plan' } });
+    fireEvent.change(screen.getByLabelText('Coach skill level'), { target: { value: 'Intermediate' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate proposal' }));
+
+    await waitFor(() => expect(practiceAiCoachServiceMocks.generatePracticeAiCoachPlan).toHaveBeenCalledWith(expect.objectContaining({
+      teamName: 'Bears',
+      sport: 'Soccer',
+      skillLevel: 'Intermediate',
+      targetMinutes: '10',
+      coachRequest: '60 minute shooting plan',
+      planScope: 'append'
+    })));
+    expect(practiceTimelineServiceMocks.savePracticeTimelineForApp).not.toHaveBeenCalled();
+
+    expect(await screen.findByDisplayValue('Finishing ladder')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Proposal block 1 minutes'), { target: { value: '18' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Accept timeline' }));
+
+    await waitFor(() => expect(practiceTimelineServiceMocks.savePracticeTimelineForApp).toHaveBeenCalledWith(expect.objectContaining({
+      teamId: 'team-1',
+      eventId: 'practice-1',
+      sessionId: 'session-1',
+      user: auth.user,
+      blocks: [
+        expect.objectContaining({ order: 0, drillTitle: 'Warm-up lanes', duration: 10 }),
+        expect.objectContaining({ order: 1, drillTitle: 'Finishing ladder', duration: 18 })
+      ]
+    })));
+    expect(window.confirm).toHaveBeenCalledWith('Accept this AI proposal and append these AI blocks to the practice timeline?');
+    expect(await screen.findByText('Practice timeline updated.')).toBeTruthy();
   });
 
   it('shows the access guard when the user cannot manage team drills', async () => {

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -286,6 +286,8 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
         user: auth.user,
         sessionId: practiceModel.sessionId,
         blocks: nextBlocks,
+        date: practiceModel.date,
+        location: practiceModel.location,
         title: `${practiceModel.teamName} practice`
       });
       setPracticeModel({

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
-import { Link, Navigate, useParams } from 'react-router-dom';
-import { ChevronLeft, ExternalLink, Heart, Loader2, Search, Shield } from 'lucide-react';
+import { Link, Navigate, useParams, useSearchParams } from 'react-router-dom';
+import { ChevronLeft, ExternalLink, Heart, Loader2, Save, Search, Shield, Sparkles } from 'lucide-react';
 import { DRILL_LEVELS, DRILL_TYPES, DRILL_TYPE_COLORS } from '../lib/adapters/legacyDrills';
+import { generatePracticeAiCoachPlan, type PracticeAiCoachPlanResult } from '../lib/practiceAiCoachService';
+import { getPracticeTimelineTotalMinutes, loadPracticeTimelineModel, savePracticeTimelineForApp, type PracticeTimelineBlock, type PracticeTimelineModel } from '../lib/practiceTimelineService';
 import { openPublicUrl } from '../lib/publicActions';
 import { filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite, type TeamDrillSummary } from '../lib/teamDrillsService';
 import type { AuthState } from '../lib/types';
@@ -17,6 +19,8 @@ function mergeUniqueDrills(drills: TeamDrillSummary[]) {
 
 export function TeamDrills({ auth }: { auth: AuthState }) {
   const { teamId = '' } = useParams();
+  const [searchParams] = useSearchParams();
+  const eventIdFromUrl = searchParams.get('eventId') || '';
   const [teamName, setTeamName] = useState('Team');
   const [teamSport, setTeamSport] = useState('Soccer');
   const [canManageDrills, setCanManageDrills] = useState(true);
@@ -37,6 +41,18 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
   const [error, setError] = useState('');
   const [selectedDrill, setSelectedDrill] = useState<TeamDrillSummary | null>(null);
   const [favoriteBusyId, setFavoriteBusyId] = useState('');
+  const [practiceEventId, setPracticeEventId] = useState(eventIdFromUrl);
+  const [practiceModel, setPracticeModel] = useState<PracticeTimelineModel | null>(null);
+  const [practiceLoading, setPracticeLoading] = useState(false);
+  const [practiceError, setPracticeError] = useState('');
+  const [coachRequest, setCoachRequest] = useState('Build a balanced practice focused on shooting and finishing.');
+  const [coachMinutes, setCoachMinutes] = useState('60');
+  const [coachSkillLevel, setCoachSkillLevel] = useState('');
+  const [coachGenerating, setCoachGenerating] = useState(false);
+  const [coachProposal, setCoachProposal] = useState<PracticeAiCoachPlanResult | null>(null);
+  const [coachAcceptMode, setCoachAcceptMode] = useState<'replace' | 'append'>('replace');
+  const [coachSaving, setCoachSaving] = useState(false);
+  const [coachStatus, setCoachStatus] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -102,6 +118,12 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
       cancelled = true;
     };
   }, [auth.user, canManageDrills, favoriteDrills, selectedTab, teamId]);
+
+  useEffect(() => {
+    if (eventIdFromUrl) {
+      setPracticeEventId(eventIdFromUrl);
+    }
+  }, [eventIdFromUrl]);
 
   const visibleFavoriteDrills = useMemo(() => filterDrillSummaries(favoriteDrills || [], {
     searchText,
@@ -172,8 +194,118 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
     setLevelFilter(levelDraft);
   }
 
+  async function loadPracticeSession() {
+    const eventId = practiceEventId.trim();
+    if (!eventId) {
+      setPracticeError('Enter a practice event ID before loading the AI coach context.');
+      return;
+    }
+
+    setPracticeLoading(true);
+    setPracticeError('');
+    setCoachStatus('');
+    setCoachProposal(null);
+    try {
+      const model = await loadPracticeTimelineModel(teamId, eventId, auth.user);
+      setPracticeModel(model);
+      const currentMinutes = getPracticeTimelineTotalMinutes(model.blocks);
+      setCoachMinutes(String(currentMinutes || 60));
+      setCoachAcceptMode(model.blocks.length ? 'append' : 'replace');
+    } catch (loadError: any) {
+      setPracticeModel(null);
+      setPracticeError(loadError?.message || 'Unable to load that practice session.');
+    } finally {
+      setPracticeLoading(false);
+    }
+  }
+
+  async function generateCoachProposal() {
+    if (!practiceModel) {
+      setPracticeError('Load an existing practice session before asking the AI coach for a timeline.');
+      return;
+    }
+
+    setCoachGenerating(true);
+    setPracticeError('');
+    setCoachStatus('');
+    setCoachProposal(null);
+    try {
+      const favoriteContextDrills = (favoriteDrills || communityDrills.filter((drill) => favoriteIds.includes(drill.id))).slice(0, 10);
+      const result = await generatePracticeAiCoachPlan({
+        teamName: practiceModel.teamName || teamName,
+        sport: practiceModel.teamSport || teamSport,
+        skillLevel: coachSkillLevel,
+        targetMinutes: coachMinutes,
+        coachRequest,
+        currentBlocks: practiceModel.blocks,
+        drillOptions: practiceModel.drillOptions,
+        favoriteDrills: favoriteContextDrills,
+        planScope: practiceModel.blocks.length ? 'append' : 'full-session'
+      });
+      if (result.errors.length) {
+        setPracticeError(result.errors[0]);
+        return;
+      }
+      setCoachProposal(result);
+    } catch (coachError: any) {
+      setPracticeError(coachError?.message || 'AI practice coach could not generate a proposal. Try again.');
+    } finally {
+      setCoachGenerating(false);
+    }
+  }
+
+  function updateProposalBlock(index: number, patch: Partial<PracticeTimelineBlock>) {
+    setCoachProposal((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        blocks: current.blocks.map((block, blockIndex) => blockIndex === index ? { ...block, ...patch } : block)
+      };
+    });
+  }
+
+  async function acceptCoachProposal() {
+    if (!practiceModel || !coachProposal?.blocks.length || coachSaving) return;
+    const proposedBlocks = coachProposal.blocks.map((block, index) => ({
+      ...block,
+      duration: Math.max(1, Number.parseInt(String(block.duration), 10) || 1),
+      order: index
+    }));
+    const nextBlocks = (coachAcceptMode === 'append' ? [...practiceModel.blocks, ...proposedBlocks] : proposedBlocks)
+      .map((block, index) => ({ ...block, order: index }));
+    const modeLabel = coachAcceptMode === 'append' ? 'append these AI blocks to' : 'replace';
+    if (!window.confirm(`Accept this AI proposal and ${modeLabel} the practice timeline?`)) return;
+
+    setCoachSaving(true);
+    setPracticeError('');
+    setCoachStatus('');
+    try {
+      const sessionId = await savePracticeTimelineForApp({
+        teamId,
+        eventId: practiceModel.eventId,
+        user: auth.user,
+        sessionId: practiceModel.sessionId,
+        blocks: nextBlocks,
+        title: `${practiceModel.teamName} practice`
+      });
+      setPracticeModel({
+        ...practiceModel,
+        sessionId,
+        blocks: nextBlocks
+      });
+      setCoachProposal(null);
+      setCoachStatus('Practice timeline updated.');
+    } catch (saveError: any) {
+      setPracticeError(saveError?.message || 'Unable to save the AI practice proposal.');
+    } finally {
+      setCoachSaving(false);
+    }
+  }
+
   const activeDrills = selectedTab === 'community' ? communityDrills : visibleFavoriteDrills;
   const heading = `${teamName} drills`;
+  const practiceTotalMinutes = practiceModel ? getPracticeTimelineTotalMinutes(practiceModel.blocks) : 0;
+  const proposalTotalMinutes = coachProposal ? getPracticeTimelineTotalMinutes(coachProposal.blocks) : 0;
 
   if (loading) {
     return (
@@ -248,6 +380,151 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
           </button>
         </div>
         {error ? <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 p-3 text-xs font-black text-rose-700">{error}</div> : null}
+      </section>
+
+      <section className="app-card p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.04em] text-primary-700">
+              <Sparkles className="h-4 w-4" aria-hidden="true" />
+              AI practice coach
+            </div>
+            <h2 className="mt-1 text-xl font-black text-gray-950">Build a proposed practice timeline</h2>
+            <p className="mt-1 text-sm font-semibold text-gray-600">Load an existing practice event, generate a timeline proposal, edit it, then accept before anything is saved.</p>
+          </div>
+          {practiceModel ? (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-xs font-black text-gray-700">
+              Current timeline: {practiceModel.blocks.length} block{practiceModel.blocks.length === 1 ? '' : 's'} · {practiceTotalMinutes} min
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto]">
+          <label className="block">
+            <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Practice event ID</span>
+            <input
+              aria-label="Practice event ID"
+              value={practiceEventId}
+              onChange={(event) => setPracticeEventId(event.target.value)}
+              placeholder="Paste a practice event ID"
+              className="mt-1 min-h-10 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+            />
+          </label>
+          <button type="button" className="secondary-button self-end !min-h-10 text-xs" onClick={() => void loadPracticeSession()} disabled={practiceLoading}>
+            {practiceLoading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            Load practice
+          </button>
+        </div>
+
+        <div className="mt-4 grid gap-3 lg:grid-cols-[120px_160px_minmax(0,1fr)_auto]">
+          <label className="block">
+            <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Minutes</span>
+            <input
+              aria-label="Target minutes"
+              type="number"
+              min="1"
+              value={coachMinutes}
+              onChange={(event) => setCoachMinutes(event.target.value)}
+              className="mt-1 min-h-10 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Coach level</span>
+            <select aria-label="Coach skill level" value={coachSkillLevel} onChange={(event) => setCoachSkillLevel(event.target.value)} className="mt-1 min-h-10 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100">
+              <option value="">All</option>
+              {drillLevelOptions.map((level) => <option key={level} value={level}>{level}</option>)}
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Practice focus</span>
+            <input
+              aria-label="Practice focus"
+              value={coachRequest}
+              onChange={(event) => setCoachRequest(event.target.value)}
+              placeholder="60 min, shooting focus, 12 players..."
+              className="mt-1 min-h-10 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+            />
+          </label>
+          <button type="button" className="primary-button self-end !min-h-10 text-xs" onClick={() => void generateCoachProposal()} disabled={!practiceModel || coachGenerating}>
+            {coachGenerating ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Sparkles className="h-4 w-4" aria-hidden="true" />}
+            Generate proposal
+          </button>
+        </div>
+
+        {practiceError ? <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 p-3 text-xs font-black text-rose-700">{practiceError}</div> : null}
+        {coachStatus ? <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-xs font-black text-emerald-700">{coachStatus}</div> : null}
+
+        {coachProposal?.blocks.length ? (
+          <div className="mt-4 border-t border-gray-100 pt-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="text-sm font-black text-gray-950">Proposed timeline</div>
+                <div className="mt-1 text-xs font-semibold text-gray-500">{coachProposal.blocks.length} block{coachProposal.blocks.length === 1 ? '' : 's'} · {proposalTotalMinutes} min</div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <label className="inline-flex items-center gap-2 text-xs font-black text-gray-700">
+                  <input type="radio" name="coach-accept-mode" checked={coachAcceptMode === 'replace'} onChange={() => setCoachAcceptMode('replace')} />
+                  Replace
+                </label>
+                <label className="inline-flex items-center gap-2 text-xs font-black text-gray-700">
+                  <input type="radio" name="coach-accept-mode" checked={coachAcceptMode === 'append'} onChange={() => setCoachAcceptMode('append')} />
+                  Append
+                </label>
+                <button type="button" className="primary-button !min-h-9 text-xs" onClick={() => void acceptCoachProposal()} disabled={coachSaving}>
+                  {coachSaving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
+                  Accept timeline
+                </button>
+              </div>
+            </div>
+            {coachProposal.assistantMessage ? <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">{coachProposal.assistantMessage}</p> : null}
+            <div className="mt-3 space-y-3">
+              {coachProposal.blocks.map((block, index) => (
+                <div key={`${block.drillTitle}-${index}`} className="grid gap-2 rounded-xl border border-gray-200 bg-white p-3 lg:grid-cols-[minmax(0,1fr)_100px_150px]">
+                  <label className="block">
+                    <span className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Block {index + 1}</span>
+                    <input
+                      aria-label={`Proposal block ${index + 1} title`}
+                      value={block.drillTitle}
+                      onChange={(event) => updateProposalBlock(index, { drillTitle: event.target.value })}
+                      className="mt-1 min-h-9 w-full rounded-lg border border-gray-200 px-2 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Minutes</span>
+                    <input
+                      aria-label={`Proposal block ${index + 1} minutes`}
+                      type="number"
+                      min="1"
+                      value={block.duration}
+                      onChange={(event) => updateProposalBlock(index, { duration: Number.parseInt(event.target.value, 10) || 1 })}
+                      className="mt-1 min-h-9 w-full rounded-lg border border-gray-200 px-2 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Type</span>
+                    <select
+                      aria-label={`Proposal block ${index + 1} type`}
+                      value={block.type}
+                      onChange={(event) => updateProposalBlock(index, { type: event.target.value })}
+                      className="mt-1 min-h-9 w-full rounded-lg border border-gray-200 px-2 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+                    >
+                      {drillTypeOptions.map((type) => <option key={type} value={type}>{type}</option>)}
+                    </select>
+                  </label>
+                  <label className="block lg:col-span-3">
+                    <span className="text-[10px] font-black uppercase tracking-[0.04em] text-gray-500">Notes</span>
+                    <input
+                      aria-label={`Proposal block ${index + 1} notes`}
+                      value={block.notes}
+                      onChange={(event) => updateProposalBlock(index, { notes: event.target.value })}
+                      className="mt-1 min-h-9 w-full rounded-lg border border-gray-200 px-2 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+                    />
+                  </label>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
       </section>
 
       <section className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">

--- a/tests/unit/issue-1986-drills-ai-coach-source.test.js
+++ b/tests/unit/issue-1986-drills-ai-coach-source.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const teamDrillsServiceSource = readFileSync(new URL('../../apps/app/src/lib/teamDrillsService.ts', import.meta.url), 'utf8');
+const practiceAiCoachServiceSource = readFileSync(new URL('../../apps/app/src/lib/practiceAiCoachService.ts', import.meta.url), 'utf8');
 const teamDrillsServiceTestSource = readFileSync(new URL('../../apps/app/src/lib/teamDrillsService.test.ts', import.meta.url), 'utf8');
 const scheduleEventDetailSource = readFileSync(new URL('../../apps/app/src/pages/ScheduleEventDetail.tsx', import.meta.url), 'utf8');
 const practiceTimelineServiceTestSource = readFileSync(new URL('../../apps/app/src/lib/practiceTimelineService.test.ts', import.meta.url), 'utf8');
@@ -10,12 +11,13 @@ const starterDrillsTestSource = readFileSync(new URL('./practice-starter-drills.
 
 describe('issue 1986 drills AI coach source contract', () => {
     it('keeps the practice AI coach prompt grounded in team context and favorite drills', () => {
-        expect(teamDrillsServiceSource).toContain('export type PracticeAiCoachPromptInput');
-        expect(teamDrillsServiceSource).toContain('export function buildPracticeAiCoachPrompt');
-        expect(teamDrillsServiceSource).toContain('You are an assistant coach helping plan');
-        expect(teamDrillsServiceSource).toContain('Favorite drills to prefer when they fit:');
-        expect(teamDrillsServiceSource).toContain('Create a minute-by-minute practice plan with drill names, setup notes, coaching cues, and an adjustment for fewer players.');
-        expect(teamDrillsServiceSource).toContain('.slice(0, 5)');
+        expect(teamDrillsServiceSource).toContain("export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';");
+        expect(practiceAiCoachServiceSource).toContain('export type PracticeAiCoachPromptInput');
+        expect(practiceAiCoachServiceSource).toContain('export function buildPracticeAiCoachPrompt');
+        expect(practiceAiCoachServiceSource).toContain('You are ALL PLAYS AI coach');
+        expect(practiceAiCoachServiceSource).toContain('drillLibraryCatalog');
+        expect(practiceAiCoachServiceSource).toContain('The total planned drill durations must equal exactly');
+        expect(practiceAiCoachServiceSource).toContain('maxPromptDrills = 80');
     });
 
     it('keeps live practice notes saving into the practice timeline', () => {

--- a/tests/unit/issue-2026-team-drills-picker-source.test.js
+++ b/tests/unit/issue-2026-team-drills-picker-source.test.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 
 const teamDrillsPageSource = readFileSync(new URL('../../apps/app/src/pages/TeamDrills.tsx', import.meta.url), 'utf8');
 const teamDrillsServiceSource = readFileSync(new URL('../../apps/app/src/lib/teamDrillsService.ts', import.meta.url), 'utf8');
+const practiceAiCoachServiceSource = readFileSync(new URL('../../apps/app/src/lib/practiceAiCoachService.ts', import.meta.url), 'utf8');
 const scheduleEventDetailSource = readFileSync(new URL('../../apps/app/src/pages/ScheduleEventDetail.tsx', import.meta.url), 'utf8');
 const practiceTimelineServiceTestSource = readFileSync(new URL('../../apps/app/src/lib/practiceTimelineService.test.ts', import.meta.url), 'utf8');
 const teamDrillsPageTestSource = readFileSync(new URL('../../apps/app/src/pages/TeamDrills.test.tsx', import.meta.url), 'utf8');
@@ -21,8 +22,9 @@ describe('issue 2026 team drills picker source contract', () => {
     it('keeps drill service pagination and AI practice-coach prompt inputs available', () => {
         expect(teamDrillsServiceSource).toContain('const drillLibraryPageSize = 12;');
         expect(teamDrillsServiceSource).toContain('export function filterDrillSummaries');
-        expect(teamDrillsServiceSource).toContain('export function buildPracticeAiCoachPrompt');
-        expect(teamDrillsServiceSource).toContain('Favorite drills to prefer when they fit:');
+        expect(teamDrillsServiceSource).toContain("export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';");
+        expect(practiceAiCoachServiceSource).toContain('export function buildPracticeAiCoachPrompt');
+        expect(practiceAiCoachServiceSource).toContain('drillLibraryCatalog');
         expect(teamDrillsServiceSource).toContain('export async function loadTeamDrillLibraryPage');
         expect(teamDrillsServiceSource).toContain('export async function loadFavoriteDrills');
     });


### PR DESCRIPTION
Closes #1986

## Summary
- Adds a native app AI practice coach service that builds the legacy-style JSON practice-plan prompt, lazy-loads Firebase GenAI, and safely parses proposals into #1983 practice timeline blocks.
- Adds an AI coach panel on the team drills page for loading an existing practice event, generating an editable proposed timeline, and accepting it into the session only after confirmation.
- Re-exports the shared prompt builder from the existing team drills service and covers prompt, parse, failure, and UI write-boundary behavior.

## Validation
- `npm exec vitest run src/lib/practiceAiCoachService.test.ts src/lib/teamDrillsService.test.ts src/pages/TeamDrills.test.tsx -- --reporter=verbose` from `apps/app`
- `npm run app:build`

## Notes
- The app panel currently loads an existing practice by event ID or `?eventId=...`; generation never writes until the user accepts the proposal.
- Unmapped AI drill titles are kept as free-text timeline blocks with `drillId: null` instead of corrupting the timeline.