### PR TITLE
Defer schedule tracker config loading

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -34,6 +34,10 @@ const initialLoadTelemetryMocks = vi.hoisted(() => ({
   end: vi.fn()
 }));
 
+const shellLayoutMocks = vi.hoisted(() => ({
+  isDesktopWeb: false
+}));
+
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
 vi.mock('../lib/appDataCache', () => appDataCacheMocks);
 vi.mock('../lib/telemetry', () => ({
@@ -44,7 +48,7 @@ vi.mock('../lib/uxTiming', () => ({
   startScreenMountTimer: vi.fn(() => ({ end: uxTimingMocks.end }))
 }));
 vi.mock('../lib/useShellLayout', () => ({
-  useShellLayout: () => ({ isDesktopWeb: false })
+  useShellLayout: () => ({ isDesktopWeb: shellLayoutMocks.isDesktopWeb })
 }));
 
 const auth: AuthState = {
@@ -108,6 +112,19 @@ function buildScheduleEvent(index: number, overrides: Record<string, unknown> = 
   };
 }
 
+function buildStaffScheduleResult() {
+  return {
+    children: [
+      { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+    ],
+    events: [
+      buildScheduleEvent(1, {
+        isTeamStaff: true
+      })
+    ]
+  };
+}
+
 function resolveAppSourcePath(relativePath: string) {
   const cwd = process.cwd();
   const appRoot = cwd.endsWith('/apps/app') || cwd.endsWith('\\apps\\app')
@@ -119,6 +136,7 @@ function resolveAppSourcePath(relativePath: string) {
 describe('Schedule', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    shellLayoutMocks.isDesktopWeb = false;
     Object.defineProperty(window, 'scrollTo', {
       value: vi.fn(),
       writable: true
@@ -506,5 +524,54 @@ describe('Schedule', () => {
     expect(source).toContain('return runScheduleRead(');
     expect(source).toContain('const loaded = await runPastHistoryRead(');
     expect(source).not.toContain('const [loadingPastHistory, setLoadingPastHistory]');
+  });
+
+  it('defers tracker config loading on mobile until staff tools are opened and caches the result', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
+    scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp.mockResolvedValueOnce([
+      { id: 'config-1', name: 'Varsity Tracker' }
+    ]);
+
+    renderSchedule();
+
+    expect(await screen.findByRole('button', { name: /manage schedule/i })).toBeTruthy();
+    expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledWith('team-1', auth.user);
+    });
+    expect(await screen.findByRole('option', { name: 'Varsity Tracker' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
+    fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Varsity Tracker' })).toBeTruthy();
+    });
+    expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers desktop tracker config loading until staff starts using game creation', async () => {
+    shellLayoutMocks.isDesktopWeb = true;
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
+    scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp.mockResolvedValueOnce([
+      { id: 'config-1', name: 'Varsity Tracker' }
+    ]);
+
+    renderSchedule();
+
+    expect(await screen.findByRole('heading', { name: 'Add game for Bears' })).toBeTruthy();
+    expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).not.toHaveBeenCalled();
+
+    fireEvent.focus(screen.getByLabelText('Opponent'));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledWith('team-1', auth.user);
+    });
+    expect(await screen.findByRole('option', { name: 'Varsity Tracker' })).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -218,6 +218,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const pastHistoryLoadedRef = useRef(false);
   const childrenRef = useRef<ParentScheduleChild[]>([]);
   const eventsRef = useRef<ParentScheduleEvent[]>([]);
+  const trackerConfigCacheRef = useRef<Record<string, ScheduleStatTrackerConfigOption[]>>({});
+  const trackerConfigRequestPromiseRef = useRef<Record<string, Promise<ScheduleStatTrackerConfigOption[]>>>({});
+  const [trackerConfigRequestedTeamIds, setTrackerConfigRequestedTeamIds] = useState<Record<string, true>>({});
 
   const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
     childrenRef.current = data.children;
@@ -533,23 +536,68 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
   }, [isDesktopWeb, selectedCalendarTeam]);
 
+  const requestTrackerConfigLoad = () => {
+    if (!selectedCalendarTeam) return;
+    setTrackerConfigRequestedTeamIds((current) => {
+      if (current[selectedCalendarTeam.teamId]) return current;
+      return {
+        ...current,
+        [selectedCalendarTeam.teamId]: true
+      };
+    });
+  };
+
+  useEffect(() => {
+    if (!selectedCalendarTeam) {
+      setGameTrackerConfigs([]);
+      setGameTrackerConfigError(null);
+      return;
+    }
+    const cachedConfigs = trackerConfigCacheRef.current[selectedCalendarTeam.teamId];
+    setGameTrackerConfigs(cachedConfigs || []);
+    setGameTrackerConfigError(null);
+  }, [selectedCalendarTeam]);
+
 
   useEffect(() => {
     let cancelled = false;
+    if (!selectedCalendarTeam || !auth.user) return;
+    const shouldLoadTrackerConfigs = mobileStaffToolsOpen
+      || trackerConfigRequestedTeamIds[selectedCalendarTeam.teamId]
+      || (isDesktopWeb && desktopAdvancedControlsOpen);
+    if (!shouldLoadTrackerConfigs) return;
+
+    const cachedConfigs = trackerConfigCacheRef.current[selectedCalendarTeam.teamId];
+    if (cachedConfigs) {
+      setGameTrackerConfigs(cachedConfigs);
+      setGameTrackerConfigError(null);
+      return;
+    }
+
     setGameTrackerConfigs([]);
     setGameTrackerConfigError(null);
-    if (!selectedCalendarTeam || !auth.user) return;
-    loadScheduleStatTrackerConfigsForApp(selectedCalendarTeam.teamId, auth.user)
+
+    const cachedPromise = trackerConfigRequestPromiseRef.current[selectedCalendarTeam.teamId]
+      || loadScheduleStatTrackerConfigsForApp(selectedCalendarTeam.teamId, auth.user);
+    trackerConfigRequestPromiseRef.current[selectedCalendarTeam.teamId] = cachedPromise;
+
+    cachedPromise
       .then((configs) => {
-        if (!cancelled) setGameTrackerConfigs(configs);
+        trackerConfigCacheRef.current[selectedCalendarTeam.teamId] = configs;
+        delete trackerConfigRequestPromiseRef.current[selectedCalendarTeam.teamId];
+        if (!cancelled) {
+          setGameTrackerConfigs(configs);
+          setGameTrackerConfigError(null);
+        }
       })
       .catch((configError: any) => {
+        delete trackerConfigRequestPromiseRef.current[selectedCalendarTeam.teamId];
         if (!cancelled) setGameTrackerConfigError(configError?.message || 'Unable to load tracker configs.');
       });
     return () => {
       cancelled = true;
     };
-  }, [auth.user, selectedCalendarTeam]);
+  }, [auth.user, desktopAdvancedControlsOpen, isDesktopWeb, mobileStaffToolsOpen, selectedCalendarTeam, trackerConfigRequestedTeamIds]);
 
   useEffect(() => {
     setGameForm((current) => {
@@ -1082,7 +1130,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
               onRefresh={() => refreshSchedule(true)}
               onExport={handleExport}
               advancedControlsOpen={desktopAdvancedControlsOpen}
-              onAdvancedControlsOpenChange={setDesktopAdvancedControlsOpen}
+              onAdvancedControlsOpenChange={(open) => {
+                if (open) requestTrackerConfigLoad();
+                setDesktopAdvancedControlsOpen(open);
+              }}
               onCopyAgenda={handleCopyAgenda}
               onResetFilters={() => {
                 setFilter('upcoming-all');
@@ -1119,6 +1170,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
                 saving={savingGame}
                 error={gameFormError}
                 configError={gameTrackerConfigError}
+                onStartUsing={requestTrackerConfigLoad}
                 onChange={(nextForm) => {
                   setGameForm(nextForm);
                   if (gameFormError) setGameFormError(null);
@@ -1219,7 +1271,11 @@ export function Schedule({ auth }: { auth: AuthState }) {
             <MobileScheduleStaffToolsSection
               open={mobileStaffToolsOpen}
               teamName={selectedCalendarTeam.teamName}
-              onToggle={() => setMobileStaffToolsOpen((current) => !current)}
+              onToggle={() => setMobileStaffToolsOpen((current) => {
+                const nextOpen = !current;
+                if (nextOpen) requestTrackerConfigLoad();
+                return nextOpen;
+              })}
             >
               <ScheduleGameCreatePanel
                 teamName={selectedCalendarTeam.teamName}
@@ -1228,6 +1284,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
                 saving={savingGame}
                 error={gameFormError}
                 configError={gameTrackerConfigError}
+                onStartUsing={requestTrackerConfigLoad}
                 onChange={(nextForm) => {
                   setGameForm(nextForm);
                   if (gameFormError) setGameFormError(null);
@@ -1339,10 +1396,10 @@ function getDefaultSchedulePracticeForm(): SchedulePracticeFormInput {
   };
 }
 
-function ScheduleGameCreatePanel({ teamName, form, configs, saving, error, configError, onChange, onSubmit }: { teamName: string; form: ScheduleGameFormInput; configs: ScheduleStatTrackerConfigOption[]; saving: boolean; error: string | null; configError: string | null; onChange: (form: ScheduleGameFormInput) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {
+function ScheduleGameCreatePanel({ teamName, form, configs, saving, error, configError, onStartUsing, onChange, onSubmit }: { teamName: string; form: ScheduleGameFormInput; configs: ScheduleStatTrackerConfigOption[]; saving: boolean; error: string | null; configError: string | null; onStartUsing?: () => void; onChange: (form: ScheduleGameFormInput) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {
   const updateField = (field: keyof ScheduleGameFormInput, value: string | Date | boolean | null) => onChange({ ...form, [field]: value });
   return (
-    <section className="app-card p-3 sm:p-4" aria-label="Create game">
+    <section className="app-card p-3 sm:p-4" aria-label="Create game" onFocusCapture={onStartUsing}>
       <div className="app-label">Game scheduling</div>
       <h2 className="mt-1 text-base font-black text-gray-950">Add game for {teamName}</h2>
       <form className="mt-3 space-y-3" onSubmit={onSubmit}>


### PR DESCRIPTION
Closes #3039

## What changed
- gated `loadScheduleStatTrackerConfigsForApp` behind the first explicit staff-tool interaction instead of loading on Schedule mount
- cached loaded tracker configs by `teamId` for the session so reopening the same tools reuses the prior result
- wired focused regression tests for both mobile staff-tools expansion and desktop game-creation use

## Root Cause
The Schedule page tied tracker-config loading directly to `selectedCalendarTeam`. Because Schedule auto-selects the only manageable team, staff users triggered permission and stat-config reads during initial route load even when the staff tools stayed collapsed and unused.

## Prevention / Learning
Treat hidden or staff-only workflow data as secondary. Lazy-load it only after an explicit user action and keep a per-entity session cache so repeated opens do not fan out more reads.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/Schedule.test.tsx --reporter=verbose`
- mobile regression asserts initial collapsed render does not fetch tracker configs, opening Manage schedule fetches once, and reopening reuses cached results
- desktop regression asserts initial render does not fetch tracker configs and first interaction with game creation triggers the load

## Recurrence Risk
Medium. Schedule still has several staff-only surfaces, so similar eager effects could return unless interaction-gated tests stay adjacent to those flows.