### PR TITLE
Defer native push setup until auth exists

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -55,7 +55,7 @@ const capacitorMock = vi.hoisted(() => ({
 }));
 const pushRoutingMock = vi.hoisted(() => ({
   clearPendingPushRoute: vi.fn(),
-  readPendingPushRoute: vi.fn(() => null)
+  readPendingPushRoute: vi.fn<() => string | null>(() => null)
 }));
 const pushServiceMock = vi.hoisted(() => {
   const state = {

--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -48,6 +48,28 @@ const nativeBackMock = vi.hoisted(() => {
     })
   };
 });
+const capacitorMock = vi.hoisted(() => ({
+  isNativePlatform: vi.fn(() => true),
+  isPluginAvailable: vi.fn(() => true),
+  getPlatform: vi.fn(() => 'ios')
+}));
+const pushRoutingMock = vi.hoisted(() => ({
+  clearPendingPushRoute: vi.fn(),
+  readPendingPushRoute: vi.fn(() => null)
+}));
+const pushServiceMock = vi.hoisted(() => {
+  const state = {
+    lastListener: null as ((route: string) => void) | null
+  };
+  return {
+    ...state,
+    addPushNotificationOpenListener: vi.fn(async (listener: (route: string) => void) => {
+      state.lastListener = listener;
+      return () => {};
+    }),
+    ensureAndroidNotificationChannels: vi.fn(async () => {})
+  };
+});
 
 vi.mock('@capacitor/app', () => ({
   App: {
@@ -57,11 +79,7 @@ vi.mock('@capacitor/app', () => ({
 }));
 
 vi.mock('@capacitor/core', () => ({
-  Capacitor: {
-    isNativePlatform: () => true,
-    isPluginAvailable: () => true,
-    getPlatform: () => 'ios'
-  }
+  Capacitor: capacitorMock
 }));
 
 vi.mock('./lib/useAuth', () => ({
@@ -77,19 +95,13 @@ vi.mock('./components/AppShell', () => ({
   ),
 }));
 
-vi.mock('./lib/pushNotificationRouting', () => ({
-  clearPendingPushRoute: vi.fn(),
-  readPendingPushRoute: vi.fn(() => null),
-}));
+vi.mock('./lib/pushNotificationRouting', () => pushRoutingMock);
 
 vi.mock('./lib/reloadRouting', () => ({
   shouldReloadTeamsToHome: vi.fn(() => false),
 }));
 
-vi.mock('./lib/pushService', () => ({
-  addPushNotificationOpenListener: vi.fn(async () => () => {}),
-  ensureAndroidNotificationChannels: vi.fn(async () => {}),
-}));
+vi.mock('./lib/pushService', () => pushServiceMock);
 
 vi.mock('./pages/Home', () => ({
   Home: () => {
@@ -114,6 +126,10 @@ vi.mock('./pages/Schedule', () => ({
 
 vi.mock('./pages/ScheduleEventDetail', () => ({
   ScheduleEventDetail: () => <div>Event detail page</div>,
+}));
+
+vi.mock('./pages/Messages', () => ({
+  Messages: () => <div>Messages page</div>,
 }));
 
 function installTestLocalStorage() {
@@ -150,6 +166,15 @@ describe('App protected route loading', () => {
     nativeBackMock.addListener.mockClear();
     nativeBackMock.exitApp.mockClear();
     nativeBackMock.remove.mockClear();
+    capacitorMock.isNativePlatform.mockReturnValue(true);
+    capacitorMock.isPluginAvailable.mockReturnValue(true);
+    capacitorMock.getPlatform.mockReturnValue('ios');
+    pushRoutingMock.clearPendingPushRoute.mockClear();
+    pushRoutingMock.readPendingPushRoute.mockReset();
+    pushRoutingMock.readPendingPushRoute.mockReturnValue(null);
+    pushServiceMock.addPushNotificationOpenListener.mockClear();
+    pushServiceMock.ensureAndroidNotificationChannels.mockClear();
+    pushServiceMock.lastListener = null;
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
@@ -233,6 +258,84 @@ describe('App protected route loading', () => {
 
     expect(await screen.findByText('Officials assignments page')).toBeTruthy();
     expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
+  });
+
+  it('skips push setup during signed-out boot', () => {
+    authMock.state = {
+      ...authMock.signedInAuth,
+      user: null,
+      loading: false,
+      roles: [],
+      isParent: false
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/auth']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(pushServiceMock.ensureAndroidNotificationChannels).not.toHaveBeenCalled();
+    expect(pushServiceMock.addPushNotificationOpenListener).not.toHaveBeenCalled();
+  });
+
+  it('skips push setup on web but registers it once for signed-in native boot', async () => {
+    capacitorMock.isNativePlatform.mockReturnValue(false);
+
+    const firstRender = render(
+      <MemoryRouter initialEntries={['/officials']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Officials assignments page')).toBeTruthy();
+    expect(pushServiceMock.ensureAndroidNotificationChannels).not.toHaveBeenCalled();
+    expect(pushServiceMock.addPushNotificationOpenListener).not.toHaveBeenCalled();
+
+    firstRender.unmount();
+    capacitorMock.isNativePlatform.mockReturnValue(true);
+
+    render(
+      <MemoryRouter initialEntries={['/officials']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Officials assignments page')).toBeTruthy();
+    await waitFor(() => expect(pushServiceMock.ensureAndroidNotificationChannels).toHaveBeenCalledTimes(1));
+    expect(pushServiceMock.addPushNotificationOpenListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves pending push routing after auth resolves in a native session', async () => {
+    authMock.state = {
+      ...authMock.signedInAuth,
+      user: null,
+      loading: true,
+      roles: [],
+      isParent: false
+    };
+    pushRoutingMock.readPendingPushRoute.mockImplementationOnce(() => '/messages').mockReturnValue(null);
+    writeAuthBootstrapHint({ uid: 'user-1', email: 'parent@example.com', displayName: 'Pat Parent', roles: ['parent'] });
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/home']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('navigation', { name: 'Primary navigation' })).toBeTruthy();
+    expect(pushServiceMock.ensureAndroidNotificationChannels).not.toHaveBeenCalled();
+
+    authMock.state = { ...authMock.signedInAuth, refresh: vi.fn(), signOut: vi.fn() };
+    rerender(
+      <MemoryRouter initialEntries={['/home']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Messages page')).toBeTruthy();
+    await waitFor(() => expect(pushServiceMock.ensureAndroidNotificationChannels).toHaveBeenCalledTimes(1));
+    expect(pushRoutingMock.clearPendingPushRoute).toHaveBeenCalledTimes(1);
   });
 
   it('keeps the app shell visible when a protected route throws while rendering', async () => {

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -1,4 +1,5 @@
 import { lazy, ReactNode, Suspense, useEffect, useRef, useState } from 'react';
+import { Capacitor } from '@capacitor/core';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -149,6 +150,16 @@ export default function App() {
   }, [navigate]);
 
   useEffect(() => {
+    if (!auth.user) {
+      return;
+    }
+
+    const isNativeRuntime = Capacitor.isNativePlatform()
+      || (typeof window !== 'undefined' && window.location.protocol === 'capacitor:');
+    if (!isNativeRuntime) {
+      return;
+    }
+
     let active = true;
     let removeListener = () => {};
 
@@ -174,7 +185,7 @@ export default function App() {
       active = false;
       removeListener();
     };
-  }, [navigate]);
+  }, [auth.user, navigate]);
 
   useEffect(() => {
     if (auth.loading || !auth.user) {


### PR DESCRIPTION
Closes #3102

## What changed
- Gated the App-level push initialization effect behind both an authenticated user and a native runtime check before importing `./lib/pushService`.
- Kept the existing pending push route handling intact so deferred routing still happens after auth resolves.
- Added focused App regression tests for signed-out boot, web boot vs signed-in native boot, and pending push routing after auth resolves.

## Root Cause
`App.tsx` mounted the push-registration effect on every boot and dynamically imported `./lib/pushService` before confirming that the session was both native and authenticated. That made signed-out and web sessions load the native messaging stack and startup bridge work they could never use.

## Prevention / Learning
For native-only integrations with heavy imports, gate the effect on the owning runtime and session invariants before the dynamic import. That keeps unsupported or unauthenticated sessions from pulling native-only chunks into the boot path.

## Regression Tests
- `npx vitest run apps/app/src/App.test.tsx --reporter=verbose`
- `apps/app/src/App.test.tsx` asserts signed-out boot skips push setup.
- `apps/app/src/App.test.tsx` asserts web boot skips push setup while signed-in native boot registers it once.
- `apps/app/src/App.test.tsx` asserts pending push routing still navigates after auth resolves.