### PR TITLE
Defer desktop schedule staff tools

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -590,6 +590,22 @@ describe('Schedule', () => {
     expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
   });
 
+  it('hides desktop staff schedule tools until Manage schedule is opened', async () => {
+    shellLayoutMocks.isDesktopWeb = true;
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
+
+    renderSchedule();
+
+    expect(await screen.findByRole('button', { name: /manage schedule/i })).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'Add game for Bears' })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Add external calendar' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
+
+    expect(await screen.findByRole('heading', { name: 'Add game for Bears' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Add external calendar' })).toBeTruthy();
+  });
+
   it('defers desktop tracker config loading until staff starts using game creation', async () => {
     shellLayoutMocks.isDesktopWeb = true;
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
@@ -598,6 +614,11 @@ describe('Schedule', () => {
     ]);
 
     renderSchedule();
+
+    expect(await screen.findByRole('button', { name: /manage schedule/i })).toBeTruthy();
+    expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
 
     expect(await screen.findByRole('heading', { name: 'Add game for Bears' })).toBeTruthy();
     expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).not.toHaveBeenCalled();

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -180,6 +180,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   });
   const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [desktopAdvancedControlsOpen, setDesktopAdvancedControlsOpen] = useState(false);
+  const [desktopStaffToolsOpen, setDesktopStaffToolsOpen] = useState(false);
   const [calendarUrl, setCalendarUrl] = useState('');
   const [calendarUrlError, setCalendarUrlError] = useState<string | null>(null);
   const [savingCalendarUrl, setSavingCalendarUrl] = useState(false);
@@ -540,6 +541,12 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
   }, [isDesktopWeb, selectedCalendarTeam]);
 
+  useEffect(() => {
+    if (!isDesktopWeb || !selectedCalendarTeam) {
+      setDesktopStaffToolsOpen(false);
+    }
+  }, [isDesktopWeb, selectedCalendarTeam]);
+
   const requestTrackerConfigLoad = () => {
     if (!selectedCalendarTeam) return;
     setTrackerConfigRequestedTeamIds((current) => {
@@ -567,8 +574,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     let cancelled = false;
     if (!selectedCalendarTeam || !auth.user) return;
     const shouldLoadTrackerConfigs = mobileStaffToolsOpen
-      || trackerConfigRequestedTeamIds[selectedCalendarTeam.teamId]
-      || (isDesktopWeb && desktopAdvancedControlsOpen);
+      || trackerConfigRequestedTeamIds[selectedCalendarTeam.teamId];
     if (!shouldLoadTrackerConfigs) return;
 
     const cachedConfigs = trackerConfigCacheRef.current[selectedCalendarTeam.teamId];
@@ -601,7 +607,76 @@ export function Schedule({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [auth.user, desktopAdvancedControlsOpen, isDesktopWeb, mobileStaffToolsOpen, selectedCalendarTeam, trackerConfigRequestedTeamIds]);
+  }, [auth.user, mobileStaffToolsOpen, selectedCalendarTeam, trackerConfigRequestedTeamIds]);
+
+  const renderScheduleStaffToolsContent = () => selectedCalendarTeam ? (
+    <>
+      <ScheduleGameCreatePanel
+        teamName={selectedCalendarTeam.teamName}
+        form={gameForm}
+        configs={gameTrackerConfigs}
+        saving={savingGame}
+        error={gameFormError}
+        configError={gameTrackerConfigError}
+        onStartUsing={requestTrackerConfigLoad}
+        onChange={(nextForm) => {
+          setGameForm(nextForm);
+          if (gameFormError) setGameFormError(null);
+        }}
+        onSubmit={handleCreateGame}
+      />
+      <SchedulePracticeCreatePanel
+        teamName={selectedCalendarTeam.teamName}
+        form={practiceForm}
+        saving={savingPractice}
+        error={practiceFormError}
+        onChange={(nextForm) => {
+          setPracticeForm(nextForm);
+          if (practiceFormError) setPracticeFormError(null);
+        }}
+        onSubmit={handleCreatePractice}
+      />
+      <ScheduleStaffTools
+        teamName={selectedCalendarTeam.teamName}
+        calendarUrl={calendarUrl}
+        calendarUrls={selectedCalendarTeam.calendarUrls || []}
+        calendarUrlError={calendarUrlError}
+        savingCalendarUrl={savingCalendarUrl}
+        removingCalendarUrl={removingCalendarUrl}
+        aiScheduleText={aiScheduleText}
+        aiScheduleImageName={aiScheduleImageName}
+        aiPreviewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
+        aiImportErrors={aiImportErrors}
+        processingAiImport={processingAiImport}
+        csvHeaders={csvHeaders}
+        csvMapping={csvMapping}
+        csvPreviewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
+        csvImportErrors={csvImportErrors}
+        csvFileName={csvFileName}
+        loadingCsvFile={loadingCsvFile}
+        importingCsv={importingCsv}
+        onCalendarUrlChange={(value) => {
+          setCalendarUrl(value);
+          if (calendarUrlError) setCalendarUrlError(null);
+        }}
+        onAddCalendarUrl={handleAddCalendarUrl}
+        onRemoveCalendarUrl={handleRemoveCalendarUrl}
+        onAiTextChange={(value) => {
+          setAiScheduleText(value);
+          clearAiPreview();
+          if (aiImportErrors.length) setAiImportErrors([]);
+        }}
+        onAiImageChange={handleAiImageChange}
+        onAiGeneratePreview={handleAiGeneratePreview}
+        onImportCsv={handleCsvImport}
+        onClearAi={handleAiClear}
+        onCsvFileChange={handleCsvFileChange}
+        onCsvMappingChange={handleCsvMappingChange}
+        onCsvPreview={handleCsvPreview}
+        onClearCsv={handleCsvClear}
+      />
+    </>
+  ) : null;
 
   useEffect(() => {
     setGameForm((current) => {
@@ -1134,10 +1209,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
               onRefresh={() => refreshSchedule(true)}
               onExport={handleExport}
               advancedControlsOpen={desktopAdvancedControlsOpen}
-              onAdvancedControlsOpenChange={(open) => {
-                if (open) requestTrackerConfigLoad();
-                setDesktopAdvancedControlsOpen(open);
-              }}
+              onAdvancedControlsOpenChange={setDesktopAdvancedControlsOpen}
               onCopyAgenda={handleCopyAgenda}
               onResetFilters={() => {
                 setFilter('upcoming-all');
@@ -1164,76 +1236,6 @@ export function Schedule({ auth }: { auth: AuthState }) {
               ))}
             </div>
           ) : null}
-
-          {isDesktopWeb && selectedCalendarTeam ? (
-            <>
-              <ScheduleGameCreatePanel
-                teamName={selectedCalendarTeam.teamName}
-                form={gameForm}
-                configs={gameTrackerConfigs}
-                saving={savingGame}
-                error={gameFormError}
-                configError={gameTrackerConfigError}
-                onStartUsing={requestTrackerConfigLoad}
-                onChange={(nextForm) => {
-                  setGameForm(nextForm);
-                  if (gameFormError) setGameFormError(null);
-                }}
-                onSubmit={handleCreateGame}
-              />
-              <SchedulePracticeCreatePanel
-                teamName={selectedCalendarTeam.teamName}
-                form={practiceForm}
-                saving={savingPractice}
-                error={practiceFormError}
-                onChange={(nextForm) => {
-                  setPracticeForm(nextForm);
-                  if (practiceFormError) setPracticeFormError(null);
-                }}
-                onSubmit={handleCreatePractice}
-              />
-            <ScheduleStaffTools
-              teamName={selectedCalendarTeam.teamName}
-              calendarUrl={calendarUrl}
-              calendarUrls={selectedCalendarTeam.calendarUrls || []}
-              calendarUrlError={calendarUrlError}
-              savingCalendarUrl={savingCalendarUrl}
-              removingCalendarUrl={removingCalendarUrl}
-              aiScheduleText={aiScheduleText}
-              aiScheduleImageName={aiScheduleImageName}
-              aiPreviewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
-              aiImportErrors={aiImportErrors}
-              processingAiImport={processingAiImport}
-              csvHeaders={csvHeaders}
-              csvMapping={csvMapping}
-              csvPreviewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
-              csvImportErrors={csvImportErrors}
-              csvFileName={csvFileName}
-              loadingCsvFile={loadingCsvFile}
-              importingCsv={importingCsv}
-              onCalendarUrlChange={(value) => {
-                setCalendarUrl(value);
-                if (calendarUrlError) setCalendarUrlError(null);
-              }}
-              onAddCalendarUrl={handleAddCalendarUrl}
-              onRemoveCalendarUrl={handleRemoveCalendarUrl}
-              onAiTextChange={(value) => {
-                setAiScheduleText(value);
-                clearAiPreview();
-                if (aiImportErrors.length) setAiImportErrors([]);
-              }}
-              onAiImageChange={handleAiImageChange}
-              onAiGeneratePreview={handleAiGeneratePreview}
-              onImportCsv={handleCsvImport}
-              onClearAi={handleAiClear}
-              onCsvFileChange={handleCsvFileChange}
-              onCsvMappingChange={handleCsvMappingChange}
-              onCsvPreview={handleCsvPreview}
-              onClearCsv={handleCsvClear}
-            />
-            </>
-          ) : null}
-
           {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
           {scheduleReadError ? <Status tone="error" message={scheduleLoadError ? getScheduleLoadErrorMessage(scheduleLoadError, hasLoadedSchedule) : scheduleReadError} /> : null}
 
@@ -1271,81 +1273,30 @@ export function Schedule({ auth }: { auth: AuthState }) {
             />
           )}
 
+          {isDesktopWeb && selectedCalendarTeam ? (
+            <ScheduleStaffToolsSection
+              open={desktopStaffToolsOpen}
+              teamName={selectedCalendarTeam.teamName}
+              contentId="desktop-schedule-staff-tools"
+              onToggle={() => setDesktopStaffToolsOpen((current) => !current)}
+            >
+              {renderScheduleStaffToolsContent()}
+            </ScheduleStaffToolsSection>
+          ) : null}
+
           {!isDesktopWeb && selectedCalendarTeam ? (
-            <MobileScheduleStaffToolsSection
+            <ScheduleStaffToolsSection
               open={mobileStaffToolsOpen}
               teamName={selectedCalendarTeam.teamName}
+              contentId="mobile-schedule-staff-tools"
               onToggle={() => setMobileStaffToolsOpen((current) => {
                 const nextOpen = !current;
                 if (nextOpen) requestTrackerConfigLoad();
                 return nextOpen;
               })}
             >
-              <ScheduleGameCreatePanel
-                teamName={selectedCalendarTeam.teamName}
-                form={gameForm}
-                configs={gameTrackerConfigs}
-                saving={savingGame}
-                error={gameFormError}
-                configError={gameTrackerConfigError}
-                onStartUsing={requestTrackerConfigLoad}
-                onChange={(nextForm) => {
-                  setGameForm(nextForm);
-                  if (gameFormError) setGameFormError(null);
-                }}
-                onSubmit={handleCreateGame}
-              />
-              <SchedulePracticeCreatePanel
-                teamName={selectedCalendarTeam.teamName}
-                form={practiceForm}
-                saving={savingPractice}
-                error={practiceFormError}
-                onChange={(nextForm) => {
-                  setPracticeForm(nextForm);
-                  if (practiceFormError) setPracticeFormError(null);
-                }}
-                onSubmit={handleCreatePractice}
-              />
-              <ScheduleStaffTools
-                teamName={selectedCalendarTeam.teamName}
-                calendarUrl={calendarUrl}
-                calendarUrls={selectedCalendarTeam.calendarUrls || []}
-                calendarUrlError={calendarUrlError}
-                savingCalendarUrl={savingCalendarUrl}
-                removingCalendarUrl={removingCalendarUrl}
-                aiScheduleText={aiScheduleText}
-                aiScheduleImageName={aiScheduleImageName}
-                aiPreviewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
-                aiImportErrors={aiImportErrors}
-                processingAiImport={processingAiImport}
-                csvHeaders={csvHeaders}
-                csvMapping={csvMapping}
-                csvPreviewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
-                csvImportErrors={csvImportErrors}
-                csvFileName={csvFileName}
-                loadingCsvFile={loadingCsvFile}
-                importingCsv={importingCsv}
-                onCalendarUrlChange={(value) => {
-                  setCalendarUrl(value);
-                  if (calendarUrlError) setCalendarUrlError(null);
-                }}
-                onAddCalendarUrl={handleAddCalendarUrl}
-                onRemoveCalendarUrl={handleRemoveCalendarUrl}
-                onAiTextChange={(value) => {
-                  setAiScheduleText(value);
-                  clearAiPreview();
-                  if (aiImportErrors.length) setAiImportErrors([]);
-                }}
-                onAiImageChange={handleAiImageChange}
-                onAiGeneratePreview={handleAiGeneratePreview}
-                onImportCsv={handleCsvImport}
-                onClearAi={handleAiClear}
-                onCsvFileChange={handleCsvFileChange}
-                onCsvMappingChange={handleCsvMappingChange}
-                onCsvPreview={handleCsvPreview}
-                onClearCsv={handleCsvClear}
-              />
-            </MobileScheduleStaffToolsSection>
+              {renderScheduleStaffToolsContent()}
+            </ScheduleStaffToolsSection>
           ) : null}
         </div>
       </div>
@@ -1476,14 +1427,14 @@ function PracticeRecurrenceFields({ form, onChange }: { form: SchedulePracticeFo
   );
 }
 
-function MobileScheduleStaffToolsSection({ open, teamName, onToggle, children }: { open: boolean; teamName: string; onToggle: () => void; children: ReactNode }) {
+function ScheduleStaffToolsSection({ open, teamName, contentId, onToggle, children }: { open: boolean; teamName: string; contentId: string; onToggle: () => void; children: ReactNode }) {
   return (
     <section className="app-card p-3" aria-label="Manage schedule tools">
       <button
         type="button"
         className="flex w-full items-center justify-between gap-3 text-left"
         aria-expanded={open}
-        aria-controls="mobile-schedule-staff-tools"
+        aria-controls={contentId}
         onClick={onToggle}
       >
         <div className="min-w-0">
@@ -1494,7 +1445,7 @@ function MobileScheduleStaffToolsSection({ open, teamName, onToggle, children }:
         <ChevronDown className={`h-5 w-5 flex-none text-gray-500 transition ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
       </button>
       {open ? (
-        <div id="mobile-schedule-staff-tools" className="mt-3 space-y-3">
+        <div id={contentId} className="mt-3 space-y-3">
           {children}
         </div>
       ) : null}

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -161,6 +161,15 @@ async function waitForButtonEnabled(container, text) {
     throw new Error(`Timed out waiting for enabled button: ${text}`);
 }
 
+async function openManageSchedule(container) {
+    await waitForText(container, 'Manage schedule');
+    if (buttonContainingText(container, 'Manage schedule').getAttribute('aria-expanded') !== 'true') {
+        await act(async () => {
+            buttonContainingText(container, 'Manage schedule').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+    }
+}
+
 async function changeInput(input, value) {
     await act(async () => {
         const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
@@ -319,6 +328,7 @@ describe('React app desktop Schedule controls', () => {
         });
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Add external calendar');
 
         const input = container.querySelector('input[aria-label="External .ics calendar URL"]');
@@ -430,6 +440,7 @@ describe('React app desktop Schedule controls', () => {
         });
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Saved calendar links');
         expect(container.textContent).toContain('https://example.com/stale.ics');
 
@@ -476,6 +487,7 @@ describe('React app desktop Schedule controls', () => {
         });
         clearAppDataCache('app-schedule-summary');
         const staff = await renderSchedule();
+        await openManageSchedule(staff.container);
         await waitForText(staff.container, 'Add external calendar');
         await clickButton(staff.container, 'Save calendar');
 
@@ -497,6 +509,7 @@ describe('React app desktop Schedule controls', () => {
         clearAppDataCache('app-schedule-summary');
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Import schedule CSV');
         const csvModuleLoadsBeforeUpload = scheduleMocks.csvModuleLoads;
         const input = container.querySelector('input[aria-label="Schedule CSV file"]');
@@ -591,6 +604,7 @@ describe('React app desktop Schedule controls', () => {
         clearAppDataCache('app-schedule-summary');
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Draft schedule with AI');
         const aiModuleLoadsBeforeGenerate = scheduleMocks.aiModuleLoads;
         const textarea = container.querySelector('textarea[aria-label="Schedule text or AI instructions"]');
@@ -643,6 +657,7 @@ describe('React app desktop Schedule controls', () => {
         });
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Draft schedule with AI');
         const textarea = container.querySelector('textarea[aria-label="Schedule text or AI instructions"]');
 
@@ -667,6 +682,7 @@ describe('React app desktop Schedule controls', () => {
         });
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Import schedule CSV');
         const input = container.querySelector('input[aria-label="Schedule CSV file"]');
         const file = new File([
@@ -697,6 +713,7 @@ describe('React app desktop Schedule controls', () => {
         scheduleMocks.createScheduleImportGame.mockRejectedValueOnce(new Error('Firestore write failed'));
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Import schedule CSV');
         const input = container.querySelector('input[aria-label="Schedule CSV file"]');
         const file = new File([
@@ -737,6 +754,7 @@ describe('React app desktop Schedule controls', () => {
             .mockResolvedValueOnce('game-4');
 
         const { container } = await renderSchedule();
+        await openManageSchedule(container);
         await waitForText(container, 'Import schedule CSV');
         const input = container.querySelector('input[aria-label="Schedule CSV file"]');
         const file = new File([
@@ -787,9 +805,15 @@ describe('React app desktop Schedule controls', () => {
         await waitForText(container, 'Main Gym');
         await clickButton(container, 'Filters and views');
         await changeSelect(selectByLabel(container, 'Team'), 'team-1');
+        await openManageSchedule(container);
         await waitForText(container, 'Add game for Bears');
 
         const teamOnePanel = container.querySelector('section[aria-label="Create game"]');
+        await act(async () => {
+            teamOnePanel.querySelector('input').focus();
+            await Promise.resolve();
+        });
+        await waitForText(container, 'Bears Tracker');
         const teamOneSelects = teamOnePanel.querySelectorAll('select');
         await changeSelect(teamOneSelects[1], 'cfg-team-1');
         expect(teamOneSelects[1].value).toBe('cfg-team-1');


### PR DESCRIPTION
Closes #3044

## What changed
- moved the desktop staff-only schedule create and import panels behind the same collapsed **Manage schedule** affordance already used on mobile
- placed the desktop section after the primary schedule content so the default desktop view stays focused on upcoming events
- kept the existing game, practice, external calendar, AI import, and CSV import behavior intact once the section is expanded
- tightened tracker-config lazy loading so expanding desktop chrome alone does not fetch configs, and the existing form-interaction trigger still does
- updated the focused Schedule page tests for the new desktop visibility contract and lazy-load behavior

## Root Cause
Desktop Schedule rendered the full staff management stack immediately whenever a manageable team was selected, instead of gating that secondary workflow behind an explicit disclosure. The tracker-config lazy-load guard also considered unrelated desktop advanced-controls state as a valid fetch trigger.

## Prevention / Learning
When mobile already defers an admin-only workflow behind a collapsed section, mirror that information architecture on desktop instead of reintroducing always-open power-user UI. Keep lazy data fetches tied to the exact user interaction that needs them, not nearby layout toggles.

## Regression Tests
- `npm exec --prefix apps/app vitest run src/pages/Schedule.test.tsx`
- `apps/app/src/pages/Schedule.test.tsx` verifies desktop staff tools are hidden by default and appear after opening **Manage schedule**
- `apps/app/src/pages/Schedule.test.tsx` verifies desktop tracker configs still wait for direct game-form interaction before loading