### PR TITLE
Allow shared game reports for private teams

### DIFF
--- a/game.html
+++ b/game.html
@@ -1280,9 +1280,16 @@ Write the match report now:`;
                     }
                     throw error;
                 });
+                const teamPromise = getTeam(teamId, { includeInactive: true }).catch((error) => {
+                    if (error?.code === 'permission-denied') {
+                        console.warn('Failed to load team document for public game report viewer:', error);
+                        return null;
+                    }
+                    throw error;
+                });
                 const [team, game, players] = await Promise.all([
-                    // Reports are historical and must resolve soft-deleted teams.
-                    getTeam(teamId, { includeInactive: true }),
+                    // Reports are historical and must resolve soft-deleted teams when viewers can access them.
+                    teamPromise,
                     getGame(teamId, gameId),
                     playersPromise
                 ]);
@@ -1292,8 +1299,15 @@ Write the match report now:`;
                     return;
                 }
 
+                const resolvedTeam = team || {
+                    id: teamId,
+                    name: game.teamName || game.homeTeamName || 'Team',
+                    photoUrl: game.teamPhotoUrl || game.homeTeamPhoto || '',
+                    sport: game.sport || 'Basketball'
+                };
+
                 // Render team navigation banner if user has access
-                if (currentUser) {
+                if (currentUser && team) {
                     // Enrich user profile if needed
                     try {
                         const profile = await getUserProfile(currentUser.uid);
@@ -1362,8 +1376,8 @@ Write the match report now:`;
                     </div>
                     <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-6 md:mb-8 text-gray-900">
                         <span class="inline-flex items-center gap-2">
-                            ${team.photoUrl ? `<img src="${escapeHtml(team.photoUrl)}" alt="" class="w-10 h-10 rounded-full object-cover border border-gray-200">` : ''}
-                            ${escapeHtml(team.name)}
+                            ${resolvedTeam.photoUrl ? `<img src="${escapeHtml(resolvedTeam.photoUrl)}" alt="" class="w-10 h-10 rounded-full object-cover border border-gray-200">` : ''}
+                            ${escapeHtml(resolvedTeam.name)}
                         </span>
                         <span class="text-gray-400 mx-2 md:mx-3">vs</span>
                         <span class="inline-flex items-center gap-2">
@@ -1373,7 +1387,7 @@ Write the match report now:`;
                     </h1>
                     <div class="flex justify-center items-center gap-6 md:gap-8 mb-6">
                         <div class="text-center">
-                            <div class="text-sm text-gray-500 mb-2 font-medium">${escapeHtml(team.name)}</div>
+                            <div class="text-sm text-gray-500 mb-2 font-medium">${escapeHtml(resolvedTeam.name)}</div>
                             <div class="text-5xl md:text-6xl lg:text-7xl font-mono font-bold ${isWin ? 'text-green-600' : 'text-primary-600'
                     }">${game.homeScore || 0}</div>
                         </div>
@@ -1432,7 +1446,7 @@ Write the match report now:`;
                 const shareBtn = document.getElementById('share-report-btn');
                 if (shareBtn) {
                     shareBtn.addEventListener('click', async () => {
-                        const teamName = team?.name || 'Team';
+                        const teamName = resolvedTeam?.name || 'Team';
                         const opponent = game?.opponent || 'Opponent';
                         const dateLabel = formatShortDate(game?.date);
                         const url = `${window.location.origin}/game.html#teamId=${teamId}&gameId=${gameId}`;
@@ -1495,7 +1509,7 @@ Write the match report now:`;
                     resolvedConfig = resolveLiveStatConfig({
                         configs,
                         game,
-                        team
+                        team: resolvedTeam
                     });
                 } catch (err) {
                     console.error('Error fetching config:', err);
@@ -1523,7 +1537,7 @@ Write the match report now:`;
                 });
 
                 // Setup summary controls
-                setupSummaryControls(teamId, gameId, game, team, players, statsMap, statKeys, statLabels);
+                setupSummaryControls(teamId, gameId, game, resolvedTeam, players, statsMap, statKeys, statLabels);
                 const headerRow = document.getElementById('stats-header-row');
                 const computeHasPlayingTime = () => Object.values(timeMap).some((t) => t > 0);
                 function renderStatsTable() {

--- a/tests/unit/game-auth-reload.test.js
+++ b/tests/unit/game-auth-reload.test.js
@@ -46,4 +46,18 @@ describe('game auth reload', () => {
         expect(source).toContain('return [];');
         expect(source).toContain('playersPromise');
     });
+
+    it('keeps shareable game reports rendering when the parent team doc is private', () => {
+        const source = readGameHtml();
+
+        expect(source).toContain("const teamPromise = getTeam(teamId, { includeInactive: true }).catch((error) => {");
+        expect(source).toContain("console.warn('Failed to load team document for public game report viewer:', error);");
+        expect(source).toContain('return null;');
+        expect(source).toContain('const resolvedTeam = team || {');
+        expect(source).toContain("name: game.teamName || game.homeTeamName || 'Team'");
+        expect(source).toContain("photoUrl: game.teamPhotoUrl || game.homeTeamPhoto || ''");
+        expect(source).toContain("sport: game.sport || 'Basketball'");
+        expect(source).toContain('if (currentUser && team) {');
+        expect(source).toContain('setupSummaryControls(teamId, gameId, game, resolvedTeam, players, statsMap, statKeys, statLabels);');
+    });
 });


### PR DESCRIPTION
Closes #3122

## What changed
- Made the initial `getTeam(teamId, { includeInactive: true })` read optional in `game.html` when Firestore returns `permission-denied`.
- Added a `resolvedTeam` fallback built from game-visible fields so public/shareable reports still render their header, share text, and stat config context without the parent team document.
- Kept staff-only banner and edit controls tied to the real team document by only rendering those paths when the team read succeeds.
- Added a focused regression unit test covering the private-team public-report load path.

## Root Cause
`game.html` loaded the private parent team document and the shareable game document in the same `Promise.all(...)`. For logged-out viewers of a public/shareable game on a private team, the team read failed with `permission-denied`, which rejected the entire page load before the publicly readable game report could render.

## Prevention / Learning
For public/shareable surfaces, do not couple critical first paint to parent documents that have stricter visibility rules than the child resource being rendered. Load the public artifact first, treat higher-privilege reads as optional enrichment, and keep privileged UI paths behind successful privileged reads.

## Regression Tests
- `npx vitest run tests/unit/game-auth-reload.test.js --reporter=verbose`
- Added assertions that `game.html` tolerates `getTeam()` permission denial, derives `resolvedTeam` fallback data from the game document, and still wires report rendering through that fallback.

## Recurrence Risk
Medium: this bug class can recur anywhere a public child document is loaded together with a stricter parent read, but the new test now pins this exact game-report path.