### PR TITLE
Route Fees shortcut to the native team picker

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -7,6 +7,10 @@ import type { NotificationInboxItem } from '../lib/notificationInboxService';
 import type { AuthState } from '../lib/types';
 import { APP_BACK_DISMISS_EVENT } from '../lib/nativeBackButton';
 
+const publicActionMocks = vi.hoisted(() => ({
+  openPublicUrl: vi.fn(() => Promise.resolve()),
+}));
+
 type SubscribeToNotificationInbox = (
   uid: string,
   onItems: (items: NotificationInboxItem[]) => void,
@@ -33,6 +37,8 @@ vi.mock('../lib/useShellLayout', () => ({
 vi.mock('../lib/uxTiming', () => ({
   recordUxTiming: vi.fn(),
 }));
+
+vi.mock('../lib/publicActions', () => publicActionMocks);
 
 vi.mock('../lib/badgeService', () => ({
   updateAppIconBadge: updateAppIconBadgeMock,
@@ -118,6 +124,7 @@ describe('AppShell', () => {
     subscribeToUnreadNotificationCountMock.mockReset();
     subscribeToUnreadNotificationCountMock.mockReturnValue(vi.fn());
     updateAppIconBadgeMock.mockClear();
+    publicActionMocks.openPublicUrl.mockClear();
   });
 
   afterEach(() => {
@@ -416,6 +423,25 @@ describe('AppShell', () => {
 
     expect(event.defaultPrevented).toBe(true);
     await waitFor(() => expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy());
+  });
+
+  it('routes Fees through the native team picker instead of the public website handoff', async () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+          <Route path="/teams" element={<AppShell auth={signedInAuth}><div>Teams hub</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getByRole('button', { name: /FeesSelect a team for fee setup, checkout, and balancesCoach\/Admin/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Teams hub')).toBeTruthy();
+    });
+    expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
   });
 
   it('dismisses the search dialog when native back asks overlays to close', async () => {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -689,11 +689,11 @@ function buildAddWorkflows(): AddWorkflow[] {
     {
       id: 'fees',
       label: 'Fees',
-      detail: 'Create fees, checkout, balances',
+      detail: 'Select a team for fee setup, checkout, and balances',
       section: 'Team Ops',
       icon: CreditCard,
-      kind: 'website',
-      href: legacyUrl('team-fees.html'),
+      kind: 'native',
+      href: '/teams',
       badge: 'Coach/Admin'
     },
     {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -693,7 +693,7 @@ function buildAddWorkflows(): AddWorkflow[] {
       section: 'Team Ops',
       icon: CreditCard,
       kind: 'native',
-      href: '/teams',
+      href: '/teams?workflow=fees',
       badge: 'Coach/Admin'
     },
     {

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -104,12 +104,13 @@ function TeamHubRoute() {
   return <div data-testid="team-hub">Team hub: {teamId}</div>;
 }
 
-function renderTeamsWithNav() {
+function renderTeamsWithNav(initialEntry = '/teams') {
   return render(
-    <MemoryRouter initialEntries={["/teams"]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/teams" element={<Teams auth={auth} />} />
         <Route path="/teams/:teamId" element={<TeamHubRoute />} />
+        <Route path="/teams/:teamId/fees" element={<div data-testid="team-fees-route">Team fees route</div>} />
       </Routes>
     </MemoryRouter>
   );
@@ -323,6 +324,17 @@ describe('Teams single-team auto-navigate', () => {
     expect(screen.getByTestId('team-hub').textContent).toBe('Team hub: team-solo');
     expect(screen.queryByText('Choose a team')).toBeNull();
     expect(screen.queryByText('Loading teams')).toBeNull();
+  });
+
+  it('opens team fees directly when the fees workflow targets a single linked team', async () => {
+    renderTeamsWithNav('/teams?workflow=fees');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('team-fees-route')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('team-hub')).toBeNull();
+    expect(screen.queryByText('Choose a team')).toBeNull();
   });
 
   it('keeps the chooser visible when the only team has no linked players yet', async () => {

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -82,6 +82,7 @@ export function Teams({ auth }: { auth: AuthState }) {
     run: runTeamEnrichmentLoad
   } = useAsyncOperation();
   const selectedTeamId = searchParams.get('selectedTeamId') || '';
+  const requestedWorkflow = searchParams.get('workflow') || '';
   const authUserId = auth.user?.uid || null;
   const hasLoadedTeamSummary = Boolean(authUserId) && authUserId === loadedTeamSummaryUserId;
   const hasLoadedTeamDetails = Boolean(authUserId) && authUserId === loadedTeamUserId;
@@ -176,9 +177,9 @@ export function Teams({ auth }: { auth: AuthState }) {
   useEffect(() => {
     if (loading || selectedTeamId) return;
     if (shouldAutoNavigateToSingleTeam(home.teams)) {
-      navigate(`/teams/${encodeURIComponent(home.teams[0].teamId)}`, { replace: true });
+      navigate(getSingleTeamDestination(home.teams[0].teamId, requestedWorkflow), { replace: true });
     }
-  }, [loading, home.teams, navigate, selectedTeamId]);
+  }, [loading, home.teams, navigate, requestedWorkflow, selectedTeamId]);
 
   const showBlockingErrorState = !loading && !hasLoadedTeamDetails && Boolean(teamsLoadError);
 
@@ -263,6 +264,13 @@ function mergeTeamSummary(current: ParentHomeModel, enriched: ParentHomeModel): 
 
 function shouldAutoNavigateToSingleTeam(teams: ParentHomeTeam[]): boolean {
   return teams.length === 1 && teams[0]?.players.length === 1;
+}
+
+function getSingleTeamDestination(teamId: string, workflow: string) {
+  if (workflow === 'fees') {
+    return `/teams/${encodeURIComponent(teamId)}/fees`;
+  }
+  return `/teams/${encodeURIComponent(teamId)}`;
 }
 
 function TeamsHeader({ loading, refreshing, teams, teamRoles, onRefresh }: {


### PR DESCRIPTION
Closes #3019

## What changed
- changed the global Add menu `Fees` shortcut in `apps/app/src/components/AppShell.tsx` from a hard-coded website handoff to the native `/teams` route
- updated the shortcut copy to tell staff they will select a team for fee setup, checkout, and balances
- added an `AppShell` regression test that proves the Fees shortcut stays in-app and does not call the public website opener

## Root Cause
The Add menu defined `Fees` as a `website` workflow pointing to `https://allplays.ai/team-fees.html`, even though the app already has native team fee routes. That mismatch forced authenticated app users out of the local app session and into the production website login flow.

## Prevention / Learning
When a native app route already exists for a workflow, global shortcuts must prefer the native route and only use website handoffs when there is no in-app path. Add-menu entries need regression coverage for route intent so they cannot silently drift back to legacy website links.

## Regression Tests
- `apps/app/src/components/AppShell.test.tsx` verifies the Add menu `Fees` action navigates to `/teams` and does not call `openPublicUrl`
- `cd apps/app && npx vitest run src/components/AppShell.test.tsx --reporter=verbose`

## Recurrence Risk
Low. The defect was a single hard-coded menu target, and the new regression test now guards the exact handoff path that caused signed-in users to hit the production login page.