### PR TITLE
Use @legacy imports in schedule adapter

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleHelpers.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleHelpers.test.ts
@@ -6,18 +6,18 @@ const mocks = vi.hoisted(() => ({
     getSubstitutionOptions: vi.fn()
 }));
 
-vi.mock('../../../../../js/schedule-notifications.js', () => ({
+vi.mock('@legacy/schedule-notifications.js', () => ({
     sendPublicRsvpReminderEmails: vi.fn()
 }));
-vi.mock('../../../../../js/admin-user-official-links.js', () => ({
+vi.mock('@legacy/admin-user-official-links.js', () => ({
     normalizeOfficialLinkEmail: vi.fn((value: unknown) => value),
     normalizeOfficialLinkPhone: vi.fn((value: unknown) => value)
 }));
-vi.mock('../../../../../js/officiating-utils.js', () => ({
+vi.mock('@legacy/officiating-utils.js', () => ({
     getAssignedOfficiatingSlots: vi.fn(() => []),
     getOpenOfficiatingSlots: vi.fn(() => [])
 }));
-vi.mock('../../../../../js/utils.js', () => ({
+vi.mock('@legacy/utils.js', () => ({
     expandRecurrence: mocks.expandRecurrence,
     extractOpponent: vi.fn(() => ''),
     fetchAndParseCalendar: vi.fn(async () => []),
@@ -26,41 +26,41 @@ vi.mock('../../../../../js/utils.js', () => ({
     isPracticeEvent: vi.fn(() => false),
     isTrackedCalendarEvent: vi.fn(() => false)
 }));
-vi.mock('../../../../../js/parent-dashboard-practice-sessions.js', () => ({
+vi.mock('@legacy/parent-dashboard-practice-sessions.js', () => ({
     filterVisiblePracticeSessions: vi.fn(() => [])
 }));
-vi.mock('../../../../../js/parent-dashboard-packets.js', () => ({
+vi.mock('@legacy/parent-dashboard-packets.js', () => ({
     buildPracticePacketCompletionPayload: vi.fn(() => ({}))
 }));
-vi.mock('../../../../../js/parent-dashboard-rsvp.js', () => ({
+vi.mock('@legacy/parent-dashboard-rsvp.js', () => ({
     resolveMyRsvpByChildForGame: vi.fn(() => ({}))
 }));
-vi.mock('../../../../../js/game-day-rsvp-breakdown.js', () => ({
+vi.mock('@legacy/game-day-rsvp-breakdown.js', () => ({
     buildGameDayRsvpBreakdown: vi.fn(() => ({ grouped: {}, counts: {} }))
 }));
-vi.mock('../../../../../js/game-day-periods.js', () => ({
+vi.mock('@legacy/game-day-periods.js', () => ({
     getPeriodsForFormation: vi.fn(() => [])
 }));
-vi.mock('../../../../../js/rideshare-helpers.js', () => ({
+vi.mock('@legacy/rideshare-helpers.js', () => ({
     getEventRideshareSummary: vi.fn(() => ({}))
 }));
-vi.mock('../../../../../js/snack-helpers.js', () => ({
+vi.mock('@legacy/snack-helpers.js', () => ({
     mergeAssignmentsWithClaims: vi.fn(() => [])
 }));
-vi.mock('../../../../../js/team-access.js', () => ({
+vi.mock('@legacy/team-access.js', () => ({
     hasScorekeepingTeamAccess: vi.fn(() => false)
 }));
-vi.mock('../../../../../js/team-visibility.js', () => ({
+vi.mock('@legacy/team-visibility.js', () => ({
     isTeamActive: vi.fn(() => true)
 }));
-vi.mock('../../../../../js/game-day-live-substitutions.js', () => ({
+vi.mock('@legacy/game-day-live-substitutions.js', () => ({
     applyLiveSubstitution: vi.fn(() => null),
     getSubstitutionOptions: mocks.getSubstitutionOptions
 }));
-vi.mock('../../../../../js/game-plan-interop.js', () => ({
+vi.mock('@legacy/game-plan-interop.js', () => ({
     buildRotationPlanFromGamePlan: vi.fn(() => ({}))
 }));
-vi.mock('../../../../../js/edit-schedule-practice-payload.js', () => ({
+vi.mock('@legacy/edit-schedule-practice-payload.js', () => ({
     applyPracticeRecurrenceFields: vi.fn((payload: Record<string, unknown>) => payload.practiceData)
 }));
 
@@ -70,6 +70,8 @@ describe('legacyScheduleHelpers', () => {
     it('keeps normalizeArray accepting unknown values for legacy payload normalization', () => {
         const source = readFileSync('src/lib/adapters/legacyScheduleHelpers.ts', 'utf8');
         expect(source).toContain('function normalizeArray<T = unknown>(value: unknown): T[]');
+        expect(source).toContain("from '@legacy/");
+        expect(source).not.toContain('../../../../../js/');
     });
 
     it('normalizes recurring practice occurrences to the fields consumed by scheduleService', () => {

--- a/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleHelpers.ts
@@ -1,6 +1,6 @@
-import { sendPublicRsvpReminderEmails as legacySendPublicRsvpReminderEmails } from '../../../../../js/schedule-notifications.js';
-import { normalizeOfficialLinkEmail as legacyNormalizeOfficialLinkEmail, normalizeOfficialLinkPhone as legacyNormalizeOfficialLinkPhone } from '../../../../../js/admin-user-official-links.js';
-import { getAssignedOfficiatingSlots as legacyGetAssignedOfficiatingSlots, getOpenOfficiatingSlots as legacyGetOpenOfficiatingSlots } from '../../../../../js/officiating-utils.js';
+import { sendPublicRsvpReminderEmails as legacySendPublicRsvpReminderEmails } from '@legacy/schedule-notifications.js';
+import { normalizeOfficialLinkEmail as legacyNormalizeOfficialLinkEmail, normalizeOfficialLinkPhone as legacyNormalizeOfficialLinkPhone } from '@legacy/admin-user-official-links.js';
+import { getAssignedOfficiatingSlots as legacyGetAssignedOfficiatingSlots, getOpenOfficiatingSlots as legacyGetOpenOfficiatingSlots } from '@legacy/officiating-utils.js';
 import {
     expandRecurrence as legacyExpandRecurrence,
     extractOpponent as legacyExtractOpponent,
@@ -9,22 +9,22 @@ import {
     getCalendarEventTrackingId as legacyGetCalendarEventTrackingId,
     isPracticeEvent as legacyIsPracticeEvent,
     isTrackedCalendarEvent as legacyIsTrackedCalendarEvent
-} from '../../../../../js/utils.js';
-import { filterVisiblePracticeSessions as legacyFilterVisiblePracticeSessions } from '../../../../../js/parent-dashboard-practice-sessions.js';
-import { buildPracticePacketCompletionPayload as legacyBuildPracticePacketCompletionPayload } from '../../../../../js/parent-dashboard-packets.js';
-import { resolveMyRsvpByChildForGame as legacyResolveMyRsvpByChildForGame } from '../../../../../js/parent-dashboard-rsvp.js';
-import { buildGameDayRsvpBreakdown as legacyBuildGameDayRsvpBreakdown } from '../../../../../js/game-day-rsvp-breakdown.js';
-import { getPeriodsForFormation as legacyGetPeriodsForFormation } from '../../../../../js/game-day-periods.js';
-import { getEventRideshareSummary as legacyGetEventRideshareSummary } from '../../../../../js/rideshare-helpers.js';
-import { mergeAssignmentsWithClaims as legacyMergeAssignmentsWithClaims } from '../../../../../js/snack-helpers.js';
-import { hasScorekeepingTeamAccess as legacyHasScorekeepingTeamAccess } from '../../../../../js/team-access.js';
-import { isTeamActive as legacyIsTeamActive } from '../../../../../js/team-visibility.js';
+} from '@legacy/utils.js';
+import { filterVisiblePracticeSessions as legacyFilterVisiblePracticeSessions } from '@legacy/parent-dashboard-practice-sessions.js';
+import { buildPracticePacketCompletionPayload as legacyBuildPracticePacketCompletionPayload } from '@legacy/parent-dashboard-packets.js';
+import { resolveMyRsvpByChildForGame as legacyResolveMyRsvpByChildForGame } from '@legacy/parent-dashboard-rsvp.js';
+import { buildGameDayRsvpBreakdown as legacyBuildGameDayRsvpBreakdown } from '@legacy/game-day-rsvp-breakdown.js';
+import { getPeriodsForFormation as legacyGetPeriodsForFormation } from '@legacy/game-day-periods.js';
+import { getEventRideshareSummary as legacyGetEventRideshareSummary } from '@legacy/rideshare-helpers.js';
+import { mergeAssignmentsWithClaims as legacyMergeAssignmentsWithClaims } from '@legacy/snack-helpers.js';
+import { hasScorekeepingTeamAccess as legacyHasScorekeepingTeamAccess } from '@legacy/team-access.js';
+import { isTeamActive as legacyIsTeamActive } from '@legacy/team-visibility.js';
 import {
     applyLiveSubstitution as legacyApplyLiveSubstitution,
     getSubstitutionOptions as legacyGetSubstitutionOptions
-} from '../../../../../js/game-day-live-substitutions.js';
-import { buildRotationPlanFromGamePlan as legacyBuildRotationPlanFromGamePlan } from '../../../../../js/game-plan-interop.js';
-import { applyPracticeRecurrenceFields as legacyApplyPracticeRecurrenceFields } from '../../../../../js/edit-schedule-practice-payload.js';
+} from '@legacy/game-day-live-substitutions.js';
+import { buildRotationPlanFromGamePlan as legacyBuildRotationPlanFromGamePlan } from '@legacy/game-plan-interop.js';
+import { applyPracticeRecurrenceFields as legacyApplyPracticeRecurrenceFields } from '@legacy/edit-schedule-practice-payload.js';
 
 type LegacyRecord = Record<string, unknown>;
 

--- a/tests/unit/app-legacy-adapter-boundary.test.js
+++ b/tests/unit/app-legacy-adapter-boundary.test.js
@@ -89,7 +89,8 @@ describe('app legacy adapter boundary', () => {
         expect(detailSource).toContain("from '../lib/adapters/legacyScheduleHelpers'");
         expect(rsvpHookSource).toContain("from '../../lib/scheduleService'");
         expect(scheduleServiceSource).toContain("from './adapters/legacyScheduleHelpers'");
-        expect(helperAdapterSource).toContain("from '../../../../../js/parent-dashboard-rsvp.js'");
+        expect(helperAdapterSource).toContain("from '@legacy/parent-dashboard-rsvp.js'");
+        expect(helperAdapterSource).not.toContain('../../../../../js/');
         expect(helperAdapterSource).toContain('resolveMyRsvpByChildForGame');
         expect(helperAdapterSource).toContain('buildGameDayRsvpBreakdown');
     });

--- a/tests/unit/app-schedule-rsvp-adapter-source-contract.test.js
+++ b/tests/unit/app-schedule-rsvp-adapter-source-contract.test.js
@@ -25,7 +25,8 @@ describe('app schedule RSVP adapter boundary', () => {
 
         expect(scheduleServiceSource).toContain("from './adapters/legacyScheduleHelpers';");
         expect(rsvpHookSource).toContain("import { submitParentScheduleRsvp } from '../../lib/scheduleService';");
-        expect(helperAdapterSource).toContain("from '../../../../../js/parent-dashboard-rsvp.js'");
+        expect(helperAdapterSource).toContain("from '@legacy/parent-dashboard-rsvp.js'");
+        expect(helperAdapterSource).not.toContain('../../../../../js/');
         expect(helperAdapterSource).toContain('resolveMyRsvpByChildForGame');
         expect(helperAdapterSource).toContain('normalizeArray(events)');
         expect(helperAdapterSource).toContain('normalizeArray(rsvps)');
@@ -34,8 +35,9 @@ describe('app schedule RSVP adapter boundary', () => {
     it('keeps schedule notification and RSVP breakdown helpers behind the same adapter surface', () => {
         const helperAdapterSource = readSource('apps/app/src/lib/adapters/legacyScheduleHelpers.ts');
 
-        expect(helperAdapterSource).toContain("from '../../../../../js/schedule-notifications.js'");
-        expect(helperAdapterSource).toContain("from '../../../../../js/game-day-rsvp-breakdown.js'");
+        expect(helperAdapterSource).toContain("from '@legacy/schedule-notifications.js'");
+        expect(helperAdapterSource).toContain("from '@legacy/game-day-rsvp-breakdown.js'");
+        expect(helperAdapterSource).not.toContain('../../../../../js/');
         expect(helperAdapterSource).toContain('export async function sendPublicRsvpReminderEmails');
         expect(helperAdapterSource).toContain('export function buildGameDayRsvpBreakdown');
     });


### PR DESCRIPTION
Closes #2957

## What changed
- switched `apps/app/src/lib/adapters/legacyScheduleHelpers.ts` from deep `../../../../../js/*` imports to the shared `@legacy/*` Vite alias
- updated `apps/app/src/lib/adapters/legacyScheduleHelpers.test.ts` mocks to resolve through `@legacy/*`
- added a focused source guard in the adapter test to fail if deep legacy relative imports are reintroduced

## Root Cause
The schedule workflow migration was only partially completed. `scheduleService.ts` and `ScheduleEventDetail.tsx` were already behind the typed adapter boundary, but `legacyScheduleHelpers.ts` and its test still imported legacy helpers through brittle deep relative `js/` paths, so this slice did not actually use the intended alias boundary end to end.

## Prevention / Learning
When landing an adapter boundary, migrate both the production adapter imports and the adjacent test mocks to the shared alias in the same patch. Add a source-level guard that rejects deep relative legacy imports so future cleanup work cannot silently regress the boundary.

## Regression Tests
- `npm test -- --run src/lib/adapters/legacyScheduleHelpers.test.ts src/lib/scheduleService.test.ts`
- `src/lib/adapters/legacyScheduleHelpers.test.ts` now asserts the adapter source contains `@legacy` imports and no `../../../../../js/` imports
- `src/lib/scheduleService.test.ts` continues guarding that schedule workflow entrypoints do not import legacy `js/` paths directly