### PR TITLE
Refresh live Game Day lineup on remote updates

### DIFF
--- a/game-day.html
+++ b/game-day.html
@@ -509,9 +509,10 @@
         import { createGameDayRsvpController } from './js/game-day-rsvp-controls.js?v=1';
         import {
             buildOnFieldMap as buildLiveOnFieldMap,
+            syncGameDayLiveState,
             getSubstitutionOptions,
             applyLiveSubstitution
-        } from './js/game-day-live-substitutions.js?v=1';
+        } from './js/game-day-live-substitutions.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -1090,6 +1091,14 @@
                 const unsubGame = subscribeGame(teamId, state.gameId, (updatedGame) => {
                     const prevLiveStatus = state.game?.liveStatus;
                     state.game = updatedGame;
+                    const liveStateUpdate = syncGameDayLiveState({
+                        currentState: state,
+                        updatedGame
+                    });
+                    state.gamePlan = liveStateUpdate.gamePlan;
+                    state.rotationPlan = liveStateUpdate.rotationPlan;
+                    state.rotationActual = liveStateUpdate.rotationActual;
+                    state.formationId = liveStateUpdate.formationId;
                     state.score = { home: updatedGame.homeScore || 0, away: updatedGame.awayScore || 0 };
                     const remoteChat = extractChatStateFromGameDoc(updatedGame);
                     if (remoteChat && !state.chatPersistInFlight && !state.chatPersistTimer) {
@@ -1103,6 +1112,9 @@
                     }
                     markAiChatContextDirty();
                     updateScoreDisplay();
+                    if (liveStateUpdate.hasLineupChange) {
+                        renderCurrentMode();
+                    }
                     // Detect transitions
                     if (updatedGame.liveStatus === 'live' && prevLiveStatus !== 'live' && state.mode !== 'gameday') {
                         if (confirm('The game is now live! Switch to Game Day mode?')) setMode('gameday');

--- a/js/game-day-live-substitutions.js
+++ b/js/game-day-live-substitutions.js
@@ -77,6 +77,10 @@ function buildLineupSyncSignature({
     });
 }
 
+function hasGamePlanChanged(currentGamePlan, nextGamePlan) {
+    return JSON.stringify(currentGamePlan || null) !== JSON.stringify(nextGamePlan || null);
+}
+
 export function syncGameDayLiveState({
     currentState = {},
     updatedGame = {}
@@ -84,11 +88,16 @@ export function syncGameDayLiveState({
     const nextGamePlan = hasOwnField(updatedGame, 'gamePlan')
         ? updatedGame.gamePlan || null
         : currentState.gamePlan || null;
-    const nextRotationPlan = hasOwnField(updatedGame, 'rotationPlan')
-        ? updatedGame.rotationPlan || {}
-        : (hasOwnField(updatedGame, 'gamePlan')
-            ? buildRotationPlanFromGamePlan(nextGamePlan)
-            : currentState.rotationPlan || {});
+    const rebuiltRotationPlan = buildRotationPlanFromGamePlan(nextGamePlan);
+    const shouldRebuildRotationPlan = hasOwnField(updatedGame, 'gamePlan')
+        && hasGamePlanChanged(currentState.gamePlan, nextGamePlan);
+    const nextRotationPlan = shouldRebuildRotationPlan
+        ? rebuiltRotationPlan
+        : (hasOwnField(updatedGame, 'rotationPlan')
+            ? updatedGame.rotationPlan || {}
+            : (hasOwnField(updatedGame, 'gamePlan')
+                ? rebuiltRotationPlan
+                : currentState.rotationPlan || {}));
     const nextRotationActual = hasOwnField(updatedGame, 'rotationActual')
         ? updatedGame.rotationActual || {}
         : currentState.rotationActual || {};

--- a/js/game-day-live-substitutions.js
+++ b/js/game-day-live-substitutions.js
@@ -1,3 +1,5 @@
+import { buildRotationPlanFromGamePlan } from './game-plan-interop.js';
+
 function getPlayersByName(players = []) {
     const byName = new Map();
     players.forEach((player) => {
@@ -54,6 +56,57 @@ export function getSubstitutionOptions({
         onField,
         onFieldPlayers: players.filter((player) => onFieldIds.has(player.id)),
         offFieldPlayers: players.filter((player) => !onFieldIds.has(player.id))
+    };
+}
+
+function hasOwnField(doc, field) {
+    return Object.prototype.hasOwnProperty.call(doc || {}, field);
+}
+
+function buildLineupSyncSignature({
+    gamePlan = null,
+    rotationPlan = {},
+    rotationActual = {},
+    formationId = null
+}) {
+    return JSON.stringify({
+        gamePlan,
+        rotationPlan,
+        rotationActual,
+        formationId
+    });
+}
+
+export function syncGameDayLiveState({
+    currentState = {},
+    updatedGame = {}
+}) {
+    const nextGamePlan = hasOwnField(updatedGame, 'gamePlan')
+        ? updatedGame.gamePlan || null
+        : currentState.gamePlan || null;
+    const nextRotationPlan = hasOwnField(updatedGame, 'rotationPlan')
+        ? updatedGame.rotationPlan || {}
+        : (hasOwnField(updatedGame, 'gamePlan')
+            ? buildRotationPlanFromGamePlan(nextGamePlan)
+            : currentState.rotationPlan || {});
+    const nextRotationActual = hasOwnField(updatedGame, 'rotationActual')
+        ? updatedGame.rotationActual || {}
+        : currentState.rotationActual || {};
+    const nextFormationId = nextGamePlan?.formationId || currentState.formationId || null;
+    const previousSignature = buildLineupSyncSignature(currentState);
+    const nextSignature = buildLineupSyncSignature({
+        gamePlan: nextGamePlan,
+        rotationPlan: nextRotationPlan,
+        rotationActual: nextRotationActual,
+        formationId: nextFormationId
+    });
+
+    return {
+        gamePlan: nextGamePlan,
+        rotationPlan: nextRotationPlan,
+        rotationActual: nextRotationActual,
+        formationId: nextFormationId,
+        hasLineupChange: previousSignature !== nextSignature
     };
 }
 

--- a/tests/unit/game-day-live-substitutions.test.js
+++ b/tests/unit/game-day-live-substitutions.test.js
@@ -5,7 +5,8 @@ import { buildRotationPlanFromGamePlan } from '../../js/game-plan-interop.js';
 import {
     buildOnFieldMap,
     getSubstitutionOptions,
-    applyLiveSubstitution
+    applyLiveSubstitution,
+    syncGameDayLiveState
 } from '../../js/game-day-live-substitutions.js';
 
 const players = [
@@ -110,16 +111,97 @@ describe('game day live substitutions', () => {
             appliedAt: '2026-04-14T19:26:00.000Z'
         });
     });
+
+    it('refreshes remote lineup state for already-open game day sessions', () => {
+        const currentState = {
+            gamePlan: createSavedGamePlan(),
+            rotationPlan: buildRotationPlanFromGamePlan(createSavedGamePlan()),
+            rotationActual: {},
+            formationId: 'soccer-9v9'
+        };
+
+        const updatedGame = {
+            gamePlan: createSavedGamePlan(),
+            rotationPlan: {
+                H1: { keeper: 'p1', striker: 'p3' }
+            },
+            rotationActual: {
+                H1: {
+                    'sub-1776194700000': [{
+                        position: 'striker',
+                        out: 'Blake',
+                        outId: 'p2',
+                        outPlayerId: 'p2',
+                        in: 'Casey',
+                        inId: 'p3',
+                        inPlayerId: 'p3',
+                        appliedAt: '2026-04-14T19:25:00.000Z'
+                    }]
+                }
+            }
+        };
+
+        const synced = syncGameDayLiveState({ currentState, updatedGame });
+
+        expect(synced.hasLineupChange).toBe(true);
+        expect(synced.rotationPlan).toEqual(updatedGame.rotationPlan);
+        expect(synced.rotationActual).toEqual(updatedGame.rotationActual);
+        expect(buildOnFieldMap({
+            period: 'H1',
+            rotationPlan: synced.rotationPlan,
+            rotationActual: synced.rotationActual,
+            players
+        })).toEqual({ keeper: 'p1', striker: 'p3' });
+    });
+
+    it('rebuilds the live rotation plan from a refreshed game plan when no explicit plan is stored', () => {
+        const updatedGame = {
+            gamePlan: {
+                formationId: 'soccer-9v9',
+                numPeriods: 2,
+                lineups: {
+                    'H1-keeper': 'p3',
+                    'H1-striker': 'p2'
+                }
+            }
+        };
+
+        const synced = syncGameDayLiveState({
+            currentState: {
+                rotationPlan: {},
+                rotationActual: {},
+                formationId: null,
+                gamePlan: null
+            },
+            updatedGame
+        });
+
+        expect(synced.hasLineupChange).toBe(true);
+        expect(synced.formationId).toBe('soccer-9v9');
+        expect(synced.rotationPlan).toEqual({
+            H1: { keeper: 'p3', striker: 'p2' }
+        });
+    });
 });
 
 describe('game day live substitution wiring', () => {
     it('routes on-field reconstruction and apply-sub behavior through the shared helper module', () => {
         const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
 
-        expect(source).toContain("from './js/game-day-live-substitutions.js?v=1'");
+        expect(source).toContain("from './js/game-day-live-substitutions.js?v=2'");
         expect(source).toContain('return buildLiveOnFieldMap({');
         expect(source).toContain('const { onFieldPlayers, offFieldPlayers } = getSubstitutionOptions({');
         expect(source).toContain('const subResult = applyLiveSubstitution({');
         expect(source).toContain('populateSubDropdowns();');
+    });
+
+    it('syncs remote lineup updates from the live game subscription before re-rendering', () => {
+        const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
+
+        expect(source).toContain('const liveStateUpdate = syncGameDayLiveState({');
+        expect(source).toContain('state.rotationPlan = liveStateUpdate.rotationPlan;');
+        expect(source).toContain('state.rotationActual = liveStateUpdate.rotationActual;');
+        expect(source).toContain('if (liveStateUpdate.hasLineupChange) {');
+        expect(source).toContain('renderCurrentMode();');
     });
 });

--- a/tests/unit/game-day-live-substitutions.test.js
+++ b/tests/unit/game-day-live-substitutions.test.js
@@ -182,6 +182,53 @@ describe('game day live substitutions', () => {
             H1: { keeper: 'p3', striker: 'p2' }
         });
     });
+
+    it('rebuilds the live rotation plan when a refreshed game plan arrives with a stale persisted rotation plan', () => {
+        const currentState = {
+            gamePlan: createSavedGamePlan(),
+            rotationPlan: {
+                H1: { keeper: 'p1', striker: 'p3' }
+            },
+            rotationActual: {
+                H1: {
+                    'sub-1776194700000': [{
+                        position: 'striker',
+                        out: 'Blake',
+                        outId: 'p2',
+                        outPlayerId: 'p2',
+                        in: 'Casey',
+                        inId: 'p3',
+                        inPlayerId: 'p3',
+                        appliedAt: '2026-04-14T19:25:00.000Z'
+                    }]
+                }
+            },
+            formationId: 'soccer-9v9'
+        };
+        const updatedGame = {
+            gamePlan: {
+                formationId: 'soccer-9v9',
+                numPeriods: 2,
+                lineups: {
+                    'H1-keeper': 'p1',
+                    'H1-striker': 'p2',
+                    'H2-keeper': 'p3',
+                    'H2-striker': 'p1'
+                }
+            },
+            rotationPlan: currentState.rotationPlan,
+            rotationActual: currentState.rotationActual
+        };
+
+        const synced = syncGameDayLiveState({ currentState, updatedGame });
+
+        expect(synced.hasLineupChange).toBe(true);
+        expect(synced.rotationActual).toEqual(currentState.rotationActual);
+        expect(synced.rotationPlan).toEqual({
+            H1: { keeper: 'p1', striker: 'p2' },
+            H2: { keeper: 'p3', striker: 'p1' }
+        });
+    });
 });
 
 describe('game day live substitution wiring', () => {


### PR DESCRIPTION
Closes #3112

## What changed
- synced the Game Day Firestore subscription with persisted `gamePlan`, `rotationPlan`, `rotationActual`, and `formationId` updates so already-open sessions ingest remote lineup changes
- moved that reconciliation into the shared `js/game-day-live-substitutions.js` helper and re-rendered the active Game Day view only when lineup state actually changes
- added focused regression coverage for remote subscription refresh behavior and the fallback path that rebuilds a live rotation plan from `gamePlan`

## Root Cause
The Game Day subscription callback only refreshed `state.game`, score, and chat state. It never copied updated lineup fields from the subscribed game document back into `state.gamePlan`, `state.rotationPlan`, `state.rotationActual`, or `formationId`, so peer sessions kept rendering stale on-field and substitution state until a reload.

## Prevention / Learning
When a legacy page keeps derived live state outside the subscribed document, every persisted field that drives rendering must be explicitly reconciled inside the subscription callback. For live collaboration flows, treat Firestore snapshot handlers as the source of truth for all rendered state, not just the top-level document reference.

## Regression Tests
- `npx vitest run tests/unit/game-day-live-substitutions.test.js --reporter=verbose`
- added unit coverage for remote lineup-state sync from subscription updates
- added unit coverage for rebuilding live rotation state from refreshed `gamePlan` data when no explicit `rotationPlan` is stored

## Recurrence Risk
low: the live subscription now routes lineup refresh through a shared helper with focused regression coverage on the stale-state failure path.