### PR TITLE
Avoid duplicate parent schedule RSVP reads

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -644,6 +644,29 @@ describe('parent schedule detail hydration', () => {
     expect(futureEvent.myRsvp).toBe('not_responded');
   });
 
+  it('preserves denormalized RSVP summaries without preloading duplicate summaries', async () => {
+    const nearEvent = buildHydrationEvent('near-game', new Date(Date.now() + 24 * 60 * 60 * 1000));
+    nearEvent.rsvpSummary = {
+      going: 8,
+      maybe: 1,
+      notGoing: 2,
+      notResponded: 3,
+      total: 14
+    };
+
+    await hydrateParentScheduleDetails({ children: [], events: [nearEvent] }, user);
+
+    expect(getRsvpSummaries).not.toHaveBeenCalled();
+    expect(getRsvps).toHaveBeenCalledWith('team-1', 'near-game');
+    expect(nearEvent.rsvpSummary).toEqual({
+      going: 8,
+      maybe: 1,
+      notGoing: 2,
+      notResponded: 3,
+      total: 14
+    });
+  });
+
   it('reuses cached per-event hydration details across repeated Home hydration passes', async () => {
     const cached = new Map<string, Promise<unknown>>();
     vi.mocked(loadCachedAppData).mockImplementation((key: string, loader: () => Promise<unknown>) => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -624,16 +624,23 @@ describe('parent schedule detail hydration', () => {
     vi.mocked(getAssignmentClaims).mockResolvedValue({} as any);
   });
 
-  it('eagerly hydrates only near-term Home events', async () => {
+  it('eagerly hydrates only near-term Home events without preloading duplicate RSVP summaries', async () => {
     const nearEvent = buildHydrationEvent('near-game', new Date(Date.now() + 24 * 60 * 60 * 1000));
     const futureEvent = buildHydrationEvent('future-game', new Date(Date.now() + 30 * 24 * 60 * 60 * 1000));
 
     await hydrateParentScheduleDetails({ children: [], events: [nearEvent, futureEvent] }, user);
 
-    expect(getRsvpSummaries).toHaveBeenCalledWith('team-1', ['near-game']);
+    expect(getRsvpSummaries).not.toHaveBeenCalled();
     expect(getRsvps).toHaveBeenCalledWith('team-1', 'near-game');
     expect(getRsvps).not.toHaveBeenCalledWith('team-1', 'future-game');
     expect(nearEvent.myRsvp).toBe('going');
+    expect(nearEvent.rsvpSummary).toEqual({
+      going: 1,
+      maybe: 0,
+      notGoing: 0,
+      notResponded: 0,
+      total: 1
+    });
     expect(futureEvent.myRsvp).toBe('not_responded');
   });
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -11,7 +11,6 @@ import {
   getPlayers,
   getRsvps,
   getRsvpBreakdownByPlayer,
-  getRsvpSummaries,
   getTeam,
   getTeams,
   addGame,
@@ -2442,21 +2441,6 @@ function normalizeAssignments(assignments: any[]): ScheduleAssignment[] {
     .filter((assignment) => assignment.role || assignment.value);
 }
 
-async function loadRsvpSummaryMap(teamId: string, gameIds: string[]) {
-  try {
-    return await withTimeout(Promise.resolve(getRsvpSummaries(teamId, gameIds)), `RSVP summaries ${teamId}`);
-  } catch (error) {
-    if (!isNativeRuntime()) throw error;
-    logScheduleWarning(`Falling back to local RSVP summaries for ${teamId}.`, 'rsvp-summary-local-fallback', error, { fallback: 'local', teamId });
-    const map = new Map<string, ScheduleRsvpSummary>();
-    await Promise.all(gameIds.map(async (gameId) => {
-      const rsvps = await loadRsvps(teamId, gameId).catch(() => []);
-      map.set(gameId, summarizeRsvps(rsvps));
-    }));
-    return map;
-  }
-}
-
 function summarizeRsvps(rsvps: any[]): ScheduleRsvpSummary {
   return (Array.isArray(rsvps) ? rsvps : []).reduce<Required<ScheduleRsvpSummary>>((acc, rsvp) => {
     const response = normalizeRsvpResponse(rsvp?.response);
@@ -3090,19 +3074,6 @@ async function hydrateEventDetails(events: ParentScheduleEvent[], user: AuthUser
       .map((event) => `${event.teamId}::${event.id}`)
   )];
 
-  const gameIdsByTeam = new Map<string, string[]>();
-  uniqueEventKeys.forEach((key) => {
-    const [teamId, gameId] = key.split('::');
-    if (!teamId || !gameId) return;
-    if (!gameIdsByTeam.has(teamId)) gameIdsByTeam.set(teamId, []);
-    gameIdsByTeam.get(teamId)?.push(gameId);
-  });
-
-  const summaryMapsByTeam = new Map<string, Map<string, ScheduleRsvpSummary>>();
-  await Promise.all([...gameIdsByTeam.entries()].map(async ([teamId, gameIds]) => {
-    summaryMapsByTeam.set(teamId, await loadRsvpSummaryMap(teamId, gameIds).catch(() => new Map()));
-  }));
-
   await Promise.all(uniqueEventKeys.map(async (key) => {
     const [teamId, gameId] = key.split('::');
     const matchingEvents = events.filter((event) => event.teamId === teamId && event.id === gameId);
@@ -3112,7 +3083,7 @@ async function hydrateEventDetails(events: ParentScheduleEvent[], user: AuthUser
     const { rsvps, offers, claims } = await loadCachedEventHydrationDetails(teamId, gameId);
     const myRsvpByChild = resolveMyRsvpByChildForGame(events, teamId, gameId, rsvps, user.uid);
     const myRsvpNotesByChild = resolveMyRsvpNotesByChildForGame(events, teamId, gameId, rsvps, user.uid);
-    const summary = summaryMapsByTeam.get(teamId)?.get(gameId) || firstEvent.rsvpSummary || summarizeRsvps(rsvps);
+    const summary = firstEvent.rsvpSummary || summarizeRsvps(rsvps);
     const rideshareSummary = getEventRideshareSummary(offers) as ScheduleRideSummary;
     const assignments = mergeAssignmentsWithClaims(firstEvent.assignments, claims) as ScheduleAssignment[];
     const preferences = firstEvent.availabilityPreferences || {};

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -528,7 +528,7 @@ describe('React app auth/profile capability parity', () => {
             'getGames',
             'getPracticeSessions',
             'getRsvps',
-            'getRsvpSummaries',
+            'summarizeRsvps',
             'listRideOffersForEvent',
             'getAssignmentClaims',
             'fetchAndParseCalendar',

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -469,7 +469,11 @@ describe('React app schedule service contract integration', () => {
             startDate: expect.any(Date)
         });
         expect(utilsMocks.fetchAndParseCalendar).toHaveBeenCalledWith('mock://team-calendar');
-        expect(dbMocks.getRsvpSummaries).toHaveBeenCalledWith('team-1', expect.arrayContaining(['game-1', 'practice-1', 'final-1']));
+        expect(dbMocks.getRsvpSummaries).not.toHaveBeenCalled();
+        expect(dbMocks.getRsvps).toHaveBeenCalledWith('team-1', 'game-1');
+        expect(dbMocks.getRsvps).toHaveBeenCalledWith('team-1', 'practice-1');
+        expect(dbMocks.getRsvps).toHaveBeenCalledWith('team-1', 'final-1');
+        expect(dbMocks.getRsvps).toHaveBeenCalledTimes(3);
         expect(dbMocks.listRideOffersForEvent).toHaveBeenCalledWith('team-1', 'game-1', { fallbackGameIds: [] });
         expect(dbMocks.getAssignmentClaims).toHaveBeenCalledWith('team-1', 'game-1');
 
@@ -649,7 +653,7 @@ describe('React app schedule service contract integration', () => {
         expect(dbMocks.getPracticeSessions).not.toHaveBeenCalled();
         expect(utilsMocks.fetchAndParseCalendar).not.toHaveBeenCalled();
         expect(dbMocks.getPracticeSessionByEvent).not.toHaveBeenCalled();
-        expect(dbMocks.getRsvpSummaries).toHaveBeenCalledWith('team-1', ['game-1']);
+        expect(dbMocks.getRsvpSummaries).not.toHaveBeenCalled();
         expect(dbMocks.getRsvps).toHaveBeenCalledTimes(1);
         expect(dbMocks.getRsvps).toHaveBeenCalledWith('team-1', 'game-1');
         expect(dbMocks.listRideOffersForEvent).toHaveBeenCalledTimes(1);
@@ -672,6 +676,7 @@ describe('React app schedule service contract integration', () => {
             myRsvp: 'going',
             myRsvpNote: 'Needs a ride home',
             teamNotificationEmail: 'team-notify@example.com',
+            rsvpSummary: { going: 1, maybe: 1, notGoing: 0, notResponded: 0, total: 2 },
             rideshareSummary: { offerCount: 1, seatsLeft: 2, requests: 1, pending: 1, confirmed: 0, isFull: false }
         });
         expect(result.events.find((event) => event.childId === 'player-2')).toMatchObject({


### PR DESCRIPTION
## Summary
- Remove the parent schedule hydration RSVP summary preload for eager near-term event hydration.
- Reuse the RSVP docs already loaded by cached event detail hydration to derive RSVP summaries.
- Add regression coverage asserting eager hydration does not call getRsvpSummaries and still hydrates the summary.

Closes #2893

## Tests
- npm ci
- npm --prefix apps/app ci
- npm --prefix apps/app exec vitest run src/lib/scheduleService.test.ts --reporter=verbose
- npm run app:build