### PR TITLE
Show registration closed when all options are full

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -475,8 +475,12 @@ function getActivePublicRegistrationOptions(form = {}, counts = {}) {
   });
 }
 
+function hasConfiguredPublicRegistrationOptions(form = {}) {
+  return (form.registrationOptions || []).some((option) => option.active === true);
+}
+
 function publicRegistrationRequiresOption(form = {}) {
-  return (form.registrationOptions || []).some((option) => option.active !== false);
+  return getActivePublicRegistrationOptions(form, form.registrationOptionCounts || {}).length > 0;
 }
 
 function getConfiguredPublicRegistrationOptionById(form = {}, selectedOptionId = '') {
@@ -770,6 +774,12 @@ exports.submitPublicRegistration = functions.https.onCall(async (data, context =
     const formData = formSnap.data() || {};
     const latestForm = normalizePublicRegistrationForm(formData, input);
     validatePublicRegistrationSubmission(latestForm, input);
+
+    if (hasConfiguredPublicRegistrationOptions(latestForm) && !publicRegistrationRequiresOption(latestForm)) {
+      throwPublicRegistrationError('failed-precondition', 'Registration is currently unavailable. No registration options are available.', {
+        reason: 'no-options-available'
+      });
+    }
 
     let status = 'pending';
     let selectedOption = null;

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -317,9 +317,13 @@ test('normalizes guardian email casing for parent readback rules', async () => {
 
 test('rejects blocked capacity without creating a registration or changing counters', async () => {
     const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState({
-        registrationOptions: [{ id: 'u10', title: 'U10', capacityLimit: 1, waitlistEnabled: false, active: true }],
+        registrationOptions: [
+            { id: 'u10', title: 'U10', capacityLimit: 1, waitlistEnabled: false, active: true },
+            { id: 'u12', title: 'U12', capacityLimit: 5, waitlistEnabled: false, active: true }
+        ],
         registrationOptionCounts: {
-            u10: { enrolled: 1, waitlisted: 0 }
+            u10: { enrolled: 1, waitlisted: 0 },
+            u12: { enrolled: 0, waitlisted: 0 }
         }
     }));
 
@@ -328,6 +332,32 @@ test('rejects blocked capacity without creating a registration or changing count
         (error) => {
             assert.equal(error.code, 'failed-precondition');
             assert.equal(error.details.reason, 'option-full');
+            return true;
+        }
+    );
+
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
+    assert.equal(form.registrationOptionCounts.u10.waitlisted, 0);
+    assert.equal(form.registrationOptionCounts.u12.enrolled, 0);
+    assert.equal(form.registrationOptionCounts.u12.waitlisted, 0);
+    assert.equal(firestore.registrationDocs().length, 0);
+});
+
+test('rejects submissions when every configured option is full without a waitlist', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState({
+        registrationOptions: [{ id: 'u10', title: 'U10', capacityLimit: 1, waitlistEnabled: false, active: true }],
+        registrationOptionCounts: {
+            u10: { enrolled: 1, waitlisted: 0 }
+        }
+    }));
+
+    await assert.rejects(
+        submitPublicRegistration(buildSubmission({ selectedOptionId: '' }), context),
+        (error) => {
+            assert.equal(error.code, 'failed-precondition');
+            assert.equal(error.message, 'Registration is currently unavailable. No registration options are available.');
+            assert.equal(error.details.reason, 'no-options-available');
             return true;
         }
     );

--- a/registration.html
+++ b/registration.html
@@ -307,10 +307,11 @@
         function setRegistrationUnavailableState(form) {
             const unavailable = hasUnavailableRegistrationOptions(form);
             const unavailableMessage = document.getElementById('registration-options-unavailable');
+            const allowRetryPayment = retryPaymentRequested && hasOnlineRegistrationCheckout(form);
 
             unavailableMessage.classList.toggle('hidden', !unavailable);
             submitButton.disabled = unavailable;
-            payRegistrationButton.disabled = unavailable;
+            payRegistrationButton.disabled = unavailable && !allowRetryPayment;
 
             if (unavailable) {
                 showFormError('Registration is currently unavailable. No registration options are available.');
@@ -632,7 +633,7 @@
                 showFormError('Payment is not configured for this registration.');
                 return;
             }
-            if (hasUnavailableRegistrationOptions(activeForm)) {
+            if (hasUnavailableRegistrationOptions(activeForm) && !retryPaymentRequested) {
                 showFormError('Registration is currently unavailable. No registration options are available.');
                 return;
             }

--- a/registration.html
+++ b/registration.html
@@ -55,6 +55,7 @@
                 <section id="registration-options-section" class="hidden">
                     <h2 class="text-xl font-semibold text-gray-900">Registration option</h2>
                     <p class="mt-1 text-sm text-gray-600">Choose the option that fits this participant.</p>
+                    <p id="registration-options-unavailable" class="hidden mt-3 rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">Registration is currently unavailable. No registration options are available.</p>
                     <div id="registration-options" class="mt-3 grid gap-3"></div>
                 </section>
 
@@ -260,6 +261,7 @@
             renderRegistrationPaymentSettings(form);
             renderRegistrationOptions(form);
             renderPaymentPlanChoices(form);
+            setRegistrationUnavailableState(form);
 
             loadingState.classList.add('hidden');
             formElement.classList.remove('hidden');
@@ -294,14 +296,36 @@
             section.classList.remove('hidden');
         }
 
+        function hasConfiguredRegistrationOptions(form) {
+            return (form.registrationOptions || []).some(option => option.active === true);
+        }
+
+        function hasUnavailableRegistrationOptions(form) {
+            return hasConfiguredRegistrationOptions(form) && !requiresRegistrationOption(form);
+        }
+
+        function setRegistrationUnavailableState(form) {
+            const unavailable = hasUnavailableRegistrationOptions(form);
+            const unavailableMessage = document.getElementById('registration-options-unavailable');
+
+            unavailableMessage.classList.toggle('hidden', !unavailable);
+            submitButton.disabled = unavailable;
+            payRegistrationButton.disabled = unavailable;
+
+            if (unavailable) {
+                showFormError('Registration is currently unavailable. No registration options are available.');
+            }
+        }
+
         function renderRegistrationOptions(form) {
             const section = document.getElementById('registration-options-section');
             const container = document.getElementById('registration-options');
             const options = getActiveRegistrationOptions(form, form.registrationOptionCounts || {});
+            const configuredOptions = hasConfiguredRegistrationOptions(form);
             container.innerHTML = '';
 
             if (options.length === 0) {
-                section.classList.add('hidden');
+                section.classList.toggle('hidden', !configuredOptions);
                 return;
             }
 
@@ -481,6 +505,10 @@
         formElement.addEventListener('submit', async (event) => {
             event.preventDefault();
             if (!activeForm) return;
+            if (hasUnavailableRegistrationOptions(activeForm)) {
+                showFormError('Registration is currently unavailable. No registration options are available.');
+                return;
+            }
 
             // If online checkout is required, the payment button handles the flow.
             if (hasOnlineRegistrationCheckout(activeForm)) {
@@ -602,6 +630,10 @@
             event.preventDefault(); // Prevent any default form submission
             if (!activeForm || !hasOnlineRegistrationCheckout(activeForm)) {
                 showFormError('Payment is not configured for this registration.');
+                return;
+            }
+            if (hasUnavailableRegistrationOptions(activeForm)) {
+                showFormError('Registration is currently unavailable. No registration options are available.');
                 return;
             }
 

--- a/tests/smoke/registration-public.spec.js
+++ b/tests/smoke/registration-public.spec.js
@@ -203,6 +203,34 @@ test('public registration submits an offline-payment registration with option, p
     });
 });
 
+test('public registration shows an unavailable state when all configured options are full', async ({ page, baseURL }) => {
+    await mockRegistrationModules(page, {
+        form: registrationForm({
+            registrationOptions: [
+                {
+                    id: 'u10',
+                    title: 'U10 Travel',
+                    description: 'Roster is full.',
+                    capacityLimit: 1,
+                    waitlistEnabled: false,
+                    active: true
+                }
+            ],
+            registrationOptionCounts: {
+                u10: { enrolled: 1, waitlisted: 0 }
+            }
+        })
+    });
+    await page.goto(buildUrl(baseURL, '/registration.html?teamId=team-1&formId=form-1'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByText('Registration is currently unavailable. No registration options are available.')).toBeVisible();
+    await expect(page.locator('#registration-options')).toBeEmpty();
+    await expect(page.getByRole('button', { name: 'Submit registration' })).toBeDisabled();
+
+    const calls = await page.evaluate(() => window.__registrationCalls);
+    expect(calls.filter((call) => call.name === 'submitPublicRegistration')).toEqual([]);
+});
+
 test('online registration prepares one server registration and redirects to Stripe checkout', async ({ page, baseURL }) => {
     await mockRegistrationModules(page, {
         form: registrationForm({

--- a/tests/smoke/registration-public.spec.js
+++ b/tests/smoke/registration-public.spec.js
@@ -223,7 +223,8 @@ test('public registration shows an unavailable state when all configured options
     });
     await page.goto(buildUrl(baseURL, '/registration.html?teamId=team-1&formId=form-1'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByText('Registration is currently unavailable. No registration options are available.')).toBeVisible();
+    await expect(page.locator('#registration-options-unavailable')).toBeVisible();
+    await expect(page.locator('#error-message')).toHaveText('Registration is currently unavailable. No registration options are available.');
     await expect(page.locator('#registration-options')).toBeEmpty();
     await expect(page.getByRole('button', { name: 'Submit registration' })).toBeDisabled();
 

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -389,6 +389,9 @@ describe('public registration flow', () => {
         expect(page).toContain("const retryPaymentRequested = params.get('retryPayment') === '1' && !!(retryPublicCheckoutCapability || retryRegistrationId);");
         expect(page).toContain('Use the button below to retry payment without submitting a new registration.');
         expect(page).toContain('if (retryPaymentRequested) {');
+        expect(page).toContain('const allowRetryPayment = retryPaymentRequested && hasOnlineRegistrationCheckout(form);');
+        expect(page).toContain('payRegistrationButton.disabled = unavailable && !allowRetryPayment;');
+        expect(page).toContain('if (hasUnavailableRegistrationOptions(activeForm) && !retryPaymentRequested) {');
         expect(page).toContain("registrationId: currentPublicCheckoutCapability ? '' : retryRegistrationId,");
         expect(page).toContain('retryPayment: true');
         expect(page).toContain('const retryKey = buildCheckoutRetryKey(submission, amountCents, currency);');

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -7,12 +7,14 @@ import {
     collectFieldValues,
     decideRegistrationPlacement,
     formatFeeAmount,
+    getActiveRegistrationOptions,
     getRegistrationPaymentNotice,
     hasRegistrationPaymentSettings,
     hasOnlineRegistrationCheckout,
     getPaymentPlanChoices,
     formatFeeSnapshotLines,
     normalizeRegistrationForm,
+    requiresRegistrationOption,
     validateRegistrationSubmission
 } from '../../js/registration-flow.js';
 import fs from 'node:fs';
@@ -277,6 +279,23 @@ describe('public registration flow', () => {
         expect(validateRegistrationSubmission(form, { waiverAccepted: true, selectedOptionId: 'u10' })).toEqual([]);
     });
 
+    it('treats all-full non-waitlisted options as unavailable before submission', () => {
+        const form = normalizeRegistrationForm({
+            programName: 'Clinic',
+            published: true,
+            registrationOptions: [
+                { id: 'u10', title: 'U10', capacityLimit: 1, waitlistEnabled: false, active: true }
+            ],
+            registrationOptionCounts: {
+                u10: { enrolled: 1, waitlisted: 0 }
+            }
+        }, { teamId: 'team-1', formId: 'form-1' });
+
+        expect(getActiveRegistrationOptions(form, form.registrationOptionCounts)).toEqual([]);
+        expect(requiresRegistrationOption(form)).toBe(false);
+        expect(validateRegistrationSubmission(form, { waiverAccepted: true, selectedOptionId: '' })).toEqual([]);
+    });
+
     it('places selected option registrations into pending, waitlisted, or blocked states', () => {
         const form = normalizeRegistrationForm({
             programName: 'Clinic',
@@ -352,6 +371,8 @@ describe('public registration flow', () => {
         expect(page).toContain("doc(db, 'teams', teamId, 'registrationForms', formId)");
         expect(page).not.toContain("collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations')");
         expect(page).toContain('registration-options-section');
+        expect(page).toContain('registration-options-unavailable');
+        expect(page).toContain('Registration is currently unavailable. No registration options are available.');
         expect(page).toContain('registration-payment-section');
         expect(page).toContain('getRegistrationPaymentNotice');
         expect(page).toContain('hasOnlineRegistrationCheckout');
@@ -389,6 +410,7 @@ describe('public registration flow', () => {
         expect(page).not.toContain('runTransaction(db, async (transaction)');
         expect(page).not.toContain('addDoc(');
         expect(page).toContain('decideRegistrationPlacement');
+        expect(page).toContain('hasUnavailableRegistrationOptions');
         expect(page).toContain('option-full');
         expect(page).toContain('waiver-accepted');
         expect(page).toContain('confirmation-message');
@@ -752,6 +774,8 @@ describe('public registration flow', () => {
         expect(functionsSource).toContain('form.currency || registration.feeSnapshot?.currency || registration.currency');
         expect(functionsSource).toContain("Current public checkout capability is required to retry this payment.");
         expect(functionsSource).toContain("This registration option is no longer available. Please restart registration or contact the organizer.");
+        expect(functionsSource).toContain("Registration is currently unavailable. No registration options are available.");
+        expect(functionsSource).toContain("reason: 'no-options-available'");
         expect(functionsSource).toContain("registrationCapacityReleased: false");
         expect(functionsSource).toContain("capacityReleasedAt: admin.firestore.FieldValue.delete()");
         expect(functionsSource).toContain("const currency = String(");


### PR DESCRIPTION
Closes #3048

## What changed
- aligned public-registration option availability so the server only requires a selection when at least one selectable option remains
- added a server-side failed-precondition guard for forms whose configured options are all full with waitlists disabled, returning a clear unavailable message instead of a missing-option error
- updated `registration.html` to show an explicit unavailable state in the registration-options section and disable submit/payment actions before families can hit the dead end
- added focused regression coverage for the shared availability rule, the callable rejection path, and the public-page unavailable UX

## Root Cause
The client and server used different definitions of option availability. The client filtered out full non-waitlisted options and stopped requiring a selection when none remained, but the callable still treated any active configured option as requiring placement, so the page became a dead end and the server rejected the empty selection late.

## Prevention / Learning
When capacity-filtered options drive a public workflow, use the same selectable-options predicate for render gating, client validation, and server enforcement. If configured options collapse to zero selectable choices, ship an explicit unavailable state instead of silently hiding the selector.

## Regression Tests
- `npx vitest run tests/unit/registration-flow.test.js --reporter=dot`
- `node --test functions/test/public-registration-submission.test.cjs`
- added `tests/smoke/registration-public.spec.js` coverage for the unavailable-state UX
- attempted `npx playwright test tests/smoke/registration-public.spec.js --config=playwright.smoke.config.js --reporter=line`, but local validation was blocked because the Playwright Chromium binary is not installed in this environment