### PR TITLE
Reuse parent team lookup for collection-group game reads

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -549,10 +549,12 @@ service cloud.firestore {
     }
 
     function canReadCollectionGroupGameDocument(teamPath, data) {
-      return exists(/databases/$(database)/documents/$(teamPath)) &&
+      let parentTeamPath = /databases/$(database)/documents/$(teamPath);
+      let parentTeam = get(parentTeamPath).data;
+      return parentTeam != null &&
              (
-               canReadManagedTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data) ||
-               canReadPublicGameDocument(get(/databases/$(database)/documents/$(teamPath)).data, data)
+               canReadManagedTeamDocument(parentTeam) ||
+               canReadPublicGameDocument(parentTeam, data)
              );
     }
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -33,6 +33,7 @@ export function validateFirebaseRulesCi() {
     const firestoreRules = readText('firestore.rules');
     const storageRules = readText('storage.rules');
     const legacyGameClipRules = extractMatchBlock(storageRules, 'match /game-clips/{fileName} {');
+    const collectionGroupGamesHelper = (firestoreRules.match(/function canReadCollectionGroupGameDocument\(teamPath, data\) \{[\s\S]*?\n\s*}/) || [''])[0];
     const gameEventsRules = (firestoreRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const aggregatedStatsRules = (firestoreRules.match(/match \/aggregatedStats\/\{statId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const deployProd = readText('.github/workflows/deploy-prod.yml');
@@ -60,6 +61,15 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'function canReadGameDocument(teamId, gameId, data)', 'Firestore game visibility helper');
     assertIncludes(firestoreRules, 'function canReadGameSubcollectionDocument(teamId, gameId)', 'Firestore game subcollection visibility helper');
     assertIncludes(firestoreRules, 'function canReadCollectionGroupGameDocument(teamPath, data)', 'Firestore collection-group game visibility helper');
+    assertIncludes(collectionGroupGamesHelper, 'let parentTeamPath = /databases/$(database)/documents/$(teamPath);', 'Firestore collection-group team path reuse');
+    assertIncludes(collectionGroupGamesHelper, 'let parentTeam = get(parentTeamPath).data;', 'Firestore collection-group parent team lookup reuse');
+    assertIncludes(collectionGroupGamesHelper, 'return parentTeam != null &&', 'Firestore collection-group parent team existence guard');
+    if ((collectionGroupGamesHelper.match(/get\(parentTeamPath\)/g) || []).length !== 1) {
+        throw new Error('Firestore collection-group game visibility helper must resolve the parent team document exactly once.');
+    }
+    if (collectionGroupGamesHelper.includes('exists(parentTeamPath)')) {
+        throw new Error('Firestore collection-group game visibility helper must not re-read the parent team document with exists(parentTeamPath).');
+    }
     assertIncludes(firestoreRules, 'allow read: if canReadGameDocument(teamId, gameId, resource.data);', 'Firestore team game read rules');
     assertIncludes(firestoreRules, 'allow read: if canReadGameSubcollectionDocument(teamId, gameId);', 'Firestore game subcollection read rules');
     assertIncludes(firestoreRules, 'allow read: if canReadCollectionGroupGameDocument(path, resource.data);', 'Firestore collection-group game read rules');

--- a/tests/unit/game-read-rules.test.js
+++ b/tests/unit/game-read-rules.test.js
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
-const collectionGroupGamesMatch = rules.match(/match \/{path=\*\*}\/games\/\{gameId} \{[\s\S]*?\n\s*}/);
+const collectionGroupGamesHelperMatch = rules.match(/function canReadCollectionGroupGameDocument\(teamPath, data\) \{[\s\S]*?\n\s*}/);
+const collectionGroupGamesHelper = collectionGroupGamesHelperMatch?.[0] || '';
+const collectionGroupGamesMatch = rules.match(/match \/\{path=\*\*}\/games\/\{gameId} \{[\s\S]*?\n\s*}/);
 const collectionGroupGamesRules = collectionGroupGamesMatch?.[0] || '';
 const teamGamesStart = rules.indexOf('match /games/{gameId} {');
 const teamGamesEnd = rules.indexOf('// Live Events subcollection - for real-time game broadcasting', teamGamesStart);
@@ -41,7 +43,15 @@ describe('game Firestore read rules', () => {
         expect(rules).toContain("isPublicGameReadTeam(teamData) || isShareableGameDocument(data)");
         expect(rules).toContain("data.get('shareable', false) == true");
         expect(rules).toContain("data.get('publicCalendar', false) == true");
-        expect(rules).toContain('canReadManagedTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data)');
+        expect(collectionGroupGamesHelper).toContain('let parentTeamPath = /databases/$(database)/documents/$(teamPath);');
+        expect(collectionGroupGamesHelper).toContain('let parentTeam = get(parentTeamPath).data;');
+        expect(collectionGroupGamesHelper).toContain('return parentTeam != null &&');
+        expect(collectionGroupGamesHelper).toContain('canReadManagedTeamDocument(parentTeam)');
+        expect(collectionGroupGamesHelper).toContain('canReadPublicGameDocument(parentTeam, data)');
+        expect(collectionGroupGamesHelper).not.toContain('canReadManagedTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data)');
+        expect(collectionGroupGamesHelper).not.toContain('canReadPublicGameDocument(get(/databases/$(database)/documents/$(teamPath)).data, data)');
+        expect(collectionGroupGamesHelper.match(/get\(parentTeamPath\)/g) || []).toHaveLength(1);
+        expect(collectionGroupGamesHelper).not.toContain('exists(parentTeamPath)');
         expect(rules).not.toContain('canReadTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data)');
     });
 


### PR DESCRIPTION
Closes #3098

## What changed
- Refactored `canReadCollectionGroupGameDocument(teamPath, data)` in `firestore.rules` to resolve the parent team document once, store it in a local variable, and reuse that map for both managed-team and public-game authorization checks.
- Added a focused unit regression in `tests/unit/game-read-rules.test.js` that asserts the helper uses one shared parent-team lookup and does not fall back to duplicated inline `get(...).data` calls or an `exists(...)` re-read.
- Strengthened `scripts/validate-firebase-rules-ci.mjs` so CI fails if the collection-group games helper stops reusing the single parent-team lookup.

## Root Cause
The collection-group games read helper duplicated the same parent-team document fetch across both authorization branches and also used a separate existence check. On homepage cross-team `collectionGroup('games')` queries, that forced repeated rule lookups of the same parent team document for each game result.

## Prevention / Learning
When a Firestore rule helper needs the same cross-document data for multiple auth branches, resolve it once into a local variable and pass that shared map through the checks. Regression coverage should assert the lookup count and helper shape, not the old inlined access pattern.

## Regression Tests
- `npx vitest run tests/unit/game-read-rules.test.js --reporter=verbose`
- `node scripts/validate-firebase-rules-ci.mjs`