### PR TITLE
[codex] Add workflow coverage for recent features

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -80,10 +80,10 @@ describe('PublicTeamSearch', () => {
         renderSearch();
 
         expect(screen.getByPlaceholderText('Search by team, city, state, or zip')).toBeTruthy();
-        expect(screen.getByRole('button', { name: /Search/i })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Search public teams' })).toBeTruthy();
         expect(screen.getByRole('button', { name: /Browse all public teams/i })).toBeTruthy();
         expect(screen.getByText('Search for public teams near you')).toBeTruthy();
-        expect(screen.queryByRole('button', { name: /Clear/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Clear public team search' })).toBeNull();
         expect(screen.queryByText('Atlanta United')).toBeNull();
         expect(getPublicTeamsPage).not.toHaveBeenCalled();
     });
@@ -94,12 +94,12 @@ describe('PublicTeamSearch', () => {
 
         const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
         fireEvent.change(searchInput, { target: { value: 'atlanta' } });
-        fireEvent.click(screen.getByRole('button', { name: /Search/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
 
         await waitFor(() => expect(getPublicTeamsPage).toHaveBeenCalledWith({ searchText: 'atlanta', cursor: null }));
         expect(screen.getByText('Atlanta United')).toBeTruthy();
         expect(screen.queryByText('New York Knicks')).toBeNull();
-        expect(screen.getByRole('button', { name: /Clear/i })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Clear public team search' })).toBeTruthy();
     });
 
     it('loads all public teams only when browse all is used and can load the next page', async () => {
@@ -145,7 +145,7 @@ describe('PublicTeamSearch', () => {
 
         const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
         fireEvent.change(searchInput, { target: { value: 'atlanta' } });
-        fireEvent.click(screen.getByRole('button', { name: /Search/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
 
         await waitFor(() => expect(getPublicTeamsPage).toHaveBeenCalledWith({ searchText: 'atlanta', cursor: null }));
         expect(screen.getByText('Atlanta Fire')).toBeTruthy();
@@ -168,12 +168,12 @@ describe('PublicTeamSearch', () => {
 
         const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
         fireEvent.change(searchInput, { target: { value: 'atlanta' } });
-        fireEvent.click(screen.getByRole('button', { name: /Search/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
 
         await waitFor(() => expect(getPublicTeamsPage).toHaveBeenCalledTimes(1));
         expect(screen.getByText('Atlanta United')).toBeTruthy();
 
-        fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Clear public team search' }));
 
         expect(searchInput.value).toBe('');
         expect(screen.getByText('Search for public teams near you')).toBeTruthy();
@@ -196,7 +196,7 @@ describe('PublicTeamSearch', () => {
         renderSearch();
 
         fireEvent.change(screen.getByPlaceholderText('Search by team, city, state, or zip'), { target: { value: 'boston' } });
-        fireEvent.click(screen.getByRole('button', { name: /Search/i }));
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
 
         await waitFor(() => {
             const message = screen.getByText(/No public teams found/i);

--- a/apps/app/src/pages/AcceptInvite.test.tsx
+++ b/apps/app/src/pages/AcceptInvite.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { HashRouter, MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AcceptInvite } from './AcceptInvite';
 import type { AuthState } from '../lib/types';
@@ -55,6 +55,20 @@ function renderAcceptInvite() {
     );
 }
 
+function renderAcceptInviteHashRoute() {
+    window.location.hash = '#/accept-invite?code=ABCDEFGH&type=parent';
+
+    return render(
+        <HashRouter>
+            <Routes>
+                <Route path="/accept-invite" element={<AcceptInvite auth={auth} />} />
+                <Route path="/reset-password" element={<div>Reset route</div>} />
+                <Route path="/home" element={<div>Home route</div>} />
+            </Routes>
+        </HashRouter>
+    );
+}
+
 describe('AcceptInvite', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -67,6 +81,7 @@ describe('AcceptInvite', () => {
 
     afterEach(() => {
         cleanup();
+        window.location.hash = '';
     });
 
     it('shows signed-in invite success before redirecting to the destination route', async () => {
@@ -84,5 +99,21 @@ describe('AcceptInvite', () => {
             email: 'parent@example.com',
             refresh: auth.refresh
         });
+    });
+
+    it('does not apply the delayed success redirect after leaving the invite route', async () => {
+        renderAcceptInviteHashRoute();
+
+        expect(await screen.findByText('Invite accepted.')).toBeTruthy();
+
+        window.location.hash = '#/reset-password?mode=resetPassword&oobCode=valid-code';
+        window.dispatchEvent(new Event('hashchange'));
+
+        expect(await screen.findByText('Reset route')).toBeTruthy();
+
+        await new Promise((resolve) => setTimeout(resolve, 750));
+
+        expect(screen.getByText('Reset route')).toBeTruthy();
+        expect(screen.queryByText('Home route')).toBeNull();
     });
 });

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { CheckCircle2, KeyRound, LogIn, ShieldCheck, UserPlus, XCircle } from 'lucide-react';
 import { AuthFrame } from '../components/AuthFrame';
 import {
@@ -26,6 +26,7 @@ function readEmailForSignIn() {
 
 export function AcceptInvite({ auth }: { auth: AuthState }) {
   const [searchParams] = useSearchParams();
+  const location = useLocation();
   const navigate = useNavigate();
   const pendingInvite = readPendingInvite();
   const urlCode = (searchParams.get('code') || '').trim().toUpperCase();
@@ -35,32 +36,42 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
   const [email, setEmail] = useState(readEmailForSignIn);
   const [state, setState] = useState<'idle' | 'processing' | 'email-link' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
-  const [pendingRedirectPath, setPendingRedirectPath] = useState('');
   const processedKeyRef = useRef('');
   const redirectTimerRef = useRef<number | null>(null);
+  const currentPathnameRef = useRef(location.pathname);
 
   const authUrl = useMemo(() => {
     return buildInviteAuthUrl(code, inviteType);
   }, [code, inviteType]);
 
   useEffect(() => {
-    if (!pendingRedirectPath) {
-      return undefined;
-    }
+    currentPathnameRef.current = location.pathname;
+  }, [location.pathname]);
 
-    if (redirectTimerRef.current !== null) {
-      window.clearTimeout(redirectTimerRef.current);
-    }
-
-    redirectTimerRef.current = window.setTimeout(() => navigate(pendingRedirectPath, { replace: true }), 700);
-
+  useEffect(() => {
     return () => {
       if (redirectTimerRef.current !== null) {
         window.clearTimeout(redirectTimerRef.current);
         redirectTimerRef.current = null;
       }
     };
-  }, [navigate, pendingRedirectPath]);
+  }, []);
+
+  function scheduleRedirect(path: string) {
+    if (!path) return;
+
+    if (redirectTimerRef.current !== null) {
+      window.clearTimeout(redirectTimerRef.current);
+    }
+
+    redirectTimerRef.current = window.setTimeout(() => {
+      redirectTimerRef.current = null;
+      if (!isCurrentInviteRoute(currentPathnameRef.current)) {
+        return;
+      }
+      navigate(path, { replace: true });
+    }, 700);
+  }
 
   async function redeem(codeToRedeem: string) {
     const normalizedCode = normalizeInviteCode(codeToRedeem);
@@ -88,7 +99,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
       });
       setState('success');
       setMessage(result.message);
-      setPendingRedirectPath(result.redirectPath);
+      scheduleRedirect(result.redirectPath);
     } catch (error: any) {
       processedKeyRef.current = '';
       setState('error');
@@ -131,11 +142,11 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
         clearPendingInvite();
         setState('success');
         setMessage(inviteResult?.message || 'Invite accepted.');
-        setPendingRedirectPath(mapLegacyRedirectToAppRoute(inviteResult?.redirectUrl));
+        scheduleRedirect(mapLegacyRedirectToAppRoute(inviteResult?.redirectUrl));
       } else {
         setState('success');
         setMessage('Signed in successfully.');
-        setPendingRedirectPath('/home');
+        scheduleRedirect('/home');
       }
     } catch (error: any) {
       setState('error');
@@ -198,6 +209,17 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
       {state === 'error' ? <Status icon={XCircle} message={message} tone="error" /> : null}
     </AuthFrame>
   );
+}
+
+function isCurrentInviteRoute(fallbackPathname: string) {
+  if (typeof window !== 'undefined') {
+    const hashPath = window.location.hash.replace(/^#/, '').split('?')[0];
+    if (hashPath) {
+      return hashPath === '/accept-invite';
+    }
+  }
+
+  return fallbackPathname === '/accept-invite';
 }
 
 function buildInviteAuthUrl(code: string, inviteType: string) {

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TeamMedia } from './TeamMedia';
@@ -205,7 +205,7 @@ describe('TeamMedia bulk delete', () => {
     fireEvent.change(screen.getByLabelText('Caption for team chat'), { target: { value: '  Great start  ' } });
     fireEvent.click(screen.getByRole('button', { name: 'Send to chat' }));
 
-    expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledWith(expect.objectContaining({
+    await waitFor(() => expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledWith(expect.objectContaining({
       teamId: 'team-1',
       text: 'Great start',
       selectedConversationId: 'team-chat',
@@ -216,7 +216,7 @@ describe('TeamMedia bulk delete', () => {
         url: 'https://example.com/photo-1.jpg',
         name: 'Photo one'
       })]
-    }));
+    })));
     expect(await screen.findByText('Photo posted to team chat.')).toBeTruthy();
   });
 

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -24,7 +24,7 @@ import {
 } from 'lucide-react';
 import { isRetryableAppServiceError, toAppServiceError } from '../lib/appErrors';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
-import { sendTeamChatMessage, type ChatAttachment } from '../lib/chatService';
+import type { ChatAttachment } from '../lib/chatService';
 import { DEFAULT_TEAM_CONVERSATION_ID } from '../lib/chatLogic';
 import {
   addParentTeamMediaLink,
@@ -268,6 +268,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         path: null,
         thumbnailUrl: item.url
       };
+      const { sendTeamChatMessage } = await import('../lib/chatService');
       await sendTeamChatMessage({
         teamId,
         user: auth.user,

--- a/calendar.html
+++ b/calendar.html
@@ -1042,7 +1042,7 @@
         async function copyPublicGamesFeedUrl() {
             const team = getSelectedPublicGamesFeedTeam();
             const feedUrl = team ? getPublicGamesFeedUrl(team) : '';
-            if (!team || !feedUrl) {
+            if (!team || !feedUrl || !canExposePublicFanFeed(team)) {
                 alert('Select a team with public games before copying the Fan Feed link.');
                 return;
             }

--- a/tests/smoke/calendar-sharing.spec.js
+++ b/tests/smoke/calendar-sharing.spec.js
@@ -1,0 +1,302 @@
+import { test, expect } from '@playwright/test';
+
+function buildUrl(baseURL, path) {
+    const url = new URL(path, `${baseURL}/`);
+    url.searchParams.set('cb', String(Date.now()));
+    return url.toString();
+}
+
+const PUBLIC_FEED_URL = 'https://functions.example.test/publicTeamGamesIcs';
+
+const DB_STUB = `
+const teams = [
+    { id: 'public-team', name: 'Comets', isPublic: true, active: true, adminEmails: ['coach@example.com'] },
+    { id: 'private-team', name: 'Private Squad', isPublic: false, active: true, adminEmails: ['coach@example.com'] }
+];
+
+const gamesByTeam = {
+    'public-team': [
+        {
+            id: 'public-game',
+            type: 'game',
+            opponent: 'Rockets',
+            location: 'Main Field',
+            date: '2026-06-24T18:00:00Z',
+            visibility: 'public',
+            status: 'scheduled'
+        }
+    ],
+    'private-team': [
+        {
+            id: 'private-game',
+            type: 'game',
+            opponent: 'Closed Door',
+            location: 'Practice Court',
+            date: '2026-06-25T18:00:00Z',
+            visibility: 'private',
+            status: 'scheduled'
+        }
+    ]
+};
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+export async function getUserTeamsWithAccess() {
+    return clone(teams);
+}
+
+export async function getParentTeams() {
+    return [];
+}
+
+export async function getGames(teamId) {
+    return clone(gamesByTeam[teamId] || []);
+}
+
+export async function getTeam(teamId) {
+    return clone(teams.find((team) => team.id === teamId) || null);
+}
+
+export async function getTrackedCalendarEventUids() {
+    return [];
+}
+
+export async function getUserProfile() {
+    return { email: 'coach@example.com', parentOf: [] };
+}
+
+export async function submitRsvp() {
+    return null;
+}
+
+export async function submitRsvpForPlayer() {
+    return null;
+}
+
+export async function getMyRsvp() {
+    return null;
+}
+
+export async function getRsvpSummaries() {
+    return new Map();
+}
+
+export async function getRsvps() {
+    return [];
+}
+`;
+
+const UTILS_STUB = `
+export function renderHeader() {}
+export function renderFooter() {}
+
+export function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+export function formatDate(value) {
+    return new Date(value).toLocaleDateString();
+}
+
+export function formatTime(value) {
+    return new Date(value).toLocaleTimeString();
+}
+
+export async function fetchAndParseCalendar() {
+    return [];
+}
+
+export function expandRecurrence() {
+    return [];
+}
+
+export function buildGlobalCalendarIcsEvent(event) {
+    return event;
+}
+
+export function isTrackedCalendarEvent() {
+    return false;
+}
+`;
+
+const AUTH_STUB = `
+export async function requireAuth() {
+    return { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach Test' };
+}
+
+export function checkAuth(callback) {
+    callback({ uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach Test' });
+}
+`;
+
+const CALENDAR_RSVP_STUB = `
+export function buildLinkedPlayersByTeam() {
+    return new Map();
+}
+
+export function resolveCalendarRsvpSubmission() {
+    return { playerIds: [], submitMode: 'account' };
+}
+`;
+
+const AVAILABILITY_STUB = `
+export function buildAvailabilityNoteRows() {
+    return [];
+}
+
+export function canViewAvailabilityNotes() {
+    return false;
+}
+
+export function formatAvailabilityCutoff() {
+    return 'No cutoff';
+}
+
+export function isAvailabilityLocked() {
+    return false;
+}
+
+export function normalizeAvailabilityPreferences(preferences = {}) {
+    return preferences;
+}
+`;
+
+async function mockCalendarModules(page) {
+    await page.addInitScript(({ publicFeedUrl }) => {
+        const RealDate = Date;
+        const fixedNow = new RealDate('2026-06-23T12:00:00Z').getTime();
+        class FixedDate extends RealDate {
+            constructor(...args) {
+                if (args.length === 0) {
+                    super(fixedNow);
+                } else {
+                    super(...args);
+                }
+            }
+
+            static now() {
+                return fixedNow;
+            }
+
+            static parse(value) {
+                return RealDate.parse(value);
+            }
+
+            static UTC(...args) {
+                return RealDate.UTC(...args);
+            }
+        }
+
+        window.Date = FixedDate;
+        window.__ALLPLAYS_CONFIG__ = { publicTeamGamesIcsFunctionUrl: publicFeedUrl };
+        window.__fanFeedSmoke = { alerts: [], copied: [] };
+        window.alert = (message) => {
+            window.__fanFeedSmoke.alerts.push(String(message));
+        };
+        Object.defineProperty(navigator, 'share', { value: undefined, configurable: true });
+        Object.defineProperty(navigator, 'clipboard', {
+            value: {
+                writeText: async (value) => {
+                    window.__fanFeedSmoke.copied.push(String(value));
+                }
+            },
+            configurable: true
+        });
+    }, { publicFeedUrl: PUBLIC_FEED_URL });
+
+    await page.route('https://www.googletagmanager.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: ''
+    }));
+    await page.route('https://cdn.tailwindcss.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: 'window.tailwind = window.tailwind || { config: {} };'
+    }));
+    await page.route('**/js/telemetry.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: ''
+    }));
+    await page.route('**/js/db.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: DB_STUB
+    }));
+    await page.route('**/js/utils.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: UTILS_STUB
+    }));
+    await page.route('**/js/calendar-ics-sync.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: 'export function mergeGlobalCalendarIcsEvents() { return []; }'
+    }));
+    await page.route('**/js/auth.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: AUTH_STUB
+    }));
+    await page.route('**/js/calendar-rsvp.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: CALENDAR_RSVP_STUB
+    }));
+    await page.route('**/js/rsvp-hydration.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: 'export function applyRsvpHydration() {}'
+    }));
+    await page.route('**/js/availability-preferences.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: AVAILABILITY_STUB
+    }));
+    await page.route('**/js/schedule-print.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: 'export function getDefaultSchedulePrintOptions() { return {}; } export function printSchedule() {} export function promptSchedulePrintOptions() { return null; }'
+    }));
+}
+
+test('calendar Fan Feed only copies for selected teams with public games', async ({ page, baseURL }) => {
+    await mockCalendarModules(page);
+    await page.goto(buildUrl(baseURL, '/calendar.html'), { waitUntil: 'domcontentloaded' });
+
+    const teamFilter = page.locator('#team-filter');
+    const fanFeedButton = page.locator('#public-games-feed');
+
+    await expect(teamFilter).toContainText('Comets');
+    await expect(teamFilter).toContainText('Private Squad');
+    await expect(fanFeedButton).toBeHidden();
+
+    await teamFilter.selectOption('private-team');
+    await expect(fanFeedButton).toBeHidden();
+    await page.evaluate(() => document.getElementById('public-games-feed')?.click());
+
+    await expect.poll(() => page.evaluate(() => window.__fanFeedSmoke)).toMatchObject({
+        alerts: ['Select a team with public games before copying the Fan Feed link.'],
+        copied: []
+    });
+
+    await teamFilter.selectOption('public-team');
+    await expect(fanFeedButton).toBeVisible();
+    await fanFeedButton.click();
+
+    await expect.poll(() => page.evaluate(() => window.__fanFeedSmoke)).toMatchObject({
+        alerts: [
+            'Select a team with public games before copying the Fan Feed link.',
+            'Fan Feed URL copied.'
+        ],
+        copied: [`${PUBLIC_FEED_URL}?teamId=public-team`]
+    });
+});

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -124,6 +124,22 @@ function selectValue(select, value) {
   });
 }
 
+async function waitForAssertion(assertion) {
+  let lastError;
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+    }
+  }
+  throw lastError;
+}
+
 function changeFiles(input, files) {
   act(() => {
     Object.defineProperty(input, 'files', {
@@ -492,6 +508,7 @@ describe('React app TeamMedia team chat posting', () => {
       buttons.find((button) => button.textContent.includes('Send to chat')).dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
+    await waitForAssertion(() => expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledTimes(1));
     const sendCall = chatServiceMocks.sendTeamChatMessage.mock.calls[0][0];
     expect(sendCall.teamId).toBe('team-1');
     expect(sendCall.text).toBe('Great start');
@@ -503,7 +520,7 @@ describe('React app TeamMedia team chat posting', () => {
       url: 'https://example.test/tipoff.jpg',
       name: 'Tipoff',
     })]);
-    expect(container.textContent).toContain('Photo posted to team chat.');
+    await waitForAssertion(() => expect(container.textContent).toContain('Photo posted to team chat.'));
     expect(container.querySelector('[aria-label="Caption for team chat"]')).toBeNull();
 
     await act(async () => root.unmount());
@@ -525,7 +542,7 @@ describe('React app TeamMedia team chat posting', () => {
       sendButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledTimes(1);
+    await waitForAssertion(() => expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledTimes(1));
     expect(sendButton.disabled).toBe(true);
     expect(sendButton.textContent).toContain('Posting');
     expect(container.textContent).toContain('Posting');
@@ -552,7 +569,7 @@ describe('React app TeamMedia team chat posting', () => {
       buttons.find((button) => button.textContent.includes('Send to chat')).dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(container.textContent).toContain('Chat offline');
+    await waitForAssertion(() => expect(container.textContent).toContain('Chat offline'));
     expect(container.querySelector('[aria-label="Caption for team chat"]')).not.toBeNull();
     expect(container.textContent).toContain('Tipoff');
     expect(parentToolsServiceMocks.updateTeamMediaItemForApp).not.toHaveBeenCalled();

--- a/tests/unit/team-calendar-sync.test.js
+++ b/tests/unit/team-calendar-sync.test.js
@@ -115,4 +115,16 @@ describe('all teams calendar sync controls', () => {
         expect(source).toContain('updatePublicGamesFeedButton();');
         expect(source).toContain('Select a team with public games before copying the Fan Feed link.');
     });
+
+    it('rechecks Fan Feed eligibility inside the copy handler', () => {
+        const source = readCalendarPage();
+        const handlerStart = source.indexOf('async function copyPublicGamesFeedUrl()');
+        const handlerEnd = source.indexOf("document.getElementById('sync-calendar-apple')");
+        const handler = source.slice(handlerStart, handlerEnd);
+
+        expect(handlerStart).toBeGreaterThan(-1);
+        expect(handlerEnd).toBeGreaterThan(handlerStart);
+        expect(handler).toContain('!canExposePublicFanFeed(team)');
+        expect(handler).toContain("alert('Select a team with public games before copying the Fan Feed link.');");
+    });
 });


### PR DESCRIPTION
## Summary
- Added a Playwright workflow test for `calendar.html` Fan Feed sharing and fixed the copy handler to re-check public-game eligibility before copying.
- Fixed signed-in invite acceptance so its delayed dashboard redirect cannot override a later hash-route navigation, with regression coverage for the reset-password flow.
- Kept TeamMedia chat posting lazy-loaded until the user posts media, and updated the related app/root unit tests.
- Tightened PublicTeamSearch accessibility queries so the app-local test suite runs cleanly.

## Root Causes
- The calendar Fan Feed button visibility enforced eligibility, but the copy handler did not re-check it.
- Invite acceptance scheduled a delayed redirect that could race with a user/test navigating to another hash route.
- TeamMedia imported chat service at route-load time even though chat posting is optional.

## Validation
- `npx vitest run tests/unit --reporter=dot --silent=passed-only --exclude '.claude/**'` — 535 files, 3216 tests passed.
- `npm test -- --run --reporter=dot --silent=passed-only` from `apps/app` — 86 files, 656 tests passed.
- `npm run app:build` — passed.
- `SMOKE_BASE_URL=http://127.0.0.1:4173 SMOKE_APP_BASE_URL=http://127.0.0.1:5175/ npx playwright test --config=playwright.smoke.config.js --reporter=dot` — 108 passed, 2 skipped.