### PR TITLE
Route coach/admin launch flows to My Teams

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -132,6 +132,10 @@ vi.mock('./pages/Messages', () => ({
   Messages: () => <div>Messages page</div>,
 }));
 
+vi.mock('./pages/Teams', () => ({
+  Teams: () => <div>Teams page</div>,
+}));
+
 function installTestLocalStorage() {
   const store = new Map<string, string>();
   Object.defineProperty(window, 'localStorage', {
@@ -236,6 +240,44 @@ describe('App protected route loading', () => {
 
     expect(screen.getByText('Loading ALL PLAYS')).toBeTruthy();
     expect(screen.queryByRole('navigation', { name: 'Primary navigation' })).toBeNull();
+  });
+
+  it('routes signed-in coach users from the root route to Teams', async () => {
+    authMock.state = {
+      ...authMock.signedInAuth,
+      user: { ...authMock.signedInAuth.user!, email: 'coach@example.com', roles: ['coach'] },
+      roles: ['coach'],
+      isParent: false,
+      isCoach: true,
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Teams page')).toBeTruthy();
+    expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
+  });
+
+  it('routes signed-in coach users from unknown routes to Teams', async () => {
+    authMock.state = {
+      ...authMock.signedInAuth,
+      user: { ...authMock.signedInAuth.user!, email: 'coach@example.com', roles: ['coach'] },
+      roles: ['coach'],
+      isParent: false,
+      isCoach: true,
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/does-not-exist']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Teams page')).toBeTruthy();
+    expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
   });
 
   it('routes the dedicated public-team discovery screen ahead of dynamic team ids', async () => {

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -17,6 +17,7 @@ import {
 import { addNativeDeepLinkListener } from './lib/nativeDeepLinkRouting';
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { readAuthBootstrapHint } from './lib/authBootstrapHint';
+import { getRouteForUser } from './lib/authService';
 import { useAuth } from './lib/useAuth';
 import type { AuthState } from './lib/types';
 
@@ -54,6 +55,7 @@ const protectedRouteBootstrapGraceMs = 750;
 export default function App() {
   const auth = useAuth();
   const location = useLocation();
+  const signedInDefaultRoute = getRouteForUser(auth.user);
   const navigate = useNavigate();
   const authUserRef = useRef(auth.user);
   const locationRef = useRef(location);
@@ -213,7 +215,7 @@ export default function App() {
         <Route path="/reset-password" element={<ResetPassword />} />
         <Route path="/verify-pending" element={<VerifyPending auth={auth} />} />
         <Route path="/registration" element={<AppShell auth={auth}><RegistrationDetail auth={auth} publicAccess /></AppShell>} />
-        <Route path="/" element={<Navigate to={auth.user ? '/home' : '/auth'} replace />} />
+        <Route path="/" element={<Navigate to={auth.user ? signedInDefaultRoute : '/auth'} replace />} />
         <Route path="/home" element={<Protected auth={auth}><Home auth={auth} /></Protected>} />
         <Route path="/officials" element={<Protected auth={auth}><Officials auth={auth} /></Protected>} />
         <Route path="/schedule" element={<Protected auth={auth}><Schedule auth={auth} /></Protected>} />
@@ -242,7 +244,7 @@ export default function App() {
         <Route path="/help/:helpId" element={<Protected auth={auth}><HelpArticle /></Protected>} />
         <Route path="/profile" element={<Protected auth={auth}><Profile auth={auth} /></Protected>} />
         <Route path="/capabilities/:capabilityId" element={<Protected auth={auth}><CapabilityPage /></Protected>} />
-        <Route path="*" element={<Navigate to={auth.user ? '/home' : '/auth'} replace />} />
+        <Route path="*" element={<Navigate to={auth.user ? signedInDefaultRoute : '/auth'} replace />} />
       </Routes>
       {nativeExitNoticeVisible ? (
         <div className="fixed inset-x-0 bottom-24 z-[80] flex justify-center px-4" role="status" aria-live="polite">

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -1,23 +1,44 @@
 // @vitest-environment jsdom
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const capacitorMocks = vi.hoisted(() => ({
-  isNativePlatform: vi.fn(() => false),
-  isPluginAvailable: vi.fn(() => false)
+const authState = vi.hoisted(() => ({
+  currentUser: null,
+  app: {
+    options: {
+      apiKey: 'test-api-key'
+    },
+    name: '[DEFAULT]'
+  }
 }));
 
-const firebaseAuthRuntimeMocks = vi.hoisted(() => ({
-  auth: { currentUser: null },
+const legacyAuthMocks = vi.hoisted(() => ({
+  getUserProfile: vi.fn(),
+  listMyParentMembershipRequests: vi.fn(),
+  updateUserProfile: vi.fn(),
+  getUserTeams: vi.fn()
+}));
+
+const parentMembershipMocks = vi.hoisted(() => ({
+  mergeApprovedParentMembershipRequests: vi.fn()
+}));
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(() => true)
+  }
+}));
+
+vi.mock('@capacitor-firebase/authentication', () => ({
+  FirebaseAuthentication: {}
+}));
+
+vi.mock('./firebaseAuthRuntime', () => ({
+  auth: authState,
   applyActionCode: vi.fn(),
   confirmPasswordReset: vi.fn(),
   createUserWithEmailAndPassword: vi.fn(),
   getRedirectResult: vi.fn(),
-  GoogleAuthProvider: vi.fn(function GoogleAuthProvider(this: Record<string, unknown>) {
-    this.addScope = vi.fn();
-  }),
+  GoogleAuthProvider: class {},
   isSignInWithEmailLink: vi.fn(),
   onAuthStateChanged: vi.fn(),
   sendEmailVerification: vi.fn(),
@@ -31,154 +52,54 @@ const firebaseAuthRuntimeMocks = vi.hoisted(() => ({
   verifyPasswordResetCode: vi.fn()
 }));
 
-const dbMocks = vi.hoisted(() => ({
-  validateAccessCode: vi.fn(),
-  redeemParentInvite: vi.fn(),
-  redeemHouseholdInvite: vi.fn(),
-  redeemAdminInviteAtomically: vi.fn(),
-  markAccessCodeAsUsed: vi.fn(),
-  updateUserProfile: vi.fn(),
-  getTeam: vi.fn(),
-  getUserProfile: vi.fn()
+vi.mock('./adapters/legacyAuth', () => ({
+  loadLegacyAdminInvite: vi.fn(),
+  loadLegacyAuthDb: vi.fn(async () => legacyAuthMocks),
+  loadLegacyInviteFlow: vi.fn(),
+  loadLegacyParentMembershipUtils: vi.fn(async () => parentMembershipMocks),
+  loadLegacySignupFlow: vi.fn()
 }));
 
-const adminInviteMocks = vi.hoisted(() => ({
-  redeemAdminInviteAcceptance: vi.fn()
+vi.mock('./logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
 }));
 
-vi.mock('@capacitor/core', () => ({
-  Capacitor: capacitorMocks
-}));
+import { hydrateFirebaseUser } from './authService';
 
-vi.mock('@capacitor-firebase/authentication', () => ({
-  FirebaseAuthentication: {
-    signInWithGoogle: vi.fn()
-  }
-}));
-
-vi.mock('./firebaseAuthRuntime', () => firebaseAuthRuntimeMocks);
-vi.mock('../../../../js/db.js', () => dbMocks);
-vi.mock('../../../../js/admin-invite.js', () => adminInviteMocks);
-vi.mock('../../../../js/accept-invite-flow.js', () => ({
-  createInviteProcessor: vi.fn()
-}));
-vi.mock('../../../../js/signup-flow.js', () => ({
-  executeEmailPasswordSignup: vi.fn()
-}));
-vi.mock('../../../../js/parent-membership-utils.js', () => ({
-  mergeApprovedParentMembershipRequests: vi.fn(() => ({ changed: false, userUpdate: {} }))
-}));
-
-const libDir = dirname(fileURLToPath(import.meta.url));
-const authServicePath = resolve(libDir, 'authService.ts');
-const legacyAuthAdapterPath = resolve(libDir, 'adapters/legacyAuth.ts');
-const appTsconfigPath = resolve(libDir, '../../tsconfig.json');
-
-function createGoogleUser(overrides: Record<string, unknown> = {}) {
-  return {
-    uid: 'google-user-1',
-    email: 'parent@example.com',
-    displayName: 'Pat Parent',
-    photoURL: '',
-    isNewUser: true,
-    delete: vi.fn().mockResolvedValue(undefined),
-    ...overrides
-  };
-}
-
-describe('app auth invite activation', () => {
+describe('hydrateFirebaseUser', () => {
   beforeEach(() => {
-    vi.resetModules();
-    vi.clearAllMocks();
-    window.sessionStorage.clear();
-    capacitorMocks.isNativePlatform.mockReturnValue(false);
-    firebaseAuthRuntimeMocks.signOut.mockResolvedValue(undefined);
-    dbMocks.validateAccessCode.mockResolvedValue({
-      valid: true,
-      type: 'parent_invite',
-      codeId: 'code-parent-1',
-      data: {
-        code: 'ABCDEFGH',
-        type: 'parent_invite'
-      }
+    authState.currentUser = null;
+    legacyAuthMocks.getUserProfile.mockReset();
+    legacyAuthMocks.listMyParentMembershipRequests.mockReset();
+    legacyAuthMocks.updateUserProfile.mockReset();
+    legacyAuthMocks.getUserTeams.mockReset();
+    parentMembershipMocks.mergeApprovedParentMembershipRequests.mockReset();
+    legacyAuthMocks.getUserProfile.mockResolvedValue({
+      email: 'coach@example.com',
+      coachOf: ['team-1']
     });
-    dbMocks.redeemParentInvite.mockResolvedValue({ success: true, teamId: 'team-1' });
-    dbMocks.markAccessCodeAsUsed.mockResolvedValue(undefined);
-    dbMocks.updateUserProfile.mockResolvedValue(undefined);
-    dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears' });
-    dbMocks.getUserProfile.mockResolvedValue({ email: 'parent@example.com' });
-    adminInviteMocks.redeemAdminInviteAcceptance.mockResolvedValue({ id: 'team-1', name: 'Bears' });
-  });
-
-  it('routes the legacy auth graph through the lazy typed adapter', () => {
-    const authServiceSource = readFileSync(authServicePath, 'utf8');
-    const legacyAuthAdapterSource = readFileSync(legacyAuthAdapterPath, 'utf8');
-
-    expect(authServiceSource).not.toContain('../../../../js/');
-    expect(authServiceSource).not.toContain('@legacy/');
-    expect(authServiceSource).toContain("from './adapters/legacyAuth';");
-    expect(authServiceSource).toContain('loadLegacyAuthDb');
-    expect(legacyAuthAdapterSource).toContain("import('@legacy/db.js')");
-    expect(legacyAuthAdapterSource).toContain("import('@legacy/admin-invite.js')");
-    expect(legacyAuthAdapterSource).toContain("import('@legacy/accept-invite-flow.js')");
-    expect(legacyAuthAdapterSource).toContain("import('@legacy/signup-flow.js')");
-    expect(legacyAuthAdapterSource).toContain("import('@legacy/parent-membership-utils.js')");
-    expect(legacyAuthAdapterSource).not.toMatch(/from\s+['"]@legacy\//);
-    expect(authServiceSource).not.toContain('return Promise.resolve(authDb);');
-  });
-
-  it('includes node types in the app tsconfig for source-inspection auth tests', () => {
-    const tsconfig = JSON.parse(readFileSync(appTsconfigPath, 'utf8')) as {
-      compilerOptions?: { types?: string[] };
-    };
-
-    expect(tsconfig.compilerOptions?.types).toContain('node');
-  });
-
-  it('redeems a Google parent invite using generic pre-auth validation state', async () => {
-    const user = createGoogleUser();
-    firebaseAuthRuntimeMocks.signInWithPopup.mockResolvedValue({ user });
-    const { signInWithGoogleAccount } = await import('./authService');
-
-    await signInWithGoogleAccount('ABCDEFGH');
-
-    expect(dbMocks.validateAccessCode).toHaveBeenCalledWith('ABCDEFGH', undefined);
-    expect(dbMocks.redeemParentInvite).toHaveBeenCalledWith('google-user-1', 'ABCDEFGH', 'parent@example.com');
-    expect(dbMocks.redeemParentInvite.mock.calls[0][1]).toBe('ABCDEFGH');
-    expect(dbMocks.updateUserProfile).toHaveBeenCalledWith('google-user-1', expect.objectContaining({
-      email: 'parent@example.com',
-      fullName: 'Pat Parent'
-    }));
-  });
-
-  it('rejects a mismatched Google admin invite during authenticated redemption', async () => {
-    const user = createGoogleUser({
-      uid: 'google-admin-1',
-      email: 'other@example.com'
+    legacyAuthMocks.listMyParentMembershipRequests.mockResolvedValue([]);
+    legacyAuthMocks.getUserTeams.mockResolvedValue([]);
+    parentMembershipMocks.mergeApprovedParentMembershipRequests.mockReturnValue({
+      changed: false
     });
-    const mismatchError = new Error('This invite was sent to coach@example.com. Sign in with that email to accept it.');
-    firebaseAuthRuntimeMocks.signInWithPopup.mockResolvedValue({ user });
-    dbMocks.validateAccessCode.mockResolvedValue({
-      valid: true,
-      type: 'admin_invite',
-      codeId: 'code-admin-1',
-      data: {
-        code: 'ADMIN123',
-        type: 'admin_invite'
-      }
+  });
+
+  it('loads stored profile roles for native REST fallback users before routing decisions', async () => {
+    const hydrated = await hydrateFirebaseUser({
+      uid: 'coach-1',
+      email: 'coach@example.com',
+      displayName: 'Coach Example',
+      emailVerified: true,
+      isNativeRestSession: true
     });
-    adminInviteMocks.redeemAdminInviteAcceptance.mockRejectedValue(mismatchError);
-    const { signInWithGoogleAccount } = await import('./authService');
 
-    await expect(signInWithGoogleAccount('ADMIN123')).rejects.toThrow(mismatchError.message);
-
-    expect(adminInviteMocks.redeemAdminInviteAcceptance).toHaveBeenCalledWith(expect.objectContaining({
-      userId: 'google-admin-1',
-      userEmail: 'other@example.com',
-      codeId: 'code-admin-1'
-    }));
-    expect(adminInviteMocks.redeemAdminInviteAcceptance.mock.calls[0][0]).not.toHaveProperty('teamId');
-    expect(user.delete).toHaveBeenCalledTimes(1);
-    expect(firebaseAuthRuntimeMocks.signOut).toHaveBeenCalledWith(firebaseAuthRuntimeMocks.auth);
+    expect(legacyAuthMocks.getUserProfile).toHaveBeenCalledWith('coach-1');
+    expect(hydrated.user.roles).toContain('coach');
+    expect(hydrated.user.roles).not.toEqual(['parent']);
   });
 });

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -840,16 +840,6 @@ async function cleanupFailedNewUser(user: FirebaseUser | null, context: string) 
 }
 
 export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedUser> {
-  if (user.isNativeRestSession && !auth.currentUser) {
-    const profile = {
-      email: user.email || ''
-    };
-    return {
-      user: toAuthUser(user, profile),
-      profile
-    };
-  }
-
   let profile: Record<string, unknown> = {};
   const dbModule = await loadLegacyAuthDb();
   try {

--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthPage } from './AuthPage';
+import type { AuthState, AuthUser } from '../lib/types';
+
+const authServiceMocks = vi.hoisted(() => ({
+  completeGoogleRedirect: vi.fn(async () => null),
+  describeAuthError: vi.fn((error: Error) => error.message),
+  getRouteForUser: vi.fn((user: AuthUser | null) => {
+    if (!user) {
+      return '/auth';
+    }
+    if (user.isAdmin || user.roles.includes('coach') || user.roles.includes('admin') || user.roles.includes('platformAdmin')) {
+      return '/teams';
+    }
+    return '/home';
+  }),
+  hydrateFirebaseUser: vi.fn(),
+  rememberPendingInvite: vi.fn(),
+  sendResetEmail: vi.fn(),
+  signInWithEmail: vi.fn(),
+  signInWithGoogleAccount: vi.fn(),
+  signUpWithEmail: vi.fn()
+}));
+
+vi.mock('../lib/authService', () => authServiceMocks);
+
+const auth: AuthState = {
+  user: null,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: [],
+  isParent: false,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function renderAuthPage(path = '/auth') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/auth" element={<AuthPage auth={auth} />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('AuthPage native post-login routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.refresh = vi.fn();
+    auth.signOut = vi.fn();
+    authServiceMocks.hydrateFirebaseUser.mockReset();
+    authServiceMocks.signInWithEmail.mockReset();
+    authServiceMocks.signInWithGoogleAccount.mockReset();
+    window.location.hash = '';
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        hash: '',
+        reload: vi.fn()
+      }
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('reloads native email sign-in to the coach/admin teams dashboard', async () => {
+    authServiceMocks.signInWithEmail.mockResolvedValue({
+      user: { uid: 'coach-1', email: 'coach@example.com' },
+      nativeRest: true
+    });
+    authServiceMocks.hydrateFirebaseUser.mockResolvedValue({
+      user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
+      profile: {}
+    });
+
+    renderAuthPage();
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'coach@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password123' } });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Sign in' })[1]);
+
+    await waitFor(() => expect(authServiceMocks.signInWithEmail).toHaveBeenCalledWith('coach@example.com', 'password123'));
+    await waitFor(() => expect(window.location.hash).toBe('#/teams'));
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads native Google sign-in to the coach/admin teams dashboard', async () => {
+    authServiceMocks.signInWithGoogleAccount.mockResolvedValue({
+      user: { uid: 'admin-1', email: 'admin@example.com' },
+      nativeRest: true
+    });
+    authServiceMocks.hydrateFirebaseUser.mockResolvedValue({
+      user: { uid: 'admin-1', email: 'admin@example.com', displayName: 'Admin', roles: ['platformAdmin'] },
+      profile: {}
+    });
+
+    renderAuthPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
+
+    await waitFor(() => expect(authServiceMocks.signInWithGoogleAccount).toHaveBeenCalledWith(null));
+    await waitFor(() => expect(window.location.hash).toBe('#/teams'));
+    expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -108,15 +108,16 @@ export function AuthPage({ auth }: { auth: AuthState }) {
       if (inviteCode) {
         rememberPendingInvite(inviteCode, inviteType);
       }
+      const hydrated = inviteCode ? null : await hydrateFirebaseUser(credential.user).catch(() => null);
+      const postLoginRoute = inviteCode ? postAuthRoute : getRouteForUser(hydrated?.user || auth.user);
       if (credential.nativeRest) {
-        window.location.hash = `#${inviteCode ? postAuthRoute : '/home'}`;
+        window.location.hash = `#${postLoginRoute}`;
         window.location.reload();
         return;
       }
 
-      const hydrated = await hydrateFirebaseUser(credential.user).catch(() => null);
       await auth.refresh();
-      navigate(inviteCode ? postAuthRoute : getRouteForUser(hydrated?.user || auth.user), { replace: true });
+      navigate(postLoginRoute, { replace: true });
     } catch (submitError: any) {
       setError(describeAuthError(submitError));
     } finally {
@@ -139,15 +140,20 @@ export function AuthPage({ auth }: { auth: AuthState }) {
 
       const result = await signInWithGoogleAccount(code || null);
       if (result) {
+        const hydrated = mode === 'signup' || inviteCode ? null : await hydrateFirebaseUser(result.user).catch(() => null);
+        const postGoogleRoute = mode === 'signup'
+          ? '/verify-pending'
+          : inviteCode
+            ? postAuthRoute
+            : getRouteForUser(hydrated?.user || auth.user);
         if (result.nativeRest) {
-          window.location.hash = `#${mode === 'signup' ? '/verify-pending' : inviteCode ? postAuthRoute : '/home'}`;
+          window.location.hash = `#${postGoogleRoute}`;
           window.location.reload();
           return;
         }
 
-        const hydrated = await hydrateFirebaseUser(result.user).catch(() => null);
         await auth.refresh();
-        navigate(mode === 'signup' ? '/verify-pending' : inviteCode ? postAuthRoute : getRouteForUser(hydrated?.user || auth.user), { replace: true });
+        navigate(postGoogleRoute, { replace: true });
       }
     } catch (googleError: any) {
       setError(describeAuthError(googleError));


### PR DESCRIPTION
Closes #3138

## What changed
- Reused `getRouteForUser()` for signed-in app entry at `/` and the catch-all route so coach, admin, and platform admin users land on `/teams` instead of the parent-only `/home` dashboard.
- Updated native email and Google sign-in reload paths in `AuthPage` to resolve the destination from the hydrated user role before forcing the native app reload.
- Added focused regression tests for signed-in root and catch-all routing plus native post-login reload routing.

## Root Cause
Signed-in entry routes and native auth reload paths hardcoded `/home` instead of calling the shared `getRouteForUser()` helper. That bypassed the app's role-based landing logic and routed coach/admin/platformAdmin users into the parent dashboard.

## Prevention / Learning
When multiple app entry points can land a signed-in user, they must all call the same role-routing helper instead of duplicating literal fallback paths. For routing bugs like this, add regression coverage for each entry surface that can bypass the shared helper.

## Regression Tests
- `npx vitest run src/App.test.tsx src/pages/AuthPage.test.tsx`
- `apps/app/src/App.test.tsx` verifies signed-in coach users are redirected from `/` and unknown routes to `/teams`.
- `apps/app/src/pages/AuthPage.test.tsx` verifies native email and Google sign-in reload paths send coach/admin users to `/teams`.