### PR TITLE
Keep Manage Schedule visible for multi-team staff

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -135,6 +135,32 @@ function buildStaffScheduleResult() {
   };
 }
 
+function buildMultiTeamStaffScheduleResult() {
+  return {
+    children: [
+      { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
+      { playerId: 'player-2', playerName: 'Sam', teamId: 'team-2', teamName: 'Wolves' }
+    ],
+    events: [
+      buildScheduleEvent(1, {
+        isTeamStaff: true
+      }),
+      buildScheduleEvent(2, {
+        eventKey: 'team-2::event-2::player-2::2100-06-02T18:00:00.000Z::practice',
+        id: 'event-2',
+        teamId: 'team-2',
+        teamName: 'Wolves',
+        type: 'practice',
+        childId: 'player-2',
+        childName: 'Sam',
+        isDbGame: false,
+        isTeamStaff: true,
+        title: 'Practice'
+      })
+    ]
+  };
+}
+
 function resolveAppSourcePath(relativePath: string) {
   const cwd = process.cwd();
   const appRoot = cwd.endsWith('/apps/app') || cwd.endsWith('\\apps\\app')
@@ -396,8 +422,10 @@ describe('Schedule', () => {
 
     await screen.findByText('Parent queue');
 
-    expect(container.querySelector('.schedule-action-queue a[href="/schedule/team-1/event-1?childId=player-1&section=assignments"]')).toBeTruthy();
-    expect(container.querySelector('.schedule-action-queue a[href="/schedule/team-1/event-2?childId=player-1&section=rideshare"]')).toBeTruthy();
+    const queueLinks = Array.from(container.querySelectorAll('.schedule-action-queue a')).map((link) => link.getAttribute('href'));
+
+    expect(queueLinks).toContain('/schedule/team-1/event-1?childId=player-1&section=assignments');
+    expect(queueLinks).toContain('/schedule/team-1/event-2?childId=player-1&section=rideshare');
   });
 
   it('shows the remaining event count when only one more event is hidden', async () => {
@@ -726,6 +754,51 @@ describe('Schedule', () => {
       expect(screen.getAllByRole('option', { name: 'Varsity Tracker' }).length).toBeGreaterThan(0);
     });
     expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Manage schedule for multi-team staff and opens to a team selector before tools', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildMultiTeamStaffScheduleResult());
+
+    renderSchedule();
+
+    expect(await screen.findByRole('button', { name: /manage schedule/i })).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'Add game for Bears' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
+
+    expect(await screen.findByRole('heading', { name: 'Choose the team to manage' })).toBeTruthy();
+    expect(screen.getByLabelText('Team to manage')).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'Add game for Bears' })).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Add practice for Bears' })).toBeNull();
+  });
+
+  it('uses the Manage schedule team selector to reveal and submit team-specific staff tools', async () => {
+    scheduleServiceMocks.loadParentSchedule
+      .mockResolvedValueOnce(buildMultiTeamStaffScheduleResult())
+      .mockResolvedValueOnce(buildMultiTeamStaffScheduleResult());
+    scheduleServiceMocks.createScheduledGameForApp.mockResolvedValueOnce('game-2');
+
+    renderSchedule();
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+    expect(await screen.findByRole('heading', { name: 'Choose the team to manage' })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Team to manage'), { target: { value: 'team-2' } });
+
+    expect(await screen.findByRole('heading', { name: 'Add game for Wolves' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Add external calendar' })).toBeTruthy();
+
+    fireEvent.change(screen.getAllByLabelText('Opponent')[0], { target: { value: 'Falcons' } });
+    fireEvent.change(screen.getAllByLabelText('Location')[0], { target: { value: 'West Gym' } });
+    fireEvent.click(screen.getByRole('button', { name: /^create game$/i }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.createScheduledGameForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.createScheduledGameForApp).toHaveBeenCalledWith('team-2', expect.objectContaining({
+        opponent: 'Falcons',
+        location: 'West Gym'
+      }), auth.user);
+    });
   });
 
   it('hides desktop staff schedule tools until Manage schedule is opened', async () => {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -161,6 +161,43 @@ function buildMultiTeamStaffScheduleResult() {
   };
 }
 
+function buildMixedTeamScheduleResult() {
+  return {
+    children: [
+      { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
+      { playerId: 'player-2', playerName: 'Sam', teamId: 'team-2', teamName: 'Wolves' },
+      { playerId: 'player-3', playerName: 'Jordan', teamId: 'team-3', teamName: 'Hawks' }
+    ],
+    events: [
+      buildScheduleEvent(1, {
+        isTeamStaff: true
+      }),
+      buildScheduleEvent(2, {
+        eventKey: 'team-2::event-2::player-2::2100-06-02T18:00:00.000Z::practice',
+        id: 'event-2',
+        teamId: 'team-2',
+        teamName: 'Wolves',
+        type: 'practice',
+        childId: 'player-2',
+        childName: 'Sam',
+        isDbGame: false,
+        isTeamStaff: true,
+        title: 'Practice'
+      }),
+      buildScheduleEvent(3, {
+        eventKey: 'team-3::event-3::player-3::2100-06-03T18:00:00.000Z::game',
+        id: 'event-3',
+        teamId: 'team-3',
+        teamName: 'Hawks',
+        childId: 'player-3',
+        childName: 'Jordan',
+        isTeamStaff: false,
+        opponent: 'Comets'
+      })
+    ]
+  };
+}
+
 function resolveAppSourcePath(relativePath: string) {
   const cwd = process.cwd();
   const appRoot = cwd.endsWith('/apps/app') || cwd.endsWith('\\apps\\app')
@@ -799,6 +836,21 @@ describe('Schedule', () => {
         location: 'West Gym'
       }), auth.user);
     });
+  });
+
+  it('lets staff team selection override a non-manageable page team filter', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildMixedTeamScheduleResult());
+
+    renderSchedule('/schedule?teamId=team-3');
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+    expect(await screen.findByRole('heading', { name: 'Choose the team to manage' })).toBeTruthy();
+    expect((screen.getByLabelText('Team filter') as HTMLSelectElement).value).toBe('team-3');
+
+    fireEvent.change(screen.getByLabelText('Team to manage'), { target: { value: 'team-2' } });
+
+    expect(await screen.findByRole('heading', { name: 'Add game for Wolves' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Add external calendar' })).toBeTruthy();
   });
 
   it('hides desktop staff schedule tools until Manage schedule is opened', async () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -534,8 +534,11 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [selectedStaffManageTeamId, setSelectedStaffManageTeamId] = useState('');
   const hasManageableScheduleTeams = manageableTeamOptions.length > 0;
   const selectedCalendarTeam = useMemo(() => {
-    if (selectedTeamId) {
-      return manageableTeamOptions.find((team) => team.teamId === selectedTeamId) || null;
+    const pageSelectedManageableTeam = selectedTeamId
+      ? manageableTeamOptions.find((team) => team.teamId === selectedTeamId) || null
+      : null;
+    if (pageSelectedManageableTeam) {
+      return pageSelectedManageableTeam;
     }
     if (selectedStaffManageTeamId) {
       return manageableTeamOptions.find((team) => team.teamId === selectedStaffManageTeamId) || null;

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -531,24 +531,40 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const manageableTeamOptions = useMemo(() => (
     teamOptions.filter((team) => events.some((event) => event.teamId === team.teamId && event.isTeamStaff === true))
   ), [events, teamOptions]);
+  const [selectedStaffManageTeamId, setSelectedStaffManageTeamId] = useState('');
+  const hasManageableScheduleTeams = manageableTeamOptions.length > 0;
   const selectedCalendarTeam = useMemo(() => {
     if (selectedTeamId) {
       return manageableTeamOptions.find((team) => team.teamId === selectedTeamId) || null;
     }
+    if (selectedStaffManageTeamId) {
+      return manageableTeamOptions.find((team) => team.teamId === selectedStaffManageTeamId) || null;
+    }
     return manageableTeamOptions.length === 1 ? manageableTeamOptions[0] : null;
-  }, [manageableTeamOptions, selectedTeamId]);
+  }, [manageableTeamOptions, selectedStaffManageTeamId, selectedTeamId]);
+  const shouldShowManageScheduleTeamPicker = !selectedCalendarTeam && manageableTeamOptions.length > 1;
 
   useEffect(() => {
-    if (isDesktopWeb || !selectedCalendarTeam) {
+    if (!selectedStaffManageTeamId) {
+      return;
+    }
+    const stillManageable = manageableTeamOptions.some((team) => team.teamId === selectedStaffManageTeamId);
+    if (!stillManageable) {
+      setSelectedStaffManageTeamId('');
+    }
+  }, [manageableTeamOptions, selectedStaffManageTeamId]);
+
+  useEffect(() => {
+    if (isDesktopWeb || !hasManageableScheduleTeams) {
       setMobileStaffToolsOpen(false);
     }
-  }, [isDesktopWeb, selectedCalendarTeam]);
+  }, [hasManageableScheduleTeams, isDesktopWeb]);
 
   useEffect(() => {
-    if (!isDesktopWeb || !selectedCalendarTeam) {
+    if (!isDesktopWeb || !hasManageableScheduleTeams) {
       setDesktopStaffToolsOpen(false);
     }
-  }, [isDesktopWeb, selectedCalendarTeam]);
+  }, [hasManageableScheduleTeams, isDesktopWeb]);
 
   const requestTrackerConfigLoad = () => {
     if (!selectedCalendarTeam) return;
@@ -612,88 +628,113 @@ export function Schedule({ auth }: { auth: AuthState }) {
     };
   }, [auth.user, mobileStaffToolsOpen, selectedCalendarTeam, trackerConfigRequestedTeamIds]);
 
-  const renderScheduleStaffToolsContent = () => selectedCalendarTeam ? (
-    <>
-      <ScheduleGameCreatePanel
-        teamName={selectedCalendarTeam.teamName}
-        form={gameForm}
-        configs={gameTrackerConfigs}
-        saving={savingGame}
-        error={gameFormError}
-        configError={gameTrackerConfigError}
-        onStartUsing={requestTrackerConfigLoad}
-        onChange={(nextForm) => {
-          setGameForm(nextForm);
-          if (gameFormError) setGameFormError(null);
-        }}
-        onSubmit={handleCreateGame}
-      />
-      <ScheduleTournamentCreatePanel
-        teamName={selectedCalendarTeam.teamName}
-        form={tournamentForm}
-        configs={gameTrackerConfigs}
-        saving={savingTournament}
-        error={tournamentFormError}
-        configError={gameTrackerConfigError}
-        onStartUsing={requestTrackerConfigLoad}
-        onChange={(nextForm) => {
-          setTournamentForm(nextForm);
-          if (tournamentFormError) setTournamentFormError(null);
-        }}
-        onSubmit={handleCreateTournament}
-      />
-      <SchedulePracticeCreatePanel
-        teamName={selectedCalendarTeam.teamName}
-        form={practiceForm}
-        saving={savingPractice}
-        error={practiceFormError}
-        onChange={(nextForm) => {
-          setPracticeForm(nextForm);
-          if (practiceFormError) setPracticeFormError(null);
-        }}
-        onSubmit={handleCreatePractice}
-      />
-      <ScheduleStaffTools
-        teamName={selectedCalendarTeam.teamName}
-        calendarUrl={calendarUrl}
-        calendarUrls={selectedCalendarTeam.calendarUrls || []}
-        calendarUrlError={calendarUrlError}
-        savingCalendarUrl={savingCalendarUrl}
-        removingCalendarUrl={removingCalendarUrl}
-        aiScheduleText={aiScheduleText}
-        aiScheduleImageName={aiScheduleImageName}
-        aiPreviewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
-        aiImportErrors={aiImportErrors}
-        processingAiImport={processingAiImport}
-        csvHeaders={csvHeaders}
-        csvMapping={csvMapping}
-        csvPreviewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
-        csvImportErrors={csvImportErrors}
-        csvFileName={csvFileName}
-        loadingCsvFile={loadingCsvFile}
-        importingCsv={importingCsv}
-        onCalendarUrlChange={(value) => {
-          setCalendarUrl(value);
-          if (calendarUrlError) setCalendarUrlError(null);
-        }}
-        onAddCalendarUrl={handleAddCalendarUrl}
-        onRemoveCalendarUrl={handleRemoveCalendarUrl}
-        onAiTextChange={(value) => {
-          setAiScheduleText(value);
-          clearAiPreview();
-          if (aiImportErrors.length) setAiImportErrors([]);
-        }}
-        onAiImageChange={handleAiImageChange}
-        onAiGeneratePreview={handleAiGeneratePreview}
-        onImportCsv={handleCsvImport}
-        onClearAi={handleAiClear}
-        onCsvFileChange={handleCsvFileChange}
-        onCsvMappingChange={handleCsvMappingChange}
-        onCsvPreview={handleCsvPreview}
-        onClearCsv={handleCsvClear}
-      />
-    </>
-  ) : null;
+  const renderScheduleStaffToolsContent = () => {
+    if (shouldShowManageScheduleTeamPicker) {
+      return (
+        <section className="app-card p-3 sm:p-4" aria-label="Choose team to manage">
+          <div className="app-label">Choose team</div>
+          <h3 className="mt-1 text-base font-black text-gray-950">Choose the team to manage</h3>
+          <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">Pick a team here to unlock game, practice, tournament, and import tools.</p>
+          <label className="mt-3 block text-xs font-bold uppercase tracking-wide text-gray-600">
+            Team to manage
+            <select
+              aria-label="Team to manage"
+              className="auth-input mt-1"
+              value={selectedStaffManageTeamId}
+              onChange={(event) => setSelectedStaffManageTeamId(event.target.value)}
+            >
+              <option value="">Select a team</option>
+              {manageableTeamOptions.map((team) => (
+                <option key={team.teamId} value={team.teamId}>{team.teamName}</option>
+              ))}
+            </select>
+          </label>
+        </section>
+      );
+    }
+    return selectedCalendarTeam ? (
+      <>
+        <ScheduleGameCreatePanel
+          teamName={selectedCalendarTeam.teamName}
+          form={gameForm}
+          configs={gameTrackerConfigs}
+          saving={savingGame}
+          error={gameFormError}
+          configError={gameTrackerConfigError}
+          onStartUsing={requestTrackerConfigLoad}
+          onChange={(nextForm) => {
+            setGameForm(nextForm);
+            if (gameFormError) setGameFormError(null);
+          }}
+          onSubmit={handleCreateGame}
+        />
+        <ScheduleTournamentCreatePanel
+          teamName={selectedCalendarTeam.teamName}
+          form={tournamentForm}
+          configs={gameTrackerConfigs}
+          saving={savingTournament}
+          error={tournamentFormError}
+          configError={gameTrackerConfigError}
+          onStartUsing={requestTrackerConfigLoad}
+          onChange={(nextForm) => {
+            setTournamentForm(nextForm);
+            if (tournamentFormError) setTournamentFormError(null);
+          }}
+          onSubmit={handleCreateTournament}
+        />
+        <SchedulePracticeCreatePanel
+          teamName={selectedCalendarTeam.teamName}
+          form={practiceForm}
+          saving={savingPractice}
+          error={practiceFormError}
+          onChange={(nextForm) => {
+            setPracticeForm(nextForm);
+            if (practiceFormError) setPracticeFormError(null);
+          }}
+          onSubmit={handleCreatePractice}
+        />
+        <ScheduleStaffTools
+          teamName={selectedCalendarTeam.teamName}
+          calendarUrl={calendarUrl}
+          calendarUrls={selectedCalendarTeam.calendarUrls || []}
+          calendarUrlError={calendarUrlError}
+          savingCalendarUrl={savingCalendarUrl}
+          removingCalendarUrl={removingCalendarUrl}
+          aiScheduleText={aiScheduleText}
+          aiScheduleImageName={aiScheduleImageName}
+          aiPreviewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
+          aiImportErrors={aiImportErrors}
+          processingAiImport={processingAiImport}
+          csvHeaders={csvHeaders}
+          csvMapping={csvMapping}
+          csvPreviewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
+          csvImportErrors={csvImportErrors}
+          csvFileName={csvFileName}
+          loadingCsvFile={loadingCsvFile}
+          importingCsv={importingCsv}
+          onCalendarUrlChange={(value) => {
+            setCalendarUrl(value);
+            if (calendarUrlError) setCalendarUrlError(null);
+          }}
+          onAddCalendarUrl={handleAddCalendarUrl}
+          onRemoveCalendarUrl={handleRemoveCalendarUrl}
+          onAiTextChange={(value) => {
+            setAiScheduleText(value);
+            clearAiPreview();
+            if (aiImportErrors.length) setAiImportErrors([]);
+          }}
+          onAiImageChange={handleAiImageChange}
+          onAiGeneratePreview={handleAiGeneratePreview}
+          onImportCsv={handleCsvImport}
+          onClearAi={handleAiClear}
+          onCsvFileChange={handleCsvFileChange}
+          onCsvMappingChange={handleCsvMappingChange}
+          onCsvPreview={handleCsvPreview}
+          onClearCsv={handleCsvClear}
+        />
+      </>
+    ) : null;
+  };
 
   useEffect(() => {
     setGameForm((current) => {
@@ -1323,10 +1364,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
             />
           )}
 
-          {isDesktopWeb && selectedCalendarTeam ? (
+          {isDesktopWeb && hasManageableScheduleTeams ? (
             <ScheduleStaffToolsSection
               open={desktopStaffToolsOpen}
-              teamName={selectedCalendarTeam.teamName}
+              teamName={selectedCalendarTeam?.teamName || null}
               contentId="desktop-schedule-staff-tools"
               onToggle={() => setDesktopStaffToolsOpen((current) => !current)}
             >
@@ -1334,10 +1375,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
             </ScheduleStaffToolsSection>
           ) : null}
 
-          {!isDesktopWeb && selectedCalendarTeam ? (
+          {!isDesktopWeb && hasManageableScheduleTeams ? (
             <ScheduleStaffToolsSection
               open={mobileStaffToolsOpen}
-              teamName={selectedCalendarTeam.teamName}
+              teamName={selectedCalendarTeam?.teamName || null}
               contentId="mobile-schedule-staff-tools"
               onToggle={() => setMobileStaffToolsOpen((current) => {
                 const nextOpen = !current;
@@ -1547,7 +1588,7 @@ function PracticeRecurrenceFields({ form, onChange }: { form: SchedulePracticeFo
   );
 }
 
-function ScheduleStaffToolsSection({ open, teamName, contentId, onToggle, children }: { open: boolean; teamName: string; contentId: string; onToggle: () => void; children: ReactNode }) {
+function ScheduleStaffToolsSection({ open, teamName, contentId, onToggle, children }: { open: boolean; teamName: string | null; contentId: string; onToggle: () => void; children: ReactNode }) {
   return (
     <section className="app-card p-3" aria-label="Manage schedule tools">
       <button
@@ -1560,7 +1601,7 @@ function ScheduleStaffToolsSection({ open, teamName, contentId, onToggle, childr
         <div className="min-w-0">
           <div className="app-label">Staff schedule tools</div>
           <h2 className="mt-1 text-base font-black text-gray-950">Manage schedule</h2>
-          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Calendar feeds and imports for {teamName} stay tucked away until you need them.</p>
+          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">{teamName ? `Calendar feeds and imports for ${teamName} stay tucked away until you need them.` : 'Choose a team here to unlock schedule tools without relying on the page-level team filter.'}</p>
         </div>
         <ChevronDown className={`h-5 w-5 flex-none text-gray-500 transition ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
       </button>


### PR DESCRIPTION
Closes #3124

## What changed
- kept the Manage Schedule accordion visible for any staff user with at least one manageable team
- added an in-section team picker when staff can manage multiple teams but have not selected a team yet
- preserved the existing single-team path so staff with one manageable team still open directly into that team's schedule tools
- added regression coverage for the multi-team staff discovery flow and for selecting a team and creating a schedule item from that in-section picker

## Root Cause
`Schedule.tsx` only rendered Manage Schedule when `selectedCalendarTeam` was truthy. That value only resolved when the page-level team filter already matched a manageable team or when exactly one manageable team existed, so multi-team staff with no selected filter lost the staff-tools entry point entirely.

## Prevention / Learning
When a workflow requires staff scope, keep the workflow entry point visible for any user who has at least one manageable scope. Gate the follow-on actions with an in-flow selector instead of hiding the whole workflow behind a separate parent-facing filter.

## Regression Tests
- `npx vitest run src/pages/Schedule.test.tsx --reporter=verbose`
- `npm run app:build`
- added `shows Manage schedule for multi-team staff and opens to a team selector before tools`
- added `uses the Manage schedule team selector to reveal and submit team-specific staff tools`