### PR TITLE
[codex] Fix Vite config ESM path resolution

### DIFF
--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,15 +1,18 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { patchBundleVisualizerTooltipFile } from './build/fixBundleVisualizerTooltip.js';
+
+const appDirectory = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
 const bundleVisualizerTooltipFixPlugin = {
   name: 'bundle-visualizer-tooltip-fix',
   apply: 'build',
   writeBundle() {
-    patchBundleVisualizerTooltipFile(path.resolve(__dirname, 'bundle-visualizer.html'));
+    patchBundleVisualizerTooltipFile(path.resolve(appDirectory, 'bundle-visualizer.html'));
   }
 };
 
@@ -17,7 +20,7 @@ export default defineConfig({
   base: './',
   resolve: {
     alias: {
-      '@legacy': path.resolve(__dirname, '../../js')
+      '@legacy': path.resolve(appDirectory, '../../js')
     }
   },
   plugins: [

--- a/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
+++ b/tests/unit/app-legacy-adapter-initiative-source-contract.test.js
@@ -57,7 +57,7 @@ describe('app legacy adapter initiative source contract', () => {
         const playerProfileAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyPlayerProfile.ts');
         const rosterPrivacyAdapterSource = readRepoFile('apps/app/src/lib/adapters/legacyRosterPrivacy.ts');
 
-        expect(viteConfigSource).toContain("'@legacy': path.resolve(__dirname, '../../js')");
+        expect(viteConfigSource).toContain("'@legacy': path.resolve(appDirectory, '../../js')");
         expect(parentToolsAdapterSource).toContain("import * as legacyDb from '@legacy/db.js';");
         expect(chatAdapterSource).toContain("import * as legacyDb from '@legacy/db.js';");
         expect(gameReportAdapterSource).toContain("from '@legacy/game-report-stats.js';");

--- a/tests/unit/app-vite-config.test.ts
+++ b/tests/unit/app-vite-config.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -23,6 +24,15 @@ describe('app Vite config', () => {
         expect(appViteConfig.resolve?.alias).toEqual(expect.objectContaining({
             '@legacy': expect.stringContaining('/js')
         }));
+    });
+
+    it('resolves config-relative paths without CommonJS directory globals', () => {
+        const viteConfigSource = readFileSync(new URL('../../apps/app/vite.config.ts', import.meta.url), 'utf8');
+
+        expect(viteConfigSource).not.toContain('__dirname');
+        expect(viteConfigSource).toContain('fileURLToPath(import.meta.url)');
+        expect(viteConfigSource).toContain("path.resolve(appDirectory, '../../js')");
+        expect(viteConfigSource).toContain("path.resolve(appDirectory, 'bundle-visualizer.html')");
     });
 
     it('enables app coverage reports across source files', () => {


### PR DESCRIPTION
## Summary
- Resolve the app Vite config directory through `fileURLToPath(import.meta.url)` instead of CommonJS `__dirname`.
- Keep the `@legacy` alias and bundle visualizer tooltip patch pointed at the same app-relative locations.
- Add/update focused unit contracts covering the ESM-safe config path behavior.

Closes #2901

## Verification
- `npx vitest run tests/unit/app-vite-config.test.ts tests/unit/app-legacy-adapter-initiative-source-contract.test.js --reporter=verbose`
- `npm run app:build`