### PR TITLE
[codex] Adopt async operation for home loads

### DIFF
--- a/apps/app/src/lib/useAsyncOperation.test.tsx
+++ b/apps/app/src/lib/useAsyncOperation.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useAsyncOperation } from './useAsyncOperation';
@@ -51,6 +52,37 @@ function AsyncOperationHarness({
     );
 }
 
+function StaleOperationHarness({
+    firstOperation,
+    secondOperation,
+    onError
+}: {
+    firstOperation: () => Promise<string>;
+    secondOperation: () => Promise<string>;
+    onError: (error: unknown) => void;
+}) {
+    const { loading, error, run } = useAsyncOperation();
+    const [value, setValue] = useState('');
+
+    const options = {
+        ignoreStale: true,
+        rethrow: false,
+        getErrorMessage: (error: unknown) => error instanceof Error ? error.message : 'Failed',
+        onError,
+        onSuccess: setValue
+    };
+
+    return (
+        <div>
+            <div data-testid="loading">{String(loading)}</div>
+            <div data-testid="error">{error || ''}</div>
+            <div data-testid="value">{value}</div>
+            <button type="button" onClick={() => { void run(firstOperation, options); }}>Run first</button>
+            <button type="button" onClick={() => { void run(secondOperation, options); }}>Run second</button>
+        </div>
+    );
+}
+
 describe('useAsyncOperation', () => {
     afterEach(() => {
         cleanup();
@@ -91,5 +123,41 @@ describe('useAsyncOperation', () => {
         expect(operation).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledWith(expect.any(Error));
         expect(onFinally).toHaveBeenCalledTimes(1);
+    });
+
+    it('can ignore stale failures without clearing the latest loading state', async () => {
+        const firstDeferred = createDeferred<string>();
+        const secondDeferred = createDeferred<string>();
+        const onError = vi.fn();
+
+        render(
+            <StaleOperationHarness
+                firstOperation={() => firstDeferred.promise}
+                secondOperation={() => secondDeferred.promise}
+                onError={onError}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Run first' }));
+        await waitFor(() => {
+            expect(screen.getByTestId('loading').textContent).toBe('true');
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Run second' }));
+        firstDeferred.reject(new Error('stale failure'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('loading').textContent).toBe('true');
+        });
+        expect(screen.getByTestId('error').textContent).toBe('');
+        expect(onError).not.toHaveBeenCalled();
+
+        secondDeferred.resolve('latest value');
+
+        await waitFor(() => {
+            expect(screen.getByTestId('loading').textContent).toBe('false');
+            expect(screen.getByTestId('value').textContent).toBe('latest value');
+        });
+        expect(screen.getByTestId('error').textContent).toBe('');
     });
 });

--- a/apps/app/src/lib/useAsyncOperation.test.tsx
+++ b/apps/app/src/lib/useAsyncOperation.test.tsx
@@ -83,6 +83,38 @@ function StaleOperationHarness({
     );
 }
 
+function GuardedErrorHarness({
+    operation,
+    shouldHandleError,
+    onError
+}: {
+    operation: () => Promise<string>;
+    shouldHandleError: (error: unknown) => boolean;
+    onError: (error: unknown) => void;
+}) {
+    const { loading, error, run } = useAsyncOperation();
+
+    return (
+        <div>
+            <div data-testid="loading">{String(loading)}</div>
+            <div data-testid="error">{error || ''}</div>
+            <button
+                type="button"
+                onClick={() => {
+                    void run(operation, {
+                        rethrow: false,
+                        getErrorMessage: (error: unknown) => error instanceof Error ? error.message : 'Failed',
+                        shouldHandleError,
+                        onError
+                    });
+                }}
+            >
+                Run guarded
+            </button>
+        </div>
+    );
+}
+
 describe('useAsyncOperation', () => {
     afterEach(() => {
         cleanup();
@@ -158,6 +190,35 @@ describe('useAsyncOperation', () => {
             expect(screen.getByTestId('loading').textContent).toBe('false');
             expect(screen.getByTestId('value').textContent).toBe('latest value');
         });
+        expect(screen.getByTestId('error').textContent).toBe('');
+    });
+
+    it('can skip handling current-run errors when a caller guard rejects them', async () => {
+        const deferred = createDeferred<string>();
+        const onError = vi.fn();
+        const shouldHandleError = vi.fn(() => false);
+
+        render(
+            <GuardedErrorHarness
+                operation={() => deferred.promise}
+                shouldHandleError={shouldHandleError}
+                onError={onError}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Run guarded' }));
+        await waitFor(() => {
+            expect(screen.getByTestId('loading').textContent).toBe('true');
+        });
+
+        const guardedError = new Error('guarded failure');
+        deferred.reject(guardedError);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('loading').textContent).toBe('false');
+        });
+        expect(shouldHandleError).toHaveBeenCalledWith(guardedError);
+        expect(onError).not.toHaveBeenCalled();
         expect(screen.getByTestId('error').textContent).toBe('');
     });
 });

--- a/apps/app/src/lib/useAsyncOperation.ts
+++ b/apps/app/src/lib/useAsyncOperation.ts
@@ -8,6 +8,7 @@ type UseAsyncOperationRunOptions<T> = {
     onError?: (error: unknown) => void | Promise<void>;
     onFinally?: () => void | Promise<void>;
     ignoreStale?: boolean;
+    shouldHandleError?: (error: unknown) => boolean;
     rethrow?: boolean;
 };
 
@@ -37,6 +38,7 @@ export function useAsyncOperation() {
             onError,
             onFinally,
             ignoreStale = false,
+            shouldHandleError,
             rethrow = true
         }: UseAsyncOperationRunOptions<T> = {}
     ) {
@@ -56,7 +58,7 @@ export function useAsyncOperation() {
             }
             return value;
         } catch (error) {
-            if (isCurrentRun()) {
+            if (isCurrentRun() && (shouldHandleError?.(error) ?? true)) {
                 setError(errorMessage || getErrorMessage?.(error) || getDefaultErrorMessage(error));
                 await onError?.(error);
             }

--- a/apps/app/src/lib/useAsyncOperation.ts
+++ b/apps/app/src/lib/useAsyncOperation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 type UseAsyncOperationRunOptions<T> = {
     clearError?: boolean;
@@ -7,6 +7,7 @@ type UseAsyncOperationRunOptions<T> = {
     onSuccess?: (value: T) => void | Promise<void>;
     onError?: (error: unknown) => void | Promise<void>;
     onFinally?: () => void | Promise<void>;
+    ignoreStale?: boolean;
     rethrow?: boolean;
 };
 
@@ -20,6 +21,7 @@ function getDefaultErrorMessage(error: unknown) {
 export function useAsyncOperation() {
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const latestRunIdRef = useRef(0);
 
     const clearError = useCallback(() => {
         setError(null);
@@ -34,9 +36,14 @@ export function useAsyncOperation() {
             onSuccess,
             onError,
             onFinally,
+            ignoreStale = false,
             rethrow = true
         }: UseAsyncOperationRunOptions<T> = {}
     ) {
+        const runId = latestRunIdRef.current + 1;
+        latestRunIdRef.current = runId;
+        const isCurrentRun = () => !ignoreStale || latestRunIdRef.current === runId;
+
         setLoading(true);
         if (shouldClearError) {
             setError(null);
@@ -44,18 +51,24 @@ export function useAsyncOperation() {
 
         try {
             const value = await operation();
-            await onSuccess?.(value);
+            if (isCurrentRun()) {
+                await onSuccess?.(value);
+            }
             return value;
         } catch (error) {
-            setError(errorMessage || getErrorMessage?.(error) || getDefaultErrorMessage(error));
-            await onError?.(error);
+            if (isCurrentRun()) {
+                setError(errorMessage || getErrorMessage?.(error) || getDefaultErrorMessage(error));
+                await onError?.(error);
+            }
             if (rethrow) {
                 throw error;
             }
             return null;
         } finally {
-            setLoading(false);
-            await onFinally?.();
+            if (isCurrentRun()) {
+                setLoading(false);
+                await onFinally?.();
+            }
         }
     }, []);
 

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -135,6 +135,7 @@ export function Teams({ auth }: { auth: AuthState }) {
       {
         ignoreStale: true,
         rethrow: false,
+        shouldHandleError: () => loadId === activeLoadIdRef.current,
         getErrorMessage: (enrichError) => getTeamsLoadErrorMessage(toAppServiceError(enrichError, 'Unable to load teams.'), true),
         onSuccess: (enrichedHome) => {
           if (loadId !== activeLoadIdRef.current) return;

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -30,6 +30,7 @@ import { getEventDetailPath, getPlayerDetailPath, type ParentHomeModel, type Par
 import { loadParentHomeSummary, loadParentTeamsSummary } from '../lib/homeService';
 import { openPublicUrl } from '../lib/publicActions';
 import { PullToRefresh } from '../components/PullToRefresh';
+import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { useRefreshOnResume } from '../lib/useRefreshOnResume';
 import { useShellLayout } from '../lib/useShellLayout';
 import {
@@ -63,15 +64,31 @@ export function Teams({ auth }: { auth: AuthState }) {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [home, setHome] = useState<ParentHomeModel>(() => emptyHome());
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState('');
   const [teamsLoadError, setTeamsLoadError] = useState<AppServiceError | null>(null);
+  const [loadedTeamSummaryUserId, setLoadedTeamSummaryUserId] = useState<string | null>(null);
   const [loadedTeamUserId, setLoadedTeamUserId] = useState<string | null>(null);
   const activeLoadIdRef = useRef(0);
+  const hasStartedInitialTeamLoadRef = useRef(false);
+  const {
+    loading: teamSummaryLoading,
+    error: teamSummaryError,
+    clearError: clearTeamSummaryError,
+    run: runTeamSummaryLoad
+  } = useAsyncOperation();
+  const {
+    loading: teamEnrichmentLoading,
+    error: teamEnrichmentError,
+    clearError: clearTeamEnrichmentError,
+    run: runTeamEnrichmentLoad
+  } = useAsyncOperation();
   const selectedTeamId = searchParams.get('selectedTeamId') || '';
   const authUserId = auth.user?.uid || null;
+  const hasLoadedTeamSummary = Boolean(authUserId) && authUserId === loadedTeamSummaryUserId;
   const hasLoadedTeamDetails = Boolean(authUserId) && authUserId === loadedTeamUserId;
+  const isInitialTeamLoad = Boolean(authUserId) && !hasLoadedTeamSummary && !teamsLoadError;
+  const loading = isInitialTeamLoad && (teamSummaryLoading || !hasStartedInitialTeamLoadRef.current);
+  const refreshing = !loading && (teamSummaryLoading || teamEnrichmentLoading);
+  const error = teamSummaryError || teamEnrichmentError || '';
 
   const loadTeams = async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
     const user = auth.user;
@@ -80,54 +97,72 @@ export function Teams({ auth }: { auth: AuthState }) {
     activeLoadIdRef.current = loadId;
     const hasExistingTeams = loadedTeamUserId === user.uid;
     if (showLoading) {
-      setLoading(true);
-    } else {
-      setRefreshing(true);
+      setLoadedTeamSummaryUserId(null);
     }
-    setError('');
+    clearTeamSummaryError();
+    clearTeamEnrichmentError();
     setTeamsLoadError(null);
-    try {
-      const fastHome = await loadParentTeamsSummary(user, { force: !showLoading });
-      if (loadId !== activeLoadIdRef.current) return;
-      const hasFastTeams = fastHome.teams.length > 0;
-      setHome(fastHome);
-      setTeamsLoadError(null);
-      setLoading(false);
-      setRefreshing(true);
-      try {
-        const enrichedHome = await loadParentHomeSummary(user, { force: !showLoading });
-        if (loadId !== activeLoadIdRef.current) return;
-        setHome((current) => mergeTeamSummary(current, enrichedHome));
-        setLoadedTeamUserId(user.uid);
-        setTeamsLoadError(null);
-      } catch (enrichError) {
-        if (loadId !== activeLoadIdRef.current) return;
-        const appError = toAppServiceError(enrichError, 'Unable to load teams.');
-        if (!hasExistingTeams && !hasFastTeams) {
-          setHome(emptyHome());
-          setLoadedTeamUserId(null);
+
+    const fastHome = await runTeamSummaryLoad(
+      () => loadParentTeamsSummary(user, { force: !showLoading }),
+      {
+        ignoreStale: true,
+        rethrow: false,
+        getErrorMessage: (loadError) => getTeamsLoadErrorMessage(toAppServiceError(loadError, 'Unable to load teams.'), hasExistingTeams),
+        onSuccess: (fastHome) => {
+          if (loadId !== activeLoadIdRef.current) return;
+          setHome(fastHome);
+          setLoadedTeamSummaryUserId(user.uid);
+          setTeamsLoadError(null);
+        },
+        onError: (loadError) => {
+          if (loadId !== activeLoadIdRef.current) return;
+          const appError = toAppServiceError(loadError, 'Unable to load teams.');
           setTeamsLoadError(appError);
-        } else {
-          setError(getTeamsLoadErrorMessage(appError, true));
+          if (!hasExistingTeams) {
+            setHome(emptyHome());
+            setLoadedTeamSummaryUserId(null);
+            setLoadedTeamUserId(null);
+          }
         }
       }
-    } catch (loadError: any) {
-      if (loadId !== activeLoadIdRef.current) return;
-      const appError = toAppServiceError(loadError, 'Unable to load teams.');
-      setError(getTeamsLoadErrorMessage(appError, hasExistingTeams));
-      setTeamsLoadError(appError);
-      if (!hasExistingTeams) {
-        setHome(emptyHome());
-        setLoadedTeamUserId(null);
+    );
+    if (!fastHome || loadId !== activeLoadIdRef.current) return;
+
+    const hasFastTeams = fastHome.teams.length > 0;
+    await runTeamEnrichmentLoad(
+      () => loadParentHomeSummary(user, { force: !showLoading }),
+      {
+        ignoreStale: true,
+        rethrow: false,
+        getErrorMessage: (enrichError) => getTeamsLoadErrorMessage(toAppServiceError(enrichError, 'Unable to load teams.'), true),
+        onSuccess: (enrichedHome) => {
+          if (loadId !== activeLoadIdRef.current) return;
+          setHome((current) => mergeTeamSummary(current, enrichedHome));
+          setLoadedTeamSummaryUserId(user.uid);
+          setLoadedTeamUserId(user.uid);
+          setTeamsLoadError(null);
+        },
+        onError: (enrichError) => {
+          if (loadId !== activeLoadIdRef.current) return;
+          const appError = toAppServiceError(enrichError, 'Unable to load teams.');
+          if (!hasExistingTeams && !hasFastTeams) {
+            clearTeamEnrichmentError();
+            setHome(emptyHome());
+            setLoadedTeamUserId(null);
+            setTeamsLoadError(appError);
+          }
+        }
       }
-    } finally {
-      if (loadId !== activeLoadIdRef.current) return;
-      setLoading(false);
-      setRefreshing(false);
-    }
+    );
   };
 
   useEffect(() => {
+    if (!auth.user?.uid) {
+      hasStartedInitialTeamLoadRef.current = false;
+      return;
+    }
+    hasStartedInitialTeamLoadRef.current = true;
     loadTeams({ showLoading: true });
     return () => {
       activeLoadIdRef.current += 1;

--- a/tests/unit/app-teams-async-operation-contract.test.js
+++ b/tests/unit/app-teams-async-operation-contract.test.js
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const teamsSource = readFileSync(new URL('../../apps/app/src/pages/Teams.tsx', import.meta.url), 'utf8');
+
+function getLoadTeamsSource() {
+    const start = teamsSource.indexOf('  const loadTeams = async');
+    const end = teamsSource.indexOf('\n\n  useEffect(() => {', start);
+    if (start === -1 || end === -1) {
+        throw new Error('Unable to extract Teams loadTeams source.');
+    }
+    return teamsSource.slice(start, end);
+}
+
+describe('Teams async operation contract', () => {
+    it('runs the Teams summary and enrichment reads through shared async operations', () => {
+        const loadTeamsSource = getLoadTeamsSource();
+
+        expect(teamsSource).toContain("import { useAsyncOperation } from '../lib/useAsyncOperation';");
+        expect(teamsSource).toContain('loading: teamSummaryLoading');
+        expect(teamsSource).toContain('error: teamSummaryError');
+        expect(teamsSource).toContain('run: runTeamSummaryLoad');
+        expect(teamsSource).toContain('loading: teamEnrichmentLoading');
+        expect(teamsSource).toContain('error: teamEnrichmentError');
+        expect(teamsSource).toContain('run: runTeamEnrichmentLoad');
+        expect(loadTeamsSource).toContain('const fastHome = await runTeamSummaryLoad(');
+        expect(loadTeamsSource).toContain('await runTeamEnrichmentLoad(');
+        expect(loadTeamsSource).toContain('ignoreStale: true');
+        expect(loadTeamsSource).not.toContain('setLoading(');
+        expect(loadTeamsSource).not.toContain('setRefreshing(');
+        expect(loadTeamsSource).not.toContain('finally {');
+        expect(loadTeamsSource).not.toContain('catch (');
+    });
+
+    it('keeps Teams load failures on typed retry copy while preserving fast summary data', () => {
+        const loadTeamsSource = getLoadTeamsSource();
+
+        expect(loadTeamsSource).toContain("getTeamsLoadErrorMessage(toAppServiceError(loadError, 'Unable to load teams.'), hasExistingTeams)");
+        expect(loadTeamsSource).toContain("const appError = toAppServiceError(loadError, 'Unable to load teams.');");
+        expect(loadTeamsSource).toContain('setTeamsLoadError(appError);');
+        expect(loadTeamsSource).toContain('if (!hasExistingTeams) {');
+        expect(loadTeamsSource).toContain('setHome(emptyHome());');
+        expect(loadTeamsSource).toContain('const hasFastTeams = fastHome.teams.length > 0;');
+        expect(loadTeamsSource).toContain("getTeamsLoadErrorMessage(toAppServiceError(enrichError, 'Unable to load teams.'), true)");
+        expect(loadTeamsSource).toContain('if (!hasExistingTeams && !hasFastTeams) {');
+        expect(loadTeamsSource).toContain('setHome((current) => mergeTeamSummary(current, enrichedHome));');
+    });
+});

--- a/tests/unit/app-teams-async-operation-contract.test.js
+++ b/tests/unit/app-teams-async-operation-contract.test.js
@@ -42,6 +42,7 @@ describe('Teams async operation contract', () => {
         expect(loadTeamsSource).toContain('setHome(emptyHome());');
         expect(loadTeamsSource).toContain('const hasFastTeams = fastHome.teams.length > 0;');
         expect(loadTeamsSource).toContain("getTeamsLoadErrorMessage(toAppServiceError(enrichError, 'Unable to load teams.'), true)");
+        expect(loadTeamsSource).toContain('shouldHandleError: () => loadId === activeLoadIdRef.current');
         expect(loadTeamsSource).toContain('if (!hasExistingTeams && !hasFastTeams) {');
         expect(loadTeamsSource).toContain('setHome((current) => mergeTeamSummary(current, enrichedHome));');
     });


### PR DESCRIPTION
Refs #2067

## Summary
- Move the Teams launcher home-service load path onto `useAsyncOperation` for fast summary and enrichment reads.
- Add opt-in stale-run handling to `useAsyncOperation` so overlapping loads do not clear the latest loading/error state.
- Add focused hook, Teams behavior, and source-contract coverage for success, failure, and stale request behavior.

## Tests
- `npm --prefix apps/app run test -- --run src/lib/useAsyncOperation.test.tsx src/pages/Teams.test.tsx --reporter=verbose`
- `npx vitest run tests/unit/app-async-operation-initiative-source-contract.test.js tests/unit/app-teams-async-operation-contract.test.js --reporter=verbose`
- `npm run app:build`