### PR TITLE
[codex] Add team media audience resolver

### DIFF
--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -117,7 +117,7 @@ function normalizeTeamMediaAudienceRoles(value) {
 }
 
 function getTeamMediaAudienceValue(source = {}, keys = []) {
-    return keys.reduce((selected, key) => (selected === undefined ? source?.[key] : selected), undefined);
+    return keys.reduce((selected, key) => (selected == null ? source?.[key] : selected), undefined);
 }
 
 function getTeamMediaAudienceAccessLevel(user = {}) {

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -84,6 +84,82 @@ export function canViewTeamMediaFolder(folder, accessLevel) {
     return accessLevel === 'parent' && canReadTeamMediaAlbum(folder, false);
 }
 
+function normalizeTeamMediaNotificationAlbumVisibility(folder = {}) {
+    if (folder?.staffOnly === true) return 'private';
+    const rawVisibility = folder?.visibility ?? folder?.albumVisibility;
+    const normalized = asTrimmedString(rawVisibility).toLowerCase().replace(/[\s_]+/g, '-');
+    if (['private', 'staff', 'staff-only'].includes(normalized)) return 'private';
+    return normalizeAlbumVisibility(rawVisibility);
+}
+
+function normalizeTeamMediaAudienceList(value) {
+    if (Array.isArray(value)) return value;
+    if (value instanceof Set) return Array.from(value);
+    if (typeof value === 'string') return value.split(',');
+    return [];
+}
+
+function normalizeTeamMediaAudienceUserIds(value) {
+    return Array.from(new Set(
+        normalizeTeamMediaAudienceList(value)
+            .map((entry) => asTrimmedString(entry))
+            .filter(Boolean)
+    ));
+}
+
+function normalizeTeamMediaAudienceRoles(value) {
+    return Array.from(new Set(
+        normalizeTeamMediaAudienceList(value)
+            .map((entry) => asTrimmedString(entry).toLowerCase().replace(/[\s_]+/g, '-'))
+            .map((role) => (['admin', 'coach', 'manager', 'owner'].includes(role) ? 'staff' : role))
+            .filter((role) => ['parent', 'staff'].includes(role))
+    ));
+}
+
+function getTeamMediaAudienceValue(source = {}, keys = []) {
+    return keys.reduce((selected, key) => (selected === undefined ? source?.[key] : selected), undefined);
+}
+
+function getTeamMediaAudienceAccessLevel(user = {}) {
+    const roles = normalizeTeamMediaAudienceRoles(user.roles);
+    if (roles.includes('staff')) return 'full';
+    if (roles.includes('parent')) return 'parent';
+    return null;
+}
+
+function canAudienceUserViewTeamMediaAlbum(folder, user) {
+    const visibility = normalizeTeamMediaNotificationAlbumVisibility(folder);
+    return canViewTeamMediaFolder({ ...folder, visibility }, getTeamMediaAudienceAccessLevel(user));
+}
+
+export function resolveTeamMediaAlbumNotificationAudience(folder = {}, users = []) {
+    const audienceSource = folder?.audienceContext && typeof folder.audienceContext === 'object'
+        ? { ...folder.audienceContext, ...folder }
+        : folder;
+    const allowedUserIds = normalizeTeamMediaAudienceUserIds(getTeamMediaAudienceValue(audienceSource, [
+        'allowedUserIds',
+        'audienceUserIds',
+        'visibleToUserIds',
+        'userIds'
+    ]));
+    const allowedRoles = normalizeTeamMediaAudienceRoles(getTeamMediaAudienceValue(audienceSource, [
+        'allowedRoles',
+        'audienceRoles',
+        'visibleToRoles',
+        'roles'
+    ]));
+    const hasAudienceRestrictions = allowedUserIds.length > 0 || allowedRoles.length > 0;
+
+    return (Array.isArray(users) ? users : []).filter((user) => {
+        const uid = asTrimmedString(user?.uid);
+        if (!uid || !canAudienceUserViewTeamMediaAlbum(audienceSource, user)) return false;
+        if (!hasAudienceRestrictions) return true;
+
+        const roles = normalizeTeamMediaAudienceRoles(user.roles);
+        return allowedUserIds.includes(uid) || roles.some((role) => allowedRoles.includes(role));
+    });
+}
+
 export function hasTeamMediaUploadGrant(user, teamId) {
     const normalizedTeamId = String(teamId || '').trim();
     if (!user || !normalizedTeamId) return false;

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -22,6 +22,7 @@ import {
     normalizeSelectedMediaIds,
     normalizeTeamMediaFolderDraft,
     normalizeTeamMediaVideoDraft,
+    resolveTeamMediaAlbumNotificationAudience,
     sortByMediaOrder
 } from '../../js/team-media-utils.js';
 
@@ -117,6 +118,40 @@ describe('team media album visibility', () => {
         expect(canReadTeamMediaAlbum({ visibility: 'team' }, false)).toBe(true);
         expect(canReadTeamMediaAlbum({ visibility: 'private' }, false)).toBe(false);
         expect(canReadTeamMediaAlbum({ visibility: 'private' }, true)).toBe(true);
+    });
+});
+
+describe('team media notification audience resolver', () => {
+    const users = [
+        { uid: 'parent-1', roles: ['parent'] },
+        { uid: 'parent-2', roles: ['parent'] },
+        { uid: 'staff-1', roles: ['staff'] },
+        { uid: 'staff-parent-1', roles: ['parent', 'staff'] }
+    ];
+    const resolveIds = (folder) => resolveTeamMediaAlbumNotificationAudience(folder, users).map((user) => user.uid);
+
+    it('resolves staff-only albums without parent-only users', () => {
+        expect(resolveIds({ visibility: 'staff-only' })).toEqual(['staff-1', 'staff-parent-1']);
+        expect(resolveIds({ albumVisibility: 'team', staffOnly: true })).toEqual(['staff-1', 'staff-parent-1']);
+    });
+
+    it('resolves visibility-restricted albums to explicitly allowed visible users', () => {
+        expect(resolveIds({
+            visibility: 'team',
+            visibleToUserIds: ['parent-2'],
+            visibleToRoles: ['staff']
+        })).toEqual(['parent-2', 'staff-1', 'staff-parent-1']);
+
+        expect(resolveIds({
+            visibility: 'private',
+            allowedUserIds: ['parent-2'],
+            allowedRoles: ['staff']
+        })).toEqual(['staff-1', 'staff-parent-1']);
+    });
+
+    it('keeps standard visible albums on the current eligible audience', () => {
+        expect(resolveTeamMediaAlbumNotificationAudience({ visibility: 'team' }, users)).toEqual(users);
+        expect(resolveTeamMediaAlbumNotificationAudience({}, users)).toEqual(users);
     });
 });
 

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -149,6 +149,23 @@ describe('team media notification audience resolver', () => {
         })).toEqual(['staff-1', 'staff-parent-1']);
     });
 
+    it('treats null audience fields as absent so populated aliases still apply', () => {
+        expect(resolveIds({
+            visibility: 'team',
+            allowedUserIds: null,
+            visibleToUserIds: ['parent-2'],
+            visibleToRoles: ['staff']
+        })).toEqual(['parent-2', 'staff-1', 'staff-parent-1']);
+
+        expect(resolveIds({
+            audienceContext: {
+                allowedUserIds: null,
+                visibleToUserIds: ['parent-2'],
+                visibleToRoles: ['staff']
+            }
+        })).toEqual(['parent-2', 'staff-1', 'staff-parent-1']);
+    });
+
     it('keeps standard visible albums on the current eligible audience', () => {
         expect(resolveTeamMediaAlbumNotificationAudience({ visibility: 'team' }, users)).toEqual(users);
         expect(resolveTeamMediaAlbumNotificationAudience({}, users)).toEqual(users);


### PR DESCRIPTION
## Summary
- Add a reusable `resolveTeamMediaAlbumNotificationAudience` helper in `js/team-media-utils.js`.
- Filter candidate notification audiences through the existing TeamMedia album visibility model.
- Cover staff-only, restricted, and standard team-visible album audience resolution.

Closes #2904

## Tests
- `npx vitest run tests/unit/team-media-utils.test.js --reporter=verbose` (21 passed)

## Notes
- This slice does not change notification delivery wiring in `functions/index.js`.