### PR TITLE
Stop game-day panels from reloading on live updates

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1371,6 +1371,155 @@ describe('ScheduleEventDetail assignments', () => {
     });
   });
 
+  it('keeps lineup builder loaded during live score updates', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        status: 'live',
+        canUpdateScore: true,
+        isTeamStaff: true,
+        homeScore: 41,
+        awayScore: 38,
+        gamePlan: {
+          formationId: 'basketball-5v5',
+          lineups: { 'Q1-pg': 'p1' },
+          publishedLineups: {},
+          publishedVersion: 0
+        }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({
+      formationId: 'basketball-5v5',
+      formationName: 'Basketball 5v5',
+      numPeriods: 4,
+      positions: [],
+      availablePlayers: [{ id: 'p1', name: 'Avery Smith', number: '1' }],
+      goingPlayers: [{ id: 'p1', name: 'Avery Smith', number: '1' }],
+      gamePlan: {
+        formationId: 'basketball-5v5',
+        lineups: { 'Q1-pg': 'p1' },
+        publishedLineups: {},
+        publishedVersion: 0
+      }
+    });
+    scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 42, awayScore: 38 });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Lineup builder' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('button', { name: /#1 Avery Smith/i })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Home score up' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save score' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 42, awayScore: 38 }, auth.user);
+    });
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('button', { name: /#1 Avery Smith/i })).toBeTruthy();
+    });
+    expect(screen.queryByText('Loading lineup builder…')).toBeNull();
+  });
+
+  it('keeps live substitutions loaded during live clock updates', async () => {
+    const gamePlan = {
+      formationId: 'basketball-5v5',
+      numPeriods: 4,
+      periodDuration: 8,
+      lineups: {
+        'Q1-pg': 'p1',
+        'Q1-sg': 'p2',
+        'Q1-sf': 'p3',
+        'Q1-pf': 'p4',
+        'Q1-c': 'p5'
+      },
+      isPublished: true,
+      publishedLineups: {
+        'Q1-pg': 'p1',
+        'Q1-sg': 'p2',
+        'Q1-sf': 'p3',
+        'Q1-pf': 'p4',
+        'Q1-c': 'p5'
+      }
+    };
+    const players = [
+      { id: 'p1', name: 'Avery Smith', number: '1' },
+      { id: 'p2', name: 'Blake Jones', number: '2' },
+      { id: 'p3', name: 'Casey Brown', number: '3' },
+      { id: 'p4', name: 'Devon Lee', number: '4' },
+      { id: 'p5', name: 'Emerson Fox', number: '5' },
+      { id: 'p6', name: 'Finley Ray', number: '6' }
+    ];
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        status: 'live',
+        canUpdateScore: true,
+        isTeamStaff: true,
+        gamePlan,
+        rotationPlan: { Q1: { pg: 'p1', sg: 'p2', sf: 'p3', pf: 'p4', c: 'p5' } }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({
+      availablePlayers: players,
+      goingPlayers: players,
+      gamePlan
+    });
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleServiceMocks.updateLiveGameClockState.mockResolvedValue({
+      liveClockMs: 0,
+      liveClockRunning: true,
+      liveClockPeriod: 'Q1',
+      liveClockUpdatedAt: '2026-06-04T18:00:00.000Z'
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live substitutions' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(2);
+      expect(screen.getByLabelText('Out')).toBeTruthy();
+      expect(screen.getByLabelText('In')).toBeTruthy();
+    });
+    const initialLiveEventLoadCount = scheduleServiceMocks.loadGameDayLiveEventsForApp.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start clock' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateLiveGameClockState).toHaveBeenCalledWith(
+        'team-1',
+        'game-1',
+        expect.objectContaining({ liveClockRunning: true, liveClockPeriod: 'Q1' }),
+        auth.user
+      );
+    });
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(initialLiveEventLoadCount);
+      expect(screen.getByLabelText('Out')).toBeTruthy();
+      expect(screen.getByLabelText('In')).toBeTruthy();
+      expect(screen.getByText('1 periods')).toBeTruthy();
+    });
+  });
+
   it('resets deferred game hub panels before rendering a switched event', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockImplementation(async (_user, { eventId }) => ({
       events: [eventId === 'game-2'

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1520,6 +1520,81 @@ describe('ScheduleEventDetail assignments', () => {
     });
   });
 
+  it('clears live substitutions after cancelling the game from the same hub', async () => {
+    const gamePlan = {
+      formationId: 'basketball-5v5',
+      numPeriods: 4,
+      periodDuration: 8,
+      lineups: {
+        'Q1-pg': 'p1',
+        'Q1-sg': 'p2',
+        'Q1-sf': 'p3',
+        'Q1-pf': 'p4',
+        'Q1-c': 'p5'
+      },
+      isPublished: true,
+      publishedLineups: {
+        'Q1-pg': 'p1',
+        'Q1-sg': 'p2',
+        'Q1-sf': 'p3',
+        'Q1-pf': 'p4',
+        'Q1-c': 'p5'
+      }
+    };
+    const players = [
+      { id: 'p1', name: 'Avery Smith', number: '1' },
+      { id: 'p2', name: 'Blake Jones', number: '2' },
+      { id: 'p3', name: 'Casey Brown', number: '3' },
+      { id: 'p4', name: 'Devon Lee', number: '4' },
+      { id: 'p5', name: 'Emerson Fox', number: '5' },
+      { id: 'p6', name: 'Finley Ray', number: '6' }
+    ];
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        status: 'live',
+        canUpdateScore: true,
+        isTeamStaff: true,
+        isTeamAdmin: true,
+        gamePlan,
+        rotationPlan: { Q1: { pg: 'p1', sg: 'p2', sf: 'p3', pf: 'p4', c: 'p5' } }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({
+      availablePlayers: players,
+      goingPlayers: players,
+      gamePlan
+    });
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleServiceMocks.cancelScheduledGameForApp.mockResolvedValue({ notificationError: null });
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live substitutions' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Out')).toBeTruthy();
+      expect(screen.getByLabelText('In')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel game' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.cancelScheduledGameForApp).toHaveBeenCalledWith(expect.any(Object), auth.user);
+    });
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Out')).toBeNull();
+      expect(screen.queryByLabelText('In')).toBeNull();
+      expect(screen.getByText('Publish a lineup first to enable live substitution planning.')).toBeTruthy();
+    });
+  });
+
   it('resets deferred game hub panels before rendering a switched event', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockImplementation(async (_user, { eventId }) => ({
       events: [eventId === 'game-2'

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2170,8 +2170,9 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
   }, [event.eventKey, event.gamePlan, event.rotationPlan, event.rotationActual, event.coachingNotes, event.liveEvents]);
 
   useEffect(() => {
-    if (!auth.user || !formationId) {
+    if (!auth.user || !formationId || event.isCancelled) {
       setPlayers([]);
+      setLoading(false);
       return undefined;
     }
     let cancelled = false;
@@ -2195,7 +2196,7 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [auth.user, event.teamId, event.id, event.gamePlan, formationId]);
+  }, [auth.user, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
 
   useEffect(() => {
     if (period && periods.includes(period)) return;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2195,7 +2195,7 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [auth.user, event, formationId]);
+  }, [auth.user, event.teamId, event.id, event.gamePlan, formationId]);
 
   useEffect(() => {
     if (period && periods.includes(period)) return;
@@ -2396,7 +2396,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
       });
 
     return () => { cancelled = true; };
-  }, [auth.user, event, formationId]);
+  }, [auth.user, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
 
   useEffect(() => {
     latestDraftRef.current = draftLineups;


### PR DESCRIPTION
Closes #2910

## What changed
- narrowed the lineup builder preview effect to reload only when stable lineup inputs change: team id, event id, formation id, game plan, or cancellation state
- narrowed the live substitutions data-loading effect to reload only when stable substitution inputs change: team id, event id, formation id, or game plan
- added regression tests that keep each panel open during a live score or clock update and verify the expensive loaders do not run again while the populated controls stay visible

## Root Cause
Both game-day panels keyed their data-loading effects to the entire `event` object. Live score and live clock saves replace that parent object, so React saw a dependency change and reran lineup and live-event fetches even when the actual lineup inputs had not changed.

## Prevention / Learning
When a panel fetch depends on a few stable identifiers or nested source fields, depend on those explicit inputs instead of the full parent object identity. Parent live-update objects are noisy and should not be used as effect keys for expensive reloads.

## Regression Tests
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx -t "keeps lineup builder loaded during live score updates|keeps live substitutions loaded during live clock updates|keeps deferred game hub panels idle until staff opens them|executes substitutions against shared game-day rotation fields and renders live logs"`
- added `keeps lineup builder loaded during live score updates`
- added `keeps live substitutions loaded during live clock updates`