### PR TITLE
Add schedule sharing controls

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -109,6 +109,9 @@
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
                     Sync Calendar
                 </button>
+                <button id="public-games-feed" hidden class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 rounded-lg hover:bg-emerald-100 transition border border-emerald-200">
+                    Fan Feed
+                </button>
             </div>
         </div>
 
@@ -421,6 +424,14 @@
                                 end: game.endDate?.toDate ? game.endDate.toDate() : (game.endDate ? new Date(game.endDate) : null), // Add this line
                                 location: game.location || 'TBD',
                                 status: game.status,
+                                visibility: game.visibility,
+                                isPublic: game.isPublic,
+                                public: game.public,
+                                isPrivate: game.isPrivate,
+                                private: game.private,
+                                shareable: game.shareable,
+                                isShareable: game.isShareable,
+                                publicCalendar: game.publicCalendar,
                                 isHome: game.isHome,
                                 kitColor: game.kitColor,
                                 arrivalTime: game.arrivalTime,
@@ -555,6 +566,7 @@
                 return true;
             });
 
+            updatePublicGamesFeedButton();
             render();
         }
 
@@ -977,6 +989,93 @@
             }
         }
 
+        function isShareableFanGame(game = {}) {
+            const visibility = String(game?.visibility || '').toLowerCase();
+            if (visibility === 'private' || game?.isPrivate === true || game?.private === true) return false;
+            return visibility === 'public' ||
+                game?.isPublic === true ||
+                game?.public === true ||
+                game?.shareable === true ||
+                game?.isShareable === true ||
+                game?.publicCalendar === true;
+        }
+
+        function isPublicFanFeedGame(team = {}, game = {}) {
+            if (String(game?.type || 'game').toLowerCase() !== 'game') return false;
+            if (String(game?.visibility || '').toLowerCase() === 'private') return false;
+            if (game?.isPrivate === true || game?.private === true) return false;
+            if (String(game?.status || '').toLowerCase() === 'deleted') return false;
+            if (String(game?.liveStatus || '').toLowerCase() === 'deleted') return false;
+            return (team?.isPublic !== false && team?.active !== false) || isShareableFanGame(game);
+        }
+
+        function getSelectedPublicGamesFeedTeam() {
+            if (!currentTeamFilter) return null;
+            return calendarTeams.find((team) => team.id === currentTeamFilter) || null;
+        }
+
+        function canExposePublicFanFeed(team = {}) {
+            if (!team?.id) return false;
+            return (allEvents || []).some((event) => event.teamId === team.id && isPublicFanFeedGame(team, event));
+        }
+
+        function getPublicGamesFeedUrl(team) {
+            if (!team?.id) return '';
+            const configuredUrl = window.__ALLPLAYS_CONFIG__?.publicTeamGamesIcsFunctionUrl || window.ALLPLAYS_PUBLIC_GAMES_ICS_URL;
+            const fallbackUrl = window.__ALLPLAYS_CONFIG__?.calendarFetchFunctionUrl || window.ALLPLAYS_CALENDAR_FUNCTION_URL;
+            const baseUrl = (typeof configuredUrl === 'string' && configuredUrl.trim())
+                ? configuredUrl.trim()
+                : (typeof fallbackUrl === 'string' && fallbackUrl.includes('fetchCalendarIcs')
+                    ? fallbackUrl.replace('fetchCalendarIcs', 'publicTeamGamesIcs')
+                    : 'https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs');
+            const separator = baseUrl.includes('?') ? '&' : '?';
+            return `${baseUrl}${separator}teamId=${encodeURIComponent(team.id)}`;
+        }
+
+        function updatePublicGamesFeedButton() {
+            const button = document.getElementById('public-games-feed');
+            if (!button) return;
+            const team = getSelectedPublicGamesFeedTeam();
+            button.hidden = !team || !canExposePublicFanFeed(team);
+        }
+
+        async function copyPublicGamesFeedUrl() {
+            const team = getSelectedPublicGamesFeedTeam();
+            const feedUrl = team ? getPublicGamesFeedUrl(team) : '';
+            if (!team || !feedUrl) {
+                alert('Select a team with public games before copying the Fan Feed link.');
+                return;
+            }
+            try {
+                if (navigator.share) {
+                    await navigator.share({
+                        title: `${team.name || 'Team'} public games`,
+                        text: 'Subscribe to the public games-only calendar feed.',
+                        url: feedUrl
+                    });
+                    return;
+                }
+                if (navigator.clipboard?.writeText) {
+                    await navigator.clipboard.writeText(feedUrl);
+                } else {
+                    const input = document.createElement('textarea');
+                    input.value = feedUrl;
+                    input.setAttribute('readonly', '');
+                    input.style.position = 'fixed';
+                    input.style.left = '-9999px';
+                    document.body.appendChild(input);
+                    input.select();
+                    const copied = document.execCommand('copy');
+                    document.body.removeChild(input);
+                    if (!copied) throw new Error('Copy command failed');
+                }
+                alert('Fan Feed URL copied.');
+            } catch (error) {
+                console.error('Failed to copy public games feed URL:', error);
+                alert('Could not copy the Fan Feed link.');
+            }
+        }
+
         document.getElementById('sync-calendar-apple')?.addEventListener('click', () => {
             const feedUrl = getCurrentCalendarFeedUrl();
             if (!feedUrl) {
@@ -998,6 +1097,7 @@
         document.getElementById('sync-calendar-copy')?.addEventListener('click', () => {
             copyPrivateCalendarFeedUrl(getCurrentCalendarFeedUrl());
         });
+        document.getElementById('public-games-feed')?.addEventListener('click', copyPublicGamesFeedUrl);
 
         // ===== ICS EXPORT =====
         function exportIcs() {

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -78,6 +78,25 @@
             </div>
         </div>
 
+        <div id="schedule-sharing-panel" class="mb-6 bg-white border border-emerald-200 rounded-lg p-4 shadow-sm">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <div>
+                    <h3 class="font-semibold text-emerald-900">Schedule Sharing</h3>
+                    <p class="text-sm text-emerald-800">Open the team schedule sharing controls for live calendar sync and public games-only fan feeds.</p>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                    <a id="edit-schedule-sync-calendar-link" href="team.html"
+                        class="inline-flex items-center justify-center rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-semibold text-emerald-700 hover:bg-emerald-100">
+                        Sync Calendar
+                    </a>
+                    <a id="edit-schedule-fan-feed-link" href="team.html"
+                        class="inline-flex items-center justify-center rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm font-semibold text-emerald-700 hover:bg-emerald-100">
+                        Fan Feed
+                    </a>
+                </div>
+            </div>
+        </div>
+
         <div id="registration-schedule-import" class="hidden mb-6 bg-emerald-50 border border-emerald-200 rounded-lg p-4">
             <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
                 <div>
@@ -1775,6 +1794,9 @@
             setupOpponentSearch();
             document.getElementById('team-name-display').textContent = team.name;
             document.getElementById('organization-schedule-link').href = `organization-schedule.html#teamId=${currentTeamId}`;
+            const teamScheduleUrl = `team.html#teamId=${encodeURIComponent(currentTeamId)}`;
+            document.getElementById('edit-schedule-sync-calendar-link').href = teamScheduleUrl;
+            document.getElementById('edit-schedule-fan-feed-link').href = teamScheduleUrl;
 
             // Fetch unread count and render banner
             let unreadCount = 0;

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -156,7 +156,8 @@ function createEnvironment() {
         'sync-calendar-apple',
         'sync-calendar-google',
         'sync-calendar-copy',
-        'sync-calendar-feedback'
+        'sync-calendar-feedback',
+        'public-games-feed'
     ];
     const elements = new Map(ids.map((id) => [id, new MockElement(id)]));
     elements.get('team-filter').value = '';

--- a/tests/unit/team-calendar-sync.test.js
+++ b/tests/unit/team-calendar-sync.test.js
@@ -9,6 +9,10 @@ function readCalendarPage() {
     return readFileSync(new URL('../../calendar.html', import.meta.url), 'utf8');
 }
 
+function readEditSchedulePage() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
 function readWorkflowSchedule() {
     return readFileSync(new URL('../../workflow-schedule.html', import.meta.url), 'utf8');
 }
@@ -67,6 +71,19 @@ describe('all teams calendar sync controls', () => {
         expect(source).toContain('Copy Link');
     });
 
+    it('keeps schedule-editor sharing links available for current-team sync and fan feeds', () => {
+        const source = readEditSchedulePage();
+
+        expect(source).toContain('id="schedule-sharing-panel"');
+        expect(source).toContain('id="edit-schedule-sync-calendar-link"');
+        expect(source).toContain('Sync Calendar');
+        expect(source).toContain('id="edit-schedule-fan-feed-link"');
+        expect(source).toContain('Fan Feed');
+        expect(source).toContain('const teamScheduleUrl = `team.html#teamId=${encodeURIComponent(currentTeamId)}`;');
+        expect(source).toContain("document.getElementById('edit-schedule-sync-calendar-link').href = teamScheduleUrl;");
+        expect(source).toContain("document.getElementById('edit-schedule-fan-feed-link').href = teamScheduleUrl;");
+    });
+
     it('builds selected-team private subscription links and wires modal actions', () => {
         const source = readCalendarPage();
 
@@ -80,5 +97,22 @@ describe('all teams calendar sync controls', () => {
         expect(source).toContain('navigator.clipboard.writeText(feedUrl)');
         expect(source).toContain('onclick="openSyncCalendarModal()"');
         expect(source).toContain('Select a team before opening a live calendar subscription.');
+    });
+
+    it('adds selected-team Fan Feed controls to the calendar export area', () => {
+        const source = readCalendarPage();
+
+        expect(source).toContain('id="public-games-feed"');
+        expect(source).toContain('Fan Feed');
+        expect(source).toContain('function getSelectedPublicGamesFeedTeam()');
+        expect(source).toContain('function getPublicGamesFeedUrl(team)');
+        expect(source).toContain('publicTeamGamesIcs');
+        expect(source).toContain('visibility: game.visibility');
+        expect(source).toContain('shareable: game.shareable');
+        expect(source).toContain('isShareable: game.isShareable');
+        expect(source).toContain('publicCalendar: game.publicCalendar');
+        expect(source).toContain("document.getElementById('public-games-feed')?.addEventListener('click', copyPublicGamesFeedUrl);");
+        expect(source).toContain('updatePublicGamesFeedButton();');
+        expect(source).toContain('Select a team with public games before copying the Fan Feed link.');
     });
 });


### PR DESCRIPTION
Closes #2976.

## Summary
- add schedule-sharing links to edit-schedule so coaches can reach Sync Calendar and Fan Feed controls from the schedule workflow
- add a selected-team Fan Feed action to the all-teams calendar export controls
- add unit coverage for the new schedule and calendar sharing controls

## Testing
- npm test -- --run tests/unit/team-calendar-sync.test.js tests/unit/calendar-day-modal-rsvp.test.js
- SMOKE_BASE_URL=http://127.0.0.1:4177 npx playwright test --config=playwright.smoke.config.js tests/smoke/static-hosting-bootstrap.spec.js --grep "edit schedule boot" --reporter=line
- direct Playwright boot check for http://127.0.0.1:4177/calendar.html