### PR TITLE
Auto-include single linked athlete profile season

### DIFF
--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -225,7 +225,37 @@ describe('PlayerDetail athlete profile season selection', () => {
     });
   });
 
-  it('defaults first save to the current season and blocks zero-season saves', async () => {
+  it('auto-includes the only linked season and saves without season selection input', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      athleteProfile: {
+        ...buildDetailData().athleteProfile,
+        seasonOptions: [buildDetailData().athleteProfile.seasonOptions[0]]
+      }
+    }));
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+    await screen.findByText('Athlete Profile Builder');
+
+    expect(screen.getByText('Included linked season')).toBeTruthy();
+    expect(screen.getByText('Current Team')).toBeTruthy();
+    expect(screen.queryByRole('checkbox')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Athlete Profile' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.saveParentAthleteProfileDraft).toHaveBeenCalledWith(expect.objectContaining({
+        draft: expect.objectContaining({
+          selectedSeasonKeys: ['team-current::player-current']
+        })
+      }));
+    });
+  });
+
+  it('defaults first save to the current season and blocks zero-season saves when multiple seasons are available', async () => {
     renderPlayerDetail();
 
     await screen.findByText('Sam Player');
@@ -325,8 +355,9 @@ describe('PlayerDetail athlete profile season selection', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
     await screen.findByText('Athlete Profile Builder');
 
-    const fallbackSeason = await screen.findByLabelText('Sam Player Current Team');
-    expect((fallbackSeason as HTMLInputElement).checked).toBe(true);
+    expect(screen.getByText('Included linked season')).toBeTruthy();
+    expect(screen.getByText('Current Team')).toBeTruthy();
+    expect(screen.queryByRole('checkbox')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Publish Athlete Profile' }));
 

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -255,6 +255,48 @@ describe('PlayerDetail athlete profile season selection', () => {
     });
   });
 
+  it('clamps hidden single-season saves to the lone available linked season', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      athleteProfile: {
+        profile: {
+          id: 'profile-1',
+          athlete: { name: 'Sam Player' },
+          bio: {},
+          privacy: 'public',
+          clips: [],
+          seasons: [
+            { seasonKey: 'team-current::player-current', teamName: 'Current Team', playerName: 'Sam Player' },
+            { seasonKey: 'team-prior::player-prior', teamName: 'Prior Team', playerName: 'Sam Player' }
+          ]
+        },
+        shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1',
+        builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-current&playerId=player-current&profileId=profile-1',
+        seasonOptions: [buildDetailData().athleteProfile.seasonOptions[0]]
+      }
+    }));
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+    await screen.findByText('Athlete Profile Builder');
+
+    expect(screen.getByText('Included linked season')).toBeTruthy();
+    expect(screen.getByText('Current Team')).toBeTruthy();
+    expect(screen.queryByRole('checkbox')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Publish Athlete Profile' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.saveParentAthleteProfileDraft).toHaveBeenCalledWith(expect.objectContaining({
+        draft: expect.objectContaining({
+          selectedSeasonKeys: ['team-current::player-current']
+        })
+      }));
+    });
+  });
+
   it('defaults first save to the current season and blocks zero-season saves when multiple seasons are available', async () => {
     renderPlayerDetail();
 

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -1072,8 +1072,11 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
     if (existingKeys.length) {
       return [...new Set(existingKeys)];
     }
+    if (seasonOptions.length === 1) {
+      return [seasonOptions[0].seasonKey];
+    }
     return currentSeasonKey ? [currentSeasonKey] : [];
-  }, [currentSeasonKey, existing]);
+  }, [currentSeasonKey, existing, seasonOptions]);
   const initialClipDrafts = useMemo(() => normalizeExistingAthleteClips(existing?.clips), [existing?.clips]);
   const [name, setName] = useState(existing?.athlete?.name || data.player.name || data.child.playerName || '');
   const [headline, setHeadline] = useState(existing?.athlete?.headline || '');
@@ -1084,6 +1087,8 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
   const [achievements, setAchievements] = useState(existing?.bio?.achievements || '');
   const [privacy, setPrivacy] = useState<AthleteProfilePrivacy>(existing?.privacy === 'public' ? 'public' : 'private');
   const [selectedSeasonKeys, setSelectedSeasonKeys] = useState<string[]>(initialSelectedSeasonKeys);
+  const hasSingleSeasonOption = seasonOptions.length === 1;
+  const singleSeasonOption = hasSingleSeasonOption ? seasonOptions[0] : null;
   const [saving, setSaving] = useState(false);
   const [awaitingPersistedPublish, setAwaitingPersistedPublish] = useState(false);
   const [status, setStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
@@ -1619,27 +1624,39 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
         </label>
         <div className="rounded-2xl border border-gray-200 bg-white p-3">
           <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Selected seasons</div>
-          <p className="mt-1 text-sm font-semibold text-gray-700">Choose which linked seasons roll into the public athlete profile.</p>
-          <div className="mt-3 space-y-2">
-            {seasonOptions.map((option) => {
-              const checked = selectedSeasonKeys.includes(option.seasonKey);
-              return (
-                <label key={option.seasonKey} className={`flex items-start gap-3 rounded-xl border p-3 ${checked ? 'border-primary-300 bg-primary-50' : 'border-gray-200 bg-gray-50'}`}>
-                  <input
-                    type="checkbox"
-                    aria-label={`${option.playerName} ${option.teamName}`}
-                    checked={checked}
-                    onChange={() => toggleSeasonKey(option.seasonKey)}
-                    className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-                  />
-                  <span className="min-w-0">
-                    <span className="block text-sm font-black text-gray-900">{option.playerName}</span>
-                    <span className="block text-xs font-semibold text-gray-500">{option.teamName}</span>
-                  </span>
-                </label>
-              );
-            })}
-          </div>
+          {hasSingleSeasonOption && singleSeasonOption ? (
+            <>
+              <p className="mt-1 text-sm font-semibold text-gray-700">Included linked season</p>
+              <div className="mt-3 rounded-xl border border-primary-200 bg-primary-50 px-3 py-3">
+                <div className="text-sm font-black text-gray-900">{singleSeasonOption.playerName}</div>
+                <div className="text-xs font-semibold text-gray-500">{singleSeasonOption.teamName}</div>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="mt-1 text-sm font-semibold text-gray-700">Choose which linked seasons roll into the public athlete profile.</p>
+              <div className="mt-3 space-y-2">
+                {seasonOptions.map((option) => {
+                  const checked = selectedSeasonKeys.includes(option.seasonKey);
+                  return (
+                    <label key={option.seasonKey} className={`flex items-start gap-3 rounded-xl border p-3 ${checked ? 'border-primary-300 bg-primary-50' : 'border-gray-200 bg-gray-50'}`}>
+                      <input
+                        type="checkbox"
+                        aria-label={`${option.playerName} ${option.teamName}`}
+                        checked={checked}
+                        onChange={() => toggleSeasonKey(option.seasonKey)}
+                        className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                      />
+                      <span className="min-w-0">
+                        <span className="block text-sm font-black text-gray-900">{option.playerName}</span>
+                        <span className="block text-xs font-semibold text-gray-500">{option.teamName}</span>
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </>
+          )}
         </div>
         <div className="rounded-2xl border border-primary-100 bg-primary-50/60 p-3">
           <div className="text-xs font-black uppercase tracking-[0.04em] text-primary-700">What others see</div>

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -1056,6 +1056,11 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
     }];
   }, [currentSeasonKey, data.athleteProfile.seasonOptions, data.child.playerId, data.child.playerName, data.child.teamId, data.child.teamName, data.player.name, data.team?.name]);
   const initialSelectedSeasonKeys = useMemo(() => {
+    const availableSeasonKeys = new Set(
+      seasonOptions
+        .map((option) => String(option?.seasonKey || '').trim())
+        .filter(Boolean)
+    );
     const existingKeys = Array.isArray(existing?.seasons)
       ? existing.seasons
         .map((season: any) => {
@@ -1067,7 +1072,7 @@ function AthleteProfileBuilderCard({ data, auth, onChanged, onShareStateChange }
           const seasonPlayerId = String(season?.playerId || '').trim();
           return seasonTeamId && seasonPlayerId ? `${seasonTeamId}::${seasonPlayerId}` : '';
         })
-        .filter(Boolean)
+        .filter((seasonKey: string) => !availableSeasonKeys.size || availableSeasonKeys.has(seasonKey))
       : [];
     if (existingKeys.length) {
       return [...new Set(existingKeys)];


### PR DESCRIPTION
Closes #3134

## What changed
- Auto-select the only available athlete profile season from `seasonOptions` instead of defaulting from the generic current-season fallback.
- Replace the single-season checkbox list in Player Detail with a read-only included-season summary.
- Keep the existing checkbox chooser and zero-season validation for true multi-season flows.
- Added focused Player Detail regressions for the single-season auto-include path and updated the single-season fallback coverage.

## Root Cause
The athlete profile builder always rendered the season checkbox chooser and defaulted unsaved profiles from `currentSeasonKey` instead of the actual available `seasonOptions`. That left the single-season path with an unnecessary interactive control and allowed the only valid season to be removed before save.

## Prevention / Learning
When a workflow exposes a required selection list, derive both the default state and the UI from the real option cardinality. If there is only one valid option, auto-apply it and remove the optional-looking control instead of forcing user interaction.

## Regression Tests
- `npx vitest run apps/app/src/pages/PlayerDetail.test.tsx --reporter=verbose`
- Added coverage that a single linked season renders as a read-only included summary and saves `selectedSeasonKeys` with that season.
- Kept multi-season coverage asserting zero selected seasons still blocks save.