### PR TITLE
[codex] Share staff RSVP availability loads

### DIFF
--- a/apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx
@@ -1,16 +1,12 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-    loadStaffRsvpReminderPreview,
-    sendStaffRsvpReminder
-} from '../../lib/scheduleService';
+import { sendStaffRsvpReminder } from '../../lib/scheduleService';
 import { ScheduleEventDetailProvider } from '../../pages/schedule/ScheduleEventDetailContext';
 import { StaffRsvpReminderPanel } from './StaffRsvpReminderPanel';
 import type { AuthState } from '../../lib/types';
 
 vi.mock('../../lib/scheduleService', () => ({
-    loadStaffRsvpReminderPreview: vi.fn(),
     sendStaffRsvpReminder: vi.fn()
 }));
 
@@ -55,20 +51,31 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
     } as any;
 }
 
-function renderPanel(eventOverrides: Record<string, unknown> = {}) {
-    return render(
-        <ScheduleEventDetailProvider
-            value={{
-                auth,
-                event: buildEvent(eventOverrides),
-                childEvents: [buildEvent(eventOverrides)],
-                refreshEvent: vi.fn(),
-                updateEvents: vi.fn()
-            }}
-        >
-            <StaffRsvpReminderPanel />
-        </ScheduleEventDetailProvider>
-    );
+function createStaffRsvpLoader() {
+    return {
+        loadBreakdown: vi.fn(),
+        loadReminderPreview: vi.fn(),
+        invalidateEvent: vi.fn()
+    };
+}
+
+function renderPanel(eventOverrides: Record<string, unknown> = {}, staffRsvpLoader = createStaffRsvpLoader()) {
+    return {
+        ...render(
+            <ScheduleEventDetailProvider
+                value={{
+                    auth,
+                    event: buildEvent(eventOverrides),
+                    childEvents: [buildEvent(eventOverrides)],
+                    refreshEvent: vi.fn(),
+                    updateEvents: vi.fn()
+                }}
+            >
+                <StaffRsvpReminderPanel staffRsvpLoader={staffRsvpLoader} />
+            </ScheduleEventDetailProvider>
+        ),
+        staffRsvpLoader
+    };
 }
 
 describe('StaffRsvpReminderPanel', () => {
@@ -79,18 +86,20 @@ describe('StaffRsvpReminderPanel', () => {
     });
 
     it('loads reminder preview and sends a confirmed reminder', async () => {
-        vi.mocked(loadStaffRsvpReminderPreview).mockResolvedValue(preview);
+        const staffRsvpLoader = createStaffRsvpLoader();
+        staffRsvpLoader.loadReminderPreview.mockResolvedValue(preview);
         vi.mocked(sendStaffRsvpReminder).mockResolvedValue({
             ...preview,
             emailSentCount: 3
         });
         vi.spyOn(window, 'confirm').mockReturnValue(true);
 
-        renderPanel();
+        renderPanel({}, staffRsvpLoader);
 
         await waitFor(() => {
             expect(screen.getByText('Staff RSVP reminder')).toBeTruthy();
         });
+        expect(staffRsvpLoader.loadReminderPreview).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user);
         expect(screen.getByText('2 no-response players · 3 eligible parent/guardian emails.')).toBeTruthy();
 
         fireEvent.click(screen.getByRole('button', { name: 'Send reminder' }));
@@ -102,15 +111,16 @@ describe('StaffRsvpReminderPanel', () => {
     });
 
     it('does not render when there are no missing player RSVPs', async () => {
-        vi.mocked(loadStaffRsvpReminderPreview).mockResolvedValue({
+        const staffRsvpLoader = createStaffRsvpLoader();
+        staffRsvpLoader.loadReminderPreview.mockResolvedValue({
             ...preview,
             missingPlayerCount: 0
         });
 
-        renderPanel();
+        renderPanel({}, staffRsvpLoader);
 
         await waitFor(() => {
-            expect(loadStaffRsvpReminderPreview).toHaveBeenCalled();
+            expect(staffRsvpLoader.loadReminderPreview).toHaveBeenCalled();
         });
         expect(screen.queryByText('Staff RSVP reminder')).toBeNull();
     });

--- a/apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
-  loadStaffRsvpReminderPreview,
   sendStaffRsvpReminder,
+  type StaffRsvpAvailabilityLoader,
   type StaffRsvpReminderSendResult
 } from '../../lib/scheduleService';
 import { type StaffRsvpReminderPreview } from '../../lib/scheduleLogic';
 import { useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
 
-export function StaffRsvpReminderPanel({ refreshToken = 0 }: { refreshToken?: number }) {
+export function StaffRsvpReminderPanel({ refreshToken = 0, staffRsvpLoader }: { refreshToken?: number; staffRsvpLoader: StaffRsvpAvailabilityLoader }) {
   const { auth, event } = useScheduleEventDetailContext();
   const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);
   const [loading, setLoading] = useState(false);
@@ -22,14 +22,14 @@ export function StaffRsvpReminderPanel({ refreshToken = 0 }: { refreshToken?: nu
     setLoading(true);
     setError(null);
     try {
-      setPreview(await loadStaffRsvpReminderPreview(event, auth.user));
+      setPreview(await staffRsvpLoader.loadReminderPreview(event, auth.user));
     } catch (loadError: any) {
       setError(loadError?.message || 'Unable to load RSVP reminder preview.');
       setPreview(null);
     } finally {
       setLoading(false);
     }
-  }, [auth.user, canLoad, event.eventKey, event.teamId, event.id]);
+  }, [auth.user, canLoad, event.eventKey, event.teamId, event.id, staffRsvpLoader]);
 
   useEffect(() => {
     setStatus(null);
@@ -37,6 +37,7 @@ export function StaffRsvpReminderPanel({ refreshToken = 0 }: { refreshToken?: nu
       refreshPreview();
     } else {
       setPreview(null);
+      setLoading(false);
     }
   }, [canLoad, refreshPreview, refreshToken]);
 

--- a/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx
+++ b/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx
@@ -73,8 +73,16 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
     } as any;
 }
 
-function StaffRsvpProbe() {
-    const workflow = useStaffRsvpBreakdown();
+function createStaffRsvpLoader() {
+    return {
+        loadBreakdown: vi.fn((event: any, user: any) => loadStaffScheduleRsvpBreakdown(event, user)),
+        loadReminderPreview: vi.fn(),
+        invalidateEvent: vi.fn()
+    };
+}
+
+function StaffRsvpProbe({ staffRsvpLoader }: { staffRsvpLoader: ReturnType<typeof createStaffRsvpLoader> }) {
+    const workflow = useStaffRsvpBreakdown(staffRsvpLoader);
     const { event } = useScheduleEventDetailContext();
 
     return (
@@ -93,6 +101,8 @@ function StaffRsvpProbe() {
 }
 
 function renderProbe(eventOverrides: Record<string, unknown> = {}) {
+    const staffRsvpLoader = createStaffRsvpLoader();
+
     function Harness() {
         const [events, setEvents] = useState([buildEvent(eventOverrides)]);
 
@@ -106,12 +116,15 @@ function renderProbe(eventOverrides: Record<string, unknown> = {}) {
                     updateEvents: (updater) => setEvents((current) => updater(current))
                 }}
             >
-                <StaffRsvpProbe />
+                <StaffRsvpProbe staffRsvpLoader={staffRsvpLoader} />
             </ScheduleEventDetailProvider>
         );
     }
 
-    return render(<Harness />);
+    return {
+        ...render(<Harness />),
+        staffRsvpLoader
+    };
 }
 
 describe('useStaffRsvpBreakdown', () => {
@@ -129,11 +142,12 @@ describe('useStaffRsvpBreakdown', () => {
             total: 1
         }));
 
-        renderProbe();
+        const { staffRsvpLoader } = renderProbe();
 
         await waitFor(() => {
             expect(screen.getByTestId('row-count').textContent).toBe('1');
         });
+        expect(staffRsvpLoader.loadBreakdown).toHaveBeenCalledTimes(1);
         expect(loadStaffScheduleRsvpBreakdown).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user);
         expect(screen.getByTestId('loading').textContent).toBe('false');
     });
@@ -156,7 +170,7 @@ describe('useStaffRsvpBreakdown', () => {
             }));
         vi.mocked(submitStaffScheduleRsvpOverride).mockResolvedValue({ going: 1, maybe: 0, notGoing: 0, notResponded: 0, total: 1 } as any);
 
-        renderProbe();
+        const { staffRsvpLoader } = renderProbe();
 
         await waitFor(() => {
             expect(screen.getByTestId('row-count').textContent).toBe('1');
@@ -166,6 +180,8 @@ describe('useStaffRsvpBreakdown', () => {
         await waitFor(() => {
             expect(submitStaffScheduleRsvpOverride).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user, 'player-1', 'going');
         });
+        expect(staffRsvpLoader.invalidateEvent).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }));
+        expect(staffRsvpLoader.loadBreakdown).toHaveBeenCalledTimes(2);
         await waitFor(() => {
             expect(screen.getByText('Avery Smith marked going.')).toBeTruthy();
         });

--- a/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts
+++ b/apps/app/src/hooks/schedule/useStaffRsvpBreakdown.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import {
-  loadStaffScheduleRsvpBreakdown,
   submitStaffScheduleRsvpOverride,
+  type StaffRsvpAvailabilityLoader,
   type StaffScheduleRsvpBreakdown,
   type StaffScheduleRsvpRow
 } from '../../lib/scheduleService';
@@ -15,7 +15,7 @@ export type StaffRsvpOverrideStatus = {
   message: string;
 };
 
-export function useStaffRsvpBreakdown() {
+export function useStaffRsvpBreakdown(staffRsvpLoader: StaffRsvpAvailabilityLoader) {
   const { auth, event, updateEvents } = useScheduleEventDetailContext();
   const [breakdown, setBreakdown] = useState<StaffScheduleRsvpBreakdown | null>(null);
   const [loading, setLoading] = useState(false);
@@ -33,7 +33,7 @@ export function useStaffRsvpBreakdown() {
     if (showLoading) setLoading(true);
     setError(null);
     try {
-      const nextBreakdown = await loadStaffScheduleRsvpBreakdown(event, auth.user);
+      const nextBreakdown = await staffRsvpLoader.loadBreakdown(event, auth.user);
       setBreakdown(nextBreakdown);
       return nextBreakdown;
     } catch (loadError: any) {
@@ -43,7 +43,7 @@ export function useStaffRsvpBreakdown() {
     } finally {
       if (showLoading) setLoading(false);
     }
-  }, [auth.user, event.eventKey, event.teamId, event.id, event.isTeamAdmin, event.isDbGame]);
+  }, [auth.user, event.eventKey, event.teamId, event.id, event.isTeamAdmin, event.isDbGame, staffRsvpLoader]);
 
   useEffect(() => {
     setStatus(null);
@@ -64,6 +64,7 @@ export function useStaffRsvpBreakdown() {
     setError(null);
     try {
       await submitStaffScheduleRsvpOverride(event, auth.user, player.playerId, response);
+      staffRsvpLoader.invalidateEvent(event);
       const nextBreakdown = await refreshBreakdown(false);
       if (nextBreakdown) {
         updateEvents((current) => current.map((currentEvent) => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mocks = vi.hoisted(() => {
   const transactionSet = vi.fn();
@@ -166,7 +166,7 @@ import { expandRecurrence, fetchAndParseCalendar, isTeamActive } from './adapter
 import { getCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
-import { buildPlayerScoringLiveEvent, claimOfficialAssignmentItem, createScheduledPracticeForApp, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
+import { buildPlayerScoringLiveEvent, claimOfficialAssignmentItem, createScheduledPracticeForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
   return {
@@ -1591,11 +1591,64 @@ describe('staff RSVP management', () => {
     isCancelled: false,
     availabilityLocked: false,
     isTeamAdmin: true,
-    isTeamStaff: true
+    isTeamStaff: true,
+    isTeamRsvpReminderManager: true
   } as any;
+  let restoreTestWindow: (() => void) | null = null;
+
+  function installTestWindow() {
+    const previousWindow = (globalThis as any).window;
+    (globalThis as any).window = {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+      location: { protocol: 'http:' }
+    };
+    return () => {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    };
+  }
+
+  function buildSharedRsvpSource(missingPlayerId = 'p2') {
+    const goingRow = { playerId: 'p1', playerName: 'Avery Smith', response: 'going' };
+    const missingRow = { playerId: missingPlayerId, playerName: missingPlayerId === 'p2' ? 'Devon Lee' : 'Blake Jones', response: 'not_responded' };
+    const notResponded = missingPlayerId ? [missingRow] : [];
+    return {
+      players: [
+        { id: 'p1', name: 'Avery Smith', active: true, parents: [{ email: 'avery@example.com' }] },
+        { id: 'p2', name: 'Devon Lee', active: true, parents: [{ email: 'devon@example.com' }] }
+      ],
+      rsvps: missingPlayerId
+        ? [{ playerId: 'p1', response: 'going' }]
+        : [{ playerId: 'p1', response: 'going' }, { playerId: 'p2', response: 'going' }],
+      grouped: {
+        going: missingPlayerId ? [goingRow] : [goingRow, { playerId: 'p2', playerName: 'Devon Lee', response: 'going' }],
+        maybe: [],
+        not_going: [],
+        not_responded: notResponded
+      },
+      counts: {
+        going: missingPlayerId ? 1 : 2,
+        maybe: 0,
+        notGoing: 0,
+        notResponded: notResponded.length,
+        total: 2
+      }
+    };
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
+    restoreTestWindow?.();
+    restoreTestWindow = installTestWindow();
+  });
+
+  afterEach(() => {
+    restoreTestWindow?.();
+    restoreTestWindow = null;
   });
 
   it('maps staff RSVP breakdown rows including no-response players', async () => {
@@ -1616,6 +1669,54 @@ describe('staff RSVP management', () => {
     expect(result.grouped.not_responded).toEqual([
       expect.objectContaining({ playerId: 'p4', playerName: 'Devon Lee', response: 'not_responded' })
     ]);
+  });
+
+  it('reuses one in-flight staff RSVP event-data load for breakdown and reminder preview', async () => {
+    let resolveEventData!: (value: any) => void;
+    vi.mocked(getRsvpBreakdownByPlayer).mockImplementation(() => new Promise((resolve) => {
+      resolveEventData = resolve;
+    }));
+
+    const loader = createStaffRsvpAvailabilityLoader();
+    const breakdownPromise = loader.loadBreakdown(event, user as any);
+    const previewPromise = loader.loadReminderPreview(event, user as any);
+
+    expect(getRsvpBreakdownByPlayer).toHaveBeenCalledTimes(1);
+    expect(getRsvpBreakdownByPlayer).toHaveBeenCalledWith('team-1', 'game-1');
+
+    resolveEventData(buildSharedRsvpSource('p2'));
+    const [breakdown, preview] = await Promise.all([breakdownPromise, previewPromise]);
+
+    expect(breakdown.counts).toMatchObject({ going: 1, notResponded: 1, total: 2 });
+    expect(preview.missingPlayerCount).toBe(1);
+    expect(preview.eligibleEmailCount).toBe(1);
+    expect(preview.players[0]).toMatchObject({ playerId: 'p2', playerName: 'Devon Lee' });
+  });
+
+  it('invalidates the shared staff RSVP event-data load before refreshes', async () => {
+    vi.mocked(getRsvpBreakdownByPlayer)
+      .mockResolvedValueOnce(buildSharedRsvpSource('p2') as any)
+      .mockResolvedValueOnce(buildSharedRsvpSource('') as any);
+
+    const loader = createStaffRsvpAvailabilityLoader();
+    await expect(loader.loadBreakdown(event, user as any)).resolves.toMatchObject({
+      counts: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+    });
+    await expect(loader.loadReminderPreview(event, user as any)).resolves.toMatchObject({
+      missingPlayerCount: 1,
+      eligibleEmailCount: 1
+    });
+    expect(getRsvpBreakdownByPlayer).toHaveBeenCalledTimes(1);
+
+    loader.invalidateEvent(event);
+
+    const [breakdown, preview] = await Promise.all([
+      loader.loadBreakdown(event, user as any),
+      loader.loadReminderPreview(event, user as any)
+    ]);
+    expect(getRsvpBreakdownByPlayer).toHaveBeenCalledTimes(2);
+    expect(breakdown.counts).toMatchObject({ going: 2, notResponded: 0, total: 2 });
+    expect(preview.missingPlayerCount).toBe(0);
   });
 
   it('submits staff RSVP overrides for the selected player instead of event.childId', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -262,6 +262,13 @@ export type StaffRsvpReminderSendResult = StaffRsvpReminderPreview & {
   rsvpPushError: string | null;
 };
 
+type StaffRsvpEventData = {
+  breakdown: StaffScheduleRsvpBreakdown;
+  reminderPreview: StaffRsvpReminderPreview;
+};
+
+export type StaffRsvpAvailabilityLoader = ReturnType<typeof createStaffRsvpAvailabilityLoader>;
+
 export type ParentPracticePacketChild = {
   id: string;
   name: string;
@@ -3521,21 +3528,30 @@ function normalizeStaffScheduleRsvpBreakdown(value: any): StaffScheduleRsvpBreak
   };
 }
 
-export async function loadStaffScheduleRsvpBreakdown(event: ParentScheduleEvent, user: AuthUser | null): Promise<StaffScheduleRsvpBreakdown> {
-  assertStaffRsvpManagementEvent(event, user);
-
+async function loadStaffRsvpEventData(event: ParentScheduleEvent): Promise<StaffRsvpEventData> {
   try {
-    const breakdown = await withTimeout(Promise.resolve(getRsvpBreakdownByPlayer(event.teamId, event.id)), 'Staff RSVP breakdown');
-    return normalizeStaffScheduleRsvpBreakdown(breakdown);
+    const source = await withTimeout(Promise.resolve(getRsvpBreakdownByPlayer(event.teamId, event.id)), 'Staff RSVP event data');
+    return {
+      breakdown: normalizeStaffScheduleRsvpBreakdown(source),
+      reminderPreview: buildStaffRsvpReminderPreview(source?.players, source?.rsvps)
+    };
   } catch (error) {
     if (!isNativeRuntime()) throw error;
-    logScheduleWarning('Falling back to REST RSVP breakdown load.', 'staff-rsvp-breakdown-load', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id });
+    logScheduleWarning('Falling back to REST staff RSVP event data load.', 'staff-rsvp-event-data-load', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id });
     const [players, rsvps] = await Promise.all([
       loadPlayers(event.teamId),
       loadRsvps(event.teamId, event.id)
     ]);
-    return normalizeStaffScheduleRsvpBreakdown(buildGameDayRsvpBreakdown({ players, rsvps }));
+    return {
+      breakdown: normalizeStaffScheduleRsvpBreakdown(buildGameDayRsvpBreakdown({ players, rsvps })),
+      reminderPreview: buildStaffRsvpReminderPreview(players, rsvps)
+    };
   }
+}
+
+export async function loadStaffScheduleRsvpBreakdown(event: ParentScheduleEvent, user: AuthUser | null): Promise<StaffScheduleRsvpBreakdown> {
+  assertStaffRsvpManagementEvent(event, user);
+  return (await loadStaffRsvpEventData(event)).breakdown;
 }
 
 export async function submitStaffScheduleRsvpOverride(event: ParentScheduleEvent, user: AuthUser | null, playerId: string, response: Exclude<RsvpResponse, 'not_responded'>) {
@@ -4713,15 +4729,43 @@ function assertStaffRsvpReminderEvent(event: ParentScheduleEvent, user: AuthUser
   if (event.isCancelled) throw new Error('RSVP reminders are unavailable for cancelled events.');
 }
 
-async function loadStaffRsvpReminderData(event: ParentScheduleEvent) {
-  const { players, rsvps } = await getRsvpBreakdownByPlayer(event.teamId, event.id);
-  return { players, rsvps };
-}
-
 export async function loadStaffRsvpReminderPreview(event: ParentScheduleEvent, user: AuthUser | null): Promise<StaffRsvpReminderPreview> {
   assertStaffRsvpReminderEvent(event, user);
-  const { players, rsvps } = await loadStaffRsvpReminderData(event);
-  return buildStaffRsvpReminderPreview(players, rsvps);
+  return (await loadStaffRsvpEventData(event)).reminderPreview;
+}
+
+function getStaffRsvpEventDataCacheKey(event: ParentScheduleEvent) {
+  return `${compactString(event.teamId)}:${compactString(event.id)}`;
+}
+
+export function createStaffRsvpAvailabilityLoader() {
+  const eventDataByEventKey = new Map<string, Promise<StaffRsvpEventData>>();
+
+  const getEventData = (event: ParentScheduleEvent) => {
+    const eventKey = getStaffRsvpEventDataCacheKey(event);
+    const existing = eventDataByEventKey.get(eventKey);
+    if (existing) return existing;
+    const nextLoad = loadStaffRsvpEventData(event).catch((error) => {
+      eventDataByEventKey.delete(eventKey);
+      throw error;
+    });
+    eventDataByEventKey.set(eventKey, nextLoad);
+    return nextLoad;
+  };
+
+  return {
+    async loadBreakdown(event: ParentScheduleEvent, user: AuthUser | null): Promise<StaffScheduleRsvpBreakdown> {
+      assertStaffRsvpManagementEvent(event, user);
+      return (await getEventData(event)).breakdown;
+    },
+    async loadReminderPreview(event: ParentScheduleEvent, user: AuthUser | null): Promise<StaffRsvpReminderPreview> {
+      assertStaffRsvpReminderEvent(event, user);
+      return (await getEventData(event)).reminderPreview;
+    },
+    invalidateEvent(event: ParentScheduleEvent) {
+      eventDataByEventKey.delete(getStaffRsvpEventDataCacheKey(event));
+    }
+  };
 }
 
 export function createStaffRsvpReminderPreviewLoader() {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -33,6 +33,12 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   loadParentScheduleRideOffers: vi.fn(),
   loadStaffScheduleRsvpBreakdown: vi.fn(),
   loadStaffRsvpReminderPreview: vi.fn(),
+  invalidateStaffRsvpAvailabilityEvent: vi.fn(),
+  createStaffRsvpAvailabilityLoader: vi.fn(() => ({
+    loadBreakdown: (...args: any[]) => scheduleServiceMocks.loadStaffScheduleRsvpBreakdown(...args),
+    loadReminderPreview: (...args: any[]) => scheduleServiceMocks.loadStaffRsvpReminderPreview(...args),
+    invalidateEvent: (...args: any[]) => scheduleServiceMocks.invalidateStaffRsvpAvailabilityEvent(...args)
+  })),
   loadAutoFilledLineupDraftPreviewForApp: vi.fn<(...args: any[]) => Promise<any>>(() => Promise.resolve({ availablePlayers: [] as any[], goingPlayers: [] as any[], gamePlan: null as any })),
   markParentPracticePacketComplete: vi.fn(),
   publishGamePlanForApp: vi.fn(),
@@ -1488,7 +1494,7 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
 
   it('renders staff breakdown controls and refreshes counts after an override', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
-      events: [buildEvent({ isTeamAdmin: true })],
+      events: [buildEvent({ isTeamAdmin: true, isTeamRsvpReminderManager: true })],
       children: []
     });
     scheduleServiceMocks.loadStaffScheduleRsvpBreakdown
@@ -1513,12 +1519,26 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
         },
         counts: { going: 2, maybe: 1, notGoing: 1, notResponded: 0, total: 4 }
       });
+    scheduleServiceMocks.loadStaffRsvpReminderPreview
+      .mockResolvedValueOnce({
+        missingPlayerCount: 1,
+        eligibleEmailCount: 1,
+        players: [{ playerId: 'p4', playerName: 'Devon Lee', parentEmails: ['devon@example.com'] }]
+      })
+      .mockResolvedValueOnce({
+        missingPlayerCount: 0,
+        eligibleEmailCount: 0,
+        players: []
+      });
     scheduleServiceMocks.submitStaffScheduleRsvpOverride.mockResolvedValue({ playerId: 'p4', response: 'going' });
 
     renderScheduleEventDetail();
 
     await waitFor(() => {
       expect(screen.getByText('Staff RSVP overrides')).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('1 no-response player · 1 eligible parent/guardian email.')).toBeTruthy();
     });
 
     const noResponseRow = screen.getByTestId('staff-rsvp-row-p4');
@@ -1527,11 +1547,15 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     await waitFor(() => {
       expect(scheduleServiceMocks.submitStaffScheduleRsvpOverride).toHaveBeenCalledWith(expect.any(Object), auth.user, 'p4', 'going');
     });
+    expect(scheduleServiceMocks.invalidateStaffRsvpAvailabilityEvent).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }));
     await waitFor(() => {
       expect(screen.getByText('Devon Lee marked going.')).toBeTruthy();
     });
     await waitFor(() => {
       expect(screen.getAllByText('2 going · 1 maybe · 1 out · 0 missing').length).toBeGreaterThan(0);
+    });
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadStaffRsvpReminderPreview).toHaveBeenCalledTimes(2);
     });
     expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown.mock.calls.length).toBeGreaterThanOrEqual(2);
   });

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -36,6 +36,7 @@ import {
   updateLiveGameClockState,
   buildLiveGameClockPeriods,
   resolveLiveGameClockSnapshot,
+  createStaffRsvpAvailabilityLoader,
   type PracticeAttendancePlayer,
   type StaffPracticeAttendance,
   type StaffPracticePacket,
@@ -874,7 +875,8 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
   onSelectSection: (sectionId: EventDetailSectionId) => void;
 }) {
   const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });
-  const staffRsvp = useStaffRsvpBreakdown();
+  const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);
+  const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
 
   return (
     <section className="app-card overflow-hidden p-0">
@@ -908,7 +910,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
           status={staffRsvp.status}
           onOverride={staffRsvp.submitOverride}
         />
-        <StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />
+        <StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />
         <AvailabilityNotesList event={event} />
         {!event.isDbGame ? <div className="mt-2 text-xs font-semibold text-gray-500">Availability opens after this event is tracked in the schedule.</div> : null}
         {event.availabilityLocked ? <div className="mt-2 text-xs font-semibold text-amber-700">Availability locked {String(event.availabilityCutoffLabel || '').toLowerCase()}.</div> : null}

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -879,6 +879,18 @@ async function mockScheduleModules(page, options = {}) {
                     return { missingPlayerCount: 0, eligibleEmailCount: 0, emailSentCount: 0, players: [] };
                 }
 
+                export function createStaffRsvpAvailabilityLoader() {
+                    return {
+                        loadBreakdown(event, user) {
+                            return loadStaffScheduleRsvpBreakdown(event, user);
+                        },
+                        loadReminderPreview(event, user) {
+                            return loadStaffRsvpReminderPreview(event, user);
+                        },
+                        invalidateEvent() {}
+                    };
+                }
+
                 export function summarizeParentScheduleRideOffers(offers) {
                     return summarizeRideOffers(offers);
                 }

--- a/tests/unit/app-schedule-detail-decomposition.test.js
+++ b/tests/unit/app-schedule-detail-decomposition.test.js
@@ -31,7 +31,7 @@ describe('ScheduleEventDetail decomposition', () => {
         expect(source).toContain("from '../hooks/schedule/useStaffRsvpBreakdown'");
         expect(source).toContain('<ScheduleEventDetailProvider value={{');
         expect(source).toContain('useScheduleEventRsvp({ availabilityNote })');
-        expect(source).toContain('useStaffRsvpBreakdown()');
+        expect(source).toContain('useStaffRsvpBreakdown(staffRsvpLoader)');
         expect(source).toContain('<GameReportSections event={event} />');
         expect(source).toContain('<PlayerSwitcher events={events} selectedChildId={selectedEvent.childId} onSelect={selectChild} compact />');
         expect(source).not.toMatch(/^function GameReportSections\b/m);

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -31,6 +31,32 @@ const scheduleMocks = vi.hoisted(() => ({
         const activePeriod = String(game?.liveClockPeriod || game?.period || '').trim();
         return activePeriod ? [activePeriod] : ['H1', 'H2'];
     }),
+    createStaffRsvpAvailabilityLoader: vi.fn(() => ({
+        loadBreakdown: vi.fn().mockResolvedValue({
+            grouped: {
+                going: [],
+                maybe: [],
+                not_going: [],
+                not_responded: []
+            },
+            counts: {
+                going: 0,
+                maybe: 0,
+                notGoing: 0,
+                notResponded: 0,
+                total: 0
+            }
+        }),
+        loadReminderPreview: vi.fn().mockResolvedValue({
+            totalPlayers: 0,
+            respondedCount: 0,
+            missingCount: 0,
+            missingPlayers: [],
+            reminderMessage: '',
+            targetLabel: 'staff'
+        }),
+        invalidateEvent: vi.fn()
+    })),
     resolveLiveGameClockSnapshot: vi.fn((game, now = new Date()) => ({
         persistedClockMs: Number(game?.liveClockMs ?? game?.gameClockMs ?? 0) || 0,
         effectiveClockMs: Number(game?.liveClockMs ?? game?.gameClockMs ?? 0) || 0,

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -16,6 +16,14 @@ const scheduleMocks = vi.hoisted(() => ({
     resolveCachedParentScheduleEvents: vi.fn(() => []),
     loadParentScheduleAssignments: vi.fn().mockResolvedValue([]),
     loadParentScheduleRideOffers: vi.fn().mockResolvedValue([]),
+    loadStaffScheduleRsvpBreakdown: vi.fn(),
+    loadStaffRsvpReminderPreview: vi.fn(),
+    invalidateStaffRsvpAvailabilityEvent: vi.fn(),
+    createStaffRsvpAvailabilityLoader: vi.fn(() => ({
+        loadBreakdown: (...args) => scheduleMocks.loadStaffScheduleRsvpBreakdown(...args),
+        loadReminderPreview: (...args) => scheduleMocks.loadStaffRsvpReminderPreview(...args),
+        invalidateEvent: (...args) => scheduleMocks.invalidateStaffRsvpAvailabilityEvent(...args)
+    })),
     loadHomeScoringPlayers: vi.fn().mockResolvedValue([]),
     loadAutoFilledLineupDraftPreviewForApp: vi.fn(),
     loadGameDayLiveEventsForApp: vi.fn().mockResolvedValue([]),

--- a/tests/unit/issue-1966-schedule-rsvp-reminders-source.test.js
+++ b/tests/unit/issue-1966-schedule-rsvp-reminders-source.test.js
@@ -30,6 +30,7 @@ describe('issue 1966 schedule RSVP reminders source contract', () => {
         expect(scheduleServiceSource).toContain('function assertStaffRsvpReminderEvent');
         expect(scheduleServiceSource).toContain('if (!event.isTeamRsvpReminderManager)');
         expect(scheduleServiceSource).toContain('export async function loadStaffRsvpReminderPreview');
+        expect(scheduleServiceSource).toContain('export function createStaffRsvpAvailabilityLoader');
         expect(scheduleServiceSource).toContain('export function createStaffRsvpReminderPreviewLoader');
         expect(scheduleServiceSource).toContain('export async function sendStaffRsvpReminder');
         expect(scheduleServiceSource).toContain('const emailResult = await sendPublicRsvpReminderEmailsNativeSafe(event);');
@@ -39,10 +40,10 @@ describe('issue 1966 schedule RSVP reminders source contract', () => {
 
     it('keeps mobile schedule and team screens exposing the manager-only reminder action', () => {
         expect(scheduleEventDetailSource).toContain("import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';");
-        expect(scheduleEventDetailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(scheduleEventDetailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
         expect(staffRsvpReminderPanelSource).toContain('export function StaffRsvpReminderPanel');
         expect(staffRsvpReminderPanelSource).toContain('event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled');
-        expect(staffRsvpReminderPanelSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
+        expect(staffRsvpReminderPanelSource).toContain('staffRsvpLoader.loadReminderPreview(event, auth.user)');
         expect(staffRsvpReminderPanelSource).toContain('await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
         expect(teamDetailSource).toContain('function TeamEventReminderAction');
         expect(teamDetailSource).toContain('createStaffRsvpReminderPreviewLoader');

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -189,20 +189,22 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
 
     it('keeps staff RSVP admin workflow behind extracted panel and hook modules', () => {
         expect(detailSource).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
-        expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown();');
+        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
+        expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
-        expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
         expect(detailSource).not.toMatch(/const\s+\[staffRsvpBreakdown\b/);
         expect(detailSource).not.toMatch(/^function StaffRsvpBreakdownPanel\b/m);
         expect(detailSource).not.toMatch(/^function StaffRsvpReminderPanel\b/m);
 
         expect(staffRsvpBreakdownHookSource).toContain('export function useStaffRsvpBreakdown');
         expect(staffRsvpBreakdownHookSource).toContain('useScheduleEventDetailContext()');
-        expect(staffRsvpBreakdownHookSource).toContain('loadStaffScheduleRsvpBreakdown');
+        expect(staffRsvpBreakdownHookSource).toContain('staffRsvpLoader.loadBreakdown');
+        expect(staffRsvpBreakdownHookSource).toContain('staffRsvpLoader.invalidateEvent(event)');
         expect(staffRsvpBreakdownHookSource).toContain('submitStaffScheduleRsvpOverride');
         expect(staffRsvpHookTestSource).toContain("describe('useStaffRsvpBreakdown'");
         expect(staffRsvpBreakdownPanelSource).toContain('StaffRsvpPlayerRow');
-        expect(staffRsvpReminderPanelSource).toContain('loadStaffRsvpReminderPreview');
+        expect(staffRsvpReminderPanelSource).toContain('staffRsvpLoader.loadReminderPreview');
         expect(staffRsvpReminderPanelSource).toContain('sendStaffRsvpReminder');
     });
 });

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -90,7 +90,8 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(page).toContain("import { RideshareSection } from '../components/schedule/RideshareSection';");
         expect(page).toContain('<ScheduleEventDetailProvider value={{');
         expect(page).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });');
-        expect(page).toContain('const staffRsvp = useStaffRsvpBreakdown();');
+        expect(page).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
+        expect(page).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(page).toContain('<RideshareSection />');
         expect(page).not.toMatch(/^function RideshareSection\b/m);
         expect(page).not.toMatch(/^function RideOfferCard\b/m);
@@ -120,7 +121,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(page).toContain("import { StaffRsvpReminderPanel } from '../components/schedule/StaffRsvpReminderPanel';");
         expect(page).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
         expect(page).toContain('<StaffRsvpBreakdownPanel');
-        expect(page).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(page).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
         expect(page).not.toMatch(/^function StaffRsvpBreakdownPanel\b/m);
         expect(page).not.toMatch(/^function StaffRsvpReminderPanel\b/m);
         expect(page).not.toMatch(/const\s+\[staffRsvpBreakdown\b/);
@@ -128,13 +129,14 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(page).not.toMatch(/sendStaffRsvpReminder\(/);
 
         expect(breakdownHook).toContain('export function useStaffRsvpBreakdown');
-        expect(breakdownHook).toContain('loadStaffScheduleRsvpBreakdown');
+        expect(breakdownHook).toContain('staffRsvpLoader.loadBreakdown');
+        expect(breakdownHook).toContain('staffRsvpLoader.invalidateEvent(event)');
         expect(breakdownHook).toContain('submitStaffScheduleRsvpOverride');
         expect(breakdownHook).toContain('setRefreshToken((current) => current + 1)');
         expect(breakdownPanel).toContain('export function StaffRsvpBreakdownPanel');
         expect(breakdownPanel).toContain('StaffRsvpPlayerRow');
         expect(reminderPanel).toContain('export function StaffRsvpReminderPanel');
-        expect(reminderPanel).toContain('loadStaffRsvpReminderPreview');
+        expect(reminderPanel).toContain('staffRsvpLoader.loadReminderPreview');
         expect(reminderPanel).toContain('sendStaffRsvpReminder');
     });
 

--- a/tests/unit/schedule-rsvp-reminder.test.js
+++ b/tests/unit/schedule-rsvp-reminder.test.js
@@ -124,8 +124,9 @@ describe('staff RSVP reminder service wiring', () => {
 
     expect(serviceSource).toContain('function isPublicRsvpReminderManager');
     expect(serviceSource).toContain('if (!event.isTeamRsvpReminderManager)');
-    expect(serviceSource).toContain('const { players, rsvps } = await getRsvpBreakdownByPlayer(event.teamId, event.id);');
-    expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+    expect(serviceSource).toContain('return (await loadStaffRsvpEventData(event)).reminderPreview;');
+    expect(serviceSource).toContain('export function createStaffRsvpAvailabilityLoader');
+    expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
     expect(reminderPanelSource).toContain('event.isTeamRsvpReminderManager');
     expect(reminderPanelSource).not.toContain('event.isTeamStaff && event.isDbGame');
   });

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -9,9 +9,10 @@ const playerRowSource = readFileSync(new URL('../../apps/app/src/components/sche
 describe('staff RSVP panel decomposition contract', () => {
     it('keeps the availability section wired through named staff RSVP panels', () => {
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
-        expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} />');
+        expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
         expect(detailSource).toContain('onOverride={staffRsvp.submitOverride}');
-        expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown();');
+        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
+        expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });');
     });
 
@@ -31,7 +32,7 @@ describe('staff RSVP panel decomposition contract', () => {
         expect(reminderPanelSource).toContain('const { auth, event } = useScheduleEventDetailContext();');
         expect(reminderPanelSource).toContain('const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);');
         expect(reminderPanelSource).toContain('const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);');
-        expect(reminderPanelSource).toContain('setPreview(await loadStaffRsvpReminderPreview(event, auth.user));');
+        expect(reminderPanelSource).toContain('staffRsvpLoader.loadReminderPreview(event, auth.user)');
         expect(reminderPanelSource).toContain('const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
         expect(reminderPanelSource).toContain('setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? \'email\' : \'emails\'}.`);');
     });


### PR DESCRIPTION
## Summary
- Add a shared staff RSVP availability loader that builds both the admin breakdown and reminder preview from one per-event data promise.
- Wire `ScheduleEventDetail` availability, `useStaffRsvpBreakdown`, and `StaffRsvpReminderPanel` to reuse that loader and invalidate it after staff RSVP overrides.
- Update focused service, hook, panel, page, and source-contract coverage for in-flight reuse and refresh invalidation.

## Tests
- `npx vitest run apps/app/src/lib/scheduleService.test.ts apps/app/src/hooks/schedule/useStaffRsvpBreakdown.test.tsx apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx apps/app/src/pages/ScheduleEventDetail.test.tsx tests/unit/staff-rsvp-panel-source-contract.test.js tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js tests/unit/schedule-event-detail-decomposition-contract.test.js tests/unit/issue-1966-schedule-rsvp-reminders-source.test.js tests/unit/schedule-rsvp-reminder.test.js tests/unit/app-schedule-detail-decomposition.test.js -t "staff RSVP|StaffRsvp|ScheduleEventDetail staff RSVP|decomposition|schedule RSVP reminders|staff RSVP reminder" --reporter=verbose`
- `npm run app:build`

Fixes #2878