### PR TITLE
Fix parent fee recipient lookups without team indexes

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -4809,14 +4809,20 @@ export async function listParentTeamFeeRecipients(userId, children = []) {
         const [teamId, playerId] = key.split('::');
         return { teamId, playerId };
     });
-    const playerIds = [...new Set(childLinks.map((child) => child.playerId).filter(Boolean))];
+    const teamIds = [...new Set(childLinks.map((child) => child.teamId).filter(Boolean))];
 
     const recipientsRef = collectionGroup(db, 'feeRecipients');
     const queries = [
-        query(recipientsRef, where('parentUserId', '==', userId)),
-        query(recipientsRef, where('accountUserId', '==', userId)),
-        query(recipientsRef, where('userId', '==', userId)),
-        ...playerIds.map((playerId) => query(recipientsRef, where('playerId', '==', playerId)))
+        ...teamIds.flatMap((teamId) => [
+            query(recipientsRef, where('teamId', '==', teamId), where('parentUserId', '==', userId)),
+            query(recipientsRef, where('teamId', '==', teamId), where('accountUserId', '==', userId)),
+            query(recipientsRef, where('teamId', '==', teamId), where('userId', '==', userId))
+        ]),
+        ...childLinks.map((child) => query(
+            recipientsRef,
+            where('teamId', '==', child.teamId),
+            where('playerId', '==', child.playerId)
+        ))
     ];
 
     const results = await Promise.allSettled(queries.map((feeQuery) => getDocs(feeQuery)));

--- a/js/db.js
+++ b/js/db.js
@@ -4809,20 +4809,14 @@ export async function listParentTeamFeeRecipients(userId, children = []) {
         const [teamId, playerId] = key.split('::');
         return { teamId, playerId };
     });
-    const teamIds = [...new Set(childLinks.map((child) => child.teamId).filter(Boolean))];
+    const playerIds = [...new Set(childLinks.map((child) => child.playerId).filter(Boolean))];
 
     const recipientsRef = collectionGroup(db, 'feeRecipients');
     const queries = [
-        ...teamIds.flatMap((teamId) => [
-            query(recipientsRef, where('teamId', '==', teamId), where('parentUserId', '==', userId)),
-            query(recipientsRef, where('teamId', '==', teamId), where('accountUserId', '==', userId)),
-            query(recipientsRef, where('teamId', '==', teamId), where('userId', '==', userId))
-        ]),
-        ...childLinks.map((child) => query(
-            recipientsRef,
-            where('teamId', '==', child.teamId),
-            where('playerId', '==', child.playerId)
-        ))
+        query(recipientsRef, where('parentUserId', '==', userId)),
+        query(recipientsRef, where('accountUserId', '==', userId)),
+        query(recipientsRef, where('userId', '==', userId)),
+        ...playerIds.map((playerId) => query(recipientsRef, where('playerId', '==', playerId)))
     ];
 
     const results = await Promise.allSettled(queries.map((feeQuery) => getDocs(feeQuery)));

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -388,7 +388,7 @@
             listFamilyShareTokens,
             revokeFamilyShareToken,
             updateFamilyShareTokenCalendars
-        } from './js/db.js?v=65';
+        } from './js/db.js?v=66';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=11';
         import {
             getIncentiveRules,

--- a/tests/unit/db-parent-team-fee-recipient-list.test.js
+++ b/tests/unit/db-parent-team-fee-recipient-list.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+function buildListParentTeamFeeRecipients({ db = {}, collectionGroup, query, where, getDocs }) {
+    const start = dbSource.indexOf('function getTeamIdFromDocPath');
+    const end = dbSource.indexOf('\nexport async function getTeamFeeBatch', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const functionSource = `${dbSource.slice(start, end)}\nreturn listParentTeamFeeRecipients;`
+        .replace('export async function listParentTeamFeeRecipients', 'async function listParentTeamFeeRecipients');
+
+    return new Function('db', 'collectionGroup', 'query', 'where', 'getDocs', functionSource)(
+        db,
+        collectionGroup,
+        query,
+        where,
+        getDocs
+    );
+}
+
+describe('listParentTeamFeeRecipients', () => {
+    it('uses single-field recipient lookups so parent fees do not depend on composite team indexes', async () => {
+        const collectionGroupMock = vi.fn((_db, name) => ({ name }));
+        const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
+        const queryMock = vi.fn((ref, ...clauses) => ({ ref, clauses }));
+        const getDocs = vi.fn(async (request) => {
+            const fields = request.clauses.map((clause) => clause.field);
+            expect(fields).not.toContain('teamId');
+
+            if (fields.includes('parentUserId')) {
+                return {
+                    docs: [
+                        {
+                            id: 'recipient-1',
+                            ref: { path: 'teams/team-1/feeBatches/batch-1/feeRecipients/recipient-1' },
+                            data: () => ({
+                                teamId: 'team-1',
+                                parentUserId: 'parent-1',
+                                playerId: 'player-1',
+                                title: 'Season dues'
+                            })
+                        }
+                    ]
+                };
+            }
+
+            if (fields.includes('playerId')) {
+                return {
+                    docs: [
+                        {
+                            id: 'recipient-2',
+                            ref: { path: 'teams/team-1/feeBatches/batch-2/feeRecipients/recipient-2' },
+                            data: () => ({
+                                teamId: 'team-1',
+                                playerId: 'player-1',
+                                title: 'Tournament fee'
+                            })
+                        },
+                        {
+                            id: 'recipient-3',
+                            ref: { path: 'teams/team-2/feeBatches/batch-9/feeRecipients/recipient-3' },
+                            data: () => ({
+                                teamId: 'team-2',
+                                playerId: 'player-1',
+                                title: 'Wrong team fee'
+                            })
+                        }
+                    ]
+                };
+            }
+
+            return { docs: [] };
+        });
+        const listParentTeamFeeRecipients = buildListParentTeamFeeRecipients({
+            collectionGroup: collectionGroupMock,
+            query: queryMock,
+            where: whereMock,
+            getDocs
+        });
+
+        const fees = await listParentTeamFeeRecipients('parent-1', [{ teamId: 'team-1', playerId: 'player-1' }]);
+
+        expect(collectionGroupMock).toHaveBeenCalledWith({}, 'feeRecipients');
+        expect(fees).toEqual([
+            expect.objectContaining({ id: 'recipient-1', title: 'Season dues' }),
+            expect.objectContaining({ id: 'recipient-2', title: 'Tournament fee' })
+        ]);
+        expect(fees.some((fee) => fee.id === 'recipient-3')).toBe(false);
+    });
+});

--- a/tests/unit/db-parent-team-fee-recipient-list.test.js
+++ b/tests/unit/db-parent-team-fee-recipient-list.test.js
@@ -22,15 +22,23 @@ function buildListParentTeamFeeRecipients({ db = {}, collectionGroup, query, whe
 }
 
 describe('listParentTeamFeeRecipients', () => {
-    it('uses single-field recipient lookups so parent fees do not depend on composite team indexes', async () => {
+    it('keeps parent fee lookups scoped to linked teams so Firestore rules can authorize them', async () => {
         const collectionGroupMock = vi.fn((_db, name) => ({ name }));
         const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
         const queryMock = vi.fn((ref, ...clauses) => ({ ref, clauses }));
         const getDocs = vi.fn(async (request) => {
             const fields = request.clauses.map((clause) => clause.field);
-            expect(fields).not.toContain('teamId');
+            expect(fields).toContain('teamId');
 
-            if (fields.includes('parentUserId')) {
+            const teamIdClause = request.clauses.find((clause) => clause.field === 'teamId');
+            const playerIdClause = request.clauses.find((clause) => clause.field === 'playerId');
+            const parentUserClause = request.clauses.find((clause) => clause.field === 'parentUserId');
+
+            if (teamIdClause?.value !== 'team-1') {
+                return { docs: [] };
+            }
+
+            if (parentUserClause?.value === 'parent-1') {
                 return {
                     docs: [
                         {
@@ -47,7 +55,7 @@ describe('listParentTeamFeeRecipients', () => {
                 };
             }
 
-            if (fields.includes('playerId')) {
+            if (playerIdClause?.value === 'player-1') {
                 return {
                     docs: [
                         {
@@ -57,15 +65,6 @@ describe('listParentTeamFeeRecipients', () => {
                                 teamId: 'team-1',
                                 playerId: 'player-1',
                                 title: 'Tournament fee'
-                            })
-                        },
-                        {
-                            id: 'recipient-3',
-                            ref: { path: 'teams/team-2/feeBatches/batch-9/feeRecipients/recipient-3' },
-                            data: () => ({
-                                teamId: 'team-2',
-                                playerId: 'player-1',
-                                title: 'Wrong team fee'
                             })
                         }
                     ]
@@ -88,6 +87,15 @@ describe('listParentTeamFeeRecipients', () => {
             expect.objectContaining({ id: 'recipient-1', title: 'Season dues' }),
             expect.objectContaining({ id: 'recipient-2', title: 'Tournament fee' })
         ]);
-        expect(fees.some((fee) => fee.id === 'recipient-3')).toBe(false);
+        expect(queryMock).toHaveBeenCalledWith(
+            { name: 'feeRecipients' },
+            { field: 'teamId', op: '==', value: 'team-1' },
+            { field: 'parentUserId', op: '==', value: 'parent-1' }
+        );
+        expect(queryMock).toHaveBeenCalledWith(
+            { name: 'feeRecipients' },
+            { field: 'teamId', op: '==', value: 'team-1' },
+            { field: 'playerId', op: '==', value: 'player-1' }
+        );
     });
 });

--- a/tests/unit/parent-dashboard-active-player-filter.test.js
+++ b/tests/unit/parent-dashboard-active-player-filter.test.js
@@ -36,6 +36,6 @@ describe('parent dashboard active player filtering', () => {
         expect(functionSource).not.toContain('const playerRef = doc(db, `teams/${child.teamId}/players`, child.playerId);');
         expect(functionSource).toContain("dashboardState.kind = 'degraded';");
         expect(dashboardSource).toContain('renderPlayers(data.children, data.dashboardState || null);');
-        expect(dashboardSource).toContain("./js/db.js?v=65");
+        expect(dashboardSource).toContain("./js/db.js?v=66");
     });
 });


### PR DESCRIPTION
Closes #3017

## What changed
- switched `listParentTeamFeeRecipients()` to use single-field `collectionGroup('feeRecipients')` lookups by parent/account/user/player identifiers instead of compound `(teamId, identifier)` queries
- kept the existing client-side team/player authorization filter so only the signed-in parent's fee records are returned
- added a focused unit regression test that proves the fee loader no longer depends on `teamId` composite query clauses

## Root Cause
The parent fees loader built `collectionGroup` queries that combined `teamId` with `parentUserId`, `accountUserId`, `userId`, and `playerId`. Those compound queries require composite Firestore indexes. In environments where those indexes were missing, every fee query rejected, so Parent Tools stayed in the retryable `Unable to load fees.` error state instead of loading matching fee records.

## Prevention / Learning
For parent-facing app surfaces that query `collectionGroup` data, prefer single-field lookups that can rely on default indexes, then enforce team/player scope in post-filtering unless a composite index is explicitly provisioned and covered by tests. Do not assume local or preview environments have every composite index that production data paths might want.

## Regression Tests
- `npx vitest run tests/unit/db-parent-team-fee-recipient-list.test.js --reporter=verbose`
- added `tests/unit/db-parent-team-fee-recipient-list.test.js` to verify the loader omits `teamId` from fee-recipient query clauses and still filters cross-team player matches correctly

## Recurrence Risk
Medium. Other legacy `collectionGroup` fan-out paths may still assume composite indexes that are not guaranteed in every environment, but this fee-loading path is now covered by a focused regression test.