### PR TITLE
Fix live tracker bench participation detection

### DIFF
--- a/js/live-tracker-finish.js
+++ b/js/live-tracker-finish.js
@@ -39,6 +39,16 @@ function getPlayerElapsedTimeMs(playerStats) {
     ?? 0;
 }
 
+function hasLiveTrackerParticipation(playerStats = {}, columns = []) {
+  const timeMs = getPlayerElapsedTimeMs(playerStats);
+  if (timeMs > 0) return true;
+
+  return (Array.isArray(columns) ? columns : []).some((col) => {
+    const key = String(col || '').toLowerCase();
+    return Number(playerStats?.[key] || 0) !== 0;
+  }) || Number(playerStats?.fouls || 0) !== 0;
+}
+
 export function buildFinishCompletionPlan({
   requestedHome,
   requestedAway,
@@ -122,21 +132,23 @@ export function buildFinishCompletionPlan({
   });
 
   const aggregatedStatsWrites = safeRoster.map((player) => {
+    const playerStats = safeStatsByPlayerId[player.id] || {};
     const statsObj = {};
     safeColumns.forEach((col) => {
       const key = col.toLowerCase();
-      statsObj[key] = safeStatsByPlayerId[player.id]?.[key] || 0;
+      statsObj[key] = playerStats[key] || 0;
     });
-    statsObj.fouls = safeStatsByPlayerId[player.id]?.fouls || 0;
-    const actuallyParticipated = !!safeStatsByPlayerId[player.id];
+    statsObj.fouls = playerStats.fouls || 0;
+    const actuallyParticipated = hasLiveTrackerParticipation(playerStats, safeColumns);
 
     const baseData = {
       playerName: player.name,
       playerNumber: player.num,
-      timeMs: getPlayerElapsedTimeMs(safeStatsByPlayerId[player.id]),
+      timeMs: getPlayerElapsedTimeMs(playerStats),
       participated: actuallyParticipated,
       participationStatus: actuallyParticipated ? 'appeared' : 'did-not-appear',
       participationSource: 'live-tracker-finish',
+      ...(actuallyParticipated ? {} : { didNotPlay: true })
     };
 
     const { publicStats, privateStats } = splitPlayerStatsByVisibility(statTrackerConfig, statsObj);

--- a/tests/unit/live-tracker-finish.test.js
+++ b/tests/unit/live-tracker-finish.test.js
@@ -110,7 +110,7 @@ describe('live tracker finish completion plan', () => {
     ]);
   });
 
-  it('marks standard live-tracker zero-stat aggregate writes as profile appearances', () => {
+  it('marks pre-seeded zero-stat live-tracker players as did not appear', () => {
     const plan = buildFinishCompletionPlan({
       requestedHome: 0,
       requestedAway: 0,
@@ -132,20 +132,21 @@ describe('live tracker finish completion plan', () => {
       {
         playerId: 'p-zero',
         data: {
+          didNotPlay: true,
           playerName: 'Zero Stat',
           playerNumber: '12',
-          participated: true,
-          participationStatus: 'appeared',
+          participated: false,
+          participationStatus: 'did-not-appear',
           participationSource: 'live-tracker-finish',
           stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
           timeMs: 0
         }
       }
     ]);
-    expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(true);
+    expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(false);
   });
 
-  it('keeps standard finish aggregate readback visible in player profile history', () => {
+  it('keeps live-tracker aggregates with real participation visible in player profile history', () => {
     const standardFinishAggregateDoc = {
       playerName: 'Zero Stat',
       playerNumber: '12',
@@ -157,6 +158,41 @@ describe('live tracker finish completion plan', () => {
     };
 
     expect(hasPlayerProfileParticipation(standardFinishAggregateDoc)).toBe(true);
+  });
+
+  it('marks live-tracker players with recorded playing time as having appeared even without counting stats', () => {
+    const plan = buildFinishCompletionPlan({
+      requestedHome: 0,
+      requestedAway: 0,
+      liveHome: 0,
+      liveAway: 0,
+      scoreLogIsComplete: true,
+      log: [],
+      columns: ['PTS', 'REB', 'AST'],
+      roster: [
+        { id: 'p-minutes', name: 'Minutes Only', num: '21' }
+      ],
+      statsByPlayerId: {
+        'p-minutes': { pts: 0, reb: 0, ast: 0, fouls: 0, time: 60000 }
+      },
+      opponentEntries: []
+    });
+
+    expect(plan.aggregatedStatsWrites).toEqual([
+      {
+        playerId: 'p-minutes',
+        data: {
+          playerName: 'Minutes Only',
+          playerNumber: '21',
+          participated: true,
+          participationStatus: 'appeared',
+          participationSource: 'live-tracker-finish',
+          stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
+          timeMs: 60000
+        }
+      }
+    ]);
+    expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(true);
   });
 
   it('splits private player stats into manager-only finish writes', () => {


### PR DESCRIPTION
Closes #3063

## What changed
- changed live tracker completion to mark a player as having appeared only when the player has real participation evidence
- treat non-zero tracked stats, fouls, or positive playing time as participation evidence instead of trusting the pre-seeded roster stats object
- write `didNotPlay: true` for rostered players who never recorded activity
- added focused regression coverage for zero-stat bench players and minutes-only appearances

## Root Cause
Live tracker finish used `!!safeStatsByPlayerId[player.id]` as the participation check. Because live tracker pre-populates `state.stats` for every rostered player before the game starts, every rostered player was persisted as `participated: true` and `participationStatus: 'appeared'` even when all stats and playing time stayed at zero.

## Prevention / Learning
When tracker state is initialized for the full roster, object existence is not participation evidence. Finalization logic must derive participation from actual activity signals such as non-zero stats or positive playing time, and regression tests should cover pre-seeded zero-stat bench records.

## Regression Tests
- `npx vitest run tests/unit/live-tracker-finish.test.js --reporter=verbose`
- added assertions that a pre-seeded zero-stat player is saved as `did-not-appear`
- added assertions that a player with only recorded minutes is still saved as `appeared`