### PR TITLE
Expand Game Day lineups across Game Plan intervals

### DIFF
--- a/js/game-plan-interop.js
+++ b/js/game-plan-interop.js
@@ -31,17 +31,33 @@ export function normalizeLineupsForGamePlanPlanner(gamePlan) {
 
   const intervals = buildGamePlanIntervals(gamePlan);
   const normalized = {};
+  const currentShapeWholePeriodEntries = [];
+  const currentShapeTimedEntries = [];
   const legacyAndOtherEntries = [];
 
   Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
+    const parsedCurrentShapeKey = parseCurrentShapeKey(key);
     const plannerKeys = plannerKeysForCurrentShapeKey(key, intervals);
     if (plannerKeys.length > 0) {
-      plannerKeys.forEach((plannerKey) => {
-        normalized[plannerKey] = playerId;
-      });
+      const targetEntries = parsedCurrentShapeKey?.time == null
+        ? currentShapeWholePeriodEntries
+        : currentShapeTimedEntries;
+      targetEntries.push([plannerKeys, playerId]);
     } else {
       legacyAndOtherEntries.push([key, playerId]);
     }
+  });
+
+  currentShapeWholePeriodEntries.forEach(([plannerKeys, playerId]) => {
+    plannerKeys.forEach((plannerKey) => {
+      normalized[plannerKey] = playerId;
+    });
+  });
+
+  currentShapeTimedEntries.forEach(([plannerKeys, playerId]) => {
+    plannerKeys.forEach((plannerKey) => {
+      normalized[plannerKey] = playerId;
+    });
   });
 
   legacyAndOtherEntries.forEach(([key, playerId]) => {

--- a/js/game-plan-interop.js
+++ b/js/game-plan-interop.js
@@ -11,18 +11,19 @@ function parseCurrentShapeKey(key) {
   };
 }
 
-function plannerKeyForCurrentShapeKey(key, intervals) {
+function plannerKeysForCurrentShapeKey(key, intervals) {
   const parsed = parseCurrentShapeKey(key);
-  if (!parsed || !Number.isFinite(parsed.periodNum)) return null;
+  if (!parsed || !Number.isFinite(parsed.periodNum)) return [];
 
   const periodIntervals = intervals.filter(interval => interval.period === parsed.periodNum);
-  if (periodIntervals.length === 0) return null;
+  if (periodIntervals.length === 0) return [];
 
-  const interval = parsed.time == null
-    ? periodIntervals[0]
-    : periodIntervals.find(candidate => Number(candidate.time) === parsed.time);
+  if (parsed.time == null) {
+    return periodIntervals.map(interval => `${interval.key}-${parsed.posId}`);
+  }
 
-  return interval ? `${interval.key}-${parsed.posId}` : null;
+  const interval = periodIntervals.find(candidate => Number(candidate.time) === parsed.time);
+  return interval ? [`${interval.key}-${parsed.posId}`] : [];
 }
 
 export function normalizeLineupsForGamePlanPlanner(gamePlan) {
@@ -33,9 +34,11 @@ export function normalizeLineupsForGamePlanPlanner(gamePlan) {
   const legacyAndOtherEntries = [];
 
   Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
-    const plannerKey = plannerKeyForCurrentShapeKey(key, intervals);
-    if (plannerKey) {
-      normalized[plannerKey] = playerId;
+    const plannerKeys = plannerKeysForCurrentShapeKey(key, intervals);
+    if (plannerKeys.length > 0) {
+      plannerKeys.forEach((plannerKey) => {
+        normalized[plannerKey] = playerId;
+      });
     } else {
       legacyAndOtherEntries.push([key, playerId]);
     }

--- a/tests/unit/game-plan-interop.test.js
+++ b/tests/unit/game-plan-interop.test.js
@@ -110,6 +110,25 @@ describe('game plan interop helpers', () => {
     });
   });
 
+  it('preserves timed Game Day assignments when whole-period keys are encountered later', () => {
+    const lineups = normalizeLineupsForGamePlanPlanner({
+      numPeriods: 2,
+      periodDuration: 25,
+      subTimes: [7, 14, 21],
+      lineups: {
+        "H1 14'-keeper": 'timed-player',
+        'H1-keeper': 'whole-period-player'
+      }
+    });
+
+    expect(lineups).toEqual({
+      '1-7-keeper': 'whole-period-player',
+      '1-14-keeper': 'timed-player',
+      '1-21-keeper': 'whole-period-player',
+      '1-25-keeper': 'whole-period-player'
+    });
+  });
+
   it('uses quarter prefixes for 4-period legacy plans', () => {
     const plan = buildRotationPlanFromGamePlan({
       numPeriods: 4,

--- a/tests/unit/game-plan-interop.test.js
+++ b/tests/unit/game-plan-interop.test.js
@@ -53,7 +53,7 @@ describe('game plan interop helpers', () => {
     });
   });
 
-  it('maps Game Day half lineup keys into planner interval keys', () => {
+  it('expands Game Day half lineup keys across every planner interval in that period', () => {
     const lineups = normalizeLineupsForGamePlanPlanner({
       numPeriods: 2,
       periodDuration: 25,
@@ -66,7 +66,13 @@ describe('game plan interop helpers', () => {
 
     expect(lineups).toEqual({
       '1-7-keeper': 'p1',
-      '2-7-striker': 'p2'
+      '1-14-keeper': 'p1',
+      '1-21-keeper': 'p1',
+      '1-25-keeper': 'p1',
+      '2-7-striker': 'p2',
+      '2-14-striker': 'p2',
+      '2-21-striker': 'p2',
+      '2-25-striker': 'p2'
     });
   });
 
@@ -82,7 +88,10 @@ describe('game plan interop helpers', () => {
     });
 
     expect(lineups).toEqual({
-      '1-7-keeper': 'new-player'
+      '1-7-keeper': 'new-player',
+      '1-14-keeper': 'old-player',
+      '1-21-keeper': 'old-player',
+      '1-25-keeper': 'old-player'
     });
   });
 


### PR DESCRIPTION
Closes #3093

## What changed
- Updated `normalizeLineupsForGamePlanPlanner` so Game Day lineup keys without an explicit substitution time expand across every planner interval in that period instead of only the first interval.
- Kept existing explicit planner interval keys authoritative so saved interval-specific edits still override imported whole-period assignments for the same cell.
- Replaced the old first-interval regression with focused unit coverage that asserts full-period expansion and mixed whole-period plus explicit-interval override behavior.

## Root Cause
Game Plan normalization treated Game Day lineup keys like `H1-keeper` as a single planner cell and always mapped them to the first interval for that period. For sports with multiple substitution intervals, that dropped the rest of the saved lineup during import and made later cells appear blank.

## Prevention / Learning
When importing coarser-grained saved lineup data into a finer-grained planner, expand the assignment across every matching interval unless the source key explicitly narrows the time slice. Add regression coverage for both the expansion path and the override path where finer-grained saved data already exists.

## Regression Tests
- `npx vitest run tests/unit/game-plan-interop.test.js --reporter=verbose`
- `tests/unit/game-plan-interop.test.js` now verifies whole-period Game Day assignments populate every interval cell for that period and that explicit planner keys still win for overlapping cells.

## Recurrence Risk
low: the interop helper now centralizes the expansion behavior and the focused unit test locks the exact invariant that regressed here.