### PR TITLE
Keep linked opponent controls visible

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -856,15 +856,7 @@ function updateSubtitle() {
 
 function updateOpponentLinkVisibility() {
   if (!els.oppTeamSection) return;
-  const hasOppPlayers = state.opp.some(o => {
-    const hasName = (o.name || '').trim().length > 0;
-    const hasNumber = (o.number || '').trim().length > 0;
-    const hasStats = o.stats && Object.values(o.stats).some(val => val > 0);
-    return hasName || hasNumber || hasStats;
-  });
-  const isLinked = !!currentGame?.opponentTeamId;
-  const shouldHide = isLinked && hasOppPlayers;
-  els.oppTeamSection.classList.toggle('hidden', shouldHide);
+  els.oppTeamSection.classList.remove('hidden');
 }
 
 function getOpponentRecordedPoints(opp) {

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -254,6 +254,8 @@ return {
   els,
   renderOpponents,
   addSelectedOpponentRoster,
+  setLinkedOpponentTeam,
+  loadOpponentRoster,
   setContext(context = {}) {
     currentTeamId = context.teamId || null;
     currentGameId = context.gameId || null;
@@ -279,7 +281,7 @@ const runModule = new AsyncFunction(
   moduleSource
 );
 
-async function bootLiveTracker({ updateGame }) {
+async function bootLiveTracker({ updateGame, getPlayers = async () => [] }) {
   const { document } = createEnvironment();
   const scheduledTimeouts = new Map();
   let nextTimeoutId = 1;
@@ -288,7 +290,7 @@ async function bootLiveTracker({ updateGame }) {
       getTeam: async () => ({}),
       getTeams: async () => [],
       getGame: async () => ({}),
-      getPlayers: async () => [],
+      getPlayers,
       getConfigs: async () => [],
       updateGame,
       collection: () => ({}),
@@ -475,6 +477,30 @@ describe('live tracker opponent stats harness', () => {
 });
 
 describe('live tracker opponent stats hydration', () => {
+  it('keeps linked opponent controls visible after roster auto-populates players', async () => {
+    const page = await bootLiveTracker({
+      updateGame: async () => {},
+      getPlayers: async () => [
+        { id: 'opp10', name: 'Taylor Guard', number: '10', photoUrl: 'https://img/10.png' },
+        { id: 'opp22', name: 'Jordan Wing', number: '22', photoUrl: '' }
+      ]
+    });
+
+    page.setContext({
+      teamId: 'team-1',
+      gameId: 'game-1',
+      config: { columns: ['PTS'] },
+      game: { opponent: 'Rivals', opponentTeamId: null }
+    });
+    page.state.opp = [];
+
+    await page.setLinkedOpponentTeam({ id: 'opp-team-1', name: 'Rivals', photoUrl: '' });
+
+    expect(page.state.opp).toHaveLength(2);
+    expect(page.els.oppTeamLinked.classList.tokens.has('hidden')).toBe(false);
+    expect(page.els.oppTeamSection.classList.tokens.has('hidden')).toBe(false);
+  });
+
   it('preserves linked opponent roster additions so resume restores selected players', async () => {
     const updateCalls = [];
     const page = await bootLiveTracker({


### PR DESCRIPTION
Closes #3114

## What changed
- stopped hiding the entire opponent link management section after opponent roster players or stats exist
- kept the existing linked opponent summary and Clear control reachable even after roster auto-populate
- added a focused regression test that links an opponent, auto-imports the roster, and verifies the link controls remain visible

## Root Cause
`updateOpponentLinkVisibility()` treated any populated opponent roster plus a linked opponent team as a reason to hide `#opp-team-section`. That section also contained the only visible Clear/change controls, so linking a team and auto-populating its roster immediately removed the only correction path.

## Prevention / Learning
Do not hide the only management controls for a linked entity based on derived content state. If imported or hydrated data depends on a link, keep the edit and unlink controls visible after hydration so users can recover from a bad selection without deleting downstream data.

## Regression Tests
- `npx vitest run tests/unit/live-tracker-opponent-stats.test.js --reporter=verbose`
- added coverage for the linked-opponent auto-populate flow to assert `#opp-team-section` stays visible after roster import