### PR TITLE
Fix manual QA workflow defects

### DIFF
--- a/apps/app/src/lib/notificationInboxService.test.ts
+++ b/apps/app/src/lib/notificationInboxService.test.ts
@@ -20,7 +20,9 @@ vi.mock('./adapters/legacyNotificationInboxDb', () => adapterMocks);
 import {
     collection,
     db,
+    limit,
     onSnapshot,
+    orderBy,
     query,
     where
 } from './adapters/legacyNotificationInboxDb';
@@ -31,6 +33,8 @@ describe('notificationInboxService', () => {
         vi.clearAllMocks();
         vi.mocked(collection).mockReturnValue({ kind: 'collection' } as never);
         vi.mocked(where).mockReturnValue({ kind: 'where' } as never);
+        vi.mocked(orderBy).mockReturnValue({ kind: 'orderBy' } as never);
+        vi.mocked(limit).mockReturnValue({ kind: 'limit' } as never);
         vi.mocked(query).mockReturnValue({ kind: 'query' } as never);
         vi.mocked(onSnapshot).mockReturnValue(vi.fn());
     });
@@ -48,5 +52,51 @@ describe('notificationInboxService', () => {
         expect(where).toHaveBeenCalledWith('readAt', '==', null);
         expect(query).toHaveBeenCalledWith({ kind: 'collection' }, { kind: 'where' });
         expect(callback).toHaveBeenCalledWith(3);
+    });
+
+    it('falls back to counting unread items from the full inbox when the unread query fails', () => {
+        const callback = vi.fn();
+        const primaryUnsubscribe = vi.fn();
+        const fallbackUnsubscribe = vi.fn();
+        const primaryCollection = { kind: 'primaryCollection' };
+        const fallbackCollection = { kind: 'fallbackCollection' };
+        const primaryQuery = { kind: 'primaryQuery' };
+        vi.mocked(collection)
+            .mockReturnValueOnce(primaryCollection as never)
+            .mockReturnValueOnce(fallbackCollection as never);
+        vi.mocked(query).mockReturnValueOnce(primaryQuery as never);
+        vi.mocked(onSnapshot)
+            .mockImplementationOnce((_query, _onNext, onError) => {
+                onError?.(new Error('The query requires an index.'));
+                return primaryUnsubscribe;
+            })
+            .mockImplementationOnce((_query, onNext) => {
+                onNext({
+                    docs: [
+                        {
+                            id: 'notif-1',
+                            data: () => ({ title: 'Unread', readAt: null, createdAt: null })
+                        },
+                        {
+                            id: 'notif-2',
+                            data: () => ({ title: 'Read', readAt: { seconds: 1 }, createdAt: null })
+                        }
+                    ]
+                } as never);
+                return fallbackUnsubscribe;
+            });
+
+        const unsubscribe = subscribeToUnreadNotificationCount('user-123', callback);
+
+        expect(query).toHaveBeenCalledWith(primaryCollection, { kind: 'where' });
+        expect(onSnapshot).toHaveBeenNthCalledWith(1, primaryQuery, expect.any(Function), expect.any(Function));
+        expect(onSnapshot).toHaveBeenNthCalledWith(2, fallbackCollection, expect.any(Function), expect.any(Function));
+        expect(orderBy).not.toHaveBeenCalled();
+        expect(limit).not.toHaveBeenCalled();
+        expect(callback).toHaveBeenCalledWith(1);
+
+        unsubscribe();
+        expect(primaryUnsubscribe).toHaveBeenCalledTimes(1);
+        expect(fallbackUnsubscribe).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -54,19 +54,35 @@ export function subscribeToUnreadNotificationCount(
         where('readAt', '==', null)
     );
 
-    return onSnapshot(
+    let fallbackUnsubscribe: (() => void) | null = null;
+    const primaryUnsubscribe = onSnapshot(
         q,
         (snapshot: QuerySnapshot<DocumentData>) => {
             callback(snapshot.size);
         },
         (error: unknown) => {
-            if (onError) {
-                onError(error);
-            } else {
-                logger.error('Failed to subscribe to unread notification count.', { error });
-            }
+            logger.warn('Unread notification count query failed; falling back to inbox snapshot count.', { error });
+            if (fallbackUnsubscribe) return;
+            fallbackUnsubscribe = onSnapshot(
+                collection(db, `users/${uid}/notificationInbox`),
+                (snapshot: QuerySnapshot<DocumentData>) => {
+                    callback(snapshot.docs.filter((docSnap) => !docSnap.data()?.['readAt']).length);
+                },
+                (fallbackError: unknown) => {
+                    if (onError) {
+                        onError(fallbackError);
+                    } else {
+                        logger.error('Failed to subscribe to unread notification count.', { error: fallbackError });
+                    }
+                }
+            );
         }
     );
+
+    return () => {
+        primaryUnsubscribe();
+        fallbackUnsubscribe?.();
+    };
 }
 
 /**

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -640,6 +640,34 @@ async function loadTeamConfigs(teamId: string) {
   ).catch(() => []);
 }
 
+async function loadTeamTrackingItems(teamId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  return readWithNativeFallback(
+    `team tracking items ${normalizedTeamId}`,
+    async () => {
+      const itemSnapshot = await getDocs(collection(db, `teams/${normalizedTeamId}/trackingItems`));
+      return (itemSnapshot.docs as any[]).map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }));
+    },
+    async () => nativeListCollection(`teams/${encodeURIComponent(normalizedTeamId)}/trackingItems`)
+  );
+}
+
+async function loadTeamTrackingStatuses(teamId: string, itemId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  const normalizedItemId = cleanString(itemId);
+  return readWithNativeFallback(
+    `team tracking statuses ${normalizedTeamId}/${normalizedItemId}`,
+    async () => {
+      const statusSnapshot = await getDocs(collection(db, `teams/${normalizedTeamId}/trackingItems/${normalizedItemId}/memberTracking`));
+      return (statusSnapshot.docs as any[]).map((statusDoc) => ({
+        id: statusDoc.id,
+        ...statusDoc.data()
+      }));
+    },
+    async () => nativeListCollection(`teams/${encodeURIComponent(normalizedTeamId)}/trackingItems/${encodeURIComponent(normalizedItemId)}/memberTracking`)
+  );
+}
+
 function getExpirationTime(expiresAt: any): number | null {
   if (expiresAt == null) return null;
   if (typeof expiresAt?.toMillis === 'function') return expiresAt.toMillis();
@@ -1401,9 +1429,8 @@ export async function loadTeamTrackingAdmin(teamId: string, user: AuthUser | nul
   }
 
   const normalizedTeamId = cleanString(teamId);
-  const itemSnapshot = await getDocs(collection(db, `teams/${normalizedTeamId}/trackingItems`));
-  const trackingItems = (itemSnapshot.docs as any[])
-    .map((itemDoc) => normalizeTeamTrackingItem({ id: itemDoc.id, ...itemDoc.data() }))
+  const trackingItems = (await loadTeamTrackingItems(normalizedTeamId))
+    .map((itemDoc) => normalizeTeamTrackingItem(itemDoc))
     .filter((item): item is ReturnType<typeof normalizeTeamTrackingItem> => Boolean(item.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 
@@ -1412,12 +1439,8 @@ export async function loadTeamTrackingAdmin(teamId: string, user: AuthUser | nul
 
   if (trackingItems.length) {
     await Promise.all(trackingItems.map(async (item) => {
-      const statusSnapshot = await getDocs(collection(db, `teams/${normalizedTeamId}/trackingItems/${item.id}/memberTracking`));
-      const statuses = (statusSnapshot.docs as any[])
-        .map((statusDoc) => normalizeTrackingStatus({
-          id: statusDoc.id,
-          ...statusDoc.data()
-        }))
+      const statuses = (await loadTeamTrackingStatuses(normalizedTeamId, item.id))
+        .map((statusDoc) => normalizeTrackingStatus(statusDoc))
         .filter((status) => cleanString((status as any)?.trackingItemId || (status as any)?.itemId) === item.id);
       trackingStatusesByItemId.set(item.id, statuses);
     }));

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -44,6 +44,27 @@ vi.mock('../lib/publicActions', () => ({
     openPublicUrl: vi.fn(),
     sharePublicUrl: vi.fn()
 }));
+vi.mock('lucide-react', () => {
+    const Icon = () => null;
+    return {
+        AlertCircle: Icon,
+        Award: Icon,
+        CalendarDays: Icon,
+        CheckCircle2: Icon,
+        ChevronLeft: Icon,
+        Copy: Icon,
+        DollarSign: Icon,
+        Download: Icon,
+        ExternalLink: Icon,
+        KeyRound: Icon,
+        Loader2: Icon,
+        RefreshCw: Icon,
+        Share2: Icon,
+        Shield: Icon,
+        Ticket: Icon,
+        Users: Icon
+    };
+});
 
 const auth: AuthState = {
     user: {
@@ -492,6 +513,16 @@ describe('ParentTools access', () => {
             expect(openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/legacy');
         });
         expect(parentToolsServiceMocks.initiateParentTeamFeeCheckout).not.toHaveBeenCalled();
+    });
+
+    it('shows safe Fees copy instead of raw Firestore index errors', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockRejectedValue(new Error('The query requires an index. You can create it here: https://console.firebase.google.com/v1/r/project/game-flow-c6311/firestore/indexes?create_composite=test'));
+
+        renderParentTools(['/parent-tools/fees']);
+
+        expect(await screen.findByText('Unable to load fees.')).toBeTruthy();
+        expect(screen.queryByText(/console\.firebase\.google\.com/)).toBeNull();
+        expect(screen.queryByText(/query requires an index/i)).toBeNull();
     });
 
     it('regenerates stale team fee checkout links instead of opening the stored URL', async () => {

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -109,9 +109,9 @@ const auth: AuthState = {
   signOut: vi.fn()
 };
 
-function renderProfile() {
+function renderProfile(initialEntry = '/profile') {
   return render(
-    <MemoryRouter initialEntries={['/profile']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/profile" element={<Profile auth={auth} />} />
       </Routes>
@@ -142,16 +142,27 @@ describe('Profile', () => {
   it('keeps mobile profile section buttons in a two-column grid so Alerts stays reachable', async () => {
     renderProfile();
 
-    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
     const alertsButton = screen.getByRole('button', { name: /^Alerts$/ });
-    expect(alertsButton).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^Invites$/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^Security$/ })).toBeInTheDocument();
+    expect(alertsButton).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^Invites$/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^Security$/ })).toBeTruthy();
 
     const sectionGrid = alertsButton.parentElement;
     expect(sectionGrid).not.toBeNull();
     expect(sectionGrid?.className).toContain('grid-cols-2');
     expect(sectionGrid?.className).toContain('sm:grid-cols-4');
     expect(sectionGrid?.className).not.toContain('min-w-max');
+  });
+
+  it('loads the Invites section to a normal empty state when invite history is empty', async () => {
+    profileServiceMocks.loadProfileAccessCodesPage.mockResolvedValue({ codes: [], nextCursor: null });
+
+    renderProfile('/profile?section=invites');
+
+    expect(await screen.findByText('Invite codes')).toBeTruthy();
+    expect(await screen.findByText('No codes generated yet.')).toBeTruthy();
+    expect(screen.queryByText('Unable to load invite history.')).toBeNull();
+    expect(profileServiceMocks.loadProfileAccessCodesPage).toHaveBeenCalledWith('user-1', { pageSize: 3 });
   });
 });

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Schedule } from './Schedule';
 import type { AuthState } from '../lib/types';
@@ -67,13 +67,23 @@ const auth: AuthState = {
   signOut: vi.fn()
 };
 
-function renderSchedule() {
+function renderSchedule(initialEntry = '/schedule') {
   return render(
-    <MemoryRouter initialEntries={['/schedule']}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/schedule" element={<Schedule auth={auth} />} />
       </Routes>
     </MemoryRouter>
+  );
+}
+
+function ScheduleNavigationHarness() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate('/schedule')}>Go root schedule</button>
+      <Schedule auth={auth} />
+    </>
   );
 }
 
@@ -252,6 +262,80 @@ describe('Schedule', () => {
 
     expect(await screen.findByText('Showing 20 of 21 events')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Show 1 more' })).toBeTruthy();
+  });
+
+  it('applies schedule team and view query params on direct links', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
+        { playerId: 'player-2', playerName: 'Sam', teamId: 'team-2', teamName: 'Wolves' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          eventKey: 'team-1::event-1::player-1::2100-06-01T18:00:00.000Z::game',
+          teamId: 'team-1',
+          teamName: 'Bears',
+          opponent: 'Bears Opponent'
+        }),
+        buildScheduleEvent(2, {
+          eventKey: 'team-2::event-2::player-2::2100-06-02T18:00:00.000Z::game',
+          teamId: 'team-2',
+          teamName: 'Wolves',
+          childId: 'player-2',
+          childName: 'Sam',
+          opponent: 'Wolves Opponent'
+        })
+      ]
+    });
+
+    renderSchedule('/schedule?teamId=team-2&view=packets');
+
+    await screen.findByText('No practice packets in this filter');
+    expect((screen.getByLabelText('Team filter') as HTMLSelectElement).value).toBe('team-2');
+    expect(screen.getAllByRole('button', { name: 'Packets' }).some((button) => button.getAttribute('aria-pressed') === 'true')).toBe(true);
+  });
+
+  it('clears URL-scoped team and player filters when schedule query params disappear', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
+        { playerId: 'player-2', playerName: 'Sam', teamId: 'team-2', teamName: 'Wolves' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          eventKey: 'team-1::event-1::player-1::2100-06-01T18:00:00.000Z::game',
+          teamId: 'team-1',
+          teamName: 'Bears'
+        }),
+        buildScheduleEvent(2, {
+          eventKey: 'team-2::event-2::player-2::2100-06-02T18:00:00.000Z::game',
+          teamId: 'team-2',
+          teamName: 'Wolves',
+          childId: 'player-2',
+          childName: 'Sam'
+        })
+      ]
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/schedule?teamId=team-2&playerId=player-2']}>
+        <Routes>
+          <Route path="/schedule" element={<ScheduleNavigationHarness />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Team filter') as HTMLSelectElement).value).toBe('team-2');
+      expect((screen.getByLabelText('Player filter') as HTMLSelectElement).value).toBe('player-2');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go root schedule' }));
+
+    await waitFor(() => {
+      expect((screen.getByLabelText('Team filter') as HTMLSelectElement).value).toBe('');
+      expect((screen.getByLabelText('Player filter') as HTMLSelectElement).value).toBe('');
+    });
   });
 
   it('renders web-created tournament game metadata read-only in the schedule list', async () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { AlertCircle, CalendarDays, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { Modal } from '../components/Modal';
 import { SchedulePageSkeleton } from '../components/PageSkeletons';
 import { PullToRefresh } from '../components/PullToRefresh';
@@ -57,6 +57,9 @@ const timeRangeOptions: Array<{ value: ScheduleTimeRange; label: string }> = [
   { value: 'quarter', label: 'Quarter' },
   { value: 'all', label: 'All' }
 ];
+const scheduleViewModes: ScheduleViewMode[] = ['list', 'compact', 'calendar', 'packets'];
+const scheduleFilterValues = filterOptions.map((option) => option.value);
+const scheduleTimeRangeValues = timeRangeOptions.map((option) => option.value);
 
 const upcomingListPageSize = 20;
 const pastListPageSize = 10;
@@ -133,13 +136,29 @@ function loadScheduleAiImportModule() {
   return scheduleAiImportModulePromise;
 }
 
+function getScheduleViewFromQuery(value: string | null): ScheduleViewMode | null {
+  const normalized = String(value || '').trim().toLowerCase();
+  return scheduleViewModes.includes(normalized as ScheduleViewMode) ? normalized as ScheduleViewMode : null;
+}
+
+function getScheduleFilterFromQuery(value: string | null): ParentScheduleFilter | null {
+  const normalized = String(value || '').trim().toLowerCase();
+  return scheduleFilterValues.includes(normalized as ParentScheduleFilter) ? normalized as ParentScheduleFilter : null;
+}
+
+function getScheduleTimeRangeFromQuery(value: string | null): ScheduleTimeRange | null {
+  const normalized = String(value || '').trim().toLowerCase();
+  return scheduleTimeRangeValues.includes(normalized as ScheduleTimeRange) ? normalized as ScheduleTimeRange : null;
+}
+
 export function Schedule({ auth }: { auth: AuthState }) {
+  const [searchParams] = useSearchParams();
   const { isDesktopWeb } = useShellLayout();
-  const [filter, setFilter] = useState<ParentScheduleFilter>('upcoming-all');
-  const [view, setView] = useState<ScheduleViewMode>('list');
-  const [selectedPlayerId, setSelectedPlayerId] = useState('');
-  const [selectedTeamId, setSelectedTeamId] = useState('');
-  const [timeRange, setTimeRange] = useState<ScheduleTimeRange>('all');
+  const [filter, setFilter] = useState<ParentScheduleFilter>(() => getScheduleFilterFromQuery(searchParams.get('filter')) || 'upcoming-all');
+  const [view, setView] = useState<ScheduleViewMode>(() => getScheduleViewFromQuery(searchParams.get('view')) || 'list');
+  const [selectedPlayerId, setSelectedPlayerId] = useState(() => String(searchParams.get('playerId') || '').trim());
+  const [selectedTeamId, setSelectedTeamId] = useState(() => String(searchParams.get('teamId') || '').trim());
+  const [timeRange, setTimeRange] = useState<ScheduleTimeRange>(() => getScheduleTimeRangeFromQuery(searchParams.get('range')) || 'all');
   const [children, setChildren] = useState<ParentScheduleChild[]>([]);
   const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
   const [scheduleLoadError, setScheduleLoadError] = useState<AppServiceError | null>(null);
@@ -318,6 +337,20 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
   };
 
+  useEffect(() => {
+    const nextFilter = getScheduleFilterFromQuery(searchParams.get('filter'));
+    if (nextFilter) setFilter(nextFilter);
+
+    const nextView = getScheduleViewFromQuery(searchParams.get('view'));
+    if (nextView) setView(nextView);
+
+    const nextRange = getScheduleTimeRangeFromQuery(searchParams.get('range'));
+    if (nextRange) setTimeRange(nextRange);
+
+    setSelectedTeamId(String(searchParams.get('teamId') || '').trim());
+    setSelectedPlayerId(String(searchParams.get('playerId') || '').trim());
+  }, [searchParams]);
+
   const refreshSchedule = async (force = false) => {
     if (!auth.user) return null;
     clearScheduleReadError();
@@ -361,7 +394,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           if (selectedPlayerId && !result.children.some((child) => child.playerId === selectedPlayerId)) {
             setSelectedPlayerId('');
           }
-          if (selectedTeamId && !result.children.some((child) => child.teamId === selectedTeamId)) {
+          if (selectedTeamId && !result.children.some((child) => child.teamId === selectedTeamId) && !result.events.some((event) => event.teamId === selectedTeamId)) {
             setSelectedTeamId('');
           }
           const firstUpcoming = filterParentScheduleEvents(result.events, { filter: 'upcoming-all' })[0];

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -65,6 +65,36 @@ vi.mock('../lib/parentToolsService', () => ({
   getGoogleCalendarFeedUrl: vi.fn(() => 'https://calendar.google.com/calendar/render')
 }));
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('lucide-react', () => {
+  const Icon = () => null;
+  return {
+    Award: Icon,
+    BarChart3: Icon,
+    CalendarDays: Icon,
+    CheckCircle2: Icon,
+    ChevronRight: Icon,
+    Code2: Icon,
+    Copy: Icon,
+    DollarSign: Icon,
+    Dumbbell: Icon,
+    ExternalLink: Icon,
+    ImageIcon: Icon,
+    LinkIcon: Icon,
+    Loader2: Icon,
+    MapPin: Icon,
+    MessageCircle: Icon,
+    Radio: Icon,
+    RefreshCw: Icon,
+    Save: Icon,
+    Shield: Icon,
+    Ticket: Icon,
+    Trophy: Icon,
+    UserPlus: Icon,
+    UserRound: Icon,
+    Users: Icon,
+    Zap: Icon
+  };
+});
 
 const auth: AuthState = {
   user: {
@@ -133,6 +163,14 @@ const model = {
   staffPermissions: null,
   counts: { games: 0, practices: 0, completedGames: 0 }
 };
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
 
 describe('TeamDetail', () => {
   beforeEach(() => {
@@ -500,7 +538,7 @@ describe('TeamDetail', () => {
       currentPlayers: [managedModel.players[0], managedModel.inactivePlayers[0]]
     }));
     expect(await screen.findByText('Possible duplicate of existing roster player Pat Star #9.')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Import reviewed players' })).toBeDisabled();
+    expect((screen.getByRole('button', { name: 'Import reviewed players' }) as HTMLButtonElement).disabled).toBe(true);
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Remove' })[0]);
     expect(await screen.findByDisplayValue('Alex New')).toBeTruthy();
@@ -539,6 +577,38 @@ describe('TeamDetail', () => {
     expect(await screen.findByAltText('Bears team photo')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /roster/i }));
     expect(await screen.findByAltText('Pat Star player photo')).toBeTruthy();
+  });
+
+  it('clears roster invite and tracking loading states after deferred roster loads finish', async () => {
+    const managedModel = {
+      ...model,
+      canManageTeam: true
+    };
+    const inviteLoad = createDeferred<unknown[]>();
+    const trackingLoad = createDeferred<unknown[]>();
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(managedModel);
+    teamDetailServiceMocks.loadTeamRosterParentInvites.mockReturnValue(inviteLoad.promise);
+    teamDetailServiceMocks.loadTeamTrackingAdmin.mockReturnValue(trackingLoad.promise);
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=roster']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Loading parent invite status…')).toBeTruthy();
+    expect(await screen.findByText('Loading tracking items…')).toBeTruthy();
+
+    inviteLoad.resolve([]);
+    trackingLoad.resolve([]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading parent invite status…')).toBeNull();
+      expect(screen.queryByText('Loading tracking items…')).toBeNull();
+    });
+    expect(screen.getByText('No tracking items found.')).toBeTruthy();
   });
 
   it('renders multiple tracking items with completion badges and lets staff manage statuses from the roster tab', async () => {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -229,7 +229,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   useEffect(() => {
     let cancelled = false;
     async function loadRosterInvitesForTab() {
-      if (!teamId || activeTab !== 'roster' || !model?.canManageTeam || rosterInviteLoading || rosterInviteAttempted) return;
+      if (!teamId || activeTab !== 'roster' || !model?.canManageTeam || rosterInviteAttempted) return;
       setRosterInviteLoading(true);
       setRosterInviteError('');
       try {
@@ -252,12 +252,12 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, authUserId, model?.canManageTeam, teamId, rosterInviteLoading, rosterInviteAttempted, auth.user]);
+  }, [activeTab, authUserId, model?.canManageTeam, teamId, rosterInviteAttempted, auth.user]);
 
   useEffect(() => {
     let cancelled = false;
     async function loadTrackingForRosterTab() {
-      if (!teamId || activeTab !== 'roster' || !model?.canManageTeam || trackingLoading || trackingAttempted) return;
+      if (!teamId || activeTab !== 'roster' || !model?.canManageTeam || trackingAttempted) return;
       setTrackingLoading(true);
       setTrackingError('');
       try {
@@ -280,7 +280,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, authUserId, auth.user, model?.canManageTeam, teamId, trackingAttempted, trackingLoading]);
+  }, [activeTab, authUserId, auth.user, model?.canManageTeam, teamId, trackingAttempted]);
 
   useEffect(() => {
     const scroll = () => {

--- a/apps/app/src/pages/messages/components/ChatComposer.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatComposer.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Composer } from './ChatComposer';
+
+vi.mock('lucide-react', () => {
+    const Icon = () => null;
+    return {
+        Bot: Icon,
+        Loader2: Icon,
+        Mail: Icon,
+        Mic: Icon,
+        Paperclip: Icon,
+        Send: Icon,
+        Users: Icon,
+        X: Icon
+    };
+});
+
+vi.mock('../../../lib/chatLogic', () => ({
+    getChatMentionInsertion: vi.fn((_text: string, _mentionLabel: string, cursorPosition = 0) => ({ cursorPosition })),
+    hasAllPlaysMention: vi.fn(() => false)
+}));
+
+function renderComposer(overrides: Partial<Parameters<typeof Composer>[0]> = {}) {
+    const props: Parameters<typeof Composer>[0] = {
+        teamName: 'Bears',
+        text: 'draft',
+        filePreviews: [],
+        sending: false,
+        composerNotice: '',
+        aiThinking: false,
+        voiceListening: false,
+        voiceSupported: true,
+        canModerate: true,
+        canSendTeamEmail: true,
+        mentionSuggestions: [],
+        mentionSuggestionsLoading: false,
+        mentionTriggerActive: false,
+        audienceSummary: 'Everyone',
+        onCursorChange: vi.fn(),
+        onTextChange: vi.fn(),
+        onSubmit: vi.fn(),
+        onAttach: vi.fn(),
+        onRemoveFile: vi.fn(),
+        onVoice: vi.fn(),
+        onAudience: vi.fn(),
+        onTeamEmail: vi.fn(),
+        onMention: vi.fn(),
+        onRecipientMention: vi.fn(),
+        ...overrides
+    };
+    render(<Composer {...props} />);
+    return props;
+}
+
+describe('Chat Composer', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('blocks typing and actions while a chat sheet is open', () => {
+        const props = renderComposer({ disabled: true });
+        const textarea = screen.getByPlaceholderText('Message Bears') as HTMLTextAreaElement;
+
+        expect(textarea.disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Send message' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Add attachment' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Voice to text' }) as HTMLButtonElement).disabled).toBe(true);
+        expect((screen.getByRole('button', { name: 'Open Team Email' }) as HTMLButtonElement).disabled).toBe(true);
+
+        fireEvent.change(textarea, { target: { value: 'background edit' } });
+        fireEvent.submit(textarea.closest('form')!);
+
+        expect(props.onTextChange).not.toHaveBeenCalled();
+        expect(props.onSubmit).not.toHaveBeenCalled();
+    });
+});

--- a/apps/app/src/pages/messages/components/ChatComposer.tsx
+++ b/apps/app/src/pages/messages/components/ChatComposer.tsx
@@ -22,6 +22,7 @@ export function Composer({
     mentionSuggestionsLoading,
     mentionTriggerActive,
     audienceSummary,
+    disabled = false,
     onCursorChange,
     onTextChange,
     onSubmit,
@@ -47,6 +48,7 @@ export function Composer({
     mentionSuggestionsLoading: boolean;
     mentionTriggerActive: boolean;
     audienceSummary: string;
+    disabled?: boolean;
     onCursorChange: (cursorPosition: number | undefined) => void;
     onTextChange: (value: string) => void;
     onSubmit: (event?: FormEvent) => void;
@@ -61,7 +63,7 @@ export function Composer({
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     const pendingCursorPositionRef = useRef<number | null>(null);
     const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0);
-    const canSend = Boolean(text.trim() || filePreviews.length) && !aiThinking;
+    const canSend = Boolean(text.trim() || filePreviews.length) && !aiThinking && !disabled;
     const cursorPosition = textareaRef.current?.selectionStart ?? text.length;
     const beforeCursor = useMemo(() => text.slice(0, cursorPosition), [cursorPosition, text]);
     const showMentionQuickAction = /(^|\s)@\w*$/i.test(beforeCursor) && !hasAllPlaysMention(text);
@@ -115,7 +117,17 @@ export function Composer({
     };
 
     return (
-        <form className="chat-composer safe-bottom border border-gray-200 bg-white p-2 shadow-app" onSubmit={onSubmit}>
+        <form
+            className="chat-composer safe-bottom border border-gray-200 bg-white p-2 shadow-app"
+            onSubmit={(event) => {
+                if (disabled) {
+                    event.preventDefault();
+                    return;
+                }
+                onSubmit(event);
+            }}
+            aria-disabled={disabled}
+        >
             {filePreviews.length ? (
                 <div className="chat-attachment-strip">
                     {filePreviews.map((preview, index) => (
@@ -125,7 +137,7 @@ export function Composer({
                             ) : (
                                 <img src={preview.url} alt={preview.file.name || `Attachment preview ${index + 1}`} className="h-full w-full object-cover" />
                             )}
-                            <button type="button" className="absolute right-1 top-1 rounded-full bg-gray-950/70 p-1 text-white" onClick={() => onRemoveFile(index)} aria-label="Remove attachment">
+                            <button type="button" className="absolute right-1 top-1 rounded-full bg-gray-950/70 p-1 text-white" onClick={() => onRemoveFile(index)} aria-label="Remove attachment" disabled={disabled}>
                                 <X className="h-3 w-3" aria-hidden="true" />
                             </button>
                         </div>
@@ -133,14 +145,14 @@ export function Composer({
                 </div>
             ) : null}
 
-            {showMentionQuickAction ? (
+            {showMentionQuickAction && !disabled ? (
                 <button type="button" className="mb-2 flex w-full items-center gap-2 rounded-xl border border-indigo-100 bg-indigo-50 px-3 py-2 text-left text-sm font-black text-indigo-700" onMouseDown={(event) => event.preventDefault()} onClick={onMention}>
                     <Bot className="h-4 w-4" aria-hidden="true" />
                     @ALL PLAYS
                 </button>
             ) : null}
 
-            {showMentionSuggestions ? (
+            {showMentionSuggestions && !disabled ? (
                 <div className="mb-2 rounded-xl border border-gray-200 bg-white p-1 shadow-sm" aria-label="Mention suggestions">
                     {mentionSuggestionsLoading && mentionSuggestions.length === 0 ? (
                         <div className="px-3 py-2 text-xs font-bold text-gray-500">Loading teammates...</div>
@@ -173,16 +185,24 @@ export function Composer({
                     ref={textareaRef}
                     value={text}
                     onChange={(event) => {
+                        if (disabled) return;
                         onTextChange(event.target.value);
                         onCursorChange(event.target.selectionStart ?? event.target.value.length);
                     }}
-                    onClick={(event) => syncCursorPosition(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
-                    onKeyUp={(event) => syncCursorPosition(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
-                    onSelect={(event) => syncCursorPosition(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
+                    onClick={(event) => {
+                        if (!disabled) syncCursorPosition(event.currentTarget.selectionStart ?? event.currentTarget.value.length);
+                    }}
+                    onKeyUp={(event) => {
+                        if (!disabled) syncCursorPosition(event.currentTarget.selectionStart ?? event.currentTarget.value.length);
+                    }}
+                    onSelect={(event) => {
+                        if (!disabled) syncCursorPosition(event.currentTarget.selectionStart ?? event.currentTarget.value.length);
+                    }}
                     rows={1}
                     maxLength={2000}
                     className="chat-composer-textarea"
                     placeholder={placeholder}
+                    disabled={disabled}
                     enterKeyHint="send"
                     onKeyDown={(event) => {
                         if (showMentionSuggestions && mentionSuggestions.length > 0) {
@@ -202,7 +222,7 @@ export function Composer({
                                 return;
                             }
                         }
-                        if (event.key === 'Enter' && !event.shiftKey) {
+                        if (!disabled && event.key === 'Enter' && !event.shiftKey) {
                             event.preventDefault();
                             onSubmit();
                         }
@@ -221,7 +241,7 @@ export function Composer({
             ) : null}
 
             <div className="chat-composer-toolbar">
-                <button type="button" className="chat-tool-button" onClick={onAttach} aria-label="Add attachment">
+                <button type="button" className="chat-tool-button" onClick={onAttach} aria-label="Add attachment" disabled={disabled}>
                     <Paperclip className="h-4 w-4" aria-hidden="true" />
                 </button>
                 {voiceSupported ? (
@@ -230,18 +250,19 @@ export function Composer({
                         className={`chat-tool-button ${voiceListening ? 'chat-tool-button-active' : ''}`}
                         onClick={onVoice}
                         aria-label={voiceListening ? 'Stop voice input' : 'Voice to text'}
+                        disabled={disabled}
                     >
                         <Mic className="h-4 w-4" aria-hidden="true" />
                     </button>
                 ) : null}
                 {canModerate ? (
-                    <button type="button" className="chat-audience-pill" onClick={onAudience}>
+                    <button type="button" className="chat-audience-pill" onClick={onAudience} disabled={disabled}>
                         <Users className="h-4 w-4 flex-none" aria-hidden="true" />
                         <span className="truncate">Audience: {audienceSummary}</span>
                     </button>
                 ) : null}
                 {canSendTeamEmail ? (
-                    <button type="button" className="chat-audience-pill" onClick={onTeamEmail} aria-label="Open Team Email">
+                    <button type="button" className="chat-audience-pill" onClick={onTeamEmail} aria-label="Open Team Email" disabled={disabled}>
                         <Mail className="h-4 w-4 flex-none" aria-hidden="true" />
                         <span className="truncate">Team Email</span>
                     </button>

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -424,6 +424,13 @@ export function ChatWindow({
   const mentionTriggerActive = hasChatMentionTrigger(text, composerCursorPosition);
   const mediaEntries = useMemo(() => collectThreadMedia(visibleMessages), [visibleMessages]);
   const teamName = team?.name || inboxTeam?.name || 'Team chat';
+  const composerDisabled = showConversationSheet
+    || showAudienceSheet
+    || showMediaGallery
+    || showAttachSheet
+    || showLinkSheet
+    || showEmailSheet
+    || Boolean(editingMessage);
 
   const ensureRecipientOptionsLoaded = useCallback(async () => {
     if (!canModerate) return [] as ChatRecipientOption[];
@@ -1505,6 +1512,7 @@ export function ChatWindow({
         mentionSuggestionsLoading={mentionTriggerActive && recipientOptionsLoading}
         mentionTriggerActive={mentionTriggerActive}
         audienceSummary={audienceSummary}
+        disabled={composerDisabled}
         onCursorChange={setComposerCursorPosition}
         onTextChange={setText}
         onSubmit={handleSend}

--- a/apps/app/src/pages/parent-tools/shared.tsx
+++ b/apps/app/src/pages/parent-tools/shared.tsx
@@ -124,7 +124,12 @@ export function RetryableStatus({
 
 export function getParentToolErrorMessage(error: AppServiceError | null, fallbackMessage: string) {
     if (!error) return fallbackMessage;
-    return String(error.message || '').trim() || fallbackMessage;
+    const message = String(error.message || '').trim();
+    if (!message) return fallbackMessage;
+    if (/query requires an index|console\.firebase\.google\.com|firestore\/indexes/i.test(message)) {
+        return fallbackMessage;
+    }
+    return message;
 }
 
 export function LoadingBlock({ label }: { label: string }) {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -105,6 +105,38 @@
       ]
     },
     {
+      "collectionGroup": "feeRecipients",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "teamId", "order": "ASCENDING" },
+        { "fieldPath": "parentUserId", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "feeRecipients",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "teamId", "order": "ASCENDING" },
+        { "fieldPath": "accountUserId", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "feeRecipients",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "teamId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "feeRecipients",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "teamId", "order": "ASCENDING" },
+        { "fieldPath": "playerId", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "registrations",
       "queryScope": "COLLECTION_GROUP",
       "fields": [

--- a/js/db.js
+++ b/js/db.js
@@ -3766,23 +3766,23 @@ export async function getUserAccessCodesPage(userId, options = {}) {
     const pageSize = Number.isFinite(rawPageSize)
         ? Math.min(Math.max(Math.floor(rawPageSize), 1), 50)
         : 10;
-    const constraints = [
-        where("generatedBy", "==", userId),
-        orderBy("createdAt", "desc")
-    ];
-    if (options.cursor) {
-        constraints.push(startAfter(options.cursor));
+    const codes = await getUserAccessCodes(userId);
+    const rawCursor = options.cursor;
+    let offset = typeof rawCursor === 'number' && Number.isFinite(rawCursor)
+        ? Math.max(0, Math.floor(rawCursor))
+        : 0;
+    if (!offset && rawCursor && typeof rawCursor === 'object') {
+        const cursorId = rawCursor.id || rawCursor.ref?.id;
+        if (cursorId) {
+            const cursorIndex = codes.findIndex(code => code.id === cursorId);
+            offset = cursorIndex >= 0 ? cursorIndex + 1 : 0;
+        }
     }
-    constraints.push(limit(pageSize));
-    const q = query(
-        collection(db, "accessCodes"),
-        ...constraints
-    );
-    const snapshot = await getDocs(q);
-    const codes = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const pageCodes = codes.slice(offset, offset + pageSize);
+    const nextOffset = offset + pageCodes.length;
     return {
-        codes,
-        nextCursor: snapshot.docs.length === pageSize ? snapshot.docs[snapshot.docs.length - 1] : null
+        codes: pageCodes,
+        nextCursor: nextOffset < codes.length ? nextOffset : null
     };
 }
 

--- a/profile.html
+++ b/profile.html
@@ -444,7 +444,7 @@
             getNotificationPreferencesForTeam,
             saveNotificationPreferencesForTeam,
             upsertNotificationDeviceToken
-        } from './js/db.js?v=66';
+        } from './js/db.js?v=67';
         import { normalizeTeamNotificationPreferences, NOTIFICATION_PREFERENCE_GROUPS } from './js/notification-preferences.js?v=2';
         import { registerPushNotifications } from './js/push-notifications.js?v=1';
 

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1688,10 +1688,11 @@ describe('React app messages integration', () => {
         expect(buttonByText(container, 'Done').disabled).toBe(true);
 
         const textarea = container.querySelector('textarea');
+        expect(textarea.disabled).toBe(true);
+        expect(buttonByText(container, 'Send message').disabled).toBe(true);
         await setFieldValue(textarea, 'This should stay targeted.');
-        await click(container, 'Send message');
 
-        expect(container.textContent).toContain('Choose at least one selected member before sending.');
+        expect(container.textContent).toContain('Choose at least one selected member, or switch back to Full team.');
         expect(container.textContent).toContain('Message audience');
         expect(chatMocks.sendTeamChatMessage).not.toHaveBeenCalled();
     });

--- a/tests/unit/profile-access-code-pagination.test.js
+++ b/tests/unit/profile-access-code-pagination.test.js
@@ -6,26 +6,22 @@ function readProjectFile(path) {
 }
 
 describe('profile access code pagination contract', () => {
-    it('uses an ordered cursor-limited access-code query for app invite history pages', () => {
+    it('uses the no-index access-code read path for app invite history pages', () => {
         const dbSource = readProjectFile('js/db.js');
         const profileServiceSource = readProjectFile('apps/app/src/lib/profileService.ts');
         const profilePageSource = readProjectFile('apps/app/src/pages/Profile.tsx');
+        const start = dbSource.indexOf('export async function getUserAccessCodesPage');
+        const end = dbSource.indexOf('export async function getTeamAccessCodes', start);
+        const helperSource = dbSource.slice(start, end);
 
         expect(dbSource).toContain('export async function getUserAccessCodesPage');
-        expect(dbSource).toContain('orderBy("createdAt", "desc")');
-        expect(dbSource).toContain('startAfter(options.cursor)');
-        expect(dbSource).toContain('limit(pageSize)');
+        expect(helperSource).toContain('const codes = await getUserAccessCodes(userId);');
+        expect(helperSource).toContain('const pageCodes = codes.slice(offset, offset + pageSize);');
+        expect(helperSource).toContain('nextCursor: nextOffset < codes.length ? nextOffset : null');
+        expect(helperSource).not.toContain('orderBy("createdAt"');
+        expect(helperSource).not.toContain('startAfter(options.cursor)');
         expect(profileServiceSource).toContain('getUserAccessCodesPage(userId, { cursor, pageSize })');
         expect(profilePageSource).toContain('loadProfileAccessCodesPage(user.uid, { pageSize: collapsedInviteCount })');
         expect(profilePageSource).not.toContain('setAccessCodes(await loadProfileAccessCodes(user.uid))');
-    });
-
-    it('declares the composite Firestore index required by the paged access-code query', () => {
-        const indexes = JSON.parse(readProjectFile('firestore.indexes.json'));
-        const accessCodeIndexes = indexes.indexes
-            .filter((index) => index.collectionGroup === 'accessCodes' && index.queryScope === 'COLLECTION')
-            .map((index) => index.fields.map((field) => `${field.fieldPath}:${field.order || field.arrayConfig}`).join(','));
-
-        expect(accessCodeIndexes).toContain('generatedBy:ASCENDING,createdAt:DESCENDING');
     });
 });


### PR DESCRIPTION
## Summary
- Add fallbacks and query/index fixes for notification inbox, fees, profile invite history, roster tracking, and schedule deep links.
- Disable the chat composer while sheets are open so background input and sends do not leak through modal workflows.
- Add focused regression coverage for the six manual QA issues and update existing contracts for the new behavior.

## Issues
Fixes #3001
Fixes #3002
Fixes #3003
Fixes #3004
Fixes #3005
Fixes #3006

## Testing
- npx vitest run apps/app/src/lib/notificationInboxService.test.ts apps/app/src/pages/Schedule.test.tsx apps/app/src/pages/messages/components/ChatComposer.test.tsx apps/app/src/pages/TeamDetail.test.tsx apps/app/src/pages/ParentTools.test.tsx apps/app/src/pages/Profile.test.tsx --reporter=verbose
- npm test
- npm run app:build