### PR TITLE
[codex] Add notification recipient index foundation

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4807,6 +4807,11 @@ function buildIndexedEligibleUsers(recipientDocs, category, audienceContext = {}
     .map((user) => [user.uid, user]));
 }
 
+function notificationRecipientDocNeedsRoleBackfill(docSnap) {
+  const user = getNotificationRecipientUserFromDoc(docSnap);
+  return Boolean(user?.uid) && (!Array.isArray(user.roles) || user.roles.length === 0);
+}
+
 async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
 
@@ -4815,7 +4820,12 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
     .get();
   const indexedRecipientDocs = targetSnap.docs || [];
   if (indexedRecipientDocs.length) {
-    const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers);
+    let indexedAdditionalUsers = Array.isArray(additionalUsers) ? additionalUsers : [];
+    if (indexedRecipientDocs.some((docSnap) => notificationRecipientDocNeedsRoleBackfill(docSnap))) {
+      const candidateUsers = await getCandidateUsersForTeam(teamId);
+      indexedAdditionalUsers = [...candidateUsers, ...indexedAdditionalUsers];
+    }
+    const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, indexedAdditionalUsers);
     return indexedRecipientDocs
       .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
       .filter(Boolean);

--- a/functions/index.js
+++ b/functions/index.js
@@ -4779,9 +4779,14 @@ function mergeNotificationResolutionUser(usersByUid, user) {
   usersByUid.set(uid, entry);
 }
 
+function getNotificationRecipientDocUid(docSnap) {
+  const data = docSnap?.data?.() || {};
+  return String(data.uid || docSnap?.id || '').trim();
+}
+
 function getNotificationRecipientUserFromDoc(docSnap) {
   const data = docSnap?.data?.() || {};
-  const uid = String(data.uid || docSnap?.id || '').trim();
+  const uid = getNotificationRecipientDocUid(docSnap);
   if (!uid) return null;
   return {
     uid,
@@ -4794,6 +4799,15 @@ function getNotificationRecipientUserFromDoc(docSnap) {
 function isAggregateNotificationRecipientDoc(docSnap) {
   const data = docSnap?.data?.() || {};
   return Array.isArray(data.roles) || Array.isArray(data.tokens);
+}
+
+function isLegacyTargetNotificationRecipientDoc(docSnap) {
+  const data = docSnap?.data?.() || {};
+  return !isAggregateNotificationRecipientDoc(docSnap)
+    && !String(data.teamId || '').trim()
+    && String(data.uid || '').trim()
+    && String(data.deviceId || '').trim()
+    && String(data.token || '').trim();
 }
 
 function buildIndexedEligibleUsers(recipientDocs, category, audienceContext = {}, additionalUsers = []) {
@@ -4822,7 +4836,8 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
   const targetSnap = await firestore.collection(`teams/${teamId}/notificationRecipients`)
     .where(`categories.${category}`, '==', true)
     .get();
-  const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);
+  const categoryRecipientDocs = targetSnap.docs || [];
+  const indexedRecipientDocs = categoryRecipientDocs.filter(isAggregateNotificationRecipientDoc);
   if (indexedRecipientDocs.length) {
     additionalUsers = Array.isArray(additionalUsers) ? additionalUsers : [];
     if (indexedRecipientDocs.some((docSnap) => notificationRecipientDocNeedsRoleBackfill(docSnap))) {
@@ -4830,15 +4845,52 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
       additionalUsers = [...candidateUsers, ...additionalUsers];
     }
     const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers);
-    return indexedRecipientDocs
+    const explicitlyEligibleLegacyRecipientDocs = categoryRecipientDocs.filter((docSnap) => (
+      isLegacyTargetNotificationRecipientDoc(docSnap)
+      && eligibleUsers.has(getNotificationRecipientDocUid(docSnap))
+    ));
+    return [...indexedRecipientDocs, ...explicitlyEligibleLegacyRecipientDocs]
       .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
       .filter(Boolean);
+  }
+
+  const legacyTargetRecipientDocs = categoryRecipientDocs.filter(isLegacyTargetNotificationRecipientDoc);
+  if (legacyTargetRecipientDocs.length) {
+    const candidateUsers = await getCandidateUsersForTeam(teamId);
+    const indexedAdditionalUsers = [
+      ...candidateUsers,
+      ...(Array.isArray(additionalUsers) ? additionalUsers : [])
+    ];
+    const eligibleUsers = buildIndexedEligibleUsers([], category, audienceContext, indexedAdditionalUsers);
+    const explicitlyEligibleLegacyRecipientDocs = legacyTargetRecipientDocs.filter((docSnap) => (
+      eligibleUsers.has(getNotificationRecipientDocUid(docSnap))
+    ));
+    if (explicitlyEligibleLegacyRecipientDocs.length) {
+      return explicitlyEligibleLegacyRecipientDocs
+        .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
+        .filter(Boolean);
+    }
   }
 
   const indexIsEmpty = typeof teamNotificationRecipientIndexIsEmpty === 'function'
     ? await teamNotificationRecipientIndexIsEmpty(teamId)
     : true;
   if (!indexIsEmpty) {
+    const candidateUsers = categoryRecipientDocs.length ? await getCandidateUsersForTeam(teamId) : [];
+    const indexedAdditionalUsers = [
+      ...candidateUsers,
+      ...(Array.isArray(additionalUsers) ? additionalUsers : [])
+    ];
+    const eligibleUsers = buildIndexedEligibleUsers([], category, audienceContext, indexedAdditionalUsers);
+    const explicitlyEligibleLegacyRecipientDocs = categoryRecipientDocs.filter((docSnap) => (
+      !isAggregateNotificationRecipientDoc(docSnap)
+      && eligibleUsers.has(getNotificationRecipientDocUid(docSnap))
+    ));
+    if (explicitlyEligibleLegacyRecipientDocs.length) {
+      return explicitlyEligibleLegacyRecipientDocs
+        .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
+        .filter(Boolean);
+    }
     return [];
   }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -3400,9 +3400,8 @@ async function syncNotificationTargetsForDevice(uid, deviceId, rawDevice) {
 
 async function teamNotificationRecipientIndexIsEmpty(teamId) {
   const recipientSnap = await firestore.collection(`teams/${teamId}/notificationRecipients`)
-    .limit(1)
     .get();
-  return recipientSnap.empty;
+  return !(recipientSnap.docs || []).some((docSnap) => isAggregateNotificationRecipientDoc(docSnap));
 }
 
 function getNotificationRecipientRoles({ teamId, team, user, uid, email = '' }) {
@@ -4792,6 +4791,11 @@ function getNotificationRecipientUserFromDoc(docSnap) {
   };
 }
 
+function isAggregateNotificationRecipientDoc(docSnap) {
+  const data = docSnap?.data?.() || {};
+  return Array.isArray(data.roles) || Array.isArray(data.tokens);
+}
+
 function buildIndexedEligibleUsers(recipientDocs, category, audienceContext = {}, additionalUsers = []) {
   const usersByUid = new Map();
   (recipientDocs || []).forEach((docSnap) => {
@@ -4818,7 +4822,7 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
   const targetSnap = await firestore.collection(`teams/${teamId}/notificationRecipients`)
     .where(`categories.${category}`, '==', true)
     .get();
-  const indexedRecipientDocs = targetSnap.docs || [];
+  const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);
   if (indexedRecipientDocs.length) {
     let indexedAdditionalUsers = Array.isArray(additionalUsers) ? additionalUsers : [];
     if (indexedRecipientDocs.some((docSnap) => notificationRecipientDocNeedsRoleBackfill(docSnap))) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -4767,58 +4767,83 @@ async function backfillNotificationRecipientsForTeam(teamId, users, options = {}
   return writeCount;
 }
 
+function mergeNotificationResolutionUser(usersByUid, user) {
+  const uid = String(user?.uid || '').trim();
+  if (!uid) return;
+  const entry = usersByUid.get(uid) || { uid, roles: new Set() };
+  (Array.isArray(user?.roles) ? user.roles : []).forEach((role) => {
+    const normalizedRole = String(role || '').trim();
+    if (normalizedRole) {
+      entry.roles.add(normalizedRole);
+    }
+  });
+  usersByUid.set(uid, entry);
+}
+
+function getNotificationRecipientUserFromDoc(docSnap) {
+  const data = docSnap?.data?.() || {};
+  const uid = String(data.uid || docSnap?.id || '').trim();
+  if (!uid) return null;
+  return {
+    uid,
+    roles: Array.isArray(data.roles)
+      ? data.roles.map((role) => String(role || '').trim()).filter(Boolean)
+      : []
+  };
+}
+
+function buildIndexedEligibleUsers(recipientDocs, category, audienceContext = {}, additionalUsers = []) {
+  const usersByUid = new Map();
+  (recipientDocs || []).forEach((docSnap) => {
+    mergeNotificationResolutionUser(usersByUid, getNotificationRecipientUserFromDoc(docSnap));
+  });
+  (Array.isArray(additionalUsers) ? additionalUsers : []).forEach((user) => {
+    mergeNotificationResolutionUser(usersByUid, user);
+  });
+
+  return new Map(Array.from(usersByUid.values())
+    .map((entry) => ({ uid: entry.uid, roles: Array.from(entry.roles) }))
+    .filter((user) => canReceiveCategoryNotification(category, user, audienceContext))
+    .map((user) => [user.uid, user]));
+}
+
 async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return [];
 
   const targetSnap = await firestore.collection(`teams/${teamId}/notificationRecipients`)
     .where(`categories.${category}`, '==', true)
     .get();
+  const indexedRecipientDocs = targetSnap.docs || [];
+  if (indexedRecipientDocs.length) {
+    const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers);
+    return indexedRecipientDocs
+      .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
+      .filter(Boolean);
+  }
+
+  const indexIsEmpty = typeof teamNotificationRecipientIndexIsEmpty === 'function'
+    ? await teamNotificationRecipientIndexIsEmpty(teamId)
+    : true;
+  if (!indexIsEmpty) {
+    return [];
+  }
+
   const candidateUsers = await getCandidateUsersForTeam(teamId);
   const mergedUsers = new Map();
-  const mergeUser = (user) => {
-    const uid = String(user?.uid || '').trim();
-    if (!uid) return;
-    const entry = mergedUsers.get(uid) || { uid, roles: new Set() };
-    const roles = Array.isArray(user?.roles) ? user.roles : [];
-    roles.forEach((role) => {
-      const normalizedRole = String(role || '').trim();
-      if (normalizedRole) {
-        entry.roles.add(normalizedRole);
-      }
-    });
-    mergedUsers.set(uid, entry);
-  };
-
-  candidateUsers.forEach(mergeUser);
-  (Array.isArray(additionalUsers) ? additionalUsers : []).forEach(mergeUser);
+  candidateUsers.forEach((user) => mergeNotificationResolutionUser(mergedUsers, user));
+  (Array.isArray(additionalUsers) ? additionalUsers : []).forEach((user) => mergeNotificationResolutionUser(mergedUsers, user));
 
   const users = Array.from(mergedUsers.values()).map((entry) => ({
     uid: entry.uid,
     roles: Array.from(entry.roles)
   }));
-  const eligibleUsers = new Map(users
-    .filter((user) => canReceiveCategoryNotification(category, user, audienceContext))
-    .map((user) => [user.uid, user]));
-  const indexedTargets = targetSnap.docs
-    .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
-    .filter(Boolean);
 
-  const indexedUserIds = new Set(indexedTargets.map((target) => target.uid));
-  const missingUsers = users.filter((user) => (
-    user?.uid
-    && user.uid !== actorUid
-    && !indexedUserIds.has(user.uid)
-    && eligibleUsers.has(user.uid)
-  ));
-  if (!missingUsers.length) {
-    return indexedTargets;
-  }
-
-  if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId)) {
+  if (typeof backfillNotificationRecipientsForTeam === 'function') {
     try {
       await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true });
     } catch (error) {
-      functions.logger.warn('Failed to backfill notification recipient index after empty lookup', {
+      const logger = typeof functions !== 'undefined' ? functions.logger : null;
+      logger?.warn?.('Failed to backfill notification recipient index after empty lookup', {
         teamId,
         category,
         error: error?.message || String(error || 'Unknown error')
@@ -4826,8 +4851,8 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
     }
   }
 
-  const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);
-  return [...indexedTargets, ...fallbackTargets];
+  const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext);
+  return fallbackTargets;
 }
 
 async function getTargetsForCategoryUserIds(teamId, category, userIds = [], actorUid = null, audienceContext = {}) {
@@ -5048,6 +5073,56 @@ function buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, a
     .filter((entry) => entry.deviceId && entry.token);
 }
 
+async function pruneInvalidNotificationRecipientTokens(targets) {
+  const targetsByRecipient = new Map();
+  (Array.isArray(targets) ? targets : []).forEach((target) => {
+    const teamId = String(target?.teamId || '').trim();
+    const uid = String(target?.uid || '').trim();
+    if (!teamId || !uid) return;
+    const key = `${teamId}::${uid}`;
+    const entry = targetsByRecipient.get(key) || {
+      teamId,
+      uid,
+      invalidDeviceIds: new Set(),
+      invalidTokens: new Set()
+    };
+    const deviceId = String(target?.deviceId || '').trim();
+    const token = String(target?.token || '').trim();
+    if (deviceId) entry.invalidDeviceIds.add(deviceId);
+    if (token) entry.invalidTokens.add(token);
+    targetsByRecipient.set(key, entry);
+  });
+
+  if (!targetsByRecipient.size) return;
+
+  await Promise.allSettled(Array.from(targetsByRecipient.values()).map(async (entry) => {
+    const recipientRef = buildTeamNotificationRecipientRef(entry.teamId, entry.uid);
+    if (!recipientRef) return;
+
+    const recipientSnap = await recipientRef.get();
+    if (!recipientSnap.exists) return;
+
+    const data = recipientSnap.data() || {};
+    const tokens = Array.isArray(data.tokens) ? data.tokens : [];
+    const nextTokens = tokens.filter((tokenEntry) => {
+      const deviceId = String(tokenEntry?.deviceId || '').trim();
+      const token = String(tokenEntry?.token || '').trim();
+      return !(entry.invalidDeviceIds.has(deviceId) || entry.invalidTokens.has(token));
+    });
+
+    if (nextTokens.length === tokens.length) return;
+    if (!nextTokens.length) {
+      await recipientRef.delete();
+      return;
+    }
+
+    await recipientRef.update({
+      tokens: nextTokens,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    });
+  }));
+}
+
 async function pruneInvalidTokens(sendResult, targets) {
   if (!sendResult || !Array.isArray(sendResult.responses)) return;
   const removableCodes = new Set([
@@ -5056,12 +5131,14 @@ async function pruneInvalidTokens(sendResult, targets) {
   ]);
 
   const removals = [];
+  const invalidTargets = [];
   sendResult.responses.forEach((response, index) => {
     if (response.success) return;
     const code = response.error?.code;
     if (!removableCodes.has(code)) return;
     const target = targets[index];
     if (!target?.uid || !target?.deviceId) return;
+    invalidTargets.push(target);
     removals.push(
       firestore.doc(`users/${target.uid}/notificationDevices/${target.deviceId}`).delete()
     );
@@ -5070,6 +5147,10 @@ async function pruneInvalidTokens(sendResult, targets) {
       removals.push(targetRef.delete());
     }
   });
+
+  if (invalidTargets.length) {
+    removals.push(pruneInvalidNotificationRecipientTokens(invalidTargets));
+  }
 
   if (removals.length) {
     await Promise.allSettled(removals);

--- a/functions/index.js
+++ b/functions/index.js
@@ -4824,12 +4824,12 @@ async function getTargetsForCategory(teamId, category, actorUid = null, audience
     .get();
   const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);
   if (indexedRecipientDocs.length) {
-    let indexedAdditionalUsers = Array.isArray(additionalUsers) ? additionalUsers : [];
+    additionalUsers = Array.isArray(additionalUsers) ? additionalUsers : [];
     if (indexedRecipientDocs.some((docSnap) => notificationRecipientDocNeedsRoleBackfill(docSnap))) {
       const candidateUsers = await getCandidateUsersForTeam(teamId);
-      indexedAdditionalUsers = [...candidateUsers, ...indexedAdditionalUsers];
+      additionalUsers = [...candidateUsers, ...additionalUsers];
     }
-    const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, indexedAdditionalUsers);
+    const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers);
     return indexedRecipientDocs
       .flatMap((docSnap) => buildTargetsFromNotificationRecipientDoc(docSnap, { teamId, category, actorUid, eligibleUsers }))
       .filter(Boolean);

--- a/functions/test/send-category-notification-load.test.js
+++ b/functions/test/send-category-notification-load.test.js
@@ -47,7 +47,7 @@ describe('sendCategoryNotification load coverage', () => {
             assert.equal(result.successCount, 500);
             assert.equal(result.failureCount, 0);
             assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.parentQueries, 0);
             assert.equal(env.counts.preferenceGets, 0);
             assert.equal(env.counts.deviceGets, 0);
             assert.equal(env.messagingCalls.length, 1);
@@ -75,7 +75,7 @@ describe('sendCategoryNotification load coverage', () => {
             assert.equal(result.successCount, 1000);
             assert.equal(result.failureCount, 0);
             assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.parentQueries, 0);
             assert.equal(env.counts.preferenceGets, 0);
             assert.equal(env.counts.deviceGets, 0);
             assert.equal(env.messagingCalls.length, 2);

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -33,7 +33,8 @@ test('getTargetsForCategory uses indexed targets without legacy per-user device 
 
             assert.equal(targets.length, 2);
             assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.parentQueries, 0);
+            assert.equal(env.counts.teamDocGets, 0);
             assert.equal(env.counts.recipientCollectionGets, 0);
             assert.equal(env.counts.preferenceGets, 0);
             assert.equal(env.counts.deviceGets, 0);
@@ -140,6 +141,7 @@ test('getTargetsForCategory returns the same recipient set from indexed resoluti
 
             assert.deepEqual(normalizeTargets(indexedTargets), normalizeTargets(legacyTargets));
             assert.equal(indexed.env.counts.recipientQueries, 1);
+            assert.equal(indexed.env.counts.parentQueries, 0);
             assert.equal(indexed.env.counts.preferenceGets, 0);
             assert.equal(indexed.env.counts.deviceGets, 0);
             assert.equal(legacy.env.counts.recipientQueries, 1);
@@ -191,8 +193,9 @@ test('getTargetsForCategory does not backfill repeatedly when the recipient coll
             assert.deepEqual(targets, []);
             assert.equal(env.counts.recipientQueries, 1);
             assert.equal(env.counts.recipientCollectionGets, 1);
-            assert.equal(env.counts.preferenceGets, 2);
-            assert.equal(env.counts.deviceGets, 2);
+            assert.equal(env.counts.parentQueries, 0);
+            assert.equal(env.counts.preferenceGets, 0);
+            assert.equal(env.counts.deviceGets, 0);
             assert.equal(
                 env.dedupWrites.filter((write) => write.path.includes('/notificationRecipients/'))
                     .length,
@@ -203,7 +206,7 @@ test('getTargetsForCategory does not backfill repeatedly when the recipient coll
         }
 });
 
-test('getTargetsForCategory falls back only for users missing from the notification target index', async () => {
+test('getTargetsForCategory does not legacy-scan missing users once the recipient index exists', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {
                 ownerId: 'coach-1',
@@ -231,14 +234,14 @@ test('getTargetsForCategory falls back only for users missing from the notificat
         try {
             const targets = await internals.getTargetsForCategory('team-1', 'schedule');
 
-            assert.equal(targets.length, 2);
+            assert.equal(targets.length, 1);
             assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.parentQueries, 0);
             assert.equal(env.counts.recipientCollectionGets, 0);
-            assert.equal(env.counts.preferenceGets, 1);
-            assert.equal(env.counts.deviceGets, 1);
+            assert.equal(env.counts.preferenceGets, 0);
+            assert.equal(env.counts.deviceGets, 0);
             assert.deepEqual(targets.map((target) => target.token).sort(), [
-                'coach-token', 'parent-token'
+                'coach-token'
             ]);
         } finally {
             cleanup();
@@ -313,6 +316,7 @@ test('getTargetsForCategory limits staff-only media notifications to staff recip
             indexedTargets: [
                 {
                     uid: 'coach-1',
+                    roles: ['staff'],
                     deviceId: 'coach-device',
                     token: 'coach-token',
                     categories: { media: true }
@@ -331,7 +335,7 @@ test('getTargetsForCategory limits staff-only media notifications to staff recip
 
             assert.deepEqual(targets.map((target) => target.token), ['coach-token']);
             assert.equal(env.counts.recipientQueries, 1);
-            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.parentQueries, 0);
             assert.equal(env.counts.preferenceGets, 0);
             assert.equal(env.counts.deviceGets, 0);
         } finally {
@@ -349,6 +353,7 @@ test('getTargetsForCategory preserves eligible recipients for visible media albu
             indexedTargets: [
                 {
                     uid: 'coach-1',
+                    roles: ['staff'],
                     deviceId: 'coach-device',
                     token: 'coach-token',
                     categories: { media: true }
@@ -795,6 +800,7 @@ test('sendCategoryNotification prunes invalid tokens from both notification inde
 
             assert.equal(result?.failureCount, 1);
             assert.deepEqual(env.deletedPaths.sort(), [
+                'teams/team-1/notificationRecipients/coach-1',
                 'teams/team-1/notificationTargets/coach-1__coach-device',
                 'users/coach-1/notificationDevices/coach-device'
             ]);

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -248,6 +248,54 @@ test('getTargetsForCategory does not legacy-scan missing users once the recipien
         }
 });
 
+test('getTargetsForCategory resolves legacy per-device recipient docs with candidate-user roles', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            notificationRecipientDocs: [
+                {
+                    id: 'coach-1__coach-device',
+                    data: {
+                        uid: 'coach-1',
+                        deviceId: 'coach-device',
+                        token: 'coach-token',
+                        categories: { schedule: true }
+                    }
+                },
+                {
+                    id: 'parent-1__parent-device',
+                    data: {
+                        uid: 'parent-1',
+                        deviceId: 'parent-device',
+                        token: 'parent-token',
+                        categories: { schedule: true }
+                    }
+                }
+            ]
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategory('team-1', 'schedule');
+
+            assert.equal(targets.length, 2);
+            assert.equal(env.counts.recipientQueries, 1);
+            assert.equal(env.counts.teamDocGets, 1);
+            assert.equal(env.counts.parentQueries, 1);
+            assert.equal(env.counts.recipientCollectionGets, 0);
+            assert.equal(env.counts.preferenceGets, 0);
+            assert.equal(env.counts.deviceGets, 0);
+            assert.deepEqual(targets.map((target) => `${target.uid}:${target.deviceId}:${target.token}`).sort(), [
+                'coach-1:coach-device:coach-token',
+                'parent-1:parent-device:parent-token'
+            ]);
+        } finally {
+            cleanup();
+        }
+});
+
 test('getTargetsForCategory falls back to legacy resolution and backfills recipients when the team index is empty', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {

--- a/functions/test/send-category-notification.test.js
+++ b/functions/test/send-category-notification.test.js
@@ -354,6 +354,79 @@ test('getTargetsForCategory falls back to legacy resolution and backfills recipi
         }
 });
 
+test('getTargetsForCategory falls back when category matches only legacy per-device recipient docs', async () => {
+        const { internals, env, cleanup } = loadNotificationInternals({
+            teamDoc: {
+                ownerId: 'coach-1',
+                adminEmails: []
+            },
+            parentUserIds: ['parent-1'],
+            userDocs: {
+                'coach-1': { email: 'coach@example.com', parentTeamIds: [] },
+                'parent-1': { email: 'parent@example.com', parentTeamIds: ['team-1'] }
+            },
+            notificationRecipientDocs: [
+                {
+                    id: 'coach-1__coach-device',
+                    data: {
+                        uid: 'coach-1',
+                        teamId: 'team-1',
+                        deviceId: 'coach-device',
+                        token: 'stale-coach-token',
+                        categories: { schedule: true }
+                    }
+                },
+                {
+                    id: 'parent-1__parent-device',
+                    data: {
+                        uid: 'parent-1',
+                        teamId: 'team-1',
+                        deviceId: 'parent-device',
+                        token: 'stale-parent-token',
+                        categories: { schedule: true }
+                    }
+                }
+            ],
+            preferenceDocs: {
+                'users/coach-1/notificationPreferences/team-1': { schedule: true },
+                'users/parent-1/notificationPreferences/team-1': { schedule: true }
+            },
+            deviceDocs: {
+                'coach-1': [
+                    { id: 'coach-device', token: 'coach-token', platform: 'ios' }
+                ],
+                'parent-1': [
+                    { id: 'parent-device', token: 'parent-token', platform: 'android' }
+                ]
+            }
+        });
+
+        try {
+            const targets = await internals.getTargetsForCategory('team-1', 'schedule');
+
+            assert.equal(targets.length, 2);
+            assert.equal(env.counts.recipientQueries, 1);
+            assert.equal(env.counts.recipientCollectionGets, 1);
+            assert.equal(env.counts.preferenceGets, 4);
+            assert.equal(env.counts.deviceGets, 4);
+            assert.deepEqual(targets.map((target) => `${target.uid}:${target.deviceId}:${target.token}`).sort(), [
+                'coach-1:coach-device:coach-token',
+                'parent-1:parent-device:parent-token'
+            ]);
+            assert.deepEqual(
+                env.dedupWrites
+                    .filter((write) => write.path.includes('/notificationRecipients/'))
+                    .map((write) => write.path)
+                    .sort(),
+                [
+                    'teams/team-1/notificationRecipients/coach-1',
+                    'teams/team-1/notificationRecipients/parent-1'
+                ]);
+        } finally {
+            cleanup();
+        }
+});
+
 test('getTargetsForCategory limits staff-only media notifications to staff recipients', async () => {
         const { internals, env, cleanup } = loadNotificationInternals({
             teamDoc: {

--- a/tests/unit/certificate-award-notifications.test.js
+++ b/tests/unit/certificate-award-notifications.test.js
@@ -37,7 +37,7 @@ function getTargetsForCategoryFactory() {
         'backfillNotificationRecipientsForTeam',
         'getLegacyTargetsForCategory',
         'functions',
-        `${extractChunk('async function getTargetsForCategory(', 'async function pruneInvalidTokens')}
+        `${extractChunk('function mergeNotificationResolutionUser(', 'async function pruneInvalidTokens')}
         return getTargetsForCategory;`
     );
 }

--- a/tests/unit/notification-recipient-index-contract.test.js
+++ b/tests/unit/notification-recipient-index-contract.test.js
@@ -39,10 +39,12 @@ describe('notification recipient index foundation', () => {
 
     it('falls back to live preference/device reads and backfills after empty indexed lookups', () => {
         expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category');
+        expect(functionsSource).toContain('const indexedRecipientDocs = targetSnap.docs || [];');
+        expect(functionsSource).toContain('const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers);');
         expect(functionsSource).toContain('await teamNotificationRecipientIndexIsEmpty(teamId)');
         expect(functionsSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true })');
-        expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);');
-        expect(functionsSource).toContain('return [...indexedTargets, ...fallbackTargets];');
+        expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext);');
+        expect(functionsSource).toContain('return fallbackTargets;');
     });
 
     it('deduplicates non-chat sends with a short-lived send log and records audit metadata', () => {

--- a/tests/unit/notification-recipient-index-contract.test.js
+++ b/tests/unit/notification-recipient-index-contract.test.js
@@ -39,9 +39,11 @@ describe('notification recipient index foundation', () => {
 
     it('falls back to live preference/device reads and backfills after empty indexed lookups', () => {
         expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category');
-        expect(functionsSource).toContain('const indexedRecipientDocs = targetSnap.docs || [];');
+        expect(functionsSource).toContain('function isAggregateNotificationRecipientDoc(docSnap) {');
+        expect(functionsSource).toContain('const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);');
         expect(functionsSource).toContain('const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers);');
         expect(functionsSource).toContain('await teamNotificationRecipientIndexIsEmpty(teamId)');
+        expect(functionsSource).toContain('some((docSnap) => isAggregateNotificationRecipientDoc(docSnap))');
         expect(functionsSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true })');
         expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext);');
         expect(functionsSource).toContain('return fallbackTargets;');

--- a/tests/unit/notification-recipient-index-contract.test.js
+++ b/tests/unit/notification-recipient-index-contract.test.js
@@ -40,8 +40,10 @@ describe('notification recipient index foundation', () => {
     it('falls back to live preference/device reads and backfills after empty indexed lookups', () => {
         expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category');
         expect(functionsSource).toContain('function isAggregateNotificationRecipientDoc(docSnap) {');
-        expect(functionsSource).toContain('const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);');
+        expect(functionsSource).toContain('const categoryRecipientDocs = targetSnap.docs || [];');
+        expect(functionsSource).toContain('const indexedRecipientDocs = categoryRecipientDocs.filter(isAggregateNotificationRecipientDoc);');
         expect(functionsSource).toContain('const eligibleUsers = buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers);');
+        expect(functionsSource).toContain('const explicitlyEligibleLegacyRecipientDocs = categoryRecipientDocs.filter((docSnap) => (');
         expect(functionsSource).toContain('await teamNotificationRecipientIndexIsEmpty(teamId)');
         expect(functionsSource).toContain('some((docSnap) => isAggregateNotificationRecipientDoc(docSnap))');
         expect(functionsSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true })');

--- a/tests/unit/notification-recipient-index-initiative-source-contract.test.js
+++ b/tests/unit/notification-recipient-index-initiative-source-contract.test.js
@@ -15,7 +15,8 @@ describe('notification recipient index initiative source contract', () => {
 
     it('keeps a migration fallback that backfills the index when a team has no indexed recipients yet', () => {
         expect(functionsSource).toContain('async function backfillNotificationRecipientsForTeam(teamId, users, options = {})');
-        expect(functionsSource).toContain('if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId)) {');
+        expect(functionsSource).toContain('const indexIsEmpty = typeof teamNotificationRecipientIndexIsEmpty === \'function\'');
+        expect(functionsSource).toContain('if (!indexIsEmpty) {');
         expect(functionsSource).toContain('await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true });');
         expect(functionsSource).toContain('Failed to backfill notification recipient index after empty lookup');
     });

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -109,7 +109,9 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain('users/${uid}/notificationDevices');
         expect(targetResolverSource).toContain('if (!NOTIFICATION_CATEGORIES.includes(category)) return []');
         expect(targetResolverSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
-        expect(targetResolverSource).toContain('const indexedRecipientDocs = targetSnap.docs || [];');
+        expect(targetResolverSource).toContain('function isAggregateNotificationRecipientDoc(docSnap) {');
+        expect(targetResolverSource).toContain('return Array.isArray(data.roles) || Array.isArray(data.tokens);');
+        expect(targetResolverSource).toContain('const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);');
         expect(targetResolverSource).toContain('if (indexedRecipientDocs.length) {');
         expect(targetResolverSource).toContain('buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers)');
         expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true");
@@ -118,6 +120,7 @@ describe('notification target index core helpers', () => {
         expect(functionsSource).toContain('return mediaAudienceAllowsUser(user, audienceContext);');
         expect(functionsSource).toContain("const isStaffUser = Array.isArray(user.roles) && user.roles.includes('staff');");
         expect(targetResolverSource).toContain('teamNotificationRecipientIndexIsEmpty(teamId)');
+        expect(functionsSource).toContain('some((docSnap) => isAggregateNotificationRecipientDoc(docSnap))');
         expect(targetResolverSource).toContain('if (!indexIsEmpty) {');
         expect(targetResolverSource).toContain("await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true });");
         expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext)');

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -95,7 +95,7 @@ describe('notification target index core helpers', () => {
         expect(syncSource).toContain('indexRefs.forEach((ref) => batch.delete(ref));');
     });
 
-    it('uses the team recipient index first and falls back to legacy user scans for missing indexed recipients', () => {
+    it('uses populated team recipient indexes without legacy user scans and falls back only when empty', () => {
         const targetResolverSource = functionsSource.slice(
             functionsSource.indexOf('async function getLegacyTargetsForCategory'),
             functionsSource.indexOf('async function pruneInvalidTokens')
@@ -109,17 +109,20 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain('users/${uid}/notificationDevices');
         expect(targetResolverSource).toContain('if (!NOTIFICATION_CATEGORIES.includes(category)) return []');
         expect(targetResolverSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
+        expect(targetResolverSource).toContain('const indexedRecipientDocs = targetSnap.docs || [];');
+        expect(targetResolverSource).toContain('if (indexedRecipientDocs.length) {');
+        expect(targetResolverSource).toContain('buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers)');
         expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true");
         expect(functionsSource).toContain("return ['private', 'staff', 'staff-only'].includes(normalized) ? 'private' : 'team';");
         expect(functionsSource).toContain('if (hasMediaAudienceConstraints(audienceContext))');
         expect(functionsSource).toContain('return mediaAudienceAllowsUser(user, audienceContext);');
         expect(functionsSource).toContain("const isStaffUser = Array.isArray(user.roles) && user.roles.includes('staff');");
-        expect(targetResolverSource).toContain('const missingUsers = users.filter');
         expect(targetResolverSource).toContain('teamNotificationRecipientIndexIsEmpty(teamId)');
-        expect(targetResolverSource).toContain('if (targetSnap.empty && await teamNotificationRecipientIndexIsEmpty(teamId))');
+        expect(targetResolverSource).toContain('if (!indexIsEmpty) {');
         expect(targetResolverSource).toContain("await backfillNotificationRecipientsForTeam(teamId, users, { skipLegacyCleanup: true });");
-        expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
+        expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext)');
         expect(functionsSource).toContain('buildTeamNotificationTargetRef(target.teamId, target.uid, target.deviceId)');
+        expect(functionsSource).toContain('pruneInvalidNotificationRecipientTokens(invalidTargets)');
     });
 
     it('uses indexed recipient docs before fallback reads for explicit user-id target resolution', () => {

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -111,7 +111,9 @@ describe('notification target index core helpers', () => {
         expect(targetResolverSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
         expect(targetResolverSource).toContain('function isAggregateNotificationRecipientDoc(docSnap) {');
         expect(targetResolverSource).toContain('return Array.isArray(data.roles) || Array.isArray(data.tokens);');
-        expect(targetResolverSource).toContain('const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);');
+        expect(targetResolverSource).toContain('const categoryRecipientDocs = targetSnap.docs || [];');
+        expect(targetResolverSource).toContain('const indexedRecipientDocs = categoryRecipientDocs.filter(isAggregateNotificationRecipientDoc);');
+        expect(targetResolverSource).toContain('const explicitlyEligibleLegacyRecipientDocs = categoryRecipientDocs.filter((docSnap) => (');
         expect(targetResolverSource).toContain('if (indexedRecipientDocs.length) {');
         expect(targetResolverSource).toContain('buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers)');
         expect(functionsSource).toContain("const albumVisibility = audienceContext?.staffOnly === true");

--- a/tests/unit/notification-target-resolution-fixtures.cjs
+++ b/tests/unit/notification-target-resolution-fixtures.cjs
@@ -48,10 +48,10 @@ const LEGACY_CATEGORY_RESOLUTION_FIXTURES = Object.freeze([
             }
         },
         expectedTargets: [
-            { uid: 'coach-1', deviceId: 'coach-phone', token: 'coach-phone-token' },
-            { uid: 'coach-1', deviceId: 'coach-watch', token: 'coach-watch-token' },
-            { uid: 'parent-1', deviceId: 'parent-1-phone', token: 'parent-1-phone-token' },
-            { uid: 'parent-3', deviceId: 'parent-3-tablet', token: 'parent-3-tablet-token' }
+            { uid: 'coach-1', roles: ['staff'], deviceId: 'coach-phone', token: 'coach-phone-token' },
+            { uid: 'coach-1', roles: ['staff'], deviceId: 'coach-watch', token: 'coach-watch-token' },
+            { uid: 'parent-1', roles: ['parent'], deviceId: 'parent-1-phone', token: 'parent-1-phone-token' },
+            { uid: 'parent-3', roles: ['parent'], deviceId: 'parent-3-tablet', token: 'parent-3-tablet-token' }
         ],
         expectedCounts: {
             targetQueries: 1,
@@ -60,8 +60,8 @@ const LEGACY_CATEGORY_RESOLUTION_FIXTURES = Object.freeze([
             deviceGets: 4
         },
         expectedIndexedCounts: {
-            preferenceGets: 1,
-            deviceGets: 1
+            preferenceGets: 0,
+            deviceGets: 0
         }
     },
     {
@@ -105,8 +105,8 @@ const LEGACY_CATEGORY_RESOLUTION_FIXTURES = Object.freeze([
             }
         },
         expectedTargets: [
-            { uid: 'coach-2', deviceId: 'coach-2-phone', token: 'coach-2-phone-token' },
-            { uid: 'coach-2', deviceId: 'coach-2-tablet', token: 'coach-2-tablet-token' }
+            { uid: 'coach-2', roles: ['staff'], deviceId: 'coach-2-phone', token: 'coach-2-phone-token' },
+            { uid: 'coach-2', roles: ['staff'], deviceId: 'coach-2-tablet', token: 'coach-2-tablet-token' }
         ],
         expectedCounts: {
             targetQueries: 1,
@@ -138,6 +138,7 @@ function normalizeResolvedTargets(targets = []) {
 function buildIndexedTargetsFromExpected(category, expectedTargets = []) {
     return expectedTargets.map((target) => ({
         uid: target.uid,
+        roles: target.roles || ['parent'],
         deviceId: target.deviceId,
         token: target.token,
         categories: {

--- a/tests/unit/team-media-notification-recipients.test.js
+++ b/tests/unit/team-media-notification-recipients.test.js
@@ -82,7 +82,12 @@ function createHarness({ candidateUsers = [], indexedTargets = [], preferences =
         'function normalizeNotificationAlbumVisibility',
         '\nasync function pruneInvalidTokens'
     );
-    const firestore = createFirestoreMock({ indexedTargets, preferences, devices });
+    const rolesByUid = new Map(candidateUsers.map((user) => [user.uid, user.roles || []]));
+    const indexedTargetsWithRoles = indexedTargets.map((target) => ({
+        ...target,
+        roles: target.roles || rolesByUid.get(target.uid) || []
+    }));
+    const firestore = createFirestoreMock({ indexedTargets: indexedTargetsWithRoles, preferences, devices });
     const getCandidateUsersForTeam = vi.fn(async () => candidateUsers);
     const notificationAudienceAllowsRoles = vi.fn((category, roles = []) => {
         if (category !== 'media') return false;

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -57,9 +57,11 @@ describe('team media visibility notification contract', () => {
         expect(functionsSource).toContain('if (indexedRecipientDocs.some((docSnap) => notificationRecipientDocNeedsRoleBackfill(docSnap))) {');
         expect(functionsSource).toContain('additionalUsers = [...candidateUsers, ...additionalUsers];');
         expect(functionsSource).toContain('buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers)');
+        expect(functionsSource).toContain('const explicitlyEligibleLegacyRecipientDocs = categoryRecipientDocs.filter((docSnap) => (');
         expect(functionsSource).toContain('getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext)');
         expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {');
-        expect(functionsSource).toContain('const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);');
+        expect(functionsSource).toContain('const categoryRecipientDocs = targetSnap.docs || [];');
+        expect(functionsSource).toContain('const indexedRecipientDocs = categoryRecipientDocs.filter(isAggregateNotificationRecipientDoc);');
         expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext);');
         expect(functionsSource).toContain('audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility }');
         expect(functionsSource).toContain('folder.allowedUserIds || folder.audienceUserIds || folder.visibleToUserIds || folder.userIds');

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -54,6 +54,8 @@ describe('team media visibility notification contract', () => {
 
     it('passes media audience context through indexed and legacy target lookups', () => {
         expect(functionsSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
+        expect(functionsSource).toContain('if (indexedRecipientDocs.some((docSnap) => notificationRecipientDocNeedsRoleBackfill(docSnap))) {');
+        expect(functionsSource).toContain('additionalUsers = [...candidateUsers, ...additionalUsers];');
         expect(functionsSource).toContain('buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers)');
         expect(functionsSource).toContain('getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext)');
         expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {');

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -54,11 +54,11 @@ describe('team media visibility notification contract', () => {
 
     it('passes media audience context through indexed and legacy target lookups', () => {
         expect(functionsSource).toContain('canReceiveCategoryNotification(category, user, audienceContext)');
-        expect(functionsSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext)');
+        expect(functionsSource).toContain('buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers)');
+        expect(functionsSource).toContain('getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext)');
         expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {');
-        expect(functionsSource).toContain('const eligibleUsers = new Map(users');
-        expect(functionsSource).toContain('eligibleUsers.has(user.uid)');
-        expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUsers, actorUid, audienceContext);');
+        expect(functionsSource).toContain('const indexedRecipientDocs = targetSnap.docs || [];');
+        expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext);');
         expect(functionsSource).toContain('audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility }');
         expect(functionsSource).toContain('folder.allowedUserIds || folder.audienceUserIds || folder.visibleToUserIds || folder.userIds');
         expect(functionsSource).toContain('folder.allowedRoles || folder.audienceRoles || folder.visibleToRoles || folder.roles');

--- a/tests/unit/team-media-visibility-notification-contract.test.js
+++ b/tests/unit/team-media-visibility-notification-contract.test.js
@@ -57,7 +57,7 @@ describe('team media visibility notification contract', () => {
         expect(functionsSource).toContain('buildIndexedEligibleUsers(indexedRecipientDocs, category, audienceContext, additionalUsers)');
         expect(functionsSource).toContain('getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext)');
         expect(functionsSource).toContain('async function getTargetsForCategory(teamId, category, actorUid = null, audienceContext = {}, additionalUsers = []) {');
-        expect(functionsSource).toContain('const indexedRecipientDocs = targetSnap.docs || [];');
+        expect(functionsSource).toContain('const indexedRecipientDocs = (targetSnap.docs || []).filter(isAggregateNotificationRecipientDoc);');
         expect(functionsSource).toContain('const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, users, actorUid, audienceContext);');
         expect(functionsSource).toContain('audienceContext: metadata.audienceContext || { albumVisibility: metadata.albumVisibility }');
         expect(functionsSource).toContain('folder.allowedUserIds || folder.audienceUserIds || folder.visibleToUserIds || folder.userIds');


### PR DESCRIPTION
## Summary
- Resolve populated category sends directly from `teams/{teamId}/notificationRecipients` using denormalized recipient roles, avoiding the legacy full-team candidate/user scan on indexed sends.
- Keep the migration-safe legacy scan and recipient backfill only for teams whose recipient index is empty.
- Prune invalid FCM tokens from the aggregate recipient index immediately, in addition to the device doc and legacy per-device target index.
- Update focused function/unit contracts for O(1) indexed resolution, disabled-category behavior, load coverage, media audience filtering, and certificate award extraction.

## Validation
- `npm run test:functions:notifications`
- `npx vitest run functions/test/notification-recipient-index.test.js tests/unit/notification-recipient-index-contract.test.js tests/unit/notification-recipient-index-initiative-source-contract.test.js tests/unit/notification-target-index-core.test.js tests/unit/notification-target-legacy-resolution.test.js tests/unit/team-media-notification-recipients.test.js tests/unit/team-media-visibility-notification-contract.test.js tests/unit/certificate-award-notifications.test.js --environment node --reporter=verbose`
- `npm test -- --reporter=dot`

Refs #2099