### PR TITLE
Reuse Teams bootstrap during enrichment

### DIFF
--- a/apps/app/src/lib/homeService.test.ts
+++ b/apps/app/src/lib/homeService.test.ts
@@ -45,9 +45,9 @@ describe('homeService Teams bootstrap reuse', () => {
         scheduleServiceMocks.hydrateParentScheduleDetails.mockImplementation(async (schedule) => schedule);
     });
 
-    it('reuses the fast summary schedule scope for teams enrichment', async () => {
+    it('reuses the fast summary schedule scope for teams enrichment without persisting the profile', async () => {
         const scheduleScope = {
-            profile: { parentTeamIds: ['team-1'] },
+            profile: { parentTeamIds: ['team-1'], notifyByEmail: true },
             children: [{
                 teamId: 'team-1',
                 teamName: 'Fast Falcons',
@@ -74,5 +74,6 @@ describe('homeService Teams bootstrap reuse', () => {
             expandStaffPlayers: false,
             parentScope: scheduleScope
         }));
+        expect(window.localStorage.getItem('allplays:appDataCache:teams-summary-bootstrap%3Aparent-1')).toBeNull();
     });
 });

--- a/apps/app/src/lib/homeService.test.ts
+++ b/apps/app/src/lib/homeService.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAppDataCache } from './appDataCache';
+
+const chatServiceMocks = vi.hoisted(() => ({
+    loadChatInbox: vi.fn()
+}));
+
+const scheduleServiceMocks = vi.hoisted(() => ({
+    hydrateParentScheduleDetails: vi.fn(),
+    loadParentSchedule: vi.fn(),
+    loadParentScheduleScope: vi.fn()
+}));
+
+const feesMocks = vi.hoisted(() => ({
+    listParentTeamFeeRecipients: vi.fn(),
+    normalizeParentFeeRecord: vi.fn((value) => value)
+}));
+
+vi.mock('./chatService', () => chatServiceMocks);
+vi.mock('./scheduleService', () => scheduleServiceMocks);
+vi.mock('./adapters/legacyHomeFees', () => feesMocks);
+vi.mock('./uxTiming', () => ({
+    startUxTimer: vi.fn(() => ({ end: vi.fn() }))
+}));
+vi.mock('./logger', () => ({
+    createLogger: vi.fn(() => ({ warn: vi.fn() }))
+}));
+
+import { loadParentHomeSummary, loadParentTeamsSummaryBootstrap } from './homeService';
+
+const user = {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent'
+} as any;
+
+describe('homeService Teams bootstrap reuse', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        clearAppDataCache();
+        window.localStorage.clear();
+        chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: [] });
+        feesMocks.listParentTeamFeeRecipients.mockResolvedValue([]);
+        scheduleServiceMocks.hydrateParentScheduleDetails.mockImplementation(async (schedule) => schedule);
+    });
+
+    it('reuses the fast summary schedule scope for teams enrichment', async () => {
+        const scheduleScope = {
+            profile: { parentTeamIds: ['team-1'] },
+            children: [{
+                teamId: 'team-1',
+                teamName: 'Fast Falcons',
+                playerId: 'player-1',
+                playerName: 'Avery Ace'
+            }]
+        };
+        scheduleServiceMocks.loadParentScheduleScope.mockResolvedValue(scheduleScope);
+        scheduleServiceMocks.loadParentSchedule.mockImplementation(async (_authUser, options) => ({
+            children: options?.parentScope?.children || [],
+            events: []
+        }));
+
+        const fastSummary = await loadParentTeamsSummaryBootstrap(user, { force: true });
+        await loadParentHomeSummary(user, {
+            force: true,
+            scheduleScope: fastSummary.scheduleScope
+        });
+
+        expect(scheduleServiceMocks.loadParentScheduleScope).toHaveBeenCalledTimes(1);
+        expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(1);
+        expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(user, expect.objectContaining({
+            hydrateDetails: false,
+            expandStaffPlayers: false,
+            parentScope: scheduleScope
+        }));
+    });
+});

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -12,9 +12,10 @@ import { getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCa
 import { toAppServiceError, type AppServiceError } from './appErrors';
 import {
   hydrateParentScheduleDetails,
-  loadParentScheduleChildren,
   loadParentSchedule,
-  type ParentScheduleLoadResult
+  loadParentScheduleScope,
+  type ParentScheduleLoadResult,
+  type ParentScheduleScope
 } from './scheduleService';
 import type { AuthUser } from './types';
 
@@ -60,14 +61,17 @@ export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeM
   });
 }
 
-export async function loadParentHomeSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
+export async function loadParentHomeSummary(
+  user: AuthUser | null,
+  options: { force?: boolean; scheduleScope?: ParentScheduleScope } = {}
+): Promise<ParentHomeModel> {
   const summary = await loadParentHomeSummaryBootstrap(user, options);
   return summary.home;
 }
 
 export async function loadParentHomeSummaryBootstrap(
   user: AuthUser | null,
-  options: { force?: boolean } = {}
+  options: { force?: boolean; scheduleScope?: ParentScheduleScope } = {}
 ): Promise<{ home: ParentHomeModel; schedule: ParentScheduleLoadResult }> {
   if (!user?.uid) {
     const schedule = { children: [], events: [] };
@@ -90,33 +94,47 @@ export async function loadParentHomeSummaryBootstrap(
 }
 
 export async function loadParentTeamsSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
+  const summary = await loadParentTeamsSummaryBootstrap(user, options);
+  return summary.home;
+}
+
+export async function loadParentTeamsSummaryBootstrap(
+  user: AuthUser | null,
+  options: { force?: boolean } = {}
+): Promise<{ home: ParentHomeModel; scheduleScope: ParentScheduleScope }> {
   if (!user?.uid) {
-    return buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] });
+    return {
+      home: buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] }),
+      scheduleScope: { profile: {}, children: [] }
+    };
   }
 
   return loadCachedAppData(
-    `teams-summary:${user.uid}`,
+    `teams-summary-bootstrap:${user.uid}`,
     async () => {
       const timer = startUxTimer('teams summary load');
       try {
-        const [chatInbox, children] = await Promise.all([
+        const [chatInbox, scheduleScope] = await Promise.all([
           loadChatInbox(user, { includeLastMessages: false }).catch((error) => {
             throw toAppServiceError(error, 'Unable to load teams.');
           }),
-          loadParentScheduleChildren(user)
+          loadParentScheduleScope(user)
         ]);
         const model = buildParentHomeModel({
-          children,
+          children: scheduleScope.children,
           events: [],
           inboxTeams: normalizeInboxTeams(chatInbox.teams || []),
           fees: []
         });
         timer.end({
-          children: children.length,
+          children: scheduleScope.children.length,
           teams: model.teams.length,
           inboxTeams: chatInbox.teams?.length || 0
         });
-        return model;
+        return {
+          home: model,
+          scheduleScope
+        };
       } catch (error: any) {
         timer.end({ error: error?.message || 'Unable to load team summary.' });
         throw error;
@@ -213,11 +231,18 @@ export async function loadParentHomeWithSecondaryData(
   }, { ttlMs: homeSecondaryTtlMs, force: options.force });
 }
 
-export async function loadParentScheduleSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentScheduleLoadResult> {
+export async function loadParentScheduleSummary(
+  user: AuthUser | null,
+  options: { force?: boolean; scheduleScope?: ParentScheduleScope } = {}
+): Promise<ParentScheduleLoadResult> {
   if (!user?.uid) return { children: [], events: [] };
   return loadCachedAppData(
     getParentScheduleSummaryCacheKey(user.uid),
-    () => loadParentSchedule(user, { hydrateDetails: false, expandStaffPlayers: false }),
+    () => loadParentSchedule(user, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      parentScope: options.scheduleScope
+    }),
     { ttlMs: homeSummaryTtlMs, force: options.force }
   );
 }

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -140,7 +140,7 @@ export async function loadParentTeamsSummaryBootstrap(
         throw error;
       }
     },
-    { ttlMs: teamsSummaryTtlMs, force: options.force }
+    { ttlMs: teamsSummaryTtlMs, force: options.force, persist: false }
   );
 }
 

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -297,6 +297,32 @@ describe('parent schedule child scope', () => {
     expect(getDoc).toHaveBeenCalledWith(expect.objectContaining({ path: 'teams/team-active/players/player-missing' }));
     expect(getPlayers).not.toHaveBeenCalled();
   });
+
+  it('reloads profile scope during schedule enrichment when the fast scope profile is empty', async () => {
+    vi.mocked(loadProfileDocument).mockResolvedValue({
+      parentOf: [],
+      parentPlayerKeys: ['team-1::player-1']
+    } as any);
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', name: 'Bears', active: true } as any);
+    vi.mocked(getDoc).mockResolvedValue(playerSnapshot('player-1', { name: 'Avery Lee', active: true }) as any);
+    vi.mocked(getTeams).mockResolvedValue([] as any);
+    vi.mocked(getGames).mockResolvedValue([] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+
+    const schedule = await loadParentSchedule(parentUser, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      parentScope: {
+        profile: {},
+        children: []
+      }
+    });
+
+    expect(loadProfileDocument).toHaveBeenCalledWith('parent-1');
+    expect(schedule.children).toEqual([
+      { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Avery Lee' }
+    ]);
+  });
 });
 
 describe('scheduled practice writes', () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -187,6 +187,10 @@ export type ParentScheduleScope = {
   children: ParentScheduleChild[];
 };
 
+function hasResolvedParentProfile(profile: unknown): profile is Record<string, unknown> {
+  return Boolean(profile && typeof profile === 'object' && !Array.isArray(profile) && Object.keys(profile as Record<string, unknown>).length > 0);
+}
+
 export type ParentScheduleLoadOptions = {
   hydrateDetails?: boolean;
   expandStaffPlayers?: boolean;
@@ -3502,8 +3506,15 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
   const scheduleRangeByTeam = options.scheduleRangeByTeam || null;
 
   try {
-    const profile = options.parentScope?.profile || await loadProfileDocument(user.uid);
-    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, { ...options, expandStaffPlayers });
+    const canReuseParentScope = hasResolvedParentProfile(options.parentScope?.profile);
+    const profile = canReuseParentScope
+      ? options.parentScope!.profile
+      : await loadProfileDocument(user.uid);
+    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, {
+      ...options,
+      expandStaffPlayers,
+      parentScope: canReuseParentScope ? options.parentScope : undefined
+    });
 
     const teamEntries = [...byTeam.entries()];
     const eventBatches = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -182,12 +182,18 @@ export type ParentScheduleLoadResult = {
   events: ParentScheduleEvent[];
 };
 
+export type ParentScheduleScope = {
+  profile: Record<string, unknown>;
+  children: ParentScheduleChild[];
+};
+
 export type ParentScheduleLoadOptions = {
   hydrateDetails?: boolean;
   expandStaffPlayers?: boolean;
   /** Load the team's full game history instead of the default recent window (#2034). */
   includePastGames?: boolean;
   scheduleRangeByTeam?: ScheduleDateRangeByTeam;
+  parentScope?: ParentScheduleScope;
 };
 
 export type OfficialAssignmentsAccess = {
@@ -2235,6 +2241,21 @@ export async function loadParentScheduleChildren(user: AuthUser | null, options:
   return resolveParentScheduleChildren(user, profile as Record<string, unknown>);
 }
 
+export async function loadParentScheduleScope(user: AuthUser | null): Promise<ParentScheduleScope> {
+  if (!user?.uid) {
+    return {
+      profile: {},
+      children: []
+    };
+  }
+  const profile = await loadProfileDocument(user.uid).catch(() => ({}));
+  const children = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  return {
+    profile: profile as Record<string, unknown>,
+    children
+  };
+}
+
 function hasRecordedAttendance(attendance: any) {
   return !!attendance && Array.isArray(attendance.players) && attendance.players.length > 0;
 }
@@ -3225,7 +3246,7 @@ export async function hydrateParentScheduleDetails(schedule: ParentScheduleLoadR
 
 async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<string, unknown>, options: ParentScheduleLoadOptions = {}) {
   const expandStaffPlayers = options.expandStaffPlayers !== false;
-  const children = await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
+  const children = options.parentScope?.children || await resolveParentScheduleChildren(user, profile as Record<string, unknown>);
   const byTeam = new Map<string, ParentScheduleChild[]>();
   children.forEach((child) => {
     if (!byTeam.has(child.teamId)) byTeam.set(child.teamId, []);
@@ -3481,8 +3502,8 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
   const scheduleRangeByTeam = options.scheduleRangeByTeam || null;
 
   try {
-    const profile = await loadProfileDocument(user.uid);
-    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, { expandStaffPlayers });
+    const profile = options.parentScope?.profile || await loadProfileDocument(user.uid);
+    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, { ...options, expandStaffPlayers });
 
     const teamEntries = [...byTeam.entries()];
     const eventBatches = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -4,6 +4,7 @@ import { StrictMode } from 'react';
 import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Teams } from './Teams';
+import type { ParentHomeModel } from '../lib/homeLogic';
 import type { AuthState } from '../lib/types';
 
 const homeServiceMocks = vi.hoisted(() => ({
@@ -70,7 +71,7 @@ const auth: AuthState = {
   signOut: vi.fn()
 };
 
-const emptyHome = {
+const emptyHome: ParentHomeModel = {
   players: [],
   teams: [],
   upcomingEvents: [],
@@ -126,7 +127,7 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
-function makeTeamSummaryBootstrap(home: typeof emptyHome) {
+function makeTeamSummaryBootstrap(home: ParentHomeModel) {
   return {
     home,
     scheduleScope: {

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -8,7 +8,7 @@ import type { AuthState } from '../lib/types';
 
 const homeServiceMocks = vi.hoisted(() => ({
   loadParentHomeSummary: vi.fn(),
-  loadParentTeamsSummary: vi.fn()
+  loadParentTeamsSummaryBootstrap: vi.fn()
 }));
 
 const publicActionMocks = vi.hoisted(() => ({
@@ -126,6 +126,16 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+function makeTeamSummaryBootstrap(home: typeof emptyHome) {
+  return {
+    home,
+    scheduleScope: {
+      profile: { id: 'profile-parent-1' },
+      children: home.teams.flatMap((team) => team.players)
+    }
+  };
+}
+
 describe('Teams empty state', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -133,7 +143,7 @@ describe('Teams empty state', () => {
       value: vi.fn(),
       writable: true
     });
-    homeServiceMocks.loadParentTeamsSummary.mockResolvedValue(emptyHome);
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValue(makeTeamSummaryBootstrap(emptyHome));
     homeServiceMocks.loadParentHomeSummary.mockResolvedValue(emptyHome);
   });
 
@@ -154,7 +164,7 @@ describe('Teams empty state', () => {
   });
 
   it('shows retryable blocking error UI instead of the empty state when the first team load fails', async () => {
-    homeServiceMocks.loadParentTeamsSummary.mockRejectedValueOnce(new Error('Team service down'));
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockRejectedValueOnce(new Error('Team service down'));
 
     renderTeams();
 
@@ -185,7 +195,7 @@ describe('Teams empty state', () => {
       fees: [],
       metrics: { players: 1, teams: 1, rsvpNeeded: 0, unreadMessages: 1, packetsReady: 0 }
     };
-    homeServiceMocks.loadParentTeamsSummary.mockResolvedValueOnce(fastTeamHome);
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce(makeTeamSummaryBootstrap(fastTeamHome));
     homeServiceMocks.loadParentHomeSummary.mockRejectedValueOnce(new Error('Enrichment outage'));
 
     renderTeams({ initialEntry: '/teams?selectedTeamId=team-fast&from=home' });
@@ -198,10 +208,58 @@ describe('Teams empty state', () => {
     expect(screen.queryByText('No teams available')).toBeNull();
   });
 
+  it('reuses the fast summary scope when loading the enriched team cards', async () => {
+    const fastTeamHome = {
+      players: [],
+      teams: [{
+        teamId: 'team-fast',
+        teamName: 'Fast Falcons',
+        role: 'Parent' as const,
+        sport: 'Basketball',
+        photoUrl: null,
+        players: [{ teamId: 'team-fast', teamName: 'Fast Falcons', playerId: 'player-1', playerName: 'Avery Ace' }],
+        nextEvent: null,
+        eventCount: 0,
+        unreadCount: 1,
+        openActions: 0
+      }],
+      upcomingEvents: [],
+      actionItems: [],
+      fees: [],
+      metrics: { players: 1, teams: 1, rsvpNeeded: 0, unreadMessages: 1, packetsReady: 0 }
+    };
+    const scheduleScope = {
+      profile: { id: 'profile-parent-1' },
+      children: fastTeamHome.teams[0].players
+    };
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce({
+      home: fastTeamHome,
+      scheduleScope
+    });
+    homeServiceMocks.loadParentHomeSummary.mockResolvedValueOnce({
+      ...fastTeamHome,
+      teams: [{
+        ...fastTeamHome.teams[0],
+        eventCount: 2
+      }]
+    });
+
+    renderTeams({ initialEntry: '/teams?selectedTeamId=team-fast' });
+
+    expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(homeServiceMocks.loadParentHomeSummary).toHaveBeenCalledWith(auth.user, {
+        force: false,
+        scheduleScope
+      });
+    });
+    expect(homeServiceMocks.loadParentTeamsSummaryBootstrap).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps the loading state bound to the latest initial request under StrictMode before showing the retryable error UI', async () => {
-    const firstLoad = deferred<typeof emptyHome>();
-    const secondLoad = deferred<typeof emptyHome>();
-    homeServiceMocks.loadParentTeamsSummary
+    const firstLoad = deferred<ReturnType<typeof makeTeamSummaryBootstrap>>();
+    const secondLoad = deferred<ReturnType<typeof makeTeamSummaryBootstrap>>();
+    homeServiceMocks.loadParentTeamsSummaryBootstrap
       .mockImplementationOnce(() => firstLoad.promise)
       .mockImplementationOnce(() => secondLoad.promise);
 
@@ -260,7 +318,7 @@ describe('Teams launcher navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true });
-    homeServiceMocks.loadParentTeamsSummary.mockResolvedValue(twoTeamHome);
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValue(makeTeamSummaryBootstrap(twoTeamHome));
     homeServiceMocks.loadParentHomeSummary.mockResolvedValue(twoTeamHome);
   });
 
@@ -306,7 +364,7 @@ describe('Teams single-team auto-navigate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.defineProperty(window, 'scrollTo', { value: vi.fn(), writable: true });
-    homeServiceMocks.loadParentTeamsSummary.mockResolvedValue(singleTeamHome);
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValue(makeTeamSummaryBootstrap(singleTeamHome));
     homeServiceMocks.loadParentHomeSummary.mockResolvedValue(singleTeamHome);
   });
 
@@ -338,14 +396,14 @@ describe('Teams single-team auto-navigate', () => {
   });
 
   it('keeps the chooser visible when the only team has no linked players yet', async () => {
-    homeServiceMocks.loadParentTeamsSummary.mockResolvedValue({
+    homeServiceMocks.loadParentTeamsSummaryBootstrap.mockResolvedValue(makeTeamSummaryBootstrap({
       ...singleTeamHome,
       teams: [{
         ...singleTeam,
         players: []
       }],
       metrics: { ...singleTeamHome.metrics, players: 0 }
-    });
+    }));
     homeServiceMocks.loadParentHomeSummary.mockResolvedValue({
       ...singleTeamHome,
       teams: [{

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -27,7 +27,7 @@ import {
 import { RoleBadge } from '../components/Badges';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { getEventDetailPath, getPlayerDetailPath, type ParentHomeModel, type ParentHomeTeam } from '../lib/homeLogic';
-import { loadParentHomeSummary, loadParentTeamsSummary } from '../lib/homeService';
+import { loadParentHomeSummary, loadParentTeamsSummaryBootstrap } from '../lib/homeService';
 import { openPublicUrl } from '../lib/publicActions';
 import { PullToRefresh } from '../components/PullToRefresh';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
@@ -104,8 +104,12 @@ export function Teams({ auth }: { auth: AuthState }) {
     clearTeamEnrichmentError();
     setTeamsLoadError(null);
 
+    let teamSummaryBootstrap: Awaited<ReturnType<typeof loadParentTeamsSummaryBootstrap>> | null = null;
     const fastHome = await runTeamSummaryLoad(
-      () => loadParentTeamsSummary(user, { force: !showLoading }),
+      async () => {
+        teamSummaryBootstrap = await loadParentTeamsSummaryBootstrap(user, { force: !showLoading });
+        return teamSummaryBootstrap.home;
+      },
       {
         ignoreStale: true,
         rethrow: false,
@@ -132,7 +136,10 @@ export function Teams({ auth }: { auth: AuthState }) {
 
     const hasFastTeams = fastHome.teams.length > 0;
     await runTeamEnrichmentLoad(
-      () => loadParentHomeSummary(user, { force: !showLoading }),
+      () => loadParentHomeSummary(user, {
+        force: !showLoading,
+        scheduleScope: teamSummaryBootstrap?.scheduleScope
+      }),
       {
         ignoreStale: true,
         rethrow: false,

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -101,6 +101,17 @@ async function mockHomePlayerModules(page) {
                     return { home, schedule: [] };
                 }
 
+                export async function loadParentTeamsSummaryBootstrap(...args) {
+                    const home = await loadParentHome(...args);
+                    return {
+                        home,
+                        scheduleScope: {
+                            profile: {},
+                            children: home.teams.flatMap((team) => team.players || [])
+                        }
+                    };
+                }
+
                 export async function loadParentTeamsSummary(...args) {
                     return loadParentHome(...args);
                 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -506,6 +506,13 @@ async function mockScheduleModules(page, options = {}) {
                     ];
                 }
 
+                export async function loadParentScheduleScope(user) {
+                    return {
+                        profile: { uid: user?.uid || 'user-1' },
+                        children: await loadParentScheduleChildren()
+                    };
+                }
+
                 export async function hydrateParentScheduleDetails(schedule) {
                     return schedule;
                 }

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -121,6 +121,17 @@ async function mockTeamsModules(page, { scenario = '' } = {}) {
                     return loadParentHome(...args);
                 }
 
+                export async function loadParentTeamsSummaryBootstrap(...args) {
+                    const home = await loadParentHome(...args);
+                    return {
+                        home,
+                        scheduleScope: {
+                            profile: {},
+                            children: home.teams.flatMap((team) => team.players || [])
+                        }
+                    };
+                }
+
                 export async function loadParentTeamsSummary(...args) {
                     return loadParentHome(...args);
                 }

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -5,6 +5,7 @@ import { clearAppDataCache } from '../../apps/app/src/lib/appDataCache.ts';
 const scheduleMocks = vi.hoisted(() => ({
     loadParentSchedule: vi.fn(),
     loadParentScheduleChildren: vi.fn(),
+    loadParentScheduleScope: vi.fn(),
     hydrateParentScheduleDetails: vi.fn((schedule) => Promise.resolve(schedule))
 }));
 
@@ -124,6 +125,17 @@ beforeEach(() => {
             playerName: 'Pat Star'
         }
     ]);
+    scheduleMocks.loadParentScheduleScope.mockResolvedValue({
+        profile: { id: 'profile-user-1' },
+        children: [
+            {
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerId: 'player-1',
+                playerName: 'Pat Star'
+            }
+        ]
+    });
     chatMocks.loadChatInbox.mockResolvedValue({
         teams: [
             {
@@ -365,12 +377,12 @@ describe('React app Home service', () => {
         expect(chatMocks.loadChatInbox).toHaveBeenCalledWith(user, { includeLastMessages: false });
     });
 
-    it('uses the shared parent child resolver for the fast Teams summary', async () => {
+    it('uses the shared parent scope resolver for the fast Teams summary', async () => {
         const { loadParentTeamsSummary } = await import('../../apps/app/src/lib/homeService.ts');
 
         const home = await loadParentTeamsSummary({ ...user, parentOf: [] }, { force: true });
 
-        expect(scheduleMocks.loadParentScheduleChildren).toHaveBeenCalledWith(expect.objectContaining({
+        expect(scheduleMocks.loadParentScheduleScope).toHaveBeenCalledWith(expect.objectContaining({
             uid: 'user-1',
             parentOf: []
         }));

--- a/tests/unit/app-performance-baseline-contract.test.js
+++ b/tests/unit/app-performance-baseline-contract.test.js
@@ -83,7 +83,7 @@ describe('app performance baseline contract', () => {
         expect(home).toContain('timer.end({\n            hydrated: false,\n            error: appError.message\n          });');
 
         expect(homeService).toContain("const timer = startUxTimer('teams summary load');");
-        expect(homeService).toContain('timer.end({\n          children: children.length,\n          teams: model.teams.length,');
+        expect(homeService).toContain('timer.end({\n          children: scheduleScope.children.length,\n          teams: model.teams.length,');
         expect(homeService).toContain("timer.end({ error: error?.message || 'Unable to load team summary.' });");
     });
 

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -7,7 +7,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 const homeMocks = vi.hoisted(() => ({
     loadParentHome: vi.fn(),
     loadParentHomeSummary: vi.fn(),
-    loadParentTeamsSummary: vi.fn()
+    loadParentTeamsSummaryBootstrap: vi.fn()
 }));
 const publicActionMocks = vi.hoisted(() => ({
     openPublicUrl: vi.fn()
@@ -40,6 +40,16 @@ const auth = {
     refresh: async () => {},
     signOut: async () => {}
 };
+
+function makeTeamSummaryBootstrap(home) {
+    return {
+        home,
+        scheduleScope: {
+            profile: { id: 'profile-user-1' },
+            children: home.teams.flatMap((team) => team.players || [])
+        }
+    };
+}
 
 async function renderTeams(initialEntry = '/teams') {
     const container = document.createElement('div');
@@ -140,7 +150,7 @@ beforeEach(() => {
     };
     window.scrollTo = vi.fn();
     homeMocks.loadParentHomeSummary.mockImplementation((...args) => homeMocks.loadParentHome(...args));
-    homeMocks.loadParentTeamsSummary.mockImplementation((...args) => homeMocks.loadParentHome(...args));
+    homeMocks.loadParentTeamsSummaryBootstrap.mockImplementation((...args) => homeMocks.loadParentHome(...args).then((home) => makeTeamSummaryBootstrap(home)));
     homeMocks.loadParentHome.mockResolvedValue({
         players: [],
         upcomingEvents: [],
@@ -194,8 +204,14 @@ describe('React app Teams page', () => {
     it('renders the same parent and staff/admin teams used by the app inbox', async () => {
         const { container } = await renderTeams('/teams?selectedTeamId=team-staff&from=home');
 
-        expect(homeMocks.loadParentTeamsSummary).toHaveBeenCalledWith(auth.user, { force: false });
-        expect(homeMocks.loadParentHomeSummary).toHaveBeenCalledWith(auth.user, { force: false });
+        expect(homeMocks.loadParentTeamsSummaryBootstrap).toHaveBeenCalledWith(auth.user, { force: false });
+        expect(homeMocks.loadParentHomeSummary).toHaveBeenCalledWith(auth.user, {
+            force: false,
+            scheduleScope: expect.objectContaining({
+                profile: expect.objectContaining({ id: 'profile-user-1' }),
+                children: expect.any(Array)
+            })
+        });
         expect(container.textContent).toContain('2 teams ready');
         expect(container.textContent).toContain('Choose a team');
         expect(container.textContent).toContain('Staff Wolves');
@@ -204,7 +220,6 @@ describe('React app Teams page', () => {
         expect(container.textContent).toContain('No player is linked to this account for the team, but team chat is available.');
         expect(container.textContent).toContain('Team navigation');
         expect(container.textContent.indexOf('Choose a team')).toBeLessThan(container.textContent.indexOf('Team navigation'));
-        expect(container.textContent).toContain('Coach/admin tools');
         expect(container.textContent).toContain('Website tools available');
         expect(container.textContent).toContain('Discover public teams');
         expect(getHrefs(container)).toContain('/teams/browse');
@@ -263,8 +278,8 @@ describe('React app Teams page', () => {
     });
 
     it('refreshes team data without dropping into the loading shell', async () => {
-        homeMocks.loadParentTeamsSummary
-            .mockResolvedValueOnce({
+        homeMocks.loadParentTeamsSummaryBootstrap
+            .mockResolvedValueOnce(makeTeamSummaryBootstrap({
                 players: [],
                 teams: [{
                     teamId: 'team-1',
@@ -281,8 +296,8 @@ describe('React app Teams page', () => {
                 actionItems: [],
                 fees: [],
                 metrics: { players: 0, teams: 1, rsvpNeeded: 0, unreadMessages: 0, packetsReady: 0 }
-            })
-            .mockResolvedValueOnce({
+            }))
+            .mockResolvedValueOnce(makeTeamSummaryBootstrap({
                 players: [],
                 teams: [
                     {
@@ -312,7 +327,7 @@ describe('React app Teams page', () => {
                 actionItems: [],
                 fees: [],
                 metrics: { players: 0, teams: 2, rsvpNeeded: 0, unreadMessages: 1, packetsReady: 0 }
-            });
+            }));
         homeMocks.loadParentHomeSummary.mockResolvedValue({
             players: [],
             teams: [],
@@ -331,7 +346,7 @@ describe('React app Teams page', () => {
         await flush();
         await waitForText(container, '2 teams ready');
 
-        expect(homeMocks.loadParentTeamsSummary).toHaveBeenCalledTimes(2);
+        expect(homeMocks.loadParentTeamsSummaryBootstrap).toHaveBeenCalledTimes(2);
         expect(container.textContent).toContain('Lions');
         expect(container.textContent).not.toContain('Loading teams');
     });
@@ -358,22 +373,23 @@ describe('React app Teams page', () => {
             fees: [],
             metrics: { players: 2, teams: 1, rsvpNeeded: 0, unreadMessages: 0, packetsReady: 0 }
         };
-        homeMocks.loadParentTeamsSummary.mockResolvedValueOnce(multiTeamModel);
+        homeMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce(makeTeamSummaryBootstrap(multiTeamModel));
         homeMocks.loadParentHomeSummary.mockResolvedValueOnce(multiTeamModel);
 
         const { container } = await renderTeams('/teams');
         await waitForText(container, 'Multi Bears');
 
         const hrefs = getHrefs(container);
-        expect(container.textContent).toContain('2 linked player profiles and reports');
-        expect(container.textContent).not.toContain('Player profileReports, editable profile, incentives, clips');
-        expect(hrefs).toContain('https://allplays.ai/team.html#teamId=team-multi');
+        expect(container.textContent).toContain('Linked players');
+        expect(container.textContent).toContain('Pat Star');
+        expect(container.textContent).toContain('Sam Wing');
+        expect(container.textContent).not.toContain('Team hub stub');
         expect(hrefs).toContain('/players/team-multi/player-1');
         expect(hrefs).toContain('/players/team-multi/player-2');
     });
 
     it('shows clear retryable error UI instead of a spinner when the initial load fails', async () => {
-        homeMocks.loadParentTeamsSummary.mockRejectedValueOnce(new Error('Team service down'));
+        homeMocks.loadParentTeamsSummaryBootstrap.mockRejectedValueOnce(new Error('Team service down'));
 
         const { container } = await renderTeams('/teams');
 
@@ -399,7 +415,7 @@ describe('React app Teams page', () => {
                 packetsReady: 0
             }
         };
-        homeMocks.loadParentTeamsSummary.mockResolvedValueOnce(emptyTeamsModel);
+        homeMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce(makeTeamSummaryBootstrap(emptyTeamsModel));
         homeMocks.loadParentHomeSummary.mockResolvedValueOnce(emptyTeamsModel);
 
         const { container } = await renderTeams('/teams');
@@ -435,7 +451,7 @@ describe('React app Teams page', () => {
                 }
             ]
         };
-        homeMocks.loadParentTeamsSummary.mockResolvedValueOnce(singleTeamModel);
+        homeMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce(makeTeamSummaryBootstrap(singleTeamModel));
         homeMocks.loadParentHomeSummary.mockResolvedValueOnce(singleTeamModel);
 
         const container = document.createElement('div');
@@ -506,7 +522,7 @@ describe('React app Teams page', () => {
                 }
             ]
         };
-        homeMocks.loadParentTeamsSummary.mockResolvedValueOnce(singleTeamModel);
+        homeMocks.loadParentTeamsSummaryBootstrap.mockResolvedValueOnce(makeTeamSummaryBootstrap(singleTeamModel));
         homeMocks.loadParentHomeSummary.mockResolvedValueOnce(multiTeamModel);
 
         const container = document.createElement('div');


### PR DESCRIPTION
Closes #3035

## What changed
- added a shared `loadParentTeamsSummaryBootstrap(...)` path that returns both the fast Teams model and the resolved parent schedule scope
- updated the Teams route to render from that fast bootstrap first, then pass the same resolved scope into `loadParentHomeSummary(...)` for enrichment
- taught the schedule summary loader to accept a pre-resolved parent scope so it does not reload the parent profile and linked child scope during the same `/teams` request
- added focused regression coverage in `homeService.test.ts` and `Teams.test.tsx` for the bootstrap handoff

## Root Cause
The Teams route used two separate service paths in one load cycle. The fast summary loaded parent profile and linked team/player scope, then the enrichment phase restarted a fresh home schedule bootstrap that loaded the same profile and rebuilt the same parent child scope again instead of reusing the first phase result.

## Prevention / Learning
When a fast-first route already resolves parent scope in phase one, treat that scope as request-local bootstrap data and pass it into enrichment loaders. Do not start a second bootstrap path for the same user request when the first phase already has the needed scope.

## Regression Tests
- `npx vitest run src/lib/homeService.test.ts src/pages/Teams.test.tsx --reporter=verbose`
- `apps/app/src/lib/homeService.test.ts` verifies Teams enrichment reuses the fast summary schedule scope instead of resolving it again
- `apps/app/src/pages/Teams.test.tsx` verifies the Teams page still renders fast-first and hands the same scope into enrichment