### PR TITLE
Honor installment selection in registration checkout

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -1043,11 +1043,14 @@ function toTeamRegistrationReviewCard(review: any): TeamRegistrationReviewCard {
     || review?.payment?.status
   );
   const paymentAmount = Number(
-    feeSnapshot.finalAmountDueCents
+    review?.balanceDueCents
+    ?? review?.paymentPlan?.remainingBalanceCents
+    ?? feeSnapshot.finalAmountDueCents
     ?? feeSnapshot.amountDueCents
     ?? feeSnapshot.feeAmountCents
     ?? review?.feeAmountCents
   );
+  const paymentStateLabel = paymentState.replace(/_/g, ' ');
 
   return {
     ...review,
@@ -1062,7 +1065,7 @@ function toTeamRegistrationReviewCard(review: any): TeamRegistrationReviewCard {
     submittedAt: review?.reviewSummary?.submittedAt || review?.submittedAt || review?.createdAt || null,
     selectedOptionLabel: compactString(selectedOption.title || selectedOption.label || review?.selectedOptionLabel || review?.selectedOptionId),
     paymentLabel: paymentState
-      ? `${paymentState}${Number.isFinite(paymentAmount) ? ` · ${formatCurrency(paymentAmount, feeSnapshot.currency || review?.currency || 'USD')}` : ''}`
+      ? `${paymentStateLabel}${Number.isFinite(paymentAmount) ? ` · ${formatCurrency(paymentAmount, feeSnapshot.currency || review?.currency || 'USD')}` : ''}`
       : (Number.isFinite(paymentAmount) ? formatCurrency(paymentAmount, feeSnapshot.currency || review?.currency || 'USD') : 'Not recorded'),
     waiverAccepted: Boolean(
       review?.waiverAccepted

--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -168,6 +168,34 @@ describe('RegistrationDetail payment notice', () => {
     expect(openPublicUrlMock).toHaveBeenCalledWith('https://stripe.example/checkout');
   });
 
+  it('shows the first installment due now plus the remaining schedule before checkout', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      onlineCheckout: true,
+      paymentNotice: 'Pay online.',
+      paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }, { id: 'installments', title: 'Monthly installments' }],
+      form: {
+        installmentPlan: {
+          enabled: true,
+          title: 'Monthly installments',
+          installmentCount: 3,
+          firstDueDate: '2026-07-01',
+          intervalDays: 30
+        }
+      }
+    }));
+
+    renderPublicRegistration();
+
+    const paymentPlan = await screen.findByLabelText('Payment plan');
+    fireEvent.change(paymentPlan, { target: { value: 'installments' } });
+
+    expect(await screen.findByLabelText('Installment payment summary')).toBeTruthy();
+    expect(screen.getByText('Amount due now')).toBeTruthy();
+    expect(screen.getAllByText('$41.66')).toHaveLength(2);
+    expect(screen.getByText('Installment 2 · Due Jul 31, 2026')).toBeTruthy();
+    expect(screen.getByText('Installment 3 · Due Aug 30, 2026')).toBeTruthy();
+  });
+
   it('replaces the form with a success confirmation after Stripe success returns', async () => {
     parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       onlineCheckout: true,
@@ -180,5 +208,32 @@ describe('RegistrationDetail payment notice', () => {
     expect(screen.getByText('Your registration payment was received. The program organizer will follow up with next steps.')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Retry payment with Stripe' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Pay registration with Stripe' })).toBeNull();
+  });
+
+  it('shows remaining installments after a successful installment payment', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      onlineCheckout: true,
+      paymentNotice: 'Pay online.',
+      paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }, { id: 'installments', title: 'Monthly installments' }],
+      form: {
+        installmentPlan: {
+          enabled: true,
+          title: 'Monthly installments',
+          installmentCount: 3,
+          firstDueDate: '2026-07-01',
+          intervalDays: 30
+        }
+      }
+    }));
+
+    renderPublicRegistration('/registration?teamId=team-1&formId=form-1&publicCheckoutCapability=cap-1&retryPayment=1&paymentPlanId=installments&status=success');
+
+    expect(await screen.findByRole('heading', { name: 'Payment successful' })).toBeTruthy();
+    expect(screen.getByText('Your installment payment was received. Here is what remains on your payment schedule.')).toBeTruthy();
+    expect(screen.getByLabelText('Remaining installment schedule')).toBeTruthy();
+    expect(screen.getByText('Remaining balance')).toBeTruthy();
+    expect(screen.getByText('$83.34')).toBeTruthy();
+    expect(screen.getByText('Installment 2 · Due Jul 31, 2026')).toBeTruthy();
+    expect(screen.getByText('Installment 3 · Due Aug 30, 2026')).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -226,14 +226,14 @@ describe('RegistrationDetail payment notice', () => {
       }
     }));
 
-    renderPublicRegistration('/registration?teamId=team-1&formId=form-1&publicCheckoutCapability=cap-1&retryPayment=1&paymentPlanId=installments&status=success');
+    renderPublicRegistration('/registration?teamId=team-1&formId=form-1&publicCheckoutCapability=cap-1&retryPayment=1&paymentPlanId=installments&paidInstallmentCount=2&status=success');
 
     expect(await screen.findByRole('heading', { name: 'Payment successful' })).toBeTruthy();
     expect(screen.getByText('Your installment payment was received. Here is what remains on your payment schedule.')).toBeTruthy();
     expect(screen.getByLabelText('Remaining installment schedule')).toBeTruthy();
     expect(screen.getByText('Remaining balance')).toBeTruthy();
-    expect(screen.getByText('$83.34')).toBeTruthy();
-    expect(screen.getByText('Installment 2 · Due Jul 31, 2026')).toBeTruthy();
+    expect(screen.getByText('$41.68')).toBeTruthy();
+    expect(screen.queryByText('Installment 2 · Due Jul 31, 2026')).toBeNull();
     expect(screen.getByText('Installment 3 · Due Aug 30, 2026')).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -51,6 +51,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
   const returnCheckoutAttemptToken = searchParams.get('checkoutAttemptToken') || '';
   const returnPublicCheckoutCapability = searchParams.get('publicCheckoutCapability') || '';
   const retryPaymentRequested = searchParams.get('retryPayment') === '1' && Boolean(returnPublicCheckoutCapability || returnRegistrationId);
+  const successfulPaymentPlanId = normalizePaymentPlanId(searchParams.get('paymentPlanId'));
   const returnStatus = normalizeRegistrationReturnStatus(searchParams.get('status'));
   const isPaymentSuccessReturn = returnStatus === 'success' && Boolean(returnPublicCheckoutCapability || returnRegistrationId);
   const isRetryPaymentMode = retryPaymentRequested && !isPaymentSuccessReturn;
@@ -145,6 +146,16 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
   const effectiveQuantity = useMemo(() => hasQuantityDiscount ? quantity : 1, [hasQuantityDiscount, quantity]);
   const displayFeeSnapshot = useMemo(() => form ? calculateRegistrationFeeSnapshot(form, { quantity: effectiveQuantity, now: new Date() }) : null, [form, effectiveQuantity]);
   const displayFeeLines = useMemo<FeeSummaryLine[]>(() => displayFeeSnapshot ? formatFeeSnapshotLines(displayFeeSnapshot) : [], [displayFeeSnapshot]);
+  const selectedPaymentPlanSummary = useMemo(() => {
+    if (!form || !displayFeeSnapshot) return null;
+    return buildRegistrationPaymentPlanSummary(form, displayFeeSnapshot, selectedPaymentPlanId, 0);
+  }, [displayFeeSnapshot, form, selectedPaymentPlanId]);
+  const successfulPaymentPlanSummary = useMemo(() => {
+    if (!form || !displayFeeSnapshot || !isPaymentSuccessReturn) return null;
+    const paymentPlanId = successfulPaymentPlanId || selectedPaymentPlanId;
+    const paidInstallmentCount = paymentPlanId === 'installments' ? 1 : 0;
+    return buildRegistrationPaymentPlanSummary(form, displayFeeSnapshot, paymentPlanId, paidInstallmentCount);
+  }, [displayFeeSnapshot, form, isPaymentSuccessReturn, selectedPaymentPlanId, successfulPaymentPlanId]);
   const selectedReview = useMemo(() => {
     const allReviews = [...(queue?.reviews || []), ...(queue?.waitlistedReviews || [])];
     return allReviews.find((review) => review.id === selectedReviewId) || allReviews[0] || null;
@@ -580,9 +591,25 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
         <section className="app-card p-5">
           <div className="flex items-start gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-emerald-900">
             <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none" aria-hidden="true" />
-            <div>
+            <div className="w-full">
               <h2 className="text-base font-black">Payment successful</h2>
-              <p className="mt-1 text-sm font-semibold text-emerald-800">Your registration payment was received. The program organizer will follow up with next steps.</p>
+              <p className="mt-1 text-sm font-semibold text-emerald-800">{successfulPaymentPlanSummary?.isInstallments ? 'Your installment payment was received. Here is what remains on your payment schedule.' : 'Your registration payment was received. The program organizer will follow up with next steps.'}</p>
+              {successfulPaymentPlanSummary?.isInstallments ? (
+                <div className="mt-3 rounded-xl border border-emerald-200 bg-white/70 p-3 text-sm text-emerald-950" aria-label="Remaining installment schedule">
+                  <div className="flex items-center justify-between gap-3 text-sm font-black">
+                    <span>Remaining balance</span>
+                    <span>{formatMoney(successfulPaymentPlanSummary.remainingBalanceCents, successfulPaymentPlanSummary.currency)}</span>
+                  </div>
+                  <div className="mt-2 grid gap-2">
+                    {successfulPaymentPlanSummary.remainingSchedule.length ? successfulPaymentPlanSummary.remainingSchedule.map((installment, index) => (
+                      <div key={`${installment.label}-${index}`} className="flex items-center justify-between gap-3 text-xs font-semibold text-emerald-900">
+                        <span>{installment.label}{installment.dueDate ? ` · Due ${formatDueDateLabel(installment.dueDate)}` : ''}</span>
+                        <span>{formatMoney(installment.amountCents, successfulPaymentPlanSummary.currency)}</span>
+                      </div>
+                    )) : <div className="text-xs font-semibold text-emerald-900">No remaining installments.</div>}
+                  </div>
+                </div>
+              ) : null}
             </div>
           </div>
         </section>
@@ -630,6 +657,30 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
             <div className="rounded-xl border border-sky-200 bg-sky-50 p-3 text-sm text-sky-950" aria-label="Registration payment notice">
               <h2 className="text-sm font-black text-sky-950">Payment</h2>
               <p className="mt-1 whitespace-pre-line font-semibold leading-5 text-sky-900">{form.paymentNotice}</p>
+            </div>
+          ) : null}
+
+          {selectedPaymentPlanSummary?.isInstallments ? (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950" aria-label="Installment payment summary">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-black">Amount due now</h2>
+                  <p className="mt-1 text-xs font-semibold text-amber-900">Pay the first installment now. The rest of the schedule stays due on the dates below.</p>
+                </div>
+                <div className="text-right">
+                  <div className="text-lg font-black tabular-nums">{formatMoney(selectedPaymentPlanSummary.currentInstallment?.amountCents || 0, selectedPaymentPlanSummary.currency)}</div>
+                  {selectedPaymentPlanSummary.currentInstallment?.dueDate ? <div className="text-xs font-semibold text-amber-900">Due {formatDueDateLabel(selectedPaymentPlanSummary.currentInstallment.dueDate)}</div> : null}
+                </div>
+              </div>
+              <div className="mt-3 grid gap-2">
+                <div className="text-xs font-black uppercase tracking-wide text-amber-700">Remaining schedule</div>
+                {selectedPaymentPlanSummary.remainingSchedule.map((installment, index) => (
+                  <div key={`${installment.label}-${index}`} className="flex items-center justify-between gap-3 text-xs font-semibold text-amber-900">
+                    <span>{installment.label}{installment.dueDate ? ` · Due ${formatDueDateLabel(installment.dueDate)}` : ''}</span>
+                    <span>{formatMoney(installment.amountCents, selectedPaymentPlanSummary.currency)}</span>
+                  </div>
+                ))}
+              </div>
             </div>
           ) : null}
 
@@ -842,6 +893,70 @@ function formatOptionAvailability(option: any, counts: Record<string, any>) {
   if (!capacity) return option.description || 'Registration option available';
   const remaining = Math.max(0, capacity - enrolled);
   return `${remaining} ${remaining === 1 ? 'spot' : 'spots'} left`;
+}
+
+function normalizePaymentPlanId(value: string | null) {
+  return String(value || '').trim() === 'installments' ? 'installments' : 'pay_full';
+}
+
+function buildRegistrationPaymentPlanSummary(form: ParentRegistrationCard, feeSnapshot: Record<string, any>, paymentPlanId: string, paidInstallmentCount = 0) {
+  const totalBalanceDueCents = Math.max(0, Math.round(Number(feeSnapshot?.finalAmountDueCents ?? form.feeAmountCents ?? 0) || 0));
+  const currency = String(feeSnapshot?.currency || form.currency || 'USD');
+  const useInstallments = paymentPlanId === 'installments' && form.installmentPlan?.enabled === true;
+  if (!useInstallments) {
+    return {
+      isInstallments: false,
+      currency,
+      totalBalanceDueCents,
+      currentInstallment: null,
+      remainingSchedule: [],
+      remainingBalanceCents: 0
+    };
+  }
+
+  const count = Math.max(2, Math.min(12, Math.floor(Number(form.installmentPlan?.installmentCount) || 2)));
+  const baseAmount = Math.floor(totalBalanceDueCents / count);
+  const remainder = totalBalanceDueCents - (baseAmount * count);
+  const firstDueDate = parseLocalDate(form.installmentPlan?.firstDueDate);
+  const intervalDays = Math.max(1, Math.floor(Number(form.installmentPlan?.intervalDays) || 30));
+  const schedule = Array.from({ length: count }, (_, index) => {
+    const dueDate = firstDueDate ? addDays(firstDueDate, intervalDays * index) : null;
+    return {
+      label: `Installment ${index + 1}`,
+      dueDate: dueDate ? dueDate.toISOString().slice(0, 10) : String(form.installmentPlan?.firstDueDate || ''),
+      amountCents: baseAmount + (index === count - 1 ? remainder : 0)
+    };
+  });
+  const safePaidInstallmentCount = Math.min(schedule.length, Math.max(0, Math.floor(Number(paidInstallmentCount) || 0)));
+  const currentInstallment = schedule[safePaidInstallmentCount] || null;
+  const remainingSchedule = schedule.slice(safePaidInstallmentCount === 0 ? 1 : safePaidInstallmentCount);
+  const remainingBalanceCents = remainingSchedule.reduce((sum, installment) => sum + Math.max(0, Number(installment.amountCents || 0)), 0);
+  return {
+    isInstallments: true,
+    currency,
+    totalBalanceDueCents,
+    currentInstallment,
+    remainingSchedule,
+    remainingBalanceCents
+  };
+}
+
+function parseLocalDate(value: unknown) {
+  const match = String(value || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+  return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function formatDueDateLabel(value: string) {
+  const date = parseLocalDate(value);
+  if (!date) return value;
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' }).format(date);
 }
 
 function formatMoney(cents: number, currency = 'USD') {

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -52,6 +52,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
   const returnPublicCheckoutCapability = searchParams.get('publicCheckoutCapability') || '';
   const retryPaymentRequested = searchParams.get('retryPayment') === '1' && Boolean(returnPublicCheckoutCapability || returnRegistrationId);
   const successfulPaymentPlanId = normalizePaymentPlanId(searchParams.get('paymentPlanId'));
+  const successfulPaidInstallmentCount = normalizePaidInstallmentCount(searchParams.get('paidInstallmentCount'));
   const returnStatus = normalizeRegistrationReturnStatus(searchParams.get('status'));
   const isPaymentSuccessReturn = returnStatus === 'success' && Boolean(returnPublicCheckoutCapability || returnRegistrationId);
   const isRetryPaymentMode = retryPaymentRequested && !isPaymentSuccessReturn;
@@ -153,9 +154,9 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
   const successfulPaymentPlanSummary = useMemo(() => {
     if (!form || !displayFeeSnapshot || !isPaymentSuccessReturn) return null;
     const paymentPlanId = successfulPaymentPlanId || selectedPaymentPlanId;
-    const paidInstallmentCount = paymentPlanId === 'installments' ? 1 : 0;
+    const paidInstallmentCount = paymentPlanId === 'installments' ? Math.max(1, successfulPaidInstallmentCount) : 0;
     return buildRegistrationPaymentPlanSummary(form, displayFeeSnapshot, paymentPlanId, paidInstallmentCount);
-  }, [displayFeeSnapshot, form, isPaymentSuccessReturn, selectedPaymentPlanId, successfulPaymentPlanId]);
+  }, [displayFeeSnapshot, form, isPaymentSuccessReturn, selectedPaymentPlanId, successfulPaidInstallmentCount, successfulPaymentPlanId]);
   const selectedReview = useMemo(() => {
     const allReviews = [...(queue?.reviews || []), ...(queue?.waitlistedReviews || [])];
     return allReviews.find((review) => review.id === selectedReviewId) || allReviews[0] || null;
@@ -897,6 +898,10 @@ function formatOptionAvailability(option: any, counts: Record<string, any>) {
 
 function normalizePaymentPlanId(value: string | null) {
   return String(value || '').trim() === 'installments' ? 'installments' : 'pay_full';
+}
+
+function normalizePaidInstallmentCount(value: string | null) {
+  return Math.max(0, Math.floor(Number(value || 0) || 0));
 }
 
 function buildRegistrationPaymentPlanSummary(form: ParentRegistrationCard, feeSnapshot: Record<string, any>, paymentPlanId: string, paidInstallmentCount = 0) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -338,6 +338,9 @@ function buildRegistrationCheckoutUrls(appUrl, input) {
   if (input.retryPayment) {
     params.set('retryPayment', '1');
   }
+  if (input.paymentPlanId) {
+    params.set('paymentPlanId', String(input.paymentPlanId));
+  }
   return {
     successUrl: `${baseUrl}/registration.html?${params.toString()}&status=success`,
     cancelUrl: `${baseUrl}/registration.html?${params.toString()}&status=cancelled`
@@ -889,11 +892,66 @@ function computeRegistrationFeeAmountCentsFromForm(form, now = new Date()) {
   return Math.max(0, remainingAmountCents);
 }
 
+function buildRegistrationInstallmentScheduleFromAuthoritativeForm(form, totalBalanceDueCents) {
+  if (form?.installmentPlan?.enabled !== true) return [];
+  return buildPublicRegistrationInstallmentSchedule(totalBalanceDueCents, form.installmentPlan);
+}
+
+function getRegistrationPaymentPlanPaidInstallmentCount(registration = {}) {
+  return Math.max(0, Math.floor(Number(registration.paymentPlan?.paidInstallmentCount || 0) || 0));
+}
+
+function buildRegistrationInstallmentPaymentState(registration = {}, form = null, nextPaidInstallmentCount = getRegistrationPaymentPlanPaidInstallmentCount(registration)) {
+  const authoritativeTotalBalanceDueCents = form
+    ? computeRegistrationFeeAmountCentsFromForm(form)
+    : Math.max(0, Math.round(Number(registration.paymentPlan?.totalBalanceDueCents ?? registration.feeSnapshot?.finalAmountDueCents ?? registration.feeAmountCents ?? 0)));
+  const authoritativeSchedule = form
+    ? buildRegistrationInstallmentScheduleFromAuthoritativeForm(form, authoritativeTotalBalanceDueCents)
+    : Array.isArray(registration.paymentPlan?.schedule)
+      ? registration.paymentPlan.schedule.filter(Boolean)
+      : [];
+  if (!authoritativeSchedule.length) {
+    return {
+      totalBalanceDueCents: authoritativeTotalBalanceDueCents,
+      schedule: authoritativeSchedule,
+      paidInstallmentCount: 0,
+      currentInstallment: null,
+      remainingSchedule: [],
+      remainingBalanceCents: authoritativeTotalBalanceDueCents,
+      nextDueDate: ''
+    };
+  }
+
+  const paidInstallmentCount = Math.min(authoritativeSchedule.length, Math.max(0, Math.floor(Number(nextPaidInstallmentCount) || 0)));
+  const currentInstallment = authoritativeSchedule[paidInstallmentCount] || null;
+  const remainingSchedule = authoritativeSchedule.slice(paidInstallmentCount);
+  const remainingBalanceCents = remainingSchedule.reduce((sum, installment) => {
+    return sum + Math.max(0, Math.round(Number(installment?.amountCents || 0) || 0));
+  }, 0);
+  return {
+    totalBalanceDueCents: authoritativeTotalBalanceDueCents,
+    schedule: authoritativeSchedule,
+    paidInstallmentCount,
+    currentInstallment,
+    remainingSchedule,
+    remainingBalanceCents,
+    nextDueDate: String(remainingSchedule[0]?.dueDate || '')
+  };
+}
+
 function getRegistrationCheckoutAmountCents(registration = {}, form = null) {
+  if (form && registration.paymentPlan?.id === 'installments' && form.installmentPlan?.enabled === true) {
+    const installmentState = buildRegistrationInstallmentPaymentState(registration, form);
+    return Math.max(0, Math.round(Number(installmentState.currentInstallment?.amountCents || 0) || 0));
+  }
   if (form) {
     // Use the server-recomputed amount from the authoritative form document so
-    // a tampered feeSnapshot stored on the registration cannot lower the charge.
+    // a tampered feeSnapshot stored on the stored registration cannot lower the charge.
     return computeRegistrationFeeAmountCentsFromForm(form);
+  }
+  if (registration.paymentPlan?.id === 'installments') {
+    const installmentState = buildRegistrationInstallmentPaymentState(registration, null);
+    return Math.max(0, Math.round(Number(installmentState.currentInstallment?.amountCents || 0) || 0));
   }
   return Math.max(0, Math.round(Number(registration.feeSnapshot?.finalAmountDueCents ?? registration.feeAmountCents ?? 0)));
 }
@@ -2862,6 +2920,9 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   // This prevents a tampered feeSnapshot on the stored registration from lowering the charge.
   const expectedAmountCents = getRegistrationCheckoutAmountCents(registration, form);
   const amountCents = expectedAmountCents;
+  if (!Number.isFinite(amountCents) || amountCents <= 0) {
+    throw new functions.https.HttpsError('failed-precondition', 'This registration does not have a payment due.');
+  }
   const currency = String(
     form.currency || registration.feeSnapshot?.currency || registration.currency || 'usd'
   ).trim().toLowerCase() || 'usd';
@@ -2884,7 +2945,8 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   const issuedPublicCheckoutCapability = createRawPublicCheckoutCapability();
   const checkoutUrlInput = {
     ...resolvedInput,
-    publicCheckoutCapability: issuedPublicCheckoutCapability
+    publicCheckoutCapability: issuedPublicCheckoutCapability,
+    paymentPlanId: String(registration.paymentPlan?.id || 'pay_full').trim() || 'pay_full'
   };
   const { successUrl, cancelUrl } = buildRegistrationCheckoutUrls(appUrl, checkoutUrlInput);
   const title = registration.programName || form.programName || form.title || form.name || 'Program registration';
@@ -3021,21 +3083,52 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
           throw new Error('Registration form not found for Stripe webhook.');
         }
 
+        const form = formSnap.data() || {};
+        const registration = registrationSnap.data() || {};
         if (shouldMarkRegistrationPaidFromEvent(event)) {
-          transaction.set(registrationRef, {
-            checkoutStatus: 'complete',
-            paymentStatus: 'paid',
-            paidAt: receivedAt,
-            stripeCheckoutSessionId: session.id || null,
-            stripePaymentIntentId: session.payment_intent || null,
-            stripePaymentStatus: session.payment_status || 'paid',
-            stripeEventId: event.id,
-            updatedAt: receivedAt
-          }, { merge: true });
-          transaction.update(registrationRef, buildRegistrationReminderStopUpdate({ reason: 'paid', nowIso: queuedAtIso }));
+          if (registration.paymentPlan?.id === 'installments' && form.installmentPlan?.enabled === true) {
+            const nextPaidInstallmentCount = getRegistrationPaymentPlanPaidInstallmentCount(registration) + 1;
+            const installmentState = buildRegistrationInstallmentPaymentState(registration, form, nextPaidInstallmentCount);
+            const hasRemainingInstallments = installmentState.remainingBalanceCents > 0 && installmentState.remainingSchedule.length > 0;
+            transaction.set(registrationRef, {
+              checkoutStatus: 'complete',
+              paymentStatus: hasRemainingInstallments ? 'installment_in_progress' : 'paid',
+              paidAt: receivedAt,
+              balanceDueCents: installmentState.remainingBalanceCents,
+              nextPaymentDueDate: installmentState.nextDueDate || null,
+              stripeCheckoutSessionId: session.id || null,
+              stripePaymentIntentId: session.payment_intent || null,
+              stripePaymentStatus: session.payment_status || 'paid',
+              stripeEventId: event.id,
+              paymentPlan: {
+                ...registration.paymentPlan,
+                totalBalanceDueCents: installmentState.totalBalanceDueCents,
+                schedule: installmentState.schedule,
+                paidInstallmentCount: installmentState.paidInstallmentCount,
+                remainingBalanceCents: installmentState.remainingBalanceCents,
+                nextDueDate: installmentState.nextDueDate || null,
+                lastPaidInstallmentAmountCents: Math.max(0, Math.round(Number(session.amount_total || 0) || 0)),
+                lastPaidInstallmentAt: receivedAt
+              },
+              updatedAt: receivedAt
+            }, { merge: true });
+            transaction.update(registrationRef, buildRegistrationReminderStopUpdate({ reason: hasRemainingInstallments ? 'installment_in_progress' : 'paid', nowIso: queuedAtIso }));
+          } else {
+            transaction.set(registrationRef, {
+              checkoutStatus: 'complete',
+              paymentStatus: 'paid',
+              paidAt: receivedAt,
+              balanceDueCents: 0,
+              nextPaymentDueDate: null,
+              stripeCheckoutSessionId: session.id || null,
+              stripePaymentIntentId: session.payment_intent || null,
+              stripePaymentStatus: session.payment_status || 'paid',
+              stripeEventId: event.id,
+              updatedAt: receivedAt
+            }, { merge: true });
+            transaction.update(registrationRef, buildRegistrationReminderStopUpdate({ reason: 'paid', nowIso: queuedAtIso }));
+          }
         } else {
-          const form = formSnap.data() || {};
-          const registration = registrationSnap.data() || {};
           if (!registrationCheckoutAuthorityMatches(registration, registrationInput)) {
             transaction.set(eventRef, {
               provider: 'stripe',

--- a/functions/index.js
+++ b/functions/index.js
@@ -341,6 +341,10 @@ function buildRegistrationCheckoutUrls(appUrl, input) {
   if (input.paymentPlanId) {
     params.set('paymentPlanId', String(input.paymentPlanId));
   }
+  const paidInstallmentCount = Math.max(0, Math.floor(Number(input.paidInstallmentCount) || 0));
+  if (paidInstallmentCount > 0) {
+    params.set('paidInstallmentCount', String(paidInstallmentCount));
+  }
   return {
     successUrl: `${baseUrl}/registration.html?${params.toString()}&status=success`,
     cancelUrl: `${baseUrl}/registration.html?${params.toString()}&status=cancelled`
@@ -897,18 +901,40 @@ function buildRegistrationInstallmentScheduleFromAuthoritativeForm(form, totalBa
   return buildPublicRegistrationInstallmentSchedule(totalBalanceDueCents, form.installmentPlan);
 }
 
+function getStoredRegistrationInstallmentSchedule(registration = {}) {
+  return Array.isArray(registration.paymentPlan?.schedule)
+    ? registration.paymentPlan.schedule.filter(Boolean)
+    : [];
+}
+
+function getStoredRegistrationInstallmentTotalBalanceDueCents(registration = {}) {
+  return Math.max(0, Math.round(Number(
+    registration.paymentPlan?.totalBalanceDueCents
+    ?? registration.feeSnapshot?.finalAmountDueCents
+    ?? registration.feeAmountCents
+    ?? 0
+  ) || 0));
+}
+
 function getRegistrationPaymentPlanPaidInstallmentCount(registration = {}) {
   return Math.max(0, Math.floor(Number(registration.paymentPlan?.paidInstallmentCount || 0) || 0));
 }
 
+function shouldKeepRegistrationCapacityReserved(registration = {}) {
+  return registration.paymentPlan?.id === 'installments' && getRegistrationPaymentPlanPaidInstallmentCount(registration) > 0;
+}
+
 function buildRegistrationInstallmentPaymentState(registration = {}, form = null, nextPaidInstallmentCount = getRegistrationPaymentPlanPaidInstallmentCount(registration)) {
-  const authoritativeTotalBalanceDueCents = form
-    ? computeRegistrationFeeAmountCentsFromForm(form)
-    : Math.max(0, Math.round(Number(registration.paymentPlan?.totalBalanceDueCents ?? registration.feeSnapshot?.finalAmountDueCents ?? registration.feeAmountCents ?? 0)));
-  const authoritativeSchedule = form
-    ? buildRegistrationInstallmentScheduleFromAuthoritativeForm(form, authoritativeTotalBalanceDueCents)
-    : Array.isArray(registration.paymentPlan?.schedule)
-      ? registration.paymentPlan.schedule.filter(Boolean)
+  const storedSchedule = getStoredRegistrationInstallmentSchedule(registration);
+  const authoritativeTotalBalanceDueCents = storedSchedule.length
+    ? getStoredRegistrationInstallmentTotalBalanceDueCents(registration)
+    : form
+      ? computeRegistrationFeeAmountCentsFromForm(form)
+      : getStoredRegistrationInstallmentTotalBalanceDueCents(registration);
+  const authoritativeSchedule = storedSchedule.length
+    ? storedSchedule
+    : form
+      ? buildRegistrationInstallmentScheduleFromAuthoritativeForm(form, authoritativeTotalBalanceDueCents)
       : [];
   if (!authoritativeSchedule.length) {
     return {
@@ -2946,7 +2972,10 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   const checkoutUrlInput = {
     ...resolvedInput,
     publicCheckoutCapability: issuedPublicCheckoutCapability,
-    paymentPlanId: String(registration.paymentPlan?.id || 'pay_full').trim() || 'pay_full'
+    paymentPlanId: String(registration.paymentPlan?.id || 'pay_full').trim() || 'pay_full',
+    paidInstallmentCount: registration.paymentPlan?.id === 'installments'
+      ? getRegistrationPaymentPlanPaidInstallmentCount(registration) + 1
+      : 0
   };
   const { successUrl, cancelUrl } = buildRegistrationCheckoutUrls(appUrl, checkoutUrlInput);
   const title = registration.programName || form.programName || form.title || form.name || 'Program registration';
@@ -3158,7 +3187,8 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
           const countKey = String(selectedOption.countKey || selectedOption.id || '').trim();
           const counts = form.registrationOptionCounts || {};
           const optionCounts = countKey ? counts[countKey] || {} : {};
-          const shouldReleaseCapacity = registration.registrationCapacityReleased !== true && registration.paymentStatus !== 'paid' && countKey;
+          const shouldRetainCapacity = shouldKeepRegistrationCapacityReserved(registration);
+          const shouldReleaseCapacity = !shouldRetainCapacity && registration.registrationCapacityReleased !== true && registration.paymentStatus !== 'paid' && countKey;
           if (shouldReleaseCapacity && registration.status === 'pending') {
             transaction.update(formRef, {
               [`registrationOptionCounts.${countKey}.enrolled`]: Math.max(0, Number(optionCounts.enrolled || 0) - 1),
@@ -3178,8 +3208,10 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
             stripeCheckoutSessionId: session.id || null,
             stripePaymentStatus: session.payment_status || 'unpaid',
             stripeEventId: event.id,
-            registrationCapacityReleased: true,
-            capacityReleasedAt: receivedAt,
+            ...(shouldReleaseCapacity ? {
+              registrationCapacityReleased: true,
+              capacityReleasedAt: receivedAt
+            } : {}),
             updatedAt: receivedAt
           }, { merge: true });
 

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -8,6 +8,7 @@ const originalModuleLoad = Module._load;
 let adminStub = null;
 let functionsStub = null;
 let StripeStub = null;
+let stripeState = null;
 
 function patchedModuleLoad(request, parent, isMain) {
     if (request === 'firebase-admin' && adminStub) {
@@ -173,7 +174,7 @@ function makeFunctionsStub() {
     triggerChain.pubsub = triggerChain;
 
     return {
-        config: () => ({ stripe: { secret_key: 'sk_test_123', app_url: 'https://allplays.test' } }),
+        config: () => ({ stripe: { secret_key: 'sk_test_123', webhook_secret: 'whsec_test_123', app_url: 'https://allplays.test' } }),
         https: {
             HttpsError,
             onCall: (fn) => fn,
@@ -195,6 +196,11 @@ function makeFunctionsStub() {
 }
 
 function installModuleStubs(firestore) {
+    stripeState = {
+        checkoutSessions: [],
+        webhookEvent: null,
+        nextCheckoutResponse: null
+    };
     adminStub = {
         apps: [true],
         initializeApp: () => {},
@@ -206,10 +212,35 @@ function installModuleStubs(firestore) {
     StripeStub = class StripeMock {
         constructor() {
             return {
-                checkout: { sessions: { create: async () => ({}) } },
-                webhooks: { constructEvent: () => { throw new Error('Not implemented in test.'); } }
+                checkout: { sessions: { create: async (payload) => {
+                    stripeState.checkoutSessions.push(clone(payload));
+                    return {
+                        id: `cs_test_${stripeState.checkoutSessions.length}`,
+                        url: `https://stripe.test/checkout/${stripeState.checkoutSessions.length}`,
+                        payment_status: 'unpaid',
+                        ...(clone(stripeState.nextCheckoutResponse) || {})
+                    };
+                } } },
+                webhooks: { constructEvent: () => {
+                    if (!stripeState.webhookEvent) {
+                        throw new Error('Not implemented in test.');
+                    }
+                    return clone(stripeState.webhookEvent);
+                } }
             };
         }
+    };
+}
+
+function loadFunctionsModule(seed) {
+    delete require.cache[repoIndexPath];
+    const firestore = makeFirestore(seed);
+    installModuleStubs(firestore);
+    const mod = require('../index.js');
+    return {
+        firestore,
+        stripeState,
+        mod
     };
 }
 
@@ -220,6 +251,7 @@ function loadSubmitPublicRegistration(seed) {
     const mod = require('../index.js');
     return {
         firestore,
+        stripeState,
         submitPublicRegistration: mod.submitPublicRegistration
     };
 }
@@ -271,6 +303,7 @@ test.beforeEach(() => {
     adminStub = null;
     functionsStub = null;
     StripeStub = null;
+    stripeState = null;
 });
 
 test.afterEach(() => {
@@ -279,6 +312,7 @@ test.afterEach(() => {
     adminStub = null;
     functionsStub = null;
     StripeStub = null;
+    stripeState = null;
 });
 
 test('creates exactly one pending registration and reserves matching capacity', async () => {
@@ -390,4 +424,136 @@ test('throttles repeated anonymous submissions before reserving more capacity', 
     const formAfterThrottle = firestore.snapshot('teams/team-1/registrationForms/form-1');
     assert.equal(formAfterThrottle.registrationOptionCounts.u10.enrolled, formBeforeThrottle.registrationOptionCounts.u10.enrolled);
     assert.equal(firestore.registrationDocs().length, registrationCountBeforeThrottle);
+});
+
+test('charges only the first scheduled installment for installment registrations', async () => {
+    const { firestore, stripeState, mod } = loadFunctionsModule(buildSeedState({
+        feeAmountCents: 12500,
+        paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+        installmentPlan: {
+            enabled: true,
+            title: 'Monthly installments',
+            installmentCount: 3,
+            firstDueDate: '2026-07-01',
+            intervalDays: 30
+        }
+    }));
+
+    const submission = await mod.submitPublicRegistration(buildSubmission({
+        selectedPaymentPlanId: 'installments',
+        checkoutAttemptToken: 'checkouttoken123456'
+    }), context);
+
+    const registrationPath = `teams/team-1/registrationForms/form-1/registrations/${submission.registrationId}`;
+    const storedRegistration = firestore.snapshot(registrationPath);
+    assert.equal(storedRegistration.paymentPlan.id, 'installments');
+    assert.deepEqual(storedRegistration.paymentPlan.schedule.map((entry) => entry.amountCents), [4166, 4166, 4168]);
+
+    const checkout = await mod.createStripeRegistrationCheckout({
+        teamId: 'team-1',
+        formId: 'form-1',
+        registrationId: submission.registrationId,
+        amountCents: 12500,
+        currency: 'usd',
+        checkoutAttemptToken: 'checkouttoken123456'
+    });
+
+    assert.equal(checkout.checkoutUrl, 'https://stripe.test/checkout/1');
+    assert.equal(stripeState.checkoutSessions.length, 1);
+    assert.equal(stripeState.checkoutSessions[0].line_items[0].price_data.unit_amount, 4166);
+    assert.match(stripeState.checkoutSessions[0].success_url, /paymentPlanId=installments/);
+
+    const checkoutRegistration = firestore.snapshot(registrationPath);
+    assert.equal(checkoutRegistration.checkoutAmountCents, 4166);
+    assert.equal(checkoutRegistration.paymentStatus, 'checkout_open');
+  });
+
+function createMockResponse() {
+    return {
+        statusCode: 200,
+        body: null,
+        headers: {},
+        set(name, value) {
+            this.headers[name] = value;
+            return this;
+        },
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        send(payload) {
+            this.body = payload;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        }
+    };
+}
+
+test('records installment payment progress after Stripe marks the first installment paid', async () => {
+    const { firestore, stripeState, mod } = loadFunctionsModule(buildSeedState({
+        feeAmountCents: 12500,
+        paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+        installmentPlan: {
+            enabled: true,
+            title: 'Monthly installments',
+            installmentCount: 3,
+            firstDueDate: '2026-07-01',
+            intervalDays: 30
+        }
+    }));
+
+    const submission = await mod.submitPublicRegistration(buildSubmission({
+        selectedPaymentPlanId: 'installments',
+        checkoutAttemptToken: 'checkouttoken123456'
+    }), context);
+
+    await mod.createStripeRegistrationCheckout({
+        teamId: 'team-1',
+        formId: 'form-1',
+        registrationId: submission.registrationId,
+        amountCents: 12500,
+        currency: 'usd',
+        checkoutAttemptToken: 'checkouttoken123456'
+    });
+
+    stripeState.webhookEvent = {
+        id: 'evt_installment_paid_1',
+        type: 'checkout.session.completed',
+        data: {
+            object: {
+                id: 'cs_test_1',
+                payment_status: 'paid',
+                payment_intent: 'pi_test_1',
+                amount_total: 4166,
+                metadata: {
+                    product: 'registration',
+                    teamId: 'team-1',
+                    formId: 'form-1',
+                    registrationId: submission.registrationId,
+                    checkoutAttemptToken: 'checkouttoken123456'
+                }
+            }
+        }
+    };
+
+    const req = {
+        method: 'POST',
+        rawBody: Buffer.from('event'),
+        headers: { 'stripe-signature': 'sig_test' }
+    };
+    const res = createMockResponse();
+
+    await mod.stripeTeamPassWebhook(req, res);
+
+    assert.equal(res.statusCode, 200);
+    const registration = firestore.snapshot(`teams/team-1/registrationForms/form-1/registrations/${submission.registrationId}`);
+    assert.equal(registration.paymentStatus, 'installment_in_progress');
+    assert.equal(registration.balanceDueCents, 8334);
+    assert.equal(registration.nextPaymentDueDate, '2026-07-31');
+    assert.equal(registration.paymentPlan.paidInstallmentCount, 1);
+    assert.equal(registration.paymentPlan.remainingBalanceCents, 8334);
+    assert.equal(registration.paymentPlan.nextDueDate, '2026-07-31');
 });

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -468,6 +468,71 @@ test('charges only the first scheduled installment for installment registrations
     assert.equal(checkoutRegistration.paymentStatus, 'checkout_open');
   });
 
+test('keeps the stored installment schedule for later checkout attempts after form pricing changes', async () => {
+    const { firestore, stripeState, mod } = loadFunctionsModule(buildSeedState({
+        feeAmountCents: 12500,
+        paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+        installmentPlan: {
+            enabled: true,
+            title: 'Monthly installments',
+            installmentCount: 3,
+            firstDueDate: '2026-07-01',
+            intervalDays: 30
+        }
+    }));
+
+    const submission = await mod.submitPublicRegistration(buildSubmission({
+        selectedPaymentPlanId: 'installments',
+        checkoutAttemptToken: 'checkouttoken123456'
+    }), context);
+
+    const registrationPath = `teams/team-1/registrationForms/form-1/registrations/${submission.registrationId}`;
+    await firestore.doc(registrationPath).set({
+        paymentPlan: {
+            id: 'installments',
+            schedule: [
+                { label: 'Installment 1', dueDate: '2026-07-01', amountCents: 4166 },
+                { label: 'Installment 2', dueDate: '2026-07-31', amountCents: 4166 },
+                { label: 'Installment 3', dueDate: '2026-08-30', amountCents: 4168 }
+            ],
+            totalBalanceDueCents: 12500,
+            paidInstallmentCount: 1,
+            remainingBalanceCents: 8334,
+            nextDueDate: '2026-07-31'
+        },
+        paymentStatus: 'installment_in_progress',
+        balanceDueCents: 8334,
+        nextPaymentDueDate: '2026-07-31'
+    }, { merge: true });
+    await firestore.doc('teams/team-1/registrationForms/form-1').set({
+        feeAmountCents: 18000,
+        installmentPlan: {
+            enabled: true,
+            title: 'Biweekly installments',
+            installmentCount: 4,
+            firstDueDate: '2026-07-10',
+            intervalDays: 14
+        }
+    }, { merge: true });
+
+    const checkout = await mod.createStripeRegistrationCheckout({
+        teamId: 'team-1',
+        formId: 'form-1',
+        registrationId: submission.registrationId,
+        amountCents: 18000,
+        currency: 'usd',
+        checkoutAttemptToken: 'checkouttoken123456'
+    });
+
+    assert.equal(checkout.checkoutUrl, 'https://stripe.test/checkout/1');
+    assert.equal(stripeState.checkoutSessions[0].line_items[0].price_data.unit_amount, 4166);
+    assert.match(stripeState.checkoutSessions[0].success_url, /paymentPlanId=installments/);
+    assert.match(stripeState.checkoutSessions[0].success_url, /paidInstallmentCount=2/);
+
+    const checkoutRegistration = firestore.snapshot(registrationPath);
+    assert.equal(checkoutRegistration.checkoutAmountCents, 4166);
+});
+
 function createMockResponse() {
     return {
         statusCode: 200,
@@ -556,4 +621,79 @@ test('records installment payment progress after Stripe marks the first installm
     assert.equal(registration.paymentPlan.paidInstallmentCount, 1);
     assert.equal(registration.paymentPlan.remainingBalanceCents, 8334);
     assert.equal(registration.paymentPlan.nextDueDate, '2026-07-31');
+});
+
+test('keeps capacity reserved when a later installment payment fails', async () => {
+    const { firestore, stripeState, mod } = loadFunctionsModule(buildSeedState({
+        feeAmountCents: 12500,
+        paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
+        installmentPlan: {
+            enabled: true,
+            title: 'Monthly installments',
+            installmentCount: 3,
+            firstDueDate: '2026-07-01',
+            intervalDays: 30
+        }
+    }));
+
+    const submission = await mod.submitPublicRegistration(buildSubmission({
+        selectedPaymentPlanId: 'installments',
+        checkoutAttemptToken: 'checkouttoken123456'
+    }), context);
+
+    const registrationPath = `teams/team-1/registrationForms/form-1/registrations/${submission.registrationId}`;
+    await firestore.doc(registrationPath).set({
+        paymentStatus: 'installment_in_progress',
+        paymentPlan: {
+            id: 'installments',
+            schedule: [
+                { label: 'Installment 1', dueDate: '2026-07-01', amountCents: 4166 },
+                { label: 'Installment 2', dueDate: '2026-07-31', amountCents: 4166 },
+                { label: 'Installment 3', dueDate: '2026-08-30', amountCents: 4168 }
+            ],
+            totalBalanceDueCents: 12500,
+            paidInstallmentCount: 1,
+            remainingBalanceCents: 8334,
+            nextDueDate: '2026-07-31'
+        },
+        registrationCapacityReleased: false,
+        balanceDueCents: 8334,
+        nextPaymentDueDate: '2026-07-31',
+        publicCheckoutCapabilityHash: ''
+    }, { merge: true });
+
+    stripeState.webhookEvent = {
+        id: 'evt_installment_failed_2',
+        type: 'checkout.session.async_payment_failed',
+        data: {
+            object: {
+                id: 'cs_test_2',
+                payment_status: 'failed',
+                payment_intent: 'pi_test_2',
+                metadata: {
+                    product: 'registration',
+                    teamId: 'team-1',
+                    formId: 'form-1',
+                    registrationId: submission.registrationId,
+                    checkoutAttemptToken: 'checkouttoken123456'
+                }
+            }
+        }
+    };
+
+    const req = {
+        method: 'POST',
+        rawBody: Buffer.from('event'),
+        headers: { 'stripe-signature': 'sig_test' }
+    };
+    const res = createMockResponse();
+
+    await mod.stripeTeamPassWebhook(req, res);
+
+    assert.equal(res.statusCode, 200);
+    const registration = firestore.snapshot(registrationPath);
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(registration.paymentStatus, 'payment_failed');
+    assert.equal(registration.registrationCapacityReleased, false);
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 1);
 });

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -775,6 +775,30 @@ describe('React app parent tools service', () => {
         expect(dbMocks.rejectTeamRegistration).toHaveBeenCalledWith('team-coach', 'form-review', 'reg-1', 'Not eligible');
     });
 
+    it('surfaces installment-in-progress review labels from stored payment state', async () => {
+        dbMocks.listTeamRegistrationReviews.mockResolvedValue([
+            {
+                id: 'reg-installment-1',
+                status: 'pending',
+                participant: { name: 'Riley Runner' },
+                guardian: { email: 'parent@example.com', name: 'Pat Parent' },
+                selectedOption: { title: 'Travel' },
+                feeSnapshot: { finalAmountDueCents: 15000, currency: 'USD' },
+                paymentStatus: 'installment_in_progress',
+                balanceDueCents: 10000,
+                paymentPlan: { remainingBalanceCents: 10000 },
+                waiverAccepted: true
+            }
+        ]);
+        dbMocks.getPlayers.mockResolvedValue([]);
+
+        const queue = await loadTeamRegistrationQueue(user, 'team-coach', 'form-review');
+
+        expect(queue.reviews[0]).toMatchObject({
+            paymentLabel: 'installment in progress · $100.00'
+        });
+    });
+
     it('loads first page of registration reviews using a bounded query', async () => {
         const mockReviews = [
             {

--- a/tests/unit/stripe-async-payment-webhook.test.js
+++ b/tests/unit/stripe-async-payment-webhook.test.js
@@ -40,7 +40,7 @@ describe('Stripe async payment webhook handling (issue #2203)', () => {
         expect(source).toContain("checkoutStatus: event.type === 'checkout.session.expired' ? 'expired' : 'payment_failed',");
         expect(source).toContain("paymentStatus: event.type === 'checkout.session.expired' ? 'checkout_expired' : 'payment_failed',");
         expect(source).toContain('registrationCapacityReleased: true,');
-        expect(source).toContain('capacityReleasedAt: receivedAt,');
+        expect(source).toContain('capacityReleasedAt: receivedAt');
     });
 
     it('accepts public checkout capability metadata for non-paid webhook retries', () => {


### PR DESCRIPTION
Closes #3081

## What changed
- Updated Stripe registration checkout creation to charge the next scheduled installment amount when a registration selected the installment plan, instead of always charging the full form total.
- Persisted installment progress on the registration after Stripe payment succeeds, including paid installment count, remaining balance, and next due date.
- Added app UI messaging to show the amount due now and remaining installment schedule before checkout, plus the remaining schedule after a successful installment payment.
- Updated staff-facing registration payment labels to surface installment-in-progress state from stored registration data.

## Root Cause
The checkout flow stored the selected installment plan on the registration, but `createStripeRegistrationCheckout` ignored that stored plan and always recomputed Stripe charges from the full authoritative form total. The success-state UI and stored payment state also assumed every successful Stripe payment meant the registration was fully paid.

## Prevention / Learning
When the server stores an authoritative payment-plan snapshot, every downstream checkout, webhook, reminder, and confirmation path must derive amount due and remaining balance from that plan instead of assuming one full-balance payment.

## Regression Tests
- `functions/test/public-registration-submission.test.cjs` verifies installment registrations store the schedule, create checkout for the first installment amount, and persist installment-in-progress state after the Stripe webhook.
- `apps/app/src/pages/RegistrationDetail.test.tsx` verifies the registration page shows amount due now, remaining installment schedule before checkout, and remaining balance after successful installment payment.
- `tests/unit/app-parent-tools-service.test.js` verifies staff review labels reflect stored installment-in-progress payment state.

## Recurrence Risk
Medium. Payment flows span checkout creation, webhook mutation, and UI confirmation surfaces, so future changes can drift if one surface is updated without the others.