### PR TITLE
Simplify AppSearchDialog help flow

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -182,6 +182,35 @@ describe('AppSearchDialog', () => {
     });
   });
 
+  it('lets Enter activate the more help results button instead of the highlighted result', async () => {
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+
+    const moreHelpResultsButton = await screen.findByRole('button', { name: /More help results/i });
+    moreHelpResultsButton.focus();
+    fireEvent.keyDown(moreHelpResultsButton, { key: 'Enter' });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    fireEvent.click(moreHelpResultsButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/help', {
+      state: {
+        helpQuery: 'ro',
+        helpRoleFilter: 'all'
+      }
+    });
+  });
+
   it('keeps the opening tap guard active long enough for slower mobile pointer sequences', async () => {
     vi.useFakeTimers();
     const onClose = vi.fn();

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -132,7 +132,7 @@ describe('AppSearchDialog', () => {
     expect(screen.getByText('Type at least 2 characters to search players')).not.toBeNull();
   });
 
-  it('shows help role filters and player results once the query reaches two characters', async () => {
+  it('shows help results without role filters once the query reaches two characters', async () => {
     const onClose = vi.fn();
     searchAppPlayersMock.mockResolvedValueOnce([{
       id: 'player:team-2:player-2',
@@ -152,10 +152,34 @@ describe('AppSearchDialog', () => {
 
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
 
-    expect(await screen.findByLabelText('Filter help by role')).not.toBeNull();
+    await waitFor(() => expect(screen.queryByLabelText('Filter help by role')).toBeNull());
     expect(await screen.findByText('Players')).not.toBeNull();
     expect(await screen.findByRole('button', { name: /#10 Rocket Kid/i })).not.toBeNull();
     expect(screen.getByRole('button', { name: /Search like a coach/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /More help results/i })).not.toBeNull();
+  });
+
+  it('opens the help portal with the current query preserved', async () => {
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+
+    const moreHelpResultsButton = await screen.findByRole('button', { name: /More help results/i });
+    fireEvent.click(moreHelpResultsButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/help', {
+      state: {
+        helpQuery: 'ro',
+        helpRoleFilter: 'all'
+      }
+    });
   });
 
   it('keeps the opening tap guard active long enough for slower mobile pointer sequences', async () => {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -370,6 +370,11 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
                   type="button"
                   className="text-xs font-extrabold text-primary-700 transition hover:text-primary-800"
                   onClick={openHelpPortal}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      event.stopPropagation();
+                    }
+                  }}
                 >
                   More help results
                 </button>

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -10,7 +10,6 @@ import {
   loadAppSearchTeams,
   searchAppTeams,
   searchAppPlayers,
-  type AppSearchHelpRoleFilter,
   type AppSearchItem,
   type AppSearchPlayer,
   type AppSearchTeam
@@ -36,7 +35,6 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [playersLoading, setPlayersLoading] = useState(false);
   const [playersError, setPlayersError] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
-  const [helpRoleFilter, setHelpRoleFilter] = useState<AppSearchHelpRoleFilter>('all');
   const searchRequestId = useRef(0);
   const openedAtRef = useRef(Date.now());
   const preloadedRoutesRef = useRef(new Set<string>());
@@ -45,8 +43,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const navigate = useNavigate();
 
   const results = useMemo(
-    () => computeAppSearchResults({ queryText: query, auth, teams, players, helpRoleFilter }),
-    [auth, helpRoleFilter, players, query, teams]
+    () => computeAppSearchResults({ queryText: query, auth, teams, players, helpRoleFilter: 'all' }),
+    [auth, players, query, teams]
   );
   const helpResults = results.help ?? [];
   const flatResults = results.flat ?? [...results.actions, ...results.teams, ...helpResults, ...results.players];
@@ -66,7 +64,6 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setBaseTeams(knownTeams);
     setTeams(knownTeams);
     setActiveIndex(0);
-    setHelpRoleFilter('all');
     setTeamsLoading(false);
     setTeamsError('');
 
@@ -201,7 +198,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [helpRoleFilter, query]);
+  }, [query]);
 
   useEffect(() => {
     if (activeIndex >= flatResults.length) {
@@ -235,6 +232,18 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     if (item.href) {
       void openPublicUrl(item.href);
     }
+  };
+
+  const openHelpPortal = () => {
+    const trimmedQuery = query.trim();
+    onClose();
+    setQuery('');
+    navigate('/help', {
+      state: {
+        helpQuery: trimmedQuery,
+        helpRoleFilter: 'all'
+      }
+    });
   };
 
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -272,9 +281,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
           : ''
     : teamsError;
   const helpStatus = hasRealQuery && helpResults.length === 0
-    ? helpRoleFilter === 'all'
-      ? 'No matching help articles'
-      : `No ${getHelpRoleLabel(helpRoleFilter)} help articles match this search`
+    ? 'No matching help articles'
     : '';
   const playersStatus = !hasRealQuery
     ? 'Type at least 2 characters to search players'
@@ -358,7 +365,15 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               activeIndex={activeIndex}
               offset={results.actions.length + results.teams.length}
               status={helpStatus}
-              headerAccessory={hasRealQuery ? <HelpRoleFilter value={helpRoleFilter} onChange={setHelpRoleFilter} /> : null}
+              headerAccessory={hasRealQuery ? (
+                <button
+                  type="button"
+                  className="text-xs font-extrabold text-primary-700 transition hover:text-primary-800"
+                  onClick={openHelpPortal}
+                >
+                  More help results
+                </button>
+              ) : null}
               onOpen={openResult}
               onHover={setActiveResultIndex}
             />
@@ -384,46 +399,6 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       </div>
     </div>
   );
-}
-
-const helpRoleOptions: Array<{ value: AppSearchHelpRoleFilter; label: string }> = [
-  { value: 'all', label: 'All' },
-  { value: 'parent', label: 'Parent' },
-  { value: 'coach', label: 'Coach' },
-  { value: 'admin', label: 'Admin' },
-  { value: 'member', label: 'Member' }
-];
-
-function HelpRoleFilter({ value, onChange }: {
-  value: AppSearchHelpRoleFilter;
-  onChange: (value: AppSearchHelpRoleFilter) => void;
-}) {
-  return (
-    <div className="flex flex-wrap items-center justify-end gap-1.5" aria-label="Filter help by role">
-      <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Help role</div>
-      <div className="flex flex-wrap gap-1.5">
-        {helpRoleOptions.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            className={`rounded-full border px-3 py-1 text-xs font-extrabold transition ${
-              value === option.value
-                ? 'border-primary-300 bg-primary-50 text-primary-700'
-                : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
-            }`}
-            aria-pressed={value === option.value}
-            onClick={() => onChange(option.value)}
-          >
-            {option.label}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function getHelpRoleLabel(value: AppSearchHelpRoleFilter) {
-  return helpRoleOptions.find((option) => option.value === value)?.label || 'selected role';
 }
 
 function SearchSection({

--- a/apps/app/src/pages/HelpPortal.tsx
+++ b/apps/app/src/pages/HelpPortal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { LifeBuoy, Search } from 'lucide-react';
 import { getHelpKnowledgeDocs, searchHelpKnowledge } from '../lib/helpKnowledgeService';
@@ -22,10 +22,15 @@ const helpRoleOptions: Array<{ value: HelpPortalRoleFilter; label: string }> = [
 
 export function HelpPortal() {
   const location = useLocation();
-  const initialState = normalizePortalState(location.state);
-  const [query, setQuery] = useState(initialState.helpQuery);
-  const [roleFilter, setRoleFilter] = useState<HelpPortalRoleFilter>(initialState.helpRoleFilter);
+  const portalState = useMemo(() => normalizePortalState(location.state), [location.state]);
+  const [query, setQuery] = useState(portalState.helpQuery);
+  const [roleFilter, setRoleFilter] = useState<HelpPortalRoleFilter>(portalState.helpRoleFilter);
   const helpDocs = useMemo(() => getHelpKnowledgeDocs(), []);
+
+  useEffect(() => {
+    setQuery(portalState.helpQuery);
+    setRoleFilter(portalState.helpRoleFilter);
+  }, [portalState.helpQuery, portalState.helpRoleFilter]);
 
   const visibleDocs = useMemo<HelpPortalListItem[]>(() => {
     const trimmedQuery = query.trim();

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -476,7 +476,7 @@ test.describe('desktop app global search', () => {
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls)).toEqual([]);
     });
 
-    test('desktop search filters help results by selected role', async ({ page, baseURL }) => {
+    test('desktop search shows matching help results without role filter controls', async ({ page, baseURL }) => {
         await mockSearchModules(page);
         await gotoAppRoute(page, baseURL, '/home');
 
@@ -484,14 +484,9 @@ test.describe('desktop app global search', () => {
         await page.getByLabel('Search teams, players, actions, help').fill('live tracker');
         await expect(page.getByRole('button', { name: /Track Live Games with the Live Tracker/ })).toBeVisible();
         await expect(page.getByRole('button', { name: /Watch Live Games and Replays/ })).toBeVisible();
-
-        await page.getByRole('button', { name: 'Coach', exact: true }).click();
-        await expect(page.getByRole('button', { name: /Track Live Games with the Live Tracker/ })).toBeVisible();
-        await expect(page.getByRole('button', { name: /Watch Live Games and Replays/ })).toBeHidden();
-
-        await page.getByRole('button', { name: 'Member', exact: true }).click();
-        await expect(page.getByRole('button', { name: /Watch Live Games and Replays/ })).toBeVisible();
-        await expect(page.getByRole('button', { name: /Track Live Games with the Live Tracker/ })).toBeHidden();
+        await expect(page.getByRole('button', { name: /More help results/ })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Coach', exact: true })).toHaveCount(0);
+        await expect(page.getByRole('button', { name: 'Member', exact: true })).toHaveCount(0);
     });
 
     test('desktop search supports typed keyboard navigation from the dialog', async ({ page, baseURL }) => {

--- a/tests/unit/app-help-portal.test.jsx
+++ b/tests/unit/app-help-portal.test.jsx
@@ -2,7 +2,7 @@
 import React, { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 
 const helpMocks = vi.hoisted(() => ({
     getHelpKnowledgeDocs: vi.fn(),
@@ -46,7 +46,16 @@ const docs = [
     }
 ];
 
-async function renderHelp(initialEntry = '/help') {
+function SameRouteLauncher({ nextState }) {
+    const navigate = useNavigate();
+
+    return React.createElement('button', {
+        type: 'button',
+        onClick: () => navigate('/help', { state: nextState })
+    }, 'Load same route state');
+}
+
+async function renderHelp(initialEntry = '/help', extraHelpContent = null) {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -58,7 +67,10 @@ async function renderHelp(initialEntry = '/help') {
             React.createElement(
                 Routes,
                 null,
-                React.createElement(Route, { path: '/help', element: React.createElement(HelpPortal) }),
+                React.createElement(Route, {
+                    path: '/help',
+                    element: React.createElement(React.Fragment, null, extraHelpContent, React.createElement(HelpPortal))
+                }),
                 React.createElement(Route, { path: '/help/:helpId', element: React.createElement(HelpArticle) })
             )
         ));
@@ -149,6 +161,35 @@ describe('HelpPortal', () => {
         await clickElement(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Back to Help Portal'));
         expect(container.querySelector('input[aria-label="Search help articles"]')?.value).toBe('schedule');
         expect(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Coach')?.getAttribute('aria-pressed')).toBe('true');
+
+        await act(async () => root.unmount());
+    });
+
+    it('resyncs search state when the help portal receives a same-route navigation handoff', async () => {
+        helpMocks.getHelpKnowledgeDocs.mockReturnValue(docs);
+        helpMocks.searchHelpKnowledge.mockImplementation(({ query, roleFilter }) => {
+            if (query === 'fees' && roleFilter === 'parent') return [docs[2]];
+            if (query === 'schedule' && roleFilter === 'coach') return [docs[1]];
+            return [];
+        });
+
+        const initialEntry = {
+            pathname: '/help',
+            state: { helpQuery: 'fees', helpRoleFilter: 'parent' }
+        };
+        const nextState = { helpQuery: 'schedule', helpRoleFilter: 'coach' };
+        const launcher = React.createElement(SameRouteLauncher, { nextState });
+        const { container, root } = await renderHelp(initialEntry, launcher);
+
+        expect(container.querySelector('input[aria-label="Search help articles"]')?.value).toBe('fees');
+        expect(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Parent')?.getAttribute('aria-pressed')).toBe('true');
+
+        await clickElement(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Load same route state'));
+
+        expect(container.querySelector('input[aria-label="Search help articles"]')?.value).toBe('schedule');
+        expect(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Coach')?.getAttribute('aria-pressed')).toBe('true');
+        expect(container.textContent).toContain('Coach schedule tools');
+        expect(container.textContent).not.toContain('Parent fee guide');
 
         await act(async () => root.unmount());
     });

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -384,7 +384,7 @@ describe('React app shell search', () => {
         expect(container.textContent).not.toContain('Paige Forward');
     });
 
-    it('filters help matches by selected role and opens the filtered help result with Enter', async () => {
+    it('shows unfiltered help matches in search and routes advanced help filtering to the help portal', async () => {
         helpMocks.searchHelpKnowledge.mockReturnValue([
             {
                 id: 'coach-roster-help',
@@ -412,57 +412,26 @@ describe('React app shell search', () => {
         await clickButton(container, 'Search');
         await fillSearch(container, 'help');
 
-        const filterGroup = container.querySelector('[aria-label="Filter help by role"]');
-        expect(filterGroup).toBeTruthy();
-
-        const roleButton = (label) => {
-            const button = Array.from(filterGroup.querySelectorAll('button')).find((candidate) => candidate.textContent.trim() === label);
-            if (!button) throw new Error(`Role filter button not found: ${label}`);
-            return button;
-        };
-
-        ['All', 'Parent', 'Coach', 'Admin', 'Member'].forEach((label) => {
-            expect(roleButton(label)).toBeTruthy();
+        expect(container.querySelector('[aria-label="Filter help by role"]')).toBeNull();
+        expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
+            query: 'help',
+            roles: ['parent'],
+            roleFilter: 'all',
+            limit: 5
         });
-        expect(roleButton('All').getAttribute('aria-pressed')).toBe('true');
         expect(container.textContent).toContain('Manage a roster');
         expect(container.textContent).toContain('Reset a password');
-
-        const helpSearchCallCount = helpMocks.searchHelpKnowledge.mock.calls.length;
-        await act(async () => {
-            roleButton('Parent').dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-        });
-        await flush();
-
-        expect(roleButton('All').getAttribute('aria-pressed')).toBe('false');
-        expect(roleButton('Parent').getAttribute('aria-pressed')).toBe('true');
-        expect(helpMocks.searchHelpKnowledge).toHaveBeenCalledTimes(helpSearchCallCount + 1);
-        expect(container.textContent).not.toContain('Manage a roster');
-        expect(container.textContent).toContain('Reset a password');
+        expect(buttonByText(container, 'More help results')).toBeTruthy();
 
         await pressDialogKey(container, 'Enter');
-        expect(container.querySelector('[data-testid="route"]').textContent).toBe('/help/parent-password-help');
+        expect(container.querySelector('[data-testid="route"]').textContent).toBe('/help/coach-roster-help');
         expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
 
         await clickButton(container, 'Search');
         await fillSearch(container, 'help');
-        const reopenedFilterGroup = container.querySelector('[aria-label="Filter help by role"]');
-        const reopenedRoleButton = (label) => {
-            const button = Array.from(reopenedFilterGroup.querySelectorAll('button')).find((candidate) => candidate.textContent.trim() === label);
-            if (!button) throw new Error(`Role filter button not found after reopen: ${label}`);
-            return button;
-        };
-        await act(async () => {
-            reopenedRoleButton('Member').dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-        });
-        await flush();
-
-        expect(reopenedRoleButton('Parent').getAttribute('aria-pressed')).toBe('false');
-        expect(reopenedRoleButton('Member').getAttribute('aria-pressed')).toBe('true');
-        expect(container.textContent).not.toContain('Manage a roster');
-        expect(container.textContent).not.toContain('Reset a password');
-        expect(container.textContent).toContain('No Member help articles match this search');
-        expect(container.querySelector('input[aria-label="Search teams, players, actions, help"]')).toBeTruthy();
+        await clickButton(container, 'More help results');
+        expect(container.querySelector('[data-testid="route"]').textContent).toBe('/help');
+        expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
     });
 
     it('renders help matches and opens help articles inside the app', async () => {
@@ -492,7 +461,7 @@ describe('React app shell search', () => {
         expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
     });
 
-    it('updates help results immediately when the role filter changes', async () => {
+    it('keeps dialog help search scoped to the default all-roles filter', async () => {
         helpMocks.searchHelpKnowledge.mockImplementation(({ roleFilter }) => {
             if (roleFilter === 'coach') {
                 return [{
@@ -524,28 +493,17 @@ describe('React app shell search', () => {
 
         await clickButton(container, 'Search');
         await fillSearch(container, 'live tracker');
+
+        expect(container.querySelector('[aria-label="Filter help by role"]')).toBeNull();
+        expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
+            query: 'live tracker',
+            roles: ['parent'],
+            roleFilter: 'all',
+            limit: 5
+        });
         expect(container.textContent).toContain('Watch Live Games and Replays');
-
-        await clickButton(container, 'Coach');
-        expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
-            query: 'live tracker',
-            roles: ['parent'],
-            roleFilter: 'coach',
-            limit: 5
-        });
-        expect(container.textContent).toContain('Track Live Games with the Live Tracker');
-        expect(container.textContent).toContain('coach');
-        expect(container.textContent).toContain('admin');
-
-        await clickButton(container, 'Member');
-        expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
-            query: 'live tracker',
-            roles: ['parent'],
-            roleFilter: 'member',
-            limit: 5
-        });
         expect(container.textContent).not.toContain('Track Live Games with the Live Tracker');
-        expect(container.textContent).toContain('No Member help articles match this search');
+        expect(buttonByText(container, 'More help results')).toBeTruthy();
     });
 
     it('opens Browse Teams through the native app route for signed-in users', async () => {

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -413,6 +413,8 @@ describe('React app shell search', () => {
         await fillSearch(container, 'help');
 
         expect(container.querySelector('[aria-label="Filter help by role"]')).toBeNull();
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent === 'Coach')).toBe(false);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent === 'Member')).toBe(false);
         expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
             query: 'help',
             roles: ['parent'],
@@ -495,6 +497,8 @@ describe('React app shell search', () => {
         await fillSearch(container, 'live tracker');
 
         expect(container.querySelector('[aria-label="Filter help by role"]')).toBeNull();
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent === 'Coach')).toBe(false);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent === 'Member')).toBe(false);
         expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
             query: 'live tracker',
             roles: ['parent'],


### PR DESCRIPTION
Closes #3012

## What changed
- Removed the inline help role chip group from `AppSearchDialog` so 2+ character quick searches show scoped help matches without extra filter clutter.
- Added a `More help results` escape hatch in the dialog that routes to `/help` and preserves the current query in route state.
- Updated the focused dialog tests to prove help results still render, the chips stay hidden by default, and the Help Portal handoff preserves search context.

## Root Cause
`AppSearchDialog` treated help-role refinement as part of the default quick-search surface, always rendering the full `HelpRoleFilter` chip group for any 2+ character query even though `searchService` already scopes help results by the signed-in user's roles.

## Prevention / Learning
When the shared search service already applies user-role scope, keep quick-search UI focused on top matches and defer advanced refinement controls to the dedicated destination workflow instead of duplicating them in the modal.

## Regression Tests
- `npx vitest run apps/app/src/components/AppSearchDialog.test.tsx --reporter=verbose`
- `apps/app/src/components/AppSearchDialog.test.tsx` now asserts help role chips do not appear for a 2+ character query while help results still do.
- `apps/app/src/components/AppSearchDialog.test.tsx` now asserts the dialog's help escalation path navigates to `/help` with `helpQuery` preserved in route state.

## Recurrence Risk
Low. The quick-search help path is now hard-wired to default scoped results, and focused tests cover both the missing chip regression and the preserved Help Portal handoff.