### PR TITLE
Route homepage CTA to request access

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
     import { checkAuth, getRedirectUrl } from './js/auth.js?v=34';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
     import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=66';
-    import { initHomepage } from './js/homepage.js?v=3';
+    import { initHomepage } from './js/homepage.js?v=4';
 
     initHomepage({
       document,

--- a/index.html
+++ b/index.html
@@ -79,9 +79,9 @@
         </p>
 
         <div class="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">
-          <a id="hero-cta" href="login.html#signup"
+          <a id="hero-cta" href="mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request"
             class="w-full sm:w-auto px-10 py-5 bg-gradient-to-r from-primary-600 to-primary-700 text-white rounded-xl hover:from-primary-700 hover:to-primary-800 transition shadow-xl hover:shadow-2xl font-bold text-lg transform hover:scale-105">
-            Get Started Now
+            Request Access
           </a>
           <a href="teams.html"
             class="w-full sm:w-auto px-10 py-5 bg-white text-gray-700 rounded-xl hover:bg-gray-50 transition shadow-lg border-2 border-gray-200 font-bold text-lg">
@@ -591,9 +591,9 @@
       <p class="text-xl md:text-2xl text-primary-50 mb-10 max-w-3xl mx-auto leading-relaxed">Join thousands of coaches
         using AI to run better practices, make smarter decisions, and keep families connected.</p>
       <div class="flex flex-col sm:flex-row gap-6 justify-center items-center">
-        <a href="login.html#signup"
+        <a href="mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request"
           class="w-full sm:w-auto px-12 py-6 bg-white text-primary-600 rounded-xl hover:bg-gray-50 transition shadow-2xl font-bold text-xl transform hover:scale-105">
-          Get Started Today
+          Request Access
         </a>
         <a href="teams.html"
           class="w-full sm:w-auto px-12 py-6 bg-primary-700/50 backdrop-blur-sm text-white rounded-xl hover:bg-primary-700 transition border-2 border-white/30 font-bold text-xl">
@@ -628,7 +628,7 @@
           <ul class="space-y-2 text-sm">
             <li><a href="teams.html" class="hover:text-white transition">Browse Teams</a></li>
             <li><a href="login.html" class="hover:text-white transition">Sign In</a></li>
-            <li><a href="login.html#signup" class="hover:text-white transition">Get Started</a></li>
+            <li><a href="mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request" class="hover:text-white transition">Request Access</a></li>
             <li><a href="dashboard.html" class="hover:text-white transition">Dashboard</a></li>
           </ul>
         </div>

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -1,3 +1,5 @@
+const REQUEST_ACCESS_HREF = 'mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request';
+
 function resolveTeamId(game) {
     return game.teamId || game.team?.id || '';
 }
@@ -58,8 +60,8 @@ export function applyHeroCta(user, heroCta, getRedirectUrl = () => 'dashboard.ht
         return;
     }
 
-    heroCta.textContent = 'Create Your Team';
-    heroCta.href = 'login.html#signup';
+    heroCta.textContent = 'Request Access';
+    heroCta.href = REQUEST_ACCESS_HREF;
 }
 
 export async function loadLiveGames({

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -1,4 +1,5 @@
 const REQUEST_ACCESS_HREF = 'mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request';
+const REQUEST_ACCESS_TEXT = 'Request Access';
 
 function resolveTeamId(game) {
     return game.teamId || game.team?.id || '';
@@ -49,6 +50,24 @@ function renderTeamAvatar(game) {
     return `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${teamInitial}</div>`;
 }
 
+function applyRequestAccessCta(cta) {
+    if (!cta) {
+        return;
+    }
+
+    cta.textContent = REQUEST_ACCESS_TEXT;
+    cta.href = REQUEST_ACCESS_HREF;
+}
+
+export function applyHeaderCtas(document, user) {
+    if (user) {
+        return;
+    }
+
+    applyRequestAccessCta(document.getElementById('nav-cta-desktop'));
+    applyRequestAccessCta(document.getElementById('nav-cta-mobile'));
+}
+
 export function applyHeroCta(user, heroCta, getRedirectUrl = () => 'dashboard.html') {
     if (!heroCta) {
         return;
@@ -60,8 +79,7 @@ export function applyHeroCta(user, heroCta, getRedirectUrl = () => 'dashboard.ht
         return;
     }
 
-    heroCta.textContent = 'Request Access';
-    heroCta.href = REQUEST_ACCESS_HREF;
+    applyRequestAccessCta(heroCta);
 }
 
 export async function loadLiveGames({
@@ -190,6 +208,7 @@ export async function initHomepage({
 
     checkAuth((user) => {
         renderHeader(document.getElementById('header-container'), user);
+        applyHeaderCtas(document, user);
         applyHeroCta(user, heroCta, getRedirectUrl);
     });
 

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { initHomepage } from '../../js/homepage.js';
 
@@ -117,6 +119,14 @@ async function runHomepage({
 }
 
 describe('homepage index workflow', () => {
+    it('keeps public homepage CTAs on the request-access path instead of blocked signup', () => {
+        const homepageHtml = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+
+        expect(homepageHtml).not.toContain('login.html#signup');
+        expect(homepageHtml).toContain('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
+        expect(homepageHtml).toContain('Request Access');
+    });
+
     it('routes coach users to the team dashboard CTA, deduplicates live and upcoming games, and preserves replay links', async () => {
         const duplicatedLiveGame = createGame({ liveViewerCount: 5 });
         const replayGame = createGame({
@@ -183,7 +193,7 @@ describe('homepage index workflow', () => {
         expect(elements.get('hero-cta').href).toBe('parent-dashboard.html');
     });
 
-    it('keeps upcoming cards visible when live games fail and sets the guest CTA', async () => {
+    it('keeps upcoming cards visible when live games fail and sets the guest CTA to request access', async () => {
         const upcomingGame = createGame({ id: 'game-3', opponent: 'Owls' });
 
         const { elements } = await runHomepage({
@@ -191,8 +201,8 @@ describe('homepage index workflow', () => {
             upcomingGames: [upcomingGame]
         });
 
-        expect(elements.get('hero-cta').textContent).toBe('Create Your Team');
-        expect(elements.get('hero-cta').href).toBe('login.html#signup');
+        expect(elements.get('hero-cta').textContent).toBe('Request Access');
+        expect(elements.get('hero-cta').href).toBe('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
 
         const liveMarkup = elements.get('live-games-list').innerHTML;
         expect(liveMarkup).not.toContain('Loading games...');

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -25,6 +25,8 @@ function createEnvironment() {
     const elements = new Map([
         ['header-container', new MockElement('header-container')],
         ['hero-cta', new MockElement('hero-cta')],
+        ['nav-cta-desktop', new MockElement('nav-cta-desktop')],
+        ['nav-cta-mobile', new MockElement('nav-cta-mobile')],
         ['live-games-list', new MockElement('live-games-list')],
         ['past-games-list', new MockElement('past-games-list')]
     ]);
@@ -125,6 +127,7 @@ describe('homepage index workflow', () => {
         expect(homepageHtml).not.toContain('login.html#signup');
         expect(homepageHtml).toContain('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
         expect(homepageHtml).toContain('Request Access');
+        expect(homepageHtml).toContain("./js/homepage.js?v=4");
     });
 
     it('routes coach users to the team dashboard CTA, deduplicates live and upcoming games, and preserves replay links', async () => {
@@ -203,6 +206,10 @@ describe('homepage index workflow', () => {
 
         expect(elements.get('hero-cta').textContent).toBe('Request Access');
         expect(elements.get('hero-cta').href).toBe('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
+        expect(elements.get('nav-cta-desktop').textContent).toBe('Request Access');
+        expect(elements.get('nav-cta-desktop').href).toBe('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
+        expect(elements.get('nav-cta-mobile').textContent).toBe('Request Access');
+        expect(elements.get('nav-cta-mobile').href).toBe('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Access%20Request');
 
         const liveMarkup = elements.get('live-games-list').innerHTML;
         expect(liveMarkup).not.toContain('Loading games...');


### PR DESCRIPTION
Closes #3053

## What changed
- Repointed signed-out homepage CTAs away from `login.html#signup` and onto an explicit request-access email path.
- Updated the runtime guest hero CTA in `js/homepage.js` to match the static homepage markup.
- Added focused homepage regression coverage to lock both the static CTA targets and the guest CTA behavior.

## Root Cause
The public homepage hard-coded guest CTAs to `login.html#signup` even though the login and signup flow intentionally rejects new accounts without an activation code. That sent anonymous visitors into an invite-only flow with no request-access escape hatch.

## Prevention / Learning
When signup requires an invite or activation code, public landing-page CTAs must point to an explicit request-access or invite-acceptance path instead of a generic signup entry point. Add a static page assertion for every public CTA that enters auth so marketing copy and auth policy cannot drift apart silently.

## Regression Tests
- `npx vitest run tests/unit/homepage-index.test.js --reporter=verbose`
- Added assertions that `index.html` no longer contains `login.html#signup` for public homepage CTAs.
- Added assertions that the guest hero CTA resolves to the request-access mailto target at runtime.