### PR TITLE
Preserve basketball scoring column renames

### DIFF
--- a/edit-config.html
+++ b/edit-config.html
@@ -260,6 +260,17 @@
             };
         }
 
+        function getConfigWritePayload() {
+            const { name, baseType, columns, statDefinitions, scoringColumn } = getFormPayload();
+            return {
+                name,
+                baseType,
+                columns,
+                statDefinitions,
+                ...(scoringColumn ? { scoringColumn } : {})
+            };
+        }
+
         function slugifyStatKey(value = '') {
             return String(value || '')
                 .trim()
@@ -601,7 +612,8 @@
 
         document.getElementById('add-config-form').addEventListener('submit', async (e) => {
             e.preventDefault();
-            const { name, baseType, columns, statDefinitions } = getFormPayload();
+            const configPayload = getConfigWritePayload();
+            const { name, columns, statDefinitions } = configPayload;
 
             if (!name) {
                 alert('Please add a config name.');
@@ -621,19 +633,9 @@
 
             try {
                 if (editingConfigId) {
-                    await updateConfig(currentTeamId, editingConfigId, {
-                        name,
-                        baseType,
-                        columns,
-                        statDefinitions
-                    });
+                    await updateConfig(currentTeamId, editingConfigId, configPayload);
                 } else {
-                    await createConfig(currentTeamId, {
-                        name,
-                        baseType,
-                        columns,
-                        statDefinitions
-                    });
+                    await createConfig(currentTeamId, configPayload);
                 }
                 resetFormState();
                 await loadConfigs();

--- a/edit-config.html
+++ b/edit-config.html
@@ -242,7 +242,76 @@
             const advancedStatDefinitionsStr = document.getElementById('advancedStatDefinitions').value;
             const columns = columnsStr.split(',').map(s => s.trim()).filter(s => s.length > 0);
             const statDefinitions = parseAdvancedStatDefinitions(advancedStatDefinitionsStr);
-            return { name, baseType, columns, statDefinitions };
+            const existingConfig = editingConfigId
+                ? currentConfigs.find((config) => config.id === editingConfigId)
+                : null;
+            const scoringColumn = deriveBasketballScoringColumn({
+                baseType,
+                columns,
+                statDefinitions,
+                existingConfig
+            });
+            return {
+                name,
+                baseType,
+                columns,
+                statDefinitions,
+                ...(scoringColumn ? { scoringColumn } : {})
+            };
+        }
+
+        function slugifyStatKey(value = '') {
+            return String(value || '')
+                .trim()
+                .toLowerCase()
+                .replace(/[^a-z0-9_]+/g, '');
+        }
+
+        function findCanonicalBasketballScoringColumn(columns = []) {
+            return (Array.isArray(columns) ? columns : []).find((column) => {
+                const normalized = String(column || '').trim().toUpperCase();
+                return normalized === 'PTS' || normalized === 'POINTS' || normalized === 'GOALS';
+            }) || '';
+        }
+
+        function deriveBasketballScoringColumn({ baseType = '', columns = [], statDefinitions = [], existingConfig = null } = {}) {
+            if (String(baseType || '').trim().toLowerCase() !== 'basketball') {
+                return '';
+            }
+
+            const safeColumns = (Array.isArray(columns) ? columns : []).map((column) => String(column || '').trim()).filter(Boolean);
+            if (!safeColumns.length) {
+                return '';
+            }
+
+            const directMatch = findCanonicalBasketballScoringColumn(safeColumns);
+            if (directMatch) {
+                return directMatch;
+            }
+
+            const previousColumns = Array.isArray(existingConfig?.columns) ? existingConfig.columns : [];
+            const previousScoringColumn = String(existingConfig?.scoringColumn || '').trim();
+            const previousScoringIndex = previousScoringColumn
+                ? previousColumns.findIndex((column) => String(column || '').trim().toLowerCase() === previousScoringColumn.toLowerCase())
+                : previousColumns.findIndex((column) => Boolean(findCanonicalBasketballScoringColumn([column])));
+
+            if (previousScoringIndex >= 0 && safeColumns[previousScoringIndex]) {
+                return safeColumns[previousScoringIndex];
+            }
+
+            const providedIds = new Set((Array.isArray(statDefinitions) ? statDefinitions : [])
+                .filter((definition) => !definition?.formula)
+                .map((definition) => slugifyStatKey(definition.id || definition.acronym || definition.label))
+                .filter(Boolean));
+
+            if (providedIds.has('pts')) {
+                const unmatchedColumns = safeColumns.filter((column) => !providedIds.has(slugifyStatKey(column)));
+                if (unmatchedColumns.length === 1) {
+                    return unmatchedColumns[0];
+                }
+            }
+
+            return '';
         }
 
         function syncColumnsInputWithStatId(statId = '') {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -2046,8 +2046,24 @@ function formatClock(ms) {
   return `${m}:${sec}`;
 }
 
+function getConfiguredPointsColumn() {
+  const configured = String(currentConfig?.scoringColumn || '').trim();
+  const columns = Array.isArray(currentConfig?.columns) ? currentConfig.columns : [];
+  if (configured && columns.some((column) => String(column || '').trim().toLowerCase() === configured.toLowerCase())) {
+    return configured;
+  }
+  return columns.find((column) => {
+    const normalized = String(column || '').trim().toUpperCase();
+    return normalized === 'PTS' || normalized === 'POINTS' || normalized === 'GOALS';
+  }) || '';
+}
+
 function isPointsColumn(colOrKey) {
   const u = (colOrKey || '').toString().toUpperCase();
+  const configured = getConfiguredPointsColumn();
+  if (configured) {
+    return u === configured.toUpperCase();
+  }
   return u === 'PTS' || u === 'POINTS' || u === 'GOALS';
 }
 

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -734,8 +734,24 @@ function formatClock(ms) {
   return `${m}:${sec}`;
 }
 
+function getConfiguredPointsColumn() {
+  const configured = String(currentConfig?.scoringColumn || '').trim();
+  const columns = Array.isArray(currentConfig?.columns) ? currentConfig.columns : [];
+  if (configured && columns.some((column) => String(column || '').trim().toLowerCase() === configured.toLowerCase())) {
+    return configured;
+  }
+  return columns.find((column) => {
+    const normalized = String(column || '').trim().toUpperCase();
+    return normalized === 'PTS' || normalized === 'POINTS' || normalized === 'GOALS';
+  }) || '';
+}
+
 function isPointsColumn(colOrKey) {
   const u = (colOrKey || '').toString().toUpperCase();
+  const configured = getConfiguredPointsColumn();
+  if (configured) {
+    return u === configured.toUpperCase();
+  }
   return u === 'PTS' || u === 'POINTS' || u === 'GOALS';
 }
 

--- a/tests/unit/basketball-scoring-column-regression.test.js
+++ b/tests/unit/basketball-scoring-column-regression.test.js
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+function extractFunction(source, functionName, fileLabel) {
+    const signature = `function ${functionName}`;
+    const start = source.indexOf(signature);
+    if (start === -1) {
+        throw new Error(`Could not find ${functionName} in ${fileLabel}`);
+    }
+
+    let paramsDepth = 0;
+    let bodyStart = -1;
+    for (let index = start; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '(') paramsDepth += 1;
+        if (char === ')') paramsDepth = Math.max(0, paramsDepth - 1);
+        if (char === '{' && paramsDepth === 0) {
+            bodyStart = index;
+            break;
+        }
+    }
+    if (bodyStart === -1) {
+        throw new Error(`Could not find ${functionName} body start in ${fileLabel}`);
+    }
+
+    let depth = 0;
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, index + 1);
+        }
+    }
+
+    throw new Error(`Could not extract ${functionName} from ${fileLabel}`);
+}
+
+function runFunction(scriptParts, hookNames, contextValues = {}) {
+    const context = vm.createContext({
+        ...contextValues,
+        globalThis: {}
+    });
+    const hookAssignments = hookNames.map((name) => `${name}: typeof ${name} === 'function' ? ${name} : undefined`).join(', ');
+    vm.runInContext(scriptParts.join('\n'), context);
+    vm.runInContext(`globalThis.__testHooks = { ${hookAssignments} };`, context);
+    return context.globalThis.__testHooks;
+}
+
+describe('basketball scoring column regression', () => {
+    it('preserves a renamed basketball scoring column during config saves', () => {
+        const source = readFileSync(new URL('../../edit-config.html', import.meta.url), 'utf8');
+        const hooks = runFunction([
+            extractFunction(source, 'slugifyStatKey', 'edit-config.html'),
+            extractFunction(source, 'findCanonicalBasketballScoringColumn', 'edit-config.html'),
+            extractFunction(source, 'deriveBasketballScoringColumn', 'edit-config.html')
+        ], ['deriveBasketballScoringColumn']);
+
+        expect(hooks.deriveBasketballScoringColumn({
+            baseType: 'Basketball',
+            columns: ['SCORE', 'REB', 'AST'],
+            statDefinitions: [
+                { id: 'pts', label: 'PTS', topStat: true },
+                { id: 'reb', label: 'REB' },
+                { id: 'ast', label: 'AST' }
+            ],
+            existingConfig: {
+                columns: ['PTS', 'REB', 'AST']
+            }
+        })).toBe('SCORE');
+    });
+
+    it.each([
+        ['track-basketball.js', '../../js/track-basketball.js'],
+        ['live-tracker.js', '../../js/live-tracker.js']
+    ])('treats the configured basketball scoring column as points in %s', (_, relativePath) => {
+        const source = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+        const hooks = runFunction([
+            extractFunction(source, 'getConfiguredPointsColumn', relativePath),
+            extractFunction(source, 'isPointsColumn', relativePath)
+        ], ['getConfiguredPointsColumn', 'isPointsColumn'], {
+            currentConfig: {
+                baseType: 'Basketball',
+                columns: ['SCORE', 'REB', 'AST'],
+                scoringColumn: 'SCORE'
+            }
+        });
+
+        expect(hooks.getConfiguredPointsColumn()).toBe('SCORE');
+        expect(hooks.isPointsColumn('SCORE')).toBe(true);
+        expect(hooks.isPointsColumn('score')).toBe(true);
+        expect(hooks.isPointsColumn('PTS')).toBe(false);
+    });
+});

--- a/tests/unit/basketball-scoring-column-regression.test.js
+++ b/tests/unit/basketball-scoring-column-regression.test.js
@@ -71,6 +71,37 @@ describe('basketball scoring column regression', () => {
         })).toBe('SCORE');
     });
 
+    it('includes the derived basketball scoring column in config writes', () => {
+        const source = readFileSync(new URL('../../edit-config.html', import.meta.url), 'utf8');
+        const hooks = runFunction([
+            extractFunction(source, 'getConfigWritePayload', 'edit-config.html')
+        ], ['getConfigWritePayload'], {
+            getFormPayload: () => ({
+                name: 'Basketball Standard',
+                baseType: 'Basketball',
+                columns: ['SCORE', 'REB', 'AST'],
+                statDefinitions: [
+                    { id: 'pts', label: 'PTS', topStat: true },
+                    { id: 'reb', label: 'REB' },
+                    { id: 'ast', label: 'AST' }
+                ],
+                scoringColumn: 'SCORE'
+            })
+        });
+
+        expect(hooks.getConfigWritePayload()).toEqual({
+            name: 'Basketball Standard',
+            baseType: 'Basketball',
+            columns: ['SCORE', 'REB', 'AST'],
+            statDefinitions: [
+                { id: 'pts', label: 'PTS', topStat: true },
+                { id: 'reb', label: 'REB' },
+                { id: 'ast', label: 'AST' }
+            ],
+            scoringColumn: 'SCORE'
+        });
+    });
+
     it.each([
         ['track-basketball.js', '../../js/track-basketball.js'],
         ['live-tracker.js', '../../js/live-tracker.js']


### PR DESCRIPTION
Closes #3128

## What changed
- Persist a `scoringColumn` field when saving basketball stat configs so renamed scoring stats keep their basketball scoring meaning.
- Taught both `track-basketball.js` and `live-tracker.js` to treat the configured `scoringColumn` as the scoring stat instead of relying only on hard-coded labels like `PTS`.
- Added a focused regression test that covers saving a renamed basketball scoring column and consuming it in both basketball trackers.

## Root Cause
The edit-config flow saved renamed basketball columns exactly as typed, but the basketball trackers still used a hard-coded `isPointsColumn()` check for `PTS`, `POINTS`, or `GOALS`. That let a basketball config keep routing into basketball tracking while losing the scoring-column identity the tracker needed for +1/+2/+3 controls and scoreboard updates.

## Prevention / Learning
When a workflow lets admins customize schema labels, sport-specific runtime behavior cannot depend only on display text heuristics. Persist the semantic role that downstream code needs, then have every consumer read that persisted role instead of re-inferring it from labels.

## Regression Tests
- `npx vitest run tests/unit/basketball-scoring-column-regression.test.js tests/unit/edit-config-schema-workflow.test.js tests/unit/track-basketball-opponent-hydration.test.js --reporter=verbose`
- `tests/unit/basketball-scoring-column-regression.test.js` verifies a renamed basketball scoring column saves as `scoringColumn` and is recognized by both basketball trackers.

## Recurrence Risk
Low. Basketball configs now persist the scoring-column identity, and both basketball tracker implementations consume that field with legacy-label fallback for older configs.