### PR TITLE
Add basic app tournament schedule creation flow

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -160,13 +160,13 @@ vi.mock('./appDataCache', () => ({
   getParentScheduleSummaryCacheKey: (userId: string) => `app-schedule-summary:${userId}`
 }));
 
-import { addPractice, broadcastLiveEvent, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getTeam, getTeams, listRideOffersForEvent, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
+import { addGame, addPractice, broadcastLiveEvent, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getTeam, getTeams, listRideOffersForEvent, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
 import { getNativeAuthIdToken } from './authService';
 import { expandRecurrence, fetchAndParseCalendar, isTeamActive } from './adapters/legacyScheduleHelpers';
 import { getCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
-import { buildPlayerScoringLiveEvent, claimOfficialAssignmentItem, createScheduledPracticeForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
+import { buildPlayerScoringLiveEvent, claimOfficialAssignmentItem, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
   return {
@@ -322,6 +322,91 @@ describe('parent schedule child scope', () => {
     expect(schedule.children).toEqual([
       { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Avery Lee' }
     ]);
+  });
+});
+
+describe('scheduled tournament writes', () => {
+  const coachUser = { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'] } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', ownerId: 'coach-1', adminEmails: [], admins: [] } as any);
+  });
+
+  it('creates tournament child games with the legacy-compatible tournament shape', async () => {
+    vi.mocked(addGame)
+      .mockResolvedValueOnce('game-1' as any)
+      .mockResolvedValueOnce('game-2' as any);
+
+    const createdIds = await createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z'),
+          location: 'Main Gym',
+          arrivalTime: new Date('2026-06-24T18:00:00.000Z'),
+          isHome: true,
+          notes: 'Bring dark jerseys'
+        },
+        {
+          opponent: 'Lions',
+          startDate: new Date('2026-06-25T18:30:00.000Z'),
+          endDate: new Date('2026-06-25T20:00:00.000Z'),
+          location: 'Field 2',
+          arrivalTime: new Date('2026-06-25T18:00:00.000Z'),
+          isHome: false,
+          notes: ''
+        }
+      ]
+    }, coachUser);
+
+    expect(createdIds).toEqual(['game-1', 'game-2']);
+    expect(addGame).toHaveBeenCalledTimes(2);
+    expect(addGame).toHaveBeenNthCalledWith(1, 'team-1', expect.objectContaining({
+      type: 'game',
+      opponent: 'Tigers',
+      competitionType: 'tournament',
+      tournament: {
+        divisionName: '10U Gold',
+        bracketName: 'Gold Bracket',
+        roundName: 'Semifinal',
+        poolName: 'Pool A'
+      }
+    }));
+    expect(addGame).toHaveBeenNthCalledWith(2, 'team-1', expect.objectContaining({
+      type: 'game',
+      opponent: 'Lions',
+      competitionType: 'tournament',
+      tournament: {
+        divisionName: '10U Gold',
+        bracketName: 'Gold Bracket',
+        roundName: 'Semifinal',
+        poolName: 'Pool A'
+      }
+    }));
+  });
+
+  it('rejects tournament blocks without required metadata or child games', async () => {
+    await expect(createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [{ opponent: 'Tigers', startDate: new Date('2026-06-24T18:30:00.000Z') } as any]
+    }, coachUser)).rejects.toThrow('Tournament blocks require division, bracket, and round names.');
+
+    await expect(createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: []
+    }, coachUser)).rejects.toThrow('Tournament blocks require at least one game.');
   });
 });
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1370,6 +1370,16 @@ export type ScheduleGameFormInput = {
   opponentTeamPhoto?: string | null;
 };
 
+export type ScheduleTournamentGameFormInput = ScheduleGameFormInput;
+
+export type ScheduleTournamentCreateFormInput = {
+  divisionName: string;
+  bracketName: string;
+  roundName: string;
+  poolName?: string | null;
+  games: ScheduleTournamentGameFormInput[];
+};
+
 export type ScheduleStatTrackerConfigOption = {
   id: string;
   name: string;
@@ -1479,6 +1489,22 @@ function buildScheduledGamePayload(input: ScheduleGameFormInput, user: AuthUser)
     opponentTeamName: compactString(input.opponentTeamName) || null,
     opponentTeamPhoto: compactString(input.opponentTeamPhoto) || null,
     createdBy: user.uid
+  };
+}
+
+function buildScheduledTournamentMetadata(input: ScheduleTournamentCreateFormInput) {
+  const divisionName = compactString(input.divisionName);
+  const bracketName = compactString(input.bracketName);
+  const roundName = compactString(input.roundName);
+  const poolName = compactString(input.poolName);
+  if (!divisionName || !bracketName || !roundName) {
+    throw new Error('Tournament blocks require division, bracket, and round names.');
+  }
+  return {
+    divisionName,
+    bracketName,
+    roundName,
+    ...(poolName ? { poolName } : {})
   };
 }
 
@@ -1621,6 +1647,45 @@ export async function createScheduledGameForApp(teamId: string, input: ScheduleG
     });
     return doc?.id || '';
   }
+}
+
+export async function createScheduledTournamentBlockForApp(teamId: string, input: ScheduleTournamentCreateFormInput, user: AuthUser | null) {
+  const normalizedTeamId = compactString(teamId);
+  if (!normalizedTeamId) throw new Error('Team is required.');
+  await requireScheduleImportStaff(normalizedTeamId, user);
+
+  const tournament = buildScheduledTournamentMetadata(input);
+  const games = Array.isArray(input.games) ? input.games : [];
+  if (!games.length) {
+    throw new Error('Tournament blocks require at least one game.');
+  }
+
+  const createdIds: string[] = [];
+  for (const game of games) {
+    const payload = {
+      ...buildScheduledGamePayload({
+        ...game,
+        competitionType: 'tournament'
+      }, user as AuthUser),
+      competitionType: 'tournament',
+      tournament
+    };
+
+    try {
+      const createdId = await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Scheduled tournament game create');
+      createdIds.push(createdId || '');
+    } catch (error) {
+      if (!isNativeRuntime()) throw error;
+      logScheduleWarning('Falling back to REST scheduled tournament game create.', 'scheduled-tournament-game-create', error, { fallback: 'rest', teamId: normalizedTeamId });
+      const doc = await nativeCreateDocument(`teams/${encodeURIComponent(normalizedTeamId)}/games`, {
+        ...payload,
+        createdAt: new Date()
+      });
+      createdIds.push(doc?.id || '');
+    }
+  }
+
+  return createdIds;
 }
 
 export async function updateScheduledGameForApp(teamId: string, gameId: string, input: ScheduleGameFormInput, user: AuthUser | null) {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -11,6 +11,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   addTeamCalendarUrl: vi.fn(),
   createScheduledGameForApp: vi.fn(),
   createScheduledPracticeForApp: vi.fn(),
+  createScheduledTournamentBlockForApp: vi.fn(),
   createScheduleImportGame: vi.fn(),
   createScheduleImportPractice: vi.fn(),
   finalizeScheduleImportBatch: vi.fn(),
@@ -392,13 +393,14 @@ describe('Schedule', () => {
     });
   });
 
-  it('renders web-created tournament game metadata read-only in the schedule list', async () => {
+  it('renders web-created tournament game metadata and the create tournament flow', async () => {
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [
         { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
       ],
       events: [
         buildScheduleEvent(1, {
+          isTeamStaff: true,
           competitionType: 'tournament',
           tournament: {
             divisionName: '10U Gold',
@@ -428,7 +430,48 @@ describe('Schedule', () => {
     expect(screen.getAllByText(/Pool: Pool A/).length).toBeGreaterThan(0);
     expect(screen.getAllByText('10U Gold / Pool A standings').length).toBeGreaterThan(0);
     expect(screen.getAllByText('#1 Tigers (2-0, 6 pts)').length).toBeGreaterThan(0);
-    expect(screen.queryByRole('button', { name: /create tournament/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
+
+    expect(await screen.findByRole('heading', { name: 'Add tournament for Bears' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /create tournament/i })).toBeTruthy();
+  });
+
+  it('submits tournament blocks with metadata and child games from schedule tools', async () => {
+    scheduleServiceMocks.loadParentSchedule
+      .mockResolvedValueOnce(buildStaffScheduleResult())
+      .mockResolvedValueOnce(buildStaffScheduleResult());
+    scheduleServiceMocks.createScheduledTournamentBlockForApp.mockResolvedValueOnce(['game-1']);
+
+    renderSchedule();
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+    expect(await screen.findByRole('heading', { name: 'Add tournament for Bears' })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Tournament division'), { target: { value: '10U Gold' } });
+    fireEvent.change(screen.getByLabelText('Tournament bracket'), { target: { value: 'Gold Bracket' } });
+    fireEvent.change(screen.getByLabelText('Tournament round'), { target: { value: 'Semifinal' } });
+    fireEvent.change(screen.getByLabelText('Tournament pool'), { target: { value: 'Pool A' } });
+    fireEvent.change(screen.getByLabelText('Game 1 opponent'), { target: { value: 'Tigers' } });
+    fireEvent.change(screen.getByLabelText('Game 1 location'), { target: { value: 'Main Gym' } });
+    fireEvent.change(screen.getByLabelText('Game 1 starts'), { target: { value: '2026-06-24T18:30' } });
+    fireEvent.change(screen.getByLabelText('Game 1 ends'), { target: { value: '2026-06-24T20:00' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^create tournament$/i }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.createScheduledTournamentBlockForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.createScheduledTournamentBlockForApp).toHaveBeenCalledWith('team-1', expect.objectContaining({
+        divisionName: '10U Gold',
+        bracketName: 'Gold Bracket',
+        roundName: 'Semifinal',
+        poolName: 'Pool A',
+        games: [expect.objectContaining({
+          opponent: 'Tigers',
+          location: 'Main Gym'
+        })]
+      }), auth.user);
+    });
   });
 
   it('does not label scheduled games with default 0-0 scores as final results', async () => {
@@ -579,13 +622,13 @@ describe('Schedule', () => {
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledWith('team-1', auth.user);
     });
-    expect(await screen.findByRole('option', { name: 'Varsity Tracker' })).toBeTruthy();
+    expect((await screen.findAllByRole('option', { name: 'Varsity Tracker' })).length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
     fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('option', { name: 'Varsity Tracker' })).toBeTruthy();
+      expect(screen.getAllByRole('option', { name: 'Varsity Tracker' }).length).toBeGreaterThan(0);
     });
     expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
   });
@@ -623,12 +666,12 @@ describe('Schedule', () => {
     expect(await screen.findByRole('heading', { name: 'Add game for Bears' })).toBeTruthy();
     expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).not.toHaveBeenCalled();
 
-    fireEvent.focus(screen.getByLabelText('Opponent'));
+    fireEvent.focus(screen.getAllByLabelText('Opponent')[0]);
 
     await waitFor(() => {
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledWith('team-1', auth.user);
     });
-    expect(await screen.findByRole('option', { name: 'Varsity Tracker' })).toBeTruthy();
+    expect((await screen.findAllByRole('option', { name: 'Varsity Tracker' })).length).toBeGreaterThan(0);
   });
 });

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -4,7 +4,7 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { Modal } from '../components/Modal';
 import { SchedulePageSkeleton } from '../components/PageSkeletons';
 import { PullToRefresh } from '../components/PullToRefresh';
-import { addTeamCalendarUrl, createScheduledGameForApp, createScheduledPracticeForApp, createScheduleImportGame, createScheduleImportPractice, finalizeScheduleImportBatch, loadParentSchedule, loadScheduleStatTrackerConfigsForApp, removeTeamCalendarUrl, type ParentScheduleChild, type ScheduleGameFormInput, type SchedulePracticeFormInput, type PracticeRecurrenceFormInput, type ScheduleStatTrackerConfigOption } from '../lib/scheduleService';
+import { addTeamCalendarUrl, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createScheduleImportGame, createScheduleImportPractice, finalizeScheduleImportBatch, loadParentSchedule, loadScheduleStatTrackerConfigsForApp, removeTeamCalendarUrl, type ParentScheduleChild, type ScheduleGameFormInput, type SchedulePracticeFormInput, type PracticeRecurrenceFormInput, type ScheduleStatTrackerConfigOption, type ScheduleTournamentCreateFormInput } from '../lib/scheduleService';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from '../lib/appDataCache';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { startAppInitialLoadTimer } from '../lib/telemetry';
@@ -209,6 +209,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [gameFormError, setGameFormError] = useState<string | null>(null);
   const [gameTrackerConfigs, setGameTrackerConfigs] = useState<ScheduleStatTrackerConfigOption[]>([]);
   const [gameTrackerConfigError, setGameTrackerConfigError] = useState<string | null>(null);
+  const [tournamentForm, setTournamentForm] = useState<ScheduleTournamentCreateFormInput>(() => getDefaultScheduleTournamentForm());
+  const [savingTournament, setSavingTournament] = useState(false);
+  const [tournamentFormError, setTournamentFormError] = useState<string | null>(null);
   const [practiceForm, setPracticeForm] = useState<SchedulePracticeFormInput>(() => getDefaultSchedulePracticeForm());
   const [savingPractice, setSavingPractice] = useState(false);
   const [practiceFormError, setPracticeFormError] = useState<string | null>(null);
@@ -625,6 +628,20 @@ export function Schedule({ auth }: { auth: AuthState }) {
         }}
         onSubmit={handleCreateGame}
       />
+      <ScheduleTournamentCreatePanel
+        teamName={selectedCalendarTeam.teamName}
+        form={tournamentForm}
+        configs={gameTrackerConfigs}
+        saving={savingTournament}
+        error={tournamentFormError}
+        configError={gameTrackerConfigError}
+        onStartUsing={requestTrackerConfigLoad}
+        onChange={(nextForm) => {
+          setTournamentForm(nextForm);
+          if (tournamentFormError) setTournamentFormError(null);
+        }}
+        onSubmit={handleCreateTournament}
+      />
       <SchedulePracticeCreatePanel
         teamName={selectedCalendarTeam.teamName}
         form={practiceForm}
@@ -690,6 +707,17 @@ export function Schedule({ auth }: { auth: AuthState }) {
     });
   }, [gameTrackerConfigs]);
 
+  useEffect(() => {
+    setTournamentForm((current) => ({
+      ...current,
+      games: current.games.map((game) => {
+        if (!game.statTrackerConfigId) return game;
+        const hasMatchingConfig = gameTrackerConfigs.some((config) => config.id === game.statTrackerConfigId);
+        return hasMatchingConfig ? game : { ...game, statTrackerConfigId: '' };
+      })
+    }));
+  }, [gameTrackerConfigs]);
+
   const handleCreateGame = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!selectedCalendarTeam || !auth.user || savingGame) return;
@@ -706,6 +734,25 @@ export function Schedule({ auth }: { auth: AuthState }) {
       setGameFormError(gameError?.message || 'Unable to create game.');
     } finally {
       setSavingGame(false);
+    }
+  };
+
+  const handleCreateTournament = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedCalendarTeam || !auth.user || savingTournament) return;
+    setSavingTournament(true);
+    setTournamentFormError(null);
+    setStatusMessage(null);
+    clearScheduleReadError();
+    try {
+      await createScheduledTournamentBlockForApp(selectedCalendarTeam.teamId, tournamentForm, auth.user);
+      setTournamentForm(getDefaultScheduleTournamentForm());
+      await refreshSchedule(true);
+      setStatusMessage('Tournament created and schedule refreshed.');
+    } catch (tournamentError: any) {
+      setTournamentFormError(tournamentError?.message || 'Unable to create tournament.');
+    } finally {
+      setSavingTournament(false);
     }
   };
 
@@ -1335,6 +1382,23 @@ function getDefaultScheduleGameForm(): ScheduleGameFormInput {
   };
 }
 
+function getDefaultScheduleTournamentGameForm(): ScheduleGameFormInput {
+  return {
+    ...getDefaultScheduleGameForm(),
+    competitionType: 'tournament'
+  };
+}
+
+function getDefaultScheduleTournamentForm(): ScheduleTournamentCreateFormInput {
+  return {
+    divisionName: '',
+    bracketName: '',
+    roundName: '',
+    poolName: '',
+    games: [getDefaultScheduleTournamentGameForm()]
+  };
+}
+
 function getDefaultSchedulePracticeForm(): SchedulePracticeFormInput {
   const startDate = new Date();
   startDate.setDate(startDate.getDate() + 1);
@@ -1371,6 +1435,59 @@ function ScheduleGameCreatePanel({ teamName, form, configs, saving, error, confi
         <label className="flex items-center gap-2 text-sm font-black text-gray-800"><input type="checkbox" checked={form.countsTowardSeasonRecord !== false} onChange={(event) => updateField('countsTowardSeasonRecord', event.target.checked)} /> Counts toward season record</label>
         <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Notes<textarea className="auth-input mt-1 min-h-20" value={form.notes || ''} onChange={(event) => updateField('notes', event.target.value)} /></label>
         <button type="submit" className="primary-button" disabled={saving}>{saving ? 'Creating game' : 'Create game'}</button>
+        {configError ? <div className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-bold text-amber-700">{configError}</div> : null}
+        {error ? <div className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">{error}</div> : null}
+      </form>
+    </section>
+  );
+}
+
+function ScheduleTournamentCreatePanel({ teamName, form, configs, saving, error, configError, onStartUsing, onChange, onSubmit }: { teamName: string; form: ScheduleTournamentCreateFormInput; configs: ScheduleStatTrackerConfigOption[]; saving: boolean; error: string | null; configError: string | null; onStartUsing?: () => void; onChange: (form: ScheduleTournamentCreateFormInput) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {
+  const updateField = (field: keyof Omit<ScheduleTournamentCreateFormInput, 'games'>, value: string) => onChange({ ...form, [field]: value });
+  const updateGame = (index: number, field: keyof ScheduleGameFormInput, value: string | Date | boolean | null) => onChange({
+    ...form,
+    games: form.games.map((game, gameIndex) => gameIndex === index ? { ...game, [field]: value } : game)
+  });
+  const addGame = () => onChange({ ...form, games: [...form.games, getDefaultScheduleTournamentGameForm()] });
+  const removeGame = (index: number) => onChange({ ...form, games: form.games.filter((_, gameIndex) => gameIndex !== index) });
+
+  return (
+    <section className="app-card p-3 sm:p-4" aria-label="Create tournament" onFocusCapture={onStartUsing}>
+      <div className="app-label">Tournament scheduling</div>
+      <h2 className="mt-1 text-base font-black text-gray-950">Add tournament for {teamName}</h2>
+      <form className="mt-3 space-y-3" onSubmit={onSubmit}>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tournament division<input aria-label="Tournament division" className="auth-input mt-1" value={form.divisionName} onChange={(event) => updateField('divisionName', event.target.value)} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Bracket<input aria-label="Tournament bracket" className="auth-input mt-1" value={form.bracketName} onChange={(event) => updateField('bracketName', event.target.value)} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Round<input aria-label="Tournament round" className="auth-input mt-1" value={form.roundName} onChange={(event) => updateField('roundName', event.target.value)} /></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Pool<input aria-label="Tournament pool" className="auth-input mt-1" value={form.poolName || ''} onChange={(event) => updateField('poolName', event.target.value)} /></label>
+        </div>
+
+        <div className="space-y-3">
+          {form.games.map((game, index) => (
+            <div key={`tournament-game-${index}`} className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-sm font-black text-gray-900">Game {index + 1}</div>
+                <button type="button" className="text-xs font-black text-gray-500 disabled:text-gray-300" onClick={() => removeGame(index)} disabled={saving || form.games.length <= 0}>Remove</button>
+              </div>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Opponent<input aria-label={`Game ${index + 1} opponent`} className="auth-input mt-1" value={game.opponent} onChange={(event) => updateGame(index, 'opponent', event.target.value)} /></label>
+                <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Location<input aria-label={`Game ${index + 1} location`} className="auth-input mt-1" value={game.location || ''} onChange={(event) => updateGame(index, 'location', event.target.value)} /></label>
+                <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Starts<input aria-label={`Game ${index + 1} starts`} type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(game.startDate)} onChange={(event) => updateGame(index, 'startDate', new Date(event.target.value))} /></label>
+                <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Ends<input aria-label={`Game ${index + 1} ends`} type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(game.endDate)} onChange={(event) => updateGame(index, 'endDate', event.target.value ? new Date(event.target.value) : null)} /></label>
+                <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Arrival<input aria-label={`Game ${index + 1} arrival`} type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(game.arrivalTime)} onChange={(event) => updateGame(index, 'arrivalTime', event.target.value ? new Date(event.target.value) : null)} /></label>
+                <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Home / away<select aria-label={`Game ${index + 1} home away`} className="auth-input mt-1" value={game.isHome === false ? 'away' : game.isHome === true ? 'home' : 'neutral'} onChange={(event) => updateGame(index, 'isHome', event.target.value === 'neutral' ? null : event.target.value === 'home')}><option value="home">Home</option><option value="away">Away</option><option value="neutral">Neutral</option></select></label>
+                <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tracker config<select aria-label={`Game ${index + 1} tracker config`} className="auth-input mt-1" value={game.statTrackerConfigId || ''} onChange={(event) => updateGame(index, 'statTrackerConfigId', event.target.value)}><option value="">No tracker config</option>{configs.map((config) => <option key={`${index}-${config.id}`} value={config.id}>{config.name}</option>)}</select></label>
+              </div>
+              <label className="mt-3 block text-xs font-bold uppercase tracking-wide text-gray-600">Notes<textarea aria-label={`Game ${index + 1} notes`} className="auth-input mt-1 min-h-20" value={game.notes || ''} onChange={(event) => updateGame(index, 'notes', event.target.value)} /></label>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button type="button" className="rounded-full border border-gray-300 px-3 py-2 text-sm font-black text-gray-700" onClick={addGame} disabled={saving}>Add another game</button>
+        </div>
+        <button type="submit" className="primary-button" disabled={saving}>{saving ? 'Creating tournament' : 'Create tournament'}</button>
         {configError ? <div className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-bold text-amber-700">{configError}</div> : null}
         {error ? <div className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">{error}</div> : null}
       </form>

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -311,6 +311,11 @@ async function mockScheduleModules(page, options = {}) {
                     return { id: 'game-created' };
                 }
 
+                export async function createScheduledTournamentBlockForApp(teamId, form, user) {
+                    window.__scheduleCalls.tournamentCreates = (window.__scheduleCalls.tournamentCreates || []).concat({ teamId, form, userId: user?.uid || null });
+                    return { id: 'tournament-created' };
+                }
+
                 export async function createScheduledPracticeForApp(teamId, form, user) {
                     window.__scheduleCalls.practiceCreates = (window.__scheduleCalls.practiceCreates || []).concat({ teamId, form, userId: user?.uid || null });
                     return { id: 'practice-created' };

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -444,7 +444,14 @@ describe('React app desktop Schedule controls', () => {
         await waitForText(container, 'Saved calendar links');
         expect(container.textContent).toContain('https://example.com/stale.ics');
 
-        await clickButton(container, 'Remove');
+        const savedCalendarUrl = Array.from(container.querySelectorAll('div')).find((candidate) => candidate.textContent.trim() === 'https://example.com/stale.ics');
+        const savedCalendarRow = savedCalendarUrl?.parentElement;
+        const removeButton = savedCalendarRow?.querySelector('button');
+        if (!savedCalendarRow || !removeButton) throw new Error('Saved calendar row not found');
+
+        await act(async () => {
+            removeButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
 
         expect(window.confirm).toHaveBeenCalledWith('Remove this external calendar link? Imported events from this feed will disappear after the schedule refreshes.');
         expect(scheduleMocks.removeTeamCalendarUrl).toHaveBeenCalledWith('team-1', 'https://example.com/stale.ics', auth.user);


### PR DESCRIPTION
Closes #3025

## What changed
- added a native schedule management tournament create panel in the app with required tournament metadata fields and a manual child-game list
- added service support to create one or more child game documents with `competitionType: "tournament"` plus the legacy-compatible nested `tournament` metadata shape the existing web schedule already renders
- added focused regression coverage for tournament payload creation, validation, schedule tool rendering, and schedule tool submission

## Root Cause
The app schedule tools only supported single-game and practice creation. Tournament rendering already existed, but there was no app-side grouped creation path that validated required tournament metadata and wrote child game documents in the legacy tournament shape.

## Prevention / Learning
When app schedule parity work exposes read-only legacy data, check whether the adjacent create flow exists before marking the slice complete. If the web already renders a legacy shape, add a narrow app writer plus regression coverage around both validation and persistence shape instead of treating display support as sufficient.

## Regression Tests
- `apps/app/src/lib/scheduleService.test.ts` covers successful tournament child-game writes and validation failures for missing metadata and zero games
- `apps/app/src/pages/Schedule.test.tsx` covers tournament create flow visibility and submission from the app schedule tools UI

## Recurrence Risk
Medium. Tournament support now has targeted coverage, but adjacent schedule-management parity work can still miss create/edit gaps when legacy display support already exists.