### PR TITLE
Split Parent Tools tab services into focused chunks

### DIFF
--- a/apps/app/src/lib/parentCalendarService.ts
+++ b/apps/app/src/lib/parentCalendarService.ts
@@ -1,0 +1,149 @@
+import { getTeam } from './adapters/legacyParentTools';
+import { firebaseAuth, getNativeAuthIdToken } from './authService';
+import { loadParentScheduleSummary } from './homeService';
+import { formatEventDateLabel, formatEventTimeLabel, getScheduleTitle, type ParentScheduleEvent } from './scheduleLogic';
+import type { AuthUser } from './types';
+
+export type ParentCalendarTeam = {
+    teamId: string;
+    teamName: string;
+    eventCount: number;
+};
+
+export async function loadParentCalendarTools(user: AuthUser | null, options: { force?: boolean } = {}) {
+    if (!user?.uid) return { events: [], teams: [] };
+    const schedule = await loadParentScheduleSummary(user, { force: options.force });
+    const teamsById = new Map<string, ParentCalendarTeam>();
+    (schedule.events || []).forEach((event) => {
+        if (!event.teamId) return;
+        const existing = teamsById.get(event.teamId);
+        teamsById.set(event.teamId, {
+            teamId: event.teamId,
+            teamName: event.teamName || existing?.teamName || 'Team',
+            eventCount: (existing?.eventCount || 0) + 1
+        });
+    });
+    return {
+        events: schedule.events || [],
+        teams: [...teamsById.values()].sort((a, b) => a.teamName.localeCompare(b.teamName))
+    };
+}
+
+export function buildParentScheduleIcs(events: ParentScheduleEvent[], calendarName = 'ALL PLAYS Schedule') {
+    const lines = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//ALL PLAYS//Parent App//EN',
+        `X-WR-CALNAME:${escapeIcs(calendarName)}`
+    ];
+
+    (events || []).forEach((event) => {
+        const start = toDate(event.date);
+        if (!start) return;
+        const end = toDate(event.endDate) || new Date(start.getTime() + 60 * 60 * 1000);
+        const title = getScheduleTitle(event);
+        const description = [
+            event.teamName,
+            event.type === 'practice' ? 'Practice' : 'Game',
+            event.childName ? `Player: ${event.childName}` : '',
+            event.notes || ''
+        ].filter(Boolean).join('\n');
+        lines.push(
+            'BEGIN:VEVENT',
+            `UID:${escapeIcs(event.eventKey || `${event.teamId}-${event.id}`)}@allplays.ai`,
+            `DTSTAMP:${formatIcsDate(new Date())}`,
+            `DTSTART:${formatIcsDate(start)}`,
+            `DTEND:${formatIcsDate(end)}`,
+            `SUMMARY:${escapeIcs(title)}`,
+            `LOCATION:${escapeIcs(event.location || 'TBD')}`,
+            `DESCRIPTION:${escapeIcs(description)}`,
+            'END:VEVENT'
+        );
+    });
+
+    lines.push('END:VCALENDAR');
+    return lines.join('\r\n');
+}
+
+export function buildParentScheduleEventIcs(event: ParentScheduleEvent, calendarName = 'ALL PLAYS Schedule') {
+    return buildParentScheduleIcs(event ? [event] : [], calendarName);
+}
+
+export function buildPrivateTeamCalendarFeedUrl(teamId: string, team: Record<string, any> | null | undefined) {
+    const directUrl = team?.privateCalendarFeedUrl
+        || team?.calendarSubscriptionUrl
+        || team?.calendarFeedUrl
+        || team?.teamCalendarFeedUrl;
+    if (typeof directUrl === 'string' && directUrl.trim()) {
+        return directUrl.trim().replace(/^webcal:\/\//i, 'https://');
+    }
+
+    const token = team?.calendarSubscriptionToken
+        || team?.privateCalendarToken
+        || team?.calendarFeedToken
+        || team?.teamCalendarToken;
+    if (!teamId || !token) return '';
+
+    const configured = (window as any).__ALLPLAYS_CONFIG__?.teamCalendarFeedFunctionUrl || (window as any).ALLPLAYS_TEAM_CALENDAR_FEED_URL;
+    const fallback = (window as any).__ALLPLAYS_CONFIG__?.calendarFetchFunctionUrl || (window as any).ALLPLAYS_CALENDAR_FUNCTION_URL;
+    const baseUrl = typeof configured === 'string' && configured.trim()
+        ? configured.trim()
+        : typeof fallback === 'string' && fallback.includes('fetchCalendarIcs')
+            ? fallback.replace('fetchCalendarIcs', 'teamCalendarFeed')
+            : 'https://us-central1-all-plays-prod.cloudfunctions.net/teamCalendarFeed';
+    const separator = baseUrl.includes('?') ? '&' : '?';
+    return `${baseUrl}${separator}teamId=${encodeURIComponent(teamId)}&token=${encodeURIComponent(token)}`;
+}
+
+export async function getPrivateTeamCalendarFeedUrl(teamId: string) {
+    const teamSnap = await Promise.resolve(getTeam(teamId)).catch(() => null);
+    const teamFeedUrl = buildPrivateTeamCalendarFeedUrl(teamId, teamSnap);
+    if (teamFeedUrl) return teamFeedUrl;
+    const token = await getNativeAuthIdToken(false).catch(() => null)
+        || await firebaseAuth.currentUser?.getIdToken?.(false).catch(() => null);
+    if (!teamId || !token) return '';
+    const configured = (window as any).__ALLPLAYS_CONFIG__?.teamCalendarFeedFunctionUrl || (window as any).ALLPLAYS_TEAM_CALENDAR_FEED_URL;
+    const fallback = (window as any).__ALLPLAYS_CONFIG__?.calendarFetchFunctionUrl || (window as any).ALLPLAYS_CALENDAR_FUNCTION_URL;
+    const baseUrl = typeof configured === 'string' && configured.trim()
+        ? configured.trim()
+        : typeof fallback === 'string' && fallback.includes('fetchCalendarIcs')
+            ? fallback.replace('fetchCalendarIcs', 'teamCalendarFeed')
+            : 'https://us-central1-all-plays-prod.cloudfunctions.net/teamCalendarFeed';
+    const separator = baseUrl.includes('?') ? '&' : '?';
+    return `${baseUrl}${separator}teamId=${encodeURIComponent(teamId)}&token=${encodeURIComponent(token)}`;
+}
+
+export function getAppleCalendarFeedUrl(feedUrl: string) {
+    return String(feedUrl || '').replace(/^https?:\/\//i, 'webcal://');
+}
+
+export function getGoogleCalendarFeedUrl(feedUrl: string) {
+    return `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedUrl)}`;
+}
+
+export function getCalendarEventShareText(event: ParentScheduleEvent) {
+    return [
+        getScheduleTitle(event),
+        formatEventDateLabel(event.date),
+        formatEventTimeLabel(event.date),
+        event.location || 'Location TBD'
+    ].filter(Boolean).join(' - ');
+}
+
+function escapeIcs(value: unknown) {
+    return String(value || '')
+        .replace(/\\/g, '\\\\')
+        .replace(/\n/g, '\\n')
+        .replace(/,/g, '\\,')
+        .replace(/;/g, '\\;');
+}
+
+function formatIcsDate(date: Date) {
+    return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function toDate(value: unknown): Date | null {
+    if (!value) return null;
+    const date = value instanceof Date ? value : typeof (value as any)?.toDate === 'function' ? (value as any).toDate() : new Date(value as any);
+    return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/apps/app/src/lib/parentCertificatesService.ts
+++ b/apps/app/src/lib/parentCertificatesService.ts
@@ -1,0 +1,76 @@
+import { getTeam, listCertificatesForPlayer } from './adapters/legacyParentTools';
+import type { AuthUser } from './types';
+
+const legacyOrigin = 'https://allplays.ai';
+
+export type ParentCertificateCard = Record<string, any> & {
+    teamId: string;
+    teamName: string;
+    playerId: string;
+    playerName: string;
+    url: string;
+};
+
+export async function loadParentCertificates(user: AuthUser | null): Promise<ParentCertificateCard[]> {
+    const children = normalizeFamilyChildren(user?.parentOf || []);
+    const rows = await Promise.all(children.map(async (child: any) => {
+        const [team, certificates] = await Promise.all([
+            Promise.resolve(getTeam(child.teamId)).catch(() => null),
+            Promise.resolve(listCertificatesForPlayer(child.teamId, child.playerId, { status: 'published', limit: 25 })).catch(() => [])
+        ]);
+        return (certificates || []).map((certificate: any) => ({
+            ...certificate,
+            teamId: child.teamId,
+            teamName: team?.name || child.teamName || 'Team',
+            playerId: child.playerId,
+            playerName: child.playerName || certificate.recipientName || 'Player',
+            url: getCertificateUrl(child.teamId, certificate.id)
+        }));
+    }));
+    return rows.flat().sort((a, b) => {
+        const aTime = toMillis(a.updatedAt || a.createdAt);
+        const bTime = toMillis(b.updatedAt || b.createdAt);
+        return bTime - aTime;
+    });
+}
+
+function getLegacyUrl(path: string, hashParams: Record<string, string> = {}) {
+    const url = new URL(path, legacyOrigin);
+    const hash = new URLSearchParams();
+    Object.entries(hashParams).forEach(([key, value]) => {
+        if (value) hash.set(key, value);
+    });
+    if ([...hash.keys()].length) url.hash = hash.toString();
+    return url.toString();
+}
+
+function getCertificateUrl(teamId: string, certificateId: string) {
+    return getLegacyUrl('certificates.html', { teamId, certificateId });
+}
+
+function normalizeFamilyChildren(children: any[]) {
+    return (Array.isArray(children) ? children : [])
+        .filter((child) => child?.teamId && child?.playerId)
+        .map((child) => ({
+            teamId: compactString(child.teamId),
+            teamName: compactString(child.teamName),
+            playerId: compactString(child.playerId),
+            playerName: compactString(child.playerName),
+            playerNumber: compactString(child.playerNumber || child.number),
+            playerPhotoUrl: child.playerPhotoUrl || null
+        }));
+}
+
+function toDate(value: unknown): Date | null {
+    if (!value) return null;
+    const date = value instanceof Date ? value : typeof (value as any)?.toDate === 'function' ? (value as any).toDate() : new Date(value as any);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toMillis(value: unknown) {
+    return toDate(value)?.getTime() || 0;
+}
+
+function compactString(value: unknown) {
+    return String(value || '').trim();
+}

--- a/apps/app/src/lib/parentFamilyShareService.ts
+++ b/apps/app/src/lib/parentFamilyShareService.ts
@@ -1,0 +1,94 @@
+import { createFamilyShareToken, listFamilyShareTokens, revokeFamilyShareToken, updateFamilyShareTokenCalendars } from './adapters/legacyParentTools';
+import type { AuthUser } from './types';
+
+const legacyOrigin = 'https://allplays.ai';
+
+export type FamilyShareTokenCard = Record<string, any> & {
+    url: string;
+    childCount: number;
+};
+
+export async function loadFamilyShareModel(user: AuthUser | null): Promise<{ children: any[]; tokens: FamilyShareTokenCard[] }> {
+    if (!user?.uid) return { children: [], tokens: [] };
+    const children = normalizeFamilyChildren(user.parentOf || []);
+    const tokens = await Promise.resolve(listFamilyShareTokens(user.uid));
+    return {
+        children,
+        tokens: (tokens || []).map((token: any) => ({
+            ...token,
+            expired: isFamilyShareTokenExpired(token),
+            statusLabel: getFamilyShareTokenStatusLabel(token),
+            url: getFamilyShareUrl(token.id),
+            childCount: Array.isArray(token.children) ? token.children.length : 0
+        }))
+    };
+}
+
+export async function createParentFamilyShare(user: AuthUser | null, label: string, extraCalendarUrls: string[] = []) {
+    if (!user?.uid) throw new Error('Sign in before creating a family share link.');
+    const tokenId = await createFamilyShareToken(user.uid, normalizeFamilyChildren(user.parentOf || []), label, extraCalendarUrls);
+    return { tokenId, url: getFamilyShareUrl(tokenId) };
+}
+
+export async function revokeParentFamilyShare(tokenId: string) {
+    await revokeFamilyShareToken(tokenId);
+}
+
+export async function updateParentFamilyShareCalendars(tokenId: string, urls: string[]) {
+    await updateFamilyShareTokenCalendars(tokenId, urls);
+}
+
+function getLegacyUrl(path: string, params: Record<string, string> = {}) {
+    const url = new URL(path, legacyOrigin);
+    Object.entries(params).forEach(([key, value]) => {
+        if (value) url.searchParams.set(key, value);
+    });
+    return url.toString();
+}
+
+function getFamilyShareUrl(tokenId: string) {
+    return getLegacyUrl('family.html', { token: tokenId });
+}
+
+function normalizeFamilyChildren(children: any[]) {
+    return (Array.isArray(children) ? children : [])
+        .filter((child) => child?.teamId && child?.playerId)
+        .map((child) => ({
+            teamId: compactString(child.teamId),
+            teamName: compactString(child.teamName),
+            playerId: compactString(child.playerId),
+            playerName: compactString(child.playerName),
+            playerNumber: compactString(child.playerNumber || child.number),
+            playerPhotoUrl: child.playerPhotoUrl || null
+        }));
+}
+
+function toDate(value: unknown): Date | null {
+    if (!value) return null;
+    const date = value instanceof Date ? value : typeof (value as any)?.toDate === 'function' ? (value as any).toDate() : new Date(value as any);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toMillis(value: unknown) {
+    return toDate(value)?.getTime() || 0;
+}
+
+function isFamilyShareTokenExpired(token: unknown) {
+    const expiresAt = toMillis(asObject(token).expiresAt);
+    return expiresAt > 0 && expiresAt <= Date.now();
+}
+
+function getFamilyShareTokenStatusLabel(token: unknown) {
+    const data = asObject(token);
+    if (data.revokedAt || data.revoked || data.active === false) return 'Revoked';
+    if (isFamilyShareTokenExpired(data)) return 'Expired';
+    return 'Active';
+}
+
+function compactString(value: unknown) {
+    return String(value || '').trim();
+}
+
+function asObject(value: unknown): Record<string, any> {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, any> : {};
+}

--- a/apps/app/src/lib/parentFeesService.ts
+++ b/apps/app/src/lib/parentFeesService.ts
@@ -1,0 +1,125 @@
+import {
+    formatParentFeeAmount,
+    formatParentFeeDueDate,
+    getParentFeeStatusMeta,
+    initiateTeamFeeCheckout,
+    listParentTeamFeeRecipients,
+    normalizeParentFeeRecord,
+    sortParentFeeRecords
+} from './adapters/legacyParentTools';
+import type { AuthUser } from './types';
+
+export type ParentFeeAppRecord = Record<string, any> & {
+    amountLabel: string;
+    dueLabel: string;
+    statusLabel: string;
+    notes?: string;
+    feeNotes?: string;
+    offlinePaymentInstructions?: string;
+    paymentInstructions?: string;
+    collectionMode?: string;
+    checkoutUrl?: string;
+    checkoutStatus?: string;
+    canPay: boolean;
+    checkoutInitiatable: boolean;
+    paymentAction: 'checkoutUrl' | 'createCheckout' | '';
+    lineItems: Array<Record<string, any>>;
+    installments: Array<Record<string, any>>;
+    ledgerEntries: Array<Record<string, any>>;
+};
+
+export async function loadParentFeesForApp(user: AuthUser | null): Promise<ParentFeeAppRecord[]> {
+    if (!user?.uid) return [];
+    const rawFees = await Promise.resolve(listParentTeamFeeRecipients(user.uid, user.parentOf || []));
+    return sortParentFeeRecords(rawFees || []).map((fee: any) => toParentFeeAppRecord(fee));
+}
+
+export async function initiateParentTeamFeeCheckout(teamId: string, batchId: string, recipientId: string): Promise<{ success: true; checkoutUrl: string }> {
+    if (!teamId || !batchId || !recipientId) {
+        throw new Error('Missing required fields for team fee checkout.');
+    }
+
+    const checkoutUrl = await initiateTeamFeeCheckout({ teamId, batchId, recipientId });
+    if (!checkoutUrl) {
+        throw new Error('Failed to get checkout URL.');
+    }
+
+    return { success: true, checkoutUrl };
+}
+
+export function isParentTeamFeePayActionAllowed(fee: any) {
+    if (!isOnlineParentTeamFeeCollection(fee)) return false;
+
+    const status = compactString(fee?.status).toLowerCase();
+    if (status === 'paid' || status === 'canceled' || status === 'cancelled') return false;
+
+    const balanceCents = Number(fee?.balanceDueCents);
+    if (!Number.isFinite(balanceCents) || balanceCents <= 0) return false;
+
+    return true;
+}
+
+export function canInitiateParentTeamFeeCheckout(fee: any) {
+    return Boolean(
+        isParentTeamFeePayActionAllowed(fee)
+        && !hasReusableParentTeamFeeCheckoutUrl(fee)
+        && compactString(fee?.teamId)
+        && compactString(fee?.batchId)
+        && compactString(fee?.recipientId)
+    );
+}
+
+function toParentFeeAppRecord(fee: any): ParentFeeAppRecord {
+    const normalized = normalizeParentFeeRecord(fee);
+    const collectionMode = compactString(normalized.collectionMode);
+    const checkoutUrl = compactString(normalized.checkoutUrl);
+    const checkoutStatus = compactString(normalized.checkoutStatus);
+    const parentFee = {
+        ...normalized,
+        collectionMode,
+        checkoutUrl,
+        checkoutStatus
+    };
+    const meta = getParentFeeStatusMeta(normalized.status);
+    const canOpenCheckoutUrl = isParentTeamFeePayActionAllowed(parentFee) && hasReusableParentTeamFeeCheckoutUrl(parentFee);
+    const checkoutInitiatable = canInitiateParentTeamFeeCheckout(parentFee);
+    return {
+        ...parentFee,
+        amountLabel: formatParentFeeAmount(parentFee),
+        dueLabel: formatParentFeeDueDate(parentFee.dueDate),
+        statusLabel: meta.label,
+        canPay: canOpenCheckoutUrl || checkoutInitiatable,
+        checkoutInitiatable,
+        paymentAction: canOpenCheckoutUrl ? 'checkoutUrl' : checkoutInitiatable ? 'createCheckout' : '',
+        lineItems: getArrayField(normalized, ['lineItems', 'invoiceLineItems', 'invoiceItems', 'items']),
+        installments: getArrayField(normalized, ['installments', 'installmentSchedule', 'paymentSchedule', 'scheduledPayments']),
+        ledgerEntries: getArrayField(normalized, ['ledgerEntries', 'paymentLedger', 'activity', 'receipts', 'payments', 'adjustments'])
+    };
+}
+
+function isOnlineParentTeamFeeCollection(fee: any) {
+    const collectionMode = compactString(fee?.collectionMode).toLowerCase();
+    if (!collectionMode) {
+        return Boolean(compactString(fee?.checkoutUrl));
+    }
+
+    return ['online_stripe', 'stripe', 'stripe_checkout', 'online'].includes(collectionMode);
+}
+
+function hasReusableParentTeamFeeCheckoutUrl(fee: any) {
+    if (!compactString(fee?.checkoutUrl)) return false;
+
+    const checkoutStatus = compactString(fee?.checkoutStatus).toLowerCase();
+    return !checkoutStatus || checkoutStatus === 'open';
+}
+
+function getArrayField(source: any, keys: string[]) {
+    for (const key of keys) {
+        if (Array.isArray(source?.[key])) return source[key].filter(Boolean);
+    }
+    return [];
+}
+
+function compactString(value: unknown) {
+    return String(value || '').trim();
+}

--- a/apps/app/src/lib/parentHouseholdService.ts
+++ b/apps/app/src/lib/parentHouseholdService.ts
@@ -1,0 +1,110 @@
+import { addPendingFamilyMember, readFamilyMembers } from './adapters/legacyParentTools';
+import type { AuthUser } from './types';
+
+const legacyOrigin = 'https://allplays.ai';
+
+export type ParentHouseholdLinkedPlayer = {
+    teamId: string;
+    teamName: string;
+    playerId: string;
+    playerName: string;
+    playerNumber?: string;
+    playerPhotoUrl?: string | null;
+};
+
+export type ParentHouseholdFamilyMember = Record<string, any> & {
+    id: string;
+    email: string;
+    displayName: string;
+    status: string;
+    teamName: string;
+    playerName: string;
+    playerNumber?: string;
+    relation: string;
+    accessCode?: string;
+    inviteUrl?: string;
+};
+
+export type ParentHouseholdInviteRequest = {
+    playerKey: string;
+    email: string;
+    displayName?: string;
+    relation: string;
+};
+
+export type ParentHouseholdInviteResult = {
+    code: string;
+    inviteUrl: string;
+};
+
+export async function loadParentHouseholdInviteModel(user: AuthUser | null): Promise<{ linkedPlayers: ParentHouseholdLinkedPlayer[]; members: ParentHouseholdFamilyMember[] }> {
+    if (!user?.uid) return { linkedPlayers: [], members: [] };
+    const [linkedPlayers, members] = await Promise.all([
+        Promise.resolve(normalizeFamilyChildren(user.parentOf || []) as ParentHouseholdLinkedPlayer[]),
+        Promise.resolve(readFamilyMembers(user.uid))
+    ]);
+    return {
+        linkedPlayers,
+        members: (members || []).map((member: any) => ({
+            ...member,
+            inviteUrl: toAbsoluteLegacyUrl(member.inviteUrl)
+        }))
+    };
+}
+
+export async function createParentHouseholdMemberInvite(user: AuthUser | null, request: ParentHouseholdInviteRequest): Promise<ParentHouseholdInviteResult> {
+    if (!user?.uid) throw new Error('Sign in before creating a household invite.');
+    const linkedPlayers = normalizeFamilyChildren(user.parentOf || []) as ParentHouseholdLinkedPlayer[];
+    if (!linkedPlayers.length) throw new Error('No linked players are available for household invites.');
+    const selected = linkedPlayers.find((player) => `${player.teamId}::${player.playerId}` === request.playerKey);
+    if (!selected) throw new Error('Choose a linked player to share.');
+    const email = compactString(request.email).toLowerCase();
+    const relation = compactString(request.relation);
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new Error('Enter a valid email for the household contact.');
+    if (!relation) throw new Error('Enter the household contact relation.');
+
+    const existingMembers = await Promise.resolve(readFamilyMembers(user.uid));
+    const result = await addPendingFamilyMember(user.uid, {
+        email,
+        displayName: compactString(request.displayName),
+        relation,
+        teamId: selected.teamId,
+        teamName: selected.teamName,
+        playerId: selected.playerId,
+        playerName: selected.playerName,
+        playerNumber: selected.playerNumber,
+        playerPhotoUrl: selected.playerPhotoUrl
+    }, { existingMembers });
+    return {
+        code: compactString((result as any)?.code),
+        inviteUrl: toAbsoluteLegacyUrl((result as any)?.inviteUrl)
+    };
+}
+
+function getLegacyUrl(path: string) {
+    return new URL(path, legacyOrigin).toString();
+}
+
+function normalizeFamilyChildren(children: any[]) {
+    return (Array.isArray(children) ? children : [])
+        .filter((child) => child?.teamId && child?.playerId)
+        .map((child) => ({
+            teamId: compactString(child.teamId),
+            teamName: compactString(child.teamName),
+            playerId: compactString(child.playerId),
+            playerName: compactString(child.playerName),
+            playerNumber: compactString(child.playerNumber || child.number),
+            playerPhotoUrl: child.playerPhotoUrl || null
+        }));
+}
+
+function toAbsoluteLegacyUrl(value: unknown) {
+    const path = compactString(value);
+    if (!path) return '';
+    if (/^https?:\/\//i.test(path)) return path;
+    return getLegacyUrl(path.replace(/^\//, ''));
+}
+
+function compactString(value: unknown) {
+    return String(value || '').trim();
+}

--- a/apps/app/src/lib/parentRegistrationsService.ts
+++ b/apps/app/src/lib/parentRegistrationsService.ts
@@ -1,0 +1,107 @@
+import {
+    calculateRegistrationFeeSnapshot,
+    getActiveRegistrationOptions,
+    getRegistrationPaymentNotice,
+    getTeam,
+    hasOnlineRegistrationCheckout,
+    listPublishedTeamRegistrationForms,
+    normalizeRegistrationForm
+} from './adapters/legacyParentTools';
+import { formatCurrencyFromCents as formatCurrency } from './money';
+import type { AuthUser } from './types';
+
+const legacyOrigin = 'https://allplays.ai';
+
+export type RegistrationDiscountRule = {
+    id: string;
+    type: 'early_bird' | 'quantity';
+    label: string;
+    amountType: 'percent' | 'fixed';
+    amountValue: number;
+    earlyBirdDeadline?: string;
+    minimumQuantity?: number;
+    active: boolean;
+};
+
+export type ParentRegistrationCard = Record<string, any> & {
+    id: string;
+    teamId: string;
+    teamName: string;
+    programName: string;
+    description: string;
+    season: string;
+    feeLabel: string;
+    paymentNotice: string;
+    onlineCheckout: boolean;
+    options: Array<Record<string, any>>;
+    discountRules?: RegistrationDiscountRule[];
+    url: string;
+    appUrl?: string;
+};
+
+export async function loadParentRegistrations(user: AuthUser | null): Promise<ParentRegistrationCard[]> {
+    const teamIds = getLinkedTeamIds(user);
+    const cards = await Promise.all(teamIds.map(async (teamId) => {
+        const [team, forms] = await Promise.all([
+            Promise.resolve(getTeam(teamId)).catch(() => null),
+            Promise.resolve(listPublishedTeamRegistrationForms(teamId, { pageSize: 50 })).catch(() => [])
+        ]);
+        return (forms || []).map((form: any) => toRegistrationCard(team || { id: teamId }, form));
+    }));
+    return cards.flat()
+        .filter((card): card is ParentRegistrationCard => Boolean(card))
+        .sort((a, b) => a.teamName.localeCompare(b.teamName) || a.programName.localeCompare(b.programName));
+}
+
+function getLegacyUrl(path: string, params: Record<string, string> = {}) {
+    const url = new URL(path, legacyOrigin);
+    Object.entries(params).forEach(([key, value]) => {
+        if (value) url.searchParams.set(key, value);
+    });
+    return url.toString();
+}
+
+function getRegistrationUrl(teamId: string, formId: string) {
+    return getLegacyUrl('registration.html', { teamId, formId });
+}
+
+function getAppRegistrationUrl(teamId: string, formId: string) {
+    const url = new URL('app/', legacyOrigin);
+    const params = new URLSearchParams();
+    if (teamId) params.set('teamId', teamId);
+    if (formId) params.set('formId', formId);
+    url.hash = `/registration${params.toString() ? `?${params.toString()}` : ''}`;
+    return url.toString();
+}
+
+function toRegistrationCard(team: any, form: any): ParentRegistrationCard | null {
+    const normalized = normalizeRegistrationForm(form, { teamId: team.id || form.teamId, formId: form.id });
+    if (!normalized.published || normalized.status === 'closed' || normalized.status === 'archived') return null;
+    const feeSnapshot = calculateRegistrationFeeSnapshot(normalized, { now: new Date() });
+    return {
+        ...normalized,
+        id: normalized.id,
+        teamId: normalized.teamId,
+        teamName: compactString(team.name) || 'Team',
+        programName: normalized.programName || 'Registration',
+        description: normalized.description,
+        season: normalized.season,
+        feeLabel: formatCurrency(feeSnapshot.finalAmountDueCents, normalized.currency),
+        paymentNotice: getRegistrationPaymentNotice(normalized),
+        onlineCheckout: hasOnlineRegistrationCheckout(normalized),
+        options: getActiveRegistrationOptions(normalized, normalized.registrationOptionCounts || {}),
+        url: getRegistrationUrl(normalized.teamId, normalized.id),
+        appUrl: getAppRegistrationUrl(normalized.teamId, normalized.id)
+    };
+}
+
+function getLinkedTeamIds(user: AuthUser | null) {
+    return [...new Set([
+        ...(Array.isArray(user?.parentOf) ? user!.parentOf.map((entry: any) => compactString(entry.teamId)) : []),
+        ...(Array.isArray(user?.coachOf) ? user!.coachOf.map(compactString) : [])
+    ].filter(Boolean))];
+}
+
+function compactString(value: unknown) {
+    return String(value || '').trim();
+}

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -324,9 +324,9 @@ describe('ParentTools access', () => {
 
         await screen.findByText('Request player access');
         await waitFor(() => expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1));
-        expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
 
         const teamSelect = await screen.findByRole('combobox', { name: 'Team' }) as HTMLSelectElement;
+        expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
         expect(teamSelect.value).toBe('team-1');
         await waitFor(() => expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-1'));
         expect(screen.getByRole('option', { name: 'Loading players...' })).toBeTruthy();

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -39,6 +39,34 @@ const inviteRedemptionMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../lib/parentToolsService', () => parentToolsServiceMocks);
+vi.mock('../lib/parentCalendarService', () => ({
+    buildParentScheduleIcs: parentToolsServiceMocks.buildParentScheduleIcs,
+    getAppleCalendarFeedUrl: parentToolsServiceMocks.getAppleCalendarFeedUrl,
+    getCalendarEventShareText: parentToolsServiceMocks.getCalendarEventShareText,
+    getGoogleCalendarFeedUrl: parentToolsServiceMocks.getGoogleCalendarFeedUrl,
+    getPrivateTeamCalendarFeedUrl: parentToolsServiceMocks.getPrivateTeamCalendarFeedUrl,
+    loadParentCalendarTools: parentToolsServiceMocks.loadParentCalendarTools
+}));
+vi.mock('../lib/parentFeesService', () => ({
+    initiateParentTeamFeeCheckout: parentToolsServiceMocks.initiateParentTeamFeeCheckout,
+    loadParentFeesForApp: parentToolsServiceMocks.loadParentFeesForApp
+}));
+vi.mock('../lib/parentFamilyShareService', () => ({
+    createParentFamilyShare: parentToolsServiceMocks.createParentFamilyShare,
+    loadFamilyShareModel: parentToolsServiceMocks.loadFamilyShareModel,
+    revokeParentFamilyShare: parentToolsServiceMocks.revokeParentFamilyShare,
+    updateParentFamilyShareCalendars: parentToolsServiceMocks.updateParentFamilyShareCalendars
+}));
+vi.mock('../lib/parentHouseholdService', () => ({
+    createParentHouseholdMemberInvite: parentToolsServiceMocks.createParentHouseholdMemberInvite,
+    loadParentHouseholdInviteModel: parentToolsServiceMocks.loadParentHouseholdInviteModel
+}));
+vi.mock('../lib/parentRegistrationsService', () => ({
+    loadParentRegistrations: parentToolsServiceMocks.loadParentRegistrations
+}));
+vi.mock('../lib/parentCertificatesService', () => ({
+    loadParentCertificates: parentToolsServiceMocks.loadParentCertificates
+}));
 vi.mock('../lib/parentToolsAccessService', () => parentToolsAccessServiceMocks);
 vi.mock('../lib/inviteRedemption', () => inviteRedemptionMocks);
 vi.mock('../lib/publicActions', () => ({

--- a/apps/app/src/pages/parent-tools/CalendarTool.tsx
+++ b/apps/app/src/pages/parent-tools/CalendarTool.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { CalendarDays, Copy, Download, Loader2, RefreshCw } from 'lucide-react';
 import { exportCalendarIcsFile, openPublicUrl } from '../../lib/publicActions';
-import { buildParentScheduleIcs, getAppleCalendarFeedUrl, getCalendarEventShareText, getGoogleCalendarFeedUrl, getPrivateTeamCalendarFeedUrl, loadParentCalendarTools, type ParentCalendarTeam } from '../../lib/parentToolsService';
+import { buildParentScheduleIcs, getAppleCalendarFeedUrl, getCalendarEventShareText, getGoogleCalendarFeedUrl, getPrivateTeamCalendarFeedUrl, loadParentCalendarTools, type ParentCalendarTeam } from '../../lib/parentCalendarService';
 import type { ParentScheduleEvent } from '../../lib/scheduleLogic';
 import type { AuthState } from '../../lib/types';
 import { LoadingBlock, MetricCard, RetryableStatus, Status, ToolHeader, copyText, useParentToolAsyncOperation } from './shared';

--- a/apps/app/src/pages/parent-tools/CertificatesTool.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Award, ExternalLink, RefreshCw, Share2 } from 'lucide-react';
-import { loadParentCertificates, type ParentCertificateCard } from '../../lib/parentToolsService';
+import { loadParentCertificates, type ParentCertificateCard } from '../../lib/parentCertificatesService';
 import { openPublicUrl, sharePublicUrl } from '../../lib/publicActions';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, ToolHeader, useParentToolAsyncOperation } from './shared';

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { Copy, Loader2, RefreshCw, Share2 } from 'lucide-react';
-import { createParentFamilyShare, loadFamilyShareModel, revokeParentFamilyShare, updateParentFamilyShareCalendars, type FamilyShareTokenCard } from '../../lib/parentToolsService';
+import { createParentFamilyShare, loadFamilyShareModel, revokeParentFamilyShare, updateParentFamilyShareCalendars, type FamilyShareTokenCard } from '../../lib/parentFamilyShareService';
 import { sharePublicUrl } from '../../lib/publicActions';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, splitLines, useParentToolAsyncOperation } from './shared';

--- a/apps/app/src/pages/parent-tools/FeesTool.tsx
+++ b/apps/app/src/pages/parent-tools/FeesTool.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { DollarSign, ExternalLink, Loader2, RefreshCw } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { openPublicUrl } from '../../lib/publicActions';
-import { initiateParentTeamFeeCheckout, loadParentFeesForApp, type ParentFeeAppRecord } from '../../lib/parentToolsService';
+import { initiateParentTeamFeeCheckout, loadParentFeesForApp, type ParentFeeAppRecord } from '../../lib/parentFeesService';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, MetricCard, RetryableStatus, ToolHeader, formatDetailAmount, formatMoney, useParentToolAsyncOperation } from './shared';
 

--- a/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
+++ b/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Copy, Loader2, RefreshCw, Users } from 'lucide-react';
-import { createParentHouseholdMemberInvite, loadParentHouseholdInviteModel, type ParentHouseholdFamilyMember, type ParentHouseholdLinkedPlayer } from '../../lib/parentToolsService';
+import { createParentHouseholdMemberInvite, loadParentHouseholdInviteModel, type ParentHouseholdFamilyMember, type ParentHouseholdLinkedPlayer } from '../../lib/parentHouseholdService';
 import { toAppServiceError } from '../../lib/appErrors';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, useParentToolAsyncOperation } from './shared';

--- a/apps/app/src/pages/parent-tools/RegistrationsTool.tsx
+++ b/apps/app/src/pages/parent-tools/RegistrationsTool.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { ExternalLink, RefreshCw, Share2, Ticket } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { loadParentRegistrations, type ParentRegistrationCard } from '../../lib/parentToolsService';
+import { loadParentRegistrations, type ParentRegistrationCard } from '../../lib/parentRegistrationsService';
 import { openPublicUrl, sharePublicUrl } from '../../lib/publicActions';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, MetricCard, RetryableStatus, ToolHeader, useParentToolAsyncOperation } from './shared';

--- a/apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts
+++ b/apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const pageContracts = [
+    { file: 'CalendarTool.tsx', focusedImport: "../../lib/parentCalendarService" },
+    { file: 'FeesTool.tsx', focusedImport: "../../lib/parentFeesService" },
+    { file: 'FamilyShareTool.tsx', focusedImport: "../../lib/parentFamilyShareService" },
+    { file: 'HouseholdInviteTool.tsx', focusedImport: "../../lib/parentHouseholdService" },
+    { file: 'RegistrationsTool.tsx', focusedImport: "../../lib/parentRegistrationsService" },
+    { file: 'CertificatesTool.tsx', focusedImport: "../../lib/parentCertificatesService" }
+] as const;
+
+describe('Parent Tools focused service imports', () => {
+    it.each(pageContracts)('%s imports only its focused service module', ({ file, focusedImport }) => {
+        const source = readFileSync(resolve(__dirname, file), 'utf8');
+
+        expect(source).toContain(focusedImport);
+        expect(source).not.toContain("../../lib/parentToolsService");
+    });
+});

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -11,6 +11,137 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+const parentHouseholdServiceMock = `
+    export async function loadParentHouseholdInviteModel() {
+        return {
+            linkedPlayers: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9' }],
+            members: []
+        };
+    }
+    export async function createParentHouseholdMemberInvite() {
+        return { code: 'HOUSE123', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOUSE123' };
+    }
+`;
+
+const parentFeesServiceMock = `
+    export async function loadParentFeesForApp() {
+        return [{
+            id: 'fee-1',
+            title: 'Team dues',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            playerName: 'Pat Star',
+            status: 'open',
+            amountLabel: '$120',
+            dueLabel: 'Jun 1',
+            statusLabel: 'Open',
+            balanceDueCents: 12000,
+            checkoutUrl: 'https://pay.example.test/fee',
+            canPay: true,
+            lineItems: [{ title: 'Season', amountCents: 12000 }],
+            installments: [{ label: 'Deposit', amountCents: 6000 }],
+            ledgerEntries: [{ label: 'Adjustment', amountCents: -1000 }]
+        }];
+    }
+    export async function initiateParentTeamFeeCheckout() {
+        return { success: true, checkoutUrl: 'https://pay.example.test/created-fee' };
+    }
+`;
+
+const parentCalendarServiceMock = `
+    export async function loadParentCalendarTools() {
+        return {
+            events: [{ teamId: 'team-1', teamName: 'Bears', title: 'Practice', opponent: '', date: new Date('2100-06-01T18:00:00Z') }],
+            teams: [{ teamId: 'team-1', teamName: 'Bears', eventCount: 1 }]
+        };
+    }
+    export function buildParentScheduleIcs() {
+        return 'BEGIN:VCALENDAR\\r\\nEND:VCALENDAR';
+    }
+    export function getCalendarEventShareText(event) {
+        return event.teamName + ' ' + event.title;
+    }
+    export async function getPrivateTeamCalendarFeedUrl() {
+        return 'https://feed.example.test/team-1.ics';
+    }
+    export function getAppleCalendarFeedUrl(url) {
+        return 'webcal://' + url.replace(/^https?:\\/\\//, '');
+    }
+    export function getGoogleCalendarFeedUrl(url) {
+        return 'https://calendar.google.com/calendar/render?cid=' + encodeURIComponent(url);
+    }
+`;
+
+const parentFamilyShareServiceMock = `
+    export async function loadFamilyShareModel() {
+        return {
+            children: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Pat Star' }],
+            tokens: [{ id: 'token-1', label: 'Grandma', url: 'https://allplays.ai/family.html?token=token-1', childCount: 1, extraCalendarUrls: [] }]
+        };
+    }
+    export async function createParentFamilyShare(user, label, urls) {
+        window.__familyCreates.push({ label, urls });
+        return { tokenId: 'token-2', url: 'https://allplays.ai/family.html?token=token-2' };
+    }
+    export async function revokeParentFamilyShare() {}
+    export async function updateParentFamilyShareCalendars() {}
+`;
+
+const parentRegistrationsServiceMock = `
+    export async function loadParentRegistrations() {
+        return [{
+            id: 'form-1',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            programName: 'Summer Camp',
+            description: 'Skills week',
+            season: 'Summer',
+            feeLabel: '$75.00',
+            paymentNotice: 'Online checkout available.',
+            onlineCheckout: true,
+            options: [{ id: 'opt-1' }],
+            url: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1'
+        }];
+    }
+    export async function loadParentRegistrationDetail() {
+        return {
+            teamName: 'Bears',
+            isPublished: true,
+            onlineCheckout: true,
+            legacyUrl: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1',
+            form: {
+                programName: 'Summer Camp',
+                description: 'Skills week',
+                season: 'Summer',
+                currency: 'USD',
+                participantFields: [],
+                guardianFields: [],
+                waiverText: '',
+                registrationOptionCounts: {}
+            },
+            options: [{ id: 'opt-1', title: 'Full week', description: 'Skills week', capacityLimit: 20, waitlistEnabled: true }],
+            feeSnapshot: { finalAmountDueCents: 7500 },
+            paymentNotice: 'Online checkout available.',
+            paymentPlans: []
+        };
+    }
+`;
+
+const parentCertificatesServiceMock = `
+    export async function loadParentCertificates() {
+        return [{
+            id: 'cert-1',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            playerId: 'player-1',
+            playerName: 'Pat Star',
+            title: 'Hustle Award',
+            narrative: 'Great effort.',
+            url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1'
+        }];
+    }
+`;
+
 async function mockParentToolsModules(page) {
     await page.addInitScript(() => {
         window.__openedPublicUrls = [];
@@ -111,6 +242,54 @@ async function mockParentToolsModules(page) {
                     return { success: true };
                 }
             `
+        });
+    });
+
+    await page.route(/\/src\/lib\/parentHouseholdService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: parentHouseholdServiceMock
+        });
+    });
+
+    await page.route(/\/src\/lib\/parentFeesService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: parentFeesServiceMock
+        });
+    });
+
+    await page.route(/\/src\/lib\/parentCalendarService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: parentCalendarServiceMock
+        });
+    });
+
+    await page.route(/\/src\/lib\/parentFamilyShareService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: parentFamilyShareServiceMock
+        });
+    });
+
+    await page.route(/\/src\/lib\/parentRegistrationsService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: parentRegistrationsServiceMock
+        });
+    });
+
+    await page.route(/\/src\/lib\/parentCertificatesService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: parentCertificatesServiceMock
         });
     });
 

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -47,6 +47,34 @@ const inviteRedemptionMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../apps/app/src/lib/parentToolsService.ts', () => serviceMocks);
+vi.mock('../../apps/app/src/lib/parentFeesService.ts', () => ({
+    loadParentFeesForApp: serviceMocks.loadParentFeesForApp,
+    initiateParentTeamFeeCheckout: serviceMocks.initiateParentTeamFeeCheckout
+}));
+vi.mock('../../apps/app/src/lib/parentFamilyShareService.ts', () => ({
+    loadFamilyShareModel: serviceMocks.loadFamilyShareModel,
+    createParentFamilyShare: serviceMocks.createParentFamilyShare,
+    revokeParentFamilyShare: serviceMocks.revokeParentFamilyShare,
+    updateParentFamilyShareCalendars: serviceMocks.updateParentFamilyShareCalendars
+}));
+vi.mock('../../apps/app/src/lib/parentCalendarService.ts', () => ({
+    loadParentCalendarTools: serviceMocks.loadParentCalendarTools,
+    buildParentScheduleIcs: serviceMocks.buildParentScheduleIcs,
+    getPrivateTeamCalendarFeedUrl: serviceMocks.getPrivateTeamCalendarFeedUrl,
+    getAppleCalendarFeedUrl: serviceMocks.getAppleCalendarFeedUrl,
+    getGoogleCalendarFeedUrl: serviceMocks.getGoogleCalendarFeedUrl,
+    getCalendarEventShareText: serviceMocks.getCalendarEventShareText
+}));
+vi.mock('../../apps/app/src/lib/parentHouseholdService.ts', () => ({
+    loadParentHouseholdInviteModel: serviceMocks.loadParentHouseholdInviteModel,
+    createParentHouseholdMemberInvite: serviceMocks.createParentHouseholdMemberInvite
+}));
+vi.mock('../../apps/app/src/lib/parentRegistrationsService.ts', () => ({
+    loadParentRegistrations: serviceMocks.loadParentRegistrations
+}));
+vi.mock('../../apps/app/src/lib/parentCertificatesService.ts', () => ({
+    loadParentCertificates: serviceMocks.loadParentCertificates
+}));
 vi.mock('../../apps/app/src/lib/parentToolsAccessService.ts', () => accessServiceMocks);
 vi.mock('../../apps/app/src/lib/inviteRedemption.ts', () => inviteRedemptionMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);


### PR DESCRIPTION
Closes #3109

## What changed
- Added focused Parent Tools service entrypoints for calendar, fees, family share, household invites, registrations, and certificates.
- Updated each lazy-loaded Parent Tools tab to import only its own focused service module instead of `../../lib/parentToolsService`.
- Added a source-contract regression test that locks those tab imports to their focused modules.
- Kept the existing Parent Tools lazy-load and revisit behavior covered by `ParentTools.test.tsx`, then rebuilt the app to verify the new imports compile into separate tab chunks.

## Root Cause
The lazy Parent Tools panels were still importing the monolithic `parentToolsService` module, so each panel async chunk inherited a broad `legacyParentTools` dependency graph with unrelated calendar, fees, share, registrations, and certificates logic.

## Prevention / Learning
When we code-split tabs or routes for performance, we also need to split their data-service entrypoints. UI lazy loading does not help much if all lazy panels still converge on one heavyweight shared service module. Add import-contract tests any time bundle isolation is a requirement.

## Regression Tests
- `apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts`
- `apps/app/src/pages/ParentTools.test.tsx`
- `npm test -- --run src/pages/ParentTools.test.tsx src/pages/parent-tools/parentToolServiceImports.test.ts`
- `npm run app:build`

## Recurrence Risk
Medium. The parent tabs are now protected by a contract test, but other routes still use `parentToolsService`, so future lazy tab work could regress if new panels import the monolith again.