### PR TITLE
Speed up app global team search

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -38,11 +38,17 @@ vi.mock('../lib/searchRoutePreload', () => ({
 }));
 
 const {
+  getImmediateAppTeamSearchResultsMock,
   getKnownAppSearchTeamsMock,
   loadAppSearchTeamsMock,
   searchAppTeamsMock,
   searchAppPlayersMock,
 } = vi.hoisted(() => ({
+  getImmediateAppTeamSearchResultsMock: vi.fn((query: string, teams: AppSearchTeam[]) => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (normalizedQuery.length < 2) return teams;
+    return teams.filter((team) => team.name.toLowerCase().includes(normalizedQuery));
+  }),
   getKnownAppSearchTeamsMock: vi.fn((): AppSearchTeam[] => []),
   loadAppSearchTeamsMock: vi.fn(async (): Promise<AppSearchTeam[]> => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
   searchAppTeamsMock: vi.fn<(query: string, teams: AppSearchTeam[], user: AuthState['user']) => Promise<AppSearchTeam[]>>(),
@@ -86,6 +92,7 @@ vi.mock('../lib/searchService', () => ({
       flat: [...actionItems, ...teamItems, ...helpItems, ...players],
     };
   },
+  getImmediateAppTeamSearchResults: getImmediateAppTeamSearchResultsMock,
   getKnownAppSearchTeams: getKnownAppSearchTeamsMock,
   loadAppSearchTeams: loadAppSearchTeamsMock,
   searchAppTeams: searchAppTeamsMock,

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -7,6 +7,7 @@ import { openPublicUrl } from '../lib/publicActions';
 import { preloadSearchRoute } from '../lib/searchRoutePreload';
 import {
   computeAppSearchResults,
+  getImmediateAppTeamSearchResults,
   getKnownAppSearchTeams,
   loadAppSearchTeams,
   searchAppTeams,
@@ -125,6 +126,10 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
       const runSearch = async (accessibleTeams: AppSearchTeam[]) => {
         const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
+        const localTeams = getImmediateAppTeamSearchResults(trimmedQuery, accessibleTeams);
+        setTeams(localTeams);
+        setTeamsLoading(localTeams.length === 0);
+
         const [teamsResult, playersResult] = await Promise.allSettled([
           searchAppTeams(trimmedQuery, accessibleTeams, auth.user),
           searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -29,6 +29,7 @@ let cachedTeamsUserKey = '';
 let cachedTeamsPromise: Promise<AppSearchTeam[]> | null = null;
 let cachedTeamsPromiseUserKey = '';
 const playerSearchCache = new Map<string, PlayerSearchCacheEntry>();
+const publicTeamSearchCache = new Map<string, PublicTeamSearchCacheEntry>();
 
 type PlayerSearchCacheEntry = {
   scopeKey: string;
@@ -38,6 +39,11 @@ type PlayerSearchCacheEntry = {
   sourceDocs?: any[];
   exhaustiveForNarrowerQueries?: boolean;
   promise?: Promise<AppSearchPlayer[]>;
+};
+
+type PublicTeamSearchCacheEntry = {
+  teams?: AppSearchTeam[];
+  promise?: Promise<AppSearchTeam[]>;
 };
 
 export type AppSearchKind = 'action' | 'team' | 'player' | 'social' | 'help';
@@ -358,37 +364,36 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
 
 export async function searchAppTeams(queryText: string, appAccessTeams: AppSearchTeam[], user: AuthUser | null): Promise<AppSearchTeam[]> {
   const rawQuery = String(queryText || '').trim();
+  const localTeams = getImmediateAppTeamSearchResults(rawQuery, appAccessTeams);
+  if (rawQuery.length < 2) return localTeams;
+
+  const firstToken = splitSearchTokens(rawQuery)[0] || '';
+  if (!firstToken) return localTeams;
+
+  try {
+    const publicTeams = await getCachedPublicTeamSearchResults(rawQuery, user);
+    const localTeamsById = new Map(appAccessTeams.map((team) => [team.id, team]));
+    publicTeams.forEach((team) => {
+      if (canUserDiscoverTeamInAppSearch(team, user)) {
+        localTeamsById.set(team.id, team);
+      }
+    });
+
+    return rankTeamsForQuery(Array.from(localTeamsById.values()), rawQuery).slice(0, teamSearchQueryLimit);
+  } catch (error) {
+    if (localTeams.length) return localTeams;
+    throw error;
+  }
+}
+
+export function getImmediateAppTeamSearchResults(queryText: string, appAccessTeams: AppSearchTeam[]): AppSearchTeam[] {
+  const rawQuery = String(queryText || '').trim();
   if (rawQuery.length < 2) return appAccessTeams.slice(0, teamSearchQueryLimit);
 
   const firstToken = splitSearchTokens(rawQuery)[0] || '';
   if (!firstToken) return appAccessTeams.slice(0, teamSearchQueryLimit);
 
-  const localTeamsById = new Map(appAccessTeams.map((team) => [team.id, team]));
-  const publicTeamsResult = await Promise.allSettled([
-    getPublicTeamsPage({ searchText: rawQuery, pageSize: teamSearchQueryLimit })
-  ]);
-
-  const rejected = publicTeamsResult
-    .filter((result) => result.status === 'rejected')
-    .map((result: any) => result.reason)
-    .filter(Boolean);
-  const hasFulfilled = publicTeamsResult.some((result) => result.status === 'fulfilled');
-
-  publicTeamsResult.forEach((result: any) => {
-    if (result.status !== 'fulfilled') return;
-    normalizePublicTeamSearchResults(result.value?.teams || []).forEach((team) => {
-      if (canUserDiscoverTeamInAppSearch(team, user)) {
-        localTeamsById.set(team.id, team);
-      }
-    });
-  });
-
-  const rankedTeams = rankTeamsForQuery(Array.from(localTeamsById.values()), rawQuery).slice(0, teamSearchQueryLimit);
-  if (rankedTeams.length || hasFulfilled || rejected.length === 0) {
-    return rankedTeams;
-  }
-
-  throw rejected[0];
+  return rankTeamsForQuery(appAccessTeams, rawQuery).slice(0, teamSearchQueryLimit);
 }
 
 export async function searchAppPlayers(queryText: string, teamsById: Map<string, AppSearchTeam>, user: AuthUser | null): Promise<AppSearchPlayer[]> {
@@ -574,6 +579,30 @@ export function resetAppSearchCacheForTests() {
   cachedTeamsPromise = null;
   cachedTeamsPromiseUserKey = '';
   playerSearchCache.clear();
+  publicTeamSearchCache.clear();
+}
+
+async function getCachedPublicTeamSearchResults(queryText: string, user: AuthUser | null): Promise<AppSearchTeam[]> {
+  const normalizedQuery = normalizeSearchQuery(queryText);
+  const cacheKey = `${getAppSearchUserCacheKey(user)}::${normalizedQuery}`;
+  const cachedEntry = publicTeamSearchCache.get(cacheKey);
+
+  if (cachedEntry?.teams) return cachedEntry.teams;
+  if (cachedEntry?.promise) return cachedEntry.promise;
+
+  const promise = getPublicTeamsPage({ searchText: queryText, pageSize: teamSearchQueryLimit })
+    .then((result) => {
+      const teams = normalizePublicTeamSearchResults(result?.teams || []);
+      publicTeamSearchCache.set(cacheKey, { teams });
+      return teams;
+    })
+    .catch((error) => {
+      publicTeamSearchCache.delete(cacheKey);
+      throw error;
+    });
+
+  publicTeamSearchCache.set(cacheKey, { promise });
+  return promise;
 }
 
 async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>, homeTeams: any[], user: AuthUser | null) {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -159,6 +159,15 @@ async function mockSearchModules(page) {
                     return getKnownAppSearchTeams(user);
                 }
 
+                export function getImmediateAppTeamSearchResults(queryText, appAccessTeams = []) {
+                    const q = String(queryText || '').trim().toLowerCase();
+                    if (q.length < 2) return appAccessTeams.slice(0, 20);
+                    return appAccessTeams.filter((team) => {
+                        const haystack = [team.name, team.sport, team.zip].filter(Boolean).join(' ').toLowerCase();
+                        return haystack.includes(q);
+                    }).slice(0, 20);
+                }
+
                 export async function searchAppTeams(queryText, appAccessTeams = []) {
                     window.__teamSearchQueries.push(String(queryText || ''));
                     const q = String(queryText || '').trim().toLowerCase();

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -272,6 +272,33 @@ describe('React app shell search', () => {
         expect(container.querySelector('[data-testid="route"]').textContent).toBe('/players/team-home/player-1');
     });
 
+    it('shows local team matches before delayed public-team enrichment resolves', async () => {
+        let resolvePublicTeams;
+        dbMocks.discoverPublicTeams.mockImplementationOnce(() => new Promise((resolve) => {
+            resolvePublicTeams = resolve;
+        }));
+
+        const { container } = await renderShell();
+
+        await clickButton(container, 'Search');
+        await fillSearch(container, 'home');
+
+        expect(container.textContent).toContain('Home Rockets');
+        expect(container.textContent).not.toContain('Home Heroes');
+        expect(container.textContent).not.toContain('Searching teams...');
+
+        resolvePublicTeams({
+            teams: [
+                { id: 'team-public-home', name: 'Home Heroes', sport: 'Basketball', city: 'Austin', state: 'TX', isPublic: true }
+            ],
+            nextCursor: null
+        });
+        await flush(50);
+
+        await waitForText(container, 'Home Heroes');
+        expect(container.textContent).toContain('Home Rockets');
+    });
+
     it('lets player search start before slow team hydration finishes and merges team results afterward', async () => {
         let resolveParentHome;
         homeMocks.loadParentHome.mockImplementationOnce(() => new Promise((resolve) => {
@@ -382,6 +409,27 @@ describe('React app shell search', () => {
         expect(container.textContent).toContain('#9 Pat Star');
         expect(container.textContent).toContain('#10 Pat Stone');
         expect(container.textContent).not.toContain('Paige Forward');
+    });
+
+    it('reuses cached public-team searches for repeated normalized dialog queries', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                { id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210', isPublic: true, appAccess: true },
+                { id: 'team-public-2', name: 'Bear Creek', sport: 'Soccer', city: 'Olathe', state: 'KS', isPublic: true }
+            ],
+            nextCursor: null
+        });
+
+        const { container } = await renderShell();
+
+        await clickButton(container, 'Search');
+        await fillSearch(container, 'bea');
+        await waitForText(container, 'Bear Creek');
+
+        await fillSearch(container, ' BEA ');
+        await waitForText(container, 'Bear Creek');
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(1);
     });
 
     it('shows unfiltered help matches in search and routes advanced help filtering to the help portal', async () => {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -36,6 +36,7 @@ vi.mock('../../apps/app/src/lib/helpKnowledgeService', () => helpMocks);
 import {
     buildAppSearchActions,
     computeAppSearchResults,
+    getImmediateAppTeamSearchResults,
     getKnownAppSearchTeams,
     getSearchHelpRoles,
     loadAppSearchTeams,
@@ -797,6 +798,31 @@ describe('React app search service', () => {
             name: 'Bearcats Public',
             isPublic: true
         });
+    });
+
+    it('returns matching app-access teams immediately before public enrichment resolves', () => {
+        const teams = getImmediateAppTeamSearchResults('be', [
+            { id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true },
+            { id: 'team-other', name: 'Rockets', sport: 'Basketball', fromAppAccess: true }
+        ]);
+
+        expect(teams.map((team) => team.id)).toEqual(['team-home']);
+    });
+
+    it('reuses cached public-team results for repeated normalized queries', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                { id: 'team-public', name: 'Bears', sport: 'Basketball', city: 'Kansas City', state: 'MO', isPublic: true }
+            ],
+            nextCursor: null
+        });
+
+        const first = await searchAppTeams('be', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
+        const second = await searchAppTeams(' BE ', [{ id: 'team-home', name: 'Bearcats', sport: 'Soccer', fromAppAccess: true }], auth.user);
+
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(1);
+        expect(first.map((team) => team.id)).toEqual(['team-home', 'team-public']);
+        expect(second.map((team) => team.id)).toEqual(['team-home', 'team-public']);
     });
 
     it('includes location-matched public teams in global app search results', async () => {


### PR DESCRIPTION
Closes #3153

## What changed
- returned ranked app-access team matches immediately in the app search dialog instead of waiting for public-team discovery
- added a normalized per-user session cache for public-team search results so repeated queries reuse the first discovery response
- kept public-team enrichment and ranking behavior intact after the remote lookup resolves
- added regression coverage for immediate local rendering and repeated-query cache reuse in both service and dialog integration tests

## Root Cause
`searchAppTeams()` was network-first for every 2+ character query and had no normalized query cache for public-team discovery. `AppSearchDialog` then tied the Teams section loading lifecycle to that remote promise, so even already-known accessible teams waited behind the public lookup and repeated identical queries re-fired discovery.

## Prevention / Learning
For mixed local-plus-remote search flows, treat local accessible results as the critical path and remote discovery as enrichment. Cache normalized remote lookups per session before wiring UI loading states to the slower path.

## Regression Tests
- `tests/unit/app-search-service.test.js` proves immediate local team filtering and single-call reuse for repeated normalized team queries
- `tests/unit/app-search-integration.test.jsx` proves the dialog shows a local team before a delayed public lookup resolves, then enriches later, and does not re-discover for the same normalized query

## Recurrence Risk
Medium. The core behavior is now covered, but future dialog loading-state refactors could still accidentally reintroduce remote-first rendering without these tests.