### PR TITLE
[codex] Extend roster import player profile fields

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -129,7 +129,7 @@
                     <div id="content-csv-import" class="p-6 hidden">
                         <div class="mb-3">
                             <h2 class="text-xl font-bold">CSV Roster Import</h2>
-                            <p class="text-sm text-gray-600">Upload or paste a CSV with Name, Number, roster field label/key columns, and parent/guardian/contact columns such as Parent Email or Guardian Phone. Unknown headers and invalid field values are rejected before anything is saved.</p>
+                            <p class="text-sm text-gray-600">Upload or paste a CSV with Name, Number, profile columns such as Position, DOB, Gender, or Address, roster field label/key columns, and parent/guardian/contact columns such as Parent Email or Guardian Phone. Unknown headers and invalid field values are rejected before anything is saved.</p>
                         </div>
 
                         <div class="space-y-4">
@@ -142,7 +142,7 @@
                                 <label class="block text-sm font-medium text-gray-700 mb-2">CSV data</label>
                                 <textarea id="roster-csv-input" rows="8"
                                     class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono"
-                                    placeholder="Name,Number,Parent Name,Parent Email,Grade&#10;Avery Lee,4,Pat Lee,pat@example.com,6"></textarea>
+                                    placeholder="Name,Number,Position,DOB,Parent Name,Parent Email,Grade&#10;Avery Lee,4,Forward,2014-02-03,Pat Lee,pat@example.com,6"></textarea>
                             </div>
                             <button id="import-csv-btn" type="button"
                                 class="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Import CSV</button>

--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -174,6 +174,17 @@ function parseCheckboxValue(value) {
     return null;
 }
 
+function parseIsoDateValue(label, rawValue) {
+    const value = String(rawValue ?? '').trim();
+    if (value === '') return { value: '' };
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return { error: `${label} must use YYYY-MM-DD format.` };
+    const date = new Date(`${value}T00:00:00Z`);
+    if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+        return { error: `${label} must be a valid date.` };
+    }
+    return { value };
+}
+
 function parseRosterCsvFieldValue(field, rawValue) {
     const value = String(rawValue ?? '').trim();
     if (value === '') return { value: field.type === 'checkbox' ? false : '' };
@@ -185,12 +196,7 @@ function parseRosterCsvFieldValue(field, rawValue) {
     }
 
     if (field.type === 'date') {
-        if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return { error: `${field.label} must use YYYY-MM-DD format.` };
-        const date = new Date(`${value}T00:00:00Z`);
-        if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
-            return { error: `${field.label} must be a valid date.` };
-        }
-        return { value };
+        return parseIsoDateValue(field.label, value);
     }
 
     if (field.type === 'menu') {
@@ -267,6 +273,82 @@ const CONTACT_FIELD_ALIASES = new Map([
     ['relationship', 'relation']
 ]);
 
+const PROFILE_HEADER_ALIASES = new Map([
+    ['position', { profileField: 'position' }],
+    ['primaryposition', { profileField: 'position' }],
+    ['playerposition', { profileField: 'position' }],
+    ['pos', { profileField: 'position' }],
+    ['birthdate', { profileField: 'birthDate' }],
+    ['dateofbirth', { profileField: 'birthDate' }],
+    ['dob', { profileField: 'birthDate' }],
+    ['birthday', { profileField: 'birthDate' }],
+    ['gender', { profileField: 'gender' }],
+    ['sex', { profileField: 'gender' }],
+    ['street', { profileField: 'address', addressField: 'street' }],
+    ['streetaddress', { profileField: 'address', addressField: 'street' }],
+    ['address', { profileField: 'address', addressField: 'address1' }],
+    ['homeaddress', { profileField: 'address', addressField: 'address1' }],
+    ['address1', { profileField: 'address', addressField: 'address1' }],
+    ['addressline1', { profileField: 'address', addressField: 'address1' }],
+    ['line1', { profileField: 'address', addressField: 'address1' }],
+    ['address2', { profileField: 'address', addressField: 'address2' }],
+    ['addressline2', { profileField: 'address', addressField: 'address2' }],
+    ['line2', { profileField: 'address', addressField: 'address2' }],
+    ['street2', { profileField: 'address', addressField: 'address2' }],
+    ['unit', { profileField: 'address', addressField: 'address2' }],
+    ['apt', { profileField: 'address', addressField: 'address2' }],
+    ['apartment', { profileField: 'address', addressField: 'address2' }],
+    ['suite', { profileField: 'address', addressField: 'address2' }],
+    ['city', { profileField: 'address', addressField: 'city' }],
+    ['town', { profileField: 'address', addressField: 'city' }],
+    ['state', { profileField: 'address', addressField: 'state' }],
+    ['province', { profileField: 'address', addressField: 'state' }],
+    ['zip', { profileField: 'address', addressField: 'zip' }],
+    ['zipcode', { profileField: 'address', addressField: 'zip' }],
+    ['postalcode', { profileField: 'address', addressField: 'zip' }],
+    ['postal', { profileField: 'address', addressField: 'zip' }],
+    ['rosterstatus', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['playerstatus', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['participantstatus', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['memberstatus', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['playertype', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['participanttype', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['membertype', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['rostertype', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['rosterrole', { profileField: 'rosterStatus', statusMode: 'status' }],
+    ['staffstatus', { profileField: 'rosterStatus', statusMode: 'staffFlag' }],
+    ['nonplayerstatus', { profileField: 'rosterStatus', statusMode: 'nonPlayerFlag' }],
+    ['staff', { profileField: 'rosterStatus', statusMode: 'staffFlag' }],
+    ['isstaff', { profileField: 'rosterStatus', statusMode: 'staffFlag' }],
+    ['staffmember', { profileField: 'rosterStatus', statusMode: 'staffFlag' }],
+    ['nonplayer', { profileField: 'rosterStatus', statusMode: 'nonPlayerFlag' }],
+    ['isnonplayer', { profileField: 'rosterStatus', statusMode: 'nonPlayerFlag' }],
+    ['notaplayer', { profileField: 'rosterStatus', statusMode: 'nonPlayerFlag' }]
+]);
+
+const ROSTER_STATUS_VALUE_ALIASES = new Map([
+    ['player', 'player'],
+    ['athlete', 'player'],
+    ['participant', 'player'],
+    ['rosterplayer', 'player'],
+    ['activeplayer', 'player'],
+    ['staff', 'staff'],
+    ['coach', 'staff'],
+    ['headcoach', 'staff'],
+    ['assistantcoach', 'staff'],
+    ['manager', 'staff'],
+    ['teammanager', 'staff'],
+    ['admin', 'staff'],
+    ['administrator', 'staff'],
+    ['volunteer', 'staff'],
+    ['trainer', 'staff'],
+    ['nonplayer', 'non-player'],
+    ['nonathlete', 'non-player'],
+    ['notplayer', 'non-player'],
+    ['notaplayer', 'non-player'],
+    ['benchstaff', 'staff']
+]);
+
 function getContactHeaderMapping(normalizedHeader = '', label = '') {
     for (const group of CONTACT_HEADER_GROUPS) {
         if (!normalizedHeader.startsWith(group.prefix)) continue;
@@ -286,6 +368,16 @@ function getContactHeaderMapping(normalizedHeader = '', label = '') {
         };
     }
     return null;
+}
+
+function getProfileHeaderMapping(normalizedHeader = '', label = '') {
+    const profile = PROFILE_HEADER_ALIASES.get(normalizedHeader);
+    if (!profile) return null;
+    return {
+        type: 'profile',
+        label,
+        ...profile
+    };
 }
 
 function normalizeImportedContact(contact = {}) {
@@ -357,6 +449,59 @@ function buildRosterCsvContactPlan(contactValues = new Map(), rowNumber = 0) {
     return { guardians, contacts, familyContacts, inviteRequests, errors };
 }
 
+function normalizeRosterStatusProfile(status = '') {
+    const rosterStatus = String(status || '').trim();
+    const isStaff = rosterStatus === 'staff';
+    const nonPlayer = isStaff || rosterStatus === 'non-player';
+    return { rosterStatus, isStaff, nonPlayer };
+}
+
+function normalizeRosterStatusValue(rawValue, mapping = {}) {
+    const value = String(rawValue ?? '').trim();
+    if (!value) return { value: null };
+    const normalized = normalizeHeaderKey(value);
+    const alias = ROSTER_STATUS_VALUE_ALIASES.get(normalized);
+    if (alias) return { value: normalizeRosterStatusProfile(alias) };
+
+    if (mapping.statusMode === 'staffFlag' || mapping.statusMode === 'nonPlayerFlag') {
+        const parsed = parseCheckboxValue(value);
+        if (parsed === null) return { error: `${mapping.label} must be yes/no or a supported roster status.` };
+        const status = parsed
+            ? mapping.statusMode === 'staffFlag' ? 'staff' : 'non-player'
+            : 'player';
+        return { value: normalizeRosterStatusProfile(status) };
+    }
+
+    return { value: normalizeRosterStatusProfile(value) };
+}
+
+function parseRosterCsvProfileValue(mapping = {}, rawValue) {
+    const value = String(rawValue ?? '').trim();
+    if (!value) return { value: null };
+    if (mapping.profileField === 'birthDate') return parseIsoDateValue(mapping.label, value);
+    if (mapping.profileField === 'rosterStatus') return normalizeRosterStatusValue(value, mapping);
+    return { value };
+}
+
+function getProfileMappingDedupeKey(mapping = {}) {
+    if (mapping.profileField === 'address') return `address.${mapping.addressField}`;
+    return mapping.profileField || '';
+}
+
+function mergeProfileImportValues(existingProfile = {}, profileValues = {}, addressValues = {}) {
+    const nextProfile = {
+        ...existingProfile,
+        ...profileValues
+    };
+    if (Object.keys(addressValues).length > 0) {
+        nextProfile.address = {
+            ...(existingProfile.address || {}),
+            ...addressValues
+        };
+    }
+    return nextProfile;
+}
+
 export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers = [] } = {}) {
     const errors = [];
     const normalizedFields = normalizeRosterFieldDefinitions(fields);
@@ -392,6 +537,8 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
         if (contact) return { index, ...contact };
         const field = fieldByHeader.get(normalized);
         if (field) return { index, type: 'field', field, label: header };
+        const profile = getProfileHeaderMapping(normalized, header);
+        if (profile) return { index, ...profile };
         return { index, type: 'unknown', label: header };
     });
 
@@ -402,9 +549,10 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
     const seenTypes = new Set();
     const seenFields = new Set();
     const seenContacts = new Set();
+    const seenProfileFields = new Set();
     mappings.forEach((mapping) => {
         if (mapping.type === 'unknown') {
-            errors.push(`Unknown CSV header "${mapping.label}". Use Name, Number, a supported parent/guardian contact header, or a configured roster field label/key.`);
+            errors.push(`Unknown CSV header "${mapping.label}". Use Name, Number, a supported player profile header, a supported parent/guardian contact header, or a configured roster field label/key.`);
         } else if (mapping.type === 'name' || mapping.type === 'number') {
             if (seenTypes.has(mapping.type)) errors.push(`Duplicate ${mapping.type === 'name' ? 'name' : 'number'} header.`);
             seenTypes.add(mapping.type);
@@ -415,6 +563,10 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
             const contactKey = `${mapping.contactKey}:${mapping.contactField}`;
             if (seenContacts.has(contactKey)) errors.push(`Duplicate contact header for ${mapping.label}.`);
             seenContacts.add(contactKey);
+        } else if (mapping.type === 'profile') {
+            const profileKey = getProfileMappingDedupeKey(mapping);
+            if (seenProfileFields.has(profileKey)) errors.push(`Duplicate player profile header for ${mapping.label}.`);
+            seenProfileFields.add(profileKey);
         }
     });
 
@@ -430,12 +582,28 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
         let name = '';
         let number = '';
         const contactValues = new Map();
+        const profileValues = {};
+        const addressValues = {};
         const hasNumberColumn = mappings.some((mapping) => mapping.type === 'number');
         mappings.forEach((mapping) => {
             const rawValue = row[mapping.index] ?? '';
             if (mapping.type === 'name') name = String(rawValue || '').trim();
             if (mapping.type === 'number') number = String(rawValue || '').trim();
             if (mapping.type === 'field') values[mapping.field.key] = rawValue;
+            if (mapping.type === 'profile') {
+                const parsed = parseRosterCsvProfileValue(mapping, rawValue);
+                if (parsed.error) {
+                    errors.push(`Row ${rowNumber}: ${parsed.error}`);
+                } else if (parsed.value !== null && parsed.value !== '') {
+                    if (mapping.profileField === 'address') {
+                        addressValues[mapping.addressField] = parsed.value;
+                    } else if (mapping.profileField === 'rosterStatus') {
+                        Object.assign(profileValues, parsed.value);
+                    } else {
+                        profileValues[mapping.profileField] = parsed.value;
+                    }
+                }
+            }
             if (mapping.type === 'contact') {
                 const existing = contactValues.get(mapping.contactKey) || {
                     bucket: mapping.contactBucket,
@@ -476,7 +644,7 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
         const existing = matches[0];
         const existingProfile = existing?.profile || {};
         const profile = {
-            ...existingProfile,
+            ...mergeProfileImportValues(existingProfile, profileValues, addressValues),
             customFields: {
                 ...(existingProfile.customFields || {}),
                 ...publicValues
@@ -484,6 +652,7 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
         };
         const payload = { name, profile };
         if (hasNumberColumn) payload.number = number;
+        if (Object.prototype.hasOwnProperty.call(profileValues, 'position')) payload.position = profileValues.position;
         const mergedGuardians = mergeImportedContacts(existing?.guardians || existing?.parents || existing?.familyContacts || [], contactPlan.guardians);
         const mergedContacts = mergeImportedContacts(existing?.contacts || [], contactPlan.contacts);
         const privateRosterFields = Object.keys(privateValues).length > 0 ? privateValues : null;

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -66,9 +66,150 @@ describe('roster CSV import planning', () => {
 
         const invalid = planRosterCsvImport({ fields, csvText: 'Name,Favorite Snack\nAvery Lee,Crackers' });
         expect(invalid.errors).toEqual([
-            'Unknown CSV header "Favorite Snack". Use Name, Number, a supported parent/guardian contact header, or a configured roster field label/key.'
+            'Unknown CSV header "Favorite Snack". Use Name, Number, a supported player profile header, a supported parent/guardian contact header, or a configured roster field label/key.'
         ]);
         expect(invalid.operations).toEqual([]);
+    });
+
+    it('maps common unconfigured player profile columns into the import payload', () => {
+        const plan = planRosterCsvImport({
+            fields: [],
+            existingPlayers: [{
+                id: 'p1',
+                name: 'Avery Lee',
+                number: '3',
+                profile: {
+                    address: { city: 'Old City' },
+                    customFields: { grade: '6' }
+                }
+            }],
+            csvText: [
+                'Name,Jersey,Position,Date of Birth,Gender,Street,Address1,Address Line 2,City,State,Zip,Roster Status',
+                'Avery Lee,4,Forward,2014-02-03,Female,123 Main,PO Box 8,Apt 2,Kansas City,MO,64110,Player',
+                'Coach Kim,,Coach,,Female,,,,,,,Staff'
+            ].join('\n')
+        });
+
+        expect(plan.errors).toEqual([]);
+        expect(plan.operations).toHaveLength(2);
+        expect(plan.operations[0]).toMatchObject({
+            type: 'update',
+            playerId: 'p1',
+            payload: {
+                name: 'Avery Lee',
+                number: '4',
+                position: 'Forward',
+                profile: {
+                    position: 'Forward',
+                    birthDate: '2014-02-03',
+                    gender: 'Female',
+                    address: {
+                        street: '123 Main',
+                        address1: 'PO Box 8',
+                        address2: 'Apt 2',
+                        city: 'Kansas City',
+                        state: 'MO',
+                        zip: '64110'
+                    },
+                    rosterStatus: 'player',
+                    isStaff: false,
+                    nonPlayer: false,
+                    customFields: { grade: '6' }
+                }
+            }
+        });
+        expect(plan.operations[1]).toMatchObject({
+            type: 'add',
+            payload: {
+                name: 'Coach Kim',
+                position: 'Coach',
+                profile: {
+                    position: 'Coach',
+                    gender: 'Female',
+                    rosterStatus: 'staff',
+                    isStaff: true,
+                    nonPlayer: true
+                }
+            }
+        });
+    });
+
+    it('keeps configured roster fields ahead of built-in profile aliases', () => {
+        const plan = planRosterCsvImport({
+            fields: [
+                { key: 'position', label: 'Position', type: 'text', active: true },
+                { key: 'gender', label: 'Gender', type: 'text', active: true }
+            ],
+            csvText: 'Name,Position,Gender\nAvery Lee,Forward,Female'
+        });
+
+        expect(plan.errors).toEqual([]);
+        expect(plan.operations).toHaveLength(1);
+        expect(plan.operations[0]).toMatchObject({
+            payload: {
+                name: 'Avery Lee',
+                profile: {
+                    customFields: {
+                        position: 'Forward',
+                        gender: 'Female'
+                    }
+                }
+            }
+        });
+        expect(plan.operations[0].payload).not.toHaveProperty('position');
+        expect(plan.operations[0].payload.profile).not.toHaveProperty('gender');
+    });
+
+    it('normalizes staff and non-player status flag aliases', () => {
+        const staffPlan = planRosterCsvImport({
+            fields: [],
+            csvText: [
+                'Name,Staff?',
+                'Coach Kim,yes',
+                'Avery Lee,no'
+            ].join('\n')
+        });
+
+        expect(staffPlan.errors).toEqual([]);
+        expect(staffPlan.operations.map((operation) => operation.payload.profile)).toEqual([
+            expect.objectContaining({ rosterStatus: 'staff', isStaff: true, nonPlayer: true }),
+            expect.objectContaining({ rosterStatus: 'player', isStaff: false, nonPlayer: false })
+        ]);
+
+        const nonPlayerPlan = planRosterCsvImport({
+            fields: [],
+            csvText: [
+                'Name,Non Player',
+                'Alex Manager,true',
+                'Avery Lee,false'
+            ].join('\n')
+        });
+
+        expect(nonPlayerPlan.errors).toEqual([]);
+        expect(nonPlayerPlan.operations.map((operation) => operation.payload.profile)).toEqual([
+            expect.objectContaining({ rosterStatus: 'non-player', isStaff: false, nonPlayer: true }),
+            expect.objectContaining({ rosterStatus: 'player', isStaff: false, nonPlayer: false })
+        ]);
+    });
+
+    it('rejects invalid built-in profile dates, status flags, and duplicate profile aliases', () => {
+        const duplicate = planRosterCsvImport({
+            fields: [],
+            csvText: 'Name,DOB,Birthday\nAvery Lee,2014-02-03,2014-02-03'
+        });
+        expect(duplicate.errors).toEqual(['Duplicate player profile header for Birthday.']);
+        expect(duplicate.operations).toEqual([]);
+
+        const invalid = planRosterCsvImport({
+            fields: [],
+            csvText: 'Name,DOB,Staff?\nAvery Lee,02/03/2014,maybe'
+        });
+
+        expect(invalid.operations).toEqual([]);
+        expect(invalid.errors).toEqual([
+            'Row 2: DOB must use YYYY-MM-DD format.',
+            'Row 2: Staff? must be yes/no or a supported roster status.'
+        ]);
     });
 
     it('imports parent, guardian, and contact columns with invite metadata', () => {
@@ -230,7 +371,8 @@ describe('roster CSV import planning', () => {
     it('describes parent and guardian contact columns in the roster CSV import UI', () => {
         const page = readFileSync('edit-roster.html', 'utf8');
 
+        expect(page).toContain('profile columns such as Position, DOB, Gender, or Address');
         expect(page).toContain('parent/guardian/contact columns such as Parent Email or Guardian Phone');
-        expect(page).toContain('Name,Number,Parent Name,Parent Email,Grade');
+        expect(page).toContain('Name,Number,Position,DOB,Parent Name,Parent Email,Grade');
     });
 });


### PR DESCRIPTION
## Summary
- Recognize common player profile CSV headers for position, DOB/birthday, gender, address, and roster status/staff flags.
- Map unconfigured profile values into the import operation payload while keeping configured roster fields and contact columns unchanged.
- Add validation coverage for built-in profile date/status aliases and refresh the legacy CSV help copy.

Refs #959

## Tests
- `npx vitest run tests/unit/roster-csv-import.test.js --reporter=verbose`
- `npx vitest run tests/unit/roster-csv-import.test.js tests/unit/roster-profile-fields.test.js --reporter=verbose`