### PR TITLE
Keep team detail tabs in route state

### DIFF
--- a/apps/app/src/lib/nativeBackButton.test.ts
+++ b/apps/app/src/lib/nativeBackButton.test.ts
@@ -13,6 +13,9 @@ describe('native back button helpers', () => {
     expect(getNativeBackTarget('/schedule')).toBe('/home');
     expect(getNativeBackTarget('/messages/team-1')).toBe('/messages');
     expect(getNativeBackTarget('/teams/team-1/fees')).toBe('/teams/team-1');
+    expect(getNativeBackTarget('/teams/team-1', '?tab=roster')).toBe('/teams/team-1');
+    expect(getNativeBackTarget('/teams/team-1', '?tab=more')).toBe('/teams/team-1');
+    expect(getNativeBackTarget('/teams/team-1', '?tab=overview')).toBe('/teams');
     expect(getNativeBackTarget('/teams/team-1')).toBe('/teams');
     expect(getNativeBackTarget('/teams/browse')).toBe('/teams');
     expect(getNativeBackTarget('/parent-tools/registrations/team-1/form-1')).toBe('/parent-tools');

--- a/apps/app/src/lib/nativeBackButton.ts
+++ b/apps/app/src/lib/nativeBackButton.ts
@@ -38,6 +38,7 @@ export function dispatchNativeBackDismissEvent() {
 
 export function getNativeBackTarget(pathname: string, search = '') {
   const path = normalizePathname(pathname);
+  const normalizedSearch = normalizeSearch(search);
   const homeStateTarget = getNativeHomeBackTarget(path, search);
   if (homeStateTarget) return homeStateTarget;
   if (isNativeExitRoute(path, search)) return null;
@@ -47,6 +48,13 @@ export function getNativeBackTarget(pathname: string, search = '') {
   if (path === '/teams/browse') return '/teams';
   const teamSubroute = path.match(/^\/teams\/([^/]+)\/.+/);
   if (teamSubroute) return `/teams/${teamSubroute[1]}`;
+  if (/^\/teams\/[^/]+$/.test(path)) {
+    const params = new URLSearchParams(normalizedSearch);
+    if (params.get('tab') && params.get('tab') !== 'overview') {
+      params.delete('tab');
+      return buildRoute(path, params);
+    }
+  }
   if (/^\/teams\/[^/]+$/.test(path)) return '/teams';
   if (/^\/parent-tools\/.+/.test(path)) return '/parent-tools';
   if (/^\/players\//.test(path)) return '/home';

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TeamDetail } from './TeamDetail';
 import type { AuthState } from '../lib/types';
@@ -338,6 +338,68 @@ describe('TeamDetail', () => {
     expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
   });
 
+  it('drives team tabs from the route search state', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/teams/:teamId',
+          element: <TeamDetail auth={auth} />
+        }
+      ],
+      { initialEntries: ['/teams/team-1?tab=roster'] }
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /roster/i }).getAttribute('aria-pressed')).toBe('true');
+    expect(router.state.location.search).toBe('?tab=roster');
+
+    fireEvent.click(screen.getByRole('button', { name: /more/i }));
+    await waitFor(() => expect(router.state.location.search).toBe('?tab=more'));
+    expect(screen.getByRole('button', { name: /more/i }).getAttribute('aria-pressed')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: /overview/i }));
+    await waitFor(() => expect(router.state.location.search).toBe(''));
+    expect(screen.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('steps back to team overview before leaving the team hub', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/teams',
+          element: <div>Teams list</div>
+        },
+        {
+          path: '/teams/:teamId',
+          element: <TeamDetail auth={auth} />
+        }
+      ],
+      { initialEntries: ['/teams', '/teams/team-1', '/teams/team-1?tab=roster'], initialIndex: 2 }
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /roster/i }).getAttribute('aria-pressed')).toBe('true');
+
+    await act(async () => {
+      await router.navigate(-1);
+    });
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/teams/team-1'));
+    expect(router.state.location.search).toBe('');
+    expect(screen.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
+
+    await act(async () => {
+      await router.navigate(-1);
+    });
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/teams'));
+    expect(await screen.findByText('Teams list')).toBeTruthy();
+  });
+
   it('renders native standings rows with the current team highlight and expandable overflow', async () => {
     const standingsRows = [
       { rank: 1, team: 'Lions', w: 8, l: 1, t: 0, points: 16 },
@@ -371,10 +433,10 @@ describe('TeamDetail', () => {
     expect(screen.getByRole('columnheader', { name: 'PTS' })).toBeTruthy();
     expect(screen.getByText('Lions')).toBeTruthy();
     expect(screen.queryByText('Falcons')).toBeNull();
-    expect(screen.getByText('Bears')).toBeTruthy();
+    const currentTeamCell = screen.getAllByText('Bears').find((element) => element.tagName === 'TD');
+    expect(currentTeamCell).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Show 1 more team' })).toBeTruthy();
 
-    const currentTeamCell = screen.getAllByText('Bears').find((element) => element.tagName === 'TD');
     const currentTeamRow = currentTeamCell?.closest('tr');
     expect(currentTeamRow?.getAttribute('aria-current')).toBe('true');
 

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
-import { Link, Navigate, useLocation, useParams } from 'react-router-dom';
+import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 import {
   Award,
@@ -62,15 +62,24 @@ function loadRosterAiImportModule() {
   return rosterAiImportModulePromise;
 }
 
+function getTeamTabFromSearch(search: string): TeamTab {
+  const nextTab = new URLSearchParams(search).get('tab');
+  if (nextTab === 'schedule' || nextTab === 'roster' || nextTab === 'insights' || nextTab === 'more') {
+    return nextTab;
+  }
+  return 'overview';
+}
+
 export function TeamDetail({ auth }: { auth: AuthState }) {
   const { teamId = '' } = useParams();
   const location = useLocation();
+  const navigate = useNavigate();
   const authUserId = auth.user?.uid || '';
   const [model, setModel] = useState<TeamDetailModel | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<AppServiceError | null>(null);
   const [reloadVersion, setReloadVersion] = useState(0);
-  const [activeTab, setActiveTab] = useState<TeamTab>('overview');
+  const activeTab = getTeamTabFromSearch(location.search);
   const [staffPermissionsLoading, setStaffPermissionsLoading] = useState(false);
   const [staffPermissionsError, setStaffPermissionsError] = useState('');
   const [insightsLoading, setInsightsLoading] = useState(false);
@@ -88,12 +97,22 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   const [trackingAttempted, setTrackingAttempted] = useState(false);
   const [trackingItems, setTrackingItems] = useState<TeamTrackingAdminItem[]>([]);
 
-  useEffect(() => {
-    const nextTab = new URLSearchParams(location.search).get('tab');
-    if (nextTab === 'overview' || nextTab === 'schedule' || nextTab === 'roster' || nextTab === 'insights' || nextTab === 'more') {
-      setActiveTab(nextTab);
+  function navigateToTab(nextTab: TeamTab) {
+    if (nextTab === activeTab) return;
+
+    const nextParams = new URLSearchParams(location.search);
+    if (nextTab === 'overview') {
+      nextParams.delete('tab');
+    } else {
+      nextParams.set('tab', nextTab);
     }
-  }, [location.search]);
+
+    const nextSearch = nextParams.toString();
+    navigate({
+      pathname: location.pathname,
+      search: nextSearch ? `?${nextSearch}` : ''
+    });
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -392,7 +411,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
                 key={tab.id}
                 type="button"
                 className={`flex min-h-14 flex-col items-center justify-center gap-1 rounded-xl px-1 text-[11px] font-black transition ${selected ? 'bg-primary-600 text-white shadow-sm' : 'text-gray-600 hover:bg-gray-100'}`}
-                onClick={() => setActiveTab(tab.id)}
+                onClick={() => navigateToTab(tab.id)}
                 aria-pressed={selected}
               >
                 <span className="relative">
@@ -407,7 +426,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       </section>
 
       {activeTab === 'overview' ? <OverviewTab model={model} /> : null}
-      {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} onOpenStatTrackerConfigs={() => setActiveTab('more')} /> : null}
+      {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} onOpenStatTrackerConfigs={() => navigateToTab('more')} /> : null}
       {activeTab === 'roster' ? <RosterTab model={model} authUser={auth.user} onRefresh={refreshTeamDetail} rosterInviteLoading={rosterInviteLoading} rosterInviteError={rosterInviteError} rosterInviteSummaries={rosterInviteSummaries} onInviteCreated={refreshRosterInvites} trackingLoading={trackingLoading} trackingError={trackingError} trackingItems={trackingItems} onTrackingChanged={refreshTrackingItems} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} loading={insightsLoading} error={insightsError} /> : null}
       {activeTab === 'more' ? <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} sponsorsLoading={sponsorsLoading} sponsorsError={sponsorsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -680,6 +680,29 @@ test.describe('mobile My Teams', () => {
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
     });
 
+    test('team detail tab routes preserve back navigation inside the team hub', async ({ page, baseURL }) => {
+        await mockTeamsModules(page);
+        await page.goto(appUrl(baseURL, '/teams'), { waitUntil: 'domcontentloaded' });
+
+        const teamsReadyHeading = page.getByRole('heading', { name: '3 teams ready' });
+        await waitForTeamsRoute(page, teamsReadyHeading);
+        await page.getByRole('link', { name: 'Open Bears' }).first().click();
+
+        await waitForTeamDetailRoute(page, 'Bears');
+        await page.getByRole('button', { name: /Roster/ }).click();
+        await expect(page).toHaveURL(/#\/teams\/team-1\?tab=roster$/);
+        await expect(page.getByRole('button', { name: /Roster/ })).toHaveAttribute('aria-pressed', 'true');
+
+        await page.goBack();
+        await waitForTeamDetailRoute(page, 'Bears');
+        await expect(page).toHaveURL(/#\/teams\/team-1$/);
+        await expect(page.getByRole('button', { name: /Overview/ })).toHaveAttribute('aria-pressed', 'true');
+
+        await page.goBack();
+        await waitForTeamsRoute(page, teamsReadyHeading);
+        await expect(page).toHaveURL(/#\/teams$/);
+    });
+
     test('team detail empty tabs are useful and navigable', async ({ page, baseURL }) => {
         await mockTeamsModules(page);
         await page.goto(appUrl(baseURL, '/teams/team-empty'), { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
Closes #3137

## What changed
- made Team Detail tab selection route-driven by deriving the active tab from `location.search` and pushing `?tab=<id>` on tab changes
- kept overview as the default route state by removing the `tab` query param when users return to Overview
- updated native back targeting so `/teams/:teamId?tab=<non-overview>` steps back to `/teams/:teamId` before leaving to `/teams`
- added focused Team Detail and native back regression coverage, plus a mobile smoke flow for tab-route back navigation

## Root Cause
Team Detail mixed route-derived initial state with local component state after first render. The page could load from `?tab=roster`, but tab clicks only updated React state, not the URL or browser history. Native back logic only inspects pathname and search, so once the user was on `/teams/:teamId` it had no way to distinguish Overview from Roster or More and exited the team hub immediately.

## Prevention / Learning
When a mobile app shell, deep links, or native back behavior depends on view state, that state must live in the route, not only in component state. For tabbed team workflows, treat query-param state as the source of truth and add a regression test that proves both tab clicks and back navigation mutate history correctly.

## Regression Tests
- `npm --prefix apps/app exec vitest run src/lib/nativeBackButton.test.ts src/pages/TeamDetail.test.tsx`
- `npm run app:build`
- added `tests/smoke/app-teams.spec.js` coverage for team tab route/back behavior
- local Playwright execution of the new smoke case is currently blocked because the required Playwright Chromium binary is not installed in this workspace (`npx playwright install` needed)