### PR TITLE
[codex] Extend roster import contact mapping

### DIFF
--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -238,32 +238,61 @@ function getExistingPlayersByName(existingPlayers = []) {
     return byName;
 }
 
+const CONTACT_HEADER_GROUPS = [
+    { prefix: 'emergencycontact', bucket: 'contacts', defaultRelation: 'Emergency Contact' },
+    { prefix: 'familycontact', bucket: 'contacts', defaultRelation: 'Family Contact' },
+    { prefix: 'guardian', bucket: 'guardians', defaultRelation: 'Guardian' },
+    { prefix: 'mother', bucket: 'guardians', defaultRelation: 'Mother' },
+    { prefix: 'father', bucket: 'guardians', defaultRelation: 'Father' },
+    { prefix: 'parent', bucket: 'guardians', defaultRelation: 'Parent' },
+    { prefix: 'contact', bucket: 'contacts', defaultRelation: 'Contact' }
+];
+
+const CONTACT_FIELD_ALIASES = new Map([
+    ['name', 'name'],
+    ['fullname', 'name'],
+    ['firstname', 'firstName'],
+    ['first', 'firstName'],
+    ['lastname', 'lastName'],
+    ['last', 'lastName'],
+    ['email', 'email'],
+    ['emailaddress', 'email'],
+    ['phone', 'phone'],
+    ['phonenumber', 'phone'],
+    ['mobile', 'phone'],
+    ['mobilephone', 'phone'],
+    ['cell', 'phone'],
+    ['cellphone', 'phone'],
+    ['relation', 'relation'],
+    ['relationship', 'relation']
+]);
+
 function getContactHeaderMapping(normalizedHeader = '', label = '') {
-    const match = normalizedHeader.match(/^(parent|guardian|mother|father|contact)(\d*)(name|email|phone|relation)$/);
-    if (!match) return null;
-    const [, group, suffix, field] = match;
-    const contactKey = `${group}${suffix || '1'}`;
-    const defaultRelation = group === 'mother'
-        ? 'Mother'
-        : group === 'father'
-            ? 'Father'
-            : group === 'guardian'
-                ? 'Guardian'
-                : group === 'contact'
-                    ? 'Contact'
-                    : 'Parent';
-    return {
-        type: 'contact',
-        label,
-        contactKey,
-        contactField: field,
-        contactBucket: group === 'contact' ? 'contacts' : 'guardians',
-        defaultRelation
-    };
+    for (const group of CONTACT_HEADER_GROUPS) {
+        if (!normalizedHeader.startsWith(group.prefix)) continue;
+        const remainder = normalizedHeader.slice(group.prefix.length);
+        const match = remainder.match(/^(\d*)([a-z]+)(\d*)$/);
+        if (!match) continue;
+        const [, leadingSuffix, fieldToken, trailingSuffix] = match;
+        const field = CONTACT_FIELD_ALIASES.get(fieldToken);
+        if (!field) continue;
+        return {
+            type: 'contact',
+            label,
+            contactKey: `${group.prefix}${leadingSuffix || trailingSuffix || '1'}`,
+            contactField: field,
+            contactBucket: group.bucket,
+            defaultRelation: group.defaultRelation
+        };
+    }
+    return null;
 }
 
 function normalizeImportedContact(contact = {}) {
-    const name = String(contact.name || '').trim();
+    const name = String(contact.name || '').trim() || [contact.firstName, contact.lastName]
+        .map((part) => String(part || '').trim())
+        .filter(Boolean)
+        .join(' ');
     const email = String(contact.email || '').trim().toLowerCase();
     const phone = String(contact.phone || '').trim();
     const relation = String(contact.relation || contact.defaultRelation || 'Parent').trim() || 'Parent';

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -117,6 +117,60 @@ describe('roster CSV import planning', () => {
         expect(plan.operations[0].payload).not.toHaveProperty('contacts');
     });
 
+    it('accepts common contact header aliases and numbered suffix placement', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            csvText: [
+                'Name,Parent First Name,Parent Last Name,Parent Email Address,Parent Mobile Phone,Guardian Full Name 2,Guardian Email 2,Emergency Contact Name,Emergency Contact Phone Number',
+                'Avery Lee,Pat,Lee,PAT@example.com,555-0101,Robin Lee,robin@example.com,Dr Smith,555-0999'
+            ].join('\n')
+        });
+
+        expect(plan.errors).toEqual([]);
+        expect(plan.operations).toHaveLength(1);
+        expect(plan.operations[0]).toMatchObject({
+            privateFamilyContacts: {
+                parents: [
+                    {
+                        name: 'Pat Lee',
+                        email: 'pat@example.com',
+                        phone: '555-0101',
+                        relation: 'Parent',
+                        source: 'roster-csv'
+                    },
+                    {
+                        name: 'Robin Lee',
+                        email: 'robin@example.com',
+                        phone: '',
+                        relation: 'Guardian',
+                        source: 'roster-csv'
+                    }
+                ],
+                contacts: [{
+                    name: 'Dr Smith',
+                    email: '',
+                    phone: '555-0999',
+                    relation: 'Emergency Contact',
+                    source: 'roster-csv'
+                }]
+            },
+            inviteRequests: [
+                { email: 'pat@example.com', displayName: 'Pat Lee', relation: 'Parent', phone: '555-0101' },
+                { email: 'robin@example.com', displayName: 'Robin Lee', relation: 'Guardian', phone: '' }
+            ]
+        });
+    });
+
+    it('rejects duplicate contact headers after alias normalization', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            csvText: 'Name,Parent Phone,Parent Phone Number\nAvery Lee,555-0101,555-0102'
+        });
+
+        expect(plan.errors).toEqual(['Duplicate contact header for Parent Phone Number.']);
+        expect(plan.operations).toEqual([]);
+    });
+
     it('merges imported guardian contacts onto existing player updates without duplicates', () => {
         const plan = planRosterCsvImport({
             fields,


### PR DESCRIPTION
## Summary
- Refs #959
- Extend roster CSV contact header recognition beyond the existing parent/guardian/contact basics.
- Support first/last/full name aliases, email address aliases, phone/mobile/cell aliases, relationship aliases, trailing numbered suffixes, family contact columns, and emergency contact columns.
- Keep mapped contacts in the existing private family contact import plan and preserve invite request metadata for later bulk invite workflow work.

## Tests
- `npx vitest run tests/unit/roster-csv-import.test.js --reporter=verbose`
- `npm test` attempted; fails in unrelated app suites, including unresolved `dompurify` from `apps/app/src/lib/chatLogic.ts` and existing React component/mock failures outside this roster import slice.

## Follow-up
- This does not complete the full issue. Remaining work includes a bulk import review UI, persisted invite creation/resend flow, invite status tracking, and broader player profile columns such as address, birthday, position, gender, and non-player roles.