### PR TITLE
[codex] Add athlete profile media drafts

### DIFF
--- a/apps/app/src/lib/playerService.test.ts
+++ b/apps/app/src/lib/playerService.test.ts
@@ -79,7 +79,13 @@ const appDataCacheMocks = vi.hoisted(() => ({
 
 vi.mock('./appDataCache', () => appDataCacheMocks);
 
-import { loadParentPlayerDetail, saveParentAthleteProfileDraft, savePlayerCustomRosterFieldValues, saveStaffPlayerRosterDetails } from './playerService';
+import {
+  loadParentPlayerDetail,
+  normalizeAthleteProfileHighlightClipUrl,
+  saveParentAthleteProfileDraft,
+  savePlayerCustomRosterFieldValues,
+  saveStaffPlayerRosterDetails
+} from './playerService';
 
 describe('saveParentAthleteProfileDraft', () => {
   beforeEach(() => {
@@ -154,7 +160,7 @@ describe('saveParentAthleteProfileDraft', () => {
         bio: {},
         privacy: 'public',
         profilePhoto: null,
-        clips: [{ id: 'existing-clip', title: 'Existing clip' }]
+        clips: [{ id: 'existing-clip', source: 'external', mediaType: 'link', title: 'Existing clip', url: 'https://video.example/existing' }]
       },
       profilePhotoFile: headshot,
       highlightClipFile: clip,
@@ -173,7 +179,13 @@ describe('saveParentAthleteProfileDraft', () => {
           mediaType: 'image'
         }),
         clips: [
-          { id: 'existing-clip', title: 'Existing clip' },
+          expect.objectContaining({
+            id: 'existing-clip',
+            source: 'external',
+            mediaType: 'link',
+            title: 'Existing clip',
+            url: 'https://video.example/existing'
+          }),
           expect.objectContaining({
             source: 'upload',
             mediaType: 'video',
@@ -266,6 +278,189 @@ describe('saveParentAthleteProfileDraft', () => {
     })).rejects.toThrow('Choose a highlight clip under 100 MB.');
 
     expect(legacyPlayerDbMocks.uploadAthleteProfileMedia).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.saveAthleteProfile).not.toHaveBeenCalled();
+  });
+
+  it('saves ordered legacy-compatible clip lists with add remove reorder and upload placeholders', async () => {
+    const clip = new File(['clip-data'], 'putback.mp4', { type: 'video/mp4' });
+    legacyPlayerDbMocks.uploadAthleteProfileMedia.mockResolvedValueOnce({
+      url: 'https://cdn.example.com/putback.mp4',
+      storagePath: 'athlete-profile-media/parent-1/profile-1/putback.mp4',
+      mediaType: 'video',
+      mimeType: 'video/mp4',
+      sizeBytes: clip.size,
+      uploadedAtMs: 300
+    });
+    legacyPlayerDbMocks.saveAthleteProfile.mockImplementation(async (_userId, nextDraft, options) => ({
+      id: options.profileId,
+      ...nextDraft
+    }));
+
+    await saveParentAthleteProfileDraft({
+      user: {
+        uid: 'parent-1',
+        parentOf: [{ teamId: 'team-current', playerId: 'player-current' }]
+      } as any,
+      teamId: 'team-current',
+      playerId: 'player-current',
+      profileId: 'profile-1',
+      draft: {
+        athlete: { name: 'Sam Player' },
+        bio: {},
+        privacy: 'private',
+        clips: [
+          {
+            id: 'clip-youtube',
+            source: 'external',
+            mediaType: 'link',
+            title: 'Corner three',
+            label: 'Semifinal',
+            url: ' https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s '
+          },
+          {
+            id: 'clip-upload-new',
+            source: 'upload',
+            mediaType: 'video',
+            title: 'Putback',
+            label: 'Finals',
+            pendingUpload: true
+          },
+          {
+            id: 'clip-kept',
+            source: 'upload',
+            mediaType: 'video',
+            title: 'Existing kept clip',
+            label: '',
+            url: 'https://cdn.example.com/kept.mp4',
+            storagePath: 'athlete-profile-media/parent-1/profile-1/kept.mp4',
+            mimeType: 'video/mp4',
+            sizeBytes: 2048,
+            uploadedAtMs: 100
+          }
+        ]
+      },
+      highlightClipUploads: [{ id: 'clip-upload-new', file: clip, title: 'Putback', label: 'Finals' }]
+    });
+
+    expect(legacyPlayerDbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('parent-1', 'profile-1', clip, { kind: 'clip' });
+    expect(legacyPlayerDbMocks.saveAthleteProfile).toHaveBeenCalledWith(
+      'parent-1',
+      expect.objectContaining({
+        clips: [
+          {
+            id: 'clip-youtube',
+            source: 'external',
+            mediaType: 'link',
+            title: 'Corner three',
+            label: 'Semifinal',
+            url: 'https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s',
+            storagePath: '',
+            mimeType: '',
+            sizeBytes: null,
+            uploadedAtMs: null
+          },
+          {
+            id: 'clip-upload-new',
+            source: 'upload',
+            mediaType: 'video',
+            title: 'Putback',
+            label: 'Finals',
+            url: 'https://cdn.example.com/putback.mp4',
+            storagePath: 'athlete-profile-media/parent-1/profile-1/putback.mp4',
+            mimeType: 'video/mp4',
+            sizeBytes: clip.size,
+            uploadedAtMs: 300
+          },
+          {
+            id: 'clip-kept',
+            source: 'upload',
+            mediaType: 'video',
+            title: 'Existing kept clip',
+            label: '',
+            url: 'https://cdn.example.com/kept.mp4',
+            storagePath: 'athlete-profile-media/parent-1/profile-1/kept.mp4',
+            mimeType: 'video/mp4',
+            sizeBytes: 2048,
+            uploadedAtMs: 100
+          }
+        ]
+      }),
+      { profileId: 'profile-1' }
+    );
+  });
+
+  it('validates external athlete profile clip links before save', async () => {
+    expect(normalizeAthleteProfileHighlightClipUrl(' https://youtu.be/LJNfHqRRhBI ')).toBe('https://youtu.be/LJNfHqRRhBI');
+    expect(normalizeAthleteProfileHighlightClipUrl('https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s')).toBe('https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s');
+    expect(normalizeAthleteProfileHighlightClipUrl('https://www.hudl.com/video/3/123')).toBe('https://www.hudl.com/video/3/123');
+    expect(() => normalizeAthleteProfileHighlightClipUrl('javascript:alert(1)')).toThrow('http or https');
+    expect(() => normalizeAthleteProfileHighlightClipUrl('not a url')).toThrow('valid highlight clip link');
+
+    await expect(saveParentAthleteProfileDraft({
+      user: {
+        uid: 'parent-1',
+        parentOf: [{ teamId: 'team-current', playerId: 'player-current' }]
+      } as any,
+      teamId: 'team-current',
+      playerId: 'player-current',
+      profileId: 'profile-1',
+      draft: {
+        athlete: { name: 'Sam Player' },
+        bio: {},
+        privacy: 'private',
+        clips: [{ id: 'clip-bad', source: 'external', url: 'ftp://video.example/clip.mp4' }]
+      }
+    })).rejects.toThrow('http or https');
+
+    expect(legacyPlayerDbMocks.uploadAthleteProfileMedia).not.toHaveBeenCalled();
+    expect(legacyPlayerDbMocks.saveAthleteProfile).not.toHaveBeenCalled();
+  });
+
+  it('cleans up uploaded athlete profile media when clip link validation fails', async () => {
+    const headshot = new File(['headshot'], 'headshot.png', { type: 'image/png' });
+    const clip = new File(['clip-data'], 'putback.mp4', { type: 'video/mp4' });
+    legacyPlayerDbMocks.deleteAthleteProfileMediaByPath.mockResolvedValue(undefined);
+    legacyPlayerDbMocks.uploadAthleteProfileMedia
+      .mockResolvedValueOnce({
+        url: 'https://cdn.example.com/headshot.png',
+        storagePath: 'athlete-profile-media/parent-1/profile-1/headshot.png',
+        mediaType: 'image',
+        mimeType: 'image/png',
+        sizeBytes: headshot.size,
+        uploadedAtMs: 100
+      })
+      .mockResolvedValueOnce({
+        url: 'https://cdn.example.com/putback.mp4',
+        storagePath: 'athlete-profile-media/parent-1/profile-1/putback.mp4',
+        mediaType: 'video',
+        mimeType: 'video/mp4',
+        sizeBytes: clip.size,
+        uploadedAtMs: 200
+      });
+
+    await expect(saveParentAthleteProfileDraft({
+      user: {
+        uid: 'parent-1',
+        parentOf: [{ teamId: 'team-current', playerId: 'player-current' }]
+      } as any,
+      teamId: 'team-current',
+      playerId: 'player-current',
+      profileId: 'profile-1',
+      draft: {
+        athlete: { name: 'Sam Player' },
+        bio: {},
+        privacy: 'private',
+        clips: [
+          { id: 'clip-bad', source: 'external', url: 'ftp://video.example/clip.mp4' },
+          { id: 'clip-upload-new', source: 'upload', mediaType: 'video', pendingUpload: true }
+        ]
+      },
+      profilePhotoFile: headshot,
+      highlightClipUploads: [{ id: 'clip-upload-new', file: clip, title: 'Putback' }]
+    })).rejects.toThrow('http or https');
+
+    expect(legacyPlayerDbMocks.deleteAthleteProfileMediaByPath).toHaveBeenCalledWith('athlete-profile-media/parent-1/profile-1/headshot.png');
+    expect(legacyPlayerDbMocks.deleteAthleteProfileMediaByPath).toHaveBeenCalledWith('athlete-profile-media/parent-1/profile-1/putback.mp4');
     expect(legacyPlayerDbMocks.saveAthleteProfile).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -142,6 +142,27 @@ export type ParentPlayerDetailData = {
   athleteProfile: ParentAthleteProfileData;
 };
 
+export type AthleteProfileHighlightClipDraft = {
+  id?: string;
+  source?: 'external' | 'upload';
+  mediaType?: 'link' | 'image' | 'video';
+  title?: string;
+  label?: string;
+  url?: string;
+  storagePath?: string;
+  mimeType?: string;
+  sizeBytes?: number | null;
+  uploadedAtMs?: number | null;
+  pendingUpload?: boolean;
+};
+
+export type AthleteProfileHighlightClipUpload = {
+  id?: string;
+  file: File;
+  title?: string;
+  label?: string;
+};
+
 export async function loadParentPlayerDetail(user: AuthUser | null, teamId: string, playerId: string): Promise<ParentPlayerDetailData> {
   if (!user?.uid) {
     throw new Error('Player details require a signed-in user.');
@@ -509,7 +530,8 @@ export async function saveParentAthleteProfileDraft({
   profilePhotoFile,
   resetProfilePhoto = false,
   highlightClipFile = null,
-  highlightClipTitle = ''
+  highlightClipTitle = '',
+  highlightClipUploads = []
 }: {
   user: AuthUser | null;
   teamId: string;
@@ -520,6 +542,7 @@ export async function saveParentAthleteProfileDraft({
   resetProfilePhoto?: boolean;
   highlightClipFile?: File | null;
   highlightClipTitle?: string;
+  highlightClipUploads?: AthleteProfileHighlightClipUpload[];
 }) {
   assertLinkedParent(user, teamId, playerId);
   const seasonKey = buildParentSeasonKey(teamId, playerId);
@@ -528,41 +551,30 @@ export async function saveParentAthleteProfileDraft({
     : [seasonKey];
   const workingProfileId = profileId || createLocalId('profile');
   let uploadedProfilePhoto: Record<string, any> | null = null;
-  let uploadedHighlightClip: Record<string, any> | null = null;
+  const uploadedHighlightClips: Array<Record<string, any>> = [];
+  const uploadRequests = buildHighlightClipUploadRequests(highlightClipUploads, highlightClipFile, highlightClipTitle);
   if (profilePhotoFile) validateImageFile(profilePhotoFile);
-  if (highlightClipFile) validateHighlightClipFile(highlightClipFile);
+  uploadRequests.forEach((upload) => validateHighlightClipFile(upload.file));
   if (profilePhotoFile) {
     uploadedProfilePhoto = await uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' });
   }
-  if (highlightClipFile) {
-    try {
-      uploadedHighlightClip = await uploadAthleteProfileMedia(user!.uid, workingProfileId, highlightClipFile, { kind: 'clip' });
-    } catch (error) {
-      if (uploadedProfilePhoto?.storagePath) {
-        await deleteAthleteProfileMediaByPath(uploadedProfilePhoto.storagePath).catch(() => undefined);
-      }
-      throw error;
+  try {
+    for (const upload of uploadRequests) {
+      const uploaded = await uploadAthleteProfileMedia(user!.uid, workingProfileId, upload.file, { kind: 'clip' });
+      uploadedHighlightClips.push(buildUploadedHighlightClip(upload, uploaded));
     }
+  } catch (error) {
+    await cleanupUploadedAthleteProfileMedia([
+      uploadedProfilePhoto?.storagePath,
+      ...uploadedHighlightClips.map((clip) => clip.storagePath)
+    ]);
+    throw error;
   }
   const profilePhoto = uploadedProfilePhoto || (resetProfilePhoto ? null : draft.profilePhoto);
-  const clips = [
-    ...(Array.isArray(draft.clips) ? draft.clips : []),
-    ...(uploadedHighlightClip ? [{
-      id: createLocalId('clip'),
-      source: 'upload',
-      mediaType: uploadedHighlightClip.mediaType,
-      title: String(highlightClipTitle || '').trim() || fileTitle(highlightClipFile?.name || ''),
-      label: '',
-      url: uploadedHighlightClip.url,
-      storagePath: uploadedHighlightClip.storagePath,
-      mimeType: uploadedHighlightClip.mimeType,
-      sizeBytes: uploadedHighlightClip.sizeBytes,
-      uploadedAtMs: uploadedHighlightClip.uploadedAtMs
-    }] : [])
-  ];
 
   let saved;
   try {
+    const clips = buildAthleteProfileHighlightClips(draft.clips, uploadedHighlightClips);
     saved = await saveAthleteProfile(user!.uid, {
       ...draft,
       profilePhoto,
@@ -570,12 +582,10 @@ export async function saveParentAthleteProfileDraft({
       selectedSeasonKeys
     }, { profileId: workingProfileId });
   } catch (error) {
-    if (uploadedProfilePhoto?.storagePath) {
-      await deleteAthleteProfileMediaByPath(uploadedProfilePhoto.storagePath).catch(() => undefined);
-    }
-    if (uploadedHighlightClip?.storagePath) {
-      await deleteAthleteProfileMediaByPath(uploadedHighlightClip.storagePath).catch(() => undefined);
-    }
+    await cleanupUploadedAthleteProfileMedia([
+      uploadedProfilePhoto?.storagePath,
+      ...uploadedHighlightClips.map((clip) => clip.storagePath)
+    ]);
     throw error;
   }
   return {
@@ -585,11 +595,156 @@ export async function saveParentAthleteProfileDraft({
   };
 }
 
+export function normalizeAthleteProfileHighlightClipUrl(value: unknown) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) {
+    throw new Error('Enter a highlight clip link.');
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Enter a valid http or https highlight clip link.');
+    }
+    return parsed.toString();
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('http or https')) {
+      throw error;
+    }
+    throw new Error('Enter a valid highlight clip link.');
+  }
+}
+
 function createLocalId(prefix: string) {
   if (globalThis.crypto?.randomUUID) {
     return `${prefix}_${globalThis.crypto.randomUUID()}`;
   }
   return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function buildHighlightClipUploadRequests(
+  highlightClipUploads: AthleteProfileHighlightClipUpload[],
+  highlightClipFile: File | null,
+  highlightClipTitle: string
+) {
+  const requests = (Array.isArray(highlightClipUploads) ? highlightClipUploads : [])
+    .filter((upload) => upload?.file)
+    .map((upload) => ({
+      id: String(upload.id || createLocalId('clip')).trim(),
+      file: upload.file,
+      title: String(upload.title || '').trim(),
+      label: String(upload.label || '').trim()
+    }));
+
+  if (highlightClipFile) {
+    requests.push({
+      id: createLocalId('clip'),
+      file: highlightClipFile,
+      title: String(highlightClipTitle || '').trim(),
+      label: ''
+    });
+  }
+
+  return requests;
+}
+
+function buildUploadedHighlightClip(upload: { id: string; file: File; title: string; label: string }, uploaded: Record<string, any>) {
+  return {
+    id: upload.id,
+    source: 'upload',
+    mediaType: uploaded.mediaType,
+    title: upload.title || fileTitle(upload.file?.name || ''),
+    label: upload.label,
+    url: uploaded.url,
+    storagePath: uploaded.storagePath,
+    mimeType: uploaded.mimeType,
+    sizeBytes: uploaded.sizeBytes,
+    uploadedAtMs: uploaded.uploadedAtMs
+  };
+}
+
+function buildAthleteProfileHighlightClips(rawClips: unknown, uploadedClips: Array<Record<string, any>>) {
+  const uploadsById = new Map(uploadedClips.map((clip) => [String(clip.id || '').trim(), clip]));
+  const consumedUploadIds = new Set<string>();
+  const clips: Array<Record<string, any>> = [];
+
+  (Array.isArray(rawClips) ? rawClips : []).forEach((rawClip, index) => {
+    if (!rawClip || typeof rawClip !== 'object') return;
+    const clip = rawClip as AthleteProfileHighlightClipDraft;
+    const clipId = String(clip.id || '').trim();
+    if (clip.pendingUpload) {
+      const uploaded = uploadsById.get(clipId);
+      if (!uploaded) {
+        throw new Error('One highlight clip could not be found. Re-add it and try again.');
+      }
+      consumedUploadIds.add(clipId);
+      clips.push(uploaded);
+      return;
+    }
+
+    const normalized = normalizeAthleteProfileHighlightClipDraft(clip, index);
+    if (normalized) {
+      clips.push(normalized);
+    }
+  });
+
+  uploadedClips.forEach((clip) => {
+    const clipId = String(clip.id || '').trim();
+    if (!consumedUploadIds.has(clipId)) {
+      clips.push(clip);
+    }
+  });
+
+  return clips;
+}
+
+function normalizeAthleteProfileHighlightClipDraft(clip: AthleteProfileHighlightClipDraft, index: number) {
+  const source = clip.source === 'upload' ? 'upload' : 'external';
+  const rawUrl = String(clip.url || '').trim();
+  if (!rawUrl) return null;
+  const url = source === 'external'
+    ? normalizeAthleteProfileHighlightClipUrl(rawUrl)
+    : rawUrl;
+
+  return {
+    id: String(clip.id || '').trim() || createLocalId(`clip_${index + 1}`),
+    source,
+    mediaType: normalizeHighlightClipMediaType(clip.mediaType, clip.mimeType, url, source),
+    title: String(clip.title || '').trim(),
+    label: String(clip.label || '').trim(),
+    url,
+    storagePath: String(clip.storagePath || '').trim(),
+    mimeType: String(clip.mimeType || '').trim(),
+    sizeBytes: Number.isFinite(Number(clip.sizeBytes)) ? Number(clip.sizeBytes) : null,
+    uploadedAtMs: Number.isFinite(Number(clip.uploadedAtMs)) ? Number(clip.uploadedAtMs) : null
+  };
+}
+
+function normalizeHighlightClipMediaType(
+  mediaType: unknown,
+  mimeType: unknown,
+  url: string,
+  source: 'external' | 'upload'
+) {
+  const explicit = String(mediaType || '').trim().toLowerCase();
+  if (explicit === 'image' || explicit === 'video' || explicit === 'link') {
+    return source === 'external' && explicit === 'link' ? 'link' : explicit;
+  }
+
+  const mime = String(mimeType || '').trim().toLowerCase();
+  if (mime.startsWith('image/')) return 'image';
+  if (mime.startsWith('video/')) return 'video';
+
+  const lowerUrl = String(url || '').toLowerCase();
+  if (/\.(png|jpe?g|gif|webp|avif)(\?|#|$)/.test(lowerUrl)) return 'image';
+  if (/\.(mp4|webm|mov|m4v|ogg)(\?|#|$)/.test(lowerUrl)) return 'video';
+  return 'link';
+}
+
+async function cleanupUploadedAthleteProfileMedia(paths: Array<string | null | undefined>) {
+  await Promise.all(paths
+    .filter((path): path is string => !!path)
+    .map((path) => deleteAthleteProfileMediaByPath(path).catch(() => undefined)));
 }
 
 function normalizePrivateProfile(profile: any): ParentPlayerPrivateProfile | null {

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -396,6 +396,33 @@ describe('PlayerDetail athlete profile season selection', () => {
     expect(screen.getByText('• 1 highlight clip')).toBeTruthy();
   });
 
+  it('shows saved athlete clip titles in the profile builder', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      athleteProfile: {
+        profile: {
+          id: 'profile-1',
+          athlete: { name: 'Sam Player' },
+          bio: {},
+          privacy: 'public',
+          clips: [{ id: 'clip-old', source: 'upload', title: 'Old clip', url: 'https://example.test/old.mp4' }],
+          seasons: [{ seasonKey: 'team-current::player-current' }]
+        },
+        shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1',
+        builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-current&playerId=player-current&profileId=profile-1',
+        seasonOptions: buildDetailData().athleteProfile.seasonOptions
+      }
+    }));
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+
+    expect(await screen.findByText('Old clip')).toBeTruthy();
+    expect(screen.getByText('https://example.test/old.mp4')).toBeTruthy();
+  });
+
   it('switches the athlete profile save CTA with the selected privacy option', async () => {
     renderPlayerDetail();
 

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -24,15 +24,22 @@ const playerServiceMocks = vi.hoisted(() => ({
   saveParentPlayerIncentiveRule: vi.fn(),
   sendParentCoParentInvite: vi.fn(),
   toggleParentPlayerIncentiveRule: vi.fn(),
-  updateParentPlayerEditableProfile: vi.fn()
+  updateParentPlayerEditableProfile: vi.fn(),
+  normalizeAthleteProfileHighlightClipUrl: vi.fn((url: string) => String(url || '').trim())
 }));
 
 const publicActionMocks = vi.hoisted(() => ({
   sharePublicUrl: vi.fn()
 }));
 
+const profilePhotoServiceMocks = vi.hoisted(() => ({
+  acquireProfilePhoto: vi.fn(),
+  normalizeProfilePhoto: vi.fn(async (file: File) => file)
+}));
+
 vi.mock('../lib/playerService', () => playerServiceMocks);
 vi.mock('../lib/publicActions', () => publicActionMocks);
+vi.mock('../lib/profilePhotoService', () => profilePhotoServiceMocks);
 
 import { PlayerDetail } from './PlayerDetail';
 import type { AuthState } from '../lib/types';
@@ -375,7 +382,7 @@ describe('PlayerDetail athlete profile season selection', () => {
           athlete: { name: 'Sam Player', headline: '2028 Guard' },
           bio: { position: 'Guard', hometown: 'Kansas City' },
           privacy: 'private',
-          clips: [{ id: 'clip-1', title: 'Step back' }],
+          clips: [{ id: 'clip-1', title: 'Step back', url: 'https://example.test/step-back.mp4' }],
           seasons: [{ seasonKey: 'team-current::player-current' }]
         },
         shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1',
@@ -421,6 +428,33 @@ describe('PlayerDetail athlete profile season selection', () => {
 
     expect(await screen.findByText('Old clip')).toBeTruthy();
     expect(screen.getByText('https://example.test/old.mp4')).toBeTruthy();
+  });
+
+  it('prevents saving while an athlete headshot is still preparing', async () => {
+    const normalizeDeferred = createDeferred<File>();
+    const headshotFile = new File(['headshot-bytes'], 'new-headshot.png', { type: 'image/png' });
+    profilePhotoServiceMocks.normalizeProfilePhoto.mockImplementationOnce(() => normalizeDeferred.promise);
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+    await screen.findByText('Athlete Profile Builder');
+
+    fireEvent.change(screen.getByLabelText('Browse file'), { target: { files: [headshotFile] } });
+
+    const preparingButton = await screen.findByRole('button', { name: 'Preparing' });
+    expect((preparingButton as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.submit(preparingButton.closest('form') as HTMLFormElement);
+
+    expect(await screen.findByText('Finish preparing the athlete headshot before saving.')).toBeTruthy();
+    expect(playerServiceMocks.saveParentAthleteProfileDraft).not.toHaveBeenCalled();
+
+    normalizeDeferred.resolve(headshotFile);
+    expect(await screen.findByText('New headshot selected. Save to publish it.')).toBeTruthy();
+    expect((screen.getByRole('button', { name: 'Save Athlete Profile' }) as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('switches the athlete profile save CTA with the selected privacy option', async () => {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -2,9 +2,12 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent, 
 import { Link, useParams } from 'react-router-dom';
 import {
   AlertCircle,
+  ArrowDown,
+  ArrowUp,
   Award,
   BarChart3,
   CalendarDays,
+  Camera,
   CheckCircle2,
   ChevronLeft,
   ChevronRight,
@@ -13,6 +16,8 @@ import {
   Edit3,
   ExternalLink,
   FileVideo,
+  ImagePlus,
+  Link2,
   Mail,
   Loader2,
   Plus,
@@ -39,6 +44,9 @@ import {
   sendParentCoParentInvite,
   toggleParentPlayerIncentiveRule,
   updateParentPlayerEditableProfile,
+  normalizeAthleteProfileHighlightClipUrl,
+  type AthleteProfileHighlightClipDraft,
+  type AthleteProfileHighlightClipUpload,
   type ParentPlayerDetailData,
   type ParentPlayerStatRow
 } from '../lib/playerService';
@@ -56,9 +64,24 @@ import {
 } from '../lib/scheduleLogic';
 import { sharePublicUrl } from '../lib/publicActions';
 import type { AuthState } from '../lib/types';
+import type { ProfilePhotoSource } from '../lib/profilePhotoService';
 
 type PlayerSectionId = 'overview' | 'schedule' | 'performance' | 'profile';
 type AthleteProfilePrivacy = 'private' | 'public';
+type AthleteProfileClipDraftState = {
+  id: string;
+  source: 'external' | 'upload';
+  mediaType: 'link' | 'image' | 'video';
+  title: string;
+  label: string;
+  url: string;
+  storagePath: string;
+  mimeType: string;
+  sizeBytes: number | null;
+  uploadedAtMs: number | null;
+  pendingUpload: boolean;
+  file: File | null;
+};
 
 const playerSections: Array<{ id: PlayerSectionId; label: string }> = [
   { id: 'overview', label: 'Overview' },
@@ -116,6 +139,160 @@ function isPersistedPublicProfileReady(
   options: { hasUnsavedPublishChanges?: boolean; saving?: boolean } = {}
 ) {
   return hasPersistedPublicProfile(profile, shareUrl) && !hasPendingPublicProfilePublish(options);
+}
+
+function createAthleteProfileClipId() {
+  if (globalThis.crypto?.randomUUID) {
+    return `clip_${globalThis.crypto.randomUUID()}`;
+  }
+  return `clip_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function compactString(value: unknown) {
+  return String(value || '').trim();
+}
+
+function nullableNumber(value: unknown) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function inferClipMediaTypeFromFile(file: File): 'image' | 'video' | 'link' {
+  const type = compactString(file?.type).toLowerCase();
+  if (type.startsWith('image/')) return 'image';
+  if (type.startsWith('video/')) return 'video';
+  return 'link';
+}
+
+function normalizeExistingAthleteClip(clip: Record<string, any>, index: number): AthleteProfileClipDraftState | null {
+  const url = compactString(clip?.url);
+  if (!url) return null;
+  const source = clip?.source === 'upload' ? 'upload' : 'external';
+  const mediaType = ['image', 'video', 'link'].includes(compactString(clip?.mediaType).toLowerCase())
+    ? compactString(clip?.mediaType).toLowerCase() as 'image' | 'video' | 'link'
+    : source === 'upload' ? 'video' : 'link';
+
+  return {
+    id: compactString(clip?.id) || `clip_${index + 1}`,
+    source,
+    mediaType,
+    title: compactString(clip?.title),
+    label: compactString(clip?.label),
+    url,
+    storagePath: compactString(clip?.storagePath),
+    mimeType: compactString(clip?.mimeType),
+    sizeBytes: nullableNumber(clip?.sizeBytes),
+    uploadedAtMs: nullableNumber(clip?.uploadedAtMs),
+    pendingUpload: false,
+    file: null
+  };
+}
+
+function normalizeExistingAthleteClips(clips: unknown): AthleteProfileClipDraftState[] {
+  return (Array.isArray(clips) ? clips : [])
+    .map((clip, index) => normalizeExistingAthleteClip(clip, index))
+    .filter((clip): clip is AthleteProfileClipDraftState => !!clip);
+}
+
+function createExternalAthleteClip(): AthleteProfileClipDraftState {
+  return {
+    id: createAthleteProfileClipId(),
+    source: 'external',
+    mediaType: 'link',
+    title: '',
+    label: '',
+    url: '',
+    storagePath: '',
+    mimeType: '',
+    sizeBytes: null,
+    uploadedAtMs: null,
+    pendingUpload: false,
+    file: null
+  };
+}
+
+function createPendingAthleteClip(file: File): AthleteProfileClipDraftState {
+  const title = compactString(file.name).replace(/\.[^.]+$/, '');
+  return {
+    id: createAthleteProfileClipId(),
+    source: 'upload',
+    mediaType: inferClipMediaTypeFromFile(file),
+    title,
+    label: '',
+    url: '',
+    storagePath: '',
+    mimeType: compactString(file.type),
+    sizeBytes: nullableNumber(file.size),
+    uploadedAtMs: null,
+    pendingUpload: true,
+    file
+  };
+}
+
+function buildAthleteProfileClipSignature(clips: AthleteProfileClipDraftState[]) {
+  return JSON.stringify(clips.map((clip) => ({
+    id: clip.id,
+    source: clip.source,
+    mediaType: clip.mediaType,
+    title: clip.title,
+    label: clip.label,
+    url: clip.url,
+    storagePath: clip.storagePath,
+    mimeType: clip.mimeType,
+    sizeBytes: clip.sizeBytes,
+    uploadedAtMs: clip.uploadedAtMs,
+    pendingUpload: clip.pendingUpload,
+    fileName: clip.file?.name || '',
+    fileSize: clip.file?.size || null
+  })));
+}
+
+function buildAthleteProfileClipSaveState(clips: AthleteProfileClipDraftState[]) {
+  const draftClips: AthleteProfileHighlightClipDraft[] = [];
+  const highlightClipUploads: AthleteProfileHighlightClipUpload[] = [];
+
+  clips.forEach((clip) => {
+    if (clip.pendingUpload) {
+      if (!clip.file) {
+        throw new Error('One highlight clip could not be found. Re-add it and try again.');
+      }
+      draftClips.push({
+        id: clip.id,
+        source: 'upload',
+        mediaType: clip.mediaType,
+        title: clip.title,
+        label: clip.label,
+        pendingUpload: true
+      });
+      highlightClipUploads.push({
+        id: clip.id,
+        file: clip.file,
+        title: clip.title,
+        label: clip.label
+      });
+      return;
+    }
+
+    const url = clip.source === 'external'
+      ? normalizeAthleteProfileHighlightClipUrl(clip.url)
+      : compactString(clip.url);
+    if (!url) return;
+
+    draftClips.push({
+      id: clip.id,
+      source: clip.source,
+      mediaType: clip.mediaType,
+      title: clip.title,
+      label: clip.label,
+      url,
+      storagePath: clip.storagePath,
+      mimeType: clip.mimeType,
+      sizeBytes: clip.sizeBytes,
+      uploadedAtMs: clip.uploadedAtMs
+    });
+  });
+
+  return { draftClips, highlightClipUploads };
 }
 
 export function PlayerDetail({ auth }: { auth: AuthState }) {
@@ -897,6 +1074,7 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
     }
     return currentSeasonKey ? [currentSeasonKey] : [];
   }, [currentSeasonKey, existing]);
+  const initialClipDrafts = useMemo(() => normalizeExistingAthleteClips(existing?.clips), [existing?.clips]);
   const [name, setName] = useState(existing?.athlete?.name || data.player.name || data.child.playerName || '');
   const [headline, setHeadline] = useState(existing?.athlete?.headline || '');
   const [position, setPosition] = useState(existing?.bio?.position || '');
@@ -911,9 +1089,11 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
   const [status, setStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const [headshotFile, setHeadshotFile] = useState<File | null>(null);
   const [headshotError, setHeadshotError] = useState('');
+  const [headshotBusy, setHeadshotBusy] = useState(false);
   const [resetHeadshot, setResetHeadshot] = useState(false);
-  const [highlightClipFile, setHighlightClipFile] = useState<File | null>(null);
+  const [clipDrafts, setClipDrafts] = useState<AthleteProfileClipDraftState[]>(initialClipDrafts);
   const [highlightClipError, setHighlightClipError] = useState('');
+  const headshotInputRef = useRef<HTMLInputElement | null>(null);
   const persistedPrivacy = existing?.privacy === 'public' ? 'public' : 'private';
   const existingHeadshotUrl = existing?.profilePhotoUrl || '';
   const linkedHeadshotUrl = data.player.photoUrl || '';
@@ -935,10 +1115,10 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
       dominantHand ? `${dominantHand} hand` : '',
       achievements,
       selectedSeasonKeys.length ? `${selectedSeasonKeys.length} season${selectedSeasonKeys.length === 1 ? '' : 's'} of stats and game clips` : '',
-      (existing?.clips?.length || 0) + (highlightClipFile ? 1 : 0) ? `${(existing?.clips?.length || 0) + (highlightClipFile ? 1 : 0)} highlight clip${(existing?.clips?.length || 0) + (highlightClipFile ? 1 : 0) === 1 ? '' : 's'}` : ''
+      clipDrafts.length ? `${clipDrafts.length} highlight clip${clipDrafts.length === 1 ? '' : 's'}` : ''
     ].filter(Boolean);
     return items;
-  }, [achievements, data.child.playerName, dominantHand, existing?.clips?.length, graduationYear, headline, highlightClipFile, hometown, name, position, selectedSeasonKeys.length]);
+  }, [achievements, clipDrafts.length, data.child.playerName, dominantHand, graduationYear, headline, hometown, name, position, selectedSeasonKeys.length]);
   const normalizedExistingName = existing?.athlete?.name || data.player.name || data.child.playerName || '';
   const normalizedExistingHeadline = existing?.athlete?.headline || '';
   const normalizedExistingPosition = existing?.bio?.position || '';
@@ -948,6 +1128,8 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
   const normalizedExistingAchievements = existing?.bio?.achievements || '';
   const normalizedInitialSelectedSeasonKeys = [...initialSelectedSeasonKeys].sort();
   const normalizedSelectedSeasonKeys = [...selectedSeasonKeys].sort();
+  const normalizedInitialClipSignature = buildAthleteProfileClipSignature(initialClipDrafts);
+  const normalizedClipSignature = buildAthleteProfileClipSignature(clipDrafts);
   const hasUnsavedPublishChanges = (
     privacy !== persistedPrivacy ||
     name !== normalizedExistingName ||
@@ -959,9 +1141,9 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
     achievements !== normalizedExistingAchievements ||
     normalizedInitialSelectedSeasonKeys.length !== normalizedSelectedSeasonKeys.length ||
     normalizedInitialSelectedSeasonKeys.some((seasonKey, index) => seasonKey !== normalizedSelectedSeasonKeys[index]) ||
+    normalizedInitialClipSignature !== normalizedClipSignature ||
     !!headshotFile ||
-    resetHeadshot ||
-    !!highlightClipFile
+    resetHeadshot
   );
   const normalizedShareUrl = String(data.athleteProfile.shareUrl || '').trim();
   const persistedPublicProfileUrl = getPersistedPublicProfileUrl(existing, normalizedShareUrl);
@@ -1014,12 +1196,122 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
     setSelectedSeasonKeys(initialSelectedSeasonKeys);
   }, [initialSelectedSeasonKeys]);
 
+  useEffect(() => {
+    setClipDrafts(initialClipDrafts);
+    setHighlightClipError('');
+  }, [initialClipDrafts]);
+
   const toggleSeasonKey = (seasonKey: string) => {
     setSelectedSeasonKeys((current) => (
       current.includes(seasonKey)
         ? current.filter((key) => key !== seasonKey)
         : [...current, seasonKey]
     ));
+  };
+
+  const prepareHeadshotFile = async (file: File | null, options: { normalize?: boolean } = {}) => {
+    if (!file) {
+      setHeadshotFile(null);
+      setHeadshotError('');
+      return;
+    }
+    if (!String(file.type || '').startsWith('image/')) {
+      setHeadshotFile(null);
+      setHeadshotError('Choose an image file for the athlete headshot.');
+      return;
+    }
+
+    setHeadshotBusy(true);
+    setHeadshotError('');
+    try {
+      const nextFile = options.normalize === false
+        ? file
+        : await import('../lib/profilePhotoService').then((module) => module.normalizeProfilePhoto(file));
+      setHeadshotFile(nextFile);
+      setResetHeadshot(false);
+    } catch (error: any) {
+      setHeadshotFile(null);
+      setHeadshotError(error?.message || 'Athlete headshot could not be prepared right now.');
+    } finally {
+      setHeadshotBusy(false);
+    }
+  };
+
+  const chooseNativeHeadshot = async (source: ProfilePhotoSource) => {
+    setHeadshotBusy(true);
+    setHeadshotError('');
+    try {
+      const { acquireProfilePhoto } = await import('../lib/profilePhotoService');
+      const file = await acquireProfilePhoto(source);
+      await prepareHeadshotFile(file, { normalize: false });
+    } catch (error: any) {
+      if (error?.code === 'cancelled') {
+        return;
+      }
+      if (error?.code === 'unavailable' && source === 'photos') {
+        headshotInputRef.current?.click();
+        return;
+      }
+      const message = error?.code === 'permission-denied'
+        ? source === 'camera'
+          ? 'Camera permission was denied. Allow camera access to take a headshot.'
+          : 'Photo permission was denied. Allow photo library access to choose a headshot.'
+        : error?.message || 'Athlete headshot could not be selected right now.';
+      setHeadshotError(message);
+    } finally {
+      setHeadshotBusy(false);
+    }
+  };
+
+  const addExternalClip = () => {
+    setClipDrafts((current) => [...current, createExternalAthleteClip()]);
+    setHighlightClipError('');
+  };
+
+  const addUploadClips = (files: File[]) => {
+    if (!files.length) return;
+    const nextClips: AthleteProfileClipDraftState[] = [];
+    for (const file of files) {
+      const type = String(file.type || '');
+      if (!type.startsWith('image/') && !type.startsWith('video/')) {
+        setHighlightClipError('Choose image or video files for highlight clips.');
+        return;
+      }
+      if (file.size > 100 * 1024 * 1024) {
+        setHighlightClipError('Choose highlight clips under 100 MB.');
+        return;
+      }
+      nextClips.push(createPendingAthleteClip(file));
+    }
+    setClipDrafts((current) => [...current, ...nextClips]);
+    setHighlightClipError('');
+  };
+
+  const updateClipDraft = (clipId: string, patch: Partial<AthleteProfileClipDraftState>) => {
+    setClipDrafts((current) => current.map((clip) => (
+      clip.id === clipId ? { ...clip, ...patch } : clip
+    )));
+    setHighlightClipError('');
+  };
+
+  const removeClipDraft = (clipId: string) => {
+    setClipDrafts((current) => current.filter((clip) => clip.id !== clipId));
+    setHighlightClipError('');
+  };
+
+  const moveClipDraft = (clipId: string, direction: -1 | 1) => {
+    setClipDrafts((current) => {
+      const index = current.findIndex((clip) => clip.id === clipId);
+      const nextIndex = index + direction;
+      if (index < 0 || nextIndex < 0 || nextIndex >= current.length) {
+        return current;
+      }
+      const next = [...current];
+      const [clip] = next.splice(index, 1);
+      next.splice(nextIndex, 0, clip);
+      return next;
+    });
+    setHighlightClipError('');
   };
 
   const submit = async (event: FormEvent) => {
@@ -1029,11 +1321,18 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
       setStatus({ tone: 'error', message: 'Select at least one linked season to build an athlete profile.' });
       return;
     }
+    let clipSaveState: ReturnType<typeof buildAthleteProfileClipSaveState>;
+    try {
+      clipSaveState = buildAthleteProfileClipSaveState(clipDrafts);
+    } catch (error: any) {
+      setHighlightClipError(error?.message || 'Check the highlight clips and try again.');
+      return;
+    }
     setSaving(true);
     setStatus(null);
     setAwaitingPersistedPublish(isPublishingNewPublicProfile);
     try {
-      await saveParentAthleteProfileDraft({
+      const savedProfile = await saveParentAthleteProfileDraft({
         user: auth.user,
         teamId: data.child.teamId,
         playerId: data.child.playerId,
@@ -1043,7 +1342,7 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
           bio: { position, graduationYear, hometown, dominantHand, achievements },
           privacy,
           selectedSeasonKeys,
-          clips: existing?.clips || [],
+          clips: clipSaveState.draftClips,
           profilePhoto: existing?.profilePhotoUrl ? {
             url: existing.profilePhotoUrl,
             storagePath: existing.profilePhotoPath,
@@ -1054,11 +1353,14 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
         },
         profilePhotoFile: headshotFile,
         resetProfilePhoto: resetHeadshot,
-        highlightClipFile
+        highlightClipUploads: clipSaveState.highlightClipUploads
       });
       setHeadshotFile(null);
       setResetHeadshot(false);
-      setHighlightClipFile(null);
+      if (Array.isArray(savedProfile.profile?.clips)) {
+        setClipDrafts(normalizeExistingAthleteClips(savedProfile.profile.clips));
+      }
+      setHighlightClipError('');
       setStatus({ tone: 'success', message: 'Athlete profile saved.' });
       await onChanged();
     } catch (error: any) {
@@ -1129,22 +1431,36 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
             </div>
           </div>
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            <button
+              type="button"
+              className="secondary-button justify-center"
+              disabled={headshotBusy}
+              onClick={() => void chooseNativeHeadshot('camera')}
+            >
+              {headshotBusy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Camera className="h-4 w-4" aria-hidden="true" />}
+              Take photo
+            </button>
+            <button
+              type="button"
+              className="secondary-button justify-center"
+              disabled={headshotBusy}
+              onClick={() => void chooseNativeHeadshot('photos')}
+            >
+              <ImagePlus className="h-4 w-4" aria-hidden="true" />
+              Photo library
+            </button>
             <label className="secondary-button justify-center">
-              <span>Choose headshot</span>
+              <ImagePlus className="h-4 w-4" aria-hidden="true" />
+              <span>Browse file</span>
               <input
+                ref={headshotInputRef}
                 type="file"
                 accept="image/*"
                 className="sr-only"
                 onChange={(event) => {
                   const file = event.currentTarget.files?.[0] || null;
-                  if (file && !String(file.type || '').startsWith('image/')) {
-                    setHeadshotFile(null);
-                    setHeadshotError('Choose an image file for the athlete headshot.');
-                    return;
-                  }
-                  setHeadshotFile(file);
-                  setResetHeadshot(false);
-                  setHeadshotError('');
+                  void prepareHeadshotFile(file);
+                  event.currentTarget.value = '';
                 }}
               />
             </label>
@@ -1168,50 +1484,103 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
               <FileVideo className="h-5 w-5" aria-hidden="true" />
             </div>
             <div className="min-w-0 flex-1">
-              <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Manual highlight clip</div>
-              <p className="mt-1 text-sm font-semibold text-gray-700">Add one image or video highlight. It publishes when you save.</p>
-              {highlightClipFile ? <p className="mt-1 truncate text-xs font-semibold text-primary-700">{highlightClipFile.name} selected. Save to publish it.</p> : null}
-              {existing?.clips?.length ? <p className="mt-1 text-xs font-semibold text-gray-500">Existing clips stay on the profile.</p> : null}
+              <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Highlight clips</div>
+              <p className="mt-1 text-sm font-semibold text-gray-700">Add links or upload image/video highlights, then drag the order with move controls.</p>
             </div>
           </div>
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            <button type="button" className="secondary-button justify-center" onClick={addExternalClip}>
+              <Link2 className="h-4 w-4" aria-hidden="true" />
+              Add link
+            </button>
             <label className="secondary-button justify-center">
-              <span>Choose highlight clip</span>
+              <FileVideo className="h-4 w-4" aria-hidden="true" />
+              <span>Upload clips</span>
               <input
                 type="file"
                 accept="video/*,image/*"
+                multiple
                 className="sr-only"
                 onChange={(event) => {
-                  const file = event.currentTarget.files?.[0] || null;
-                  if (file) {
-                    const fileType = String(file.type || '');
-                    if (!fileType.startsWith('image/') && !fileType.startsWith('video/')) {
-                      setHighlightClipFile(null);
-                      setHighlightClipError('Choose an image or video file for the highlight clip.');
-                      return;
-                    }
-                    if (file.size > 100 * 1024 * 1024) {
-                      setHighlightClipFile(null);
-                      setHighlightClipError('Choose a highlight clip under 100 MB.');
-                      return;
-                    }
-                  }
-                  setHighlightClipFile(file);
-                  setHighlightClipError('');
+                  addUploadClips(Array.from(event.currentTarget.files || []));
+                  event.currentTarget.value = '';
                 }}
               />
             </label>
-            <button
-              type="button"
-              className="secondary-button justify-center"
-              disabled={!highlightClipFile && !highlightClipError}
-              onClick={() => {
-                setHighlightClipFile(null);
-                setHighlightClipError('');
-              }}
-            >
-              Clear selected clip
-            </button>
+          </div>
+          <div className="mt-3 space-y-2">
+            {clipDrafts.length ? clipDrafts.map((clip, index) => (
+              <div key={clip.id} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">
+                      {clip.pendingUpload ? 'Pending upload' : clip.source === 'upload' ? 'Uploaded clip' : 'External link'}
+                    </div>
+                    <p className="mt-1 truncate text-xs font-semibold text-gray-500">
+                      {clip.pendingUpload ? clip.file?.name || 'Selected clip' : clip.url || 'Add a URL before saving'}
+                    </p>
+                  </div>
+                  <div className="flex flex-none items-center gap-1">
+                    <button
+                      type="button"
+                      className="icon-button h-8 w-8"
+                      aria-label="Move clip up"
+                      disabled={index === 0}
+                      onClick={() => moveClipDraft(clip.id, -1)}
+                    >
+                      <ArrowUp className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      className="icon-button h-8 w-8"
+                      aria-label="Move clip down"
+                      disabled={index === clipDrafts.length - 1}
+                      onClick={() => moveClipDraft(clip.id, 1)}
+                    >
+                      <ArrowDown className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      className="icon-button h-8 w-8 text-rose-600"
+                      aria-label="Remove clip"
+                      onClick={() => removeClipDraft(clip.id)}
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <TextField
+                    label="Clip title"
+                    value={clip.title}
+                    onChange={(value) => updateClipDraft(clip.id, { title: value })}
+                    placeholder="Fast break"
+                  />
+                  <TextField
+                    label="Note"
+                    value={clip.label}
+                    onChange={(value) => updateClipDraft(clip.id, { label: value })}
+                    placeholder="Optional context"
+                  />
+                </div>
+                {clip.source === 'external' ? (
+                  <label className="mt-2 block">
+                    <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Clip URL</span>
+                    <input
+                      type="url"
+                      value={clip.url}
+                      onChange={(event) => updateClipDraft(clip.id, { url: event.currentTarget.value })}
+                      placeholder="https://www.youtube.com/watch?v=..."
+                      className="mt-1 block w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-semibold text-gray-800 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
+                    />
+                  </label>
+                ) : null}
+              </div>
+            )) : (
+              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-3 text-sm font-semibold text-gray-500">
+                No highlight clips yet.
+              </div>
+            )}
           </div>
           {highlightClipError ? <p className="mt-2 text-xs font-bold text-rose-600">{highlightClipError}</p> : null}
         </div>

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -1516,6 +1516,9 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
                     <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">
                       {clip.pendingUpload ? 'Pending upload' : clip.source === 'upload' ? 'Uploaded clip' : 'External link'}
                     </div>
+                    <p className="mt-1 truncate text-sm font-bold text-gray-900">
+                      {clip.title || (clip.pendingUpload ? clip.file?.name : '') || 'Untitled clip'}
+                    </p>
                     <p className="mt-1 truncate text-xs font-semibold text-gray-500">
                       {clip.pendingUpload ? clip.file?.name || 'Selected clip' : clip.url || 'Add a URL before saving'}
                     </p>

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -1175,6 +1175,14 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
     canSharePublicProfile,
     persistedPublicProfileUrl
   };
+  const saveDisabled = saving || headshotBusy;
+  const saveLabel = headshotBusy
+    ? 'Preparing'
+    : saving
+      ? 'Saving'
+      : privacy === 'public'
+        ? 'Publish Athlete Profile'
+        : 'Save Athlete Profile';
 
   useLayoutEffect(() => {
     onShareStateChange({
@@ -1317,6 +1325,10 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     if (headshotError || highlightClipError) return;
+    if (headshotBusy) {
+      setStatus({ tone: 'error', message: 'Finish preparing the athlete headshot before saving.' });
+      return;
+    }
     if (!selectedSeasonKeys.length) {
       setStatus({ tone: 'error', message: 'Select at least one linked season to build an athlete profile.' });
       return;
@@ -1651,9 +1663,9 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
         </div>
         {status?.tone === 'error' ? <Status tone={status.tone} message={status.message} /> : null}
         <div className="athlete-profile-actions grid gap-2 sm:grid-cols-2">
-          <button type="submit" className="primary-button justify-center" disabled={saving}>
-            {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
-            {saving ? 'Saving' : privacy === 'public' ? 'Publish Athlete Profile' : 'Save Athlete Profile'}
+          <button type="submit" className="primary-button justify-center" disabled={saveDisabled}>
+            {saveDisabled ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
+            {saveLabel}
           </button>
           {canSharePublicProfile ? (
             <button type="button" className="secondary-button justify-center" onClick={shareProfile}>

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -360,6 +360,10 @@ async function mockHomePlayerModules(page) {
                 export async function savePlayerCustomRosterFieldValues() {}
                 export async function saveStaffPlayerRosterDetails() { return { updatedFields: [] }; }
                 export async function sendParentCoParentInvite() { return { code: 'ABC12345' }; }
+                export function normalizeAthleteProfileHighlightClipUrl(url) {
+                    const value = String(url || '').trim();
+                    return value;
+                }
                 export async function saveParentAthleteProfileDraft() { return { shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1' }; }
                 export async function saveParentPlayerIncentiveRule() { return 'rule-2'; }
                 export async function toggleParentPlayerIncentiveRule() {}

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -806,8 +806,8 @@ describe('React app Home and player drill-in integration', () => {
         expect(buttonByText(container, 'Athlete Profile').getAttribute('aria-pressed')).toBe('true');
 
         expect(container.textContent).toContain('Custom athlete profile headshot');
-        expect(container.textContent).toContain('Manual highlight clip');
-        expect(container.textContent).toContain('Existing clips stay on the profile.');
+        expect(container.textContent).toContain('Uploaded clip');
+        expect(container.textContent).toContain('Old clip');
         await attachAthleteHeadshotFile(container, 'new-headshot.png');
         await attachAthleteHighlightClipFile(container, 'highlight.mp4');
         expect(container.textContent).toContain('New headshot selected. Save to publish it.');

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -40,9 +40,15 @@ const playerMocks = vi.hoisted(() => ({
     updateParentPlayerEditableProfile: vi.fn()
 }));
 
+const profilePhotoServiceMocks = vi.hoisted(() => ({
+    acquireProfilePhoto: vi.fn(),
+    normalizeProfilePhoto: vi.fn(async (file) => file)
+}));
+
 vi.mock('../../apps/app/src/lib/homeService.ts', () => homeMocks);
 vi.mock('../../apps/app/src/lib/socialService.ts', () => socialMocks);
 vi.mock('../../apps/app/src/lib/playerService.ts', () => playerMocks);
+vi.mock('../../apps/app/src/lib/profilePhotoService', () => profilePhotoServiceMocks);
 
 import { Home } from '../../apps/app/src/pages/Home.tsx';
 import { PlayerDetail } from '../../apps/app/src/pages/PlayerDetail.tsx';
@@ -157,6 +163,12 @@ async function clickButtonByAriaLabel(container, label) {
         buttonByAriaLabel(container, label).dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await flush();
+}
+
+async function clickAllButtonsByAriaLabel(container, label) {
+    while (Array.from(container.querySelectorAll('button')).some((candidate) => candidate.getAttribute('aria-label') === label)) {
+        await clickButtonByAriaLabel(container, label);
+    }
 }
 
 async function clickLastButton(container, text) {
@@ -806,12 +818,16 @@ describe('React app Home and player drill-in integration', () => {
         expect(buttonByText(container, 'Athlete Profile').getAttribute('aria-pressed')).toBe('true');
 
         expect(container.textContent).toContain('Custom athlete profile headshot');
+        expect(container.textContent).toContain('Highlight clips');
         expect(container.textContent).toContain('Uploaded clip');
-        expect(container.textContent).toContain('Old clip');
+        expect(container.textContent).toContain('Clip title');
+        expect(container.textContent).toContain('Note');
         await attachAthleteHeadshotFile(container, 'new-headshot.png');
+        await waitForText(container, 'New headshot selected. Save to publish it.');
+        await waitForText(container, 'new-headshot.png');
         await attachAthleteHighlightClipFile(container, 'highlight.mp4');
-        expect(container.textContent).toContain('New headshot selected. Save to publish it.');
-        expect(container.textContent).toContain('highlight.mp4 selected. Save to publish it.');
+        await waitForText(container, 'Pending upload');
+        await waitForText(container, 'highlight.mp4');
         await clickButton(container, 'Publish Athlete Profile');
         await waitForText(container, 'Saved');
         expect(playerMocks.saveParentAthleteProfileDraft).toHaveBeenCalledWith(expect.objectContaining({
@@ -821,9 +837,14 @@ describe('React app Home and player drill-in integration', () => {
             profileId: 'profile-1',
             profilePhotoFile: expect.objectContaining({ name: 'new-headshot.png', type: 'image/png' }),
             resetProfilePhoto: false,
-            highlightClipFile: expect.objectContaining({ name: 'highlight.mp4', type: 'video/mp4' }),
+            highlightClipUploads: [expect.objectContaining({
+                file: expect.objectContaining({ name: 'highlight.mp4', type: 'video/mp4' })
+            })],
             draft: expect.objectContaining({
-                clips: [{ id: 'clip-old', source: 'upload', title: 'Old clip', url: 'https://example.test/old.mp4' }]
+                clips: [
+                    expect.objectContaining({ id: 'clip-old', source: 'upload', title: 'Old clip', url: 'https://example.test/old.mp4' }),
+                    expect.objectContaining({ source: 'upload', pendingUpload: true })
+                ]
             })
         }));
         expect(playerMocks.loadParentPlayerDetail).toHaveBeenCalledTimes(2);
@@ -835,14 +856,14 @@ describe('React app Home and player drill-in integration', () => {
         await attachAthleteHeadshotFile(container, 'notes.txt', 'text/plain');
         await waitForText(container, 'Choose an image file for the athlete headshot.');
         await attachAthleteHighlightClipFile(container, 'notes.txt', 'text/plain');
-        await waitForText(container, 'Choose an image or video file for the highlight clip.');
+        await waitForText(container, 'Choose image or video files for highlight clips.');
         await clickButton(container, 'Use linked season photo');
-        await clickButton(container, 'Clear selected clip');
+        await clickAllButtonsByAriaLabel(container, 'Remove clip');
         await clickButton(container, 'Publish Athlete Profile');
         expect(playerMocks.saveParentAthleteProfileDraft).toHaveBeenLastCalledWith(expect.objectContaining({
             profilePhotoFile: null,
             resetProfilePhoto: true,
-            highlightClipFile: null
+            highlightClipUploads: []
         }));
 
         await clickButton(container, 'Incentives');

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -62,6 +62,7 @@ vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
 
 import {
     loadParentPlayerDetail,
+    normalizeAthleteProfileHighlightClipUrl,
     saveParentAthleteProfileDraft,
     saveParentPlayerIncentiveRule,
     sendParentCoParentInvite,
@@ -508,7 +509,12 @@ describe('React app parent player detail service', () => {
         expect(dbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('user-1', 'profile-1', clip, { kind: 'clip' });
         expect(dbMocks.saveAthleteProfile).toHaveBeenLastCalledWith('user-1', expect.objectContaining({
             clips: [
-                existingClip,
+                expect.objectContaining({
+                    id: 'clip-old',
+                    source: 'upload',
+                    title: 'Old clip',
+                    url: 'https://example.test/old.mp4'
+                }),
                 expect.objectContaining({
                     source: 'upload',
                     mediaType: 'video',
@@ -520,6 +526,119 @@ describe('React app parent player detail service', () => {
             ],
             selectedSeasonKeys: ['team-1::player-1']
         }), { profileId: 'profile-1' });
+    });
+
+    it('saves ordered athlete profile clip links and matched uploads in the legacy draft shape', async () => {
+        const clip = new File(['clip-bytes'], 'putback.mp4', { type: 'video/mp4' });
+
+        await saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profileId: 'profile-1',
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'private',
+                clips: [
+                    {
+                        id: 'clip-youtube',
+                        source: 'external',
+                        mediaType: 'link',
+                        title: 'Corner three',
+                        label: 'Semifinal',
+                        url: ' https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s '
+                    },
+                    {
+                        id: 'clip-upload-new',
+                        source: 'upload',
+                        mediaType: 'video',
+                        title: 'Putback',
+                        label: 'Finals',
+                        pendingUpload: true
+                    },
+                    {
+                        id: 'clip-kept',
+                        source: 'upload',
+                        mediaType: 'video',
+                        title: 'Existing kept clip',
+                        url: 'https://example.test/kept.mp4',
+                        storagePath: 'athlete-profile-media/user-1/profile-1/kept.mp4',
+                        mimeType: 'video/mp4',
+                        sizeBytes: 2048,
+                        uploadedAtMs: 100
+                    }
+                ]
+            },
+            highlightClipUploads: [{ id: 'clip-upload-new', file: clip, title: 'Putback', label: 'Finals' }]
+        });
+
+        expect(dbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('user-1', 'profile-1', clip, { kind: 'clip' });
+        expect(dbMocks.saveAthleteProfile).toHaveBeenLastCalledWith('user-1', expect.objectContaining({
+            clips: [
+                {
+                    id: 'clip-youtube',
+                    source: 'external',
+                    mediaType: 'link',
+                    title: 'Corner three',
+                    label: 'Semifinal',
+                    url: 'https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s',
+                    storagePath: '',
+                    mimeType: '',
+                    sizeBytes: null,
+                    uploadedAtMs: null
+                },
+                {
+                    id: 'clip-upload-new',
+                    source: 'upload',
+                    mediaType: 'video',
+                    title: 'Putback',
+                    label: 'Finals',
+                    url: 'https://example.test/putback.mp4',
+                    storagePath: 'athlete-profile-media/user-1/profile-1/putback.mp4',
+                    mimeType: 'video/mp4',
+                    sizeBytes: clip.size,
+                    uploadedAtMs: 1234
+                },
+                {
+                    id: 'clip-kept',
+                    source: 'upload',
+                    mediaType: 'video',
+                    title: 'Existing kept clip',
+                    label: '',
+                    url: 'https://example.test/kept.mp4',
+                    storagePath: 'athlete-profile-media/user-1/profile-1/kept.mp4',
+                    mimeType: 'video/mp4',
+                    sizeBytes: 2048,
+                    uploadedAtMs: 100
+                }
+            ],
+            selectedSeasonKeys: ['team-1::player-1']
+        }), { profileId: 'profile-1' });
+    });
+
+    it('validates athlete profile external clip links before saving', async () => {
+        expect(normalizeAthleteProfileHighlightClipUrl(' https://youtu.be/LJNfHqRRhBI ')).toBe('https://youtu.be/LJNfHqRRhBI');
+        expect(normalizeAthleteProfileHighlightClipUrl('https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s')).toBe('https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s');
+        expect(normalizeAthleteProfileHighlightClipUrl('https://www.hudl.com/video/3/123')).toBe('https://www.hudl.com/video/3/123');
+        expect(() => normalizeAthleteProfileHighlightClipUrl('javascript:alert(1)')).toThrow('http or https');
+        expect(() => normalizeAthleteProfileHighlightClipUrl('not a url')).toThrow('valid highlight clip link');
+
+        await expect(saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profileId: 'profile-1',
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'private',
+                clips: [{ id: 'clip-bad', source: 'external', url: 'ftp://video.example/clip.mp4' }]
+            }
+        })).rejects.toThrow('http or https');
+
+        expect(dbMocks.uploadAthleteProfileMedia).not.toHaveBeenCalled();
+        expect(dbMocks.saveAthleteProfile).not.toHaveBeenCalled();
     });
 
     it('rejects invalid athlete profile highlight clips before saving', async () => {

--- a/tests/unit/issue-1998-athlete-profile-upload-source.test.js
+++ b/tests/unit/issue-1998-athlete-profile-upload-source.test.js
@@ -11,28 +11,38 @@ describe('issue 1998 athlete profile upload source contract', () => {
     it('keeps the native athlete profile editor exposing headshot and highlight uploads', () => {
         expect(playerDetailSource).toContain('function AthleteProfileBuilderCard');
         expect(playerDetailSource).toContain('const [headshotFile, setHeadshotFile] = useState<File | null>(null);');
-        expect(playerDetailSource).toContain('const [highlightClipFile, setHighlightClipFile] = useState<File | null>(null);');
+        expect(playerDetailSource).toContain('const [clipDrafts, setClipDrafts] = useState<AthleteProfileClipDraftState[]>(initialClipDrafts);');
+        expect(playerDetailSource).toContain("void chooseNativeHeadshot('camera')");
+        expect(playerDetailSource).toContain("void chooseNativeHeadshot('photos')");
+        expect(playerDetailSource).toContain('Add link');
+        expect(playerDetailSource).toContain('Upload clips');
+        expect(playerDetailSource).toContain('moveClipDraft(clip.id, -1)');
         expect(playerDetailSource).toContain('accept="image/*"');
         expect(playerDetailSource).toContain('accept="video/*,image/*"');
-        expect(playerDetailSource).toContain('Choose a highlight clip under 100 MB.');
+        expect(playerDetailSource).toContain('Choose highlight clips under 100 MB.');
         expect(playerDetailSource).toContain('profilePhotoFile: headshotFile');
-        expect(playerDetailSource).toContain('highlightClipFile');
+        expect(playerDetailSource).toContain('highlightClipUploads: clipSaveState.highlightClipUploads');
     });
 
     it('keeps service uploads validated, saved, and cleaned up on failure', () => {
         expect(playerServiceSource).toContain('export async function saveParentAthleteProfileDraft');
         expect(playerServiceSource).toContain('if (profilePhotoFile) validateImageFile(profilePhotoFile);');
-        expect(playerServiceSource).toContain('if (highlightClipFile) validateHighlightClipFile(highlightClipFile);');
+        expect(playerServiceSource).toContain('uploadRequests.forEach((upload) => validateHighlightClipFile(upload.file));');
         expect(playerServiceSource).toContain("uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' })");
-        expect(playerServiceSource).toContain("uploadAthleteProfileMedia(user!.uid, workingProfileId, highlightClipFile, { kind: 'clip' })");
+        expect(playerServiceSource).toContain("uploadAthleteProfileMedia(user!.uid, workingProfileId, upload.file, { kind: 'clip' })");
         expect(playerServiceSource).toContain("source: 'upload'");
-        expect(playerServiceSource).toContain('await deleteAthleteProfileMediaByPath(uploadedProfilePhoto.storagePath).catch(() => undefined);');
-        expect(playerServiceSource).toContain('await deleteAthleteProfileMediaByPath(uploadedHighlightClip.storagePath).catch(() => undefined);');
+        expect(playerServiceSource).toContain('normalizeAthleteProfileHighlightClipUrl');
+        expect(playerServiceSource).toContain('buildAthleteProfileHighlightClips(draft.clips, uploadedHighlightClips)');
+        expect(playerServiceSource).toContain('uploadedProfilePhoto?.storagePath');
+        expect(playerServiceSource).toContain('...uploadedHighlightClips.map((clip) => clip.storagePath)');
+        expect(playerServiceSource).toContain('cleanupUploadedAthleteProfileMedia');
     });
 
     it('keeps upload regression, legacy wiring, and storage-rule coverage in place', () => {
         expect(playerServiceTestSource).toContain('uploads athlete profile headshots before saving and supports linked-photo reset');
         expect(playerServiceTestSource).toContain('uploads a manual athlete profile highlight clip and preserves existing clips');
+        expect(playerServiceTestSource).toContain('saves ordered athlete profile clip links and matched uploads in the legacy draft shape');
+        expect(playerServiceTestSource).toContain('validates athlete profile external clip links before saving');
         expect(playerServiceTestSource).toContain('cleans up uploaded athlete profile highlight clips when saving the profile fails');
         expect(wiringTestSource).toContain('uploadAthleteProfileMedia');
         expect(wiringTestSource).toContain('deleteAthleteProfileMediaByPath');


### PR DESCRIPTION
## Summary
- Adds app athlete-profile headshot selection from camera, photo library, or file picker with preview/normalization before draft save.
- Extends `saveParentAthleteProfileDraft` to save ordered legacy-compatible highlight clip lists, matched upload placeholders, add/remove/reorder payloads, HTTP(S) external link validation, and cleanup of failed uploads.
- Updates focused app/root unit coverage and the issue #1998 source-contract test for the new native media flow.

## Validation
- `npx vitest run apps/app/src/lib/playerService.test.ts tests/unit/app-player-service.test.js tests/unit/issue-1998-athlete-profile-upload-source.test.js --reporter=verbose`
- `npm run app:build`

Partial progress on #1998. Remaining work includes device-level camera/upload QA, any richer crop UI beyond the current preview/normalization flow, and broader publish/share parity tracked separately from this draft-media slice.