### PR TITLE
[codex] Route schedule event reads through typed mappers

### DIFF
--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -132,7 +132,7 @@ import { toAppServiceError } from './appErrors';
 import { createLogger } from './logger';
 import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
 import { mapFirestoreDocument, mapScheduleEventDocument, mapScheduleEventDocuments, mapScheduleEventRecord, mapScheduleEventRecords } from './firestore/mappers';
-import type { FirestoreDecodedDocument, FirestoreDocument as NativeFirestoreDocument } from './firestore/types';
+import type { FirestoreDecodedDocument, FirestoreDocument as NativeFirestoreDocument, ScheduleEventFirestoreRecord } from './firestore/types';
 import type { AuthUser } from './types';
 
 const buildPracticePacketCompletionPayloadBase = buildPracticePacketCompletionPayload;
@@ -821,7 +821,7 @@ async function nativeRunQuery(collectionId: string, fieldPath: string, op: 'EQUA
     : [];
 }
 
-async function nativeGetScheduleEventDocument(path: string) {
+async function nativeGetScheduleEventDocument(path: string): Promise<ScheduleEventFirestoreRecord | null> {
   try {
     return mapScheduleEventDocument(await nativeFirestoreRequest(`/${path}`) as NativeFirestoreDocument);
   } catch (error: any) {
@@ -833,7 +833,7 @@ async function nativeGetScheduleEventDocument(path: string) {
   }
 }
 
-async function nativeListScheduleEventDocuments(path: string) {
+async function nativeListScheduleEventDocuments(path: string): Promise<ScheduleEventFirestoreRecord[]> {
   const payload = await nativeFirestoreRequest(`/${path}`);
   return mapScheduleEventDocuments((payload.documents || []) as NativeFirestoreDocument[]);
 }
@@ -2242,7 +2242,7 @@ function isEventWithinRange(game: any, range: ScheduleDateRange) {
   return true;
 }
 
-async function loadGames(teamId: string, range: ScheduleDateRange = {}) {
+async function loadGames(teamId: string, range: ScheduleDateRange = {}): Promise<ScheduleEventFirestoreRecord[]> {
   return readWithNativeFallback(
     `games ${teamId}`,
     async () => mapScheduleEventRecords(await getGames(teamId, range)),
@@ -2256,7 +2256,7 @@ async function loadGames(teamId: string, range: ScheduleDateRange = {}) {
   );
 }
 
-async function loadGameById(teamId: string, gameId: string) {
+async function loadGameById(teamId: string, gameId: string): Promise<ScheduleEventFirestoreRecord | null> {
   return readWithNativeFallback(
     `game ${teamId}/${gameId}`,
     async () => mapScheduleEventRecord(await getGame(teamId, gameId), gameId),

--- a/tests/unit/app-firestore-boundary-initiative-source-contract.test.js
+++ b/tests/unit/app-firestore-boundary-initiative-source-contract.test.js
@@ -45,7 +45,7 @@ describe('app Firestore boundary initiative source contract', () => {
         expect(firestoreMappersSource).toContain('export function mapScheduleEventDocuments(documents: FirestoreDocument[] | null | undefined): ScheduleEventFirestoreRecord[]');
 
         expect(scheduleServiceSource).toContain("import { mapFirestoreDocument, mapScheduleEventDocument, mapScheduleEventDocuments, mapScheduleEventRecord, mapScheduleEventRecords } from './firestore/mappers';");
-        expect(scheduleServiceSource).toContain('import type { FirestoreDecodedDocument, FirestoreDocument as NativeFirestoreDocument } from \'./firestore/types\';');
+        expect(scheduleServiceSource).toContain('import type { FirestoreDecodedDocument, FirestoreDocument as NativeFirestoreDocument, ScheduleEventFirestoreRecord } from \'./firestore/types\';');
         expect(scheduleServiceSource).toContain('return mapScheduleEventDocument(await nativeFirestoreRequest(`/${path}`) as NativeFirestoreDocument);');
         expect(scheduleServiceSource).toContain('async () => mapScheduleEventRecords(await getGames(teamId, range))');
         expect(scheduleServiceSource).toContain('async () => mapScheduleEventRecord(await getGame(teamId, gameId), gameId)');

--- a/tests/unit/app-firestore-mappers.test.ts
+++ b/tests/unit/app-firestore-mappers.test.ts
@@ -10,7 +10,9 @@ import {
     mapGameReportOpponentStatsRecord,
     mapGameReportPlayerRecords,
     mapGameReportTeamRecord,
-    mapGameReportTeamStatsRecord
+    mapGameReportTeamStatsRecord,
+    mapScheduleEventDocument,
+    mapScheduleEventRecords
 } from '../../apps/app/src/lib/firestore/mappers.ts';
 import type { FirestoreDocument } from '../../apps/app/src/lib/firestore/types.ts';
 
@@ -131,6 +133,96 @@ describe('firestore mappers', () => {
                 })
             ]
         });
+    });
+
+    it('maps schedule game and practice documents through typed event records', () => {
+        const gameDocument: FirestoreDocument = {
+            name: 'projects/allplays/databases/(default)/documents/teams/team-1/games/game-1',
+            fields: {
+                type: { stringValue: 'game' },
+                date: { timestampValue: '2026-06-20T18:00:00.000Z' },
+                opponent: { stringValue: ' Tigers ' },
+                location: { stringValue: ' Main Gym ' },
+                liveClockMs: { integerValue: '120000' },
+                liveClockRunning: { booleanValue: true },
+                assignments: {
+                    arrayValue: {
+                        values: [
+                            {
+                                mapValue: {
+                                    fields: {
+                                        role: { stringValue: 'Scoreboard' },
+                                        value: { stringValue: 'Open' }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                },
+                sourceMetadata: {
+                    mapValue: {
+                        fields: {
+                            sourceType: { stringValue: 'registration' }
+                        }
+                    }
+                }
+            }
+        };
+        const practiceDocument: FirestoreDocument = {
+            name: 'projects/allplays/databases/(default)/documents/teams/team-1/games/practice-1',
+            fields: {
+                type: { stringValue: 'practice' },
+                date: { timestampValue: '2026-06-21T19:00:00.000Z' },
+                title: { stringValue: ' Skills Session ' },
+                location: { stringValue: ' North Field ' }
+            }
+        };
+
+        expect(mapScheduleEventDocument(gameDocument)).toMatchObject({
+            id: 'game-1',
+            type: 'game',
+            date: new Date('2026-06-20T18:00:00.000Z'),
+            opponent: 'Tigers',
+            location: 'Main Gym',
+            liveClockMs: 120000,
+            liveClockRunning: true,
+            assignments: [{ role: 'Scoreboard', value: 'Open' }],
+            sourceMetadata: { sourceType: 'registration' }
+        });
+        expect(mapScheduleEventDocument(practiceDocument)).toMatchObject({
+            id: 'practice-1',
+            type: 'practice',
+            date: new Date('2026-06-21T19:00:00.000Z'),
+            title: 'Skills Session',
+            location: 'North Field',
+            opponent: null,
+            assignments: [],
+            sourceMetadata: null,
+            exDates: []
+        });
+    });
+
+    it('rejects invalid schedule event documents at the mapper boundary', () => {
+        expect(mapScheduleEventRecords([
+            { id: 'valid-practice', type: 'practice', date: new Date('2026-06-21T19:00:00.000Z') },
+            { id: 'missing-date', type: 'game' },
+            { id: 'bad-date', type: 'game', date: 'not a date' },
+            { id: 'unsupported-type', type: 'meeting', date: new Date('2026-06-22T19:00:00.000Z') },
+            { type: 'game', date: new Date('2026-06-23T19:00:00.000Z') }
+        ])).toEqual([
+            expect.objectContaining({
+                id: 'valid-practice',
+                type: 'practice',
+                date: new Date('2026-06-21T19:00:00.000Z')
+            })
+        ]);
+        expect(mapScheduleEventDocument({
+            name: 'projects/allplays/databases/(default)/documents/teams/team-1/games/bad-game',
+            fields: {
+                type: { stringValue: 'game' },
+                date: { stringValue: 'not-a-date' }
+            }
+        })).toBeNull();
     });
 
     it('normalizes partial and malformed game report payloads at the Firestore boundary', () => {


### PR DESCRIPTION
## Summary
- Add explicit `ScheduleEventFirestoreRecord` return types to parent schedule event read helpers so list/detail paths stay behind the typed mapper boundary.
- Add Firestore mapper regression coverage for game and practice schedule documents, including invalid records being rejected before service use.

## Tests
- `npx vitest run tests/unit/app-firestore-mappers.test.ts --reporter=verbose`
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=verbose`
- `npx vitest run src/lib/scheduleService.test.ts --reporter=verbose` from `apps/app`
- `npm run app:build`

Closes #2618