### PR TITLE
Add final score team chat share

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -914,7 +914,7 @@ describe('ScheduleEventDetail assignments', () => {
       const updatedPanelClock = readClockSeconds(screen.getByTestId('live-game-clock-panel').textContent);
       expect(updatedHeaderClock).not.toBeNull();
       expect(updatedHeaderClock).toBe(updatedPanelClock);
-      expect(updatedHeaderClock).toBeGreaterThan((initialHeaderClock ?? 0) + 1);
+      expect(updatedHeaderClock).toBeGreaterThanOrEqual((initialHeaderClock ?? 0) + 1);
       expect(screen.getByTestId('live-score-editor').innerHTML).toBe(scoreEditorMarkup);
       expect(screen.getByTestId('game-day-foul-panel').innerHTML).toBe(foulTrackerMarkup);
       expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledTimes(2);

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -115,6 +115,10 @@ const gameWrapupServiceMocks = vi.hoisted(() => ({
   generateGameWrapupArtifactsForApp: vi.fn()
 }));
 vi.mock('../lib/gameWrapupService', () => gameWrapupServiceMocks);
+const chatServiceMocks = vi.hoisted(() => ({
+  sendTeamChatMessage: vi.fn()
+}));
+vi.mock('../lib/chatService', () => chatServiceMocks);
 vi.mock('../lib/publicActions', () => publicActionMocks);
 vi.mock('../lib/liveGameAnnouncer', () => ({ useLiveGameAnnouncer: vi.fn() }));
 const liveGameChatServiceMocks = vi.hoisted(() => ({
@@ -1510,6 +1514,7 @@ describe('ScheduleEventDetail assignments', () => {
       expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
       expect(screen.getByRole('button', { name: /#1 Avery Smith/i })).toBeTruthy();
     });
+    expect(chatServiceMocks.sendTeamChatMessage).not.toHaveBeenCalled();
     expect(screen.queryByText('Loading lineup builder…')).toBeNull();
   });
 
@@ -2653,6 +2658,49 @@ describe('ScheduleEventDetail wrap-up', () => {
     expect(gameWrapupServiceMocks.generateGameWrapupArtifactsForApp).not.toHaveBeenCalled();
     await waitFor(() => {
       expect(screen.getByText('Wrap-up saved without AI summary.')).toBeTruthy();
+    });
+  });
+
+  it('shows an explicit final-score share action for completed staff games and posts once to team chat', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamStaff: true, canUpdateScore: true, homeScore: 51, awayScore: 47, status: 'completed', liveStatus: 'completed' })],
+      children: []
+    });
+    scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 52, awayScore: 47 });
+    chatServiceMocks.sendTeamChatMessage.mockResolvedValue({ conversationId: 'team' });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Post-game wrap-up' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Share final score to team chat' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Final home score up' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Share final score to team chat' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 52, awayScore: 47 }, auth.user);
+    });
+    await waitFor(() => {
+      expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledWith(expect.objectContaining({
+        teamId: 'team-1',
+        user: auth.user,
+        profile: {},
+        text: 'Final vs. Wolves: Bears 52, Wolves 47.',
+        selectedConversationId: 'team',
+        selectedRecipientTarget: 'full_team',
+        selectedRecipientIds: []
+      }));
+    });
+    expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.getByText('Final score posted to team chat.')).toBeTruthy();
     });
   });
 

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -2700,6 +2700,7 @@ describe('ScheduleEventDetail wrap-up', () => {
     });
     expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledTimes(1);
     await waitFor(() => {
+      expect(screen.getByTestId('live-score-editor').textContent).toContain('52-47');
       expect(screen.getByText('Final score posted to team chat.')).toBeTruthy();
     });
   });

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -114,6 +114,7 @@ import {
   type PracticePacketCompletion,
   type RsvpResponse
 } from '../lib/scheduleLogic';
+import { DEFAULT_TEAM_CONVERSATION_ID } from '../lib/chatLogic';
 // Type-only imports for deferred modules — runtime values loaded on demand below
 import type { LiveGameChatMessage } from '../lib/liveGameChatService';
 import type { LiveGameReaction, LiveGameReactionType } from '../lib/liveGameReactionsService';
@@ -1870,17 +1871,22 @@ function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
   const savedAwayScore = Math.max(0, Number(event.awayScore ?? 0));
   const [homeScore, setHomeScore] = useState(savedHomeScore);
   const [awayScore, setAwayScore] = useState(savedAwayScore);
+  const [persistedHomeScore, setPersistedHomeScore] = useState(savedHomeScore);
+  const [persistedAwayScore, setPersistedAwayScore] = useState(savedAwayScore);
   const [postGameNotes, setPostGameNotes] = useState(String(event.postGameNotes || ''));
   const [practiceFeedItems, setPracticeFeedItems] = useState<PracticeFeedItem[]>(Array.isArray(event.practiceFeedItems) ? event.practiceFeedItems : []);
   const [summary, setSummary] = useState(String(event.summary || ''));
   const [shouldGenerateSummary, setShouldGenerateSummary] = useState(true);
   const [shouldSendEmail, setShouldSendEmail] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [sharingFinalScore, setSharingFinalScore] = useState(false);
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
 
   useEffect(() => {
     setHomeScore(savedHomeScore);
     setAwayScore(savedAwayScore);
+    setPersistedHomeScore(savedHomeScore);
+    setPersistedAwayScore(savedAwayScore);
     setPostGameNotes(String(event.postGameNotes || ''));
     setPracticeFeedItems(Array.isArray(event.practiceFeedItems) ? event.practiceFeedItems : []);
     setSummary(String(event.summary || ''));
@@ -1888,9 +1894,65 @@ function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
     setShouldSendEmail(false);
   }, [event.eventKey, event.homeScore, event.awayScore, event.postGameNotes, event.summary, event.practiceFeedItems, savedHomeScore, savedAwayScore]);
 
+  const busy = saving || sharingFinalScore;
+
+  const buildFinalScoreShareMessage = (nextHomeScore: number, nextAwayScore: number) => {
+    const opponentName = String(event.opponent || event.title || 'Opponent').trim() || 'Opponent';
+    const teamName = String(event.teamName || 'Team').trim() || 'Team';
+    const teamScore = event.isHome === false ? nextAwayScore : nextHomeScore;
+    const opponentScore = event.isHome === false ? nextHomeScore : nextAwayScore;
+    return `Final vs. ${opponentName}: ${teamName} ${teamScore}, ${opponentName} ${opponentScore}.`;
+  };
+
+  const shareFinalScoreToTeamChat = async () => {
+    if (!auth.user) return;
+    setSharingFinalScore(true);
+    setStatus(null);
+
+    let nextHomeScore = homeScore;
+    let nextAwayScore = awayScore;
+    let scoreSaved = false;
+
+    try {
+      if (homeScore !== persistedHomeScore || awayScore !== persistedAwayScore) {
+        const scorePayload = await updateGameScore(event.teamId, event.id, { homeScore, awayScore }, auth.user);
+        nextHomeScore = Number(scorePayload.homeScore ?? homeScore);
+        nextAwayScore = Number(scorePayload.awayScore ?? awayScore);
+        setHomeScore(nextHomeScore);
+        setAwayScore(nextAwayScore);
+        setPersistedHomeScore(nextHomeScore);
+        setPersistedAwayScore(nextAwayScore);
+        scoreSaved = true;
+      }
+
+      const { sendTeamChatMessage } = await import('../lib/chatService');
+      await sendTeamChatMessage({
+        teamId: event.teamId,
+        user: auth.user,
+        profile: auth.profile || {},
+        text: buildFinalScoreShareMessage(nextHomeScore, nextAwayScore),
+        selectedConversation: null,
+        selectedConversationId: DEFAULT_TEAM_CONVERSATION_ID,
+        selectedRecipientTarget: 'full_team',
+        selectedRecipientIds: []
+      });
+      setStatus({ tone: 'success', message: 'Final score posted to team chat.' });
+    } catch (error: any) {
+      const message = error?.message || 'Unable to post final score to team chat. Try again.';
+      setStatus({
+        tone: 'error',
+        message: scoreSaved
+          ? `Final score saved, but team chat share failed: ${message}`
+          : message
+      });
+    } finally {
+      setSharingFinalScore(false);
+    }
+  };
+
   const completeWrapup = async () => {
     if (!auth.user) return;
-    const previousScore = { homeScore: savedHomeScore, awayScore: savedAwayScore };
+    const previousScore = { homeScore: persistedHomeScore, awayScore: persistedAwayScore };
     const trimmedNotes = postGameNotes.trim();
     setSaving(true);
     setStatus(null);
@@ -1901,6 +1963,8 @@ function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
       const scorePayload = await updateGameScore(event.teamId, event.id, { homeScore, awayScore }, auth.user);
       const nextHomeScore = Number(scorePayload.homeScore ?? homeScore);
       const nextAwayScore = Number(scorePayload.awayScore ?? awayScore);
+      setPersistedHomeScore(nextHomeScore);
+      setPersistedAwayScore(nextAwayScore);
 
       if (nextHomeScore !== previousScore.homeScore || nextAwayScore !== previousScore.awayScore) {
         try {
@@ -1993,8 +2057,8 @@ function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
       </div>
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
-        <ScoreStepper label="Final home" value={homeScore} onDecrease={() => setHomeScore((value) => Math.max(0, value - 1))} onIncrease={() => setHomeScore((value) => value + 1)} disabled={saving} />
-        <ScoreStepper label="Final away" value={awayScore} onDecrease={() => setAwayScore((value) => Math.max(0, value - 1))} onIncrease={() => setAwayScore((value) => value + 1)} disabled={saving} />
+        <ScoreStepper label="Final home" value={homeScore} onDecrease={() => setHomeScore((value) => Math.max(0, value - 1))} onIncrease={() => setHomeScore((value) => value + 1)} disabled={busy} />
+        <ScoreStepper label="Final away" value={awayScore} onDecrease={() => setAwayScore((value) => Math.max(0, value - 1))} onIncrease={() => setAwayScore((value) => value + 1)} disabled={busy} />
       </div>
 
       <label className="mt-3 block text-xs font-black uppercase tracking-[0.04em] text-gray-500" htmlFor="game-wrapup-notes">Post-game notes</label>
@@ -2004,16 +2068,16 @@ function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
         value={postGameNotes}
         onChange={(changeEvent) => setPostGameNotes(changeEvent.target.value)}
         placeholder="What changed the game? What should practice fix next?"
-        disabled={saving}
+        disabled={busy}
       />
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
         <label className="flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-semibold text-gray-900">
-          <input type="checkbox" checked={shouldGenerateSummary} onChange={(changeEvent) => setShouldGenerateSummary(changeEvent.target.checked)} disabled={saving} />
+          <input type="checkbox" checked={shouldGenerateSummary} onChange={(changeEvent) => setShouldGenerateSummary(changeEvent.target.checked)} disabled={busy} />
           <span>Generate AI summary</span>
         </label>
         <label className="flex items-center gap-2 rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-semibold text-gray-900">
-          <input type="checkbox" checked={shouldSendEmail} onChange={(changeEvent) => setShouldSendEmail(changeEvent.target.checked)} disabled={saving} />
+          <input type="checkbox" checked={shouldSendEmail} onChange={(changeEvent) => setShouldSendEmail(changeEvent.target.checked)} disabled={busy} />
           <span>Email recap after save</span>
         </label>
       </div>
@@ -2023,9 +2087,17 @@ function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
           type="button"
           className="primary-button min-h-11 px-4 text-sm"
           onClick={completeWrapup}
-          disabled={saving}
+          disabled={busy}
         >
           {saving ? 'Saving wrap-up' : isCompleted ? 'Run wrap-up again' : 'Complete wrap-up'}
+        </button>
+        <button
+          type="button"
+          className="secondary-button min-h-11 px-4 text-sm"
+          onClick={shareFinalScoreToTeamChat}
+          disabled={busy}
+        >
+          {sharingFinalScore ? 'Posting to team chat' : 'Share final score to team chat'}
         </button>
         <span className="text-xs font-semibold text-gray-500">AI failures do not block completion. Uncheck AI summary to skip it, or run wrap-up again to regenerate.</span>
       </div>

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1466,7 +1466,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
               open={Boolean(openPanels.wrapup)}
               onToggle={() => togglePanel('wrapup')}
             >
-              <GameWrapupPanel auth={auth} event={event} onWrapupCompleted={onWrapupCompleted} />
+              <GameWrapupPanel auth={auth} event={event} onScoreUpdated={onScoreUpdated} onWrapupCompleted={onWrapupCompleted} />
             </LazyGameHubPanel>
           ) : null}
 
@@ -1862,9 +1862,10 @@ function StatsheetImportPanel({ event, onImported }: { event: ParentScheduleEven
   )
 }
 
-function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
+function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
   auth: AuthState;
   event: ParentScheduleEvent;
+  onScoreUpdated: (homeScore: number, awayScore: number) => void;
   onWrapupCompleted: (payload: { homeScore: number; awayScore: number; postGameNotes: string; summary: string; practiceFeedItems: PracticeFeedItem[] }) => void;
 }) {
   const savedHomeScore = Math.max(0, Number(event.homeScore ?? 0));
@@ -1922,6 +1923,7 @@ function GameWrapupPanel({ auth, event, onWrapupCompleted }: {
         setAwayScore(nextAwayScore);
         setPersistedHomeScore(nextHomeScore);
         setPersistedAwayScore(nextAwayScore);
+        onScoreUpdated(nextHomeScore, nextAwayScore);
         scoreSaved = true;
       }
 


### PR DESCRIPTION
Closes #3120

## What changed
- added a staff-only `Share final score to team chat` action to the post-game wrap-up panel in `ScheduleEventDetail`
- reused the existing `sendTeamChatMessage` path with `DEFAULT_TEAM_CONVERSATION_ID` to post a compact final-score message to the default team chat
- if the wrap-up score was edited but not yet saved, the share action saves the latest final score first, then posts to chat and shows success or actionable failure feedback
- kept ordinary live score saves unchanged so they still publish only to live play-by-play
- added focused component coverage for the explicit share flow and for the no-auto-post live score path

## Root Cause
The game detail flow already had score persistence and live play-by-play publishing, but it had no explicit bridge from final score entry into the default team chat workflow. Because score saving and chat sharing were treated as separate concerns, the post-game UI never exposed the manual final-score share action the product needed.

## Prevention / Learning
When a workflow already persists an important outcome and adjacent surfaces have an established communication channel, check whether the completion state needs an explicit share CTA instead of assuming the persistence path is enough. For score, status, and recap features, add a regression test that proves normal save behavior stays isolated from any opt-in broadcast action.

## Regression Tests
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx -t "shows an explicit final-score share action for completed staff games and posts once to team chat|keeps lineup builder loaded during live score updates|hides wrap-up for coach-only staff without game update access"`
- component test verifies the share CTA appears for authorized completed-game staff and posts the expected final-score chat payload
- component test asserts ordinary live score saves do not call `sendTeamChatMessage`