### PR TITLE
Fix shared staff-only team chat thread

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -787,7 +787,7 @@ export async function ensureStaffChatConversation(teamId: string, user: AuthUser
 
   return await withTimeout(Promise.resolve(upsertChatConversation(teamId, {
     type: 'group',
-    participantIds: [user.uid],
+    participantIds: [],
     participantRoles: ['staff'],
     mutedBy: [],
     name: 'Staff only'
@@ -1147,7 +1147,7 @@ export async function sendTeamChatMessage({
     let createdConversation: ChatConversation | null = null;
     if (isDefaultTeamConversation(conversationId) && targetMetadata.targetType !== 'full_team') {
       const participantIds = targetMetadata.targetType === 'staff'
-        ? [user.uid]
+        ? []
         : Array.from(new Set([user.uid, ...targetMetadata.recipientIds]));
       const participantRoles = targetMetadata.targetType === 'staff' ? ['staff'] : [];
       createdConversation = await withTimeout(Promise.resolve(upsertChatConversation(teamId, {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -781,8 +781,13 @@ export async function loadChatConversations(teamId: string, user: AuthUser, team
   }
 }
 
+function canReuseStaffChatConversation(conversation: ChatConversation | null | undefined) {
+  if (!isStaffConversation(conversation)) return false;
+  return !Array.isArray(conversation?.participantIds) || conversation.participantIds.length === 0;
+}
+
 export async function ensureStaffChatConversation(teamId: string, user: AuthUser, conversations: ChatConversation[] = []): Promise<ChatConversation> {
-  const existing = conversations.find((conversation) => isStaffConversation(conversation));
+  const existing = conversations.find((conversation) => canReuseStaffChatConversation(conversation));
   if (existing) return existing;
 
   return await withTimeout(Promise.resolve(upsertChatConversation(teamId, {

--- a/js/db.js
+++ b/js/db.js
@@ -6094,14 +6094,14 @@ export async function upsertChatConversation(teamId, conversation = {}) {
     } = conversation;
     const normalizedType = normalizeConversationType(type);
     const normalizedParticipantIds = normalizeConversationParticipantIds(participantIds);
-    const conversationId = buildConversationId(normalizedType, normalizedParticipantIds);
-    const now = Timestamp.now();
-    const conversationRef = doc(db, 'teams', teamId, 'chatConversations', conversationId);
-    const existing = await getDoc(conversationRef);
     const normalizedParticipantRoles = Array.from(new Set((Array.isArray(participantRoles) ? participantRoles : [])
         .map((role) => String(role || '').trim())
         .filter(Boolean)))
         .sort();
+    const conversationId = buildConversationId(normalizedType, normalizedParticipantIds, normalizedParticipantRoles);
+    const now = Timestamp.now();
+    const conversationRef = doc(db, 'teams', teamId, 'chatConversations', conversationId);
+    const existing = await getDoc(conversationRef);
     const normalizedMutedBy = Array.from(new Set(Array.isArray(mutedBy) ? mutedBy : []));
     const hasMutedByUpdate = Object.prototype.hasOwnProperty.call(conversation, 'mutedBy');
 

--- a/js/team-chat-conversations.js
+++ b/js/team-chat-conversations.js
@@ -1,4 +1,5 @@
 export const DEFAULT_TEAM_CONVERSATION_ID = 'team';
+const STAFF_ROLE_CONVERSATION_ID = 'group_role%3Astaff';
 
 const CONVERSATION_TYPES = new Set(['team', 'group', 'direct']);
 
@@ -18,9 +19,21 @@ export function normalizeConversationParticipantIds(participantIds = []) {
         .sort();
 }
 
-export function buildConversationId(type, participantIds = []) {
+function normalizeConversationParticipantRoles(participantRoles = []) {
+    return Array.from(new Set((Array.isArray(participantRoles) ? participantRoles : [])
+        .map((role) => String(role || '').trim().toLowerCase())
+        .filter(Boolean)))
+        .sort();
+}
+
+export function buildConversationId(type, participantIds = [], participantRoles = []) {
     const normalizedType = normalizeConversationType(type);
     if (normalizedType === 'team') return DEFAULT_TEAM_CONVERSATION_ID;
+
+    const roles = normalizeConversationParticipantRoles(participantRoles);
+    if (normalizedType === 'group' && roles.length === 1 && roles[0] === 'staff') {
+        return STAFF_ROLE_CONVERSATION_ID;
+    }
 
     const participants = normalizeConversationParticipantIds(participantIds);
     const prefix = normalizedType === 'direct' && participants.length === 2 ? 'direct' : 'group';

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,8 +344,8 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=34';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=66';
-        import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=67';
+        import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=2';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {
             MAX_CHAT_MEDIA_SIZE,
@@ -2892,7 +2892,7 @@
                 let conversationId = selectedConversationId;
                 if (isDefaultTeamConversation(conversationId) && targetMetadata.targetType !== 'full_team') {
                     const participantIds = targetMetadata.targetType === 'staff'
-                        ? [currentUser.uid]
+                        ? []
                         : Array.from(new Set([currentUser.uid, ...targetMetadata.recipientIds]));
                     const participantRoles = targetMetadata.targetType === 'staff' ? ['staff'] : [];
                     const conversation = await upsertChatConversation(teamId, {

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -793,6 +793,41 @@ describe('React app chat recipient service', () => {
         });
     });
 
+    it('reuses only canonical staff conversations and ignores legacy coach-scoped staff threads', async () => {
+        dbMocks.upsertChatConversation.mockResolvedValue({
+            id: 'group_role%3Astaff',
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff']
+        });
+
+        const { ensureStaffChatConversation } = await import('../../apps/app/src/lib/chatService.ts');
+        const result = await ensureStaffChatConversation('team-1', {
+            uid: 'coach-1',
+            email: 'coach@example.com',
+            displayName: 'Coach Jamie'
+        }, [
+            {
+                id: 'legacy-staff-thread',
+                type: 'group',
+                participantIds: ['coach-1'],
+                participantRoles: ['staff']
+            }
+        ]);
+
+        expect(dbMocks.upsertChatConversation).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff'],
+            name: 'Staff only'
+        }));
+        expect(result).toEqual(expect.objectContaining({
+            id: 'group_role%3Astaff',
+            participantIds: [],
+            participantRoles: ['staff']
+        }));
+    });
+
     it('routes staff-only messages into a non-default conversation before posting', async () => {
         dbMocks.upsertChatConversation.mockResolvedValue({
             id: 'staff-conversation',

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -823,7 +823,7 @@ describe('React app chat recipient service', () => {
 
         expect(dbMocks.upsertChatConversation).toHaveBeenCalledWith('team-1', expect.objectContaining({
             type: 'group',
-            participantIds: ['coach-1'],
+            participantIds: [],
             participantRoles: ['staff'],
             name: 'Staff only'
         }));

--- a/tests/unit/db-chat-conversation-upsert.test.js
+++ b/tests/unit/db-chat-conversation-upsert.test.js
@@ -148,4 +148,51 @@ describe('upsertChatConversation', () => {
             updatedAt: now
         });
     });
+
+    it('builds one stable conversation id for staff-only role conversations', async () => {
+        const now = { seconds: 456 };
+        const getDoc = vi.fn().mockResolvedValue(makeSnapshot(null));
+        const setDoc = vi.fn().mockResolvedValue(undefined);
+        const conversationRef = { path: 'teams/team-1/chatConversations/group_role%3Astaff' };
+        const buildConversationId = vi.fn(() => 'group_role%3Astaff');
+        const upsertChatConversation = buildUpsertChatConversation({
+            normalizeConversationType: vi.fn((value) => value),
+            normalizeConversationParticipantIds: vi.fn(() => []),
+            buildConversationId,
+            Timestamp: { now: vi.fn(() => now) },
+            doc: vi.fn(() => conversationRef),
+            db: {},
+            getDoc,
+            setDoc
+        });
+
+        const result = await upsertChatConversation('team-1', {
+            type: 'group',
+            participantIds: ['coach-2'],
+            participantRoles: ['staff'],
+            mutedBy: [],
+            name: 'Staff only'
+        });
+
+        expect(buildConversationId).toHaveBeenCalledWith('group', [], ['staff']);
+        expect(setDoc).toHaveBeenCalledWith(conversationRef, {
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff'],
+            mutedBy: [],
+            updatedAt: now,
+            name: 'Staff only',
+            createdAt: now
+        }, { merge: true });
+        expect(result).toEqual({
+            id: 'group_role%3Astaff',
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff'],
+            mutedBy: [],
+            updatedAt: now,
+            name: 'Staff only',
+            createdAt: now
+        });
+    });
 });

--- a/tests/unit/team-chat-conversations.test.js
+++ b/tests/unit/team-chat-conversations.test.js
@@ -35,6 +35,8 @@ describe('team chat conversations', () => {
         expect(normalizeConversationParticipantIds(['email:Parent@Example.com'])).toEqual(['email:parent@example.com']);
         expect(buildConversationId('direct', ['user:b', 'user:a'])).toBe('direct_user%3Aa__user%3Ab');
         expect(buildConversationId('group', ['player:42', 'email:parent@example.com'])).toBe('group_email%3Aparent%40example.com__player%3A42');
+        expect(buildConversationId('group', ['coach-a'], ['staff'])).toBe('group_role%3Astaff');
+        expect(buildConversationId('group', ['coach-b'], ['staff'])).toBe('group_role%3Astaff');
     });
 
     it('recognizes user, email, role, moderator, and team conversation participation', () => {

--- a/tests/unit/team-chat-recipient-targets.test.js
+++ b/tests/unit/team-chat-recipient-targets.test.js
@@ -37,6 +37,7 @@ describe('team chat recipient targets', () => {
         expect(html).toContain('function buildEmailTargetMetadata()');
         expect(html).toContain("participantRoles.includes('staff')");
         expect(html).toContain('const targetMetadata = buildEmailTargetMetadata();');
+        expect(html).toContain("const participantIds = targetMetadata.targetType === 'staff'\n                        ? []");
     });
 
     it('persists normalized target metadata from postChatMessage', () => {

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=66';");
+        expect(html).toContain("from './js/db.js?v=67';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {


### PR DESCRIPTION
Closes #3075

## What changed
- gave staff-only team chat a stable shared conversation identity instead of deriving it from the current sender
- stopped seeding new staff-only conversations with the sender UID in both the legacy Team Chat page and the React chat service
- updated targeted regression tests for conversation ID generation, conversation upsert behavior, legacy recipient wiring, and app send behavior
- bumped the legacy `team-chat.html` cache-bust imports for `js/db.js` and `js/team-chat-conversations.js`

## Root Cause
Staff-only sends were modeled as role-based in the UI, but conversation creation stored the current sender as the only participant and `buildConversationId()` only used `participantIds`. That meant Coach A and Coach B generated different conversation document IDs for the same staff audience, which split messages across duplicate "Staff only" threads.

## Prevention / Learning
When a chat audience is role-scoped rather than person-scoped, give it a stable role-based conversation identity and do not seed `participantIds` with the current sender. Role audiences and person audiences need different identity rules, and tests should cover both the ID builder and the send path.

## Regression Tests
- `npx vitest run tests/unit/team-chat-conversations.test.js tests/unit/db-chat-conversation-upsert.test.js tests/unit/app-chat-service-recipients.test.js tests/unit/team-chat-recipient-targets.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`