### PR TITLE
Query only published parent registration forms

### DIFF
--- a/apps/app/src/lib/adapters/legacyParentTools.ts
+++ b/apps/app/src/lib/adapters/legacyParentTools.ts
@@ -54,6 +54,7 @@ export const listFamilyShareTokens = (...args: any[]) => callLegacyDb('listFamil
 export const listMyParentMembershipRequests = (...args: any[]) => callLegacyDb('listMyParentMembershipRequests', args);
 export const listParentTeamFeeRecipients = (...args: any[]) => callLegacyDb('listParentTeamFeeRecipients', args);
 export const listTeamRegistrationForms = (...args: any[]) => callLegacyDb('listTeamRegistrationForms', args);
+export const listPublishedTeamRegistrationForms = (...args: any[]) => callLegacyDb('listPublishedTeamRegistrationForms', args);
 export const listTeamRegistrationReviews = (...args: any[]) => callLegacyDb('listTeamRegistrationReviews', args);
 export const listTeamRegistrationReviewsPage = (...args: any[]) => callLegacyDb('listTeamRegistrationReviewsPage', args);
 export const rejectTeamRegistration = (...args: any[]) => callLegacyDb('rejectTeamRegistration', args);

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -43,7 +43,7 @@ import {
   listFamilyShareTokens,
   listMyParentMembershipRequests,
   listParentTeamFeeRecipients,
-  listTeamRegistrationForms,
+  listPublishedTeamRegistrationForms,
   listTeamRegistrationReviews,
   listTeamRegistrationReviewsPage,
   moveTeamMediaItems,
@@ -604,7 +604,7 @@ export async function loadParentRegistrations(user: AuthUser | null): Promise<Pa
   const cards = await Promise.all(teamIds.map(async (teamId) => {
     const [team, forms] = await Promise.all([
       Promise.resolve(getTeam(teamId)).catch(() => null),
-      Promise.resolve(listTeamRegistrationForms(teamId)).catch(() => [])
+      Promise.resolve(listPublishedTeamRegistrationForms(teamId, { pageSize: 50 })).catch(() => [])
     ]);
     return (forms || []).map((form: any) => toRegistrationCard(team || { id: teamId }, form));
   }));

--- a/js/db.js
+++ b/js/db.js
@@ -2355,6 +2355,16 @@ export async function listTeamRegistrationForms(teamId) {
         .sort((a, b) => String(a.name || a.title || a.id).localeCompare(String(b.name || b.title || b.id)));
 }
 
+export async function listPublishedTeamRegistrationForms(teamId, options = {}) {
+    if (!teamId) return [];
+    const pageSize = Math.max(1, Math.min(100, Number(options.pageSize) || 50));
+    const formsRef = collection(db, `teams/${teamId}/registrationForms`);
+    const snapshot = await getDocs(query(formsRef, where('status', '==', 'published'), limit(pageSize)));
+    return snapshot.docs
+        .map((formDoc) => ({ id: formDoc.id, ...formDoc.data() }))
+        .sort((a, b) => String(a.name || a.title || a.id).localeCompare(String(b.name || b.title || b.id)));
+}
+
 export async function getTeamRegistrationForm(teamId, formId) {
     if (!teamId || !formId) return null;
     const formSnap = await getDoc(doc(db, 'teams', teamId, 'registrationForms', formId));

--- a/js/db.js
+++ b/js/db.js
@@ -2359,9 +2359,17 @@ export async function listPublishedTeamRegistrationForms(teamId, options = {}) {
     if (!teamId) return [];
     const pageSize = Math.max(1, Math.min(100, Number(options.pageSize) || 50));
     const formsRef = collection(db, `teams/${teamId}/registrationForms`);
-    const snapshot = await getDocs(query(formsRef, where('status', '==', 'published'), limit(pageSize)));
-    return snapshot.docs
-        .map((formDoc) => ({ id: formDoc.id, ...formDoc.data() }))
+    const snapshots = await Promise.all([
+        getDocs(query(formsRef, where('status', '==', 'published'), limit(pageSize))),
+        getDocs(query(formsRef, where('published', '==', true), limit(pageSize)))
+    ]);
+    const formsById = new Map();
+    snapshots.forEach((snapshot) => {
+        snapshot.docs.forEach((formDoc) => {
+            formsById.set(formDoc.id, { id: formDoc.id, ...formDoc.data() });
+        });
+    });
+    return Array.from(formsById.values())
         .sort((a, b) => String(a.name || a.title || a.id).localeCompare(String(b.name || b.title || b.id)));
 }
 

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -388,7 +388,7 @@
             listFamilyShareTokens,
             revokeFamilyShareToken,
             updateFamilyShareTokenCalendars
-        } from './js/db.js?v=66';
+        } from './js/db.js?v=67';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=11';
         import {
             getIncentiveRules,

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -638,6 +638,7 @@ describe('React app parent tools service', () => {
             expect(options).toEqual({ pageSize: 50 });
             return [
                 { id: `${teamId}-open`, programName: 'Summer Camp', description: 'Skills', season: 'Summer', finalAmountDueCents: 7500, checkoutUrl: 'https://pay.example.test/camp', options: [{ id: 'opt-1' }] },
+                { id: `${teamId}-legacy`, programName: 'Legacy Camp', status: 'draft', published: true, finalAmountDueCents: 5000 },
                 { id: `${teamId}-draft`, programName: 'Draft Camp', status: 'draft', published: false },
                 { id: `${teamId}-closed`, programName: 'Closed Camp', status: 'closed', published: true }
             ];
@@ -645,16 +646,26 @@ describe('React app parent tools service', () => {
 
         const cards = await loadParentRegistrations(user);
 
-        expect(cards).toHaveLength(2);
-        expect(cards[0]).toMatchObject({
-            programName: 'Summer Camp',
-            feeLabel: '$75.00',
-            onlineCheckout: true,
-            options: [{ id: 'opt-1' }]
-        });
+        expect(cards).toHaveLength(4);
+        expect(cards).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                programName: 'Summer Camp',
+                feeLabel: '$75.00',
+                onlineCheckout: true,
+                options: [{ id: 'opt-1' }]
+            }),
+            expect.objectContaining({
+                programName: 'Legacy Camp',
+                feeLabel: '$50.00',
+                onlineCheckout: false,
+                options: []
+            })
+        ]));
         expect(cards.map((card) => card.url)).toEqual(expect.arrayContaining([
             'https://allplays.ai/registration.html?teamId=team-1&formId=team-1-open',
-            'https://allplays.ai/registration.html?teamId=team-coach&formId=team-coach-open'
+            'https://allplays.ai/registration.html?teamId=team-1&formId=team-1-legacy',
+            'https://allplays.ai/registration.html?teamId=team-coach&formId=team-coach-open',
+            'https://allplays.ai/registration.html?teamId=team-coach&formId=team-coach-legacy'
         ]));
         expect(cards.map((card) => card.appUrl)).toEqual(expect.arrayContaining([
             'https://allplays.ai/app/#/registration?teamId=team-1&formId=team-1-open',

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -33,6 +33,7 @@ const dbMocks = vi.hoisted(() => ({
     listFamilyShareTokens: vi.fn(),
     listMyParentMembershipRequests: vi.fn(),
     listParentTeamFeeRecipients: vi.fn(),
+    listPublishedTeamRegistrationForms: vi.fn(),
     listTeamRegistrationForms: vi.fn(),
     listTeamRegistrationReviews: vi.fn(),
     listTeamRegistrationReviewsPage: vi.fn(),
@@ -630,12 +631,17 @@ describe('React app parent tools service', () => {
         expect(dbMocks.updateFamilyShareTokenCalendars).toHaveBeenCalledWith('token-1', ['https://calendar.example.test/b.ics']);
     });
 
-    it('loads published registrations for parent and coach teams', async () => {
+    it('loads published registrations for parent and coach teams without scanning every form', async () => {
         dbMocks.getTeam.mockImplementation(async (teamId) => ({ id: teamId, name: teamId === 'team-1' ? 'Bears' : 'Coach Wolves' }));
-        dbMocks.listTeamRegistrationForms.mockImplementation(async (teamId) => ([
-            { id: `${teamId}-open`, programName: 'Summer Camp', description: 'Skills', season: 'Summer', finalAmountDueCents: 7500, checkoutUrl: 'https://pay.example.test/camp', options: [{ id: 'opt-1' }] },
-            { id: `${teamId}-closed`, programName: 'Closed Camp', status: 'closed' }
-        ]));
+        dbMocks.listTeamRegistrationForms.mockRejectedValue(new Error('parent discovery should not scan all forms'));
+        dbMocks.listPublishedTeamRegistrationForms.mockImplementation(async (teamId, options) => {
+            expect(options).toEqual({ pageSize: 50 });
+            return [
+                { id: `${teamId}-open`, programName: 'Summer Camp', description: 'Skills', season: 'Summer', finalAmountDueCents: 7500, checkoutUrl: 'https://pay.example.test/camp', options: [{ id: 'opt-1' }] },
+                { id: `${teamId}-draft`, programName: 'Draft Camp', status: 'draft', published: false },
+                { id: `${teamId}-closed`, programName: 'Closed Camp', status: 'closed', published: true }
+            ];
+        });
 
         const cards = await loadParentRegistrations(user);
 
@@ -654,6 +660,8 @@ describe('React app parent tools service', () => {
             'https://allplays.ai/app/#/registration?teamId=team-1&formId=team-1-open',
             'https://allplays.ai/app/#/registration?teamId=team-coach&formId=team-coach-open'
         ]));
+        expect(dbMocks.listPublishedTeamRegistrationForms).toHaveBeenCalledTimes(2);
+        expect(dbMocks.listTeamRegistrationForms).not.toHaveBeenCalled();
     });
 
     it('loads a linked registration detail model for in-app review', async () => {

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -396,6 +396,23 @@ describe('private AI service', () => {
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(authUser, { includePastGames: true });
     });
 
+    it('uses the parent registrations loader for private AI parent tools summaries', async () => {
+        toolsMocks.loadParentRegistrations.mockResolvedValueOnce([{ id: 'form-1', teamName: 'Bears', programName: 'Summer Camp' }]);
+        toolsMocks.loadParentCertificates.mockResolvedValueOnce([{ id: 'cert-1', title: 'Hustle Award' }]);
+        const { runPrivateAiTool } = await import('../../apps/app/src/lib/privateAiService.ts');
+
+        await expect(runPrivateAiTool(authUser, { name: 'get_parent_tools' })).resolves.toMatchObject({
+            ok: true,
+            data: {
+                registrations: [{ id: 'form-1', teamName: 'Bears', programName: 'Summer Camp' }],
+                certificates: [{ id: 'cert-1', title: 'Hustle Award' }]
+            }
+        });
+
+        expect(toolsMocks.loadParentRegistrations).toHaveBeenCalledWith(authUser);
+        expect(toolsMocks.loadParentCertificates).toHaveBeenCalledWith(authUser);
+    });
+
     it('retrieves help workflow pages for functional questions', async () => {
         const { runPrivateAiTool } = await import('../../apps/app/src/lib/privateAiService.ts');
 

--- a/tests/unit/db-published-registration-forms-source.test.js
+++ b/tests/unit/db-published-registration-forms-source.test.js
@@ -10,6 +10,7 @@ describe('published registration form query helper source', () => {
         expect(dbSource).toContain('export async function listPublishedTeamRegistrationForms(teamId, options = {})');
         expect(dbSource).toContain("const pageSize = Math.max(1, Math.min(100, Number(options.pageSize) || 50));");
         expect(dbSource).toContain("getDocs(query(formsRef, where('status', '==', 'published'), limit(pageSize)))");
+        expect(dbSource).toContain("getDocs(query(formsRef, where('published', '==', true), limit(pageSize)))");
         expect(parentToolsSource).toContain("listPublishedTeamRegistrationForms(teamId, { pageSize: 50 })");
         expect(parentToolsSource).not.toContain("loadParentRegistrations(user: AuthUser | null): Promise<ParentRegistrationCard[]> {\n  const teamIds = getLinkedTeamIds(user);\n  const cards = await Promise.all(teamIds.map(async (teamId) => {\n    const [team, forms] = await Promise.all([\n      Promise.resolve(getTeam(teamId)).catch(() => null),\n      Promise.resolve(listTeamRegistrationForms(teamId)).catch(() => [])");
     });

--- a/tests/unit/db-published-registration-forms-source.test.js
+++ b/tests/unit/db-published-registration-forms-source.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('published registration form query helper source', () => {
+    it('uses a bounded published-only Firestore query for parent-facing registration discovery', () => {
+        const dbSource = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
+        const parentToolsSource = readFileSync(resolve(process.cwd(), 'apps/app/src/lib/parentToolsService.ts'), 'utf8');
+
+        expect(dbSource).toContain('export async function listPublishedTeamRegistrationForms(teamId, options = {})');
+        expect(dbSource).toContain("const pageSize = Math.max(1, Math.min(100, Number(options.pageSize) || 50));");
+        expect(dbSource).toContain("getDocs(query(formsRef, where('status', '==', 'published'), limit(pageSize)))");
+        expect(parentToolsSource).toContain("listPublishedTeamRegistrationForms(teamId, { pageSize: 50 })");
+        expect(parentToolsSource).not.toContain("loadParentRegistrations(user: AuthUser | null): Promise<ParentRegistrationCard[]> {\n  const teamIds = getLinkedTeamIds(user);\n  const cards = await Promise.all(teamIds.map(async (teamId) => {\n    const [team, forms] = await Promise.all([\n      Promise.resolve(getTeam(teamId)).catch(() => null),\n      Promise.resolve(listTeamRegistrationForms(teamId)).catch(() => [])");
+    });
+});

--- a/tests/unit/parent-dashboard-active-player-filter.test.js
+++ b/tests/unit/parent-dashboard-active-player-filter.test.js
@@ -36,6 +36,6 @@ describe('parent dashboard active player filtering', () => {
         expect(functionSource).not.toContain('const playerRef = doc(db, `teams/${child.teamId}/players`, child.playerId);');
         expect(functionSource).toContain("dashboardState.kind = 'degraded';");
         expect(dashboardSource).toContain('renderPlayers(data.children, data.dashboardState || null);');
-        expect(dashboardSource).toContain("./js/db.js?v=66");
+        expect(dashboardSource).toContain("./js/db.js?v=67");
     });
 });


### PR DESCRIPTION
Closes #3029

## What changed
- Added `listPublishedTeamRegistrationForms(teamId, { pageSize })` in `js/db.js` so parent-facing registration discovery uses a bounded Firestore query filtered to published forms.
- Switched `loadParentRegistrations` to use the new published-only helper instead of scanning each team's full `registrationForms` collection.
- Kept private AI parent-tools registration summaries on the same bounded path by covering `get_parent_tools` through the shared parent registrations loader.
- Added focused regression coverage for the service path, the private AI path, and the Firestore helper source contract.

## Root Cause
Parent registration discovery reused the unbounded admin-style `listTeamRegistrationForms` helper, which read every form document in each linked team's collection and then filtered client-side. That conflicted with Firestore rules that only allow parents to read published forms, and the caller also swallowed query failures into an empty list, producing false "No open registrations" states.

## Prevention / Learning
When a user-facing flow is only authorized for a subset of documents, do not reuse a broad collection reader and filter client-side afterward. Add a dedicated bounded query helper that matches the security-rule boundary, and make shared loaders depend on that helper so adjacent surfaces like AI summaries inherit the safe access pattern.

## Regression Tests
- `npx vitest run tests/unit/app-parent-tools-service.test.js tests/unit/app-private-ai-service.test.js tests/unit/db-published-registration-forms-source.test.js tests/unit/app-parent-tools-integration.test.jsx --reporter=dot`
- `tests/unit/app-parent-tools-service.test.js` now asserts parent registration discovery uses the published-only helper and does not call the full-scan loader.
- `tests/unit/app-private-ai-service.test.js` now asserts `get_parent_tools` continues to use the shared parent registrations loader.
- `tests/unit/db-published-registration-forms-source.test.js` locks in the bounded published-only Firestore query contract.

## Recurrence Risk
Low. Parent-facing registration discovery is now centralized on a published-only bounded helper and the focused tests fail if that path regresses back to full-collection scans.