### PR TITLE
Clear legacy registration provider on disconnect

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -555,7 +555,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=64';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=65';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';

--- a/js/db.js
+++ b/js/db.js
@@ -1672,6 +1672,9 @@ export async function createTeam(teamData) {
 export async function updateTeam(teamId, teamData) {
     teamData.updatedAt = Timestamp.now();
     const docRef = doc(db, "teams", teamId);
+    if (teamData.registrationSource === null) {
+        teamData.registrationProvider = deleteField();
+    }
     Object.assign(teamData, buildPublicTeamSearchFields(teamData));
     await updateDoc(docRef, teamData);
 }

--- a/tests/unit/db-update-team-registration-provider-clear.test.js
+++ b/tests/unit/db-update-team-registration-provider-clear.test.js
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateDoc = vi.fn();
+const deleteField = vi.fn(() => '__DELETE_FIELD__');
+const doc = vi.fn((database, ...segments) => ({ database, path: segments.join('/') }));
+
+vi.mock('../../js/firebase.js?v=19', () => ({
+    db: { name: 'mock-db' },
+    auth: {},
+    storage: {},
+    collection: vi.fn(),
+    getDocs: vi.fn(),
+    getDoc: vi.fn(),
+    doc,
+    addDoc: vi.fn(),
+    updateDoc,
+    deleteDoc: vi.fn(),
+    setDoc: vi.fn(),
+    query: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    Timestamp: { now: vi.fn(() => 'mock-timestamp') },
+    increment: vi.fn(),
+    arrayUnion: vi.fn(),
+    arrayRemove: vi.fn(),
+    deleteField,
+    limit: vi.fn(),
+    startAfter: vi.fn(),
+    getCountFromServer: vi.fn(),
+    onSnapshot: vi.fn(),
+    serverTimestamp: vi.fn(),
+    collectionGroup: vi.fn(),
+    writeBatch: vi.fn(),
+    runTransaction: vi.fn(),
+    functions: {},
+    httpsCallable: vi.fn(),
+    ref: vi.fn(),
+    uploadBytes: vi.fn(),
+    getDownloadURL: vi.fn(),
+    deleteObject: vi.fn()
+}));
+
+vi.mock('../../js/firebase-images.js?v=6', () => ({
+    imageStorage: {},
+    ensureImageAuth: vi.fn(),
+    requireImageAuth: vi.fn()
+}));
+
+vi.mock('../../js/vendor/firebase-storage.js', () => ({
+    uploadBytesResumable: vi.fn()
+}));
+
+const { updateTeam } = await import('../../js/db.js');
+
+describe('updateTeam registration provider clearing', () => {
+    beforeEach(() => {
+        updateDoc.mockReset();
+        deleteField.mockClear();
+        doc.mockClear();
+    });
+
+    it('deletes the legacy registrationProvider field when the registration source is cleared', async () => {
+        await updateTeam('team-1', {
+            name: 'Sharks',
+            registrationSource: null
+        });
+
+        expect(deleteField).toHaveBeenCalledTimes(1);
+        expect(doc).toHaveBeenCalledWith({ name: 'mock-db' }, 'teams', 'team-1');
+        expect(updateDoc).toHaveBeenCalledWith(
+            { database: { name: 'mock-db' }, path: 'teams/team-1' },
+            expect.objectContaining({
+                name: 'Sharks',
+                registrationSource: null,
+                registrationProvider: '__DELETE_FIELD__',
+                updatedAt: 'mock-timestamp'
+            })
+        );
+    });
+
+    it('does not delete the legacy registrationProvider field for normal team updates', async () => {
+        await updateTeam('team-1', {
+            name: 'Sharks',
+            registrationSource: {
+                provider: 'Sports Connect',
+                externalTeamId: 'SC-123'
+            }
+        });
+
+        expect(deleteField).not.toHaveBeenCalled();
+        expect(updateDoc).toHaveBeenCalledWith(
+            { database: { name: 'mock-db' }, path: 'teams/team-1' },
+            expect.not.objectContaining({
+                registrationProvider: '__DELETE_FIELD__'
+            })
+        );
+    });
+});

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -1092,7 +1092,7 @@ describe('edit team admin access persistence', () => {
     });
 
 
-    it('allows admins to edit and clear registration provider metadata without external calls', async () => {
+    it('allows admins to edit and clear legacy registration provider metadata without external calls', async () => {
         const initialState = {
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },
             team: {
@@ -1107,7 +1107,7 @@ describe('edit team admin access persistence', () => {
                 zip: '66209',
                 isPublic: true,
                 adminEmails: [],
-                registrationSource: {
+                registrationProvider: {
                     provider: 'sports-connect',
                     externalTeamId: 'SC-123',
                     sourceId: 'sports-connect',


### PR DESCRIPTION
Closes #2978

## What changed
- delete the legacy `registrationProvider` Firestore field inside `updateTeam()` when Edit Team explicitly saves `registrationSource: null`
- bump `edit-team.html` to `./js/db.js?v=65` so browsers fetch the updated team-save logic
- extend the Edit Team regression to cover a team that only has legacy `registrationProvider` metadata loaded into the form
- add a focused `updateTeam()` unit test proving the legacy field is deleted on disconnect and left alone for normal saves

## Root Cause
Edit Team correctly treated a cleared provider connection as `registrationSource: null`, but `js/db.js` passed that payload through `updateDoc()` without deleting the legacy `registrationProvider` field. Because legacy reload and import paths still fall back to `registrationProvider`, the stale external mapping survived the save and reappeared on reopen.

## Prevention / Learning
When migrating from a legacy field to a replacement field, clearing the new field is not enough if downstream code still reads the legacy fallback. Any explicit disconnect or unset path must remove both the current field and any legacy aliases, and the persistence helper should carry that cleanup so every caller gets the invariant.

## Regression Tests
- `npx vitest run tests/unit/db-update-team-registration-provider-clear.test.js tests/unit/edit-team-admin-access-persistence.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`