### PR TITLE
[codex] Default unmatched statsheet rows to review

### DIFF
--- a/apps/app/src/lib/statsheetImportService.test.ts
+++ b/apps/app/src/lib/statsheetImportService.test.ts
@@ -69,13 +69,52 @@ describe('buildTrackStatsheetReviewModel', () => {
 
     expect(review.shouldSwap).toBe(true)
     expect(review.homeRows).toEqual([
-      expect.objectContaining({ number: '12', name: 'Avery Smith', mappedPlayerId: 'p1', totalPoints: 10, fouls: 3 })
+      expect.objectContaining({ number: '12', name: 'Avery Smith', include: true, mappedPlayerId: 'p1', totalPoints: 10, fouls: 3 })
     ])
     expect(review.visitorRows).toEqual([
       expect.objectContaining({ number: '99', name: 'Unknown', mappedPlayerId: '' })
     ])
     expect(review.homeScore).toBe(41)
     expect(review.awayScore).toBe(53)
+  })
+
+  it('defaults unmatched home rows to review-only while including unique roster matches', () => {
+    const review = buildTrackStatsheetReviewModel({
+      scores: { homeFinal: 19, visitorFinal: 24 },
+      homePlayers: [
+        { number: '12', name: 'Avery Smith', totalPoints: 10, fouls: 3 },
+        { number: '55', name: 'Mystery Player', totalPoints: 7, fouls: 1 }
+      ],
+      visitorPlayers: [{ number: '10', name: 'River Stone', totalPoints: 24, fouls: 2 }]
+    }, [
+      { id: 'p1', number: '12', name: 'Avery Smith' },
+      { id: 'p2', number: '5', name: 'Mia Diaz' }
+    ])
+
+    expect(review.homeRows).toEqual([
+      expect.objectContaining({ name: 'Avery Smith', include: true, mappedPlayerId: 'p1' }),
+      expect.objectContaining({ name: 'Mystery Player', include: false, mappedPlayerId: '' })
+    ])
+    expect(review.visitorRows).toEqual([
+      expect.objectContaining({ name: 'River Stone', include: true, mappedPlayerId: '' })
+    ])
+  })
+
+  it('leaves all home rows review-only when no unique roster matches are found', () => {
+    const review = buildTrackStatsheetReviewModel({
+      homePlayers: [
+        { number: '55', name: 'Mystery Player', totalPoints: 7, fouls: 1 },
+        { number: '56', name: 'Unknown Guard', totalPoints: 4, fouls: 0 }
+      ]
+    }, [
+      { id: 'p1', number: '12', name: 'Avery Smith' }
+    ])
+
+    expect(review.homeMatches).toBe(0)
+    expect(review.homeRows).toEqual([
+      expect.objectContaining({ name: 'Mystery Player', include: false, mappedPlayerId: '' }),
+      expect.objectContaining({ name: 'Unknown Guard', include: false, mappedPlayerId: '' })
+    ])
   })
 })
 
@@ -111,7 +150,9 @@ describe('analyzeTrackStatsheetPhoto', () => {
       homeMatches: 0,
       visitorMatches: 0
     })
-    expect(warnSpy).toHaveBeenCalledWith('[statsheetImportService] Failed to parse AI response', expect.any(SyntaxError))
+    expect(warnSpy).toHaveBeenCalledWith('[statsheetImportService] Failed to parse AI response.', expect.objectContaining({
+      error: expect.objectContaining({ name: 'SyntaxError' })
+    }))
 
     warnSpy.mockRestore()
     globalThis.FileReader = originalFileReader
@@ -119,6 +160,23 @@ describe('analyzeTrackStatsheetPhoto', () => {
 })
 
 describe('applyTrackStatsheetImportForApp', () => {
+  it('prevents saving when every home row is still review-only', async () => {
+    await expect(applyTrackStatsheetImportForApp({
+      teamId: 'team-1',
+      gameId: 'game-1',
+      roster: [{ id: 'p1', name: 'Avery Smith', number: '12' }],
+      columns: ['PTS'],
+      homeRows: [{ number: '55', name: 'Mystery Player', fouls: 1, totalPoints: 7, include: false, mappedPlayerId: '' }],
+      visitorRows: [],
+      homeScore: 7,
+      awayScore: 0,
+      file: null
+    })).rejects.toThrow('Please review or map at least one home player before applying.')
+
+    expect(firebaseMocks.getDocs).not.toHaveBeenCalled()
+    expect(firebaseMocks.writeBatch).not.toHaveBeenCalled()
+  })
+
   it('returns a replacement confirmation instead of writing over existing game data', async () => {
     firebaseMocks.getDocs
       .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'event-1' } }] })

--- a/apps/app/src/lib/statsheetImportService.ts
+++ b/apps/app/src/lib/statsheetImportService.ts
@@ -142,6 +142,7 @@ export function autoAssignTrackStatsheetRosterMatches(rows: TrackStatsheetReview
     }
     return {
       ...row,
+      include: Boolean(mappedPlayerId),
       mappedPlayerId
     }
   })

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -2911,6 +2911,124 @@ describe('ScheduleEventDetail statsheet import', () => {
     });
   });
 
+  it('applies matched statsheet rows while leaving unmatched rows available for manual mapping', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamStaff: true, canUpdateScore: true })],
+      children: []
+    });
+    statsheetImportServiceMocks.loadTrackStatsheetContextForApp.mockResolvedValue({
+      roster: [
+        { id: 'p1', name: 'Avery Smith', number: '12' },
+        { id: 'p2', name: 'Mia Diaz', number: '5' }
+      ],
+      config: { columns: ['PTS'] }
+    });
+    statsheetImportServiceMocks.analyzeTrackStatsheetPhoto.mockResolvedValue({
+      homeRows: [
+        { number: '12', name: 'Avery Smith', fouls: 1, totalPoints: 10, include: true, mappedPlayerId: 'p1' },
+        { number: '55', name: 'Mystery Player', fouls: 2, totalPoints: 7, include: false, mappedPlayerId: '' }
+      ],
+      visitorRows: [],
+      homeScore: 17,
+      awayScore: 8,
+      shouldSwap: false,
+      homeMatches: 1,
+      visitorMatches: 0
+    });
+    statsheetImportServiceMocks.applyTrackStatsheetImportForApp.mockResolvedValue({
+      requiresReplaceConfirmation: false,
+      uploadedPhotoUrl: 'https://img.test/statsheet.png'
+    });
+
+    const rendered = renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Statsheet import' }));
+
+    const fileInput = rendered.container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [new File(['sheet'], 'statsheet.png', { type: 'image/png' })] } });
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze photo' }));
+
+    const panel = await screen.findByTestId('statsheet-import-panel');
+    await screen.findByLabelText('Home player 2 roster match');
+    const includeInputs = within(panel).getAllByLabelText('Include') as HTMLInputElement[];
+    expect(includeInputs[0].checked).toBe(true);
+    expect(includeInputs[1].checked).toBe(false);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to game' }));
+
+    await waitFor(() => {
+      expect(statsheetImportServiceMocks.applyTrackStatsheetImportForApp).toHaveBeenCalledWith(expect.objectContaining({
+        homeRows: [
+          expect.objectContaining({ name: 'Avery Smith', include: true, mappedPlayerId: 'p1' }),
+          expect.objectContaining({ name: 'Mystery Player', include: false, mappedPlayerId: '' })
+        ]
+      }));
+    });
+  });
+
+  it('lets coaches manually include and map a review-only statsheet row before applying', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamStaff: true, canUpdateScore: true })],
+      children: []
+    });
+    statsheetImportServiceMocks.loadTrackStatsheetContextForApp.mockResolvedValue({
+      roster: [
+        { id: 'p1', name: 'Avery Smith', number: '12' },
+        { id: 'p2', name: 'Mia Diaz', number: '5' }
+      ],
+      config: { columns: ['PTS'] }
+    });
+    statsheetImportServiceMocks.analyzeTrackStatsheetPhoto.mockResolvedValue({
+      homeRows: [
+        { number: '12', name: 'Avery Smith', fouls: 1, totalPoints: 10, include: true, mappedPlayerId: 'p1' },
+        { number: '55', name: 'Mystery Player', fouls: 2, totalPoints: 7, include: false, mappedPlayerId: '' }
+      ],
+      visitorRows: [],
+      homeScore: 17,
+      awayScore: 8,
+      shouldSwap: false,
+      homeMatches: 1,
+      visitorMatches: 0
+    });
+    statsheetImportServiceMocks.applyTrackStatsheetImportForApp.mockResolvedValue({
+      requiresReplaceConfirmation: false,
+      uploadedPhotoUrl: 'https://img.test/statsheet.png'
+    });
+
+    const rendered = renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Statsheet import' }));
+
+    const fileInput = rendered.container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [new File(['sheet'], 'statsheet.png', { type: 'image/png' })] } });
+    fireEvent.click(screen.getByRole('button', { name: 'Analyze photo' }));
+
+    const panel = await screen.findByTestId('statsheet-import-panel');
+    await screen.findByLabelText('Home player 2 roster match');
+    const includeInputs = within(panel).getAllByLabelText('Include') as HTMLInputElement[];
+    fireEvent.click(includeInputs[1]);
+    fireEvent.change(screen.getByLabelText('Home player 2 roster match'), { target: { value: 'p2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply to game' }));
+
+    await waitFor(() => {
+      expect(statsheetImportServiceMocks.applyTrackStatsheetImportForApp).toHaveBeenCalledTimes(1);
+    });
+    expect(statsheetImportServiceMocks.applyTrackStatsheetImportForApp).toHaveBeenCalledWith(expect.objectContaining({
+      homeRows: [
+        expect.objectContaining({ name: 'Avery Smith', include: true, mappedPlayerId: 'p1' }),
+        expect.objectContaining({ name: 'Mystery Player', include: true, mappedPlayerId: 'p2', totalPoints: 7, fouls: 2 })
+      ]
+    }));
+  });
+
   it('stops retrying when replacement confirmation keeps being required', async () => {
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({

--- a/js/track-statsheet-apply.js
+++ b/js/track-statsheet-apply.js
@@ -14,7 +14,7 @@ export function validateTrackStatsheetApplyRows(homeRows = []) {
     if (includedHome.length === 0) {
         return {
             ok: false,
-            alertMessage: 'Please include at least one home player.'
+            alertMessage: 'Please review or map at least one home player before applying.'
         };
     }
 

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -643,24 +643,38 @@ test('defers score and side controls until statsheet analysis completes', async 
     await expect(page.locator('#visitor-score-input')).toHaveValue('24');
 });
 
-test('blocks apply until every included home row is mapped, then saves report data', async ({ page, baseURL }) => {
+test('applies matched rows while unmatched home rows stay available for review', async ({ page, baseURL }) => {
     await seedScenario(page, baseURL, createScenario());
     await analyzeStatsheet(page, baseURL);
 
-    await page.locator('#apply-btn').click();
+    const unmatchedRow = page.locator('#home-rows tr').nth(1);
+    await expect(unmatchedRow.locator('input[data-field="include"]')).not.toBeChecked();
+    await expect(unmatchedRow.locator('select[data-field="mappedPlayerId"]')).toHaveValue('');
 
-    const blockedState = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
-    expect(blockedState.alerts).toContain('Please map every included home row to a roster player or uncheck it.');
-    expect(blockedState.commitCalls).toBe(0);
-
-    await page.locator('#home-rows tr').nth(1).locator('select[data-field="mappedPlayerId"]').selectOption('p2');
     await page.locator('#apply-btn').click();
 
     await expect(page.locator('#apply-status')).toHaveText('Stats saved! Now you can add a game summary.');
     await expect(page.locator('#summary-section')).not.toHaveClass(/hidden/);
     await expect(page.locator('#apply-btn')).toBeVisible();
 
+    const matchedOnlyState = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(matchedOnlyState.alerts || []).not.toContain('Please map every included home row to a roster player or uncheck it.');
+    expect(matchedOnlyState.commitCalls).toBe(1);
+    expect(matchedOnlyState.aggregatedStats).toEqual({
+        p1: {
+            playerName: 'Ava Cole',
+            playerNumber: '3',
+            participated: true,
+            participationStatus: 'appeared',
+            participationSource: 'statsheet-import',
+            stats: { pts: 12, fouls: 2 }
+        }
+    });
+
+    await unmatchedRow.locator('input[data-field="include"]').check();
+    await unmatchedRow.locator('select[data-field="mappedPlayerId"]').selectOption('p2');
     await page.locator('#home-score-input').fill('21');
+
     await page.locator('#apply-btn').click();
     await expect(page.locator('#apply-status')).toHaveText('Stats saved! Now you can add a game summary.');
 
@@ -694,6 +708,35 @@ test('blocks apply until every included home row is mapped, then saves report da
         statsheet_2: { name: 'Kai North', number: '11', pts: 9, fouls: 2 }
     });
 
+});
+
+test('prevents apply when analysis finds no uniquely matched home rows', async ({ page, baseURL }) => {
+    await seedScenario(page, baseURL, createScenario({
+        aiResponse: {
+            homePlayers: [
+                { number: '55', name: 'Mystery Player', totalPoints: 7, fouls: 1 },
+                { number: '56', name: 'Unknown Guard', totalPoints: 4, fouls: 0 }
+            ],
+            visitorPlayers: [
+                { number: '10', name: 'River Stone', totalPoints: 11, fouls: 2 }
+            ],
+            scores: {
+                homeFinal: 11,
+                visitorFinal: 11
+            }
+        }
+    }));
+    await analyzeStatsheet(page, baseURL);
+
+    await expect(page.locator('#home-rows input[data-field="include"]')).toHaveCount(2);
+    await expect(page.locator('#home-rows input[data-field="include"]').first()).not.toBeChecked();
+    await expect(page.locator('#home-rows input[data-field="include"]').nth(1)).not.toBeChecked();
+
+    await page.locator('#apply-btn').click();
+
+    const savedState = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(savedState.alerts).toContain('Please review or map at least one home player before applying.');
+    expect(savedState.commitCalls).toBe(0);
 });
 
 test('keeps zero-stat statsheet import appearances in player history', async ({ page, baseURL }) => {
@@ -759,6 +802,7 @@ test('respects overwrite confirmation and renders rewritten stats on the game re
     }));
 
     await analyzeStatsheet(page, baseURL);
+    await page.locator('#home-rows tr').nth(1).locator('input[data-field="include"]').check();
     await page.locator('#home-rows tr').nth(1).locator('select[data-field="mappedPlayerId"]').selectOption('p2');
 
     await page.locator('#apply-btn').click();

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -7,6 +7,27 @@ import {
 } from '../../js/track-statsheet-apply.js';
 
 describe('track statsheet apply helpers', () => {
+    it('allows excluded unmatched home rows when included rows are mapped', () => {
+        expect(validateTrackStatsheetApplyRows([
+            { include: true, mappedPlayerId: 'p1' },
+            { include: false, mappedPlayerId: '' }
+        ])).toEqual({
+            ok: true,
+            includedHome: [
+                { include: true, mappedPlayerId: 'p1' }
+            ]
+        });
+    });
+
+    it('blocks apply when no home row is included for saving', () => {
+        expect(validateTrackStatsheetApplyRows([
+            { include: false, mappedPlayerId: '' }
+        ])).toEqual({
+            ok: false,
+            alertMessage: 'Please review or map at least one home player before applying.'
+        });
+    });
+
     it('blocks apply when included home rows are still unmatched', () => {
         expect(validateTrackStatsheetApplyRows([
             { include: true, mappedPlayerId: 'p1' },

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -205,7 +205,7 @@
     import { checkAuth } from './js/auth.js?v=33';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
     import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=7';
-    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=3';
+    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=4';
     import { getApp } from './js/vendor/firebase-app.js';
     import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
@@ -379,6 +379,7 @@
         if (next.mappedPlayerId) {
           usedIds.add(next.mappedPlayerId);
         }
+        next.include = Boolean(next.mappedPlayerId);
         return next;
       });
     }


### PR DESCRIPTION
## Summary
- Default auto-assigned home statsheet rows to included only when a unique roster match is found.
- Leave unmatched home rows visible with Include off so Apply can save matched rows without a validation block.
- Keep the zero-matched-home-row guard by prompting scorekeepers to review or map at least one home player.
- Cover manual include + roster mapping in legacy smoke and app interaction tests.

Fixes #2967

## Validation
- `npx vitest run tests/unit/track-statsheet-apply.test.js apps/app/src/lib/statsheetImportService.test.ts --reporter=verbose`
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx -t "ScheduleEventDetail statsheet import" --reporter=verbose`
- `python3 -m http.server 4173 --bind 127.0.0.1`
- `npx playwright test tests/smoke/track-statsheet-apply.spec.js --config=playwright.smoke.config.js --reporter=line`
- `npm run app:build`