### PR TITLE
Block stat config resets used by completed games

### DIFF
--- a/edit-config.html
+++ b/edit-config.html
@@ -200,7 +200,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=66';
+        import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=67';
         import { parseAdvancedStatDefinitions, validateStatDefinitionsForPublicLeaderboards } from './js/stat-leaderboards.js?v=2';
         import { getStatConfigPresetOptions, getStatConfigPresetById, serializeAdvancedStatDefinitions } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';

--- a/js/db.js
+++ b/js/db.js
@@ -3544,13 +3544,6 @@ export async function deleteConfig(teamId, configId) {
 }
 
 function isResetBlockingLocalGameAssignment(game = {}) {
-    const status = String(game?.status || '').toLowerCase();
-    const liveStatus = String(game?.liveStatus || '').toLowerCase();
-
-    if (status === 'completed' || status === 'final' || status === 'cancelled' || liveStatus === 'completed') {
-        return false;
-    }
-
     return Boolean(String(game?.statTrackerConfigId || '').trim());
 }
 
@@ -3583,7 +3576,7 @@ export async function resetTeamStatConfigs(teamId) {
 
     for (const config of configs) {
         if (await hasResetBlockingLocalGameUsingConfig(teamId, config.id) || await hasResetBlockingSharedGameUsingConfig(teamId, config.id)) {
-            throw new Error('One or more stat configs are still assigned to scheduled or shared games. Remove those assignments before resetting the stats setup.');
+            throw new Error('One or more stat configs are still assigned to existing games, including completed history. Remove those assignments before resetting the stats setup.');
         }
     }
 

--- a/tests/smoke/edit-config-platform-admin.spec.js
+++ b/tests/smoke/edit-config-platform-admin.spec.js
@@ -197,7 +197,7 @@ async function mockDependencies(page) {
         contentType: 'application/javascript',
         body: ''
     }));
-    await page.route('**/js/db.js?v=66', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route('**/js/edit-config-access.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));

--- a/tests/unit/edit-config-schema-workflow.test.js
+++ b/tests/unit/edit-config-schema-workflow.test.js
@@ -147,6 +147,6 @@ describe('edit config schema workflow', () => {
         expect(source).toContain('export async function resetTeamStatConfigs(teamId) {');
         expect(source).toContain('const batch = writeBatch(db);');
         expect(source).toContain('batch.delete(doc(db, `teams/${teamId}/statTrackerConfigs`, config.id));');
-        expect(source).toContain("throw new Error('One or more stat configs are still assigned to scheduled or shared games. Remove those assignments before resetting the stats setup.')");
+        expect(source).toContain("throw new Error('One or more stat configs are still assigned to existing games, including completed history. Remove those assignments before resetting the stats setup.')");
     });
 });

--- a/tests/unit/reset-team-stat-configs-guard.test.js
+++ b/tests/unit/reset-team-stat-configs-guard.test.js
@@ -53,18 +53,19 @@ function loadResetHelpers(overrides = {}) {
 }
 
 describe('resetTeamStatConfigs guard', () => {
-    it('treats completed, final, cancelled, and completed-live games as reset-safe history', () => {
+    it('treats any game with a config assignment as reset-blocking history', () => {
         const { isResetBlockingLocalGameAssignment } = loadResetHelpers();
 
-        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', status: 'completed' })).toBe(false);
-        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', status: 'final' })).toBe(false);
-        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', status: 'cancelled' })).toBe(false);
-        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', liveStatus: 'completed' })).toBe(false);
+        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', status: 'completed' })).toBe(true);
+        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', status: 'final' })).toBe(true);
+        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', status: 'cancelled' })).toBe(true);
+        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', liveStatus: 'completed' })).toBe(true);
         expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', status: 'scheduled' })).toBe(true);
         expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: 'cfg-1', liveStatus: 'live' })).toBe(true);
+        expect(isResetBlockingLocalGameAssignment({ statTrackerConfigId: '' })).toBe(false);
     });
 
-    it('allows reset when only historical local games reference the config and no shared games do', async () => {
+    it('blocks reset when completed local games still reference the config', async () => {
         const batch = {
             delete: vi.fn(),
             commit: vi.fn().mockResolvedValue(undefined)
@@ -90,13 +91,13 @@ describe('resetTeamStatConfigs guard', () => {
             doc
         });
 
-        const deletedCount = await resetTeamStatConfigs('team-1');
-
-        expect(deletedCount).toBe(1);
-        expect(getDocs).toHaveBeenCalledTimes(4);
-        expect(batch.delete).toHaveBeenCalledTimes(1);
-        expect(batch.commit).toHaveBeenCalledTimes(1);
-        expect(doc).toHaveBeenCalledWith(expect.anything(), 'teams/team-1/statTrackerConfigs', 'cfg-1');
+        await expect(resetTeamStatConfigs('team-1')).rejects.toThrow(
+            'One or more stat configs are still assigned to existing games, including completed history. Remove those assignments before resetting the stats setup.'
+        );
+        expect(getDocs).toHaveBeenCalledTimes(1);
+        expect(batch.delete).not.toHaveBeenCalled();
+        expect(batch.commit).not.toHaveBeenCalled();
+        expect(doc).not.toHaveBeenCalled();
     });
 
     it('blocks reset when a scheduled local game still references the config', async () => {
@@ -117,13 +118,13 @@ describe('resetTeamStatConfigs guard', () => {
         });
 
         await expect(resetTeamStatConfigs('team-1')).rejects.toThrow(
-            'One or more stat configs are still assigned to scheduled or shared games. Remove those assignments before resetting the stats setup.'
+            'One or more stat configs are still assigned to existing games, including completed history. Remove those assignments before resetting the stats setup.'
         );
         expect(batch.delete).not.toHaveBeenCalled();
         expect(batch.commit).not.toHaveBeenCalled();
     });
 
-    it('allows reset when only completed shared games reference the config', async () => {
+    it('blocks reset when completed shared games still reference the config', async () => {
         const batch = {
             delete: vi.fn(),
             commit: vi.fn().mockResolvedValue(undefined)
@@ -144,11 +145,11 @@ describe('resetTeamStatConfigs guard', () => {
             writeBatch: () => batch
         });
 
-        const deletedCount = await resetTeamStatConfigs('team-1');
-
-        expect(deletedCount).toBe(1);
-        expect(batch.delete).toHaveBeenCalledTimes(1);
-        expect(batch.commit).toHaveBeenCalledTimes(1);
+        await expect(resetTeamStatConfigs('team-1')).rejects.toThrow(
+            'One or more stat configs are still assigned to existing games, including completed history. Remove those assignments before resetting the stats setup.'
+        );
+        expect(batch.delete).not.toHaveBeenCalled();
+        expect(batch.commit).not.toHaveBeenCalled();
     });
 
     it('blocks reset when a scheduled shared game still references the config', async () => {
@@ -173,7 +174,7 @@ describe('resetTeamStatConfigs guard', () => {
         });
 
         await expect(resetTeamStatConfigs('team-1')).rejects.toThrow(
-            'One or more stat configs are still assigned to scheduled or shared games. Remove those assignments before resetting the stats setup.'
+            'One or more stat configs are still assigned to existing games, including completed history. Remove those assignments before resetting the stats setup.'
         );
         expect(batch.delete).not.toHaveBeenCalled();
         expect(batch.commit).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #3067

## What changed
- Updated `resetTeamStatConfigs` so any game still carrying a `statTrackerConfigId` blocks schema reset, including completed, final, cancelled, and shared historical games.
- Updated the reset error message to tell admins that completed history also prevents deletion.
- Added regression coverage for completed local and shared games so reset cannot silently delete schemas still needed by historical reports.
- Bumped `edit-config.html` to `./js/db.js?v=67` so browsers fetch the guarded `db.js` change.

## Root Cause
`resetTeamStatConfigs` relied on `isResetBlockingLocalGameAssignment`, which explicitly treated completed, final, cancelled, and `liveStatus=completed` games as safe to ignore. That allowed schema deletion even though completed game reports still resolve their columns from the live team config collection by `statTrackerConfigId`, so historical pages lost the original schema and fell back to inferred/default columns.

## Prevention / Learning
When a persisted record stores a foreign key that is still used for historical rendering, delete and reset flows must treat that reference as authoritative until the historical record has its own immutable snapshot. Do not special-case completed history as "safe to delete" unless the downstream read path no longer depends on the live referenced document.

## Regression Tests
- `npx vitest run tests/unit/reset-team-stat-configs-guard.test.js tests/unit/edit-config-schema-workflow.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`