### PR TITLE
Move public registration capacity writes server-side

### DIFF
--- a/apps/app/src/lib/adapters/legacyParentTools.ts
+++ b/apps/app/src/lib/adapters/legacyParentTools.ts
@@ -68,9 +68,11 @@ export const setTeamMediaAlbumCover = (...args: any[]) => callLegacyDb('setTeamM
 export const addPendingFamilyMember = legacy_addPendingFamilyMember as (...args: any[]) => any;
 export const readFamilyMembers = legacy_readFamilyMembers as (...args: any[]) => any;
 export const db: unknown = legacyFirebase.db;
+export const functions: unknown = legacyFirebase.functions;
 export const doc = (...args: any[]) => callLegacyFirebase('doc', args);
 export const collection = (...args: any[]) => callLegacyFirebase('collection', args);
 export const getDoc = (...args: any[]) => callLegacyFirebase('getDoc', args);
+export const httpsCallable = (...args: any[]) => callLegacyFirebase('httpsCallable', args);
 export const serverTimestamp = (...args: any[]) => callLegacyFirebase('serverTimestamp', args);
 export const runTransaction = (...args: any[]) => callLegacyFirebase('runTransaction', args);
 export const formatParentFeeAmount = legacy_formatParentFeeAmount as (...args: any[]) => any;

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -2,21 +2,18 @@ import {
   addPendingFamilyMember,
   acceptTeamRegistrationOffer,
   approveTeamRegistration,
-  buildPendingRegistrationRecord,
   calculateRegistrationFeeSnapshot,
   canAccessTeamChat,
   canContributeTeamMedia,
   canManageTeamMedia,
   canReadTeamMediaAlbum,
   cancelStripeRegistrationCheckout,
-  collection,
   createFamilyShareToken,
   createParentMembershipRequest,
   createRegistrationCheckoutSession,
   createTeamMediaFolder,
   createTeamMediaLink,
   db,
-  decideRegistrationPlacement,
   deleteTeamMediaItem,
   discoverPublicTeams,
   doc,
@@ -38,6 +35,8 @@ import {
   getTeamMediaItemsPage,
   getTeamRegistrationForm,
   hasOnlineRegistrationCheckout,
+  functions,
+  httpsCallable,
   initiateTeamFeeCheckout,
   isSafeTeamMediaUrl,
   listCertificatesForPlayer,
@@ -55,8 +54,6 @@ import {
   rejectTeamRegistration,
   requiresRegistrationOption,
   revokeFamilyShareToken,
-  runTransaction,
-  serverTimestamp,
   setTeamMediaAlbumCover,
   sortByMediaOrder,
   sortParentFeeRecords,
@@ -313,64 +310,28 @@ export function getFamilyShareUrl(tokenId: string) {
 export async function submitOfflineRegistration(teamId: string, formId: string, submission: Record<string, any>) {
   if (!teamId || !formId || !submission) throw new Error('Registration submission is incomplete.');
 
-  const formRef = doc(db, 'teams', teamId, 'registrationForms', formId);
-  const registrationRef = doc(collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations'));
-
-  return runTransaction(db, async (transaction: any) => {
-    const formSnap = await transaction.get(formRef);
-    if (!formSnap.exists()) throw new Error('Registration form could not be found.');
-
-    const formData = formSnap.data() || {};
-    const latestForm = normalizeRegistrationForm(formData, { teamId, formId });
-    let status = 'pending';
-    let selectedOption = submission.selectedOption || null;
-    let feeSnapshot = submission.feeSnapshot || calculateRegistrationFeeSnapshot(latestForm, { quantity: submission.quantity || 1, now: new Date() });
-
-    if (requiresRegistrationOption(latestForm)) {
-      const placement = decideRegistrationPlacement({
-        form: latestForm,
-        selectedOptionId: submission.selectedOptionId || submission.selectedOption?.id,
-        counts: formData.registrationOptionCounts || {}
-      });
-      if (placement.status === 'blocked') {
-        const error = new Error(placement.message || 'Registration option is not available.');
-        (error as any).code = placement.reason === 'option-full' ? 'option-full' : 'invalid-option';
-        throw error;
-      }
-      const selectedCountKey = placement.selectedOption.countKey;
-      const optionCounts = formData.registrationOptionCounts || null;
-      if (!optionCounts || typeof optionCounts !== 'object' || !optionCounts[selectedCountKey] || typeof optionCounts[selectedCountKey] !== 'object') {
-        throw new Error('Registration form capacity tracking is not properly configured.');
-      }
-      const countPath = `registrationOptionCounts.${selectedCountKey}`;
-      transaction.update(formRef, {
-        [`${countPath}.enrolled`]: placement.nextCounts.enrolled,
-        [`${countPath}.waitlisted`]: placement.nextCounts.waitlisted,
-        registrationCapacityUpdateId: registrationRef.id,
-        updatedAt: serverTimestamp()
-      });
-      status = placement.status;
-      selectedOption = placement.selectedOption;
-      feeSnapshot = calculateRegistrationFeeSnapshot(latestForm, { quantity: submission.quantity || 1, now: new Date() });
-    }
-
-    const registrationRecord = buildPendingRegistrationRecord({
-      form: latestForm,
+  const submitPublicRegistration = httpsCallable(functions, 'submitPublicRegistration');
+  try {
+    const result = await submitPublicRegistration({
+      teamId,
+      formId,
       participant: submission.participant,
       guardian: submission.guardian,
       waiverAccepted: submission.waiverAccepted,
-      selectedOption,
-      selectedPaymentPlanId: submission.selectedPaymentPlanId,
-      status,
-      feeSnapshot,
-      checkoutAttemptToken: submission.checkoutAttemptToken,
-      now: serverTimestamp()
+      selectedOptionId: submission.selectedOptionId || submission.selectedOption?.id || '',
+      selectedPaymentPlanId: submission.selectedPaymentPlanId || 'pay_full',
+      quantity: submission.quantity || submission.feeSnapshot?.quantity || 1,
+      checkoutAttemptToken: submission.checkoutAttemptToken || ''
     });
-
-    transaction.set(registrationRef, registrationRecord);
-
-    return { success: true, status, registrationId: registrationRef.id, feeSnapshot: registrationRecord.feeSnapshot };
-  });
+    return result?.data || {};
+  } catch (error: any) {
+    const code = String(error?.code || '').replace(/^functions\//, '');
+    const details = error?.details || {};
+    if (details.reason === 'option-full' || details.reason === 'missing-option' || code === 'failed-precondition' || code === 'invalid-argument' || code === 'resource-exhausted') {
+      throw new Error(error?.message || 'Registration could not be submitted.');
+    }
+    throw error;
+  }
 }
 
 export function getRegistrationUrl(teamId: string, formId: string) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -785,74 +785,6 @@ service cloud.firestore {
 
     }
 
-    function hasExpectedRegistrationCounterDelta(registration, beforeCounts, afterCounts) {
-      let option = registration.selectedOption;
-      let countKey = option.countKey;
-      let beforeOption = beforeCounts.get(countKey, {});
-      let afterOption = afterCounts.get(countKey, {});
-      let beforeEnrolled = beforeOption.get('enrolled', 0);
-      let beforeWaitlisted = beforeOption.get('waitlisted', 0);
-      let afterEnrolled = afterOption.get('enrolled', 0);
-      let afterWaitlisted = afterOption.get('waitlisted', 0);
-      let capacityLimit = option.get('capacityLimit', null);
-      return beforeCounts.keys().hasAll([countKey]) &&
-             afterCounts.keys().hasAll([countKey]) &&
-             beforeEnrolled is int &&
-             beforeWaitlisted is int &&
-             afterEnrolled is int &&
-             afterWaitlisted is int &&
-             afterCounts.diff(beforeCounts).affectedKeys().hasOnly([countKey]) &&
-             afterOption.diff(beforeOption).affectedKeys().hasOnly(['enrolled', 'waitlisted']) &&
-             (
-               (registration.status == 'pending' &&
-                afterEnrolled == beforeEnrolled + 1 &&
-                afterWaitlisted == beforeWaitlisted &&
-                (capacityLimit == null || afterEnrolled <= capacityLimit)) ||
-               (registration.status == 'waitlisted' &&
-                option.waitlistEnabled == true &&
-                capacityLimit is int &&
-                beforeEnrolled >= capacityLimit &&
-                afterEnrolled == beforeEnrolled &&
-                afterWaitlisted == beforeWaitlisted + 1)
-             );
-    }
-
-    function isRegistrationCapacityTransitionValid(formBefore, formAfter, registration) {
-      return registration.keys().hasAny(['selectedOption']) &&
-             hasExpectedRegistrationCounterDelta(
-               registration,
-               formBefore.get('registrationOptionCounts', {}),
-               formAfter.get('registrationOptionCounts', {})
-             );
-    }
-
-    function isPublicRegistrationCapacityCounterUpdate(teamId, formId) {
-      let registrationId = request.resource.data.get('registrationCapacityUpdateId', '');
-      let registrationPath = registrationDocPath(teamId, formId, registrationId);
-      return isPublishedRegistrationForm(resource.data) &&
-             registrationId is string &&
-             registrationId != '' &&
-             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['registrationOptionCounts', 'registrationCapacityUpdateId', 'updatedAt']) &&
-             !exists(registrationPath) &&
-             existsAfter(registrationPath) &&
-             isPendingRegistrationPayloadValid(teamId, formId, getAfter(registrationPath).data) &&
-             isRegistrationCapacityTransitionValid(resource.data, request.resource.data, getAfter(registrationPath).data);
-    }
-
-    function isPublicPendingRegistrationCreate(teamId, formId, registrationId) {
-      let formPath = registrationFormPath(teamId, formId);
-      return isPublishedRegistrationForm(get(formPath).data) &&
-             isPendingRegistrationPayloadValid(teamId, formId, request.resource.data) &&
-             (
-               (!hasConfiguredRegistrationOptions(get(formPath).data) &&
-                request.resource.data.status == 'pending' &&
-                !request.resource.data.keys().hasAny(['selectedOption', 'waitlistedAt'])) ||
-               (hasConfiguredRegistrationOptions(get(formPath).data) &&
-                getAfter(formPath).data.get('registrationCapacityUpdateId', '') == registrationId &&
-                isRegistrationCapacityTransitionValid(get(formPath).data, getAfter(formPath).data, request.resource.data))
-             );
-    }
-
     // Chat access: team owner, team admins, global admins, or any parent linked to the team
     function isOfficialGameUpdate() {
       return request.resource.data.diff(resource.data).affectedKeys().hasOnly([
@@ -1727,14 +1659,13 @@ service cloud.firestore {
       match /registrationForms/{formId} {
         allow read: if isPublishedRegistrationForm(resource.data) || isTeamOwnerOrAdmin(teamId);
         allow create, delete: if isTeamOwnerOrAdmin(teamId);
-        allow update: if isTeamOwnerOrAdmin(teamId) || isPublicRegistrationCapacityCounterUpdate(teamId, formId);
+        allow update: if isTeamOwnerOrAdmin(teamId);
 
         match /registrations/{registrationId} {
           allow read: if isTeamOwnerOrAdmin(teamId) || isCurrentUserRegistrationGuardian(resource.data);
           allow update: if isTeamOwnerOrAdmin(teamId);
           allow delete: if isTeamOwnerOrAdmin(teamId);
-          allow create: if (isTeamOwnerOrAdmin(teamId) && request.resource.data.status == 'pending') ||
-                          isPublicPendingRegistrationCreate(teamId, formId, registrationId);
+          allow create: if isTeamOwnerOrAdmin(teamId) && request.resource.data.status == 'pending';
         }
       }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -363,7 +363,8 @@ function normalizePublicRegistrationFlatObject(value = {}) {
   return Object.entries(value).reduce((result, [key, rawValue]) => {
     const cleanKey = String(key || '').trim();
     if (!cleanKey || rawValue == null || typeof rawValue === 'object') return result;
-    result[cleanKey] = String(rawValue).trim();
+    const cleanValue = String(rawValue).trim();
+    result[cleanKey] = /email/i.test(cleanKey) ? cleanValue.toLowerCase() : cleanValue;
     return result;
   }, {});
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -29,7 +29,7 @@ const {
   buildTeamFeePaidUpdate,
   buildTeamFeeStripeRefundUpdate
 } = require('./team-fees-core.cjs');
-const { createInMemoryRateLimiter } = require('./rate-limit.cjs');
+const { createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const {
   buildTeamCalendarIcs,
@@ -136,6 +136,11 @@ const checkStripeWebhookRateLimit = createInMemoryRateLimiter({
   windowMs: 60_000,
   maxRequests: 120,
   maxKeys: 2_000
+});
+const checkPublicRegistrationSubmissionRateLimit = createInMemoryRateLimiter({
+  windowMs: 10 * 60_000,
+  maxRequests: 3,
+  maxKeys: 5_000
 });
 
 function getStripeConfig() {
@@ -338,6 +343,485 @@ function buildRegistrationCheckoutUrls(appUrl, input) {
     cancelUrl: `${baseUrl}/registration.html?${params.toString()}&status=cancelled`
   };
 }
+
+function normalizePublicRegistrationInput(data = {}) {
+  return {
+    teamId: normalizeFirestoreId(data.teamId, 'teamId'),
+    formId: normalizeFirestoreId(data.formId, 'formId'),
+    participant: normalizePublicRegistrationFlatObject(data.participant),
+    guardian: normalizePublicRegistrationFlatObject(data.guardian),
+    waiverAccepted: data.waiverAccepted === true,
+    selectedOptionId: String(data.selectedOptionId || data.selectedOption?.id || '').trim(),
+    selectedPaymentPlanId: String(data.selectedPaymentPlanId || 'pay_full').trim() || 'pay_full',
+    quantity: Math.max(1, Math.floor(Number(data.quantity || data.feeSnapshot?.quantity || 1) || 1)),
+    checkoutAttemptToken: normalizeCheckoutAttemptToken(data.checkoutAttemptToken)
+  };
+}
+
+function normalizePublicRegistrationFlatObject(value = {}) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  return Object.entries(value).reduce((result, [key, rawValue]) => {
+    const cleanKey = String(key || '').trim();
+    if (!cleanKey || rawValue == null || typeof rawValue === 'object') return result;
+    result[cleanKey] = String(rawValue).trim();
+    return result;
+  }, {});
+}
+
+function normalizePublicRegistrationForm(form = {}, context = {}) {
+  const registrationOptionCounts = form.registrationOptionCounts || {};
+  const feeAmountCents = Math.max(0, Math.round(Number(form.feeAmountCents || 0)));
+  return {
+    id: context.formId || form.id || '',
+    teamId: context.teamId || form.teamId || '',
+    programName: String(form.programName || form.title || form.name || '').trim(),
+    description: String(form.description || form.programDescription || '').trim(),
+    season: String(form.season || '').trim(),
+    feeAmountCents,
+    currency: String(form.currency || 'USD').trim() || 'USD',
+    installmentPlan: normalizePublicRegistrationInstallmentPlan(form.installmentPlan),
+    participantFields: normalizePublicRegistrationFields(form.participantFields || form.playerFields || []),
+    guardianFields: normalizePublicRegistrationFields(form.guardianFields || []),
+    waiverText: String(form.waiverText || form.waiver || '').trim(),
+    status: String(form.status || '').trim(),
+    published: form.published === true || form.status === 'published',
+    paymentSettings: normalizeRegistrationPaymentSettings(form.paymentSettings),
+    discountRules: normalizePublicRegistrationDiscountRules(form.discountRules || []),
+    backgroundCheck: normalizePublicRegistrationBackgroundCheck(form.backgroundCheck),
+    registrationOptions: normalizePublicRegistrationOptions(form.registrationOptions || form.options || []),
+    registrationOptionCounts
+  };
+}
+
+function normalizeRegistrationPaymentSettings(settings = {}) {
+  return {
+    offlinePaymentEnabled: settings?.offlinePaymentEnabled === true,
+    onlineCheckoutEnabled: settings?.onlineCheckoutEnabled === true
+  };
+}
+
+function normalizePublicRegistrationInstallmentPlan(plan = null) {
+  if (!plan || plan.enabled !== true) return null;
+  const installmentCount = Math.max(2, Math.min(12, Math.floor(Number(plan.installmentCount) || 0)));
+  const intervalDays = Math.max(1, Math.min(365, Math.floor(Number(plan.intervalDays) || 30)));
+  const firstDueDate = String(plan.firstDueDate || '').trim();
+  if (!firstDueDate) return null;
+  return {
+    enabled: true,
+    title: String(plan.title || 'Installment plan').trim() || 'Installment plan',
+    installmentCount,
+    firstDueDate,
+    intervalDays
+  };
+}
+
+function normalizePublicRegistrationFields(fields = []) {
+  if (!Array.isArray(fields)) return [];
+  return fields
+    .map((field, index) => ({
+      id: String(field?.id || field?.key || `field_${index + 1}`).trim(),
+      label: String(field?.label || field?.name || field?.id || field?.key || `Field ${index + 1}`).trim(),
+      required: field?.required === true
+    }))
+    .filter((field) => field.id && field.label);
+}
+
+function normalizePublicRegistrationBackgroundCheck(settings = {}) {
+  const enabled = settings?.enabled === true || settings?.backgroundCheckEnabled === true;
+  const status = String(settings?.initialScreeningStatus || 'pending').trim().toLowerCase().replace(/[ _]+/g, '-');
+  const allowedStatuses = ['pending', 'submitted', 'cleared', 'flagged', 'expired', 'rejected'];
+  return {
+    enabled,
+    initialScreeningStatus: enabled && allowedStatuses.includes(status) ? status : 'pending',
+    providerName: String(settings?.providerName || '').trim()
+  };
+}
+
+function normalizePublicRegistrationOptions(options = []) {
+  if (!Array.isArray(options)) return [];
+  return options
+    .map((option, index) => {
+      const id = String(option?.id || option?.key || `option_${index + 1}`).trim();
+      const title = String(option?.title || option?.name || option?.label || `Option ${index + 1}`).trim();
+      const capacityNumber = Number(option?.capacityLimit ?? option?.capacity ?? option?.maxRegistrations);
+      const capacityLimit = Number.isFinite(capacityNumber) && capacityNumber > 0 ? Math.floor(capacityNumber) : null;
+      return {
+        id,
+        countKey: buildPublicRegistrationOptionCountKey(id),
+        title,
+        description: String(option?.description || '').trim(),
+        capacityLimit,
+        waitlistEnabled: option?.waitlistEnabled === true || option?.waitlist === true,
+        active: option?.active !== false && option?.status !== 'inactive' && option?.status !== 'archived',
+        feeAmountCents: Number.isFinite(Number(option?.feeAmountCents)) ? Math.max(0, Math.round(Number(option.feeAmountCents))) : undefined
+      };
+    })
+    .filter((option) => option.id && option.title);
+}
+
+function buildPublicRegistrationOptionCountKey(optionId = '') {
+  const key = String(optionId || '').trim().replace(/[^A-Za-z0-9_-]/g, '_');
+  return key || 'option';
+}
+
+function getActivePublicRegistrationOptions(form = {}, counts = {}) {
+  return (form.registrationOptions || []).filter((option) => {
+    if (!option.active) return false;
+    const optionCounts = counts[option.countKey] || counts[option.id] || {};
+    const enrolledCount = Number(optionCounts.enrolled || 0);
+    if (!option.capacityLimit || enrolledCount < option.capacityLimit) return true;
+    return option.waitlistEnabled === true;
+  });
+}
+
+function publicRegistrationRequiresOption(form = {}) {
+  return (form.registrationOptions || []).some((option) => option.active !== false);
+}
+
+function getConfiguredPublicRegistrationOptionById(form = {}, selectedOptionId = '') {
+  return (form.registrationOptions || [])
+    .filter((option) => option.active !== false)
+    .find((option) => option.id === selectedOptionId) || null;
+}
+
+function decidePublicRegistrationPlacement({ form, selectedOptionId, counts = {} }) {
+  const selectedOption = getConfiguredPublicRegistrationOptionById(form, selectedOptionId);
+  if (!selectedOption) {
+    return { status: 'blocked', reason: 'missing-option', message: 'Please select a registration option.' };
+  }
+
+  const optionCounts = counts[selectedOption.countKey] || counts[selectedOption.id] || {};
+  const enrolledCount = Number(optionCounts.enrolled || 0);
+  const waitlistedCount = Number(optionCounts.waitlisted || 0);
+  const hasCapacity = !selectedOption.capacityLimit || enrolledCount < selectedOption.capacityLimit;
+
+  if (hasCapacity) {
+    return {
+      status: 'pending',
+      selectedOption,
+      nextCounts: { enrolled: enrolledCount + 1, waitlisted: waitlistedCount }
+    };
+  }
+
+  if (selectedOption.waitlistEnabled) {
+    return {
+      status: 'waitlisted',
+      selectedOption,
+      nextCounts: { enrolled: enrolledCount, waitlisted: waitlistedCount + 1 }
+    };
+  }
+
+  return {
+    status: 'blocked',
+    reason: 'option-full',
+    selectedOption,
+    message: `${selectedOption.title} is full and is not accepting waitlist registrations.`
+  };
+}
+
+function normalizePublicRegistrationDiscountRules(rules = []) {
+  if (!Array.isArray(rules)) return [];
+  return rules
+    .map((rule, index) => {
+      const type = String(rule?.type || '').toLowerCase();
+      const amountType = rule?.amountType === 'percent' ? 'percent' : 'fixed';
+      const amountValue = Math.max(0, Number(rule?.amountValue || 0));
+      const earlyBirdDeadline = String(rule?.earlyBirdDeadline || '').trim();
+      const minimumQuantity = Math.max(1, Math.floor(Number(rule?.minimumQuantity || 1)));
+      if (!['early_bird', 'quantity'].includes(type) || amountValue <= 0) return null;
+      return {
+        id: String(rule?.id || `discount_${index + 1}`).trim(),
+        type,
+        label: String(rule?.label || (type === 'early_bird' ? 'Early bird discount' : 'Sibling/cart discount')).trim(),
+        amountType,
+        amountValue,
+        earlyBirdDeadline,
+        minimumQuantity,
+        active: rule?.active !== false
+      };
+    })
+    .filter(Boolean);
+}
+
+function calculatePublicRegistrationFeeSnapshot(form = {}, options = {}) {
+  const currency = String(form.currency || 'USD').trim() || 'USD';
+  const originalFeeAmountCents = Math.max(0, Math.round(Number(form.feeAmountCents || 0)));
+  const quantity = Math.max(1, Math.floor(Number(options.quantity || 1)));
+  const submittedAt = options.now instanceof Date ? options.now : new Date();
+  const subtotalAmountCents = originalFeeAmountCents * quantity;
+  let finalAmountDueCents = subtotalAmountCents;
+  const appliedDiscounts = [];
+
+  normalizePublicRegistrationDiscountRules(form.discountRules || []).forEach((rule) => {
+    if (!rule.active || !isPublicRegistrationDiscountEligible(rule, { quantity, now: submittedAt })) return;
+    const discountAmountCents = rule.amountType === 'percent'
+      ? Math.round(finalAmountDueCents * (rule.amountValue / 100))
+      : Math.round(rule.amountValue);
+    const appliedAmountCents = Math.min(finalAmountDueCents, Math.max(0, discountAmountCents));
+    if (appliedAmountCents <= 0) return;
+    finalAmountDueCents -= appliedAmountCents;
+    appliedDiscounts.push({
+      id: rule.id,
+      type: rule.type,
+      label: rule.label,
+      amountType: rule.amountType,
+      amountValue: rule.amountValue,
+      amountCents: appliedAmountCents
+    });
+  });
+
+  return {
+    currency,
+    quantity,
+    originalFeeAmountCents,
+    subtotalAmountCents,
+    appliedDiscounts,
+    finalAmountDueCents
+  };
+}
+
+function isPublicRegistrationDiscountEligible(rule, { quantity, now }) {
+  if (rule.type === 'quantity') return quantity >= rule.minimumQuantity;
+  if (rule.type === 'early_bird') {
+    const deadline = Date.parse(`${rule.earlyBirdDeadline}T23:59:59.999`);
+    return Number.isFinite(deadline) && now.getTime() <= deadline;
+  }
+  return false;
+}
+
+function buildPublicRegistrationPaymentPlanSnapshot(form = {}, selectedPaymentPlanId = 'pay_full') {
+  const totalBalanceDueCents = Math.max(0, Math.round(Number(form.feeAmountCents) || 0));
+  const useInstallments = selectedPaymentPlanId === 'installments' && form.installmentPlan?.enabled === true;
+  const schedule = useInstallments
+    ? buildPublicRegistrationInstallmentSchedule(totalBalanceDueCents, form.installmentPlan)
+    : [{ label: 'Pay in full', dueDate: form.installmentPlan?.firstDueDate || '', amountCents: totalBalanceDueCents }];
+  return {
+    id: useInstallments ? 'installments' : 'pay_full',
+    type: useInstallments ? 'installments' : 'pay_full',
+    title: useInstallments ? form.installmentPlan.title : 'Pay in full',
+    installmentCount: schedule.length,
+    totalBalanceDueCents,
+    schedule
+  };
+}
+
+function buildPublicRegistrationInstallmentSchedule(totalBalanceDueCents = 0, plan = {}) {
+  const count = Math.max(2, Math.min(12, Math.floor(Number(plan.installmentCount) || 2)));
+  const baseAmount = Math.floor(totalBalanceDueCents / count);
+  const remainder = totalBalanceDueCents - (baseAmount * count);
+  const firstDate = parsePublicRegistrationLocalDate(plan.firstDueDate);
+  const intervalDays = Math.max(1, Math.floor(Number(plan.intervalDays) || 30));
+  return Array.from({ length: count }, (_, index) => {
+    const dueDate = firstDate ? addPublicRegistrationDays(firstDate, intervalDays * index) : null;
+    return {
+      label: `Installment ${index + 1}`,
+      dueDate: dueDate ? dueDate.toISOString().slice(0, 10) : String(plan.firstDueDate || ''),
+      amountCents: baseAmount + (index === count - 1 ? remainder : 0)
+    };
+  });
+}
+
+function parsePublicRegistrationLocalDate(value = '') {
+  const match = String(value || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+  return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+}
+
+function addPublicRegistrationDays(date, days) {
+  const next = new Date(date.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function validatePublicRegistrationSubmission(form, input) {
+  if (!form?.published) {
+    throwPublicRegistrationError('failed-precondition', 'This registration form is not accepting submissions.');
+  }
+  validatePublicRegistrationRequiredFields(form.participantFields || [], input.participant || {}, 'Participant');
+  validatePublicRegistrationRequiredFields(form.guardianFields || [], input.guardian || {}, 'Guardian');
+  if (input.waiverAccepted !== true) {
+    throwPublicRegistrationError('invalid-argument', 'Waiver acceptance is required.');
+  }
+  if (form.installmentPlan?.enabled === true && !['pay_full', 'installments'].includes(input.selectedPaymentPlanId)) {
+    throwPublicRegistrationError('invalid-argument', 'Please select a payment plan.');
+  }
+  if (form.installmentPlan?.enabled !== true && input.selectedPaymentPlanId !== 'pay_full') {
+    throwPublicRegistrationError('invalid-argument', 'Please select a payment plan.');
+  }
+  if (form.paymentSettings?.onlineCheckoutEnabled === true && !input.checkoutAttemptToken) {
+    throwPublicRegistrationError('invalid-argument', 'A checkout attempt token is required.');
+  }
+}
+
+function validatePublicRegistrationRequiredFields(fields, values, groupLabel) {
+  for (const field of fields) {
+    if (field.required && !String(values[field.id] || '').trim()) {
+      throwPublicRegistrationError('invalid-argument', `${groupLabel} ${field.label} is required.`);
+    }
+  }
+}
+
+function buildPublicPendingRegistrationRecord({ form, input, selectedOption = null, status = 'pending', feeSnapshot, now }) {
+  const paymentPlanForm = {
+    ...form,
+    feeAmountCents: feeSnapshot.finalAmountDueCents ?? form.feeAmountCents
+  };
+  const record = {
+    teamId: form.teamId,
+    formId: form.id,
+    programName: form.programName,
+    feeAmountCents: form.feeAmountCents,
+    currency: form.currency,
+    paymentSettings: normalizeRegistrationPaymentSettings(form.paymentSettings),
+    feeSnapshot,
+    participant: input.participant,
+    guardian: input.guardian,
+    waiverAccepted: input.waiverAccepted === true,
+    waiverText: form.waiverText,
+    paymentPlan: buildPublicRegistrationPaymentPlanSnapshot(paymentPlanForm, input.selectedPaymentPlanId),
+    status,
+    submittedAt: now,
+    source: 'public-registration'
+  };
+
+  if (input.checkoutAttemptToken) {
+    record.checkoutAttemptToken = input.checkoutAttemptToken;
+  }
+
+  if (form.backgroundCheck?.enabled === true) {
+    record.screeningRequired = true;
+    record.screeningStatus = form.backgroundCheck.initialScreeningStatus;
+    record.screeningProvider = form.backgroundCheck.providerName;
+    record.screeningProviderReference = '';
+  }
+
+  if (selectedOption) {
+    record.selectedOption = {
+      id: selectedOption.id,
+      countKey: selectedOption.countKey,
+      title: selectedOption.title,
+      feeAmountCents: selectedOption.feeAmountCents ?? form.feeAmountCents,
+      capacityLimit: selectedOption.capacityLimit,
+      waitlistEnabled: selectedOption.waitlistEnabled === true
+    };
+  }
+
+  if (status === 'waitlisted') {
+    record.waitlistedAt = now;
+  }
+
+  return record;
+}
+
+function getHeaderValue(headers = {}, name = '') {
+  const direct = headers[name] || headers[name.toLowerCase()];
+  return Array.isArray(direct) ? direct[0] : String(direct || '');
+}
+
+function buildPublicRegistrationRateLimitBoundary(input, context = {}) {
+  const rawRequest = context.rawRequest || {};
+  const requestIp = getRequestIp(rawRequest);
+  const appCheck = String(context.app?.appId || getHeaderValue(rawRequest.headers, 'x-firebase-appcheck') || '').trim();
+  const email = String(input.guardian?.email || input.guardian?.guardianEmail || '').trim().toLowerCase();
+  return [
+    input.teamId,
+    input.formId,
+    email || 'no-email',
+    appCheck || requestIp || 'unknown'
+  ].join('|');
+}
+
+function assertPublicRegistrationRateLimit(input, context = {}) {
+  const boundary = buildPublicRegistrationRateLimitBoundary(input, context);
+  const rateLimit = checkPublicRegistrationSubmissionRateLimit({ ip: boundary });
+  if (!rateLimit.allowed) {
+    throwPublicRegistrationError('resource-exhausted', 'Too many registration attempts. Please wait a few minutes and try again.', {
+      reason: 'rate-limited',
+      retryAfterSeconds: rateLimit.retryAfterSeconds
+    });
+  }
+}
+
+function throwPublicRegistrationError(code, message, details = {}) {
+  throw new functions.https.HttpsError(code, message, details);
+}
+
+exports.submitPublicRegistration = functions.https.onCall(async (data, context = {}) => {
+  let input;
+  try {
+    input = normalizePublicRegistrationInput(data || {});
+  } catch (error) {
+    throwPublicRegistrationError('invalid-argument', error.message || 'Invalid registration submission.');
+  }
+
+  assertPublicRegistrationRateLimit(input, context);
+
+  const formRef = buildRegistrationFormRef(input);
+  const registrationRef = formRef.collection('registrations').doc();
+  let result = null;
+
+  await firestore.runTransaction(async (transaction) => {
+    const formSnap = await transaction.get(formRef);
+    if (!formSnap.exists) {
+      throwPublicRegistrationError('not-found', 'Registration form not found.');
+    }
+
+    const formData = formSnap.data() || {};
+    const latestForm = normalizePublicRegistrationForm(formData, input);
+    validatePublicRegistrationSubmission(latestForm, input);
+
+    let status = 'pending';
+    let selectedOption = null;
+    if (publicRegistrationRequiresOption(latestForm)) {
+      const placement = decidePublicRegistrationPlacement({
+        form: latestForm,
+        selectedOptionId: input.selectedOptionId,
+        counts: formData.registrationOptionCounts || {}
+      });
+      if (placement.status === 'blocked') {
+        throwPublicRegistrationError('failed-precondition', placement.message || 'Registration option is not available.', {
+          reason: placement.reason || 'invalid-option'
+        });
+      }
+
+      selectedOption = placement.selectedOption;
+      const selectedCountKey = selectedOption.countKey;
+      const optionCounts = formData.registrationOptionCounts || null;
+      if (!optionCounts || typeof optionCounts !== 'object' || !optionCounts[selectedCountKey] || typeof optionCounts[selectedCountKey] !== 'object') {
+        throwPublicRegistrationError('failed-precondition', 'Registration form capacity tracking is not properly configured.');
+      }
+
+      const countPath = `registrationOptionCounts.${selectedCountKey}`;
+      transaction.update(formRef, {
+        [`${countPath}.enrolled`]: placement.nextCounts.enrolled,
+        [`${countPath}.waitlisted`]: placement.nextCounts.waitlisted,
+        registrationCapacityUpdateId: registrationRef.id,
+        updatedAt: admin.firestore.FieldValue.serverTimestamp()
+      });
+      status = placement.status;
+    }
+
+    const feeSnapshot = calculatePublicRegistrationFeeSnapshot(latestForm, { quantity: input.quantity, now: new Date() });
+    const registrationRecord = buildPublicPendingRegistrationRecord({
+      form: latestForm,
+      input,
+      selectedOption,
+      status,
+      feeSnapshot,
+      now: admin.firestore.FieldValue.serverTimestamp()
+    });
+
+    transaction.set(registrationRef, registrationRecord);
+    result = {
+      success: true,
+      status,
+      registrationId: registrationRef.id,
+      feeSnapshot: registrationRecord.feeSnapshot
+    };
+  });
+
+  return result;
+});
 
 function isServerDiscountRuleEligible(rule, { now }) {
   if (rule.type === 'quantity') return true; // quantity discounts always apply (single registration = quantity 1 satisfies minimum >= 1)
@@ -873,14 +1357,18 @@ async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}, opt
       transaction.update(formRef, updates);
     }
 
-    const nextPublicCheckoutCapability = createRawPublicCheckoutCapability();
-
-    transaction.set(registrationRef, {
+    const capacityReleaseUpdate = {
       ...registrationUpdate,
       registrationCapacityReleased: true,
-      capacityReleasedAt: now,
-      publicCheckoutCapabilityHash: hashPublicCheckoutCapability(nextPublicCheckoutCapability)
-    }, { merge: true });
+      capacityReleasedAt: now
+    };
+    let nextPublicCheckoutCapability = '';
+    if (options.suppressPublicCheckoutCapabilityRotation !== true) {
+      nextPublicCheckoutCapability = createRawPublicCheckoutCapability();
+      capacityReleaseUpdate.publicCheckoutCapabilityHash = hashPublicCheckoutCapability(nextPublicCheckoutCapability);
+    }
+
+    transaction.set(registrationRef, capacityReleaseUpdate, { merge: true });
 
     return { released, nextPublicCheckoutCapability };
   });
@@ -2416,7 +2904,8 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
           ...resolvedInput,
           publicCheckoutCapability: resolvedInput.publicCheckoutCapability || issuedPublicCheckoutCapability
         }, {}, {
-          retryCapacityReservationId: retryCapacityReservation.retryCapacityReservationId
+          retryCapacityReservationId: retryCapacityReservation.retryCapacityReservationId,
+          suppressPublicCheckoutCapabilityRotation: true
         });
       } catch (releaseError) {
         functions.logger.error('Failed to roll back registration retry capacity after Stripe checkout creation failed.', {

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -302,6 +302,19 @@ test('creates exactly one pending registration and reserves matching capacity', 
     assert.equal(registrations[0].data.selectedOption.countKey, 'u10');
 });
 
+test('normalizes guardian email casing for parent readback rules', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+
+    const result = await submitPublicRegistration(buildSubmission({
+        guardian: { email: ' Parent@Example.COM ' }
+    }), context);
+
+    const registrations = firestore.registrationDocs();
+    assert.equal(registrations.length, 1);
+    assert.equal(registrations[0].data.guardian.email, 'parent@example.com');
+    assert.equal(result.registrationId, registrations[0].path.split('/').pop());
+});
+
 test('rejects blocked capacity without creating a registration or changing counters', async () => {
     const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState({
         registrationOptions: [{ id: 'u10', title: 'U10', capacityLimit: 1, waitlistEnabled: false, active: true }],

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -1,0 +1,350 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const Module = require('node:module');
+
+const repoIndexPath = require.resolve('../index.js');
+const originalModuleLoad = Module._load;
+
+let adminStub = null;
+let functionsStub = null;
+let StripeStub = null;
+
+function patchedModuleLoad(request, parent, isMain) {
+    if (request === 'firebase-admin' && adminStub) {
+        return adminStub;
+    }
+    if (request === 'firebase-functions' && functionsStub) {
+        return functionsStub;
+    }
+    if (request === 'stripe' && StripeStub) {
+        return StripeStub;
+    }
+    return originalModuleLoad(request, parent, isMain);
+}
+
+function clone(value) {
+    return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function setNested(target, path, value) {
+    const parts = String(path || '').split('.').filter(Boolean);
+    let cursor = target;
+    for (let i = 0; i < parts.length - 1; i++) {
+        const key = parts[i];
+        if (!cursor[key] || typeof cursor[key] !== 'object' || Array.isArray(cursor[key])) {
+            cursor[key] = {};
+        }
+        cursor = cursor[key];
+    }
+    cursor[parts[parts.length - 1]] = value;
+}
+
+function makeFirestore(seed = {}) {
+    const state = new Map(Object.entries(clone(seed)));
+    let nextAutoId = 1;
+    const fieldValue = {
+        serverTimestamp: () => ({ __op: 'serverTimestamp' }),
+        delete: () => ({ __op: 'delete' }),
+        increment: (amount) => ({ __op: 'increment', amount }),
+        arrayUnion: (...items) => ({ __op: 'arrayUnion', items })
+    };
+
+    function isOp(value, kind) {
+        return value && typeof value === 'object' && value.__op === kind;
+    }
+
+    function applyPatch(baseValue, patchValue, merge) {
+        const target = merge ? clone(baseValue || {}) : {};
+        Object.entries(patchValue || {}).forEach(([key, value]) => {
+            if (isOp(value, 'serverTimestamp')) {
+                setNested(target, key, 'SERVER_TIMESTAMP');
+            } else if (isOp(value, 'delete')) {
+                const parts = key.split('.');
+                const leaf = parts.pop();
+                const parent = parts.reduce((acc, part) => (acc == null ? acc : acc[part]), target);
+                if (parent && leaf) delete parent[leaf];
+            } else if (isOp(value, 'increment')) {
+                const current = Number(key.split('.').reduce((acc, part) => (acc == null ? acc : acc[part]), target) || 0);
+                setNested(target, key, current + value.amount);
+            } else if (isOp(value, 'arrayUnion')) {
+                setNested(target, key, value.items.map(clone));
+            } else {
+                setNested(target, key, clone(value));
+            }
+        });
+        return target;
+    }
+
+    function write(path, value, options = {}) {
+        const current = state.get(path);
+        state.set(path, applyPatch(current, value, options.merge === true));
+    }
+
+    function doc(path) {
+        return {
+            path,
+            id: String(path).split('/').pop(),
+            async get() {
+                const data = state.get(path);
+                return {
+                    exists: data !== undefined,
+                    id: String(path).split('/').pop(),
+                    ref: this,
+                    data: () => clone(data)
+                };
+            },
+            async set(value, options) {
+                write(path, value, options || {});
+            },
+            async update(value) {
+                if (!state.has(path)) {
+                    throw new Error(`Missing document for update: ${path}`);
+                }
+                write(path, value, { merge: true });
+            },
+            collection(name) {
+                return collection(`${path}/${name}`);
+            }
+        };
+    }
+
+    function collection(path) {
+        return {
+            path,
+            doc(id) {
+                const docId = id || `auto-${nextAutoId++}`;
+                return doc(`${path}/${docId}`);
+            }
+        };
+    }
+
+    return {
+        _state: state,
+        doc,
+        collection,
+        async runTransaction(handler) {
+            const transaction = {
+                get: (ref) => ref.get(),
+                set: (ref, value, options) => ref.set(value, options),
+                update: (ref, value) => ref.update(value)
+            };
+            return handler(transaction);
+        },
+        snapshot(path) {
+            return clone(state.get(path));
+        },
+        registrationDocs() {
+            return [...state.entries()]
+                .filter(([path]) => path.startsWith('teams/team-1/registrationForms/form-1/registrations/'))
+                .map(([path, data]) => ({ path, data: clone(data) }));
+        },
+        FieldValue: fieldValue
+    };
+}
+
+function makeFunctionsStub() {
+    class HttpsError extends Error {
+        constructor(code, message, details) {
+            super(message);
+            this.code = code;
+            this.details = details;
+        }
+    }
+
+    const triggerChain = {
+        onCall: (fn) => fn,
+        onRequest: (fn) => fn,
+        onCreate: (fn) => fn,
+        onUpdate: (fn) => fn,
+        onWrite: (fn) => fn,
+        onRun: (fn) => fn,
+        document() {
+            return this;
+        },
+        schedule() {
+            return this;
+        },
+        timeZone() {
+            return this;
+        }
+    };
+    triggerChain.https = triggerChain;
+    triggerChain.firestore = triggerChain;
+    triggerChain.pubsub = triggerChain;
+
+    return {
+        config: () => ({ stripe: { secret_key: 'sk_test_123', app_url: 'https://allplays.test' } }),
+        https: {
+            HttpsError,
+            onCall: (fn) => fn,
+            onRequest: (fn) => fn
+        },
+        firestore: {
+            document: () => triggerChain
+        },
+        pubsub: {
+            schedule: () => triggerChain
+        },
+        runWith: () => triggerChain,
+        logger: {
+            error: () => {},
+            warn: () => {},
+            info: () => {}
+        }
+    };
+}
+
+function installModuleStubs(firestore) {
+    adminStub = {
+        apps: [true],
+        initializeApp: () => {},
+        firestore: Object.assign(() => firestore, { FieldValue: firestore.FieldValue }),
+        auth: () => ({ verifyIdToken: async () => null }),
+        messaging: () => ({})
+    };
+    functionsStub = makeFunctionsStub();
+    StripeStub = class StripeMock {
+        constructor() {
+            return {
+                checkout: { sessions: { create: async () => ({}) } },
+                webhooks: { constructEvent: () => { throw new Error('Not implemented in test.'); } }
+            };
+        }
+    };
+}
+
+function loadSubmitPublicRegistration(seed) {
+    delete require.cache[repoIndexPath];
+    const firestore = makeFirestore(seed);
+    installModuleStubs(firestore);
+    const mod = require('../index.js');
+    return {
+        firestore,
+        submitPublicRegistration: mod.submitPublicRegistration
+    };
+}
+
+function buildSeedState(formOverrides = {}) {
+    return {
+        'teams/team-1/registrationForms/form-1': {
+            published: true,
+            programName: 'Summer Camp',
+            feeAmountCents: 5000,
+            currency: 'USD',
+            paymentSettings: { offlinePaymentEnabled: true },
+            participantFields: [{ id: 'playerName', label: 'Player name', required: true }],
+            guardianFields: [{ id: 'email', label: 'Email', required: true }],
+            waiverText: 'Waiver',
+            registrationOptions: [{ id: 'u10', title: 'U10', capacityLimit: 5, waitlistEnabled: true, active: true }],
+            registrationOptionCounts: {
+                u10: { enrolled: 0, waitlisted: 0 }
+            },
+            ...formOverrides
+        }
+    };
+}
+
+function buildSubmission(overrides = {}) {
+    return {
+        teamId: 'team-1',
+        formId: 'form-1',
+        participant: { playerName: 'Sam Player' },
+        guardian: { email: 'parent@example.com' },
+        waiverAccepted: true,
+        selectedOptionId: 'u10',
+        selectedPaymentPlanId: 'pay_full',
+        quantity: 1,
+        ...overrides
+    };
+}
+
+const context = {
+    rawRequest: {
+        ip: '203.0.113.10',
+        headers: {}
+    }
+};
+
+test.beforeEach(() => {
+    delete require.cache[repoIndexPath];
+    Module._load = patchedModuleLoad;
+    adminStub = null;
+    functionsStub = null;
+    StripeStub = null;
+});
+
+test.afterEach(() => {
+    delete require.cache[repoIndexPath];
+    Module._load = originalModuleLoad;
+    adminStub = null;
+    functionsStub = null;
+    StripeStub = null;
+});
+
+test('creates exactly one pending registration and reserves matching capacity', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+
+    const result = await submitPublicRegistration(buildSubmission(), context);
+
+    assert.equal(result.success, true);
+    assert.equal(result.status, 'pending');
+    assert.match(result.registrationId, /^auto-\d+$/);
+    assert.equal(result.feeSnapshot.finalAmountDueCents, 5000);
+
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registrations = firestore.registrationDocs();
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
+    assert.equal(form.registrationOptionCounts.u10.waitlisted, 0);
+    assert.equal(form.registrationCapacityUpdateId, result.registrationId);
+    assert.equal(registrations.length, 1);
+    assert.equal(registrations[0].data.status, 'pending');
+    assert.equal(registrations[0].data.source, 'public-registration');
+    assert.equal(registrations[0].data.selectedOption.countKey, 'u10');
+});
+
+test('rejects blocked capacity without creating a registration or changing counters', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState({
+        registrationOptions: [{ id: 'u10', title: 'U10', capacityLimit: 1, waitlistEnabled: false, active: true }],
+        registrationOptionCounts: {
+            u10: { enrolled: 1, waitlisted: 0 }
+        }
+    }));
+
+    await assert.rejects(
+        submitPublicRegistration(buildSubmission(), context),
+        (error) => {
+            assert.equal(error.code, 'failed-precondition');
+            assert.equal(error.details.reason, 'option-full');
+            return true;
+        }
+    );
+
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
+    assert.equal(form.registrationOptionCounts.u10.waitlisted, 0);
+    assert.equal(firestore.registrationDocs().length, 0);
+});
+
+test('throttles repeated anonymous submissions before reserving more capacity', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+    const input = buildSubmission();
+
+    await submitPublicRegistration(input, context);
+    await submitPublicRegistration(input, context);
+    await submitPublicRegistration(input, context);
+    const formBeforeThrottle = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registrationCountBeforeThrottle = firestore.registrationDocs().length;
+
+    await assert.rejects(
+        submitPublicRegistration(input, context),
+        (error) => {
+            assert.equal(error.code, 'resource-exhausted');
+            assert.equal(error.details.reason, 'rate-limited');
+            return true;
+        }
+    );
+
+    const formAfterThrottle = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(formAfterThrottle.registrationOptionCounts.u10.enrolled, formBeforeThrottle.registrationOptionCounts.u10.enrolled);
+    assert.equal(firestore.registrationDocs().length, registrationCountBeforeThrottle);
+});

--- a/registration.html
+++ b/registration.html
@@ -97,11 +97,10 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=19';
+        import { db, doc, getDoc, getFunctions, httpsCallable } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { cancelStripeRegistrationCheckout, initiateStripeCheckout } from './js/stripe-service.js';
         import {
-            buildPendingRegistrationRecord,
             calculateRegistrationFeeSnapshot,
             collectFieldValues,
             decideRegistrationPlacement,
@@ -527,9 +526,7 @@
                 confirmationMessage.classList.remove('hidden');
             } catch (error) {
                 console.error(error);
-                errorMessage.textContent = error.code === 'option-full'
-                    ? error.message
-                    : 'Registration could not be submitted. Please try again.';
+                errorMessage.textContent = getPublicRegistrationErrorMessage(error, 'Registration could not be submitted. Please try again.');
                 errorMessage.classList.remove('hidden');
                 submitButton.disabled = false;
                 spinner.classList.add('hidden');
@@ -538,62 +535,37 @@
         });
 
         async function submitRegistrationWithoutCapacity(submission) {
-            const registrationRef = await addDoc(collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations'), buildPendingRegistrationRecord({
-                form: activeForm,
-                ...submission,
-                now: serverTimestamp()
-            }));
-            return { status: 'pending', registrationId: registrationRef.id };
+            return submitRegistrationToServer(submission);
         }
 
         async function submitRegistrationWithCapacity(submission) {
-            const formRef = doc(db, 'teams', teamId, 'registrationForms', formId);
-            const registrationRef = doc(collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations'));
+            return submitRegistrationToServer(submission);
+        }
 
-            return runTransaction(db, async (transaction) => {
-                const formSnap = await transaction.get(formRef);
-                if (!formSnap.exists()) {
-                    throw new Error('Registration form could not be found.');
-                }
-
-                const formData = formSnap.data() || {};
-                const latestForm = normalizeRegistrationForm(formData, { teamId, formId });
-                const placement = decideRegistrationPlacement({
-                    form: latestForm,
-                    selectedOptionId: submission.selectedOptionId,
-                    counts: formData.registrationOptionCounts || {}
-                });
-
-                if (placement.status === 'blocked') {
-                    const error = new Error(placement.message);
-                    error.code = placement.reason === 'option-full' ? 'option-full' : 'invalid-option';
-                    throw error;
-                }
-
-                const optionCounts = formData.registrationOptionCounts || null;
-                const selectedCountKey = placement.selectedOption.countKey;
-                if (!optionCounts || typeof optionCounts !== 'object' || !optionCounts[selectedCountKey] || typeof optionCounts[selectedCountKey] !== 'object') {
-                    throw new Error('Registration form capacity tracking is not properly configured.');
-                }
-
-                const countPath = `registrationOptionCounts.${placement.selectedOption.countKey}`;
-                transaction.update(formRef, {
-                    [`${countPath}.enrolled`]: placement.nextCounts.enrolled,
-                    [`${countPath}.waitlisted`]: placement.nextCounts.waitlisted,
-                    registrationCapacityUpdateId: registrationRef.id,
-                    updatedAt: serverTimestamp()
-                });
-                transaction.set(registrationRef, buildPendingRegistrationRecord({
-                    form: latestForm,
-                    ...submission,
-                    selectedOption: placement.selectedOption,
-                    status: placement.status,
-                    feeSnapshot: calculateRegistrationFeeSnapshot(latestForm, { quantity: submission.feeSnapshot?.quantity || 1, now: new Date() }),
-                    now: serverTimestamp()
-                }));
-
-                return { status: placement.status, registrationId: registrationRef.id };
+        async function submitRegistrationToServer(submission) {
+            const functions = getFunctions();
+            const submitPublicRegistration = httpsCallable(functions, 'submitPublicRegistration');
+            const result = await submitPublicRegistration({
+                teamId,
+                formId,
+                participant: submission.participant,
+                guardian: submission.guardian,
+                waiverAccepted: submission.waiverAccepted,
+                selectedPaymentPlanId: submission.selectedPaymentPlanId,
+                selectedOptionId: submission.selectedOptionId,
+                quantity: submission.feeSnapshot?.quantity || 1,
+                checkoutAttemptToken: submission.checkoutAttemptToken || ''
             });
+            return result?.data || {};
+        }
+
+        function getPublicRegistrationErrorMessage(error, fallback) {
+            const details = error?.details || {};
+            const code = String(error?.code || '').replace(/^functions\//, '');
+            if (details.reason === 'option-full' || details.reason === 'missing-option' || code === 'failed-precondition' || code === 'invalid-argument' || code === 'resource-exhausted') {
+                return error?.message || fallback;
+            }
+            return fallback;
         }
 
         let preparedCheckoutRegistration = null;
@@ -737,7 +709,7 @@
                 }
             } catch (error) {
                 console.error('Stripe payment initiation error:', error);
-                showFormError('Failed to initiate payment. Please try again later.');
+                showFormError(getPublicRegistrationErrorMessage(error, 'Failed to initiate payment. Please try again later.'));
             } finally {
                 payRegistrationButton.disabled = false;
                 paymentLoadingState.classList.add('hidden');

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -50,6 +50,8 @@ const firebaseMocks = vi.hoisted(() => {
     let nextDocId = 1;
     return {
         db: { _is_mock_db_instance: true },
+        functions: { _is_mock_functions_instance: true },
+        httpsCallable: vi.fn(),
         serverTimestamp: vi.fn(() => ({ _serverTimestamp: true })),
         collection: vi.fn((db, ...segments) => ({ path: segments.join('/') })),
         getDoc: vi.fn(),
@@ -323,76 +325,35 @@ describe('React app parent tools service', () => {
             waiverAccepted: true,
             selectedOption: { id: 'opt-1', countKey: 'opt-1-key' },
             selectedPaymentPlanId: 'pay_full',
+            quantity: 2,
+            checkoutAttemptToken: 'attempt-token-123456',
             submittedAt: new Date(),
         };
-
-        const mockForm = {
-            id: formId,
-            teamId,
-            programName: 'Summer Camp',
-            registrationOptions: [
-                { id: 'opt-1', countKey: 'opt-1-key', capacityLimit: 10, waitlistEnabled: true, active: true },
-            ],
-            registrationOptionCounts: {
-                'opt-1-key': { enrolled: 9, waitlisted: 0 },
-            },
-        };
-
-        dbMocks.getDoc.mockImplementation((docRef) => {
-            if (docRef.path.includes(`teams/${teamId}/registrationForms/${formId}`)) {
-                return Promise.resolve({
-                    exists: () => true,
-                    data: () => mockForm,
-                    id: formId,
-                });
-            }
-            return Promise.resolve({ exists: () => false, data: () => null });
+        const submitPublicRegistration = vi.fn().mockResolvedValue({
+            data: { success: true, status: 'pending', registrationId: 'reg-1', feeSnapshot: { finalAmountDueCents: 5000 } }
         });
-
-        // Mock runTransaction
-        firebaseMocks.runTransaction.mockImplementation(async (db, updateFunction) => {
-            const mockTransaction = {
-                get: (docRef) => dbMocks.getDoc(docRef),
-                update: dbMocks.updateDoc,
-                set: dbMocks.setDoc,
-            };
-            return updateFunction(mockTransaction);
-        });
-
-        registrationMocks.decideRegistrationPlacement.mockReturnValue({
-            status: 'pending',
-            message: 'Placement pending',
-            selectedOption: { id: 'opt-1', countKey: 'opt-1-key' },
-            nextCounts: { enrolled: 10, waitlisted: 0 },
-        });
+        firebaseMocks.httpsCallable.mockReturnValue(submitPublicRegistration);
 
         const result = await submitOfflineRegistration(teamId, formId, registrationRecord);
 
-        expect(result).toEqual({ success: true, status: 'pending', registrationId: expect.any(String), feeSnapshot: expect.any(Object) });
-        expect(firebaseMocks.runTransaction).toHaveBeenCalledTimes(1);
-
-        // Verify that updateDoc was called on the formRef with updated counts
-        expect(dbMocks.updateDoc).toHaveBeenCalledWith(
-            expect.objectContaining({ path: `teams/${teamId}/registrationForms/${formId}` }),
+        expect(result).toEqual({ success: true, status: 'pending', registrationId: 'reg-1', feeSnapshot: { finalAmountDueCents: 5000 } });
+        expect(firebaseMocks.httpsCallable).toHaveBeenCalledWith(firebaseMocks.functions, 'submitPublicRegistration');
+        expect(submitPublicRegistration).toHaveBeenCalledWith(
             expect.objectContaining({
-                'registrationOptionCounts.opt-1-key.enrolled': 10,
-                'registrationOptionCounts.opt-1-key.waitlisted': 0,
-                registrationCapacityUpdateId: expect.any(String),
-                updatedAt: { _serverTimestamp: true },
-            })
-        );
-
-        // Verify that setDoc was called to add the new registration record
-        expect(dbMocks.setDoc).toHaveBeenCalledWith(
-            expect.objectContaining({ path: expect.stringContaining(`teams/${teamId}/registrationForms/${formId}/registrations/`) }),
-            expect.objectContaining({
+                teamId,
+                formId,
                 participant: registrationRecord.participant,
                 guardian: registrationRecord.guardian,
                 waiverAccepted: true,
-                selectedOption: expect.objectContaining({ id: 'opt-1' }),
-                status: 'pending',
+                selectedOptionId: 'opt-1',
+                selectedPaymentPlanId: 'pay_full',
+                quantity: 2,
+                checkoutAttemptToken: 'attempt-token-123456'
             })
         );
+        expect(firebaseMocks.runTransaction).not.toHaveBeenCalled();
+        expect(dbMocks.updateDoc).not.toHaveBeenCalled();
+        expect(dbMocks.setDoc).not.toHaveBeenCalled();
     });
 
     it('handles waitlisted placement correctly', async () => {
@@ -406,68 +367,24 @@ describe('React app parent tools service', () => {
             selectedPaymentPlanId: 'pay_full',
             submittedAt: new Date(),
         };
-
-        const mockForm = {
-            id: formId,
-            teamId,
-            programName: 'Summer Camp',
-            registrationOptions: [
-                { id: 'opt-1', countKey: 'opt-1-key', capacityLimit: 10, waitlistEnabled: true, active: true },
-            ],
-            registrationOptionCounts: {
-                'opt-1-key': { enrolled: 10, waitlisted: 0 }, // Form is full
-            },
-        };
-
-        dbMocks.getDoc.mockImplementation((docRef) => {
-            if (docRef.path.includes(`teams/${teamId}/registrationForms/${formId}`)) {
-                return Promise.resolve({
-                    exists: () => true,
-                    data: () => mockForm,
-                    id: formId,
-                });
-            }
-            return Promise.resolve({ exists: () => false, data: () => null });
+        const submitPublicRegistration = vi.fn().mockResolvedValue({
+            data: { success: true, status: 'waitlisted', registrationId: 'reg-waitlist', feeSnapshot: { finalAmountDueCents: 5000 } }
         });
-
-        firebaseMocks.runTransaction.mockImplementation(async (db, updateFunction) => {
-            const mockTransaction = {
-                get: (docRef) => dbMocks.getDoc(docRef),
-                update: dbMocks.updateDoc,
-                set: dbMocks.setDoc,
-            };
-            return updateFunction(mockTransaction);
-        });
-
-        registrationMocks.decideRegistrationPlacement.mockReturnValue({
-            status: 'waitlisted',
-            message: 'Placement waitlisted',
-            selectedOption: { id: 'opt-1', countKey: 'opt-1-key' },
-            nextCounts: { enrolled: 10, waitlisted: 1 },
-        });
+        firebaseMocks.httpsCallable.mockReturnValue(submitPublicRegistration);
 
         const result = await submitOfflineRegistration(teamId, formId, registrationRecord);
 
-        expect(result).toEqual({ success: true, status: 'waitlisted', registrationId: expect.any(String), feeSnapshot: expect.any(Object) });
-        expect(dbMocks.updateDoc).toHaveBeenCalledWith(
-            expect.objectContaining({ path: `teams/${teamId}/registrationForms/${formId}` }),
+        expect(result).toEqual({ success: true, status: 'waitlisted', registrationId: 'reg-waitlist', feeSnapshot: { finalAmountDueCents: 5000 } });
+        expect(submitPublicRegistration).toHaveBeenCalledWith(
             expect.objectContaining({
-                'registrationOptionCounts.opt-1-key.enrolled': 10,
-                'registrationOptionCounts.opt-1-key.waitlisted': 1,
-                registrationCapacityUpdateId: expect.any(String),
-                updatedAt: { _serverTimestamp: true },
+                teamId,
+                formId,
+                selectedOptionId: 'opt-1'
             })
         );
-        expect(dbMocks.setDoc).toHaveBeenCalledWith(
-            expect.any(Object),
-            expect.objectContaining({
-                participant: registrationRecord.participant,
-                guardian: registrationRecord.guardian,
-                waiverAccepted: true,
-                selectedOption: expect.objectContaining({ id: 'opt-1' }),
-                status: 'waitlisted',
-            })
-        );
+        expect(firebaseMocks.runTransaction).not.toHaveBeenCalled();
+        expect(dbMocks.updateDoc).not.toHaveBeenCalled();
+        expect(dbMocks.setDoc).not.toHaveBeenCalled();
     });
 
     it('throws an error if placement is blocked', async () => {
@@ -481,49 +398,22 @@ describe('React app parent tools service', () => {
             selectedPaymentPlanId: 'pay_full',
             submittedAt: new Date(),
         };
-
-        const mockForm = {
-            id: formId,
-            teamId,
-            programName: 'Summer Camp',
-            registrationOptions: [
-                { id: 'opt-2', countKey: 'opt-2-key', capacityLimit: 10, waitlistEnabled: false, active: true },
-            ],
-            registrationOptionCounts: {
-                'opt-2-key': { enrolled: 10, waitlisted: 0 }, // Form is full, no waitlist
-            },
-        };
-
-        dbMocks.getDoc.mockImplementation((docRef) => {
-            if (docRef.path.includes(`teams/${teamId}/registrationForms/${formId}`)) {
-                return Promise.resolve({
-                    exists: () => true,
-                    data: () => mockForm,
-                    id: formId,
-                });
-            }
-            return Promise.resolve({ exists: () => false, data: () => null });
-        });
-
-        firebaseMocks.runTransaction.mockImplementation(async (db, updateFunction) => {
-            const mockTransaction = {
-                get: (docRef) => dbMocks.getDoc(docRef),
-                update: dbMocks.updateDoc,
-                set: dbMocks.setDoc,
-            };
-            return updateFunction(mockTransaction);
-        });
-
-        registrationMocks.decideRegistrationPlacement.mockReturnValue({
-            status: 'blocked',
+        const submitPublicRegistration = vi.fn().mockRejectedValue({
+            code: 'functions/failed-precondition',
+            details: { reason: 'option-full' },
             message: 'Option is full and not accepting waitlist registrations.',
-            selectedOption: { id: 'opt-2', countKey: 'opt-2-key' },
-            nextCounts: { enrolled: 10, waitlisted: 0 },
         });
+        firebaseMocks.httpsCallable.mockReturnValue(submitPublicRegistration);
 
         await expect(submitOfflineRegistration(teamId, formId, registrationRecord)).rejects.toThrow(
             'Option is full and not accepting waitlist registrations.'
         );
+        expect(submitPublicRegistration).toHaveBeenCalledWith(expect.objectContaining({
+            teamId,
+            formId,
+            selectedOptionId: 'opt-2'
+        }));
+        expect(firebaseMocks.runTransaction).not.toHaveBeenCalled();
         expect(dbMocks.updateDoc).not.toHaveBeenCalled();
         expect(dbMocks.setDoc).not.toHaveBeenCalled();
     });

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -347,10 +347,10 @@ describe('public registration flow', () => {
         });
     });
 
-    it('wires registration page to public form reads and pending registration writes', () => {
+    it('wires registration page to public form reads and server-owned pending registration submission', () => {
         const page = fs.readFileSync('registration.html', 'utf8');
         expect(page).toContain("doc(db, 'teams', teamId, 'registrationForms', formId)");
-        expect(page).toContain("collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations')");
+        expect(page).not.toContain("collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations')");
         expect(page).toContain('registration-options-section');
         expect(page).toContain('registration-payment-section');
         expect(page).toContain('getRegistrationPaymentNotice');
@@ -375,8 +375,10 @@ describe('public registration flow', () => {
         expect(page).toContain('preparedCheckoutRegistration = { retryKey, result, checkoutAttemptToken };');
         expect(page).toContain('await releaseCancelledStripeRegistration(result.registrationId, checkoutAttemptToken);');
         expect(page).toContain('preparedCheckoutRegistration = null;');
-        expect(page).toContain('return { status: \'pending\', registrationId: registrationRef.id };');
-        expect(page).toContain('return { status: placement.status, registrationId: registrationRef.id };');
+        expect(page).toContain("httpsCallable(functions, 'submitPublicRegistration')");
+        expect(page).toContain('return result?.data || {};');
+        expect(page).toContain('getPublicRegistrationErrorMessage');
+        expect(page).toContain("code === 'resource-exhausted'");
         expect(page).toContain("paymentLoadingState.classList.add('hidden');");
         expect(page).toContain('cancelStripeRegistrationCheckout({ teamId, formId, registrationId, checkoutAttemptToken, publicCheckoutCapability });');
         expect(page).toContain('releaseCancelledStripeRegistration(cancelledRegistrationId, cancelledCheckoutAttemptToken, cancelledPublicCheckoutCapability)');
@@ -384,10 +386,9 @@ describe('public registration flow', () => {
         expect(page).toContain('? preparedCheckoutRegistration.checkoutAttemptToken');
         expect(page).toContain(': createCheckoutAttemptToken();');
         expect(page).toContain('checkoutAttemptToken,');
-        expect(page).toContain('runTransaction(db, async (transaction)');
+        expect(page).not.toContain('runTransaction(db, async (transaction)');
+        expect(page).not.toContain('addDoc(');
         expect(page).toContain('decideRegistrationPlacement');
-        expect(page).toContain('registrationCapacityUpdateId: registrationRef.id');
-        expect(page).toContain('Registration form capacity tracking is not properly configured.');
         expect(page).toContain('option-full');
         expect(page).toContain('waiver-accepted');
         expect(page).toContain('confirmation-message');
@@ -397,9 +398,9 @@ describe('public registration flow', () => {
 
         const rules = fs.readFileSync('firestore.rules', 'utf8');
         expect(rules).toContain('match /registrationForms/{formId}');
-        expect(rules).toContain('allow create: if (');
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId);');
+        expect(rules).toContain("allow create: if isTeamOwnerOrAdmin(teamId) && request.resource.data.status == 'pending';");
         expect(rules).toContain('function registrationFormPath(teamId, formId)');
-        expect(rules).toContain('isPublishedRegistrationForm(get(formPath).data)');
         expect(rules).toContain("data.status in ['pending', 'waitlisted']");
         expect(rules).toContain("'paymentSettings'");
         expect(rules).toContain("'selectedOption'");
@@ -413,12 +414,9 @@ describe('public registration flow', () => {
         expect(rules).toContain("!data.keys().hasAny(['screeningRequired', 'screeningStatus', 'screeningProvider', 'screeningProviderReference'])");
         expect(rules).toContain("data.screeningStatus == get(registrationFormPath(teamId, formId)).data.get('backgroundCheck', {}).get('initialScreeningStatus', 'pending')");
         expect(rules).toContain('isRegistrationFeeSnapshotValid');
-        expect(rules).toContain('isPublicRegistrationCapacityCounterUpdate');
-        expect(rules).toContain('registrationCapacityUpdateId');
-        expect(rules).toContain('existsAfter(registrationPath)');
-        expect(rules).toContain('isPublicPendingRegistrationCreate(teamId, formId, registrationId)');
-        expect(rules).toContain("affectedKeys().hasOnly(['registrationOptionCounts', 'registrationCapacityUpdateId', 'updatedAt'])");
-        expect(rules).toContain("afterOption.diff(beforeOption).affectedKeys().hasOnly(['enrolled', 'waitlisted'])");
+        expect(rules).not.toContain('isPublicRegistrationCapacityCounterUpdate');
+        expect(rules).not.toContain('isPublicPendingRegistrationCreate');
+        expect(rules).not.toContain('existsAfter(registrationPath)');
         expect(rules).toContain('data.waiverAccepted == true');
         expect(rules).toContain('hasOnlyFlatStringValues(data.participant)');
         expect(rules).toContain('hasOnlyFlatStringValues(data.guardian)');
@@ -725,7 +723,7 @@ describe('public registration flow', () => {
     it('omits raw registration identifiers from public Stripe return URLs', () => {
         const functionsSource = fs.readFileSync('functions/index.js', 'utf8');
         const urlBuilderStart = functionsSource.indexOf('function buildRegistrationCheckoutUrls');
-        const urlBuilderEnd = functionsSource.indexOf('function isServerDiscountRuleEligible');
+        const urlBuilderEnd = functionsSource.indexOf('function normalizePublicRegistrationInput');
         const urlBuilder = functionsSource.slice(urlBuilderStart, urlBuilderEnd);
         const page = fs.readFileSync('registration.html', 'utf8');
 


### PR DESCRIPTION
## Summary
- Move public registration creation and capacity reservation into a server-controlled `submitPublicRegistration` callable.
- Remove anonymous/public Firestore rule paths that allowed direct registration doc creates and `registrationOptionCounts` updates.
- Update legacy and app registration clients to call the server endpoint and surface function errors, including throttling.
- Add focused function coverage for success, blocked capacity, and throttled submissions without extra counter writes.

Closes #2913

## Tests
- `npx vitest run tests/unit/registration-flow.test.js --reporter=verbose`
- `npm test --prefix functions`
- `npm run ci:firebase-rules`
- `npx vitest run tests/unit/app-parent-tools-service.test.js --reporter=verbose`
- `npm --prefix apps/app run typecheck`