### PR TITLE
Preserve final bundle visualizer filter value

### DIFF
--- a/apps/app/build/fixBundleVisualizerTooltip.js
+++ b/apps/app/build/fixBundleVisualizerTooltip.js
@@ -20,12 +20,52 @@ const FIXED_TOOLTIP_HANDLER = `          const handleMouseOut = (event) => {
               document.removeEventListener("mouseover", handleMouseOut);
           };`;
 
+const BROKEN_FILTER_THROTTLE = `  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      return (val) => {
+          if (!waiting) {
+              callback(val);
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+              }, limit);
+          }
+      };
+  };`;
+
+const FIXED_FILTER_THROTTLE = `  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      let latestValue;
+      let lastEmittedValue;
+      return (val) => {
+          latestValue = val;
+          if (!waiting) {
+              callback(val);
+              lastEmittedValue = val;
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+                  if (latestValue !== lastEmittedValue) {
+                      callback(latestValue);
+                      lastEmittedValue = latestValue;
+                  }
+              }, limit);
+          }
+      };
+  };`;
+
 export function fixBundleVisualizerTooltip(html) {
-    if (!html.includes(BROKEN_TOOLTIP_HANDLER)) {
-        return html;
+    let patchedHtml = html;
+
+    if (patchedHtml.includes(BROKEN_TOOLTIP_HANDLER)) {
+        patchedHtml = patchedHtml.replace(BROKEN_TOOLTIP_HANDLER, FIXED_TOOLTIP_HANDLER);
     }
 
-    return html.replace(BROKEN_TOOLTIP_HANDLER, FIXED_TOOLTIP_HANDLER);
+    if (patchedHtml.includes(BROKEN_FILTER_THROTTLE)) {
+        patchedHtml = patchedHtml.replace(BROKEN_FILTER_THROTTLE, FIXED_FILTER_THROTTLE);
+    }
+
+    return patchedHtml;
 }
 
 export function patchBundleVisualizerTooltipFile(filePath) {

--- a/tests/unit/app-bundle-visualizer-tooltip.test.js
+++ b/tests/unit/app-bundle-visualizer-tooltip.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { fixBundleVisualizerTooltip } from '../../apps/app/build/fixBundleVisualizerTooltip.js';
 
@@ -12,7 +12,7 @@ const brokenVisualizerHtml = `  y(() => {
           };
   }, []);`;
 
-describe('bundle visualizer tooltip patch', () => {
+describe('bundle visualizer patch', () => {
     it('replaces the document-level hover hide handler with a guarded version', () => {
         const patchedHtml = fixBundleVisualizerTooltip(brokenVisualizerHtml);
 
@@ -20,6 +20,41 @@ describe('bundle visualizer tooltip patch', () => {
         expect(patchedHtml).toContain('const handleMouseOut = (event) => {');
         expect(patchedHtml).toContain('target.closest(".node") || target.closest(".tooltip")');
         expect(patchedHtml).toContain('document.addEventListener("mouseover", handleMouseOut);');
+    });
+
+    it('adds a trailing filter update so the final typed value is not dropped', () => {
+        const brokenFilterHtml = `  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      return (val) => {
+          if (!waiting) {
+              callback(val);
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+              }, limit);
+          }
+      };
+  };`;
+
+        const patchedHtml = fixBundleVisualizerTooltip(brokenFilterHtml);
+        const throttleFilter = new Function(`${patchedHtml}; return throttleFilter;`)();
+        const values = [];
+        const throttled = throttleFilter((value) => values.push(value), 200);
+
+        vi.useFakeTimers();
+        try {
+            throttled('v');
+            throttled('ve');
+            throttled('ven');
+
+            expect(values).toEqual(['v']);
+
+            vi.advanceTimersByTime(200);
+
+            expect(values).toEqual(['v', 'ven']);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('leaves already-patched reports unchanged', () => {
@@ -35,7 +70,28 @@ describe('bundle visualizer tooltip patch', () => {
       return () => {
           document.removeEventListener("mouseover", handleMouseOut);
       };
-  }, []);`;
+  }, []);
+
+  const throttleFilter = (callback, limit) => {
+      let waiting = false;
+      let latestValue;
+      let lastEmittedValue;
+      return (val) => {
+          latestValue = val;
+          if (!waiting) {
+              callback(val);
+              lastEmittedValue = val;
+              waiting = true;
+              setTimeout(() => {
+                  waiting = false;
+                  if (latestValue !== lastEmittedValue) {
+                      callback(latestValue);
+                      lastEmittedValue = latestValue;
+                  }
+              }, limit);
+          }
+      };
+  };`;
 
         expect(fixBundleVisualizerTooltip(patchedHtml)).toBe(patchedHtml);
     });


### PR DESCRIPTION
Closes #3131

## What changed
- extended the existing bundle visualizer post-build patcher to rewrite the generated leading-only `throttleFilter` into a trailing-aware version
- kept the current leading update behavior, but now flush the latest queued Include/Exclude value after the 200 ms window so the treemap matches the text shown in the input
- added a focused regression test that executes the patched throttle and verifies a fast typing burst emits the final value

## Root Cause
The generated bundle visualizer used a leading-only throttle for Include/Exclude updates. The input component kept its own local text state, but the actual chart filter state only received the first value in each 200 ms window, so later keystrokes in the same burst were dropped and the treemap filtered on a stale prefix.

## Prevention / Learning
When UI input state and applied filter state are decoupled for performance, throttling must preserve the trailing value or explicitly flush on idle. A leading-only throttle is unsafe for text filters because it can leave the rendered results behind the visible input.

## Regression Tests
- `npx vitest run tests/unit/app-bundle-visualizer-tooltip.test.js --reporter=verbose`
- added coverage that patches the generated throttle, runs a rapid `v -> ve -> ven` burst, and verifies the final `ven` value is emitted after the throttle window