### PR TITLE
Preselect deep-linked team in parent access

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -282,6 +282,52 @@ describe('ParentTools access', () => {
         expect((screen.getByLabelText('Team') as HTMLSelectElement).disabled).toBe(false);
     });
 
+    it('auto-opens and preselects the deep-linked team on access routes', async () => {
+        type ParentAccessPlayerRow = { id: string; name: string; number: string };
+        const deferredPlayers: { resolve: ((value: ParentAccessPlayerRow[]) => void) | null } = { resolve: null };
+        parentToolsAccessServiceMocks.loadParentAccessPlayers.mockImplementation((teamId: string) => {
+            expect(teamId).toBe('team-1');
+            return new Promise<ParentAccessPlayerRow[]>((resolve) => {
+                deferredPlayers.resolve = resolve;
+            });
+        });
+
+        renderParentTools(['/parent-tools/access?teamId=team-1']);
+
+        await screen.findByText('Request player access');
+        await waitFor(() => expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1));
+        expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
+
+        const teamSelect = await screen.findByRole('combobox', { name: 'Team' }) as HTMLSelectElement;
+        expect(teamSelect.value).toBe('team-1');
+        await waitFor(() => expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-1'));
+        expect(screen.getByRole('option', { name: 'Loading players...' })).toBeTruthy();
+
+        await waitFor(() => expect(deferredPlayers.resolve).toBeTruthy());
+        if (!deferredPlayers.resolve) throw new Error('Expected players loader to be pending.');
+        deferredPlayers.resolve([{ id: 'player-1', name: 'Sam Player', number: '12' }]);
+
+        expect(await screen.findByRole('option', { name: '#12 Sam Player' })).toBeTruthy();
+        expect((screen.getByLabelText('Player') as HTMLSelectElement).value).toBe('player-1');
+    });
+
+    it('falls back safely when the deep-linked team is missing', async () => {
+        renderParentTools(['/parent-tools/access?teamId=missing-team']);
+
+        await screen.findByText('Request player access');
+        await waitFor(() => expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1));
+        expect(screen.getByRole('button', { name: 'Request access without a code' })).toBeTruthy();
+        expect(screen.queryByRole('combobox', { name: 'Team' })).toBeNull();
+        expect(screen.getByRole('button', { name: 'Redeem code' })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+
+        const teamSelect = await screen.findByRole('combobox', { name: 'Team' }) as HTMLSelectElement;
+        expect(teamSelect.value).toBe('');
+        expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
+        expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
+    });
+
     it('allows retry when public team loading fails after opening manual requests', async () => {
         parentToolsAccessServiceMocks.loadParentAccessTeams
             .mockRejectedValueOnce(new Error('Network hiccup.'))

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { AlertCircle, CheckCircle2, KeyRound, Loader2, RefreshCw, Shield, Users } from 'lucide-react';
 import { redeemSignedInInvite } from '../../lib/inviteRedemption';
 import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
@@ -16,6 +16,8 @@ import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, getParentToolErrorMessage, useParentToolAsyncOperation } from './shared';
 
 export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChanged: () => void }) {
+    const [searchParams] = useSearchParams();
+    const deepLinkedTeamId = searchParams.get('teamId')?.trim() || '';
     const [teams, setTeams] = useState<ParentAccessTeam[]>([]);
     const [requests, setRequests] = useState<ParentAccessRequest[]>([]);
     const [players, setPlayers] = useState<ParentAccessPlayer[]>([]);
@@ -109,6 +111,17 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         setSelectedTeamId('');
         setSelectedPlayerId('');
     }, [auth.user?.uid]);
+
+    useEffect(() => {
+        if (!deepLinkedTeamId || teams.length || loadingTeams) return;
+        void loadTeams();
+    }, [deepLinkedTeamId, loadTeams, loadingTeams, teams.length]);
+
+    useEffect(() => {
+        if (!deepLinkedTeamId || !teams.some((team) => team.id === deepLinkedTeamId)) return;
+        setManualRequestOpen(true);
+        setSelectedTeamId((current) => current || deepLinkedTeamId);
+    }, [deepLinkedTeamId, teams]);
 
     useEffect(() => {
         if (!manualRequestOpen || manualTeamsRequested || teams.length || loadingTeams) return;


### PR DESCRIPTION
Closes #3082

## What changed
- Read `teamId` from the `/parent-tools/access` route and preload public teams when a deep link includes team context.
- Auto-open the manual request form only when the deep-linked team exists, then preselect that team so player loading starts immediately.
- Kept the invite-code path unchanged and preserved the existing collapsed manual-request entry point when the `teamId` is missing or invalid.
- Added focused Parent Tools regression coverage for both valid and invalid deep-link cases.

## Root Cause
`AccessTool` only opened and populated the manual request flow from local button-driven state. Even though notifications already routed to `/parent-tools/access?teamId=...`, the page never read route search params, so it could not preload teams, select the linked team, or trigger player loading.

## Prevention / Learning
When a route already carries workflow context like `teamId`, reconcile that context with fetched options before requiring another user action. Cover both the happy path and the invalid-id fallback so route-driven UX shortcuts cannot silently regress.

## Regression Tests
- `npx vitest run apps/app/src/pages/ParentTools.test.tsx --reporter=verbose`
- Added coverage that `/parent-tools/access?teamId=team-1` auto-opens the manual request form, preselects the team, and starts player loading automatically.
- Added coverage that an unknown deep-linked `teamId` falls back safely to the existing manual request entry point without locking the user into a missing selection.