### PR TITLE
[codex] Add shared legacy import alias

### DIFF
--- a/apps/app/src/lib/pushService.ts
+++ b/apps/app/src/lib/pushService.ts
@@ -138,7 +138,7 @@ export async function enablePushNotificationsForUser(userId: string): Promise<Pu
   }
 
   if (!Capacitor.isNativePlatform()) {
-    const { registerPushNotifications } = await import('../../../../js/push-notifications.js');
+    const { registerPushNotifications } = await import('@legacy/push-notifications.js');
     const { token } = await registerPushNotifications();
     await saveNotificationDeviceToken(userId, {
       token,

--- a/apps/app/src/lib/telemetry.test.ts
+++ b/apps/app/src/lib/telemetry.test.ts
@@ -16,7 +16,7 @@ const sentryMocks = vi.hoisted(() => {
 });
 
 vi.mock('@sentry/browser', () => sentryMocks);
-vi.mock('../../../../js/telemetry.js', () => ({}));
+vi.mock('@legacy/telemetry.js', () => ({}));
 
 describe('app telemetry bridge', () => {
   beforeEach(() => {

--- a/apps/app/src/lib/telemetry.ts
+++ b/apps/app/src/lib/telemetry.ts
@@ -218,7 +218,7 @@ export function ensureTelemetryPipeline(): Promise<AppTelemetryApi | null> {
     return Promise.resolve(null);
   }
 
-  telemetryPromise = import('../../../../js/telemetry.js')
+  telemetryPromise = import('@legacy/telemetry.js')
     .catch(() => null)
     .then(() => getTelemetryApi());
 

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -338,7 +338,7 @@ describe('React app auth/profile capability parity', () => {
 
         expectContains(pushService, [
             'if (!Capacitor.isNativePlatform()) {',
-            "await import('../../../../js/push-notifications.js')",
+            "await import('@legacy/push-notifications.js')",
             'const { token } = await registerPushNotifications();',
             'await saveNotificationDeviceToken(userId, {',
             "platform: 'web'",
@@ -346,6 +346,7 @@ describe('React app auth/profile capability parity', () => {
             'getNativeMessagingToken()',
             'platform = Capacitor.getPlatform()'
         ]);
+        expect(pushService).not.toContain("await import('../../../../js/push-notifications.js')");
         expect(pushService).not.toContain("import { registerPushNotifications } from '../../../../js/push-notifications.js';");
         expect(pushService).not.toContain('Push registration for the web app still runs through the current website profile page.');
     });

--- a/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
+++ b/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
@@ -4,6 +4,12 @@ import { join } from 'node:path';
 
 const repoRoot = process.cwd();
 const directLegacyReferencePattern = /(from\s+['"](?:\.\.\/){4,}js\/|import\(['"](?:\.\.\/){4,}js\/)/;
+const legacyAliasReferencePattern = /(from\s+['"]@legacy\/|import\(['"]@legacy\/)/;
+const legacyAdapterDir = 'apps/app/src/lib/adapters/';
+const approvedRuntimeBridgePaths = [
+    'apps/app/src/lib/pushService.ts',
+    'apps/app/src/lib/telemetry.ts'
+];
 
 function readRepoFile(path) {
     return readFileSync(join(repoRoot, path), 'utf8');
@@ -55,18 +61,30 @@ describe('app legacy adapter initiative source contract', () => {
         expect(authAdapterSource).toContain("import('@legacy/admin-invite.js')");
     });
 
-    it('keeps direct ../../../../js references limited to known app-shell exceptions and adapter shims', () => {
-        const filesWithDirectLegacyReferences = listSourceFiles('apps/app/src')
+    it('keeps direct ../../../../js references behind adapter shims', () => {
+        const nonAdapterFilesWithDirectLegacyReferences = listSourceFiles('apps/app/src')
+            .filter((path) => !path.startsWith(legacyAdapterDir))
             .filter((path) => directLegacyReferencePattern.test(readRepoFile(path)))
             .sort();
 
-        expect(filesWithDirectLegacyReferences).toEqual([
-            'apps/app/src/lib/adapters/legacyPlayerProfile.ts',
-            'apps/app/src/lib/adapters/legacyRosterPrivacy.ts',
-            'apps/app/src/lib/adapters/legacyScheduleHelpers.ts',
-            'apps/app/src/lib/pushService.ts',
-            'apps/app/src/lib/telemetry.ts'
-        ]);
+        expect(nonAdapterFilesWithDirectLegacyReferences).toEqual([]);
+    });
+
+    it('keeps @legacy imports at the adapter boundary and approved runtime bridges', () => {
+        const filesWithLegacyAliasReferences = listSourceFiles('apps/app/src')
+            .filter((path) => legacyAliasReferencePattern.test(readRepoFile(path)))
+            .filter((path) => !path.startsWith(legacyAdapterDir))
+            .sort();
+
+        expect(filesWithLegacyAliasReferences).toEqual(approvedRuntimeBridgePaths);
+
+        const telemetrySource = readRepoFile('apps/app/src/lib/telemetry.ts');
+        const pushServiceSource = readRepoFile('apps/app/src/lib/pushService.ts');
+
+        expect(telemetrySource).toContain("import('@legacy/telemetry.js')");
+        expect(pushServiceSource).toContain("import('@legacy/push-notifications.js')");
+        expect(telemetrySource).not.toMatch(directLegacyReferencePattern);
+        expect(pushServiceSource).not.toMatch(directLegacyReferencePattern);
     });
 
     it('routes migrated parent tools, auth, chat, schedule, player, and game report services through adapters', () => {


### PR DESCRIPTION
## Summary
- Move the app telemetry and web push runtime bridge imports from deep `../../../../js` paths to the shared `@legacy` alias.
- Update telemetry/push source-contract expectations for the alias-based boundary.
- Strengthen the legacy adapter initiative guard so non-adapter app source files cannot reintroduce direct deep legacy JS imports, while adapters and approved runtime bridges remain allowed.

Fixes #2890

## Tests
- `npx vitest run tests/unit/app-legacy-adapter-initiative-source-contract.test.js tests/unit/app-auth-profile-capabilities.test.js tests/unit/app-vite-config.test.ts --reporter=verbose`
- `npm --prefix apps/app run test -- --run src/lib/telemetry.test.ts src/lib/pushService.test.ts --reporter=verbose`
- `npm run app:build`