### PR TITLE
Allow anonymous reads for legacy family share links

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2330,8 +2330,11 @@ service cloud.firestore {
     // The tokenId is a 40-char hex string that serves as a bearer credential.
     match /familyShareTokens/{tokenId} {
       // Anyone who has the token ID can read it (to validate and load the family page).
+      // Legacy revoked tokens may use revoked/revokedAt without active=false, so honor all revocation markers.
       // Owner can always read their own tokens (including revoked ones).
-      allow get: if resource.data.get('active', true) == true ||
+      allow get: if (resource.data.get('active', true) == true &&
+                     resource.data.get('revoked', false) != true &&
+                     resource.data.get('revokedAt', null) == null) ||
                     (isSignedIn() && resource.data.ownerUserId == request.auth.uid) ||
                     isGlobalAdmin();
       // Only the owner can list their own tokens (rule applied per-document).

--- a/firestore.rules
+++ b/firestore.rules
@@ -2331,7 +2331,7 @@ service cloud.firestore {
     match /familyShareTokens/{tokenId} {
       // Anyone who has the token ID can read it (to validate and load the family page).
       // Owner can always read their own tokens (including revoked ones).
-      allow get: if resource.data.get('active', false) == true ||
+      allow get: if resource.data.get('active', true) == true ||
                     (isSignedIn() && resource.data.ownerUserId == request.auth.uid) ||
                     isGlobalAdmin();
       // Only the owner can list their own tokens (rule applied per-document).

--- a/tests/unit/family-share-token-rules.test.js
+++ b/tests/unit/family-share-token-rules.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
+const familyShareTokenMatch = rules.match(/match \/familyShareTokens\/\{tokenId\} \{[\s\S]*?\n\s*}/);
+const familyShareTokenRules = familyShareTokenMatch?.[0] || '';
+
+describe('family share token Firestore rules', () => {
+    it('allows anonymous reads for legacy tokens that omit the active field', () => {
+        expect(familyShareTokenRules).toContain("match /familyShareTokens/{tokenId}");
+        expect(familyShareTokenRules).toContain("resource.data.get('active', true) == true");
+        expect(familyShareTokenRules).toContain("resource.data.ownerUserId == request.auth.uid");
+        expect(familyShareTokenRules).not.toContain("resource.data.get('active', false) == true");
+    });
+
+    it('still reserves revoked-token access for owners and global admins', () => {
+        expect(familyShareTokenRules).toContain("isSignedIn() && resource.data.ownerUserId == request.auth.uid");
+        expect(familyShareTokenRules).toContain('isGlobalAdmin()');
+    });
+});

--- a/tests/unit/family-share-token-rules.test.js
+++ b/tests/unit/family-share-token-rules.test.js
@@ -14,6 +14,11 @@ describe('family share token Firestore rules', () => {
         expect(familyShareTokenRules).not.toContain("resource.data.get('active', false) == true");
     });
 
+    it('blocks anonymous reads when legacy revocation flags are present', () => {
+        expect(familyShareTokenRules).toContain("resource.data.get('revoked', false) != true");
+        expect(familyShareTokenRules).toContain("resource.data.get('revokedAt', null) == null");
+    });
+
     it('still reserves revoked-token access for owners and global admins', () => {
         expect(familyShareTokenRules).toContain("isSignedIn() && resource.data.ownerUserId == request.auth.uid");
         expect(familyShareTokenRules).toContain('isGlobalAdmin()');


### PR DESCRIPTION
Closes #2993

## What changed
- Updated the `familyShareTokens/{tokenId}` Firestore `get` rule so anonymous recipients can read legacy tokens that omit the `active` field.
- Kept revoked-token access limited to the token owner and global admins.
- Added a focused unit regression test that locks in the legacy-token read behavior at the rules layer.

## Root Cause
The Firestore rule defaulted missing `active` values to `false` for anonymous `get` requests on `familyShareTokens`, while the family page and existing token-validation logic treat only `active === false` as revoked. That rules/app mismatch caused anonymous reads of legacy tokens to fail before the page could apply its intended validation.

## Prevention / Learning
When legacy documents intentionally treat a missing flag as valid, Firestore rules must use the same default semantics as the application code. For bearer-link flows, add a rules regression test whenever the client and rules depend on the same optional-field contract.

## Regression Tests
- `npx vitest run tests/unit/family-share-token-rules.test.js --reporter=verbose`
- Added `tests/unit/family-share-token-rules.test.js` to assert legacy tokens without `active` remain anonymously readable while revoked-token access stays restricted.