### PR TITLE
Fix verify-pending parent redirect

### DIFF
--- a/tests/unit/verify-pending-page.test.js
+++ b/tests/unit/verify-pending-page.test.js
@@ -12,4 +12,15 @@ describe('verify pending legacy page redirect wiring', () => {
         expect(source).toContain("window.location.href = redirectUrl;");
         expect(source).not.toContain('href="dashboard.html"');
     });
+
+    it('keeps Continue disabled until the redirect target is ready', () => {
+        const source = readFileSync(resolve(process.cwd(), 'verify-pending.html'), 'utf8');
+
+        expect(source).toContain('id="continue-btn" href="#" aria-disabled="true" tabindex="-1"');
+        expect(source).toContain('opacity-50 cursor-not-allowed pointer-events-none');
+        expect(source).toContain("continueBtn.removeAttribute('aria-disabled');");
+        expect(source).toContain("continueBtn.removeAttribute('tabindex');");
+        expect(source).toContain("continueBtn.classList.remove('opacity-50', 'cursor-not-allowed', 'pointer-events-none');");
+        expect(source).toContain("continueBtn.classList.add('hover:bg-indigo-700');");
+    });
 });

--- a/tests/unit/verify-pending-page.test.js
+++ b/tests/unit/verify-pending-page.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('verify pending legacy page redirect wiring', () => {
+    it('uses role-aware redirect logic instead of hardcoded dashboard links', () => {
+        const source = readFileSync(resolve(process.cwd(), 'verify-pending.html'), 'utf8');
+
+        expect(source).toContain("import { checkAuth, getRedirectUrl, logout, resendVerificationEmail } from './js/auth.js?v=30';");
+        expect(source).toContain('const redirectUrl = getRedirectUrl(user);');
+        expect(source).toContain('continueBtn.href = redirectUrl;');
+        expect(source).toContain("window.location.href = redirectUrl;");
+        expect(source).not.toContain('href="dashboard.html"');
+    });
+});

--- a/verify-pending.html
+++ b/verify-pending.html
@@ -59,7 +59,7 @@
             <p class="text-gray-600 mb-6">Please check your inbox and click the verification link. You can verify now or later from your profile.</p>
 
             <div class="space-y-3">
-                <a id="continue-btn" href="dashboard.html"
+                <a id="continue-btn" href="#"
                     class="block w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition text-center font-medium">
                     Continue to Dashboard
                 </a>
@@ -82,13 +82,14 @@
 
     <script type="module">
         import { auth } from './js/firebase.js?v=19';
-        import { checkAuth, logout, resendVerificationEmail } from './js/auth.js?v=30';
+        import { checkAuth, getRedirectUrl, logout, resendVerificationEmail } from './js/auth.js?v=30';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderHeader(document.getElementById('header-container'), null);
         renderFooter(document.getElementById('footer-container'));
 
         const userEmailEl = document.getElementById('user-email');
+        const continueBtn = document.getElementById('continue-btn');
         const resendBtn = document.getElementById('resend-btn');
         const logoutBtn = document.getElementById('logout-btn');
         const messageEl = document.getElementById('message');
@@ -107,10 +108,12 @@
             }
 
             userEmailEl.textContent = user.email;
+            const redirectUrl = getRedirectUrl(user);
+            continueBtn.href = redirectUrl;
 
             // If already verified, go straight to dashboard
             if (user.emailVerified) {
-                window.location.href = 'dashboard.html';
+                window.location.href = redirectUrl;
                 return;
             }
 
@@ -122,7 +125,7 @@
                 countdownEl.textContent = seconds;
                 if (seconds <= 0) {
                     clearInterval(interval);
-                    window.location.href = 'dashboard.html';
+                    window.location.href = redirectUrl;
                 }
             }, 1000);
         }, { skipEmailVerificationCheck: true });

--- a/verify-pending.html
+++ b/verify-pending.html
@@ -59,8 +59,8 @@
             <p class="text-gray-600 mb-6">Please check your inbox and click the verification link. You can verify now or later from your profile.</p>
 
             <div class="space-y-3">
-                <a id="continue-btn" href="#"
-                    class="block w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition text-center font-medium">
+                <a id="continue-btn" href="#" aria-disabled="true" tabindex="-1"
+                    class="block w-full bg-indigo-600 text-white py-2 px-4 rounded-md transition text-center font-medium opacity-50 cursor-not-allowed pointer-events-none">
                     Continue to Dashboard
                 </a>
                 <p id="auto-redirect-msg" class="text-xs text-gray-400 text-center">Redirecting in <span id="countdown">5</span> seconds...</p>
@@ -110,6 +110,10 @@
             userEmailEl.textContent = user.email;
             const redirectUrl = getRedirectUrl(user);
             continueBtn.href = redirectUrl;
+            continueBtn.removeAttribute('aria-disabled');
+            continueBtn.removeAttribute('tabindex');
+            continueBtn.classList.remove('opacity-50', 'cursor-not-allowed', 'pointer-events-none');
+            continueBtn.classList.add('hover:bg-indigo-700');
 
             // If already verified, go straight to dashboard
             if (user.emailVerified) {


### PR DESCRIPTION
Closes #2936

## What changed
- Updated `verify-pending.html` to reuse `getRedirectUrl(user)` for the Continue button, verified-user redirect, and countdown redirect.
- Removed the hardcoded `dashboard.html` fallback from the legacy verify-pending CTA.
- Added a focused regression test to lock the legacy page onto role-aware redirect wiring.

## Root Cause
`verify-pending.html` duplicated post-auth routing with hardcoded `dashboard.html` destinations instead of using the existing shared role-aware redirect helper. Parent invite signups already had parent role data by this point, but the legacy verify-pending page discarded it and always sent users to the generic dashboard.

## Prevention / Learning
When a post-login or post-signup page forwards authenticated users, it should derive the destination from the shared auth redirect helper rather than duplicating a fixed dashboard path. This keeps role-based routing consistent across legacy pages and avoids drift when signup state already carries role data.

## Regression Tests
- `npx vitest run tests/unit/verify-pending-page.test.js --reporter=verbose`
- `tests/unit/verify-pending-page.test.js` asserts the legacy verify-pending page imports `getRedirectUrl`, assigns the continue CTA from it, and no longer hardcodes `dashboard.html`.

## Recurrence Risk
Low. The page now uses the central redirect helper, and the regression test specifically guards against reintroducing hardcoded dashboard redirects on verify-pending.