### PR TITLE
Bound admin official lookup to visible users

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -644,7 +644,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="js/admin.js?v=2"></script>
+    <script type="module" src="js/admin.js?v=3"></script>
 </body>
 
 </html>

--- a/js/admin-user-official-links.js
+++ b/js/admin-user-official-links.js
@@ -27,6 +27,28 @@ export function collectOfficialLookupTargets(users = []) {
     };
 }
 
+export function collectOfficialLookupQueryTargets(users = []) {
+    const emails = new Set();
+    const phones = new Set();
+
+    users.forEach((user) => {
+        const rawEmail = String(user?.email || '').trim();
+        const normalizedEmail = normalizeOfficialLinkEmail(user?.email);
+        const rawPhone = String(user?.phone || '').trim();
+        const normalizedPhone = normalizeOfficialLinkPhone(user?.phone);
+
+        if (rawEmail) emails.add(rawEmail);
+        if (normalizedEmail) emails.add(normalizedEmail);
+        if (rawPhone) phones.add(rawPhone);
+        if (normalizedPhone) phones.add(normalizedPhone);
+    });
+
+    return {
+        emails: Array.from(emails),
+        phones: Array.from(phones)
+    };
+}
+
 export function buildOfficialLookupCacheKey(users = []) {
     return users.map((user) => [
         String(user?.id || '').trim(),

--- a/js/admin-user-official-links.js
+++ b/js/admin-user-official-links.js
@@ -10,6 +10,31 @@ export function normalizeOfficialLinkPhone(phone) {
     return digits;
 }
 
+export function collectOfficialLookupTargets(users = []) {
+    const emails = new Set();
+    const phones = new Set();
+
+    users.forEach((user) => {
+        const email = normalizeOfficialLinkEmail(user?.email);
+        const phone = normalizeOfficialLinkPhone(user?.phone);
+        if (email) emails.add(email);
+        if (phone) phones.add(phone);
+    });
+
+    return {
+        emails: Array.from(emails),
+        phones: Array.from(phones)
+    };
+}
+
+export function buildOfficialLookupCacheKey(users = []) {
+    return users.map((user) => [
+        String(user?.id || '').trim(),
+        normalizeOfficialLinkEmail(user?.email),
+        normalizeOfficialLinkPhone(user?.phone)
+    ].join(':')).join('|');
+}
+
 function getOfficialLookupKeys(official = {}) {
     return [
         normalizeOfficialLinkEmail(official.email),

--- a/js/admin.js
+++ b/js/admin.js
@@ -5,6 +5,7 @@ import {
     getAllUsers,
     getGames,
     getOfficials,
+    getOfficialsForUsers,
     addOfficial,
     updateOfficial,
     deleteOfficial,
@@ -14,7 +15,7 @@ import {
     getTelemetryPageDaily,
     getTelemetryEventDaily,
     getTelemetrySessions
-} from './db.js?v=72';
+} from './db.js?v=73';
 import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=19';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=36';
@@ -30,11 +31,12 @@ import {
 } from './admin-registration-forms.js?v=3';
 import { buildRecentGameResultsRows } from './admin-game-results.js?v=1';
 import {
+    buildOfficialLookupCacheKey,
     buildOfficialUserLookup,
     formatOfficialUserSummary,
     getOfficialUserSummary,
     matchesOfficialUserSearch
-} from './admin-user-official-links.js?v=1';
+} from './admin-user-official-links.js?v=2';
 import { buildAdminTeamOfficialsSummary } from './admin-team-officials.js?v=1';
 
 let allTeams = [];
@@ -87,6 +89,12 @@ function getTeamsKey(teams = []) {
 
 function getCurrentTeamPageKey() {
     return getTeamsKey(getCurrentTeamPage());
+}
+
+function getTeamNameById(teamId) {
+    const team = getDashboardTeams().find((entry) => entry.id === teamId)
+        || allTeams.find((entry) => entry.id === teamId);
+    return team?.name || 'Team';
 }
 
 function getDashboardTeams() {
@@ -298,6 +306,25 @@ async function loadOfficialUserLinks(teams = allTeams, { scope = 'page' } = {}) 
     loadedTeamsOfficialsPageKey = teamsKey;
 }
 
+async function loadVisibleOfficialUserLinks(users = allUsers) {
+    const usersKey = buildOfficialLookupCacheKey(users);
+    if (!usersKey) {
+        officialUserLookup = new Map();
+        loadedUsersOfficialsKey = '';
+        return;
+    }
+    if (usersKey && loadedUsersOfficialsKey === usersKey) {
+        return;
+    }
+
+    const officialEntries = await getOfficialsForUsers(users);
+    officialUserLookup = buildOfficialUserLookup(officialEntries.map((entry) => ({
+        ...entry,
+        teamName: getTeamNameById(entry.teamId)
+    })));
+    loadedUsersOfficialsKey = usersKey;
+}
+
 async function loadGameStatsForTeams(teams = allTeams, { scope = 'page' } = {}) {
     const teamsKey = getTeamsKey(teams);
     if (scope === 'page' && teamsKey && loadedGamesPageKey === teamsKey) {
@@ -342,8 +369,8 @@ async function ensureCurrentTeamOfficialsLoaded() {
     await loadOfficialUserLinks(getCurrentTeamPage(), { scope: 'page' });
 }
 
-async function ensureAllOfficialsLoaded() {
-    await loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' });
+async function ensureCurrentUsersOfficialsLoaded() {
+    await loadVisibleOfficialUserLinks(getCurrentUsersPage());
 }
 
 function getTelemetryRangeDays() {
@@ -1453,7 +1480,7 @@ async function loadNextTeamsPage() {
             await ensureCurrentTeamOfficialsLoaded();
         }
         if (activeTab === 'users') {
-            await ensureAllOfficialsLoaded();
+            await ensureCurrentUsersOfficialsLoaded();
             renderCurrentUsersView();
         }
         renderCurrentTeamsView();
@@ -1480,7 +1507,7 @@ async function loadPreviousTeamsPage() {
             await ensureCurrentTeamOfficialsLoaded();
         }
         if (activeTab === 'users') {
-            await ensureAllOfficialsLoaded();
+            await ensureCurrentUsersOfficialsLoaded();
             renderCurrentUsersView();
         }
         renderCurrentTeamsView();
@@ -1508,6 +1535,7 @@ async function loadNextUsersPage() {
         } else {
             return;
         }
+        await ensureCurrentUsersOfficialsLoaded();
         renderCurrentUsersView();
         if (activeTab === 'dashboard') {
             updateDashboard();
@@ -1525,6 +1553,7 @@ async function loadPreviousUsersPage() {
     try {
         const previousIndex = userPageState.currentIndex - 1;
         setUsersPage(userPageState.pages[previousIndex] || [], userPageState.nextCursor, previousIndex);
+        await ensureCurrentUsersOfficialsLoaded();
         renderCurrentUsersView();
         if (activeTab === 'dashboard') {
             updateDashboard();
@@ -1548,7 +1577,7 @@ async function handleTabChange(tab) {
         return;
     }
     if (tab === 'users') {
-        await ensureAllOfficialsLoaded();
+        await ensureCurrentUsersOfficialsLoaded();
         renderCurrentUsersView();
         return;
     }

--- a/js/db.js
+++ b/js/db.js
@@ -48,6 +48,7 @@ import { buildCoachOverrideRsvpDocId, shouldDeleteLegacyRsvpForOverride } from '
 import { computeEffectiveRsvpSummary } from './rsvp-summary.js?v=1';
 import { buildGameDayRsvpBreakdown } from './game-day-rsvp-breakdown.js?v=1';
 import { isAvailabilityLocked, normalizeAvailabilityPreferences } from './availability-preferences.js?v=1';
+import { collectOfficialLookupTargets } from './admin-user-official-links.js?v=2';
 import { resolveAvailabilityCutoffEventDate } from './availability-cutoff-date.js?v=1';
 import { normalizeFamilyShareCalendarUrls, normalizeFamilyShareChildren } from './family-share-utils.js?v=1';
 import { normalizeChatAttachments } from './team-chat-media.js';
@@ -2213,6 +2214,48 @@ export async function getOfficials(teamId) {
             .map(mapOfficial)
             .sort((a, b) => String(a.name || a.displayName || a.email || '').localeCompare(String(b.name || b.displayName || b.email || '')));
     }
+}
+
+function chunkArray(values = [], chunkSize = 10) {
+    const chunks = [];
+    for (let index = 0; index < values.length; index += chunkSize) {
+        chunks.push(values.slice(index, index + chunkSize));
+    }
+    return chunks;
+}
+
+export async function getOfficialsForUsers(users = []) {
+    const { emails, phones } = collectOfficialLookupTargets(users);
+    if (!emails.length && !phones.length) {
+        return [];
+    }
+
+    const entries = [];
+    const seenDocKeys = new Set();
+    const addSnapshotEntries = (snapshot) => {
+        snapshot.docs.forEach((docSnap) => {
+            const teamId = docSnap.ref.parent.parent?.id || '';
+            const docKey = `${teamId}:${docSnap.id}`;
+            if (!teamId || seenDocKeys.has(docKey)) return;
+            seenDocKeys.add(docKey);
+            entries.push({
+                teamId,
+                official: { id: docSnap.id, ...docSnap.data() }
+            });
+        });
+    };
+
+    const emailQueries = chunkArray(emails).map(async (chunk) => {
+        const snapshot = await getDocs(query(collectionGroup(db, 'officials'), where('email', 'in', chunk)));
+        addSnapshotEntries(snapshot);
+    });
+    const phoneQueries = chunkArray(phones).map(async (chunk) => {
+        const snapshot = await getDocs(query(collectionGroup(db, 'officials'), where('phone', 'in', chunk)));
+        addSnapshotEntries(snapshot);
+    });
+
+    await Promise.all([...emailQueries, ...phoneQueries]);
+    return entries;
 }
 
 export async function getPlayers(teamId, options = {}) {

--- a/js/db.js
+++ b/js/db.js
@@ -48,7 +48,10 @@ import { buildCoachOverrideRsvpDocId, shouldDeleteLegacyRsvpForOverride } from '
 import { computeEffectiveRsvpSummary } from './rsvp-summary.js?v=1';
 import { buildGameDayRsvpBreakdown } from './game-day-rsvp-breakdown.js?v=1';
 import { isAvailabilityLocked, normalizeAvailabilityPreferences } from './availability-preferences.js?v=1';
-import { collectOfficialLookupTargets } from './admin-user-official-links.js?v=2';
+import {
+    collectOfficialLookupQueryTargets,
+    collectOfficialLookupTargets
+} from './admin-user-official-links.js?v=2';
 import { resolveAvailabilityCutoffEventDate } from './availability-cutoff-date.js?v=1';
 import { normalizeFamilyShareCalendarUrls, normalizeFamilyShareChildren } from './family-share-utils.js?v=1';
 import { normalizeChatAttachments } from './team-chat-media.js';
@@ -2225,8 +2228,9 @@ function chunkArray(values = [], chunkSize = 10) {
 }
 
 export async function getOfficialsForUsers(users = []) {
-    const { emails, phones } = collectOfficialLookupTargets(users);
-    if (!emails.length && !phones.length) {
+    const normalizedTargets = collectOfficialLookupTargets(users);
+    const queryTargets = collectOfficialLookupQueryTargets(users);
+    if (!normalizedTargets.emails.length && !normalizedTargets.phones.length) {
         return [];
     }
 
@@ -2245,11 +2249,11 @@ export async function getOfficialsForUsers(users = []) {
         });
     };
 
-    const emailQueries = chunkArray(emails).map(async (chunk) => {
+    const emailQueries = chunkArray(queryTargets.emails).map(async (chunk) => {
         const snapshot = await getDocs(query(collectionGroup(db, 'officials'), where('email', 'in', chunk)));
         addSnapshotEntries(snapshot);
     });
-    const phoneQueries = chunkArray(phones).map(async (chunk) => {
+    const phoneQueries = chunkArray(queryTargets.phones).map(async (chunk) => {
         const snapshot = await getDocs(query(collectionGroup(db, 'officials'), where('phone', 'in', chunk)));
         addSnapshotEntries(snapshot);
     });

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -23,7 +23,9 @@ describe('admin dashboard statistics scope', () => {
         expect(adminJs).toContain('getUsersPage: getAdminUsersPage');
         expect(adminJs).toContain('await Promise.all([');
         expect(adminJs).toContain('loadDashboardData()');
-        expect(adminJs).toContain('await ensureAllOfficialsLoaded();');
+        expect(adminJs).toContain('ensureCurrentTeamGamesLoaded()');
+        expect(adminJs).toContain('await ensureCurrentTeamOfficialsLoaded();');
+        expect(adminJs).toContain('await ensureCurrentUsersOfficialsLoaded();');
         expect(adminHtml).toContain('id="teams-pagination-status"');
         expect(adminHtml).toContain('id="users-pagination-status"');
     });

--- a/tests/unit/admin-user-official-links.test.js
+++ b/tests/unit/admin-user-official-links.test.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import {
     buildOfficialLookupCacheKey,
     buildOfficialUserLookup,
+    collectOfficialLookupQueryTargets,
     collectOfficialLookupTargets,
     formatOfficialUserSummary,
     getOfficialUserSummary,
@@ -82,6 +83,10 @@ describe('admin users official links', () => {
             emails: ['ref@one.com', 'other@example.com'],
             phones: ['5551234567']
         });
+        expect(collectOfficialLookupQueryTargets(users)).toEqual({
+            emails: ['Ref@One.com', 'ref@one.com', 'other@example.com'],
+            phones: ['+1 (555) 123-4567', '5551234567']
+        });
         expect(buildOfficialLookupCacheKey(users)).toBe('user-1:ref@one.com:5551234567|user-2:ref@one.com:5551234567|user-3:other@example.com:');
     });
 
@@ -100,6 +105,7 @@ describe('admin users official links', () => {
         expect(adminJs).toContain('loadVisibleOfficialUserLinks(getCurrentUsersPage())');
         expect(adminJs).not.toContain("loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' })");
         expect(dbJs).toContain("collectionGroup(db, 'officials')");
+        expect(dbJs).toContain('collectOfficialLookupQueryTargets');
         expect(dbJs).toContain("where('email', 'in', chunk)");
         expect(adminJs).toContain('buildOfficialUserLookup');
         expect(adminJs).toContain('formatOfficialUserSummary');

--- a/tests/unit/admin-user-official-links.test.js
+++ b/tests/unit/admin-user-official-links.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
+    buildOfficialLookupCacheKey,
     buildOfficialUserLookup,
+    collectOfficialLookupTargets,
     formatOfficialUserSummary,
     getOfficialUserSummary,
     matchesOfficialUserSearch
@@ -69,9 +71,24 @@ describe('admin users official links', () => {
         expect(formatOfficialUserSummary(summary)).toBe('1 team: Falcons');
     });
 
-    it('wires the admin users tab to show and filter official-linked users across every team', () => {
+    it('collects bounded lookup targets from only the visible users slice', () => {
+        const users = [
+            { id: 'user-1', email: ' Ref@One.com ', phone: '+1 (555) 123-4567' },
+            { id: 'user-2', email: 'ref@one.com', phone: '5551234567' },
+            { id: 'user-3', email: 'other@example.com', phone: '' }
+        ];
+
+        expect(collectOfficialLookupTargets(users)).toEqual({
+            emails: ['ref@one.com', 'other@example.com'],
+            phones: ['5551234567']
+        });
+        expect(buildOfficialLookupCacheKey(users)).toBe('user-1:ref@one.com:5551234567|user-2:ref@one.com:5551234567|user-3:other@example.com:');
+    });
+
+    it('wires the admin users tab to show and filter official-linked users for the visible page', () => {
         const adminHtml = readSource('admin.html');
         const adminJs = readSource('js/admin.js');
+        const dbJs = readSource('js/db.js');
 
         expect(adminHtml).toContain('id="filter-users-official-status"');
         expect(adminHtml).toContain('Officials only');
@@ -79,7 +96,11 @@ describe('admin users official links', () => {
         expect(adminHtml).toContain('Official</th>');
 
         expect(adminJs).toContain('getOfficials');
-        expect(adminJs).toContain("loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' })");
+        expect(adminJs).toContain('getOfficialsForUsers');
+        expect(adminJs).toContain('loadVisibleOfficialUserLinks(getCurrentUsersPage())');
+        expect(adminJs).not.toContain("loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' })");
+        expect(dbJs).toContain("collectionGroup(db, 'officials')");
+        expect(dbJs).toContain("where('email', 'in', chunk)");
         expect(adminJs).toContain('buildOfficialUserLookup');
         expect(adminJs).toContain('formatOfficialUserSummary');
         expect(adminJs).toContain('matchesOfficialUserSearch');
@@ -87,12 +108,13 @@ describe('admin users official links', () => {
         expect(adminJs).toContain('inline-flex items-center rounded-full bg-emerald-100');
     });
 
-    it('loads team-page summaries separately from the full users-tab official lookup', () => {
+    it('refreshes team-page and users-page official loaders separately', () => {
         const adminJs = readSource('js/admin.js');
 
         expect(adminJs).toContain("async function ensureCurrentTeamOfficialsLoaded() {");
         expect(adminJs).toContain("await loadOfficialUserLinks(getCurrentTeamPage(), { scope: 'page' });");
-        expect(adminJs).toContain("async function ensureAllOfficialsLoaded() {");
-        expect(adminJs).toContain("await loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' });");
+        expect(adminJs).toContain("async function ensureCurrentUsersOfficialsLoaded() {");
+        expect(adminJs).toContain("await loadVisibleOfficialUserLinks(getCurrentUsersPage());");
+        expect(adminJs).toContain('await ensureCurrentUsersOfficialsLoaded();');
     });
 });


### PR DESCRIPTION
Closes #3090

## What changed
- replaced the Users-tab bootstrap path with a page-scoped official lookup that queries only the currently visible users instead of scanning every team's `officials` subcollection
- added bounded email/phone target collection and cache-key helpers for the visible users slice
- refreshed the users-tab official lookup on user pagination so each page loads only its own official matches
- updated the admin users regression test to fail if the code falls back to `loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' })`
- bumped the admin page cache-bust and verified the critical cache-bust guard

## Root Cause
The admin Users tab reused the full-team official directory loader and awaited `loadOfficialUserLinks(getDashboardTeams(), { scope: 'all' })`, so first render blocked on an O(team_count) fan-out of `getOfficials(teamId)` reads instead of a lookup scoped to the visible users page.

## Prevention / Learning
For paged admin tables, derive enrichment lookups from the visible slice instead of the full dataset. Add a focused regression test that fails if bootstrap work expands from bounded per-page queries back to whole-dataset scans.

## Regression Tests
- `npx vitest run tests/unit/admin-user-official-links.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`

## Recurrence Risk
Low. The users-tab flow now has a dedicated visible-page loader plus regression coverage that rejects the old cross-team bootstrap path.