### PR TITLE
Send deduped live score alerts with inbox fallback

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -6054,30 +6054,44 @@ async function sendCategoryNotification({
 
   for (let i = 0; i < targets.length; i += maxMulticastTokens) {
     const targetChunk = targets.slice(i, i + maxMulticastTokens);
-    const sendResult = await admin.messaging().sendEachForMulticast({
-      tokens: targetChunk.map((target) => target.token),
-      notification: { title, body },
-      data: {
-        teamId: String(teamId),
-        gameId: String(gameId || ''),
-        eventId: String(eventId || gameId || ''),
-        conversationId: String(conversationId || ''),
-        childId: String(childId || ''),
-        rsvpId: String(childId || ''),
-        category: String(category),
-        appRoute,
-        link
-      },
-      ...deliveryOptions,
-      webpush: mergeWebpushOptions({
-        notification: WEB_PUSH_NOTIFICATION_ASSETS,
-        fcmOptions: { link }
-      }, deliveryOptions)
-    });
-    allResponses.push(...(Array.isArray(sendResult.responses) ? sendResult.responses : []));
-    successCount += Number(sendResult.successCount || 0);
-    failureCount += Number(sendResult.failureCount || 0);
-    await pruneInvalidTokens(sendResult, targetChunk);
+    try {
+      const sendResult = await admin.messaging().sendEachForMulticast({
+        tokens: targetChunk.map((target) => target.token),
+        notification: { title, body },
+        data: {
+          teamId: String(teamId),
+          gameId: String(gameId || ''),
+          eventId: String(eventId || gameId || ''),
+          conversationId: String(conversationId || ''),
+          childId: String(childId || ''),
+          rsvpId: String(childId || ''),
+          category: String(category),
+          appRoute,
+          link
+        },
+        ...deliveryOptions,
+        webpush: mergeWebpushOptions({
+          notification: WEB_PUSH_NOTIFICATION_ASSETS,
+          fcmOptions: { link }
+        }, deliveryOptions)
+      });
+      allResponses.push(...(Array.isArray(sendResult.responses) ? sendResult.responses : []));
+      successCount += Number(sendResult.successCount || 0);
+      failureCount += Number(sendResult.failureCount || 0);
+      await pruneInvalidTokens(sendResult, targetChunk);
+    } catch (error) {
+      failureCount += targetChunk.length;
+      allResponses.push(...targetChunk.map((target) => ({
+        success: false,
+        error: new Error(`Push delivery failed for ${target.uid || 'unknown-user'}: ${error?.message || String(error || 'Unknown error')}`)
+      })));
+      functions.logger.warn('Failed to send push notification chunk', {
+        teamId,
+        category,
+        targetCount: targetChunk.length,
+        error: error?.message || String(error || 'Unknown error')
+      });
+    }
   }
 
   const inboxResult = await writeNotificationInboxRecords({
@@ -8597,13 +8611,26 @@ exports.notifyGameUpdated = functions.firestore
     const actorUid = after.updatedBy || null;
 
     if (category === 'liveScore') {
+      const liveScoreDedupKey = `score:${toNumericScore(before.homeScore)}:${toNumericScore(before.awayScore)}->${toNumericScore(after.homeScore)}:${toNumericScore(after.awayScore)}`;
+      const canSendLiveScore = await checkAndSetNotificationDedup(teamId, category, gameId, liveScoreDedupKey);
+      if (!canSendLiveScore) {
+        functions.logger.info('Notification dedup: skipping duplicate live score send', {
+          teamId,
+          category,
+          gameId,
+          dedupKey: liveScoreDedupKey
+        });
+        return null;
+      }
+
       return sendCategoryNotification({
         teamId,
         gameId,
         category,
         title: 'Live score update',
         body: `Score is now ${toNumericScore(after.homeScore)}-${toNumericScore(after.awayScore)}`,
-        actorUid
+        actorUid,
+        dedupKey: liveScoreDedupKey
       });
     }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -5937,8 +5937,17 @@ function buildNotificationDedupRef(teamId, category, dedupIdentity = '') {
   return firestore.doc(`teams/${teamId}/notificationSendLog/${hash}`);
 }
 
+function buildNotificationDedupIdentity(gameId, dedupKey = null) {
+  const normalizedGameId = String(gameId || '').trim();
+  const normalizedDedupKey = String(dedupKey || '').trim();
+  if (normalizedGameId && normalizedDedupKey) {
+    return `${normalizedGameId}::${normalizedDedupKey}`;
+  }
+  return normalizedDedupKey || normalizedGameId;
+}
+
 async function markNotificationDedupSent(teamId, category, gameId, dedupKey = null) {
-  const dedupIdentity = String(dedupKey || gameId || '').trim();
+  const dedupIdentity = buildNotificationDedupIdentity(gameId, dedupKey);
   const dedupRef = buildNotificationDedupRef(teamId, category, dedupIdentity);
   await dedupRef.set({
     teamId,
@@ -5950,7 +5959,7 @@ async function markNotificationDedupSent(teamId, category, gameId, dedupKey = nu
 }
 
 async function checkAndSetNotificationDedup(teamId, category, gameId, dedupKey = null) {
-  const dedupIdentity = String(dedupKey || gameId || '').trim();
+  const dedupIdentity = buildNotificationDedupIdentity(gameId, dedupKey);
   const dedupRef = buildNotificationDedupRef(teamId, category, dedupIdentity);
 
   const result = await firestore.runTransaction(async (txn) => {

--- a/tests/unit/game-update-push-notifications.test.js
+++ b/tests/unit/game-update-push-notifications.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 
@@ -110,5 +110,55 @@ describe('game schedule update push notifications', () => {
         expect(indexedLookupIndex).toBeGreaterThan(-1);
         expect(notifyBody).toContain('title: payload.title');
         expect(notifyBody).toContain('body: payload.body');
+    });
+
+    it('deduplicates live score sends by the before/after score transition before delivering notifications', async () => {
+        const sendCategoryNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
+        const checkAndSetNotificationDedup = vi.fn(async () => true);
+        const handler = new Function(
+            'functions',
+            'detectGameNotificationCategory',
+            'sendCategoryNotification',
+            'checkAndSetNotificationDedup',
+            'toNumericScore',
+            'buildScheduleUpdateNotificationPayload',
+            `const exports = {};
+${functionsSource.slice(functionsSource.indexOf('exports.notifyGameUpdated = functions.firestore'), functionsSource.indexOf('const notifyGameCreated ='))}
+return exports.notifyGameUpdated;`
+        )(
+            {
+                firestore: {
+                    document: () => ({ onUpdate: (onUpdateHandler) => onUpdateHandler })
+                },
+                logger: {
+                    info: vi.fn()
+                }
+            },
+            () => 'liveScore',
+            sendCategoryNotification,
+            checkAndSetNotificationDedup,
+            (value) => Number(value || 0),
+            () => ({ title: 'unused', body: 'unused' })
+        );
+
+        await handler({
+            before: { data: () => ({ homeScore: 1, awayScore: 0 }) },
+            after: { data: () => ({ homeScore: 2, awayScore: 0, updatedBy: 'staff-1' }) }
+        }, {
+            params: { teamId: 'team-1', gameId: 'game-7' }
+        });
+
+        expect(checkAndSetNotificationDedup).toHaveBeenCalledWith(
+            'team-1',
+            'liveScore',
+            'game-7',
+            'score:1:0->2:0'
+        );
+        expect(sendCategoryNotification).toHaveBeenCalledWith(expect.objectContaining({
+            teamId: 'team-1',
+            gameId: 'game-7',
+            category: 'liveScore',
+            dedupKey: 'score:1:0->2:0'
+        }));
     });
 });

--- a/tests/unit/notification-send-dedup.test.js
+++ b/tests/unit/notification-send-dedup.test.js
@@ -20,9 +20,14 @@ function buildFirestoreTimestamp(ms) {
     };
 }
 
-function buildDedupDocPath(teamId, category, gameId = null) {
+function buildDedupDocPath(teamId, category, gameId = null, dedupKey = null) {
     const crypto = require('node:crypto');
-    const key = [teamId, category, gameId || ''].join('::');
+    const normalizedGameId = String(gameId || '').trim();
+    const normalizedDedupKey = String(dedupKey || '').trim();
+    const dedupIdentity = normalizedGameId && normalizedDedupKey
+        ? `${normalizedGameId}::${normalizedDedupKey}`
+        : (normalizedDedupKey || normalizedGameId);
+    const key = [teamId, category, dedupIdentity].join('::');
     const hash = crypto.createHash('sha256').update(key).digest('hex').slice(0, 16);
     return `teams/${teamId}/notificationSendLog/${hash}`;
 }
@@ -251,6 +256,29 @@ describe('notification send dedup guard — checkAndSetNotificationDedup', () =>
         expect(first.mockFirestore.doc.mock.calls[0][0]).not.toBe(second.mockFirestore.doc.mock.calls[0][0]);
         expect([...first.store.values()][0]).toMatchObject({ category: 'schedule', gameId: 'game-1' });
         expect([...second.store.values()][0]).toMatchObject({ category: 'practice', gameId: 'game-1' });
+    });
+
+    it('scopes custom dedup keys to the gameId so matching score transitions do not collide across games', async () => {
+        const now = Date.now();
+        const existingPath = buildDedupDocPath('team-1', 'liveScore', 'game-1', 'score:0:0->2:0');
+        const { fn, mockFirestore } = createDedupHarness({
+            nowMs: now,
+            docs: {
+                [existingPath]: {
+                    teamId: 'team-1',
+                    category: 'liveScore',
+                    gameId: 'game-1',
+                    dedupKey: 'score:0:0->2:0',
+                    sentAt: buildFirestoreTimestamp(now - 60 * 1000)
+                }
+            }
+        });
+
+        const result = await fn('team-1', 'liveScore', 'game-2', 'score:0:0->2:0');
+
+        expect(result).toBe(true);
+        expect(mockFirestore.doc).toHaveBeenCalledWith(expect.stringMatching(/^teams\/team-1\/notificationSendLog\//));
+        expect(mockFirestore.doc.mock.calls.at(-1)[0]).not.toBe(existingPath);
     });
 });
 

--- a/tests/unit/notification-send-dedup.test.js
+++ b/tests/unit/notification-send-dedup.test.js
@@ -89,17 +89,18 @@ function buildSendCategoryNotificationHarness({
     canSend = true,
     targets = [{ uid: 'user-1', token: 'token-1' }],
     categories = ['schedule', 'liveScore', 'mentions', 'liveChat'],
-    deliveryOptions = {}
+    deliveryOptions = {},
+    sendEachForMulticastImpl = async () => ({
+        responses: [{ success: true }],
+        successCount: targets.length,
+        failureCount: 0
+    })
 } = {}) {
     const sendSource = getSourceSlice(
         'async function sendCategoryNotification({',
         '\nasync function sendDirectTargetsNotification'
     );
-    const sendEachForMulticast = vi.fn(async () => ({
-        responses: [{ success: true }],
-        successCount: targets.length,
-        failureCount: 0
-    }));
+    const sendEachForMulticast = vi.fn(sendEachForMulticastImpl);
     const admin = {
         messaging: () => ({
             sendEachForMulticast
@@ -119,7 +120,8 @@ function buildSendCategoryNotificationHarness({
     const writeNotificationAuditRecord = vi.fn(async () => {});
     const functions = {
         logger: {
-            info: vi.fn()
+            info: vi.fn(),
+            warn: vi.fn()
         }
     };
 
@@ -386,6 +388,47 @@ describe('notification send dedup guard — sendCategoryNotification', () => {
             gameId: 'game-1',
             eventId: 'message-1',
             timeSensitive: false
+        });
+    });
+
+    it('still writes inbox records when push delivery throws for live score updates', async () => {
+        const harness = buildSendCategoryNotificationHarness({
+            categories: ['liveScore'],
+            targets: [
+                { uid: 'parent-1', token: 'token-1' },
+                { uid: 'parent-2', token: 'token-2' }
+            ],
+            sendEachForMulticastImpl: async () => {
+                throw new Error('messaging unavailable');
+            }
+        });
+
+        const result = await harness.fn({
+            teamId: 'team-1',
+            category: 'liveScore',
+            gameId: 'game-7',
+            title: 'Live score update',
+            body: 'Score is now 2-1'
+        });
+
+        expect(harness.sendEachForMulticast).toHaveBeenCalledOnce();
+        expect(harness.writeNotificationInboxRecords).toHaveBeenCalledWith(expect.objectContaining({
+            category: 'liveScore',
+            teamId: 'team-1',
+            gameId: 'game-7',
+            targets: [
+                { uid: 'parent-1', token: 'token-1' },
+                { uid: 'parent-2', token: 'token-2' }
+            ]
+        }));
+        expect(harness.writeNotificationAuditRecord).toHaveBeenCalledWith(expect.objectContaining({
+            failureCount: 2,
+            inboxResult: expect.objectContaining({ writeCount: 2 })
+        }));
+        expect(result).toMatchObject({
+            successCount: 0,
+            failureCount: 2,
+            inboxWriteCount: 2
         });
     });
 


### PR DESCRIPTION
Closes #3076

## What changed
- deduplicated live score notifications by the exact score transition (`before -> after`) before sending alerts
- preserved live score inbox delivery even when FCM push delivery throws, so opted-in users still get an inbox item for later open/read behavior
- added regression coverage for live score dedupe and push-failure inbox fallback
- re-ran the existing app liveScore routing test to confirm notifications still deep-link to the correct game route

## Root Cause
Live score alerts were sent through the generic game-update notification path without a score-transition-specific dedupe key, and the sender aborted before writing inbox records when push delivery threw. That made duplicate score alerts possible on repeated transition processing and could drop the inbox fallback entirely during push outages.

## Prevention / Learning
For event-driven notifications, dedupe on the exact state transition that triggered the alert, not just the broad category. Also treat external push delivery as best-effort and persist the inbox record even when the provider fails.

## Regression Tests
- `tests/unit/notification-send-dedup.test.js`
  - verifies live score inbox records are still written when push delivery throws
- `tests/unit/game-update-push-notifications.test.js`
  - verifies live score notifications are deduplicated by the exact before/after score transition
- `tests/unit/app-push-notification-routing.test.ts`
  - confirms `liveScore` notifications still open the correct game route