### PR TITLE
Fix parent certificate direct-link fallback

### DIFF
--- a/certificates.html
+++ b/certificates.html
@@ -97,7 +97,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/certificates/studio.js?v=9"></script>
+    <script type="module" src="./js/certificates/studio.js?v=10"></script>
 </body>
 
 </html>

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -2227,7 +2227,7 @@ async function loadParentCertificates(params = getParams()) {
             .flatMap((entry) => entry.certificates)
             .find((cert) => cert.id === certificateId);
 
-        if (!certificate && !state.demoMode && !state.certificatePersistenceUnavailable) {
+        if (!certificate && !state.demoMode) {
             try {
                 const requestedCertificate = await getCertificate(state.teamId, certificateId);
                 if (canViewSavedCertificate(state.user, state.team, requestedCertificate)) {

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -2223,9 +2223,26 @@ async function loadParentCertificates(params = getParams()) {
     }
     const certificateId = params.get('certificateId');
     if (certificateId) {
-        const certificate = entries
+        let certificate = entries
             .flatMap((entry) => entry.certificates)
             .find((cert) => cert.id === certificateId);
+
+        if (!certificate && !state.demoMode && !state.certificatePersistenceUnavailable) {
+            try {
+                const requestedCertificate = await getCertificate(state.teamId, certificateId);
+                if (canViewSavedCertificate(state.user, state.team, requestedCertificate)) {
+                    certificate = requestedCertificate;
+                    const matchingEntry = entries.find((entry) => entry.playerId === certificate.playerId);
+                    if (matchingEntry && !matchingEntry.certificates.some((item) => item.id === certificate.id)) {
+                        matchingEntry.certificates.unshift(certificate);
+                    }
+                }
+            } catch (error) {
+                if (!isPermissionError(error)) throw error;
+                state.certificatePersistenceUnavailable = true;
+            }
+        }
+
         if (certificate) {
             renderParentCertificateDetail(certificate);
             return;

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -178,6 +178,8 @@ describe('awards and certificates workflow wiring', () => {
 
         expect(parentLoadBody).toContain('let certificate = entries');
         expect(parentLoadBody).toContain('const requestedCertificate = await getCertificate(state.teamId, certificateId);');
+        expect(parentLoadBody).toContain('if (!certificate && !state.demoMode) {');
+        expect(parentLoadBody).not.toContain('if (!certificate && !state.demoMode && !state.certificatePersistenceUnavailable) {');
         expect(parentLoadBody).toContain('if (canViewSavedCertificate(state.user, state.team, requestedCertificate)) {');
         expect(parentLoadBody).toContain('matchingEntry.certificates.unshift(certificate);');
         expect(parentLoadBody).toContain("showAlert('Saved certificate could not be found for your linked players.', 'warning');");

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -23,7 +23,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(html).toContain('Start new run');
         expect(html).toContain('View saved work');
         expect(html).toContain('Create one-off certificate');
-        expect(html).toContain('./js/certificates/studio.js?v=9');
+        expect(html).toContain('./js/certificates/studio.js?v=10');
         expect(studio).toContain("from './templates.js?v=2'");
         expect(studio).toContain("from './renderer.js?v=2'");
         expect(studio).toContain("from './aiDescriptions.js?v=4'");
@@ -170,6 +170,17 @@ describe('awards and certificates workflow wiring', () => {
         expect(indexes).toContain('"collectionGroup": "certificates"');
         expect(indexes).toContain('"collectionGroup": "certificateBatches"');
         expect(indexes).toContain('"fieldPath": "playerId"');
+    });
+
+    it('falls back to loading the requested parent certificate by id', () => {
+        const studio = readRepoFile('js/certificates/studio.js');
+        const parentLoadBody = studio.match(/async function loadParentCertificates\(params = getParams\(\)\) \{[\s\S]*?\n\}/)?.[0] || '';
+
+        expect(parentLoadBody).toContain('let certificate = entries');
+        expect(parentLoadBody).toContain('const requestedCertificate = await getCertificate(state.teamId, certificateId);');
+        expect(parentLoadBody).toContain('if (canViewSavedCertificate(state.user, state.team, requestedCertificate)) {');
+        expect(parentLoadBody).toContain('matchingEntry.certificates.unshift(certificate);');
+        expect(parentLoadBody).toContain("showAlert('Saved certificate could not be found for your linked players.', 'warning');");
     });
 
     it('wires team color editing for certificate palettes and PNG-backed print', () => {


### PR DESCRIPTION
Closes #2991

## What changed
- Added a direct `getCertificate()` fallback in the parent certificate detail flow when a `certificateId` is present but the requested certificate is not in the preloaded 25-item parent list.
- Reused `canViewSavedCertificate()` before rendering the fetched certificate so parents only see published certificates for linked players.
- Cache-busted `certificates.html` to load the updated studio module immediately.
- Added a regression unit test that verifies the parent direct-link flow now performs the id-based fallback.

## Root Cause
The parent direct-link path only searched the in-memory results from `listCertificatesForPlayer()`, which defaults to the newest 25 published certificates per player. Once a player had more than 25 awards, older published certificates were never fetched and the page incorrectly reported them as missing.

## Prevention / Learning
When a route accepts a record id, do not rely only on a paginated list fetch to satisfy the detail view. Add a direct lookup fallback for the requested id and reapply the same authorization check before rendering.

## Regression Tests
- `npx vitest run tests/unit/certificates-workflow.test.js --reporter=verbose`
- Added assertions that `loadParentCertificates()` falls back to `getCertificate(state.teamId, certificateId)` and still gates rendering through `canViewSavedCertificate()`.

## Recurrence Risk
Low. The parent direct-link path now fetches the exact certificate by id and reuses the existing visibility guard, so the 25-item list window no longer blocks older published certificates.