### PR TITLE
Stop persisting team media download URLs

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -155,8 +155,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=33';
-        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=65';
+        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=34';
+        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=66';
         import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -156,7 +156,7 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=33';
-        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=64';
+        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=65';
         import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 

--- a/athlete-profile-builder.html
+++ b/athlete-profile-builder.html
@@ -147,7 +147,7 @@
 
     <script type="module">
         import { renderHeader, renderFooter, getUrlParams, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
-        import { requireAuth, checkAuth } from './js/auth.js?v=33';
+        import { requireAuth, checkAuth } from './js/auth.js?v=34';
         import {
             getUserProfile,
             getAthleteProfile,
@@ -155,7 +155,7 @@
             listAthleteProfilesForParent,
             uploadAthleteProfileMedia,
             deleteAthleteProfileMediaByPath
-        } from './js/db.js?v=65';
+        } from './js/db.js?v=66';
         import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=2';
 
         const params = getUrlParams();

--- a/athlete-profile-builder.html
+++ b/athlete-profile-builder.html
@@ -155,7 +155,7 @@
             listAthleteProfilesForParent,
             uploadAthleteProfileMedia,
             deleteAthleteProfileMediaByPath
-        } from './js/db.js?v=64';
+        } from './js/db.js?v=65';
         import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=2';
 
         const params = getUrlParams();

--- a/athlete-profile.html
+++ b/athlete-profile.html
@@ -27,7 +27,7 @@
     <script type="module">
         import { renderHeader, renderFooter, getUrlParams, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=33';
-        import { getAthleteProfile } from './js/db.js?v=64';
+        import { getAthleteProfile } from './js/db.js?v=65';
         import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=2';
 
         const params = getUrlParams();

--- a/athlete-profile.html
+++ b/athlete-profile.html
@@ -26,8 +26,8 @@
 
     <script type="module">
         import { renderHeader, renderFooter, getUrlParams, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=33';
-        import { getAthleteProfile } from './js/db.js?v=65';
+        import { checkAuth } from './js/auth.js?v=34';
+        import { getAthleteProfile } from './js/db.js?v=66';
         import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=2';
 
         const params = getUrlParams();

--- a/dashboard.html
+++ b/dashboard.html
@@ -88,7 +88,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=64';
+        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=65';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=33';
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -88,9 +88,9 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=65';
+        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=66';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/drills.html
+++ b/drills.html
@@ -614,7 +614,7 @@
             createPracticeSession, updatePracticeSession,
             getPracticeSessionByEvent, upsertPracticeSessionForEvent, updatePracticeAttendance, getPracticeSessions, getPracticePacketCompletions,
             savePracticeTemplate, getPracticeTemplates, deletePracticeTemplate
-        } from './js/db.js?v=64';
+        } from './js/db.js?v=65';
         import { renderHeader, renderFooter, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { requireAuth } from './js/auth.js?v=33';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=4';

--- a/drills.html
+++ b/drills.html
@@ -614,9 +614,9 @@
             createPracticeSession, updatePracticeSession,
             getPracticeSessionByEvent, upsertPracticeSessionForEvent, updatePracticeAttendance, getPracticeSessions, getPracticePacketCompletions,
             savePracticeTemplate, getPracticeTemplates, deletePracticeTemplate
-        } from './js/db.js?v=65';
+        } from './js/db.js?v=66';
         import { renderHeader, renderFooter, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
-        import { requireAuth } from './js/auth.js?v=33';
+        import { requireAuth } from './js/auth.js?v=34';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=4';
         import { DRILL_TYPES, DRILL_LEVELS, DRILL_TYPE_COLORS, getAllSkillTags } from './js/drill-constants.js?v=1';
         import { getStarterDrillById, getStarterDrills } from './js/practice-starter-drills.js?v=1';

--- a/edit-config.html
+++ b/edit-config.html
@@ -200,7 +200,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=64';
+        import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=65';
         import { parseAdvancedStatDefinitions, validateStatDefinitionsForPublicLeaderboards } from './js/stat-leaderboards.js?v=2';
         import { getStatConfigPresetOptions, getStatConfigPresetById, serializeAdvancedStatDefinitions } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';

--- a/edit-config.html
+++ b/edit-config.html
@@ -200,11 +200,11 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=65';
+        import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=66';
         import { parseAdvancedStatDefinitions, validateStatDefinitionsForPublicLeaderboards } from './js/stat-leaderboards.js?v=2';
         import { getStatConfigPresetOptions, getStatConfigPresetById, serializeAdvancedStatDefinitions } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getEditConfigAccessDecision } from './js/edit-config-access.js?v=2';
 

--- a/edit-team.html
+++ b/edit-team.html
@@ -559,7 +559,7 @@
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth, sendInviteEmail } from './js/auth.js?v=33';
+        import { checkAuth, sendInviteEmail } from './js/auth.js?v=34';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=3';

--- a/family.html
+++ b/family.html
@@ -173,7 +173,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=64';
+    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=65';
     import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';
     import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=11';
 

--- a/family.html
+++ b/family.html
@@ -173,7 +173,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=65';
+    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=66';
     import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';
     import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=11';
 

--- a/game-plan.html
+++ b/game-plan.html
@@ -300,9 +300,9 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=65';
+        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=66';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent } from './js/utils.js?v=11';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { createAutoSaveController } from './js/game-plan-autosave.js?v=1';
         import { buildGamePlanIntervals } from './js/game-plan-intervals.js?v=2';

--- a/game-plan.html
+++ b/game-plan.html
@@ -300,7 +300,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=64';
+        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=65';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent } from './js/utils.js?v=11';
         import { checkAuth } from './js/auth.js?v=33';
         import { getTeamAccessInfo } from './js/team-access.js';

--- a/game.html
+++ b/game.html
@@ -388,7 +388,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto, setCompletedGamePlayerStats, getTeamStatsForGame, setCompletedGameTeamStats } from './js/db.js?v=64';
+        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto, setCompletedGamePlayerStats, getTeamStatsForGame, setCompletedGameTeamStats } from './js/db.js?v=65';
         import { generateGameInsights } from './js/post-game-insights.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=33';

--- a/game.html
+++ b/game.html
@@ -388,10 +388,10 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto, setCompletedGamePlayerStats, getTeamStatsForGame, setCompletedGameTeamStats } from './js/db.js?v=65';
+        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto, setCompletedGamePlayerStats, getTeamStatsForGame, setCompletedGameTeamStats } from './js/db.js?v=66';
         import { generateGameInsights } from './js/post-game-insights.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
         import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=19";
         import { db } from './js/firebase.js?v=19';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';

--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@
   <script type="module">
     import { checkAuth, getRedirectUrl } from './js/auth.js?v=33';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=64';
+    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=65';
     import { initHomepage } from './js/homepage.js?v=3';
 
     initHomepage({

--- a/index.html
+++ b/index.html
@@ -651,9 +651,9 @@
   </footer>
 
   <script type="module">
-    import { checkAuth, getRedirectUrl } from './js/auth.js?v=33';
+    import { checkAuth, getRedirectUrl } from './js/auth.js?v=34';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=65';
+    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=66';
     import { initHomepage } from './js/homepage.js?v=3';
 
     initHomepage({

--- a/js/admin-invite.js
+++ b/js/admin-invite.js
@@ -1,4 +1,4 @@
-import { redeemAdminInviteAtomicPersistence } from './db.js?v=64';
+import { redeemAdminInviteAtomicPersistence } from './db.js?v=65';
 
 export async function redeemAdminInviteAcceptance({
     userId,

--- a/js/admin-invite.js
+++ b/js/admin-invite.js
@@ -1,4 +1,4 @@
-import { redeemAdminInviteAtomicPersistence } from './db.js?v=65';
+import { redeemAdminInviteAtomicPersistence } from './db.js?v=66';
 
 export async function redeemAdminInviteAcceptance({
     userId,

--- a/js/admin.js
+++ b/js/admin.js
@@ -14,7 +14,7 @@ import {
     getTelemetryPageDaily,
     getTelemetryEventDaily,
     getTelemetrySessions
-} from './db.js?v=64';
+} from './db.js?v=65';
 import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=19';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=33';

--- a/js/admin.js
+++ b/js/admin.js
@@ -14,10 +14,10 @@ import {
     getTelemetryPageDaily,
     getTelemetryEventDaily,
     getTelemetrySessions
-} from './db.js?v=65';
+} from './db.js?v=66';
 import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=19';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=33';
+import { checkAuth } from './auth.js?v=34';
 import { DEFAULT_ADMIN_PAGE_SIZE, loadAdminCollectionPage, loadInitialAdminBootstrap } from './admin-bootstrap.js?v=1';
 import {
     adminRegistrationDefaults,

--- a/js/auth.js
+++ b/js/auth.js
@@ -15,7 +15,7 @@ import {
     signInWithEmailLink,
     updatePassword
 } from './firebase.js?v=19';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=65';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=66';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=5';
 import { redeemAdminInviteAcceptance } from './admin-invite.js?v=5';
 import { mergeApprovedParentMembershipRequests } from './parent-membership-utils.js?v=2';

--- a/js/auth.js
+++ b/js/auth.js
@@ -15,7 +15,7 @@ import {
     signInWithEmailLink,
     updatePassword
 } from './firebase.js?v=19';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=64';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=65';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=5';
 import { redeemAdminInviteAcceptance } from './admin-invite.js?v=5';
 import { mergeApprovedParentMembershipRequests } from './parent-membership-utils.js?v=2';

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -1,4 +1,4 @@
-import { checkAuth } from '../auth.js?v=33';
+import { checkAuth } from '../auth.js?v=34';
 import {
     getTeam,
     getUserProfile,
@@ -21,7 +21,7 @@ import {
     getCertificate,
     canAccessCertificates,
     canViewSavedCertificate
-} from '../db.js?v=65';
+} from '../db.js?v=66';
 import { renderHeader, renderFooter, escapeHtml, shareOrCopy } from '../utils.js?v=8';
 import { renderTeamAdminBanner, getTeamAccessInfo } from '../team-admin-banner.js?v=4';
 import { TEMPLATES } from './templates.js?v=2';

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -21,7 +21,7 @@ import {
     getCertificate,
     canAccessCertificates,
     canViewSavedCertificate
-} from '../db.js?v=64';
+} from '../db.js?v=65';
 import { renderHeader, renderFooter, escapeHtml, shareOrCopy } from '../utils.js?v=8';
 import { renderTeamAdminBanner, getTeamAccessInfo } from '../team-admin-banner.js?v=4';
 import { TEMPLATES } from './templates.js?v=2';

--- a/js/db.js
+++ b/js/db.js
@@ -950,12 +950,22 @@ export async function getTeamMediaFolders(teamId, options = {}) {
     }));
 }
 
-async function removeLegacyTeamMediaDownloadUrl(teamId, itemId) {
-    return updateDoc(doc(db, `teams/${teamId}/mediaItems`, itemId), {
-        downloadUrl: deleteField(),
+async function removeLegacyTeamMediaUrls(teamId, itemId, item = {}) {
+    const legacyUrlFields = ['downloadUrl', 'url', 'src']
+        .filter((field) => String(item?.[field] || '').trim());
+    if (legacyUrlFields.length === 0) {
+        return Promise.resolve();
+    }
+
+    const updatePayload = {
         updatedAt: serverTimestamp()
-    }).catch((error) => {
-        console.warn('Unable to remove legacy cached team media download URL:', error);
+    };
+    legacyUrlFields.forEach((field) => {
+        updatePayload[field] = deleteField();
+    });
+
+    return updateDoc(doc(db, `teams/${teamId}/mediaItems`, itemId), updatePayload).catch((error) => {
+        console.warn('Unable to remove legacy cached team media URL fields:', error);
     });
 }
 
@@ -966,11 +976,12 @@ async function resolveAuthorizedTeamMediaItem(teamId, item) {
         return item;
     }
 
-    if (String(item.downloadUrl || '').trim()) {
-        removeLegacyTeamMediaDownloadUrl(teamId, item.id);
-    }
+    removeLegacyTeamMediaUrls(teamId, item.id, item);
 
-    const { downloadUrl, ...sanitizedItem } = item;
+    const sanitizedItem = { ...item };
+    delete sanitizedItem.downloadUrl;
+    delete sanitizedItem.url;
+    delete sanitizedItem.src;
 
     try {
         const url = await getDownloadURL(ref(storage, item.storagePath));

--- a/js/db.js
+++ b/js/db.js
@@ -196,7 +196,7 @@ import {
 } from './registration-review.js?v=2';
 import { assertVolunteerScreeningCleared } from './volunteer-screening-access.js?v=2';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
-import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=3';
+import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
 import { getApp } from './vendor/firebase-app.js';
 import {
     computeOfficiatingCoverageStatus,
@@ -950,6 +950,37 @@ export async function getTeamMediaFolders(teamId, options = {}) {
     }));
 }
 
+async function removeLegacyTeamMediaDownloadUrl(teamId, itemId) {
+    return updateDoc(doc(db, `teams/${teamId}/mediaItems`, itemId), {
+        downloadUrl: deleteField(),
+        updatedAt: serverTimestamp()
+    }).catch((error) => {
+        console.warn('Unable to remove legacy cached team media download URL:', error);
+    });
+}
+
+async function resolveAuthorizedTeamMediaItem(teamId, item) {
+    if (!['photo', 'file'].includes(String(item?.type || '').toLowerCase())) return item;
+
+    if (!item.storagePath) {
+        return item;
+    }
+
+    if (String(item.downloadUrl || '').trim()) {
+        removeLegacyTeamMediaDownloadUrl(teamId, item.id);
+    }
+
+    const { downloadUrl, ...sanitizedItem } = item;
+
+    try {
+        const url = await getDownloadURL(ref(storage, item.storagePath));
+        return { ...sanitizedItem, url };
+    } catch (error) {
+        console.warn('Unable to resolve authorized team media download URL:', error);
+        return sanitizedItem;
+    }
+}
+
 export async function getTeamMediaItems(teamId, folderId = null) {
     if (!teamId) return [];
     const itemsRef = getTeamMediaItemsRef(teamId);
@@ -959,24 +990,7 @@ export async function getTeamMediaItems(teamId, folderId = null) {
         .filter((item) => item.deleted !== true)
         .filter((item) => !folderId || item.folderId === folderId);
 
-    const resolvedItems = await Promise.all(items.map(async (item) => {
-        if (!['photo', 'file'].includes(String(item?.type || '').toLowerCase())) return item;
-        if (String(item.downloadUrl || item.url || item.src || '').trim()) return item;
-        if (!item.storagePath) return item;
-        try {
-            const downloadUrl = await getDownloadURL(ref(storage, item.storagePath));
-            updateDoc(doc(db, `teams/${teamId}/mediaItems`, item.id), {
-                downloadUrl,
-                updatedAt: serverTimestamp()
-            }).catch((error) => {
-                console.warn('Unable to backfill cached team media download URL:', error);
-            });
-            return { ...item, downloadUrl };
-        } catch (error) {
-            console.warn('Unable to resolve team media download URL:', error);
-            return item;
-        }
-    }));
+    const resolvedItems = await Promise.all(items.map((item) => resolveAuthorizedTeamMediaItem(teamId, item)));
 
     return sortByMediaOrder(resolvedItems);
 }
@@ -1035,24 +1049,7 @@ export async function getTeamMediaItemsPage(teamId, folderId, options = {}) {
     const pageDocs = sortedDocs.slice(startOffset, startOffset + pageSize);
     const hasMore = startOffset + pageSize < sortedDocs.length;
     const items = pageDocs.map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }));
-    const resolvedItems = await Promise.all(items.map(async (item) => {
-        if (!['photo', 'file'].includes(String(item?.type || '').toLowerCase())) return item;
-        if (String(item.downloadUrl || item.url || item.src || '').trim()) return item;
-        if (!item.storagePath) return item;
-        try {
-            const downloadUrl = await getDownloadURL(ref(storage, item.storagePath));
-            updateDoc(doc(db, `teams/${teamId}/mediaItems`, item.id), {
-                downloadUrl,
-                updatedAt: serverTimestamp()
-            }).catch((error) => {
-                console.warn('Unable to backfill cached team media download URL:', error);
-            });
-            return { ...item, downloadUrl };
-        } catch (error) {
-            console.warn('Unable to resolve team media download URL:', error);
-            return item;
-        }
-    }));
+    const resolvedItems = await Promise.all(items.map((item) => resolveAuthorizedTeamMediaItem(teamId, item)));
     const lastDoc = pageDocs[pageDocs.length - 1] || null;
 
     return {
@@ -1199,14 +1196,13 @@ export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {})
         }, reject, () => resolve(uploadTask.snapshot));
     });
 
-    const downloadUrl = await getDownloadURL(snapshot.ref);
+    const runtimeUrl = options?.returnItem === true ? await getDownloadURL(snapshot.ref) : '';
     const order = await reserveNextTeamMediaOrder(cleanTeamId, cleanFolderId);
     const mediaItem = {
         folderId: cleanFolderId,
         title: String(file.name || 'Uploaded photo').trim() || 'Uploaded photo',
         type: 'photo',
         storagePath,
-        downloadUrl,
         uploadedBy: currentUser.uid,
         size: Number(file.size || 0),
         mimeType: file.type || 'image/jpeg',
@@ -1217,7 +1213,7 @@ export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {})
     };
     const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), mediaItem);
     if (options?.returnItem === true) {
-        return { id: docRef.id, ...mediaItem, url: downloadUrl };
+        return { id: docRef.id, ...mediaItem, url: runtimeUrl };
     }
     return docRef.id;
 }
@@ -1249,7 +1245,7 @@ export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) 
         }, reject, () => resolve(uploadTask.snapshot));
     });
 
-    const downloadUrl = await getDownloadURL(snapshot.ref);
+    const runtimeUrl = options?.returnItem === true ? await getDownloadURL(snapshot.ref) : '';
     const order = await reserveNextTeamMediaOrder(cleanTeamId, cleanFolderId);
     const mediaItem = {
         folderId: cleanFolderId,
@@ -1257,7 +1253,6 @@ export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) 
         fileName: String(file.name || '').trim(),
         type: 'file',
         storagePath,
-        downloadUrl,
         uploadedBy: currentUser.uid,
         size: Number(file.size || 0),
         mimeType: file.type,
@@ -1268,7 +1263,7 @@ export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) 
     };
     const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), mediaItem);
     if (options?.returnItem === true) {
-        return { id: docRef.id, ...mediaItem, url: downloadUrl };
+        return { id: docRef.id, ...mediaItem, url: runtimeUrl };
     }
     return docRef.id;
 }

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from './utils.js?v=8';
-import { discoverPublicTeams } from './db.js?v=64';
+import { discoverPublicTeams } from './db.js?v=65';
 import { canUserDiscoverPlayerInSearch, filterSearchableTeams } from './global-search-visibility.js?v=2';
 import { isTeamActive } from './team-visibility.js?v=2';
 import {

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from './utils.js?v=8';
-import { discoverPublicTeams } from './db.js?v=65';
+import { discoverPublicTeams } from './db.js?v=66';
 import { canUserDiscoverPlayerInSearch, filterSearchableTeams } from './global-search-visibility.js?v=2';
 import { isTeamActive } from './team-visibility.js?v=2';
 import {

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -15,7 +15,7 @@ import {
   subscribeGame,
   updateGame,
   uploadGameClip
-} from './db.js?v=64';
+} from './db.js?v=65';
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=9';
 import { hasFullTeamAccess } from './team-access.js?v=1';
 import { buildScoreLinkedClipRecord, isScoredPlayEvent, validateGameClipFile } from './game-clips.js?v=1';

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -15,12 +15,12 @@ import {
   subscribeGame,
   updateGame,
   uploadGameClip
-} from './db.js?v=65';
+} from './db.js?v=66';
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=9';
 import { hasFullTeamAccess } from './team-access.js?v=1';
 import { buildScoreLinkedClipRecord, isScoredPlayEvent, validateGameClipFile } from './game-clips.js?v=1';
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
-import { checkAuth } from './auth.js?v=33';
+import { checkAuth } from './auth.js?v=34';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { createPlayAnnouncer } from './live-game-announcer.js?v=1';
 import {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=64';
+import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=65';
 import { db } from './firebase.js?v=19';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
 import { checkAuth } from './auth.js?v=33';

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,8 +1,8 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=65';
+import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=66';
 import { db } from './firebase.js?v=19';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
-import { checkAuth } from './auth.js?v=33';
+import { checkAuth } from './auth.js?v=34';
 import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=19';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -274,7 +274,10 @@ export function buildBulkDeleteUpdates(ids = []) {
 }
 
 export function getTeamMediaItemUrl(item = {}) {
-    return String(item.downloadUrl || item.url || item.src || '').trim();
+    const runtimeUrl = String(item.url || item.src || '').trim();
+    if (runtimeUrl) return runtimeUrl;
+    if (asTrimmedString(item.storagePath)) return '';
+    return String(item.downloadUrl || '').trim();
 }
 
 export function isSafeTeamMediaPhoto(item = {}) {

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem
-} from './db.js?v=64';
+} from './db.js?v=65';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,
@@ -30,7 +30,7 @@ import {
     isSupportedTeamMediaImage,
     isTeamMediaDocument,
     sortByMediaOrder
-} from './team-media-utils.js?v=3';
+} from './team-media-utils.js?v=4';
 
 const state = {
     teamId: '',

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -1,4 +1,4 @@
-import { checkAuth } from './auth.js?v=33';
+import { checkAuth } from './auth.js?v=34';
 import {
     getTeam,
     getTeamMediaFolders,
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem
-} from './db.js?v=65';
+} from './db.js?v=66';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,8 +1,8 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=65';
+import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=66';
 import { db } from './firebase.js?v=19';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=33';
+import { checkAuth } from './auth.js?v=34';
 import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=19';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=64';
+import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=65';
 import { db } from './firebase.js?v=19';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=33';

--- a/js/tracking-items-admin.js
+++ b/js/tracking-items-admin.js
@@ -204,7 +204,7 @@ async function initTrackingItemsAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [dbModule, authModule, firebaseModule] = await Promise.all([
-        import('./db.js?v=64'),
+        import('./db.js?v=65'),
         import('./auth.js?v=33'),
         import('./firebase.js?v=19')
     ]);

--- a/js/tracking-items-admin.js
+++ b/js/tracking-items-admin.js
@@ -204,8 +204,8 @@ async function initTrackingItemsAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [dbModule, authModule, firebaseModule] = await Promise.all([
-        import('./db.js?v=65'),
-        import('./auth.js?v=33'),
+        import('./db.js?v=66'),
+        import('./auth.js?v=34'),
         import('./firebase.js?v=19')
     ]);
     const { getTeam, getUserProfile, canModerateChat } = dbModule;

--- a/login.html
+++ b/login.html
@@ -98,7 +98,7 @@
 
     <script type="module">
         import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=33';
-        import { getUserProfile } from './js/db.js?v=64';
+        import { getUserProfile } from './js/db.js?v=65';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';
         import * as loginPageModule from './js/login-page.js?v=5';

--- a/login.html
+++ b/login.html
@@ -97,8 +97,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=33';
-        import { getUserProfile } from './js/db.js?v=65';
+        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=34';
+        import { getUserProfile } from './js/db.js?v=66';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';
         import * as loginPageModule from './js/login-page.js?v=5';

--- a/officials.html
+++ b/officials.html
@@ -42,8 +42,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { checkAuth } from './js/auth.js?v=33';
-        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=65';
+        import { checkAuth } from './js/auth.js?v=34';
+        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=66';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
         import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots, hasSubmittedOfficiatingResult, validateOfficiatingResultSubmission } from './js/officiating-utils.js?v=4';
 

--- a/officials.html
+++ b/officials.html
@@ -43,7 +43,7 @@
 
     <script type="module">
         import { checkAuth } from './js/auth.js?v=33';
-        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=64';
+        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=65';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
         import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots, hasSubmittedOfficiatingResult, validateOfficiatingResultSubmission } from './js/officiating-utils.js?v=4';
 

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -319,10 +319,10 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { addGame, createOrganizationBlackout, createVenueAvailability, createVenueBlackout, getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls } from './js/db.js?v=65';
+        import { addGame, createOrganizationBlackout, createVenueAvailability, createVenueBlackout, getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls } from './js/db.js?v=66';
         import { parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=10';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { addDoc, collection, db, deleteDoc, doc, getDocs, Timestamp, updateDoc } from './js/firebase.js?v=19';
         import { functions, httpsCallable } from './js/firebase.js?v=19';

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -319,7 +319,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { addGame, createOrganizationBlackout, createVenueAvailability, createVenueBlackout, getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls } from './js/db.js?v=64';
+        import { addGame, createOrganizationBlackout, createVenueAvailability, createVenueBlackout, getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls } from './js/db.js?v=65';
         import { parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=10';
         import { checkAuth } from './js/auth.js?v=33';

--- a/player.html
+++ b/player.html
@@ -236,7 +236,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, updatePlayerPrivateProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=64';
+        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, updatePlayerPrivateProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=65';
         import { collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=2';
         import { generatePlayerGameInsights } from './js/post-game-insights.js?v=1';
         import { hasPlayerProfileParticipation, collectPlayerVideoClips } from './js/player-profile-stats.js?v=3';

--- a/player.html
+++ b/player.html
@@ -236,13 +236,13 @@
     </div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, updatePlayerPrivateProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=65';
+        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, updatePlayerPrivateProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=66';
         import { collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=2';
         import { generatePlayerGameInsights } from './js/post-game-insights.js?v=1';
         import { hasPlayerProfileParticipation, collectPlayerVideoClips } from './js/player-profile-stats.js?v=3';
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig, summarizePlayerTopStats } from './js/stat-leaderboards.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
         import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=19";
         import { db } from './js/firebase.js?v=19';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';

--- a/profile.html
+++ b/profile.html
@@ -431,7 +431,7 @@
 
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth, setUserPassword, resendVerificationEmail } from './js/auth.js?v=33';
+        import { checkAuth, setUserPassword, resendVerificationEmail } from './js/auth.js?v=34';
         import {
             getUserProfile,
             updateUserProfile,
@@ -444,7 +444,7 @@
             getNotificationPreferencesForTeam,
             saveNotificationPreferencesForTeam,
             upsertNotificationDeviceToken
-        } from './js/db.js?v=65';
+        } from './js/db.js?v=66';
         import { normalizeTeamNotificationPreferences, NOTIFICATION_PREFERENCE_GROUPS } from './js/notification-preferences.js?v=2';
         import { registerPushNotifications } from './js/push-notifications.js?v=1';
 

--- a/profile.html
+++ b/profile.html
@@ -444,7 +444,7 @@
             getNotificationPreferencesForTeam,
             saveNotificationPreferencesForTeam,
             upsertNotificationDeviceToken
-        } from './js/db.js?v=64';
+        } from './js/db.js?v=65';
         import { normalizeTeamNotificationPreferences, NOTIFICATION_PREFERENCE_GROUPS } from './js/notification-preferences.js?v=2';
         import { registerPushNotifications } from './js/push-notifications.js?v=1';
 

--- a/team-chat.html
+++ b/team-chat.html
@@ -343,8 +343,8 @@
 
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=33';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=65';
+        import { checkAuth } from './js/auth.js?v=34';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=66';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,7 +344,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=33';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=64';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=65';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/teams.html
+++ b/teams.html
@@ -102,7 +102,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { discoverPublicTeams } from './js/db.js?v=64';
+    import { discoverPublicTeams } from './js/db.js?v=65';
     import { renderHeader, renderFooter, escapeHtml, getSafeImageUrl, resolveZip } from './js/utils.js?v=9';
     import { checkAuth } from './js/auth.js?v=33';
 

--- a/teams.html
+++ b/teams.html
@@ -102,9 +102,9 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { discoverPublicTeams } from './js/db.js?v=65';
+    import { discoverPublicTeams } from './js/db.js?v=66';
     import { renderHeader, renderFooter, escapeHtml, getSafeImageUrl, resolveZip } from './js/utils.js?v=9';
-    import { checkAuth } from './js/auth.js?v=33';
+    import { checkAuth } from './js/auth.js?v=34';
 
     checkAuth((user) => {
       // Allow viewing without login - user can be null

--- a/tests/smoke/edit-config-platform-admin.spec.js
+++ b/tests/smoke/edit-config-platform-admin.spec.js
@@ -197,7 +197,7 @@ async function mockDependencies(page) {
         contentType: 'application/javascript',
         body: ''
     }));
-    await page.route('**/js/db.js?v=65', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
+    await page.route('**/js/db.js?v=66', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route('**/js/edit-config-access.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));

--- a/tests/smoke/edit-config-platform-admin.spec.js
+++ b/tests/smoke/edit-config-platform-admin.spec.js
@@ -197,7 +197,7 @@ async function mockDependencies(page) {
         contentType: 'application/javascript',
         body: ''
     }));
-    await page.route('**/js/db.js?v=64', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
+    await page.route('**/js/db.js?v=65', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route('**/js/edit-config-access.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from '../../js/accept-invite-flow.js';
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=65';";
+const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=66';";
 
 class MockClassList {
     constructor(initial = []) {
@@ -104,7 +104,7 @@ const URLSearchParams = deps.URLSearchParams;
 const setTimeout = deps.setTimeout;
 ` + match[1]
         .replace(
-            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=33';",
+            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=34';",
             'const { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } = deps.auth;'
         )
         .replace(

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from '../../js/accept-invite-flow.js';
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=64';";
+const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=65';";
 
 class MockClassList {
     constructor(initial = []) {

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -8,14 +8,14 @@ describe('admin invite signup cache busting', () => {
 
         expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=5';");
         expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=5';");
-        expect(authSource).toContain("from './db.js?v=65';");
+        expect(authSource).toContain("from './db.js?v=66';");
     });
 
     it('pins fresh invite acceptance module versions for admin invite redemption', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=65';"
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=66';"
         );
         expect(acceptInviteSource).toContain(
             "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';"
@@ -24,13 +24,13 @@ describe('admin invite signup cache busting', () => {
 
     it('bumps auth module consumers after signup flow changes', () => {
         const authConsumers = {
-            'login.html': 'auth.js?v=33',
-            'accept-invite.html': 'auth.js?v=33',
-            'edit-team.html': 'auth.js?v=33',
-            'js/admin.js': 'auth.js?v=33',
-            'js/live-game.js': 'auth.js?v=33',
-            'js/live-tracker.js': 'auth.js?v=33',
-            'js/track-basketball.js': 'auth.js?v=33'
+            'login.html': 'auth.js?v=34',
+            'accept-invite.html': 'auth.js?v=34',
+            'edit-team.html': 'auth.js?v=34',
+            'js/admin.js': 'auth.js?v=34',
+            'js/live-game.js': 'auth.js?v=34',
+            'js/live-tracker.js': 'auth.js?v=34',
+            'js/track-basketball.js': 'auth.js?v=34'
         };
 
         for (const [relativePath, expectedVersion] of Object.entries(authConsumers)) {
@@ -44,7 +44,7 @@ describe('admin invite signup cache busting', () => {
         const logoutImportMatches = utilsSource.match(/const \{ logout \} = await import\('\.\/auth\.js\?v=22'\);/g) || [];
 
         expect(logoutImportMatches).toHaveLength(1);
-        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=33');");
-        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=33');");
+        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=34');");
+        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=34');");
     });
 });

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -8,14 +8,14 @@ describe('admin invite signup cache busting', () => {
 
         expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=5';");
         expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=5';");
-        expect(authSource).toContain("from './db.js?v=64';");
+        expect(authSource).toContain("from './db.js?v=65';");
     });
 
     it('pins fresh invite acceptance module versions for admin invite redemption', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=64';"
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=65';"
         );
         expect(acceptInviteSource).toContain(
             "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';"

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -37,6 +37,10 @@ describe('admin invite signup cache busting', () => {
             const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
             expect(source).toContain(expectedVersion);
         }
+
+        const editTeamSource = readFileSync(resolve(process.cwd(), 'edit-team.html'), 'utf8');
+        expect(editTeamSource).toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=34';");
+        expect(editTeamSource).not.toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=33';");
     });
 
     it('keeps the shared header logout import pinned to auth.js v22', () => {

--- a/tests/unit/admin-invite.test.js
+++ b/tests/unit/admin-invite.test.js
@@ -4,7 +4,7 @@ const dbMocks = vi.hoisted(() => ({
     redeemAdminInviteAtomicPersistence: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=65', () => dbMocks);
+vi.mock('../../js/db.js?v=66', () => dbMocks);
 
 const { redeemAdminInviteAcceptance } = await import('../../js/admin-invite.js');
 

--- a/tests/unit/admin-invite.test.js
+++ b/tests/unit/admin-invite.test.js
@@ -4,7 +4,7 @@ const dbMocks = vi.hoisted(() => ({
     redeemAdminInviteAtomicPersistence: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=64', () => dbMocks);
+vi.mock('../../js/db.js?v=65', () => dbMocks);
 
 const { redeemAdminInviteAcceptance } = await import('../../js/admin-invite.js');
 

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=65', () => ({
+vi.mock('../../js/db.js?v=66', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=64', () => ({
+vi.mock('../../js/db.js?v=65', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=65', () => ({
+vi.mock('../../js/db.js?v=66', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=64', () => ({
+vi.mock('../../js/db.js?v=65', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-google-popup-fallback.test.js
+++ b/tests/unit/auth-google-popup-fallback.test.js
@@ -21,7 +21,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=65', () => ({
+vi.mock('../../js/db.js?v=66', () => ({
     validateAccessCode: vi.fn(),
     markAccessCodeAsUsed: vi.fn(),
     updateUserProfile: vi.fn(),

--- a/tests/unit/auth-google-popup-fallback.test.js
+++ b/tests/unit/auth-google-popup-fallback.test.js
@@ -21,7 +21,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=64', () => ({
+vi.mock('../../js/db.js?v=65', () => ({
     validateAccessCode: vi.fn(),
     markAccessCodeAsUsed: vi.fn(),
     updateUserProfile: vi.fn(),

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -33,7 +33,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
-vi.mock('../../js/db.js?v=64', () => dbMocks);
+vi.mock('../../js/db.js?v=65', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=5', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -33,7 +33,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
-vi.mock('../../js/db.js?v=65', () => dbMocks);
+vi.mock('../../js/db.js?v=66', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=5', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));

--- a/tests/unit/auth-send-invite-email-no-localstorage.test.js
+++ b/tests/unit/auth-send-invite-email-no-localstorage.test.js
@@ -21,7 +21,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=65', () => ({
+vi.mock('../../js/db.js?v=66', () => ({
     validateAccessCode: vi.fn(),
     markAccessCodeAsUsed: vi.fn(),
     updateUserProfile: vi.fn(),

--- a/tests/unit/auth-send-invite-email-no-localstorage.test.js
+++ b/tests/unit/auth-send-invite-email-no-localstorage.test.js
@@ -21,7 +21,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=64', () => ({
+vi.mock('../../js/db.js?v=65', () => ({
     validateAccessCode: vi.fn(),
     markAccessCodeAsUsed: vi.fn(),
     updateUserProfile: vi.fn(),

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -36,7 +36,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
-vi.mock('../../js/db.js?v=65', () => dbMocks);
+vi.mock('../../js/db.js?v=66', () => dbMocks);
 
 const { signup, loginWithGoogle, handleGoogleRedirectResult } = await import('../../js/auth.js');
 

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -36,7 +36,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
-vi.mock('../../js/db.js?v=64', () => dbMocks);
+vi.mock('../../js/db.js?v=65', () => dbMocks);
 
 const { signup, loginWithGoogle, handleGoogleRedirectResult } = await import('../../js/auth.js');
 

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -27,7 +27,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(studio).toContain("from './templates.js?v=2'");
         expect(studio).toContain("from './renderer.js?v=2'");
         expect(studio).toContain("from './aiDescriptions.js?v=4'");
-        expect(studio).toContain("from '../db.js?v=65'");
+        expect(studio).toContain("from '../db.js?v=66'");
 
         expect(studio).toContain('Create drafts for selected players');
         expect(studio).toContain('Saved work');

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -27,7 +27,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(studio).toContain("from './templates.js?v=2'");
         expect(studio).toContain("from './renderer.js?v=2'");
         expect(studio).toContain("from './aiDescriptions.js?v=4'");
-        expect(studio).toContain("from '../db.js?v=64'");
+        expect(studio).toContain("from '../db.js?v=65'");
 
         expect(studio).toContain('Create drafts for selected players');
         expect(studio).toContain('Saved work');

--- a/tests/unit/dashboard-parent-membership-sync.test.js
+++ b/tests/unit/dashboard-parent-membership-sync.test.js
@@ -21,8 +21,8 @@ describe('dashboard parent membership sync', () => {
     const html = readRepoFile('dashboard.html');
 
     it('uses the rich auth path before loading parent-linked teams', () => {
-        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=65';");
-        expect(html).toContain("import { checkAuth } from './js/auth.js?v=33';");
+        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=66';");
+        expect(html).toContain("import { checkAuth } from './js/auth.js?v=34';");
         expect(html).toContain('function requireSyncedAuth()');
         expect(html).toContain('const user = await requireSyncedAuth();');
         expect(html).toContain('getParentTeams(user.uid)');

--- a/tests/unit/dashboard-parent-membership-sync.test.js
+++ b/tests/unit/dashboard-parent-membership-sync.test.js
@@ -21,7 +21,7 @@ describe('dashboard parent membership sync', () => {
     const html = readRepoFile('dashboard.html');
 
     it('uses the rich auth path before loading parent-linked teams', () => {
-        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=64';");
+        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=65';");
         expect(html).toContain("import { checkAuth } from './js/auth.js?v=33';");
         expect(html).toContain('function requireSyncedAuth()');
         expect(html).toContain('const user = await requireSyncedAuth();');

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -105,7 +105,7 @@ describe('discoverPublicTeams search pagination', () => {
             .mockResolvedValueOnce({ docs: [] })
             .mockResolvedValueOnce({ docs: [] });
 
-        const { discoverPublicTeams } = await import('../../js/db.js?v=64');
+        const { discoverPublicTeams } = await import('../../js/db.js?v=65');
 
         const firstPage = await discoverPublicTeams({ searchText: 'atlanta', pageSize: 2 });
 
@@ -148,7 +148,7 @@ describe('discoverPublicTeams search pagination', () => {
             publicSearchName: 'atlanta united 2'
         });
 
-        const { discoverPublicTeams } = await import('../../js/db.js?v=64');
+        const { discoverPublicTeams } = await import('../../js/db.js?v=65');
 
         const page = await discoverPublicTeams({
             searchText: 'atlanta',

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -105,7 +105,7 @@ describe('discoverPublicTeams search pagination', () => {
             .mockResolvedValueOnce({ docs: [] })
             .mockResolvedValueOnce({ docs: [] });
 
-        const { discoverPublicTeams } = await import('../../js/db.js?v=65');
+        const { discoverPublicTeams } = await import('../../js/db.js?v=66');
 
         const firstPage = await discoverPublicTeams({ searchText: 'atlanta', pageSize: 2 });
 
@@ -148,7 +148,7 @@ describe('discoverPublicTeams search pagination', () => {
             publicSearchName: 'atlanta united 2'
         });
 
-        const { discoverPublicTeams } = await import('../../js/db.js?v=65');
+        const { discoverPublicTeams } = await import('../../js/db.js?v=66');
 
         const page = await discoverPublicTeams({
             searchText: 'atlanta',

--- a/tests/unit/edit-roster-tracking-status.test.js
+++ b/tests/unit/edit-roster-tracking-status.test.js
@@ -243,7 +243,7 @@ describe('edit roster tracking status matrix wiring', () => {
         const source = readEditRoster();
 
         expect(source).toContain("from './js/db.js?v=65'");
-        expect(source).not.toContain("from './js/db.js?v=65'");
+        expect(source).not.toContain("from './js/db.js?v=64'");
         expect(source).toContain("from './js/tracking-status-admin.js?v=2'");
         expect(source).toContain('item.title || item.name || item.id');
         expect(source).toContain("selectedItem.title || selectedItem.name || 'selected item'");

--- a/tests/unit/edit-roster-tracking-status.test.js
+++ b/tests/unit/edit-roster-tracking-status.test.js
@@ -243,7 +243,7 @@ describe('edit roster tracking status matrix wiring', () => {
         const source = readEditRoster();
 
         expect(source).toContain("from './js/db.js?v=65'");
-        expect(source).not.toContain("from './js/db.js?v=64'");
+        expect(source).not.toContain("from './js/db.js?v=65'");
         expect(source).toContain("from './js/tracking-status-admin.js?v=2'");
         expect(source).toContain('item.title || item.name || item.id');
         expect(source).toContain("selectedItem.title || selectedItem.name || 'selected item'");

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -17,7 +17,7 @@ const firebaseMocks = vi.hoisted(() => ({
     limit: vi.fn((count) => ({ type: 'limit', count }))
 }));
 
-vi.mock('../../js/db.js?v=64', () => dbMocks);
+vi.mock('../../js/db.js?v=65', () => dbMocks);
 vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
 vi.mock('../../js/utils.js?v=8', () => ({
     escapeHtml: (value) => String(value || '')

--- a/tests/unit/global-search-modal-integration.test.js
+++ b/tests/unit/global-search-modal-integration.test.js
@@ -17,7 +17,7 @@ const firebaseMocks = vi.hoisted(() => ({
     limit: vi.fn((count) => ({ type: 'limit', count }))
 }));
 
-vi.mock('../../js/db.js?v=65', () => dbMocks);
+vi.mock('../../js/db.js?v=66', () => dbMocks);
 vi.mock('../../js/firebase.js?v=19', () => firebaseMocks);
 vi.mock('../../js/utils.js?v=8', () => ({
     escapeHtml: (value) => String(value || '')

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -6,7 +6,7 @@ const source = readFileSync(resolve(process.cwd(), 'js/global-search.js'), 'utf8
 
 describe('legacy global player search scoping', () => {
     it('uses bounded public team discovery instead of bootstrapping the full catalog', () => {
-        expect(source).toContain("import { discoverPublicTeams } from './db.js?v=65';");
+        expect(source).toContain("import { discoverPublicTeams } from './db.js?v=66';");
         expect(source).not.toContain('import { getTeams }');
         expect(source).toContain('const teamSearchQueryLimit = 20;');
         expect(source).toContain('if (q.length < 2) {');

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -6,7 +6,7 @@ const source = readFileSync(resolve(process.cwd(), 'js/global-search.js'), 'utf8
 
 describe('legacy global player search scoping', () => {
     it('uses bounded public team discovery instead of bootstrapping the full catalog', () => {
-        expect(source).toContain("import { discoverPublicTeams } from './db.js?v=64';");
+        expect(source).toContain("import { discoverPublicTeams } from './db.js?v=65';");
         expect(source).not.toContain('import { getTeams }');
         expect(source).toContain('const teamSearchQueryLimit = 20;');
         expect(source).toContain('if (q.length < 2) {');

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -224,7 +224,7 @@ function createEnvironment() {
 function buildModuleSource() {
     return readFileSync(new URL('../../js/live-game.js', import.meta.url), 'utf8')
         .replace(
-            "import {\n  getTeam,\n  getGame,\n  getPlayers,\n  subscribeLiveEvents,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  subscribeReactions,\n  sendReaction,\n  trackViewerPresence,\n  getLiveEvents,\n  getLiveChatHistory,\n  getLiveReactions,\n  getConfigs,\n  subscribeGame,\n  updateGame,\n  uploadGameClip\n} from './db.js?v=64';",
+            "import {\n  getTeam,\n  getGame,\n  getPlayers,\n  subscribeLiveEvents,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  subscribeReactions,\n  sendReaction,\n  trackViewerPresence,\n  getLiveEvents,\n  getLiveChatHistory,\n  getLiveReactions,\n  getConfigs,\n  subscribeGame,\n  updateGame,\n  uploadGameClip\n} from './db.js?v=65';",
             'const { getTeam, getGame, getPlayers, subscribeLiveEvents, subscribeLiveChat, postLiveChatMessage, subscribeReactions, sendReaction, trackViewerPresence, getLiveEvents, getLiveChatHistory, getLiveReactions, getConfigs, subscribeGame, updateGame, uploadGameClip } = deps.db;'
         )
         .replace(

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -224,7 +224,7 @@ function createEnvironment() {
 function buildModuleSource() {
     return readFileSync(new URL('../../js/live-game.js', import.meta.url), 'utf8')
         .replace(
-            "import {\n  getTeam,\n  getGame,\n  getPlayers,\n  subscribeLiveEvents,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  subscribeReactions,\n  sendReaction,\n  trackViewerPresence,\n  getLiveEvents,\n  getLiveChatHistory,\n  getLiveReactions,\n  getConfigs,\n  subscribeGame,\n  updateGame,\n  uploadGameClip\n} from './db.js?v=65';",
+            "import {\n  getTeam,\n  getGame,\n  getPlayers,\n  subscribeLiveEvents,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  subscribeReactions,\n  sendReaction,\n  trackViewerPresence,\n  getLiveEvents,\n  getLiveChatHistory,\n  getLiveReactions,\n  getConfigs,\n  subscribeGame,\n  updateGame,\n  uploadGameClip\n} from './db.js?v=66';",
             'const { getTeam, getGame, getPlayers, subscribeLiveEvents, subscribeLiveChat, postLiveChatMessage, subscribeReactions, sendReaction, trackViewerPresence, getLiveEvents, getLiveChatHistory, getLiveReactions, getConfigs, subscribeGame, updateGame, uploadGameClip } = deps.db;'
         )
         .replace(

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -459,12 +459,12 @@ describe('live tracker opponent stats harness', () => {
   it('rewrites module imports when cache-buster versions and formatting change', () => {
     const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8')
       .replace(
-        "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=65';",
-        "import {\n  getTeam,\n  getTeams,\n  getGame,\n  getPlayers,\n  getConfigs,\n  updateGame,\n  collection,\n  getDocs,\n  deleteDoc,\n  query,\n  broadcastLiveEvent,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  setGameLiveStatus\n} from './db.js?v=65';"
+        "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=66';",
+        "import {\n  getTeam,\n  getTeams,\n  getGame,\n  getPlayers,\n  getConfigs,\n  updateGame,\n  collection,\n  getDocs,\n  deleteDoc,\n  query,\n  broadcastLiveEvent,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  setGameLiveStatus\n} from './db.js?v=66';"
       )
       .replace('./firebase.js?v=15', './firebase.js?v=15')
       .replace('./utils.js?v=9', './utils.js?v=123')
-      .replace('./auth.js?v=33', './auth.js?v=466');
+      .replace('./auth.js?v=34', './auth.js?v=467');
 
     const rewritten = buildModuleSource(source);
 

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -459,8 +459,8 @@ describe('live tracker opponent stats harness', () => {
   it('rewrites module imports when cache-buster versions and formatting change', () => {
     const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8')
       .replace(
-        "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=64';",
-        "import {\n  getTeam,\n  getTeams,\n  getGame,\n  getPlayers,\n  getConfigs,\n  updateGame,\n  collection,\n  getDocs,\n  deleteDoc,\n  query,\n  broadcastLiveEvent,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  setGameLiveStatus\n} from './db.js?v=64';"
+        "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=65';",
+        "import {\n  getTeam,\n  getTeams,\n  getGame,\n  getPlayers,\n  getConfigs,\n  updateGame,\n  collection,\n  getDocs,\n  deleteDoc,\n  query,\n  broadcastLiveEvent,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  setGameLiveStatus\n} from './db.js?v=65';"
       )
       .replace('./firebase.js?v=15', './firebase.js?v=15')
       .replace('./utils.js?v=9', './utils.js?v=123')

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -107,9 +107,9 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain('Result submitted');
         expect(officialsSource).toContain("slot.status !== 'accepted' || !hasGameStarted(game) || isCancelled(game)");
         expect(officialsSource).toContain("document.getElementById('officials-status').textContent = 'Result saved.';");
-        expect(officialsSource).toContain("'./js/db.js?v=65'");
-        expect(officialsSource).not.toContain("'./js/db.js?v=41'");
-        expect(officialsSource).not.toContain("'./js/db.js?v=63'");
+        expect(officialsSource).toContain("'./js/db.js?v=66'");
+        expect(officialsSource).not.toContain("'./js/db.js?v=42'");
+        expect(officialsSource).not.toContain("'./js/db.js?v=64'");
         expect(dbSource).toContain('export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser)');
         expect(dbSource).toContain("throw new Error('Cancelled games cannot accept final results.');");
         expect(dbSource).toContain('homeScore: submittedResult.homeScore');

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -107,7 +107,7 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain('Result submitted');
         expect(officialsSource).toContain("slot.status !== 'accepted' || !hasGameStarted(game) || isCancelled(game)");
         expect(officialsSource).toContain("document.getElementById('officials-status').textContent = 'Result saved.';");
-        expect(officialsSource).toContain("'./js/db.js?v=64'");
+        expect(officialsSource).toContain("'./js/db.js?v=65'");
         expect(officialsSource).not.toContain("'./js/db.js?v=41'");
         expect(officialsSource).not.toContain("'./js/db.js?v=63'");
         expect(dbSource).toContain('export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser)');

--- a/tests/unit/scoped-fallback-uploads.test.js
+++ b/tests/unit/scoped-fallback-uploads.test.js
@@ -67,7 +67,7 @@ describe('scoped fallback uploads', () => {
     });
 
     it('falls back to a team-scoped stat sheet path when image storage rejects the upload', async () => {
-        const { uploadStatSheetPhoto } = await import('../../js/db.js?v=64');
+        const { uploadStatSheetPhoto } = await import('../../js/db.js?v=65');
 
         const url = await uploadStatSheetPhoto('team/alpha', {
             name: 'box score (1).png',
@@ -81,7 +81,7 @@ describe('scoped fallback uploads', () => {
     });
 
     it('falls back to a team-scoped drill path when image storage rejects the upload', async () => {
-        const { uploadDrillDiagram } = await import('../../js/db.js?v=64');
+        const { uploadDrillDiagram } = await import('../../js/db.js?v=65');
 
         const url = await uploadDrillDiagram('team/alpha', 'drill 7', {
             name: 'diagram #1.png',

--- a/tests/unit/scoped-fallback-uploads.test.js
+++ b/tests/unit/scoped-fallback-uploads.test.js
@@ -67,7 +67,7 @@ describe('scoped fallback uploads', () => {
     });
 
     it('falls back to a team-scoped stat sheet path when image storage rejects the upload', async () => {
-        const { uploadStatSheetPhoto } = await import('../../js/db.js?v=65');
+        const { uploadStatSheetPhoto } = await import('../../js/db.js?v=66');
 
         const url = await uploadStatSheetPhoto('team/alpha', {
             name: 'box score (1).png',
@@ -81,7 +81,7 @@ describe('scoped fallback uploads', () => {
     });
 
     it('falls back to a team-scoped drill path when image storage rejects the upload', async () => {
-        const { uploadDrillDiagram } = await import('../../js/db.js?v=65');
+        const { uploadDrillDiagram } = await import('../../js/db.js?v=66');
 
         const url = await uploadDrillDiagram('team/alpha', 'drill 7', {
             name: 'diagram #1.png',

--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -22,7 +22,7 @@ describe('scoreboard widget embed', () => {
         const source = readPage('widget-scoreboard.html');
 
         expect(source).toContain('ALL PLAYS live scoreboard');
-        expect(source).toContain("import { getTeam, getGames } from './js/db.js?v=65';");
+        expect(source).toContain("import { getTeam, getGames } from './js/db.js?v=66';");
         expect(source).toContain('const REFRESH_MS = 60000;');
         expect(source).toContain('function selectWidgetGames(games)');
         expect(source).toContain('.filter((game) => game._date && (isLive(game) || game._date >= now || (isCompleted(game) && game._date >= recentCutoff)))');

--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -22,7 +22,7 @@ describe('scoreboard widget embed', () => {
         const source = readPage('widget-scoreboard.html');
 
         expect(source).toContain('ALL PLAYS live scoreboard');
-        expect(source).toContain("import { getTeam, getGames } from './js/db.js?v=64';");
+        expect(source).toContain("import { getTeam, getGames } from './js/db.js?v=65';");
         expect(source).toContain('const REFRESH_MS = 60000;');
         expect(source).toContain('function selectWidgetGames(games)');
         expect(source).toContain('.filter((game) => game._date && (isLive(game) || game._date >= now || (isCompleted(game) && game._date >= recentCutoff)))');

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=65';");
+        expect(html).toContain("from './js/db.js?v=66';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=64';");
+        expect(html).toContain("from './js/db.js?v=65';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -196,7 +196,7 @@ describe('team media db ordering', () => {
         });
     });
 
-    it('re-resolves storage-backed media URLs and strips legacy cached download URLs', async () => {
+    it('re-resolves storage-backed media URLs and strips legacy cached url fields', async () => {
         firebaseMocks.getDocs.mockResolvedValueOnce({
             docs: [{
                 id: 'media-cached',
@@ -205,6 +205,8 @@ describe('team media db ordering', () => {
                     type: 'photo',
                     storagePath: 'team-media/team-1/folder-1/user-1/already-cached.jpg',
                     downloadUrl: 'https://cdn.example.test/already-cached.jpg',
+                    url: 'https://cdn.example.test/already-cached-persisted.jpg',
+                    src: 'https://cdn.example.test/already-cached-src.jpg',
                     order: 0,
                     deleted: false
                 })
@@ -234,6 +236,8 @@ describe('team media db ordering', () => {
             { path: 'teams/team-1/mediaItems/media-cached' },
             {
                 downloadUrl: 'DELETE_FIELD',
+                url: 'DELETE_FIELD',
+                src: 'DELETE_FIELD',
                 updatedAt: 'server-ts'
             }
         );
@@ -250,7 +254,47 @@ describe('team media db ordering', () => {
             })
         ]);
         expect(items[0]).not.toHaveProperty('downloadUrl');
+        expect(items[0]).not.toHaveProperty('src');
         expect(items[1]).not.toHaveProperty('downloadUrl');
+    });
+
+    it('drops persisted storage urls when fresh authorization cannot be resolved', async () => {
+        firebaseMocks.getDocs.mockResolvedValueOnce({
+            docs: [{
+                id: 'media-stale',
+                data: () => ({
+                    folderId: 'folder-1',
+                    type: 'photo',
+                    storagePath: 'team-media/team-1/folder-1/user-1/stale.jpg',
+                    url: 'https://cdn.example.test/stale-persisted.jpg',
+                    src: 'https://cdn.example.test/stale-src.jpg',
+                    order: 0,
+                    deleted: false
+                })
+            }]
+        });
+        firebaseMocks.getDownloadURL.mockRejectedValueOnce(new Error('storage/unauthorized'));
+
+        const { getTeamMediaItems } = await import('../../js/db.js');
+        const items = await getTeamMediaItems('team-1', 'folder-1');
+
+        expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
+            { path: 'teams/team-1/mediaItems/media-stale' },
+            {
+                url: 'DELETE_FIELD',
+                src: 'DELETE_FIELD',
+                updatedAt: 'server-ts'
+            }
+        );
+        expect(items).toEqual([
+            expect.objectContaining({
+                id: 'media-stale',
+                storagePath: 'team-media/team-1/folder-1/user-1/stale.jpg'
+            })
+        ]);
+        expect(items[0]).not.toHaveProperty('url');
+        expect(items[0]).not.toHaveProperty('src');
+        expect(items[0]).not.toHaveProperty('downloadUrl');
     });
 
     it('returns bounded media item pages with stable folder order and cursor metadata', async () => {

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -5,6 +5,7 @@ const addDocState = vi.hoisted(() => ({ nextId: 1 }));
 const firebaseMocks = vi.hoisted(() => ({
     addDoc: vi.fn(async (_collectionRef, data) => ({ id: `media-${addDocState.nextId++}`, data })),
     collection: vi.fn((_db, path) => ({ path })),
+    deleteField: vi.fn(() => 'DELETE_FIELD'),
     getCountFromServer: vi.fn(),
     getDoc: vi.fn(),
     getDocs: vi.fn(),
@@ -51,7 +52,7 @@ vi.mock('../../js/firebase.js?v=19', () => ({
     increment: vi.fn(),
     arrayUnion: vi.fn(),
     arrayRemove: vi.fn(),
-    deleteField: vi.fn(),
+    deleteField: firebaseMocks.deleteField,
     limit: firebaseMocks.limit,
     startAfter: firebaseMocks.startAfter,
     getCountFromServer: firebaseMocks.getCountFromServer,
@@ -73,7 +74,7 @@ vi.mock('../../js/firebase-images.js?v=6', () => ({
     requireImageAuth: vi.fn()
 }));
 
-vi.mock('../../js/team-media-utils.js?v=3', () => ({
+vi.mock('../../js/team-media-utils.js?v=4', () => ({
     buildBulkDeleteUpdates: vi.fn(),
     buildMoveUpdates: vi.fn(),
     buildReorderUpdates: vi.fn(),
@@ -108,7 +109,7 @@ describe('team media db ordering', () => {
         uploadTaskQueue.length = 0;
     });
 
-    it('assigns unique sequential orders to concurrent photo uploads and stores download URLs once', async () => {
+    it('assigns unique sequential orders to concurrent photo uploads without persisting download URLs', async () => {
         const { uploadTeamMediaPhoto } = await import('../../js/db.js');
         const files = [
             new File(['photo-1'], 'tipoff.jpg', { type: 'image/jpeg' }),
@@ -127,20 +128,20 @@ describe('team media db ordering', () => {
             folderId: 'folder-1',
             title: 'tipoff.jpg',
             order: 0,
-            type: 'photo',
-            downloadUrl: 'https://cdn.example.test/uploaded-file'
+            type: 'photo'
         }));
+        expect(firebaseMocks.addDoc.mock.calls[0][1]).not.toHaveProperty('downloadUrl');
         expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
             folderId: 'folder-1',
             title: 'bench.jpg',
             order: 1,
-            type: 'photo',
-            downloadUrl: 'https://cdn.example.test/uploaded-file'
+            type: 'photo'
         }));
-        expect(firebaseMocks.getDownloadURL).toHaveBeenCalledTimes(2);
+        expect(firebaseMocks.addDoc.mock.calls[1][1]).not.toHaveProperty('downloadUrl');
+        expect(firebaseMocks.getDownloadURL).not.toHaveBeenCalled();
     });
 
-    it('starts legacy folders at zero when the media order counter is missing and stores file download URLs', async () => {
+    it('starts legacy folders at zero when the media order counter is missing without storing file download URLs', async () => {
         folderState.nextMediaOrder = Number.NaN;
         const { createTeamMediaLink, uploadTeamMediaFile } = await import('../../js/db.js');
         const file = new File(['doc'], 'lineup.pdf', { type: 'application/pdf' });
@@ -164,10 +165,10 @@ describe('team media db ordering', () => {
         expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
             title: 'lineup.pdf',
             order: 1,
-            type: 'file',
-            downloadUrl: 'https://cdn.example.test/uploaded-file'
+            type: 'file'
         }));
-        expect(firebaseMocks.getDownloadURL).toHaveBeenCalledTimes(1);
+        expect(firebaseMocks.addDoc.mock.calls[1][1]).not.toHaveProperty('downloadUrl');
+        expect(firebaseMocks.getDownloadURL).not.toHaveBeenCalled();
     });
 
     it('returns the created media item for app callers that opt into the richer upload payload', async () => {
@@ -184,20 +185,18 @@ describe('team media db ordering', () => {
             title: 'packet.pdf',
             type: 'file',
             order: 0,
-            url: 'https://cdn.example.test/uploaded-file',
-            downloadUrl: 'https://cdn.example.test/uploaded-file'
+            url: 'https://cdn.example.test/uploaded-file'
         });
         await expect(uploadedPhotoPromise).resolves.toMatchObject({
             id: 'media-2',
             title: 'tipoff.jpg',
             type: 'photo',
             order: 1,
-            url: 'https://cdn.example.test/uploaded-file',
-            downloadUrl: 'https://cdn.example.test/uploaded-file'
+            url: 'https://cdn.example.test/uploaded-file'
         });
     });
 
-    it('reuses cached media URLs and backfills legacy items after the first storage lookup', async () => {
+    it('re-resolves storage-backed media URLs and strips legacy cached download URLs', async () => {
         firebaseMocks.getDocs.mockResolvedValueOnce({
             docs: [{
                 id: 'media-cached',
@@ -220,17 +219,21 @@ describe('team media db ordering', () => {
                 })
             }]
         });
-        firebaseMocks.getDownloadURL.mockResolvedValueOnce('https://cdn.example.test/legacy.pdf');
+        firebaseMocks.getDownloadURL
+            .mockResolvedValueOnce('https://cdn.example.test/already-cached-fresh.jpg')
+            .mockResolvedValueOnce('https://cdn.example.test/legacy.pdf');
 
         const { getTeamMediaItems } = await import('../../js/db.js');
         const items = await getTeamMediaItems('team-1', 'folder-1');
 
-        expect(firebaseMocks.getDownloadURL).toHaveBeenCalledTimes(1);
-        expect(firebaseMocks.getDownloadURL).toHaveBeenCalledWith({ fullPath: 'team-media/team-1/folder-1/user-1/legacy.pdf' });
+        expect(firebaseMocks.getDownloadURL).toHaveBeenCalledTimes(2);
+        expect(firebaseMocks.getDownloadURL).toHaveBeenNthCalledWith(1, { fullPath: 'team-media/team-1/folder-1/user-1/already-cached.jpg' });
+        expect(firebaseMocks.getDownloadURL).toHaveBeenNthCalledWith(2, { fullPath: 'team-media/team-1/folder-1/user-1/legacy.pdf' });
+        expect(firebaseMocks.updateDoc).toHaveBeenCalledTimes(1);
         expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
-            { path: 'teams/team-1/mediaItems/media-legacy' },
+            { path: 'teams/team-1/mediaItems/media-cached' },
             {
-                downloadUrl: 'https://cdn.example.test/legacy.pdf',
+                downloadUrl: 'DELETE_FIELD',
                 updatedAt: 'server-ts'
             }
         );
@@ -238,14 +241,16 @@ describe('team media db ordering', () => {
             expect.objectContaining({
                 id: 'media-cached',
                 storagePath: 'team-media/team-1/folder-1/user-1/already-cached.jpg',
-                downloadUrl: 'https://cdn.example.test/already-cached.jpg'
+                url: 'https://cdn.example.test/already-cached-fresh.jpg'
             }),
             expect.objectContaining({
                 id: 'media-legacy',
                 storagePath: 'team-media/team-1/folder-1/user-1/legacy.pdf',
-                downloadUrl: 'https://cdn.example.test/legacy.pdf'
+                url: 'https://cdn.example.test/legacy.pdf'
             })
         ]);
+        expect(items[0]).not.toHaveProperty('downloadUrl');
+        expect(items[1]).not.toHaveProperty('downloadUrl');
     });
 
     it('returns bounded media item pages with stable folder order and cursor metadata', async () => {

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=64', () => {
+vi.mock('../../js/db.js?v=65', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=65', () => {
+vi.mock('../../js/db.js?v=66', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,
@@ -37,7 +37,7 @@ vi.mock('../../js/db.js?v=65', () => {
     };
 });
 
-vi.mock('../../js/auth.js?v=33', () => {
+vi.mock('../../js/auth.js?v=34', () => {
     return {
         checkAuth: mocks.checkAuth
     };

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -33,7 +33,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toContain("from './db.js?v=64'");
+        expect(pageJs).toContain("from './db.js?v=65'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -33,7 +33,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toContain("from './db.js?v=65'");
+        expect(pageJs).toContain("from './db.js?v=66'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -205,7 +205,7 @@ describe('team media bulk actions', () => {
         expect(isSafeTeamMediaUrl('not a url')).toBe(false);
     });
 
-    it('identifies uploaded photo items and uploader metadata', () => {
+    it('identifies uploaded photo items and ignores persisted download URLs when storage re-authorization is required', () => {
         const item = {
             downloadUrl: 'https://cdn.example.com/photo.png',
             type: 'photo',
@@ -213,6 +213,15 @@ describe('team media bulk actions', () => {
         };
 
         expect(getTeamMediaItemUrl(item)).toBe('https://cdn.example.com/photo.png');
+        expect(getTeamMediaItemUrl({
+            storagePath: 'team-media/team-1/folder-1/user-1/photo.png',
+            downloadUrl: 'https://cdn.example.com/stale-token.png'
+        })).toBe('');
+        expect(getTeamMediaItemUrl({
+            storagePath: 'team-media/team-1/folder-1/user-1/photo.png',
+            url: 'https://cdn.example.com/fresh-session.png',
+            downloadUrl: 'https://cdn.example.com/stale-token.png'
+        })).toBe('https://cdn.example.com/fresh-session.png');
         expect(isSafeTeamMediaPhoto(item)).toBe(true);
         expect(isSafeTeamMediaPhoto({ url: 'https://cdn.example.com/photo.jpg?token=1' })).toBe(true);
         expect(isSafeTeamMediaPhoto({ url: 'javascript:alert(1)', type: 'photo' })).toBe(false);

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -24,7 +24,7 @@ describe('team media page wiring', () => {
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=64'");
+        expect(source).toContain("from './db.js?v=65'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=33';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -24,8 +24,8 @@ describe('team media page wiring', () => {
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=65'");
-        expect(source).toContain("import { checkAuth } from './auth.js?v=33';");
+        expect(source).toContain("from './db.js?v=66'");
+        expect(source).toContain("import { checkAuth } from './auth.js?v=34';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(source).toContain('Team media permissions are not enabled');

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -67,7 +67,7 @@ describe('public teams visibility', () => {
     it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {
         const source = readRepoFile('teams.html');
 
-        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=64';");
+        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=65';");
         expect(source).toContain('discoverPublicTeams(locationFilter');
         expect(source).toContain("{ cursor, pageSize: 24 }");
         expect(source).toContain('allTeams.filter(t => t.isPublic === true)');

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -67,7 +67,7 @@ describe('public teams visibility', () => {
     it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {
         const source = readRepoFile('teams.html');
 
-        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=65';");
+        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=66';");
         expect(source).toContain('discoverPublicTeams(locationFilter');
         expect(source).toContain("{ cursor, pageSize: 24 }");
         expect(source).toContain('allTeams.filter(t => t.isPublic === true)');

--- a/track-live.html
+++ b/track-live.html
@@ -667,7 +667,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=64';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=65';
         import { db } from './js/firebase.js?v=19';
         import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';

--- a/track-live.html
+++ b/track-live.html
@@ -667,7 +667,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=65';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=66';
         import { db } from './js/firebase.js?v=19';
         import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
@@ -680,7 +680,7 @@
         import { applyVolleyballServeOutcome, createVolleyballUndoState, restoreVolleyballUndoState, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=2';
 
         import { applyBaseballScorekeepingAction, createBaseballLiveState, getBaseballPeriodLabel, getBaseballSituationSummary, isBaseballScorekeepingSport, parseBaseballPeriodLabel } from './js/live-scorekeeping-baseball.js?v=1';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, removeGameSummaryLine, buildGameNoteLogText, buildGoalSportNoteText } from './js/live-tracker-notes.js?v=3';
         import { collectTournamentAdvancementPatches } from './js/tournament-brackets.js?v=1';

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -198,11 +198,11 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=65';
+    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=66';
     import { db } from './js/firebase.js?v=19';
     import { writeBatch, doc, setDoc } from './js/firebase.js?v=19';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=8';
-    import { checkAuth } from './js/auth.js?v=33';
+    import { checkAuth } from './js/auth.js?v=34';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
     import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=7';
     import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=4';
@@ -924,7 +924,7 @@ Write the match report now:`;
       try {
         if (summaryText) {
           status.textContent = 'Saving summary…';
-          const { updateGame } = await import('./js/db.js?v=65');
+          const { updateGame } = await import('./js/db.js?v=66');
           await updateGame(currentTeamId, currentGameId, { summary: summaryText });
           status.textContent = 'Summary saved!';
         }

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -198,7 +198,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=64';
+    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=65';
     import { db } from './js/firebase.js?v=19';
     import { writeBatch, doc, setDoc } from './js/firebase.js?v=19';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=8';
@@ -924,7 +924,7 @@ Write the match report now:`;
       try {
         if (summaryText) {
           status.textContent = 'Saving summary…';
-          const { updateGame } = await import('./js/db.js?v=64');
+          const { updateGame } = await import('./js/db.js?v=65');
           await updateGame(currentTeamId, currentGameId, { summary: summaryText });
           status.textContent = 'Summary saved!';
         }

--- a/track.html
+++ b/track.html
@@ -274,7 +274,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=64';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=65';
         import { db } from './js/firebase.js?v=19';
         import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';

--- a/track.html
+++ b/track.html
@@ -274,11 +274,11 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=65';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=66';
         import { db } from './js/firebase.js?v=19';
         import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=33';
+        import { checkAuth } from './js/auth.js?v=34';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';
         import { resolveSummaryRecipient } from './js/live-tracker-email.js?v=1';
         import { hasScorekeepingTeamAccess } from './js/team-access.js?v=2';

--- a/widget-scoreboard.html
+++ b/widget-scoreboard.html
@@ -33,7 +33,7 @@
     </main>
 
     <script type="module">
-        import { getTeam, getGames } from './js/db.js?v=64';
+        import { getTeam, getGames } from './js/db.js?v=65';
         import { getUrlParams, formatShortDate, formatTime, escapeHtml } from './js/utils.js?v=10';
 
         const REFRESH_MS = 60000;

--- a/widget-scoreboard.html
+++ b/widget-scoreboard.html
@@ -33,7 +33,7 @@
     </main>
 
     <script type="module">
-        import { getTeam, getGames } from './js/db.js?v=65';
+        import { getTeam, getGames } from './js/db.js?v=66';
         import { getUrlParams, formatShortDate, formatTime, escapeHtml } from './js/utils.js?v=10';
 
         const REFRESH_MS = 60000;


### PR DESCRIPTION
Closes #2995

## What changed
- Removed `downloadUrl` persistence from `uploadTeamMediaPhoto` and `uploadTeamMediaFile` so team media documents store `storagePath` metadata only.
- Updated `getTeamMediaItems` and `getTeamMediaItemsPage` to ignore legacy persisted `downloadUrl` values when `storagePath` exists, resolve an authorized runtime URL per read, and strip stale cached URL fields instead of backfilling them.
- Tightened `getTeamMediaItemUrl` so storage-backed items only use runtime `url`/`src` values and do not fall back to persisted bearer URLs.
- Updated focused regression coverage for upload, read, pagination, and helper behavior.
- Bumped cache-bust import versions for `js/db.js` and `js/team-media-utils.js`, then validated the cache-bust guard.

## Root Cause
Team media stored Firebase Storage bearer-style `downloadUrl` values in Firestore and reused them on later reads. Once issued, those tokenized URLs bypassed current team membership and album visibility checks because clients no longer needed a fresh authorized storage lookup.

## Prevention / Learning
For access-controlled storage objects, persist only stable locators like `storagePath`. Resolve bearer URLs per authorized session at read time, never backfill them into durable state, and treat any legacy persisted access token URL as data that should be ignored or removed.

## Regression Tests
- `npx vitest run tests/unit/team-media-db-ordering.test.js tests/unit/team-media-utils.test.js tests/unit/team-media-wiring.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`

## Recurrence Risk
Medium. This fix closes the team media path, but other media flows could recreate the same bug class if they persist bearer URLs instead of stable object locators.