### PR TITLE
Preserve retry mode on Stripe registration cancel

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -328,26 +328,27 @@ function buildRegistrationReminderMailRef(mailDocId) {
 
 function buildRegistrationCheckoutUrls(appUrl, input) {
   const baseUrl = String(appUrl || 'https://allplays.ai').replace(/\/$/, '');
-  const params = new URLSearchParams({
+  const successParams = new URLSearchParams({
     teamId: input.teamId,
     formId: input.formId
   });
   if (input.publicCheckoutCapability) {
-    params.set('publicCheckoutCapability', input.publicCheckoutCapability);
-  }
-  if (input.retryPayment) {
-    params.set('retryPayment', '1');
+    successParams.set('publicCheckoutCapability', input.publicCheckoutCapability);
   }
   if (input.paymentPlanId) {
-    params.set('paymentPlanId', String(input.paymentPlanId));
+    successParams.set('paymentPlanId', String(input.paymentPlanId));
   }
   const paidInstallmentCount = Math.max(0, Math.floor(Number(input.paidInstallmentCount) || 0));
   if (paidInstallmentCount > 0) {
-    params.set('paidInstallmentCount', String(paidInstallmentCount));
+    successParams.set('paidInstallmentCount', String(paidInstallmentCount));
+  }
+  const cancelParams = new URLSearchParams(successParams);
+  if (input.retryPayment || input.publicCheckoutCapability) {
+    cancelParams.set('retryPayment', '1');
   }
   return {
-    successUrl: `${baseUrl}/registration.html?${params.toString()}&status=success`,
-    cancelUrl: `${baseUrl}/registration.html?${params.toString()}&status=cancelled`
+    successUrl: `${baseUrl}/registration.html?${successParams.toString()}&status=success`,
+    cancelUrl: `${baseUrl}/registration.html?${cancelParams.toString()}&status=cancelled`
   };
 }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -328,27 +328,29 @@ function buildRegistrationReminderMailRef(mailDocId) {
 
 function buildRegistrationCheckoutUrls(appUrl, input) {
   const baseUrl = String(appUrl || 'https://allplays.ai').replace(/\/$/, '');
-  const successParams = new URLSearchParams({
+  const params = new URLSearchParams({
     teamId: input.teamId,
     formId: input.formId
   });
   if (input.publicCheckoutCapability) {
-    successParams.set('publicCheckoutCapability', input.publicCheckoutCapability);
+    params.set('publicCheckoutCapability', input.publicCheckoutCapability);
   }
   if (input.paymentPlanId) {
-    successParams.set('paymentPlanId', String(input.paymentPlanId));
+    params.set('paymentPlanId', String(input.paymentPlanId));
   }
   const paidInstallmentCount = Math.max(0, Math.floor(Number(input.paidInstallmentCount) || 0));
   if (paidInstallmentCount > 0) {
-    successParams.set('paidInstallmentCount', String(paidInstallmentCount));
+    params.set('paidInstallmentCount', String(paidInstallmentCount));
   }
-  const cancelParams = new URLSearchParams(successParams);
-  if (input.retryPayment || input.publicCheckoutCapability) {
-    cancelParams.set('retryPayment', '1');
+  const successParams = new URLSearchParams(params);
+  if (input.retryPayment) {
+    params.set('retryPayment', '1');
+  } else if (input.publicCheckoutCapability) {
+    params.set('retryPayment', '1');
   }
   return {
     successUrl: `${baseUrl}/registration.html?${successParams.toString()}&status=success`,
-    cancelUrl: `${baseUrl}/registration.html?${cancelParams.toString()}&status=cancelled`
+    cancelUrl: `${baseUrl}/registration.html?${params.toString()}&status=cancelled`
   };
 }
 

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -1,7 +1,8 @@
-const assert = require('node:assert/strict');
-const test = require('node:test');
-const Module = require('node:module');
+import assert from 'node:assert/strict';
+import Module, { createRequire } from 'node:module';
+import { afterEach, beforeEach, test } from 'vitest';
 
+const require = createRequire(import.meta.url);
 const repoIndexPath = require.resolve('../index.js');
 const originalModuleLoad = Module._load;
 
@@ -289,7 +290,7 @@ const checkoutInput = {
     retryPayment: true
 };
 
-test.beforeEach(() => {
+beforeEach(() => {
     delete require.cache[repoIndexPath];
     Module._load = patchedModuleLoad;
     adminStub = null;
@@ -297,7 +298,7 @@ test.beforeEach(() => {
     StripeStub = null;
 });
 
-test.afterEach(() => {
+afterEach(() => {
     delete require.cache[repoIndexPath];
     Module._load = originalModuleLoad;
     adminStub = null;

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -502,6 +502,7 @@ test('includes retryPayment on Stripe cancel returns for initial public registra
     assert.equal(successUrl.searchParams.get('paymentPlanId'), 'pay_full');
     assert.match(successUrl.searchParams.get('publicCheckoutCapability') || '', /^[A-Za-z0-9_-]{32,}$/);
     assert.equal(successUrl.searchParams.get('retryPayment'), null);
+    assert.deepEqual(successUrl.searchParams.getAll('retryPayment'), []);
     assert.equal(successUrl.searchParams.get('status'), 'success');
 
     assert.equal(cancelUrl.origin, 'https://allplays.test');
@@ -511,5 +512,6 @@ test('includes retryPayment on Stripe cancel returns for initial public registra
     assert.equal(cancelUrl.searchParams.get('paymentPlanId'), 'pay_full');
     assert.equal(cancelUrl.searchParams.get('publicCheckoutCapability'), successUrl.searchParams.get('publicCheckoutCapability'));
     assert.equal(cancelUrl.searchParams.get('retryPayment'), '1');
+    assert.deepEqual(cancelUrl.searchParams.getAll('retryPayment'), ['1']);
     assert.equal(cancelUrl.searchParams.get('status'), 'cancelled');
 });

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -466,3 +466,49 @@ test('reserves capacity exactly once after a failed retry is retried successfull
     assert.equal(registration.checkoutAmountCents, 5000);
     assert.equal(Object.prototype.hasOwnProperty.call(registration, 'retryCapacityReservationId'), false);
 });
+
+test('includes retryPayment on Stripe cancel returns for initial public registration checkout', async () => {
+    let stripeCreateArgs = null;
+    const { createStripeRegistrationCheckout } = loadCheckoutHandler({
+        seed: buildSeedState({
+            registrationCapacityReleased: false
+        }),
+        stripeCreateImpl: async (args) => {
+            stripeCreateArgs = args;
+            return {
+                id: 'cs_test_initial_retry',
+                url: 'https://checkout.stripe.com/c/session_initial_retry',
+                payment_status: 'unpaid'
+            };
+        }
+    });
+
+    await createStripeRegistrationCheckout({
+        teamId: 'team-1',
+        formId: 'form-1',
+        registrationId: 'reg-1',
+        checkoutAttemptToken: 'attempttoken12345'
+    });
+
+    assert.ok(stripeCreateArgs);
+    const successUrl = new URL(stripeCreateArgs.success_url);
+    const cancelUrl = new URL(stripeCreateArgs.cancel_url);
+
+    assert.equal(successUrl.origin, 'https://allplays.test');
+    assert.equal(successUrl.pathname, '/registration.html');
+    assert.equal(successUrl.searchParams.get('teamId'), 'team-1');
+    assert.equal(successUrl.searchParams.get('formId'), 'form-1');
+    assert.equal(successUrl.searchParams.get('paymentPlanId'), 'pay_full');
+    assert.match(successUrl.searchParams.get('publicCheckoutCapability') || '', /^[A-Za-z0-9_-]{32,}$/);
+    assert.equal(successUrl.searchParams.get('retryPayment'), null);
+    assert.equal(successUrl.searchParams.get('status'), 'success');
+
+    assert.equal(cancelUrl.origin, 'https://allplays.test');
+    assert.equal(cancelUrl.pathname, '/registration.html');
+    assert.equal(cancelUrl.searchParams.get('teamId'), 'team-1');
+    assert.equal(cancelUrl.searchParams.get('formId'), 'form-1');
+    assert.equal(cancelUrl.searchParams.get('paymentPlanId'), 'pay_full');
+    assert.equal(cancelUrl.searchParams.get('publicCheckoutCapability'), successUrl.searchParams.get('publicCheckoutCapability'));
+    assert.equal(cancelUrl.searchParams.get('retryPayment'), '1');
+    assert.equal(cancelUrl.searchParams.get('status'), 'cancelled');
+});

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
 import Module, { createRequire } from 'node:module';
-import { afterEach, beforeEach, test } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const repoIndexPath = require.resolve('../index.js');


### PR DESCRIPTION
Closes #3126

## What changed
- Updated the public registration Stripe checkout URL builder so cancel returns always include `retryPayment=1` when returning to an existing pending registration.
- Kept success returns clean so the paid confirmation path does not carry retry-only state.
- Added a focused functions regression test that verifies an initial public checkout emits a cancel URL with `retryPayment=1` and the same public checkout capability token.

## Root Cause
The Stripe registration checkout URL builder only added `retryPayment=1` when the request was already a retry. Initial checkout cancel returns therefore came back to `registration.html` without the retry flag, so the page stayed on the fresh-submission branch and created a second pending registration before reopening Stripe.

## Prevention / Learning
Any payment cancel or recovery return URL for an existing pending record must preserve the state needed to re-enter the existing-record path. Treat retry flags and capabilities as part of the server-owned return contract, not as optional client hints.

## Regression Tests
- `node --test functions/test/registration-checkout-retry-capacity.test.js`
- Added coverage in `functions/test/registration-checkout-retry-capacity.test.js` to assert initial public registration checkout sets `retryPayment=1` on the cancel URL while leaving the success URL clean.

## Recurrence Risk
Low. The checkout URL contract is now covered by a focused regression test that would fail if cancel returns stop preserving retry-payment state.