### PR TITLE
Adopt shared async handling across parent tools

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -175,9 +175,13 @@ describe('ParentTools access', () => {
     it('opens the manual request form immediately while public teams finish loading', async () => {
         type PublicTeamRow = { id: string; name: string; sport: string };
         const deferredTeams: { resolve: ((value: PublicTeamRow[]) => void) | null } = { resolve: null };
-        parentToolsAccessServiceMocks.loadParentAccessTeams.mockImplementation(() => new Promise<PublicTeamRow[]>((resolve) => {
-            deferredTeams.resolve = resolve;
-        }));
+        let loadStartedAfterFormRendered = false;
+        parentToolsAccessServiceMocks.loadParentAccessTeams.mockImplementation(() => {
+            loadStartedAfterFormRendered = Boolean(screen.queryByRole('combobox', { name: 'Team' }));
+            return new Promise<PublicTeamRow[]>((resolve) => {
+                deferredTeams.resolve = resolve;
+            });
+        });
         renderParentTools();
 
         await screen.findByText('Request player access');
@@ -190,6 +194,7 @@ describe('ParentTools access', () => {
         expect(teamSelect.disabled).toBe(true);
         expect(playerSelect.disabled).toBe(true);
         expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(loadStartedAfterFormRendered).toBe(true);
         expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
         expect(screen.getByRole('option', { name: 'Loading public teams...' })).toBeTruthy();
 

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -112,6 +112,26 @@ describe('ParentTools access', () => {
             { id: 'player-1', name: 'Sam Player', number: '12' }
         ]);
         parentToolsAccessServiceMocks.submitParentAccessRequest.mockResolvedValue(undefined);
+        parentToolsServiceMocks.loadParentCalendarTools.mockResolvedValue({
+            events: [],
+            teams: []
+        });
+        parentToolsServiceMocks.loadFamilyShareModel.mockResolvedValue({
+            children: [],
+            tokens: []
+        });
+        parentToolsServiceMocks.loadParentHouseholdInviteModel.mockResolvedValue({
+            linkedPlayers: [
+                {
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    playerId: 'player-1',
+                    playerName: 'Sam Player',
+                    playerNumber: '12'
+                }
+            ],
+            members: []
+        });
         inviteRedemptionMocks.redeemSignedInInvite.mockResolvedValue({
             code: 'AB12CD34',
             redirectPath: '/home',
@@ -216,7 +236,7 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
 
         expect(await screen.findByText('Network hiccup.')).toBeTruthy();
-        const retryButton = screen.getByRole('button', { name: 'Retry loading public teams' });
+        const retryButton = screen.getByRole('button', { name: 'Retry' });
         expect(retryButton).toBeTruthy();
         fireEvent.click(retryButton);
 
@@ -410,6 +430,34 @@ describe('ParentTools access', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
         await waitFor(() => expect(parentToolsServiceMocks.loadParentCalendarTools).toHaveBeenNthCalledWith(3, auth.user, { force: true }));
+    });
+
+    it('keeps parent tool refresh effects stable during local rerenders', async () => {
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        expect(parentToolsAccessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
+        fireEvent.change(screen.getByPlaceholderText('XXXXXXXX'), { target: { value: 'stays-local' } });
+        expect(parentToolsAccessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Calendar' }));
+        await screen.findByText('No team schedules');
+        expect(parentToolsServiceMocks.loadParentCalendarTools).toHaveBeenCalledTimes(1);
+        fireEvent.click(screen.getByRole('button', { name: 'Copy agenda' }));
+        expect(await screen.findByText('No events to copy yet.')).toBeTruthy();
+        expect(parentToolsServiceMocks.loadParentCalendarTools).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Share' }));
+        await screen.findByText('No family links');
+        expect(parentToolsServiceMocks.loadFamilyShareModel).toHaveBeenCalledTimes(1);
+        fireEvent.change(screen.getByPlaceholderText('Label, like Grandma or babysitter'), { target: { value: 'Grandma' } });
+        expect(parentToolsServiceMocks.loadFamilyShareModel).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Household' }));
+        await screen.findByText('No pending household invites');
+        expect(parentToolsServiceMocks.loadParentHouseholdInviteModel).toHaveBeenCalledTimes(1);
+        fireEvent.change(screen.getByPlaceholderText('Household contact email'), { target: { value: 'guardian@example.com' } });
+        expect(parentToolsServiceMocks.loadParentHouseholdInviteModel).toHaveBeenCalledTimes(1);
     });
 
     it('opens reusable team fee checkout links when legacy fee payloads omit paymentAction', async () => {

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -64,10 +64,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
 
     const openManualRequest = useCallback(() => {
         setManualRequestOpen(true);
-        if (!teams.length && !loadingTeams) {
-            void loadTeams();
-        }
-    }, [loadTeams, loadingTeams, teams.length]);
+    }, []);
 
     const refresh = useCallback(async () => {
         accessLoadOperation.clearError();
@@ -98,6 +95,11 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         setSelectedTeamId('');
         setSelectedPlayerId('');
     }, [auth.user?.uid]);
+
+    useEffect(() => {
+        if (!manualRequestOpen || teams.length || loadingTeams) return;
+        void loadTeams();
+    }, [loadTeams, loadingTeams, manualRequestOpen, teams.length]);
 
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
         const rows = await runPlayerLoad(

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -20,6 +20,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const [requests, setRequests] = useState<ParentAccessRequest[]>([]);
     const [players, setPlayers] = useState<ParentAccessPlayer[]>([]);
     const [manualRequestOpen, setManualRequestOpen] = useState(false);
+    const [manualTeamsRequested, setManualTeamsRequested] = useState(false);
     const [selectedTeamId, setSelectedTeamId] = useState('');
     const [selectedPlayerId, setSelectedPlayerId] = useState('');
     const [relation, setRelation] = useState('Parent');
@@ -75,6 +76,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
 
     const openManualRequest = useCallback(() => {
         setManualRequestOpen(true);
+        setManualTeamsRequested(false);
     }, []);
 
     const refresh = useCallback(async () => {
@@ -101,6 +103,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
 
     useEffect(() => {
         setManualRequestOpen(false);
+        setManualTeamsRequested(false);
         setTeams([]);
         setPlayers([]);
         setSelectedTeamId('');
@@ -108,9 +111,10 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [auth.user?.uid]);
 
     useEffect(() => {
-        if (!manualRequestOpen || teams.length || loadingTeams) return;
+        if (!manualRequestOpen || manualTeamsRequested || teams.length || loadingTeams) return;
+        setManualTeamsRequested(true);
         void loadTeams();
-    }, [loadTeams, loadingTeams, manualRequestOpen, teams.length]);
+    }, [loadTeams, loadingTeams, manualRequestOpen, manualTeamsRequested, teams.length]);
 
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
         const rows = await runPlayerLoad(

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -35,21 +35,32 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const runPlayerLoad = playerLoadOperation.run;
     const runSubmit = submitOperation.run;
     const runRedeem = redeemOperation.run;
+    const clearAccessLoadError = accessLoadOperation.clearError;
+    const clearTeamLoadError = teamLoadOperation.clearError;
+    const clearPlayerLoadError = playerLoadOperation.clearError;
+    const clearSubmitError = submitOperation.clearError;
+    const clearRedeemError = redeemOperation.clearError;
+    const setSubmitError = submitOperation.setError;
+    const setRedeemError = redeemOperation.setError;
 
     const loading = accessLoadOperation.loading;
     const loadingTeams = teamLoadOperation.loading;
     const loadingPlayers = playerLoadOperation.loading;
     const saving = submitOperation.loading;
     const redeeming = redeemOperation.loading;
-    const loadError = accessLoadOperation.error;
-    const manualLookupError = teamLoadOperation.error ?? playerLoadOperation.error;
-    const actionError = submitOperation.error ?? redeemOperation.error;
+    const { error: loadError } = accessLoadOperation;
+    const { error: teamLoadError } = teamLoadOperation;
+    const { error: playerLoadError } = playerLoadOperation;
+    const { error: submitError } = submitOperation;
+    const { error: redeemError } = redeemOperation;
+    const manualLookupError = teamLoadError ?? playerLoadError;
+    const actionError = submitError ?? redeemError;
 
     const loadTeams = useCallback(async () => {
-        teamLoadOperation.clearError();
-        playerLoadOperation.clearError();
-        submitOperation.clearError();
-        redeemOperation.clearError();
+        clearTeamLoadError();
+        clearPlayerLoadError();
+        clearSubmitError();
+        clearRedeemError();
         return runTeamLoad(
             () => loadParentAccessTeams(),
             'Unable to load public teams.',
@@ -60,18 +71,18 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                 }
             }
         );
-    }, [playerLoadOperation, redeemOperation, runTeamLoad, submitOperation, teamLoadOperation]);
+    }, [clearPlayerLoadError, clearRedeemError, clearSubmitError, clearTeamLoadError, runTeamLoad]);
 
     const openManualRequest = useCallback(() => {
         setManualRequestOpen(true);
     }, []);
 
     const refresh = useCallback(async () => {
-        accessLoadOperation.clearError();
-        teamLoadOperation.clearError();
-        playerLoadOperation.clearError();
-        submitOperation.clearError();
-        redeemOperation.clearError();
+        clearAccessLoadError();
+        clearTeamLoadError();
+        clearPlayerLoadError();
+        clearSubmitError();
+        clearRedeemError();
         setMessage('');
         return runAccessLoad(
             () => loadParentAccessModel(auth.user),
@@ -82,7 +93,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                 }
             }
         );
-    }, [accessLoadOperation, auth.user, playerLoadOperation, redeemOperation, runAccessLoad, submitOperation, teamLoadOperation]);
+    }, [auth.user, clearAccessLoadError, clearPlayerLoadError, clearRedeemError, clearSubmitError, clearTeamLoadError, runAccessLoad]);
 
     useEffect(() => {
         void refresh();
@@ -120,7 +131,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             setPlayers([]);
             setSelectedPlayerId('');
             if (!selectedTeamId) {
-                playerLoadOperation.clearError();
+                clearPlayerLoadError();
                 return;
             }
             const rows = await runPlayerLoad(
@@ -140,18 +151,18 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         return () => {
             cancelled = true;
         };
-    }, [playerLoadOperation, runPlayerLoad, selectedTeamId]);
+    }, [clearPlayerLoadError, runPlayerLoad, selectedTeamId]);
 
     const redeem = async (event: FormEvent) => {
         event.preventDefault();
         const currentUser = auth.user;
         if (!currentUser?.uid) {
-            redeemOperation.setError(toAppServiceError(new Error('Sign in to redeem an invite code.'), 'Sign in to redeem an invite code.'));
+            setRedeemError(toAppServiceError(new Error('Sign in to redeem an invite code.'), 'Sign in to redeem an invite code.'));
             return;
         }
 
-        submitOperation.clearError();
-        redeemOperation.clearError();
+        clearSubmitError();
+        clearRedeemError();
         setMessage('');
         await runRedeem(
             () => redeemSignedInInvite({
@@ -175,11 +186,11 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const submit = async (event: FormEvent) => {
         event.preventDefault();
         if (!selectedTeamId || !selectedPlayerId) {
-            submitOperation.setError(toAppServiceError(new Error('Choose a team and player first.'), 'Choose a team and player first.'));
+            setSubmitError(toAppServiceError(new Error('Choose a team and player first.'), 'Choose a team and player first.'));
             return;
         }
-        submitOperation.clearError();
-        redeemOperation.clearError();
+        clearSubmitError();
+        clearRedeemError();
         setMessage('');
         await runSubmit(
             () => submitParentAccessRequest(selectedTeamId, selectedPlayerId, relation),
@@ -229,7 +240,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                         </form>
                         {manualRequestOpen ? (
                             <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
-                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={playerLoadOperation.error && selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : loadTeams} retrying={loadingTeams || loadingPlayers} /></div> : null}
+                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={playerLoadError && selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : loadTeams} retrying={loadingTeams || loadingPlayers} /></div> : null}
                                 <div className="min-w-0">
                                     <label className="app-label" htmlFor="parent-access-team">Team</label>
                                     <select id="parent-access-team" aria-label="Team" className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -12,9 +12,8 @@ import {
     type ParentAccessRequest,
     type ParentAccessTeam
 } from '../../lib/parentToolsAccessService';
-import { useAsyncOperation } from '../../lib/useAsyncOperation';
 import type { AuthState } from '../../lib/types';
-import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, getParentToolErrorMessage } from './shared';
+import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, getParentToolErrorMessage, useParentToolAsyncOperation } from './shared';
 
 export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChanged: () => void }) {
     const [teams, setTeams] = useState<ParentAccessTeam[]>([]);
@@ -26,14 +25,11 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const [relation, setRelation] = useState('Parent');
     const [redeemCode, setRedeemCode] = useState('');
     const [message, setMessage] = useState('');
-    const [loadError, setLoadError] = useState<AppServiceError | null>(null);
-    const [manualLookupError, setManualLookupError] = useState<AppServiceError | null>(null);
-    const [actionError, setActionError] = useState<AppServiceError | null>(null);
-    const accessLoadOperation = useAsyncOperation();
-    const teamLoadOperation = useAsyncOperation();
-    const playerLoadOperation = useAsyncOperation();
-    const submitOperation = useAsyncOperation();
-    const redeemOperation = useAsyncOperation();
+    const accessLoadOperation = useParentToolAsyncOperation();
+    const teamLoadOperation = useParentToolAsyncOperation();
+    const playerLoadOperation = useParentToolAsyncOperation();
+    const submitOperation = useParentToolAsyncOperation();
+    const redeemOperation = useParentToolAsyncOperation();
     const runAccessLoad = accessLoadOperation.run;
     const runTeamLoad = teamLoadOperation.run;
     const runPlayerLoad = playerLoadOperation.run;
@@ -45,25 +41,26 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const loadingPlayers = playerLoadOperation.loading;
     const saving = submitOperation.loading;
     const redeeming = redeemOperation.loading;
+    const loadError = accessLoadOperation.error;
+    const manualLookupError = teamLoadOperation.error ?? playerLoadOperation.error;
+    const actionError = submitOperation.error ?? redeemOperation.error;
 
     const loadTeams = useCallback(async () => {
-        setManualLookupError(null);
-        setActionError(null);
+        teamLoadOperation.clearError();
+        playerLoadOperation.clearError();
+        submitOperation.clearError();
+        redeemOperation.clearError();
         return runTeamLoad(
             () => loadParentAccessTeams(),
+            'Unable to load public teams.',
             {
-                rethrow: false,
-                getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load public teams.'), 'Unable to load public teams.'),
                 onSuccess: (rows) => {
                     setTeams(rows);
                     setSelectedTeamId((current) => rows.some((team) => team.id === current) ? current : '');
-                },
-                onError: (error) => {
-                    setManualLookupError(toAppServiceError(error, 'Unable to load public teams.'));
                 }
             }
         );
-    }, [runTeamLoad]);
+    }, [playerLoadOperation, redeemOperation, runTeamLoad, submitOperation, teamLoadOperation]);
 
     const openManualRequest = useCallback(() => {
         setManualRequestOpen(true);
@@ -73,24 +70,22 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [loadTeams, loadingTeams, teams.length]);
 
     const refresh = useCallback(async () => {
-        setLoadError(null);
-        setManualLookupError(null);
-        setActionError(null);
+        accessLoadOperation.clearError();
+        teamLoadOperation.clearError();
+        playerLoadOperation.clearError();
+        submitOperation.clearError();
+        redeemOperation.clearError();
         setMessage('');
         return runAccessLoad(
             () => loadParentAccessModel(auth.user),
+            'Unable to load team access.',
             {
-                rethrow: false,
-                getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load team access.'), 'Unable to load team access.'),
                 onSuccess: (model) => {
                     setRequests(model.requests);
-                },
-                onError: (error) => {
-                    setLoadError(toAppServiceError(error, 'Unable to load team access.'));
                 }
             }
         );
-    }, [auth.user, runAccessLoad]);
+    }, [accessLoadOperation, auth.user, playerLoadOperation, redeemOperation, runAccessLoad, submitOperation, teamLoadOperation]);
 
     useEffect(() => {
         void refresh();
@@ -105,22 +100,16 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [auth.user?.uid]);
 
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
-        setManualLookupError(null);
         const rows = await runPlayerLoad(
             () => loadParentAccessPlayers(teamId),
+            'Unable to load players for this team.',
             {
-                rethrow: false,
-                getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load players for this team.'), 'Unable to load players for this team.'),
-                onError: (error) => {
-                    setManualLookupError(toAppServiceError(error, 'Unable to load players for this team.'));
+                onSuccess: (result) => {
+                    setPlayers(result);
+                    setSelectedPlayerId(result[0]?.id || '');
                 }
             }
         );
-        if (rows) {
-            setPlayers(rows);
-            setSelectedPlayerId(rows[0]?.id || '');
-            return;
-        }
     }, [runPlayerLoad]);
 
     useEffect(() => {
@@ -128,40 +117,39 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         async function loadPlayers() {
             setPlayers([]);
             setSelectedPlayerId('');
-            if (!selectedTeamId) return;
+            if (!selectedTeamId) {
+                playerLoadOperation.clearError();
+                return;
+            }
             const rows = await runPlayerLoad(
                 () => loadParentAccessPlayers(selectedTeamId),
+                'Unable to load players for this team.',
                 {
-                    rethrow: false,
-                    getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to load players for this team.'), 'Unable to load players for this team.'),
-                    onError: (error) => {
-                        if (!cancelled) {
-                            setManualLookupError(toAppServiceError(error, 'Unable to load players for this team.'));
-                        }
+                    onSuccess: (result) => {
+                        if (cancelled) return;
+                        setPlayers(result);
+                        setSelectedPlayerId(result[0]?.id || '');
                     }
                 }
             );
-            if (!cancelled && rows) {
-                setManualLookupError(null);
-                setPlayers(rows);
-                setSelectedPlayerId(rows[0]?.id || '');
-            }
+            if (cancelled || !rows) return;
         }
         void loadPlayers();
         return () => {
             cancelled = true;
         };
-    }, [runPlayerLoad, selectedTeamId]);
+    }, [playerLoadOperation, runPlayerLoad, selectedTeamId]);
 
     const redeem = async (event: FormEvent) => {
         event.preventDefault();
         const currentUser = auth.user;
         if (!currentUser?.uid) {
-            setActionError(toAppServiceError(new Error('Sign in to redeem an invite code.'), 'Sign in to redeem an invite code.'));
+            redeemOperation.setError(toAppServiceError(new Error('Sign in to redeem an invite code.'), 'Sign in to redeem an invite code.'));
             return;
         }
 
-        setActionError(null);
+        submitOperation.clearError();
+        redeemOperation.clearError();
         setMessage('');
         await runRedeem(
             () => redeemSignedInInvite({
@@ -170,17 +158,13 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                 email: currentUser.email,
                 refresh: auth.refresh
             }),
+            'Unable to redeem this invite code.',
             {
-                rethrow: false,
-                getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to redeem this invite code.'), 'Unable to redeem this invite code.'),
                 onSuccess: async (result) => {
                     await refresh();
                     onAccessChanged();
                     setRedeemCode('');
                     setMessage(result.message);
-                },
-                onError: (error) => {
-                    setActionError(toAppServiceError(error, 'Unable to redeem this invite code.'));
                 }
             }
         );
@@ -189,23 +173,20 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const submit = async (event: FormEvent) => {
         event.preventDefault();
         if (!selectedTeamId || !selectedPlayerId) {
-            setActionError(toAppServiceError(new Error('Choose a team and player first.'), 'Choose a team and player first.'));
+            submitOperation.setError(toAppServiceError(new Error('Choose a team and player first.'), 'Choose a team and player first.'));
             return;
         }
-        setActionError(null);
+        submitOperation.clearError();
+        redeemOperation.clearError();
         setMessage('');
         await runSubmit(
             () => submitParentAccessRequest(selectedTeamId, selectedPlayerId, relation),
+            'Unable to send access request.',
             {
-                rethrow: false,
-                getErrorMessage: (error) => getParentToolErrorMessage(toAppServiceError(error, 'Unable to send access request.'), 'Unable to send access request.'),
                 onSuccess: async () => {
                     await refresh();
                     onAccessChanged();
                     setMessage('Access request sent.');
-                },
-                onError: (error) => {
-                    setActionError(toAppServiceError(error, 'Unable to send access request.'));
                 }
             }
         );
@@ -246,7 +227,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                         </form>
                         {manualRequestOpen ? (
                             <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
-                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : loadTeams} retrying={loadingTeams || loadingPlayers} /></div> : null}
+                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={playerLoadOperation.error && selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : loadTeams} retrying={loadingTeams || loadingPlayers} /></div> : null}
                                 <div className="min-w-0">
                                     <label className="app-label" htmlFor="parent-access-team">Team</label>
                                     <select id="parent-access-team" aria-label="Team" className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>

--- a/apps/app/src/pages/parent-tools/CalendarTool.tsx
+++ b/apps/app/src/pages/parent-tools/CalendarTool.tsx
@@ -2,45 +2,41 @@ import { useCallback, useEffect, useState } from 'react';
 import { CalendarDays, Copy, Download, Loader2, RefreshCw } from 'lucide-react';
 import { exportCalendarIcsFile, openPublicUrl } from '../../lib/publicActions';
 import { buildParentScheduleIcs, getAppleCalendarFeedUrl, getCalendarEventShareText, getGoogleCalendarFeedUrl, getPrivateTeamCalendarFeedUrl, loadParentCalendarTools, type ParentCalendarTeam } from '../../lib/parentToolsService';
-import { useAsyncOperation } from '../../lib/useAsyncOperation';
 import type { ParentScheduleEvent } from '../../lib/scheduleLogic';
 import type { AuthState } from '../../lib/types';
-import { LoadingBlock, MetricCard, RetryableStatus, Status, ToolHeader, copyText } from './shared';
-import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
+import { LoadingBlock, MetricCard, RetryableStatus, Status, ToolHeader, copyText, useParentToolAsyncOperation } from './shared';
 
 export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
     const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
     const [teams, setTeams] = useState<ParentCalendarTeam[]>([]);
     const [busyTeamId, setBusyTeamId] = useState('');
     const [message, setMessage] = useState('');
-    const [error, setError] = useState<AppServiceError | null>(null);
-    const loadOperation = useAsyncOperation();
-    const exportOperation = useAsyncOperation();
-    const feedOperation = useAsyncOperation();
+    const loadOperation = useParentToolAsyncOperation();
+    const exportOperation = useParentToolAsyncOperation();
+    const feedOperation = useParentToolAsyncOperation();
     const runLoad = loadOperation.run;
     const runExport = exportOperation.run;
     const runFeed = feedOperation.run;
     const loading = loadOperation.loading;
     const exporting = exportOperation.loading;
+    const error = loadOperation.error ?? exportOperation.error ?? feedOperation.error;
 
     const refresh = useCallback(async (options: { force?: boolean } = {}) => {
-        setError(null);
+        loadOperation.clearError();
+        exportOperation.clearError();
+        feedOperation.clearError();
         setMessage('');
         return runLoad(
             () => loadParentCalendarTools(auth.user, options),
+            'Unable to load calendar tools.',
             {
-                rethrow: false,
-                getErrorMessage: (loadError) => String(toAppServiceError(loadError, 'Unable to load calendar tools.').message || 'Unable to load calendar tools.'),
                 onSuccess: (model) => {
                     setEvents(model.events);
                     setTeams(model.teams);
-                },
-                onError: (loadError) => {
-                    setError(toAppServiceError(loadError, 'Unable to load calendar tools.'));
                 }
             }
         );
-    }, [auth.user, runLoad]);
+    }, [auth.user, exportOperation, feedOperation, loadOperation, runLoad]);
 
     useEffect(() => {
         void refresh(refreshVersion > 0 ? { force: true } : {});
@@ -51,18 +47,15 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
             setMessage('No events to export yet.');
             return;
         }
-        setError(null);
+        exportOperation.clearError();
+        feedOperation.clearError();
         setMessage('');
         await runExport(
             () => exportCalendarIcsFile('all-plays-family-schedule.ics', buildParentScheduleIcs(events)),
+            'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.',
             {
-                rethrow: false,
-                getErrorMessage: (downloadError) => String(toAppServiceError(downloadError, 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.').message || 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.'),
                 onSuccess: () => {
                     setMessage('Calendar file ready to share.');
-                },
-                onError: (downloadError) => {
-                    setError(toAppServiceError(downloadError, 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.'));
                 }
             }
         );
@@ -79,7 +72,8 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
 
     const openFeed = async (team: ParentCalendarTeam, target: 'copy' | 'apple' | 'google') => {
         setBusyTeamId(team.teamId);
-        setError(null);
+        exportOperation.clearError();
+        feedOperation.clearError();
         setMessage('');
         await runFeed(
             async () => {
@@ -91,12 +85,8 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
                 }
                 await openPublicUrl(target === 'apple' ? getAppleCalendarFeedUrl(feedUrl) : getGoogleCalendarFeedUrl(feedUrl));
             },
+            'Unable to open calendar feed.',
             {
-                rethrow: false,
-                getErrorMessage: (feedError) => String(toAppServiceError(feedError, 'Unable to open calendar feed.').message || 'Unable to open calendar feed.'),
-                onError: (feedError) => {
-                    setError(toAppServiceError(feedError, 'Unable to open calendar feed.'));
-                },
                 onFinally: () => {
                     setBusyTeamId('');
                 }

--- a/apps/app/src/pages/parent-tools/CalendarTool.tsx
+++ b/apps/app/src/pages/parent-tools/CalendarTool.tsx
@@ -17,14 +17,17 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
     const runLoad = loadOperation.run;
     const runExport = exportOperation.run;
     const runFeed = feedOperation.run;
+    const clearLoadError = loadOperation.clearError;
+    const clearExportError = exportOperation.clearError;
+    const clearFeedError = feedOperation.clearError;
     const loading = loadOperation.loading;
     const exporting = exportOperation.loading;
     const error = loadOperation.error ?? exportOperation.error ?? feedOperation.error;
 
     const refresh = useCallback(async (options: { force?: boolean } = {}) => {
-        loadOperation.clearError();
-        exportOperation.clearError();
-        feedOperation.clearError();
+        clearLoadError();
+        clearExportError();
+        clearFeedError();
         setMessage('');
         return runLoad(
             () => loadParentCalendarTools(auth.user, options),
@@ -36,7 +39,7 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
                 }
             }
         );
-    }, [auth.user, exportOperation, feedOperation, loadOperation, runLoad]);
+    }, [auth.user, clearExportError, clearFeedError, clearLoadError, runLoad]);
 
     useEffect(() => {
         void refresh(refreshVersion > 0 ? { force: true } : {});
@@ -47,8 +50,8 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
             setMessage('No events to export yet.');
             return;
         }
-        exportOperation.clearError();
-        feedOperation.clearError();
+        clearExportError();
+        clearFeedError();
         setMessage('');
         await runExport(
             () => exportCalendarIcsFile('all-plays-family-schedule.ics', buildParentScheduleIcs(events)),
@@ -72,8 +75,8 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
 
     const openFeed = async (team: ParentCalendarTeam, target: 'copy' | 'apple' | 'google') => {
         setBusyTeamId(team.teamId);
-        exportOperation.clearError();
-        feedOperation.clearError();
+        clearExportError();
+        clearFeedError();
         setMessage('');
         await runFeed(
             async () => {

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -17,13 +17,15 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     const saveOperation = useParentToolAsyncOperation();
     const runLoad = loadOperation.run;
     const runSave = saveOperation.run;
+    const clearLoadError = loadOperation.clearError;
+    const clearSaveError = saveOperation.clearError;
     const loading = loadOperation.loading;
     const saving = saveOperation.loading;
     const error = loadOperation.error ?? saveOperation.error;
 
     const refresh = useCallback(async () => {
-        loadOperation.clearError();
-        saveOperation.clearError();
+        clearLoadError();
+        clearSaveError();
         return runLoad(
             () => loadFamilyShareModel(auth.user),
             'Unable to load family share links.',
@@ -34,7 +36,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                 }
             }
         );
-    }, [auth.user, loadOperation, runLoad, saveOperation]);
+    }, [auth.user, clearLoadError, clearSaveError, runLoad]);
 
     useEffect(() => {
         void refresh();
@@ -42,7 +44,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
 
     const create = async (event: FormEvent) => {
         event.preventDefault();
-        saveOperation.clearError();
+        clearSaveError();
         setMessage('');
         await runSave(
             () => createParentFamilyShare(auth.user, label || 'Family share', splitLines(calendarText)),
@@ -60,7 +62,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     };
 
     const revoke = async (tokenId: string) => {
-        saveOperation.clearError();
+        clearSaveError();
         setMessage('');
         await runSave(
             () => revokeParentFamilyShare(tokenId),
@@ -78,7 +80,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     };
 
     const saveCalendars = async (tokenId: string, value: string) => {
-        saveOperation.clearError();
+        clearSaveError();
         setMessage('');
         await runSave(
             () => updateParentFamilyShareCalendars(tokenId, splitLines(value)),

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -2,10 +2,8 @@ import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { Copy, Loader2, RefreshCw, Share2 } from 'lucide-react';
 import { createParentFamilyShare, loadFamilyShareModel, revokeParentFamilyShare, updateParentFamilyShareCalendars, type FamilyShareTokenCard } from '../../lib/parentToolsService';
 import { sharePublicUrl } from '../../lib/publicActions';
-import { useAsyncOperation } from '../../lib/useAsyncOperation';
 import type { AuthState } from '../../lib/types';
-import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, splitLines } from './shared';
-import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
+import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, splitLines, useParentToolAsyncOperation } from './shared';
 
 export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
     const [tokens, setTokens] = useState<FamilyShareTokenCard[]>([]);
@@ -15,31 +13,28 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     const [editingTokenId, setEditingTokenId] = useState('');
     const [pendingRevokeToken, setPendingRevokeToken] = useState<FamilyShareTokenCard | null>(null);
     const [message, setMessage] = useState('');
-    const [error, setError] = useState<AppServiceError | null>(null);
-    const loadOperation = useAsyncOperation();
-    const saveOperation = useAsyncOperation();
+    const loadOperation = useParentToolAsyncOperation();
+    const saveOperation = useParentToolAsyncOperation();
     const runLoad = loadOperation.run;
     const runSave = saveOperation.run;
     const loading = loadOperation.loading;
     const saving = saveOperation.loading;
+    const error = loadOperation.error ?? saveOperation.error;
 
     const refresh = useCallback(async () => {
-        setError(null);
+        loadOperation.clearError();
+        saveOperation.clearError();
         return runLoad(
             () => loadFamilyShareModel(auth.user),
+            'Unable to load family share links.',
             {
-                rethrow: false,
-                getErrorMessage: (loadError) => String(toAppServiceError(loadError, 'Unable to load family share links.').message || 'Unable to load family share links.'),
                 onSuccess: (model) => {
                     setChildren(model.children);
                     setTokens(model.tokens);
-                },
-                onError: (loadError) => {
-                    setError(toAppServiceError(loadError, 'Unable to load family share links.'));
                 }
             }
         );
-    }, [auth.user, runLoad]);
+    }, [auth.user, loadOperation, runLoad, saveOperation]);
 
     useEffect(() => {
         void refresh();
@@ -47,41 +42,33 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
 
     const create = async (event: FormEvent) => {
         event.preventDefault();
-        setError(null);
+        saveOperation.clearError();
         setMessage('');
         await runSave(
             () => createParentFamilyShare(auth.user, label || 'Family share', splitLines(calendarText)),
+            'Unable to create family share link.',
             {
-                rethrow: false,
-                getErrorMessage: (createError) => String(toAppServiceError(createError, 'Unable to create family share link.').message || 'Unable to create family share link.'),
                 onSuccess: async (result) => {
                     setMessage('Family link created.');
                     setLabel('');
                     setCalendarText('');
                     await copyText(result.url, setMessage);
                     await refresh();
-                },
-                onError: (createError) => {
-                    setError(toAppServiceError(createError, 'Unable to create family share link.'));
                 }
             }
         );
     };
 
     const revoke = async (tokenId: string) => {
-        setError(null);
+        saveOperation.clearError();
         setMessage('');
         await runSave(
             () => revokeParentFamilyShare(tokenId),
+            'Unable to revoke family share link.',
             {
-                rethrow: false,
-                getErrorMessage: (revokeError) => String(toAppServiceError(revokeError, 'Unable to revoke family share link.').message || 'Unable to revoke family share link.'),
                 onSuccess: async () => {
                     setMessage('Family link revoked.');
                     await refresh();
-                },
-                onError: (revokeError) => {
-                    setError(toAppServiceError(revokeError, 'Unable to revoke family share link.'));
                 },
                 onFinally: () => {
                     setPendingRevokeToken(null);
@@ -91,20 +78,16 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     };
 
     const saveCalendars = async (tokenId: string, value: string) => {
-        setError(null);
+        saveOperation.clearError();
         setMessage('');
         await runSave(
             () => updateParentFamilyShareCalendars(tokenId, splitLines(value)),
+            'Unable to update calendar links.',
             {
-                rethrow: false,
-                getErrorMessage: (saveError) => String(toAppServiceError(saveError, 'Unable to update calendar links.').message || 'Unable to update calendar links.'),
                 onSuccess: async () => {
                     setEditingTokenId('');
                     setMessage('Calendar links updated.');
                     await refresh();
-                },
-                onError: (saveError) => {
-                    setError(toAppServiceError(saveError, 'Unable to update calendar links.'));
                 }
             }
         );

--- a/apps/app/src/pages/parent-tools/FeesTool.tsx
+++ b/apps/app/src/pages/parent-tools/FeesTool.tsx
@@ -3,10 +3,8 @@ import { DollarSign, ExternalLink, Loader2, RefreshCw } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { openPublicUrl } from '../../lib/publicActions';
 import { initiateParentTeamFeeCheckout, loadParentFeesForApp, type ParentFeeAppRecord } from '../../lib/parentToolsService';
-import { useAsyncOperation } from '../../lib/useAsyncOperation';
 import type { AuthState } from '../../lib/types';
-import { EmptyState, LoadingBlock, MetricCard, RetryableStatus, ToolHeader, formatDetailAmount, formatMoney, getParentToolErrorMessage, useParentToolAsyncOperation } from './shared';
-import { toAppServiceError } from '../../lib/appErrors';
+import { EmptyState, LoadingBlock, MetricCard, RetryableStatus, ToolHeader, formatDetailAmount, formatMoney, useParentToolAsyncOperation } from './shared';
 
 export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
     const [searchParams] = useSearchParams();
@@ -15,7 +13,7 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
     const [payingFeeId, setPayingFeeId] = useState('');
     const [feeErrors, setFeeErrors] = useState<Record<string, string>>({});
     const { loading, error, run: runLoad } = useParentToolAsyncOperation();
-    const payOperation = useAsyncOperation();
+    const payOperation = useParentToolAsyncOperation();
     const requestedTeamId = String(searchParams.get('teamId') || '').trim();
     const requestedBatchId = String(searchParams.get('batchId') || '').trim();
     const requestedRecipientId = String(searchParams.get('recipientId') || '').trim();
@@ -71,6 +69,7 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
         const reusableCheckoutUrl = Boolean(fee.checkoutUrl) && (!checkoutStatus || checkoutStatus === 'open');
         setPayingFeeId(feeKey);
         setFeeErrors((current) => ({ ...current, [feeKey]: '' }));
+        payOperation.clearError();
         await payOperation.run(
             async () => {
                 if (fee.paymentAction === 'checkoutUrl' || (!fee.paymentAction && reusableCheckoutUrl)) {
@@ -87,11 +86,10 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
                 }
                 await openPublicUrl(String(fee.checkoutUrl));
             },
+            'Unable to open checkout. Please try again.',
             {
-                rethrow: false,
-                getErrorMessage: (payError) => getParentToolErrorMessage(toAppServiceError(payError, 'Unable to open checkout. Please try again.'), 'Unable to open checkout. Please try again.'),
                 onError: (payError) => {
-                    setFeeErrors((current) => ({ ...current, [feeKey]: getParentToolErrorMessage(toAppServiceError(payError, 'Unable to open checkout. Please try again.'), 'Unable to open checkout. Please try again.') }));
+                    setFeeErrors((current) => ({ ...current, [feeKey]: String(payError.message || 'Unable to open checkout. Please try again.') }));
                 },
                 onFinally: () => {
                     setPayingFeeId('');

--- a/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
+++ b/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
@@ -18,6 +18,9 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
     const submitOperation = useParentToolAsyncOperation();
     const runLoad = loadOperation.run;
     const runSubmit = submitOperation.run;
+    const clearLoadError = loadOperation.clearError;
+    const clearSubmitError = submitOperation.clearError;
+    const setSubmitError = submitOperation.setError;
     const loading = loadOperation.loading;
     const saving = submitOperation.loading;
     const error = loadOperation.error ?? submitOperation.error;
@@ -25,8 +28,8 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
     const pendingMembers = useMemo(() => members.filter((member) => String(member.status || '').toLowerCase() === 'pending'), [members]);
 
     const refresh = useCallback(async () => {
-        loadOperation.clearError();
-        submitOperation.clearError();
+        clearLoadError();
+        clearSubmitError();
         return runLoad(
             () => loadParentHouseholdInviteModel(auth.user),
             'Unable to load household invites.',
@@ -38,7 +41,7 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
                 }
             }
         );
-    }, [auth.user, loadOperation, runLoad, submitOperation]);
+    }, [auth.user, clearLoadError, clearSubmitError, runLoad]);
 
     useEffect(() => {
         void refresh();
@@ -49,18 +52,18 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
         const trimmedEmail = email.trim();
         const trimmedRelation = relation.trim();
         if (!playerKey) {
-            submitOperation.setError(toAppServiceError(new Error('Choose a linked player first.'), 'Choose a linked player first.'));
+            setSubmitError(toAppServiceError(new Error('Choose a linked player first.'), 'Choose a linked player first.'));
             return;
         }
         if (!trimmedEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
-            submitOperation.setError(toAppServiceError(new Error('Enter a valid email for the household contact.'), 'Enter a valid email for the household contact.'));
+            setSubmitError(toAppServiceError(new Error('Enter a valid email for the household contact.'), 'Enter a valid email for the household contact.'));
             return;
         }
         if (!trimmedRelation) {
-            submitOperation.setError(toAppServiceError(new Error('Enter the household contact relation.'), 'Enter the household contact relation.'));
+            setSubmitError(toAppServiceError(new Error('Enter the household contact relation.'), 'Enter the household contact relation.'));
             return;
         }
-        submitOperation.clearError();
+        clearSubmitError();
         setMessage('');
         setCreatedInvite(null);
         await runSubmit(

--- a/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
+++ b/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Copy, Loader2, RefreshCw, Users } from 'lucide-react';
 import { createParentHouseholdMemberInvite, loadParentHouseholdInviteModel, type ParentHouseholdFamilyMember, type ParentHouseholdLinkedPlayer } from '../../lib/parentToolsService';
-import { useAsyncOperation } from '../../lib/useAsyncOperation';
+import { toAppServiceError } from '../../lib/appErrors';
 import type { AuthState } from '../../lib/types';
-import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText } from './shared';
-import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
+import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, useParentToolAsyncOperation } from './shared';
 
 export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
     const [linkedPlayers, setLinkedPlayers] = useState<ParentHouseholdLinkedPlayer[]>([]);
@@ -15,34 +14,31 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
     const [relation, setRelation] = useState('');
     const [createdInvite, setCreatedInvite] = useState<{ code: string; inviteUrl: string } | null>(null);
     const [message, setMessage] = useState('');
-    const [error, setError] = useState<AppServiceError | null>(null);
-    const loadOperation = useAsyncOperation();
-    const submitOperation = useAsyncOperation();
+    const loadOperation = useParentToolAsyncOperation();
+    const submitOperation = useParentToolAsyncOperation();
     const runLoad = loadOperation.run;
     const runSubmit = submitOperation.run;
     const loading = loadOperation.loading;
     const saving = submitOperation.loading;
+    const error = loadOperation.error ?? submitOperation.error;
 
     const pendingMembers = useMemo(() => members.filter((member) => String(member.status || '').toLowerCase() === 'pending'), [members]);
 
     const refresh = useCallback(async () => {
-        setError(null);
+        loadOperation.clearError();
+        submitOperation.clearError();
         return runLoad(
             () => loadParentHouseholdInviteModel(auth.user),
+            'Unable to load household invites.',
             {
-                rethrow: false,
-                getErrorMessage: (loadError) => String(toAppServiceError(loadError, 'Unable to load household invites.').message || 'Unable to load household invites.'),
                 onSuccess: (model) => {
                     setLinkedPlayers(model.linkedPlayers);
                     setMembers(model.members);
                     setPlayerKey((current) => current || (model.linkedPlayers[0] ? `${model.linkedPlayers[0].teamId}::${model.linkedPlayers[0].playerId}` : ''));
-                },
-                onError: (loadError) => {
-                    setError(toAppServiceError(loadError, 'Unable to load household invites.'));
                 }
             }
         );
-    }, [auth.user, runLoad]);
+    }, [auth.user, loadOperation, runLoad, submitOperation]);
 
     useEffect(() => {
         void refresh();
@@ -53,18 +49,18 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
         const trimmedEmail = email.trim();
         const trimmedRelation = relation.trim();
         if (!playerKey) {
-            setError(toAppServiceError(new Error('Choose a linked player first.'), 'Choose a linked player first.'));
+            submitOperation.setError(toAppServiceError(new Error('Choose a linked player first.'), 'Choose a linked player first.'));
             return;
         }
         if (!trimmedEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
-            setError(toAppServiceError(new Error('Enter a valid email for the household contact.'), 'Enter a valid email for the household contact.'));
+            submitOperation.setError(toAppServiceError(new Error('Enter a valid email for the household contact.'), 'Enter a valid email for the household contact.'));
             return;
         }
         if (!trimmedRelation) {
-            setError(toAppServiceError(new Error('Enter the household contact relation.'), 'Enter the household contact relation.'));
+            submitOperation.setError(toAppServiceError(new Error('Enter the household contact relation.'), 'Enter the household contact relation.'));
             return;
         }
-        setError(null);
+        submitOperation.clearError();
         setMessage('');
         setCreatedInvite(null);
         await runSubmit(
@@ -74,9 +70,8 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
                 email: trimmedEmail,
                 relation: trimmedRelation
             }),
+            'Unable to create household invite.',
             {
-                rethrow: false,
-                getErrorMessage: (createError) => String(toAppServiceError(createError, 'Unable to create household invite.').message || 'Unable to create household invite.'),
                 onSuccess: async (result) => {
                     setCreatedInvite(result);
                     setMessage('Household invite created.');
@@ -84,9 +79,6 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
                     setEmail('');
                     setRelation('');
                     await refresh();
-                },
-                onError: (createError) => {
-                    setError(toAppServiceError(createError, 'Unable to create household invite.'));
                 }
             }
         );

--- a/apps/app/src/pages/parent-tools/async-pattern-regression.test.ts
+++ b/apps/app/src/pages/parent-tools/async-pattern-regression.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+const migratedParentToolFiles = [
+    'AccessTool.tsx',
+    'CalendarTool.tsx',
+    'FamilyShareTool.tsx',
+    'HouseholdInviteTool.tsx',
+    'FeesTool.tsx'
+];
+
+describe('parent tool async pattern regression', () => {
+    it.each(migratedParentToolFiles)('%s uses the shared parent async helper', (fileName) => {
+        const source = readFileSync(resolve(currentDir, fileName), 'utf8');
+
+        expect(source).toContain('useParentToolAsyncOperation');
+        expect(source).not.toContain("../../lib/useAsyncOperation");
+    });
+});

--- a/apps/app/src/pages/parent-tools/shared.tsx
+++ b/apps/app/src/pages/parent-tools/shared.tsx
@@ -7,6 +7,7 @@ import { useAsyncOperation } from '../../lib/useAsyncOperation';
 type ParentToolAsyncOptions<T> = {
     onSuccess?: (value: T) => void | Promise<void>;
     onError?: (error: AppServiceError) => void | Promise<void>;
+    onFinally?: () => void | Promise<void>;
     clearError?: boolean;
 };
 
@@ -40,6 +41,9 @@ export function useParentToolAsyncOperation() {
                 const appError = toAppServiceError(taskError, fallbackMessage);
                 setError(appError);
                 await options.onError?.(appError);
+            },
+            onFinally: async () => {
+                await options.onFinally?.();
             }
         });
     }, [clearOperationError, runOperation]);


### PR DESCRIPTION
Closes #2914

## What changed
- Migrated the parent tools pages in scope to `useParentToolAsyncOperation` so access, calendar, family share, household invite, and fee actions all use the shared AppServiceError mapping path.
- Extended the shared parent-tools async helper to support `onFinally`, which let the migrated pages keep their existing busy-state cleanup and post-submit refresh behavior.
- Added a focused regression test that fails if these parent-tools pages fall back to direct `useAsyncOperation` imports instead of the shared helper.

## Root Cause
These parent-tools pages kept duplicating async state wiring with direct `useAsyncOperation` usage instead of the shared parent helper. That duplication let error typing, retry handling, and submit-refresh behavior drift page by page even though the cluster was supposed to share one async contract.

## Prevention / Learning
When a route cluster already has a shared async helper, extend that helper for the missing lifecycle hook instead of rebuilding per-page loading and error state locally. For follow-on migrations, add a regression check that the pages import the shared helper and do not reintroduce direct base-hook wiring.

## Regression Tests
- `npx vitest run src/lib/useAsyncOperation.test.tsx src/pages/parent-tools/async-pattern-regression.test.ts --reporter=verbose`
- `npx tsc --noEmit`

## Recurrence Risk
Low. The shared helper now covers the cleanup hook these pages needed, and the regression test guards the exact drift that caused this cluster to diverge.