### PR TITLE
Fix team fee back-to-team routing

### DIFF
--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -1096,7 +1096,7 @@ async function renderManageMode({ container, teamId, batchId, team, user, getTea
     container.innerHTML = `
         <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
             <div>
-                <a href="team.html?id=${encodeURIComponent(teamId)}" class="text-sm font-semibold text-primary-600 hover:text-primary-700">Back to team</a>
+                <a href="team.html#teamId=${encodeURIComponent(teamId)}" class="text-sm font-semibold text-primary-600 hover:text-primary-700">Back to team</a>
                 <h1 id="page-title" class="mt-2 text-3xl font-bold text-gray-900">Manage team fee</h1>
                 <p id="page-subtitle" class="mt-1 text-sm text-gray-600">Review assigned recipients, record offline payments, and adjust balances.</p>
             </div>

--- a/team-fees.html
+++ b/team-fees.html
@@ -45,7 +45,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=11"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=12"></script>
 </body>
 
 </html>

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -22,7 +22,16 @@ describe('team fees admin page routing', () => {
         const pageSource = readFileSync(new URL('../../team-fees.html', import.meta.url), 'utf8');
 
         expect(adminSource).toContain("import('./db.js?v=74')");
-        expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=11"></script>');
+        expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=12"></script>');
+    });
+
+    it('routes the manage view back link with the teamId hash parameter that team.html reads', () => {
+        const adminSource = readFileSync(new URL('../../js/team-fees-admin.js', import.meta.url), 'utf8');
+        const teamPageSource = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+
+        expect(adminSource).toContain('href="team.html#teamId=${encodeURIComponent(teamId)}"');
+        expect(adminSource).not.toContain('href="team.html?id=${encodeURIComponent(teamId)}"');
+        expect(teamPageSource).toContain('const { teamId } = getUrlParams();');
     });
 });
 


### PR DESCRIPTION
Closes #3152

## What changed
- Updated the Team Fees manage view "Back to team" link to use `team.html#teamId=...` instead of `team.html?id=...`
- Bumped the legacy `team-fees-admin.js` cache-bust from `v=11` to `v=12` so the navigation fix ships immediately
- Added a focused regression test in `tests/unit/team-fees-admin.test.js` that verifies the manage view links with `teamId` and that `team.html` still reads `teamId` from URL params

## Root Cause
The Team Fees manage page hardcoded its return link as `team.html?id=...`, but `team.html` only reads `teamId` from `getUrlParams()`. Because no alias exists from `id` to `teamId`, the destination page treated the request as missing team context and redirected to `index.html`.

## Prevention / Learning
When linking between legacy ALL PLAYS pages, reuse the exact route parameter contract the destination page parses. For page-to-page navigation in the legacy shell, add a focused source-level regression test that asserts both sides of the contract: the link format emitted by the source page and the param name consumed by the destination page.

## Regression Tests
- `npx vitest run tests/unit/team-fees-admin.test.js --reporter=verbose`
- Added coverage that fails if the manage view regresses back to `team.html?id=...`
- Added coverage that confirms `team.html` still expects `teamId` from URL params