### PR TITLE
Tighten schedule adapters and fix non-window timeout guard

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleHelpers.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleHelpers.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    expandRecurrence: vi.fn(),
+    getSubstitutionOptions: vi.fn()
+}));
+
+vi.mock('../../../../../js/schedule-notifications.js', () => ({
+    sendPublicRsvpReminderEmails: vi.fn()
+}));
+vi.mock('../../../../../js/admin-user-official-links.js', () => ({
+    normalizeOfficialLinkEmail: vi.fn((value: unknown) => value),
+    normalizeOfficialLinkPhone: vi.fn((value: unknown) => value)
+}));
+vi.mock('../../../../../js/officiating-utils.js', () => ({
+    getAssignedOfficiatingSlots: vi.fn(() => []),
+    getOpenOfficiatingSlots: vi.fn(() => [])
+}));
+vi.mock('../../../../../js/utils.js', () => ({
+    expandRecurrence: mocks.expandRecurrence,
+    extractOpponent: vi.fn(() => ''),
+    fetchAndParseCalendar: vi.fn(async () => []),
+    generateSeriesId: vi.fn(() => 'series-1'),
+    getCalendarEventTrackingId: vi.fn(() => ''),
+    isPracticeEvent: vi.fn(() => false),
+    isTrackedCalendarEvent: vi.fn(() => false)
+}));
+vi.mock('../../../../../js/parent-dashboard-practice-sessions.js', () => ({
+    filterVisiblePracticeSessions: vi.fn(() => [])
+}));
+vi.mock('../../../../../js/parent-dashboard-packets.js', () => ({
+    buildPracticePacketCompletionPayload: vi.fn(() => ({}))
+}));
+vi.mock('../../../../../js/parent-dashboard-rsvp.js', () => ({
+    resolveMyRsvpByChildForGame: vi.fn(() => ({}))
+}));
+vi.mock('../../../../../js/game-day-rsvp-breakdown.js', () => ({
+    buildGameDayRsvpBreakdown: vi.fn(() => ({ grouped: {}, counts: {} }))
+}));
+vi.mock('../../../../../js/game-day-periods.js', () => ({
+    getPeriodsForFormation: vi.fn(() => [])
+}));
+vi.mock('../../../../../js/rideshare-helpers.js', () => ({
+    getEventRideshareSummary: vi.fn(() => ({}))
+}));
+vi.mock('../../../../../js/snack-helpers.js', () => ({
+    mergeAssignmentsWithClaims: vi.fn(() => [])
+}));
+vi.mock('../../../../../js/team-access.js', () => ({
+    hasScorekeepingTeamAccess: vi.fn(() => false)
+}));
+vi.mock('../../../../../js/team-visibility.js', () => ({
+    isTeamActive: vi.fn(() => true)
+}));
+vi.mock('../../../../../js/game-day-live-substitutions.js', () => ({
+    applyLiveSubstitution: vi.fn(() => null),
+    getSubstitutionOptions: mocks.getSubstitutionOptions
+}));
+vi.mock('../../../../../js/game-plan-interop.js', () => ({
+    buildRotationPlanFromGamePlan: vi.fn(() => ({}))
+}));
+vi.mock('../../../../../js/edit-schedule-practice-payload.js', () => ({
+    applyPracticeRecurrenceFields: vi.fn((payload: Record<string, unknown>) => payload.practiceData)
+}));
+
+import { expandRecurrence, getSubstitutionOptions } from './legacyScheduleHelpers';
+
+describe('legacyScheduleHelpers', () => {
+    it('keeps normalizeArray accepting unknown values for legacy payload normalization', () => {
+        const source = readFileSync('src/lib/adapters/legacyScheduleHelpers.ts', 'utf8');
+        expect(source).toContain('function normalizeArray<T = unknown>(value: unknown): T[]');
+    });
+
+    it('normalizes recurring practice occurrences to the fields consumed by scheduleService', () => {
+        mocks.expandRecurrence.mockReturnValueOnce([
+            {
+                masterId: 'practice-master',
+                instanceDate: '2026-06-24',
+                date: '2026-06-24T18:00:00.000Z',
+                end: '2026-06-24T19:30:00.000Z',
+                notes: 'Bring water',
+                location: 'North Field',
+                title: 'Weekly Practice'
+            },
+            {
+                masterId: 'missing-date'
+            }
+        ]);
+
+        expect(expandRecurrence({ id: 'practice-master' })).toEqual([
+            {
+                masterId: 'practice-master',
+                instanceDate: '2026-06-24',
+                date: '2026-06-24T18:00:00.000Z',
+                end: '2026-06-24T19:30:00.000Z',
+                notes: 'Bring water',
+                location: 'North Field',
+                title: 'Weekly Practice'
+            }
+        ]);
+    });
+
+    it('accepts unknown substitution player collections before normalizing arrays', () => {
+        mocks.getSubstitutionOptions.mockReturnValueOnce({
+            onField: {
+                GK: 'player-1'
+            },
+            onFieldPlayers: { id: 'bad-shape' },
+            offFieldPlayers: 'not-an-array'
+        });
+
+        expect(getSubstitutionOptions({})).toEqual({
+            onField: {
+                GK: 'player-1'
+            },
+            onFieldPlayers: [],
+            offFieldPlayers: []
+        });
+    });
+});

--- a/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
@@ -38,7 +38,7 @@ type LegacyCalendarEvent = LegacyRecord & {
 type LegacyPracticeOccurrence = LegacyRecord & {
     masterId?: string;
     instanceDate?: string;
-    date?: string | Date;
+    date: string | Date;
     endDate?: string | Date;
     end?: string | Date;
     location?: string;
@@ -109,6 +109,16 @@ function normalizeCalendarEvent(value: unknown): LegacyCalendarEvent {
     return normalizeRecord<LegacyCalendarEvent>(value);
 }
 
+function normalizePracticeOccurrence(value: unknown): LegacyPracticeOccurrence | null {
+    const record = normalizeRecord(value);
+    const date = record.date ?? record.instanceDate;
+    if (!(typeof date === 'string' || date instanceof Date)) return null;
+    return {
+        ...record,
+        date
+    } as LegacyPracticeOccurrence;
+}
+
 function normalizeSubstitutionPlayer(value: unknown): LegacySubstitutionPlayer {
     const record = normalizeRecord(value);
     return {
@@ -177,7 +187,7 @@ export function getOpenOfficiatingSlots(game: unknown): LegacyRecord[] {
 }
 
 export function expandRecurrence(game: unknown): LegacyPracticeOccurrence[] {
-    return normalizeArray<LegacyPracticeOccurrence>(legacyExpandRecurrence(game) as LegacyPracticeOccurrence[]);
+    return normalizeArray(legacyExpandRecurrence(game)).map(normalizePracticeOccurrence).filter(Boolean) as LegacyPracticeOccurrence[];
 }
 
 export function extractOpponent(summary: unknown, teamName: unknown): string {

--- a/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
@@ -26,12 +26,125 @@ import {
 import { buildRotationPlanFromGamePlan as legacyBuildRotationPlanFromGamePlan } from '../../../../../js/game-plan-interop.js';
 import { applyPracticeRecurrenceFields as legacyApplyPracticeRecurrenceFields } from '../../../../../js/edit-schedule-practice-payload.js';
 
-function normalizeArray<T = unknown>(value: T[] | null | undefined) {
+type LegacyRecord = Record<string, unknown>;
+
+type LegacyCalendarEvent = LegacyRecord & {
+    uid?: string;
+    summary?: string;
+    location?: string;
+    dtstart?: string | Date;
+};
+
+type LegacyPracticeOccurrence = LegacyRecord & {
+    masterId?: string;
+    instanceDate?: string;
+    date?: string | Date;
+    endDate?: string | Date;
+    location?: string;
+    title?: string;
+};
+
+type LegacyRsvpBreakdownRow = LegacyRecord & {
+    playerId?: string;
+    playerName?: string;
+    response?: string;
+};
+
+export type LegacyGameDayRsvpBreakdown = {
+    grouped: {
+        going: LegacyRsvpBreakdownRow[];
+        maybe: LegacyRsvpBreakdownRow[];
+        not_going: LegacyRsvpBreakdownRow[];
+        not_responded: LegacyRsvpBreakdownRow[];
+    };
+    counts: Record<string, number>;
+};
+
+export type LegacyRotationPlan = Record<string, Record<string, string>>;
+
+export type LegacySubstitutionPlayer = {
+    id: string;
+    name: string;
+    number?: string | null;
+};
+
+export type LegacySubstitutionOptions = {
+    onField: Record<string, string>;
+    onFieldPlayers: LegacySubstitutionPlayer[];
+    offFieldPlayers: LegacySubstitutionPlayer[];
+};
+
+export type LegacyRotationActualEntry = LegacyRecord & {
+    position?: string;
+    out?: string;
+    outId?: string;
+    outPlayerId?: string;
+    in?: string;
+    inId?: string;
+    inPlayerId?: string;
+    appliedAt?: string;
+};
+
+export type LegacyRotationActual = Record<string, Record<string, LegacyRotationActualEntry[]>>;
+
+export type LegacyLiveSubstitutionResult = {
+    position: string;
+    outPlayer: LegacySubstitutionPlayer;
+    inPlayer: LegacySubstitutionPlayer;
+    rotationPlan: LegacyRotationPlan;
+    rotationActual: LegacyRotationActual;
+} | null;
+
+function normalizeArray<T = unknown>(value: T[] | null | undefined): T[] {
     return Array.isArray(value) ? value : [];
 }
 
-function normalizeRecord(value: unknown) {
-    return value && typeof value === 'object' ? value as Record<string, unknown> : {};
+function normalizeRecord<T extends LegacyRecord = LegacyRecord>(value: unknown): T {
+    return (value && typeof value === 'object' ? value : {}) as T;
+}
+
+function normalizeCalendarEvent(value: unknown): LegacyCalendarEvent {
+    return normalizeRecord<LegacyCalendarEvent>(value);
+}
+
+function normalizeSubstitutionPlayer(value: unknown): LegacySubstitutionPlayer {
+    const record = normalizeRecord(value);
+    return {
+        id: String(record.id || '').trim(),
+        name: String(record.name || '').trim() || 'Player',
+        number: record.number == null ? null : String(record.number || '').trim() || null
+    };
+}
+
+function normalizeRotationPlan(value: unknown): LegacyRotationPlan {
+    return Object.entries(normalizeRecord(value)).reduce<LegacyRotationPlan>((acc, [period, slots]) => {
+        const normalizedSlots = Object.entries(normalizeRecord(slots)).reduce<Record<string, string>>((slotAcc, [slotId, playerId]) => {
+            const safeSlotId = String(slotId || '').trim();
+            const safePlayerId = String(playerId || '').trim();
+            if (!safeSlotId || !safePlayerId) return slotAcc;
+            slotAcc[safeSlotId] = safePlayerId;
+            return slotAcc;
+        }, {});
+        if (Object.keys(normalizedSlots).length > 0) {
+            acc[String(period || '').trim()] = normalizedSlots;
+        }
+        return acc;
+    }, {});
+}
+
+function normalizeRotationActual(value: unknown): LegacyRotationActual {
+    return Object.entries(normalizeRecord(value)).reduce<LegacyRotationActual>((acc, [period, entries]) => {
+        const normalizedEntries = Object.entries(normalizeRecord(entries)).reduce<Record<string, LegacyRotationActualEntry[]>>((entryAcc, [entryId, items]) => {
+            const safeEntryId = String(entryId || '').trim();
+            if (!safeEntryId) return entryAcc;
+            entryAcc[safeEntryId] = normalizeArray(items).map((item) => normalizeRecord<LegacyRotationActualEntry>(item));
+            return entryAcc;
+        }, {});
+        if (Object.keys(normalizedEntries).length > 0) {
+            acc[String(period || '').trim()] = normalizedEntries;
+        }
+        return acc;
+    }, {});
 }
 
 export async function sendPublicRsvpReminderEmails(payload: {
@@ -45,95 +158,127 @@ export async function sendPublicRsvpReminderEmails(payload: {
     return await Promise.resolve(legacySendPublicRsvpReminderEmails(payload));
 }
 
-export function normalizeOfficialLinkEmail(value: unknown) {
+export function normalizeOfficialLinkEmail(value: unknown): string {
     return String(legacyNormalizeOfficialLinkEmail(value) || '').trim().toLowerCase();
 }
 
-export function normalizeOfficialLinkPhone(value: unknown) {
+export function normalizeOfficialLinkPhone(value: unknown): string {
     return String(legacyNormalizeOfficialLinkPhone(value) || '').trim();
 }
 
-export function getAssignedOfficiatingSlots(game: unknown, user: unknown) {
-    return normalizeArray(legacyGetAssignedOfficiatingSlots(normalizeRecord(game), normalizeRecord(user)));
+export function getAssignedOfficiatingSlots(game: unknown, user: unknown): LegacyRecord[] {
+    return normalizeArray(legacyGetAssignedOfficiatingSlots(normalizeRecord(game), normalizeRecord(user))) as LegacyRecord[];
 }
 
-export function getOpenOfficiatingSlots(game: unknown) {
-    return normalizeArray(legacyGetOpenOfficiatingSlots(game));
+export function getOpenOfficiatingSlots(game: unknown): LegacyRecord[] {
+    return normalizeArray(legacyGetOpenOfficiatingSlots(game)) as LegacyRecord[];
 }
 
-export function expandRecurrence(game: unknown): Record<string, any>[] {
-    return normalizeArray<Record<string, any>>(legacyExpandRecurrence(game) as Record<string, any>[]);
+export function expandRecurrence(game: unknown): LegacyPracticeOccurrence[] {
+    return normalizeArray<LegacyPracticeOccurrence>(legacyExpandRecurrence(game) as LegacyPracticeOccurrence[]);
 }
 
-export function extractOpponent(summary: unknown, teamName: unknown) {
+export function extractOpponent(summary: unknown, teamName: unknown): string {
     return String(legacyExtractOpponent(summary, teamName) || '').trim();
 }
 
-export async function fetchAndParseCalendar(url: string) {
-    return normalizeArray(await Promise.resolve(legacyFetchAndParseCalendar(url)));
+export async function fetchAndParseCalendar(url: string): Promise<LegacyCalendarEvent[]> {
+    return normalizeArray<LegacyCalendarEvent>(await Promise.resolve(legacyFetchAndParseCalendar(url)) as LegacyCalendarEvent[]);
 }
 
-export function getCalendarEventTrackingId(event: unknown) {
+export function getCalendarEventTrackingId(event: unknown): string {
     return String(legacyGetCalendarEventTrackingId(event) || '').trim();
 }
 
-export function isPracticeEvent(summary: unknown) {
+export function isPracticeEvent(summary: unknown): boolean {
     return legacyIsPracticeEvent(summary);
 }
 
-export function isTrackedCalendarEvent(event: unknown, trackedUids: string[]) {
-    return legacyIsTrackedCalendarEvent(event, normalizeArray(trackedUids));
+export function isTrackedCalendarEvent(event: unknown, trackedUids: string[]): boolean {
+    return legacyIsTrackedCalendarEvent(normalizeCalendarEvent(event), normalizeArray(trackedUids));
 }
 
-export function filterVisiblePracticeSessions(sessions: unknown[], games: unknown[]) {
-    return normalizeArray(legacyFilterVisiblePracticeSessions(normalizeArray(sessions), normalizeArray(games)));
+export function filterVisiblePracticeSessions(sessions: unknown[], games: unknown[]): LegacyRecord[] {
+    return normalizeArray(legacyFilterVisiblePracticeSessions(normalizeArray(sessions), normalizeArray(games))) as LegacyRecord[];
 }
 
-export function buildPracticePacketCompletionPayload(payload: Record<string, unknown>) {
+export function buildPracticePacketCompletionPayload(payload: Record<string, unknown>): LegacyRecord {
     return normalizeRecord(legacyBuildPracticePacketCompletionPayload(payload));
 }
 
-export function resolveMyRsvpByChildForGame(events: unknown[], teamId: string, gameId: string, rsvps: unknown[], userId: string) {
+export function resolveMyRsvpByChildForGame(events: unknown[], teamId: string, gameId: string, rsvps: unknown[], userId: string): LegacyRecord {
     return normalizeRecord(legacyResolveMyRsvpByChildForGame(normalizeArray(events), teamId, gameId, normalizeArray(rsvps), userId));
 }
 
-export function buildGameDayRsvpBreakdown(input: { players: unknown[]; rsvps: unknown[] }) {
-    return normalizeRecord(legacyBuildGameDayRsvpBreakdown({ players: normalizeArray(input.players), rsvps: normalizeArray(input.rsvps) }));
+export function buildGameDayRsvpBreakdown(input: { players: unknown[]; rsvps: unknown[] }): LegacyGameDayRsvpBreakdown {
+    const breakdown = normalizeRecord<LegacyGameDayRsvpBreakdown>(legacyBuildGameDayRsvpBreakdown({
+        players: normalizeArray(input.players),
+        rsvps: normalizeArray(input.rsvps)
+    }));
+    return {
+        grouped: {
+            going: normalizeArray(breakdown.grouped?.going),
+            maybe: normalizeArray(breakdown.grouped?.maybe),
+            not_going: normalizeArray(breakdown.grouped?.not_going),
+            not_responded: normalizeArray(breakdown.grouped?.not_responded)
+        },
+        counts: normalizeRecord<Record<string, number>>(breakdown.counts)
+    };
 }
 
-export function getPeriodsForFormation(value: unknown) {
-    return normalizeArray(legacyGetPeriodsForFormation(value));
+export function getPeriodsForFormation(value: unknown): string[] {
+    return normalizeArray(legacyGetPeriodsForFormation(value)).map((period) => String(period || '').trim()).filter(Boolean);
 }
 
-export function getEventRideshareSummary(offers: unknown[]) {
+export function getEventRideshareSummary(offers: unknown[]): LegacyRecord {
     return normalizeRecord(legacyGetEventRideshareSummary(normalizeArray(offers)));
 }
 
-export function mergeAssignmentsWithClaims(assignments: unknown[], claims: Record<string, unknown>) {
-    return normalizeArray(legacyMergeAssignmentsWithClaims(normalizeArray(assignments), normalizeRecord(claims)));
+export function mergeAssignmentsWithClaims(assignments: unknown[], claims: Record<string, unknown>): LegacyRecord[] {
+    return normalizeArray(legacyMergeAssignmentsWithClaims(normalizeArray(assignments), normalizeRecord(claims))) as LegacyRecord[];
 }
 
-export function hasScorekeepingTeamAccess(user: unknown, team: unknown, game: unknown, fallback: unknown) {
+export function hasScorekeepingTeamAccess(user: unknown, team: unknown, game: unknown, fallback: unknown): boolean {
     return legacyHasScorekeepingTeamAccess(user, team, game, fallback);
 }
 
-export function isTeamActive(team: unknown) {
+export function isTeamActive(team: unknown): boolean {
     return legacyIsTeamActive(team);
 }
 
-export function buildRotationPlanFromGamePlan(gamePlan: unknown): Record<string, any> {
-    return normalizeRecord(legacyBuildRotationPlanFromGamePlan(normalizeRecord(gamePlan))) as Record<string, any>;
+export function buildRotationPlanFromGamePlan(gamePlan: unknown): LegacyRotationPlan {
+    return normalizeRotationPlan(legacyBuildRotationPlanFromGamePlan(normalizeRecord(gamePlan)));
 }
 
-export function getSubstitutionOptions(input: Record<string, unknown>): any {
-    return legacyGetSubstitutionOptions(normalizeRecord(input)) as any;
+export function getSubstitutionOptions(input: Record<string, unknown>): LegacySubstitutionOptions {
+    const result = normalizeRecord(legacyGetSubstitutionOptions(normalizeRecord(input)));
+    return {
+        onField: Object.entries(normalizeRecord(result.onField)).reduce<Record<string, string>>((acc, [position, playerId]) => {
+            const safePosition = String(position || '').trim();
+            const safePlayerId = String(playerId || '').trim();
+            if (!safePosition || !safePlayerId) return acc;
+            acc[safePosition] = safePlayerId;
+            return acc;
+        }, {}),
+        onFieldPlayers: normalizeArray(result.onFieldPlayers).map(normalizeSubstitutionPlayer).filter((player) => player.id),
+        offFieldPlayers: normalizeArray(result.offFieldPlayers).map(normalizeSubstitutionPlayer).filter((player) => player.id)
+    };
 }
 
-export function applyLiveSubstitution(input: Record<string, unknown>): any {
-    return legacyApplyLiveSubstitution(normalizeRecord(input)) as any;
+export function applyLiveSubstitution(input: Record<string, unknown>): LegacyLiveSubstitutionResult {
+    const result = legacyApplyLiveSubstitution(normalizeRecord(input));
+    if (!result || typeof result !== 'object') return null;
+    const normalized = normalizeRecord(result);
+    return {
+        position: String(normalized.position || '').trim() || 'unknown',
+        outPlayer: normalizeSubstitutionPlayer(normalized.outPlayer),
+        inPlayer: normalizeSubstitutionPlayer(normalized.inPlayer),
+        rotationPlan: normalizeRotationPlan(normalized.rotationPlan),
+        rotationActual: normalizeRotationActual(normalized.rotationActual)
+    };
 }
 
-export function generateSeriesId() {
+export function generateSeriesId(): string {
     return String(legacyGenerateSeriesId() || '').trim();
 }
 
@@ -148,7 +293,7 @@ export function applyPracticeRecurrenceFields(payload: {
     Timestamp: { fromDate: (date: Date) => unknown };
     deleteField: () => unknown;
     generateSeriesId?: () => string;
-}) {
+}): Record<string, any> {
     return legacyApplyPracticeRecurrenceFields({
         ...payload,
         generateSeriesId: payload.generateSeriesId || generateSeriesId

--- a/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
@@ -40,8 +40,10 @@ type LegacyPracticeOccurrence = LegacyRecord & {
     instanceDate?: string;
     date?: string | Date;
     endDate?: string | Date;
+    end?: string | Date;
     location?: string;
     title?: string;
+    notes?: string;
 };
 
 type LegacyRsvpBreakdownRow = LegacyRecord & {
@@ -95,8 +97,8 @@ export type LegacyLiveSubstitutionResult = {
     rotationActual: LegacyRotationActual;
 } | null;
 
-function normalizeArray<T = unknown>(value: T[] | null | undefined): T[] {
-    return Array.isArray(value) ? value : [];
+function normalizeArray<T = unknown>(value: unknown): T[] {
+    return Array.isArray(value) ? value as T[] : [];
 }
 
 function normalizeRecord<T extends LegacyRecord = LegacyRecord>(value: unknown): T {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2140,10 +2140,11 @@ describe('team schedule game windowing (#2034)', () => {
       {
         masterId: 'practice-master',
         instanceDate: '2026-06-24',
-        date: new Date('2026-06-24T18:00:00.000Z'),
+        date: '2026-06-24T18:00:00.000Z',
         endDate: new Date('2026-06-24T19:30:00.000Z'),
         location: 'North Field',
-        title: 'Weekly Practice'
+        title: 'Weekly Practice',
+        notes: 'Bring water'
       }
     ] as any);
 
@@ -2156,7 +2157,8 @@ describe('team schedule game windowing (#2034)', () => {
         id: 'practice-master__2026-06-24',
         type: 'practice',
         isDbGame: true,
-        location: 'North Field'
+        location: 'North Field',
+        notes: 'Bring water'
       })
     ]));
   });

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -228,6 +228,30 @@ describe('parent schedule child scope', () => {
     expect(getPlayers).not.toHaveBeenCalled();
   });
 
+  it('loads parent-linked players without requiring a browser window for timeout guards', async () => {
+    const previousWindow = (globalThis as any).window;
+    delete (globalThis as any).window;
+    vi.mocked(loadProfileDocument).mockResolvedValue({
+      parentOf: [],
+      parentTeamIds: ['team-1'],
+      parentPlayerKeys: ['team-1::player-1']
+    } as any);
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', name: 'Bears', active: true } as any);
+    vi.mocked(getDoc).mockResolvedValue(playerSnapshot('player-1', { name: 'Avery Lee', active: true }) as any);
+
+    try {
+      await expect(loadParentScheduleChildren(parentUser)).resolves.toEqual([
+        { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Avery Lee' }
+      ]);
+    } finally {
+      if (previousWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = previousWindow;
+      }
+    }
+  });
+
   it('filters inactive teams and inactive roster players from parent child links', async () => {
     vi.mocked(loadProfileDocument).mockResolvedValue({
       parentOf: [

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2742,7 +2742,8 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
 
     if (isPractice && game.isSeriesMaster && game.recurrence) {
       for (const occurrence of expandRecurrence(game)) {
-        const date = normalizeScheduleDate(occurrence.date) || new Date(occurrence.date);
+        const date = normalizeScheduleDate(occurrence.date) || (occurrence.date ? new Date(occurrence.date) : null);
+        if (!date) continue;
         const id = `${occurrence.masterId}__${occurrence.instanceDate}`;
         const session = resolvePracticeSessionForEvent({ id }, date, sessionsByEventId, sessions, matchedSessionIds);
         teamChildren.forEach((child) => {
@@ -2770,7 +2771,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
             awayScore: game.awayScore ?? null,
             canUpdateScore: false,
             arrivalTime: game.arrivalTime || null,
-            notes: occurrence.notes || null,
+            notes: compactString(occurrence.notes) || null,
             seasonLabel: game.seasonLabel || null,
             competitionType: game.competitionType || null,
             countsTowardSeasonRecord: game.countsTowardSeasonRecord ?? null,
@@ -2985,7 +2986,8 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
     ));
     if (!occurrence) return [];
 
-    const occurrenceDate = normalizeScheduleDate(occurrence.date) || new Date(occurrence.date);
+    const occurrenceDate = normalizeScheduleDate(occurrence.date) || (occurrence.date ? new Date(occurrence.date) : null);
+    if (!occurrenceDate) return [];
     return teamChildren.map((child) => createScheduleEvent({
       teamId,
       teamName,

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -713,14 +713,22 @@ export type PublishScheduledGameLineupResult = {
   notificationError: string | null;
 };
 
+function getTimerScope() {
+  if (typeof window !== 'undefined' && typeof window.setTimeout === 'function' && typeof window.clearTimeout === 'function') {
+    return window;
+  }
+  return globalThis;
+}
+
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
-  let timeoutId: number | undefined;
+  const timers = getTimerScope();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<T>((_, reject) => {
-    timeoutId = window.setTimeout(() => reject(new Error(`${label} timed out.`)), timeoutMs);
+    timeoutId = timers.setTimeout(() => reject(new Error(`${label} timed out.`)), timeoutMs);
   });
 
   return Promise.race([promise, timeout]).finally(() => {
-    if (timeoutId) window.clearTimeout(timeoutId);
+    if (timeoutId !== undefined) timers.clearTimeout(timeoutId);
   });
 }
 


### PR DESCRIPTION
Closes #2888

## What changed
- tightened `apps/app/src/lib/adapters/legacyScheduleHelpers.ts` so the schedule workflow consumes normalized typed return shapes for calendar events, RSVP breakdowns, rotation plans, and live substitution data instead of broad `any` values
- updated `apps/app/src/lib/scheduleService.ts` timeout handling to use `globalThis` when `window` is unavailable, which keeps parent schedule flows working in test and non-browser runtimes
- added a regression test in `apps/app/src/lib/scheduleService.test.ts` that proves parent-linked child loading works even when no browser `window` object exists

## Root Cause
The schedule adapter boundary existed, but several adapter exports still leaked broad legacy shapes into app code, and `scheduleService.ts` assumed `window.setTimeout` always existed. That let schedule tests fail in non-browser execution paths and weakened the typed boundary this issue was meant to enforce.

## Prevention / Learning
When wrapping legacy `js/` helpers, normalize both inputs and outputs at the adapter edge and avoid browser-only globals in shared service code. Shared app services should use `globalThis`-safe primitives unless they are explicitly UI-only.

## Regression Tests
- `npx vitest run src/lib/scheduleService.test.ts --reporter=verbose` from `apps/app`
- added coverage for parent schedule child loading without a `window` global
- existing adapter-boundary assertion in `scheduleService.test.ts` remains green to guard against direct legacy imports in schedule workflow files