### PR TITLE
Reduce inbox unread count fan-out

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -679,7 +679,8 @@ export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoa
   const unreadCounts = await withTimeout(
     Promise.resolve(getUnreadChatCounts(user.uid, unreadCandidateTeamIds, {
       latestMessageAtByTeam,
-      conversationLookupByTeam
+      conversationLookupByTeam,
+      defaultConversationOnly: !includeLastMessages
     })),
     'Chat unread counts',
     3000

--- a/js/db.js
+++ b/js/db.js
@@ -6550,6 +6550,7 @@ export async function getUnreadChatCounts(userId, teamIds, options = {}) {
     const latestMessageAtByTeam = options?.latestMessageAtByTeam || {};
     const conversationIdsByTeam = options?.conversationIdsByTeam || {};
     const conversationLookupByTeam = options?.conversationLookupByTeam || {};
+    const defaultConversationOnly = options?.defaultConversationOnly === true;
     let userData = {};
 
     try {
@@ -6569,18 +6570,20 @@ export async function getUnreadChatCounts(userId, teamIds, options = {}) {
                 ? conversationIdsByTeam[teamId]
                 : null;
             const conversationLookup = conversationLookupByTeam?.[teamId] || {};
-            const loadedConversationIds = storedConversationIds || (await getChatConversations(
-                teamId,
-                conversationLookup.user || null,
-                {
-                    team: conversationLookup.team || null,
-                    canModerate: conversationLookup.canModerate === true
-                }
-            )).map((conversation) => conversation?.id).filter(Boolean);
-            const conversationIds = [
+            const loadedConversationIds = storedConversationIds || (defaultConversationOnly
+                ? [DEFAULT_TEAM_CONVERSATION_ID]
+                : (await getChatConversations(
+                    teamId,
+                    conversationLookup.user || null,
+                    {
+                        team: conversationLookup.team || null,
+                        canModerate: conversationLookup.canModerate === true
+                    }
+                )).map((conversation) => conversation?.id).filter(Boolean));
+            const conversationIds = Array.from(new Set([
                 DEFAULT_TEAM_CONVERSATION_ID,
                 ...loadedConversationIds.filter((conversationId) => !isDefaultTeamConversation(conversationId))
-            ];
+            ]));
 
             const unreadCounts = await Promise.all(conversationIds.map(async (conversationId) => {
                 try {

--- a/team.html
+++ b/team.html
@@ -324,7 +324,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=65';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=68';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, expandRecurrence, escapeHtml, shareOrCopy } from './js/utils.js?v=11';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -573,6 +573,9 @@ describe('React app chat recipient service', () => {
             expect.objectContaining({ id: 'team-a', lastMessage: null, unreadCount: 0 }),
             expect.objectContaining({ id: 'team-b', lastMessage: null, unreadCount: 3 })
         ]);
+        expect(dbMocks.getUnreadChatCounts).toHaveBeenCalledWith('user-1', ['team-a', 'team-b'], expect.objectContaining({
+            defaultConversationOnly: true
+        }));
         expect(dbMocks.getChatConversations).not.toHaveBeenCalled();
         expect(dbMocks.getChatMessages).not.toHaveBeenCalled();
     });

--- a/tests/unit/db-unread-chat-counts.test.js
+++ b/tests/unit/db-unread-chat-counts.test.js
@@ -327,16 +327,10 @@ describe('chat unread count helpers', () => {
         expect(warn).toHaveBeenCalledWith('Failed to get unread count for team team-b conversation team:', expect.any(Error));
     });
 
-    it('aggregates unread counts across the default and sibling conversations for one team', async () => {
+    it('keeps fast inbox unread counts on the default conversation only', async () => {
         const getUnreadChatCount = vi.fn()
-            .mockResolvedValueOnce(1)
-            .mockResolvedValueOnce(2)
-            .mockResolvedValueOnce(0);
-        const getChatConversations = vi.fn().mockResolvedValue([
-            { id: 'team' },
-            { id: 'staff-conversation' },
-            { id: 'direct-conversation' }
-        ]);
+            .mockResolvedValueOnce(1);
+        const getChatConversations = vi.fn();
         const getDoc = vi.fn().mockResolvedValue({
             data: () => ({ teamChatState: {} })
         });
@@ -354,6 +348,7 @@ describe('chat unread count helpers', () => {
         const lookupTeam = { id: 'team-a', name: 'Bears' };
 
         await expect(getUnreadChatCounts('user-5', ['team-a'], {
+            defaultConversationOnly: true,
             latestMessageAtByTeam: {
                 'team-a': { seconds: 250 }
             },
@@ -365,13 +360,51 @@ describe('chat unread count helpers', () => {
                 }
             }
         })).resolves.toEqual({
+            'team-a': 1
+        });
+
+        expect(getChatConversations).not.toHaveBeenCalled();
+        expect(getUnreadChatCount).toHaveBeenCalledTimes(1);
+        expect(getUnreadChatCount).toHaveBeenNthCalledWith(1, 'user-5', 'team-a', expect.objectContaining({
+            conversationId: 'team',
+            latestMessageAt: { seconds: 250 }
+        }));
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('aggregates unread counts across sibling conversations when ids are already loaded', async () => {
+        const getUnreadChatCount = vi.fn()
+            .mockResolvedValueOnce(1)
+            .mockResolvedValueOnce(2)
+            .mockResolvedValueOnce(0);
+        const getChatConversations = vi.fn();
+        const getDoc = vi.fn().mockResolvedValue({
+            data: () => ({ teamChatState: {} })
+        });
+        const doc = vi.fn(() => ({ path: 'users/user-5' }));
+        const warn = vi.fn();
+        const getUnreadChatCounts = buildGetUnreadChatCounts({
+            db: {},
+            getDoc,
+            doc,
+            getUnreadChatCount,
+            getChatConversations,
+            console: { warn }
+        });
+
+        await expect(getUnreadChatCounts('user-5', ['team-a'], {
+            defaultConversationOnly: true,
+            latestMessageAtByTeam: {
+                'team-a': { seconds: 250 }
+            },
+            conversationIdsByTeam: {
+                'team-a': ['team', 'staff-conversation', 'direct-conversation']
+            }
+        })).resolves.toEqual({
             'team-a': 3
         });
 
-        expect(getChatConversations).toHaveBeenCalledWith('team-a', lookupUser, {
-            team: lookupTeam,
-            canModerate: true
-        });
+        expect(getChatConversations).not.toHaveBeenCalled();
         expect(getUnreadChatCount).toHaveBeenNthCalledWith(1, 'user-5', 'team-a', expect.objectContaining({
             conversationId: 'team',
             latestMessageAt: { seconds: 250 }

--- a/tests/unit/team-scorekeeper-grants.test.js
+++ b/tests/unit/team-scorekeeper-grants.test.js
@@ -48,7 +48,7 @@ describe('team scorekeeper grants', () => {
     it('pins the latest db cache-busting version for the team page module', () => {
         const source = readTeamHtml();
 
-        expect(source).toContain("from './js/db.js?v=65'");
+        expect(source).toContain("from './js/db.js?v=68'");
     });
 
     it('wires the team page to grant and revoke scoped scorekeeper access', () => {


### PR DESCRIPTION
Closes #3038

## What changed
- Passed an explicit `defaultConversationOnly` flag from `loadChatInbox(..., { includeLastMessages: false })` so inbox and Home summary unread refreshes stay on the default team conversation.
- Updated `getUnreadChatCounts` to skip `getChatConversations(...)` fan-out in that fast path while still honoring preloaded `conversationIdsByTeam` when a detail or preview context already knows sibling threads.
- Added regression coverage for both behaviors: fast inbox default-only counting and preserved multi-conversation aggregation when conversation ids are already loaded.

## Root Cause
The inbox fast path still called the shared unread helper without constraining conversation scope. That let `getUnreadChatCounts` fall back to `getChatConversations` for every unread-candidate team and then count every sibling conversation, turning inbox badge refresh into per-team conversation enumeration before the inbox finished loading.

## Prevention / Learning
When a route intentionally uses a fast inbox or summary mode, pass an explicit scope contract into shared unread helpers. Do not rely on a detail-capable helper to "do the right thing" implicitly, because it will usually re-expand into the more expensive detail workflow unless the caller pins the scope.

## Regression Tests
- `npx vitest run tests/unit/db-unread-chat-counts.test.js tests/unit/app-chat-service-recipients.test.js --reporter=verbose`
- `tests/unit/db-unread-chat-counts.test.js` now verifies fast inbox mode counts only the default conversation and does not require `getChatConversations`.
- `tests/unit/db-unread-chat-counts.test.js` also verifies sibling conversation aggregation still works when `conversationIdsByTeam` is already supplied.
- `tests/unit/app-chat-service-recipients.test.js` verifies `loadChatInbox(..., { includeLastMessages: false })` forwards the fast-path flag.