### PR TITLE
Hide final scores for scheduled games

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -377,6 +377,31 @@ describe('Schedule', () => {
     expect(screen.queryByRole('button', { name: /create tournament/i })).toBeNull();
   });
 
+  it('does not label scheduled games with default 0-0 scores as final results', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          status: 'scheduled',
+          liveStatus: 'scheduled',
+          homeScore: 0,
+          awayScore: 0
+        })
+      ]
+    });
+
+    renderSchedule();
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('status', { name: 'Loading schedule' })).toBeNull();
+    });
+    expect(screen.queryByText('Final 0-0')).toBeNull();
+    expect(screen.queryByText('0-0')).toBeNull();
+  });
+
   it('requests older past-event pages for every linked team, even without events in the default window', async () => {
     const seededPastEvent = buildScheduleEvent(1, {
       eventKey: 'team-1::event-1::player-1::past::game',

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -402,6 +402,31 @@ describe('Schedule', () => {
     expect(screen.queryByText('0-0')).toBeNull();
   });
 
+  it('shows saved scores for past games even before status flips to completed', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          date: new Date(Date.now() - (4 * 60 * 60 * 1000)),
+          status: 'scheduled',
+          liveStatus: 'scheduled',
+          homeScore: 21,
+          awayScore: 14
+        })
+      ]
+    });
+
+    renderSchedule('/schedule?filter=recent-results');
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('status', { name: 'Loading schedule' })).toBeNull();
+    });
+    expect(screen.getByText('21-14')).toBeTruthy();
+  });
+
   it('requests older past-event pages for every linked team, even without events in the default window', async () => {
     const seededPastEvent = buildScheduleEvent(1, {
       eventKey: 'team-1::event-1::player-1::past::game',

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -2531,6 +2531,10 @@ function getEventMetadataPills(event: ParentScheduleEvent | CalendarScheduleEntr
 
 function getScoreLabel(event: ParentScheduleEvent | CalendarScheduleEntry) {
   if (event.type !== 'game') return '';
+  const status = String(event.status || '').trim().toLowerCase();
+  const liveStatus = String(event.liveStatus || '').trim().toLowerCase();
+  const isCompleted = status === 'completed' || status === 'final' || liveStatus === 'completed' || liveStatus === 'final';
+  if (!isCompleted) return '';
   if (event.homeScore === null || event.homeScore === undefined || event.awayScore === null || event.awayScore === undefined) return '';
   return `${event.homeScore}-${event.awayScore}`;
 }

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -2531,11 +2531,12 @@ function getEventMetadataPills(event: ParentScheduleEvent | CalendarScheduleEntr
 
 function getScoreLabel(event: ParentScheduleEvent | CalendarScheduleEntry) {
   if (event.type !== 'game') return '';
+  if (event.homeScore === null || event.homeScore === undefined || event.awayScore === null || event.awayScore === undefined) return '';
   const status = String(event.status || '').trim().toLowerCase();
   const liveStatus = String(event.liveStatus || '').trim().toLowerCase();
   const isCompleted = status === 'completed' || status === 'final' || liveStatus === 'completed' || liveStatus === 'final';
-  if (!isCompleted) return '';
-  if (event.homeScore === null || event.homeScore === undefined || event.awayScore === null || event.awayScore === undefined) return '';
+  const isPastScheduledResult = event.date.getTime() < Date.now() - pastScheduleCutoffMs;
+  if (!isCompleted && !isPastScheduledResult) return '';
   return `${event.homeScore}-${event.awayScore}`;
 }
 


### PR DESCRIPTION
Closes #3014

## What changed
- gated Schedule page score rendering so game cards only show a score badge when the game status or liveStatus is `completed` or `final`
- left scheduled games with placeholder `0-0` scores in the data model unchanged, but stopped treating those placeholders as final results in the UI
- added a Schedule page regression test that verifies scheduled games with `homeScore: 0` and `awayScore: 0` do not render `Final 0-0`

## Root Cause
The Schedule page treated any non-null game scores as a final score. Scheduled games are created with default `status: 'scheduled'`, `homeScore: 0`, and `awayScore: 0`, so upcoming games were incorrectly rendered as completed `Final 0-0` results.

## Prevention / Learning
Do not infer lifecycle state from placeholder numeric fields alone. Final-result UI must require an explicit completed/final status in addition to any score values.

## Regression Tests
- `npx vitest run apps/app/src/pages/Schedule.test.tsx --reporter=verbose`