### PR TITLE
Preserve zero-stat live tracker appearances

### DIFF
--- a/js/live-tracker-finish.js
+++ b/js/live-tracker-finish.js
@@ -39,7 +39,26 @@ function getPlayerElapsedTimeMs(playerStats) {
     ?? 0;
 }
 
-function hasLiveTrackerParticipation(playerStats = {}, columns = []) {
+function collectExplicitAppearancePlayerIds({ activePlayerIds = [], substitutions = [] } = {}) {
+  const playerIds = new Set();
+
+  (Array.isArray(activePlayerIds) ? activePlayerIds : []).forEach((playerId) => {
+    if (playerId) playerIds.add(playerId);
+  });
+
+  (Array.isArray(substitutions) ? substitutions : []).forEach((substitution) => {
+    const outId = substitution?.out;
+    const inId = substitution?.in;
+    if (outId) playerIds.add(outId);
+    if (inId) playerIds.add(inId);
+  });
+
+  return playerIds;
+}
+
+function hasLiveTrackerParticipation(playerStats = {}, columns = [], hasExplicitAppearance = false) {
+  if (hasExplicitAppearance) return true;
+
   const timeMs = getPlayerElapsedTimeMs(playerStats);
   if (timeMs > 0) return true;
 
@@ -69,6 +88,8 @@ export function buildFinishCompletionPlan({
   statTrackerConfig = {},
   roster = [],
   statsByPlayerId = {},
+  activePlayerIds = [],
+  substitutions = [],
   opponentEntries = [],
   currentUserUid = null,
   buildEmailBody = () => ''
@@ -101,6 +122,7 @@ export function buildFinishCompletionPlan({
   const safeColumns = Array.isArray(columns) ? columns : [];
   const safeRoster = Array.isArray(roster) ? roster : {};
   const safeStatsByPlayerId = statsByPlayerId && typeof statsByPlayerId === 'object' ? statsByPlayerId : {};
+  const explicitAppearancePlayerIds = collectExplicitAppearancePlayerIds({ activePlayerIds, substitutions });
   const effectiveLog = Array.isArray(log) ? [...log] : [];
   let reconciliationNote = '';
 
@@ -139,7 +161,11 @@ export function buildFinishCompletionPlan({
       statsObj[key] = playerStats[key] || 0;
     });
     statsObj.fouls = playerStats.fouls || 0;
-    const actuallyParticipated = hasLiveTrackerParticipation(playerStats, safeColumns);
+    const actuallyParticipated = hasLiveTrackerParticipation(
+      playerStats,
+      safeColumns,
+      explicitAppearancePlayerIds.has(player.id)
+    );
 
     const baseData = {
       playerName: player.name,

--- a/js/live-tracker-save-complete.js
+++ b/js/live-tracker-save-complete.js
@@ -238,6 +238,8 @@ export async function runSaveAndCompleteWorkflow({
     statTrackerConfig: currentConfig || {},
     roster,
     statsByPlayerId: state.stats,
+    activePlayerIds: state.onCourt,
+    substitutions: state.subs,
     opponentEntries: state.opp,
     currentUserUid: currentUser?.uid,
     buildEmailBody: (finalHome, finalAway, recapSummary, logEntries) => generateEmailBody(finalHome, finalAway, recapSummary, logEntries)

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1192,6 +1192,7 @@ function saveHistory(action) {
     bench: [...state.bench],
     stats: JSON.parse(JSON.stringify(state.stats)),
     log: [...state.log],
+    subs: [...state.subs],
     opp: JSON.parse(JSON.stringify(state.opp)),
     scoreLogIsComplete: state.scoreLogIsComplete
   };
@@ -1216,6 +1217,7 @@ function undo() {
   state.bench = prev.bench;
   state.stats = prev.stats;
   state.log = prev.log;
+  state.subs = Array.isArray(prev.subs) ? prev.subs : [];
   state.opp = prev.opp;
   state.scoreLogIsComplete = prev.scoreLogIsComplete !== false;
   renderAll();

--- a/test-track-zero-stat-player-history.js
+++ b/test-track-zero-stat-player-history.js
@@ -104,6 +104,7 @@ test('standard finish writes zero-stat appearances with player profile participa
         statsByPlayerId: {
             'player-b': { pts: 0, reb: 0, ast: 0, fouls: 0, time: 0 }
         },
+        activePlayerIds: ['player-b'],
         opponentEntries: []
     });
 
@@ -116,7 +117,7 @@ test('standard finish writes zero-stat appearances with player profile participa
             participated: true,
             participationStatus: 'appeared',
             participationSource: 'live-tracker-finish',
-            stats: { pts: 0, reb: 0, ast: 0 }
+            stats: { pts: 0, reb: 0, ast: 0, fouls: 0 }
         },
         'Standard finish zero-stat write should include explicit profile participation markers'
     );

--- a/tests/unit/issue-1972-standard-tracker-undo-source.test.js
+++ b/tests/unit/issue-1972-standard-tracker-undo-source.test.js
@@ -15,6 +15,8 @@ describe('issue 1972 standard tracker undo source contract', () => {
         expect(liveTrackerSource).toContain('const prev = state.history.pop();');
         expect(liveTrackerSource).toContain('state.home = prev.home;');
         expect(liveTrackerSource).toContain('state.away = prev.away;');
+        expect(liveTrackerSource).toContain('subs: [...state.subs],');
+        expect(liveTrackerSource).toContain('state.subs = Array.isArray(prev.subs) ? prev.subs : [];');
         expect(liveTrackerSource).toContain('state.scoreLogIsComplete = prev.scoreLogIsComplete !== false;');
     });
 

--- a/tests/unit/live-tracker-finish.test.js
+++ b/tests/unit/live-tracker-finish.test.js
@@ -146,6 +146,42 @@ describe('live tracker finish completion plan', () => {
     expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(false);
   });
 
+  it('marks zero-stat players with lineup-only live tracker appearances as having appeared', () => {
+    const plan = buildFinishCompletionPlan({
+      requestedHome: 0,
+      requestedAway: 0,
+      liveHome: 0,
+      liveAway: 0,
+      scoreLogIsComplete: true,
+      log: [],
+      columns: ['PTS', 'REB', 'AST'],
+      roster: [
+        { id: 'p-zero', name: 'Zero Stat', num: '12' }
+      ],
+      statsByPlayerId: {
+        'p-zero': { pts: 0, reb: 0, ast: 0, fouls: 0, time: 0 }
+      },
+      activePlayerIds: ['p-zero'],
+      opponentEntries: []
+    });
+
+    expect(plan.aggregatedStatsWrites).toEqual([
+      {
+        playerId: 'p-zero',
+        data: {
+          playerName: 'Zero Stat',
+          playerNumber: '12',
+          participated: true,
+          participationStatus: 'appeared',
+          participationSource: 'live-tracker-finish',
+          stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
+          timeMs: 0
+        }
+      }
+    ]);
+    expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(true);
+  });
+
   it('keeps live-tracker aggregates with real participation visible in player profile history', () => {
     const standardFinishAggregateDoc = {
       playerName: 'Zero Stat',

--- a/tests/unit/live-tracker-save-complete.test.js
+++ b/tests/unit/live-tracker-save-complete.test.js
@@ -194,6 +194,35 @@ describe('live tracker save-and-complete workflow', () => {
     ]);
   });
 
+  it('preserves lineup-only zero-stat appearances in finish writes', async () => {
+    const harness = buildHarness();
+    harness.context.state.stats = {
+      'p-zero': { pts: 0, ast: 0, fouls: 0, time: 0 }
+    };
+    harness.context.state.onCourt = ['p-zero'];
+    harness.context.state.subs = [];
+    harness.context.roster = [
+      { id: 'p-zero', name: 'Zero Stat', num: '12' }
+    ];
+    harness.context.currentConfig = { columns: ['PTS', 'AST'] };
+
+    await runSaveAndCompleteWorkflow(harness.context);
+
+    const zeroStatWrite = harness.setCalls.find(({ ref }) => ref.path === 'teams/team-1/games/game-9/aggregatedStats/p-zero');
+    expect(zeroStatWrite).toEqual({
+      ref: { kind: 'doc', path: 'teams/team-1/games/game-9/aggregatedStats/p-zero' },
+      data: {
+        playerName: 'Zero Stat',
+        playerNumber: '12',
+        timeMs: 0,
+        participated: true,
+        participationStatus: 'appeared',
+        participationSource: 'live-tracker-finish',
+        stats: { pts: 0, ast: 0, fouls: 0 }
+      }
+    });
+  });
+
   it('accepts only one in-flight finish submission and keeps the button disabled until commit settles', async () => {
     let resolveCommit;
     const commitControl = {};


### PR DESCRIPTION
Closes #3108

## What changed
- Taught live tracker finalization to treat explicit lineup participation as a real appearance, even when time, fouls, and tracked stats all remain zero.
- Passed current on-court players and substitution history into the finish plan so the save path can distinguish true appearances from pre-seeded zero-stat non-participants.
- Added focused regression coverage for both the finish-plan helper and the end-to-end save-and-complete workflow, plus updated the existing zero-stat history script.

## Root Cause
`buildFinishCompletionPlan` inferred participation only from persisted numeric outputs like `timeMs`, fouls, and configured stat totals. Live tracker lineup state and substitutions were tracked separately, but that appearance evidence was never fed into finalization, so real zero-stat appearances were serialized as `didNotPlay` and later filtered out of player history.

## Prevention / Learning
When a workflow tracks participation separately from outcome stats, final persistence must carry an explicit appearance signal instead of trying to reconstruct participation from nonzero metrics alone. For tracker-style flows, treat lineup/substitution state as first-class participation evidence and add regression tests for zero-output participants.

## Regression Tests
- `npx vitest run tests/unit/live-tracker-finish.test.js tests/unit/live-tracker-save-complete.test.js --reporter=verbose`
- `node test-track-zero-stat-player-history.js`