### PR TITLE
[codex] Add game report Firestore mappers

### DIFF
--- a/apps/app/src/lib/firestore/mappers.ts
+++ b/apps/app/src/lib/firestore/mappers.ts
@@ -297,12 +297,24 @@ export function mapGameReportPlayerRecords(value: unknown): GameReportPlayerFire
     }).filter((entry) => Boolean(entry.id));
 }
 
+export function mapGameReportOpponentStatsRecord(value: unknown): GameReportOpponentFirestoreRecord {
+    const source = asLooseObject(value);
+    return {
+        ...asGameReportStatsRecord(source),
+        name: asTrimmedString(source.name),
+        number: asTrimmedString(source.number),
+        notes: asTrimmedString(source.notes),
+        playerId: asTrimmedString(source.playerId),
+        photoUrl: asTrimmedString(source.photoUrl)
+    };
+}
+
 export function mapGameReportGameRecord(value: unknown, fallbackGameId = ''): GameReportGameFirestoreRecord {
     const source = asLooseObject(value);
     const opponentStatsSource = asObject(source.opponentStats);
     const opponentStats = opponentStatsSource
         ? Object.entries(opponentStatsSource).reduce<Record<string, GameReportOpponentFirestoreRecord>>((acc, [key, entry]) => {
-            acc[key] = asLooseObject(entry);
+            acc[key] = mapGameReportOpponentStatsRecord(entry);
             return acc;
         }, {})
         : {};

--- a/apps/app/src/lib/firestore/types.ts
+++ b/apps/app/src/lib/firestore/types.ts
@@ -164,6 +164,7 @@ export type GameReportOpponentFirestoreRecord = {
     name?: string | null;
     number?: string | null;
     notes?: string | null;
+    playerId?: string | null;
     photoUrl?: string | null;
     [key: string]: unknown;
 };

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -15,12 +15,14 @@ const firebaseMocks = vi.hoisted(() => ({
   getDocs: vi.fn()
 }));
 
-vi.mock('../../../../js/db.js', () => dbMocks);
-vi.mock('../../../../js/firebase.js', () => firebaseMocks);
-vi.mock('../../../../js/game-report-stats.js', () => ({
+const gameReportStatsMocks = vi.hoisted(() => ({
   resolveReportStatColumns: vi.fn(() => ({ statKeys: [], statLabels: {} })),
   resolveOpponentReportStatColumns: vi.fn(() => ({ oppKeys: [], oppLabels: {} }))
 }));
+
+vi.mock('../../../../js/db.js', () => dbMocks);
+vi.mock('../../../../js/firebase.js', () => firebaseMocks);
+vi.mock('../../../../js/game-report-stats.js', () => gameReportStatsMocks);
 vi.mock('../../../../js/live-game-video.js', () => ({
   buildHighlightShareUrl: vi.fn(() => ''),
   normalizeGameRecapHighlightClips: vi.fn(() => [])
@@ -80,12 +82,14 @@ describe('gameReportService', () => {
       statSheetPhotoUrl: 123,
       opponentStats: {
         'opp-1': {
-          name: 'Opponent Guard',
+          name: ' Opponent Guard ',
           number: 5,
+          notes: ' linked ',
+          playerId: ' opponent-player-1 ',
           pts: 11,
           fouls: '2',
           assists: { invalid: true },
-          photoUrl: false
+          photoUrl: ' https://img.example.test/opponent.png '
         },
         'opp-2': 'bad-payload'
       }
@@ -130,7 +134,7 @@ describe('gameReportService', () => {
         id: 'opp-1',
         name: 'Opponent Guard',
         number: '5',
-        photoUrl: undefined,
+        photoUrl: 'https://img.example.test/opponent.png',
         stats: { pts: 11, fouls: '2' }
       },
       {
@@ -141,6 +145,12 @@ describe('gameReportService', () => {
         stats: {}
       }
     ]);
+    expect(gameReportStatsMocks.resolveOpponentReportStatColumns).toHaveBeenCalledWith(expect.objectContaining({
+      opponentStats: {
+        'opp-1': { pts: 11, fouls: '2' },
+        'opp-2': {}
+      }
+    }));
     expect(report.teamStats).toEqual({ turnovers: 7, assists: '11' });
     expect(report.plays).toEqual([
       {

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -174,8 +174,9 @@ function normalizePlay(entry: GameReportEventFirestoreRecord): GameReportPlay {
 
 function normalizeOpponentRows(opponentStats: GameReportGameFirestoreRecord['opponentStats'] = {}): GameReportOpponentRow[] {
   return Object.entries(opponentStats || {}).map(([id, rawStats]) => {
-    const { name, number, notes, photoUrl, ...stats } = rawStats || {};
+    const { name, number, notes, playerId, photoUrl, ...stats } = rawStats || {};
     void notes;
+    void playerId;
     return {
       id,
       name: String(name || 'Opponent Player'),
@@ -184,6 +185,19 @@ function normalizeOpponentRows(opponentStats: GameReportGameFirestoreRecord['opp
       stats: mapGameReportTeamStatsRecord(stats)
     };
   });
+}
+
+function normalizeOpponentStatsForColumns(opponentStats: GameReportGameFirestoreRecord['opponentStats'] = {}): Record<string, GameReportStatsRecord> {
+  return Object.entries(opponentStats || {}).reduce<Record<string, GameReportStatsRecord>>((acc, [id, rawStats]) => {
+    const { name, number, notes, playerId, photoUrl, ...stats } = rawStats || {};
+    void name;
+    void number;
+    void notes;
+    void playerId;
+    void photoUrl;
+    acc[id] = mapGameReportTeamStatsRecord(stats);
+    return acc;
+  }, {});
 }
 
 function normalizeHighlightClips(teamId: string, gameId: string, game: GameReportGameFirestoreRecord): GameReportHighlightClip[] {
@@ -260,7 +274,7 @@ export async function loadGameReportSections(teamId: string, gameId: string): Pr
   });
   const opponentStats = game.opponentStats || {};
   const { oppKeys, oppLabels } = resolveOpponentReportStatColumns({
-    opponentStats,
+    opponentStats: normalizeOpponentStatsForColumns(opponentStats),
     resolvedConfig
   });
   const teamStatFields = resolvePostGameTeamStatFields({ resolvedConfig, teamStats });

--- a/tests/unit/app-firestore-boundary-initiative-source-contract.test.js
+++ b/tests/unit/app-firestore-boundary-initiative-source-contract.test.js
@@ -53,9 +53,11 @@ describe('app Firestore boundary initiative source contract', () => {
 
     it('keeps game report Firestore records typed and mapped before report assembly', () => {
         expect(firestoreTypesSource).toContain('export type GameReportGameFirestoreRecord = {');
+        expect(firestoreTypesSource).toContain('export type GameReportOpponentFirestoreRecord = {');
         expect(firestoreTypesSource).toContain('export type GameReportAggregatedStatsFirestoreRecord = {');
         expect(firestoreTypesSource).toContain('export type GameReportEventFirestoreRecord = {');
         expect(firestoreMappersSource).toContain('export function mapGameReportGameRecord(value: unknown, fallbackGameId = \'\'): GameReportGameFirestoreRecord');
+        expect(firestoreMappersSource).toContain('export function mapGameReportOpponentStatsRecord(value: unknown): GameReportOpponentFirestoreRecord');
         expect(firestoreMappersSource).toContain('export function mapGameReportAggregatedStatsRecord(id: string, value: unknown): GameReportAggregatedStatsFirestoreRecord');
         expect(firestoreMappersSource).toContain('export function mapGameReportEventRecords(value: unknown): GameReportEventFirestoreRecord[]');
 

--- a/tests/unit/app-firestore-mappers.test.ts
+++ b/tests/unit/app-firestore-mappers.test.ts
@@ -7,6 +7,7 @@ import {
     mapGameReportAggregatedStatsRecord,
     mapGameReportEventRecords,
     mapGameReportGameRecord,
+    mapGameReportOpponentStatsRecord,
     mapGameReportPlayerRecords,
     mapGameReportTeamRecord,
     mapGameReportTeamStatsRecord
@@ -159,7 +160,15 @@ describe('firestore mappers', () => {
             summary: '  Tight finish  ',
             statSheetPhotoUrl: ' https://example.test/sheet.png ',
             opponentStats: {
-                opponent1: { name: '  Riley ', number: ' 4 ', pts: 12 },
+                opponent1: {
+                    name: '  Riley ',
+                    number: ' 4 ',
+                    notes: ' linked roster player ',
+                    playerId: ' opponent-player-1 ',
+                    photoUrl: 8,
+                    pts: 12,
+                    nested: { value: 1 }
+                },
                 malformed: null
             }
         }, 'game-1')).toMatchObject({
@@ -167,9 +176,42 @@ describe('firestore mappers', () => {
             summary: 'Tight finish',
             statSheetPhotoUrl: 'https://example.test/sheet.png',
             opponentStats: {
-                opponent1: { name: '  Riley ', number: ' 4 ', pts: 12 },
-                malformed: {}
+                opponent1: {
+                    name: 'Riley',
+                    number: '4',
+                    notes: 'linked roster player',
+                    playerId: 'opponent-player-1',
+                    photoUrl: '8',
+                    pts: 12
+                },
+                malformed: {
+                    name: null,
+                    number: null,
+                    notes: null,
+                    playerId: null,
+                    photoUrl: null
+                }
             }
+        });
+
+        expect(mapGameReportOpponentStatsRecord({
+            name: { invalid: true },
+            number: 0,
+            photoUrl: false,
+            playerId: ' roster-opponent-1 ',
+            notes: ' ',
+            pts: 8,
+            fouls: '3',
+            ignored: Number.NaN,
+            nested: { value: 1 }
+        })).toEqual({
+            name: null,
+            number: null,
+            notes: null,
+            playerId: 'roster-opponent-1',
+            photoUrl: null,
+            pts: 8,
+            fouls: '3'
         });
 
         expect(mapGameReportAggregatedStatsRecord('p1', {

--- a/tests/unit/app-game-report-firestore-records-contract.test.ts
+++ b/tests/unit/app-game-report-firestore-records-contract.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
     mapGameReportEventRecord,
     mapGameReportGameRecord,
+    mapGameReportOpponentStatsRecord,
     mapGameReportPlayerRecords,
     mapGameReportTeamRecord
 } from '../../apps/app/src/lib/firestore/mappers.ts';
@@ -40,6 +41,27 @@ describe('game report Firestore record boundary', () => {
             number: '9',
             photoUrl: 'https://img.example.test/ava.jpg'
         }]);
+    });
+
+    it('normalizes opponent stat rows without leaking metadata into stats', () => {
+        expect(mapGameReportOpponentStatsRecord({
+            name: ' Opponent Guard ',
+            number: 5,
+            notes: ' linked ',
+            playerId: ' opponent-player-1 ',
+            photoUrl: '',
+            pts: 14,
+            assists: '6',
+            malformed: { invalid: true }
+        })).toEqual({
+            name: 'Opponent Guard',
+            number: '5',
+            notes: 'linked',
+            playerId: 'opponent-player-1',
+            photoUrl: null,
+            pts: 14,
+            assists: '6'
+        });
     });
 
     it('defaults event timeline records without leaking malformed rows', () => {

--- a/tests/unit/app-game-report-mapper-boundary-contract.test.js
+++ b/tests/unit/app-game-report-mapper-boundary-contract.test.js
@@ -19,6 +19,7 @@ describe('game report Firestore mapper boundary', () => {
             expect(serviceSource).toContain(mapperName);
             expect(mapperSource).toContain(`export function ${mapperName}`);
         });
+        expect(mapperSource).toContain('export function mapGameReportOpponentStatsRecord');
     });
 
     it('keeps the report service typed to normalized mapper records', () => {
@@ -33,5 +34,6 @@ describe('game report Firestore mapper boundary', () => {
             expect(serviceSource).toContain(typeName);
             expect(typeSource).toContain(`export type ${typeName}`);
         });
+        expect(typeSource).toContain('export type GameReportOpponentFirestoreRecord');
     });
 });


### PR DESCRIPTION
## Summary
- Add typed normalization for game report opponent stat rows, including optional linked opponent `playerId` metadata.
- Route game report opponent stat reads through the Firestore mapper before report assembly.
- Keep opponent metadata out of stat column resolution while preserving normalized report rows.
- Extend focused mapper, service, and source-contract coverage for missing and malformed report fields.

Closes #2617

## Tests
- `npx vitest run apps/app/src/lib/gameReportService.test.ts tests/unit/app-firestore-mappers.test.ts tests/unit/app-game-report-firestore-records-contract.test.ts tests/unit/app-game-report-mapper-boundary-contract.test.js tests/unit/app-firestore-boundary-initiative-source-contract.test.js --reporter=verbose`
- `npm run app:build`