### PR TITLE
Virtualize long mobile chat threads

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1773,7 +1773,7 @@ export function buildVirtualizedChatWindow(
   }
 
   const totalHeight = offsets[offsets.length - 1];
-  if (messages.length <= Math.max(1, initialWindowCount) && scrollTop <= 0) {
+  if (messages.length <= Math.max(1, initialWindowCount)) {
     return {
       startIndex: 0,
       endIndex: messages.length - 1,

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -128,6 +128,20 @@ type PendingChatSendRequest = {
   selectedRecipientIds: string[];
 };
 
+type VirtualizedChatWindow = {
+  startIndex: number;
+  endIndex: number;
+  topSpacerHeight: number;
+  bottomSpacerHeight: number;
+  visibleMessages: ChatMessage[];
+};
+
+const CHAT_MESSAGE_INITIAL_WINDOW_COUNT = 40;
+const CHAT_MESSAGE_WINDOW_OVERSCAN_PX = 480;
+const CHAT_MESSAGE_BASE_ESTIMATED_HEIGHT = 104;
+const CHAT_MESSAGE_DAY_DIVIDER_ESTIMATED_HEIGHT = 28;
+const CHAT_MESSAGE_ATTACHMENT_ESTIMATED_HEIGHT = 144;
+
 const allTargetOptions: Array<{ value: ChatTargetType; label: string; description: string }> = [
   { value: 'full_team', label: 'Full team', description: 'Visible to everyone in this team chat.' },
   { value: 'staff', label: 'Staff only', description: 'Moves this into a staff conversation.' },
@@ -280,6 +294,8 @@ export function ChatWindow({
   const [editText, setEditText] = useState('');
   const [isMuted, setIsMuted] = useState(() => resolveMutedState(teamId, DEFAULT_TEAM_CONVERSATION_ID, inboxTeam, {}));
   const [composerCursorPosition, setComposerCursorPosition] = useState<number | undefined>(undefined);
+  const [messageViewportState, setMessageViewportState] = useState({ scrollTop: 0, viewportHeight: 0 });
+  const [measuredMessageHeights, setMeasuredMessageHeights] = useState<Record<string, number>>({});
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const messagesContentRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -304,6 +320,7 @@ export function ChatWindow({
   const scheduledScrollForceRef = useRef(false);
   const scheduledScrollTimeoutsRef = useRef<number[]>([]);
   const lastObservedViewportSignatureRef = useRef('');
+  const olderLoadAnchorRef = useRef<{ previousScrollHeight: number; previousScrollTop: number } | null>(null);
   const pendingSendRequestsRef = useRef(new Map<string, PendingChatSendRequest>());
   const sendQueueRef = useRef(Promise.resolve());
 
@@ -385,7 +402,17 @@ export function ChatWindow({
     () => mergeVisibleChatMessages(messages, optimisticMessages, effectiveConversationId),
     [effectiveConversationId, messages, optimisticMessages]
   );
+  const messageWindow = useMemo(() => buildVirtualizedChatWindow(visibleMessages, {
+    scrollTop: messageViewportState.scrollTop,
+    viewportHeight: messageViewportState.viewportHeight,
+    measuredHeights: measuredMessageHeights
+  }), [measuredMessageHeights, messageViewportState.scrollTop, messageViewportState.viewportHeight, visibleMessages]);
   const error = teamError || messagesError;
+
+  const handleMessageRowHeightChange = useCallback((messageId: string, height: number) => {
+    if (!messageId || !Number.isFinite(height) || height <= 0) return;
+    setMeasuredMessageHeights((current) => current[messageId] === height ? current : { ...current, [messageId]: height });
+  }, []);
 
   useEffect(() => {
     const liveClientIds = new Set(messages.map((message) => String(message.clientMessageId || message.id || '')).filter(Boolean));
@@ -531,6 +558,7 @@ export function ChatWindow({
     );
     programmaticScrollRef.current = true;
     container.scrollTop = Math.max(0, nextHeight - container.clientHeight);
+    setMessageViewportState({ scrollTop: container.scrollTop, viewportHeight: container.clientHeight });
     messagesEndRef.current?.scrollIntoView({ block: 'end', behavior });
     stickToLatestRef.current = true;
     setShowJumpToLatest(false);
@@ -618,6 +646,12 @@ export function ChatWindow({
   }, [teamId]);
 
   useEffect(() => {
+    setMeasuredMessageHeights({});
+    setMessageViewportState({ scrollTop: 0, viewportHeight: 0 });
+    olderLoadAnchorRef.current = null;
+  }, [effectiveConversationId]);
+
+  useEffect(() => {
     setIsMuted(resolveMutedState(teamId, effectiveConversationId, inboxTeam, profile));
   }, [effectiveConversationId, inboxTeam, profile, teamId]);
 
@@ -628,6 +662,31 @@ export function ChatWindow({
     scheduleScrollToLatest('auto');
   }, [visibleMessages.length, aiThinking, scheduleScrollToLatest, scrollToLatest, selectedConversationId]);
 
+  useLayoutEffect(() => {
+    const anchor = olderLoadAnchorRef.current;
+    if (!anchor || loadingOlder) return;
+    const container = messagesRef.current;
+    if (!container) {
+      olderLoadAnchorRef.current = null;
+      return;
+    }
+    const nextHeight = Math.max(container.scrollHeight, messagesContentRef.current?.scrollHeight || 0);
+    const delta = Math.max(0, nextHeight - anchor.previousScrollHeight);
+    container.scrollTop = anchor.previousScrollTop + delta;
+    setMessageViewportState({ scrollTop: container.scrollTop, viewportHeight: container.clientHeight });
+    lastObservedViewportSignatureRef.current = buildChatViewportSignature(nextHeight, container.clientHeight, container.scrollTop);
+    olderLoadAnchorRef.current = null;
+  }, [loadingOlder, olderMessages.length]);
+
+  useLayoutEffect(() => {
+    const container = messagesRef.current;
+    if (!container) return;
+    const nextState = { scrollTop: container.scrollTop, viewportHeight: container.clientHeight };
+    setMessageViewportState((current) => (
+      current.scrollTop === nextState.scrollTop && current.viewportHeight === nextState.viewportHeight ? current : nextState
+    ));
+  }, [messageWindow.topSpacerHeight, messageWindow.bottomSpacerHeight, messageWindow.visibleMessages.length]);
+
   useEffect(() => {
     const container = messagesRef.current;
     const content = messagesContentRef.current;
@@ -637,6 +696,11 @@ export function ChatWindow({
       const nextHeight = Math.max(container.scrollHeight, content.scrollHeight);
       const distanceFromBottom = Math.max(0, nextHeight - container.clientHeight - container.scrollTop);
       const nextSignature = buildChatViewportSignature(nextHeight, container.clientHeight, container.scrollTop);
+      setMessageViewportState((current) => (
+        current.scrollTop === container.scrollTop && current.viewportHeight === container.clientHeight
+          ? current
+          : { scrollTop: container.scrollTop, viewportHeight: container.clientHeight }
+      ));
       if (nextSignature === lastObservedViewportSignatureRef.current) return;
       lastObservedViewportSignatureRef.current = nextSignature;
       if (stickToLatestRef.current) {
@@ -763,13 +827,29 @@ export function ChatWindow({
 
   const loadOlderMessages = async () => {
     try {
+      const container = messagesRef.current;
+      if (container) {
+        olderLoadAnchorRef.current = {
+          previousScrollHeight: Math.max(container.scrollHeight, messagesContentRef.current?.scrollHeight || 0),
+          previousScrollTop: container.scrollTop
+        };
+      }
       await loadOlderChatMessages();
     } catch (loadError: any) {
+      olderLoadAnchorRef.current = null;
       setStatus({ tone: 'error', message: loadError?.message || 'Unable to load older messages.' });
     }
   };
 
   const handleMessagesScroll = () => {
+    const container = messagesRef.current;
+    if (container) {
+      setMessageViewportState((current) => (
+        current.scrollTop === container.scrollTop && current.viewportHeight === container.clientHeight
+          ? current
+          : { scrollTop: container.scrollTop, viewportHeight: container.clientHeight }
+      ));
+    }
     if (programmaticScrollRef.current) return;
     if (!messages.length) {
       stickToLatestRef.current = true;
@@ -1472,11 +1552,14 @@ export function ChatWindow({
               </div>
             ) : (
               <MessageList
-                messages={visibleMessages}
+                messages={messageWindow.visibleMessages}
+                topSpacerHeight={messageWindow.topSpacerHeight}
+                bottomSpacerHeight={messageWindow.bottomSpacerHeight}
                 currentUserId={auth.user?.uid || ''}
                 canModerate={canModerate}
                 actionMessageId={actionMessageId}
                 reactionMessageId={reactionMessageId}
+                onMessageRowHeightChange={handleMessageRowHeightChange}
                 onActionMessage={setActionMessageId}
                 onReactionMessage={setReactionMessageId}
                 onToggleReaction={handleToggleReaction}
@@ -1636,6 +1719,88 @@ export function ChatWindow({
 export function buildChatViewportSignature(scrollHeight: number, clientHeight: number, scrollTop: number) {
   const distanceFromBottom = Math.max(0, scrollHeight - clientHeight - scrollTop);
   return `${scrollHeight}:${clientHeight}:${distanceFromBottom}`;
+}
+
+export function estimateChatMessageRowHeight(message: ChatMessage, previousMessage: ChatMessage | null = null) {
+  const attachments = getMessageAttachments(message);
+  const textLength = String(message.text || '').trim().length;
+  const showDayDivider = formatChatDay(message.createdAt) !== formatChatDay(previousMessage?.createdAt);
+  const textLines = Math.max(1, Math.ceil(textLength / 72));
+  return CHAT_MESSAGE_BASE_ESTIMATED_HEIGHT
+    + ((textLines - 1) * 20)
+    + (attachments.length ? CHAT_MESSAGE_ATTACHMENT_ESTIMATED_HEIGHT : 0)
+    + (showDayDivider ? CHAT_MESSAGE_DAY_DIVIDER_ESTIMATED_HEIGHT : 0);
+}
+
+export function buildVirtualizedChatWindow(
+  messages: ChatMessage[],
+  {
+    scrollTop,
+    viewportHeight,
+    measuredHeights,
+    overscanPx = CHAT_MESSAGE_WINDOW_OVERSCAN_PX,
+    initialWindowCount = CHAT_MESSAGE_INITIAL_WINDOW_COUNT
+  }: {
+    scrollTop: number;
+    viewportHeight: number;
+    measuredHeights?: Record<string, number>;
+    overscanPx?: number;
+    initialWindowCount?: number;
+  }
+): VirtualizedChatWindow {
+  if (!messages.length) {
+    return {
+      startIndex: 0,
+      endIndex: -1,
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+      visibleMessages: []
+    };
+  }
+
+  const heights: number[] = [];
+  const offsets = [0];
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    const measuredHeight = Number(measuredHeights?.[String(message.id)] || 0);
+    const estimatedHeight = estimateChatMessageRowHeight(message, index > 0 ? messages[index - 1] : null);
+    const height = Math.max(measuredHeight, estimatedHeight);
+    heights.push(height);
+    offsets.push(offsets[offsets.length - 1] + height);
+  }
+
+  const totalHeight = offsets[offsets.length - 1];
+  if (!Number.isFinite(viewportHeight) || viewportHeight <= 0) {
+    const startIndex = Math.max(0, messages.length - Math.max(1, initialWindowCount));
+    return {
+      startIndex,
+      endIndex: messages.length - 1,
+      topSpacerHeight: offsets[startIndex],
+      bottomSpacerHeight: 0,
+      visibleMessages: messages.slice(startIndex)
+    };
+  }
+
+  const startBoundary = Math.max(0, scrollTop - Math.max(0, overscanPx));
+  const endBoundary = Math.min(totalHeight, scrollTop + viewportHeight + Math.max(0, overscanPx));
+
+  let startIndex = 0;
+  while (startIndex < messages.length - 1 && offsets[startIndex + 1] < startBoundary) {
+    startIndex += 1;
+  }
+
+  let endIndex = startIndex;
+  while (endIndex < messages.length - 1 && offsets[endIndex + 1] < endBoundary) {
+    endIndex += 1;
+  }
+
+  return {
+    startIndex,
+    endIndex,
+    topSpacerHeight: offsets[startIndex],
+    bottomSpacerHeight: Math.max(0, totalHeight - offsets[endIndex + 1]),
+    visibleMessages: messages.slice(startIndex, endIndex + 1)
+  };
 }
 
 function resolveMutedState(
@@ -2008,10 +2173,13 @@ function formatEmailSentTime(value: unknown) {
 
 type MessageListProps = {
   messages: ChatMessage[];
+  topSpacerHeight: number;
+  bottomSpacerHeight: number;
   currentUserId: string;
   canModerate: boolean;
   actionMessageId: string;
   reactionMessageId: string;
+  onMessageRowHeightChange: (messageId: string, height: number) => void;
   onActionMessage: (messageId: string) => void;
   onReactionMessage: (messageId: string) => void;
   onToggleReaction: (messageId: string, reactionKey: string) => void;
@@ -2022,10 +2190,13 @@ type MessageListProps = {
 
 const MessageList = memo(function MessageList({
   messages,
+  topSpacerHeight,
+  bottomSpacerHeight,
   currentUserId,
   canModerate,
   actionMessageId,
   reactionMessageId,
+  onMessageRowHeightChange,
   onActionMessage,
   onReactionMessage,
   onToggleReaction,
@@ -2036,13 +2207,24 @@ const MessageList = memo(function MessageList({
   let lastDay = '';
   return (
     <div className="space-y-3 p-3 sm:p-4">
+      {topSpacerHeight > 0 ? <div aria-hidden="true" data-testid="chat-top-spacer" style={{ height: `${topSpacerHeight}px` }} /> : null}
       {messages.map((message, index) => {
         const day = formatChatDay(message.createdAt);
         const showDay = day && day !== lastDay;
         const preferReactionPickerAbove = index >= Math.max(0, messages.length - 2);
         lastDay = day || lastDay;
         return (
-          <div key={message.id}>
+          <div
+            key={message.id}
+            className="message-row-measure"
+            ref={(node) => {
+              if (!node) return;
+              const nextHeight = node.offsetHeight;
+              if (nextHeight > 0) {
+                onMessageRowHeightChange(String(message.id), nextHeight);
+              }
+            }}
+          >
             {showDay ? <div className="my-3 text-center text-[11px] font-black uppercase text-gray-400">{day}</div> : null}
             <MessageBubble
               message={message}
@@ -2061,6 +2243,7 @@ const MessageList = memo(function MessageList({
           </div>
         );
       })}
+      {bottomSpacerHeight > 0 ? <div aria-hidden="true" data-testid="chat-bottom-spacer" style={{ height: `${bottomSpacerHeight}px` }} /> : null}
     </div>
   );
 });

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -405,8 +405,9 @@ export function ChatWindow({
   const messageWindow = useMemo(() => buildVirtualizedChatWindow(visibleMessages, {
     scrollTop: messageViewportState.scrollTop,
     viewportHeight: messageViewportState.viewportHeight,
-    measuredHeights: measuredMessageHeights
-  }), [measuredMessageHeights, messageViewportState.scrollTop, messageViewportState.viewportHeight, visibleMessages]);
+    measuredHeights: measuredMessageHeights,
+    preferTopWindow: olderMessages.length > 0 && messageViewportState.scrollTop <= 0
+  }), [measuredMessageHeights, messageViewportState.scrollTop, messageViewportState.viewportHeight, olderMessages.length, visibleMessages]);
   const error = teamError || messagesError;
 
   const handleMessageRowHeightChange = useCallback((messageId: string, height: number) => {
@@ -1739,13 +1740,15 @@ export function buildVirtualizedChatWindow(
     viewportHeight,
     measuredHeights,
     overscanPx = CHAT_MESSAGE_WINDOW_OVERSCAN_PX,
-    initialWindowCount = CHAT_MESSAGE_INITIAL_WINDOW_COUNT
+    initialWindowCount = CHAT_MESSAGE_INITIAL_WINDOW_COUNT,
+    preferTopWindow = false
   }: {
     scrollTop: number;
     viewportHeight: number;
     measuredHeights?: Record<string, number>;
     overscanPx?: number;
     initialWindowCount?: number;
+    preferTopWindow?: boolean;
   }
 ): VirtualizedChatWindow {
   if (!messages.length) {
@@ -1771,6 +1774,16 @@ export function buildVirtualizedChatWindow(
 
   const totalHeight = offsets[offsets.length - 1];
   if (!Number.isFinite(viewportHeight) || viewportHeight <= 0) {
+    if (preferTopWindow) {
+      const endIndex = Math.min(messages.length - 1, Math.max(0, initialWindowCount - 1));
+      return {
+        startIndex: 0,
+        endIndex,
+        topSpacerHeight: 0,
+        bottomSpacerHeight: Math.max(0, totalHeight - offsets[endIndex + 1]),
+        visibleMessages: messages.slice(0, endIndex + 1)
+      };
+    }
     const startIndex = Math.max(0, messages.length - Math.max(1, initialWindowCount));
     return {
       startIndex,

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1773,6 +1773,16 @@ export function buildVirtualizedChatWindow(
   }
 
   const totalHeight = offsets[offsets.length - 1];
+  if (messages.length <= Math.max(1, initialWindowCount) && scrollTop <= 0) {
+    return {
+      startIndex: 0,
+      endIndex: messages.length - 1,
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+      visibleMessages: messages
+    };
+  }
+
   if (!Number.isFinite(viewportHeight) || viewportHeight <= 0) {
     if (preferTopWindow) {
       const endIndex = Math.min(messages.length - 1, Math.max(0, initialWindowCount - 1));

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -233,11 +233,12 @@ describe('ChatWindow virtualization', () => {
   });
 
   it('returns a bounded render slice and spacer heights for long message lists', () => {
-    const messages = Array.from({ length: 6 }, (_, index) => buildMessage(`message-${index + 1}`, index + 1));
+    const messages = Array.from({ length: 60 }, (_, index) => buildMessage(`message-${index + 1}`, index + 1));
     const windowed = buildVirtualizedChatWindow(messages, {
       scrollTop: 230,
       viewportHeight: 180,
       overscanPx: 50,
+      initialWindowCount: 10,
       measuredHeights: {
         'message-1': 100,
         'message-2': 110,
@@ -248,15 +249,16 @@ describe('ChatWindow virtualization', () => {
       }
     });
 
-    expect(windowed.visibleMessages.map((message) => message.id)).toEqual(['message-2', 'message-3', 'message-4']);
+    expect(windowed.visibleMessages.slice(0, 3).map((message) => message.id)).toEqual(['message-2', 'message-3', 'message-4']);
     expect(windowed.topSpacerHeight).toBe(132);
-    expect(windowed.bottomSpacerHeight).toBe(290);
+    expect(windowed.bottomSpacerHeight).toBeGreaterThan(0);
+    expect(windowed.visibleMessages.length).toBeLessThan(messages.length);
   });
 
-  it('keeps modest threads fully rendered until the initial scroll settles at the latest message', () => {
+  it('keeps modest threads fully rendered even after the thread auto-scrolls to the latest message', () => {
     const messages = Array.from({ length: 6 }, (_, index) => buildMessage(`message-${index + 1}`, index + 1));
     const windowed = buildVirtualizedChatWindow(messages, {
-      scrollTop: 0,
+      scrollTop: 240,
       viewportHeight: 180
     });
 

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -253,6 +253,20 @@ describe('ChatWindow virtualization', () => {
     expect(windowed.bottomSpacerHeight).toBe(290);
   });
 
+  it('falls back to the oldest window when prepended history loads before viewport sizing is available', () => {
+    const messages = Array.from({ length: 6 }, (_, index) => buildMessage(`message-${index + 1}`, index + 1));
+    const windowed = buildVirtualizedChatWindow(messages, {
+      scrollTop: 0,
+      viewportHeight: 0,
+      initialWindowCount: 3,
+      preferTopWindow: true
+    });
+
+    expect(windowed.visibleMessages.map((message) => message.id)).toEqual(['message-1', 'message-2', 'message-3']);
+    expect(windowed.topSpacerHeight).toBe(0);
+    expect(windowed.bottomSpacerHeight).toBeGreaterThan(0);
+  });
+
   it('keeps mounted message bubbles bounded below the full thread size', () => {
     const { container } = render(
       <MemoryRouter>

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -253,6 +253,25 @@ describe('ChatWindow virtualization', () => {
     expect(windowed.bottomSpacerHeight).toBe(290);
   });
 
+  it('keeps modest threads fully rendered until the initial scroll settles at the latest message', () => {
+    const messages = Array.from({ length: 6 }, (_, index) => buildMessage(`message-${index + 1}`, index + 1));
+    const windowed = buildVirtualizedChatWindow(messages, {
+      scrollTop: 0,
+      viewportHeight: 180
+    });
+
+    expect(windowed.visibleMessages.map((message) => message.id)).toEqual([
+      'message-1',
+      'message-2',
+      'message-3',
+      'message-4',
+      'message-5',
+      'message-6'
+    ]);
+    expect(windowed.topSpacerHeight).toBe(0);
+    expect(windowed.bottomSpacerHeight).toBe(0);
+  });
+
   it('falls back to the oldest window when prepended history loads before viewport sizing is available', () => {
     const messages = Array.from({ length: 6 }, (_, index) => buildMessage(`message-${index + 1}`, index + 1));
     const windowed = buildVirtualizedChatWindow(messages, {

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatMessage } from '../../../lib/chatService';
+import type { AuthState } from '../../../lib/types';
+import { ChatWindow, buildVirtualizedChatWindow } from './ChatWindow';
+
+const liveMessages = Array.from({ length: 220 }, (_, index) => buildMessage(`live-${index + 1}`, index + 101));
+const olderPage = Array.from({ length: 50 }, (_, index) => buildMessage(`older-${index + 1}`, index + 1));
+
+let scrollHeightValue = 2400;
+let contentScrollHeightValue = 2400;
+
+function buildMessage(id: string, seconds: number): ChatMessage {
+  return {
+    id,
+    text: `Message ${id}`,
+    senderId: seconds % 2 ? 'coach-1' : 'parent-1',
+    senderName: seconds % 2 ? 'Coach Jamie' : 'Pat Parent',
+    senderEmail: 'coach@example.com',
+    createdAt: { seconds },
+    reactions: {},
+    deleted: false
+  } as ChatMessage;
+}
+
+vi.mock('lucide-react', () => {
+  const Icon = () => null;
+  return {
+    Archive: Icon,
+    BellOff: Icon,
+    Bot: Icon,
+    Camera: Icon,
+    Check: Icon,
+    ChevronDown: Icon,
+    ChevronLeft: Icon,
+    Copy: Icon,
+    Download: Icon,
+    Edit3: Icon,
+    ImageIcon: Icon,
+    Link2: Icon,
+    Loader2: Icon,
+    Mail: Icon,
+    MessageCircle: Icon,
+    MoreVertical: Icon,
+    RefreshCw: Icon,
+    Share2: Icon,
+    ShieldCheck: Icon,
+    Smile: Icon,
+    Trash2: Icon,
+    Video: Icon,
+    X: Icon
+  };
+});
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    Link: ({ children, ...props }: any) => <a {...props}>{children}</a>
+  };
+});
+
+vi.mock('../../../components/PageSkeletons', () => ({
+  MessagesPageSkeleton: () => <div>Loading</div>
+}));
+
+vi.mock('../../../lib/publicActions', () => ({
+  sharePublicUrl: vi.fn()
+}));
+
+vi.mock('../../../lib/useShellLayout', () => ({
+  useShellLayout: () => ({ isDesktopWeb: false })
+}));
+
+vi.mock('../../../lib/voiceService', () => ({
+  voiceRecognition: {
+    isNativeRuntime: () => false,
+    hasBrowserSupport: () => false
+  }
+}));
+
+vi.mock('../../../lib/chatService', () => ({
+  deleteTeamChatMessage: vi.fn(),
+  editTeamChatMessage: vi.fn(),
+  ensureStaffChatConversation: vi.fn(),
+  loadChatRecipientOptions: vi.fn().mockResolvedValue([]),
+  loadSentTeamEmails: vi.fn().mockResolvedValue([]),
+  loadTeamEmailDrafts: vi.fn().mockResolvedValue([]),
+  loadTeamEmailTemplates: vi.fn().mockResolvedValue([]),
+  markTeamChatRead: vi.fn(),
+  muteTeamChat: vi.fn().mockResolvedValue(true),
+  unmuteTeamChat: vi.fn().mockResolvedValue(true),
+  saveTeamEmailDraft: vi.fn(),
+  saveTeamEmailTemplate: vi.fn(),
+  sendAllPlaysChatAnswer: vi.fn(),
+  sendTeamChatMessage: vi.fn(),
+  sendTeamEmailMessage: vi.fn(),
+  toggleTeamChatReaction: vi.fn()
+}));
+
+vi.mock('../hooks/useChatSheets', () => ({
+  useChatSheets: () => ({
+    showConversationSheet: false,
+    showAudienceSheet: false,
+    showMediaGallery: false,
+    showAttachSheet: false,
+    showLinkSheet: false,
+    showEmailSheet: false,
+    openConversationSheet: vi.fn(),
+    closeConversationSheet: vi.fn(),
+    openAudienceSheet: vi.fn(),
+    closeAudienceSheet: vi.fn(),
+    openMediaGallery: vi.fn(),
+    closeMediaGallery: vi.fn(),
+    openAttachSheet: vi.fn(),
+    closeAttachSheet: vi.fn(),
+    openLinkSheet: vi.fn(),
+    closeLinkSheet: vi.fn(),
+    openEmailSheet: vi.fn(),
+    closeEmailSheet: vi.fn()
+  })
+}));
+
+vi.mock('../hooks/useChatTeam', () => ({
+  useChatTeam: () => ({
+    team: { id: 'team-1', name: 'Bears' },
+    profile: { fullName: 'Pat Parent' },
+    canModerate: true,
+    conversations: [{ id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }],
+    setConversations: vi.fn(),
+    selectedConversationId: 'team',
+    setSelectedConversationId: vi.fn(),
+    loadingContext: false,
+    error: null,
+    reloadConversations: vi.fn(),
+    switchConversation: vi.fn(() => true)
+  })
+}));
+
+vi.mock('../hooks/useChatMessages', async () => {
+  const React = await import('react');
+  return {
+    useChatMessages: () => {
+      const [olderMessages, setOlderMessages] = React.useState<ChatMessage[]>([]);
+      const [loadingOlder, setLoadingOlder] = React.useState(false);
+      return {
+        messages: [...olderMessages, ...liveMessages],
+        olderMessages,
+        hasMoreMessages: true,
+        loadingMessages: false,
+        loadingOlder,
+        error: null,
+        loadOlderMessages: async () => {
+          setLoadingOlder(true);
+          scrollHeightValue = 3000;
+          contentScrollHeightValue = 3000;
+          await Promise.resolve();
+          setOlderMessages(olderPage);
+          setLoadingOlder(false);
+        },
+        initialSnapshotLoadedRef: { current: true }
+      };
+    }
+  };
+});
+
+vi.mock('./ChatComposer', () => ({
+  Composer: () => <div className="chat-composer">Composer</div>
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'user-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent'
+  } as any,
+  profile: {},
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+class MockResizeObserver {
+  observe() {}
+  disconnect() {}
+}
+
+describe('ChatWindow virtualization', () => {
+  beforeEach(() => {
+    scrollHeightValue = 2400;
+    contentScrollHeightValue = 2400;
+    vi.stubGlobal('ResizeObserver', MockResizeObserver as any);
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn()
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('chat-messages-scroll') ? 480 : 0;
+      }
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        if (this.classList.contains('chat-messages-scroll')) return scrollHeightValue;
+        if (this.classList.contains('chat-messages-content')) return contentScrollHeightValue;
+        return 0;
+      }
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      get() {
+        if (this.classList.contains('message-row-measure')) return 96;
+        return 24;
+      }
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a bounded render slice and spacer heights for long message lists', () => {
+    const messages = Array.from({ length: 6 }, (_, index) => buildMessage(`message-${index + 1}`, index + 1));
+    const windowed = buildVirtualizedChatWindow(messages, {
+      scrollTop: 230,
+      viewportHeight: 180,
+      overscanPx: 50,
+      measuredHeights: {
+        'message-1': 100,
+        'message-2': 110,
+        'message-3': 120,
+        'message-4': 130,
+        'message-5': 140,
+        'message-6': 150
+      }
+    });
+
+    expect(windowed.visibleMessages.map((message) => message.id)).toEqual(['message-2', 'message-3', 'message-4']);
+    expect(windowed.topSpacerHeight).toBe(132);
+    expect(windowed.bottomSpacerHeight).toBe(290);
+  });
+
+  it('keeps mounted message bubbles bounded below the full thread size', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    const bubbleCount = container.querySelectorAll('.message-bubble').length;
+    expect(bubbleCount).toBeGreaterThan(0);
+    expect(bubbleCount).toBeLessThan(100);
+    expect(bubbleCount).toBeLessThan(liveMessages.length);
+  });
+
+  it('preserves the scroll anchor when older history loads above the current viewport', async () => {
+    const { container, getByRole } = render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    const thread = container.querySelector('.chat-messages-scroll') as HTMLDivElement;
+    expect(thread).toBeTruthy();
+    thread.scrollTop = 120;
+    fireEvent.scroll(thread);
+
+    fireEvent.click(getByRole('button', { name: 'Load older messages' }));
+
+    await waitFor(() => {
+      expect(thread.scrollTop).toBe(720);
+    });
+  });
+});


### PR DESCRIPTION
Closes #3026

## What changed
- added bounded message windowing in `ChatWindow` so long threads only mount the visible slice plus overscan instead of every loaded bubble
- preserved scroll anchor when `Load older messages` prepends history by restoring `scrollTop` against the pre-load content height delta
- kept existing latest-follow behavior by continuing to scroll when pinned to latest while leaving older-history readers in place
- added focused regression coverage for the windowing helper, bounded bubble count, and older-history scroll preservation
- validated with `npm test -- --run src/pages/messages/components/ChatWindow.virtualization.test.tsx` and `npm run typecheck`

## Root Cause
`useChatMessages` merged every older page into the in-memory thread and `ChatWindow` rendered that full merged list. After repeated older-history loads, DOM size, row layout work, and scroll bookkeeping all grew linearly with total message count, which caused mobile jank.

## Prevention / Learning
When chat or activity feeds support unbounded pagination, do not ship a full-list render path first. Add bounded render windowing and explicit prepend scroll-anchor preservation as part of the initial load-older implementation, then cover both with regression tests before landing.

## Regression Tests
- `apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx`
  - verifies the windowing helper returns a bounded slice with correct spacer heights
  - verifies mounted `.message-bubble` count stays well below total thread size
  - verifies scroll position is preserved after older history loads above the current viewport