### PR TITLE
Fix goal sport live tracker mode fallback

### DIFF
--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -73,16 +73,10 @@ export function resolvePreferredStatConfigId({ configs = [], team = null } = {})
 
 export function resolveGoalSportTrackerProfile({ trackerMode = '', game = null, team = null, config = null } = {}) {
   const mode = String(trackerMode || '').trim().toLowerCase();
-  const sport = mode === 'simple'
-    ? game?.sport || config?.baseType || team?.sport || ''
-    : game?.sport || team?.sport || '';
-  const goalSportProfile = getGoalSportProfile({ sport });
-  if (!goalSportProfile) return null;
+  if (mode !== 'simple') return null;
 
-  if (mode === 'simple') return goalSportProfile;
-
-  const hasExplicitStatTrackerConfig = !!String(game?.statTrackerConfigId || '').trim();
-  return hasExplicitStatTrackerConfig ? null : goalSportProfile;
+  const sport = game?.sport || config?.baseType || team?.sport || '';
+  return getGoalSportProfile({ sport });
 }
 
 export function resolveLiveStatColumns({ columns = [], configs = [], game = null, team = null } = {}) {

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -74,18 +74,18 @@ describe('live game state helpers', () => {
     })).toBe('cfg-only');
   });
 
-  it('keeps goal-sport scoring enabled unless the game explicitly picks a stat config', () => {
+  it('keeps full live tracker mode out of goal-only scoring even without a stat config id', () => {
     expect(resolveGoalSportTrackerProfile({
       game: { sport: 'Soccer' },
       team: { sport: 'Soccer' },
       config: { id: 'cfg-soccer', baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }
-    })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
+    })).toBeNull();
 
     expect(resolveGoalSportTrackerProfile({
       game: { sport: 'Soccer' },
       team: { sport: 'Soccer' },
       config: { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS', 'REB'] }
-    })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
+    })).toBeNull();
 
     expect(resolveGoalSportTrackerProfile({
       game: {},
@@ -103,7 +103,7 @@ describe('live game state helpers', () => {
       game: { sport: 'Soccer' },
       team: { sport: 'Soccer' },
       config: { name: 'Default', baseType: 'Soccer', columns: ['GOALS'] }
-    })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
+    })).toBeNull();
   });
 
   it('lets trackerMode=simple force goal-sport scoring without affecting non-goal sports', () => {

--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -43,7 +43,7 @@ describe('track-live live event publishing', () => {
     expect(source).toContain('id="goal-note-input"');
     expect(source).toContain('id="live-notes-list"');
     expect(source).toContain('resolveGoalSportTrackerProfile');
-    expect(source).toContain("from './js/live-game-state.js?v=7'");
+    expect(source).toContain("from './js/live-game-state.js?v=8'");
     expect(source).toContain("from './js/live-tracker-notes.js?v=3'");
     expect(source).toContain('buildGoalSportNoteText');
     expect(source).toContain('removeGameSummaryLine');

--- a/track-live.html
+++ b/track-live.html
@@ -671,7 +671,7 @@
         import { db } from './js/firebase.js?v=19';
         import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=7';
+        import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=8';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, runTrackLiveResetPersistence } from './js/track-live-state.js?v=3';
         import { getDefaultLivePeriod, getSportPeriodLabels, resolveLiveSport, isFootballSport } from './js/live-sport-config.js?v=3';


### PR DESCRIPTION
Closes #3069

## What changed
- Stopped `resolveGoalSportTrackerProfile` from inferring goal-only mode for full Live Broadcast Tracker sessions when `statTrackerConfigId` is blank.
- Kept goal-sport profile activation gated to the explicit `trackerMode=simple` path only.
- Updated the focused live game state regression test and bumped the `track-live.html` import cache-bust for the changed module.

## Root Cause
`resolveGoalSportTrackerProfile` treated any goal-sport game without `game.statTrackerConfigId` as if it should use the simple goal-only tracker. That meant the normal Live Broadcast Tracker route still produced a truthy goal-sport profile, and `track-live.html` responded by hiding the full stat panels.

## Prevention / Learning
When the product offers explicit tracker mode choices, mode resolution must follow the routed mode flag first. Missing optional config fields should not silently downgrade the user into a more restrictive workflow.

## Regression Tests
- `npx vitest run tests/unit/live-game-state.test.js tests/unit/track-live-live-events.test.js --reporter=verbose`
- `tests/unit/live-game-state.test.js` now asserts full tracker mode returns `null` for goal-sport profile resolution even when no `statTrackerConfigId` exists.
- `tests/unit/track-live-live-events.test.js` locks the updated cache-busted `track-live.html` import wiring.

## Recurrence Risk
Low. The defect lived in a single mode-resolution helper, and focused regression coverage now pins both the full-tracker and simple-tracker paths.