### PR TITLE
Lock household invite access codes

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -156,7 +156,7 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=37';
-        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=74';
+        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=75';
         import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -133,6 +133,83 @@ service cloud.firestore {
              (!request.resource.data.keys().hasAny(['updatedAt']) || request.resource.data.updatedAt is timestamp);
     }
 
+    function householdInviteMembershipMatches(data) {
+      let membershipPath = /databases/$(database)/documents/users/$(request.auth.uid)/familyMemberships/$(data.familyMembershipId);
+      return data.organizerUserId == request.auth.uid &&
+             data.generatedBy == request.auth.uid &&
+             data.familyMembershipId is string &&
+             data.familyMembershipId.size() > 0 &&
+             exists(membershipPath) &&
+             get(membershipPath).data.organizerUserId == request.auth.uid &&
+             get(membershipPath).data.status in ['pending', 'active'] &&
+             get(membershipPath).data.email == data.email &&
+             get(membershipPath).data.teamId == data.teamId &&
+             get(membershipPath).data.playerId == data.playerId;
+    }
+
+    function isHouseholdInviteAccessCodePayloadValid(data) {
+      return data.keys().hasOnly([
+               'code', 'type', 'email', 'displayName', 'generatedBy', 'organizerUserId',
+               'familyMembershipId', 'teamId', 'playerId', 'teamName', 'playerName',
+               'playerNum', 'playerPhotoUrl', 'relation', 'createdAt', 'expiresAt',
+               'used', 'usedBy', 'usedAt', 'revoked'
+             ]) &&
+             data.keys().hasAll([
+               'code', 'type', 'email', 'generatedBy', 'organizerUserId', 'familyMembershipId',
+               'teamId', 'playerId', 'createdAt', 'expiresAt', 'used', 'usedBy', 'usedAt', 'revoked'
+             ]) &&
+             data.type == 'household_invite' &&
+             data.code is string &&
+             data.code.size() > 0 &&
+             data.email is string &&
+             data.email.size() > 0 &&
+             (!('displayName' in data) || data.displayName == null || data.displayName is string) &&
+             data.teamId is string &&
+             data.teamId.size() > 0 &&
+             data.playerId is string &&
+             data.playerId.size() > 0 &&
+             (!('teamName' in data) || data.teamName == null || data.teamName is string) &&
+             (!('playerName' in data) || data.playerName == null || data.playerName is string) &&
+             (!('playerNum' in data) || data.playerNum == null || data.playerNum is string || data.playerNum is int) &&
+             (!('playerPhotoUrl' in data) || data.playerPhotoUrl == null || data.playerPhotoUrl is string) &&
+             (!('relation' in data) || data.relation == null || data.relation is string) &&
+             data.createdAt is timestamp &&
+             data.expiresAt is timestamp &&
+             data.expiresAt > request.time &&
+             data.used == false &&
+             data.usedBy == null &&
+             data.usedAt == null &&
+             data.revoked == false &&
+             householdInviteMembershipMatches(data) &&
+             isParentForPlayer(data.teamId, data.playerId);
+    }
+
+    function isHouseholdInviteRedemptionUpdate() {
+      return resource.data.get('type', null) == 'household_invite' &&
+             request.resource.data.get('type', resource.data.get('type', null)) == 'household_invite' &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
+             resource.data.used == false &&
+             resource.data.revoked != true &&
+             request.auth.token.email is string &&
+             resource.data.email is string &&
+             request.auth.token.email.lower() == resource.data.email.lower() &&
+             request.resource.data.used == true &&
+             request.resource.data.usedBy == request.auth.uid &&
+             request.resource.data.usedAt is timestamp;
+    }
+
+    function isHouseholdInviteRevocationUpdate() {
+      return resource.data.get('type', null) == 'household_invite' &&
+             resource.data.generatedBy == request.auth.uid &&
+             resource.data.organizerUserId == request.auth.uid &&
+             request.resource.data.get('type', resource.data.get('type', null)) == 'household_invite' &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt']) &&
+             request.resource.data.revoked == true &&
+             request.resource.data.revokedAt is timestamp &&
+             request.resource.data.used == true &&
+             (!request.resource.data.keys().hasAny(['updatedAt']) || request.resource.data.updatedAt is timestamp);
+    }
+
     function canReadManagedTeamDocument(data) {
       return isSignedIn() &&
              (data.ownerId == request.auth.uid ||
@@ -1376,15 +1453,12 @@ service cloud.firestore {
                           isTeamOwnerOrAdmin(request.resource.data.teamId) &&
                           isParentInvitePayloadValid(request.resource.data) &&
                           request.resource.data.code == codeId) ||
-                         (request.resource.data.get('type', null) != 'admin_invite' &&
-                          request.resource.data.get('type', null) != 'parent_invite')
+                         (request.resource.data.get('type', null) == 'household_invite' &&
+                          isHouseholdInviteAccessCodePayloadValid(request.resource.data))
                        );
       // Only allow the code generator to update/delete, OR allow system to mark as used during signup
       allow update: if isSignedIn() &&
                        ((resource.data.generatedBy == request.auth.uid &&
-                         request.resource.data.get('type', resource.data.get('type', null)) != 'admin_invite' &&
-                         request.resource.data.get('type', resource.data.get('type', null)) != 'parent_invite') ||
-                        (resource.data.generatedBy == request.auth.uid &&
                          request.resource.data.get('type', resource.data.get('type', null)) == 'admin_invite' &&
                          request.resource.data.teamId is string &&
                          isTeamOwnerOrAdmin(request.resource.data.teamId) &&
@@ -1392,11 +1466,15 @@ service cloud.firestore {
                          request.resource.data.code == codeId) ||
                         isParentInviteRedemptionUpdate() ||
                         isParentInviteRevocationUpdate() ||
+                        isHouseholdInviteRedemptionUpdate() ||
+                        isHouseholdInviteRevocationUpdate() ||
                         // Allow marking as used only if setting these specific fields
                         (resource.data.get('type', null) != 'parent_invite' &&
+                         resource.data.get('type', null) != 'household_invite' &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
                          request.resource.data.usedBy == request.auth.uid) ||
                         (resource.data.get('type', null) != 'parent_invite' &&
+                         resource.data.get('type', null) != 'household_invite' &&
                          resource.data.generatedBy == request.auth.uid &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt'])));
 	      allow delete: if isSignedIn() && resource.data.generatedBy == request.auth.uid;

--- a/firestore.rules
+++ b/firestore.rules
@@ -55,6 +55,25 @@ service cloud.firestore {
               (data.organizationTeamId is string && isTeamOwnerOrAdmin(data.organizationTeamId)));
     }
 
+    function isStandardAccessCodePayloadValid(data) {
+      return data.keys().hasOnly([
+               'code', 'generatedBy', 'email', 'phone', 'createdAt', 'used', 'usedBy', 'usedAt'
+             ]) &&
+             data.keys().hasAll([
+               'code', 'generatedBy', 'createdAt', 'used', 'usedBy', 'usedAt'
+             ]) &&
+             !data.keys().hasAny(['type']) &&
+             data.code is string &&
+             data.code.size() > 0 &&
+             data.generatedBy == request.auth.uid &&
+             (!('email' in data) || data.email == null || data.email is string) &&
+             (!('phone' in data) || data.phone == null || data.phone is string) &&
+             data.createdAt is timestamp &&
+             data.used == false &&
+             data.usedBy == null &&
+             data.usedAt == null;
+    }
+
     function isAdminInvitePayloadValid(data) {
       return data.keys().hasOnly([
                'code', 'type', 'teamId', 'teamName', 'email', 'generatedBy',
@@ -1443,6 +1462,9 @@ service cloud.firestore {
       allow create: if isSignedIn() &&
                        request.resource.data.generatedBy == request.auth.uid &&
                        (
+                         (!request.resource.data.keys().hasAny(['type']) &&
+                          isStandardAccessCodePayloadValid(request.resource.data) &&
+                          request.resource.data.code == codeId) ||
                          (request.resource.data.get('type', null) == 'admin_invite' &&
                           request.resource.data.teamId is string &&
                           isTeamOwnerOrAdmin(request.resource.data.teamId) &&

--- a/js/db.js
+++ b/js/db.js
@@ -4703,6 +4703,22 @@ function assertHouseholdInviteEmailMatches(codeData) {
     }
 }
 
+export function doesHouseholdInviteFamilyMembershipMatch(codeData = {}, membershipData = {}) {
+    const organizerUserId = String(codeData?.organizerUserId || '').trim();
+    const familyMembershipId = String(codeData?.familyMembershipId || '').trim();
+    if (!organizerUserId || !familyMembershipId) {
+        return false;
+    }
+
+    const membershipOrganizerUserId = String(membershipData?.organizerUserId || '').trim();
+    const membershipStatus = String(membershipData?.status || '').trim().toLowerCase();
+    return membershipOrganizerUserId === organizerUserId
+        && ['pending', 'active'].includes(membershipStatus)
+        && normalizeHouseholdInviteEmail(membershipData?.email) === normalizeHouseholdInviteEmail(codeData?.email)
+        && String(membershipData?.teamId || '').trim() === String(codeData?.teamId || '').trim()
+        && String(membershipData?.playerId || '').trim() === String(codeData?.playerId || '').trim();
+}
+
 async function resetHouseholdInviteCodeClaim(codeRef, userId) {
     await runTransaction(db, async (transaction) => {
         const latestCodeSnapshot = await transaction.get(codeRef);
@@ -4843,6 +4859,14 @@ export async function redeemHouseholdInvite(userId, code) {
     try {
         assertHouseholdInviteEmailMatches(codeData);
 
+        if (codeData.organizerUserId && codeData.familyMembershipId) {
+            const membershipRef = doc(db, 'users', codeData.organizerUserId, 'familyMemberships', codeData.familyMembershipId);
+            rollbackState.priorMembershipSnapshot = await getDoc(membershipRef);
+            if (!rollbackState.priorMembershipSnapshot.exists() || !doesHouseholdInviteFamilyMembershipMatch(codeData, rollbackState.priorMembershipSnapshot.data() || {})) {
+                throw new Error('This household invite is no longer valid for that player and email. Ask the organizer to send a new invite.');
+            }
+        }
+
         const [team, player] = await Promise.all([
             getTeam(codeData.teamId),
             getPlayers(codeData.teamId).then(ps => ps.find(p => p.id === codeData.playerId))
@@ -4885,7 +4909,6 @@ export async function redeemHouseholdInvite(userId, code) {
 
         if (codeData.organizerUserId && codeData.familyMembershipId) {
             const membershipRef = doc(db, 'users', codeData.organizerUserId, 'familyMemberships', codeData.familyMembershipId);
-            rollbackState.priorMembershipSnapshot = await getDoc(membershipRef);
             await updateDoc(membershipRef, {
                 status: 'active',
                 userId,

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from '../../js/accept-invite-flow.js';
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=74';";
+const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=75';";
 
 class MockClassList {
     constructor(initial = []) {

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -38,11 +38,11 @@ describe('access code Firestore rules', () => {
     });
 
     it('prevents creators from updating an existing access code into an admin invite without team-admin authorization', () => {
-        expect(accessCodeRules).toContain("request.resource.data.get('type', resource.data.get('type', null)) != 'admin_invite'");
         expect(accessCodeRules).toContain("request.resource.data.get('type', resource.data.get('type', null)) == 'admin_invite'");
         expect(accessCodeRules).toContain('isTeamOwnerOrAdmin(request.resource.data.teamId)');
         expect(accessCodeRules).toContain('isAdminInvitePayloadValid(request.resource.data)');
         expect(accessCodeRules).toContain('request.resource.data.code == codeId');
+        expect(accessCodeRules).not.toContain("request.resource.data.generatedBy == request.auth.uid &&\n                         request.resource.data.get('type', resource.data.get('type', null)) != 'admin_invite'");
     });
 
     it('requires team-admin authorization and an explicit schema for parent_invite creation', () => {
@@ -61,9 +61,37 @@ describe('access code Firestore rules', () => {
         expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
         expect(rules).toContain('function isParentInviteRevocationUpdate()');
         expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'updatedAt'])");
-        expect(accessCodeRules).toContain("request.resource.data.get('type', resource.data.get('type', null)) != 'parent_invite'");
         expect(accessCodeRules).toContain("resource.data.get('type', null) != 'parent_invite'");
+        expect(accessCodeRules).toContain("resource.data.get('type', null) != 'household_invite'");
         expect(accessCodeRules).not.toContain("resource.data.type != 'parent_invite'");
+    });
+
+    it('requires household_invite creation to match an organizer-owned family membership and linked parent scope', () => {
+        expect(rules).toContain('function householdInviteMembershipMatches(data)');
+        expect(rules).toContain("let membershipPath = /databases/$(database)/documents/users/$(request.auth.uid)/familyMemberships/$(data.familyMembershipId);");
+        expect(rules).toContain("get(membershipPath).data.email == data.email");
+        expect(rules).toContain("get(membershipPath).data.teamId == data.teamId");
+        expect(rules).toContain("get(membershipPath).data.playerId == data.playerId");
+        expect(rules).toContain("get(membershipPath).data.status in ['pending', 'active']");
+        expect(rules).toContain('function isHouseholdInviteAccessCodePayloadValid(data)');
+        expect(rules).toContain("data.type == 'household_invite'");
+        expect(rules).toContain('householdInviteMembershipMatches(data)');
+        expect(rules).toContain('isParentForPlayer(data.teamId, data.playerId)');
+        expect(accessCodeRules).toContain("request.resource.data.get('type', null) == 'household_invite'");
+        expect(accessCodeRules).toContain('isHouseholdInviteAccessCodePayloadValid(request.resource.data)');
+        expect(accessCodeRules).not.toContain("request.resource.data.get('type', null) != 'admin_invite' &&\n                          request.resource.data.get('type', null) != 'parent_invite'");
+    });
+
+    it('locks household_invite updates to invited-email redemption or organizer revocation', () => {
+        expect(rules).toContain('function isHouseholdInviteRedemptionUpdate()');
+        expect(rules).toContain("resource.data.get('type', null) == 'household_invite'");
+        expect(rules).toContain("request.auth.token.email.lower() == resource.data.email.lower()");
+        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
+        expect(rules).toContain('function isHouseholdInviteRevocationUpdate()');
+        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt'])");
+        expect(accessCodeRules).toContain('isHouseholdInviteRedemptionUpdate()');
+        expect(accessCodeRules).toContain('isHouseholdInviteRevocationUpdate()');
+        expect(accessCodeRules).toContain("resource.data.get('type', null) != 'household_invite'");
     });
 
     it('validates the allowed admin_invite payload fields before redemption can trust the record', () => {

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -28,6 +28,15 @@ describe('access code Firestore rules', () => {
         expect(accessCodeRules).not.toMatch(/allow\s+get\s*:\s*if\s+true/);
     });
 
+    it('preserves standard profile access-code creation without reopening typed invite paths', () => {
+        expect(rules).toContain('function isStandardAccessCodePayloadValid(data)');
+        expect(rules).toContain("'code', 'generatedBy', 'email', 'phone', 'createdAt', 'used', 'usedBy', 'usedAt'");
+        expect(rules).toContain("!data.keys().hasAny(['type'])");
+        expect(accessCodeRules).toContain("!request.resource.data.keys().hasAny(['type'])");
+        expect(accessCodeRules).toContain('isStandardAccessCodePayloadValid(request.resource.data)');
+        expect(accessCodeRules).toContain('request.resource.data.code == codeId');
+    });
+
     it('blocks self-minted admin invites unless the caller already administers the target team', () => {
         expect(rules).toContain('function isAdminInvitePayloadValid(data)');
         expect(accessCodeRules).toContain("request.resource.data.get('type', null) == 'admin_invite'");

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -15,7 +15,7 @@ describe('admin invite signup cache busting', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=74';"
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=75';"
         );
         expect(acceptInviteSource).toContain(
             "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=7';"

--- a/tests/unit/household-invite-redemption.test.js
+++ b/tests/unit/household-invite-redemption.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function extractFunction(source, signature) {
+    const start = source.indexOf(signature);
+    expect(start, `Expected function signature to exist: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    const braceStart = source.indexOf('{', start);
+    expect(braceStart, `Expected opening brace for: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    let depth = 1;
+    let end = -1;
+    for (let index = braceStart + 1; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            end = index;
+            break;
+        }
+    }
+
+    expect(end, `Expected closing brace for: ${signature}`).toBeGreaterThan(braceStart);
+    return source.slice(start, end + 1);
+}
+
+describe('household invite redemption guards', () => {
+    it('requires the redemption validator to compare organizer, membership status, invited email, and player linkage', () => {
+        const source = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+        expect(source).toContain('export function doesHouseholdInviteFamilyMembershipMatch(codeData = {}, membershipData = {})');
+        expect(source).toContain("['pending', 'active'].includes(membershipStatus)");
+        expect(source).toContain('normalizeHouseholdInviteEmail(membershipData?.email) === normalizeHouseholdInviteEmail(codeData?.email)');
+        expect(source).toContain("String(membershipData?.teamId || '').trim() === String(codeData?.teamId || '').trim()");
+        expect(source).toContain("String(membershipData?.playerId || '').trim() === String(codeData?.playerId || '').trim()");
+        expect(source).toContain('membershipOrganizerUserId === organizerUserId');
+    });
+
+    it('verifies redeemHouseholdInvite checks the family membership before granting parent access', () => {
+        const source = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+        const redeemSource = extractFunction(source, 'export async function redeemHouseholdInvite(');
+
+        expect(redeemSource).toContain("const membershipRef = doc(db, 'users', codeData.organizerUserId, 'familyMemberships', codeData.familyMembershipId);");
+        expect(redeemSource).toContain('doesHouseholdInviteFamilyMembershipMatch(codeData, rollbackState.priorMembershipSnapshot.data() || {})');
+        expect(redeemSource).toContain('This household invite is no longer valid for that player and email. Ask the organizer to send a new invite.');
+    });
+});


### PR DESCRIPTION
Closes #3141

## What changed
- added explicit `household_invite` validation in `firestore.rules` so access-code creation now requires the signed-in organizer to already own the referenced `familyMembership` and parent link for the same team/player
- restricted `household_invite` updates to two narrow paths only: invited-email redemption and organizer revocation
- added a defensive redemption check in `js/db.js` that reloads the backing `familyMembership` and rejects the invite if organizer, email, team, player, or membership status no longer match before parent access is granted
- extended rule regression coverage and added a focused household-invite redemption validation test

## Root Cause
`accessCodes` rules treated `household_invite` as a generic non-admin/non-parent code type, so a signed-in user could create a forged invite without proving ownership of the referenced player relationship. The redemption path then trusted the stored access-code payload and granted parent linkage without revalidating the backing `familyMembership` record.

## Prevention / Learning
When the client can mint an authorization-bearing record, the server boundary must do two things explicitly: validate the payload against the authoritative ownership record at create time, and revalidate that same authoritative linkage at redemption time before granting access.

## Regression Tests
- `npx vitest run tests/unit/access-code-rules.test.js tests/unit/household-invite-redemption.test.js tests/unit/family-plan.test.js --reporter=verbose`
- `tests/unit/access-code-rules.test.js` now asserts dedicated `household_invite` create and update restrictions
- `tests/unit/household-invite-redemption.test.js` now asserts the redemption validator and redemption flow both require the backing membership to keep matching organizer, invited email, and player linkage