### PR TITLE
[codex] Use email reducer action helpers

### DIFF
--- a/apps/app/src/pages/Messages.test.ts
+++ b/apps/app/src/pages/Messages.test.ts
@@ -1,6 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getDirectThreadMountKey, getMessagesInboxLoadRouteKey, isSelectedConversation, mergeInboxTeams, mergeVisibleChatMessages, normalizeConversationId, shouldRecordDirectThreadMount } from './Messages';
 import type { ChatInboxPreviewUpdate, ChatTeam } from '../lib/chatService';
+
+function resolveAppSourcePath(relativePath: string) {
+  const cwd = process.cwd();
+  const appRoot = cwd.endsWith('/apps/app') || cwd.endsWith('\\apps\\app')
+    ? cwd
+    : resolve(cwd, 'apps/app');
+  return resolve(appRoot, relativePath);
+}
 
 function buildTeam(overrides: Partial<ChatTeam> = {}): ChatTeam {
   return {
@@ -120,5 +130,21 @@ describe('direct thread mount telemetry', () => {
     expect(getMessagesInboxLoadRouteKey(true, 'team-2')).toBe('');
     expect(getMessagesInboxLoadRouteKey(false, 'team-1')).toBe('team-1');
     expect(getMessagesInboxLoadRouteKey(false, ' team-2 ')).toBe('team-2');
+  });
+
+  it('keeps Messages email composer dispatches on the shared action creators', () => {
+    const source = readFileSync(resolveAppSourcePath('src/pages/Messages.tsx'), 'utf8');
+
+    expect(source).toContain("import { emailComposerActions } from './messages/state/emailReducer';");
+    expect(source).toContain("emailDispatch(emailComposerActions.setTemplates(await loadTeamEmailTemplates(teamId)));");
+    expect(source).toContain("emailDispatch(emailComposerActions.setDrafts(await loadTeamEmailDrafts(teamId)));");
+    expect(source).toContain("emailDispatch(emailComposerActions.clearSelectedDraft());");
+    expect(source).toContain("emailDispatch(emailComposerActions.selectDraft(draft.id));");
+    expect(source).toContain("emailDispatch(emailComposerActions.applyTemplate(template.id));");
+    expect(source).toContain("emailDispatch(emailComposerActions.saveDraft(savedDraft));");
+    expect(source).toContain("emailDispatch(emailComposerActions.clearComposer());");
+    expect(source).not.toContain("emailDispatch({ type: 'setTemplates'");
+    expect(source).not.toContain("emailDispatch({ type: 'setDrafts'");
+    expect(source).not.toContain("emailDispatch({ type: 'clearComposer'");
   });
 });

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -104,7 +104,7 @@ import { voiceRecognition, type VoiceListenerHandle } from '../lib/voiceService'
 import { useChatSheets } from './messages/hooks/useChatSheets';
 import { useChatTeam } from './messages/hooks/useChatTeam';
 import { useChatMessages } from './messages/hooks/useChatMessages';
-import { emailReducer, initialEmailComposerState } from './messages/state/emailReducer';
+import { emailComposerActions, emailReducer, initialEmailComposerState } from './messages/state/emailReducer';
 
 type StatusTone = 'neutral' | 'success' | 'error';
 
@@ -1371,7 +1371,7 @@ function ChatWindow({
     if (!canModerate) return;
     setEmailLoadingTemplates(true);
     try {
-      emailDispatch({ type: 'setTemplates', templates: await loadTeamEmailTemplates(teamId) });
+      emailDispatch(emailComposerActions.setTemplates(await loadTeamEmailTemplates(teamId)));
       if (!suppressErrorStatus) {
         setEmailStatus(null);
       }
@@ -1388,7 +1388,7 @@ function ChatWindow({
     if (!canModerate) return;
     setEmailLoadingDrafts(true);
     try {
-      emailDispatch({ type: 'setDrafts', drafts: await loadTeamEmailDrafts(teamId) });
+      emailDispatch(emailComposerActions.setDrafts(await loadTeamEmailDrafts(teamId)));
       if (!suppressErrorStatus) {
         setEmailStatus(null);
       }
@@ -1404,10 +1404,10 @@ function ChatWindow({
   const openEmailSheet = () => {
     if (!canModerate) return;
     openTeamEmailSheet();
-    emailDispatch({ type: 'updateTemplateName', templateName: '' });
+    emailDispatch(emailComposerActions.updateTemplateName(''));
     setEmailStatus(null);
     setEmailHistoryStatus(null);
-    emailDispatch({ type: 'clearSelectedDraft' });
+    emailDispatch(emailComposerActions.clearSelectedDraft());
     void ensureRecipientOptionsLoaded().catch(() => undefined);
     if (emailSheetLoadedForTeamRef.current !== teamId) {
       emailSheetLoadedForTeamRef.current = teamId;
@@ -1425,14 +1425,14 @@ function ChatWindow({
     }
     setSelectedRecipientTarget('individuals');
     setSelectedRecipientIds(draft.recipientIds);
-    emailDispatch({ type: 'selectDraft', draftId: draft.id });
+    emailDispatch(emailComposerActions.selectDraft(draft.id));
     setEmailStatus({ tone: 'success', message: `Restored draft “${draft.subject || 'Untitled draft'}”. This replaced the current email composer.` });
   };
 
   const handleApplyEmailTemplate = (templateId: string) => {
     const template = emailState.templates.find((item) => item.id === templateId);
     if (!template) return;
-    emailDispatch({ type: 'applyTemplate', templateId: template.id });
+    emailDispatch(emailComposerActions.applyTemplate(template.id));
     setEmailStatus({ tone: 'success', message: `Applied template “${template.name}”.` });
   };
 
@@ -1447,8 +1447,8 @@ function ChatWindow({
         subject: emailState.subject,
         body: emailState.body
       });
-      emailDispatch({ type: 'updateTemplateName', templateName: '' });
-      emailDispatch({ type: 'setTemplates', templates: [savedTemplate, ...emailState.templates.filter((item) => item.id !== savedTemplate.id)] });
+      emailDispatch(emailComposerActions.updateTemplateName(''));
+      emailDispatch(emailComposerActions.setTemplates([savedTemplate, ...emailState.templates.filter((item) => item.id !== savedTemplate.id)]));
       setEmailStatus({ tone: 'success', message: `Saved template “${savedTemplate.name}”.` });
       void reloadEmailTemplates({ suppressErrorStatus: true });
     } catch (saveError: any) {
@@ -1475,7 +1475,7 @@ function ChatWindow({
         authorName: profile?.fullName || auth.user?.displayName || null
       });
       if (savedDraft?.id) {
-        emailDispatch({ type: 'saveDraft', draft: savedDraft });
+        emailDispatch(emailComposerActions.saveDraft(savedDraft));
       }
       setEmailStatus({ tone: 'success', message: `Saved draft “${savedDraft?.subject || emailState.subject || 'Untitled draft'}”. No email was sent.` });
       void reloadEmailDrafts({ suppressErrorStatus: true });
@@ -1510,7 +1510,7 @@ function ChatWindow({
         targetType: emailAudienceMetadata.targetType,
         recipientIds: emailAudienceMetadata.recipientIds
       });
-      emailDispatch({ type: 'clearComposer' });
+      emailDispatch(emailComposerActions.clearComposer());
       setEmailStatus({ tone: 'success', message: `Queued ${Number(result?.recipientCount || 0)} recipient${Number(result?.recipientCount || 0) === 1 ? '' : 's'} for backend email delivery.` });
       await reloadSentEmailHistory({ suppressErrorStatus: true });
     } catch (sendError: any) {
@@ -1966,9 +1966,9 @@ function ChatWindow({
           sentEmails={sentEmails}
           audienceSummary={getAudienceSummaryText(emailAudienceMetadata, recipientOptions)}
           audienceMetadata={emailAudienceMetadata}
-          onSubjectChange={(subject) => emailDispatch({ type: 'updateSubject', subject })}
-          onBodyChange={(body) => emailDispatch({ type: 'updateBody', body })}
-          onTemplateNameChange={(templateName) => emailDispatch({ type: 'updateTemplateName', templateName })}
+          onSubjectChange={(subject) => emailDispatch(emailComposerActions.updateSubject(subject))}
+          onBodyChange={(body) => emailDispatch(emailComposerActions.updateBody(body))}
+          onTemplateNameChange={(templateName) => emailDispatch(emailComposerActions.updateTemplateName(templateName))}
           onApplyDraft={handleApplyEmailDraft}
           onSaveDraft={handleSaveEmailDraft}
           onApplyTemplate={handleApplyEmailTemplate}

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -104,7 +104,8 @@ import { voiceRecognition, type VoiceListenerHandle } from '../lib/voiceService'
 import { useChatSheets } from './messages/hooks/useChatSheets';
 import { useChatTeam } from './messages/hooks/useChatTeam';
 import { useChatMessages } from './messages/hooks/useChatMessages';
-import { emailComposerActions, emailReducer, initialEmailComposerState } from './messages/state/emailReducer';
+import { emailReducer, initialEmailComposerState } from './messages/state/emailReducer';
+import { emailComposerActions } from './messages/state/emailReducer';
 
 type StatusTone = 'neutral' | 'success' | 'error';
 

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -104,8 +104,7 @@ import { voiceRecognition, type VoiceListenerHandle } from '../lib/voiceService'
 import { useChatSheets } from './messages/hooks/useChatSheets';
 import { useChatTeam } from './messages/hooks/useChatTeam';
 import { useChatMessages } from './messages/hooks/useChatMessages';
-import { emailReducer, initialEmailComposerState } from './messages/state/emailReducer';
-import { emailComposerActions } from './messages/state/emailReducer';
+import { emailComposerActions, emailReducer, initialEmailComposerState } from './messages/state/emailReducer';
 
 type StatusTone = 'neutral' | 'success' | 'error';
 

--- a/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
+++ b/apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { emailReducer, initialEmailComposerState } from '../emailReducer';
+import { emailComposerActions, emailReducer, initialEmailComposerState } from '../emailReducer';
 import type { TeamEmailDraft, TeamEmailTemplate } from '../../../../lib/chatService';
 
 function draft(overrides: Partial<TeamEmailDraft> = {}): TeamEmailDraft {
@@ -24,6 +24,29 @@ function template(overrides: Partial<TeamEmailTemplate> = {}): TeamEmailTemplate
 }
 
 describe('emailReducer', () => {
+  it('exposes named actions for composer edits, draft selection, template application, and draft deletion', () => {
+    const withDrafts = emailReducer(initialEmailComposerState, emailComposerActions.setDrafts([draft()]));
+    const selected = emailReducer(withDrafts, emailComposerActions.selectDraft('draft-1'));
+    const edited = emailReducer(
+      emailReducer(selected, emailComposerActions.updateSubject('Updated practice reminder')),
+      emailComposerActions.updateBody('Bring cleats, water, and a jacket.')
+    );
+    const withTemplate = emailReducer(edited, emailComposerActions.setTemplates([template()]));
+    const applied = emailReducer(withTemplate, emailComposerActions.applyTemplate('template-1'));
+
+    expect(applied).toMatchObject({
+      selectedDraftId: 'draft-1',
+      subject: 'Week ahead',
+      body: 'Here is the plan.'
+    });
+    expect(emailReducer(applied, emailComposerActions.deleteDraft('draft-1'))).toMatchObject({
+      drafts: [],
+      selectedDraftId: '',
+      subject: '',
+      body: ''
+    });
+  });
+
   it('starts with empty composer fields and applies direct subject and body edits', () => {
     expect(initialEmailComposerState).toMatchObject({
       drafts: [],

--- a/apps/app/src/pages/messages/state/emailReducer.ts
+++ b/apps/app/src/pages/messages/state/emailReducer.ts
@@ -31,6 +31,20 @@ export const initialEmailComposerState: EmailComposerState = {
   templates: []
 };
 
+export const emailComposerActions = {
+  setDrafts: (drafts: TeamEmailDraft[]): EmailComposerAction => ({ type: 'setDrafts', drafts }),
+  selectDraft: (draftId: string): EmailComposerAction => ({ type: 'selectDraft', draftId }),
+  updateSubject: (subject: string): EmailComposerAction => ({ type: 'updateSubject', subject }),
+  updateBody: (body: string): EmailComposerAction => ({ type: 'updateBody', body }),
+  updateTemplateName: (templateName: string): EmailComposerAction => ({ type: 'updateTemplateName', templateName }),
+  setTemplates: (templates: TeamEmailTemplate[]): EmailComposerAction => ({ type: 'setTemplates', templates }),
+  applyTemplate: (templateId: string): EmailComposerAction => ({ type: 'applyTemplate', templateId }),
+  saveDraft: (draft: TeamEmailDraft): EmailComposerAction => ({ type: 'saveDraft', draft }),
+  deleteDraft: (draftId: string): EmailComposerAction => ({ type: 'deleteDraft', draftId }),
+  clearSelectedDraft: (): EmailComposerAction => ({ type: 'clearSelectedDraft' }),
+  clearComposer: (): EmailComposerAction => ({ type: 'clearComposer' })
+};
+
 function getDraftContent(draft: TeamEmailDraft | undefined | null) {
   return {
     subject: draft?.subject || '',

--- a/tests/unit/messages-decomposition-contract.test.js
+++ b/tests/unit/messages-decomposition-contract.test.js
@@ -26,7 +26,10 @@ describe('Messages decomposition contract', () => {
         const messages = readRepoFile('apps/app/src/pages/Messages.tsx');
         const reducer = readRepoFile('apps/app/src/pages/messages/state/emailReducer.ts');
 
-        expect(messages).toContain("import { emailReducer, initialEmailComposerState } from './messages/state/emailReducer';");
+        expect(messages).toContain("from './messages/state/emailReducer';");
+        expect(messages).toContain('emailComposerActions');
+        expect(messages).toContain('emailReducer');
+        expect(messages).toContain('initialEmailComposerState');
         expect(messages).toMatch(/const\s+\[emailState,\s*emailDispatch\]\s*=\s*useReducer\(emailReducer,\s*initialEmailComposerState\);/);
         expect(messages).not.toMatch(/const\s+\[emailSubject\b/);
         expect(messages).not.toMatch(/const\s+\[emailBody\b/);

--- a/tests/unit/messages-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/messages-decomposition-initiative-source-contract.test.js
@@ -67,7 +67,10 @@ describe('Messages decomposition initiative source contract', () => {
     });
 
     it('keeps team email composer transitions in the reducer with dedicated reducer tests', () => {
-        expect(messagesSource).toContain("import { emailComposerActions, emailReducer, initialEmailComposerState } from './messages/state/emailReducer';");
+        expect(messagesSource).toContain("from './messages/state/emailReducer';");
+        expect(messagesSource).toContain('emailComposerActions');
+        expect(messagesSource).toContain('emailReducer');
+        expect(messagesSource).toContain('initialEmailComposerState');
         expect(messagesSource).toMatch(/useReducer\(emailReducer,\s*initialEmailComposerState\)/);
         expect(messagesSource).not.toMatch(/const\s+\[emailSubject\b/);
         expect(messagesSource).not.toMatch(/const\s+\[emailBody\b/);

--- a/tests/unit/messages-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/messages-decomposition-initiative-source-contract.test.js
@@ -67,7 +67,7 @@ describe('Messages decomposition initiative source contract', () => {
     });
 
     it('keeps team email composer transitions in the reducer with dedicated reducer tests', () => {
-        expect(messagesSource).toContain("import { emailReducer, initialEmailComposerState } from './messages/state/emailReducer';");
+        expect(messagesSource).toContain("import { emailComposerActions, emailReducer, initialEmailComposerState } from './messages/state/emailReducer';");
         expect(messagesSource).toMatch(/useReducer\(emailReducer,\s*initialEmailComposerState\)/);
         expect(messagesSource).not.toMatch(/const\s+\[emailSubject\b/);
         expect(messagesSource).not.toMatch(/const\s+\[emailBody\b/);
@@ -83,6 +83,7 @@ describe('Messages decomposition initiative source contract', () => {
             expect(emailReducerSource).toContain(action);
         });
         expect(emailReducerSource).toContain('function clearDraftComposer(state: EmailComposerState, drafts = state.drafts): EmailComposerState');
+        expect(emailReducerSource).toContain('export const emailComposerActions = {');
         expect(emailReducerTestSource).toContain("describe('emailReducer'");
     });
 


### PR DESCRIPTION
Closes #2394

## Summary
- add a named `emailComposerActions` action set alongside the Messages email reducer
- route Messages email composer dispatches through the reducer action helpers instead of inline action objects
- add reducer coverage proving the action helpers preserve draft selection, template application, composer edits, and draft deletion behavior

## Tests
- `npx vitest run apps/app/src/pages/messages/state/__tests__/emailReducer.test.ts tests/unit/app-email-reducer.test.ts tests/unit/app-chat-email-reducer.test.ts tests/unit/app-email-reducer-state-contract.test.ts apps/app/src/pages/Messages.test.ts --reporter=verbose`
- `npm run app:build`