### PR TITLE
Undo removed basketball substitution events

### DIFF
--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -344,7 +344,7 @@ function revertLogEntry(logEntry) {
     return true;
   }
 
-  const { type, playerId, statKey, value, isOpponent, outId, inId, subId } = logEntry.undoData;
+  const { type, playerId, statKey, value, isOpponent, outId, inId, subId, benchIndex } = logEntry.undoData;
 
   if (type === 'stat') {
     if (isOpponent) {
@@ -366,13 +366,29 @@ function revertLogEntry(logEntry) {
   }
 
   if (type === 'sub') {
-    const reversed = applySubstitution(state.onCourt, state.bench, inId, outId);
-    if (!reversed.applied) {
+    const onCourtIndex = state.onCourt.indexOf(inId);
+    const benchPlayerIndex = state.bench.indexOf(outId);
+    if (onCourtIndex === -1 || benchPlayerIndex === -1 || state.onCourt.includes(outId)) {
       alert('This substitution can only be removed after newer lineup changes are undone.');
       return false;
     }
-    state.onCourt = reversed.onCourt;
-    state.bench = reversed.bench;
+
+    const nextOnCourt = [...state.onCourt];
+    nextOnCourt[onCourtIndex] = outId;
+    const uniqueOnCourtCount = new Set(nextOnCourt).size;
+    if (uniqueOnCourtCount !== nextOnCourt.length) {
+      alert('This substitution can only be removed after newer lineup changes are undone.');
+      return false;
+    }
+
+    const nextBench = state.bench.filter(id => id !== outId);
+    const normalizedBenchIndex = Number.isInteger(benchIndex)
+      ? Math.max(0, Math.min(benchIndex, nextBench.length))
+      : 0;
+    nextBench.splice(normalizedBenchIndex, 0, inId);
+
+    state.onCourt = nextOnCourt;
+    state.bench = nextBench;
     state.subs = state.subs.filter(sub => sub.id !== subId);
     return true;
   }
@@ -1244,6 +1260,7 @@ function closeSubModal() {
 }
 
 function applySub(outId, inId) {
+  const benchIndex = state.bench.indexOf(inId);
   const result = applySubstitution(state.onCourt, state.bench, outId, inId);
   if (!result.applied) return;
   state.onCourt = result.onCourt;
@@ -1254,7 +1271,8 @@ function applySub(outId, inId) {
     type: 'sub',
     outId,
     inId,
-    subId: subEntry.id
+    subId: subEntry.id,
+    benchIndex
   });
   renderLineup();
   renderLive();
@@ -1268,6 +1286,7 @@ function applyQueue(closeModal = true) {
 
   // Log each individual swap for clarity
   state.subQueue.forEach(pair => {
+    const benchIndex = state.bench.indexOf(pair.in);
     const result = applySubstitution(state.onCourt, state.bench, pair.out, pair.in);
     if (result.applied) {
       state.onCourt = result.onCourt;
@@ -1278,7 +1297,8 @@ function applyQueue(closeModal = true) {
         type: 'sub',
         outId: pair.out,
         inId: pair.in,
-        subId: subEntry.id
+        subId: subEntry.id,
+        benchIndex
       });
     }
   });

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -31,6 +31,8 @@ function statDefaults(columns) {
   return stats;
 }
 
+let subSequence = 0;
+
 let state = {
   period: 'Q1',
   clock: 0,
@@ -326,6 +328,72 @@ function renderFairness() {
   els.fairness.className = `pill px-2 py-1 font-semibold text-xs ${balanced ? 'bg-white text-ink' : 'bg-accent text-ink'}`;
 }
 
+function createSubEntry(outId, inId) {
+  subSequence += 1;
+  return {
+    id: `sub-${Date.now()}-${subSequence}`,
+    out: outId,
+    in: inId,
+    period: state.period,
+    clock: formatClock(state.clock)
+  };
+}
+
+function revertLogEntry(logEntry) {
+  if (!logEntry?.undoData) {
+    return true;
+  }
+
+  const { type, playerId, statKey, value, isOpponent, outId, inId, subId } = logEntry.undoData;
+
+  if (type === 'stat') {
+    if (isOpponent) {
+      const opp = state.opp.find(o => o.id === playerId);
+      if (opp && opp.stats && opp.stats[statKey] !== undefined) {
+        opp.stats[statKey] = safeDecrement(opp.stats[statKey], value);
+        if (isPointsColumn(statKey)) {
+          state.away = safeDecrement(state.away, value);
+        }
+      }
+    } else if (state.stats[playerId] && state.stats[playerId][statKey] !== undefined) {
+      state.stats[playerId][statKey] = safeDecrement(state.stats[playerId][statKey], value);
+      if (isPointsColumn(statKey)) {
+        state.home = safeDecrement(state.home, value);
+      }
+    }
+
+    return true;
+  }
+
+  if (type === 'sub') {
+    const reversed = applySubstitution(state.onCourt, state.bench, inId, outId);
+    if (!reversed.applied) {
+      alert('This substitution can only be removed after newer lineup changes are undone.');
+      return false;
+    }
+    state.onCourt = reversed.onCourt;
+    state.bench = reversed.bench;
+    state.subs = state.subs.filter(sub => sub.id !== subId);
+    return true;
+  }
+
+  return true;
+}
+
+function removeLogEntry(index) {
+  if (isNaN(index) || index < 0 || index >= state.log.length) {
+    return;
+  }
+
+  const logEntry = state.log[index];
+  if (!revertLogEntry(logEntry)) {
+    return;
+  }
+
+  state.log.splice(index, 1);
+  renderAll();
+}
+
 function renderLog() {
   els.log.innerHTML = state.log.slice(0, 40).map((ev, idx) => `
     <div class="flex justify-between items-center border border-slate/10 rounded-lg p-2 bg-white">
@@ -340,45 +408,10 @@ function renderLog() {
     </div>
   `).join('') || '<div class="text-xs text-slate-500 text-center py-4">No events yet</div>';
 
-  // Add event listeners for remove buttons
   els.log.querySelectorAll('button[data-remove-log]').forEach(btn => {
     btn.addEventListener('click', () => {
       const index = Number(btn.dataset.removeLog);
-      if (!isNaN(index)) {
-        const logEntry = state.log[index];
-
-        // Reverse the stat change if undoData exists
-        if (logEntry && logEntry.undoData) {
-          const { type, playerId, statKey, value, isOpponent } = logEntry.undoData;
-
-          if (type === 'stat') {
-            if (isOpponent) {
-              // Reverse opponent stat
-              const opp = state.opp.find(o => o.id === playerId);
-              if (opp && opp.stats && opp.stats[statKey] !== undefined) {
-                opp.stats[statKey] = safeDecrement(opp.stats[statKey], value);
-                if (isPointsColumn(statKey)) {
-                  state.away = safeDecrement(state.away, value);
-                }
-              }
-            } else {
-              // Reverse team player stat
-              if (state.stats[playerId] && state.stats[playerId][statKey] !== undefined) {
-                state.stats[playerId][statKey] = safeDecrement(state.stats[playerId][statKey], value);
-                if (isPointsColumn(statKey)) {
-                  state.home = safeDecrement(state.home, value);
-                }
-              }
-            }
-          }
-        }
-
-        // Remove the log entry
-        state.log.splice(index, 1);
-
-        // Re-render everything to reflect the changes
-        renderAll();
-      }
+      removeLogEntry(index);
     });
   });
 }
@@ -395,6 +428,7 @@ function saveHistory(action) {
     bench: [...state.bench],
     stats: JSON.parse(JSON.stringify(state.stats)),
     log: [...state.log],
+    subs: [...state.subs],
     opp: JSON.parse(JSON.stringify(state.opp)),
     scoreLogIsComplete: state.scoreLogIsComplete
   };
@@ -417,6 +451,7 @@ function undo() {
   state.bench = prev.bench;
   state.stats = prev.stats;
   state.log = prev.log;
+  state.subs = Array.isArray(prev.subs) ? prev.subs : [];
   state.opp = prev.opp;
   state.scoreLogIsComplete = prev.scoreLogIsComplete !== false;
   renderAll();
@@ -1213,8 +1248,14 @@ function applySub(outId, inId) {
   if (!result.applied) return;
   state.onCourt = result.onCourt;
   state.bench = result.bench;
-  state.subs.push({ out: outId, in: inId, period: state.period, clock: formatClock(state.clock) });
-  addLog(`Sub: #${getNum(outId)} ${playerName(outId)} → #${getNum(inId)} ${playerName(inId)}`);
+  const subEntry = createSubEntry(outId, inId);
+  state.subs.push(subEntry);
+  addLog(`Sub: #${getNum(outId)} ${playerName(outId)} → #${getNum(inId)} ${playerName(inId)}`, {
+    type: 'sub',
+    outId,
+    inId,
+    subId: subEntry.id
+  });
   renderLineup();
   renderLive();
 }
@@ -1231,9 +1272,14 @@ function applyQueue(closeModal = true) {
     if (result.applied) {
       state.onCourt = result.onCourt;
       state.bench = result.bench;
-      state.subs.push({ out: pair.out, in: pair.in, period: state.period, clock: formatClock(state.clock) });
-      // Log each swap individually
-      addLog(`Sub: #${getNum(pair.out)} ${playerName(pair.out)} → #${getNum(pair.in)} ${playerName(pair.in)}`);
+      const subEntry = createSubEntry(pair.out, pair.in);
+      state.subs.push(subEntry);
+      addLog(`Sub: #${getNum(pair.out)} ${playerName(pair.out)} → #${getNum(pair.in)} ${playerName(pair.in)}`, {
+        type: 'sub',
+        outId: pair.out,
+        inId: pair.in,
+        subId: subEntry.id
+      });
     }
   });
 

--- a/tests/unit/track-basketball-substitution-undo.test.js
+++ b/tests/unit/track-basketball-substitution-undo.test.js
@@ -34,7 +34,8 @@ let roster = [
     { id: 'p3', num: '3', name: 'Cam' },
     { id: 'p4', num: '4', name: 'Dia' },
     { id: 'p5', num: '5', name: 'Eli' },
-    { id: 'p6', num: '6', name: 'Flo' }
+    { id: 'p6', num: '6', name: 'Flo' },
+    { id: 'p7', num: '7', name: 'Gia' }
 ];
 let state = {
     period: 'Q1',
@@ -42,14 +43,15 @@ let state = {
     home: 0,
     away: 0,
     onCourt: ['p1', 'p2', 'p3', 'p4', 'p5'],
-    bench: ['p6'],
+    bench: ['p6', 'p7'],
     stats: {
         p1: { pts: 0, time: 0 },
         p2: { pts: 0, time: 0 },
         p3: { pts: 0, time: 0 },
         p4: { pts: 0, time: 0 },
         p5: { pts: 0, time: 0 },
-        p6: { pts: 0, time: 0 }
+        p6: { pts: 0, time: 0 },
+        p7: { pts: 0, time: 0 }
     },
     log: [],
     subs: [],
@@ -93,18 +95,19 @@ describe('track basketball substitution undo', () => {
 
         hooks.applySub('p1', 'p6');
         expect(hooks.state.onCourt).toContain('p6');
-        expect(hooks.state.bench).toContain('p1');
+        expect(hooks.state.bench).toEqual(['p7', 'p1']);
         expect(hooks.state.subs).toHaveLength(1);
         expect(hooks.state.log[0].undoData).toMatchObject({
             type: 'sub',
             outId: 'p1',
-            inId: 'p6'
+            inId: 'p6',
+            benchIndex: 0
         });
 
         hooks.removeLogEntry(0);
 
         expect(hooks.state.onCourt).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
-        expect(hooks.state.bench).toEqual(['p6']);
+        expect(hooks.state.bench).toEqual(['p6', 'p7']);
         expect(hooks.state.subs).toEqual([]);
         expect(hooks.state.log).toEqual([]);
     });
@@ -121,7 +124,7 @@ describe('track basketball substitution undo', () => {
         nowSpy.mockRestore();
 
         expect(hooks.state.onCourt).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
-        expect(hooks.state.bench).toEqual(['p6']);
+        expect(hooks.state.bench).toEqual(['p6', 'p7']);
         expect(hooks.state.subs).toEqual([]);
         expect(hooks.state.log[0].text).toBe('Undid: Sub: #1 → #6');
     });

--- a/tests/unit/track-basketball-substitution-undo.test.js
+++ b/tests/unit/track-basketball-substitution-undo.test.js
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import { applySubstitution } from '../../js/live-tracker-integrity.js';
+
+const source = readFileSync(new URL('../../js/track-basketball.js', import.meta.url), 'utf8');
+
+function extractFunction(sourceText, name) {
+    const start = sourceText.indexOf(`function ${name}`);
+    if (start === -1) {
+        throw new Error(`Function ${name} not found`);
+    }
+
+    const bodyStart = sourceText.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < sourceText.length; index += 1) {
+        const char = sourceText[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return sourceText.slice(start, index + 1);
+        }
+    }
+
+    throw new Error(`Function ${name} did not terminate`);
+}
+
+function createHooks() {
+    const factory = new Function('applySubstitution', `
+let subSequence = 0;
+let roster = [
+    { id: 'p1', num: '1', name: 'Ava' },
+    { id: 'p2', num: '2', name: 'Bea' },
+    { id: 'p3', num: '3', name: 'Cam' },
+    { id: 'p4', num: '4', name: 'Dia' },
+    { id: 'p5', num: '5', name: 'Eli' },
+    { id: 'p6', num: '6', name: 'Flo' }
+];
+let state = {
+    period: 'Q1',
+    clock: 65000,
+    home: 0,
+    away: 0,
+    onCourt: ['p1', 'p2', 'p3', 'p4', 'p5'],
+    bench: ['p6'],
+    stats: {
+        p1: { pts: 0, time: 0 },
+        p2: { pts: 0, time: 0 },
+        p3: { pts: 0, time: 0 },
+        p4: { pts: 0, time: 0 },
+        p5: { pts: 0, time: 0 },
+        p6: { pts: 0, time: 0 }
+    },
+    log: [],
+    subs: [],
+    opp: [],
+    history: [],
+    scoreLogIsComplete: true
+};
+const els = { log: { innerHTML: '', querySelectorAll: () => [] } };
+const renderLog = () => {};
+const renderAll = () => {};
+const renderLineup = () => {};
+const renderLive = () => {};
+const alert = () => {};
+const isPointsColumn = () => false;
+const getNum = (id) => roster.find((player) => player.id === id)?.num || '';
+const playerName = (id) => roster.find((player) => player.id === id)?.name || '';
+${extractFunction(source, 'formatClock')}
+${extractFunction(source, 'safeDecrement')}
+${extractFunction(source, 'createSubEntry')}
+${extractFunction(source, 'addLog')}
+${extractFunction(source, 'revertLogEntry')}
+${extractFunction(source, 'removeLogEntry')}
+${extractFunction(source, 'saveHistory')}
+${extractFunction(source, 'undo')}
+${extractFunction(source, 'applySub')}
+return {
+    state,
+    applySub,
+    removeLogEntry,
+    saveHistory,
+    undo
+};
+`);
+
+    return factory(applySubstitution);
+}
+
+describe('track basketball substitution undo', () => {
+    it('removing a substitution event restores lineup state and clears substitution history', () => {
+        const hooks = createHooks();
+
+        hooks.applySub('p1', 'p6');
+        expect(hooks.state.onCourt).toContain('p6');
+        expect(hooks.state.bench).toContain('p1');
+        expect(hooks.state.subs).toHaveLength(1);
+        expect(hooks.state.log[0].undoData).toMatchObject({
+            type: 'sub',
+            outId: 'p1',
+            inId: 'p6'
+        });
+
+        hooks.removeLogEntry(0);
+
+        expect(hooks.state.onCourt).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
+        expect(hooks.state.bench).toEqual(['p6']);
+        expect(hooks.state.subs).toEqual([]);
+        expect(hooks.state.log).toEqual([]);
+    });
+
+    it('undo restores substitution history snapshots alongside lineup state', () => {
+        const hooks = createHooks();
+        const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1710000000000);
+
+        hooks.saveHistory('Sub: #1 → #6');
+        hooks.applySub('p1', 'p6');
+        expect(hooks.state.subs).toHaveLength(1);
+
+        hooks.undo();
+        nowSpy.mockRestore();
+
+        expect(hooks.state.onCourt).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
+        expect(hooks.state.bench).toEqual(['p6']);
+        expect(hooks.state.subs).toEqual([]);
+        expect(hooks.state.log[0].text).toBe('Undid: Sub: #1 → #6');
+    });
+});


### PR DESCRIPTION
Closes #3146

## What changed
- Added explicit undo metadata to basketball substitution log entries so Recent events removal can reverse the lineup swap instead of only deleting the row.
- Reworked Recent events removal through a shared helper that reverses substitution state, removes the matching `state.subs` entry, and keeps the on-court and bench lists aligned.
- Included `state.subs` in tracker history snapshots so the mini Undo path restores substitution history along with lineup state.
- Added a focused regression test covering both Recent events removal and history undo for basketball substitutions.

## Root Cause
Basketball substitutions mutated `state.onCourt`, `state.bench`, and `state.subs`, but their log entries were written without undo metadata. The Recent events delete path only knew how to reverse stat entries, so deleting a substitution removed the visible log row while leaving the actual lineup and substitution history mutated.

## Prevention / Learning
Any tracker action that mutates derived state beyond the log itself must either write a reversible undo payload or store a snapshot that covers every mutated state bucket. For tracker bugs like this, regression coverage should exercise the same removal helper the UI uses instead of only asserting source text or happy-path rendering.

## Regression Tests
- `tests/unit/track-basketball-substitution-undo.test.js`
  - removing a substitution event restores lineup state and clears substitution history
  - undo restores substitution history snapshots alongside lineup state
- `npx vitest run tests/unit/track-basketball-substitution-undo.test.js --reporter=verbose`

## Recurrence Risk
Medium: direct substitution removals and history snapshots are now covered, but other older lineup-style events still depend on narrower undo semantics unless they also carry explicit reversible state.