### PR TITLE
Fix future scheduled game status in event detail

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -467,6 +467,28 @@ describe('ScheduleEventDetail loading states', () => {
       expect(screen.getAllByText(/Avery Smith/).length).toBeGreaterThan(0);
     });
   });
+
+  it('does not label future scheduled games with a final 0-0 score', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        date: new Date('2099-11-15T18:00:00.000Z'),
+        homeScore: 0,
+        awayScore: 0,
+        status: 'scheduled',
+        liveStatus: 'scheduled'
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'vs. Wolves' })).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Final 0-0')).toBeNull();
+    expect(screen.queryByText(/^0-0$/)).toBeNull();
+  });
 });
 
 describe('ScheduleEventDetail lineup draft guards', () => {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -489,6 +489,27 @@ describe('ScheduleEventDetail loading states', () => {
     expect(screen.queryByText('Final 0-0')).toBeNull();
     expect(screen.queryByText(/^0-0$/)).toBeNull();
   });
+
+  it('shows the live score label for games that are currently live', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        date: new Date('2099-11-15T18:00:00.000Z'),
+        homeScore: 3,
+        awayScore: 2,
+        status: 'live',
+        liveStatus: 'live'
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'vs. Wolves' })).toBeTruthy();
+    });
+
+    expect(screen.getByText('3-2')).toBeTruthy();
+  });
 });
 
 describe('ScheduleEventDetail lineup draft guards', () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -3951,8 +3951,15 @@ function getEventStatusClasses(event: ParentScheduleEvent) {
   return 'border-primary-200 bg-primary-50 text-primary-700';
 }
 
+const pastScheduledGameScoreCutoffMs = 3 * 60 * 60 * 1000;
+
 function getScoreLabel(event: ParentScheduleEvent) {
   if (event.type !== 'game') return '';
   if (event.homeScore === null || event.homeScore === undefined || event.awayScore === null || event.awayScore === undefined) return '';
+  const status = String(event.status || '').trim().toLowerCase();
+  const liveStatus = String(event.liveStatus || '').trim().toLowerCase();
+  const isCompleted = status === 'completed' || status === 'final' || liveStatus === 'completed' || liveStatus === 'final';
+  const isPastScheduledResult = event.date.getTime() < Date.now() - pastScheduledGameScoreCutoffMs;
+  if (!isCompleted && !isPastScheduledResult) return '';
   return `${event.homeScore}-${event.awayScore}`;
 }

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -3958,8 +3958,9 @@ function getScoreLabel(event: ParentScheduleEvent) {
   if (event.homeScore === null || event.homeScore === undefined || event.awayScore === null || event.awayScore === undefined) return '';
   const status = String(event.status || '').trim().toLowerCase();
   const liveStatus = String(event.liveStatus || '').trim().toLowerCase();
+  const isLive = status === 'live' || liveStatus === 'live';
   const isCompleted = status === 'completed' || status === 'final' || liveStatus === 'completed' || liveStatus === 'final';
   const isPastScheduledResult = event.date.getTime() < Date.now() - pastScheduledGameScoreCutoffMs;
-  if (!isCompleted && !isPastScheduledResult) return '';
+  if (!isLive && !isCompleted && !isPastScheduledResult) return '';
   return `${event.homeScore}-${event.awayScore}`;
 }


### PR DESCRIPTION
Closes #3034

## What changed
- updated `ScheduleEventDetail`'s local game score label helper so it only shows scores for completed/final games or older past games, matching the existing schedule list behavior
- added a regression test proving a future scheduled game with default `0-0` scores does not render `Final 0-0` in the event detail route

## Root Cause
`ScheduleEventDetail` had its own page-local `getScoreLabel()` implementation that returned any numeric game scores without checking whether the game was actually completed. Future scheduled games carrying default `homeScore: 0` and `awayScore: 0` therefore rendered as `Final 0-0` in the detail header.

## Prevention / Learning
When list and detail surfaces present the same score/status concept, they need to share the same completion guard or shared helper. Duplicated page-local status logic is a repeatable source of drift bugs like this one.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/ScheduleEventDetail.test.tsx --reporter=verbose`
- added coverage in `apps/app/src/pages/ScheduleEventDetail.test.tsx` asserting a future scheduled game with `0-0` scores does not show `Final 0-0`