### PR TITLE
Filter public team browse results by active search

### DIFF
--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -67,6 +67,34 @@ describe('publicTeamsService', () => {
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: '60601', cursor: null, pageSize: 24 });
     });
 
+    it('accepts nullable location fields from legacy public team results', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                {
+                    id: 'team-null-location-1',
+                    name: 'Null Location FC',
+                    city: null,
+                    state: null,
+                    zip: '73301'
+                }
+            ],
+            nextCursor: null
+        });
+
+        await expect(getPublicTeamsPage({ searchText: '73301' })).resolves.toEqual({
+            teams: [
+                expect.objectContaining({
+                    teamId: 'team-null-location-1',
+                    location: '73301',
+                    city: null,
+                    state: null,
+                    zip: '73301'
+                })
+            ],
+            nextCursor: null
+        });
+    });
+
     it('keeps city searches on the bounded helper contract for zip-backed public teams', async () => {
         dbMocks.discoverPublicTeams.mockResolvedValue({
             teams: [

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -100,4 +100,48 @@ describe('publicTeamsService', () => {
 
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'Atlanta United', cursor: null, pageSize: 24 });
     });
+
+    it('defensively filters over-broad public browse results against the active search text', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                {
+                    id: 'team-ai-1',
+                    name: 'AI Score Reader',
+                    city: 'Kansas City',
+                    state: 'MO',
+                    zip: '64131'
+                },
+                {
+                    id: 'team-bbb-1',
+                    name: 'bbb',
+                    city: 'Kansas City',
+                    state: 'MO',
+                    zip: '64113'
+                },
+                {
+                    id: 'team-blake-1',
+                    name: 'Blake\'s Basketball',
+                    city: 'Overland Park',
+                    state: 'KS',
+                    zip: '66210'
+                }
+            ],
+            nextCursor: null
+        });
+
+        await expect(getPublicTeamsPage({ searchText: 'AI Score Reader' })).resolves.toEqual({
+            teams: [
+                expect.objectContaining({
+                    teamId: 'team-ai-1',
+                    teamName: 'AI Score Reader'
+                })
+            ],
+            nextCursor: null
+        });
+
+        await expect(getPublicTeamsPage({ searchText: 'zzzznotateam64131' })).resolves.toEqual({
+            teams: [],
+            nextCursor: null
+        });
+    });
 });

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -118,6 +118,40 @@ describe('publicTeamsService', () => {
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'Kansas City', cursor: null, pageSize: 24 });
     });
 
+    it('still matches short text prefixes before treating two-letter searches as state codes', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                {
+                    id: 'team-bears-1',
+                    name: 'Bears',
+                    city: 'Kansas City',
+                    state: 'MO'
+                },
+                {
+                    id: 'team-state-1',
+                    name: 'Wildcats',
+                    city: 'Wichita',
+                    state: 'BE'
+                }
+            ],
+            nextCursor: null
+        });
+
+        await expect(getPublicTeamsPage({ searchText: 'be' })).resolves.toEqual({
+            teams: [
+                expect.objectContaining({
+                    teamId: 'team-bears-1',
+                    teamName: 'Bears'
+                }),
+                expect.objectContaining({
+                    teamId: 'team-state-1',
+                    teamName: 'Wildcats'
+                })
+            ],
+            nextCursor: null
+        });
+    });
+
     it('trims generic search text before hitting the bounded discovery helper', async () => {
         dbMocks.discoverPublicTeams.mockResolvedValue({
             teams: [],

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -57,12 +57,12 @@ function matchesPublicTeamSearch(team: { name?: string | null; city?: string | n
         return normalizedZip.startsWith(normalizedSearchText);
     }
 
-    if (/^[a-z]{2}$/.test(normalizedSearchText)) {
-        return normalizedState === normalizedSearchText;
-    }
-
     if (teamFields.some((field) => field.includes(normalizedSearchText))) {
         return true;
+    }
+
+    if (/^[a-z]{2}$/.test(normalizedSearchText)) {
+        return normalizedState === normalizedSearchText;
     }
 
     return searchTokens.every((token) => combinedFields.includes(token));

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -10,7 +10,7 @@ function normalizePublicTeamSearchText(value: string | null | undefined): string
     return String(value || '').trim().toLowerCase();
 }
 
-function teamLocation(team: { city?: string; state?: string; zip?: string }): string | null {
+function teamLocation(team: { city?: string | null; state?: string | null; zip?: string | null }): string | null {
     if (team.city && team.state) return `${team.city}, ${team.state}`;
     if (team.zip) return team.zip;
     return null;

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -6,6 +6,10 @@ export type PublicTeamsPage = {
     nextCursor: unknown | null;
 };
 
+function normalizePublicTeamSearchText(value: string | null | undefined): string {
+    return String(value || '').trim().toLowerCase();
+}
+
 function teamLocation(team: { city?: string; state?: string; zip?: string }): string | null {
     if (team.city && team.state) return `${team.city}, ${team.state}`;
     if (team.zip) return team.zip;
@@ -34,6 +38,36 @@ function mapPublicTeam(team: { id: string; name: string; sport?: string | null; 
     };
 }
 
+function matchesPublicTeamSearch(team: { name?: string | null; city?: string | null; state?: string | null; zip?: string | null }, searchText: string): boolean {
+    const normalizedSearchText = normalizePublicTeamSearchText(searchText);
+    if (!normalizedSearchText) {
+        return true;
+    }
+
+    const normalizedName = normalizePublicTeamSearchText(team.name);
+    const normalizedCity = normalizePublicTeamSearchText(team.city);
+    const normalizedState = String(team.state || '').trim().toLowerCase();
+    const normalizedZip = String(team.zip || '').trim();
+    const location = normalizePublicTeamSearchText(teamLocation(team) || '');
+    const searchTokens = normalizedSearchText.split(/[\s,]+/).filter(Boolean);
+    const teamFields = [normalizedName, normalizedCity, normalizedState, normalizedZip, location].filter(Boolean);
+    const combinedFields = teamFields.join(' ');
+
+    if (/^\d{1,5}$/.test(normalizedSearchText)) {
+        return normalizedZip.startsWith(normalizedSearchText);
+    }
+
+    if (/^[a-z]{2}$/.test(normalizedSearchText)) {
+        return normalizedState === normalizedSearchText;
+    }
+
+    if (teamFields.some((field) => field.includes(normalizedSearchText))) {
+        return true;
+    }
+
+    return searchTokens.every((token) => combinedFields.includes(token));
+}
+
 export async function getPublicTeamsPage({ searchText, locationFilter, cursor = null, pageSize = 24 }: { searchText?: string; locationFilter?: string; cursor?: unknown | null; pageSize?: number } = {}): Promise<PublicTeamsPage> {
     const normalizedSearchText = String(searchText ?? locationFilter ?? '').trim();
     const result = await discoverPublicTeams({
@@ -41,9 +75,12 @@ export async function getPublicTeamsPage({ searchText, locationFilter, cursor = 
         cursor,
         pageSize
     });
+    const teams = result.teams
+        .filter((team: { name?: string | null; city?: string | null; state?: string | null; zip?: string | null }) => matchesPublicTeamSearch(team, normalizedSearchText))
+        .map(mapPublicTeam);
 
     return {
-        teams: result.teams.map(mapPublicTeam),
+        teams,
         nextCursor: result.nextCursor || null
     };
 }


### PR DESCRIPTION
Closes #3018

## What changed
- Added a defensive search matcher in `apps/app/src/lib/publicTeamsService.ts` so the React public-team browse page only renders teams whose name, city, state, or zip still match the active query.
- Kept the existing bounded `discoverPublicTeams` call intact, then filtered the returned records before mapping them into app-facing team cards.
- Added a regression test that simulates an over-broad browse payload and proves `AI Score Reader` stays visible while a nonsense query returns an empty result set.

## Root Cause
The React public team browse service trusted `discoverPublicTeams(...)` results verbatim. When the legacy discovery path returned an over-broad public directory page instead of search-scoped matches, the app rendered those unrelated teams as if the search had succeeded.

## Prevention / Learning
When a React surface depends on a legacy Firestore search helper, keep a client-side invariant check that verifies returned records still match the active user query before rendering them. That prevents stale search fields, backfill drift, or helper regressions from silently turning a filtered view back into a full directory.

## Regression Tests
- `npx vitest run apps/app/src/lib/publicTeamsService.test.ts apps/app/src/components/PublicTeamSearch.test.tsx --reporter=verbose`
- Added coverage in `apps/app/src/lib/publicTeamsService.test.ts` for over-broad browse payloads and no-match searches.