### PR TITLE
[codex] Pin mobile live chat to latest messages

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -183,7 +183,13 @@ const statsheetImportServiceMocks = vi.hoisted(() => ({
 
 vi.mock('../lib/statsheetImportService', () => statsheetImportServiceMocks);
 
-import { ScheduleEventDetail, shouldAutosaveGeneratedLineupDraft, shouldAutosaveLineupDraft, shouldPersistLineupDraft } from './ScheduleEventDetail';
+import {
+  ScheduleEventDetail,
+  isLiveGameChatNearBottom,
+  shouldAutosaveGeneratedLineupDraft,
+  shouldAutosaveLineupDraft,
+  shouldPersistLineupDraft
+} from './ScheduleEventDetail';
 import type { PracticeTimelineBlock } from '../lib/practiceTimelineService';
 import type { AuthState } from '../lib/types';
 
@@ -310,6 +316,38 @@ function renderScheduleEventDetailWithLocation(initialEntry = '/schedule/team-1/
     </MemoryRouter>
   );
 }
+
+function installScrollMetrics(
+  element: HTMLElement,
+  metrics: { scrollHeight: number; clientHeight: number }
+) {
+  Object.defineProperty(element, 'scrollHeight', {
+    configurable: true,
+    get: () => metrics.scrollHeight
+  });
+  Object.defineProperty(element, 'clientHeight', {
+    configurable: true,
+    get: () => metrics.clientHeight
+  });
+  return metrics;
+}
+
+function buildLiveChatMessages(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `m${index + 1}`,
+    text: `Message ${index + 1}`,
+    senderName: `Parent ${index + 1}`,
+    createdAt: `2026-06-04T18:${String(index + 1).padStart(2, '0')}:00.000Z`
+  }));
+}
+
+describe('ScheduleEventDetail live chat scroll helpers', () => {
+  it('treats live chat positions within 96 pixels of the bottom as near bottom', () => {
+    expect(isLiveGameChatNearBottom(null)).toBe(true);
+    expect(isLiveGameChatNearBottom({ scrollHeight: 1000, clientHeight: 400, scrollTop: 504 })).toBe(true);
+    expect(isLiveGameChatNearBottom({ scrollHeight: 1000, clientHeight: 400, scrollTop: 503 })).toBe(false);
+  });
+});
 
 describe('ScheduleEventDetail loading states', () => {
   afterEach(() => {
@@ -1056,6 +1094,120 @@ describe('ScheduleEventDetail assignments', () => {
     const unsubscribe = liveGameChatServiceMocks.subscribeToLiveGameChat.mock.results[0]?.value as ReturnType<typeof vi.fn>;
     unmount();
     expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('keeps mobile live chat pinned to latest messages unless the viewer scrolls up', async () => {
+    let chatCallback: (messages: Array<{ id: string; text?: string | null; senderName?: string | null; createdAt?: unknown }>) => void = () => {};
+    liveGameChatServiceMocks.subscribeToLiveGameChat.mockImplementation((_teamId, _gameId, callback) => {
+      chatCallback = callback;
+      return vi.fn();
+    });
+    liveGameChatServiceMocks.sendLiveGameChatMessage.mockResolvedValue({ id: 'sent-1' });
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ liveStatus: 'live', status: 'live' })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live chat' }));
+
+    await waitFor(() => {
+      expect(liveGameChatServiceMocks.subscribeToLiveGameChat).toHaveBeenCalledTimes(1);
+    });
+
+    const scroller = screen.getByTestId('live-game-chat-messages') as HTMLDivElement;
+    const metrics = installScrollMetrics(scroller, { scrollHeight: 520, clientHeight: 160 });
+
+    await act(async () => {
+      chatCallback(buildLiveChatMessages(8));
+    });
+    await waitFor(() => {
+      expect(scroller.scrollTop).toBe(360);
+    });
+
+    scroller.scrollTop = 330;
+    fireEvent.scroll(scroller);
+    metrics.scrollHeight = 600;
+    await act(async () => {
+      chatCallback(buildLiveChatMessages(9));
+    });
+    await waitFor(() => {
+      expect(scroller.scrollTop).toBe(440);
+    });
+
+    fireEvent.change(screen.getByLabelText('Live chat message'), { target: { value: "Let's go Bears" } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+    await waitFor(() => {
+      expect(liveGameChatServiceMocks.sendLiveGameChatMessage).toHaveBeenCalledWith('team-1', 'game-1', expect.objectContaining({
+        text: "Let's go Bears",
+        user: auth.user
+      }));
+    });
+
+    const messagesWithSentEcho = [
+      ...buildLiveChatMessages(9),
+      {
+        id: 'sent-1',
+        text: "Let's go Bears",
+        senderName: 'Coach Carter',
+        createdAt: '2026-06-04T18:10:00.000Z'
+      }
+    ];
+    metrics.scrollHeight = 680;
+    await act(async () => {
+      chatCallback(messagesWithSentEcho);
+    });
+    await waitFor(() => {
+      expect(scroller.scrollTop).toBe(520);
+    });
+
+    scroller.scrollTop = 160;
+    fireEvent.scroll(scroller);
+    metrics.scrollHeight = 760;
+    await act(async () => {
+      chatCallback([
+        ...messagesWithSentEcho,
+        {
+          id: 'm11',
+          text: 'Inbound while reading older messages',
+          senderName: 'Parent 11',
+          createdAt: '2026-06-04T18:11:00.000Z'
+        }
+      ]);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('live-chat-message-m11')).toBeTruthy();
+    });
+    expect(scroller.scrollTop).toBe(160);
+
+    scroller.scrollTop = 590;
+    fireEvent.scroll(scroller);
+    metrics.scrollHeight = 840;
+    await act(async () => {
+      chatCallback([
+        ...messagesWithSentEcho,
+        {
+          id: 'm11',
+          text: 'Inbound while reading older messages',
+          senderName: 'Parent 11',
+          createdAt: '2026-06-04T18:11:00.000Z'
+        },
+        {
+          id: 'm12',
+          text: 'Back at the latest',
+          senderName: 'Parent 12',
+          createdAt: '2026-06-04T18:12:00.000Z'
+        }
+      ]);
+    });
+    await waitFor(() => {
+      expect(scroller.scrollTop).toBe(680);
+    });
   });
 
   it('shows the locked live chat notice and disables the composer when chat is unavailable', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { CalendarDays, ChevronDown, ChevronLeft, ClipboardCheck, ExternalLink, FileText, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
 import {
@@ -1056,6 +1056,12 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const messagesScrollRef = useRef<HTMLDivElement | null>(null);
+  const messagesContentRef = useRef<HTMLDivElement | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const stickToLatestRef = useRef(true);
+  const shouldFollowLatestRef = useRef(true);
+  const scheduledScrollTimeoutsRef = useRef<number[]>([]);
 
   useEffect(() => {
     void loadLiveGameChatModule().then(setChatModule);
@@ -1064,13 +1070,66 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
   const canChat = chatModule ? chatModule.canUseLiveGameChat(event, { now: new Date() }) : false;
   const chatNotice = chatModule ? chatModule.getLiveGameChatNotice(event, { now: new Date() }) : null;
   const canSend = canChat && Boolean(messageText.trim()) && !sending;
+  const latestMessageId = messages[messages.length - 1]?.id || '';
+
+  const scrollToLatest = useCallback(() => {
+    const container = messagesScrollRef.current;
+    if (!container) return;
+
+    const nextHeight = Math.max(container.scrollHeight, messagesContentRef.current?.scrollHeight || 0);
+    container.scrollTop = Math.max(0, nextHeight - container.clientHeight);
+    if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
+      messagesEndRef.current.scrollIntoView({ block: 'end', behavior: 'auto' });
+    }
+    stickToLatestRef.current = true;
+  }, []);
+
+  const clearScheduledScrolls = useCallback(() => {
+    scheduledScrollTimeoutsRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    scheduledScrollTimeoutsRef.current = [];
+  }, []);
+
+  const scheduleScrollToLatest = useCallback(() => {
+    clearScheduledScrolls();
+    const followIfNeeded = () => {
+      const container = messagesScrollRef.current;
+      if (!container) return;
+      if (stickToLatestRef.current || isLiveGameChatNearBottom(container)) {
+        scrollToLatest();
+      }
+    };
+
+    followIfNeeded();
+    [120, 300, 700].forEach((delay) => {
+      let timerId = 0;
+      timerId = window.setTimeout(() => {
+        scheduledScrollTimeoutsRef.current = scheduledScrollTimeoutsRef.current.filter((id) => id !== timerId);
+        followIfNeeded();
+      }, delay);
+      scheduledScrollTimeoutsRef.current.push(timerId);
+    });
+  }, [clearScheduledScrolls, scrollToLatest]);
+
+  const handleMessagesScroll = useCallback(() => {
+    stickToLatestRef.current = isLiveGameChatNearBottom(messagesScrollRef.current);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!messages.length || !shouldFollowLatestRef.current) return;
+    scheduleScrollToLatest();
+  }, [latestMessageId, messages.length, scheduleScrollToLatest]);
+
+  useEffect(() => clearScheduledScrolls, [clearScheduledScrolls]);
 
   useEffect(() => {
     if (!chatModule || !event.isDbGame || !event.teamId || !event.id) return undefined;
 
     setLoading(true);
     setStatus(null);
+    stickToLatestRef.current = true;
+    shouldFollowLatestRef.current = true;
     const unsubscribe = chatModule.subscribeToLiveGameChat(event.teamId, event.id, (nextMessages) => {
+      shouldFollowLatestRef.current = stickToLatestRef.current || isLiveGameChatNearBottom(messagesScrollRef.current);
       setMessages(sortLiveGameChatMessages(nextMessages));
       setLoading(false);
     }, (subscribeError: any) => {
@@ -1087,6 +1146,7 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
     submitEvent.preventDefault();
     if (!chatModule || !canChat || !event.teamId || !event.id || !messageText.trim() || sending) return;
 
+    shouldFollowLatestRef.current = stickToLatestRef.current || isLiveGameChatNearBottom(messagesScrollRef.current);
     setSending(true);
     setStatus(null);
     try {
@@ -1119,20 +1179,29 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
       </div>
 
       <div className="mt-3 rounded-2xl border border-white/80 bg-white p-3 shadow-sm">
-        <div className="max-h-64 space-y-2 overflow-y-auto pr-1" aria-label="Live chat messages">
-          {loading ? (
-            <div className="text-sm font-semibold text-gray-500">Loading live chat…</div>
-          ) : messages.length ? messages.map((message) => (
-            <article key={message.id} className="rounded-xl border border-gray-100 bg-gray-50 p-2.5" data-testid={`live-chat-message-${message.id}`}>
-              <div className="flex items-center justify-between gap-2">
-                <div className="truncate text-sm font-black text-gray-950">{message.senderName || 'Fan'}</div>
-                <div className="text-[11px] font-semibold text-gray-500">{formatLiveGameChatTimestamp(message.createdAt)}</div>
-              </div>
-              <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{String(message.text || '').trim() || ' '}</div>
-            </article>
-          )) : (
-            <div className="text-sm font-semibold text-gray-500">No messages yet. Start the game-day chat.</div>
-          )}
+        <div
+          ref={messagesScrollRef}
+          className="max-h-64 overflow-y-auto pr-1"
+          aria-label="Live chat messages"
+          data-testid="live-game-chat-messages"
+          onScroll={handleMessagesScroll}
+        >
+          <div ref={messagesContentRef} className="space-y-2">
+            {loading ? (
+              <div className="text-sm font-semibold text-gray-500">Loading live chat…</div>
+            ) : messages.length ? messages.map((message) => (
+              <article key={message.id} className="rounded-xl border border-gray-100 bg-gray-50 p-2.5" data-testid={`live-chat-message-${message.id}`}>
+                <div className="flex items-center justify-between gap-2">
+                  <div className="truncate text-sm font-black text-gray-950">{message.senderName || 'Fan'}</div>
+                  <div className="text-[11px] font-semibold text-gray-500">{formatLiveGameChatTimestamp(message.createdAt)}</div>
+                </div>
+                <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{String(message.text || '').trim() || ' '}</div>
+              </article>
+            )) : (
+              <div className="text-sm font-semibold text-gray-500">No messages yet. Start the game-day chat.</div>
+            )}
+            <div ref={messagesEndRef} aria-hidden="true" />
+          </div>
         </div>
 
         <form className="mt-3 space-y-2" onSubmit={sendMessage}>
@@ -3738,6 +3807,15 @@ function GameHubDestinationCard({ destination, onShare }: {
 
 function sortLiveGameChatMessages(messages: LiveGameChatMessage[]) {
   return [...messages].sort((left, right) => getLiveGameChatTimestampValue(left.createdAt) - getLiveGameChatTimestampValue(right.createdAt));
+}
+
+export function isLiveGameChatNearBottom(
+  container: Pick<HTMLElement, 'scrollHeight' | 'scrollTop' | 'clientHeight'> | null,
+  threshold = 96
+) {
+  if (!container) return true;
+  const distanceFromBottom = Math.max(0, container.scrollHeight - container.scrollTop - container.clientHeight);
+  return distanceFromBottom <= threshold;
 }
 
 function getLiveGameChatTimestampValue(value: unknown) {


### PR DESCRIPTION
## Summary
- Add ChatWindow-style near-bottom stickiness to the app game hub `LiveGameChatPanel`.
- Scroll overflowing live chat to the newest message on first load, keep following while the viewer is near bottom, and preserve manual scroll-up position for incoming messages.
- Cover the behavior with focused helper and rendered panel tests, including a sent-message echo.

## Why
Mobile game-day chat rendered oldest-first in a bounded overflow region without scroll management, so users opened stale backlog and had to manually drag back down after updates.

## Impact
The mobile game hub live chat now stays anchored to the latest messages when appropriate without changing Firestore chat delivery, notifications, or the panel's visual design.

## Tests
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx --reporter=verbose -t "live chat"` passed.
- `npm run app:build` passed.
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx --reporter=verbose` was attempted; the live-chat tests passed, but the full file still exits nonzero on an unrelated existing matcher setup issue: `Invalid Chai property: toHaveValue` in the practice timeline due date test.
- Smoke not run; this behavior depends on a mocked live chat stream and is covered by the focused rendered panel test.

Closes #2900