### PR TITLE
[codex] Move player profile legacy adapters

### DIFF
--- a/apps/app/src/lib/adapters/legacyPlayerProfile.test.ts
+++ b/apps/app/src/lib/adapters/legacyPlayerProfile.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const legacyParentIncentives = vi.hoisted(() => ({
+    calculateEarnings: vi.fn(),
+    getApplicableRulesForGame: vi.fn(),
+    getCapSetting: vi.fn(),
+    getIncentiveRules: vi.fn(),
+    getPaidGames: vi.fn(),
+    getStatOptionsForTeam: vi.fn(),
+    isCurrentRuleVersion: vi.fn(),
+    markGamePaid: vi.fn(),
+    retireIncentiveRule: vi.fn(),
+    saveCapSetting: vi.fn(),
+    saveIncentiveRule: vi.fn(),
+    toggleIncentiveRule: vi.fn()
+}));
+
+vi.mock('@legacy/parent-incentives.js', () => legacyParentIncentives);
+vi.mock('@legacy/athlete-profile-utils.js', () => ({
+    buildAthleteProfileShareUrl: vi.fn()
+}));
+vi.mock('@legacy/player-profile-stats.js', () => ({
+    collectPlayerVideoClips: vi.fn()
+}));
+vi.mock('@legacy/player-tracking-summary.js', () => ({
+    getVisiblePlayerTrackingSummary: vi.fn()
+}));
+
+import { getCapSetting } from './legacyPlayerProfile';
+
+describe('legacy player profile adapter', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('preserves an unset cap setting as null', async () => {
+        legacyParentIncentives.getCapSetting.mockReturnValue(null);
+
+        await expect(getCapSetting('user-1', 'player-1')).resolves.toBeNull();
+        expect(legacyParentIncentives.getCapSetting).toHaveBeenCalledWith('user-1', 'player-1');
+    });
+
+    it('normalizes finite cap setting values without dropping zero', async () => {
+        legacyParentIncentives.getCapSetting.mockReturnValueOnce('1250');
+        await expect(getCapSetting('user-1', 'player-1')).resolves.toBe(1250);
+
+        legacyParentIncentives.getCapSetting.mockReturnValueOnce(0);
+        await expect(getCapSetting('user-1', 'player-1')).resolves.toBe(0);
+    });
+});

--- a/apps/app/src/lib/adapters/legacyPlayerProfile.ts
+++ b/apps/app/src/lib/adapters/legacyPlayerProfile.ts
@@ -98,6 +98,12 @@ function finiteNumber(value: unknown, fallback = 0): number {
     return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function finiteNullableNumber(value: unknown): number | null {
+    if (value == null || (typeof value === 'string' && value.trim() === '')) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
 function asArray(value: unknown): unknown[] {
     return Array.isArray(value) ? value : [];
 }
@@ -265,7 +271,7 @@ export async function getPaidGames(userId: string, playerId: string): Promise<Ma
 
 export async function getCapSetting(userId: string, playerId: string): Promise<number | null> {
     const capSetting = await Promise.resolve(legacyGetCapSetting(userId, playerId));
-    return Number.isFinite(Number(capSetting)) ? Number(capSetting) : null;
+    return finiteNullableNumber(capSetting);
 }
 
 export async function getStatOptionsForTeam(teamId: string): Promise<PlayerStatOption[]> {

--- a/apps/app/src/lib/adapters/legacyPlayerProfile.ts
+++ b/apps/app/src/lib/adapters/legacyPlayerProfile.ts
@@ -11,49 +11,278 @@ import {
     saveCapSetting as legacySaveCapSetting,
     saveIncentiveRule as legacySaveIncentiveRule,
     toggleIncentiveRule as legacyToggleIncentiveRule
-} from '../../../../../js/parent-incentives.js';
-import { buildAthleteProfileShareUrl as legacyBuildAthleteProfileShareUrl } from '../../../../../js/athlete-profile-utils.js';
-import { collectPlayerVideoClips as legacyCollectPlayerVideoClips } from '../../../../../js/player-profile-stats.js';
-import { getVisiblePlayerTrackingSummary as legacyGetVisiblePlayerTrackingSummary } from '../../../../../js/player-tracking-summary.js';
+} from '@legacy/parent-incentives.js';
+import { buildAthleteProfileShareUrl as legacyBuildAthleteProfileShareUrl } from '@legacy/athlete-profile-utils.js';
+import { collectPlayerVideoClips as legacyCollectPlayerVideoClips } from '@legacy/player-profile-stats.js';
+import { getVisiblePlayerTrackingSummary as legacyGetVisiblePlayerTrackingSummary } from '@legacy/player-tracking-summary.js';
 
-export type LegacyIncentiveRule = Record<string, any>;
-export type LegacyPaidGameRecord = Record<string, any>;
-export type LegacyStatOption = { key: string; label: string };
-export type LegacyPlayerClip = Record<string, any>;
-export type LegacyTrackingSummaryItem = Record<string, any>;
-export type LegacyCalculatedEarnings = {
+type LegacyRecord = Record<string, unknown>;
+
+export type PlayerIncentiveRule = {
+    id?: string;
+    statKey: string;
+    type: 'per_unit' | 'threshold';
+    amountCents: number;
+    threshold: number | null;
+    thresholdOp: 'gt' | 'gte' | null;
+    active: boolean;
+    effectiveFrom?: unknown;
+    effectiveTo?: unknown;
+    createdAt?: unknown;
+    updatedAt?: unknown;
+    [key: string]: unknown;
+};
+export type PlayerPaidGameRecord = {
+    gameId: string;
+    amountCents: number;
+    paidAt?: unknown;
+    [key: string]: unknown;
+};
+export type PlayerStatOption = { key: string; label: string };
+export type PlayerVideoClip = {
+    id: string;
+    title: string;
+    gameDate: string;
+    playLabel: string;
+    url: string;
+    thumbnailUrl: string;
+    gameLabel: string;
+    [key: string]: unknown;
+};
+export type PlayerTrackingStatus = LegacyRecord;
+export type PlayerTrackingSummaryItem = {
+    id: string;
+    title: string;
+    description: string;
+    sortOrder: number;
+    isPublic: boolean;
+    status: PlayerTrackingStatus | null;
+    isComplete: boolean;
+    [key: string]: unknown;
+};
+export type PlayerTrackingSummary = {
+    playerId: string;
+    items: PlayerTrackingSummaryItem[];
+    [key: string]: unknown;
+};
+export type PlayerEarningsBreakdownItem = {
+    rule?: PlayerIncentiveRule | LegacyRecord;
+    statValue: number;
+    earned: number;
+    [key: string]: unknown;
+};
+export type PlayerCalculatedEarnings = {
     totalCents: number;
     uncappedTotalCents: number;
     wasCapped: boolean;
-    breakdown: Array<Record<string, any>>;
+    breakdown: PlayerEarningsBreakdownItem[];
 };
 
-export async function getIncentiveRules(userId: string, playerId: string): Promise<LegacyIncentiveRule[]> {
-    return await Promise.resolve(legacyGetIncentiveRules(userId, playerId));
+export type LegacyIncentiveRule = PlayerIncentiveRule;
+export type LegacyPaidGameRecord = PlayerPaidGameRecord;
+export type LegacyStatOption = PlayerStatOption;
+export type LegacyPlayerClip = PlayerVideoClip;
+export type LegacyTrackingSummaryItem = PlayerTrackingSummaryItem;
+export type LegacyCalculatedEarnings = PlayerCalculatedEarnings;
+
+function isRecord(value: unknown): value is LegacyRecord {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-export async function getPaidGames(userId: string, playerId: string): Promise<Map<string, LegacyPaidGameRecord>> {
-    return await Promise.resolve(legacyGetPaidGames(userId, playerId));
+function cleanString(value: unknown): string {
+    return String(value ?? '').trim();
+}
+
+function finiteNumber(value: unknown, fallback = 0): number {
+    const parsed = typeof value === 'string' && value.trim() === '' ? NaN : Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function asArray(value: unknown): unknown[] {
+    return Array.isArray(value) ? value : [];
+}
+
+function normalizeIncentiveRule(value: unknown): PlayerIncentiveRule | null {
+    if (!isRecord(value)) return null;
+
+    const type = value.type === 'threshold' ? 'threshold' : 'per_unit';
+    const thresholdOp = type === 'threshold'
+        ? (value.thresholdOp === 'gte' ? 'gte' : 'gt')
+        : null;
+
+    return {
+        ...value,
+        id: cleanString(value.id || value.ruleId) || undefined,
+        statKey: cleanString(value.statKey || value.key),
+        type,
+        amountCents: finiteNumber(value.amountCents),
+        threshold: type === 'threshold' ? finiteNumber(value.threshold) : null,
+        thresholdOp,
+        active: value.active !== false
+    };
+}
+
+function normalizeIncentiveRules(value: unknown): PlayerIncentiveRule[] {
+    return asArray(value).map(normalizeIncentiveRule).filter((rule): rule is PlayerIncentiveRule => !!rule);
+}
+
+function normalizePaidGameRecord(value: unknown, fallbackGameId = ''): PlayerPaidGameRecord | null {
+    if (!isRecord(value)) return null;
+    const gameId = cleanString(value.gameId || value.id || fallbackGameId);
+    if (!gameId) return null;
+    return {
+        ...value,
+        gameId,
+        amountCents: finiteNumber(value.amountCents)
+    };
+}
+
+function normalizePaidGameMap(value: unknown): Map<string, PlayerPaidGameRecord> {
+    const paidGames = new Map<string, PlayerPaidGameRecord>();
+
+    if (value instanceof Map) {
+        value.forEach((record, key) => {
+            const paidGame = normalizePaidGameRecord(record, cleanString(key));
+            if (paidGame) paidGames.set(paidGame.gameId, paidGame);
+        });
+        return paidGames;
+    }
+
+    if (Array.isArray(value)) {
+        value.forEach((record) => {
+            const paidGame = normalizePaidGameRecord(record);
+            if (paidGame) paidGames.set(paidGame.gameId, paidGame);
+        });
+        return paidGames;
+    }
+
+    if (isRecord(value)) {
+        Object.entries(value).forEach(([key, record]) => {
+            const paidGame = normalizePaidGameRecord(record, key);
+            if (paidGame) paidGames.set(paidGame.gameId, paidGame);
+        });
+    }
+
+    return paidGames;
+}
+
+function normalizeStatOption(value: unknown): PlayerStatOption | null {
+    if (!isRecord(value)) return null;
+    const key = cleanString(value.key || value.statKey || value.id);
+    if (!key) return null;
+    return {
+        key,
+        label: cleanString(value.label || value.name || key) || key
+    };
+}
+
+function normalizeStatOptions(value: unknown): PlayerStatOption[] {
+    return asArray(value).map(normalizeStatOption).filter((option): option is PlayerStatOption => !!option);
+}
+
+function normalizeEarningsBreakdownItem(value: unknown): PlayerEarningsBreakdownItem | null {
+    if (!isRecord(value)) return null;
+    return {
+        ...value,
+        statValue: finiteNumber(value.statValue),
+        earned: finiteNumber(value.earned)
+    };
+}
+
+function normalizeCalculatedEarnings(value: unknown): PlayerCalculatedEarnings {
+    const record = isRecord(value) ? value : {};
+    return {
+        totalCents: finiteNumber(record.totalCents),
+        uncappedTotalCents: finiteNumber(record.uncappedTotalCents),
+        wasCapped: record.wasCapped === true,
+        breakdown: asArray(record.breakdown)
+            .map(normalizeEarningsBreakdownItem)
+            .filter((item): item is PlayerEarningsBreakdownItem => !!item)
+    };
+}
+
+function normalizeVideoClip(value: unknown, index: number): PlayerVideoClip | null {
+    if (!isRecord(value)) return null;
+    const url = cleanString(value.url);
+    if (!url) return null;
+    const id = cleanString(value.id || value.clipId) || `clip-${index + 1}`;
+    return {
+        ...value,
+        id,
+        title: cleanString(value.title) || 'Game clip',
+        gameDate: cleanString(value.gameDate),
+        playLabel: cleanString(value.playLabel) || 'Highlight',
+        url,
+        thumbnailUrl: cleanString(value.thumbnailUrl),
+        gameLabel: cleanString(value.gameLabel) || 'Game'
+    };
+}
+
+function normalizeVideoClips(value: unknown): PlayerVideoClip[] {
+    return asArray(value).map(normalizeVideoClip).filter((clip): clip is PlayerVideoClip => !!clip);
+}
+
+function normalizeTrackingStatus(value: unknown): PlayerTrackingStatus | null {
+    return isRecord(value) ? value : null;
+}
+
+function normalizeTrackingSummaryItem(value: unknown, index: number): PlayerTrackingSummaryItem | null {
+    if (!isRecord(value)) return null;
+    const id = cleanString(value.id || value.itemId || value.trackingItemId) || `item-${index + 1}`;
+    const status = normalizeTrackingStatus(value.status);
+    return {
+        ...value,
+        id,
+        title: cleanString(value.title || value.name || value.label) || 'Tracking item',
+        description: cleanString(value.description || value.note),
+        sortOrder: Number.isFinite(Number(value.sortOrder)) ? Number(value.sortOrder) : 9999,
+        isPublic: value.isPublic === true || value.public === true,
+        status,
+        isComplete: value.isComplete === true || status?.isComplete === true
+    };
+}
+
+function normalizeTrackingSummary(value: unknown): PlayerTrackingSummary | null {
+    if (!isRecord(value)) return null;
+    return {
+        ...value,
+        playerId: cleanString(value.playerId || value.childId || value.memberId),
+        items: asArray(value.items)
+            .map(normalizeTrackingSummaryItem)
+            .filter((item): item is PlayerTrackingSummaryItem => !!item)
+    };
+}
+
+export async function getIncentiveRules(userId: string, playerId: string): Promise<PlayerIncentiveRule[]> {
+    const rules = await Promise.resolve(legacyGetIncentiveRules(userId, playerId));
+    return normalizeIncentiveRules(rules);
+}
+
+export async function getPaidGames(userId: string, playerId: string): Promise<Map<string, PlayerPaidGameRecord>> {
+    const paidGames = await Promise.resolve(legacyGetPaidGames(userId, playerId));
+    return normalizePaidGameMap(paidGames);
 }
 
 export async function getCapSetting(userId: string, playerId: string): Promise<number | null> {
-    return await Promise.resolve(legacyGetCapSetting(userId, playerId));
+    const capSetting = await Promise.resolve(legacyGetCapSetting(userId, playerId));
+    return Number.isFinite(Number(capSetting)) ? Number(capSetting) : null;
 }
 
-export async function getStatOptionsForTeam(teamId: string): Promise<LegacyStatOption[]> {
-    return await Promise.resolve(legacyGetStatOptionsForTeam(teamId));
+export async function getStatOptionsForTeam(teamId: string): Promise<PlayerStatOption[]> {
+    const statOptions = await Promise.resolve(legacyGetStatOptionsForTeam(teamId));
+    return normalizeStatOptions(statOptions);
 }
 
-export function getApplicableRulesForGame(rules: LegacyIncentiveRule[], date: Date) {
-    return legacyGetApplicableRulesForGame(rules, date) as LegacyIncentiveRule[];
+export function getApplicableRulesForGame(rules: PlayerIncentiveRule[], date: Date): PlayerIncentiveRule[] {
+    return normalizeIncentiveRules(legacyGetApplicableRulesForGame(rules, date));
 }
 
-export function calculateEarnings(rules: LegacyIncentiveRule[], stats: Record<string, unknown>, maxPerGameCents: number | null): LegacyCalculatedEarnings {
-    return legacyCalculateEarnings(rules, stats, maxPerGameCents) as LegacyCalculatedEarnings;
+export function calculateEarnings(rules: PlayerIncentiveRule[], stats: Record<string, unknown>, maxPerGameCents: number | null): PlayerCalculatedEarnings {
+    return normalizeCalculatedEarnings(legacyCalculateEarnings(rules, stats, maxPerGameCents));
 }
 
-export function isCurrentRuleVersion(rule: LegacyIncentiveRule) {
-    return legacyIsCurrentRuleVersion(rule);
+export function isCurrentRuleVersion(rule: PlayerIncentiveRule): boolean {
+    return legacyIsCurrentRuleVersion(rule) === true;
 }
 
 export async function markGamePaid(userId: string, gameId: string, playerId: string, teamId: string, amountCents: number) {
@@ -68,7 +297,7 @@ export async function saveIncentiveRule(userId: string, rule: Record<string, unk
     return await Promise.resolve(legacySaveIncentiveRule(userId, rule));
 }
 
-export async function toggleIncentiveRule(userId: string, rule: LegacyIncentiveRule) {
+export async function toggleIncentiveRule(userId: string, rule: PlayerIncentiveRule) {
     return await Promise.resolve(legacyToggleIncentiveRule(userId, rule));
 }
 
@@ -76,18 +305,24 @@ export async function retireIncentiveRule(userId: string, ruleId: string) {
     return await Promise.resolve(legacyRetireIncentiveRule(userId, ruleId));
 }
 
-export function buildAthleteProfileShareUrl(origin: string, profileId: string) {
-    return legacyBuildAthleteProfileShareUrl(origin, profileId);
+export function buildAthleteProfileShareUrl(origin: string, profileId: string): string {
+    return cleanString(legacyBuildAthleteProfileShareUrl(origin, profileId));
 }
 
-export function collectPlayerVideoClips(games: Array<Record<string, any>>, input: { teamId: string; playerId: string }): LegacyPlayerClip[] {
-    return legacyCollectPlayerVideoClips(games, input) as LegacyPlayerClip[];
+export function collectPlayerVideoClips(games: unknown, input: { teamId: string; playerId: string }): PlayerVideoClip[] {
+    return normalizeVideoClips(legacyCollectPlayerVideoClips(asArray(games), input));
 }
 
 export function getVisiblePlayerTrackingSummary(input: {
-    items: Array<Record<string, any>>;
-    statuses: Array<Record<string, any>>;
+    items: unknown;
+    statuses: unknown;
     playerIds: string[];
-}): LegacyTrackingSummaryItem[] {
-    return legacyGetVisiblePlayerTrackingSummary(input) as LegacyTrackingSummaryItem[];
+}): PlayerTrackingSummary[] {
+    return asArray(legacyGetVisiblePlayerTrackingSummary({
+        items: asArray(input.items),
+        statuses: asArray(input.statuses),
+        playerIds: input.playerIds
+    }))
+        .map(normalizeTrackingSummary)
+        .filter((summary): summary is PlayerTrackingSummary => !!summary);
 }

--- a/apps/app/src/lib/adapters/legacyRosterPrivacy.ts
+++ b/apps/app/src/lib/adapters/legacyRosterPrivacy.ts
@@ -3,53 +3,182 @@ import {
     normalizeRosterFieldDefinitions as legacyNormalizeRosterFieldDefinitions,
     splitRosterProfileValuesByVisibility as legacySplitRosterProfileValuesByVisibility,
     validateRosterProfileValues as legacyValidateRosterProfileValues
-} from '../../../../../js/roster-profile-fields.js';
-import { canViewRosterField as legacyCanViewRosterFieldVisibility } from '../../../../../js/roster-field-privacy.js';
+} from '@legacy/roster-profile-fields.js';
+import { canViewRosterField as legacyCanViewRosterFieldVisibility } from '@legacy/roster-field-privacy.js';
 
-export type LegacyRosterFieldOption = {
+type LegacyRecord = Record<string, unknown>;
+
+export type RosterFieldType = 'text' | 'menu' | 'checkbox' | 'date';
+export type RosterFieldVisibility = 'public' | 'team' | 'parents' | 'admins';
+export type RosterFieldOption = {
     value: string;
     label: string;
 };
 
-export type LegacyRosterFieldDefinition = {
+export type RosterFieldDefinition = {
     key: string;
     label: string;
-    type: 'text' | 'menu' | 'checkbox' | 'date';
+    type: RosterFieldType;
     section?: string;
     description?: string;
-    visibility: string;
+    visibility: RosterFieldVisibility;
     required?: boolean;
-    options?: LegacyRosterFieldOption[];
+    options?: RosterFieldOption[];
     active?: boolean;
     sortOrder?: number;
-    [key: string]: any;
+    [key: string]: unknown;
 };
 
-export type LegacyRosterFieldAccess = {
+export type RosterFieldAccess = {
     isAdmin: boolean;
     isTeamMember: boolean;
     isLinkedParent: boolean;
 };
 
-export function normalizeRosterFieldDefinitions(fields: unknown[]): LegacyRosterFieldDefinition[] {
-    return legacyNormalizeRosterFieldDefinitions(fields) as LegacyRosterFieldDefinition[];
+export type RosterProfileValue = string | boolean;
+export type RosterProfileValues = Record<string, RosterProfileValue>;
+
+export type RosterFieldVisibilityInput = {
+    id?: string;
+    key?: string;
+    visibility?: string;
+    privacy?: string;
+    access?: string;
+};
+
+export type LegacyRosterFieldOption = RosterFieldOption;
+export type LegacyRosterFieldDefinition = RosterFieldDefinition;
+export type LegacyRosterFieldAccess = RosterFieldAccess;
+
+const supportedTypes = new Set<RosterFieldType>(['text', 'menu', 'checkbox', 'date']);
+const supportedVisibility = new Set<RosterFieldVisibility>(['public', 'team', 'parents', 'admins']);
+
+function isRecord(value: unknown): value is LegacyRecord {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
-export function getRosterProfileValues(player: Record<string, any>) {
-    return legacyGetRosterProfileValues(player) as Record<string, unknown>;
+function cleanString(value: unknown): string {
+    return String(value ?? '').trim();
 }
 
-export function validateRosterProfileValues(fields: LegacyRosterFieldDefinition[], values: Record<string, unknown>) {
-    return legacyValidateRosterProfileValues(fields, values);
+function asArray(value: unknown): unknown[] {
+    return Array.isArray(value) ? value : [];
 }
 
-export function splitRosterProfileValuesByVisibility(fields: LegacyRosterFieldDefinition[], values: Record<string, unknown>) {
-    return legacySplitRosterProfileValuesByVisibility(fields, values) as {
-        publicValues: Record<string, unknown>;
-        privateValues: Record<string, unknown>;
+function normalizeFieldType(value: unknown): RosterFieldType {
+    const normalized = cleanString(value).toLowerCase();
+    if (normalized === 'select' || normalized === 'dropdown') return 'menu';
+    if (normalized === 'boolean' || normalized === 'bool') return 'checkbox';
+    return supportedTypes.has(normalized as RosterFieldType) ? normalized as RosterFieldType : 'text';
+}
+
+function normalizeVisibility(value: unknown): RosterFieldVisibility {
+    const normalized = cleanString(value || 'team').toLowerCase();
+    if (normalized === 'private' || normalized === 'admin' || normalized === 'restricted') return 'admins';
+    if (normalized === 'family') return 'parents';
+    return supportedVisibility.has(normalized as RosterFieldVisibility) ? normalized as RosterFieldVisibility : 'team';
+}
+
+function normalizeOption(value: unknown): RosterFieldOption | null {
+    if (isRecord(value)) {
+        const optionValue = cleanString(value.value ?? value.label);
+        if (!optionValue) return null;
+        return {
+            value: optionValue,
+            label: cleanString(value.label ?? value.value) || optionValue
+        };
+    }
+
+    const optionValue = cleanString(value);
+    return optionValue ? { value: optionValue, label: optionValue } : null;
+}
+
+function normalizeOptions(value: unknown): RosterFieldOption[] {
+    return asArray(value).map(normalizeOption).filter((option): option is RosterFieldOption => !!option);
+}
+
+function normalizeRosterFieldDefinition(value: unknown, index: number): RosterFieldDefinition | null {
+    if (!isRecord(value)) return null;
+    const key = cleanString(value.key || value.id);
+    const label = cleanString(value.label || value.name || key);
+    if (!key || !label) return null;
+
+    return {
+        ...value,
+        key,
+        label,
+        type: normalizeFieldType(value.type || value.fieldType),
+        section: cleanString(value.section) || undefined,
+        description: cleanString(value.description || value.helpText) || undefined,
+        visibility: normalizeVisibility(value.visibility || value.defaultVisibility),
+        required: value.required === true,
+        options: normalizeOptions(value.options || value.choices || value.values),
+        active: value.active !== false,
+        sortOrder: Number.isFinite(Number(value.sortOrder ?? value.order)) ? Number(value.sortOrder ?? value.order) : index
     };
 }
 
-export function canViewRosterField(field: { id: string; visibility: string }, access: LegacyRosterFieldAccess) {
-    return legacyCanViewRosterFieldVisibility(field, access);
+function normalizeRosterProfileValue(value: unknown): RosterProfileValue {
+    if (value === true || value === false) return value;
+    return cleanString(value);
+}
+
+function normalizeRosterProfileValues(value: unknown): RosterProfileValues {
+    if (!isRecord(value)) return {};
+    return Object.entries(value).reduce<RosterProfileValues>((acc, [key, rawValue]) => {
+        const cleanKey = cleanString(key);
+        if (!cleanKey) return acc;
+        acc[cleanKey] = normalizeRosterProfileValue(rawValue);
+        return acc;
+    }, {});
+}
+
+function splitByDefinitionVisibility(fields: RosterFieldDefinition[], values: RosterProfileValues) {
+    return fields.reduce<{ publicValues: RosterProfileValues; privateValues: RosterProfileValues }>((acc, field) => {
+        if (!Object.prototype.hasOwnProperty.call(values, field.key)) return acc;
+        if (field.visibility === 'admins') {
+            acc.privateValues[field.key] = values[field.key];
+        } else {
+            acc.publicValues[field.key] = values[field.key];
+        }
+        return acc;
+    }, { publicValues: {}, privateValues: {} });
+}
+
+export function normalizeRosterFieldDefinitions(fields: unknown): RosterFieldDefinition[] {
+    return asArray(legacyNormalizeRosterFieldDefinitions(asArray(fields)))
+        .map(normalizeRosterFieldDefinition)
+        .filter((field): field is RosterFieldDefinition => !!field);
+}
+
+export function getRosterProfileValues(player: Record<string, unknown>): RosterProfileValues {
+    return normalizeRosterProfileValues(legacyGetRosterProfileValues(player));
+}
+
+export function validateRosterProfileValues(fields: RosterFieldDefinition[], values: RosterProfileValues): string[] {
+    return asArray(legacyValidateRosterProfileValues(fields, values)).map(cleanString).filter(Boolean);
+}
+
+export function splitRosterProfileValuesByVisibility(fields: RosterFieldDefinition[], values: RosterProfileValues): {
+    publicValues: RosterProfileValues;
+    privateValues: RosterProfileValues;
+} {
+    const normalizedValues = normalizeRosterProfileValues(values);
+    const result = legacySplitRosterProfileValuesByVisibility(fields, normalizedValues);
+    if (!isRecord(result)) {
+        return splitByDefinitionVisibility(fields, normalizedValues);
+    }
+
+    return {
+        publicValues: normalizeRosterProfileValues(result.publicValues),
+        privateValues: normalizeRosterProfileValues(result.privateValues)
+    };
+}
+
+export function canViewRosterField(field: RosterFieldVisibilityInput, access: RosterFieldAccess): boolean {
+    return legacyCanViewRosterFieldVisibility({
+        ...field,
+        id: cleanString(field.id || field.key),
+        visibility: normalizeVisibility(field.visibility || field.privacy || field.access)
+    }, access) === true;
 }

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -38,8 +38,12 @@ import {
   saveCapSetting,
   saveIncentiveRule,
   toggleIncentiveRule,
-  type LegacyIncentiveRule,
-  type LegacyStatOption
+  type PlayerEarningsBreakdownItem,
+  type PlayerIncentiveRule,
+  type PlayerPaidGameRecord,
+  type PlayerStatOption,
+  type PlayerTrackingSummary,
+  type PlayerVideoClip
 } from './adapters/legacyPlayerProfile';
 import {
   canViewRosterField,
@@ -47,7 +51,8 @@ import {
   normalizeRosterFieldDefinitions,
   splitRosterProfileValuesByVisibility,
   validateRosterProfileValues,
-  type LegacyRosterFieldDefinition
+  type RosterFieldDefinition,
+  type RosterProfileValues
 } from './adapters/legacyRosterPrivacy';
 import { getOpenScheduleAssignments, normalizeRsvpResponse, type ParentScheduleEvent } from './scheduleLogic';
 import { loadParentPlayerSchedule, type ParentScheduleChild } from './scheduleService';
@@ -68,9 +73,9 @@ export type ParentPlayerPrivateProfile = {
 };
 
 export type ParentPlayerIncentiveData = {
-  rules: Array<Record<string, any>>;
-  currentRules: Array<Record<string, any>>;
-  statOptions: Array<{ key: string; label: string }>;
+  rules: PlayerIncentiveRule[];
+  currentRules: PlayerIncentiveRule[];
+  statOptions: PlayerStatOption[];
   maxPerGameCents: number | null;
   seasonGameEarnings: Array<{
     event: ParentScheduleEvent;
@@ -78,7 +83,7 @@ export type ParentPlayerIncentiveData = {
     totalCents: number;
     uncappedTotalCents: number;
     wasCapped: boolean;
-    breakdown: Array<Record<string, any>>;
+    breakdown: PlayerEarningsBreakdownItem[];
     paid: boolean;
     paidAmountCents: number;
   }>;
@@ -99,8 +104,6 @@ export type ParentAthleteProfileData = {
     playerName: string;
   }>;
 };
-
-type CustomRosterFieldDefinition = LegacyRosterFieldDefinition;
 
 export type ParentPlayerDetailData = {
   child: ParentScheduleChild;
@@ -131,9 +134,9 @@ export type ParentPlayerDetailData = {
     openAssignments: number;
   };
   statRows: ParentPlayerStatRow[];
-  clips: Array<Record<string, any>>;
+  clips: PlayerVideoClip[];
   certificates: Array<Record<string, any>>;
-  trackingSummary: Array<Record<string, any>>;
+  trackingSummary: PlayerTrackingSummary[];
   privateProfile: ParentPlayerPrivateProfile | null;
   incentives: ParentPlayerIncentiveData;
   athleteProfile: ParentAthleteProfileData;
@@ -217,14 +220,14 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     stats: await getAggregatedStatsForPlayer(resolvedTeamId, event.id, resolvedPlayerId).catch(() => ({})) || {}
   })));
 
-  const clips = collectPlayerVideoClips(Array.isArray(games) ? games : [], {
+  const clips = collectPlayerVideoClips(games, {
     teamId: resolvedTeamId,
     playerId: resolvedPlayerId
   }).slice(0, 8);
 
   const trackingSummary = getVisiblePlayerTrackingSummary({
-    items: trackingItems || [],
-    statuses: trackingStatuses || [],
+    items: trackingItems,
+    statuses: trackingStatuses,
     playerIds: [resolvedPlayerId]
   });
 
@@ -257,10 +260,10 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     trackingSummary,
     privateProfile: normalizePrivateProfile(privateProfile),
     incentives: buildPlayerIncentiveData({
-      rules: Array.isArray(incentiveRules) ? incentiveRules : [],
-      paidGames: paidGames instanceof Map ? paidGames : new Map(),
-      statOptions: Array.isArray(statOptions) ? statOptions : [],
-      maxPerGameCents: typeof maxPerGameCents === 'number' ? maxPerGameCents : null,
+      rules: incentiveRules,
+      paidGames,
+      statOptions,
+      maxPerGameCents,
       statRows
     }),
     athleteProfile: buildAthleteProfileData({
@@ -300,7 +303,7 @@ export async function savePlayerCustomRosterFieldValues({
   ]);
 
   const player = (Array.isArray(players) ? players : []).find((candidate: any) => candidate?.id === playerId) || {};
-  const normalizedFields = normalizeRosterFieldDefinitions(rosterFieldDefinitions) as CustomRosterFieldDefinition[];
+  const normalizedFields = normalizeRosterFieldDefinitions(rosterFieldDefinitions);
   const filteredValues = normalizeCustomRosterFieldInput(values, normalizedFields);
   const validationErrors = validateRosterProfileValues(normalizedFields, filteredValues);
   if (validationErrors.length > 0) {
@@ -477,7 +480,7 @@ export async function saveParentPlayerIncentiveRule({
   });
 }
 
-export async function toggleParentPlayerIncentiveRule(user: AuthUser | null, teamId: string, playerId: string, rule: Record<string, any>) {
+export async function toggleParentPlayerIncentiveRule(user: AuthUser | null, teamId: string, playerId: string, rule: PlayerIncentiveRule) {
   assertLinkedParent(user, teamId, playerId);
   return toggleIncentiveRule(user!.uid, rule);
 }
@@ -604,9 +607,9 @@ function buildPlayerIncentiveData({
   maxPerGameCents,
   statRows
 }: {
-  rules: LegacyIncentiveRule[];
-  paidGames: Map<string, Record<string, any>>;
-  statOptions: LegacyStatOption[];
+  rules: PlayerIncentiveRule[];
+  paidGames: Map<string, PlayerPaidGameRecord>;
+  statOptions: PlayerStatOption[];
   maxPerGameCents: number | null;
   statRows: ParentPlayerStatRow[];
 }): ParentPlayerIncentiveData {
@@ -741,12 +744,12 @@ function buildVisibleCustomRosterFields({
   privateProfile,
   access
 }: {
-  definitions: any[];
+  definitions: unknown;
   player: LegacyPlayerRecord;
   privateProfile: LegacyPlayerPrivateProfileRecord | null;
   access: { isLinkedParent: boolean; isTeamStaff: boolean; canEditRosterDetails: boolean; canEditCustomRosterFields: boolean };
 }) {
-  const normalizedFields = normalizeRosterFieldDefinitions(definitions) as CustomRosterFieldDefinition[];
+  const normalizedFields = normalizeRosterFieldDefinitions(definitions);
   if (!normalizedFields.length) return [];
 
   const mergedValues = {
@@ -773,13 +776,13 @@ function buildVisibleCustomRosterFields({
     }));
 }
 
-function normalizeCustomRosterFieldValue(type: string, value: unknown) {
+function normalizeCustomRosterFieldValue(type: RosterFieldDefinition['type'], value: unknown) {
   if (type === 'checkbox') return value === true;
   return String(value ?? '').trim();
 }
 
-function normalizeCustomRosterFieldInput(values: Record<string, unknown>, fields: Array<{ key: string; type: string }>) {
-  const normalized: Record<string, unknown> = {};
+function normalizeCustomRosterFieldInput(values: Record<string, unknown>, fields: Array<Pick<RosterFieldDefinition, 'key' | 'type'>>): RosterProfileValues {
+  const normalized: RosterProfileValues = {};
   fields.forEach((field) => {
     if (!Object.prototype.hasOwnProperty.call(values || {}, field.key)) return;
     if (field.type === 'checkbox') {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -1372,6 +1372,7 @@ function CoParentInviteCard({ data, auth }: { data: ParentPlayerDetailData; auth
 }
 
 type IncentivePanelId = 'overview' | 'rules' | 'history';
+type PlayerIncentiveRule = ParentPlayerDetailData['incentives']['currentRules'][number];
 
 const incentivePanels: Array<{ id: IncentivePanelId; label: string }> = [
   { id: 'overview', label: 'Overview' },
@@ -1393,7 +1394,7 @@ function IncentivesCard({ data, auth, onChanged }: { data: ParentPlayerDetailDat
   const [amount, setAmount] = useState('1.00');
   const [threshold, setThreshold] = useState('3');
   const [thresholdOp, setThresholdOp] = useState<'gt' | 'gte'>('gt');
-  const [editingRule, setEditingRule] = useState<Record<string, any> | null>(null);
+  const [editingRule, setEditingRule] = useState<PlayerIncentiveRule | null>(null);
   const [cap, setCap] = useState(incentives.maxPerGameCents !== null ? String(Math.round(incentives.maxPerGameCents / 100)) : '');
   const [busy, setBusy] = useState('');
   const [status, setStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
@@ -1459,7 +1460,7 @@ function IncentivesCard({ data, auth, onChanged }: { data: ParentPlayerDetailDat
     setBuilderOpen(false);
   };
 
-  const editRule = (rule: Record<string, any>) => {
+  const editRule = (rule: PlayerIncentiveRule) => {
     setEditingRule(rule);
     setStatKey(rule.statKey || statOptions[0]?.key || 'pts');
     setType(rule.type === 'threshold' ? 'threshold' : 'per_unit');
@@ -1682,7 +1683,10 @@ function IncentivesCard({ data, auth, onChanged }: { data: ParentPlayerDetailDat
                         Edit
                       </button>
                       <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 text-xs" disabled={busy === `toggle-${rule.id}`} onClick={() => run(`toggle-${rule.id}`, () => toggleParentPlayerIncentiveRule(auth.user, data.child.teamId, data.child.playerId, rule))}>{rule.active === false ? 'Enable' : 'Disable'}</button>
-                      <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 text-xs" disabled={busy === `retire-${rule.id}`} onClick={() => run(`retire-${rule.id}`, () => retireParentPlayerIncentiveRule(auth.user, data.child.teamId, data.child.playerId, rule.id), 'Rule stopped.')}>
+                      <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 text-xs" disabled={!rule.id || busy === `retire-${rule.id}`} onClick={() => {
+                        const ruleId = rule.id;
+                        return ruleId ? run(`retire-${ruleId}`, () => retireParentPlayerIncentiveRule(auth.user, data.child.teamId, data.child.playerId, ruleId), 'Rule stopped.') : undefined;
+                      }}>
                         <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
                       </button>
                     </div>
@@ -1964,7 +1968,7 @@ function getIncentiveStatLabel(statOptions: Array<{ key: string; label: string }
   return statOptions.find((option) => option.key === statKey)?.label || String(statKey || '').toUpperCase() || 'STAT';
 }
 
-function formatIncentiveRule(rule: Record<string, any>, statOptions = defaultStatOptions) {
+function formatIncentiveRule(rule: PlayerIncentiveRule, statOptions = defaultStatOptions) {
   const stat = getIncentiveStatLabel(statOptions, rule.statKey || '');
   const amount = formatMoney(Number(rule.amountCents || 0));
   if (rule.type === 'threshold') {

--- a/tests/unit/app-legacy-adapter-boundary.test.js
+++ b/tests/unit/app-legacy-adapter-boundary.test.js
@@ -24,14 +24,22 @@ describe('app legacy adapter boundary', () => {
         const playerServiceSource = readRepoFile('apps/app/src/lib/playerService.ts');
         const scheduleAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyScheduleDb.ts');
         const playerAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyPlayerDb.ts');
+        const playerProfileAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyPlayerProfile.ts');
+        const rosterPrivacyAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyRosterPrivacy.ts');
 
         expect(scheduleServiceSource).toContain("from './adapters/legacyScheduleDb'");
         expect(playerServiceSource).toContain("from './adapters/legacyPlayerDb'");
+        expect(playerServiceSource).toContain("from './adapters/legacyPlayerProfile'");
+        expect(playerServiceSource).toContain("from './adapters/legacyRosterPrivacy'");
         expect(scheduleAdapterSource).toContain("from '@legacy/db.js'");
         expect(scheduleAdapterSource).toContain("from '@legacy/firebase.js'");
         expect(playerAdapterSource).toContain("from '@legacy/db.js'");
+        expect(playerProfileAdapterSource).toContain("from '@legacy/parent-incentives.js'");
+        expect(rosterPrivacyAdapterSource).toContain("from '@legacy/roster-profile-fields.js'");
         expect(scheduleAdapterSource).not.toMatch(directLegacyImportPattern);
         expect(playerAdapterSource).not.toMatch(directLegacyImportPattern);
+        expect(playerProfileAdapterSource).not.toMatch(directLegacyImportPattern);
+        expect(rosterPrivacyAdapterSource).not.toMatch(directLegacyImportPattern);
     });
 
     it('keeps migrated app service clusters behind typed legacy adapters', () => {

--- a/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
+++ b/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
@@ -33,7 +33,9 @@ describe('app legacy adapter initiative source contract', () => {
             'legacyHomeFees.ts',
             'legacyParentTools.ts',
             'legacyPlayerDb.ts',
+            'legacyPlayerProfile.ts',
             'legacyProfile.ts',
+            'legacyRosterPrivacy.ts',
             'legacyScheduleDb.ts',
             'legacyScheduleHelpers.ts',
             'legacyTeamDetail.ts'
@@ -46,6 +48,8 @@ describe('app legacy adapter initiative source contract', () => {
         const chatAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyChatService.ts');
         const gameReportAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyGameReport.ts');
         const authAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyAuth.ts');
+        const playerProfileAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyPlayerProfile.ts');
+        const rosterPrivacyAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyRosterPrivacy.ts');
 
         expect(viteConfigSource).toContain("'@legacy': path.resolve(__dirname, '../../js')");
         expect(parentToolsAdapterSource).toContain("import * as legacyDb from '@legacy/db.js';");
@@ -53,6 +57,8 @@ describe('app legacy adapter initiative source contract', () => {
         expect(gameReportAdapterSource).toContain("from '@legacy/game-report-stats.js';");
         expect(authAdapterSource).toContain("import('@legacy/db.js')");
         expect(authAdapterSource).toContain("import('@legacy/admin-invite.js')");
+        expect(playerProfileAdapterSource).toContain("from '@legacy/parent-incentives.js'");
+        expect(rosterPrivacyAdapterSource).toContain("from '@legacy/roster-profile-fields.js'");
     });
 
     it('keeps direct ../../../../js references limited to known app-shell exceptions and adapter shims', () => {
@@ -61,8 +67,6 @@ describe('app legacy adapter initiative source contract', () => {
             .sort();
 
         expect(filesWithDirectLegacyReferences).toEqual([
-            'apps/app/src/lib/adapters/legacyPlayerProfile.ts',
-            'apps/app/src/lib/adapters/legacyRosterPrivacy.ts',
             'apps/app/src/lib/adapters/legacyScheduleHelpers.ts',
             'apps/app/src/lib/pushService.ts',
             'apps/app/src/lib/telemetry.ts'
@@ -89,6 +93,8 @@ describe('app legacy adapter initiative source contract', () => {
         expect(readRepoFile('apps/app/src/lib/scheduleService.ts')).toContain("from './adapters/legacyScheduleDb'");
         expect(readRepoFile('apps/app/src/lib/scheduleService.ts')).toContain("from './adapters/legacyScheduleHelpers'");
         expect(readRepoFile('apps/app/src/lib/playerService.ts')).toContain("from './adapters/legacyPlayerDb'");
+        expect(readRepoFile('apps/app/src/lib/playerService.ts')).toContain("from './adapters/legacyPlayerProfile'");
+        expect(readRepoFile('apps/app/src/lib/playerService.ts')).toContain("from './adapters/legacyRosterPrivacy'");
         expect(readRepoFile('apps/app/src/lib/gameReportService.ts')).toContain("from './adapters/legacyGameReport'");
     });
 });

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -25,21 +25,16 @@ const scheduleMocks = vi.hoisted(() => ({
     loadParentPlayerSchedule: vi.fn()
 }));
 
-const profileStatMocks = vi.hoisted(() => ({
-    collectPlayerVideoClips: vi.fn()
-}));
-
-const trackingMocks = vi.hoisted(() => ({
-    getVisiblePlayerTrackingSummary: vi.fn()
-}));
-
-const incentiveMocks = vi.hoisted(() => ({
+const playerProfileMocks = vi.hoisted(() => ({
+    buildAthleteProfileShareUrl: vi.fn(() => 'https://allplays.ai/athlete-profile.html?profileId=profile-1'),
     calculateEarnings: vi.fn(),
+    collectPlayerVideoClips: vi.fn(),
     getApplicableRulesForGame: vi.fn(),
     getCapSetting: vi.fn(),
     getIncentiveRules: vi.fn(),
     getPaidGames: vi.fn(),
     getStatOptionsForTeam: vi.fn(),
+    getVisiblePlayerTrackingSummary: vi.fn(),
     isCurrentRuleVersion: vi.fn(),
     markGamePaid: vi.fn(),
     retireIncentiveRule: vi.fn(),
@@ -48,10 +43,21 @@ const incentiveMocks = vi.hoisted(() => ({
     toggleIncentiveRule: vi.fn()
 }));
 
-vi.mock('../../js/db.js', () => dbMocks);
-vi.mock('../../js/player-profile-stats.js', () => profileStatMocks);
-vi.mock('../../js/player-tracking-summary.js', () => trackingMocks);
-vi.mock('../../js/parent-incentives.js', () => incentiveMocks);
+const rosterPrivacyMocks = vi.hoisted(() => ({
+    canViewRosterField: vi.fn(() => true),
+    getRosterProfileValues: vi.fn(() => ({})),
+    normalizeRosterFieldDefinitions: vi.fn(() => []),
+    splitRosterProfileValuesByVisibility: vi.fn(() => ({ publicValues: {}, privateValues: {} })),
+    validateRosterProfileValues: vi.fn(() => [])
+}));
+
+const profileStatMocks = playerProfileMocks;
+const trackingMocks = playerProfileMocks;
+const incentiveMocks = playerProfileMocks;
+
+vi.mock('../../apps/app/src/lib/adapters/legacyPlayerDb', () => dbMocks);
+vi.mock('../../apps/app/src/lib/adapters/legacyPlayerProfile', () => playerProfileMocks);
+vi.mock('../../apps/app/src/lib/adapters/legacyRosterPrivacy', () => rosterPrivacyMocks);
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
 
 import {
@@ -301,7 +307,7 @@ describe('React app parent player detail service', () => {
     });
 
     it('keeps the player page usable when optional profile data fails', async () => {
-        dbMocks.getTeam.mockRejectedValue(new Error('team unavailable'));
+        dbMocks.getTeam.mockResolvedValue(null);
         dbMocks.getPlayers.mockRejectedValue(new Error('players unavailable'));
         dbMocks.getGames.mockRejectedValue(new Error('games unavailable'));
         dbMocks.getAggregatedStatsForPlayer.mockRejectedValue(new Error('stats unavailable'));


### PR DESCRIPTION
## Summary
- Normalize player profile legacy outputs behind `legacyPlayerProfile` for incentives, paid games, stat options, clips, tracking summaries, and share URLs.
- Normalize roster privacy outputs behind `legacyRosterPrivacy` for field definitions, values, validation, split visibility, and visibility checks.
- Update player service/page typing and player-service tests so mocks target adapter modules instead of deep legacy JS imports.

## Validation
- `npx vitest run tests/unit/app-player-service.test.js tests/unit/app-legacy-adapter-boundary.test.js tests/unit/app-legacy-adapter-initiative-source-contract.test.js --reporter=verbose`
- `npm --prefix apps/app test -- --run src/lib/playerService.test.ts --reporter=verbose`
- `npm run app:build`

Fixes #2889