### PR TITLE
Render alerts controls before team preferences finish loading

### DIFF
--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -15,7 +15,7 @@ const authServiceMocks = vi.hoisted(() => ({
 
 const profileServiceMocks = vi.hoisted(() => ({
   createProfileAccessCode: vi.fn(async () => 'CODE1234'),
-  loadNotificationPreferences: vi.fn(async () => ({ liveChat: true, liveScore: false, schedule: true })),
+  loadNotificationPreferences: vi.fn(async (_userId: string, _teamId: string) => ({ liveChat: true, liveScore: false, schedule: true })),
   loadNotificationTeams: vi.fn(async () => ([{ id: 'team-1', name: 'Blue Team' }])),
   loadParentTeams: vi.fn(async () => ([{ id: 'team-1', name: 'Blue Team' }])),
   loadProfileAccessCodes: vi.fn(async () => []),

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Profile } from './Profile';
@@ -119,6 +119,16 @@ function renderProfile(initialEntry = '/profile') {
   );
 }
 
+function createDeferredPromise<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('Profile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -164,5 +174,31 @@ describe('Profile', () => {
     expect(await screen.findByText('No codes generated yet.')).toBeTruthy();
     expect(screen.queryByText('Unable to load invite history.')).toBeNull();
     expect(profileServiceMocks.loadProfileAccessCodesPage).toHaveBeenCalledWith('user-1', { pageSize: 3 });
+  });
+
+  it('renders alerts team controls before the first team preferences finish loading', async () => {
+    const preferencesRequest = createDeferredPromise<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([{ id: 'team-1', name: 'Blue Team' }]);
+    profileServiceMocks.loadNotificationPreferences.mockImplementation(() => preferencesRequest.promise);
+
+    renderProfile('/profile?section=alerts');
+
+    expect(await screen.findByText('Notification preferences')).toBeTruthy();
+    expect(await screen.findByRole('combobox')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Enable push on this device' })).toBeTruthy();
+    expect(screen.getByText('Loading alerts for Blue Team…')).toBeTruthy();
+    expect(screen.queryByText('Loading your alert teams…')).toBeNull();
+
+    await waitFor(() => {
+      expect(profileServiceMocks.loadNotificationTeams).toHaveBeenCalledTimes(1);
+      expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1);
+      expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1');
+    });
+
+    preferencesRequest.resolve({ liveChat: true, liveScore: false, schedule: true });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading alerts for Blue Team…')).toBeNull();
+    });
   });
 });

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Profile } from './Profile';
@@ -200,5 +200,51 @@ describe('Profile', () => {
     await waitFor(() => {
       expect(screen.queryByText('Loading alerts for Blue Team…')).toBeNull();
     });
+  });
+
+  it('ignores stale initial alert preferences after switching teams mid-load', async () => {
+    const firstTeamPreferences = createDeferredPromise<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
+    const secondTeamPreferences = createDeferredPromise<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([
+      { id: 'team-1', name: 'Blue Team' },
+      { id: 'team-2', name: 'Gold Team' }
+    ]);
+    profileServiceMocks.loadNotificationPreferences.mockImplementation((_userId: string, teamId: string) => {
+      if (teamId === 'team-1') {
+        return firstTeamPreferences.promise;
+      }
+      return secondTeamPreferences.promise;
+    });
+
+    renderProfile('/profile?section=alerts');
+
+    const teamSelect = await screen.findByRole('combobox');
+    await waitFor(() => {
+      expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1');
+    });
+
+    fireEvent.change(teamSelect, { target: { value: 'team-2' } });
+
+    await waitFor(() => {
+      expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-2');
+    });
+
+    secondTeamPreferences.resolve({ liveChat: false, liveScore: true, schedule: true });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Live Chat')).toBeTruthy();
+    });
+    expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByLabelText('Schedule Changes') as HTMLInputElement).checked).toBe(true);
+
+    firstTeamPreferences.resolve({ liveChat: true, liveScore: false, schedule: false });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Loading alerts for Gold Team…')).toBeNull();
+    });
+    expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByLabelText('Schedule Changes') as HTMLInputElement).checked).toBe(true);
   });
 });

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -396,9 +396,9 @@ export function Profile({ auth }: { auth: AuthState }) {
           }
           return initialTeamId;
         });
+        setNotificationTeamsLoaded(true);
 
         if (!initialTeamId) {
-          setNotificationTeamsLoaded(true);
           return;
         }
 
@@ -419,10 +419,6 @@ export function Profile({ auth }: { auth: AuthState }) {
             const message = getLoadErrorMessage(error, 'Unable to load notification preferences.');
             setNotificationPreferenceErrorsByTeamId((current) => ({ ...current, [initialTeamId]: message }));
             setNotificationStatus({ message: 'Unable to load notification preferences.', tone: 'error' });
-          }
-        } finally {
-          if (!cancelled) {
-            setNotificationTeamsLoaded(true);
           }
         }
       } catch (error) {

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -149,6 +149,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const photoFileRef = useRef<File | null>(null);
   const photoUrlRef = useRef('');
   const photoChangedRef = useRef(false);
+  const selectedTeamIdRef = useRef('');
 
   const revokeOwnedPhotoPreviewUrl = () => {
     const activePreviewUrl = ownedPhotoPreviewUrlRef.current;
@@ -241,6 +242,10 @@ export function Profile({ auth }: { auth: AuthState }) {
       revokeOwnedPhotoPreviewUrl();
     };
   }, []);
+
+  useEffect(() => {
+    selectedTeamIdRef.current = selectedTeamId;
+  }, [selectedTeamId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -405,13 +410,15 @@ export function Profile({ auth }: { auth: AuthState }) {
         try {
           const firstPrefs = await loadNotificationPreferencesOnce(user.uid, initialTeamId);
           if (!cancelled) {
-            setNotificationPreferences(firstPrefs);
+            if (selectedTeamIdRef.current === initialTeamId) {
+              setNotificationPreferences(firstPrefs);
+              setLoadedNotificationTeamId(initialTeamId);
+            }
             setNotificationPreferencesByTeamId((current) => ({ ...current, [initialTeamId]: firstPrefs }));
             setNotificationPreferenceErrorsByTeamId((current) => {
               const { [initialTeamId]: _ignored, ...rest } = current;
               return rest;
             });
-            setLoadedNotificationTeamId(initialTeamId);
           }
         } catch (error) {
           // Don't set loadedNotificationTeamId on error so loadPreferences effect can retry

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -408,7 +408,7 @@ describe('Profile invites', () => {
     refreshDeferred.resolve();
   });
 
-  it('keeps alerts in the loading state until the first team preferences hydrate', async () => {
+  it('renders team controls as soon as alert teams load, then hydrates preferences in place', async () => {
     const deferredTeams = createDeferred<Array<{ id: string; name: string }>>();
     const deferredPreferences = createDeferred<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
     profileServiceMocks.loadNotificationTeams.mockReturnValue(deferredTeams.promise);
@@ -427,16 +427,17 @@ describe('Profile invites', () => {
     deferredTeams.resolve([{ id: 'team-1', name: 'Blue Team' }]);
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
-    expect(screen.getByText('Loading your alert teams…')).toBeTruthy();
-    expect(screen.queryByLabelText('Team')).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Turn on game-day alerts' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Save preferences' })).toBeNull();
+    await waitFor(() => expect((screen.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-1'));
+    expect(screen.queryByText('Loading your alert teams…')).toBeNull();
+    expect(await screen.findByRole('button', { name: 'Enable push on this device' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Turn on game-day alerts' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Save preferences' })).toBeTruthy();
+    expect(screen.getByText('Loading alerts for Blue Team…')).toBeTruthy();
 
     deferredPreferences.resolve({ liveChat: true, liveScore: false, schedule: true });
 
-    await waitFor(() => expect((screen.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-1'));
-    expect(await screen.findByRole('button', { name: 'Turn on game-day alerts' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Save preferences' })).toBeTruthy();
+    await waitFor(() => expect(screen.queryByText('Loading alerts for Blue Team…')).toBeNull());
+    expect(screen.getByLabelText('Live Chat')).toBeTruthy();
   });
 
   it('shows an empty state when no alert teams are available', async () => {


### PR DESCRIPTION
Closes #3100

## What changed
- flipped `notificationTeamsLoaded` to `true` immediately after the alerts team list resolves and the initial team is selected
- kept the first team preference fetch running in the background so the existing localized `Customize alerts` loader hydrates team toggles without blocking the rest of the Alerts tab
- added a regression test that holds the first preference request open and verifies the team selector, device push CTA, and localized team-loading state render before preferences finish loading

## Root Cause
The Alerts page used `notificationTeamsLoaded` for two different stages: team-list readiness and first-team preference hydration. Because that flag did not flip until after `loadNotificationPreferences()` finished, the whole section stayed behind the global loading blocker even after the team list and selected team were already known.

## Prevention / Learning
Do not reuse one route-level loading flag for both first-paint data and follow-up entity hydration. When a page can progressively render, promote the minimum data needed for interaction into its own readiness state and keep secondary async work behind localized loaders.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/Profile.test.tsx --reporter=verbose`
- `src/pages/Profile.test.tsx`: delays the initial `loadNotificationPreferences()` call, then asserts the Alerts team selector and push controls render immediately while `Customize alerts` shows the localized `Loading alerts for Blue Team…` state and only one initial preference fetch is issued