### PR TITLE
[codex] Add notification inbox retry

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -63,13 +63,16 @@ vi.mock('./NotificationInboxSheet', () => ({
     items,
     inboxState,
     onClose,
+    onRetry,
   }: {
     items: Array<{ id: string; text: string }>;
     inboxState: 'loading' | 'ready' | 'error';
     onClose: () => void;
+    onRetry?: () => void;
   }) => (
     <div role="dialog" aria-label="Notifications">
       <button type="button" aria-label="Close notifications" onClick={onClose}>Close</button>
+      {onRetry ? <button type="button" onClick={onRetry}>Retry notifications</button> : null}
       <div data-testid="notification-inbox-sheet-state">{inboxState}</div>
       {items.map((item) => (
         <div key={item.id}>{item.text}</div>
@@ -264,6 +267,56 @@ describe('AppShell', () => {
         expect.any(Function)
       );
     });
+  });
+
+  it('retries the open notification inbox subscription without closing the sheet', async () => {
+    const firstUnsubscribe = vi.fn();
+    const secondUnsubscribe = vi.fn();
+    subscribeToNotificationInboxMock
+      .mockReturnValueOnce(firstUnsubscribe)
+      .mockReturnValueOnce(secondUnsubscribe);
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+
+    await waitFor(() => {
+      expect(subscribeToNotificationInboxMock).toHaveBeenCalledTimes(1);
+    });
+
+    const onError = subscribeToNotificationInboxMock.mock.calls[0]?.[2] as ((error: unknown) => void) | undefined;
+    act(() => {
+      onError?.(new Error('offline'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-inbox-sheet-state').textContent).toBe('error');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry notifications' }));
+
+    await waitFor(() => {
+      expect(subscribeToNotificationInboxMock).toHaveBeenCalledTimes(2);
+    });
+    expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeTruthy();
+    expect(screen.getByTestId('notification-inbox-sheet-state').textContent).toBe('loading');
+
+    const onRetryItems = subscribeToNotificationInboxMock.mock.calls[1]?.[1] as ((items: NotificationInboxItem[]) => void) | undefined;
+    act(() => {
+      onRetryItems?.([]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-inbox-sheet-state').textContent).toBe('ready');
+    });
+    expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeTruthy();
   });
 
   it('clears cached inbox items when the signed-in uid changes while the sheet is closed', async () => {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -70,6 +70,7 @@ export function AppShell({ auth, children }: AppShellProps) {
   const [inboxOpen, setInboxOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<NotificationInboxItem[]>([]);
   const [inboxState, setInboxState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [inboxRetryKey, setInboxRetryKey] = useState(0);
   const [unreadCount, setUnreadCount] = useState(0);
   const [unreadState, setUnreadState] = useState<'loading' | 'ready' | 'error'>('loading');
   const { isDesktopWeb } = useShellLayout();
@@ -220,7 +221,11 @@ export function AppShell({ auth, children }: AppShellProps) {
       active = false;
       unsubscribe();
     };
-  }, [auth.user?.uid, inboxOpen]);
+  }, [auth.user?.uid, inboxOpen, inboxRetryKey]);
+
+  const handleRetryNotificationInbox = () => {
+    setInboxRetryKey((current) => current + 1);
+  };
 
   const handleMarkNotificationRead = async (uid: string, itemId: string) => {
     const mod = await loadNotificationInboxService();
@@ -467,6 +472,7 @@ export function AppShell({ auth, children }: AppShellProps) {
             inboxState={inboxState === 'idle' ? 'loading' : inboxState}
             uid={auth.user?.uid ?? ''}
             onClose={() => setInboxOpen(false)}
+            onRetry={handleRetryNotificationInbox}
             onMarkRead={handleMarkNotificationRead}
             onMarkAllRead={handleMarkAllNotificationsRead}
           />

--- a/apps/app/src/components/NotificationInboxSheet.tsx
+++ b/apps/app/src/components/NotificationInboxSheet.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Bell, CheckCheck, Loader2, X } from 'lucide-react';
+import { AlertCircle, Bell, CheckCheck, Loader2, RotateCcw, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { NotificationInboxItem } from '../lib/notificationInboxService';
 
@@ -7,11 +7,12 @@ interface NotificationInboxSheetProps {
     inboxState: 'loading' | 'ready' | 'error';
     uid: string;
     onClose: () => void;
+    onRetry?: () => void;
     onMarkRead: (uid: string, itemId: string) => Promise<void>;
     onMarkAllRead?: (uid: string, items: NotificationInboxItem[]) => Promise<void>;
 }
 
-export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMarkRead, onMarkAllRead }: NotificationInboxSheetProps) {
+export function NotificationInboxSheet({ items, inboxState, uid, onClose, onRetry, onMarkRead, onMarkAllRead }: NotificationInboxSheetProps) {
     const navigate = useNavigate();
     const unreadItems = items.filter((item) => !item.readAt);
 
@@ -58,6 +59,17 @@ export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMark
                     <AlertCircle className="h-10 w-10 text-red-300" aria-hidden="true" />
                     <p className="text-sm font-semibold text-gray-500">Could not load notifications</p>
                     <p className="text-xs text-gray-400">Check your connection and try again.</p>
+                    {onRetry ? (
+                        <button
+                            type="button"
+                            className="primary-button !h-10 !min-h-10 text-sm"
+                            onClick={onRetry}
+                            data-testid="notification-inbox-retry"
+                        >
+                            <RotateCcw className="h-4 w-4" aria-hidden="true" />
+                            Retry
+                        </button>
+                    ) : null}
                 </div>
             );
         }
@@ -79,7 +91,18 @@ export function NotificationInboxSheet({ items, inboxState, uid, onClose, onMark
                         data-testid="notification-inbox-error-banner"
                     >
                         <AlertCircle className="h-4 w-4 flex-none" aria-hidden="true" />
-                        Could not refresh — showing cached notifications.
+                        <span className="min-w-0 flex-1">Could not refresh — showing cached notifications.</span>
+                        {onRetry ? (
+                            <button
+                                type="button"
+                                className="ghost-button !h-8 !min-h-8 flex-none !border-red-200 !bg-white !px-2 !text-xs !text-red-700 hover:!bg-red-50"
+                                onClick={onRetry}
+                                data-testid="notification-inbox-retry"
+                            >
+                                <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+                                Retry
+                            </button>
+                        ) : null}
                     </div>
                 )}
                 <ul role="list" className="divide-y divide-gray-100">

--- a/tests/unit/app-notification-inbox-review.test.tsx
+++ b/tests/unit/app-notification-inbox-review.test.tsx
@@ -269,6 +269,26 @@ describe('Notification inbox review regressions', () => {
         expect(screen.queryByTestId('notification-inbox-loading')).toBeNull();
     });
 
+    it('shows a retry action for an empty error state and invokes the supplied handler', () => {
+        const onRetry = vi.fn();
+
+        render(
+            <NotificationInboxSheet
+                items={[]}
+                inboxState="error"
+                uid="user-1"
+                onClose={vi.fn()}
+                onRetry={onRetry}
+                onMarkRead={vi.fn(() => Promise.resolve())}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+        expect(screen.getByTestId('notification-inbox-error')).toBeTruthy();
+        expect(onRetry).toHaveBeenCalledTimes(1);
+    });
+
     it('shows items with an error banner when inboxState is error but prior items are loaded', () => {
         render(
             <NotificationInboxSheet
@@ -293,6 +313,36 @@ describe('Notification inbox review regressions', () => {
         expect(screen.getByTestId('notification-item-notif-2')).toBeTruthy();
         expect(screen.getByTestId('notification-inbox-error-banner')).toBeTruthy();
         expect(screen.queryByTestId('notification-inbox-error')).toBeNull();
+    });
+
+    it('shows a retry action in the cached-error banner and invokes the supplied handler', () => {
+        const onRetry = vi.fn();
+
+        render(
+            <NotificationInboxSheet
+                items={[
+                    notificationItem({
+                        id: 'notif-2',
+                        category: 'game_update',
+                        type: 'game_update',
+                        title: 'Game rescheduled',
+                        body: '',
+                        text: 'Game rescheduled',
+                        appRoute: '/schedule',
+                    }),
+                ]}
+                inboxState="error"
+                uid="user-1"
+                onClose={vi.fn()}
+                onRetry={onRetry}
+                onMarkRead={vi.fn(() => Promise.resolve())}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+        expect(screen.getByTestId('notification-inbox-error-banner')).toBeTruthy();
+        expect(onRetry).toHaveBeenCalledTimes(1);
     });
 
     it('shows "No notifications yet" only when inboxState is ready and items list is empty', () => {


### PR DESCRIPTION
## Summary
- Add in-sheet Retry actions for notification inbox empty-error and cached-error states.
- Wire AppShell retry handling so the full inbox subscription can restart while the sheet stays open.
- Add regression coverage for sheet retry actions and open-sheet AppShell resubscription.

Closes #2874

## Tests
- `npx vitest run tests/unit/app-notification-inbox-review.test.tsx apps/app/src/components/AppShell.test.tsx tests/unit/app-notification-bell.test.tsx --reporter=verbose`
- `npm run app:build`