### PR TITLE
[codex] Add legacy adapter slice

### DIFF
--- a/apps/app/src/lib/adapters/legacyAuth.ts
+++ b/apps/app/src/lib/adapters/legacyAuth.ts
@@ -1,0 +1,96 @@
+export type LegacyAccessCodeValidationOptions = {
+  nativeAuthToken?: string;
+};
+
+export type LegacyAccessCodeValidation = {
+  valid: boolean;
+  type?: string;
+  codeId: string;
+  message?: string;
+  data?: {
+    code?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+export type LegacyAuthDbModule = {
+  validateAccessCode: (code: string, options?: LegacyAccessCodeValidationOptions) => Promise<LegacyAccessCodeValidation>;
+  redeemParentInvite: (userId: string, code: string, email?: string | null) => Promise<unknown>;
+  redeemHouseholdInvite: (...args: any[]) => Promise<unknown>;
+  redeemAdminInviteAtomically: (...args: any[]) => Promise<unknown>;
+  markAccessCodeAsUsed: (codeId: string, userId: string) => Promise<unknown>;
+  updateUserProfile: (userId: string, profile: Record<string, unknown>) => Promise<unknown>;
+  updateTeam: (...args: any[]) => Promise<unknown>;
+  getTeam: (...args: any[]) => Promise<unknown>;
+  getUserProfile: (...args: any[]) => Promise<Record<string, unknown> | null | undefined>;
+  getUserTeams: (userId: string) => Promise<Array<Record<string, unknown>>>;
+  listMyParentMembershipRequests: (userId: string) => Promise<unknown[]>;
+};
+
+export type LegacyAdminInviteModule = {
+  redeemAdminInviteAcceptance: (...args: any[]) => Promise<unknown>;
+};
+
+export type LegacyInviteRedemptionResult = {
+  message?: string;
+  redirectUrl?: string;
+  [key: string]: unknown;
+};
+
+export type LegacyInviteProcessor = (
+  userId: string,
+  code: string,
+  authEmail?: string | null
+) => Promise<LegacyInviteRedemptionResult>;
+
+export type LegacyInviteFlowModule = {
+  createInviteProcessor: (...args: any[]) => LegacyInviteProcessor;
+};
+
+export type LegacySignupFlowModule = {
+  executeEmailPasswordSignup: (...args: any[]) => Promise<unknown>;
+};
+
+export type LegacyParentMembershipSync = {
+  changed: boolean;
+  userUpdate: Record<string, unknown>;
+};
+
+export type LegacyParentMembershipUtilsModule = {
+  mergeApprovedParentMembershipRequests: (
+    profile: Record<string, unknown>,
+    requests: unknown[]
+  ) => LegacyParentMembershipSync;
+};
+
+let authDbPromise: Promise<LegacyAuthDbModule> | null = null;
+let adminInvitePromise: Promise<LegacyAdminInviteModule> | null = null;
+let inviteFlowPromise: Promise<LegacyInviteFlowModule> | null = null;
+let signupFlowPromise: Promise<LegacySignupFlowModule> | null = null;
+let parentMembershipUtilsPromise: Promise<LegacyParentMembershipUtilsModule> | null = null;
+
+export function loadLegacyAuthDb() {
+  authDbPromise ||= import('@legacy/db.js') as Promise<LegacyAuthDbModule>;
+  return authDbPromise;
+}
+
+export function loadLegacyAdminInvite() {
+  adminInvitePromise ||= import('@legacy/admin-invite.js') as Promise<LegacyAdminInviteModule>;
+  return adminInvitePromise;
+}
+
+export function loadLegacyInviteFlow() {
+  inviteFlowPromise ||= import('@legacy/accept-invite-flow.js') as Promise<LegacyInviteFlowModule>;
+  return inviteFlowPromise;
+}
+
+export function loadLegacySignupFlow() {
+  signupFlowPromise ||= import('@legacy/signup-flow.js') as Promise<LegacySignupFlowModule>;
+  return signupFlowPromise;
+}
+
+export function loadLegacyParentMembershipUtils() {
+  parentMembershipUtilsPromise ||= import('@legacy/parent-membership-utils.js') as Promise<LegacyParentMembershipUtilsModule>;
+  return parentMembershipUtilsPromise;
+}

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -71,6 +71,7 @@ vi.mock('../../../../js/parent-membership-utils.js', () => ({
 
 const libDir = dirname(fileURLToPath(import.meta.url));
 const authServicePath = resolve(libDir, 'authService.ts');
+const legacyAuthAdapterPath = resolve(libDir, 'adapters/legacyAuth.ts');
 const appTsconfigPath = resolve(libDir, '../../tsconfig.json');
 
 function createGoogleUser(overrides: Record<string, unknown> = {}) {
@@ -109,11 +110,20 @@ describe('app auth invite activation', () => {
     adminInviteMocks.redeemAdminInviteAcceptance.mockResolvedValue({ id: 'team-1', name: 'Bears' });
   });
 
-  it('keeps the legacy auth db graph lazy until an auth db flow is needed', () => {
+  it('routes the legacy auth graph through the lazy typed adapter', () => {
     const authServiceSource = readFileSync(authServicePath, 'utf8');
+    const legacyAuthAdapterSource = readFileSync(legacyAuthAdapterPath, 'utf8');
 
-    expect(authServiceSource).not.toContain("import * as authDb from '../../../../js/db.js';");
-    expect(authServiceSource).toContain("authDbPromise ||= import('../../../../js/db.js');");
+    expect(authServiceSource).not.toContain('../../../../js/');
+    expect(authServiceSource).not.toContain('@legacy/');
+    expect(authServiceSource).toContain("from './adapters/legacyAuth';");
+    expect(authServiceSource).toContain('loadLegacyAuthDb');
+    expect(legacyAuthAdapterSource).toContain("import('@legacy/db.js')");
+    expect(legacyAuthAdapterSource).toContain("import('@legacy/admin-invite.js')");
+    expect(legacyAuthAdapterSource).toContain("import('@legacy/accept-invite-flow.js')");
+    expect(legacyAuthAdapterSource).toContain("import('@legacy/signup-flow.js')");
+    expect(legacyAuthAdapterSource).toContain("import('@legacy/parent-membership-utils.js')");
+    expect(legacyAuthAdapterSource).not.toMatch(/from\s+['"]@legacy\//);
     expect(authServiceSource).not.toContain('return Promise.resolve(authDb);');
   });
 
@@ -132,7 +142,7 @@ describe('app auth invite activation', () => {
 
     await signInWithGoogleAccount('ABCDEFGH');
 
-    expect(dbMocks.validateAccessCode).toHaveBeenCalledWith('ABCDEFGH');
+    expect(dbMocks.validateAccessCode).toHaveBeenCalledWith('ABCDEFGH', undefined);
     expect(dbMocks.redeemParentInvite).toHaveBeenCalledWith('google-user-1', 'ABCDEFGH', 'parent@example.com');
     expect(dbMocks.redeemParentInvite.mock.calls[0][1]).toBe('ABCDEFGH');
     expect(dbMocks.updateUserProfile).toHaveBeenCalledWith('google-user-1', expect.objectContaining({

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -19,6 +19,13 @@ import {
   updatePassword,
   verifyPasswordResetCode
 } from './firebaseAuthRuntime';
+import {
+  loadLegacyAdminInvite,
+  loadLegacyAuthDb,
+  loadLegacyInviteFlow,
+  loadLegacyParentMembershipUtils,
+  loadLegacySignupFlow
+} from './adapters/legacyAuth';
 import { createLogger } from './logger';
 import type { AuthUser, UserRole } from './types';
 
@@ -35,43 +42,6 @@ const firebaseAuthStorageDb = 'firebaseLocalStorageDb';
 const firebaseAuthStorageStore = 'firebaseLocalStorage';
 const nativeAuthSessionStorageKey = 'allplays-native-auth-session';
 const logger = createLogger('app-auth');
-
-type AuthDbModule = typeof import('../../../../js/db.js');
-type AdminInviteModule = typeof import('../../../../js/admin-invite.js');
-type InviteFlowModule = typeof import('../../../../js/accept-invite-flow.js');
-type SignupFlowModule = typeof import('../../../../js/signup-flow.js');
-type ParentMembershipUtilsModule = typeof import('../../../../js/parent-membership-utils.js');
-
-let authDbPromise: Promise<AuthDbModule> | null = null;
-let adminInvitePromise: Promise<AdminInviteModule> | null = null;
-let inviteFlowPromise: Promise<InviteFlowModule> | null = null;
-let signupFlowPromise: Promise<SignupFlowModule> | null = null;
-let parentMembershipUtilsPromise: Promise<ParentMembershipUtilsModule> | null = null;
-
-function loadAuthDb() {
-  authDbPromise ||= import('../../../../js/db.js');
-  return authDbPromise;
-}
-
-function loadAdminInvite() {
-  adminInvitePromise ||= import('../../../../js/admin-invite.js');
-  return adminInvitePromise;
-}
-
-function loadInviteFlow() {
-  inviteFlowPromise ||= import('../../../../js/accept-invite-flow.js');
-  return inviteFlowPromise;
-}
-
-function loadSignupFlow() {
-  signupFlowPromise ||= import('../../../../js/signup-flow.js');
-  return signupFlowPromise;
-}
-
-function loadParentMembershipUtils() {
-  parentMembershipUtilsPromise ||= import('../../../../js/parent-membership-utils.js');
-  return parentMembershipUtilsPromise;
-}
 
 type FirebaseUser = {
   uid: string;
@@ -881,7 +851,7 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
   }
 
   let profile: Record<string, unknown> = {};
-  const dbModule = await loadAuthDb();
+  const dbModule = await loadLegacyAuthDb();
   try {
     profile = await withTimeout(
       Promise.resolve(dbModule.getUserProfile(user.uid)),
@@ -896,7 +866,7 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
   }
 
   try {
-    const { mergeApprovedParentMembershipRequests } = await loadParentMembershipUtils();
+    const { mergeApprovedParentMembershipRequests } = await loadLegacyParentMembershipUtils();
     const approvedRequests = await withTimeout(
       Promise.resolve(dbModule.listMyParentMembershipRequests(user.uid)),
       'Parent membership sync timed out.',
@@ -976,7 +946,7 @@ export function getCurrentFirebaseUser(): FirebaseUser | null {
 
 export async function signInWithEmail(email: string, password: string) {
   const normalizedEmail = normalizeEmail(email);
-  const { updateUserProfile } = await loadAuthDb();
+  const { updateUserProfile } = await loadLegacyAuthDb();
 
   if (isNativeRuntime()) {
     const user = await signInWithNativeRestSession(normalizedEmail, password);
@@ -1009,9 +979,9 @@ export async function signUpWithEmail(email: string, password: string, activatio
     { redeemAdminInviteAcceptance },
     { executeEmailPasswordSignup }
   ] = await Promise.all([
-    loadAuthDb(),
-    loadAdminInvite(),
-    loadSignupFlow()
+    loadLegacyAuthDb(),
+    loadLegacyAdminInvite(),
+    loadLegacySignupFlow()
   ]);
 
   return executeEmailPasswordSignup({
@@ -1063,7 +1033,7 @@ async function processGoogleResult(result: UserCredential | null, activationCode
   if (!result?.user) {
     return null;
   }
-  const dbModule = await loadAuthDb();
+  const dbModule = await loadLegacyAuthDb();
 
   if (!isNewFirebaseUser(result.user)) {
     await dbModule.updateUserProfile(result.user.uid, {
@@ -1098,7 +1068,7 @@ async function processGoogleResult(result: UserCredential | null, activationCode
     if (validation.type === 'parent_invite') {
       await dbModule.redeemParentInvite(result.user.uid, validation.data?.code || code, result.user.email);
     } else if (validation.type === 'admin_invite') {
-      const { redeemAdminInviteAcceptance } = await loadAdminInvite();
+      const { redeemAdminInviteAcceptance } = await loadLegacyAdminInvite();
       await redeemAdminInviteAcceptance({
         userId: result.user.uid,
         userEmail: result.user.email,
@@ -1251,7 +1221,7 @@ export function isEmailLink(url: string) {
 
 export async function completeEmailLink(email: string, url: string) {
   const result = await signInWithEmailLink(auth, email.trim(), url) as UserCredential;
-  const { updateUserProfile } = await loadAuthDb();
+  const { updateUserProfile } = await loadLegacyAuthDb();
   await updateUserProfile(result.user.uid, {
     email: email.trim(),
     lastLogin: new Date(),
@@ -1261,7 +1231,7 @@ export async function completeEmailLink(email: string, url: string) {
 }
 
 export async function setCurrentUserPassword(newPassword: string) {
-  const { updateUserProfile } = await loadAuthDb();
+  const { updateUserProfile } = await loadLegacyAuthDb();
   const user = auth.currentUser;
   if (user) {
     await updatePassword(user, newPassword);
@@ -1304,8 +1274,8 @@ export async function redeemInviteForUser(userId: string, code: string, authEmai
     dbModule,
     { createInviteProcessor }
   ] = await Promise.all([
-    loadAuthDb(),
-    loadInviteFlow()
+    loadLegacyAuthDb(),
+    loadLegacyInviteFlow()
   ]);
   const processInvite = createInviteProcessor({
     validateAccessCode: dbModule.validateAccessCode,

--- a/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
+++ b/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
@@ -27,6 +27,7 @@ describe('app legacy adapter initiative source contract', () => {
         const adapterFiles = readdirSync(join(repoRoot, 'apps/app/src/lib/adapters')).sort();
 
         expect(adapterFiles).toEqual(expect.arrayContaining([
+            'legacyAuth.ts',
             'legacyChatService.ts',
             'legacyGameReport.ts',
             'legacyHomeFees.ts',
@@ -44,11 +45,14 @@ describe('app legacy adapter initiative source contract', () => {
         const parentToolsAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyParentTools.ts');
         const chatAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyChatService.ts');
         const gameReportAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyGameReport.ts');
+        const authAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyAuth.ts');
 
         expect(viteConfigSource).toContain("'@legacy': path.resolve(__dirname, '../../js')");
         expect(parentToolsAdapterSource).toContain("import * as legacyDb from '@legacy/db.js';");
         expect(chatAdapterSource).toContain("import * as legacyDb from '@legacy/db.js';");
         expect(gameReportAdapterSource).toContain("from '@legacy/game-report-stats.js';");
+        expect(authAdapterSource).toContain("import('@legacy/db.js')");
+        expect(authAdapterSource).toContain("import('@legacy/admin-invite.js')");
     });
 
     it('keeps direct ../../../../js references limited to known app-shell exceptions and adapter shims', () => {
@@ -60,15 +64,15 @@ describe('app legacy adapter initiative source contract', () => {
             'apps/app/src/lib/adapters/legacyPlayerProfile.ts',
             'apps/app/src/lib/adapters/legacyRosterPrivacy.ts',
             'apps/app/src/lib/adapters/legacyScheduleHelpers.ts',
-            'apps/app/src/lib/authService.ts',
             'apps/app/src/lib/pushService.ts',
             'apps/app/src/lib/telemetry.ts'
         ]);
     });
 
-    it('routes migrated parent tools, chat, schedule, player, and game report services through adapters', () => {
+    it('routes migrated parent tools, auth, chat, schedule, player, and game report services through adapters', () => {
         const servicePaths = [
             'apps/app/src/lib/parentToolsService.ts',
+            'apps/app/src/lib/authService.ts',
             'apps/app/src/lib/chatService.ts',
             'apps/app/src/lib/scheduleService.ts',
             'apps/app/src/lib/playerService.ts',
@@ -80,6 +84,7 @@ describe('app legacy adapter initiative source contract', () => {
         });
 
         expect(readRepoFile('apps/app/src/lib/parentToolsService.ts')).toContain("from './adapters/legacyParentTools'");
+        expect(readRepoFile('apps/app/src/lib/authService.ts')).toContain("from './adapters/legacyAuth'");
         expect(readRepoFile('apps/app/src/lib/chatService.ts')).toContain("from './adapters/legacyChatService'");
         expect(readRepoFile('apps/app/src/lib/scheduleService.ts')).toContain("from './adapters/legacyScheduleDb'");
         expect(readRepoFile('apps/app/src/lib/scheduleService.ts')).toContain("from './adapters/legacyScheduleHelpers'");


### PR DESCRIPTION
## Summary
- Add a lazy typed `legacyAuth` adapter for the legacy auth/import graph used by `authService`.
- Repoint `authService` from deep `../../../../js/*` dynamic imports to the adapter loader functions.
- Update focused auth/source-contract tests so `authService.ts` no longer deep-imports legacy modules and the adapter remains the boundary.

## Tests
- `npx vitest run apps/app/src/lib/authService.test.ts tests/unit/app-legacy-adapter-initiative-source-contract.test.js --reporter=verbose`
- `npm run app:build`

Refs #2066