### PR TITLE
Expand recurring team practice RSVP events

### DIFF
--- a/team.html
+++ b/team.html
@@ -2375,6 +2375,7 @@
                     type: 'db',
                     id,
                     gameId: id,
+                    realGameId: game.id || game.gameId || id,
                     title,
                     date: gameDate,
                     opponent: game.opponent,
@@ -2772,12 +2773,12 @@
                             </div>
                             <div class="flex flex-col items-end gap-2">
                                 ${(isLive || isUpcoming) ? `
-                                  <a href="live-game.html?teamId=${currentTeamId}&gameId=${game.gameId || game.id}"
+                                  <a href="live-game.html?teamId=${currentTeamId}&gameId=${game.realGameId || game.gameId || game.id}"
                                      class="inline-flex items-center gap-2 ${isLive ? 'bg-red-500 hover:bg-red-600' : 'bg-slate-800 hover:bg-slate-900'} text-white px-4 py-2 rounded-lg font-semibold shadow transition">
                                       ${isLive ? '<span class="w-2 h-2 bg-white rounded-full animate-pulse"></span>' : '<span class="text-xs">👁️</span>'}
                                       ${isLive ? 'Live Now' : 'View Live'}
                                   </a>
-                                  <button data-share-game-id="${game.gameId || game.id}" data-share-mode="live"
+                                  <button data-share-game-id="${game.realGameId || game.gameId || game.id}" data-share-mode="live"
                                      class="inline-flex items-center gap-2 bg-white text-slate-700 px-4 py-2 rounded-lg font-semibold shadow border border-gray-200 hover:bg-gray-50 transition">
                                       <span class="text-xs">🔗</span>
                                       Share
@@ -2804,14 +2805,14 @@
                                             <div class="text-2xl md:text-3xl font-bold font-mono ${lost ? 'text-red-600' : 'text-gray-700'}">${game.awayScore}</div>
                                         </div>
                                       </div>
-                                      <a href="game.html#teamId=${currentTeamId}&gameId=${game.gameId || game.id}"
+                                      <a href="game.html#teamId=${currentTeamId}&gameId=${game.realGameId || game.gameId || game.id}"
                                          class="inline-flex items-center gap-1 text-sm text-primary-600 hover:text-primary-700 transition font-medium">
                                         <span>View Report</span>
                                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                         </svg>
                                       </a>
-                                      <button data-share-game-id="${game.gameId || game.id}" data-share-mode="report"
+                                      <button data-share-game-id="${game.realGameId || game.gameId || game.id}" data-share-mode="report"
                                          class="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-slate-800 transition font-medium">
                                         <span>Share Report</span>
                                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -2819,7 +2820,7 @@
                                         </svg>
                                       </button>
                                       ${game.liveStatus === 'completed' ? `
-                                      <a href="live-game.html?teamId=${currentTeamId}&gameId=${game.gameId || game.id}&replay=true"
+                                      <a href="live-game.html?teamId=${currentTeamId}&gameId=${game.realGameId || game.gameId || game.id}&replay=true"
                                          class="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-700 transition font-medium">
                                         <span>Replay</span>
                                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/team.html
+++ b/team.html
@@ -326,7 +326,7 @@
     <script type="module">
         import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=65';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
-        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=11';
+        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, expandRecurrence, escapeHtml, shareOrCopy } from './js/utils.js?v=11';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
         import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=3';
@@ -2256,6 +2256,35 @@
 
         async function getAllEvents(team, dbGames) {
             let allEvents = [];
+            const scheduleEntries = [];
+
+            for (const game of (dbGames || [])) {
+                const id = game.id || game.gameId;
+                const isRecurringPractice = game.type === 'practice' && game.isSeriesMaster && game.recurrence;
+
+                if (isRecurringPractice) {
+                    for (const occ of expandRecurrence(game)) {
+                        scheduleEntries.push({
+                            game,
+                            id: `${occ.masterId}__${occ.instanceDate}`,
+                            date: occ.date instanceof Date ? occ.date : new Date(occ.date),
+                            title: occ.title || game.title || 'Practice',
+                            location: occ.location || game.location || 'TBD',
+                            notes: occ.notes ?? game.notes
+                        });
+                    }
+                    continue;
+                }
+
+                scheduleEntries.push({
+                    game,
+                    id,
+                    date: game.date?.toDate ? game.date.toDate() : new Date(game.date),
+                    title: game.title || null,
+                    location: game.location || 'TBD',
+                    notes: game.notes
+                });
+            }
 
             const trackedUids = await getTrackedCalendarEventUids(currentTeamId);
 
@@ -2271,10 +2300,9 @@
                             const isCancelled = event.status?.toUpperCase() === 'CANCELLED' ||
                                 event.summary?.includes('[CANCELED]');
 
-                            const hasConflict = dbGames.some(dbGame => {
-                                const dbDate = dbGame.date.toDate ? dbGame.date.toDate() : new Date(dbGame.date);
+                            const hasConflict = scheduleEntries.some((entry) => {
                                 const eventDate = event.dtstart;
-                                return Math.abs(dbDate - eventDate) < 60000;
+                                return Math.abs(entry.date - eventDate) < 60000;
                             });
 
                             if (hasConflict) return;
@@ -2313,7 +2341,7 @@
                 linkedPlayerIds.length > 0
             );
             const canSeeTeamNotes = canReadRsvps && (isTeamAdmin || (availabilityPreferences.noteVisibility === 'team' && currentTeamAccessInfo?.hasAccess));
-            const dbGameIds = (dbGames || []).map((game) => game.id || game.gameId).filter(Boolean);
+            const dbGameIds = scheduleEntries.map((entry) => entry.id).filter(Boolean);
             let rsvpSummaries = new Map();
             if (canReadRsvps) {
                 try {
@@ -2323,9 +2351,8 @@
                 }
             }
 
-            for (const game of dbGames) {
-                const gameDate = game.date.toDate ? game.date.toDate() : new Date(game.date);
-                const id = game.id || game.gameId;
+            for (const entry of scheduleEntries) {
+                const { game, date: gameDate, id, title, location, notes } = entry;
                 const isPractice = game.type === 'practice';
                 const isCancelled = String(game.status || '').toLowerCase() === 'cancelled';
                 let availabilityNotes = [];
@@ -2348,9 +2375,10 @@
                     type: 'db',
                     id,
                     gameId: id,
+                    title,
                     date: gameDate,
                     opponent: game.opponent,
-                    location: game.location || 'TBD',
+                    location,
                     status: game.status,
                     liveStatus: game.liveStatus,
                     homeScore: game.homeScore,
@@ -2358,7 +2386,7 @@
                     isHome: game.isHome,
                     kitColor: game.kitColor,
                     arrivalTime: game.arrivalTime,
-                    notes: game.notes,
+                    notes,
                     assignments: game.assignments,
                     rsvpSummary: rsvpSummaries.get(id) || game.rsvpSummary,
                     myRsvp,

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -206,6 +206,10 @@ export function isTrackedCalendarEvent(event, trackedUids) {
     return Boolean(event?.uid) && Array.isArray(trackedUids) && trackedUids.includes(event.uid);
 }
 
+export function expandRecurrence(events = []) {
+    return Array.isArray(events) ? events : [];
+}
+
 export function escapeHtml(value) {
     return String(value ?? '');
 }

--- a/tests/unit/team-schedule-filter.test.js
+++ b/tests/unit/team-schedule-filter.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { filterScheduleEventsForPrint, getDefaultSchedulePrintOptions } from '../../js/schedule-print.js';
 
@@ -18,6 +18,39 @@ function loadGetFilteredScheduleEvents() {
         let scheduleViewFilter = context.scheduleViewFilter;
         ${functionSource}
         return getFilteredScheduleEvents();
+    `);
+}
+
+function loadGetAllEvents() {
+    const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+    const start = source.indexOf('async function getAllEvents(team, dbGames) {');
+    const end = source.indexOf('\n\n        async function renderSchedule(team, dbGames) {', start);
+
+    if (start === -1 || end === -1) {
+        throw new Error('Could not locate getAllEvents() in team.html');
+    }
+
+    const functionSource = source.slice(start, end);
+    return new Function('context', `
+        let currentTeamId = context.currentTeamId;
+        let currentUser = context.currentUser;
+        let currentTeamAccessInfo = context.currentTeamAccessInfo;
+        let getTrackedCalendarEventUids = context.getTrackedCalendarEventUids;
+        let fetchAndParseCalendar = context.fetchAndParseCalendar;
+        let isTrackedCalendarEvent = context.isTrackedCalendarEvent;
+        let isPracticeEvent = context.isPracticeEvent;
+        let extractOpponent = context.extractOpponent;
+        let normalizeAvailabilityPreferences = context.normalizeAvailabilityPreferences;
+        let canManageTeamAvailability = context.canManageTeamAvailability;
+        let getRsvpSummaries = context.getRsvpSummaries;
+        let buildAvailabilityNoteRows = context.buildAvailabilityNoteRows;
+        let getRsvps = context.getRsvps;
+        let getMyRsvp = context.getMyRsvp;
+        let isAvailabilityLocked = context.isAvailabilityLocked;
+        let expandRecurrence = context.expandRecurrence;
+        let console = context.console || globalThis.console;
+        ${functionSource}
+        return getAllEvents(context.team, context.dbGames);
     `);
 }
 
@@ -43,6 +76,10 @@ function hoursFromNow(offsetHours) {
 }
 
 describe('team schedule filtering', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
     it('defaults the team page schedule to all upcoming events while keeping recent results manual', () => {
         const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
         const getFilteredScheduleEvents = loadGetFilteredScheduleEvents();
@@ -252,6 +289,82 @@ describe('team schedule filtering', () => {
         expect(all.map((event) => event.opponent || event.title)).toEqual(['Practice', 'In Range']);
         expect(games.map((event) => event.opponent)).toEqual(['In Range']);
         expect(practices.map((event) => event.title)).toEqual(['Practice']);
+    });
+
+    it('expands recurring practice masters into per-occurrence RSVP events on the team page', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+
+        const getAllEvents = loadGetAllEvents();
+        const requestedSummaryIds = [];
+        const requestedMyRsvpIds = [];
+
+        const events = await getAllEvents({
+            currentTeamId: 'team-1',
+            currentUser: {
+                uid: 'parent-1',
+                parentTeamIds: ['team-1']
+            },
+            currentTeamAccessInfo: {
+                accessLevel: 'parent',
+                hasAccess: true
+            },
+            team: {
+                name: 'Team 1',
+                availabilityPreferences: { noteVisibility: 'staff' },
+                calendarUrls: []
+            },
+            dbGames: [
+                {
+                    id: 'practice-series',
+                    type: 'practice',
+                    isSeriesMaster: true,
+                    date: new Date('2026-01-05T18:00:00Z'),
+                    recurrence: {
+                        freq: 'weekly',
+                        interval: 1,
+                        byDays: ['MO'],
+                        count: 3
+                    },
+                    status: 'scheduled',
+                    location: 'Main Field'
+                }
+            ],
+            getTrackedCalendarEventUids: async () => [],
+            fetchAndParseCalendar: async () => [],
+            isTrackedCalendarEvent: () => false,
+            isPracticeEvent: () => false,
+            extractOpponent: () => 'Opponent',
+            normalizeAvailabilityPreferences: (prefs) => prefs,
+            canManageTeamAvailability: () => false,
+            getRsvpSummaries: async (_teamId, gameIds) => {
+                requestedSummaryIds.push(...gameIds);
+                return new Map([[gameIds[1], { going: 1, maybe: 0, notGoing: 0 }]]);
+            },
+            buildAvailabilityNoteRows: () => [],
+            getRsvps: async () => [],
+            getMyRsvp: async (_teamId, gameId) => {
+                requestedMyRsvpIds.push(gameId);
+                return gameId === 'practice-series__2026-01-12' ? { response: 'going' } : null;
+            },
+            isAvailabilityLocked: () => false,
+            expandRecurrence: (await import('../../js/utils.js')).expandRecurrence
+        });
+
+        expect(requestedSummaryIds).toEqual([
+            'practice-series__2026-01-05',
+            'practice-series__2026-01-12',
+            'practice-series__2026-01-19'
+        ]);
+        expect(requestedMyRsvpIds).toEqual(requestedSummaryIds);
+        expect(events.map((event) => event.id)).toEqual(requestedSummaryIds);
+        expect(events[1]).toMatchObject({
+            id: 'practice-series__2026-01-12',
+            isPractice: true,
+            myRsvp: 'going',
+            rsvpSummary: { going: 1, maybe: 0, notGoing: 0 }
+        });
+        expect(events[1].date.toISOString()).toBe('2026-01-12T18:00:00.000Z');
     });
 
     it('wires the team availability filter and RSVP controls into team.html', () => {

--- a/tests/unit/team-schedule-filter.test.js
+++ b/tests/unit/team-schedule-filter.test.js
@@ -360,11 +360,22 @@ describe('team schedule filtering', () => {
         expect(events.map((event) => event.id)).toEqual(requestedSummaryIds);
         expect(events[1]).toMatchObject({
             id: 'practice-series__2026-01-12',
+            realGameId: 'practice-series',
             isPractice: true,
             myRsvp: 'going',
             rsvpSummary: { going: 1, maybe: 0, notGoing: 0 }
         });
         expect(events[1].date.toISOString()).toBe('2026-01-12T18:00:00.000Z');
+    });
+
+    it('uses real game IDs for live, report, and share actions while keeping occurrence RSVP ids', () => {
+        const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+
+        expect(source).toContain("realGameId: game.id || game.gameId || id");
+        expect(source).toContain('live-game.html?teamId=${currentTeamId}&gameId=${game.realGameId || game.gameId || game.id}');
+        expect(source).toContain('game.html#teamId=${currentTeamId}&gameId=${game.realGameId || game.gameId || game.id}');
+        expect(source).toContain('data-share-game-id="${game.realGameId || game.gameId || game.id}"');
+        expect(source).toContain('data-game-id="${escapeAttr(game.gameId || game.id)}"');
     });
 
     it('wires the team availability filter and RSVP controls into team.html', () => {


### PR DESCRIPTION
Closes #2952

## What changed
- expanded recurring practice series masters in `team.html` before building the team page schedule data
- assigned each expanded occurrence its own RSVP-aware id in the existing `masterId__YYYY-MM-DD` format
- reused expanded occurrence dates for upcoming/availability filtering and calendar conflict detection
- added a focused regression test that verifies the team page requests RSVP summaries and my-RSVP state by occurrence id, not by the past-dated series master id

## Root Cause
`team.html` built schedule events and RSVP lookups directly from raw `games` documents. For recurring practices, that left only the series master `id` and original `date`, so future occurrences were never materialized on the team page and upcoming/availability views filtered them out.

## Prevention / Learning
Any surface that supports recurring-event RSVP must expand series masters before date filtering, duplicate detection, or RSVP reads. The occurrence identity needs to stay aligned across surfaces as `masterId__YYYY-MM-DD`.

## Regression Tests
- `npx vitest run tests/unit/team-schedule-filter.test.js --reporter=verbose`
- added `tests/unit/team-schedule-filter.test.js` coverage that fails unless recurring practice masters are expanded into per-occurrence RSVP ids on the team page