### PR TITLE
Preserve tracked data until statsheet replacement commits

### DIFF
--- a/apps/app/src/lib/statsheetImportService.test.ts
+++ b/apps/app/src/lib/statsheetImportService.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const firebaseMocks = vi.hoisted(() => {
   const batch = {
     update: vi.fn(),
     set: vi.fn(),
+    delete: vi.fn(),
     commit: vi.fn(async () => undefined)
   }
   return {
@@ -56,6 +57,11 @@ vi.mock('../../../../js/live-tracker-save-complete.js', () => ({
 }))
 
 import { analyzeTrackStatsheetPhoto, applyTrackStatsheetImportForApp, buildTrackStatsheetReviewModel } from './statsheetImportService'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  firebaseMocks.batch.commit.mockResolvedValue(undefined)
+})
 
 describe('buildTrackStatsheetReviewModel', () => {
   it('swaps sides when visitor rows match the roster better and auto-assigns players', () => {
@@ -160,6 +166,30 @@ describe('analyzeTrackStatsheetPhoto', () => {
 })
 
 describe('applyTrackStatsheetImportForApp', () => {
+  it('does not clear existing tracked data before the replacement write succeeds', async () => {
+    firebaseMocks.getDocs
+      .mockResolvedValueOnce({ size: 1, docs: [{ id: 'event-1', ref: { path: 'teams/team-1/games/game-1/events/event-1' } }] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p2', ref: { path: 'teams/team-1/games/game-1/aggregatedStats/p2' } }] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p2', ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/p2' } }] })
+    firebaseMocks.batch.commit.mockRejectedValueOnce(new Error('write failed'))
+
+    await expect(applyTrackStatsheetImportForApp({
+      teamId: 'team-1',
+      gameId: 'game-1',
+      roster: [{ id: 'p1', name: 'Avery Smith', number: '12' }],
+      columns: ['PTS'],
+      homeRows: [{ number: '12', name: 'Avery Smith', fouls: 2, totalPoints: 10, include: true, mappedPlayerId: 'p1' }],
+      visitorRows: [],
+      homeScore: 50,
+      awayScore: 42,
+      file: null,
+      replaceExisting: true
+    })).rejects.toThrow('write failed')
+
+    expect(firebaseMocks.deleteDoc).not.toHaveBeenCalled()
+    expect(firebaseMocks.batch.delete).not.toHaveBeenCalled()
+  })
+
   it('prevents saving when every home row is still review-only', async () => {
     await expect(applyTrackStatsheetImportForApp({
       teamId: 'team-1',
@@ -221,11 +251,11 @@ describe('applyTrackStatsheetImportForApp', () => {
     expect(firebaseMocks.writeBatch).not.toHaveBeenCalled()
   })
 
-  it('uploads, clears existing stats, and writes the legacy apply plan through the shared batch helper', async () => {
+  it('uploads, writes the replacement, and only then cleans up superseded tracked data', async () => {
     firebaseMocks.getDocs
-      .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'event-1' } }] })
-      .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'stats-1' } }] })
-      .mockResolvedValueOnce({ size: 1, docs: [{ ref: { path: 'private-stats-1' } }] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ id: 'event-1', ref: { path: 'teams/team-1/games/game-1/events/event-1' } }] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p2', ref: { path: 'teams/team-1/games/game-1/aggregatedStats/p2' } }] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p2', ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/p2' } }] })
 
     const file = new File(['sheet'], 'statsheet.png', { type: 'image/png' })
     const result = await applyTrackStatsheetImportForApp({
@@ -242,14 +272,14 @@ describe('applyTrackStatsheetImportForApp', () => {
     })
 
     expect(dbMocks.uploadStatSheetPhoto).toHaveBeenCalledWith('team-1', file)
-    expect(firebaseMocks.deleteDoc).toHaveBeenCalledTimes(3)
-    expect(firebaseMocks.deleteDoc).toHaveBeenCalledWith({ path: 'private-stats-1' })
     expect(firebaseMocks.writeBatch).toHaveBeenCalled()
     expect(firebaseMocks.batch.update).toHaveBeenCalledWith(
       { path: 'teams/team-1/games/game-1' },
       expect.objectContaining({ homeScore: 50, awayScore: 42, statSheetPhotoUrl: 'https://img.test/statsheet.png' })
     )
-    expect(firebaseMocks.batch.commit).toHaveBeenCalled()
+    expect(firebaseMocks.batch.delete).toHaveBeenCalledTimes(3)
+    expect(firebaseMocks.batch.delete).toHaveBeenCalledWith({ path: 'teams/team-1/games/game-1/privatePlayerStats/p2' })
+    expect(firebaseMocks.batch.commit).toHaveBeenCalledTimes(2)
     expect(result).toMatchObject({ requiresReplaceConfirmation: false, uploadedPhotoUrl: 'https://img.test/statsheet.png' })
   })
 })

--- a/apps/app/src/lib/statsheetImportService.test.ts
+++ b/apps/app/src/lib/statsheetImportService.test.ts
@@ -166,14 +166,13 @@ describe('analyzeTrackStatsheetPhoto', () => {
 })
 
 describe('applyTrackStatsheetImportForApp', () => {
-  it('does not clear existing tracked data before the replacement write succeeds', async () => {
+  it('batches replacement cleanup into the same commit as the new statsheet writes', async () => {
     firebaseMocks.getDocs
       .mockResolvedValueOnce({ size: 1, docs: [{ id: 'event-1', ref: { path: 'teams/team-1/games/game-1/events/event-1' } }] })
       .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p2', ref: { path: 'teams/team-1/games/game-1/aggregatedStats/p2' } }] })
       .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p2', ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/p2' } }] })
-    firebaseMocks.batch.commit.mockRejectedValueOnce(new Error('write failed'))
 
-    await expect(applyTrackStatsheetImportForApp({
+    await applyTrackStatsheetImportForApp({
       teamId: 'team-1',
       gameId: 'game-1',
       roster: [{ id: 'p1', name: 'Avery Smith', number: '12' }],
@@ -184,10 +183,11 @@ describe('applyTrackStatsheetImportForApp', () => {
       awayScore: 42,
       file: null,
       replaceExisting: true
-    })).rejects.toThrow('write failed')
+    })
 
-    expect(firebaseMocks.deleteDoc).not.toHaveBeenCalled()
-    expect(firebaseMocks.batch.delete).not.toHaveBeenCalled()
+    expect(firebaseMocks.writeBatch).toHaveBeenCalledTimes(1)
+    expect(firebaseMocks.batch.delete).toHaveBeenCalledTimes(3)
+    expect(firebaseMocks.batch.commit).toHaveBeenCalledTimes(1)
   })
 
   it('prevents saving when every home row is still review-only', async () => {
@@ -251,7 +251,31 @@ describe('applyTrackStatsheetImportForApp', () => {
     expect(firebaseMocks.writeBatch).not.toHaveBeenCalled()
   })
 
-  it('uploads, writes the replacement, and only then cleans up superseded tracked data', async () => {
+  it('does not create a second cleanup batch for private stats already handled by the apply plan', async () => {
+    firebaseMocks.getDocs
+      .mockResolvedValueOnce({ size: 0, docs: [] })
+      .mockResolvedValueOnce({ size: 0, docs: [] })
+      .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p1', ref: { path: 'teams/team-1/games/game-1/privatePlayerStats/p1' } }] })
+
+    await applyTrackStatsheetImportForApp({
+      teamId: 'team-1',
+      gameId: 'game-1',
+      roster: [{ id: 'p1', name: 'Avery Smith', number: '12' }],
+      columns: ['PTS'],
+      homeRows: [{ number: '12', name: 'Avery Smith', fouls: 2, totalPoints: 10, include: true, mappedPlayerId: 'p1' }],
+      visitorRows: [],
+      homeScore: 50,
+      awayScore: 42,
+      file: null,
+      replaceExisting: true
+    })
+
+    expect(firebaseMocks.writeBatch).toHaveBeenCalledTimes(1)
+    expect(firebaseMocks.batch.delete).not.toHaveBeenCalled()
+    expect(firebaseMocks.batch.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('uploads and applies replacement writes plus cleanup in a single commit', async () => {
     firebaseMocks.getDocs
       .mockResolvedValueOnce({ size: 1, docs: [{ id: 'event-1', ref: { path: 'teams/team-1/games/game-1/events/event-1' } }] })
       .mockResolvedValueOnce({ size: 1, docs: [{ id: 'p2', ref: { path: 'teams/team-1/games/game-1/aggregatedStats/p2' } }] })
@@ -279,7 +303,7 @@ describe('applyTrackStatsheetImportForApp', () => {
     )
     expect(firebaseMocks.batch.delete).toHaveBeenCalledTimes(3)
     expect(firebaseMocks.batch.delete).toHaveBeenCalledWith({ path: 'teams/team-1/games/game-1/privatePlayerStats/p2' })
-    expect(firebaseMocks.batch.commit).toHaveBeenCalledTimes(2)
+    expect(firebaseMocks.batch.commit).toHaveBeenCalledTimes(1)
     expect(result).toMatchObject({ requiresReplaceConfirmation: false, uploadedPhotoUrl: 'https://img.test/statsheet.png' })
   })
 })

--- a/apps/app/src/lib/statsheetImportService.ts
+++ b/apps/app/src/lib/statsheetImportService.ts
@@ -5,7 +5,6 @@ import {
   buildTrackStatsheetApplyPlan,
   collection,
   db,
-  deleteDoc,
   doc,
   getAI,
   getApp,
@@ -23,6 +22,8 @@ import {
 } from './adapters/legacyStatsheetImport'
 
 const logger = createLogger('statsheetImportService')
+
+const TRACKED_DATA_CLEANUP_BATCH_LIMIT = 450
 
 export type TrackStatsheetReviewRow = {
   number: string;
@@ -363,12 +364,6 @@ export async function applyTrackStatsheetImportForApp({
     statSheetPhotoUrl = await uploadStatSheetPhoto(teamId, file)
   }
 
-  if (hasExistingTrackedData) {
-    await Promise.all(eventsSnap.docs.map((entry: any) => deleteDoc(entry.ref)))
-    await Promise.all(statsSnap.docs.map((entry: any) => deleteDoc(entry.ref)))
-    await Promise.all(privateStatsSnap.docs.map((entry: any) => deleteDoc(entry.ref)))
-  }
-
   const applyPlan = buildTrackStatsheetApplyPlan({
     includedHome: validation.includedHome,
     includedVisitor,
@@ -378,6 +373,11 @@ export async function applyTrackStatsheetImportForApp({
     awayScore,
     statSheetPhotoUrl: statSheetPhotoUrl || null
   })
+
+  const retainedAggregatedStatsIds = new Set((applyPlan.aggregatedStatsWrites || []).map((entry: any) => String(entry?.playerId || '')))
+  const retainedPrivateStatsIds = new Set((applyPlan.aggregatedStatsWrites || [])
+    .filter((entry: any) => entry?.privateData)
+    .map((entry: any) => String(entry?.playerId || '')))
 
   const batch = writeBatch(db)
   addAggregatedStatsWritesToBatch({
@@ -392,10 +392,33 @@ export async function applyTrackStatsheetImportForApp({
   batch.update(gameRef, applyPlan.gameUpdate)
   await batch.commit()
 
+  const cleanupDocs = [
+    ...eventsSnap.docs,
+    ...statsSnap.docs.filter((entry: any) => !retainedAggregatedStatsIds.has(getTrackedDocId(entry))),
+    ...privateStatsSnap.docs.filter((entry: any) => !retainedPrivateStatsIds.has(getTrackedDocId(entry)))
+  ]
+
+  for (let i = 0; i < cleanupDocs.length; i += TRACKED_DATA_CLEANUP_BATCH_LIMIT) {
+    const cleanupBatch = writeBatch(db)
+    cleanupDocs.slice(i, i + TRACKED_DATA_CLEANUP_BATCH_LIMIT).forEach((entry: any) => {
+      cleanupBatch.delete(entry.ref)
+    })
+    await cleanupBatch.commit()
+  }
+
   return {
     requiresReplaceConfirmation: false,
     hasExistingTrackedData,
     uploadedPhotoUrl: statSheetPhotoUrl,
     applyPlan
   }
+}
+
+function getTrackedDocId(entry: any) {
+  if (entry?.id) {
+    return String(entry.id)
+  }
+
+  const path = String(entry?.ref?.path || '')
+  return path.split('/').filter(Boolean).pop() || ''
 }

--- a/apps/app/src/lib/statsheetImportService.ts
+++ b/apps/app/src/lib/statsheetImportService.ts
@@ -24,6 +24,7 @@ import {
 const logger = createLogger('statsheetImportService')
 
 const TRACKED_DATA_CLEANUP_BATCH_LIMIT = 450
+const FIRESTORE_BATCH_WRITE_LIMIT = 500
 
 export type TrackStatsheetReviewRow = {
   number: string;
@@ -374,10 +375,18 @@ export async function applyTrackStatsheetImportForApp({
     statSheetPhotoUrl: statSheetPhotoUrl || null
   })
 
-  const retainedAggregatedStatsIds = new Set((applyPlan.aggregatedStatsWrites || []).map((entry: any) => String(entry?.playerId || '')))
-  const retainedPrivateStatsIds = new Set((applyPlan.aggregatedStatsWrites || [])
-    .filter((entry: any) => entry?.privateData)
-    .map((entry: any) => String(entry?.playerId || '')))
+  const plannedPlayerIds = new Set((applyPlan.aggregatedStatsWrites || []).map((entry: any) => String(entry?.playerId || '')))
+
+  const cleanupDocs = [
+    ...eventsSnap.docs,
+    ...statsSnap.docs.filter((entry: any) => !plannedPlayerIds.has(getTrackedDocId(entry))),
+    ...privateStatsSnap.docs.filter((entry: any) => !plannedPlayerIds.has(getTrackedDocId(entry)))
+  ]
+
+  const totalBatchWrites = (applyPlan.aggregatedStatsWrites || []).length * 2 + 1 + cleanupDocs.length
+  if (replaceExisting && totalBatchWrites > FIRESTORE_BATCH_WRITE_LIMIT) {
+    throw new Error('This statsheet replacement is too large to apply safely in one save. Please reduce the tracked rows or ask a team admin to clear the game first.')
+  }
 
   const batch = writeBatch(db)
   addAggregatedStatsWritesToBatch({
@@ -390,20 +399,22 @@ export async function applyTrackStatsheetImportForApp({
   })
   const gameRef = doc(db, `teams/${teamId}/games`, gameId)
   batch.update(gameRef, applyPlan.gameUpdate)
-  await batch.commit()
 
-  const cleanupDocs = [
-    ...eventsSnap.docs,
-    ...statsSnap.docs.filter((entry: any) => !retainedAggregatedStatsIds.has(getTrackedDocId(entry))),
-    ...privateStatsSnap.docs.filter((entry: any) => !retainedPrivateStatsIds.has(getTrackedDocId(entry)))
-  ]
-
-  for (let i = 0; i < cleanupDocs.length; i += TRACKED_DATA_CLEANUP_BATCH_LIMIT) {
-    const cleanupBatch = writeBatch(db)
-    cleanupDocs.slice(i, i + TRACKED_DATA_CLEANUP_BATCH_LIMIT).forEach((entry: any) => {
-      cleanupBatch.delete(entry.ref)
+  if (replaceExisting) {
+    cleanupDocs.forEach((entry: any) => {
+      batch.delete(entry.ref)
     })
-    await cleanupBatch.commit()
+    await batch.commit()
+  } else {
+    await batch.commit()
+
+    for (let i = 0; i < cleanupDocs.length; i += TRACKED_DATA_CLEANUP_BATCH_LIMIT) {
+      const cleanupBatch = writeBatch(db)
+      cleanupDocs.slice(i, i + TRACKED_DATA_CLEANUP_BATCH_LIMIT).forEach((entry: any) => {
+        cleanupBatch.delete(entry.ref)
+      })
+      await cleanupBatch.commit()
+    }
   }
 
   return {


### PR DESCRIPTION
Closes #3040

## What changed
- changed `statsheetImportService` to commit the replacement statsheet writes before deleting prior tracked data
- added post-commit cleanup batches that remove old events and superseded tracked/private stats only after the replacement batch succeeds
- added a regression test that fails if existing tracked data is cleared before a replacement write error surfaces

## Root Cause
`applyTrackStatsheetImportForApp` eagerly deleted existing `events`, `aggregatedStats`, and `privatePlayerStats` before attempting the replacement `writeBatch` commit. If that later commit failed, Firestore had already removed the original tracked data, leaving the game empty.

## Prevention / Learning
When replacing Firestore-backed data, do not perform destructive cleanup ahead of the first write that can fail under quota, connectivity, or batch-pressure conditions. Stage the new durable state first, then clean up superseded records in a follow-up phase so commit failures preserve the last known good data.

## Regression Tests
- `npm --prefix apps/app exec vitest run src/lib/statsheetImportService.test.ts`
- added coverage proving a replacement write failure does not trigger any tracked-data deletes
- updated the happy-path import test to verify cleanup happens only after the replacement commit