### PR TITLE
Keep Profile native back inside Profile

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -8,7 +8,7 @@ import { writeAuthBootstrapHint } from './lib/authBootstrapHint';
 import type { AuthState } from './lib/types';
 
 const suspendedHomePromise = new Promise<never>(() => {});
-let homeRenderMode: 'suspend' | 'throw' = 'suspend';
+let homeRenderMode: 'suspend' | 'throw' | 'render' = 'suspend';
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
 const authMock = vi.hoisted(() => {
   const signedInAuth: AuthState = {
@@ -108,6 +108,9 @@ vi.mock('./pages/Home', () => ({
     if (homeRenderMode === 'throw') {
       throw new Error('Home page render failed');
     }
+    if (homeRenderMode === 'render') {
+      return <div>Home page</div>;
+    }
     throw suspendedHomePromise;
   },
 }));
@@ -135,6 +138,22 @@ vi.mock('./pages/Messages', () => ({
 vi.mock('./pages/Teams', () => ({
   Teams: () => <div>Teams page</div>,
 }));
+
+vi.mock('./pages/Profile', async () => {
+  const reactRouterDom = await import('react-router-dom');
+  return {
+    Profile: () => {
+      const [searchParams] = reactRouterDom.useSearchParams();
+      return (
+        <div>
+          <div>Profile page</div>
+          <div>Profile section: {searchParams.get('section') || 'account'}</div>
+          <div>Profile team: {searchParams.get('teamId') || 'none'}</div>
+        </div>
+      );
+    },
+  };
+});
 
 function installTestLocalStorage() {
   const store = new Map<string, string>();
@@ -411,6 +430,34 @@ describe('App protected route loading', () => {
     });
 
     expect(await screen.findByText('Schedule page')).toBeTruthy();
+  });
+
+  it('collapses Profile query state before leaving to Home on native back', async () => {
+    homeRenderMode = 'render';
+
+    render(
+      <MemoryRouter initialEntries={['/profile?section=alerts&teamId=team-2']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Profile page')).toBeTruthy();
+    expect(screen.getByText('Profile section: alerts')).toBeTruthy();
+    expect(screen.getByText('Profile team: team-2')).toBeTruthy();
+    await waitFor(() => expect(nativeBackMock.listeners).toHaveLength(1));
+
+    await act(async () => {
+      nativeBackMock.listeners[0]({ canGoBack: false });
+    });
+
+    expect(await screen.findByText('Profile section: account')).toBeTruthy();
+    expect(screen.getByText('Profile team: none')).toBeTruthy();
+
+    await act(async () => {
+      nativeBackMock.listeners[0]({ canGoBack: false });
+    });
+
+    expect(await screen.findByText('Home page')).toBeTruthy();
   });
 
   it('routes native app links into the React app router', async () => {

--- a/apps/app/src/lib/nativeBackButton.test.ts
+++ b/apps/app/src/lib/nativeBackButton.test.ts
@@ -17,6 +17,11 @@ describe('native back button helpers', () => {
     expect(getNativeBackTarget('/teams/team-1', '?tab=more')).toBe('/teams/team-1');
     expect(getNativeBackTarget('/teams/team-1', '?tab=overview')).toBe('/teams');
     expect(getNativeBackTarget('/teams/team-1')).toBe('/teams');
+    expect(getNativeBackTarget('/profile', '?section=alerts')).toBe('/profile');
+    expect(getNativeBackTarget('/profile', '?section=invites')).toBe('/profile');
+    expect(getNativeBackTarget('/profile', '?section=security')).toBe('/profile');
+    expect(getNativeBackTarget('/profile', '?section=alerts&teamId=team-2')).toBe('/profile');
+    expect(getNativeBackTarget('/profile')).toBe('/home');
     expect(getNativeBackTarget('/teams/browse')).toBe('/teams');
     expect(getNativeBackTarget('/parent-tools/registrations/team-1/form-1')).toBe('/parent-tools');
     expect(getNativeBackTarget('/help/game-day')).toBe('/help');

--- a/apps/app/src/lib/nativeBackButton.ts
+++ b/apps/app/src/lib/nativeBackButton.ts
@@ -41,6 +41,8 @@ export function getNativeBackTarget(pathname: string, search = '') {
   const normalizedSearch = normalizeSearch(search);
   const homeStateTarget = getNativeHomeBackTarget(path, search);
   if (homeStateTarget) return homeStateTarget;
+  const profileStateTarget = getNativeProfileBackTarget(path, normalizedSearch);
+  if (profileStateTarget) return profileStateTarget;
   if (isNativeExitRoute(path, search)) return null;
   if (['/schedule', '/messages', '/teams', '/officials', '/parent-tools', '/profile', '/ai', '/help'].includes(path)) return '/home';
   if (/^\/schedule\/[^/]+\/[^/]+/.test(path)) return '/schedule';
@@ -85,6 +87,19 @@ function getNativeHomeBackTarget(pathname: string, search: string) {
   }
 
   return '/home';
+}
+
+function getNativeProfileBackTarget(pathname: string, search: string) {
+  if (pathname !== '/profile' || !search) return null;
+
+  const params = new URLSearchParams(search);
+  const activeSection = params.get('section');
+  const hasNonDefaultSection = Boolean(activeSection && activeSection !== 'account');
+  if (hasNonDefaultSection || params.has('teamId')) {
+    return '/profile';
+  }
+
+  return null;
 }
 
 function buildRoute(pathname: string, searchParams: URLSearchParams) {

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Profile } from './Profile';
 import type { AuthState } from '../lib/types';
@@ -109,11 +109,20 @@ const auth: AuthState = {
   signOut: vi.fn()
 };
 
-function renderProfile(initialEntry = '/profile') {
+function TestRouteControls() {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate('/profile', { replace: true })}>
+      Go to plain profile
+    </button>
+  );
+}
+
+function renderProfile(initialEntry = '/profile', includeRouteControls = false) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
-        <Route path="/profile" element={<Profile auth={auth} />} />
+        <Route path="/profile" element={<><Profile auth={auth} />{includeRouteControls ? <TestRouteControls /> : null}</>} />
       </Routes>
     </MemoryRouter>
   );
@@ -246,5 +255,18 @@ describe('Profile', () => {
     expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(false);
     expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(true);
     expect((screen.getByLabelText('Schedule Changes') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('re-syncs the active section and team from the URL after native back collapses profile query state', async () => {
+    renderProfile('/profile?section=alerts&teamId=team-1', true);
+
+    expect(await screen.findByText('Notification preferences')).toBeTruthy();
+    expect(await screen.findByRole('combobox')).toHaveValue('team-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to plain profile' }));
+
+    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
+    expect(screen.queryByText('Notification preferences')).toBeNull();
+    expect(screen.queryByRole('combobox')).toBeNull();
   });
 });

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -93,6 +93,11 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const { isDesktopWeb, isNative } = useShellLayout();
   const user = auth.user;
+  const searchSection = (() => {
+    const section = searchParams.get('section');
+    return (section === 'account' || section === 'alerts' || section === 'invites' || section === 'security') ? section as ProfileSectionId : 'account';
+  })();
+  const initialUrlTeamId = searchParams.get('teamId') || '';
   const [profile, setProfile] = useState<ProfileDocument>({});
   const [fullName, setFullName] = useState('');
   const [phone, setPhone] = useState('');
@@ -102,7 +107,6 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [photoChanged, setPhotoChanged] = useState(false);
   const [photoChooserOpen, setPhotoChooserOpen] = useState(false);
   const [notificationTeams, setNotificationTeams] = useState<NotificationTeam[]>([]);
-  const [initialUrlTeamId] = useState(() => searchParams.get('teamId') || '');
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [notificationPreferences, setNotificationPreferences] = useState<NotificationPreferences>(emptyPreferences);
   const [notificationPreferencesByTeamId, setNotificationPreferencesByTeamId] = useState<Record<string, NotificationPreferences>>({});
@@ -131,10 +135,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [accountMergeStatus, setAccountMergeStatus] = useState<Status | null>(null);
   const [inviteActionStatus, setInviteActionStatus] = useState('');
   const [inviteHistoryExpanded, setInviteHistoryExpanded] = useState(false);
-  const [activeProfileSection, setActiveProfileSection] = useState<ProfileSectionId>(() => {
-    const s = searchParams.get('section');
-    return (s === 'account' || s === 'alerts' || s === 'invites' || s === 'security') ? s as ProfileSectionId : 'account';
-  });
+  const [activeProfileSection, setActiveProfileSection] = useState<ProfileSectionId>(searchSection);
   const [notificationTeamsLoaded, setNotificationTeamsLoaded] = useState(false);
   const [accessCodesLoaded, setAccessCodesLoaded] = useState(false);
   const [accessCodesLoadingMore, setAccessCodesLoadingMore] = useState(false);
@@ -246,6 +247,19 @@ export function Profile({ auth }: { auth: AuthState }) {
   useEffect(() => {
     selectedTeamIdRef.current = selectedTeamId;
   }, [selectedTeamId]);
+
+  useEffect(() => {
+    setActiveProfileSection((current) => current === searchSection ? current : searchSection);
+
+    if (searchSection !== 'alerts') {
+      setSelectedTeamId((current) => current ? '' : current);
+      return;
+    }
+
+    if (searchParams.has('teamId')) {
+      setSelectedTeamId((current) => current === initialUrlTeamId ? current : initialUrlTeamId);
+    }
+  }, [initialUrlTeamId, searchParams, searchSection]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
Closes #3144

## What changed
- updated `getNativeBackTarget()` so `/profile` query-param substates collapse to bare `/profile` before the native back flow exits to `/home`
- treated non-default Profile sections and `teamId` route state as in-Profile navigation state instead of top-level hub state
- added unit coverage for Profile back targets in `apps/app/src/lib/nativeBackButton.test.ts`
- added app-level regression coverage in `apps/app/src/App.test.tsx` proving one back press clears Profile substate and the next back press leaves for Home

## Root Cause
The native back helper treated `/profile` as a flat top-level route and ignored its query-param route state. Because Profile encodes section and alert-team selection in the URL, hardware back from `/profile?section=...` incorrectly resolved straight to `/home` instead of first normalizing back to bare `/profile`.

## Prevention / Learning
When a top-level route stores meaningful UI state in query params, native back routing must normalize that route state before applying hub-exit behavior. Future back-target changes should add tests for both substate URLs and the corresponding bare route so query-param navigation cannot silently bypass an intermediate screen.

## Regression Tests
- `npx vitest run apps/app/src/lib/nativeBackButton.test.ts apps/app/src/App.test.tsx --reporter=verbose`
- unit assertions for `/profile?section=alerts`, `/profile?section=invites`, `/profile?section=security`, `/profile?section=alerts&teamId=team-2`, and bare `/profile`
- app-level native back test covering `/profile?section=alerts&teamId=team-2` -> `/profile` -> `/home`