### PR TITLE
[codex] Extract schedule detail presentational components

### DIFF
--- a/apps/app/src/components/schedule/CompactMeta.tsx
+++ b/apps/app/src/components/schedule/CompactMeta.tsx
@@ -1,0 +1,15 @@
+import type { LucideIcon } from 'lucide-react';
+
+interface CompactMetaProps {
+  icon: LucideIcon;
+  value: string;
+}
+
+export function CompactMeta({ icon: Icon, value }: CompactMetaProps) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 text-sm font-bold text-gray-800">
+      <Icon className="h-4 w-4 flex-none text-primary-600" aria-hidden="true" />
+      <span className="min-w-0 truncate">{value}</span>
+    </div>
+  );
+}

--- a/apps/app/src/components/schedule/PracticeAttendancePanel.tsx
+++ b/apps/app/src/components/schedule/PracticeAttendancePanel.tsx
@@ -1,0 +1,60 @@
+import type { PracticeAttendancePlayer, StaffPracticeAttendance } from '../../lib/scheduleService';
+
+type PracticeAttendanceStatus = 'present' | 'late' | 'absent';
+
+interface PracticeAttendancePanelProps {
+  attendance: StaffPracticeAttendance | null;
+  loading: boolean;
+  saving: boolean;
+  savingPlayerId: string | null;
+  onSelectStatus: (player: PracticeAttendancePlayer, status: PracticeAttendanceStatus) => Promise<void>;
+}
+
+export function PracticeAttendancePanel({ attendance, loading, saving, savingPlayerId, onSelectStatus }: PracticeAttendancePanelProps) {
+  if (loading && !attendance) {
+    return <div className="mb-3 rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">Loading practice attendance...</div>;
+  }
+  if (!attendance) return null;
+
+  return (
+    <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-amber-700">Practice attendance</div>
+          <div className="mt-1 text-sm font-black text-gray-950">Mark each player present, late, or absent.</div>
+        </div>
+        <span className="inline-flex min-h-8 items-center rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-900">
+          {attendance.checkedInCount}/{attendance.rosterSize} checked in
+        </span>
+      </div>
+      <div className="mt-3 space-y-2">
+        {attendance.players.map((player) => {
+          const busy = savingPlayerId === player.playerId;
+          return (
+            <div key={player.playerId} className="rounded-xl border border-amber-100 bg-white p-3" data-testid={`practice-attendance-row-${player.playerId}`}>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <div className="text-sm font-black text-gray-950">{player.playerNumber ? `#${player.playerNumber} ` : ''}{player.displayName}</div>
+                  <div className="mt-1 text-xs font-bold text-gray-500">{player.status === 'absent' ? 'Absent' : player.status === 'late' ? 'Late' : 'Present'}</div>
+                </div>
+                <div className="grid grid-cols-3 gap-1.5 sm:min-w-[220px]">
+                  {(['present', 'late', 'absent'] as const).map((status) => (
+                    <button
+                      key={status}
+                      type="button"
+                      className={`min-h-8 rounded-full border px-2 text-[11px] font-black transition ${player.status === status ? 'border-amber-300 bg-amber-100 text-amber-900' : 'border-gray-200 bg-white text-gray-600 hover:border-amber-200 hover:bg-amber-50 hover:text-amber-900'}`}
+                      disabled={saving}
+                      onClick={() => onSelectStatus(player, status)}
+                    >
+                      {busy && player.status !== status ? 'Saving' : status === 'present' ? 'Present' : status === 'late' ? 'Late' : 'Absent'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
+++ b/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { Users } from 'lucide-react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { StaffPracticeAttendance } from '../../lib/scheduleService';
+import { CompactMeta } from './CompactMeta';
+import { PracticeAttendancePanel } from './PracticeAttendancePanel';
+import { ScoreStepper } from './ScoreStepper';
+import { Status } from './ScheduleStatus';
+
+afterEach(() => {
+  cleanup();
+});
+
+function buildAttendance(overrides: Partial<StaffPracticeAttendance> = {}): StaffPracticeAttendance {
+  return {
+    sessionId: 'session-1',
+    teamId: 'team-1',
+    eventId: 'practice-1',
+    rosterSize: 2,
+    checkedInCount: 1,
+    players: [
+      { playerId: 'p1', displayName: 'Avery Smith', playerNumber: '1', status: 'present', checkedInAt: new Date('2026-06-04T17:55:00.000Z') },
+      { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'absent', checkedInAt: null }
+    ],
+    ...overrides
+  };
+}
+
+describe('ScheduleEventDetail presentational components', () => {
+  it('renders compact metadata with the supplied icon and value', () => {
+    render(<CompactMeta icon={Users} value="Avery Smith · Tigers" />);
+
+    expect(screen.getByText('Avery Smith · Tigers')).toBeTruthy();
+  });
+
+  it('renders schedule status messages for success and error tones', () => {
+    const { rerender } = render(<Status tone="success" message="Game schedule was updated." />);
+
+    expect(screen.getByText('Game schedule was updated.')).toBeTruthy();
+
+    rerender(<Status tone="error" message="Unable to update game." />);
+
+    expect(screen.getByText('Unable to update game.')).toBeTruthy();
+  });
+
+  it('keeps score controls disabled at zero and routes stepper clicks', () => {
+    const onDecrease = vi.fn();
+    const onIncrease = vi.fn();
+    const { rerender } = render(
+      <ScoreStepper label="Home" value={0} onDecrease={onDecrease} onIncrease={onIncrease} disabled={false} />
+    );
+
+    expect(screen.getByRole('button', { name: 'Home score down' })).toHaveProperty('disabled', true);
+    fireEvent.click(screen.getByRole('button', { name: 'Home score up' }));
+    expect(onIncrease).toHaveBeenCalledTimes(1);
+    expect(onDecrease).not.toHaveBeenCalled();
+
+    rerender(<ScoreStepper label="Home" value={2} onDecrease={onDecrease} onIncrease={onIncrease} disabled={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Home score down' }));
+    expect(onDecrease).toHaveBeenCalledTimes(1);
+
+    rerender(<ScoreStepper label="Home" value={2} onDecrease={onDecrease} onIncrease={onIncrease} disabled />);
+    expect(screen.getByRole('button', { name: 'Home score down' })).toHaveProperty('disabled', true);
+    expect(screen.getByRole('button', { name: 'Home score up' })).toHaveProperty('disabled', true);
+  });
+
+  it('renders practice attendance rows and delegates status selection', () => {
+    const onSelectStatus = vi.fn(() => Promise.resolve());
+    const attendance = buildAttendance();
+    const { rerender } = render(
+      <PracticeAttendancePanel
+        attendance={null}
+        loading
+        saving={false}
+        savingPlayerId={null}
+        onSelectStatus={onSelectStatus}
+      />
+    );
+
+    expect(screen.getByText('Loading practice attendance...')).toBeTruthy();
+
+    rerender(
+      <PracticeAttendancePanel
+        attendance={attendance}
+        loading={false}
+        saving={false}
+        savingPlayerId={null}
+        onSelectStatus={onSelectStatus}
+      />
+    );
+
+    expect(screen.getByText('1/2 checked in')).toBeTruthy();
+    expect(screen.getByText('#2 Blake Jones')).toBeTruthy();
+
+    const row = screen.getByTestId('practice-attendance-row-p2');
+    fireEvent.click(within(row).getByRole('button', { name: 'Late' }));
+
+    expect(onSelectStatus).toHaveBeenCalledWith(attendance.players[1], 'late');
+
+    rerender(
+      <PracticeAttendancePanel
+        attendance={attendance}
+        loading={false}
+        saving
+        savingPlayerId="p2"
+        onSelectStatus={onSelectStatus}
+      />
+    );
+
+    within(screen.getByTestId('practice-attendance-row-p2')).getAllByRole('button').forEach((button) => {
+      expect(button).toHaveProperty('disabled', true);
+    });
+  });
+});

--- a/apps/app/src/components/schedule/ScheduleStatus.tsx
+++ b/apps/app/src/components/schedule/ScheduleStatus.tsx
@@ -1,0 +1,16 @@
+import { AlertCircle, CheckCircle2 } from 'lucide-react';
+
+interface StatusProps {
+  tone: 'success' | 'error';
+  message: string;
+}
+
+export function Status({ tone, message }: StatusProps) {
+  const isError = tone === 'error';
+  return (
+    <div className={`flex items-start gap-2 rounded-xl border p-3 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
+      {isError ? <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />}
+      {message}
+    </div>
+  );
+}

--- a/apps/app/src/components/schedule/ScoreStepper.tsx
+++ b/apps/app/src/components/schedule/ScoreStepper.tsx
@@ -1,0 +1,20 @@
+interface ScoreStepperProps {
+  label: string;
+  value: number;
+  onDecrease: () => void;
+  onIncrease: () => void;
+  disabled: boolean;
+}
+
+export function ScoreStepper({ label, value, onDecrease, onIncrease, disabled }: ScoreStepperProps) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-2">
+      <div className="mb-2 text-center text-xs font-black uppercase tracking-[0.04em] text-gray-500">{label}</div>
+      <div className="flex items-center justify-center gap-3">
+        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onDecrease} disabled={disabled || value <= 0} aria-label={`${label} score down`}>−</button>
+        <div className="min-w-12 text-center text-3xl font-black tabular-nums text-gray-950">{value}</div>
+        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onIncrease} disabled={disabled} aria-label={`${label} score up`}>+</button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { AlertCircle, CalendarDays, CheckCircle2, ChevronDown, ChevronLeft, ClipboardCheck, ExternalLink, FileText, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
+import { CalendarDays, ChevronDown, ChevronLeft, ClipboardCheck, ExternalLink, FileText, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
 import {
   cancelPracticeOccurrenceForApp,
   cancelScheduledGameForApp,
@@ -78,14 +78,18 @@ import { type AppServiceError, toAppServiceError } from '../lib/appErrors';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { EventDetailPageSkeleton } from '../components/PageSkeletons';
 import { AssignmentsSection } from '../components/schedule/AssignmentsSection';
+import { CompactMeta } from '../components/schedule/CompactMeta';
 import { DateTile } from '../components/schedule/DateTile';
 import { EventBrief } from '../components/schedule/EventBrief';
 import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';
 import { EventSectionNav } from '../components/schedule/EventSectionNav';
 import { GameReportSections } from '../components/schedule/GameReportSections';
 import { PlayerSwitcher } from '../components/schedule/PlayerSwitcher';
+import { PracticeAttendancePanel } from '../components/schedule/PracticeAttendancePanel';
 import { ReportMarkdownText } from '../components/schedule/ReportMarkdownText';
 import { RideshareSection } from '../components/schedule/RideshareSection';
+import { ScoreStepper } from '../components/schedule/ScoreStepper';
+import { Status } from '../components/schedule/ScheduleStatus';
 import { StaffRsvpBreakdownPanel } from '../components/schedule/StaffRsvpBreakdownPanel';
 import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';
 import {
@@ -571,15 +575,6 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
       </div>
       </div>
     </ScheduleEventDetailProvider>
-  );
-}
-
-function CompactMeta({ icon: Icon, value }: { icon: LucideIcon; value: string }) {
-  return (
-    <div className="flex min-w-0 items-center gap-2 text-sm font-bold text-gray-800">
-      <Icon className="h-4 w-4 flex-none text-primary-600" aria-hidden="true" />
-      <span className="min-w-0 truncate">{value}</span>
-    </div>
   );
 }
 
@@ -3064,19 +3059,6 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
   );
 }
 
-function ScoreStepper({ label, value, onDecrease, onIncrease, disabled }: { label: string; value: number; onDecrease: () => void; onIncrease: () => void; disabled: boolean }) {
-  return (
-    <div className="rounded-xl border border-gray-200 bg-white p-2">
-      <div className="mb-2 text-center text-xs font-black uppercase tracking-[0.04em] text-gray-500">{label}</div>
-      <div className="flex items-center justify-center gap-3">
-        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onDecrease} disabled={disabled || value <= 0} aria-label={`${label} score down`}>−</button>
-        <div className="min-w-12 text-center text-3xl font-black tabular-nums text-gray-950">{value}</div>
-        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onIncrease} disabled={disabled} aria-label={`${label} score up`}>+</button>
-      </div>
-    </div>
-  );
-}
-
 function PracticeTimelineSection({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
   const [sessionId, setSessionId] = useState<string | null>(event.practiceSessionId || null);
   const [blocks, setBlocks] = useState<PracticeTimelineBlock[]>([]);
@@ -3699,76 +3681,11 @@ function PracticePacketSection({ auth, event, childEvents }: { auth: AuthState; 
   );
 }
 
-function PracticeAttendancePanel({ attendance, loading, saving, savingPlayerId, onSelectStatus }: {
-  attendance: StaffPracticeAttendance | null;
-  loading: boolean;
-  saving: boolean;
-  savingPlayerId: string | null;
-  onSelectStatus: (player: PracticeAttendancePlayer, status: 'present' | 'late' | 'absent') => Promise<void>;
-}) {
-  if (loading && !attendance) {
-    return <div className="mb-3 rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">Loading practice attendance...</div>;
-  }
-  if (!attendance) return null;
-
-  return (
-    <div className="mb-3 rounded-xl border border-amber-200 bg-amber-50 p-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-amber-700">Practice attendance</div>
-          <div className="mt-1 text-sm font-black text-gray-950">Mark each player present, late, or absent.</div>
-        </div>
-        <span className="inline-flex min-h-8 items-center rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-900">
-          {attendance.checkedInCount}/{attendance.rosterSize} checked in
-        </span>
-      </div>
-      <div className="mt-3 space-y-2">
-        {attendance.players.map((player) => {
-          const busy = savingPlayerId === player.playerId;
-          return (
-            <div key={player.playerId} className="rounded-xl border border-amber-100 bg-white p-3" data-testid={`practice-attendance-row-${player.playerId}`}>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="min-w-0">
-                  <div className="text-sm font-black text-gray-950">{player.playerNumber ? `#${player.playerNumber} ` : ''}{player.displayName}</div>
-                  <div className="mt-1 text-xs font-bold text-gray-500">{player.status === 'absent' ? 'Absent' : player.status === 'late' ? 'Late' : 'Present'}</div>
-                </div>
-                <div className="grid grid-cols-3 gap-1.5 sm:min-w-[220px]">
-                  {(['present', 'late', 'absent'] as const).map((status) => (
-                    <button
-                      key={status}
-                      type="button"
-                      className={`min-h-8 rounded-full border px-2 text-[11px] font-black transition ${player.status === status ? 'border-amber-300 bg-amber-100 text-amber-900' : 'border-gray-200 bg-white text-gray-600 hover:border-amber-200 hover:bg-amber-50 hover:text-amber-900'}`}
-                      disabled={saving}
-                      onClick={() => onSelectStatus(player, status)}
-                    >
-                      {busy && player.status !== status ? 'Saving' : status === 'present' ? 'Present' : status === 'late' ? 'Late' : 'Absent'}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-xl border border-gray-200 bg-gray-50 p-3">
       <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">{label}</div>
       <div className="mt-1 text-sm font-black text-gray-950">{value}</div>
-    </div>
-  );
-}
-
-function Status({ tone, message }: { tone: 'success' | 'error'; message: string }) {
-  const isError = tone === 'error';
-  return (
-    <div className={`flex items-start gap-2 rounded-xl border p-3 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
-      {isError ? <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />}
-      {message}
     </div>
   );
 }

--- a/tests/unit/app-schedule-detail-decomposition.test.js
+++ b/tests/unit/app-schedule-detail-decomposition.test.js
@@ -14,11 +14,15 @@ describe('ScheduleEventDetail decomposition', () => {
         const rideshareSource = readRepoFile('apps/app/src/components/schedule/RideshareSection.tsx');
 
         expect(source).toContain("from '../components/schedule/AssignmentsSection'");
+        expect(source).toContain("from '../components/schedule/CompactMeta'");
         expect(source).toContain("from '../components/schedule/EventSectionNav'");
         expect(source).toContain("from '../components/schedule/GameReportSections'");
         expect(source).toContain("from '../components/schedule/PlayerSwitcher'");
+        expect(source).toContain("from '../components/schedule/PracticeAttendancePanel'");
         expect(source).toContain("from '../components/schedule/ReportMarkdownText'");
         expect(source).toContain("from '../components/schedule/RideshareSection'");
+        expect(source).toContain("from '../components/schedule/ScoreStepper'");
+        expect(source).toContain("from '../components/schedule/ScheduleStatus'");
         expect(source).toContain("from '../components/schedule/AvailabilityPanels'");
         expect(source).toContain("from '../components/schedule/StaffRsvpBreakdownPanel'");
         expect(source).toContain("from '../components/schedule/StaffRsvpReminderPanel'");
@@ -33,7 +37,10 @@ describe('ScheduleEventDetail decomposition', () => {
         expect(source).not.toMatch(/^function GameReportSections\b/m);
         expect(source).not.toMatch(/^function GameReportSectionContent\b/m);
         expect(source).not.toMatch(/^function PlayerSwitcher\b/m);
+        expect(source).not.toMatch(/^function PracticeAttendancePanel\b/m);
         expect(source).not.toMatch(/^function RideshareSection\b/m);
+        expect(source).not.toMatch(/^function ScoreStepper\b/m);
+        expect(source).not.toMatch(/^function Status\b/m);
         expect(source).not.toMatch(/^function AssignmentsSection\b/m);
 
         expect(rideshareSource).toContain("import { useScheduleRideOffers } from '../../hooks/schedule/useScheduleRideOffers';");
@@ -43,12 +50,17 @@ describe('ScheduleEventDetail decomposition', () => {
     it('keeps extracted schedule detail modules and focused coverage files in the repo', () => {
         [
             'apps/app/src/components/schedule/AssignmentsSection.tsx',
+            'apps/app/src/components/schedule/CompactMeta.tsx',
             'apps/app/src/components/schedule/GameReportSectionContent.tsx',
             'apps/app/src/components/schedule/GameReportSections.tsx',
             'apps/app/src/components/schedule/PlayerSwitcher.tsx',
+            'apps/app/src/components/schedule/PracticeAttendancePanel.tsx',
             'apps/app/src/components/schedule/ReportMarkdownText.tsx',
             'apps/app/src/components/schedule/RideOfferCard.tsx',
             'apps/app/src/components/schedule/RideshareSection.tsx',
+            'apps/app/src/components/schedule/ScoreStepper.tsx',
+            'apps/app/src/components/schedule/ScheduleStatus.tsx',
+            'apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx',
             'apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx',
             'apps/app/src/hooks/schedule/useScheduleEventRsvp.ts',
             'apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx',

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -10,17 +10,22 @@ const contextSource = readSource('apps/app/src/pages/schedule/ScheduleEventDetai
 const rsvpHookSource = readSource('apps/app/src/hooks/schedule/useScheduleEventRsvp.ts');
 const ridesHookSource = readSource('apps/app/src/hooks/schedule/useScheduleRideOffers.ts');
 const availabilityPanelsSource = readSource('apps/app/src/components/schedule/AvailabilityPanels.tsx');
+const compactMetaSource = readSource('apps/app/src/components/schedule/CompactMeta.tsx');
 const assignmentsSectionSource = readSource('apps/app/src/components/schedule/AssignmentsSection.tsx');
 const gameReportSectionsSource = readSource('apps/app/src/components/schedule/GameReportSections.tsx');
 const gameReportContentSource = readSource('apps/app/src/components/schedule/GameReportSectionContent.tsx');
 const playerSwitcherSource = readSource('apps/app/src/components/schedule/PlayerSwitcher.tsx');
+const practiceAttendancePanelSource = readSource('apps/app/src/components/schedule/PracticeAttendancePanel.tsx');
 const reportMarkdownSource = readSource('apps/app/src/components/schedule/ReportMarkdownText.tsx');
 const rideOfferCardSource = readSource('apps/app/src/components/schedule/RideOfferCard.tsx');
 const rideshareSectionSource = readSource('apps/app/src/components/schedule/RideshareSection.tsx');
+const scoreStepperSource = readSource('apps/app/src/components/schedule/ScoreStepper.tsx');
+const scheduleStatusSource = readSource('apps/app/src/components/schedule/ScheduleStatus.tsx');
 const staffRsvpRowSource = readSource('apps/app/src/components/schedule/StaffRsvpPlayerRow.tsx');
 const staffRsvpBreakdownPanelSource = readSource('apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx');
 const staffRsvpReminderPanelSource = readSource('apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx');
 const staffRsvpBreakdownHookSource = readSource('apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts');
+const presentationalComponentTestSource = readSource('apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx');
 const summaryComponentTestSource = readSource('apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx');
 const rsvpHookTestSource = readSource('apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx');
 const staffRsvpHookTestSource = readSource('apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx');
@@ -104,11 +109,15 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
     it('keeps reusable schedule UI out of the detail page body', () => {
         [
             "import { DateTile } from '../components/schedule/DateTile';",
+            "import { CompactMeta } from '../components/schedule/CompactMeta';",
             "import { EventBrief } from '../components/schedule/EventBrief';",
             "import { GameReportSections } from '../components/schedule/GameReportSections';",
             "import { PlayerSwitcher } from '../components/schedule/PlayerSwitcher';",
+            "import { PracticeAttendancePanel } from '../components/schedule/PracticeAttendancePanel';",
             "import { ReportMarkdownText } from '../components/schedule/ReportMarkdownText';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
+            "import { ScoreStepper } from '../components/schedule/ScoreStepper';",
+            "import { Status } from '../components/schedule/ScheduleStatus';",
             "import { StaffRsvpBreakdownPanel } from '../components/schedule/StaffRsvpBreakdownPanel';",
             "import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';",
             'QuickAvailabilityPanel',
@@ -119,12 +128,16 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
         });
 
         [
+            /^function CompactMeta\b/m,
             /^function DateTile\b/m,
             /^function EventBrief\b/m,
             /^function EventSectionNav\b/m,
             /^function GameReportSections\b/m,
             /^function PlayerSwitcher\b/m,
+            /^function PracticeAttendancePanel\b/m,
             /^function ReportMarkdownText\b/m,
+            /^function ScoreStepper\b/m,
+            /^function Status\b/m,
             /^function StaffRsvpBreakdownPanel\b/m,
             /^function StaffRsvpReminderPanel\b/m,
             /^function QuickAvailabilityPanel\b/m,
@@ -135,12 +148,19 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
             expect(detailSource).not.toMatch(inlineDefinition);
         });
 
+        expect(compactMetaSource).toContain('export function CompactMeta');
+        expect(practiceAttendancePanelSource).toContain('export function PracticeAttendancePanel');
+        expect(practiceAttendancePanelSource).toContain('data-testid={`practice-attendance-row-${player.playerId}`}');
+        expect(scoreStepperSource).toContain('export function ScoreStepper');
+        expect(scoreStepperSource).toContain('aria-label={`${label} score down`}');
+        expect(scheduleStatusSource).toContain('export function Status');
         expect(availabilityPanelsSource).toContain('export function QuickAvailabilityPanel');
         expect(availabilityPanelsSource).toContain('export function AvailabilityNotesList');
         expect(availabilityPanelsSource).toContain('export function AttentionPanel');
         expect(staffRsvpRowSource).toContain('export function StaffRsvpPlayerRow');
         expect(staffRsvpBreakdownPanelSource).toContain('export function StaffRsvpBreakdownPanel');
         expect(staffRsvpReminderPanelSource).toContain('export function StaffRsvpReminderPanel');
+        expect(presentationalComponentTestSource).toContain("describe('ScheduleEventDetail presentational components'");
         expect(summaryComponentTestSource).toContain("describe('Schedule event summary components'");
     });
 

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -13,14 +13,18 @@ describe('ScheduleEventDetail decomposition contract', () => {
 
         [
             "import { AssignmentsSection } from '../components/schedule/AssignmentsSection';",
+            "import { CompactMeta } from '../components/schedule/CompactMeta';",
             "import { DateTile } from '../components/schedule/DateTile';",
             "import { EventBrief } from '../components/schedule/EventBrief';",
             "import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
             "import { GameReportSections } from '../components/schedule/GameReportSections';",
             "import { PlayerSwitcher } from '../components/schedule/PlayerSwitcher';",
+            "import { PracticeAttendancePanel } from '../components/schedule/PracticeAttendancePanel';",
             "import { ReportMarkdownText } from '../components/schedule/ReportMarkdownText';",
             "import { RideshareSection } from '../components/schedule/RideshareSection';",
+            "import { ScoreStepper } from '../components/schedule/ScoreStepper';",
+            "import { Status } from '../components/schedule/ScheduleStatus';",
             "import { StaffRsvpBreakdownPanel } from '../components/schedule/StaffRsvpBreakdownPanel';",
             "import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';",
             'QuickAvailabilityPanel',
@@ -33,23 +37,43 @@ describe('ScheduleEventDetail decomposition contract', () => {
         [
             /^function AssignmentCard\b/m,
             /^function AssignmentsSection\b/m,
+            /^function CompactMeta\b/m,
             /^function DateTile\b/m,
             /^function EventBrief\b/m,
             /^function EventDetailsPanel\b/m,
             /^function EventSectionNav\b/m,
             /^function GameReportSections\b/m,
             /^function PlayerSwitcher\b/m,
+            /^function PracticeAttendancePanel\b/m,
             /^function ReportMarkdownText\b/m,
             /^function RideOfferCard\b/m,
             /^function RideshareSection\b/m,
+            /^function ScoreStepper\b/m,
             /^function StaffRsvpBreakdownPanel\b/m,
             /^function StaffRsvpReminderPanel\b/m,
             /^function StaffRsvpPlayerRow\b/m,
+            /^function Status\b/m,
             /^function QuickAvailabilityPanel\b/m,
             /^function AttentionPanel\b/m
         ].forEach((inlineDefinition) => {
             expect(page).not.toMatch(inlineDefinition);
         });
+    });
+
+    it('keeps schedule detail utility controls in extracted presentational components', () => {
+        const compactMeta = readRepoFile('apps/app/src/components/schedule/CompactMeta.tsx');
+        const practiceAttendancePanel = readRepoFile('apps/app/src/components/schedule/PracticeAttendancePanel.tsx');
+        const scoreStepper = readRepoFile('apps/app/src/components/schedule/ScoreStepper.tsx');
+        const scheduleStatus = readRepoFile('apps/app/src/components/schedule/ScheduleStatus.tsx');
+        const focusedTests = readRepoFile('apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx');
+
+        expect(compactMeta).toContain('export function CompactMeta');
+        expect(practiceAttendancePanel).toContain('export function PracticeAttendancePanel');
+        expect(practiceAttendancePanel).toContain('onSelectStatus(player, status)');
+        expect(scoreStepper).toContain('export function ScoreStepper');
+        expect(scoreStepper).toContain('aria-label={`${label} score up`}');
+        expect(scheduleStatus).toContain('export function Status');
+        expect(focusedTests).toContain("describe('ScheduleEventDetail presentational components'");
     });
 
     it('keeps RSVP and rideshare workflows behind extracted hooks and page context', () => {


### PR DESCRIPTION
## Summary
- Extract `CompactMeta`, `Status`, `ScoreStepper`, and `PracticeAttendancePanel` from `ScheduleEventDetail.tsx` into typed schedule presentational components.
- Add focused component coverage for the extracted UI controls and attendance panel.
- Update ScheduleEventDetail decomposition source-contract tests to enforce the new component locations.

Refs #2063

## Validation
- `npx vitest run apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx tests/unit/app-schedule-detail-decomposition.test.js tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js tests/unit/schedule-event-detail-decomposition-contract.test.js --reporter=verbose`
- `npm run app:build`
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx --reporter=verbose` from `apps/app`