### PR TITLE
Block team alert saves after failed preference loads

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -88,6 +88,7 @@ function getLoadErrorMessage(error: unknown, fallback: string) {
 }
 
 export function Profile({ auth }: { auth: AuthState }) {
+  const notificationPreferenceLoadRequestsRef = useRef<Record<string, Promise<NotificationPreferences>>>({});
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { isDesktopWeb, isNative } = useShellLayout();
@@ -175,6 +176,22 @@ export function Profile({ auth }: { auth: AuthState }) {
   const nativePushEnabled = isNative && pushPermissionStatus?.state === 'enabled';
   const nativePushBlocked = isNative && pushPermissionStatus?.state === 'blocked';
   const nativePushUnsupported = isNative && pushPermissionStatus?.state === 'unsupported';
+
+  const loadNotificationPreferencesOnce = useCallback((userId: string, teamId: string) => {
+    const activeRequest = notificationPreferenceLoadRequestsRef.current[teamId];
+    if (activeRequest) {
+      return activeRequest;
+    }
+
+    const request = loadNotificationPreferences(userId, teamId).finally(() => {
+      if (notificationPreferenceLoadRequestsRef.current[teamId] === request) {
+        delete notificationPreferenceLoadRequestsRef.current[teamId];
+      }
+    });
+
+    notificationPreferenceLoadRequestsRef.current[teamId] = request;
+    return request;
+  }, []);
 
   const refreshPushPermissionStatus = useCallback(async (options: { silent?: boolean } = {}) => {
     if (!isNative || activeProfileSection !== 'alerts') {
@@ -386,7 +403,7 @@ export function Profile({ auth }: { auth: AuthState }) {
         }
 
         try {
-          const firstPrefs = await loadNotificationPreferences(user.uid, initialTeamId);
+          const firstPrefs = await loadNotificationPreferencesOnce(user.uid, initialTeamId);
           if (!cancelled) {
             setNotificationPreferences(firstPrefs);
             setNotificationPreferencesByTeamId((current) => ({ ...current, [initialTeamId]: firstPrefs }));
@@ -450,7 +467,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       }
 
       try {
-        const preferences = await loadNotificationPreferences(user.uid, selectedTeamId);
+        const preferences = await loadNotificationPreferencesOnce(user.uid, selectedTeamId);
         if (!cancelled) {
           setNotificationPreferences(preferences);
           setNotificationPreferencesByTeamId((current) => ({ ...current, [selectedTeamId]: preferences }));
@@ -481,7 +498,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeProfileSection, notificationPreferencesByTeamId, notificationTeamsLoaded, selectedTeamId, user, notificationPreferencesReloadNonce]);
+  }, [activeProfileSection, loadNotificationPreferencesOnce, notificationPreferencesByTeamId, notificationTeamsLoaded, selectedTeamId, user, notificationPreferencesReloadNonce]);
 
   useEffect(() => {
     let cancelled = false;
@@ -933,7 +950,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       const currentPreferences = notificationPreferencesByTeamId[teamId]
         || (loadedNotificationTeamId === teamId
           ? notificationPreferences
-          : await loadNotificationPreferences(user.uid, teamId));
+          : await loadNotificationPreferencesOnce(user.uid, teamId));
       const nextPreferences = normalizeNotificationPreferences({
         ...currentPreferences,
         ...gameDayDefaultPreferences

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -464,16 +464,12 @@ export function Profile({ auth }: { auth: AuthState }) {
       } catch (error) {
         logger.warn('Unable to load notification preferences.', { error });
         if (!cancelled) {
-          // Fall back to default preferences so the selected team still has editable
-          // toggles and game-day actions after a transient read failure, while
-          // still surfacing the load error and allowing an explicit retry.
           setNotificationPreferences(emptyPreferences);
-          setNotificationPreferencesByTeamId((current) => ({ ...current, [selectedTeamId]: emptyPreferences }));
           setNotificationPreferenceErrorsByTeamId((current) => ({
             ...current,
             [selectedTeamId]: getLoadErrorMessage(error, 'Unable to load notification preferences.')
           }));
-          setLoadedNotificationTeamId(selectedTeamId);
+          setLoadedNotificationTeamId((current) => current === selectedTeamId ? '' : current);
           setNotificationPreferencesErrorTeamId(selectedTeamId);
           setNotificationStatus({ message: 'Alerts unavailable — couldn’t load this team’s preferences.', tone: 'error' });
         }
@@ -899,6 +895,10 @@ export function Profile({ auth }: { auth: AuthState }) {
   const turnOnGameDayAlerts = async () => {
     if (!user || !selectedTeamId) {
       setNotificationStatus({ message: 'Select a team first.', tone: 'error' });
+      return;
+    }
+    if (!selectedTeamPreferencesHydrated) {
+      setNotificationStatus({ message: 'Wait for this team’s alert preferences to finish loading.', tone: 'error' });
       return;
     }
 
@@ -1371,7 +1371,7 @@ export function Profile({ auth }: { auth: AuthState }) {
                     ? 'Notifications are blocked in device settings. Open settings, allow notifications, then return here to finish game-day alerts.'
                     : 'One tap enables push on this device and turns on schedule changes and live score updates for the selected team.'}
                 </p>
-                <button type="button" className="primary-button mt-3" onClick={nativePushBlocked ? () => void openDeviceSettingsForPush('Notifications are turned off in device settings. Open device settings to finish turning on game-day alerts.') : turnOnGameDayAlerts} disabled={busy === 'game-day-alerts' || (!nativePushBlocked && (!selectedTeamId || !selectedTeamPreferencesHydrated))}>
+                <button type="button" className="primary-button mt-3" onClick={nativePushBlocked ? () => void openDeviceSettingsForPush('Notifications are turned off in device settings. Open device settings to finish turning on game-day alerts.') : turnOnGameDayAlerts} disabled={busy === 'game-day-alerts' || !selectedTeamId || !selectedTeamPreferencesHydrated}>
                   {busy === 'game-day-alerts' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Upload className="h-4 w-4" aria-hidden="true" />}
                   {nativePushBlocked ? 'Open device settings to finish alerts' : 'Turn on game-day alerts'}
                 </button>
@@ -1389,11 +1389,10 @@ export function Profile({ auth }: { auth: AuthState }) {
                       <RefreshCw className={`h-4 w-4 ${selectedTeamPreferencesLoading ? 'animate-spin' : ''}`} aria-hidden="true" />
                       Retry alerts
                     </button>
-                    <span className="text-xs font-bold text-rose-700">Using safe defaults until saved preferences load.</span>
+                    <span className="text-xs font-bold text-rose-700">Team-specific alerts stay locked until saved preferences load successfully.</span>
                   </div>
                 </div>
-              ) : null}
-              {selectedTeamPreferencesLoading ? (
+              ) : selectedTeamPreferencesLoading ? (
                 <div className="mt-3 rounded-2xl border border-gray-200 bg-gray-50 p-3" role="status" aria-live="polite">
                   <div className="flex items-center gap-2 text-sm font-black text-gray-900">
                     <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -762,7 +762,7 @@ test('profile keeps destructive alert actions disabled until a failed team load 
     await expect(page.getByLabel('Team')).toHaveValue('team-1');
     await page.getByLabel('Team').selectOption('team-2');
 
-    await expect(page.getByText('Alerts unavailable')).toBeVisible();
+    await expect(page.getByText('Alerts unavailable', { exact: true })).toBeVisible();
     await expect(page.getByText('temporary outage')).toBeVisible();
     await expect(page.getByLabel('Live Chat')).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Turn on game-day alerts' })).toBeDisabled();

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -61,6 +61,7 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             canPrompt: true,
             canOpenSettings: false
         }];
+        window.__mockNotificationPreferenceResponses = [];
     }, { mockUser: user, mockEmailLink: emailLink });
 
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {
@@ -266,6 +267,21 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
 
                 export async function loadNotificationPreferences(userId, teamId) {
                     window.__appProfileCalls.notificationLoads.push({ userId, teamId });
+                    const queue = window.__mockNotificationPreferenceResponses || [];
+                    if (queue.length > 1) {
+                        const next = queue.shift();
+                        if (next?.error) {
+                            throw new Error(next.error);
+                        }
+                        return next?.value || { liveChat: true, liveScore: false, schedule: true };
+                    }
+                    if (queue.length === 1) {
+                        const next = queue[0];
+                        if (next?.error) {
+                            throw new Error(next.error);
+                        }
+                        return next?.value || { liveChat: true, liveScore: false, schedule: true };
+                    }
                     return { liveChat: true, liveScore: false, schedule: true };
                 }
 
@@ -722,6 +738,46 @@ test('profile exposes account, notification, invite, verification, password, upl
         reset: ['parent@example.com'],
         signOut: 1
     });
+});
+
+test('profile keeps destructive alert actions disabled until a failed team load retries successfully', async ({ page, baseURL }) => {
+    const user = {
+        uid: 'user-1',
+        email: 'parent@example.com',
+        displayName: 'Pat Parent',
+        emailVerified: false,
+        roles: ['parent']
+    };
+    await mockAppModules(page, { user });
+    await page.addInitScript(() => {
+        window.__mockNotificationPreferenceResponses = [
+            { value: { liveChat: true, liveScore: false, schedule: true } },
+            { error: 'temporary outage' },
+            { value: { liveChat: false, liveScore: true, schedule: false } }
+        ];
+    });
+    await page.goto(appUrl(baseURL, '/profile'), { waitUntil: 'domcontentloaded' });
+
+    await page.getByRole('button', { name: 'Alerts', exact: true }).click();
+    await expect(page.getByLabel('Team')).toHaveValue('team-1');
+    await page.getByLabel('Team').selectOption('team-2');
+
+    await expect(page.getByText('Alerts unavailable')).toBeVisible();
+    await expect(page.getByText('temporary outage')).toBeVisible();
+    await expect(page.getByLabel('Live Chat')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Turn on game-day alerts' })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Save preferences' })).toBeDisabled();
+    await expect.poll(async () => page.evaluate(() => window.__appProfileCalls.notificationSaves.length)).toBe(0);
+
+    await page.getByRole('button', { name: 'Retry alerts' }).click();
+
+    await expect(page.getByText('temporary outage')).toHaveCount(0);
+    await expect(page.getByLabel('Live Chat')).toBeVisible();
+    await expect(page.getByLabel('Live Chat')).not.toBeChecked();
+    await expect(page.getByLabel('Live Score')).toBeChecked();
+    await expect(page.getByLabel('Schedule Changes')).not.toBeChecked();
+    await expect(page.getByRole('button', { name: 'Turn on game-day alerts' })).toBeEnabled();
+    await expect(page.getByRole('button', { name: 'Save preferences' })).toBeEnabled();
 });
 
 test('profile alerts recover from blocked native notification permissions', async ({ page, baseURL }) => {

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -61,7 +61,7 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             canPrompt: true,
             canOpenSettings: false
         }];
-        window.__mockNotificationPreferenceResponses = [];
+        window.__mockNotificationPreferenceResponses ??= [];
     }, { mockUser: user, mockEmailLink: emailLink });
 
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -771,6 +771,7 @@ test('profile keeps destructive alert actions disabled until a failed team load 
 
     await page.getByRole('button', { name: 'Retry alerts' }).click();
 
+    await expect.poll(async () => page.evaluate(() => window.__appProfileCalls.notificationLoads.length)).toBe(3);
     await expect(page.getByText('temporary outage')).toHaveCount(0);
     await expect(page.getByLabel('Live Chat')).toBeVisible();
     await expect(page.getByLabel('Live Chat')).not.toBeChecked();

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -319,7 +319,7 @@ describe('React app auth/profile capability parity', () => {
         const turnOnGameDayAlerts = profilePage.slice(turnOnStart, turnOnEnd);
 
         expect(profilePage).toContain("const selectedTeamPreferencesHydrated = Boolean(selectedTeamId) && Object.prototype.hasOwnProperty.call(notificationPreferencesByTeamId, selectedTeamId);");
-        expect(profilePage).toContain("disabled={busy === 'game-day-alerts' || (!nativePushBlocked && (!selectedTeamId || !selectedTeamPreferencesHydrated))}");
+        expect(profilePage).toContain("disabled={busy === 'game-day-alerts' || !selectedTeamId || !selectedTeamPreferencesHydrated}");
         expect(turnOnGameDayAlerts).toContain('const teamId = selectedTeamId;');
         expect(turnOnGameDayAlerts).toContain('const currentPreferences = notificationPreferencesByTeamId[teamId]');
         expect(turnOnGameDayAlerts).toContain('loadedNotificationTeamId === teamId');

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -324,7 +324,7 @@ describe('React app auth/profile capability parity', () => {
         expect(turnOnGameDayAlerts).toContain('const currentPreferences = notificationPreferencesByTeamId[teamId]');
         expect(turnOnGameDayAlerts).toContain('loadedNotificationTeamId === teamId');
         expect(turnOnGameDayAlerts).toContain('? notificationPreferences');
-        expect(turnOnGameDayAlerts).toContain(': await loadNotificationPreferences(user.uid, teamId));');
+        expect(turnOnGameDayAlerts).toContain(': await loadNotificationPreferencesOnce(user.uid, teamId));');
         expect(turnOnGameDayAlerts).toContain('...currentPreferences,');
         expect(turnOnGameDayAlerts.indexOf('await enablePushNotificationsForUser(user.uid);')).toBeLessThan(
             turnOnGameDayAlerts.indexOf('saveNotificationPreferences(user.uid, teamId, nextPreferences)')

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -606,7 +606,7 @@ describe('Profile invites', () => {
     expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(false);
   });
 
-  it('renders fallback toggles and re-enables team actions when preference loading fails', async () => {
+  it('keeps team alert actions locked when preference loading fails', async () => {
     profileServiceMocks.loadNotificationTeams.mockResolvedValue([
       { id: 'team-1', name: 'Blue Team' },
       { id: 'team-2', name: 'Gold Team' }
@@ -631,20 +631,15 @@ describe('Profile invites', () => {
     expect(await screen.findByText('Alerts unavailable')).toBeTruthy();
     expect(screen.getByText('temporary outage')).toBeTruthy();
     await waitFor(() => expect(screen.queryByText('Loading alerts for Gold Team…')).toBeNull());
-    expect(screen.getByLabelText('Live Chat')).toBeTruthy();
-    expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(true);
-    expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(false);
-    expect((screen.getByLabelText('Schedule Changes') as HTMLInputElement).checked).toBe(true);
-    expect((gameDayButton as HTMLButtonElement).disabled).toBe(false);
-    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByLabelText('Live Chat')).toBeNull();
+    expect((gameDayButton as HTMLButtonElement).disabled).toBe(true);
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
 
+    fireEvent.click(gameDayButton);
     fireEvent.click(saveButton);
 
-    await waitFor(() => expect(profileServiceMocks.saveNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-2', {
-      liveChat: true,
-      liveScore: false,
-      schedule: true
-    }));
+    expect(pushServiceMocks.enablePushNotificationsForUser).not.toHaveBeenCalled();
+    expect(profileServiceMocks.saveNotificationPreferences).not.toHaveBeenCalled();
   });
 
   it('reloads alert preferences for the selected team after tapping retry', async () => {
@@ -666,8 +661,9 @@ describe('Profile invites', () => {
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(2));
     expect(await screen.findByText('temporary outage')).toBeTruthy();
-    expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(true);
-    expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(false);
+    expect(screen.queryByLabelText('Live Chat')).toBeNull();
+    expect((screen.getByRole('button', { name: 'Turn on game-day alerts' }) as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Save preferences' }) as HTMLButtonElement).disabled).toBe(true);
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry alerts' }));
 
@@ -676,6 +672,8 @@ describe('Profile invites', () => {
     await waitFor(() => expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(false));
     expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(true);
     expect((screen.getByLabelText('Schedule Changes') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByRole('button', { name: 'Turn on game-day alerts' }) as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByRole('button', { name: 'Save preferences' }) as HTMLButtonElement).disabled).toBe(false);
   });
 
   it('shows blocked native push recovery and refreshes after returning from settings', async () => {

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import React from 'react';
+import React, { StrictMode } from 'react';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -109,12 +109,14 @@ const auth: AuthState = {
   signOut: vi.fn().mockResolvedValue(undefined)
 };
 
-function renderProfile() {
-  return render(
+function renderProfile({ strictMode = false }: { strictMode?: boolean } = {}) {
+  const tree = (
     <MemoryRouter>
       <Profile auth={auth} />
     </MemoryRouter>
   );
+
+  return render(strictMode ? <StrictMode>{tree}</StrictMode> : tree);
 }
 
 function getPhotoInput(container: HTMLElement) {
@@ -674,6 +676,31 @@ describe('Profile invites', () => {
     expect((screen.getByLabelText('Schedule Changes') as HTMLInputElement).checked).toBe(false);
     expect((screen.getByRole('button', { name: 'Turn on game-day alerts' }) as HTMLButtonElement).disabled).toBe(false);
     expect((screen.getByRole('button', { name: 'Save preferences' }) as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('deduplicates overlapping alert preference loads for the same team in StrictMode', async () => {
+    const teamOneLoad = createDeferred<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
+
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([
+      { id: 'team-1', name: 'Blue Team' },
+      { id: 'team-2', name: 'Gold Team' }
+    ]);
+    profileServiceMocks.loadNotificationPreferences.mockImplementation(async (_userId: string, teamId: string) => {
+      if (teamId === 'team-1') {
+        return teamOneLoad.promise;
+      }
+      return { liveChat: false, liveScore: true, schedule: false };
+    });
+
+    renderProfile({ strictMode: true });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
+    expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1');
+
+    teamOneLoad.resolve({ liveChat: true, liveScore: false, schedule: true });
+    await waitFor(() => expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(true));
   });
 
   it('shows blocked native push recovery and refreshes after returning from settings', async () => {


### PR DESCRIPTION
Closes #3030

## What changed
- Stopped caching `emptyPreferences` as if they were loaded team preferences when `loadNotificationPreferences` fails on the Profile Alerts screen.
- Kept the failed team in an error state so `selectedTeamPreferencesHydrated` stays false until a real payload loads.
- Hid team-specific alert toggles during the failed-load state and kept both `Save preferences` and `Turn on game-day alerts` disabled until retry succeeds.
- Added regression coverage in the focused profile unit test file and a smoke scenario for fail-then-retry behavior.

## Root Cause
The Alerts screen treated fallback defaults as hydrated server data after a read failure by inserting `emptyPreferences` into `notificationPreferencesByTeamId`. That made the hydration gate pass, which exposed editable toggles and enabled destructive save actions even though the app had never loaded the team’s real saved preferences.

## Prevention / Learning
Do not promote fallback UI defaults into hydrated persistence state. For async settings screens, keep loading, error, and hydrated states separate, and gate any write path on verified server-backed data instead of cache presence alone.

## Regression Tests
- `tests/unit/app-profile-invites.test.tsx` now verifies failed team-preference loads hide toggles, keep team actions disabled, and avoid notification saves until retry succeeds.
- `tests/smoke/app-auth-profile.spec.js` now covers the mobile/profile fail-then-retry alert flow and confirms the buttons unlock only after a successful reload.