### PR TITLE
Handle partial parent schedule team load failures

### DIFF
--- a/apps/app/src/lib/appDataCache.ts
+++ b/apps/app/src/lib/appDataCache.ts
@@ -20,6 +20,7 @@ type LoadCachedAppDataOptions<T> = {
   maxStaleMs?: number;
   staleWhileRevalidate?: boolean;
   onRefresh?: (value: T) => void;
+  shouldCache?: (value: T) => boolean;
 };
 
 type StoredCacheEntry = {
@@ -57,7 +58,8 @@ export function loadCachedAppData<T>(
     persist = true,
     maxStaleMs = defaultMaxStaleMs,
     staleWhileRevalidate = false,
-    onRefresh
+    onRefresh,
+    shouldCache
   }: LoadCachedAppDataOptions<T> = {}
 ): Promise<T> {
   const now = Date.now();
@@ -75,14 +77,14 @@ export function loadCachedAppData<T>(
     && hasCachedValue(existing)
     && existing.expiresAt + maxStaleMs > now
   ) {
-    const refreshPromise = loadAndStoreCachedAppData(key, loader, existing, { ttlMs, persist, onRefresh });
+    const refreshPromise = loadAndStoreCachedAppData(key, loader, existing, { ttlMs, persist, onRefresh, shouldCache });
     refreshPromise.catch((error) => {
       logger.warn('Background refresh failed.', { error });
     });
     return Promise.resolve(existing.value as T);
   }
 
-  return loadAndStoreCachedAppData(key, loader, existing, { ttlMs, persist, onRefresh });
+  return loadAndStoreCachedAppData(key, loader, existing, { ttlMs, persist, onRefresh, shouldCache });
 }
 
 export function clearAppDataCache(prefix = '') {
@@ -99,9 +101,28 @@ function loadAndStoreCachedAppData<T>(
   key: string,
   loader: () => Promise<T>,
   existing: CacheEntry<T> | undefined,
-  { ttlMs, persist, onRefresh }: { ttlMs: number; persist: boolean; onRefresh?: (value: T) => void }
+  {
+    ttlMs,
+    persist,
+    onRefresh,
+    shouldCache
+  }: { ttlMs: number; persist: boolean; onRefresh?: (value: T) => void; shouldCache?: (value: T) => boolean }
 ) {
   const promise = loader().then((value) => {
+    if (shouldCache && !shouldCache(value)) {
+      if (existing && hasCachedValue(existing)) {
+        cache.set(key, {
+          value: existing.value,
+          expiresAt: existing.expiresAt,
+          hydratedFromStorage: existing.hydratedFromStorage
+        });
+      } else {
+        cache.delete(key);
+      }
+      onRefresh?.(value);
+      return value;
+    }
+
     const entry = {
       value,
       expiresAt: Date.now() + ttlMs,

--- a/apps/app/src/lib/homeService.test.ts
+++ b/apps/app/src/lib/homeService.test.ts
@@ -27,7 +27,7 @@ vi.mock('./logger', () => ({
     createLogger: vi.fn(() => ({ warn: vi.fn() }))
 }));
 
-import { loadParentHomeSummary, loadParentTeamsSummaryBootstrap } from './homeService';
+import { loadParentHomeSummary, loadParentScheduleSummary, loadParentTeamsSummaryBootstrap } from './homeService';
 
 const user = {
     uid: 'parent-1',
@@ -75,5 +75,27 @@ describe('homeService Teams bootstrap reuse', () => {
             parentScope: scheduleScope
         }));
         expect(window.localStorage.getItem('allplays:appDataCache:teams-summary-bootstrap%3Aparent-1')).toBeNull();
+    });
+
+    it('does not cache partial parent schedule summaries as complete results', async () => {
+        scheduleServiceMocks.loadParentSchedule
+            .mockResolvedValueOnce({
+                children: [{ teamId: 'team-1', teamName: 'Fast Falcons', playerId: 'player-1', playerName: 'Avery Ace' }],
+                events: [],
+                isPartial: true
+            })
+            .mockResolvedValueOnce({
+                children: [{ teamId: 'team-1', teamName: 'Fast Falcons', playerId: 'player-1', playerName: 'Avery Ace' }],
+                events: [{ id: 'event-1' }],
+                isPartial: false
+            });
+
+        const partial = await loadParentScheduleSummary(user, { force: true });
+        const complete = await loadParentScheduleSummary(user);
+
+        expect(partial.isPartial).toBe(true);
+        expect(complete.isPartial).toBe(false);
+        expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+        expect(window.localStorage.getItem('allplays:appDataCache:app-schedule-summary%3Aparent-1')).toContain('event-1');
     });
 });

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -243,7 +243,11 @@ export async function loadParentScheduleSummary(
       expandStaffPlayers: false,
       parentScope: options.scheduleScope
     }),
-    { ttlMs: homeSummaryTtlMs, force: options.force }
+    {
+      ttlMs: homeSummaryTtlMs,
+      force: options.force,
+      shouldCache: (result) => result?.isPartial !== true
+    }
   );
 }
 

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2131,6 +2131,16 @@ describe('partial parent schedule team failures (#3021)', () => {
     });
   });
 
+  it('rethrows a typed schedule load error when every team schedule load fails', async () => {
+    vi.mocked(getGames).mockRejectedValue(new Error('permission-denied'));
+
+    await expect(loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false })).rejects.toMatchObject({
+      name: 'AppServiceError',
+      type: 'permission',
+      message: 'permission-denied'
+    });
+  });
+
 });
 
 describe('team schedule game windowing (#2034)', () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2090,6 +2090,7 @@ describe('partial parent schedule team failures (#3021)', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (globalThis as any).window = { location: { protocol: 'https:' }, setTimeout, clearTimeout } as any;
     vi.mocked(loadProfileDocument).mockResolvedValue({
       parentOf: parentUser.parentOf
     } as any);
@@ -2129,6 +2130,7 @@ describe('partial parent schedule team failures (#3021)', () => {
       id: 'game-1',
       opponent: 'Tigers'
     });
+    expect(result.isPartial).toBe(true);
   });
 
   it('rethrows a typed schedule load error when every team schedule load fails', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2078,6 +2078,61 @@ describe('native parent schedule Firestore mapping', () => {
   });
 });
 
+describe('partial parent schedule team failures (#3021)', () => {
+  const parentUser = {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    parentOf: [
+      { teamId: 'team-1', playerId: 'p1', playerName: 'Kid One' },
+      { teamId: 'team-2', playerId: 'p2', playerName: 'Kid Two' }
+    ]
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(loadProfileDocument).mockResolvedValue({
+      parentOf: parentUser.parentOf
+    } as any);
+    vi.mocked(getTeam).mockImplementation(async (teamId: string) => ({ id: teamId, name: teamId === 'team-1' ? 'Team One' : 'Team Two' }) as any);
+    vi.mocked(getTeams).mockResolvedValue([] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+    vi.mocked(getDoc).mockImplementation(async (ref: any) => {
+      if (ref?.path?.includes('team-1/players/p1')) return playerSnapshot('p1', { id: 'p1', name: 'Kid One', active: true }) as any;
+      if (ref?.path?.includes('team-2/players/p2')) return playerSnapshot('p2', { id: 'p2', name: 'Kid Two', active: true }) as any;
+      return playerSnapshot('missing', null) as any;
+    });
+  });
+
+  it('keeps successful teams visible when one team schedule load fails', async () => {
+    vi.mocked(getGames).mockImplementation(async (teamId: string) => {
+      if (teamId === 'team-2') {
+        throw new Error('permission-denied');
+      }
+      return [{
+        id: 'game-1',
+        type: 'game',
+        date: new Date('2026-06-25T18:00:00.000Z'),
+        opponent: 'Tigers',
+        location: 'Main Gym'
+      }] as any;
+    });
+
+    const result = await loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(result.children).toEqual(expect.arrayContaining([
+      expect.objectContaining({ teamId: 'team-1', playerId: 'p1' }),
+      expect.objectContaining({ teamId: 'team-2', playerId: 'p2' })
+    ]));
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      teamId: 'team-1',
+      id: 'game-1',
+      opponent: 'Tigers'
+    });
+  });
+
+});
+
 describe('team schedule game windowing (#2034)', () => {
   const parentUser = {
     uid: 'parent-1',

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -164,6 +164,10 @@ function logScheduleError(message: string, operation: string, error: unknown, co
   });
 }
 
+function rethrowScheduleLoadError(error: unknown): never {
+  throw toAppServiceError(error, 'Unable to load schedule.');
+}
+
 export type ParentScheduleChild = {
   teamId: string;
   teamName: string;
@@ -3540,7 +3544,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
 
     const failedTeamLoads = teamResults.filter((result) => result.error);
     if (failedTeamLoads.length === teamResults.length && failedTeamLoads.length > 0) {
-      throw failedTeamLoads[0].error;
+      rethrowScheduleLoadError(failedTeamLoads[0].error);
     }
     if (failedTeamLoads.length > 0) {
       logScheduleWarning('Continuing with partial team schedule data.', 'parent-schedule-partial-load', failedTeamLoads[0].error, {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -184,6 +184,7 @@ type ParentScopeLink = ParentScheduleChild & {
 export type ParentScheduleLoadResult = {
   children: ParentScheduleChild[];
   events: ParentScheduleEvent[];
+  isPartial?: boolean;
 };
 
 export type ParentScheduleScope = {
@@ -3558,15 +3559,17 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     if (hydrateDetails) {
       await hydrateEventDetails(events, user);
     }
+    const isPartial = failedTeamLoads.length > 0;
     timer.end({
       hydrateDetails,
       expandStaffPlayers,
       childLinks: children.length,
       teams: byTeam.size,
       staffTeams: staffTeams.length,
-      eventRows: events.length
+      eventRows: events.length,
+      isPartial
     });
-    return { children, events };
+    return { children, events, isPartial };
   } catch (error: any) {
     timer.end({ hydrateDetails, expandStaffPlayers, error: error?.message || 'Unable to load parent schedule.' });
     throw error;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3517,19 +3517,40 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     });
 
     const teamEntries = [...byTeam.entries()];
-    const eventBatches = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {
+    const teamResults = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {
       try {
-        return await buildTeamSchedule(teamId, teamChildren, user, {
-          includePastGames,
-          range: scheduleRangeByTeam?.[teamId]
-        });
+        return {
+          teamId,
+          events: await buildTeamSchedule(teamId, teamChildren, user, {
+            includePastGames,
+            range: scheduleRangeByTeam?.[teamId]
+          }),
+          error: null
+        };
       } catch (error) {
+        const appError = toAppServiceError(error, 'Unable to load schedule.');
         logScheduleWarning('Failed to load team schedule.', 'team-schedule-load', error, { teamId });
-        throw toAppServiceError(error, 'Unable to load schedule.');
+        return {
+          teamId,
+          events: [] as ParentScheduleEvent[],
+          error: appError
+        };
       }
     });
 
-    const events = eventBatches.flat().sort((a, b) => a.date.getTime() - b.date.getTime());
+    const failedTeamLoads = teamResults.filter((result) => result.error);
+    if (failedTeamLoads.length === teamResults.length && failedTeamLoads.length > 0) {
+      throw failedTeamLoads[0].error;
+    }
+    if (failedTeamLoads.length > 0) {
+      logScheduleWarning('Continuing with partial team schedule data.', 'parent-schedule-partial-load', failedTeamLoads[0].error, {
+        failedTeamIds: failedTeamLoads.map((result) => result.teamId),
+        failedTeams: failedTeamLoads.length,
+        totalTeams: teamResults.length
+      });
+    }
+
+    const events = teamResults.flatMap((result) => result.events).sort((a, b) => a.date.getTime() - b.date.getTime());
     if (hydrateDetails) {
       await hydrateEventDetails(events, user);
     }

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -22,7 +22,11 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 const appDataCacheMocks = vi.hoisted(() => ({
   getCachedAppData: vi.fn(() => null),
   getParentScheduleSummaryCacheKey: vi.fn(() => 'parent-schedule:test-user'),
-  loadCachedAppData: vi.fn(async (_key: string, loader: () => Promise<unknown>) => loader())
+  loadCachedAppData: vi.fn(async (
+    _key: string,
+    loader: () => Promise<unknown>,
+    _options?: { shouldCache?: (value: { isPartial?: boolean }) => boolean }
+  ) => loader())
 }));
 
 const uxTimingMocks = vi.hoisted(() => ({

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -194,7 +194,7 @@ describe('Schedule', () => {
     });
   });
 
-  it('passes a no-partial-caching guard into the schedule summary cache loader', async () => {
+  it('passes the full schedule cache contract into the summary loader', async () => {
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [
         { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
@@ -210,10 +210,18 @@ describe('Schedule', () => {
       'parent-schedule:test-user',
       expect.any(Function),
       expect.objectContaining({
+        ttlMs: 60 * 1000 * 5,
+        force: false,
         shouldCache: expect.any(Function)
       })
     );
-    const options = appDataCacheMocks.loadCachedAppData.mock.calls[0]?.[2] as { shouldCache: (value: { isPartial?: boolean }) => boolean };
+    const options = appDataCacheMocks.loadCachedAppData.mock.calls[0]?.[2] as {
+      ttlMs: number;
+      force: boolean;
+      shouldCache: (value: { isPartial?: boolean }) => boolean;
+    };
+    expect(options.ttlMs).toBe(60 * 1000 * 5);
+    expect(options.force).toBe(false);
     expect(options.shouldCache({ isPartial: true })).toBe(false);
     expect(options.shouldCache({ isPartial: false })).toBe(true);
   });

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -190,6 +190,30 @@ describe('Schedule', () => {
     });
   });
 
+  it('passes a no-partial-caching guard into the schedule summary cache loader', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [],
+      isPartial: true
+    });
+
+    renderSchedule();
+
+    expect(await screen.findByText('No events in this filter')).toBeTruthy();
+    expect(appDataCacheMocks.loadCachedAppData).toHaveBeenCalledWith(
+      'parent-schedule:test-user',
+      expect.any(Function),
+      expect.objectContaining({
+        shouldCache: expect.any(Function)
+      })
+    );
+    const options = appDataCacheMocks.loadCachedAppData.mock.calls[0]?.[2] as { shouldCache: (value: { isPartial?: boolean }) => boolean };
+    expect(options.shouldCache({ isPartial: true })).toBe(false);
+    expect(options.shouldCache({ isPartial: false })).toBe(true);
+  });
+
   it('keeps team and player filters after an empty schedule refresh fails', async () => {
     scheduleServiceMocks.loadParentSchedule
       .mockResolvedValueOnce({

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -375,7 +375,11 @@ export function Schedule({ auth }: { auth: AuthState }) {
       () => loadCachedAppData(
         cacheKey,
         () => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false }),
-        { ttlMs: scheduleCacheTtlMs, force }
+        {
+          ttlMs: scheduleCacheTtlMs,
+          force,
+          shouldCache: (result) => result?.isPartial !== true
+        }
       ),
       {
         getErrorMessage: (loadError) => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -369,6 +369,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     });
     const cacheKey = getParentScheduleSummaryCacheKey(auth.user.uid);
     const scheduleCacheTtlMs = 60 * 1000 * 5;
+    const scheduleCacheOptions = { ttlMs: scheduleCacheTtlMs, force };
     const cached = getCachedAppData(cacheKey);
 
     return runScheduleRead(
@@ -376,8 +377,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
         cacheKey,
         () => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false }),
         {
-          ttlMs: scheduleCacheTtlMs,
-          force,
+          ...scheduleCacheOptions,
           shouldCache: (result) => result?.isPartial !== true
         }
       ),


### PR DESCRIPTION
Closes #3021

## What changed
- Updated `loadParentSchedule(...)` to keep successful team schedule results instead of aborting the entire Home/Schedule load when one team read fails.
- Preserved existing warning logs for the failing team and added a partial-load warning so the failure stays visible in diagnostics.
- Added a focused regression test covering a multi-team parent where one team schedule read fails and the other still renders.

## Root Cause
`loadParentSchedule(...)` treated any single `buildTeamSchedule(...)` failure as fatal. On Android, the native schedule path can surface a per-team read failure through the REST fallback path. Once one team threw, the shared parent schedule loader converted that into a top-level `Unable to load schedule` error, which blocked both Home and Schedule even when other linked teams could still load successfully.

## Prevention / Learning
For parent aggregate views, do not let one child/team read failure take down the whole surface unless every branch fails. Keep partial data visible, log the failing scope clearly, and add regression coverage around mixed success/failure fan-out paths.

## Regression Tests
- `apps/app/src/lib/scheduleService.test.ts`
  - verifies `loadParentSchedule(...)` still returns events for a successful team when another linked team schedule read fails