### PR TITLE
Route mobile staff schedule cards to the game hub

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -2,9 +2,9 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Schedule } from './Schedule';
+import { Schedule, getGenericEventDetailPath } from './Schedule';
 import type { AuthState } from '../lib/types';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
@@ -94,6 +94,11 @@ function ScheduleNavigationHarness() {
       <Schedule auth={auth} />
     </>
   );
+}
+
+function RouteProbe() {
+  const location = useLocation();
+  return <div data-testid="route-probe">{location.pathname}{location.search}</div>;
 }
 
 function buildScheduleEvent(index: number, overrides: Record<string, unknown> = {}) {
@@ -302,6 +307,48 @@ describe('Schedule', () => {
           type: 'network'
         })
       }));
+    });
+  });
+
+  it('routes generic staff card opens to the game hub helper on mobile', () => {
+    expect(getGenericEventDetailPath(buildScheduleEvent(1, {
+      isTeamStaff: true,
+      myRsvp: 'not_responded'
+    }) as any, true)).toBe('/schedule/team-1/event-1?childId=player-1&section=game');
+    expect(getGenericEventDetailPath(buildScheduleEvent(1, {
+      isTeamStaff: false,
+      myRsvp: 'not_responded'
+    }) as any, true)).toBe('/schedule/team-1/event-1?childId=player-1&section=availability');
+    expect(getGenericEventDetailPath(buildScheduleEvent(1, {
+      id: 'practice-1',
+      type: 'practice',
+      isDbGame: false,
+      practiceHomePacketSummary: '2 drills',
+      isTeamStaff: true
+    }) as any, true)).toBe('/schedule/team-1/practice-1?childId=player-1&section=game');
+  });
+
+  it('opens the game hub from mobile staff schedule cards', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/schedule']}>
+        <Routes>
+          <Route path="/schedule" element={<Schedule auth={auth} />} />
+          <Route path="/schedule/:teamId/:eventId" element={<RouteProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Next up');
+
+    const nextUpLink = container.querySelector('.schedule-next-card');
+    expect(nextUpLink?.getAttribute('href')).toBe('/schedule/team-1/event-1?childId=player-1&section=game');
+
+    fireEvent.click(nextUpLink as HTMLAnchorElement);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('route-probe').textContent).toBe('/schedule/team-1/event-1?childId=player-1&section=game');
     });
   });
 
@@ -588,8 +635,8 @@ describe('Schedule', () => {
   it('keeps list pagination props in sync with the parent schedule view', () => {
     const source = readFileSync(resolveAppSourcePath('src/pages/Schedule.tsx'), 'utf8');
 
-    expect(source).toContain('function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, onShowMore }');
-    expect(source).toContain('function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, onShowMore }');
+    expect(source).toContain('function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }');
+    expect(source).toContain('function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }');
     expect(source).toContain("{loadingMore ? 'Loading more…' : `Show ${Math.min(pageSize, remainingCount || pageSize)} more`}");
   });
 

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1184,7 +1184,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
             </div>
           </div>
 
-          <ScheduleNextUpCard event={webInsights.nextEvent} />
+          <ScheduleNextUpCard event={webInsights.nextEvent} preferGameHubForStaff={!isDesktopWeb} />
         </div>
 
         {!isDesktopWeb ? (
@@ -1294,6 +1294,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
               entries={calendarEntries}
               selectedDay={selectedDay}
               selectedDayEntries={selectedDayEntries}
+              preferGameHubForStaff={!isDesktopWeb}
               onMonthChange={setCalendarMonth}
               onDaySelect={setSelectedDay}
               onDayClose={() => setSelectedDay(null)}
@@ -1307,6 +1308,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
               pageSize={listPageSize}
               canShowMore={canLoadMorePastHistory || visibleListCount < listEntries.length}
               loadingMore={filter === 'past-all' && loadingPastHistory}
+              preferGameHubForStaff={!isDesktopWeb}
               onShowMore={handleShowMore}
             />
           ) : (
@@ -1316,6 +1318,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
               pageSize={listPageSize}
               canShowMore={canLoadMorePastHistory || visibleListCount < listEntries.length}
               loadingMore={filter === 'past-all' && loadingPastHistory}
+              preferGameHubForStaff={!isDesktopWeb}
               onShowMore={handleShowMore}
             />
           )}
@@ -2003,7 +2006,7 @@ function buildScheduleWebInsights(events: ParentScheduleEvent[]): ScheduleWebIns
   });
 }
 
-function ScheduleNextUpCard({ event }: { event: ParentScheduleEvent | null }) {
+function ScheduleNextUpCard({ event, preferGameHubForStaff }: { event: ParentScheduleEvent | null; preferGameHubForStaff: boolean }) {
   if (!event) {
     return (
       <div className="schedule-next-card rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4">
@@ -2019,7 +2022,7 @@ function ScheduleNextUpCard({ event }: { event: ParentScheduleEvent | null }) {
   const tournamentInfo = getScheduleTournamentInfo(event);
 
   return (
-    <Link to={getEventDetailPath(event)} className="schedule-next-card block rounded-xl border border-primary-100 bg-primary-50 p-4 transition hover:border-primary-200 hover:bg-primary-100">
+    <Link to={getGenericEventDetailPath(event, preferGameHubForStaff)} className="schedule-next-card block rounded-xl border border-primary-100 bg-primary-50 p-4 transition hover:border-primary-200 hover:bg-primary-100">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="app-label text-primary-700">Next up</div>
@@ -2262,7 +2265,7 @@ function ScheduleActionQueue({ events }: { events: ParentScheduleEvent[] }) {
       </div>
       <div className="mt-3 space-y-2">
         {actionEvents.length ? actionEvents.map(({ event, action }) => (
-          <Link key={event.eventKey} to={getEventDetailPath(event)} className="block rounded-xl border border-gray-200 bg-white p-3 transition hover:border-primary-200 hover:bg-primary-50">
+          <Link key={event.eventKey} to={getTaskTargetedEventDetailPath(event)} className="block rounded-xl border border-gray-200 bg-white p-3 transition hover:border-primary-200 hover:bg-primary-50">
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <div className="truncate text-sm font-black text-gray-950">{action}</div>
@@ -2285,12 +2288,13 @@ function LoadingSchedule() {
   return <SchedulePageSkeleton />;
 }
 
-function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, onShowMore }: {
+function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }: {
   events: CalendarScheduleEntry[];
   visibleCount: number;
   pageSize: number;
   canShowMore: boolean;
   loadingMore: boolean;
+  preferGameHubForStaff: boolean;
   onShowMore: () => void;
 }) {
   if (!events.length) {
@@ -2310,7 +2314,7 @@ function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore
     <div className="space-y-3">
       <div className="schedule-list overflow-hidden rounded-xl border border-gray-200 bg-white shadow-app sm:space-y-3 sm:overflow-visible sm:border-0 sm:bg-transparent sm:shadow-none">
         {renderedEvents.map((event) => (
-          <ScheduleEventCard key={event.eventKey} event={event} />
+          <ScheduleEventCard key={event.eventKey} event={event} preferGameHubForStaff={preferGameHubForStaff} />
         ))}
       </div>
       {canShowMore ? (
@@ -2327,12 +2331,13 @@ function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore
   );
 }
 
-function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, onShowMore }: {
+function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }: {
   events: CalendarScheduleEntry[];
   visibleCount: number;
   pageSize: number;
   canShowMore: boolean;
   loadingMore: boolean;
+  preferGameHubForStaff: boolean;
   onShowMore: () => void;
 }) {
   if (!events.length) {
@@ -2359,7 +2364,7 @@ function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, load
             const rsvp = normalizeRsvpResponse(event.myRsvp);
             const tournamentInfo = getScheduleTournamentInfo(event);
             return (
-              <Link key={event.eventKey} to={getEventDetailPath(event)} className="compact-schedule-row grid grid-cols-[82px_minmax(0,1fr)_auto] gap-3 px-3 py-2.5 transition hover:bg-primary-50">
+              <Link key={event.eventKey} to={getGenericEventDetailPath(event, preferGameHubForStaff)} className="compact-schedule-row grid grid-cols-[82px_minmax(0,1fr)_auto] gap-3 px-3 py-2.5 transition hover:bg-primary-50">
                 <div className="text-xs font-black text-gray-700">
                   <div>{formatEventDateLabel(event.date)}</div>
                   <div className="mt-0.5 text-gray-500">{formatEventTimeLabel(event.date)}</div>
@@ -2418,7 +2423,7 @@ function PracticePacketsPanel({ rows }: { rows: PracticePacketScheduleRow[] }) {
       </div>
       <div className="schedule-list overflow-hidden rounded-xl border border-gray-200 bg-white shadow-app sm:space-y-3 sm:overflow-visible sm:border-0 sm:bg-transparent sm:shadow-none">
         {rows.map((row) => (
-          <Link key={`${row.event.eventKey}-packet`} to={getEventDetailPath(row.event)} className="block border-b border-gray-100 px-3 py-3 transition last:border-b-0 hover:bg-gray-50 sm:rounded-xl sm:border sm:border-blue-100 sm:bg-white sm:shadow-sm sm:hover:border-blue-200 sm:hover:bg-blue-50">
+          <Link key={`${row.event.eventKey}-packet`} to={getTaskTargetedEventDetailPath(row.event)} className="block border-b border-gray-100 px-3 py-3 transition last:border-b-0 hover:bg-gray-50 sm:rounded-xl sm:border sm:border-blue-100 sm:bg-white sm:shadow-sm sm:hover:border-blue-200 sm:hover:bg-blue-50">
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
@@ -2443,12 +2448,13 @@ function PracticePacketsPanel({ rows }: { rows: PracticePacketScheduleRow[] }) {
   );
 }
 
-function ScheduleEventCard({ event }: {
+function ScheduleEventCard({ event, preferGameHubForStaff }: {
   event: ParentScheduleEvent | CalendarScheduleEntry;
+  preferGameHubForStaff: boolean;
 }) {
   const rsvp = normalizeRsvpResponse(event.myRsvp);
   const eventTitle = getScheduleTitle(event);
-  const detailPath = getEventDetailPath(event);
+  const detailPath = getGenericEventDetailPath(event, preferGameHubForStaff);
   const isRsvpNeeded = rsvp === 'not_responded' && event.isDbGame && !event.isCancelled;
   const hasPracticePacket = event.type === 'practice' && Boolean(event.practiceHomePacketSummary);
   const actionPills = getEventCardActionPills(event, rsvp);
@@ -2605,8 +2611,22 @@ function formatTournamentStandingMeta(row: ScheduleTournamentStandingRow) {
   return parts.length ? ` (${parts.join(', ')})` : '';
 }
 
-function getEventDetailPath(event: ParentScheduleEvent | CalendarScheduleEntry) {
+function getTaskTargetedEventDetailPath(event: ParentScheduleEvent | CalendarScheduleEntry) {
   return getScheduleEventDetailPath(event, getScheduleTaskDetailSection(event));
+}
+
+function hasStaffGameHubAccess(event: Pick<ParentScheduleEvent, 'isTeamStaff' | 'isTeamAdmin' | 'canUpdateScore'>) {
+  return event.isTeamStaff === true || event.isTeamAdmin === true || event.canUpdateScore === true;
+}
+
+export function getGenericEventDetailPath(
+  event: ParentScheduleEvent | CalendarScheduleEntry,
+  preferGameHubForStaff = false
+) {
+  if (preferGameHubForStaff && hasStaffGameHubAccess(event)) {
+    return getScheduleEventDetailPath(event, 'game');
+  }
+  return getTaskTargetedEventDetailPath(event);
 }
 
 function getScheduleChildLabel(event: ParentScheduleEvent | CalendarScheduleEntry) {
@@ -2673,11 +2693,12 @@ function getOpenAssignmentCount(event: ParentScheduleEvent | CalendarScheduleEnt
   return event.assignments.filter((assignment) => assignment.claimable && !assignment.claim && !assignment.value).length;
 }
 
-function CalendarSchedule({ month, entries, selectedDay, selectedDayEntries, onMonthChange, onDaySelect, onDayClose }: {
+function CalendarSchedule({ month, entries, selectedDay, selectedDayEntries, preferGameHubForStaff, onMonthChange, onDaySelect, onDayClose }: {
   month: Date;
   entries: CalendarScheduleEntry[];
   selectedDay: Date | null;
   selectedDayEntries: CalendarScheduleEntry[];
+  preferGameHubForStaff: boolean;
   onMonthChange: (month: Date) => void;
   onDaySelect: (day: Date) => void;
   onDayClose: () => void;
@@ -2749,15 +2770,17 @@ function CalendarSchedule({ month, entries, selectedDay, selectedDayEntries, onM
       <CalendarEventPicker
         day={selectedDay}
         entries={selectedDayEntries}
+        preferGameHubForStaff={preferGameHubForStaff}
         onClose={onDayClose}
       />
     </div>
   );
 }
 
-function CalendarEventPicker({ day, entries, onClose }: {
+function CalendarEventPicker({ day, entries, preferGameHubForStaff, onClose }: {
   day: Date | null;
   entries: CalendarScheduleEntry[];
+  preferGameHubForStaff: boolean;
   onClose: () => void;
 }) {
   if (!day) return null;
@@ -2793,7 +2816,7 @@ function CalendarEventPicker({ day, entries, onClose }: {
           <div className="max-h-[65vh] overflow-y-auto p-3 sm:max-h-[70vh]">
             <div className="space-y-2">
               {entries.map((entry) => (
-                <CalendarEventPickerRow key={entry.eventKey} entry={entry} />
+                <CalendarEventPickerRow key={entry.eventKey} entry={entry} preferGameHubForStaff={preferGameHubForStaff} />
               ))}
             </div>
           </div>
@@ -2805,7 +2828,7 @@ function CalendarEventPicker({ day, entries, onClose }: {
   );
 }
 
-function CalendarEventPickerRow({ entry }: { entry: CalendarScheduleEntry }) {
+function CalendarEventPickerRow({ entry, preferGameHubForStaff }: { entry: CalendarScheduleEntry; preferGameHubForStaff: boolean }) {
   const rsvp = normalizeRsvpResponse(entry.myRsvp);
   const needsRsvp = entry.childRsvps.some((child) => normalizeRsvpResponse(child.myRsvp) === 'not_responded') || rsvp === 'not_responded';
   const childLabel = entry.childNames.length ? entry.childNames.join(', ') : entry.childName;
@@ -2813,7 +2836,7 @@ function CalendarEventPickerRow({ entry }: { entry: CalendarScheduleEntry }) {
   const tournamentInfo = getScheduleTournamentInfo(entry);
 
   return (
-    <Link to={getEventDetailPath(entry)} className="block rounded-2xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-primary-200 hover:bg-primary-50" onClick={(event) => event.stopPropagation()}>
+    <Link to={getGenericEventDetailPath(entry, preferGameHubForStaff)} className="block rounded-2xl border border-gray-200 bg-white p-3 shadow-sm transition hover:border-primary-200 hover:bg-primary-50" onClick={(event) => event.stopPropagation()}>
       <div className="flex items-start gap-3">
         <div className="flex h-12 w-16 flex-none flex-col items-center justify-center rounded-xl bg-gray-50 ring-1 ring-gray-100">
           <div className="text-sm font-black leading-none text-gray-950">{formatEventTimeLabel(entry.date)}</div>

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -499,7 +499,7 @@ describe('React app auth/profile capability parity', () => {
             'RSVP needed',
             'Game details',
             'Event details',
-            'getEventDetailPath'
+            'getScheduleEventDetailPath'
         ]);
         expectContains(scheduleEventDetail, [
             'useScheduleEventRsvp',

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -58,7 +58,7 @@ describe('React app parent schedule logic', () => {
         });
     });
 
-    it('builds task-targeted event detail routes while generic opens keep the availability default', () => {
+    it('keeps parent task-targeted event detail routes explicit', () => {
         const generic = event({
             teamId: 'team/with slash',
             id: 'game 1',


### PR DESCRIPTION
Closes #3020

## What changed
- Added a `getGenericEventDetailPath` helper in `apps/app/src/pages/Schedule.tsx` so generic mobile schedule entry points can prefer `?section=game` for staff-capable events.
- Applied that helper only to generic mobile/card entry points such as Next up, list cards, compact rows, and calendar picker rows.
- Kept explicit parent-task destinations on the task-targeted path, including the parent action queue and packet review links.
- Added focused Schedule page tests for the helper and for mobile click-through routing into the Game hub.
- Renamed the existing schedule-logic unit test to clarify that it protects explicit parent task routing behavior.

## Root Cause
Generic Schedule card taps and explicit parent task deep links were both routed through the same parent-first task helper. That helper intentionally prioritized availability, assignments, and rideshare, so staff users opening a card on mobile were incorrectly treated like parent triage flows and landed away from the Game hub.

## Prevention / Learning
When one page supports both generic entry and explicit task shortcuts, do not reuse the explicit-task routing helper for the generic open path. Keep those route decisions separate and make persona-aware defaults at the page entry seam, especially for mobile workflows where one extra tab switch hides time-sensitive tools.

## Regression Tests
- `npx vitest run apps/app/src/pages/Schedule.test.tsx tests/unit/app-schedule-logic.test.js --reporter=verbose`
- `apps/app/src/pages/Schedule.test.tsx` now covers staff mobile generic routing to `?section=game` and click-through navigation from `/schedule`.
- `tests/unit/app-schedule-logic.test.js` continues to lock explicit parent task-targeted route behavior in the underlying task helper.