### PR TITLE
[codex] Detect chat mention pushes

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7069,15 +7069,22 @@ function detectMentionedUids(text, members, options = {}) {
   const mentioned = new Set();
   const sourceText = String(text || '');
   const normalizedMembers = Array.isArray(members)
-    ? members.map((member) => {
-      const memberName = String(member?.displayName || member?.name || '').toLowerCase().trim().replace(/\s+/g, ' ');
-      return {
-        uid: member?.uid,
-        fullName: memberName,
-        compactName: memberName.replace(/\s+/g, ''),
-        firstName: memberName.split(' ')[0] || ''
-      };
-    }).filter((member) => member.uid && member.fullName)
+    ? members.flatMap((member) => {
+      const names = [
+        member?.displayName,
+        member?.name,
+        ...(Array.isArray(member?.mentionNames) ? member.mentionNames : [])
+      ];
+      return names.map((name) => {
+        const memberName = String(name || '').toLowerCase().trim().replace(/\s+/g, ' ');
+        return {
+          uid: member?.uid,
+          fullName: memberName,
+          compactName: memberName.replace(/\s+/g, ''),
+          firstName: memberName.split(' ')[0] || ''
+        };
+      }).filter((memberName) => memberName.uid && memberName.fullName);
+    })
     : [];
 
   for (const match of sourceText.matchAll(teamChatMentionStartRegex)) {
@@ -7098,6 +7105,10 @@ function detectMentionedUids(text, members, options = {}) {
 
     let matchedReservedMention = false;
     for (const candidate of candidateLabels) {
+      if (candidate.name === 'all plays') {
+        matchedReservedMention = true;
+        break;
+      }
       if (candidate.name !== 'all' && candidate.name !== 'team') continue;
       if (!allowReservedMentions) {
         matchedReservedMention = true;
@@ -7120,6 +7131,95 @@ function detectMentionedUids(text, members, options = {}) {
     }
   }
   return [...mentioned];
+}
+
+function normalizeTeamChatMentionName(value) {
+  return String(value || '').trim().replace(/\s+/g, ' ');
+}
+
+function getTeamChatMentionNames(source = {}, keys = []) {
+  return Array.from(new Set(
+    keys
+      .map((key) => normalizeTeamChatMentionName(source?.[key]))
+      .filter(Boolean)
+  ));
+}
+
+function getTeamChatRosterPlayerMentionNames(player = {}) {
+  return getTeamChatMentionNames(player, ['displayName', 'fullName', 'name', 'playerName', 'childName']);
+}
+
+function getTeamChatRosterContactMentionNames(contact = {}) {
+  return getTeamChatMentionNames(contact, [
+    'displayName',
+    'fullName',
+    'name',
+    'parentName',
+    'guardianName'
+  ]);
+}
+
+function getTeamChatRosterContactUid(contact = {}) {
+  return String(
+    contact.userId
+    || contact.uid
+    || contact.parentUserId
+    || contact.guardianUserId
+    || ''
+  ).trim();
+}
+
+function getTeamChatRosterContactEmail(contact = {}) {
+  return String(
+    contact.email
+    || contact.parentEmail
+    || contact.guardianEmail
+    || ''
+  ).trim().toLowerCase();
+}
+
+function getTeamChatRosterContacts(player = {}) {
+  return [
+    player,
+    ...(Array.isArray(player.parents) ? player.parents : []),
+    ...(Array.isArray(player.guardians) ? player.guardians : []),
+    ...(Array.isArray(player.familyContacts) ? player.familyContacts : []),
+    ...(Array.isArray(player.contacts) ? player.contacts : [])
+  ];
+}
+
+function normalizeTeamChatParticipantSelector(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return null;
+  const separatorIndex = raw.indexOf(':');
+  if (separatorIndex > 0) {
+    const kind = raw.slice(0, separatorIndex).trim().toLowerCase();
+    const id = raw.slice(separatorIndex + 1).trim();
+    if (!id) return null;
+    if (kind === 'email') return { kind: 'email', id: id.toLowerCase() };
+    if (kind === 'player') return { kind: 'player', id };
+    if (kind === 'user') return { kind: 'user', id };
+  }
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw)) {
+    return { kind: 'email', id: raw.toLowerCase() };
+  }
+  return { kind: 'user', id: raw };
+}
+
+function addTeamChatMemberRole(users, uid, role, aliases = []) {
+  const normalizedUid = String(uid || '').trim();
+  if (!normalizedUid) return;
+  const entry = users.get(normalizedUid) || {
+    uid: normalizedUid,
+    roles: new Set(),
+    mentionNames: new Set()
+  };
+  entry.roles.add(role);
+  (Array.isArray(aliases) ? aliases : []).forEach((alias) => {
+    const normalizedAlias = normalizeTeamChatMentionName(alias);
+    if (normalizedAlias) entry.mentionNames.add(normalizedAlias);
+  });
+  users.set(normalizedUid, entry);
 }
 
 async function buildTeamChatNotificationContext(teamId, options = {}) {
@@ -7176,43 +7276,94 @@ async function buildTeamChatNotificationContext(teamId, options = {}) {
   const scopedParticipantIds = effectiveTargetType === 'individuals'
     ? Array.from(new Set([...conversationParticipantIds, ...normalizedRecipientIds]))
     : [];
+  const scopedParticipantSelectors = scopedParticipantIds
+    .map(normalizeTeamChatParticipantSelector)
+    .filter(Boolean);
   const scopedParticipantUids = new Set(
-    scopedParticipantIds
-      .filter((id) => !id.toLowerCase().startsWith('email:'))
-      .map((id) => id.toLowerCase().startsWith('user:') ? id.slice(5).trim() : id)
+    scopedParticipantSelectors
+      .filter((selector) => selector.kind === 'user')
+      .map((selector) => selector.id)
       .filter(Boolean)
   );
   const scopedParticipantEmails = Array.from(new Set(
-    scopedParticipantIds
-      .filter((id) => id.toLowerCase().startsWith('email:'))
-      .map((id) => id.slice(6).trim().toLowerCase())
+    scopedParticipantSelectors
+      .filter((selector) => selector.kind === 'email')
+      .map((selector) => selector.id)
       .filter(Boolean)
   ));
+  const scopedParticipantPlayerIds = new Set(
+    scopedParticipantSelectors
+      .filter((selector) => selector.kind === 'player')
+      .map((selector) => selector.id)
+      .filter(Boolean)
+  );
   const users = new Map();
-  const addRole = (uid, role) => {
-    const normalizedUid = String(uid || '').trim();
-    if (!normalizedUid) return;
-    const entry = users.get(normalizedUid) || { uid: normalizedUid, roles: new Set() };
-    entry.roles.add(role);
-    users.set(normalizedUid, entry);
-  };
+  const addRole = (uid, role, aliases = []) => addTeamChatMemberRole(users, uid, role, aliases);
 
   addRole(team.ownerId, 'staff');
 
-  const [parentSnap, indexedTargetSnap, adminUserIds, participantEmailUserIds] = await Promise.all([
+  const [parentSnap, indexedTargetSnap, adminUserIds, participantEmailUserIds, playersSnap] = await Promise.all([
     firestore.collection('users').where('parentTeamIds', 'array-contains', teamId).get(),
     firestore.collection(`teams/${teamId}/notificationTargets`).get(),
     getUserIdsByEmails(team.adminEmails || []),
-    scopedParticipantEmails.length > 0 ? getUserIdsByEmails(scopedParticipantEmails) : Promise.resolve([])
+    scopedParticipantEmails.length > 0 ? getUserIdsByEmails(scopedParticipantEmails) : Promise.resolve([]),
+    firestore.collection(`teams/${teamId}/players`).get()
   ]);
 
   parentSnap.forEach((docSnap) => addRole(docSnap.id, 'parent'));
   adminUserIds.forEach((uid) => addRole(uid, 'staff'));
   participantEmailUserIds.forEach((uid) => scopedParticipantUids.add(uid));
 
+  const rosterContactAliasesByEmail = new Map();
+  const scopedRosterContactEmails = new Set();
+  const activePlayers = Array.isArray(playersSnap?.docs)
+    ? playersSnap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
+      .filter((player) => player.active !== false)
+    : [];
+
+  activePlayers.forEach((player) => {
+    const playerAliases = getTeamChatRosterPlayerMentionNames(player);
+    if (!playerAliases.length) return;
+    const playerId = String(player.id || player.playerId || '').trim();
+    const playerIsScoped = scopedParticipantPlayerIds.has(playerId);
+    getTeamChatRosterContacts(player).forEach((contact) => {
+      const contactAliases = Array.from(new Set([
+        ...playerAliases,
+        ...getTeamChatRosterContactMentionNames(contact)
+      ]));
+      const uid = getTeamChatRosterContactUid(contact);
+      const email = getTeamChatRosterContactEmail(contact);
+      if (uid) {
+        addRole(uid, 'parent', contactAliases);
+        if (playerIsScoped) scopedParticipantUids.add(uid);
+      }
+      if (email) {
+        const existingAliases = rosterContactAliasesByEmail.get(email) || new Set();
+        contactAliases.forEach((alias) => existingAliases.add(alias));
+        rosterContactAliasesByEmail.set(email, existingAliases);
+        if (playerIsScoped) scopedRosterContactEmails.add(email);
+      }
+    });
+  });
+
+  const rosterEmailUserIdEntries = await Promise.all(
+    Array.from(rosterContactAliasesByEmail.entries()).map(async ([email, aliasSet]) => ({
+      email,
+      aliases: Array.from(aliasSet),
+      uids: await getUserIdsByEmails([email])
+    }))
+  );
+  rosterEmailUserIdEntries.forEach(({ email, aliases, uids }) => {
+    (Array.isArray(uids) ? uids : []).forEach((uid) => {
+      addRole(uid, 'parent', aliases);
+      if (scopedRosterContactEmails.has(email)) scopedParticipantUids.add(uid);
+    });
+  });
+
   let members = Array.from(users.values()).map((entry) => ({
     uid: entry.uid,
-    roles: Array.from(entry.roles)
+    roles: Array.from(entry.roles),
+    mentionNames: Array.from(entry.mentionNames || [])
   }));
 
   if (effectiveTargetType === 'staff') {
@@ -7283,8 +7434,16 @@ async function buildTeamChatNotificationContext(teamId, options = {}) {
     return {
       ...member,
       displayName: includeMentions
-        ? String(userRecord.displayName || userRecord.fullName || userRecord.name || '').trim()
+        ? String(userRecord.displayName || userRecord.fullName || userRecord.name || member.mentionNames?.[0] || '').trim()
         : '',
+      mentionNames: includeMentions
+        ? Array.from(new Set([
+          String(userRecord.displayName || '').trim(),
+          String(userRecord.fullName || '').trim(),
+          String(userRecord.name || '').trim(),
+          ...(Array.isArray(member.mentionNames) ? member.mentionNames : [])
+        ].filter(Boolean)))
+        : [],
       muted: conversationMuted || Boolean(normalizedConversationId === 'team' && chatMuted && chatMuted[teamId])
     };
   });

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -717,6 +717,65 @@ test('notifyTeamChatMessageCreated honors conversation mutes while preserving di
     }
 });
 
+test('notifyTeamChatMessageCreated detects roster name mentions and does not double-push live chat', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['parent-2'],
+        userDocs: {
+            'coach-1': { displayName: 'Coach Prime' },
+            'parent-1': {
+                displayName: 'Pat Parent',
+                teamChatState: {
+                    'team-1': {
+                        mutedConversations: {
+                            'thread-9': true
+                        }
+                    }
+                }
+            },
+            'parent-2': { displayName: 'Taylor Parent' }
+        },
+        playerDocs: {
+            'player-1': {
+                name: 'Avery Smith',
+                parents: [{ userId: 'parent-1', name: 'Pat Parent' }]
+            }
+        },
+        indexedTargets: [
+            { uid: 'coach-1', deviceId: 'coach-device', token: 'coach-token', categories: { liveChat: true, mentions: true } },
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { mentions: true, liveChat: false } },
+            { uid: 'parent-2', deviceId: 'parent-2-device', token: 'parent-2-token', categories: { liveChat: true, mentions: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/chatMessages/message-2594');
+        const snapshot = makeSnapshot(ref, {
+            text: 'Can @Avery Smith bring both jerseys?',
+            senderId: 'coach-1',
+            senderName: 'Coach Prime',
+            conversationId: 'thread-9'
+        });
+        const context = { params: { teamId: 'team-1', messageId: 'message-2594' } };
+
+        const result = await moduleExports.notifyTeamChatMessageCreated(snapshot, context);
+
+        assert.equal(result.length, 2);
+        assert.deepEqual(env.messagingCalls.map((call) => `${call.data.category}:${call.tokens[0]}`).sort(), [
+            'liveChat:parent-2-token',
+            'mentions:parent-token'
+        ]);
+        assert.equal(env.messagingCalls.filter((call) => call.tokens.includes('parent-token')).length, 1);
+        const mentionCall = env.messagingCalls.find((call) => call.data.category === 'mentions');
+        assert.equal(mentionCall.data.appRoute, '/messages/team-1?conversation=thread-9');
+        assert.equal(mentionCall.data.conversationId, 'thread-9');
+        assert.equal(mentionCall.webLink, 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=thread-9');
+        assert.deepEqual(env.updatedDocs, [{ path: 'teams/team-1/chatMessages/message-2594', value: { mentionedUids: ['parent-1'] } }]);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyOfficiatingNotificationCreated mirrors assignment records to the linked official', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -448,6 +448,20 @@ function buildNotificationTestEnv({
             };
         }
 
+        if (path === `teams/${teamId}/players`) {
+            return {
+                async get() {
+                    const docs = Object.entries(playerDocs).map(([playerId, player]) => makeDocSnapshot({
+                        id: playerId,
+                        ref: doc(`${path}/${playerId}`),
+                        data: player,
+                        exists: true
+                    }));
+                    return makeQuerySnapshot(docs);
+                }
+            };
+        }
+
         if (path === `teams/${teamId}/notificationAudit`) {
             return {
                 async add(value) {

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -148,10 +148,18 @@ describe('detectMentionedUids', () => {
         expect(detectMentionedUids('Heads up @all', members)).toEqual([]);
         expect(detectMentionedUids('Heads up @team', members, { allowReservedMentions: true }).sort()).toEqual(['u1', 'u2']);
     });
+
+    it('does not treat the ALL PLAYS assistant mention as reserved @all', () => {
+        const members = [
+            { uid: 'u1', displayName: 'Alice' },
+            { uid: 'u2', displayName: 'Bob' }
+        ];
+        expect(detectMentionedUids('@ALL PLAYS who needs RSVP help?', members, { allowReservedMentions: true })).toEqual([]);
+    });
 });
 
 describe('buildTeamChatNotificationContext', () => {
-    function createTeamChatNotificationContextHarness({ conversationDocs = {}, emailUserIds = ['assistant-1'] } = {}) {
+    function createTeamChatNotificationContextHarness({ conversationDocs = {}, emailUserIds = ['assistant-1'], playerDocs = [] } = {}) {
         const teamData = { ownerId: 'coach-1', adminEmails: ['assistant@example.com'] };
         const parentDocs = [{ id: 'parent-1' }];
         const targetDocs = [
@@ -189,6 +197,20 @@ describe('buildTeamChatNotificationContext', () => {
                 if (path === 'teams/team-1/notificationTargets') {
                     return {
                         get: async () => ({ forEach: (callback) => targetDocs.forEach((doc) => callback(doc)) })
+                    };
+                }
+                if (path === 'teams/team-1/players') {
+                    return {
+                        get: async () => ({
+                            docs: playerDocs.map((player, index) => ({
+                                id: player.id || `player-${index + 1}`,
+                                data: () => player
+                            })),
+                            forEach: (callback) => playerDocs.forEach((player, index) => callback({
+                                id: player.id || `player-${index + 1}`,
+                                data: () => player
+                            }))
+                        })
                     };
                 }
                 throw new Error(`Unexpected collection path: ${path}`);
@@ -257,6 +279,52 @@ describe('buildTeamChatNotificationContext', () => {
         expect(context.members.map((member) => member.uid).sort()).toEqual(['coach-1', 'parent-1']);
         expect(context.targetsByCategory.mentions.map((target) => target.uid).sort()).toEqual(['coach-1', 'parent-1']);
         expect(context.targetsByCategory.liveChat.map((target) => target.uid).sort()).toEqual(['coach-1', 'parent-1']);
+    });
+
+    it('adds active roster player names as mention aliases for linked contacts', async () => {
+        const buildTeamChatNotificationContext = createTeamChatNotificationContextHarness({
+            playerDocs: [
+                {
+                    id: 'player-1',
+                    name: 'Avery Smith',
+                    parents: [{ userId: 'parent-1', name: 'Pat Parent' }]
+                }
+            ]
+        });
+
+        const context = await buildTeamChatNotificationContext('team-1', {
+            includeMentions: true,
+            conversationId: 'team'
+        });
+
+        const parent = context.members.find((member) => member.uid === 'parent-1');
+        expect(parent.mentionNames).toEqual(expect.arrayContaining(['Avery Smith', 'Pat Parent']));
+    });
+
+    it('resolves player-scoped conversation participants to their linked contact users', async () => {
+        const buildTeamChatNotificationContext = createTeamChatNotificationContextHarness({
+            conversationDocs: {
+                'teams/team-1/chatConversations/player_thread': {
+                    participantIds: ['coach-1', 'player:player-1']
+                }
+            },
+            playerDocs: [
+                {
+                    id: 'player-1',
+                    name: 'Avery Smith',
+                    parents: [{ userId: 'parent-1', name: 'Pat Parent' }]
+                }
+            ]
+        });
+
+        const context = await buildTeamChatNotificationContext('team-1', {
+            includeMentions: true,
+            conversationId: 'player_thread',
+            targetType: 'individuals'
+        });
+
+        expect(context.members.map((member) => member.uid).sort()).toEqual(['coach-1', 'parent-1']);
+        expect(context.targetsByCategory.mentions.map((target) => target.uid).sort()).toEqual(['coach-1', 'parent-1']);
     });
 });
 
@@ -538,6 +606,11 @@ describe('buildTeamChatNotificationPlan', () => {
             actorUid: 'coach-1',
             recipientContext
         });
+        const staffAllPlan = buildTeamChatNotificationPlan({
+            text: 'Heads up @all',
+            actorUid: 'coach-1',
+            recipientContext
+        });
         const parentPlan = buildTeamChatNotificationPlan({
             text: 'Heads up @team',
             actorUid: 'player-1',
@@ -546,6 +619,8 @@ describe('buildTeamChatNotificationPlan', () => {
 
         expect(staffPlan.mentionedUids.sort()).toEqual(['player-1', 'player-2']);
         expect(staffPlan.liveChatTargets).toEqual([]);
+        expect(staffAllPlan.mentionedUids.sort()).toEqual(['player-1', 'player-2']);
+        expect(staffAllPlan.liveChatTargets).toEqual([]);
         expect(parentPlan.mentionedUids).toEqual([]);
         expect(parentPlan.liveChatTargets.map((target) => target.uid).sort()).toEqual(['player-2']);
     });


### PR DESCRIPTION
## Summary
- Add server-side chat mention detection for roster/contact display-name aliases.
- Resolve player-scoped conversations to linked contact users for notification targets.
- Keep mention-category pushes separate from generic liveChat pushes, with staff-gated @all/@team handling.

Closes #2594

## Tests
- `npx vitest run tests/unit/functions-chat-mention-detection.test.js --reporter=verbose`
- `npx vitest run functions/test/notification-triggers.test.js --reporter=verbose`
- Chat notification contract/source tests
- Push routing / delivery metadata / recipient index tests
- `npx vitest run tests/unit/app-chat-service-recipients.test.js --reporter=verbose`
- `npm test -- --reporter=dot`