### PR TITLE
Add fee due reminder eligibility and dedupe coverage

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6079,6 +6079,11 @@ exports._internal = {
   sweepStaleNotificationDeviceTokens,
   sendRsvpReminderPushNotifications,
   sendPracticePacketDueTomorrowReminders,
+  sendFeeUnpaidDueReminders,
+  getFeeReminderDueDateMillis,
+  isFeeDueReminderCandidateEligible,
+  buildFeeReminderNotificationBody,
+  resolveEligibleFeeReminderRecipient,
   syncNotificationRecipientForTeamUser,
   syncNotificationRecipientsForUserChange,
   syncNotificationRecipientsForTeamChange
@@ -6813,6 +6818,44 @@ function formatFeeReminderWindowLabel(reminderThresholdHours = 72) {
   return `${reminderThresholdDays} day${reminderThresholdDays === 1 ? '' : 's'} or less`;
 }
 
+function getFeeReminderDueDateMillis(recipient = {}) {
+  const dueDateValue = recipient?.dueDate || recipient?.dueAt || recipient?.deadline;
+  if (typeof dueDateValue?.toMillis === 'function') {
+    return dueDateValue.toMillis();
+  }
+  return coerceDate(dueDateValue)?.getTime();
+}
+
+function isFeeDueReminderCandidateEligible(recipient = {}, {
+  nowMillis = Date.now(),
+  reminderThresholdHours = 72
+} = {}) {
+  const status = String(recipient?.status || '').trim().toLowerCase();
+  if (!['unpaid', 'pending'].includes(status)) return false;
+  if (getTeamFeeBalanceCents(recipient) <= 0) return false;
+
+  const dueDateMillis = getFeeReminderDueDateMillis(recipient);
+  if (!Number.isFinite(dueDateMillis)) return false;
+
+  const effectiveNowMillis = Number(nowMillis);
+  if (!Number.isFinite(effectiveNowMillis) || dueDateMillis < effectiveNowMillis) return false;
+
+  const reminderThresholdMillis = Number(reminderThresholdHours) * 60 * 60 * 1000;
+  if (!Number.isFinite(reminderThresholdMillis) || reminderThresholdMillis <= 0) return false;
+  if (dueDateMillis > effectiveNowMillis + reminderThresholdMillis) return false;
+
+  return !wasFeeReminderSentForThreshold(recipient, reminderThresholdHours);
+}
+
+function buildFeeReminderNotificationBody(recipient = {}, amountLabel = '', reminderThresholdHours = 72) {
+  const dueDateDisplay = formatFeeAssignmentDueDate(recipient.dueDate || recipient.dueAt || recipient.deadline);
+  const reminderWindowLabel = formatFeeReminderWindowLabel(reminderThresholdHours);
+  if (dueDateDisplay) {
+    return `${amountLabel} is due ${dueDateDisplay} (${reminderWindowLabel}).`;
+  }
+  return `${amountLabel} is due in ${reminderWindowLabel}.`;
+}
+
 async function resolveFeeReminderCandidateUserIds(teamId, recipient = {}) {
   const playerKey = getFeeReminderPlayerKey(recipient, teamId);
   let playerOwnerIds = [];
@@ -6827,8 +6870,38 @@ async function resolveFeeReminderCandidateUserIds(teamId, recipient = {}) {
   return buildFeeReminderCandidateUserIds(recipient, playerOwnerIds);
 }
 
+async function resolveEligibleFeeReminderRecipient({
+  teamId,
+  batchId,
+  recipientId,
+  recipient,
+  nowMillis,
+  reminderThresholdHours
+}) {
+  if (!isFeeDueReminderCandidateEligible(recipient, { nowMillis, reminderThresholdHours })) {
+    return null;
+  }
+
+  const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, recipient);
+  if (!candidateUserIds.length) return null;
+
+  const allTargets = await getTargetsForCategory(teamId, 'fees', null);
+  const candidateUserIdSet = new Set(candidateUserIds);
+  const payerTargets = allTargets.filter((target) => candidateUserIdSet.has(target.uid));
+  if (!payerTargets.length) return null;
+
+  return {
+    teamId,
+    batchId,
+    recipientId,
+    candidateUserIds,
+    payerTargets
+  };
+}
+
 async function sendFeeUnpaidDueReminders() {
   const now = admin.firestore.Timestamp.now();
+  const nowMillis = now.toMillis();
   const maxReminderThresholdLater = admin.firestore.Timestamp.fromMillis(now.toMillis() + 72 * 60 * 60 * 1000);
   const teamReminderThresholdHours = new Map();
 
@@ -6855,27 +6928,20 @@ async function sendFeeUnpaidDueReminders() {
       teamReminderThresholdHours.set(teamId, reminderThresholdHours);
     }
 
-    const dueDateMillis = typeof data?.dueDate?.toMillis === 'function'
-      ? data.dueDate.toMillis()
-      : coerceDate(data?.dueDate)?.getTime();
-    if (!Number.isFinite(dueDateMillis)) return null;
-
-    const reminderThresholdMillis = reminderThresholdHours * 60 * 60 * 1000;
-    if (dueDateMillis > now.toMillis() + reminderThresholdMillis) return null;
-    if (wasFeeReminderSentForThreshold(data, reminderThresholdHours)) return null;
-
     const title = data.feeTitle || data.title || 'Team fee due soon';
     const amountLabel = formatMoneyFromCents(getTeamFeeBalanceCents(data), data.currency || 'USD');
-    const reminderWindowLabel = formatFeeReminderWindowLabel(reminderThresholdHours);
+    const body = buildFeeReminderNotificationBody(data, amountLabel, reminderThresholdHours);
 
     try {
-      const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, data);
-      if (!candidateUserIds.length) return null;
-
-      const allTargets = await getTargetsForCategory(teamId, 'fees', null);
-      const candidateUserIdSet = new Set(candidateUserIds);
-      const payerTargets = allTargets.filter((t) => candidateUserIdSet.has(t.uid));
-      if (!payerTargets.length) return null;
+      const eligibleRecipient = await resolveEligibleFeeReminderRecipient({
+        teamId,
+        batchId,
+        recipientId,
+        recipient: data,
+        nowMillis,
+        reminderThresholdHours
+      });
+      if (!eligibleRecipient) return null;
 
       // Mark reminderSentAt only when targets exist, to prevent duplicate sends if function retries
       await doc.ref.update({
@@ -6884,15 +6950,15 @@ async function sendFeeUnpaidDueReminders() {
       });
 
       await sendDirectTargetsNotification({
-        targets: payerTargets,
+        targets: eligibleRecipient.payerTargets,
         category: 'fees',
         title: `Reminder: ${title} is due soon`,
-        body: `${amountLabel} is due in ${reminderWindowLabel}.`,
+        body,
         teamId,
         batchId,
         recipientId,
       });
-      return { teamId, payerUserIds: candidateUserIds, feeTitle: title };
+      return { teamId, payerUserIds: eligibleRecipient.candidateUserIds, feeTitle: title };
     } catch (err) {
       console.error('sendFeeUnpaidDueReminders: failed to notify', { teamId, candidateUserIds: buildFeeReminderCandidateUserIds(data), error: err });
       return null;

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -992,6 +992,143 @@ test('notifyOpenOfficiatingSlots sends notifications when a game is created with
     }
 });
 
+test('sendFeeUnpaidDueReminders sends eligible unpaid parent fee reminders with amount due date and fee route', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-1': { parentPlayerKeys: ['team-1::player-1'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } }
+        ],
+        nowMillis: Date.parse('2026-06-28T12:00:00.000Z')
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/feeBatches/batch-1/feeRecipients/recipient-1');
+        await ref.set({
+            status: 'unpaid',
+            playerKey: 'team-1::player-1',
+            feeTitle: 'Tournament dues',
+            amountCents: 4500,
+            dueDate: '2026-06-30T12:00:00.000Z'
+        });
+
+        await moduleExports.sendFeeUnpaidDueReminders();
+
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
+        assert.equal(env.messagingCalls[0].title, 'Reminder: Tournament dues is due soon');
+        assert.equal(env.messagingCalls[0].body, '$45.00 is due Jun 30, 2026 (3 days or less).');
+        assert.equal(env.messagingCalls[0].data.category, 'fees');
+        assert.equal(env.messagingCalls[0].data.appRoute, '/parent-tools/fees?teamId=team-1&batchId=batch-1&recipientId=recipient-1');
+        assert.equal(env.messagingCalls[0].webLink, 'https://allplays.ai/app/#/parent-tools/fees?teamId=team-1&batchId=batch-1&recipientId=recipient-1');
+        assert.deepEqual(env.updatedDocs.map((write) => write.path), [
+            'teams/team-1/feeBatches/batch-1/feeRecipients/recipient-1'
+        ]);
+        assert.equal(env.updatedDocs[0].value.reminderThresholdHours, 72);
+    } finally {
+        cleanup();
+    }
+});
+
+test('sendFeeUnpaidDueReminders excludes paid fees and parents with disabled fee notifications', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-1': { parentPlayerKeys: ['team-1::player-1'] },
+            'parent-2': { parentPlayerKeys: ['team-1::player-2'] },
+            'parent-3': { parentPlayerKeys: ['team-1::player-3'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } },
+            { uid: 'parent-2', deviceId: 'paid-device', token: 'paid-token', categories: { fees: true } },
+            { uid: 'parent-3', deviceId: 'disabled-device', token: 'disabled-token', categories: { fees: false } }
+        ],
+        nowMillis: Date.parse('2026-06-28T12:00:00.000Z')
+    });
+
+    try {
+        await env.firestoreState.doc('teams/team-1/feeBatches/batch-1/feeRecipients/eligible').set({
+            status: 'pending',
+            playerKey: 'team-1::player-1',
+            feeTitle: 'Open dues',
+            amountCents: 2500,
+            dueDate: '2026-06-29T12:00:00.000Z'
+        });
+        await env.firestoreState.doc('teams/team-1/feeBatches/batch-1/feeRecipients/paid').set({
+            status: 'paid',
+            playerKey: 'team-1::player-2',
+            feeTitle: 'Paid dues',
+            amountCents: 2500,
+            dueDate: '2026-06-29T12:00:00.000Z'
+        });
+        await env.firestoreState.doc('teams/team-1/feeBatches/batch-1/feeRecipients/disabled').set({
+            status: 'unpaid',
+            playerKey: 'team-1::player-3',
+            feeTitle: 'Silent dues',
+            amountCents: 2500,
+            dueDate: '2026-06-29T12:00:00.000Z'
+        });
+
+        await moduleExports.sendFeeUnpaidDueReminders();
+
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens, ['parent-token']);
+        assert.equal(env.messagingCalls[0].title, 'Reminder: Open dues is due soon');
+        assert.deepEqual(env.updatedDocs.map((write) => write.path), [
+            'teams/team-1/feeBatches/batch-1/feeRecipients/eligible'
+        ]);
+    } finally {
+        cleanup();
+    }
+});
+
+test('sendFeeUnpaidDueReminders dedupes repeated scheduler runs without suppressing different fees', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-1': { parentPlayerKeys: ['team-1::player-1'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } }
+        ],
+        nowMillis: Date.parse('2026-06-28T12:00:00.000Z')
+    });
+
+    try {
+        await env.firestoreState.doc('teams/team-1/feeBatches/batch-1/feeRecipients/recipient-a').set({
+            status: 'unpaid',
+            playerKey: 'team-1::player-1',
+            feeTitle: 'Tournament dues',
+            amountCents: 4500,
+            dueDate: '2026-06-30T12:00:00.000Z'
+        });
+        await env.firestoreState.doc('teams/team-1/feeBatches/batch-2/feeRecipients/recipient-b').set({
+            status: 'unpaid',
+            playerKey: 'team-1::player-1',
+            feeTitle: 'Uniform dues',
+            amountCents: 3000,
+            dueDate: '2026-06-30T12:00:00.000Z'
+        });
+
+        await moduleExports.sendFeeUnpaidDueReminders();
+        await moduleExports.sendFeeUnpaidDueReminders();
+
+        assert.equal(env.messagingCalls.length, 2);
+        assert.deepEqual(env.messagingCalls.map((call) => call.data.appRoute).sort(), [
+            '/parent-tools/fees?teamId=team-1&batchId=batch-1&recipientId=recipient-a',
+            '/parent-tools/fees?teamId=team-1&batchId=batch-2&recipientId=recipient-b'
+        ]);
+        assert.deepEqual(env.updatedDocs.map((write) => write.path).sort(), [
+            'teams/team-1/feeBatches/batch-1/feeRecipients/recipient-a',
+            'teams/team-1/feeBatches/batch-2/feeRecipients/recipient-b'
+        ]);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyFeeAssigned sends fees notifications only to opted-in payer targets', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },

--- a/functions/test/send-category-notification-test-helpers.js
+++ b/functions/test/send-category-notification-test-helpers.js
@@ -104,7 +104,8 @@ function buildNotificationTestEnv({
     preferenceDocs = {},
     deviceDocs = {},
     invalidTokenResponses = [],
-    sendEachErrors = []
+    sendEachErrors = [],
+    nowMillis = Date.parse('2026-06-28T12:00:00.000Z')
 } = {}) {
     const dedupWrites = [];
     const inboxWrites = [];
@@ -180,6 +181,65 @@ function buildNotificationTestEnv({
 
     function clone(value) {
         return value == null ? value : JSON.parse(JSON.stringify(value));
+    }
+
+    function makeTimestamp(millis) {
+        return {
+            toDate: () => new Date(millis),
+            toMillis: () => millis
+        };
+    }
+
+    function comparableMillis(value) {
+        if (typeof value?.toMillis === 'function') {
+            return value.toMillis();
+        }
+        if (value instanceof Date) {
+            return value.getTime();
+        }
+        if (typeof value === 'string' || typeof value === 'number') {
+            const millis = new Date(value).getTime();
+            return Number.isFinite(millis) ? millis : Number(value);
+        }
+        return NaN;
+    }
+
+    function matchesQueryFilter(data, filter) {
+        const actual = data?.[filter.field];
+        if (filter.op === 'in') {
+            return Array.isArray(filter.value) && filter.value.includes(actual);
+        }
+        if (filter.op === '==') {
+            return actual === filter.value;
+        }
+        if (filter.op === '>=' || filter.op === '<=') {
+            const actualMillis = comparableMillis(actual);
+            const expectedMillis = comparableMillis(filter.value);
+            if (!Number.isFinite(actualMillis) || !Number.isFinite(expectedMillis)) {
+                return false;
+            }
+            return filter.op === '>='
+                ? actualMillis >= expectedMillis
+                : actualMillis <= expectedMillis;
+        }
+        return false;
+    }
+
+    function makeQuery(getDocs) {
+        const filters = [];
+        return {
+            where(field, op, value) {
+                filters.push({ field, op, value });
+                return this;
+            },
+            async get() {
+                const docs = getDocs().filter((docSnap) => {
+                    const data = docSnap.data() || {};
+                    return filters.every((filter) => matchesQueryFilter(data, filter));
+                });
+                return makeQuerySnapshot(docs);
+            }
+        };
     }
 
     function isDeleteSentinel(value) {
@@ -568,6 +628,19 @@ function buildNotificationTestEnv({
     const firestoreState = {
         doc,
         collection,
+        collectionGroup(name) {
+            if (name !== 'feeRecipients') {
+                return makeQuery(() => []);
+            }
+            return makeQuery(() => Array.from(docStore.entries())
+                .filter(([path]) => /\/feeRecipients\/[^/]+$/.test(path))
+                .map(([path, data]) => makeDocSnapshot({
+                    id: path.split('/').pop(),
+                    ref: doc(path),
+                    data,
+                    exists: true
+                })));
+        },
         async getAll(...refs) {
             return Promise.all(refs.map((ref) => ref.get()));
         },
@@ -602,10 +675,9 @@ function buildNotificationTestEnv({
             delete: () => ({ __delete: true })
         },
         Timestamp: {
-            fromDate: (date) => ({
-                toDate: () => new Date(date),
-                toMillis: () => new Date(date).getTime()
-            })
+            now: () => makeTimestamp(nowMillis),
+            fromDate: (date) => makeTimestamp(new Date(date).getTime()),
+            fromMillis: (millis) => makeTimestamp(millis)
         }
     });
 

--- a/tests/unit/fee-due-reminders-source.test.js
+++ b/tests/unit/fee-due-reminders-source.test.js
@@ -10,11 +10,32 @@ function getHelper(name, nextMarker) {
     return new Function(`${slice}; return ${name};`)();
 }
 
+function getEligibilityHelpers() {
+    const start = functionsSource.indexOf('function wasFeeReminderSentForThreshold(');
+    const end = functionsSource.indexOf('\nasync function resolveFeeReminderCandidateUserIds');
+    const slice = functionsSource.slice(start, end);
+    const coerceDate = (value) => {
+        if (!value) return null;
+        if (typeof value?.toDate === 'function') return value.toDate();
+        const date = value instanceof Date ? value : new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+    };
+    const getTeamFeeBalanceCents = (recipient = {}) => {
+        if (recipient.balanceDueCents != null) return Number(recipient.balanceDueCents);
+        return Math.max(0, Number(recipient.amountCents || 0) - Number(recipient.amountPaidCents || 0));
+    };
+    return new Function('coerceDate', 'getTeamFeeBalanceCents', `${slice}; return { getFeeReminderDueDateMillis, isFeeDueReminderCandidateEligible };`)(
+        coerceDate,
+        getTeamFeeBalanceCents
+    );
+}
+
 const getFeeReminderPlayerKey = getHelper('getFeeReminderPlayerKey', 'function buildFeeReminderCandidateUserIds');
 const buildFeeReminderCandidateUserIds = getHelper('buildFeeReminderCandidateUserIds', 'function resolveFeeReminderThresholdHours');
 const resolveFeeReminderThresholdHours = getHelper('resolveFeeReminderThresholdHours', 'function wasFeeReminderSentForThreshold');
 const wasFeeReminderSentForThreshold = getHelper('wasFeeReminderSentForThreshold', 'function formatFeeReminderWindowLabel');
 const formatFeeReminderWindowLabel = getHelper('formatFeeReminderWindowLabel', 'async function resolveFeeReminderCandidateUserIds');
+const { getFeeReminderDueDateMillis, isFeeDueReminderCandidateEligible } = getEligibilityHelpers();
 
 describe('fee due reminder helper logic', () => {
     it('builds a player key from team and player ids when the recipient does not store one', () => {
@@ -58,6 +79,40 @@ describe('fee due reminder helper logic', () => {
         expect(formatFeeReminderWindowLabel(48)).toBe('2 days or less');
         expect(formatFeeReminderWindowLabel(72)).toBe('3 days or less');
     });
+
+    it('identifies unpaid due-window fee reminder candidates', () => {
+        const nowMillis = Date.parse('2026-06-28T12:00:00.000Z');
+
+        expect(getFeeReminderDueDateMillis({ dueDate: '2026-06-30T12:00:00.000Z' })).toBe(Date.parse('2026-06-30T12:00:00.000Z'));
+        expect(isFeeDueReminderCandidateEligible({
+            status: 'unpaid',
+            amountCents: 4500,
+            dueDate: '2026-06-30T12:00:00.000Z'
+        }, { nowMillis, reminderThresholdHours: 72 })).toBe(true);
+        expect(isFeeDueReminderCandidateEligible({
+            status: 'pending',
+            amountCents: 4500,
+            dueDate: '2026-07-02T12:00:00.000Z'
+        }, { nowMillis, reminderThresholdHours: 72 })).toBe(false);
+        expect(isFeeDueReminderCandidateEligible({
+            status: 'paid',
+            amountCents: 4500,
+            dueDate: '2026-06-30T12:00:00.000Z'
+        }, { nowMillis, reminderThresholdHours: 72 })).toBe(false);
+        expect(isFeeDueReminderCandidateEligible({
+            status: 'unpaid',
+            amountCents: 4500,
+            amountPaidCents: 4500,
+            dueDate: '2026-06-30T12:00:00.000Z'
+        }, { nowMillis, reminderThresholdHours: 72 })).toBe(false);
+        expect(isFeeDueReminderCandidateEligible({
+            status: 'unpaid',
+            amountCents: 4500,
+            dueDate: '2026-06-30T12:00:00.000Z',
+            reminderSentAt: { seconds: 1 },
+            reminderThresholdHours: 72
+        }, { nowMillis, reminderThresholdHours: 72 })).toBe(false);
+    });
 });
 
 describe('fee due reminder source wiring', () => {
@@ -71,9 +126,10 @@ describe('fee due reminder source wiring', () => {
         expect(functionsSource).toContain(".where('parentPlayerKeys', 'array-contains', playerKey)");
         expect(functionsSource).toContain("const teamSnap = await firestore.collection('teams').doc(teamId).get();");
         expect(functionsSource).toContain('reminderThresholdHours = resolveFeeReminderThresholdHours(teamSnap.exists ? teamSnap.data() : {});');
-        expect(functionsSource).toContain('const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, data);');
+        expect(functionsSource).toContain('const candidateUserIds = await resolveFeeReminderCandidateUserIds(teamId, recipient);');
         expect(functionsSource).toContain('const candidateUserIdSet = new Set(candidateUserIds);');
-        expect(functionsSource).toContain('if (wasFeeReminderSentForThreshold(data, reminderThresholdHours)) return null;');
+        expect(functionsSource).toContain('async function resolveEligibleFeeReminderRecipient({');
+        expect(functionsSource).toContain('if (!isFeeDueReminderCandidateEligible(recipient, { nowMillis, reminderThresholdHours })) {');
         expect(functionsSource).toContain('reminderThresholdHours');
     });
 
@@ -91,8 +147,9 @@ describe('fee due reminder source wiring', () => {
         expect(functionsSource).toContain("const batchId = pathParts[3];");
         expect(functionsSource).toContain("const recipientId = pathParts[5];");
         expect(functionsSource).toContain("const amountLabel = formatMoneyFromCents(getTeamFeeBalanceCents(data), data.currency || 'USD');");
-        expect(functionsSource).toContain('const reminderWindowLabel = formatFeeReminderWindowLabel(reminderThresholdHours);');
-        expect(functionsSource).toContain('body: `${amountLabel} is due in ${reminderWindowLabel}.`,');
+        expect(functionsSource).toContain('const body = buildFeeReminderNotificationBody(data, amountLabel, reminderThresholdHours);');
+        expect(functionsSource).toContain('return `${amountLabel} is due ${dueDateDisplay} (${reminderWindowLabel}).`;');
+        expect(functionsSource).toContain('body,');
         expect(functionsSource).toContain('batchId,');
         expect(functionsSource).toContain('recipientId,');
     });

--- a/tests/unit/fee-notification-contract.test.js
+++ b/tests/unit/fee-notification-contract.test.js
@@ -122,11 +122,13 @@ describe('fee notification contract', () => {
         expect(functionsSource).toContain(".where('status', 'in', ['unpaid', 'pending'])");
         expect(functionsSource).toContain(".where('dueDate', '>=', now)");
         expect(functionsSource).toContain(".where('dueDate', '<=', maxReminderThresholdLater)");
-        expect(functionsSource).toContain('if (wasFeeReminderSentForThreshold(data, reminderThresholdHours)) return null;');
+        expect(functionsSource).toContain('function isFeeDueReminderCandidateEligible(recipient = {}, {');
+        expect(functionsSource).toContain('return !wasFeeReminderSentForThreshold(recipient, reminderThresholdHours);');
+        expect(functionsSource).toContain('async function resolveEligibleFeeReminderRecipient({');
         expect(functionsSource).toContain('const allTargets = await getTargetsForCategory(teamId, \'fees\', null);');
-        expect(functionsSource).toContain('const payerTargets = allTargets.filter((t) => candidateUserIdSet.has(t.uid));');
+        expect(functionsSource).toContain('const payerTargets = allTargets.filter((target) => candidateUserIdSet.has(target.uid));');
         expect(functionsSource).toContain('reminderThresholdHours');
-        expect(functionsSource).toContain('const reminderWindowLabel = formatFeeReminderWindowLabel(reminderThresholdHours);');
+        expect(functionsSource).toContain('const body = buildFeeReminderNotificationBody(data, amountLabel, reminderThresholdHours);');
         expect(functionsSource).toContain("title: `Reminder: ${title} is due soon`");
     });
 

--- a/tests/unit/fee-notification-initiative-source-contract.test.js
+++ b/tests/unit/fee-notification-initiative-source-contract.test.js
@@ -21,13 +21,13 @@ describe('fees notification initiative source contract', () => {
 
     it('targets parents for assignment and reminders while keeping staff payment alerts separate', () => {
         expect(functionsSource).toContain('resolveFeeAssignmentPayerUserIds(teamId, data)');
-        expect(functionsSource).toContain('resolveFeeReminderCandidateUserIds(teamId, data)');
+        expect(functionsSource).toContain('resolveFeeReminderCandidateUserIds(teamId, recipient)');
         expect(functionsSource).toContain('const staffTargets = allFeeTargets.filter((target) => staffUserIds.has(target.uid) && target.uid !== payerUserId);');
         expect(functionsSource).toContain('const payerTargets = allFeeTargets.filter((target) => target.uid === payerUserId);');
     });
 
     it('marks due reminders sent only after opted-in payer targets exist', () => {
-        const reminderTargetIndex = functionsSource.indexOf('const payerTargets = allTargets.filter((t) => candidateUserIdSet.has(t.uid));');
+        const reminderTargetIndex = functionsSource.indexOf('const payerTargets = allTargets.filter((target) => candidateUserIdSet.has(target.uid));');
         const markSentIndex = functionsSource.indexOf('await doc.ref.update({');
 
         expect(reminderTargetIndex).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary
- Extracted fee due reminder eligibility into focused helpers for unpaid/pending recipients with remaining balances inside the due window.
- Kept reminder dedupe per fee recipient and threshold, while preserving separate sends for different fees.
- Added parent fee reminder payload coverage for amount, formatted due date, and fee deep links.

Closes #2949
Closes #2950
Closes #2951

## Tests
- `npx vitest run tests/unit/fee-due-reminders-source.test.js --reporter=verbose`
- `npx vitest run functions/test/notification-triggers.test.js --environment node --reporter=verbose`
- `npm run test:functions:notifications`
- `npx vitest run tests/unit/fee-due-reminders-source.test.js tests/unit/fee-notification-contract.test.js tests/unit/fee-notification-initiative-source-contract.test.js tests/unit/fee-assignment-notification-source-contract.test.js tests/unit/team-fee-paid-notifications.test.js tests/unit/push-notification-payload-contract.test.js --reporter=verbose`