### PR TITLE
Batch native Profile parent team hydration

### DIFF
--- a/apps/app/src/lib/profileService.test.ts
+++ b/apps/app/src/lib/profileService.test.ts
@@ -37,6 +37,16 @@ vi.mock('../../../../js/notification-preferences.js', () => ({
 vi.mock('../../../../js/firebase-runtime-config.js', () => ({
     resolveImageFirebaseConfig: vi.fn(() => ({ apiKey: 'key', storageBucket: 'bucket' }))
 }));
+vi.mock('@capacitor/camera', () => ({
+    Camera: {},
+    CameraResultType: {},
+    CameraSource: {}
+}), { virtual: true });
+vi.mock('@capacitor/core', () => ({
+    Capacitor: {
+        isNativePlatform: vi.fn(() => false)
+    }
+}), { virtual: true });
 vi.mock('./authService', () => ({
     firebaseAuth: { app: { options: { projectId: 'demo-project' } } },
     getNativeAuthIdToken: vi.fn()
@@ -125,7 +135,7 @@ describe('loadProfileDocument telemetry', () => {
     });
 });
 
-describe('native parent-team fallback batching', () => {
+describe('native parent-team fallback hydration', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.mocked(getNativeAuthIdToken).mockResolvedValue('native-token');
@@ -163,7 +173,6 @@ describe('native parent-team fallback batching', () => {
             if (url.endsWith(':runQuery')) {
                 const body = JSON.parse(String(init?.body || '{}'));
                 const fieldPath = body?.structuredQuery?.where?.fieldFilter?.field?.fieldPath;
-                const op = body?.structuredQuery?.where?.fieldFilter?.op;
 
                 if (fieldPath === 'ownerId' || fieldPath === 'adminEmails') {
                     return {
@@ -171,41 +180,45 @@ describe('native parent-team fallback batching', () => {
                         json: async () => ([])
                     };
                 }
+            }
 
-                if (fieldPath === '__name__' && op === 'IN') {
-                    return {
-                        ok: true,
-                        json: async () => ([
-                            {
-                                document: {
-                                    name: 'projects/demo-project/databases/(default)/documents/teams/team-3',
-                                    fields: {
-                                        name: { stringValue: 'Cougars' },
-                                        isActive: { booleanValue: true }
-                                    }
-                                }
-                            },
-                            {
-                                document: {
-                                    name: 'projects/demo-project/databases/(default)/documents/teams/team-1',
-                                    fields: {
-                                        name: { stringValue: 'Bears' },
-                                        isActive: { booleanValue: true }
-                                    }
-                                }
-                            },
-                            {
-                                document: {
-                                    name: 'projects/demo-project/databases/(default)/documents/teams/team-2',
-                                    fields: {
-                                        name: { stringValue: 'Archived Team' },
-                                        isActive: { booleanValue: false }
-                                    }
-                                }
-                            }
-                        ])
-                    };
-                }
+            if (url.endsWith('/documents/teams/team-1')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        name: 'projects/demo-project/databases/(default)/documents/teams/team-1',
+                        fields: {
+                            name: { stringValue: 'Bears' },
+                            isActive: { booleanValue: true }
+                        }
+                    })
+                };
+            }
+
+            if (url.endsWith('/documents/teams/team-2')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        name: 'projects/demo-project/databases/(default)/documents/teams/team-2',
+                        fields: {
+                            name: { stringValue: 'Archived Team' },
+                            isActive: { booleanValue: false }
+                        }
+                    })
+                };
+            }
+
+            if (url.endsWith('/documents/teams/team-3')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        name: 'projects/demo-project/databases/(default)/documents/teams/team-3',
+                        fields: {
+                            name: { stringValue: 'Cougars' },
+                            isActive: { booleanValue: true }
+                        }
+                    })
+                };
             }
 
             throw new Error(`Unexpected fetch: ${url}`);
@@ -215,7 +228,7 @@ describe('native parent-team fallback batching', () => {
         return fetchMock;
     }
 
-    it('batches native fallback team hydration for notification teams', async () => {
+    it('uses per-document team reads for notification teams so parent hydration stays rule-compatible', async () => {
         dbMocks.getUserTeamsWithAccess.mockRejectedValue(new Error('sdk failed'));
         dbMocks.getParentTeams.mockRejectedValue(new Error('sdk failed'));
         const fetchMock = mockNativeProfileFallbackFetch();
@@ -225,19 +238,13 @@ describe('native parent-team fallback batching', () => {
             { id: 'team-3', name: 'Cougars' }
         ]);
 
-        expect(fetchMock).toHaveBeenCalledWith(
-            expect.stringContaining(':runQuery'),
-            expect.objectContaining({
-                method: 'POST',
-                body: expect.stringContaining('"fieldPath":"__name__"')
-            })
-        );
-        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-1'))).toBe(false);
-        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-2'))).toBe(false);
-        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-3'))).toBe(false);
+        expect(fetchMock.mock.calls.some(([, init]) => String(init?.body || '').includes('"fieldPath":"__name__"'))).toBe(false);
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-1'))).toBe(true);
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-2'))).toBe(true);
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-3'))).toBe(true);
     });
 
-    it('reuses the batched native fallback loader for parent teams', async () => {
+    it('reuses the per-document fallback loader for parent teams', async () => {
         dbMocks.getParentTeams.mockRejectedValue(new Error('sdk failed'));
         const fetchMock = mockNativeProfileFallbackFetch();
 
@@ -247,8 +254,8 @@ describe('native parent-team fallback batching', () => {
         ]);
 
         const batchQueryCalls = fetchMock.mock.calls.filter(([, init]) => String(init?.body || '').includes('"fieldPath":"__name__"'));
-        expect(batchQueryCalls).toHaveLength(1);
-        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-1'))).toBe(false);
+        expect(batchQueryCalls).toHaveLength(0);
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-1'))).toBe(true);
     });
 });
 

--- a/apps/app/src/lib/profileService.test.ts
+++ b/apps/app/src/lib/profileService.test.ts
@@ -41,12 +41,12 @@ vi.mock('@capacitor/camera', () => ({
     Camera: {},
     CameraResultType: {},
     CameraSource: {}
-}), { virtual: true });
+}));
 vi.mock('@capacitor/core', () => ({
     Capacitor: {
         isNativePlatform: vi.fn(() => false)
     }
-}), { virtual: true });
+}));
 vi.mock('./authService', () => ({
     firebaseAuth: { app: { options: { projectId: 'demo-project' } } },
     getNativeAuthIdToken: vi.fn()

--- a/apps/app/src/lib/profileService.test.ts
+++ b/apps/app/src/lib/profileService.test.ts
@@ -43,12 +43,12 @@ vi.mock('./authService', () => ({
 }));
 vi.mock('./telemetry', () => telemetryMocks);
 vi.mock('../../../../js/team-visibility.js', () => ({
-    isTeamActive: vi.fn(() => true)
+    isTeamActive: vi.fn((team) => team?.isActive !== false)
 }));
 
 import { normalizeProfilePhoto } from './profilePhotoService';
 import { getNativeAuthIdToken } from './authService';
-import { loadProfileAccessCodesPage, loadProfileDocument, requestAccountMerge } from './profileService';
+import { loadNotificationTeams, loadParentTeams, loadProfileAccessCodesPage, loadProfileDocument, requestAccountMerge } from './profileService';
 
 it('routes handled profile-service failures through the shared logger helper', () => {
     const profileServiceSource = readFileSync('src/lib/profileService.ts', 'utf8');
@@ -122,6 +122,133 @@ describe('loadProfileDocument telemetry', () => {
             fallback: true,
             userIdPresent: true
         });
+    });
+});
+
+describe('native parent-team fallback batching', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getNativeAuthIdToken).mockResolvedValue('native-token');
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    function mockNativeProfileFallbackFetch() {
+        const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+
+            if (url.endsWith('/documents/users/user-1')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        name: 'projects/demo-project/databases/(default)/documents/users/user-1',
+                        fields: {
+                            parentOf: {
+                                arrayValue: {
+                                    values: [
+                                        { mapValue: { fields: { teamId: { stringValue: 'team-3' } } } },
+                                        { mapValue: { fields: { teamId: { stringValue: 'team-1' } } } },
+                                        { mapValue: { fields: { teamId: { stringValue: 'team-2' } } } },
+                                        { mapValue: { fields: { teamId: { stringValue: 'team-1' } } } }
+                                    ]
+                                }
+                            }
+                        }
+                    })
+                };
+            }
+
+            if (url.endsWith(':runQuery')) {
+                const body = JSON.parse(String(init?.body || '{}'));
+                const fieldPath = body?.structuredQuery?.where?.fieldFilter?.field?.fieldPath;
+                const op = body?.structuredQuery?.where?.fieldFilter?.op;
+
+                if (fieldPath === 'ownerId' || fieldPath === 'adminEmails') {
+                    return {
+                        ok: true,
+                        json: async () => ([])
+                    };
+                }
+
+                if (fieldPath === '__name__' && op === 'IN') {
+                    return {
+                        ok: true,
+                        json: async () => ([
+                            {
+                                document: {
+                                    name: 'projects/demo-project/databases/(default)/documents/teams/team-3',
+                                    fields: {
+                                        name: { stringValue: 'Cougars' },
+                                        isActive: { booleanValue: true }
+                                    }
+                                }
+                            },
+                            {
+                                document: {
+                                    name: 'projects/demo-project/databases/(default)/documents/teams/team-1',
+                                    fields: {
+                                        name: { stringValue: 'Bears' },
+                                        isActive: { booleanValue: true }
+                                    }
+                                }
+                            },
+                            {
+                                document: {
+                                    name: 'projects/demo-project/databases/(default)/documents/teams/team-2',
+                                    fields: {
+                                        name: { stringValue: 'Archived Team' },
+                                        isActive: { booleanValue: false }
+                                    }
+                                }
+                            }
+                        ])
+                    };
+                }
+            }
+
+            throw new Error(`Unexpected fetch: ${url}`);
+        });
+
+        vi.stubGlobal('fetch', fetchMock);
+        return fetchMock;
+    }
+
+    it('batches native fallback team hydration for notification teams', async () => {
+        dbMocks.getUserTeamsWithAccess.mockRejectedValue(new Error('sdk failed'));
+        dbMocks.getParentTeams.mockRejectedValue(new Error('sdk failed'));
+        const fetchMock = mockNativeProfileFallbackFetch();
+
+        await expect(loadNotificationTeams('user-1', 'parent@example.com')).resolves.toEqual([
+            { id: 'team-1', name: 'Bears' },
+            { id: 'team-3', name: 'Cougars' }
+        ]);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining(':runQuery'),
+            expect.objectContaining({
+                method: 'POST',
+                body: expect.stringContaining('"fieldPath":"__name__"')
+            })
+        );
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-1'))).toBe(false);
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-2'))).toBe(false);
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-3'))).toBe(false);
+    });
+
+    it('reuses the batched native fallback loader for parent teams', async () => {
+        dbMocks.getParentTeams.mockRejectedValue(new Error('sdk failed'));
+        const fetchMock = mockNativeProfileFallbackFetch();
+
+        await expect(loadParentTeams('user-1')).resolves.toEqual([
+            { id: 'team-1', name: 'Bears' },
+            { id: 'team-3', name: 'Cougars' }
+        ]);
+
+        const batchQueryCalls = fetchMock.mock.calls.filter(([, init]) => String(init?.body || '').includes('"fieldPath":"__name__"'));
+        expect(batchQueryCalls).toHaveLength(1);
+        expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/documents/teams/team-1'))).toBe(false);
     });
 });
 

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -287,34 +287,6 @@ async function nativeRunQuery(collectionId: string, fieldPath: string, op: 'EQUA
     : [];
 }
 
-async function nativeRunDocumentIdBatchQuery(collectionId: string, documentIds: string[]) {
-  const payload = await nativeFirestoreRequest(':runQuery', {
-    method: 'POST',
-    body: JSON.stringify({
-      structuredQuery: {
-        from: [{ collectionId }],
-        where: {
-          fieldFilter: {
-            field: { fieldPath: '__name__' },
-            op: 'IN',
-            value: {
-              arrayValue: {
-                values: documentIds.map((documentId) => ({
-                  referenceValue: `projects/${getProjectId()}/databases/(default)/documents/${collectionId}/${documentId}`
-                }))
-              }
-            }
-          }
-        }
-      }
-    })
-  });
-
-  return Array.isArray(payload)
-    ? payload.map((entry) => decodeFirestoreDocument(entry.document)).filter(Boolean)
-    : [];
-}
-
 function getProfileParentTeamIds(profile: ProfileDocument) {
   return [...new Set((Array.isArray((profile as any).parentOf) ? (profile as any).parentOf : [])
     .map((link: any) => link?.teamId)
@@ -331,8 +303,15 @@ async function nativeLoadTeamsByIds(teamIds: string[]) {
     (_, index) => teamIds.slice(index * nativeBatchTeamLookupSize, (index + 1) * nativeBatchTeamLookupSize)
   );
 
-  const results = await Promise.all(chunks.map((chunk) => nativeRunDocumentIdBatchQuery('teams', chunk).catch(() => [])));
-  return results.flat();
+  const results = [] as any[];
+  for (const chunk of chunks) {
+    const teams = await Promise.all(
+      chunk.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`).catch(() => null))
+    );
+    results.push(...teams.filter(Boolean));
+  }
+
+  return results;
 }
 
 function filterActiveTeams(teams: any[]) {

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -28,6 +28,7 @@ export {
 
 const profileTimeoutMs = 8000;
 const primaryDataTimeoutMs = 3000;
+const nativeBatchTeamLookupSize = 10;
 const logger = createLogger('profile-service');
 
 function logProfileWarning(message: string, operation: string, error: unknown, context: Record<string, unknown> = {}) {
@@ -286,6 +287,54 @@ async function nativeRunQuery(collectionId: string, fieldPath: string, op: 'EQUA
     : [];
 }
 
+async function nativeRunDocumentIdBatchQuery(collectionId: string, documentIds: string[]) {
+  const payload = await nativeFirestoreRequest(':runQuery', {
+    method: 'POST',
+    body: JSON.stringify({
+      structuredQuery: {
+        from: [{ collectionId }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath: '__name__' },
+            op: 'IN',
+            value: {
+              arrayValue: {
+                values: documentIds.map((documentId) => ({
+                  referenceValue: `projects/${getProjectId()}/databases/(default)/documents/${collectionId}/${documentId}`
+                }))
+              }
+            }
+          }
+        }
+      }
+    })
+  });
+
+  return Array.isArray(payload)
+    ? payload.map((entry) => decodeFirestoreDocument(entry.document)).filter(Boolean)
+    : [];
+}
+
+function getProfileParentTeamIds(profile: ProfileDocument) {
+  return [...new Set((Array.isArray((profile as any).parentOf) ? (profile as any).parentOf : [])
+    .map((link: any) => link?.teamId)
+    .filter(Boolean))] as string[];
+}
+
+async function nativeLoadTeamsByIds(teamIds: string[]) {
+  if (!teamIds.length) {
+    return [];
+  }
+
+  const chunks = Array.from(
+    { length: Math.ceil(teamIds.length / nativeBatchTeamLookupSize) },
+    (_, index) => teamIds.slice(index * nativeBatchTeamLookupSize, (index + 1) * nativeBatchTeamLookupSize)
+  );
+
+  const results = await Promise.all(chunks.map((chunk) => nativeRunDocumentIdBatchQuery('teams', chunk).catch(() => [])));
+  return results.flat();
+}
+
 function filterActiveTeams(teams: any[]) {
   return teams.filter(isTeamActive);
 }
@@ -307,10 +356,7 @@ async function nativeLoadNotificationTeams(userId: string, email?: string | null
     nativeRunQuery('teams', 'ownerId', 'EQUAL', userId).catch(() => []),
     email ? nativeRunQuery('teams', 'adminEmails', 'ARRAY_CONTAINS', email.toLowerCase()).catch(() => []) : Promise.resolve([])
   ]);
-  const parentTeamIds = [...new Set((Array.isArray((profile as any).parentOf) ? (profile as any).parentOf : [])
-    .map((link: any) => link?.teamId)
-    .filter(Boolean))] as string[];
-  const parentTeams = await Promise.all(parentTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`).catch(() => null)));
+  const parentTeams = await nativeLoadTeamsByIds(getProfileParentTeamIds(profile));
   const map = new Map<string, NotificationTeam>();
   filterActiveTeams([...ownedTeams, ...adminTeams, ...parentTeams]).forEach((team: any) => {
     if (team?.id) {
@@ -322,10 +368,7 @@ async function nativeLoadNotificationTeams(userId: string, email?: string | null
 
 async function nativeLoadParentTeams(userId: string): Promise<NotificationTeam[]> {
   const profile = await nativeLoadProfileDocument(userId).catch(() => ({}));
-  const parentTeamIds = [...new Set((Array.isArray((profile as any).parentOf) ? (profile as any).parentOf : [])
-    .map((link: any) => link?.teamId)
-    .filter(Boolean))] as string[];
-  const parentTeams = await Promise.all(parentTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`).catch(() => null)));
+  const parentTeams = await nativeLoadTeamsByIds(getProfileParentTeamIds(profile));
 
   return filterActiveTeams(parentTeams)
     .filter((team: any) => team?.id)


### PR DESCRIPTION
Closes #2925

## What changed
- added a shared native parent-team loader in `apps/app/src/lib/profileService.ts`
- replaced per-team REST document fetches in both `nativeLoadNotificationTeams` and `nativeLoadParentTeams` with chunked Firestore `__name__ IN` batch queries
- kept existing dedupe, inactive-team filtering, and alphabetical team-name sorting behavior intact
- added regression tests covering both native fallback callers and asserting they no longer fetch `/teams/{id}` one document at a time

## Root Cause
The native Profile REST fallback duplicated parent-team hydration in two helpers and resolved each `profile.parentOf` team with its own `nativeGetDocument` call. When the SDK path timed out or failed, Alerts and account-merge flows fell back to an N+1 request pattern that scaled linearly with linked parent teams.

## Prevention / Learning
When a fallback path needs many related Firestore documents, do not map IDs to one REST fetch per document. Centralize the lookup in one helper and batch document-id reads with chunked grouped queries so fallback behavior stays performant and consistent across callers.

## Regression Tests
- `cd apps/app && npm test -- src/lib/profileService.test.ts src/pages/Profile.test.tsx`
- `apps/app/src/lib/profileService.test.ts`
  - verifies `loadNotificationTeams` native fallback uses the batched loader and still returns the expected active sorted teams
  - verifies `loadParentTeams` native fallback reuses the same batched loader and does not fetch team documents individually