### PR TITLE
[codex] Extend app uxTiming startup and resume coverage

### DIFF
--- a/apps/app/src/lib/useRefreshOnResume.ts
+++ b/apps/app/src/lib/useRefreshOnResume.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { App as CapacitorApp } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import { createLogger } from './logger';
+import { startWarmResumeTimer } from './uxTiming';
 
 export type RefreshOnResumeFn = () => void | Promise<void>;
 
@@ -22,6 +23,8 @@ export type RefreshOnResumeDeps = {
 
 const defaultStaleAfterMs = 5 * 60_000;
 const logger = createLogger('refresh-on-resume');
+type ResumeSource = 'visibilitychange' | 'native_app_state';
+const primaryResumeRoutes = new Set(['home', 'schedule', 'messages']);
 
 /**
  * Refreshes a page when the app returns to the foreground (Capacitor `App.appStateChange`)
@@ -52,19 +55,26 @@ export function useRefreshOnResume(
     // Treat (re)mount/enable as a fresh load so we don't immediately refire.
     lastRefreshAtRef.current = now();
 
-    const maybeRefresh = () => {
+    const maybeRefresh = (source: ResumeSource) => {
       const elapsed = now() - lastRefreshAtRef.current;
       if (elapsed < staleAfterMs) return;
       lastRefreshAtRef.current = now();
-      void Promise.resolve(refreshRef.current()).catch((error) => {
-        logger.warn('Refresh failed.', { error });
-      });
+      const route = getCurrentPrimaryRoute();
+      const timer = startWarmResumeTimer({ source, staleAfterMs, elapsedMs: elapsed, ...(route ? { route } : {}) });
+      void Promise.resolve(refreshRef.current())
+        .then(() => {
+          timer.end({ source });
+        })
+        .catch((error) => {
+          timer.end({ source, error });
+          logger.warn('Refresh failed.', { error });
+        });
     };
 
     const doc = deps.doc || (typeof document !== 'undefined' ? document : null);
     const handleVisibility = () => {
       if (!doc || doc.visibilityState === 'visible') {
-        maybeRefresh();
+        maybeRefresh('visibilitychange');
       }
     };
     doc?.addEventListener('visibilitychange', handleVisibility);
@@ -80,7 +90,7 @@ export function useRefreshOnResume(
       const plugin = deps.appPlugin || CapacitorApp;
       const handle = await plugin.addListener('appStateChange', ({ isActive }) => {
         if (prevActiveRef.current === false && isActive) {
-          maybeRefresh();
+          maybeRefresh('native_app_state');
         }
         prevActiveRef.current = isActive;
       });
@@ -102,4 +112,11 @@ export function useRefreshOnResume(
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, staleAfterMs]);
+}
+
+function getCurrentPrimaryRoute() {
+  if (typeof window === 'undefined') return null;
+  const hashPath = window.location.hash.replace(/^#/, '').split('?')[0] || window.location.pathname;
+  const route = hashPath.replace(/^\//, '').split('/')[0];
+  return primaryResumeRoutes.has(route) ? route : null;
 }

--- a/apps/app/src/lib/uxTiming.test.ts
+++ b/apps/app/src/lib/uxTiming.test.ts
@@ -10,8 +10,10 @@ import {
   recordFirstMeaningfulRender,
   hasRecordedFirstMeaningfulRender,
   resetFirstMeaningfulRenderForTests,
+  startAppStartupTimer,
   startInteractionTimer,
   startScreenMountTimer,
+  startWarmResumeTimer,
   startUxTimer
 } from './uxTiming';
 
@@ -29,7 +31,9 @@ describe('uxTiming', () => {
   it('declares stable app-start and core interaction spans', () => {
     expect(UX_TIMING).toMatchObject({
       appStartup: 'app startup',
+      appStartToHomeRender: 'app start to home first meaningful render',
       firstMeaningfulRender: 'first meaningful render',
+      warmResume: 'warm resume to interactive',
       rsvpTap: 'rsvp tap latency',
       chatSend: 'chat send latency'
     });
@@ -54,6 +58,28 @@ describe('uxTiming', () => {
     });
   });
 
+  it('startAppStartupTimer tags the span as startup timing', () => {
+    const timer = startAppStartupTimer({ platform: 'web' });
+    timer.end({ phase: 'initial-render' });
+    expect(recordAppUxTiming).toHaveBeenCalledWith(UX_TIMING.appStartup, expect.any(Number), {
+      category: 'startup',
+      stage: 'startup',
+      platform: 'web',
+      phase: 'initial-render'
+    });
+  });
+
+  it('startWarmResumeTimer tags the span as resume timing', () => {
+    const timer = startWarmResumeTimer({ source: 'visibilitychange', elapsedMs: 10_000 });
+    timer.end({ route: 'home' });
+    expect(recordAppUxTiming).toHaveBeenCalledWith(UX_TIMING.warmResume, expect.any(Number), {
+      category: 'resume',
+      source: 'visibilitychange',
+      elapsedMs: 10000,
+      route: 'home'
+    });
+  });
+
   it('startScreenMountTimer uses stable labels and bounded screen metadata', () => {
     const timer = startScreenMountTimer('messages', { mode: 'inbox' });
     timer.end({ teamCount: 3, unreadCount: 5 });
@@ -66,12 +92,17 @@ describe('uxTiming', () => {
     });
   });
 
-  it('records first meaningful render exactly once per load', () => {
+  it('records first meaningful render exactly once per load and emits the cold Home span', () => {
     expect(hasRecordedFirstMeaningfulRender()).toBe(false);
     recordFirstMeaningfulRender('home', { warm: true });
     recordFirstMeaningfulRender('schedule');
     expect(hasRecordedFirstMeaningfulRender()).toBe(true);
-    expect(recordAppUxTiming).toHaveBeenCalledTimes(1);
+    expect(recordAppUxTiming).toHaveBeenCalledTimes(2);
+    expect(recordAppUxTiming).toHaveBeenCalledWith(UX_TIMING.appStartToHomeRender, 0, {
+      category: 'startup',
+      route: 'home',
+      warm: true
+    });
     expect(recordAppUxTiming).toHaveBeenCalledWith(UX_TIMING.firstMeaningfulRender, 0, {
       route: 'home',
       warm: true

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -10,7 +10,9 @@ const logger = createLogger('ux');
  */
 export const UX_TIMING = {
   appStartup: 'app startup',
+  appStartToHomeRender: 'app start to home first meaningful render',
   firstMeaningfulRender: 'first meaningful render',
+  warmResume: 'warm resume to interactive',
   homeMount: 'home mount load',
   scheduleMount: 'schedule mount load',
   messagesMount: 'messages mount load',
@@ -40,6 +42,18 @@ export function startUxTimer(label: string, baseMeta: Record<string, unknown> = 
 }
 
 /**
+ * Times the app-shell startup boundary. This keeps startup spans in uxTiming
+ * while telemetry remains the transport layer.
+ */
+export function startAppStartupTimer(baseMeta: Record<string, unknown> = {}) {
+  return startUxTimer(UX_TIMING.appStartup, {
+    category: 'startup',
+    stage: 'startup',
+    ...baseMeta
+  });
+}
+
+/**
  * Times a top-level app screen load using stable labels and bounded metadata so
  * local logs and telemetry payloads can compare before/after screen work.
  */
@@ -57,6 +71,13 @@ export function startScreenMountTimer(route: ScreenMountRoute, baseMeta: Record<
  */
 export function startInteractionTimer(label: string, baseMeta: Record<string, unknown> = {}) {
   return startUxTimer(label, { category: 'interaction', ...baseMeta });
+}
+
+export function startWarmResumeTimer(baseMeta: Record<string, unknown> = {}) {
+  return startUxTimer(UX_TIMING.warmResume, {
+    category: 'resume',
+    ...baseMeta
+  });
 }
 
 export function recordUxTiming(label: string, startedAt: number, meta: Record<string, unknown> = {}) {
@@ -79,6 +100,9 @@ export function recordFirstMeaningfulRender(route: string, meta: Record<string, 
   firstMeaningfulRenderRecorded = true;
   // performance.now() is relative to navigation start, so passing 0 yields
   // "time since the page began loading".
+  if (route === 'home') {
+    recordUxTiming(UX_TIMING.appStartToHomeRender, 0, { category: 'startup', route, ...meta });
+  }
   recordUxTiming(UX_TIMING.firstMeaningfulRender, 0, { route, ...meta });
 }
 

--- a/apps/app/src/main.test.tsx
+++ b/apps/app/src/main.test.tsx
@@ -4,13 +4,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const renderMock = vi.fn();
 const telemetryMocks = vi.hoisted(() => {
+  return {
+    captureAppStartupFailure: vi.fn(),
+    initializeAppErrorTracking: vi.fn(),
+    installReactErrorTelemetry: vi.fn()
+  };
+});
+const uxTimingMocks = vi.hoisted(() => {
   const end = vi.fn();
   return {
     end,
-    captureAppStartupFailure: vi.fn(),
-    initializeAppErrorTracking: vi.fn(),
-    startAppStartupTimer: vi.fn(() => ({ end })),
-    installReactErrorTelemetry: vi.fn()
+    startAppStartupTimer: vi.fn(() => ({ end }))
   };
 });
 
@@ -30,6 +34,7 @@ vi.mock('./components/ErrorBoundary', () => ({
 }));
 
 vi.mock('./lib/telemetry', () => telemetryMocks);
+vi.mock('./lib/uxTiming', () => uxTimingMocks);
 
 describe('main startup telemetry wiring', () => {
   beforeEach(() => {
@@ -50,10 +55,10 @@ describe('main startup telemetry wiring', () => {
 
     expect(telemetryMocks.initializeAppErrorTracking).toHaveBeenCalledTimes(1);
     expect(telemetryMocks.installReactErrorTelemetry).toHaveBeenCalledTimes(1);
-    expect(telemetryMocks.startAppStartupTimer).toHaveBeenCalledTimes(1);
+    expect(uxTimingMocks.startAppStartupTimer).toHaveBeenCalledTimes(1);
     expect(renderMock).toHaveBeenCalledTimes(1);
     expect(requestAnimationFrameMock).toHaveBeenCalledTimes(1);
-    expect(telemetryMocks.end).toHaveBeenCalledWith({ phase: 'initial-render' });
+    expect(uxTimingMocks.end).toHaveBeenCalledWith({ phase: 'initial-render' });
     expect(telemetryMocks.captureAppStartupFailure).not.toHaveBeenCalled();
   });
 
@@ -68,6 +73,6 @@ describe('main startup telemetry wiring', () => {
 
     expect(telemetryMocks.initializeAppErrorTracking).toHaveBeenCalledTimes(1);
     expect(telemetryMocks.captureAppStartupFailure).toHaveBeenCalledWith(startupError, { phase: 'initial-render' });
-    expect(telemetryMocks.end).toHaveBeenCalledWith({ phase: 'initial-render', error: startupError });
+    expect(uxTimingMocks.end).toHaveBeenCalledWith({ phase: 'initial-render', error: startupError });
   });
 });

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -6,9 +6,9 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import {
   captureAppStartupFailure,
   initializeAppErrorTracking,
-  installReactErrorTelemetry,
-  startAppStartupTimer
+  installReactErrorTelemetry
 } from './lib/telemetry';
+import { startAppStartupTimer } from './lib/uxTiming';
 import { hideNativeSplashScreen, initializeNativeAppearance } from './lib/nativeAppearance';
 import './styles/index.css';
 

--- a/tests/unit/app-refresh-on-resume.test.tsx
+++ b/tests/unit/app-refresh-on-resume.test.tsx
@@ -2,6 +2,19 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const uxTimingMocks = vi.hoisted(() => {
+    const resumeEnd = vi.fn();
+    return {
+        resumeEnd,
+        startWarmResumeTimer: vi.fn(() => ({ end: resumeEnd }))
+    };
+});
+
+vi.mock('../../apps/app/src/lib/uxTiming', () => ({
+    startWarmResumeTimer: uxTimingMocks.startWarmResumeTimer
+}));
+
 import { useRefreshOnResume, type RefreshOnResumeDeps } from '../../apps/app/src/lib/useRefreshOnResume';
 
 type FakeDoc = {
@@ -74,6 +87,7 @@ function mountUseRefreshOnResume(
 }
 
 afterEach(() => {
+    vi.clearAllMocks();
     while (mountedRoots.length) {
         const root = mountedRoots.pop();
         act(() => {
@@ -83,6 +97,7 @@ afterEach(() => {
     while (mountedContainers.length) {
         mountedContainers.pop()?.remove();
     }
+    window.history.replaceState(null, '', '/');
 });
 
 describe('useRefreshOnResume', () => {
@@ -90,6 +105,7 @@ describe('useRefreshOnResume', () => {
         const doc = makeFakeDoc('visible');
         let clock = 1_000;
         const refresh = vi.fn();
+        window.location.hash = '#/home';
         const deps: RefreshOnResumeDeps = {
             doc: doc as unknown as Document,
             isNativePlatform: () => false,
@@ -105,6 +121,15 @@ describe('useRefreshOnResume', () => {
         clock = 7_000;
         doc.fire('visibilitychange');
         expect(refresh).toHaveBeenCalledTimes(1);
+        expect(uxTimingMocks.startWarmResumeTimer).toHaveBeenCalledWith({
+            source: 'visibilitychange',
+            staleAfterMs: 5000,
+            elapsedMs: 6000,
+            route: 'home'
+        });
+        return vi.waitFor(() => {
+            expect(uxTimingMocks.resumeEnd).toHaveBeenCalledWith({ source: 'visibilitychange' });
+        });
     });
 
     it('does not refresh while the tab is hidden', () => {
@@ -127,6 +152,7 @@ describe('useRefreshOnResume', () => {
         let clock = 0;
         const refresh = vi.fn();
         const native = makeNativeAppPlugin();
+        window.location.hash = '#/messages/team-1';
         mountUseRefreshOnResume(refresh, { staleAfterMs: 1_000 }, {
             doc: doc as unknown as Document,
             isNativePlatform: () => true,
@@ -148,6 +174,12 @@ describe('useRefreshOnResume', () => {
         clock = 7_000;
         native.emit(true);
         expect(refresh).toHaveBeenCalledTimes(1);
+        expect(uxTimingMocks.startWarmResumeTimer).toHaveBeenCalledWith({
+            source: 'native_app_state',
+            staleAfterMs: 1000,
+            elapsedMs: 7000,
+            route: 'messages'
+        });
     });
 
     it('does nothing when disabled', () => {
@@ -177,6 +209,7 @@ describe('useRefreshOnResume', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
         const doc = makeFakeDoc('visible');
         let clock = 0;
+        window.location.hash = '#/schedule?filter=upcoming-all';
         const refresh = vi.fn(async () => {
             throw Object.assign(new Error('Refresh failed with Bearer unsafe-token'), {
                 headers: { Authorization: 'Bearer header-token' }
@@ -192,6 +225,10 @@ describe('useRefreshOnResume', () => {
         doc.fire('visibilitychange');
         await vi.waitFor(() => expect(warnSpy).toHaveBeenCalled());
 
+        expect(uxTimingMocks.resumeEnd).toHaveBeenCalledWith({
+            source: 'visibilitychange',
+            error: expect.any(Error)
+        });
         expect(warnSpy).toHaveBeenCalledWith(
             '[refresh-on-resume] Refresh failed.',
             {


### PR DESCRIPTION
## Summary
- Move app startup timing through `uxTiming` and add a cold Home first-meaningful-render span.
- Add a warm resume uxTiming span around shared resume refreshes with source, staleness, elapsed time, and primary route metadata.
- Extend focused uxTiming, main startup, and resume hook tests while preserving existing Home/Schedule/Messages mount coverage.

Closes #2897

## Tests
- `npx vitest run apps/app/src/lib/uxTiming.test.ts apps/app/src/main.test.tsx tests/unit/app-refresh-on-resume.test.tsx apps/app/src/pages/Home.test.tsx apps/app/src/pages/Schedule.test.tsx apps/app/src/pages/Messages.test.ts tests/unit/app-observability-initiative-source-contract.test.js tests/unit/app-performance-baseline-contract.test.js tests/unit/app-performance-measurement-initiative-source-contract.test.js tests/unit/issue-2281-ux-timing-coverage-source.test.js --reporter=verbose`
- `npm run app:build`

## Notes
- Kept scope disjoint from PR #2891 staff RSVP/schedule-detail files and PR #2899 performance baseline docs.
- Did not start #2898.