### PR TITLE
[codex] Clarify Sports Connect setup state

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -511,7 +511,7 @@
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                             <p id="registration-connection-help" class="text-xs text-blue-700">Save a Sports Connect provider mapping as metadata. A future connector is required before roster snapshots can be synced.</p>
                             <button id="registration-refresh-btn" type="button" disabled aria-disabled="true" class="shrink-0 cursor-not-allowed rounded-lg border border-slate-200 bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500">
-                                Sync unavailable
+                                Metadata only
                             </button>
                         </div>
                     </div>
@@ -555,7 +555,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=64';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources } from './js/db.js?v=64';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
@@ -770,37 +770,16 @@
             return isSportsConnectProvider(provider) ? 'sports-connect' : '';
         }
 
-        function getSavedRegistrationProvider() {
-            return String(
-                currentRegistrationSource?.provider ||
-                currentRegistrationSource?.providerName ||
-                currentRegistrationSource?.providerId ||
-                ''
-            ).trim();
-        }
-
-        function hasUnsavedRegistrationSyncChanges(provider, externalTeamId) {
-            if (!currentTeamId || !isSportsConnectProvider(provider)) {
-                return false;
-            }
-            return normalizeRegistrationProviderKey(provider) !== normalizeRegistrationProviderKey(getSavedRegistrationProvider())
-                || externalTeamId !== getRegistrationSourceValue({ registrationSource: currentRegistrationSource || {} }, 'externalTeamId');
-        }
-
-        function getRegistrationMetadataStatus(provider, externalTeamId) {
-            return getRegistrationProviderCapability(provider, externalTeamId).label;
-        }
-
         function getRegistrationProviderCapability(provider, externalTeamId, source = {}) {
             const hasProvider = Boolean(String(provider || '').trim());
             const hasExternalTeamId = Boolean(String(externalTeamId || '').trim());
-            const hasLiveConnection = ['live_connected', 'sync_success'].includes(source?.connectionStatus) && source?.syncEnabled === true;
             if (!hasProvider) {
                 return {
                     state: 'not_configured',
                     connectionStatus: 'not_configured',
                     label: 'Not configured',
                     helpText: 'Choose a provider and team mapping to save registration metadata.',
+                    refreshLabel: 'Metadata only',
                     canRefresh: false,
                     syncEnabled: false
                 };
@@ -811,28 +790,20 @@
                     connectionStatus: 'metadata_incomplete',
                     label: 'Metadata incomplete. Add provider mapping.',
                     helpText: 'Add the provider team ID or mapping to finish setup.',
+                    refreshLabel: 'Metadata only',
                     canRefresh: false,
                     syncEnabled: false
-                };
-            }
-            if (hasProvider && hasLiveConnection) {
-                return {
-                    state: 'live_connected',
-                    connectionStatus: 'live_connected',
-                    label: 'Live connected',
-                    helpText: 'Live provider refresh is available for this registration connection.',
-                    canRefresh: true,
-                    syncEnabled: true
                 };
             }
             const isSportsConnect = isSportsConnectProvider(provider);
             return {
                 state: 'metadata_configured',
                 connectionStatus: 'metadata_configured',
-                label: isSportsConnect ? 'Metadata saved; live sync unavailable' : 'Registration metadata only. No live sync.',
+                label: isSportsConnect ? 'Sports Connect metadata-only setup saved' : 'Registration metadata only. No live sync.',
                 helpText: isSportsConnect
-                    ? 'Sports Connect metadata is saved for reference only. Live refresh and re-import require a future provider connector.'
-                    : 'This provider mapping is saved as metadata only. Manual refresh stays unavailable until a live connector exists.',
+                    ? 'Sports Connect metadata is saved only in ALL PLAYS. No live Sports Connect fetch runs from Edit Team yet; refresh and re-import require a future provider connector.'
+                    : 'This provider mapping is saved as metadata only. Edit Team does not run live provider fetches yet.',
+                refreshLabel: 'Metadata only',
                 canRefresh: false,
                 syncEnabled: false
             };
@@ -861,20 +832,15 @@
             const capability = getRegistrationProviderCapability(provider, externalTeamId, source);
             const lastSyncTime = getRegistrationLastSyncTime(source);
             const refreshButton = document.getElementById('registration-refresh-btn');
-            const hasUnsavedSyncChanges = hasUnsavedRegistrationSyncChanges(provider, externalTeamId);
-            let helpText = capability.helpText;
-
-            if (capability.canRefresh && !hasUnsavedSyncChanges && source.lastSyncStatus === 'error' && source.lastSyncError) {
-                helpText = `Last sync error: ${source.lastSyncError}`;
-            }
 
             document.getElementById('registrationLastSyncStatus').value = capability.label;
             document.getElementById('registration-connection-status').textContent = capability.label;
             document.getElementById('registration-sync-status').textContent = capability.label;
             document.getElementById('registration-sync-time').textContent = formatRegistrationSyncTime(lastSyncTime);
-            document.getElementById('registration-connection-help').textContent = helpText;
+            document.getElementById('registration-connection-help').textContent = capability.helpText;
             refreshButton.disabled = !capability.canRefresh;
             refreshButton.setAttribute('aria-disabled', String(refreshButton.disabled));
+            refreshButton.textContent = capability.refreshLabel || 'Metadata only';
             refreshButton.classList.toggle('cursor-not-allowed', refreshButton.disabled);
             refreshButton.classList.toggle('border-slate-200', refreshButton.disabled);
             refreshButton.classList.toggle('bg-slate-100', refreshButton.disabled);
@@ -908,54 +874,12 @@
             renderRegistrationConnectionStatus({});
         }
 
-        async function handleRegistrationProviderSync() {
-            const button = document.getElementById('registration-refresh-btn');
-            if (!currentTeamId || button.disabled) return;
+        function handleRegistrationProviderSync() {
             const provider = document.getElementById('registrationProviderName').value.trim();
             const externalTeamId = document.getElementById('registrationExternalTeamId').value.trim();
             const capability = getRegistrationProviderCapability(provider, externalTeamId, currentRegistrationSource || {});
-            if (!capability.canRefresh) {
-                renderRegistrationConnectionStatus(currentRegistrationSource || {});
-                document.getElementById('registration-connection-help').textContent = capability.helpText;
-                return;
-            }
-
-            const originalText = button.textContent;
-            let finalHelpText = '';
-            button.disabled = true;
-            button.setAttribute('aria-disabled', 'true');
-            button.textContent = 'Syncing...';
-            document.getElementById('registration-connection-help').textContent = 'Fetching Sports Connect registration snapshot...';
-
-            try {
-                const result = await syncRegistrationProvider(currentTeamId);
-                const refreshedTeam = await getTeam(currentTeamId);
-                if (refreshedTeam?.registrationSource) {
-                    currentRegistrationSource = { ...refreshedTeam.registrationSource };
-                } else {
-                    currentRegistrationSource = {
-                        ...(currentRegistrationSource || {}),
-                        lastSyncStatus: 'success',
-                        lastSyncAt: result?.fetchedAt || new Date().toISOString(),
-                        playerCount: result?.playerCount || 0
-                    };
-                }
-                finalHelpText = `Synced ${Number(result?.playerCount || 0)} Sports Connect player${Number(result?.playerCount || 0) === 1 ? '' : 's'}. Open roster import to preview changes.`;
-            } catch (error) {
-                currentRegistrationSource = {
-                    ...(currentRegistrationSource || {}),
-                    lastSyncStatus: 'error',
-                    lastSyncAt: new Date().toISOString(),
-                    lastSyncError: error?.message || 'Sports Connect sync failed.'
-                };
-                renderRegistrationConnectionStatus(currentRegistrationSource || {});
-            } finally {
-                button.textContent = originalText;
-                renderRegistrationConnectionStatus(currentRegistrationSource || {});
-                if (finalHelpText) {
-                    document.getElementById('registration-connection-help').textContent = finalHelpText;
-                }
-            }
+            renderRegistrationConnectionStatus(currentRegistrationSource || {});
+            document.getElementById('registration-connection-help').textContent = capability.helpText;
         }
 
         function buildRegistrationSourcePayload() {

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -633,8 +633,8 @@ describe('edit team admin access persistence', () => {
         expect(html).toContain('Sports Connect live sync is unavailable until a connector is added.');
         expect(html).toContain('function getRegistrationProviderCapability(provider, externalTeamId, source = {})');
         expect(html).toContain("state: 'metadata_configured'");
-        expect(html).toContain("state: 'live_connected'");
-        expect(html).toContain('Sync unavailable');
+        expect(html).not.toContain("state: 'live_connected'");
+        expect(html).toContain('Metadata only');
         expect(html).toContain('id="team-create-mode-registration"');
         expect(html).toContain('No registration sources are configured yet. Start with a blank team or load provider data before using this import path.');
         expect(html).toContain('registrationMode.setAttribute(\'aria-disabled\', String(registrationMode.disabled));');
@@ -1125,9 +1125,9 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('registrationProviderName').value).toBe('Sports Connect');
             expect(env.elements.get('registrationExternalTeamId').value).toBe('SC-123');
             expect(env.elements.get('registrationCopiedTeamId').value).toBe('team-1');
-            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Metadata saved; live sync unavailable');
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Metadata saved; live sync unavailable');
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Sports Connect metadata-only setup saved');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata-only setup saved');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Sports Connect metadata-only setup saved');
             expect(env.elements.get('registration-sync-time').textContent).toContain('2026');
             expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
 
@@ -1196,11 +1196,12 @@ describe('edit team admin access persistence', () => {
             env.elements.get('registrationExternalTeamId').value = 'SC-987';
             await env.elements.get('registrationProviderName').dispatchEvent(new MockEvent('change'));
 
-            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Metadata saved; live sync unavailable');
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Metadata saved; live sync unavailable');
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Sports Connect metadata-only setup saved');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata-only setup saved');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Sports Connect metadata-only setup saved');
             expect(env.elements.get('registration-connection-help').textContent).toContain('future provider connector');
             expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
+            expect(env.elements.get('registration-refresh-btn').textContent).toBe('Metadata only');
             await env.elements.get('registration-refresh-btn').click();
             expect(syncCalls).toBe(0);
 
@@ -1214,7 +1215,7 @@ describe('edit team admin access persistence', () => {
                 connectionStatus: 'metadata_configured',
                 providerCapability: 'metadata_configured',
                 syncEnabled: false,
-                lastSyncStatus: 'Metadata saved; live sync unavailable'
+                lastSyncStatus: 'Sports Connect metadata-only setup saved'
             });
         } finally {
             env.cleanup();
@@ -1251,7 +1252,7 @@ describe('edit team admin access persistence', () => {
 
         const env = await bootEditTeam(initialState);
         try {
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Metadata saved; live sync unavailable');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Sports Connect metadata-only setup saved');
             expect(env.elements.get('registration-connection-help').textContent).toContain('future provider connector');
             expect(env.elements.get('registration-connection-help').textContent).not.toContain('Connector failed upstream');
         } finally {

--- a/tests/unit/edit-team-registration-sync.test.js
+++ b/tests/unit/edit-team-registration-sync.test.js
@@ -5,51 +5,33 @@ function readEditTeam() {
     return readFileSync(new URL('../../edit-team.html', import.meta.url), 'utf8');
 }
 
-function readDb() {
-    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
-}
-
-function readFunctions() {
-    return readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
-}
-
-function readSportsConnectSyncCore() {
-    return readFileSync(new URL('../../functions/sports-connect-registration-sync.cjs', import.meta.url), 'utf8');
-}
-
 describe('edit team Sports Connect registration sync wiring', () => {
-    it('keeps Sports Connect metadata wiring while manual sync remains disabled', () => {
+    it('shows Sports Connect setup as metadata-only and keeps manual fetch unavailable', () => {
         const source = readEditTeam();
-        const dbSource = readDb();
-        const functionsSource = readFunctions();
-        const coreSource = readSportsConnectSyncCore();
 
-        expect(source).toContain('syncRegistrationProvider } from');
         expect(source).toContain('id="registration-refresh-btn"');
+        expect(source).toContain('Metadata only');
         expect(source).toContain('function handleRegistrationProviderSync()');
-        expect(source).toContain('await syncRegistrationProvider(currentTeamId)');
-        expect(source).toContain('function hasUnsavedRegistrationSyncChanges(provider, externalTeamId)');
         expect(source).toContain('function getRegistrationProviderCapability(provider, externalTeamId, source = {})');
-        expect(source).toContain("['live_connected', 'sync_success'].includes(source?.connectionStatus) && source?.syncEnabled === true");
         expect(source).toContain('Sports Connect live sync is unavailable until a connector is added.');
         expect(source).toContain("state: 'metadata_configured'");
-        expect(source).toContain("state: 'live_connected'");
+        expect(source).toContain("label: isSportsConnect ? 'Sports Connect metadata-only setup saved' : 'Registration metadata only. No live sync.'");
+        expect(source).toContain('No live Sports Connect fetch runs from Edit Team yet');
         expect(source).toContain("canRefresh: false");
         expect(source).toContain("syncEnabled: false");
-        expect(source).toContain("canRefresh: true");
-        expect(source).toContain("syncEnabled: true");
         expect(source).toContain("refreshButton.disabled = !capability.canRefresh;");
-        expect(source).toContain("if (!capability.canRefresh) {");
+        expect(source).toContain("refreshButton.textContent = capability.refreshLabel || 'Metadata only';");
         expect(source).toContain("providerCapability: capability.state");
         expect(source).toContain('syncEnabled: capability.syncEnabled');
-        expect(source).toContain('Open roster import to preview changes.');
+        expect(source).not.toContain('syncRegistrationProvider } from');
+        expect(source).not.toContain('await syncRegistrationProvider(currentTeamId)');
+        expect(source).not.toContain("state: 'live_connected'");
+        expect(source).not.toContain('Live connected');
+        expect(source).not.toContain("canRefresh: true");
+        expect(source).not.toContain("syncEnabled: true");
+        expect(source).not.toContain('Fetching Sports Connect registration snapshot');
+        expect(source).not.toContain('Open roster import to preview changes.');
         expect(source).not.toContain('Manual refresh unavailable');
-
-        expect(dbSource).toContain("httpsCallable(functions, 'syncRegistrationProvider')");
-        expect(functionsSource).toContain('exports.syncRegistrationProvider = functions.https.onCall');
-        expect(functionsSource).toContain('buildSportsConnectTeamUpdate');
-        expect(coreSource).toContain('registrationRosterSnapshot');
-        expect(coreSource).not.toContain('source.syncUrl');
     });
 
     it('keeps registration provider capability states explicit for metadata-only providers', () => {
@@ -68,35 +50,34 @@ describe('edit team Sports Connect registration sync wiring', () => {
             "helpText: 'Add the provider team ID or mapping to finish setup.'",
             "state: 'metadata_configured'",
             "connectionStatus: 'metadata_configured'",
-            "label: isSportsConnect ? 'Metadata saved; live sync unavailable' : 'Registration metadata only. No live sync.'",
-            "? 'Sports Connect metadata is saved for reference only. Live refresh and re-import require a future provider connector.'",
-            "state: 'live_connected'",
-            "connectionStatus: 'live_connected'",
-            "canRefresh: true",
-            "syncEnabled: true"
+            "label: isSportsConnect ? 'Sports Connect metadata-only setup saved' : 'Registration metadata only. No live sync.'",
+            "? 'Sports Connect metadata is saved only in ALL PLAYS. No live Sports Connect fetch runs from Edit Team yet; refresh and re-import require a future provider connector.'",
+            "refreshLabel: 'Metadata only'"
         ].forEach((snippet) => {
             expect(capabilitySource).toContain(snippet);
         });
 
-        expect(capabilitySource).toContain("const hasLiveConnection = ['live_connected', 'sync_success'].includes(source?.connectionStatus) && source?.syncEnabled === true;");
-        expect(capabilitySource).toContain("if (hasProvider && hasLiveConnection) {");
         expect(capabilitySource).toContain('canRefresh: false');
         expect(capabilitySource).toContain('syncEnabled: false');
+        expect(capabilitySource).not.toContain("state: 'live_connected'");
+        expect(capabilitySource).not.toContain("connectionStatus: 'live_connected'");
+        expect(capabilitySource).not.toContain('Live connected');
+        expect(capabilitySource).not.toContain('canRefresh: true');
+        expect(capabilitySource).not.toContain('syncEnabled: true');
     });
 
-    it('does not call the Sports Connect sync callable when refresh is unavailable', () => {
+    it('does not call the Sports Connect sync callable from the refresh handler', () => {
         const source = readEditTeam();
         const syncHandlerSource = source.slice(
-            source.indexOf('async function handleRegistrationProviderSync()'),
+            source.indexOf('function handleRegistrationProviderSync()'),
             source.indexOf('function buildRegistrationSourcePayload()')
         );
 
-        expect(syncHandlerSource).toContain('if (!currentTeamId || button.disabled) return;');
         expect(syncHandlerSource).toContain('const capability = getRegistrationProviderCapability(provider, externalTeamId, currentRegistrationSource || {});');
-        expect(syncHandlerSource).toContain('if (!capability.canRefresh) {');
         expect(syncHandlerSource).toContain('renderRegistrationConnectionStatus(currentRegistrationSource || {});');
         expect(syncHandlerSource).toContain("document.getElementById('registration-connection-help').textContent = capability.helpText;");
-        expect(syncHandlerSource).toContain('return;');
-        expect(syncHandlerSource.indexOf('return;')).toBeLessThan(syncHandlerSource.indexOf('await syncRegistrationProvider(currentTeamId)'));
+        expect(syncHandlerSource).not.toContain('syncRegistrationProvider');
+        expect(syncHandlerSource).not.toContain('Syncing');
+        expect(syncHandlerSource).not.toContain('Fetching Sports Connect registration snapshot');
     });
 });

--- a/tests/unit/sports-connect-metadata-only-contract.test.js
+++ b/tests/unit/sports-connect-metadata-only-contract.test.js
@@ -16,15 +16,18 @@ describe('Sports Connect metadata-only product contract', () => {
         expect(workflow).toContain('the import button does not pull fresh Sports Connect data immediately');
     });
 
-    it('keeps Edit Team metadata-only Sports Connect refresh disabled until a live connector marks it available', () => {
+    it('keeps Edit Team Sports Connect setup metadata-only with no live fetch path', () => {
         const editTeam = readSource('edit-team.html');
 
         expect(editTeam).toContain('Selecting Sports Connect saves metadata only; it does not fetch live provider data today.');
-        expect(editTeam).toContain("const hasLiveConnection = ['live_connected', 'sync_success'].includes(source?.connectionStatus) && source?.syncEnabled === true;");
-        expect(editTeam).toContain("canRefresh: true,");
+        expect(editTeam).toContain('Sports Connect metadata-only setup saved');
+        expect(editTeam).toContain('No live Sports Connect fetch runs from Edit Team yet');
+        expect(editTeam).toContain('Metadata only');
         expect(editTeam).toContain("canRefresh: false,");
         expect(editTeam).toContain('refreshButton.disabled = !capability.canRefresh;');
-        expect(editTeam).toContain('Sports Connect metadata is saved for reference only. Live refresh and re-import require a future provider connector.');
+        expect(editTeam).not.toContain("canRefresh: true,");
+        expect(editTeam).not.toContain("state: 'live_connected'");
+        expect(editTeam).not.toContain('await syncRegistrationProvider(currentTeamId)');
     });
 
     it('prevents saved client metadata from choosing the Sports Connect backend endpoint', () => {


### PR DESCRIPTION
## Summary
- Show Sports Connect setup on Edit Team as a metadata-only saved state instead of a live connection.
- Keep the refresh control disabled and labeled as metadata-only, with inline copy that says no live Sports Connect fetch runs from Edit Team yet.
- Remove the Edit Team live sync callable path and update focused unit coverage for non-connected status and non-fetch refresh behavior.

## Tests
- `npx vitest run tests/unit/edit-team-registration-sync.test.js tests/unit/edit-team-admin-access-persistence.test.js tests/unit/sports-connect-metadata-only-contract.test.js --reporter=verbose`

Fixes #2881