### PR TITLE
Route /games deep links to task-first schedule sections

### DIFF
--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -791,6 +791,24 @@ export function getScheduleEventDetailPath(
   return `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}${query ? `?${query}` : ''}`;
 }
 
+function getTaskTargetedEventDetailPath(event: ParentScheduleEvent | CalendarScheduleEntry) {
+  return getScheduleEventDetailPath(event, getScheduleTaskDetailSection(event));
+}
+
+function hasStaffGameHubAccess(event: Pick<ParentScheduleEvent, 'isTeamStaff' | 'isTeamAdmin' | 'canUpdateScore'>) {
+  return event.isTeamStaff === true || event.isTeamAdmin === true || event.canUpdateScore === true;
+}
+
+export function getGenericEventDetailPath(
+  event: ParentScheduleEvent | CalendarScheduleEntry,
+  preferGameHubForStaff = false
+) {
+  if (preferGameHubForStaff && hasStaffGameHubAccess(event)) {
+    return getScheduleEventDetailPath(event, 'game');
+  }
+  return getTaskTargetedEventDetailPath(event);
+}
+
 export function getScheduleTournamentInfo(
   event: Pick<ParentScheduleEvent, 'competitionType' | 'tournament'> & Record<string, any>
 ): ScheduleTournamentInfo {

--- a/apps/app/src/pages/GameDetail.test.tsx
+++ b/apps/app/src/pages/GameDetail.test.tsx
@@ -149,6 +149,23 @@ describe('GameDetail route resolution', () => {
     expect(screen.getByTestId('location').textContent).toBe('/schedule/team-bears/game-1?childId=player-7&section=game')
   })
 
+  it('falls back to the resolved schedule route when detail refresh fails', async () => {
+    scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue({
+      teamId: 'team-bears',
+      eventId: 'game-1',
+      childId: 'player-7'
+    })
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockRejectedValue(new Error('offline'))
+
+    renderGameDetail()
+
+    await waitFor(() => {
+      expect(screen.getByText('Live event workflow')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('location').textContent).toBe('/schedule/team-bears/game-1?childId=player-7&section=game')
+  })
+
   it('shows a recovery state when the game cannot be resolved', async () => {
     scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue(null)
 

--- a/apps/app/src/pages/GameDetail.test.tsx
+++ b/apps/app/src/pages/GameDetail.test.tsx
@@ -5,7 +5,8 @@ import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const scheduleServiceMocks = vi.hoisted(() => ({
-  resolveParentGameRoute: vi.fn()
+  resolveParentGameRoute: vi.fn(),
+  loadParentScheduleEventDetail: vi.fn()
 }))
 
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks)
@@ -67,11 +68,28 @@ describe('GameDetail route resolution', () => {
     cleanup()
   })
 
-  it('routes /games/:gameId into the schedule event detail workflow with game section context', async () => {
+  it('routes non-staff /games/:gameId links to the next task-focused section', async () => {
     scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue({
       teamId: 'team-bears',
       eventId: 'game-1',
       childId: 'player-7'
+    })
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      children: [],
+      events: [{
+        id: 'game-1',
+        teamId: 'team-bears',
+        childId: 'player-7',
+        type: 'game',
+        isDbGame: true,
+        isCancelled: false,
+        myRsvp: 'not_responded',
+        assignments: [],
+        rideshareSummary: null,
+        isTeamStaff: false,
+        isTeamAdmin: false,
+        canUpdateScore: false
+      }]
     })
 
     renderGameDetail()
@@ -82,7 +100,7 @@ describe('GameDetail route resolution', () => {
       expect(screen.getByText('Live event workflow')).toBeTruthy()
     })
 
-    expect(screen.getByTestId('location').textContent).toBe('/schedule/team-bears/game-1?childId=player-7&section=game')
+    expect(screen.getByTestId('location').textContent).toBe('/schedule/team-bears/game-1?childId=player-7&section=availability')
     expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy()
     expect(screen.getByText('Rideshare')).toBeTruthy()
     expect(screen.getByText('Assignments')).toBeTruthy()
@@ -91,6 +109,44 @@ describe('GameDetail route resolution', () => {
     expect(scheduleServiceMocks.resolveParentGameRoute).toHaveBeenCalledWith(auth.user, 'game-1', {
       expandStaffPlayers: false
     })
+    expect(scheduleServiceMocks.loadParentScheduleEventDetail).toHaveBeenCalledWith(auth.user, {
+      teamId: 'team-bears',
+      eventId: 'game-1',
+      expandStaffPlayers: false
+    })
+  })
+
+  it('keeps staff-capable /games/:gameId links on the game hub', async () => {
+    scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue({
+      teamId: 'team-bears',
+      eventId: 'game-1',
+      childId: 'player-7'
+    })
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      children: [],
+      events: [{
+        id: 'game-1',
+        teamId: 'team-bears',
+        childId: 'player-7',
+        type: 'game',
+        isDbGame: true,
+        isCancelled: false,
+        myRsvp: 'not_responded',
+        assignments: [],
+        rideshareSummary: null,
+        isTeamStaff: true,
+        isTeamAdmin: false,
+        canUpdateScore: false
+      }]
+    })
+
+    renderGameDetail()
+
+    await waitFor(() => {
+      expect(screen.getByText('Live event workflow')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('location').textContent).toBe('/schedule/team-bears/game-1?childId=player-7&section=game')
   })
 
   it('shows a recovery state when the game cannot be resolved', async () => {

--- a/apps/app/src/pages/GameDetail.tsx
+++ b/apps/app/src/pages/GameDetail.tsx
@@ -46,15 +46,6 @@ export function GameDetail({ auth }: { auth: AuthState }) {
           return
         }
 
-        const detail = await loadParentScheduleEventDetail(auth.user, {
-          teamId: targetRoute.teamId,
-          eventId: targetRoute.eventId,
-          expandStaffPlayers: false
-        })
-
-        if (cancelled) return
-
-        const matchedEvent = detail.events.find((event) => event.childId === targetRoute.childId) || detail.events[0]
         const fallbackParams = new URLSearchParams()
         if (targetRoute.childId) {
           fallbackParams.set('childId', targetRoute.childId)
@@ -63,11 +54,30 @@ export function GameDetail({ auth }: { auth: AuthState }) {
         const fallbackQuery = fallbackParams.toString()
         const fallbackTarget = `/schedule/${encodeURIComponent(targetRoute.teamId)}/${encodeURIComponent(targetRoute.eventId)}${fallbackQuery ? `?${fallbackQuery}` : ''}`
 
-        setState({
-          loading: false,
-          redirectTarget: matchedEvent ? getGenericEventDetailPath(matchedEvent, true) : fallbackTarget,
-          error: null
-        })
+        try {
+          const detail = await loadParentScheduleEventDetail(auth.user, {
+            teamId: targetRoute.teamId,
+            eventId: targetRoute.eventId,
+            expandStaffPlayers: false
+          })
+
+          if (cancelled) return
+
+          const matchedEvent = detail.events.find((event) => event.childId === targetRoute.childId) || detail.events[0]
+
+          setState({
+            loading: false,
+            redirectTarget: matchedEvent ? getGenericEventDetailPath(matchedEvent, true) : fallbackTarget,
+            error: null
+          })
+        } catch {
+          if (cancelled) return
+          setState({
+            loading: false,
+            redirectTarget: fallbackTarget,
+            error: null
+          })
+        }
       } catch (error: any) {
         if (cancelled) return
         setState({

--- a/apps/app/src/pages/GameDetail.tsx
+++ b/apps/app/src/pages/GameDetail.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AlertCircle, ChevronLeft, RefreshCw } from 'lucide-react'
 import { Link, Navigate, useParams } from 'react-router-dom'
-import { resolveParentGameRoute, type ParentGameRouteResolution } from '../lib/scheduleService'
+import { getGenericEventDetailPath } from '../lib/scheduleLogic'
+import { loadParentScheduleEventDetail, resolveParentGameRoute } from '../lib/scheduleService'
 import type { AuthState } from '../lib/types'
 
 type ResolutionState = {
   loading: boolean
-  targetRoute: ParentGameRouteResolution | null
+  redirectTarget: string
   error: string | null
 }
 
@@ -14,7 +15,7 @@ export function GameDetail({ auth }: { auth: AuthState }) {
   const { gameId = '' } = useParams()
   const [state, setState] = useState<ResolutionState>({
     loading: true,
-    targetRoute: null,
+    redirectTarget: '',
     error: null
   })
 
@@ -24,12 +25,12 @@ export function GameDetail({ auth }: { auth: AuthState }) {
     async function resolveGameRoute() {
       if (!auth.user || !gameId) {
         if (!cancelled) {
-          setState({ loading: false, targetRoute: null, error: 'This game is not available right now.' })
+          setState({ loading: false, redirectTarget: '', error: 'This game is not available right now.' })
         }
         return
       }
 
-      setState({ loading: true, targetRoute: null, error: null })
+      setState({ loading: true, redirectTarget: '', error: null })
 
       try {
         const targetRoute = await resolveParentGameRoute(auth.user, gameId, { expandStaffPlayers: false })
@@ -39,18 +40,39 @@ export function GameDetail({ auth }: { auth: AuthState }) {
         if (!targetRoute) {
           setState({
             loading: false,
-            targetRoute: null,
+            redirectTarget: '',
             error: 'We could not find this game in your live schedule. Open Schedule to find the event or refresh after the team shares access.'
           })
           return
         }
 
-        setState({ loading: false, targetRoute, error: null })
+        const detail = await loadParentScheduleEventDetail(auth.user, {
+          teamId: targetRoute.teamId,
+          eventId: targetRoute.eventId,
+          expandStaffPlayers: false
+        })
+
+        if (cancelled) return
+
+        const matchedEvent = detail.events.find((event) => event.childId === targetRoute.childId) || detail.events[0]
+        const fallbackParams = new URLSearchParams()
+        if (targetRoute.childId) {
+          fallbackParams.set('childId', targetRoute.childId)
+        }
+        fallbackParams.set('section', 'game')
+        const fallbackQuery = fallbackParams.toString()
+        const fallbackTarget = `/schedule/${encodeURIComponent(targetRoute.teamId)}/${encodeURIComponent(targetRoute.eventId)}${fallbackQuery ? `?${fallbackQuery}` : ''}`
+
+        setState({
+          loading: false,
+          redirectTarget: matchedEvent ? getGenericEventDetailPath(matchedEvent, true) : fallbackTarget,
+          error: null
+        })
       } catch (error: any) {
         if (cancelled) return
         setState({
           loading: false,
-          targetRoute: null,
+          redirectTarget: '',
           error: error?.message || 'Unable to open this game right now.'
         })
       }
@@ -63,19 +85,8 @@ export function GameDetail({ auth }: { auth: AuthState }) {
     }
   }, [auth.user, gameId])
 
-  const redirectTarget = useMemo(() => {
-    if (!state.targetRoute) return ''
-    const params = new URLSearchParams()
-    if (state.targetRoute.childId) {
-      params.set('childId', state.targetRoute.childId)
-    }
-    params.set('section', 'game')
-    const search = params.toString()
-    return `/schedule/${encodeURIComponent(state.targetRoute.teamId)}/${encodeURIComponent(state.targetRoute.eventId)}${search ? `?${search}` : ''}`
-  }, [state.targetRoute])
-
-  if (redirectTarget) {
-    return <Navigate to={redirectTarget} replace />
+  if (state.redirectTarget) {
+    return <Navigate to={state.redirectTarget} replace />
   }
 
   if (state.loading) {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -363,6 +363,43 @@ describe('Schedule', () => {
     });
   });
 
+  it('routes desktop parent queue links through generic assignment and rideshare detail paths', async () => {
+    shellLayoutMocks.isDesktopWeb = true;
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          myRsvp: 'going',
+          assignments: [{ role: 'Snack bar', value: '', claimable: true }]
+        }),
+        buildScheduleEvent(2, {
+          eventKey: 'team-1::event-2::player-1::2100-06-02T18:00:00.000Z::game',
+          id: 'event-2',
+          date: new Date('2100-06-02T18:00:00.000Z'),
+          myRsvp: 'going',
+          assignments: [],
+          rideshareSummary: { requests: 1, pending: 0, seatsLeft: 0 }
+        })
+      ]
+    });
+
+    const { container } = render(
+      <MemoryRouter initialEntries={['/schedule']}>
+        <Routes>
+          <Route path="/schedule" element={<Schedule auth={auth} />} />
+          <Route path="/schedule/:teamId/:eventId" element={<RouteProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Parent queue');
+
+    expect(container.querySelector('.schedule-action-queue a[href="/schedule/team-1/event-1?childId=player-1&section=assignments"]')).toBeTruthy();
+    expect(container.querySelector('.schedule-action-queue a[href="/schedule/team-1/event-2?childId=player-1&section=rideshare"]')).toBeTruthy();
+  });
+
   it('shows the remaining event count when only one more event is hidden', async () => {
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -320,6 +320,17 @@ describe('Schedule', () => {
       myRsvp: 'not_responded'
     }) as any, true)).toBe('/schedule/team-1/event-1?childId=player-1&section=availability');
     expect(getGenericEventDetailPath(buildScheduleEvent(1, {
+      isTeamStaff: false,
+      myRsvp: 'going',
+      assignments: [{ role: 'Snack bar', value: '', claimable: true }]
+    }) as any, true)).toBe('/schedule/team-1/event-1?childId=player-1&section=assignments');
+    expect(getGenericEventDetailPath(buildScheduleEvent(1, {
+      isTeamStaff: false,
+      myRsvp: 'going',
+      assignments: [],
+      rideshareSummary: { requests: 1, pending: 0, seatsLeft: 0 }
+    }) as any, true)).toBe('/schedule/team-1/event-1?childId=player-1&section=rideshare');
+    expect(getGenericEventDetailPath(buildScheduleEvent(1, {
       id: 'practice-1',
       type: 'practice',
       isDbGame: false,

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -19,14 +19,13 @@ import {
   formatEventDateLabel,
   formatEventTimeLabel,
   getCalendarScheduleEntries,
-  getScheduleEventDetailPath,
+  getGenericEventDetailPath,
   getParentScheduleTeamOptions,
   getPracticePacketRows,
   getScheduleTitle,
   getScheduleTournamentInfo,
   getScheduleMapHref,
   getScheduleForecastHref,
-  getScheduleTaskDetailSection,
   normalizeRsvpResponse,
   validateExternalCalendarUrl,
   type CalendarScheduleEntry,
@@ -2265,7 +2264,7 @@ function ScheduleActionQueue({ events }: { events: ParentScheduleEvent[] }) {
       </div>
       <div className="mt-3 space-y-2">
         {actionEvents.length ? actionEvents.map(({ event, action }) => (
-          <Link key={event.eventKey} to={getTaskTargetedEventDetailPath(event)} className="block rounded-xl border border-gray-200 bg-white p-3 transition hover:border-primary-200 hover:bg-primary-50">
+          <Link key={event.eventKey} to={getGenericEventDetailPath(event)} className="block rounded-xl border border-gray-200 bg-white p-3 transition hover:border-primary-200 hover:bg-primary-50">
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <div className="truncate text-sm font-black text-gray-950">{action}</div>
@@ -2423,7 +2422,7 @@ function PracticePacketsPanel({ rows }: { rows: PracticePacketScheduleRow[] }) {
       </div>
       <div className="schedule-list overflow-hidden rounded-xl border border-gray-200 bg-white shadow-app sm:space-y-3 sm:overflow-visible sm:border-0 sm:bg-transparent sm:shadow-none">
         {rows.map((row) => (
-          <Link key={`${row.event.eventKey}-packet`} to={getTaskTargetedEventDetailPath(row.event)} className="block border-b border-gray-100 px-3 py-3 transition last:border-b-0 hover:bg-gray-50 sm:rounded-xl sm:border sm:border-blue-100 sm:bg-white sm:shadow-sm sm:hover:border-blue-200 sm:hover:bg-blue-50">
+          <Link key={`${row.event.eventKey}-packet`} to={getGenericEventDetailPath(row.event)} className="block border-b border-gray-100 px-3 py-3 transition last:border-b-0 hover:bg-gray-50 sm:rounded-xl sm:border sm:border-blue-100 sm:bg-white sm:shadow-sm sm:hover:border-blue-200 sm:hover:bg-blue-50">
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
                 <div className="flex items-center gap-2">
@@ -2611,23 +2610,7 @@ function formatTournamentStandingMeta(row: ScheduleTournamentStandingRow) {
   return parts.length ? ` (${parts.join(', ')})` : '';
 }
 
-function getTaskTargetedEventDetailPath(event: ParentScheduleEvent | CalendarScheduleEntry) {
-  return getScheduleEventDetailPath(event, getScheduleTaskDetailSection(event));
-}
-
-function hasStaffGameHubAccess(event: Pick<ParentScheduleEvent, 'isTeamStaff' | 'isTeamAdmin' | 'canUpdateScore'>) {
-  return event.isTeamStaff === true || event.isTeamAdmin === true || event.canUpdateScore === true;
-}
-
-export function getGenericEventDetailPath(
-  event: ParentScheduleEvent | CalendarScheduleEntry,
-  preferGameHubForStaff = false
-) {
-  if (preferGameHubForStaff && hasStaffGameHubAccess(event)) {
-    return getScheduleEventDetailPath(event, 'game');
-  }
-  return getTaskTargetedEventDetailPath(event);
-}
+export { getGenericEventDetailPath } from '../lib/scheduleLogic';
 
 function getScheduleChildLabel(event: ParentScheduleEvent | CalendarScheduleEntry) {
   const names = 'childNames' in event && event.childNames.length ? event.childNames : [];

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -21,6 +21,7 @@ import {
   getCalendarScheduleEntries,
   getGenericEventDetailPath,
   getParentScheduleTeamOptions,
+  getScheduleEventDetailPath,
   getPracticePacketRows,
   getScheduleTitle,
   getScheduleTournamentInfo,
@@ -2453,7 +2454,8 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
 }) {
   const rsvp = normalizeRsvpResponse(event.myRsvp);
   const eventTitle = getScheduleTitle(event);
-  const detailPath = getGenericEventDetailPath(event, preferGameHubForStaff);
+  const defaultDetailPath = getScheduleEventDetailPath(event);
+  const detailPath = getGenericEventDetailPath(event, preferGameHubForStaff) || defaultDetailPath;
   const isRsvpNeeded = rsvp === 'not_responded' && event.isDbGame && !event.isCancelled;
   const hasPracticePacket = event.type === 'practice' && Boolean(event.practiceHomePacketSummary);
   const actionPills = getEventCardActionPills(event, rsvp);

--- a/tests/unit/app-game-detail-baseball-walk.test.jsx
+++ b/tests/unit/app-game-detail-baseball-walk.test.jsx
@@ -6,7 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GameDetail } from '../../apps/app/src/pages/GameDetail.tsx';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
-    resolveParentGameRoute: vi.fn()
+    resolveParentGameRoute: vi.fn(),
+    loadParentScheduleEventDetail: vi.fn()
 }));
 
 vi.mock('../../apps/app/src/lib/scheduleService', async (importOriginal) => ({
@@ -76,6 +77,24 @@ describe('app GameDetail route resolution', () => {
             childId: 'player-1'
         });
 
+        scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+            children: [],
+            events: [{
+                id: 'game-baseball',
+                teamId: 'team-baseball',
+                childId: 'player-1',
+                type: 'game',
+                isDbGame: true,
+                isCancelled: false,
+                myRsvp: 'not_responded',
+                assignments: [],
+                rideshareSummary: null,
+                isTeamStaff: true,
+                isTeamAdmin: false,
+                canUpdateScore: false
+            }]
+        });
+
         const { container, root, router } = await renderGameDetail();
 
         await act(async () => {
@@ -90,6 +109,11 @@ describe('app GameDetail route resolution', () => {
         expect(container.textContent).toContain('Live event workflow');
         expect(container.textContent).not.toContain('Live chat');
         expect(scheduleServiceMocks.resolveParentGameRoute).toHaveBeenCalledWith(coachAuth.user, 'game-baseball', {
+            expandStaffPlayers: false
+        });
+        expect(scheduleServiceMocks.loadParentScheduleEventDetail).toHaveBeenCalledWith(coachAuth.user, {
+            teamId: 'team-baseball',
+            eventId: 'game-baseball',
             expandStaffPlayers: false
         });
 


### PR DESCRIPTION
Closes #3116

## What changed
- moved the generic schedule-detail section selection into a shared `getGenericEventDetailPath` helper in `scheduleLogic`
- updated `GameDetail` to load the resolved schedule event detail and redirect `/games/:gameId` through that shared helper, preserving `childId`
- kept the existing staff override so staff-capable users still land on `section=game`
- added focused regressions for GameDetail redirects plus shared helper coverage for availability, assignments, and rideshare routing

## Root Cause
`GameDetail` resolved `/games` deep links to a team and event, then hard-coded `section=game` for every successful redirect. That bypassed the existing task-targeted section logic already used by schedule cards, so non-staff deep links always opened the staff-oriented Game hub first.

## Prevention / Learning
When multiple entry points open the same schedule detail surface, keep section-routing in one shared helper and reuse it from each route shim. Avoid hard-coded section defaults in individual entry points unless the role-specific override is intentional.

## Regression Tests
- `npm --prefix apps/app test -- --run src/pages/GameDetail.test.tsx src/pages/Schedule.test.tsx`
- `src/pages/GameDetail.test.tsx` covers non-staff RSVP-needed redirect to `section=availability` and staff redirect to `section=game`
- `src/pages/Schedule.test.tsx` proves the shared helper still routes non-staff users to availability, assignments, and rideshare before Game hub