### PR TITLE
Add search-first recipient picking to chat audience

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -2673,7 +2673,7 @@ function ConversationSheet({
   );
 }
 
-function AudienceSheet({
+export function AudienceSheet({
   selectedTarget,
   selectedRecipientIds,
   recipientOptions,
@@ -2694,6 +2694,27 @@ function AudienceSheet({
   onRetryRecipientOptions: () => void;
   onClose: () => void;
 }) {
+  const [recipientSearch, setRecipientSearch] = useState('');
+  const normalizedRecipientSearch = recipientSearch.trim().toLowerCase();
+  const selectedRecipientIdSet = useMemo(() => new Set(selectedRecipientIds), [selectedRecipientIds]);
+  const matchesRecipientSearch = useCallback((option: ChatRecipientOption) => {
+    if (!normalizedRecipientSearch) return true;
+    const label = `${option.name} ${option.detail || ''}`.toLowerCase();
+    return label.includes(normalizedRecipientSearch);
+  }, [normalizedRecipientSearch]);
+  const matchingRecipientOptions = useMemo(
+    () => recipientOptions.filter((option) => matchesRecipientSearch(option)),
+    [matchesRecipientSearch, recipientOptions]
+  );
+  const selectedRecipientOptions = useMemo(
+    () => recipientOptions.filter((option) => selectedRecipientIdSet.has(option.id)),
+    [recipientOptions, selectedRecipientIdSet]
+  );
+  const browseRecipientOptions = useMemo(
+    () => matchingRecipientOptions.filter((option) => !selectedRecipientIdSet.has(option.id)),
+    [matchingRecipientOptions, selectedRecipientIdSet]
+  );
+  const hasMatchingRecipientOptions = matchingRecipientOptions.length > 0;
   const toggleRecipient = (recipientId: string) => {
     onRecipientsChange(
       selectedRecipientIds.includes(recipientId)
@@ -2730,6 +2751,42 @@ function AudienceSheet({
 
       {selectedTarget === 'individuals' ? (
         <>
+          <div className="mt-4">
+            <label htmlFor="chat-audience-recipient-search" className="mb-1 block text-xs font-black uppercase tracking-[0.18em] text-gray-500">
+              Search recipients
+            </label>
+            <input
+              id="chat-audience-recipient-search"
+              type="search"
+              value={recipientSearch}
+              onChange={(event) => setRecipientSearch(event.target.value)}
+              placeholder="Search by member or guardian name"
+              className="h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none transition focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+            />
+          </div>
+
+          {selectedRecipientOptions.length ? (
+            <div className="mt-4 rounded-xl border border-primary-100 bg-primary-50/60 p-3">
+              <div className="mb-2 text-xs font-black uppercase tracking-[0.18em] text-primary-700">Selected</div>
+              <div className="space-y-2">
+                {selectedRecipientOptions.map((option) => (
+                  <label key={option.id} className="flex cursor-pointer items-center gap-3 rounded-xl border border-primary-100 bg-white px-3 py-2">
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-gray-300 text-primary-600"
+                      checked={selectedRecipientIds.includes(option.id)}
+                      onChange={() => toggleRecipient(option.id)}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-black text-gray-800">{option.name}</span>
+                      {option.detail ? <span className="block truncate text-xs font-semibold text-gray-500">{option.detail}</span> : null}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
           <div className="mt-4 max-h-72 overflow-y-auto rounded-xl border border-gray-200">
             {recipientOptionsLoading ? (
               <div className="p-3 text-sm font-semibold text-gray-500">
@@ -2743,7 +2800,7 @@ function AudienceSheet({
                   Retry recipient load
                 </button>
               </div>
-            ) : recipientOptions.length ? recipientOptions.map((option) => (
+            ) : recipientOptions.length ? browseRecipientOptions.length ? browseRecipientOptions.map((option) => (
               <label key={option.id} className="flex cursor-pointer items-center gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0">
                 <input
                   type="checkbox"
@@ -2756,7 +2813,11 @@ function AudienceSheet({
                   {option.detail ? <span className="block truncate text-xs font-semibold text-gray-500">{option.detail}</span> : null}
                 </span>
               </label>
-            )) : (
+            )) : normalizedRecipientSearch && !hasMatchingRecipientOptions ? (
+              <div className="p-3 text-sm font-semibold text-gray-500">No recipients match that search yet.</div>
+            ) : (
+              <div className="p-3 text-sm font-semibold text-gray-500">No roster or community members are available yet.</div>
+            ) : (
               <div className="p-3 text-sm font-semibold text-gray-500">No roster or community members are available yet.</div>
             )}
           </div>

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatMessage } from '../../../lib/chatService';
 import type { AuthState } from '../../../lib/types';
-import { ChatWindow, buildVirtualizedChatWindow } from './ChatWindow';
+import { AudienceSheet, ChatWindow, buildVirtualizedChatWindow } from './ChatWindow';
 
 const liveMessages = Array.from({ length: 220 }, (_, index) => buildMessage(`live-${index + 1}`, index + 101));
 const olderPage = Array.from({ length: 50 }, (_, index) => buildMessage(`older-${index + 1}`, index + 1));
@@ -318,5 +319,85 @@ describe('ChatWindow virtualization', () => {
     await waitFor(() => {
       expect(thread.scrollTop).toBe(720);
     });
+  });
+});
+
+describe('AudienceSheet recipient search', () => {
+  function getRecipientCheckbox(name: string) {
+    return screen.getByText(name).closest('label')?.querySelector('input') as HTMLInputElement;
+  }
+
+  function renderAudienceSheet(initialSelectedRecipientIds: string[] = []) {
+    const recipientOptions = [
+      { id: 'player-sam', name: 'Sam Player', detail: '#12' },
+      { id: 'guardian-taylor', name: 'Taylor Guardian', detail: 'Guardian for Sam Player' },
+      { id: 'player-casey', name: 'Casey Center', detail: '#34' }
+    ];
+
+    function AudienceSheetHarness() {
+      const [selectedRecipientIds, setSelectedRecipientIds] = React.useState(initialSelectedRecipientIds);
+      return (
+        <AudienceSheet
+          selectedTarget="individuals"
+          selectedRecipientIds={selectedRecipientIds}
+          recipientOptions={recipientOptions}
+          recipientOptionsLoading={false}
+          recipientOptionsError={null}
+          onTargetChange={vi.fn() as any}
+          onRecipientsChange={setSelectedRecipientIds}
+          onRetryRecipientOptions={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+    }
+
+    return render(<AudienceSheetHarness />);
+  }
+
+  it('filters recipient options immediately by name or detail text', () => {
+    renderAudienceSheet();
+
+    fireEvent.change(screen.getByPlaceholderText('Search by member or guardian name'), {
+      target: { value: 'guardian for sam' }
+    });
+
+    expect(screen.getByText('Taylor Guardian')).toBeInTheDocument();
+    expect(screen.queryByText('Sam Player')).not.toBeInTheDocument();
+    expect(screen.queryByText('Casey Center')).not.toBeInTheDocument();
+  });
+
+  it('keeps selected recipients pinned and checked while filtering and after clearing search', () => {
+    renderAudienceSheet(['player-sam']);
+
+    expect(getRecipientCheckbox('Sam Player')).toBeChecked();
+    expect(screen.getByText('Selected')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search by member or guardian name'), {
+      target: { value: 'zzz' }
+    });
+
+    expect(getRecipientCheckbox('Sam Player')).toBeChecked();
+    expect(screen.getByText('No recipients match that search yet.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search by member or guardian name'), {
+      target: { value: '' }
+    });
+
+    expect(getRecipientCheckbox('Sam Player')).toBeChecked();
+    expect(screen.queryByText('No recipients match that search yet.')).not.toBeInTheDocument();
+  });
+
+  it('blocks Done with no selected recipients and allows it after choosing a filtered recipient', () => {
+    renderAudienceSheet();
+
+    const doneButton = screen.getByRole('button', { name: 'Done' });
+    expect(doneButton).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('Search by member or guardian name'), {
+      target: { value: 'casey' }
+    });
+    fireEvent.click(getRecipientCheckbox('Casey Center'));
+
+    expect(doneButton).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
Closes #3104

## What changed
- added a recipient search field at the top of the Selected members audience sheet in `ChatWindow`
- filter recipient options immediately by member name or detail text while keeping the empty full-roster browse path intact
- pinned already selected recipients in a dedicated Selected section so they stay visible and checked while adding more recipients
- added a no-results state that does not clear pinned selections
- added focused regression tests for filtering, pinned selection persistence, and the existing Done guard

## Root Cause
The Selected members sheet rendered one flat `recipientOptions` list with no local query state or selected-recipient grouping, so large mixed player/guardian rosters forced manual scanning and gave the UI no way to preserve chosen recipients while narrowing the list.

## Prevention / Learning
When a picker can grow with real roster size, default to search-first UX and treat current selections as pinned state separate from the browse list. Add a focused component test for filtering plus selection persistence any time a modal or sheet mixes search and checkbox state.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/messages/components/ChatWindow.virtualization.test.tsx --reporter=verbose`
- verifies recipient search filters loaded options by visible text
- verifies selected recipients stay pinned and checked through filtering and clearing search
- verifies Done remains blocked for empty Selected members and becomes enabled after choosing a filtered recipient