### PR TITLE
Extract schedule event header display component

### DIFF
--- a/apps/app/src/components/schedule/ScheduleEventHeader.tsx
+++ b/apps/app/src/components/schedule/ScheduleEventHeader.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from 'react';
+import { DateTile } from './DateTile';
+import { EventBrief } from './EventBrief';
+
+interface ScheduleEventHeaderProps {
+  date: Date;
+  teamName: string;
+  eventType: 'practice' | 'game';
+  title: string;
+  timeLabel: string;
+  location?: string | null;
+  playerSummary: ReactNode;
+  rsvpLabel: string;
+  rsvpClassName: string;
+  briefPieces: string[];
+}
+
+export function ScheduleEventHeader({
+  date,
+  teamName,
+  eventType,
+  title,
+  timeLabel,
+  location,
+  playerSummary,
+  rsvpLabel,
+  rsvpClassName,
+  briefPieces
+}: ScheduleEventHeaderProps) {
+  return (
+    <>
+      <div className="mt-1.5 flex items-start gap-2.5 sm:mt-2 sm:gap-3">
+        <DateTile date={date} />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="min-w-0 truncate text-xs font-black uppercase tracking-[0.04em] text-gray-500">{teamName}</span>
+            <span className={`inline-flex min-h-5 flex-none items-center rounded-full px-2 text-[10px] font-extrabold uppercase tracking-[0.04em] ${eventType === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800'}`}>
+              {eventType}
+            </span>
+          </div>
+          <h1 className="mt-0.5 text-lg font-black leading-tight text-gray-950 sm:text-2xl">{title}</h1>
+          <div className="mt-0 flex min-w-0 flex-wrap gap-x-2 gap-y-0.5 text-xs font-bold leading-5 text-gray-600 sm:text-sm">
+            <span>{timeLabel}</span>
+            <span className="min-w-0 truncate">{location || 'Location TBD'}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-1 flex min-w-0 items-center justify-between gap-2 sm:mt-2">
+        <div className="min-w-0 flex-1">{playerSummary}</div>
+        <span className={`inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpClassName}`}>
+          {rsvpLabel}
+        </span>
+      </div>
+
+      <EventBrief pieces={briefPieces} />
+    </>
+  );
+}

--- a/apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx
+++ b/apps/app/src/components/schedule/ScheduleEventSummaryComponents.test.tsx
@@ -6,6 +6,7 @@ import { DateTile } from './DateTile';
 import { EventBrief } from './EventBrief';
 import { EventSectionNav } from './EventSectionNav';
 import { PlayerInitials } from './PlayerInitials';
+import { ScheduleEventHeader } from './ScheduleEventHeader';
 
 describe('Schedule event summary components', () => {
   it('renders the date tile month, day, and weekday', () => {
@@ -23,6 +24,33 @@ describe('Schedule event summary components', () => {
 
     rerender(<PlayerInitials name="   " />);
     expect(screen.getByText('P')).toBeTruthy();
+  });
+
+  it('renders the extracted event header with representative props', () => {
+    render(
+      <ScheduleEventHeader
+        date={new Date('2026-06-19T18:00:00.000Z')}
+        teamName="Tigers"
+        eventType="game"
+        title="Tigers vs Lions"
+        timeLabel="Arrive 5:30 PM · Starts 6:00 PM"
+        location="North Field"
+        playerSummary={<div>Avery Smith · Tigers</div>}
+        rsvpLabel="Going"
+        rsvpClassName="border-emerald-200 bg-emerald-50 text-emerald-700"
+        briefPieces={['Final 3-1', 'Home']}
+      />
+    );
+
+    expect(screen.getByText('Tigers')).toBeTruthy();
+    expect(screen.getByText('game')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Tigers vs Lions' })).toBeTruthy();
+    expect(screen.getByText('Arrive 5:30 PM · Starts 6:00 PM')).toBeTruthy();
+    expect(screen.getByText('North Field')).toBeTruthy();
+    expect(screen.getByText('Avery Smith · Tigers')).toBeTruthy();
+    expect(screen.getByText('Going')).toBeTruthy();
+    expect(screen.getByText('Final 3-1')).toBeTruthy();
+    expect(screen.getByText('Home')).toBeTruthy();
   });
 
   it('renders event brief pills only when summary pieces exist', () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -80,9 +80,8 @@ import { useAsyncOperation } from '../lib/useAsyncOperation';
 import { EventDetailPageSkeleton } from '../components/PageSkeletons';
 import { AssignmentsSection } from '../components/schedule/AssignmentsSection';
 import { CompactMeta } from '../components/schedule/CompactMeta';
-import { DateTile } from '../components/schedule/DateTile';
-import { EventBrief } from '../components/schedule/EventBrief';
 import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';
+import { ScheduleEventHeader } from '../components/schedule/ScheduleEventHeader';
 import { EventSectionNav } from '../components/schedule/EventSectionNav';
 import { GameReportSections } from '../components/schedule/GameReportSections';
 import { PlayerSwitcher } from '../components/schedule/PlayerSwitcher';
@@ -487,40 +486,25 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
               </button>
             </div>
 
-            <div className="mt-1.5 flex items-start gap-2.5 sm:mt-2 sm:gap-3">
-              <DateTile date={selectedEvent.date} />
-              <div className="min-w-0 flex-1">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="min-w-0 truncate text-xs font-black uppercase tracking-[0.04em] text-gray-500">{selectedEvent.teamName}</span>
-                  <span className={`inline-flex min-h-5 flex-none items-center rounded-full px-2 text-[10px] font-extrabold uppercase tracking-[0.04em] ${selectedEvent.type === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800'}`}>
-                    {selectedEvent.type}
-                  </span>
-                </div>
-                <h1 className="mt-0.5 text-lg font-black leading-tight text-gray-950 sm:text-2xl">{title}</h1>
-                <div className="mt-0 flex min-w-0 flex-wrap gap-x-2 gap-y-0.5 text-xs font-bold leading-5 text-gray-600 sm:text-sm">
-                  <span>{formatHeroTime(selectedEvent)}</span>
-                  <span className="min-w-0 truncate">{selectedEvent.location || 'Location TBD'}</span>
-                </div>
-              </div>
-            </div>
-
-            <div className="mt-1 flex min-w-0 items-center justify-between gap-2 sm:mt-2">
-              <div className="min-w-0 flex-1">
-                {events.length > 1 ? (
-                  <>
-                    <PlayerSwitcher events={events} selectedChildId={selectedEvent.childId} onSelect={selectChild} compact />
-                    <div className="mt-1 truncate text-xs font-bold text-gray-600">{selectedEvent.childName} · {selectedEvent.teamName}</div>
-                  </>
-                ) : (
-                  <CompactMeta icon={Users} value={`${selectedEvent.childName} · ${selectedEvent.teamName}`} />
-                )}
-              </div>
-              <span className={`inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[rsvp]}`}>
-                {rsvpLabels[rsvp]}
-              </span>
-            </div>
-
-            <EventBrief pieces={getEventBriefPieces(selectedEvent)} />
+            <ScheduleEventHeader
+              date={selectedEvent.date}
+              teamName={selectedEvent.teamName}
+              eventType={selectedEvent.type}
+              title={title}
+              timeLabel={formatHeroTime(selectedEvent)}
+              location={selectedEvent.location}
+              playerSummary={events.length > 1 ? (
+                <>
+                  <PlayerSwitcher events={events} selectedChildId={selectedEvent.childId} onSelect={selectChild} compact />
+                  <div className="mt-1 truncate text-xs font-bold text-gray-600">{selectedEvent.childName} · {selectedEvent.teamName}</div>
+                </>
+              ) : (
+                <CompactMeta icon={Users} value={`${selectedEvent.childName} · ${selectedEvent.teamName}`} />
+              )}
+              rsvpLabel={rsvpLabels[rsvp]}
+              rsvpClassName={rsvpBadgeClasses[rsvp]}
+              briefPieces={getEventBriefPieces(selectedEvent)}
+            />
             <button
               type="button"
               className="secondary-button event-calendar-button mt-1.5 w-full justify-center sm:mt-2"

--- a/tests/unit/app-schedule-event-detail-layout.test.js
+++ b/tests/unit/app-schedule-event-detail-layout.test.js
@@ -4,10 +4,11 @@ import { describe, expect, it } from 'vitest';
 
 describe('app schedule event detail mobile layout', () => {
     it('keeps the mobile event summary shell padding and meta spacing compact', () => {
-        const source = readFileSync(resolve('apps/app/src/pages/ScheduleEventDetail.tsx'), 'utf8');
+        const pageSource = readFileSync(resolve('apps/app/src/pages/ScheduleEventDetail.tsx'), 'utf8');
+        const headerSource = readFileSync(resolve('apps/app/src/components/schedule/ScheduleEventHeader.tsx'), 'utf8');
 
-        expect(source).toContain('event-summary-shell px-3 py-1.5 sm:p-4');
-        expect(source).toContain('mt-0 flex min-w-0 flex-wrap gap-x-2 gap-y-0.5 text-xs font-bold leading-5 text-gray-600 sm:text-sm');
-        expect(source).toContain('mt-1 flex min-w-0 items-center justify-between gap-2 sm:mt-2');
+        expect(pageSource).toContain('event-summary-shell px-3 py-1.5 sm:p-4');
+        expect(headerSource).toContain('mt-0 flex min-w-0 flex-wrap gap-x-2 gap-y-0.5 text-xs font-bold leading-5 text-gray-600 sm:text-sm');
+        expect(headerSource).toContain('mt-1 flex min-w-0 items-center justify-between gap-2 sm:mt-2');
     });
 });

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -11,6 +11,7 @@ const rsvpHookSource = readSource('apps/app/src/hooks/schedule/useScheduleEventR
 const ridesHookSource = readSource('apps/app/src/hooks/schedule/useScheduleRideOffers.ts');
 const availabilityPanelsSource = readSource('apps/app/src/components/schedule/AvailabilityPanels.tsx');
 const compactMetaSource = readSource('apps/app/src/components/schedule/CompactMeta.tsx');
+const scheduleEventHeaderSource = readSource('apps/app/src/components/schedule/ScheduleEventHeader.tsx');
 const assignmentsSectionSource = readSource('apps/app/src/components/schedule/AssignmentsSection.tsx');
 const gameReportSectionsSource = readSource('apps/app/src/components/schedule/GameReportSections.tsx');
 const gameReportContentSource = readSource('apps/app/src/components/schedule/GameReportSectionContent.tsx');
@@ -108,9 +109,8 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
 
     it('keeps reusable schedule UI out of the detail page body', () => {
         [
-            "import { DateTile } from '../components/schedule/DateTile';",
             "import { CompactMeta } from '../components/schedule/CompactMeta';",
-            "import { EventBrief } from '../components/schedule/EventBrief';",
+            "import { ScheduleEventHeader } from '../components/schedule/ScheduleEventHeader';",
             "import { GameReportSections } from '../components/schedule/GameReportSections';",
             "import { PlayerSwitcher } from '../components/schedule/PlayerSwitcher';",
             "import { PracticeAttendancePanel } from '../components/schedule/PracticeAttendancePanel';",
@@ -129,8 +129,6 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
 
         [
             /^function CompactMeta\b/m,
-            /^function DateTile\b/m,
-            /^function EventBrief\b/m,
             /^function EventSectionNav\b/m,
             /^function GameReportSections\b/m,
             /^function PlayerSwitcher\b/m,
@@ -149,6 +147,9 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
         });
 
         expect(compactMetaSource).toContain('export function CompactMeta');
+        expect(scheduleEventHeaderSource).toContain("import { DateTile } from './DateTile';");
+        expect(scheduleEventHeaderSource).toContain("import { EventBrief } from './EventBrief';");
+        expect(scheduleEventHeaderSource).toContain('export function ScheduleEventHeader');
         expect(practiceAttendancePanelSource).toContain('export function PracticeAttendancePanel');
         expect(practiceAttendancePanelSource).toContain('data-testid={`practice-attendance-row-${player.playerId}`}');
         expect(scoreStepperSource).toContain('export function ScoreStepper');

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -14,9 +14,8 @@ describe('ScheduleEventDetail decomposition contract', () => {
         [
             "import { AssignmentsSection } from '../components/schedule/AssignmentsSection';",
             "import { CompactMeta } from '../components/schedule/CompactMeta';",
-            "import { DateTile } from '../components/schedule/DateTile';",
-            "import { EventBrief } from '../components/schedule/EventBrief';",
             "import { EventDetailsPanel } from '../components/schedule/EventDetailsPanel';",
+            "import { ScheduleEventHeader } from '../components/schedule/ScheduleEventHeader';",
             "import { EventSectionNav } from '../components/schedule/EventSectionNav';",
             "import { GameReportSections } from '../components/schedule/GameReportSections';",
             "import { PlayerSwitcher } from '../components/schedule/PlayerSwitcher';",
@@ -38,8 +37,6 @@ describe('ScheduleEventDetail decomposition contract', () => {
             /^function AssignmentCard\b/m,
             /^function AssignmentsSection\b/m,
             /^function CompactMeta\b/m,
-            /^function DateTile\b/m,
-            /^function EventBrief\b/m,
             /^function EventDetailsPanel\b/m,
             /^function EventSectionNav\b/m,
             /^function GameReportSections\b/m,
@@ -63,6 +60,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
     it('keeps schedule detail utility controls in extracted presentational components', () => {
         const compactMeta = readRepoFile('apps/app/src/components/schedule/CompactMeta.tsx');
         const practiceAttendancePanel = readRepoFile('apps/app/src/components/schedule/PracticeAttendancePanel.tsx');
+        const scheduleEventHeader = readRepoFile('apps/app/src/components/schedule/ScheduleEventHeader.tsx');
         const scoreStepper = readRepoFile('apps/app/src/components/schedule/ScoreStepper.tsx');
         const scheduleStatus = readRepoFile('apps/app/src/components/schedule/ScheduleStatus.tsx');
         const focusedTests = readRepoFile('apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx');
@@ -70,6 +68,9 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(compactMeta).toContain('export function CompactMeta');
         expect(practiceAttendancePanel).toContain('export function PracticeAttendancePanel');
         expect(practiceAttendancePanel).toContain('onSelectStatus(player, status)');
+        expect(scheduleEventHeader).toContain("import { DateTile } from './DateTile';");
+        expect(scheduleEventHeader).toContain("import { EventBrief } from './EventBrief';");
+        expect(scheduleEventHeader).toContain('export function ScheduleEventHeader');
         expect(scoreStepper).toContain('export function ScoreStepper');
         expect(scoreStepper).toContain('aria-label={`${label} score up`}');
         expect(scheduleStatus).toContain('export function Status');


### PR DESCRIPTION
Closes #2930

## What changed
- extracted the top-level schedule detail header/date display into a typed `ScheduleEventHeader` component under `apps/app/src/components/schedule/`
- updated `ScheduleEventDetail` to render its header/date area through the new presentational component while keeping route, auth, and mutation logic in the page
- added focused component coverage for the extracted header with representative schedule event props

## Root Cause
The schedule event detail page kept the read-only header markup inline, so there was no typed presentational boundary or focused regression coverage for the header/date display during the broader component extraction work.

## Prevention / Learning
When splitting large detail pages, extract stable read-only header/display regions into typed components first and add focused component tests before moving deeper interactive sections.

## Regression Tests
- `npx vitest run src/components/schedule/ScheduleEventSummaryComponents.test.tsx --reporter=verbose`
- `npx tsc --noEmit`