### PR TITLE
Collapse responded staff RSVP overrides by default

### DIFF
--- a/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.test.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ScheduleEventDetailProvider } from '../../pages/schedule/ScheduleEventDetailContext';
+import { StaffRsvpBreakdownPanel } from './StaffRsvpBreakdownPanel';
+import type { AuthState } from '../../lib/types';
+
+const auth: AuthState = {
+    user: {
+        uid: 'coach-1',
+        email: 'coach@example.com',
+        displayName: 'Coach One'
+    } as any,
+    profile: { displayName: 'Coach One' },
+    loading: false,
+    error: null,
+    roles: [],
+    isParent: false,
+    isCoach: true,
+    isAdmin: true,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn()
+};
+
+function buildEvent(overrides: Record<string, unknown> = {}) {
+    return {
+        eventKey: 'team-1::game-1::player-1',
+        id: 'game-1',
+        teamId: 'team-1',
+        childId: 'player-1',
+        childName: 'Avery Smith',
+        isDbGame: true,
+        isTeamAdmin: true,
+        isCancelled: false,
+        availabilityLocked: false,
+        ...overrides
+    } as any;
+}
+
+function renderPanel(breakdown: any, eventOverrides: Record<string, unknown> = {}) {
+    return render(
+        <ScheduleEventDetailProvider
+            value={{
+                auth,
+                event: buildEvent(eventOverrides),
+                childEvents: [buildEvent(eventOverrides)],
+                refreshEvent: vi.fn(),
+                updateEvents: vi.fn()
+            }}
+        >
+            <StaffRsvpBreakdownPanel
+                breakdown={breakdown}
+                loading={false}
+                error={null}
+                submittingPlayerId={null}
+                status={null}
+                onOverride={vi.fn()}
+            />
+        </ScheduleEventDetailProvider>
+    );
+}
+
+describe('StaffRsvpBreakdownPanel', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('handles an initially empty breakdown and shows missing players after data loads', () => {
+        const breakdown = {
+            grouped: {
+                going: [{ playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'going' }],
+                maybe: [],
+                not_going: [],
+                not_responded: [{ playerId: 'p2', playerName: 'Blake Jones', playerNumber: '2', response: 'not_responded' }]
+            },
+            counts: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+        } as any;
+
+        const view = renderPanel(null);
+        expect(screen.queryByText('Staff RSVP overrides')).toBeNull();
+
+        view.rerender(
+            <ScheduleEventDetailProvider
+                value={{
+                    auth,
+                    event: buildEvent(),
+                    childEvents: [buildEvent()],
+                    refreshEvent: vi.fn(),
+                    updateEvents: vi.fn()
+                }}
+            >
+                <StaffRsvpBreakdownPanel
+                    breakdown={breakdown}
+                    loading={false}
+                    error={null}
+                    submittingPlayerId={null}
+                    status={null}
+                    onOverride={vi.fn()}
+                />
+            </ScheduleEventDetailProvider>
+        );
+
+        expect(screen.getByText('Staff RSVP overrides')).toBeTruthy();
+        expect(screen.getByTestId('staff-rsvp-row-p2')).toBeTruthy();
+        expect(screen.queryByTestId('staff-rsvp-row-p1')).toBeNull();
+        expect(screen.getByRole('button', { name: 'Show responded players (1 going · 0 maybe · 0 out · 0 missing)' }).getAttribute('aria-expanded')).toBe('false');
+    });
+});

--- a/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { StaffRsvpPlayerRow } from './StaffRsvpPlayerRow';
 import {
   formatRsvpSummary,
@@ -18,6 +19,11 @@ export function StaffRsvpBreakdownPanel({ breakdown, loading, error, submittingP
   onOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
 }) {
   const { event } = useScheduleEventDetailContext();
+  const [showRespondedPlayers, setShowRespondedPlayers] = useState(false);
+
+  useEffect(() => {
+    setShowRespondedPlayers(Boolean(breakdown) && breakdown.grouped.not_responded.length === 0);
+  }, [breakdown]);
 
   if (!event.isTeamAdmin || !event.isDbGame) return null;
   if (loading && !breakdown) {
@@ -28,19 +34,41 @@ export function StaffRsvpBreakdownPanel({ breakdown, loading, error, submittingP
   }
   if (!breakdown) return null;
 
+  const hasMissingPlayers = breakdown.grouped.not_responded.length > 0;
+  const respondedPlayerCount = breakdown.grouped.going.length + breakdown.grouped.maybe.length + breakdown.grouped.not_going.length;
+  const visibleGroups = hasMissingPlayers && !showRespondedPlayers
+    ? (['not_responded'] as const)
+    : (['not_responded', 'going', 'maybe', 'not_going'] as const);
+  const respondedSummary = formatRsvpSummary({
+    going: breakdown.counts.going,
+    maybe: breakdown.counts.maybe,
+    notGoing: breakdown.counts.notGoing,
+    notResponded: 0
+  });
+
   return (
     <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="text-sm font-black text-gray-950">Staff RSVP overrides</div>
-          <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">Review every player, including no response, and update availability inline.</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">Start with missing responses, then expand responded players when you need to correct an existing RSVP.</div>
         </div>
         <span className="inline-flex min-h-8 items-center rounded-full border border-primary-100 bg-primary-50 px-3 text-xs font-black text-primary-700">
           {formatRsvpSummary(breakdown.counts)}
         </span>
       </div>
+      {hasMissingPlayers && respondedPlayerCount > 0 ? (
+        <button
+          type="button"
+          className="mt-3 inline-flex min-h-9 items-center rounded-full border border-gray-200 bg-white px-3 text-xs font-black text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700"
+          aria-expanded={showRespondedPlayers}
+          onClick={() => setShowRespondedPlayers((current) => !current)}
+        >
+          {showRespondedPlayers ? 'Hide responded players' : `Show responded players (${respondedSummary})`}
+        </button>
+      ) : null}
       <div className="mt-3 space-y-3">
-        {(['not_responded', 'going', 'maybe', 'not_going'] as const).map((responseKey) => {
+        {visibleGroups.map((responseKey) => {
           const rows = breakdown.grouped[responseKey];
           if (!rows.length) return null;
           return (

--- a/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpBreakdownPanel.tsx
@@ -22,7 +22,11 @@ export function StaffRsvpBreakdownPanel({ breakdown, loading, error, submittingP
   const [showRespondedPlayers, setShowRespondedPlayers] = useState(false);
 
   useEffect(() => {
-    setShowRespondedPlayers(Boolean(breakdown) && breakdown.grouped.not_responded.length === 0);
+    if (!breakdown) {
+      setShowRespondedPlayers(false);
+      return;
+    }
+    setShowRespondedPlayers(breakdown.grouped.not_responded.length === 0);
   }, [breakdown]);
 
   if (!event.isTeamAdmin || !event.isDbGame) return null;

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1868,7 +1868,50 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     cleanup();
   });
 
-  it('renders staff breakdown controls and refreshes counts after an override', async () => {
+  it('shows only missing-player overrides by default and expands responded sections on demand', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamAdmin: true, isTeamRsvpReminderManager: true })],
+      children: []
+    });
+    scheduleServiceMocks.loadStaffScheduleRsvpBreakdown.mockResolvedValue({
+      grouped: {
+        going: [{ playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'going' }],
+        maybe: [{ playerId: 'p2', playerName: 'Blake Jones', playerNumber: '2', response: 'maybe' }],
+        not_going: [{ playerId: 'p3', playerName: 'Casey Brown', playerNumber: '3', response: 'not_going' }],
+        not_responded: [{ playerId: 'p4', playerName: 'Devon Lee', playerNumber: '4', response: 'not_responded' }]
+      },
+      counts: { going: 1, maybe: 1, notGoing: 1, notResponded: 1, total: 4 }
+    });
+    scheduleServiceMocks.loadStaffRsvpReminderPreview.mockResolvedValue({
+      missingPlayerCount: 1,
+      eligibleEmailCount: 1,
+      players: [{ playerId: 'p4', playerName: 'Devon Lee', parentEmails: ['devon@example.com'] }]
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Staff RSVP overrides')).toBeTruthy();
+    });
+    expect(screen.getByTestId('staff-rsvp-row-p4')).toBeTruthy();
+    expect(screen.queryByTestId('staff-rsvp-row-p1')).toBeNull();
+    expect(screen.queryByTestId('staff-rsvp-row-p2')).toBeNull();
+    expect(screen.queryByTestId('staff-rsvp-row-p3')).toBeNull();
+
+    const disclosure = screen.getByRole('button', { name: 'Show responded players (1 going · 1 maybe · 1 out · 0 missing)' });
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(disclosure);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('staff-rsvp-row-p1')).toBeTruthy();
+    });
+    expect(screen.getByTestId('staff-rsvp-row-p2')).toBeTruthy();
+    expect(screen.getByTestId('staff-rsvp-row-p3')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Hide responded players' })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('lets staff override a responded player after expanding and refreshes the counts', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ isTeamAdmin: true, isTeamRsvpReminderManager: true })],
       children: []
@@ -1885,15 +1928,15 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
       })
       .mockResolvedValueOnce({
         grouped: {
-          going: [
-            { playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'going' },
-            { playerId: 'p4', playerName: 'Devon Lee', playerNumber: '4', response: 'going' }
+          going: [],
+          maybe: [
+            { playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'maybe' },
+            { playerId: 'p2', playerName: 'Blake Jones', playerNumber: '2', response: 'maybe' }
           ],
-          maybe: [{ playerId: 'p2', playerName: 'Blake Jones', playerNumber: '2', response: 'maybe' }],
           not_going: [{ playerId: 'p3', playerName: 'Casey Brown', playerNumber: '3', response: 'not_going' }],
-          not_responded: []
+          not_responded: [{ playerId: 'p4', playerName: 'Devon Lee', playerNumber: '4', response: 'not_responded' }]
         },
-        counts: { going: 2, maybe: 1, notGoing: 1, notResponded: 0, total: 4 }
+        counts: { going: 0, maybe: 2, notGoing: 1, notResponded: 1, total: 4 }
       });
     scheduleServiceMocks.loadStaffRsvpReminderPreview
       .mockResolvedValueOnce({
@@ -1902,33 +1945,32 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
         players: [{ playerId: 'p4', playerName: 'Devon Lee', parentEmails: ['devon@example.com'] }]
       })
       .mockResolvedValueOnce({
-        missingPlayerCount: 0,
-        eligibleEmailCount: 0,
-        players: []
+        missingPlayerCount: 1,
+        eligibleEmailCount: 1,
+        players: [{ playerId: 'p4', playerName: 'Devon Lee', parentEmails: ['devon@example.com'] }]
       });
-    scheduleServiceMocks.submitStaffScheduleRsvpOverride.mockResolvedValue({ playerId: 'p4', response: 'going' });
+    scheduleServiceMocks.submitStaffScheduleRsvpOverride.mockResolvedValue({ playerId: 'p1', response: 'maybe' });
 
     renderScheduleEventDetail();
 
     await waitFor(() => {
       expect(screen.getByText('Staff RSVP overrides')).toBeTruthy();
     });
-    await waitFor(() => {
-      expect(screen.getByText('1 no-response player · 1 eligible parent/guardian email.')).toBeTruthy();
-    });
 
-    const noResponseRow = screen.getByTestId('staff-rsvp-row-p4');
-    fireEvent.click(within(noResponseRow).getByRole('button', { name: 'Going' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show responded players (1 going · 1 maybe · 1 out · 0 missing)' }));
+
+    const respondedRow = await screen.findByTestId('staff-rsvp-row-p1');
+    fireEvent.click(within(respondedRow).getByRole('button', { name: 'Maybe' }));
 
     await waitFor(() => {
-      expect(scheduleServiceMocks.submitStaffScheduleRsvpOverride).toHaveBeenCalledWith(expect.any(Object), auth.user, 'p4', 'going');
+      expect(scheduleServiceMocks.submitStaffScheduleRsvpOverride).toHaveBeenCalledWith(expect.any(Object), auth.user, 'p1', 'maybe');
     });
     expect(scheduleServiceMocks.invalidateStaffRsvpAvailabilityEvent).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }));
     await waitFor(() => {
-      expect(screen.getByText('Devon Lee marked going.')).toBeTruthy();
+      expect(screen.getByText('Avery Smith marked maybe.')).toBeTruthy();
     });
     await waitFor(() => {
-      expect(screen.getAllByText('2 going · 1 maybe · 1 out · 0 missing').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('0 going · 2 maybe · 1 out · 1 missing').length).toBeGreaterThan(0);
     });
     await waitFor(() => {
       expect(scheduleServiceMocks.loadStaffRsvpReminderPreview).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Closes #2989

## What changed
- defaulted the staff RSVP override panel to show only `not_responded` players when any missing responses exist
- added a responded-player disclosure that reveals the existing going, maybe, and not going sections without changing the inline override controls
- updated the schedule detail regression coverage to verify the collapsed default view and a responded-player override after expansion

## Root Cause
`StaffRsvpBreakdownPanel` always rendered every RSVP bucket in a fixed expanded order, so the common missing-response workflow had to compete with full responded-player override controls on first paint.

## Prevention / Learning
For dense admin correction panels, lead with the highest-priority unresolved state and defer lower-priority bulk controls behind disclosure unless the primary state is empty.

## Regression Tests
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx -t "ScheduleEventDetail staff RSVP overrides" --reporter=verbose`
- verifies responded-player rows stay hidden by default when missing players exist, then appear after expanding the disclosure
- verifies an admin can still override a responded player after expansion and the refreshed counts/success state update correctly