### PR TITLE
Preserve award batch certificate ids

### DIFF
--- a/apps/app/src/lib/certificateAwardService.test.ts
+++ b/apps/app/src/lib/certificateAwardService.test.ts
@@ -219,6 +219,49 @@ describe('certificateAwardService', () => {
     });
   });
 
+  it('publishes only selected certificates without dropping the rest of the batch metadata', async () => {
+    const readyDrafts = [
+      {
+        ...draft,
+        description: 'Pat brought energy, confidence, and smart decisions to every match.',
+        descriptionSource: 'manual' as const,
+        descriptionStatus: 'ready' as const
+      },
+      {
+        ...draft,
+        id: 'cert-2',
+        certificateId: 'cert-2',
+        playerId: 'player-2',
+        recipientName: 'Sam Star',
+        includeInExport: false,
+        description: 'Sam led the group with effort.',
+        descriptionSource: 'manual' as const,
+        descriptionStatus: 'ready' as const
+      }
+    ];
+
+    const result = await publishCertificateAwardsForApp({
+      teamId: 'team-1',
+      user,
+      shared,
+      drafts: readyDrafts,
+      reviewConfirmed: true
+    });
+
+    expect(legacyDraftMocks.updateCertificate).toHaveBeenCalledTimes(1);
+    expect(legacyDraftMocks.updateCertificate).toHaveBeenCalledWith(
+      'team-1',
+      'cert-1',
+      expect.objectContaining({ status: 'published' }),
+      { action: 'published' }
+    );
+    expect(legacyDraftMocks.updateCertificateBatch).toHaveBeenCalledWith('team-1', 'batch-1', expect.objectContaining({
+      generatedCertificateIds: ['cert-1', 'cert-2'],
+      status: 'published'
+    }));
+    expect(result.publishedCertificateIds).toEqual(['cert-1']);
+  });
+
   it('builds publish payloads with normalized signers, colors, and truncated descriptions', () => {
     const payload = buildCertificateAwardPayloadForApp({
       draft: {

--- a/apps/app/src/lib/certificateAwardService.ts
+++ b/apps/app/src/lib/certificateAwardService.ts
@@ -172,7 +172,8 @@ export async function publishCertificateAwardsForApp({
   if (!user?.uid) throw new Error('You must be signed in to publish certificates.');
   if (!reviewConfirmed) throw new Error('Review and confirm certificate descriptions before publishing.');
 
-  const publishDrafts = (Array.isArray(drafts) ? drafts : []).filter((draft) => draft?.includeInExport !== false);
+  const sourceDrafts = Array.isArray(drafts) ? drafts : [];
+  const publishDrafts = sourceDrafts.filter((draft) => draft?.includeInExport !== false);
   if (!publishDrafts.length) throw new Error('Select at least one certificate before publishing.');
   if (publishDrafts.some((draft) => !draft.certificateId)) {
     throw new Error('Create certificate drafts before publishing.');
@@ -197,7 +198,7 @@ export async function publishCertificateAwardsForApp({
 
   const batchIds = Array.from(new Set(publishDrafts.map((draft) => draft.batchId).filter(Boolean)));
   for (const batchId of batchIds) {
-    const batchDrafts = publishDrafts.filter((draft) => draft.batchId === batchId);
+    const batchDrafts = sourceDrafts.filter((draft) => draft.batchId === batchId && draft.certificateId);
     await updateCertificateBatch(teamId, batchId, {
       generatedCertificateIds: batchDrafts.map((draft) => draft.certificateId),
       shared,

--- a/apps/app/src/pages/TeamCertificates.tsx
+++ b/apps/app/src/pages/TeamCertificates.tsx
@@ -242,7 +242,7 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
         teamId,
         user: auth.user,
         shared,
-        drafts: publishDrafts,
+        drafts,
         reviewConfirmed
       });
       const publishedIds = new Set(result.publishedCertificateIds);


### PR DESCRIPTION
## Summary
- Preserve all certificate IDs on an awards batch when publishing only selected certificates
- Keep individual publishing scoped to the selected certificates
- Add a regression test for partial publish batch metadata

## Tests
- `npm --prefix apps/app run test -- --run src/lib/certificateAwardService.test.ts src/pages/TeamCertificates.test.tsx --reporter=verbose`
- `npx vitest run tests/unit/issue-1997-awards-publish-export-source.test.js --reporter=verbose`