### PR TITLE
Clear private stats when replacing statsheet data

### DIFF
--- a/apps/app/src/lib/statsheetImportService.test.ts
+++ b/apps/app/src/lib/statsheetImportService.test.ts
@@ -46,7 +46,7 @@ vi.mock('../../../../js/firebase.js', () => firebaseMocks)
 vi.mock('../../../../js/db.js', () => dbMocks)
 vi.mock('../../../../js/vendor/firebase-app.js', () => firebaseAppMocks)
 vi.mock('../../../../js/vendor/firebase-ai.js', () => firebaseAiMocks)
-vi.mock('./profileService', () => ({ acquireProfilePhoto: vi.fn() }))
+vi.mock('./profilePhotoService', () => ({ acquireProfilePhoto: vi.fn() }))
 vi.mock('../../../../js/live-tracker-save-complete.js', () => ({
   addAggregatedStatsWritesToBatch: vi.fn(({ aggregatedStatsWrites = [], batch, db, currentTeamId, currentGameId, createDocRef }: any) => {
     aggregatedStatsWrites.forEach(({ playerId, data }: any) => {
@@ -181,6 +181,29 @@ describe('applyTrackStatsheetImportForApp', () => {
     firebaseMocks.getDocs
       .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'event-1' } }] })
       .mockResolvedValueOnce({ size: 0, docs: [] })
+      .mockResolvedValueOnce({ size: 0, docs: [] })
+
+    const result = await applyTrackStatsheetImportForApp({
+      teamId: 'team-1',
+      gameId: 'game-1',
+      roster: [{ id: 'p1', name: 'Avery Smith', number: '12' }],
+      columns: ['PTS'],
+      homeRows: [{ number: '12', name: 'Avery Smith', fouls: 2, totalPoints: 10, include: true, mappedPlayerId: 'p1' }],
+      visitorRows: [],
+      homeScore: 50,
+      awayScore: 42,
+      file: null
+    })
+
+    expect(result).toMatchObject({ requiresReplaceConfirmation: true, hasExistingTrackedData: true })
+    expect(firebaseMocks.writeBatch).not.toHaveBeenCalled()
+  })
+
+  it('requires replacement when only private tracked stats already exist', async () => {
+    firebaseMocks.getDocs
+      .mockResolvedValueOnce({ size: 0, docs: [] })
+      .mockResolvedValueOnce({ size: 0, docs: [] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'private-stats-1' } }] })
 
     const result = await applyTrackStatsheetImportForApp({
       teamId: 'team-1',
@@ -202,6 +225,7 @@ describe('applyTrackStatsheetImportForApp', () => {
     firebaseMocks.getDocs
       .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'event-1' } }] })
       .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'stats-1' } }] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'private-stats-1' } }] })
 
     const file = new File(['sheet'], 'statsheet.png', { type: 'image/png' })
     const result = await applyTrackStatsheetImportForApp({
@@ -218,7 +242,8 @@ describe('applyTrackStatsheetImportForApp', () => {
     })
 
     expect(dbMocks.uploadStatSheetPhoto).toHaveBeenCalledWith('team-1', file)
-    expect(firebaseMocks.deleteDoc).toHaveBeenCalledTimes(2)
+    expect(firebaseMocks.deleteDoc).toHaveBeenCalledTimes(3)
+    expect(firebaseMocks.deleteDoc).toHaveBeenCalledWith({ path: 'private-stats-1' })
     expect(firebaseMocks.writeBatch).toHaveBeenCalled()
     expect(firebaseMocks.batch.update).toHaveBeenCalledWith(
       { path: 'teams/team-1/games/game-1' },

--- a/apps/app/src/lib/statsheetImportService.ts
+++ b/apps/app/src/lib/statsheetImportService.ts
@@ -347,7 +347,8 @@ export async function applyTrackStatsheetImportForApp({
   const includedVisitor = (visitorRows || []).filter((row) => row?.include)
   const eventsSnap = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/events`))
   const statsSnap = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`))
-  const hasExistingTrackedData = eventsSnap.size > 0 || statsSnap.size > 0
+  const privateStatsSnap = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/privatePlayerStats`))
+  const hasExistingTrackedData = eventsSnap.size > 0 || statsSnap.size > 0 || privateStatsSnap.size > 0
 
   if (hasExistingTrackedData && !replaceExisting) {
     return {
@@ -365,6 +366,7 @@ export async function applyTrackStatsheetImportForApp({
   if (hasExistingTrackedData) {
     await Promise.all(eventsSnap.docs.map((entry: any) => deleteDoc(entry.ref)))
     await Promise.all(statsSnap.docs.map((entry: any) => deleteDoc(entry.ref)))
+    await Promise.all(privateStatsSnap.docs.map((entry: any) => deleteDoc(entry.ref)))
   }
 
   const applyPlan = buildTrackStatsheetApplyPlan({

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 
 import {
     buildTrackStatsheetApplyPlan,
     getTrackStatsheetPointsKey,
     validateTrackStatsheetApplyRows
 } from '../../js/track-statsheet-apply.js';
+
+const trackStatsheetSource = readFileSync(new URL('../../track-statsheet.html', import.meta.url), 'utf8');
 
 describe('track statsheet apply helpers', () => {
     it('allows excluded unmatched home rows when included rows are mapped', () => {
@@ -172,5 +175,10 @@ describe('track statsheet apply helpers', () => {
                 }
             }
         ]);
+    });
+
+    it('clears private player stats when replacing previously tracked game data', () => {
+        expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
+        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
     });
 });

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -758,7 +758,8 @@ RETURN JSON:
         applyStatus.textContent = 'Checking existing game data…';
         const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
-        if (eventsSnap.size > 0 || statsSnap.size > 0) {
+        const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
+        if (eventsSnap.size > 0 || statsSnap.size > 0 || privateStatsSnap.size > 0) {
           const confirmClear = confirm('This game already has tracked data. Replace it with the stat sheet results?');
           if (!confirmClear) {
             applyStatus.textContent = 'Cancelled.';
@@ -767,6 +768,7 @@ RETURN JSON:
           applyStatus.textContent = 'Clearing existing stats…';
           await Promise.all(eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
           await Promise.all(statsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
+          await Promise.all(privateStatsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
         }
 
         const applyPlan = buildTrackStatsheetApplyPlan({


### PR DESCRIPTION
Closes #3000

## What changed
- Updated `track-statsheet.html` so the statsheet replace flow also loads and deletes `privatePlayerStats` before saving imported results.
- Expanded `tests/unit/track-statsheet-apply.test.js` with a regression assertion that the replace branch clears `privatePlayerStats` alongside `events` and `aggregatedStats`.

## Root Cause
The statsheet replacement path only cleared `events` and `aggregatedStats`. Tracker reload paths still hydrate `privatePlayerStats`, so stale private per-player documents survived replacement and were merged back into later staff views.

## Prevention / Learning
When a workflow claims to replace or reset tracked game data, clear every persisted subcollection that later tracker hydration reads, not just the public aggregate stats collection. Replacement logic should mirror the full tracked-state reset surface.

## Regression Tests
- `npx vitest run tests/unit/track-statsheet-apply.test.js tests/unit/track-statsheet-summary-save.test.js --reporter=verbose`
- Added a regression assertion that `track-statsheet.html` now fetches and deletes `privatePlayerStats` inside the existing replace-confirmation branch.

## Recurrence Risk
Low. The replace flow now clears the same private stat subcollection that the existing tracker reset path already treats as part of persisted tracked game state.