### PR TITLE
Optimize help search main-thread work

### DIFF
--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -21,6 +21,16 @@ type HelpKnowledgeDoc = HelpKnowledgeIndexDoc & {
   roles: string[];
   summary: string;
   text: string;
+  normalizedTitle: string;
+  normalizedSummary: string;
+  normalizedFile: string;
+  normalizedText: string;
+  snippetSentences: string[];
+};
+
+type HelpKnowledgeQueryCacheEntry = {
+  key: string;
+  results: HelpKnowledgeResult[];
 };
 
 const searchableHelpRoles = ['admin', 'coach', 'member', 'parent'];
@@ -54,8 +64,15 @@ const stopWords = new Set([
   'you',
   'your'
 ]);
+const helpSearchQueryCacheMaxEntries = 40;
 
 let helpDocsCache: HelpKnowledgeDoc[] | null = null;
+const helpSearchQueryCache = new Map<string, HelpKnowledgeQueryCacheEntry>();
+const helpKnowledgeDebugState = {
+  queryCacheHits: 0,
+  snippetBuilds: 0,
+  sentenceSplits: 0
+};
 
 export function getSearchHelpRoles(helpRoleFilter?: unknown): string[] {
   const role = normalizeRoles([helpRoleFilter]).find((normalizedRole) => searchableHelpRoles.includes(normalizedRole));
@@ -67,11 +84,7 @@ export function getHelpKnowledgeDocs(): HelpKnowledgeDoc[] {
   if (helpDocsCache) return helpDocsCache;
 
   helpDocsCache = helpKnowledgeIndex
-    .map((doc) => ({
-      ...doc,
-      url: new URL(doc.file, allPlaysOrigin).toString(),
-      roles: normalizeRoles(doc.roles)
-    }))
+    .map((doc) => buildHelpKnowledgeDoc(doc))
     .sort((a, b) => a.title.localeCompare(b.title));
 
   return helpDocsCache;
@@ -91,30 +104,60 @@ export function searchHelpKnowledge({
   const docs = getHelpKnowledgeDocs();
   const cleanQuery = compactText(query);
   const queryTokens = tokenize(cleanQuery);
+  const normalizedQuery = cleanQuery.toLowerCase();
   const roleTokens = normalizeRoles(roles);
   const [normalizedRoleFilter] = normalizeRoles([roleFilter]);
   const maxResults = Math.min(Math.max(Number(limit) || 5, 1), Math.max(docs.length, 1));
+  const cacheKey = JSON.stringify({
+    query: normalizedQuery,
+    roles: roleTokens,
+    roleFilter: normalizedRoleFilter || '',
+    limit: maxResults
+  });
+  const cachedResults = helpSearchQueryCache.get(cacheKey);
+  if (cachedResults) {
+    helpKnowledgeDebugState.queryCacheHits += 1;
+    return cachedResults.results;
+  }
 
-  return docs
+  const scoredResults = docs
     .filter((doc) => normalizedRoleFilter
       ? roleFilterMatches(doc.roles, normalizedRoleFilter)
       : (!roleTokens.length || roleMatches(doc.roles, roleTokens)))
-    .map((doc) => {
-      const score = scoreHelpDoc(doc, cleanQuery, queryTokens, roleTokens);
-      return {
-        id: doc.id,
-        title: doc.title,
-        file: doc.file,
-        url: doc.url,
-        roles: doc.roles,
-        summary: doc.summary,
-        snippet: buildSnippet(doc, queryTokens),
-        score
-      };
-    })
+    .map((doc) => ({
+      doc,
+      score: scoreHelpDoc(doc, normalizedQuery, queryTokens, roleTokens)
+    }))
     .filter((result) => result.score > 0 || !queryTokens.length)
-    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
-    .slice(0, maxResults);
+    .sort((a, b) => b.score - a.score || a.doc.title.localeCompare(b.doc.title))
+    .slice(0, maxResults)
+    .map(({ doc, score }) => ({
+      id: doc.id,
+      title: doc.title,
+      file: doc.file,
+      url: doc.url,
+      roles: doc.roles,
+      summary: doc.summary,
+      snippet: buildSnippet(doc, queryTokens),
+      score
+    }));
+
+  setHelpSearchQueryCache(cacheKey, scoredResults);
+  return scoredResults;
+}
+
+function buildHelpKnowledgeDoc(doc: HelpKnowledgeIndexDoc): HelpKnowledgeDoc {
+  const normalizedText = compactText(doc.text);
+  return {
+    ...doc,
+    url: new URL(doc.file, allPlaysOrigin).toString(),
+    roles: normalizeRoles(doc.roles),
+    normalizedTitle: doc.title.toLowerCase(),
+    normalizedSummary: doc.summary.toLowerCase(),
+    normalizedFile: doc.file.toLowerCase(),
+    normalizedText: normalizedText.toLowerCase(),
+    snippetSentences: splitSnippetSentences(normalizedText)
+  };
 }
 
 function scoreHelpDoc(doc: HelpKnowledgeDoc, query: string, tokens: string[], roles: string[]) {
@@ -122,10 +165,10 @@ function scoreHelpDoc(doc: HelpKnowledgeDoc, query: string, tokens: string[], ro
     return roleMatches(doc.roles, roles) ? 2 : 1;
   }
 
-  const title = doc.title.toLowerCase();
-  const summary = doc.summary.toLowerCase();
-  const file = doc.file.toLowerCase();
-  const text = doc.text.toLowerCase();
+  const title = doc.normalizedTitle;
+  const summary = doc.normalizedSummary;
+  const file = doc.normalizedFile;
+  const text = doc.normalizedText;
   let score = roleMatches(doc.roles, roles) ? 2 : 0;
   const phrase = query.toLowerCase();
 
@@ -149,16 +192,31 @@ function buildSnippet(doc: HelpKnowledgeDoc, tokens: string[]) {
   const text = compactText(doc.text);
   if (!text) return doc.summary;
 
-  const sentences = text
-    .split(/(?<=[.!?])\s+|\n+/)
-    .map((sentence) => compactText(sentence))
-    .filter((sentence) => sentence.length > 40);
+  helpKnowledgeDebugState.snippetBuilds += 1;
   const lowerTokens = tokens.map((token) => token.toLowerCase());
-  const match = sentences.find((sentence) => lowerTokens.some((token) => sentence.toLowerCase().includes(token)))
-    || sentences[0]
+  const match = doc.snippetSentences.find((sentence) => lowerTokens.some((token) => sentence.toLowerCase().includes(token)))
+    || doc.snippetSentences[0]
     || text;
 
   return match.length > 420 ? `${match.slice(0, 417).trim()}...` : match;
+}
+
+function splitSnippetSentences(text: string) {
+  helpKnowledgeDebugState.sentenceSplits += 1;
+  return text
+    .split(/(?<=[.!?])\s+|\n+/)
+    .map((sentence) => compactText(sentence))
+    .filter((sentence) => sentence.length > 40);
+}
+
+function setHelpSearchQueryCache(key: string, results: HelpKnowledgeResult[]) {
+  helpSearchQueryCache.set(key, { key, results });
+  if (helpSearchQueryCache.size <= helpSearchQueryCacheMaxEntries) return;
+
+  const oldestKey = helpSearchQueryCache.keys().next().value;
+  if (oldestKey) {
+    helpSearchQueryCache.delete(oldestKey);
+  }
 }
 
 function normalizeRoles(roles: unknown[]) {
@@ -205,4 +263,16 @@ function countOccurrences(value: string, token: string) {
 
 function compactText(value: unknown) {
   return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+export function resetHelpKnowledgeCachesForTests() {
+  helpDocsCache = null;
+  helpSearchQueryCache.clear();
+  helpKnowledgeDebugState.queryCacheHits = 0;
+  helpKnowledgeDebugState.snippetBuilds = 0;
+  helpKnowledgeDebugState.sentenceSplits = 0;
+}
+
+export function getHelpKnowledgeDebugStateForTests() {
+  return { ...helpKnowledgeDebugState };
 }

--- a/tests/unit/app-help-knowledge-service.test.js
+++ b/tests/unit/app-help-knowledge-service.test.js
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+beforeEach(async () => {
+    const { resetHelpKnowledgeCachesForTests } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+    resetHelpKnowledgeCachesForTests();
+});
 
 describe('app help knowledge service', () => {
     it('indexes root help and workflow pages for private AI lookup', async () => {
@@ -106,5 +111,40 @@ describe('app help knowledge service', () => {
             expect(results.length).toBeGreaterThan(0);
             expect(results.every((result) => roleFilter === 'all' || result.roles.includes('all') || result.roles.includes(roleFilter))).toBe(true);
         });
+    });
+
+    it('builds snippets only for the returned top matches and caches repeated searches', async () => {
+        const {
+            getHelpKnowledgeDebugStateForTests,
+            getHelpKnowledgeDocs,
+            searchHelpKnowledge
+        } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+        const docs = getHelpKnowledgeDocs();
+        const limit = 3;
+
+        const results = searchHelpKnowledge({
+            query: 'live tracker',
+            roleFilter: 'all',
+            limit
+        });
+        const debugAfterFirstSearch = getHelpKnowledgeDebugStateForTests();
+
+        expect(results).toHaveLength(limit);
+        expect(docs.length).toBeGreaterThan(limit);
+        expect(debugAfterFirstSearch.snippetBuilds).toBe(limit);
+        expect(debugAfterFirstSearch.sentenceSplits).toBe(docs.length);
+        expect(debugAfterFirstSearch.queryCacheHits).toBe(0);
+
+        const repeatedResults = searchHelpKnowledge({
+            query: 'live tracker',
+            roleFilter: 'all',
+            limit
+        });
+        const debugAfterSecondSearch = getHelpKnowledgeDebugStateForTests();
+
+        expect(repeatedResults).toEqual(results);
+        expect(debugAfterSecondSearch.snippetBuilds).toBe(limit);
+        expect(debugAfterSecondSearch.sentenceSplits).toBe(docs.length);
+        expect(debugAfterSecondSearch.queryCacheHits).toBe(1);
     });
 });


### PR DESCRIPTION
Closes #3043

## What changed
- Precomputed immutable normalized help-doc fields once per document instead of lowercasing full article text on every search.
- Changed help search to score, sort, and slice candidates first, then build snippets only for the final top-N results.
- Added a small in-session query cache keyed by normalized query, roles, role filter, and limit so repeated searches and role toggles reuse prior help results.
- Added a focused regression test that proves snippet generation is capped to returned matches and repeated searches hit cache without re-splitting article text.

## Root Cause
Help search recomputed lowercase text and snippets for every eligible help document on each query, then sorted and sliced afterward. That meant the UI thread paid full-corpus normalization and sentence scanning cost before it even knew which 5 results would be visible.

## Prevention / Learning
For embedded content search on interactive paths, precompute immutable normalized fields once, rank and cap candidates before any expensive presentation work, and add a small session cache for repeated query/filter combinations.

## Regression Tests
- `npx vitest run tests/unit/app-help-knowledge-service.test.js tests/unit/app-search-service.test.js --reporter=verbose`
- Added `tests/unit/app-help-knowledge-service.test.js` coverage asserting snippet generation only runs for the returned limit and repeated identical searches hit the cache.