### PR TITLE
Add native standings table to team detail

### DIFF
--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -97,12 +97,14 @@ vi.mock('./nativeRestLogging', () => ({ sanitizeErrorForLogging: vi.fn((error) =
 
 import {
   __resetTeamDetailBaseSnapshotCacheForTests,
+  buildTeamDetailModel,
   createStatTrackerConfigForApp,
   loadTeamTrackingAdmin,
   saveTeamTrackingItemForApp,
   setPlayerTrackingStatusForApp,
   updateTeamSettingsForApp
 } from './teamDetailService';
+import { computeNativeStandings } from '../../../../js/native-standings.js';
 
 describe('createStatTrackerConfigForApp', () => {
   beforeEach(() => {
@@ -308,5 +310,84 @@ describe('tracking admin helpers', () => {
       updatedBy: 'coach-1',
       updatedByEmail: 'coach@example.com'
     }));
+  });
+});
+
+describe('buildTeamDetailModel standings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes completed non-practice games into native standings and preserves the returned current row', () => {
+    vi.mocked(computeNativeStandings).mockReturnValue([
+      { rank: 1, team: 'Bears', w: 1, l: 0, t: 0, points: 2 },
+      { rank: 2, team: 'Lions', w: 0, l: 1, t: 0, points: 0 }
+    ]);
+
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: {
+        id: 'team-1',
+        name: 'Bears',
+        sport: 'Basketball',
+        standingsConfig: {
+          enabled: true,
+          rankingMode: 'points'
+        }
+      },
+      players: [],
+      configs: [],
+      games: [
+        {
+          id: 'game-1',
+          type: 'game',
+          opponent: 'Lions',
+          isHome: true,
+          homeScore: 42,
+          awayScore: 35,
+          status: 'completed',
+          date: new Date('2026-06-20T10:00:00Z')
+        },
+        {
+          id: 'practice-1',
+          type: 'practice',
+          opponent: '',
+          status: 'completed',
+          date: new Date('2026-06-21T10:00:00Z')
+        },
+        {
+          id: 'game-2',
+          type: 'game',
+          opponent: 'Tigers',
+          isHome: true,
+          homeScore: null,
+          awayScore: null,
+          status: 'scheduled',
+          date: new Date('2026-06-22T10:00:00Z')
+        }
+      ]
+    });
+
+    expect(computeNativeStandings).toHaveBeenCalledWith([
+      {
+        homeTeam: 'Bears',
+        awayTeam: 'Lions',
+        homeScore: 42,
+        awayScore: 35,
+        status: 'completed'
+      },
+      {
+        homeTeam: 'Bears',
+        awayTeam: 'Tigers',
+        homeScore: null,
+        awayScore: null,
+        status: 'scheduled'
+      }
+    ], {
+      enabled: true,
+      rankingMode: 'points'
+    });
+    expect(built.standings.rows).toHaveLength(2);
+    expect(built.standings.currentRow).toEqual(expect.objectContaining({ team: 'Bears', rank: 1 }));
   });
 });

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -342,10 +342,10 @@ describe('TeamDetail', () => {
     const standingsRows = [
       { rank: 1, team: 'Lions', w: 8, l: 1, t: 0, points: 16 },
       { rank: 2, team: 'Tigers', w: 7, l: 2, t: 0, points: 14 },
-      { rank: 3, team: 'Bears', w: 6, l: 3, t: 0, points: 12 },
-      { rank: 4, team: 'Wolves', w: 5, l: 4, t: 0, points: 10 },
-      { rank: 5, team: 'Hawks', w: 4, l: 5, t: 0, points: 8 },
-      { rank: 6, team: 'Falcons', w: 3, l: 6, t: 0, points: 6 }
+      { rank: 3, team: 'Wolves', w: 6, l: 3, t: 0, points: 12 },
+      { rank: 4, team: 'Hawks', w: 5, l: 4, t: 0, points: 10 },
+      { rank: 5, team: 'Falcons', w: 4, l: 5, t: 0, points: 8 },
+      { rank: 6, team: 'Bears', w: 3, l: 6, t: 0, points: 6 }
     ];
     teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
       ...model,
@@ -353,7 +353,7 @@ describe('TeamDetail', () => {
         enabled: true,
         label: 'Points table',
         rows: standingsRows,
-        currentRow: standingsRows[2]
+        currentRow: standingsRows[5]
       }
     });
 
@@ -370,8 +370,8 @@ describe('TeamDetail', () => {
     expect(screen.getByRole('columnheader', { name: 'Record' })).toBeTruthy();
     expect(screen.getByRole('columnheader', { name: 'PTS' })).toBeTruthy();
     expect(screen.getByText('Lions')).toBeTruthy();
-    expect(screen.getByText('Hawks')).toBeTruthy();
     expect(screen.queryByText('Falcons')).toBeNull();
+    expect(screen.getByText('Bears')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Show 1 more team' })).toBeTruthy();
 
     const currentTeamCell = screen.getAllByText('Bears').find((element) => element.tagName === 'TD');
@@ -381,6 +381,35 @@ describe('TeamDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Show 1 more team' }));
     expect(await screen.findByText('Falcons')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Show fewer teams' })).toBeTruthy();
+  });
+
+  it('shows win percentage as the standings context column when the standings label is win percentage', async () => {
+    const standingsRows = [
+      { rank: 1, team: 'Lions', w: 8, l: 1, t: 0, points: 16, winPct: 0.889 },
+      { rank: 2, team: 'Bears', w: 6, l: 3, t: 0, points: 12, winPct: 0.667 }
+    ];
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      standings: {
+        enabled: true,
+        label: 'Win percentage',
+        rows: standingsRows,
+        currentRow: standingsRows[1]
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'PCT' })).toBeTruthy();
+    expect(screen.queryByRole('columnheader', { name: 'PTS' })).toBeNull();
+    expect(screen.getByText('0.667')).toBeTruthy();
   });
 
   it('falls back to the external league page when native standings rows are unavailable', async () => {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -338,6 +338,66 @@ describe('TeamDetail', () => {
     expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
   });
 
+  it('renders native standings rows with the current team highlight and expandable overflow', async () => {
+    const standingsRows = [
+      { rank: 1, team: 'Lions', w: 8, l: 1, t: 0, points: 16 },
+      { rank: 2, team: 'Tigers', w: 7, l: 2, t: 0, points: 14 },
+      { rank: 3, team: 'Bears', w: 6, l: 3, t: 0, points: 12 },
+      { rank: 4, team: 'Wolves', w: 5, l: 4, t: 0, points: 10 },
+      { rank: 5, team: 'Hawks', w: 4, l: 5, t: 0, points: 8 },
+      { rank: 6, team: 'Falcons', w: 3, l: 6, t: 0, points: 6 }
+    ];
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      standings: {
+        enabled: true,
+        label: 'Points table',
+        rows: standingsRows,
+        currentRow: standingsRows[2]
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Rank' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Record' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'PTS' })).toBeTruthy();
+    expect(screen.getByText('Lions')).toBeTruthy();
+    expect(screen.getByText('Hawks')).toBeTruthy();
+    expect(screen.queryByText('Falcons')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Show 1 more team' })).toBeTruthy();
+
+    const currentTeamCell = screen.getAllByText('Bears').find((element) => element.tagName === 'TD');
+    const currentTeamRow = currentTeamCell?.closest('tr');
+    expect(currentTeamRow?.getAttribute('aria-current')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show 1 more team' }));
+    expect(await screen.findByText('Falcons')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Show fewer teams' })).toBeTruthy();
+  });
+
+  it('falls back to the external league page when native standings rows are unavailable', async () => {
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    const leagueLinks = screen.getAllByRole('link', { name: 'League page' });
+    expect(leagueLinks.some((link) => link.getAttribute('href') === 'https://league.example.test/standings')).toBe(true);
+    expect(screen.getByText('Open the league page for current standings.')).toBeTruthy();
+  });
+
   it('lets team staff deactivate and reactivate players from the roster tab', async () => {
     const managedModel = {
       ...model,

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -494,9 +494,12 @@ function StandingsSection({ model }: { model: TeamDetailModel }) {
   const [expanded, setExpanded] = useState(false);
   const rows = Array.isArray(model.standings.rows) ? model.standings.rows : [];
   const hasRows = rows.length > 0;
-  const visibleRows = expanded ? rows : rows.slice(0, initialStandingsRowLimit);
-  const hasMoreRows = rows.length > initialStandingsRowLimit;
   const highlightKey = getStandingsRowKey(model.standings.currentRow);
+  const highlightedRowIndex = rows.findIndex((row) => getStandingsRowKey(row) === highlightKey);
+  const visibleRows = expanded
+    ? rows
+    : getCollapsedStandingsRows(rows, highlightedRowIndex, initialStandingsRowLimit);
+  const hasMoreRows = rows.length > initialStandingsRowLimit;
   const contextColumn = getStandingsContextColumn(rows, model.standings.label);
 
   if (!hasRows && !model.team.leagueUrl) {
@@ -2827,10 +2830,30 @@ function formatStandingsRecord(row: Record<string, any> | null | undefined) {
   return `${wins ?? 0}-${losses ?? 0}${ties ? `-${ties}` : ''}`;
 }
 
+function getCollapsedStandingsRows(rows: Array<Record<string, any>>, highlightedRowIndex: number, limit: number) {
+  if (rows.length <= limit || highlightedRowIndex < 0 || highlightedRowIndex < limit) {
+    return rows.slice(0, limit);
+  }
+  return rows.slice(0, Math.max(limit - 1, 0)).concat(rows[highlightedRowIndex]);
+}
+
 function getStandingsContextColumn(rows: Array<Record<string, any>> = [], label = '') {
   const safeRows = Array.isArray(rows) ? rows : [];
+  const normalizedLabel = label.toLowerCase();
+  if (normalizedLabel.includes('win percentage')) {
+    return {
+      label: 'PCT',
+      value: (row: Record<string, any>) => {
+        const winPct = row?.winPct;
+        if (typeof winPct === 'number' && Number.isFinite(winPct)) return winPct.toFixed(3);
+        const stringPct = cleanStandingsCell(winPct);
+        return stringPct || '—';
+      }
+    };
+  }
+
   const hasPoints = safeRows.some((row) => toStandingsNumber(row?.points) !== null);
-  if (hasPoints || label.toLowerCase().includes('points')) {
+  if (hasPoints || normalizedLabel.includes('points')) {
     return {
       label: 'PTS',
       value: (row: Record<string, any>) => formatStandingsCellValue(toStandingsNumber(row?.points))

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -45,6 +45,7 @@ type RosterAiImportModule = typeof import('../lib/rosterAiImport');
 type RosterAiImportPreviewRow = import('../lib/rosterAiImport').RosterAiImportPreviewRow;
 
 let rosterAiImportModulePromise: Promise<RosterAiImportModule> | null = null;
+const initialStandingsRowLimit = 5;
 
 const tabs: Array<{ id: TeamTab; label: string; icon: LucideIcon }> = [
   { id: 'overview', label: 'Overview', icon: Trophy },
@@ -462,6 +463,8 @@ function OverviewTab({ model }: { model: TeamDetailModel }) {
         <InfoCard icon={BarChart3} title="Standings" value={getStandingValue(model)} detail={getStandingDetail(model)} href={model.team.leagueUrl || undefined} />
       </section>
 
+      <StandingsSection model={model} />
+
       <section className="app-card p-4">
         <div className="flex items-start justify-between gap-3">
           <div>
@@ -484,6 +487,80 @@ function OverviewTab({ model }: { model: TeamDetailModel }) {
 
       <TeamPassCard model={model} />
     </div>
+  );
+}
+
+function StandingsSection({ model }: { model: TeamDetailModel }) {
+  const [expanded, setExpanded] = useState(false);
+  const rows = Array.isArray(model.standings.rows) ? model.standings.rows : [];
+  const hasRows = rows.length > 0;
+  const visibleRows = expanded ? rows : rows.slice(0, initialStandingsRowLimit);
+  const hasMoreRows = rows.length > initialStandingsRowLimit;
+  const highlightKey = getStandingsRowKey(model.standings.currentRow);
+  const contextColumn = getStandingsContextColumn(rows, model.standings.label);
+
+  if (!hasRows && !model.team.leagueUrl) {
+    return null;
+  }
+
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Standings</div>
+          <div className="mt-1 text-xs font-semibold text-gray-500">
+            {hasRows ? 'Quick league snapshot with the current team highlighted.' : 'Open the league page for current standings.'}
+          </div>
+        </div>
+        {model.team.leagueUrl ? <a href={model.team.leagueUrl} className="secondary-button !min-h-9 text-xs" target="_blank" rel="noreferrer">League page</a> : null}
+      </div>
+
+      {hasRows ? (
+        <>
+          <div className="mt-3 overflow-x-auto rounded-xl border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-left">
+              <thead className="bg-gray-50">
+                <tr className="text-[11px] font-black uppercase tracking-[0.04em] text-gray-500">
+                  <th className="px-3 py-2.5">Rank</th>
+                  <th className="px-3 py-2.5">Team</th>
+                  <th className="px-3 py-2.5">Record</th>
+                  <th className="px-3 py-2.5">{contextColumn.label}</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {visibleRows.map((row) => {
+                  const isHighlighted = getStandingsRowKey(row) === highlightKey;
+                  return (
+                    <tr
+                      key={getStandingsRowKey(row)}
+                      className={isHighlighted ? 'bg-primary-50/70' : 'bg-white'}
+                      aria-current={isHighlighted ? 'true' : undefined}
+                    >
+                      <td className={`whitespace-nowrap px-3 py-2.5 text-sm ${isHighlighted ? 'font-black text-primary-800' : 'font-semibold text-gray-700'}`}>{formatStandingsRank(row)}</td>
+                      <td className={`whitespace-nowrap px-3 py-2.5 text-sm ${isHighlighted ? 'font-black text-primary-800' : 'font-semibold text-gray-900'}`}>{getStandingsTeamName(row)}</td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-sm font-semibold text-gray-700">{formatStandingsRecord(row)}</td>
+                      <td className="whitespace-nowrap px-3 py-2.5 text-sm font-semibold text-gray-700">{contextColumn.value(row)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 flex items-center justify-between gap-3">
+            <div className="text-xs font-semibold text-gray-500">Computed from completed in-app games.</div>
+            {hasMoreRows ? (
+              <button type="button" className="secondary-button !min-h-9 text-xs" onClick={() => setExpanded((current) => !current)}>
+                {expanded ? 'Show fewer teams' : `Show ${rows.length - initialStandingsRowLimit} more team${rows.length - initialStandingsRowLimit === 1 ? '' : 's'}`}
+              </button>
+            ) : null}
+          </div>
+        </>
+      ) : (
+        <div className="mt-3 rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">
+          No in-app standings rows yet.
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -2715,14 +2792,83 @@ function formatRecord(record: TeamDetailModel['record']) {
 function getStandingValue(model: TeamDetailModel) {
   const row = model.standings.currentRow;
   if (!row) return model.team.leagueUrl ? 'League link' : 'Not set';
-  return row.record || `${row.w || 0}-${row.l || 0}${row.t ? `-${row.t}` : ''}`;
+  return formatStandingsRecord(row);
 }
 
 function getStandingDetail(model: TeamDetailModel) {
   const row = model.standings.currentRow;
   if (!row) return model.team.leagueUrl ? 'Open league page for standings' : 'No standings configured';
   const rank = typeof row.rank === 'number' ? `#${row.rank}` : model.standings.label;
-  return `${rank} · PF ${row.pf || 0} · PA ${row.pa || 0}`;
+  const contextColumn = getStandingsContextColumn(model.standings.rows, model.standings.label);
+  return `${rank} · ${contextColumn.label} ${contextColumn.value(row)}`;
+}
+
+function getStandingsRowKey(row: Record<string, any> | null | undefined) {
+  if (!row) return 'current-row';
+  return `${cleanStandingsCell(row.team) || 'team'}::${cleanStandingsCell(row.rank) || 'rank'}`;
+}
+
+function getStandingsTeamName(row: Record<string, any> | null | undefined) {
+  return cleanStandingsCell(row?.team) || '—';
+}
+
+function formatStandingsRank(row: Record<string, any> | null | undefined) {
+  return typeof row?.rank === 'number' ? `#${row.rank}` : '—';
+}
+
+function formatStandingsRecord(row: Record<string, any> | null | undefined) {
+  if (!row) return '—';
+  const explicitRecord = cleanStandingsCell(row.record);
+  if (explicitRecord) return explicitRecord;
+  const wins = toStandingsNumber(row.w);
+  const losses = toStandingsNumber(row.l);
+  const ties = toStandingsNumber(row.t);
+  if (wins === null && losses === null && ties === null) return '—';
+  return `${wins ?? 0}-${losses ?? 0}${ties ? `-${ties}` : ''}`;
+}
+
+function getStandingsContextColumn(rows: Array<Record<string, any>> = [], label = '') {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const hasPoints = safeRows.some((row) => toStandingsNumber(row?.points) !== null);
+  if (hasPoints || label.toLowerCase().includes('points')) {
+    return {
+      label: 'PTS',
+      value: (row: Record<string, any>) => formatStandingsCellValue(toStandingsNumber(row?.points))
+    };
+  }
+
+  const hasGoalsForAgainst = safeRows.some((row) => toStandingsNumber(row?.pf) !== null || toStandingsNumber(row?.pa) !== null);
+  if (hasGoalsForAgainst) {
+    return {
+      label: 'PF/PA',
+      value: (row: Record<string, any>) => `${formatStandingsCellValue(toStandingsNumber(row?.pf))}/${formatStandingsCellValue(toStandingsNumber(row?.pa))}`
+    };
+  }
+
+  return {
+    label: 'PCT',
+    value: (row: Record<string, any>) => {
+      const winPct = row?.winPct;
+      if (typeof winPct === 'number' && Number.isFinite(winPct)) return winPct.toFixed(3);
+      const stringPct = cleanStandingsCell(winPct);
+      return stringPct || '—';
+    }
+  };
+}
+
+function formatStandingsCellValue(value: number | string | null) {
+  if (value === null || value === '') return '—';
+  return String(value);
+}
+
+function toStandingsNumber(value: unknown) {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function cleanStandingsCell(value: unknown) {
+  return String(value ?? '').trim();
 }
 
 function formatEventDate(date: Date) {


### PR DESCRIPTION
Closes #3103

## What changed
- added a native standings section on the team detail Overview tab that renders in-app standings rows when `model.standings.rows` is present
- highlighted the current team row, showed rank/team/record plus one comparison field, and capped the initial mobile view with an expand control for additional rows
- preserved the external league-page fallback when no native standings rows are available
- added focused TeamDetail coverage for standings rendering, highlight behavior, overflow expansion, and league-link fallback
- added a service-level regression test to confirm completed-game standings data still flows through `buildTeamDetailModel` unchanged

## Root Cause
`TeamDetail` only consumed `standings.currentRow` for a single summary card and never rendered the existing `standings.rows` payload that `teamDetailService` already builds. That dropped the richer standings context and current-team highlight from the native UI even though the data model already supported it.

## Prevention / Learning
When a service model already exposes both a collection and a selected/current item, native surfaces should not stop at a summary card without an explicit UX reason. Add adjacent component tests for collection rendering, current-item highlight state, overflow handling, and empty-state fallback whenever extending summary-based mobile screens.

## Regression Tests
- `npx vitest run apps/app/src/pages/TeamDetail.test.tsx apps/app/src/lib/teamDetailService.test.ts --reporter=verbose`
- added `TeamDetail` tests for native standings rows, current-team highlight, expand/collapse overflow, and league-link fallback
- added `buildTeamDetailModel` standings test to verify completed non-practice games still feed native standings data correctly

## Recurrence Risk
Low. The fix stays inside the existing team detail page, reuses the current standings payload, and now has focused UI plus service regression coverage for this exact gap.