### PR TITLE
[codex] Start registration form editor parity

### DIFF
--- a/docs/pr-notes/issue-1995-registration-form-editor-parity.md
+++ b/docs/pr-notes/issue-1995-registration-form-editor-parity.md
@@ -1,0 +1,36 @@
+# Issue #1995: Registration Form Editor Parity
+
+Draft PR anchor for #1995.
+
+## Current Finding
+
+The app has registration detail consumers and service-level form editor plumbing,
+but the staff-facing native editor still needs full parity with the web form
+configuration workflow.
+
+## Implementation Scope
+
+- Add staff app UI for creating and editing registration forms.
+- Preserve the document shape consumed by `RegistrationDetail.tsx`,
+  `loadPublicRegistrationDetail`, `loadParentRegistrationDetail`, and
+  `registration.html`.
+- Support options, pricing, quantity discounts, waiver text, fees,
+  payment-plan availability, publish/open state, and waitlist toggle.
+- Match legacy validation rules from `js/admin-registration-forms.js`.
+- Keep review queue and waitlist action workflows out of scope.
+
+## Acceptance
+
+- A form created in the app is submittable through both the app and
+  `registration.html`.
+- A web-created form opens in the app editor without field loss.
+- Validation blocks invalid option/pricing/waiver combinations consistently with
+  the web editor.
+- Existing submissions are protected according to the legacy edit rules.
+
+## Validation
+
+- Registration form serializer and validation unit tests
+- Parent registration detail regression tests
+- `npm run app:build`
+- Manual web/app submission smoke for an app-created form


### PR DESCRIPTION
Refs #1995.

## Summary
- add a scoped PR kickoff note for app registration form editor parity
- define the remaining native editor contract, acceptance criteria, and validation plan

## Testing
- git diff --check

## Notes
Draft anchor PR. This intentionally does not close the issue until the native editor is implemented and verified against web/app consumers.