### PR TITLE
Restore live tracker history on refresh

### DIFF
--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -88,6 +88,162 @@ export function resolveTrackLiveClockResume({
   };
 }
 
+function toMillis(value) {
+  if (value == null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value?.toMillis === 'function') {
+    const ms = value.toMillis();
+    return Number.isFinite(ms) ? ms : null;
+  }
+  if (typeof value === 'object' && Number.isFinite(value.seconds)) {
+    const nanos = Number.isFinite(value.nanoseconds) ? value.nanoseconds : 0;
+    return (value.seconds * 1000) + Math.floor(nanos / 1000000);
+  }
+  return null;
+}
+
+function formatTrackGameTime(gameClockMs) {
+  const safeMs = Math.max(0, Number(gameClockMs) || 0);
+  const totalSeconds = Math.floor(safeMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function normalizeTrackLiveText(value) {
+  return String(value || '').trim();
+}
+
+function buildResumeLogText(event) {
+  const description = normalizeTrackLiveText(event?.description);
+  if (event?.type === 'clock_pause') {
+    return 'Game stopped';
+  }
+  return description;
+}
+
+function parseUndoTarget(description) {
+  const clean = normalizeTrackLiveText(description);
+  const match = clean.match(/^Undo:\s*(.+)$/i);
+  return match ? normalizeTrackLiveText(match[1]) : '';
+}
+
+function removeLastMatchingText(entries, targetText) {
+  const clean = normalizeTrackLiveText(targetText);
+  if (!clean) return;
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    if (normalizeTrackLiveText(entries[index]?.text) === clean) {
+      entries.splice(index, 1);
+      return;
+    }
+  }
+}
+
+export function buildTrackLiveResumeState({
+  liveEvents = [],
+  buildGoalNoteText = (event) => normalizeTrackLiveText(event?.note),
+  now = () => Date.now()
+} = {}) {
+  if (!Array.isArray(liveEvents) || liveEvents.length === 0) {
+    return {
+      gameLog: [],
+      liveNotes: [],
+      summaryText: ''
+    };
+  }
+
+  const orderedEvents = liveEvents
+    .map((event, index) => ({
+      event,
+      index,
+      createdAtMs: toMillis(event?.createdAt)
+    }))
+    .sort((a, b) => {
+      if (a.createdAtMs !== null && b.createdAtMs !== null && a.createdAtMs !== b.createdAtMs) {
+        return a.createdAtMs - b.createdAtMs;
+      }
+      if (a.createdAtMs !== null && b.createdAtMs === null) return -1;
+      if (a.createdAtMs === null && b.createdAtMs !== null) return 1;
+      return a.index - b.index;
+    });
+
+  const gameLog = [];
+  const liveNotes = [];
+
+  orderedEvents.forEach(({ event, index, createdAtMs }) => {
+    const type = normalizeTrackLiveText(event?.type);
+    const timestamp = createdAtMs ?? now();
+    const baseEntry = {
+      period: normalizeTrackLiveText(event?.period),
+      time: formatTrackGameTime(event?.gameClockMs),
+      timestamp
+    };
+
+    if (type === 'reset') {
+      gameLog.length = 0;
+      liveNotes.length = 0;
+      return;
+    }
+
+    if (type === 'undo') {
+      removeLastMatchingText(gameLog, parseUndoTarget(event?.description));
+      removeLastMatchingText(liveNotes, event?.removedNote);
+
+      const correctionText = normalizeTrackLiveText(event?.description);
+      if (correctionText && !parseUndoTarget(correctionText)) {
+        gameLog.push({
+          ...baseEntry,
+          text: correctionText
+        });
+      }
+      return;
+    }
+
+    if (type === 'note') {
+      const noteText = normalizeTrackLiveText(event?.note);
+      if (noteText) {
+        liveNotes.push({
+          ...baseEntry,
+          id: normalizeTrackLiveText(event?.liveNoteId) || `resume-note-${index}`,
+          text: noteText,
+          type: normalizeTrackLiveText(event?.noteType) || 'text'
+        });
+      }
+    }
+
+    if (type === 'goal') {
+      const goalNoteText = normalizeTrackLiveText(buildGoalNoteText(event));
+      if (goalNoteText) {
+        liveNotes.push({
+          ...baseEntry,
+          id: normalizeTrackLiveText(event?.liveNoteId) || `resume-goal-note-${index}`,
+          text: goalNoteText,
+          type: 'goal'
+        });
+      }
+    }
+
+    if (type === 'clock_sync') {
+      return;
+    }
+
+    const text = buildResumeLogText(event);
+    if (!text) return;
+
+    gameLog.push({
+      ...baseEntry,
+      text
+    });
+  });
+
+  return {
+    gameLog: gameLog.slice().reverse(),
+    liveNotes: liveNotes.slice().reverse(),
+    summaryText: liveNotes.map((entry) => entry.text).join('\n')
+  };
+}
+
 export async function runTrackLiveResetPersistence({
   publishResetEvent,
   updateResetState,

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -122,6 +122,37 @@ function buildResumeLogText(event) {
   return description;
 }
 
+function isHydratableLogEventType(type) {
+  return [
+    'baseball',
+    'clock_pause',
+    'clock_start',
+    'football_play',
+    'football_score',
+    'goal',
+    'note',
+    'period_change',
+    'stat',
+    'undo',
+    'volleyball'
+  ].includes(type);
+}
+
+function buildResumeUndoData(event) {
+  const type = normalizeTrackLiveText(event?.type);
+  if (type === 'stat' || type === 'goal') {
+    return {
+      type,
+      playerId: event?.playerId || null,
+      statKey: event?.statKey || null,
+      value: Number(event?.value || 0),
+      isOpponent: Boolean(event?.isOpponent)
+    };
+  }
+
+  return null;
+}
+
 function parseUndoTarget(description) {
   const clean = normalizeTrackLiveText(description);
   const match = clean.match(/^Undo:\s*(.+)$/i);
@@ -228,12 +259,17 @@ export function buildTrackLiveResumeState({
       return;
     }
 
+    if (!isHydratableLogEventType(type)) {
+      return;
+    }
+
     const text = buildResumeLogText(event);
     if (!text) return;
 
     gameLog.push({
       ...baseEntry,
-      text
+      text,
+      undoData: buildResumeUndoData(event)
     });
   });
 

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -172,6 +172,10 @@ describe('track live state helpers', () => {
         {
           type: 'stat',
           description: '#30 Alex +2 PTS',
+          playerId: 'p30',
+          statKey: 'pts',
+          value: 2,
+          isOpponent: false,
           period: 'Q1',
           gameClockMs: 15000,
           createdAt: { seconds: 11, nanoseconds: 0 }
@@ -187,11 +191,22 @@ describe('track live state helpers', () => {
           createdAt: { seconds: 12, nanoseconds: 0 }
         },
         {
+          type: 'lineup',
+          description: 'Lineup updated',
+          period: 'Q1',
+          gameClockMs: 30000,
+          createdAt: { seconds: 12, nanoseconds: 500000000 }
+        },
+        {
           type: 'goal',
           description: 'Ava scored for the home team',
           note: 'Left-footed finish',
           liveNoteId: 'goal-note-1',
           teamSide: 'home',
+          statKey: 'goals',
+          value: 1,
+          playerId: 'p9',
+          isOpponent: false,
           period: 'H2',
           gameClockMs: 61000,
           createdAt: { seconds: 13, nanoseconds: 0 }
@@ -208,11 +223,35 @@ describe('track live state helpers', () => {
     });
 
     expect(resumed.gameLog).toEqual([
-      { text: 'Game stopped', period: 'H2', time: '1:02', timestamp: 14000 },
-      { text: 'Ava scored for the home team', period: 'H2', time: '1:01', timestamp: 13000 },
-      { text: 'Note: Strong defensive stretch', period: 'Q1', time: '0:20', timestamp: 12000 },
-      { text: '#30 Alex +2 PTS', period: 'Q1', time: '0:15', timestamp: 11000 },
-      { text: 'Game started', period: 'Q1', time: '0:00', timestamp: 10000 }
+      { text: 'Game stopped', period: 'H2', time: '1:02', timestamp: 14000, undoData: null },
+      {
+        text: 'Ava scored for the home team',
+        period: 'H2',
+        time: '1:01',
+        timestamp: 13000,
+        undoData: {
+          type: 'goal',
+          playerId: 'p9',
+          statKey: 'goals',
+          value: 1,
+          isOpponent: false
+        }
+      },
+      { text: 'Note: Strong defensive stretch', period: 'Q1', time: '0:20', timestamp: 12000, undoData: null },
+      {
+        text: '#30 Alex +2 PTS',
+        period: 'Q1',
+        time: '0:15',
+        timestamp: 11000,
+        undoData: {
+          type: 'stat',
+          playerId: 'p30',
+          statKey: 'pts',
+          value: 2,
+          isOpponent: false
+        }
+      },
+      { text: 'Game started', period: 'Q1', time: '0:00', timestamp: 10000, undoData: null }
     ]);
     expect(resumed.liveNotes).toEqual([
       { id: 'goal-note-1', text: 'Home goal: Left-footed finish', type: 'goal', period: 'H2', time: '1:01', timestamp: 13000 },
@@ -227,6 +266,10 @@ describe('track live state helpers', () => {
         {
           type: 'stat',
           description: '#12 Maya +1 AST',
+          playerId: 'p12',
+          statKey: 'ast',
+          value: 1,
+          isOpponent: false,
           period: 'Q1',
           gameClockMs: 5000,
           createdAt: { seconds: 10, nanoseconds: 0 }
@@ -259,6 +302,10 @@ describe('track live state helpers', () => {
         {
           type: 'stat',
           description: '#5 Eli +3 PTS',
+          playerId: 'p5',
+          statKey: 'pts',
+          value: 3,
+          isOpponent: false,
           period: 'Q2',
           gameClockMs: 15000,
           createdAt: { seconds: 14, nanoseconds: 0 }
@@ -275,7 +322,19 @@ describe('track live state helpers', () => {
 
     expect(resumed.gameLog).toEqual([
       { text: 'Corrected: PTS adjusted', period: 'Q2', time: '0:16', timestamp: 15000 },
-      { text: '#5 Eli +3 PTS', period: 'Q2', time: '0:15', timestamp: 14000 }
+      {
+        text: '#5 Eli +3 PTS',
+        period: 'Q2',
+        time: '0:15',
+        timestamp: 14000,
+        undoData: {
+          type: 'stat',
+          playerId: 'p5',
+          statKey: 'pts',
+          value: 3,
+          isOpponent: false
+        }
+      }
     ]);
     expect(resumed.liveNotes).toEqual([]);
     expect(resumed.summaryText).toBe('');

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume } from '../../js/track-live-state.js';
+import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, buildTrackLiveResumeState } from '../../js/track-live-state.js';
 
 describe('track live state helpers', () => {
   it('summarizes when persisted data exists', () => {
@@ -157,6 +157,138 @@ describe('track live state helpers', () => {
       currentPeriod: 'Q3',
       wasRunning: true
     });
+  });
+
+  it('rebuilds resumed game log, live notes, and summary text from live events', () => {
+    const resumed = buildTrackLiveResumeState({
+      liveEvents: [
+        {
+          type: 'clock_start',
+          description: 'Game started',
+          period: 'Q1',
+          gameClockMs: 0,
+          createdAt: { seconds: 10, nanoseconds: 0 }
+        },
+        {
+          type: 'stat',
+          description: '#30 Alex +2 PTS',
+          period: 'Q1',
+          gameClockMs: 15000,
+          createdAt: { seconds: 11, nanoseconds: 0 }
+        },
+        {
+          type: 'note',
+          description: 'Note: Strong defensive stretch',
+          note: 'Strong defensive stretch',
+          noteType: 'text',
+          liveNoteId: 'note-1',
+          period: 'Q1',
+          gameClockMs: 20000,
+          createdAt: { seconds: 12, nanoseconds: 0 }
+        },
+        {
+          type: 'goal',
+          description: 'Ava scored for the home team',
+          note: 'Left-footed finish',
+          liveNoteId: 'goal-note-1',
+          teamSide: 'home',
+          period: 'H2',
+          gameClockMs: 61000,
+          createdAt: { seconds: 13, nanoseconds: 0 }
+        },
+        {
+          type: 'clock_pause',
+          description: 'Game paused',
+          period: 'H2',
+          gameClockMs: 62000,
+          createdAt: { seconds: 14, nanoseconds: 0 }
+        }
+      ],
+      buildGoalNoteText: (event) => `Home goal: ${event.note}`
+    });
+
+    expect(resumed.gameLog).toEqual([
+      { text: 'Game stopped', period: 'H2', time: '1:02', timestamp: 14000 },
+      { text: 'Ava scored for the home team', period: 'H2', time: '1:01', timestamp: 13000 },
+      { text: 'Note: Strong defensive stretch', period: 'Q1', time: '0:20', timestamp: 12000 },
+      { text: '#30 Alex +2 PTS', period: 'Q1', time: '0:15', timestamp: 11000 },
+      { text: 'Game started', period: 'Q1', time: '0:00', timestamp: 10000 }
+    ]);
+    expect(resumed.liveNotes).toEqual([
+      { id: 'goal-note-1', text: 'Home goal: Left-footed finish', type: 'goal', period: 'H2', time: '1:01', timestamp: 13000 },
+      { id: 'note-1', text: 'Strong defensive stretch', type: 'text', period: 'Q1', time: '0:20', timestamp: 12000 }
+    ]);
+    expect(resumed.summaryText).toBe('Strong defensive stretch\nHome goal: Left-footed finish');
+  });
+
+  it('applies reset and undo events when rebuilding resumed tracker state', () => {
+    const resumed = buildTrackLiveResumeState({
+      liveEvents: [
+        {
+          type: 'stat',
+          description: '#12 Maya +1 AST',
+          period: 'Q1',
+          gameClockMs: 5000,
+          createdAt: { seconds: 10, nanoseconds: 0 }
+        },
+        {
+          type: 'note',
+          description: 'Note: Hot start',
+          note: 'Hot start',
+          noteType: 'text',
+          liveNoteId: 'note-hot-start',
+          period: 'Q1',
+          gameClockMs: 10000,
+          createdAt: { seconds: 11, nanoseconds: 0 }
+        },
+        {
+          type: 'undo',
+          description: 'Undo: Note: Hot start',
+          removedNote: 'Hot start',
+          period: 'Q1',
+          gameClockMs: 12000,
+          createdAt: { seconds: 12, nanoseconds: 0 }
+        },
+        {
+          type: 'reset',
+          description: 'Tracker restarted from zero',
+          period: 'Q1',
+          gameClockMs: 0,
+          createdAt: { seconds: 13, nanoseconds: 0 }
+        },
+        {
+          type: 'stat',
+          description: '#5 Eli +3 PTS',
+          period: 'Q2',
+          gameClockMs: 15000,
+          createdAt: { seconds: 14, nanoseconds: 0 }
+        },
+        {
+          type: 'undo',
+          description: 'Corrected: PTS adjusted',
+          period: 'Q2',
+          gameClockMs: 16000,
+          createdAt: { seconds: 15, nanoseconds: 0 }
+        }
+      ]
+    });
+
+    expect(resumed.gameLog).toEqual([
+      { text: 'Corrected: PTS adjusted', period: 'Q2', time: '0:16', timestamp: 15000 },
+      { text: '#5 Eli +3 PTS', period: 'Q2', time: '0:15', timestamp: 14000 }
+    ]);
+    expect(resumed.liveNotes).toEqual([]);
+    expect(resumed.summaryText).toBe('');
+  });
+
+  it('hydrates track-live from ordered live events on init', () => {
+    const trackLiveHtml = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
+
+    expect(trackLiveHtml).toContain('buildTrackLiveResumeState');
+    expect(trackLiveHtml).toContain("orderBy('createdAt', 'asc')");
+    expect(trackLiveHtml).toContain('gameState.gameLog = resumedTrackingState.gameLog;');
+    expect(trackLiveHtml).toContain('gameState.liveNotes = resumedTrackingState.liveNotes;');
+    expect(trackLiveHtml).toContain('summaryField.value = resumedTrackingState.summaryText;');
   });
 
   it('wires Cancel Game through reset persistence without deleting immutable live events', () => {

--- a/track-live.html
+++ b/track-live.html
@@ -669,11 +669,11 @@
     <script type="module">
         import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=72';
         import { db } from './js/firebase.js?v=19';
-        import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=19';
+        import { writeBatch, doc, setDoc, addDoc, onSnapshot, orderBy } from './js/firebase.js?v=19';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=8';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
-        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, runTrackLiveResetPersistence } from './js/track-live-state.js?v=3';
+        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, buildTrackLiveResumeState, runTrackLiveResetPersistence } from './js/track-live-state.js?v=4';
         import { getDefaultLivePeriod, getSportPeriodLabels, resolveLiveSport, isFootballSport } from './js/live-sport-config.js?v=3';
         import { applyGoalSportScore, buildGoalSportEvent, resolveGoalSportScorer } from './js/live-scorekeeping-goal-sports.js?v=2';
 
@@ -954,6 +954,29 @@
                 statsSnapshot.forEach(doc => {
                     gameState.playerStats[doc.id] = doc.data().stats || {};
                 });
+
+                const liveEventsSnapshot = await getDocs(query(
+                    collection(db, `teams/${teamId}/games/${gameId}/liveEvents`),
+                    orderBy('createdAt', 'asc')
+                ));
+                const resumedTrackingState = buildTrackLiveResumeState({
+                    liveEvents: liveEventsSnapshot.docs.map((doc) => doc.data()),
+                    buildGoalNoteText: (event) => {
+                        const teamLabel = event?.teamSide === 'away'
+                            ? resolveOpponentDisplayName(currentGame)
+                            : currentTeam?.name || 'Home';
+                        return buildGoalSportNoteText(teamLabel, event?.note);
+                    }
+                });
+                gameState.gameLog = resumedTrackingState.gameLog;
+                gameState.liveNotes = resumedTrackingState.liveNotes;
+                renderGameLog();
+                renderLiveNotes();
+
+                const summaryField = document.getElementById('gameSummary');
+                if (summaryField && resumedTrackingState.summaryText) {
+                    summaryField.value = resumedTrackingState.summaryText;
+                }
 
                 // Also load existing scores from aggregated stats
                 let totalHomePoints = 0;


### PR DESCRIPTION
Closes #3118

## What changed
- hydrate `track-live.html` from persisted `liveEvents` on init, ordered by `createdAt`, instead of restoring only aggregated stats
- rebuild the in-memory game log, live notes list, and summary textarea from persisted live tracking events before the coach resumes or finishes the game
- add focused regression coverage for resume hydration, including undo/reset handling and the page wiring that loads ordered live events

## Root Cause
`track-live.html` recreated `gameState.gameLog` and `gameState.liveNotes` as empty arrays on every load and only reloaded aggregated stats from Firestore. The live tracker was already persisting narrative activity to `liveEvents`, but the page never hydrated that data back into the in-memory log, notes, or summary state after a refresh. Finishing the game then wrote only the truncated in-memory log to permanent history and recap output.

## Prevention / Learning
When a live workflow persists a canonical event stream for in-progress activity, reload paths must explicitly hydrate every user-visible narrative surface from that stream, not just derived aggregates like scores or stat totals. Add a refresh/reopen regression test any time finish/export behavior depends on in-memory arrays that are rebuilt during page boot.

## Regression Tests
- `npx vitest run tests/unit/track-live-state.test.js --reporter=verbose`
- added unit coverage for rebuilding resumed game log, live notes, and summary text from live events
- added unit coverage for reset and undo handling during resume reconstruction
- added wiring assertions that `track-live.html` loads ordered `liveEvents` and assigns the rebuilt state on init