### PR TITLE
[codex] Add registration form editor service

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -496,6 +496,7 @@
                             <select id="registration-status" class="mt-1 w-full rounded border border-gray-300 p-2">
                                 <option value="draft">Save as draft</option>
                                 <option value="published">Publish and show link</option>
+                                <option value="closed">Closed to new submissions</option>
                             </select>
                         </div>
                         <p id="registration-form-message" class="text-sm text-gray-600"></p>

--- a/apps/app/src/lib/adapters/legacyRegistrationFormAdmin.ts
+++ b/apps/app/src/lib/adapters/legacyRegistrationFormAdmin.ts
@@ -1,4 +1,12 @@
-import { buildAdminRegistrationFormPayload as legacyBuildAdminRegistrationFormPayload, formatFieldLabels as legacyFormatFieldLabels, normalizeBackgroundCheckSettings as legacyNormalizeBackgroundCheckSettings, validateAdminRegistrationFormPayload as legacyValidateAdminRegistrationFormPayload } from '@legacy/admin-registration-forms.js';
+import {
+  buildAdminRegistrationFormPayload as legacyBuildAdminRegistrationFormPayload,
+  formatFieldLabels as legacyFormatFieldLabels,
+  isPublishedAdminRegistrationFormStatus as legacyIsPublishedAdminRegistrationFormStatus,
+  normalizeAdminRegistrationFormStatus as legacyNormalizeAdminRegistrationFormStatus,
+  normalizeBackgroundCheckSettings as legacyNormalizeBackgroundCheckSettings,
+  parseAdminRegistrationFeeAmountCents as legacyParseAdminRegistrationFeeAmountCents,
+  validateAdminRegistrationFormPayload as legacyValidateAdminRegistrationFormPayload
+} from '@legacy/admin-registration-forms.js';
 import { calculateRegistrationFeeSnapshot as legacyCalculateRegistrationFeeSnapshot, getPaymentPlanChoices as legacyGetPaymentPlanChoices, normalizeRegistrationForm as legacyNormalizeRegistrationForm } from '@legacy/registration-flow.js';
 
 /**
@@ -8,7 +16,10 @@ import { calculateRegistrationFeeSnapshot as legacyCalculateRegistrationFeeSnaps
  */
 export const buildAdminRegistrationFormPayload = legacyBuildAdminRegistrationFormPayload as (...args: any[]) => any;
 export const formatFieldLabels = legacyFormatFieldLabels as (...args: any[]) => any;
+export const isPublishedAdminRegistrationFormStatus = legacyIsPublishedAdminRegistrationFormStatus as (...args: any[]) => any;
+export const normalizeAdminRegistrationFormStatus = legacyNormalizeAdminRegistrationFormStatus as (...args: any[]) => any;
 export const normalizeBackgroundCheckSettings = legacyNormalizeBackgroundCheckSettings as (...args: any[]) => any;
+export const parseAdminRegistrationFeeAmountCents = legacyParseAdminRegistrationFeeAmountCents as (...args: any[]) => any;
 export const validateAdminRegistrationFormPayload = legacyValidateAdminRegistrationFormPayload as (...args: any[]) => any;
 export const calculateRegistrationFeeSnapshot = legacyCalculateRegistrationFeeSnapshot as (...args: any[]) => any;
 export const getPaymentPlanChoices = legacyGetPaymentPlanChoices as (...args: any[]) => any;

--- a/apps/app/src/lib/adapters/legacyRegistrationFormAdminDb.ts
+++ b/apps/app/src/lib/adapters/legacyRegistrationFormAdminDb.ts
@@ -1,0 +1,17 @@
+import * as legacyFirebase from '@legacy/firebase.js';
+
+function callLegacyFirebase(name: string, args: any[]) {
+  const fn = (legacyFirebase as Record<string, any>)[name];
+  if (typeof fn !== 'function') {
+    throw new TypeError(`Legacy firebase binding ${String(name)} is not available.`);
+  }
+  return fn(...args);
+}
+
+export const db: unknown = legacyFirebase.db;
+export const collection = (...args: any[]) => callLegacyFirebase('collection', args);
+export const doc = (...args: any[]) => callLegacyFirebase('doc', args);
+export const getDoc = (...args: any[]) => callLegacyFirebase('getDoc', args);
+export const serverTimestamp = (...args: any[]) => callLegacyFirebase('serverTimestamp', args);
+export const setDoc = (...args: any[]) => callLegacyFirebase('setDoc', args);
+export const updateDoc = (...args: any[]) => callLegacyFirebase('updateDoc', args);

--- a/apps/app/src/lib/registrationFormAdmin.test.ts
+++ b/apps/app/src/lib/registrationFormAdmin.test.ts
@@ -136,7 +136,7 @@ describe('registrationFormAdmin', () => {
     });
   });
 
-  it('round-trips web-created closed fixtures without reopening them', () => {
+  it('round-trips web-created closed fixtures without reopening them for submissions', () => {
     const draft = buildRegistrationFormEditorDraft({
       id: 'form-web',
       teamId: 'team-1',
@@ -158,7 +158,7 @@ describe('registrationFormAdmin', () => {
     expect(draft).toMatchObject({
       formId: 'form-web',
       status: 'closed',
-      published: true,
+      published: false,
       isOpen: false,
       isClosed: true,
       feeAmount: '149.99'
@@ -166,7 +166,7 @@ describe('registrationFormAdmin', () => {
     expect(result.errors).toEqual([]);
     expect(result.payload).toMatchObject({
       status: 'closed',
-      published: true,
+      published: false,
       feeAmountCents: 14999,
       waiverText: 'Closed form waiver.'
     });
@@ -175,7 +175,7 @@ describe('registrationFormAdmin', () => {
     ]);
     expect(result.publishState).toEqual({
       status: 'closed',
-      published: true,
+      published: false,
       isOpen: false,
       isClosed: true
     });

--- a/apps/app/src/lib/registrationFormAdmin.test.ts
+++ b/apps/app/src/lib/registrationFormAdmin.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildAppRegistrationFormAdminPayload,
-  buildRegistrationFormEditorDraft
+  buildRegistrationFormEditorDraft,
+  toRegistrationFeeCents,
+  validateRegistrationFormEditorDraft
 } from './registrationFormAdmin';
 
 describe('registrationFormAdmin', () => {
@@ -38,7 +40,10 @@ describe('registrationFormAdmin', () => {
         providerName: 'Checkr'
       },
       waiverText: 'I accept the risk.',
-      status: 'published'
+      status: 'published',
+      published: true,
+      isOpen: true,
+      isClosed: false
     });
 
     expect(draft).toMatchObject({
@@ -65,7 +70,7 @@ describe('registrationFormAdmin', () => {
       { id: 'academy', label: 'Academy', description: '', capacityLimit: '', active: false, waitlistEnabled: false }
     ]);
     expect(draft.discountRules).toEqual([
-      { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 25, minimumQuantity: 2, active: true }
+      { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 25, earlyBirdDeadline: '', minimumQuantity: 2, active: true }
     ]);
   });
 
@@ -109,7 +114,7 @@ describe('registrationFormAdmin', () => {
       { id: 'half-day', label: 'Half day', capacityLimit: null, active: false, waitlistEnabled: false, sortOrder: 1 }
     ]);
     expect(result.payload.discountRules).toEqual([
-      { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 2500, minimumQuantity: 2, active: true, sortOrder: 0 }
+      { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '', minimumQuantity: 2, active: true, sortOrder: 0 }
     ]);
     expect(result.normalizedForm.registrationOptions[0]).toMatchObject({
       id: 'full-day',
@@ -122,6 +127,57 @@ describe('registrationFormAdmin', () => {
     expect(result.feeSnapshot).toMatchObject({
       originalFeeAmountCents: 20000,
       finalAmountDueCents: 20000
+    });
+    expect(result.publishState).toEqual({
+      status: 'published',
+      published: true,
+      isOpen: true,
+      isClosed: false
+    });
+  });
+
+  it('round-trips web-created closed fixtures without reopening them', () => {
+    const draft = buildRegistrationFormEditorDraft({
+      id: 'form-web',
+      teamId: 'team-1',
+      programName: 'Closed Spring Registration',
+      feeAmountCents: 14999,
+      participantFields: [{ id: 'participant_1', label: 'Player name', type: 'text', required: true }],
+      guardianFields: [{ id: 'guardian_1', label: 'Guardian email', type: 'email', required: true }],
+      registrationOptions: [
+        { id: 'travel', label: 'Travel', capacityLimit: 12, active: true, waitlistEnabled: true, sortOrder: 0 }
+      ],
+      paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: false },
+      installmentPlan: { enabled: true, title: 'Two payments', installmentCount: 2, firstDueDate: '2026-07-01', intervalDays: 30 },
+      waiverText: 'Closed form waiver.',
+      status: 'closed',
+      published: true
+    });
+    const result = buildAppRegistrationFormAdminPayload(draft, { teamId: 'team-1' });
+
+    expect(draft).toMatchObject({
+      formId: 'form-web',
+      status: 'closed',
+      published: true,
+      isOpen: false,
+      isClosed: true,
+      feeAmount: '149.99'
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.payload).toMatchObject({
+      status: 'closed',
+      published: true,
+      feeAmountCents: 14999,
+      waiverText: 'Closed form waiver.'
+    });
+    expect(result.payload.registrationOptions).toEqual([
+      { id: 'travel', label: 'Travel', capacityLimit: 12, active: true, waitlistEnabled: true, sortOrder: 0 }
+    ]);
+    expect(result.publishState).toEqual({
+      status: 'closed',
+      published: true,
+      isOpen: false,
+      isClosed: true
     });
   });
 
@@ -139,5 +195,38 @@ describe('registrationFormAdmin', () => {
       'Waiver text is required.'
     ]);
     expect(result.normalizedForm.published).toBe(false);
+  });
+
+  it('validates editor-only setup errors before saving', () => {
+    expect(validateRegistrationFormEditorDraft({
+      teamId: '',
+      title: '',
+      waiverText: '',
+      feeAmount: 'not money',
+      status: 'paused' as any,
+      installmentPlan: { enabled: true, installmentCount: 3, firstDueDate: '', intervalDays: 30 }
+    })).toEqual([
+      'Team is required.',
+      'Title is required.',
+      'Waiver text is required.',
+      'Fee amount must be a valid dollar amount.',
+      'Registration status is invalid.',
+      'First installment due date is required when payment plans are enabled.'
+    ]);
+
+    expect(validateRegistrationFormEditorDraft({
+      teamId: 'team-1',
+      title: 'Free clinic',
+      waiverText: 'Accepted.',
+      feeAmount: '-1'
+    })).toEqual(['Fee amount must be zero or greater.']);
+  });
+
+  it('converts registration fee inputs to cents consistently', () => {
+    expect(toRegistrationFeeCents('125.50')).toBe(12550);
+    expect(toRegistrationFeeCents('$1,234.56')).toBe(123456);
+    expect(toRegistrationFeeCents('19.995')).toBe(2000);
+    expect(toRegistrationFeeCents('')).toBe(0);
+    expect(toRegistrationFeeCents('-5')).toBe(0);
   });
 });

--- a/apps/app/src/lib/registrationFormAdmin.ts
+++ b/apps/app/src/lib/registrationFormAdmin.ts
@@ -3,10 +3,15 @@ import {
   calculateRegistrationFeeSnapshot,
   formatFieldLabels,
   getPaymentPlanChoices,
+  isPublishedAdminRegistrationFormStatus,
   normalizeBackgroundCheckSettings,
+  normalizeAdminRegistrationFormStatus,
   normalizeRegistrationForm,
+  parseAdminRegistrationFeeAmountCents,
   validateAdminRegistrationFormPayload
 } from './adapters/legacyRegistrationFormAdmin';
+
+export type RegistrationFormEditorStatus = 'draft' | 'published' | 'closed';
 
 export type RegistrationFormEditorDraft = {
   teamId?: string;
@@ -24,7 +29,10 @@ export type RegistrationFormEditorDraft = {
   discountRules: Array<Record<string, unknown>>;
   backgroundCheck: Record<string, unknown>;
   waiverText: string;
-  status: 'draft' | 'published';
+  status: RegistrationFormEditorStatus;
+  published: boolean;
+  isOpen: boolean;
+  isClosed: boolean;
 };
 
 export type RegistrationFormAdminPayloadResult = {
@@ -33,12 +41,21 @@ export type RegistrationFormAdminPayloadResult = {
   errors: string[];
   paymentPlans: Array<Record<string, unknown>>;
   feeSnapshot: Record<string, unknown>;
+  publishState: RegistrationFormPublishState;
+};
+
+export type RegistrationFormPublishState = {
+  status: RegistrationFormEditorStatus;
+  published: boolean;
+  isOpen: boolean;
+  isClosed: boolean;
 };
 
 export function buildRegistrationFormEditorDraft(form: Record<string, any> = {}, context: { teamId?: string; formId?: string } = {}): RegistrationFormEditorDraft {
   const normalizedForm = normalizeRegistrationForm(form, context);
   const installmentPlan = normalizedForm.installmentPlan || {};
   const backgroundCheck = normalizeBackgroundCheckSettings(form.backgroundCheck || normalizedForm.backgroundCheck || {});
+  const publishState = getRegistrationFormPublishState(form.status, normalizedForm.published);
 
   return {
     teamId: normalizedForm.teamId,
@@ -69,7 +86,7 @@ export function buildRegistrationFormEditorDraft(form: Record<string, any> = {},
     discountRules: denormalizeDraftDiscountRules(normalizedForm.discountRules || []),
     backgroundCheck,
     waiverText: normalizedForm.waiverText,
-    status: normalizedForm.published ? 'published' : 'draft'
+    ...publishState
   };
 }
 
@@ -82,15 +99,60 @@ export function buildAppRegistrationFormAdminPayload(
     teamId: String(payload.teamId || ''),
     formId: String(draft.formId || '')
   });
-  const errors = validateAdminRegistrationFormPayload(payload);
+  const errors = validateRegistrationFormEditorDraft(draft, { teamId: context.teamId });
+  const publishState = getRegistrationFormPublishState(payload.status, normalizedForm.published);
 
   return {
     payload,
     normalizedForm,
     errors,
     paymentPlans: getPaymentPlanChoices(normalizedForm),
-    feeSnapshot: calculateRegistrationFeeSnapshot(normalizedForm, { now: context.now || new Date() })
+    feeSnapshot: calculateRegistrationFeeSnapshot(normalizedForm, { now: context.now || new Date() }),
+    publishState
   };
+}
+
+export function validateRegistrationFormEditorDraft(
+  draft: Partial<RegistrationFormEditorDraft> = {},
+  context: { teamId?: string } = {}
+): string[] {
+  const payload = buildAdminRegistrationFormPayload(draft, { teamId: context.teamId || draft.teamId || '' });
+  const errors = [...validateAdminRegistrationFormPayload(payload)];
+  const feeError = getFeeAmountInputError(draft.feeAmount);
+  if (feeError) errors.push(feeError);
+
+  const rawStatus = String(draft.status || '').trim().toLowerCase();
+  if (rawStatus && !['draft', 'published', 'open', 'closed'].includes(rawStatus)) {
+    errors.push('Registration status is invalid.');
+  }
+
+  if (isInstallmentPlanRequested(draft) && !payload.installmentPlan) {
+    errors.push('First installment due date is required when payment plans are enabled.');
+  }
+
+  return [...new Set(errors)];
+}
+
+export function getRegistrationFormPublishState(status: unknown, published = false): RegistrationFormPublishState {
+  const normalizedStatus = normalizeRegistrationFormEditorStatus(status, published);
+  return {
+    status: normalizedStatus,
+    published: Boolean(isPublishedAdminRegistrationFormStatus(normalizedStatus)),
+    isOpen: normalizedStatus === 'published',
+    isClosed: normalizedStatus === 'closed'
+  };
+}
+
+export function normalizeRegistrationFormEditorStatus(status: unknown, published = false): RegistrationFormEditorStatus {
+  const rawStatus = String(status || '').trim().toLowerCase();
+  const normalizedStatus = normalizeAdminRegistrationFormStatus(rawStatus);
+  if (normalizedStatus === 'closed') return 'closed';
+  if (normalizedStatus === 'published' || published) return 'published';
+  return 'draft';
+}
+
+export function toRegistrationFeeCents(value: unknown) {
+  return Number(parseAdminRegistrationFeeAmountCents(value));
 }
 
 function formatFeeInput(feeAmountCents: number) {
@@ -106,4 +168,18 @@ function denormalizeDraftDiscountRules(rules: Array<Record<string, any>> = []) {
       ? Number((Math.max(0, Number(rule?.amountValue || 0)) / 100).toFixed(2))
       : Math.max(0, Number(rule?.amountValue || 0))
   }));
+}
+
+function getFeeAmountInputError(value: unknown) {
+  const normalized = String(value ?? '').replace(/[$,]/g, '').trim();
+  if (!normalized) return '';
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) return 'Fee amount must be a valid dollar amount.';
+  if (parsed < 0) return 'Fee amount must be zero or greater.';
+  return '';
+}
+
+function isInstallmentPlanRequested(draft: Partial<RegistrationFormEditorDraft>) {
+  const plan = draft.installmentPlan as Record<string, unknown> | undefined;
+  return plan?.enabled === true || plan?.enabled === 'true';
 }

--- a/apps/app/src/lib/registrationFormAdminService.test.ts
+++ b/apps/app/src/lib/registrationFormAdminService.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const firebaseMocks = vi.hoisted(() => {
+  const formatPart = (part: unknown) => {
+    if (typeof part === 'string') return part;
+    if (part && typeof part === 'object' && 'path' in part) return String((part as any).path);
+    return String(part);
+  };
+
+  return {
+    db: { path: 'db' },
+    collection: vi.fn((...parts: unknown[]) => ({ path: parts.map(formatPart).join('/') })),
+    doc: vi.fn((...parts: unknown[]) => {
+      if (parts.length === 1) {
+        return { id: 'generated-form', path: `${formatPart(parts[0])}/generated-form` };
+      }
+      return { id: formatPart(parts[parts.length - 1]), path: parts.map(formatPart).join('/') };
+    }),
+    getDoc: vi.fn(),
+    serverTimestamp: vi.fn(() => 'server-timestamp'),
+    setDoc: vi.fn(),
+    updateDoc: vi.fn()
+  };
+});
+
+vi.mock('../../../../js/firebase.js', () => firebaseMocks);
+
+import {
+  canManageRegistrationFormsForApp,
+  loadRegistrationFormEditorForApp,
+  saveRegistrationFormEditorForApp
+} from './registrationFormAdminService';
+
+const coachUser = {
+  uid: 'coach-1',
+  email: 'coach@example.com',
+  coachOf: ['team-1'],
+  roles: []
+} as any;
+
+const webCreatedFixture = {
+  teamId: 'team-1',
+  programName: 'Spring Soccer',
+  title: 'Spring Soccer',
+  description: 'Season signup',
+  season: 'Spring 2026',
+  feeAmountCents: 12550,
+  participantFields: [
+    { id: 'participant_1', label: 'Player name', type: 'text', required: true },
+    { id: 'participant_2', label: 'Birthdate', type: 'date', required: true }
+  ],
+  guardianFields: [
+    { id: 'guardian_1', label: 'Guardian email', type: 'email', required: true }
+  ],
+  registrationOptions: [
+    { id: 'travel', label: 'Travel', capacityLimit: 12, active: true, waitlistEnabled: true, sortOrder: 0 }
+  ],
+  paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+  installmentPlan: { enabled: true, title: 'Two payments', installmentCount: 2, firstDueDate: '2026-06-01', intervalDays: 14 },
+  discountRules: [
+    { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 2500, minimumQuantity: 2, active: true, sortOrder: 0 }
+  ],
+  waiverText: 'Guardian accepts the season waiver.',
+  status: 'published',
+  published: true
+};
+
+describe('registrationFormAdminService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('checks staff access for registration form management', () => {
+    expect(canManageRegistrationFormsForApp(coachUser, 'team-1')).toBe(true);
+    expect(canManageRegistrationFormsForApp({ uid: 'admin-1', roles: ['platformAdmin'] } as any, 'team-2')).toBe(true);
+    expect(canManageRegistrationFormsForApp({ uid: 'parent-1', coachOf: [] } as any, 'team-1')).toBe(false);
+    expect(canManageRegistrationFormsForApp(null, 'team-1')).toBe(false);
+  });
+
+  it('loads a web-created registration form into the app editor model', async () => {
+    firebaseMocks.getDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => webCreatedFixture
+    });
+
+    const draft = await loadRegistrationFormEditorForApp(coachUser, 'team-1', 'form-1');
+
+    expect(firebaseMocks.getDoc).toHaveBeenCalledWith({ id: 'form-1', path: 'db/teams/team-1/registrationForms/form-1' });
+    expect(draft).toMatchObject({
+      teamId: 'team-1',
+      formId: 'form-1',
+      title: 'Spring Soccer',
+      feeAmount: '125.50',
+      status: 'published',
+      published: true,
+      isOpen: true,
+      waiverText: 'Guardian accepts the season waiver.',
+      paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true }
+    });
+    expect(draft.registrationOptions).toEqual([
+      { id: 'travel', label: 'Travel', description: '', capacityLimit: '12', active: true, waitlistEnabled: true }
+    ]);
+    expect(draft.discountRules).toEqual([
+      { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 25, earlyBirdDeadline: '', minimumQuantity: 2, active: true }
+    ]);
+  });
+
+  it('creates published registration forms with legacy-compatible payload metadata', async () => {
+    const result = await saveRegistrationFormEditorForApp({
+      user: coachUser,
+      teamId: 'team-1',
+      draft: {
+        title: 'Summer Camp',
+        description: 'June camp',
+        season: 'Summer 2026',
+        feeAmount: '200.00',
+        participantFieldsText: 'Player name',
+        guardianFieldsText: 'Guardian email',
+        registrationOptions: [
+          { id: 'full-day', label: 'Full day', capacityLimit: '20', active: true, waitlistEnabled: true }
+        ],
+        paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: false },
+        installmentPlan: { enabled: true, installmentCount: 4, firstDueDate: '2026-06-01', intervalDays: 14 },
+        waiverText: 'Guardian accepts camp waiver.',
+        status: 'published'
+      },
+      now: new Date('2026-05-15T12:00:00Z')
+    });
+
+    expect(result).toMatchObject({ formId: 'generated-form', created: true });
+    expect(firebaseMocks.setDoc).toHaveBeenCalledWith(
+      { id: 'generated-form', path: 'db/teams/team-1/registrationForms/generated-form' },
+      expect.objectContaining({
+        teamId: 'team-1',
+        programName: 'Summer Camp',
+        title: 'Summer Camp',
+        feeAmountCents: 20000,
+        status: 'published',
+        published: true,
+        waiverText: 'Guardian accepts camp waiver.',
+        createdAt: 'server-timestamp',
+        createdBy: 'coach-1',
+        updatedAt: 'server-timestamp',
+        updatedBy: 'coach-1'
+      })
+    );
+    expect((firebaseMocks.setDoc.mock.calls[0][1] as any).registrationOptions).toEqual([
+      { id: 'full-day', label: 'Full day', capacityLimit: 20, active: true, waitlistEnabled: true, sortOrder: 0 }
+    ]);
+    expect((firebaseMocks.setDoc.mock.calls[0][1] as any).installmentPlan).toEqual({
+      enabled: true,
+      title: 'Installment plan',
+      installmentCount: 4,
+      firstDueDate: '2026-06-01',
+      intervalDays: 14
+    });
+  });
+
+  it('updates closed registration forms without changing their publish state', async () => {
+    const result = await saveRegistrationFormEditorForApp({
+      user: coachUser,
+      teamId: 'team-1',
+      formId: 'form-1',
+      draft: {
+        formId: 'form-1',
+        title: 'Spring Soccer Waitlist',
+        description: 'Season signup',
+        participantFieldsText: 'Player name\nBirthdate',
+        guardianFieldsText: 'Guardian email',
+        registrationOptions: [
+          { id: 'travel', label: 'Travel', capacityLimit: '12', active: true, waitlistEnabled: true }
+        ],
+        paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+        installmentPlan: { enabled: true, title: 'Two payments', installmentCount: 2, firstDueDate: '2026-06-01', intervalDays: 14 },
+        discountRules: [
+          { id: 'discount_1', type: 'quantity', label: 'Sibling discount', amountType: 'fixed', amountValue: 25, minimumQuantity: 2, active: true }
+        ],
+        waiverText: 'Guardian accepts the season waiver.',
+        feeAmount: '99.99',
+        status: 'closed'
+      }
+    });
+
+    expect(result).toMatchObject({
+      formId: 'form-1',
+      created: false,
+      publishState: {
+        status: 'closed',
+        published: true,
+        isOpen: false,
+        isClosed: true
+      }
+    });
+    expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
+      { id: 'form-1', path: 'db/teams/team-1/registrationForms/form-1' },
+      expect.objectContaining({
+        programName: 'Spring Soccer Waitlist',
+        feeAmountCents: 9999,
+        status: 'closed',
+        published: true,
+        updatedAt: 'server-timestamp',
+        updatedBy: 'coach-1'
+      })
+    );
+  });
+
+  it('rejects invalid drafts before writing to Firestore', async () => {
+    await expect(saveRegistrationFormEditorForApp({
+      user: coachUser,
+      teamId: 'team-1',
+      draft: {
+        title: '',
+        waiverText: '',
+        feeAmount: 'bad',
+        status: 'published'
+      }
+    })).rejects.toThrow('Title is required. Waiver text is required. Fee amount must be a valid dollar amount.');
+
+    expect(firebaseMocks.setDoc).not.toHaveBeenCalled();
+    expect(firebaseMocks.updateDoc).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/lib/registrationFormAdminService.test.ts
+++ b/apps/app/src/lib/registrationFormAdminService.test.ts
@@ -156,7 +156,7 @@ describe('registrationFormAdminService', () => {
     });
   });
 
-  it('updates closed registration forms without changing their publish state', async () => {
+  it('updates closed registration forms without reopening public submissions', async () => {
     const result = await saveRegistrationFormEditorForApp({
       user: coachUser,
       teamId: 'team-1',
@@ -186,7 +186,7 @@ describe('registrationFormAdminService', () => {
       created: false,
       publishState: {
         status: 'closed',
-        published: true,
+        published: false,
         isOpen: false,
         isClosed: true
       }
@@ -197,7 +197,7 @@ describe('registrationFormAdminService', () => {
         programName: 'Spring Soccer Waitlist',
         feeAmountCents: 9999,
         status: 'closed',
-        published: true,
+        published: false,
         updatedAt: 'server-timestamp',
         updatedBy: 'coach-1'
       })

--- a/apps/app/src/lib/registrationFormAdminService.ts
+++ b/apps/app/src/lib/registrationFormAdminService.ts
@@ -1,0 +1,114 @@
+import { collection, db, doc, getDoc, serverTimestamp, setDoc, updateDoc } from './adapters/legacyRegistrationFormAdminDb';
+import {
+  buildAppRegistrationFormAdminPayload,
+  buildRegistrationFormEditorDraft,
+  type RegistrationFormAdminPayloadResult,
+  type RegistrationFormEditorDraft
+} from './registrationFormAdmin';
+import type { AuthUser } from './types';
+
+export type SaveRegistrationFormEditorForAppInput = {
+  user: AuthUser | null;
+  teamId: string;
+  formId?: string;
+  draft: Partial<RegistrationFormEditorDraft>;
+  now?: Date;
+};
+
+export type SaveRegistrationFormEditorForAppResult = RegistrationFormAdminPayloadResult & {
+  formId: string;
+  created: boolean;
+};
+
+export async function loadRegistrationFormEditorForApp(
+  user: AuthUser | null,
+  teamId: string,
+  formId: string
+): Promise<RegistrationFormEditorDraft> {
+  const normalizedTeamId = compactString(teamId);
+  const normalizedFormId = compactString(formId);
+  assertCanManageRegistrationForms(user, normalizedTeamId);
+  if (!normalizedFormId) throw new Error('Registration form is required.');
+
+  const formSnap = await getDoc(doc(db, 'teams', normalizedTeamId, 'registrationForms', normalizedFormId));
+  const form = formSnap?.exists?.() ? { id: normalizedFormId, ...(formSnap.data() || {}) } : null;
+  if (!form) throw new Error('Registration form not found.');
+
+  return buildRegistrationFormEditorDraft(form, {
+    teamId: normalizedTeamId,
+    formId: normalizedFormId
+  });
+}
+
+export async function saveRegistrationFormEditorForApp({
+  user,
+  teamId,
+  formId = '',
+  draft,
+  now
+}: SaveRegistrationFormEditorForAppInput): Promise<SaveRegistrationFormEditorForAppResult> {
+  const normalizedTeamId = compactString(teamId || draft.teamId);
+  const normalizedFormId = compactString(formId || draft.formId);
+  assertCanManageRegistrationForms(user, normalizedTeamId);
+
+  const result = buildAppRegistrationFormAdminPayload({
+    ...draft,
+    teamId: normalizedTeamId,
+    formId: normalizedFormId
+  }, {
+    teamId: normalizedTeamId,
+    now
+  });
+  if (result.errors.length) {
+    throw new Error(result.errors.join(' '));
+  }
+
+  const actorId = compactString(user?.uid) || null;
+  const timestamp = serverTimestamp();
+  const updatePayload = {
+    ...result.payload,
+    teamId: normalizedTeamId,
+    updatedAt: timestamp,
+    updatedBy: actorId
+  };
+
+  if (normalizedFormId) {
+    await updateDoc(doc(db, 'teams', normalizedTeamId, 'registrationForms', normalizedFormId), updatePayload);
+    return {
+      ...result,
+      formId: normalizedFormId,
+      created: false
+    };
+  }
+
+  const formRef = doc(collection(db, `teams/${normalizedTeamId}/registrationForms`));
+  await setDoc(formRef, {
+    ...updatePayload,
+    createdAt: timestamp,
+    createdBy: actorId
+  });
+
+  return {
+    ...result,
+    formId: compactString(formRef?.id),
+    created: true
+  };
+}
+
+export function canManageRegistrationFormsForApp(user: AuthUser | null, teamId: string) {
+  const normalizedTeamId = compactString(teamId);
+  if (!normalizedTeamId || !user?.uid) return false;
+  if (Array.isArray(user.roles) && user.roles.some((role) => role === 'admin' || role === 'platformAdmin')) return true;
+  return Array.isArray(user.coachOf) && user.coachOf.map(compactString).includes(normalizedTeamId);
+}
+
+function assertCanManageRegistrationForms(user: AuthUser | null, teamId: string) {
+  if (!compactString(teamId)) throw new Error('Team is required.');
+  if (!canManageRegistrationFormsForApp(user, teamId)) {
+    throw new Error('Admin access is required to manage registration forms.');
+  }
+}
+
+function compactString(value: unknown) {
+  return String(value || '').trim();
+}

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -74,7 +74,7 @@ export function normalizeAdminRegistrationFormStatus(status = 'draft') {
 
 export function isPublishedAdminRegistrationFormStatus(status = 'draft') {
     const normalized = normalizeAdminRegistrationFormStatus(status);
-    return normalized === 'published' || normalized === 'closed';
+    return normalized === 'published';
 }
 
 export function parseAdminRegistrationFeeAmountCents(value = '') {

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -4,6 +4,7 @@ const DEFAULT_PAYMENT_SETTINGS = {
     offlinePaymentEnabled: false,
     onlineCheckoutEnabled: false
 };
+const ADMIN_REGISTRATION_FORM_STATUSES = ['draft', 'published', 'closed'];
 
 export function fieldLabelsToDefinitions(labels = [], prefix = 'field') {
     return labels
@@ -33,8 +34,8 @@ export function formatFieldLabels(fields = [], fallbackLabels = []) {
 export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
     const participantLabels = parseFieldLabels(input.participantFieldsText);
     const guardianLabels = parseFieldLabels(input.guardianFieldsText);
-    const feeAmount = Number(input.feeAmount || 0);
-    const status = input.status === 'published' ? 'published' : 'draft';
+    const feeAmountCents = parseAdminRegistrationFeeAmountCents(input.feeAmount);
+    const status = normalizeAdminRegistrationFormStatus(input.status || (input.published === true ? 'published' : 'draft'));
     const installmentPlan = normalizeInstallmentPlan(input.installmentPlan || input);
 
     return {
@@ -44,7 +45,7 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
         title: String(input.title || input.programName || '').trim(),
         description: String(input.description || '').trim(),
         season: String(input.season || '').trim(),
-        feeAmountCents: Math.max(0, Math.round(feeAmount * 100)),
+        feeAmountCents,
         currency: 'USD',
         installmentPlan,
         participantFields: fieldLabelsToDefinitions(
@@ -61,8 +62,27 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
         backgroundCheck: normalizeBackgroundCheckSettings(input.backgroundCheck),
         waiverText: String(input.waiverText || '').trim(),
         status,
-        published: status === 'published'
+        published: isPublishedAdminRegistrationFormStatus(status)
     };
+}
+
+export function normalizeAdminRegistrationFormStatus(status = 'draft') {
+    const normalized = String(status || '').trim().toLowerCase();
+    if (normalized === 'open') return 'published';
+    return ADMIN_REGISTRATION_FORM_STATUSES.includes(normalized) ? normalized : 'draft';
+}
+
+export function isPublishedAdminRegistrationFormStatus(status = 'draft') {
+    const normalized = normalizeAdminRegistrationFormStatus(status);
+    return normalized === 'published' || normalized === 'closed';
+}
+
+export function parseAdminRegistrationFeeAmountCents(value = '') {
+    const normalized = String(value ?? '').replace(/[$,]/g, '').trim();
+    if (!normalized) return 0;
+    const parsed = Number(normalized);
+    if (!Number.isFinite(parsed) || parsed < 0) return 0;
+    return Math.max(0, Math.round(parsed * 100));
 }
 
 export function normalizeBackgroundCheck(settings = {}) {
@@ -232,6 +252,12 @@ export function validateAdminRegistrationFormPayload(payload = {}) {
     if (!payload.teamId) errors.push('Team is required.');
     if (!payload.programName) errors.push('Title is required.');
     if (!payload.waiverText) errors.push('Waiver text is required.');
+    if (!ADMIN_REGISTRATION_FORM_STATUSES.includes(String(payload.status || 'draft'))) {
+        errors.push('Registration status is invalid.');
+    }
+    if (!Number.isFinite(Number(payload.feeAmountCents)) || Number(payload.feeAmountCents) < 0) {
+        errors.push('Fee amount must be zero or greater.');
+    }
     if (!Array.isArray(payload.participantFields) || payload.participantFields.length < 1) {
         errors.push('At least one participant field is required.');
     }

--- a/js/admin.js
+++ b/js/admin.js
@@ -1174,7 +1174,7 @@ window.startRegistrationFormAdmin = function (formId = '') {
     activeRegistrationOptions = Array.isArray(form.registrationOptions) ? form.registrationOptions.map(option => ({ ...option })) : [];
     renderRegistrationOptionsEditor();
     document.getElementById('registration-waiver').value = form.waiverText || '';
-    document.getElementById('registration-status').value = form.status === 'published' || form.published === true ? 'published' : 'draft';
+    document.getElementById('registration-status').value = getRegistrationAdminStatus(form);
     document.getElementById('registration-form-message').textContent = '';
     editor.classList.remove('hidden');
 };
@@ -1297,7 +1297,10 @@ function renderRegistrationFormsList() {
     }
 
     list.innerHTML = activeRegistrationForms.map(form => {
-        const published = form.status === 'published' || form.published === true;
+        const status = getRegistrationAdminStatus(form);
+        const published = status === 'published';
+        const closed = status === 'closed';
+        const statusLabel = status === 'closed' ? 'Closed' : published ? 'Published' : 'Draft';
         const link = getAdminRegistrationShareUrl(activeRegistrationTeam.id, form.id, window.location.origin);
         const teamIdArg = inlineJsString(activeRegistrationTeam.id);
         const formIdArg = inlineJsString(form.id);
@@ -1306,14 +1309,21 @@ function renderRegistrationFormsList() {
                 <div class="flex items-start justify-between gap-3">
                     <div>
                         <p class="font-semibold text-gray-900">${escapeHtml(form.programName || form.title || 'Untitled form')}</p>
-                        <p class="text-xs text-gray-500">${escapeHtml(form.programType || 'season')} • ${published ? 'Published' : 'Draft'}</p>
+                        <p class="text-xs text-gray-500">${escapeHtml(form.programType || 'season')} • ${statusLabel}</p>
                     </div>
                     <button onclick="window.startRegistrationFormAdmin(${formIdArg})" class="text-sm text-indigo-600 hover:text-indigo-800">Edit</button>
                 </div>
-                ${published ? `<div class="mt-2 rounded bg-green-50 p-2 text-xs text-green-800 break-all">${escapeHtml(link)} <button onclick="window.copyRegistrationLinkAdmin(${teamIdArg}, ${formIdArg})" class="ml-2 font-semibold underline">Copy</button></div>` : '<p class="mt-2 text-xs text-gray-500">Publish to generate a parent-facing registration link.</p>'}
+                ${published ? `<div class="mt-2 rounded bg-green-50 p-2 text-xs text-green-800 break-all">${escapeHtml(link)} <button onclick="window.copyRegistrationLinkAdmin(${teamIdArg}, ${formIdArg})" class="ml-2 font-semibold underline">Copy</button></div>` : closed ? '<p class="mt-2 text-xs text-amber-700">Closed forms keep review history but do not accept new registrations.</p>' : '<p class="mt-2 text-xs text-gray-500">Publish to generate a parent-facing registration link.</p>'}
             </div>
         `;
     }).join('');
+}
+
+function getRegistrationAdminStatus(form = {}) {
+    const status = String(form.status || '').trim().toLowerCase();
+    if (status === 'closed') return 'closed';
+    if (status === 'published' || status === 'open' || form.published === true) return 'published';
+    return 'draft';
 }
 
 async function saveRegistrationForm(event) {
@@ -1382,7 +1392,9 @@ async function saveRegistrationForm(event) {
         return;
     }
 
-    message.textContent = payload.published ? 'Registration form saved and published.' : 'Registration form saved as draft.';
+    message.textContent = payload.status === 'closed'
+        ? 'Registration form saved and closed.'
+        : payload.published ? 'Registration form saved and published.' : 'Registration form saved as draft.';
     if (activeRegistrationTeam?.id === teamId) {
         await loadRegistrationFormsForActiveTeam();
         document.getElementById('registration-form-editor').classList.add('hidden');

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -236,7 +236,7 @@ describe('admin registration form setup', () => {
         ]);
     });
 
-    it('preserves closed published forms and normalizes open status aliases', () => {
+    it('preserves closed forms as unavailable and normalizes open status aliases', () => {
         const closedPayload = buildAdminRegistrationFormPayload({
             title: 'Spring Soccer',
             waiverText: 'Accepted.',
@@ -251,7 +251,7 @@ describe('admin registration form setup', () => {
 
         expect(closedPayload).toMatchObject({
             status: 'closed',
-            published: true,
+            published: false,
             feeAmountCents: 123456
         });
         expect(openPayload).toMatchObject({
@@ -259,7 +259,7 @@ describe('admin registration form setup', () => {
             published: true
         });
         expect(normalizeAdminRegistrationFormStatus('paused')).toBe('draft');
-        expect(isPublishedAdminRegistrationFormStatus('closed')).toBe(true);
+        expect(isPublishedAdminRegistrationFormStatus('closed')).toBe(false);
     });
 
     it('converts admin registration fee inputs to safe cents', () => {

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -5,12 +5,15 @@ import {
     fieldLabelsToDefinitions,
     formatRegistrationDiscountRulesText,
     getAdminRegistrationShareUrl,
+    isPublishedAdminRegistrationFormStatus,
     normalizeBackgroundCheck,
+    normalizeAdminRegistrationFormStatus,
     normalizePaymentSettings,
     normalizeBackgroundCheckSettings,
     normalizeInstallmentPlan,
     normalizeRegistrationDiscountRules,
     normalizeRegistrationOptions,
+    parseAdminRegistrationFeeAmountCents,
     parseRegistrationDiscountRulesText,
     validateAdminRegistrationFormPayload
 } from '../../js/admin-registration-forms.js';
@@ -233,6 +236,49 @@ describe('admin registration form setup', () => {
         ]);
     });
 
+    it('preserves closed published forms and normalizes open status aliases', () => {
+        const closedPayload = buildAdminRegistrationFormPayload({
+            title: 'Spring Soccer',
+            waiverText: 'Accepted.',
+            feeAmount: '$1,234.56',
+            status: 'closed'
+        }, { teamId: 'team-1' });
+        const openPayload = buildAdminRegistrationFormPayload({
+            title: 'Summer Camp',
+            waiverText: 'Accepted.',
+            status: 'open'
+        }, { teamId: 'team-1' });
+
+        expect(closedPayload).toMatchObject({
+            status: 'closed',
+            published: true,
+            feeAmountCents: 123456
+        });
+        expect(openPayload).toMatchObject({
+            status: 'published',
+            published: true
+        });
+        expect(normalizeAdminRegistrationFormStatus('paused')).toBe('draft');
+        expect(isPublishedAdminRegistrationFormStatus('closed')).toBe(true);
+    });
+
+    it('converts admin registration fee inputs to safe cents', () => {
+        expect(parseAdminRegistrationFeeAmountCents('125.50')).toBe(12550);
+        expect(parseAdminRegistrationFeeAmountCents('$1,234.56')).toBe(123456);
+        expect(parseAdminRegistrationFeeAmountCents('19.995')).toBe(2000);
+        expect(parseAdminRegistrationFeeAmountCents('')).toBe(0);
+        expect(parseAdminRegistrationFeeAmountCents('-2')).toBe(0);
+        expect(validateAdminRegistrationFormPayload({
+            teamId: 'team-1',
+            programName: 'Bad fee',
+            waiverText: 'Accepted.',
+            status: 'published',
+            feeAmountCents: Number.NaN,
+            participantFields: [{ id: 'p', label: 'Player' }],
+            guardianFields: [{ id: 'g', label: 'Guardian' }]
+        })).toEqual(['Fee amount must be zero or greater.']);
+    });
+
     it('creates a shareable public registration URL for published forms', () => {
         expect(getAdminRegistrationShareUrl('team 1', 'form/2', 'https://allplays.example')).toBe(
             'https://allplays.example/registration.html?teamId=team%201&formId=form%2F2'
@@ -268,6 +314,7 @@ describe('admin registration form setup', () => {
         expect(adminPage).toContain('registration-background-check-instructions');
         expect(adminPage).toContain('registration-waiver');
         expect(adminPage).toContain('Publish and show link');
+        expect(adminPage).toContain('Closed to new submissions');
         expect(adminJs).toContain('window.openRegistrationFormsAdmin');
         expect(adminJs).toContain('window.addRegistrationOptionAdmin');
         expect(adminJs).toContain('window.moveRegistrationOptionAdmin');
@@ -280,6 +327,8 @@ describe('admin registration form setup', () => {
         expect(adminJs).toContain("document.getElementById('registration-background-check-enabled')");
         expect(adminJs).toContain("document.getElementById('registration-background-check-required')");
         expect(adminJs).toContain("document.getElementById('registration-background-check-instructions')");
+        expect(adminJs).toContain('getRegistrationAdminStatus(form)');
+        expect(adminJs).toContain("payload.status === 'closed'");
         expect(adminJs).toContain('const teamId = activeRegistrationTeam.id;');
         expect(adminJs).toContain('if (activeRegistrationTeam?.id !== teamId) return;');
         expect(adminJs).toContain('teams/${teamId}/registrationForms');

--- a/tests/unit/issue-1995-registration-form-admin-source.test.js
+++ b/tests/unit/issue-1995-registration-form-admin-source.test.js
@@ -48,16 +48,16 @@ describe('issue 1995 registration form admin source contract', () => {
     it('keeps regression coverage for setup, editing, validation, and workflow scope', () => {
         expect(appAdminTestSource).toContain('hydrates an existing registration form into app-editable draft state');
         expect(appAdminTestSource).toContain('builds legacy-compatible app setup payloads with options, fees, waivers, payment plans, waitlists, and editable fixed discounts');
-        expect(appAdminTestSource).toContain('round-trips web-created closed fixtures without reopening them');
+        expect(appAdminTestSource).toContain('round-trips web-created closed fixtures without reopening them for submissions');
         expect(appAdminTestSource).toContain('returns validation errors without throwing so the app editor can show inline setup problems');
         expect(appAdminTestSource).toContain('validates editor-only setup errors before saving');
         expect(appAdminTestSource).toContain('converts registration fee inputs to cents consistently');
         expect(appAdminServiceTestSource).toContain('loads a web-created registration form into the app editor model');
         expect(appAdminServiceTestSource).toContain('creates published registration forms with legacy-compatible payload metadata');
-        expect(appAdminServiceTestSource).toContain('updates closed registration forms without changing their publish state');
+        expect(appAdminServiceTestSource).toContain('updates closed registration forms without reopening public submissions');
         expect(legacyAdminTestSource).toContain('builds draft and published form payloads with metadata, fields, waiver, and fee');
         expect(legacyAdminTestSource).toContain('emits the option, waiver, fee, and payment-plan shape consumed by app and legacy registration flows');
-        expect(legacyAdminTestSource).toContain('preserves closed published forms and normalizes open status aliases');
+        expect(legacyAdminTestSource).toContain('preserves closed forms as unavailable and normalizes open status aliases');
         expect(legacyAdminTestSource).toContain('creates a shareable public registration URL for published forms');
         expect(capabilitySource).toContain('legacy still owns setup');
         expect(workflowRegistrationTestSource).toContain('manual provider pulls');

--- a/tests/unit/issue-1995-registration-form-admin-source.test.js
+++ b/tests/unit/issue-1995-registration-form-admin-source.test.js
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 
 const appAdminSource = readFileSync(new URL('../../apps/app/src/lib/registrationFormAdmin.ts', import.meta.url), 'utf8');
 const appAdminTestSource = readFileSync(new URL('../../apps/app/src/lib/registrationFormAdmin.test.ts', import.meta.url), 'utf8');
+const appAdminServiceSource = readFileSync(new URL('../../apps/app/src/lib/registrationFormAdminService.ts', import.meta.url), 'utf8');
+const appAdminServiceTestSource = readFileSync(new URL('../../apps/app/src/lib/registrationFormAdminService.test.ts', import.meta.url), 'utf8');
 const legacyAdminSource = readFileSync(new URL('../../js/admin-registration-forms.js', import.meta.url), 'utf8');
 const legacyAdminTestSource = readFileSync(new URL('./admin-registration-forms.test.js', import.meta.url), 'utf8');
 const capabilitySource = readFileSync(new URL('../../apps/app/src/data/capabilities.ts', import.meta.url), 'utf8');
@@ -13,10 +15,21 @@ describe('issue 1995 registration form admin source contract', () => {
         expect(appAdminSource).toContain('export type RegistrationFormEditorDraft');
         expect(appAdminSource).toContain('export function buildRegistrationFormEditorDraft');
         expect(appAdminSource).toContain('export function buildAppRegistrationFormAdminPayload');
+        expect(appAdminSource).toContain('export function validateRegistrationFormEditorDraft');
+        expect(appAdminSource).toContain('export function getRegistrationFormPublishState');
         expect(appAdminSource).toContain('buildAdminRegistrationFormPayload(draft, { teamId: context.teamId || draft.teamId || \'\' })');
         expect(appAdminSource).toContain('normalizeRegistrationForm(payload, {');
         expect(appAdminSource).toContain('paymentPlans: getPaymentPlanChoices(normalizedForm)');
         expect(appAdminSource).toContain('feeSnapshot: calculateRegistrationFeeSnapshot(normalizedForm, { now: context.now || new Date() })');
+    });
+
+    it('keeps app registration form admin service wired to legacy registrationForms documents', () => {
+        expect(appAdminServiceSource).toContain('export async function loadRegistrationFormEditorForApp');
+        expect(appAdminServiceSource).toContain('export async function saveRegistrationFormEditorForApp');
+        expect(appAdminServiceSource).toContain("'teams', normalizedTeamId, 'registrationForms'");
+        expect(appAdminServiceSource).toContain('createdAt: timestamp');
+        expect(appAdminServiceSource).toContain('updatedAt: timestamp');
+        expect(appAdminServiceSource).toContain('canManageRegistrationFormsForApp');
     });
 
     it('keeps the legacy admin form builder normalizing options, discounts, payment plans, and screening settings', () => {
@@ -26,6 +39,8 @@ describe('issue 1995 registration form admin source contract', () => {
         expect(legacyAdminSource).toContain('discountRules: normalizeRegistrationDiscountRules(input.discountRules)');
         expect(legacyAdminSource).toContain('backgroundCheck: normalizeBackgroundCheckSettings(input.backgroundCheck)');
         expect(legacyAdminSource).toContain('export function normalizeInstallmentPlan');
+        expect(legacyAdminSource).toContain('export function normalizeAdminRegistrationFormStatus');
+        expect(legacyAdminSource).toContain('export function parseAdminRegistrationFeeAmountCents');
         expect(legacyAdminSource).toContain('export function getAdminRegistrationShareUrl');
         expect(legacyAdminSource).toContain('export const adminRegistrationDefaults');
     });
@@ -33,9 +48,16 @@ describe('issue 1995 registration form admin source contract', () => {
     it('keeps regression coverage for setup, editing, validation, and workflow scope', () => {
         expect(appAdminTestSource).toContain('hydrates an existing registration form into app-editable draft state');
         expect(appAdminTestSource).toContain('builds legacy-compatible app setup payloads with options, fees, waivers, payment plans, waitlists, and editable fixed discounts');
+        expect(appAdminTestSource).toContain('round-trips web-created closed fixtures without reopening them');
         expect(appAdminTestSource).toContain('returns validation errors without throwing so the app editor can show inline setup problems');
+        expect(appAdminTestSource).toContain('validates editor-only setup errors before saving');
+        expect(appAdminTestSource).toContain('converts registration fee inputs to cents consistently');
+        expect(appAdminServiceTestSource).toContain('loads a web-created registration form into the app editor model');
+        expect(appAdminServiceTestSource).toContain('creates published registration forms with legacy-compatible payload metadata');
+        expect(appAdminServiceTestSource).toContain('updates closed registration forms without changing their publish state');
         expect(legacyAdminTestSource).toContain('builds draft and published form payloads with metadata, fields, waiver, and fee');
         expect(legacyAdminTestSource).toContain('emits the option, waiver, fee, and payment-plan shape consumed by app and legacy registration flows');
+        expect(legacyAdminTestSource).toContain('preserves closed published forms and normalizes open status aliases');
         expect(legacyAdminTestSource).toContain('creates a shareable public registration URL for published forms');
         expect(capabilitySource).toContain('legacy still owns setup');
         expect(workflowRegistrationTestSource).toContain('manual provider pulls');


### PR DESCRIPTION
## Summary
- Add app-side registration form editor model state for draft/published/closed forms, validation, and cents conversion against the legacy registration document shape.
- Add a Firestore-backed app registration form admin service for staff create/edit saves with created/updated metadata.
- Preserve closed-form round-tripping in the legacy admin editor and shared admin payload builder.

## Validation
- `npm --prefix apps/app test -- --run src/lib/registrationFormAdmin.test.ts src/lib/registrationFormAdminService.test.ts`
- `npx vitest run tests/unit/admin-registration-forms.test.js tests/unit/issue-1995-registration-form-admin-source.test.js --reporter=verbose`
- `npm run app:build`

Refs #1995

## Remaining work
- Wire a full app UI around the service from team settings.
- Verify end-to-end form submission through both app and `registration.html` after the UI path lands.
- Update `capabilities.ts` only when registration setup reaches full native parity.