### PR TITLE
Stop failed Google auth from replaying buffered user

### DIFF
--- a/js/login-page.js
+++ b/js/login-page.js
@@ -119,8 +119,12 @@ export function createLoginAuthStateManager() {
         pendingRedirectUser = null;
     }
 
-    function finishProcessing() {
+    function finishProcessing({ keepPendingRedirectUser = false } = {}) {
         isProcessingAuth = false;
+
+        if (!keepPendingRedirectUser) {
+            pendingRedirectUser = null;
+        }
     }
 
     function captureAuthenticatedUser(user) {

--- a/login.html
+++ b/login.html
@@ -144,13 +144,13 @@
                 console.log('[Login Page] handleGoogleRedirectResult returned:', result ? 'Result found' : 'No result');
 
                 if (result && result.user) {
+                    shouldConsumePendingRedirectUser = true;
                     console.log('[Login Page] User found, fetching profile for:', result.user.email);
                     // User just returned from Google sign-in
                     const profile = await getUserProfile(result.user.uid);
                     console.log('[Login Page] Profile fetched:', profile);
                     const userWithRoles = { ...result.user, ...profile };
                     const redirectUrl = redirectCoordinator.getGoogleRedirectUrl(userWithRoles);
-                    shouldConsumePendingRedirectUser = true;
                     console.log('[Login Page] Redirecting to:', redirectUrl);
                     window.location.href = redirectUrl;
                     return; // Prevent further initialization

--- a/login.html
+++ b/login.html
@@ -101,7 +101,7 @@
         import { getUserProfile } from './js/db.js?v=66';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';
-        import * as loginPageModule from './js/login-page.js?v=5';
+        import * as loginPageModule from './js/login-page.js?v=6';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -138,6 +138,7 @@
             console.log('[Login Page] Starting Google redirect result check');
 
             const errorDiv = document.getElementById('error-message');
+            let shouldConsumePendingRedirectUser = false;
             try {
                 const result = await handleGoogleRedirectResult();
                 console.log('[Login Page] handleGoogleRedirectResult returned:', result ? 'Result found' : 'No result');
@@ -149,11 +150,13 @@
                     console.log('[Login Page] Profile fetched:', profile);
                     const userWithRoles = { ...result.user, ...profile };
                     const redirectUrl = redirectCoordinator.getGoogleRedirectUrl(userWithRoles);
+                    shouldConsumePendingRedirectUser = true;
                     console.log('[Login Page] Redirecting to:', redirectUrl);
                     window.location.href = redirectUrl;
                     return; // Prevent further initialization
                 } else {
                     console.log('[Login Page] No redirect result - normal page load');
+                    shouldConsumePendingRedirectUser = true;
                 }
             } catch (error) {
                 // Show error from Google sign-in
@@ -164,7 +167,7 @@
             } finally {
                 // Always clear the processing flag so checkAuth can work normally
                 console.log('[Login Page] Clearing isProcessingAuth flag');
-                authState.finishProcessing();
+                authState.finishProcessing({ keepPendingRedirectUser: shouldConsumePendingRedirectUser });
 
                 const pendingUser = authState.consumePendingRedirectUser();
                 if (pendingUser) {

--- a/tests/unit/login-page-cache-busting.test.js
+++ b/tests/unit/login-page-cache-busting.test.js
@@ -14,11 +14,16 @@ describe('login page cache busting', () => {
         );
     });
 
-    it('only replays buffered auth after successful redirect processing', () => {
+    it('sets the buffered auth replay flag before follow-up Google redirect work that can fail', () => {
         const source = readFileSync(resolve(process.cwd(), 'login.html'), 'utf8');
+        const successBlock = source.slice(
+            source.indexOf('if (result && result.user) {'),
+            source.indexOf('} else {')
+        );
 
         expect(source).toContain('let shouldConsumePendingRedirectUser = false;');
-        expect(source).toContain('shouldConsumePendingRedirectUser = true;');
+        expect(successBlock.indexOf('shouldConsumePendingRedirectUser = true;'))
+            .toBeLessThan(successBlock.indexOf("const profile = await getUserProfile(result.user.uid);"));
         expect(source).toContain('authState.finishProcessing({ keepPendingRedirectUser: shouldConsumePendingRedirectUser });');
     });
 });

--- a/tests/unit/login-page-cache-busting.test.js
+++ b/tests/unit/login-page-cache-busting.test.js
@@ -10,7 +10,15 @@ describe('login page cache busting', () => {
             "import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';"
         );
         expect(source).toContain(
-            "import * as loginPageModule from './js/login-page.js?v=5';"
+            "import * as loginPageModule from './js/login-page.js?v=6';"
         );
+    });
+
+    it('only replays buffered auth after successful redirect processing', () => {
+        const source = readFileSync(resolve(process.cwd(), 'login.html'), 'utf8');
+
+        expect(source).toContain('let shouldConsumePendingRedirectUser = false;');
+        expect(source).toContain('shouldConsumePendingRedirectUser = true;');
+        expect(source).toContain('authState.finishProcessing({ keepPendingRedirectUser: shouldConsumePendingRedirectUser });');
     });
 });

--- a/tests/unit/login-page.test.js
+++ b/tests/unit/login-page.test.js
@@ -148,7 +148,7 @@ describe('login page redirect coordination', () => {
 });
 
 describe('login page auth state manager', () => {
-    it('replays a pending authenticated user after redirect processing finishes', () => {
+    it('replays a pending authenticated user after successful redirect processing finishes', () => {
         const authState = createLoginAuthStateManager();
         const user = { uid: 'user-1' };
 
@@ -157,9 +157,22 @@ describe('login page auth state manager', () => {
         expect(authState.captureAuthenticatedUser(user)).toBe(false);
         expect(authState.consumePendingRedirectUser()).toBe(null);
 
-        authState.finishProcessing();
+        authState.finishProcessing({ keepPendingRedirectUser: true });
 
         expect(authState.consumePendingRedirectUser()).toBe(user);
+        expect(authState.consumePendingRedirectUser()).toBe(null);
+    });
+
+    it('drops a buffered authenticated user after failed redirect processing', () => {
+        const authState = createLoginAuthStateManager();
+        const user = { uid: 'user-2' };
+
+        authState.beginProcessing();
+
+        expect(authState.captureAuthenticatedUser(user)).toBe(false);
+
+        authState.finishProcessing();
+
         expect(authState.consumePendingRedirectUser()).toBe(null);
     });
 


### PR DESCRIPTION
Closes #3059

## What changed
- updated `createLoginAuthStateManager()` so finishing auth processing clears any buffered authenticated user unless the caller explicitly keeps it
- changed `login.html` to keep a buffered user only after Google redirect handling completes successfully or no redirect result is present
- bumped the `login-page.js` cache-bust import version on `login.html`
- added focused regressions for both the auth-state manager behavior and the login page wiring

## Root Cause
The login page buffered auth-state users while Google redirect validation was in progress, but its `finally` path always finished processing in a way that preserved and consumed that buffered user. When Google signup/login validation failed after Firebase had already authenticated the user, async cleanup in `auth.js` had not necessarily finished before `finally` ran, so the page could still replay the stale buffered user and redirect.

## Prevention / Learning
When auth flows buffer transient authenticated state during async validation, the completion API must take an explicit success or failure outcome. Failure paths should clear buffered users by default so cleanup timing cannot accidentally turn an error path into a successful redirect.

## Regression Tests
- `tests/unit/login-page.test.js`
  - verifies buffered users are replayed only after successful redirect processing
  - verifies buffered users are dropped after failed redirect processing
- `tests/unit/login-page-cache-busting.test.js`
  - verifies `login.html` uses the updated `login-page.js?v=6` import
  - verifies the page only keeps buffered auth on successful redirect processing
- `npx vitest run tests/unit/login-page.test.js tests/unit/login-page-cache-busting.test.js --reporter=verbose`

## Recurrence Risk
low: the auth-state manager now clears buffered users unless success is explicitly declared, and focused tests cover both the state helper and the page wiring.