### PR TITLE
[codex] Validate roster CSV contact conflicts

### DIFF
--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -433,14 +433,18 @@ function collectContactIdentityConflictErrors(contacts = [], rowNumber = 0) {
     const checkIdentity = (seen, identityField, identityLabel, contact) => {
         const identityValue = normalizeContactConflictValue(contact[identityField]);
         if (!identityValue) return;
-        const existing = seen.get(identityValue);
-        if (!existing) {
-            seen.set(identityValue, contact);
+        const existingContacts = seen.get(identityValue) || [];
+        if (existingContacts.length === 0) {
+            seen.set(identityValue, [contact]);
             return;
         }
-        const conflictFields = getContactConflictFields(existing, contact, identityField);
-        if (conflictFields.length === 0) return;
-        errors.push(`Row ${rowNumber}: contact ${identityLabel} ${identityValue} has conflicting ${conflictFields.join('/')} values (${describeContactConflict(existing)} vs ${describeContactConflict(contact)}).`);
+        for (const existing of existingContacts) {
+            const conflictFields = getContactConflictFields(existing, contact, identityField);
+            if (conflictFields.length === 0) continue;
+            errors.push(`Row ${rowNumber}: contact ${identityLabel} ${identityValue} has conflicting ${conflictFields.join('/')} values (${describeContactConflict(existing)} vs ${describeContactConflict(contact)}).`);
+            break;
+        }
+        existingContacts.push(contact);
     };
 
     contacts.forEach((contact) => {

--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -406,6 +406,51 @@ function getContactDedupeKey(contact = {}) {
     return `name:${String(contact.name || '').trim().toLowerCase()}:${String(contact.relation || '').trim().toLowerCase()}`;
 }
 
+function normalizeContactConflictValue(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function describeContactConflict(contact = {}) {
+    const name = String(contact.name || contact.email || contact.phone || 'unnamed contact').trim();
+    const relation = String(contact.relation || '').trim();
+    return relation ? `${name} (${relation})` : name;
+}
+
+function getContactConflictFields(existing = {}, candidate = {}, identityField = '') {
+    return ['name', 'relation', 'email', 'phone'].filter((field) => {
+        if (field === identityField) return false;
+        const existingValue = normalizeContactConflictValue(existing[field]);
+        const candidateValue = normalizeContactConflictValue(candidate[field]);
+        return existingValue && candidateValue && existingValue !== candidateValue;
+    });
+}
+
+function collectContactIdentityConflictErrors(contacts = [], rowNumber = 0) {
+    const errors = [];
+    const seenByEmail = new Map();
+    const seenByPhone = new Map();
+
+    const checkIdentity = (seen, identityField, identityLabel, contact) => {
+        const identityValue = normalizeContactConflictValue(contact[identityField]);
+        if (!identityValue) return;
+        const existing = seen.get(identityValue);
+        if (!existing) {
+            seen.set(identityValue, contact);
+            return;
+        }
+        const conflictFields = getContactConflictFields(existing, contact, identityField);
+        if (conflictFields.length === 0) return;
+        errors.push(`Row ${rowNumber}: contact ${identityLabel} ${identityValue} has conflicting ${conflictFields.join('/')} values (${describeContactConflict(existing)} vs ${describeContactConflict(contact)}).`);
+    };
+
+    contacts.forEach((contact) => {
+        checkIdentity(seenByEmail, 'email', 'email', contact);
+        checkIdentity(seenByPhone, 'phone', 'phone', contact);
+    });
+
+    return errors;
+}
+
 function mergeImportedContacts(existingContacts = [], importedContacts = []) {
     const merged = [];
     const seen = new Set();
@@ -438,6 +483,7 @@ function buildRosterCsvContactPlan(contactValues = new Map(), rowNumber = 0) {
         }
     });
     const familyContacts = [...guardians, ...contacts];
+    errors.push(...collectContactIdentityConflictErrors(familyContacts, rowNumber));
     const inviteRequests = familyContacts
         .filter((contact) => contact.email)
         .map((contact) => ({

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -328,6 +328,21 @@ describe('roster CSV import planning', () => {
         ]);
     });
 
+    it('compares populated duplicate contacts after a sparse duplicate identity', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            csvText: [
+                'Name,Parent Email,Parent 2 Name,Parent 2 Email,Parent 3 Name,Parent 3 Email',
+                'Avery Lee,family@example.com,Pat Lee,family@example.com,Robin Lee,family@example.com'
+            ].join('\n')
+        });
+
+        expect(plan.operations).toEqual([]);
+        expect(plan.errors).toEqual([
+            'Row 2: contact email family@example.com has conflicting name values (Pat Lee (Parent) vs Robin Lee (Parent)).'
+        ]);
+    });
+
     it('merges imported guardian contacts onto existing player updates without duplicates', () => {
         const plan = planRosterCsvImport({
             fields,

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -312,6 +312,22 @@ describe('roster CSV import planning', () => {
         expect(plan.operations).toEqual([]);
     });
 
+    it('rejects contact identity conflicts within a CSV row', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            csvText: [
+                'Name,Parent Name,Parent Email,Guardian Name,Guardian Email,Contact Name,Contact Phone,Emergency Contact Name,Emergency Contact Phone',
+                'Avery Lee,Pat Lee,family@example.com,Robin Lee,family@example.com,Aunt Kim,555-0101,Uncle Kim,555-0101'
+            ].join('\n')
+        });
+
+        expect(plan.operations).toEqual([]);
+        expect(plan.errors).toEqual([
+            'Row 2: contact email family@example.com has conflicting name/relation values (Pat Lee (Parent) vs Robin Lee (Guardian)).',
+            'Row 2: contact phone 555-0101 has conflicting name/relation values (Aunt Kim (Contact) vs Uncle Kim (Emergency Contact)).'
+        ]);
+    });
+
     it('merges imported guardian contacts onto existing player updates without duplicates', () => {
         const plan = planRosterCsvImport({
             fields,


### PR DESCRIPTION
## Summary
- Add same-row conflict validation for imported roster CSV family contacts when an email or phone maps to inconsistent contact details.
- Keep the slice bounded to the legacy roster CSV import planner and its unit coverage; no roster AI import or TeamDetail app code touched.
- Preserve the existing parsed parent/guardian/contact plan behavior while rejecting ambiguous contact rows before writes run.

Refs #959

## Validation
- `npx vitest run tests/unit/roster-csv-import.test.js --reporter=verbose`

## Remaining work
- Bulk invite sending is still out of scope; `inviteRequests` remains parsed review metadata for a follow-up PR.
- Add review UI and batch invite/resend status handling for the full #959 workflow.