### PR TITLE
Block canceling paid team fee recipients

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -4950,6 +4950,8 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
     const safeLedgerEntries = Array.isArray(ledgerEntries) ? sanitizeTeamFeeRecipientValue(ledgerEntries) : [];
     const isManualPaymentUpdate = Object.prototype.hasOwnProperty.call(recipientUpdates, 'manualPayment')
         || safeLedgerEntries.some((entry) => entry?.type === 'offline_payment');
+    const isCancellationUpdate = recipientUpdates.status === 'canceled'
+        || safeLedgerEntries.some((entry) => entry?.type === 'cancellation');
     const explicitAdminBilling = adminBilling && typeof adminBilling === 'object' && !Array.isArray(adminBilling)
         ? adminBilling
         : null;
@@ -5001,7 +5003,7 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
         updatePayload.paymentLedger = arrayUnion(...safeLedgerEntries);
     }
 
-    if (isManualPaymentUpdate) {
+    if (isManualPaymentUpdate || isCancellationUpdate) {
         await runTransaction(db, async (transaction) => {
             const recipientSnapshot = await transaction.get(recipientRef);
             if (!recipientSnapshot.exists()) {
@@ -5012,16 +5014,23 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
             const amountDueCents = Number.isFinite(Number(amountDueRaw)) ? Math.max(0, Number(amountDueRaw)) : 0;
             const priorPaidRaw = recipient.amountPaidCents ?? recipient.paidAmountCents ?? 0;
             const priorPaidCents = Number.isFinite(Number(priorPaidRaw)) ? Math.max(0, Number(priorPaidRaw)) : 0;
-            const remainingBalanceCents = Math.max(0, amountDueCents - priorPaidCents);
-            const manualPaymentAmountRaw = recipientUpdates.manualPayment?.amountPaidCents
-                ?? safeLedgerEntries.find((entry) => entry?.type === 'offline_payment')?.amountCents;
-            const manualPaymentAmountCents = Number(manualPaymentAmountRaw);
 
-            if (!Number.isFinite(manualPaymentAmountCents)) {
-                throw new Error('Manual payment amount is required.');
+            if (isManualPaymentUpdate) {
+                const remainingBalanceCents = Math.max(0, amountDueCents - priorPaidCents);
+                const manualPaymentAmountRaw = recipientUpdates.manualPayment?.amountPaidCents
+                    ?? safeLedgerEntries.find((entry) => entry?.type === 'offline_payment')?.amountCents;
+                const manualPaymentAmountCents = Number(manualPaymentAmountRaw);
+
+                if (!Number.isFinite(manualPaymentAmountCents)) {
+                    throw new Error('Manual payment amount is required.');
+                }
+                if (manualPaymentAmountCents > remainingBalanceCents) {
+                    throw new Error('Manual payment amount cannot exceed the remaining balance.');
+                }
             }
-            if (manualPaymentAmountCents > remainingBalanceCents) {
-                throw new Error('Manual payment amount cannot exceed the remaining balance.');
+
+            if (isCancellationUpdate && priorPaidCents > 0) {
+                throw new Error('Paid recipients must be refunded before canceling the balance.');
             }
 
             transaction.update(recipientRef, updatePayload);

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -1178,7 +1178,7 @@ async function initTeamFeesAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
-        import('./db.js?v=64'),
+        import('./db.js?v=65'),
         import('./auth.js?v=33')
     ]);
 

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -555,7 +555,12 @@ export function buildOfflineRefundUpdate({ refundType = 'full', amount, method, 
     };
 }
 
-export function buildCancelRecipientUpdate({ note, actorId }) {
+export function buildCancelRecipientUpdate({ note, actorId, currentPaidCents }) {
+    const paidCents = Number(currentPaidCents);
+    if (Number.isFinite(paidCents) && paidCents > 0) {
+        throw new Error('Paid recipients must be refunded before canceling the balance.');
+    }
+
     const reason = normalizeString(note);
     const ledgerEntry = {
         type: 'cancellation',
@@ -823,6 +828,7 @@ function renderRecipients(container, countEl, recipients) {
         const outstanding = formatFeeCurrency(outstandingCents);
         const refundableCents = getRecipientRefundableCents(recipient);
         const canRefundOnline = isOnlineRefundEligible(recipient);
+        const canCancelRecipient = paidCents <= 0;
         const note = recipient.manualPayment?.note || recipient.adjustment?.note || recipient.canceled?.note || recipient.adminBilling?.note || recipient.adminBilling?.reason || recipient.notes || '';
         return `
             <article class="p-5" data-recipient-id="${escapeHtml(recipient.id)}" data-balance-cents="${balanceCents}" data-paid-cents="${paidCents}" data-status="${escapeHtml(normalizeFeeStatus(recipient.status))}">
@@ -865,8 +871,9 @@ function renderRecipients(container, countEl, recipients) {
                         </div>
                         <form data-action="cancel" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
                             <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Cancel recipient</div>
+                            ${canCancelRecipient ? '<p class="text-xs text-gray-500">Use this only when no payment has been recorded.</p>' : '<p class="text-xs text-amber-700">Refund paid recipients before canceling their balance.</p>'}
                             <input name="note" type="text" placeholder="Reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Cancellation note">
-                            <button class="w-full rounded-lg bg-gray-700 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800">Cancel balance</button>
+                            <button class="w-full rounded-lg bg-gray-700 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-300" ${canCancelRecipient ? '' : 'disabled'}>Cancel balance</button>
                         </form>
                     </div>
                 </div>
@@ -1139,7 +1146,7 @@ async function renderManageMode({ container, teamId, batchId, team, user, getTea
             } else if (form.dataset.action === 'refund') {
                 await submitOnlineTeamFeeRefund(buildOnlineRefundRequest({ ...data, teamId, batchId, recipientId }));
             } else {
-                updates = buildCancelRecipientUpdate({ ...data, actorId: user.uid });
+                updates = buildCancelRecipientUpdate({ ...data, actorId: user.uid, currentPaidCents: article?.dataset?.paidCents });
                 await updateTeamFeeRecipient(teamId, batchId, recipientId, updates);
             }
             showMessage(form.dataset.action === 'refund' ? 'Stripe refund submitted.' : 'Fee recipient updated.', 'success');

--- a/team-fees.html
+++ b/team-fees.html
@@ -45,7 +45,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=9"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=10"></script>
 </body>
 
 </html>

--- a/tests/unit/db-team-fee-recipient-updates.test.js
+++ b/tests/unit/db-team-fee-recipient-updates.test.js
@@ -254,14 +254,65 @@ describe('updateTeamFeeRecipient manual payment validation', () => {
         expect(payload.paymentLedger[0]).not.toHaveProperty('stripeRefundId');
     });
 
-    it('preserves cancellation reasons in admin billing metadata before sanitizing parent-readable fields', async () => {
-        const updateDoc = vi.fn(async () => undefined);
-        const setDoc = vi.fn(async () => undefined);
+    it('rejects cancellation when the latest stored recipient has a recorded payment', async () => {
+        const updateDoc = vi.fn();
+        const transactionUpdate = vi.fn();
+        const runTransaction = vi.fn(async (_db, handler) => handler({
+            get: vi.fn(async () => ({
+                exists: () => true,
+                data: () => ({ amountDueCents: 2500, amountPaidCents: 500 })
+            })),
+            update: transactionUpdate,
+            set: vi.fn()
+        }));
         const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
             doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
             updateDoc,
-            setDoc,
-            runTransaction: vi.fn(),
+            setDoc: vi.fn(async () => undefined),
+            runTransaction,
+            serverTimestamp: vi.fn(() => 'server-ts'),
+            arrayUnion: vi.fn((...entries) => entries),
+            deleteField: vi.fn(() => 'deleted')
+        });
+
+        await expect(updateTeamFeeRecipient('team-1', 'batch-1', 'recipient-1', {
+            status: 'canceled',
+            amountDueCents: 0,
+            remainingBalanceCents: 0,
+            canceled: {
+                note: 'Family moved away',
+                canceledBy: 'coach-7'
+            },
+            ledgerEntries: [{
+                type: 'cancellation',
+                amountCents: 0,
+                reason: 'Family moved away',
+                canceledBy: 'coach-7'
+            }]
+        })).rejects.toThrow('Paid recipients must be refunded before canceling the balance.');
+
+        expect(runTransaction).toHaveBeenCalledTimes(1);
+        expect(updateDoc).not.toHaveBeenCalled();
+        expect(transactionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('preserves cancellation reasons in admin billing metadata before sanitizing parent-readable fields', async () => {
+        const updateDoc = vi.fn(async () => undefined);
+        const transactionUpdate = vi.fn();
+        const transactionSet = vi.fn();
+        const runTransaction = vi.fn(async (_db, handler) => handler({
+            get: vi.fn(async () => ({
+                exists: () => true,
+                data: () => ({ amountDueCents: 2500, amountPaidCents: 0 })
+            })),
+            update: transactionUpdate,
+            set: transactionSet
+        }));
+        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
+            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
+            updateDoc,
+            setDoc: vi.fn(async () => undefined),
+            runTransaction,
             serverTimestamp: vi.fn(() => 'server-ts'),
             arrayUnion: vi.fn((...entries) => entries),
             deleteField: vi.fn(() => 'deleted')
@@ -283,7 +334,9 @@ describe('updateTeamFeeRecipient manual payment validation', () => {
             }]
         });
 
-        expect(updateDoc).toHaveBeenCalledWith(
+        expect(runTransaction).toHaveBeenCalledTimes(1);
+        expect(updateDoc).not.toHaveBeenCalled();
+        expect(transactionUpdate).toHaveBeenCalledWith(
             { path: 'teams/team-1/feeBatches/batch-1/feeRecipients/recipient-1' },
             expect.objectContaining({
                 status: 'canceled',
@@ -297,11 +350,11 @@ describe('updateTeamFeeRecipient manual payment validation', () => {
                 }]
             })
         );
-        const payload = updateDoc.mock.calls[0][1];
+        const payload = transactionUpdate.mock.calls[0][1];
         expect(payload.canceled).not.toHaveProperty('note');
         expect(payload.paymentLedger[0]).not.toHaveProperty('reason');
         expect(payload.paymentLedger[0]).not.toHaveProperty('canceledBy');
-        expect(setDoc).toHaveBeenCalledWith(
+        expect(transactionSet).toHaveBeenCalledWith(
             { path: 'teams/team-1/feeBatches/batch-1/feeRecipients/recipient-1/adminBilling/latest' },
             expect.objectContaining({
                 type: 'cancellation',

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 import { describe, it, expect } from 'vitest'; // Import Vitest globals
-import { buildManualPaymentUpdate, buildBalanceAdjustmentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, getRecipientStripePaymentRefs, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers, normalizeTeamFeeDraft } from '../../js/team-fees-admin.js'; // Adjusted path
+import { buildManualPaymentUpdate, buildBalanceAdjustmentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, getRecipientStripePaymentRefs, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers, normalizeTeamFeeDraft, buildCancelRecipientUpdate } from '../../js/team-fees-admin.js'; // Adjusted path
 
 describe('team fees admin page routing', () => {
     it('reinitializes when same-page manage links update the hash', () => {
@@ -22,7 +22,7 @@ describe('team fees admin page routing', () => {
         const pageSource = readFileSync(new URL('../../team-fees.html', import.meta.url), 'utf8');
 
         expect(adminSource).toContain("import('./db.js?v=64')");
-        expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=9"></script>');
+        expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=10"></script>');
     });
 });
 
@@ -328,6 +328,34 @@ describe('buildOfflineRefundUpdate', () => {
         expect(() => buildOfflineRefundUpdate({ refundType: 'partial', amount: '6.00', method: 'cash', note: 'Too much', currentBalanceCents: '1000', currentPaidCents: '500' })).toThrow('Refund amount cannot exceed');
         expect(() => buildOfflineRefundUpdate({ refundType: 'partial', amount: '1.00', method: 'card', note: 'Bad method', currentBalanceCents: '1000', currentPaidCents: '500' })).toThrow('Select cash or check');
         expect(() => buildOfflineRefundUpdate({ refundType: 'partial', amount: '1.00', method: 'cash', note: '', currentBalanceCents: '1000', currentPaidCents: '500' })).toThrow('Enter an admin note');
+    });
+});
+
+describe('buildCancelRecipientUpdate', () => {
+    it('blocks cancellation when a recipient still has recorded payments', () => {
+        expect(() => buildCancelRecipientUpdate({
+            note: 'Trying to void a paid recipient',
+            actorId: 'admin-1',
+            currentPaidCents: '2500'
+        })).toThrow('Paid recipients must be refunded before canceling the balance.');
+
+        expect(buildCancelRecipientUpdate({
+            note: 'Waived before payment',
+            actorId: 'admin-1',
+            currentPaidCents: '0'
+        })).toMatchObject({
+            status: 'canceled',
+            amountDueCents: 0,
+            remainingBalanceCents: 0
+        });
+    });
+
+    it('keeps the paid recipient cancel action disabled in the manage view', () => {
+        const source = readFileSync(new URL('../../js/team-fees-admin.js', import.meta.url), 'utf8');
+
+        expect(source).toContain('const canCancelRecipient = paidCents <= 0;');
+        expect(source).toContain('Refund paid recipients before canceling their balance.');
+        expect(source).toContain("${canCancelRecipient ? '' : 'disabled'}");
     });
 });
 

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -21,7 +21,7 @@ describe('team fees admin page routing', () => {
         const adminSource = readFileSync(new URL('../../js/team-fees-admin.js', import.meta.url), 'utf8');
         const pageSource = readFileSync(new URL('../../team-fees.html', import.meta.url), 'utf8');
 
-        expect(adminSource).toContain("import('./db.js?v=64')");
+        expect(adminSource).toContain("import('./db.js?v=65')");
         expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=10"></script>');
     });
 });


### PR DESCRIPTION
Closes #2987

## What changed
- blocked the cancel-recipient mutation when the recipient still has recorded paid cents
- disabled the Cancel balance action in the manage team fee UI for paid recipients and added guidance to refund first
- bumped the `team-fees.html` cache-bust for the updated admin module
- added regression coverage for both the cancel guard and the paid-recipient UI state

## Root Cause
The cancel-recipient path ignored recorded payment state in both the rendered manage action and `buildCancelRecipientUpdate()`. That let a paid recipient be force-switched to `canceled` with zero balance, and the downstream paid/refund helpers then treated the payment as gone.

## Prevention / Learning
For financial state transitions, guard the action at both the UI affordance and the mutation builder. Any path that can discard paid or refunded state needs a focused regression test before shipping.

## Regression Tests
- `npx vitest run tests/unit/team-fees-admin.test.js --reporter=verbose`
- added `buildCancelRecipientUpdate` coverage to reject canceling paid recipients
- added source-level regression coverage that the manage view disables cancel for paid recipients and shows refund-first guidance

## Recurrence Risk
Low. The cancel path now rejects non-zero paid balances before persistence, and focused unit coverage locks both the guard and the disabled UI state.