### PR TITLE
Skip recipient profile fan-out for roster labels

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1540,26 +1540,35 @@ export async function loadChatRecipientOptions(teamId: string): Promise<ChatReci
       if (!parentKey) return;
       const parentId = getRecipientOptionId(parent.userId ? 'user' : 'email', parentKey);
       const profile = parentProfiles.get(parentId) || {};
-    options.push({
-      id: parentId,
-      name: getChatMemberDisplayName({
-        name: parent.name,
+      options.push({
+        id: parentId,
+        name: getChatMemberDisplayName({
+          name: parent.name,
           fullName: parent.fullName,
           displayName: parent.displayName,
           profileName: profile.name,
           profileFullName: profile.fullName,
-        profileDisplayName: profile.displayName,
-        email: parent.email || profile.email
-      }, 'Guardian'),
-      detail: player.name ? `Guardian for ${player.name}` : 'Guardian',
-      email: compactString(parent.email || profile.email).toLowerCase() || undefined
+          profileDisplayName: profile.displayName,
+          email: parent.email || profile.email
+        }, 'Guardian'),
+        detail: player.name ? `Guardian for ${player.name}` : 'Guardian',
+        email: compactString(parent.email || profile.email).toLowerCase() || undefined
+      });
     });
-  });
   });
 
   const byId = new Map<string, ChatRecipientOption>();
   options.forEach((option) => byId.set(option.id, option));
   return [...byId.values()].sort((a, b) => `${a.name} ${a.detail || ''}`.localeCompare(`${b.name} ${b.detail || ''}`));
+}
+
+function needsChatRecipientProfile(parent: Record<string, any> = {}) {
+  return !getChatMemberDisplayName({
+    name: parent.name,
+    fullName: parent.fullName,
+    displayName: parent.displayName,
+    email: parent.email
+  }, '');
 }
 
 async function loadChatRecipientProfiles(players: any): Promise<Map<string, Record<string, any>>> {
@@ -1572,10 +1581,14 @@ async function loadChatRecipientProfiles(players: any): Promise<Map<string, Reco
       : parent?.email
         ? getRecipientOptionId('email', String(parent.email).trim().toLowerCase())
         : '';
-    if (key && !uniqueParents.has(key)) {
+    if (key && needsChatRecipientProfile(parent) && !uniqueParents.has(key)) {
       uniqueParents.set(key, parent);
     }
   });
+
+  if (!uniqueParents.size) {
+    return new Map();
+  }
 
   const entries = await Promise.all([...uniqueParents.entries()].map(async ([recipientId, parent]) => {
     const userId = compactString(parent?.userId);

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1563,12 +1563,13 @@ export async function loadChatRecipientOptions(teamId: string): Promise<ChatReci
 }
 
 function needsChatRecipientProfile(parent: Record<string, any> = {}) {
-  return !getChatMemberDisplayName({
+  const label = getChatMemberDisplayName({
     name: parent.name,
     fullName: parent.fullName,
     displayName: parent.displayName,
     email: parent.email
   }, '');
+  return !label || label === compactString(parent.email);
 }
 
 async function loadChatRecipientProfiles(players: any): Promise<Map<string, Record<string, any>>> {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1418,6 +1418,22 @@ describe('React app messages integration', () => {
         expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
     });
 
+    it('reuses the mention recipient cache when opening selected members after suggestions load', async () => {
+        const { container } = await renderMessages('/messages/team-1');
+        const composer = container.querySelector('.chat-composer-textarea');
+
+        await setFieldValue(composer, 'Can @co');
+
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
+        expect(container.textContent).toContain('@Coach Jamie');
+
+        await click(container, 'Audience: Full team');
+        await click(container, 'Selected members');
+
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
+        expect(container.textContent).toContain('Coach Jamie');
+    });
+
     it('ignores stale recipient option loads after switching teams', async () => {
         layoutMocks.isDesktopWeb = true;
         const deferredRecipients = createDeferred();

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -110,7 +110,8 @@ describe('React app chat recipient service', () => {
         const options = await loadChatRecipientOptions('team-1');
 
         expect(dbMocks.getUserProfile).not.toHaveBeenCalled();
-        expect(dbMocks.getUserByEmail).not.toHaveBeenCalled();
+        expect(dbMocks.getUserByEmail).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getUserByEmail).toHaveBeenCalledWith('noname@example.com');
         expect(options).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 id: 'user:parent-1',
@@ -175,6 +176,11 @@ describe('React app chat recipient service', () => {
             }
             return null;
         });
+        dbMocks.getUserByEmail.mockImplementation(async (email) => (
+            email === 'casey@example.com'
+                ? { fullName: 'Casey Guardian', email }
+                : null
+        ));
 
         const { loadChatRecipientOptions } = await import('../../apps/app/src/lib/chatService.ts');
         const options = await loadChatRecipientOptions('team-1');
@@ -182,7 +188,8 @@ describe('React app chat recipient service', () => {
         expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(2);
         expect(dbMocks.getUserProfile).toHaveBeenCalledWith('parent-2');
         expect(dbMocks.getUserProfile).toHaveBeenCalledWith('parent-3');
-        expect(dbMocks.getUserByEmail).not.toHaveBeenCalled();
+        expect(dbMocks.getUserByEmail).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getUserByEmail).toHaveBeenCalledWith('casey@example.com');
         expect(options).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 id: 'user:parent-1',
@@ -195,7 +202,8 @@ describe('React app chat recipient service', () => {
             }),
             expect.objectContaining({
                 id: 'email:casey@example.com',
-                name: 'casey@example.com'
+                name: 'Casey Guardian',
+                email: 'casey@example.com'
             }),
             expect.objectContaining({
                 id: 'user:parent-3',

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -77,7 +77,7 @@ beforeEach(() => {
 });
 
 describe('React app chat recipient service', () => {
-    it('hydrates selected member options with profile names and falls back to email', async () => {
+    it('builds selected member options from roster parent data without profile lookups', async () => {
         dbMocks.getPlayers.mockResolvedValue([
             {
                 id: 'player-1',
@@ -87,7 +87,65 @@ describe('React app chat recipient service', () => {
                     {
                         userId: 'parent-1',
                         email: 'pat@example.com',
-                        name: 'pat@example.com'
+                        fullName: 'Pat Parent'
+                    }
+                ]
+            },
+            {
+                id: 'player-2',
+                name: 'Blake',
+                parents: [
+                    {
+                        email: 'casey@example.com',
+                        displayName: 'Casey Guardian'
+                    },
+                    {
+                        email: 'noname@example.com'
+                    }
+                ]
+            }
+        ]);
+
+        const { loadChatRecipientOptions } = await import('../../apps/app/src/lib/chatService.ts');
+        const options = await loadChatRecipientOptions('team-1');
+
+        expect(dbMocks.getUserProfile).not.toHaveBeenCalled();
+        expect(dbMocks.getUserByEmail).not.toHaveBeenCalled();
+        expect(options).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'user:parent-1',
+                name: 'Pat Parent',
+                detail: 'Guardian for Avery',
+                email: 'pat@example.com'
+            }),
+            expect.objectContaining({
+                id: 'email:casey@example.com',
+                name: 'Casey Guardian',
+                detail: 'Guardian for Blake',
+                email: 'casey@example.com'
+            }),
+            expect.objectContaining({
+                id: 'email:noname@example.com',
+                name: 'noname@example.com',
+                detail: 'Guardian for Blake',
+                email: 'noname@example.com'
+            })
+        ]));
+    });
+
+    it('only hydrates parent profiles for roster entries missing a usable label', async () => {
+        dbMocks.getPlayers.mockResolvedValue([
+            {
+                id: 'player-1',
+                name: 'Avery',
+                parents: [
+                    {
+                        userId: 'parent-1',
+                        email: 'pat@example.com',
+                        fullName: 'Pat Parent'
+                    },
+                    {
+                        userId: 'parent-2'
                     }
                 ]
             },
@@ -99,39 +157,54 @@ describe('React app chat recipient service', () => {
                         email: 'casey@example.com'
                     },
                     {
-                        email: 'noname@example.com'
+                        userId: 'parent-3'
+                    },
+                    {
+                        email: 'named@example.com',
+                        name: 'Named Guardian'
                     }
                 ]
             }
         ]);
-        dbMocks.getUserProfile.mockResolvedValue({
-            fullName: 'Pat Parent',
-            email: 'pat@example.com'
+        dbMocks.getUserProfile.mockImplementation(async (userId) => {
+            if (userId === 'parent-2') {
+                return { fullName: 'Morgan Missing', email: 'morgan@example.com' };
+            }
+            if (userId === 'parent-3') {
+                return { fullName: 'Casey Guardian', email: 'casey@example.com' };
+            }
+            return null;
         });
-        dbMocks.getUserByEmail.mockImplementation(async (email) => (
-            email === 'casey@example.com'
-                ? { fullName: 'Casey Guardian', email }
-                : null
-        ));
 
         const { loadChatRecipientOptions } = await import('../../apps/app/src/lib/chatService.ts');
         const options = await loadChatRecipientOptions('team-1');
 
+        expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getUserProfile).toHaveBeenCalledWith('parent-2');
+        expect(dbMocks.getUserProfile).toHaveBeenCalledWith('parent-3');
+        expect(dbMocks.getUserByEmail).not.toHaveBeenCalled();
         expect(options).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 id: 'user:parent-1',
-                name: 'Pat Parent',
-                detail: 'Guardian for Avery'
+                name: 'Pat Parent'
+            }),
+            expect.objectContaining({
+                id: 'user:parent-2',
+                name: 'Morgan Missing',
+                email: 'morgan@example.com'
             }),
             expect.objectContaining({
                 id: 'email:casey@example.com',
-                name: 'Casey Guardian',
-                detail: 'Guardian for Blake'
+                name: 'casey@example.com'
             }),
             expect.objectContaining({
-                id: 'email:noname@example.com',
-                name: 'noname@example.com',
-                detail: 'Guardian for Blake'
+                id: 'user:parent-3',
+                name: 'Casey Guardian',
+                email: 'casey@example.com'
+            }),
+            expect.objectContaining({
+                id: 'email:named@example.com',
+                name: 'Named Guardian'
             })
         ]));
     });


### PR DESCRIPTION
Closes #3094

## What changed
- updated `loadChatRecipientOptions` to build parent recipient labels directly from roster `name` / `fullName` / `displayName` / `email` data and only hydrate profiles for parent records that still lack any usable label
- kept the existing recipient ordering and deduplication behavior while preserving profile fallback for truly incomplete parent entries
- added unit coverage proving roster-complete parents trigger zero `getUserProfile` / `getUserByEmail` calls and that only missing-label parents are hydrated
- added integration coverage proving mention suggestions and the Selected members audience picker reuse the same cached recipient load path

## Root Cause
`loadChatRecipientOptions` always awaited `loadChatRecipientProfiles` for every unique parent before returning any options. That put recipient rendering behind an unconditional per-parent profile fan-out even when roster data already had enough display information to render the audience picker and mention suggestions.

## Prevention / Learning
For recipient pickers, mention suggestions, and similar secondary UI data, treat roster or already-loaded route data as the critical render source. Only hydrate the subset of records that truly lacks a usable label, and keep enrichment work off the first-paint path unless the UI cannot render without it.

## Regression Tests
- `npx vitest run tests/unit/app-chat-service-recipients.test.js tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- `tests/unit/app-chat-service-recipients.test.js` now asserts roster-complete parents render with zero profile lookups and missing-label parents are the only hydrated subset
- `tests/unit/app-chat-messages-integration.test.jsx` now asserts mention suggestions and Selected members reuse a single cached recipient load path