### PR TITLE
Show tournament context on schedule event details

### DIFF
--- a/apps/app/src/components/schedule/EventDetailsPanel.tsx
+++ b/apps/app/src/components/schedule/EventDetailsPanel.tsx
@@ -4,7 +4,10 @@ import {
   formatEventTimeLabel,
   getScheduleForecastHref,
   getScheduleMapHref,
-  type ParentScheduleEvent
+  getScheduleTournamentInfo,
+  type ParentScheduleEvent,
+  type ScheduleTournamentInfo,
+  type ScheduleTournamentStandingRow
 } from '../../lib/scheduleLogic';
 
 export function EventDetailsPanel({ event, open }: { event: ParentScheduleEvent; open: boolean }) {
@@ -12,9 +15,11 @@ export function EventDetailsPanel({ event, open }: { event: ParentScheduleEvent;
   const rows = getEventDetailRows(event);
   const mapHref = getScheduleMapHref(event.location);
   const forecastHref = getScheduleForecastHref(event.location);
+  const tournamentInfo = getScheduleTournamentInfo(event);
 
   return (
     <div className="mt-3 rounded-xl border border-gray-200 bg-white">
+      {tournamentInfo.isTournament ? <TournamentEventDetailsSummary info={tournamentInfo} /> : null}
       <dl className="divide-y divide-gray-200 px-3">
         {rows.map((row) => (
           <div key={row.label} className="flex items-start gap-3 py-3">
@@ -64,6 +69,46 @@ function getEventDetailRows(event: ParentScheduleEvent) {
     event.practiceHomePacketSummary ? { label: 'Home packet', value: event.practiceHomePacketSummary, icon: FileText } : null,
     event.notes ? { label: 'Notes', value: event.notes, icon: FileText } : null
   ].filter((row): row is { label: string; value: string; icon: LucideIcon } => Boolean(row));
+}
+
+function TournamentEventDetailsSummary({ info }: { info: ScheduleTournamentInfo }) {
+  const standingsRows = info.standings?.rows.slice(0, 4) || [];
+  const hiddenStandingCount = Math.max((info.standings?.rows.length || 0) - standingsRows.length, 0);
+  const showMatchup = Boolean(info.matchupLabel && !info.details.includes(info.matchupLabel));
+
+  return (
+    <div className="border-b border-indigo-100 bg-indigo-50 px-3 py-3" aria-label="Tournament information">
+      <div className="text-xs font-black text-indigo-950">{info.label}</div>
+      {info.details ? <div className="mt-0.5 text-xs font-semibold text-indigo-800">{info.details}</div> : null}
+      {showMatchup ? <div className="mt-0.5 text-xs font-semibold text-indigo-800">{info.matchupLabel}</div> : null}
+      {info.standings ? (
+        <div className="mt-2 border-t border-indigo-100 pt-2">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] font-black uppercase tracking-[0.04em] text-indigo-900">
+            <span>{info.standings.groupName} standings</span>
+            {info.standings.note ? <span className="rounded-full bg-white px-2 py-0.5 text-indigo-700">{info.standings.note}</span> : null}
+          </div>
+          <div className="mt-1 grid gap-1">
+            {standingsRows.map((row) => (
+              <div key={`${row.rank}-${row.teamName}`} className="truncate text-xs font-semibold text-indigo-900">
+                #{row.rank} {row.teamName}{formatTournamentStandingMeta(row)}
+              </div>
+            ))}
+            {hiddenStandingCount ? (
+              <div className="text-xs font-semibold text-indigo-700">+{hiddenStandingCount} more</div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function formatTournamentStandingMeta(row: ScheduleTournamentStandingRow) {
+  const parts = [
+    row.record,
+    row.points !== null ? `${row.points} pts` : ''
+  ].filter(Boolean);
+  return parts.length ? ` (${parts.join(', ')})` : '';
 }
 
 function formatGameInfo(event: ParentScheduleEvent) {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -510,6 +510,44 @@ describe('ScheduleEventDetail loading states', () => {
 
     expect(screen.getByText('3-2')).toBeTruthy();
   });
+
+  it('renders tournament context and legacy standings on the event detail screen', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        competitionType: 'tournament',
+        tournament: {
+          divisionName: '10U Gold',
+          bracketName: 'Gold Bracket',
+          roundName: 'Semifinal',
+          poolName: 'Pool A',
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'game_result', gameId: 'R1G2', outcome: 'winner' }
+          },
+          standings: {
+            poolName: '10U Gold / Pool A',
+            rows: [
+              { rank: 1, teamName: 'Tigers', wins: 2, losses: 0, points: 6 },
+              { rank: 2, teamName: 'Lions', record: '1-1', points: 3 }
+            ],
+            isOverridden: true
+          }
+        }
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'vs. Wolves' })).toBeTruthy();
+    });
+
+    expect(screen.getAllByText('10U Gold / Gold Bracket / Semifinal').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Pool: Pool A/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('10U Gold / Pool A standings').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('#1 Tigers (2-0, 6 pts)').length).toBeGreaterThan(0);
+  });
 });
 
 describe('ScheduleEventDetail lineup draft guards', () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -3867,9 +3867,12 @@ function getAttentionItems(event: ParentScheduleEvent, rsvp: RsvpResponse): Atte
 }
 
 function getEventBriefPieces(event: ParentScheduleEvent) {
+  const scoreLabel = getScoreLabel(event);
+  const statusLabel = getEventStatusLabel(event);
+
   return [
     event.isCancelled ? 'Cancelled' : '',
-    getScoreLabel(event) ? `Final ${getScoreLabel(event)}` : '',
+    scoreLabel ? (statusLabel === 'Live now' ? scoreLabel : `Final ${scoreLabel}`) : '',
     event.isHome === true ? 'Home' : event.isHome === false ? 'Away' : '',
     event.kitColor ? `${event.kitColor} kit` : '',
     event.seasonLabel ? event.seasonLabel : '',


### PR DESCRIPTION
Closes #3024

## What changed
- reused the existing `getScheduleTournamentInfo(...)` helper inside `EventDetailsPanel` so tournament games keep their web-created grouping context on the app detail screen
- added a read-only tournament summary block to event details that shows the tournament label, pool/round details, matchup context, and legacy standings rows when present
- added a focused regression test covering the legacy tournament payload path on `ScheduleEventDetail`

## Root Cause
The app already normalized tournament metadata for the schedule list, but the event detail screen rendered only generic metadata rows and never reused that tournament helper. That left tournament games looking like normal standalone events once a coach opened the detail view.

## Prevention / Learning
When schedule metadata already has a shared normalization helper, reuse it across list and detail surfaces instead of rebuilding per-view fields. For schedule parity work, add a regression test on the detail screen whenever the list already supports the payload shape.

## Regression Tests
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx -t "renders tournament context and legacy standings on the event detail screen" --reporter=verbose`
- `npx vitest run src/pages/Schedule.test.tsx -t "renders web-created tournament game metadata read-only in the schedule list" --reporter=verbose`

## Recurrence Risk
Low. The detail screen now uses the same tournament parsing path as the list view, and the new test locks the legacy payload rendering path in place.