### PR TITLE
Defer team detail games and config hydration

### DIFF
--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -99,6 +99,8 @@ import {
   __resetTeamDetailBaseSnapshotCacheForTests,
   buildTeamDetailModel,
   createStatTrackerConfigForApp,
+  loadParentTeamDetail,
+  loadParentTeamDetailBootstrap,
   loadTeamTrackingAdmin,
   saveTeamTrackingItemForApp,
   setPlayerTrackingStatusForApp,
@@ -194,6 +196,40 @@ describe('updateTeamSettingsForApp', () => {
     })).rejects.toThrow('Livestream link must be a valid YouTube or Twitch URL.');
 
     expect(dbMocks.updateTeam).not.toHaveBeenCalled();
+  });
+});
+
+describe('team detail bootstrap loading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.getTeam.mockResolvedValue({ id: 'team-1', ownerId: 'owner-1', name: 'Bears', sport: 'Basketball' });
+    dbMocks.getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', active: true }]);
+    dbMocks.getGames.mockResolvedValue([{ id: 'game-1', type: 'game', status: 'scheduled' }]);
+    dbMocks.getConfigs.mockResolvedValue([{ id: 'config-1', name: 'Config' }]);
+    __resetTeamDetailBaseSnapshotCacheForTests();
+  });
+
+  it('skips games and stat config reads for the lightweight bootstrap path', async () => {
+    const model = await loadParentTeamDetailBootstrap('team-1', { uid: 'parent-1' } as any);
+
+    expect(model.team.name).toBe('Bears');
+    expect(model.players).toHaveLength(1);
+    expect(model.upcomingEvents).toEqual([]);
+    expect(model.statTrackerConfigs).toEqual([]);
+    expect(dbMocks.getTeam).toHaveBeenCalledTimes(1);
+    expect(dbMocks.getPlayers).toHaveBeenCalledTimes(1);
+    expect(dbMocks.getGames).not.toHaveBeenCalled();
+    expect(dbMocks.getConfigs).not.toHaveBeenCalled();
+  });
+
+  it('loads games and stat configs once a deferred detail surface requests them', async () => {
+    await loadParentTeamDetailBootstrap('team-1', { uid: 'parent-1' } as any);
+    await loadParentTeamDetail('team-1', { uid: 'parent-1' } as any, { includeDeferredData: false });
+
+    expect(dbMocks.getTeam).toHaveBeenCalledTimes(1);
+    expect(dbMocks.getPlayers).toHaveBeenCalledTimes(1);
+    expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
+    expect(dbMocks.getConfigs).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -346,6 +346,8 @@ type TeamDetailBaseSnapshot = {
   players: any[];
   games: any[];
   configs: any[];
+  gamesLoaded: boolean;
+  configsLoaded: boolean;
 };
 
 type FirestoreDocument = Record<string, any> & { id: string };
@@ -414,20 +416,32 @@ function cacheTeamDetailBaseSnapshot(snapshot: TeamDetailBaseSnapshot) {
     team: snapshot.team,
     players: Array.isArray(snapshot.players) ? snapshot.players : [],
     games: Array.isArray(snapshot.games) ? snapshot.games : [],
-    configs: Array.isArray(snapshot.configs) ? snapshot.configs : []
+    configs: Array.isArray(snapshot.configs) ? snapshot.configs : [],
+    gamesLoaded: snapshot.gamesLoaded === true,
+    configsLoaded: snapshot.configsLoaded === true
   });
 }
 
-async function loadTeamDetailBaseSnapshot(teamId: string): Promise<TeamDetailBaseSnapshot> {
+async function loadTeamDetailBaseSnapshot(teamId: string, options: { includeGamesAndConfigs?: boolean } = {}): Promise<TeamDetailBaseSnapshot> {
   const normalizedTeamId = cleanString(teamId);
+  const includeGamesAndConfigs = options.includeGamesAndConfigs !== false;
   const cachedSnapshot = teamDetailBaseSnapshotCache.get(normalizedTeamId);
-  if (cachedSnapshot?.team) return cachedSnapshot;
+  if (
+    cachedSnapshot?.team
+    && (!includeGamesAndConfigs || (cachedSnapshot.gamesLoaded === true && cachedSnapshot.configsLoaded === true))
+  ) {
+    return cachedSnapshot;
+  }
 
   const [team, players, games, configs] = await Promise.all([
-    loadTeamDocument(normalizedTeamId),
-    loadTeamPlayers(normalizedTeamId),
-    loadTeamGames(normalizedTeamId),
-    loadTeamConfigs(normalizedTeamId)
+    cachedSnapshot?.team ? Promise.resolve(cachedSnapshot.team) : loadTeamDocument(normalizedTeamId),
+    cachedSnapshot?.players ? Promise.resolve(cachedSnapshot.players) : loadTeamPlayers(normalizedTeamId),
+    includeGamesAndConfigs
+      ? (cachedSnapshot?.gamesLoaded ? Promise.resolve(cachedSnapshot.games) : loadTeamGames(normalizedTeamId))
+      : Promise.resolve(cachedSnapshot?.games || []),
+    includeGamesAndConfigs
+      ? (cachedSnapshot?.configsLoaded ? Promise.resolve(cachedSnapshot.configs) : loadTeamConfigs(normalizedTeamId))
+      : Promise.resolve(cachedSnapshot?.configs || [])
   ]);
 
   const snapshot = {
@@ -435,7 +449,9 @@ async function loadTeamDetailBaseSnapshot(teamId: string): Promise<TeamDetailBas
     team,
     players: Array.isArray(players) ? players : [],
     games: Array.isArray(games) ? games : [],
-    configs: Array.isArray(configs) ? configs : []
+    configs: Array.isArray(configs) ? configs : [],
+    gamesLoaded: includeGamesAndConfigs ? true : cachedSnapshot?.gamesLoaded === true,
+    configsLoaded: includeGamesAndConfigs ? true : cachedSnapshot?.configsLoaded === true
   };
   cacheTeamDetailBaseSnapshot(snapshot);
   return snapshot;
@@ -1302,7 +1318,7 @@ export async function loadParentTeamDetail(
   options: { includeDeferredData?: boolean } = {}
 ): Promise<TeamDetailModel> {
   const includeDeferredData = options.includeDeferredData === true;
-  const { team, players, games, configs } = await loadTeamDetailBaseSnapshot(teamId);
+  const { team, players, games, configs } = await loadTeamDetailBaseSnapshot(teamId, { includeGamesAndConfigs: true });
 
   if (!team) throw new Error('Team not found.');
 
@@ -1342,6 +1358,30 @@ export async function loadParentTeamDetail(
     sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)],
     includeStaffPermissions: false,
     includeInsights: includeDeferredData
+  });
+}
+
+export async function loadParentTeamDetailBootstrap(teamId: string, user: AuthUser | null): Promise<TeamDetailModel> {
+  const { team, players } = await loadTeamDetailBaseSnapshot(teamId, { includeGamesAndConfigs: false });
+
+  if (!team) throw new Error('Team not found.');
+
+  const linkedPlayerIds = getLinkedPlayerIds(user, teamId, players);
+
+  return buildTeamDetailModel({
+    teamId,
+    team,
+    players,
+    games: [],
+    configs: [],
+    user,
+    linkedPlayerIds,
+    seasonStatsByPlayerId: {},
+    trackingItems: [],
+    trackingStatuses: [],
+    sponsors: [],
+    includeStaffPermissions: false,
+    includeInsights: false
   });
 }
 

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -229,7 +229,7 @@ describe('TeamDetail', () => {
   });
 
   it('shows the shared team skeleton while team detail is loading', () => {
-    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockReturnValue(new Promise(() => {}));
+    teamDetailServiceMocks.loadParentTeamDetail.mockReturnValue(new Promise(() => {}));
 
     render(
       <MemoryRouter initialEntries={['/teams/team-1']}>
@@ -244,7 +244,7 @@ describe('TeamDetail', () => {
   });
 
   it('shows a retryable team detail error state and reloads on retry', async () => {
-    teamDetailServiceMocks.loadParentTeamDetailBootstrap
+    teamDetailServiceMocks.loadParentTeamDetail
       .mockRejectedValueOnce(new Error('Team detail unavailable.'))
       .mockResolvedValueOnce(model);
 
@@ -260,10 +260,10 @@ describe('TeamDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 
     expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
-    expect(teamDetailServiceMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledTimes(2);
+    expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
   });
 
-  it('uses the lightweight bootstrap on overview and defers full detail until schedule opens', async () => {
+  it('uses the lightweight bootstrap on roster and defers full detail until schedule opens', async () => {
     teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockResolvedValue({
       ...model,
       upcomingEvents: [],
@@ -298,7 +298,7 @@ describe('TeamDetail', () => {
     });
 
     render(
-      <MemoryRouter initialEntries={['/teams/team-1']}>
+      <MemoryRouter initialEntries={['/teams/team-1?tab=roster']}>
         <Routes>
           <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
         </Routes>
@@ -313,6 +313,127 @@ describe('TeamDetail', () => {
 
     await waitFor(() => expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1));
     expect(await screen.findByText('Bears vs Tigers')).toBeTruthy();
+  });
+
+  it('hydrates overview collections before rendering the default team hub stats', async () => {
+    const nextEvent = {
+      id: 'game-next',
+      title: 'Bears vs Tigers',
+      type: 'game',
+      date: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      location: 'Main Gym',
+      opponent: 'Tigers',
+      status: 'scheduled',
+      liveStatus: '',
+      visibility: 'public',
+      isPrivate: false,
+      isPublic: true,
+      shareable: true,
+      publicCalendar: true,
+      homeScore: null,
+      awayScore: null,
+      isCancelled: false,
+      statTrackerConfigId: '',
+      statTrackerConfigLabel: 'No config assigned',
+      statTrackerConfigBaseType: '',
+      statTrackerConfigExists: false,
+      statTrackerConfigIsBasketball: false
+    };
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      upcomingEvents: [nextEvent],
+      recentResults: [{
+        id: 'game-final',
+        title: 'Bears vs Wolves',
+        type: 'game',
+        date: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        location: 'Main Gym',
+        opponent: 'Wolves',
+        status: 'completed',
+        liveStatus: 'completed',
+        visibility: 'public',
+        isPrivate: false,
+        isPublic: true,
+        shareable: true,
+        publicCalendar: true,
+        homeScore: 60,
+        awayScore: 55,
+        isCancelled: false,
+        statTrackerConfigId: '',
+        statTrackerConfigLabel: 'No config assigned',
+        statTrackerConfigBaseType: '',
+        statTrackerConfigExists: false,
+        statTrackerConfigIsBasketball: false
+      }],
+      nextEvent,
+      counts: { games: 2, practices: 0, completedGames: 1 }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(screen.getByText(/Bears vs Tigers/i)).toBeTruthy();
+    expect(teamDetailServiceMocks.loadParentTeamDetailBootstrap).not.toHaveBeenCalled();
+    expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces deferred team collection failures on the schedule tab and lets users retry', async () => {
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockResolvedValue({
+      ...model,
+      upcomingEvents: [],
+      recentResults: [],
+      statTrackerConfigs: []
+    });
+    teamDetailServiceMocks.loadParentTeamDetail
+      .mockRejectedValueOnce(new Error('Schedule load failed.'))
+      .mockResolvedValueOnce({
+        ...model,
+        upcomingEvents: [{
+          id: 'game-next',
+          title: 'Bears vs Tigers',
+          type: 'game',
+          date: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          location: 'Main Gym',
+          opponent: 'Tigers',
+          status: 'scheduled',
+          liveStatus: '',
+          visibility: 'public',
+          isPrivate: false,
+          isPublic: true,
+          shareable: true,
+          publicCalendar: true,
+          homeScore: null,
+          awayScore: null,
+          isCancelled: false,
+          statTrackerConfigId: '',
+          statTrackerConfigLabel: 'No config assigned',
+          statTrackerConfigBaseType: '',
+          statTrackerConfigExists: false,
+          statTrackerConfigIsBasketball: false
+        }]
+      });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=schedule']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Schedule load failed.')).toBeTruthy();
+    expect(screen.queryByText('No team events found.')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('Bears vs Tigers')).toBeTruthy();
+    expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
   });
 
   it('retries a retryable RSVP reminder preview failure from the shared error state', async () => {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -17,6 +17,7 @@ const teamDetailServiceMocks = vi.hoisted(() => ({
   grantVideographerAccessForApp: vi.fn(),
   inviteTeamAdminForApp: vi.fn(),
   loadParentTeamDetail: vi.fn(),
+  loadParentTeamDetailBootstrap: vi.fn(),
   loadRosterFieldDefinitionsForApp: vi.fn(),
   loadTeamDetailInsights: vi.fn(),
   loadTeamDetailSponsors: vi.fn(),
@@ -180,6 +181,7 @@ describe('TeamDetail', () => {
       writable: true
     });
     teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(model);
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockImplementation((...args: any[]) => teamDetailServiceMocks.loadParentTeamDetail(...args));
     teamDetailServiceMocks.loadRosterFieldDefinitionsForApp.mockResolvedValue([]);
     teamDetailServiceMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [] });
     teamDetailServiceMocks.loadTeamDetailSponsors.mockResolvedValue({ sponsors: [] });
@@ -227,7 +229,7 @@ describe('TeamDetail', () => {
   });
 
   it('shows the shared team skeleton while team detail is loading', () => {
-    teamDetailServiceMocks.loadParentTeamDetail.mockReturnValue(new Promise(() => {}));
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockReturnValue(new Promise(() => {}));
 
     render(
       <MemoryRouter initialEntries={['/teams/team-1']}>
@@ -242,7 +244,7 @@ describe('TeamDetail', () => {
   });
 
   it('shows a retryable team detail error state and reloads on retry', async () => {
-    teamDetailServiceMocks.loadParentTeamDetail
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap
       .mockRejectedValueOnce(new Error('Team detail unavailable.'))
       .mockResolvedValueOnce(model);
 
@@ -258,7 +260,59 @@ describe('TeamDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 
     expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
-    expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+    expect(teamDetailServiceMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the lightweight bootstrap on overview and defers full detail until schedule opens', async () => {
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockResolvedValue({
+      ...model,
+      upcomingEvents: [],
+      recentResults: [],
+      statTrackerConfigs: []
+    });
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      upcomingEvents: [{
+        id: 'game-next',
+        title: 'Bears vs Tigers',
+        type: 'game',
+        date: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        location: 'Main Gym',
+        opponent: 'Tigers',
+        status: 'scheduled',
+        liveStatus: '',
+        visibility: 'public',
+        isPrivate: false,
+        isPublic: true,
+        shareable: true,
+        publicCalendar: true,
+        homeScore: null,
+        awayScore: null,
+        isCancelled: false,
+        statTrackerConfigId: '',
+        statTrackerConfigLabel: 'No config assigned',
+        statTrackerConfigBaseType: '',
+        statTrackerConfigExists: false,
+        statTrackerConfigIsBasketball: false
+      }]
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(teamDetailServiceMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledTimes(1);
+    expect(teamDetailServiceMocks.loadParentTeamDetail).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /schedule/i }));
+
+    await waitFor(() => expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Bears vs Tigers')).toBeTruthy();
   });
 
   it('retries a retryable RSVP reminder preview failure from the shared error state', async () => {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -36,7 +36,7 @@ import { getEventDetailPath } from '../lib/homeLogic';
 import { buildPrivateTeamCalendarFeedUrl, getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl } from '../lib/parentToolsService';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { addRosterPlayerForApp, archiveTeamTrackingItemForApp, buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, createRosterParentInviteForApp, createStatTrackerConfigForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadRosterFieldDefinitionsForApp, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamRosterParentInvites, loadTeamStaffPermissions, loadTeamTrackingAdmin, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeTeamAdminAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, saveTeamTrackingItemForApp, setPlayerTrackingStatusForApp, updateStatTrackerConfigForApp, type CreateRosterParentInviteForAppResult, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamRosterFieldDefinition, type TeamRosterParentInviteSummary, type TeamScorekeeperGrantTarget, type TeamTrackingAdminItem } from '../lib/teamDetailService';
+import { addRosterPlayerForApp, archiveTeamTrackingItemForApp, buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, createRosterParentInviteForApp, createStatTrackerConfigForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadParentTeamDetailBootstrap, loadRosterFieldDefinitionsForApp, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamRosterParentInvites, loadTeamStaffPermissions, loadTeamTrackingAdmin, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeTeamAdminAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, saveTeamTrackingItemForApp, setPlayerTrackingStatusForApp, updateStatTrackerConfigForApp, type CreateRosterParentInviteForAppResult, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamRosterFieldDefinition, type TeamRosterParentInviteSummary, type TeamScorekeeperGrantTarget, type TeamTrackingAdminItem } from '../lib/teamDetailService';
 import { buildStatTrackerConfigPayload, createBlankStatTrackerConfigColumnDraft, createEmptyStatTrackerConfigDraft, createStatTrackerConfigDraft, createStatTrackerConfigDraftFromPreset, getStatTrackerConfigPresetCatalog, validateStatTrackerConfigDraft, type StatTrackerConfigDraft } from '../lib/statTrackerConfigEditor';
 import type { AuthState } from '../lib/types';
 
@@ -96,6 +96,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   const [trackingError, setTrackingError] = useState('');
   const [trackingAttempted, setTrackingAttempted] = useState(false);
   const [trackingItems, setTrackingItems] = useState<TeamTrackingAdminItem[]>([]);
+  const [detailCollectionsLoaded, setDetailCollectionsLoaded] = useState(false);
 
   function navigateToTab(nextTab: TeamTab) {
     if (nextTab === activeTab) return;
@@ -121,9 +122,10 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       setLoading(true);
       setError(null);
       try {
-        const nextModel = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
+        const nextModel = await loadParentTeamDetailBootstrap(teamId, auth.user);
         if (!cancelled) {
           setModel(nextModel);
+          setDetailCollectionsLoaded(false);
           setStaffPermissionsError('');
           setStaffPermissionsLoading(false);
           setInsightsLoading(false);
@@ -171,6 +173,33 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       cancelled = true;
     };
   }, [authUserId, teamId, reloadVersion]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadDeferredTeamCollections() {
+      if (!teamId || !model || detailCollectionsLoaded || (activeTab !== 'schedule' && activeTab !== 'more')) return;
+      try {
+        const nextModel = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
+        if (!cancelled) {
+          setModel((currentModel) => currentModel ? {
+            ...nextModel,
+            leaderboards: currentModel.leaderboards,
+            trackingSummaries: currentModel.trackingSummaries,
+            sponsors: currentModel.sponsors,
+            staffPermissions: currentModel.staffPermissions || nextModel.staffPermissions
+          } : nextModel);
+          setDetailCollectionsLoaded(true);
+        }
+      } catch {
+        // Keep the lightweight model visible. The schedule or more tab can still surface its own empty state.
+      }
+    }
+
+    void loadDeferredTeamCollections();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, auth.user, detailCollectionsLoaded, model, teamId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -319,12 +348,15 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
 
   async function refreshTeamDetail() {
     if (!teamId) return;
-    const nextModel = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
+    const nextModel = detailCollectionsLoaded || activeTab === 'schedule' || activeTab === 'more'
+      ? await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false })
+      : await loadParentTeamDetailBootstrap(teamId, auth.user);
     const mergedModel = {
       ...nextModel,
       leaderboards: model?.leaderboards || nextModel.leaderboards,
       trackingSummaries: model?.trackingSummaries || nextModel.trackingSummaries,
-      sponsors: model?.sponsors || nextModel.sponsors
+      sponsors: model?.sponsors || nextModel.sponsors,
+      staffPermissions: model?.staffPermissions || nextModel.staffPermissions
     };
     if (activeTab === 'more' && nextModel.canManageTeam) {
       const staffPermissions = await loadTeamStaffPermissions(teamId, auth.user);

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -97,6 +97,9 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   const [trackingAttempted, setTrackingAttempted] = useState(false);
   const [trackingItems, setTrackingItems] = useState<TeamTrackingAdminItem[]>([]);
   const [detailCollectionsLoaded, setDetailCollectionsLoaded] = useState(false);
+  const [detailCollectionsLoading, setDetailCollectionsLoading] = useState(false);
+  const [detailCollectionsError, setDetailCollectionsError] = useState('');
+  const [detailCollectionsReloadVersion, setDetailCollectionsReloadVersion] = useState(0);
 
   function navigateToTab(nextTab: TeamTab) {
     if (nextTab === activeTab) return;
@@ -122,10 +125,16 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       setLoading(true);
       setError(null);
       try {
-        const nextModel = await loadParentTeamDetailBootstrap(teamId, auth.user);
+        const shouldHydrateOverviewCollections = activeTab === 'overview';
+        const nextModel = shouldHydrateOverviewCollections
+          ? await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false })
+          : await loadParentTeamDetailBootstrap(teamId, auth.user);
         if (!cancelled) {
           setModel(nextModel);
-          setDetailCollectionsLoaded(false);
+          setDetailCollectionsLoaded(shouldHydrateOverviewCollections);
+          setDetailCollectionsLoading(false);
+          setDetailCollectionsError('');
+          setDetailCollectionsReloadVersion(0);
           setStaffPermissionsError('');
           setStaffPermissionsLoading(false);
           setInsightsLoading(false);
@@ -147,6 +156,10 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
         if (!cancelled) {
           setError(toAppServiceError(loadError, 'Unable to load this team.'));
           setModel(null);
+          setDetailCollectionsLoaded(false);
+          setDetailCollectionsLoading(false);
+          setDetailCollectionsError('');
+          setDetailCollectionsReloadVersion(0);
           setStaffPermissionsError('');
           setStaffPermissionsLoading(false);
           setInsightsLoading(false);
@@ -177,7 +190,9 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   useEffect(() => {
     let cancelled = false;
     async function loadDeferredTeamCollections() {
-      if (!teamId || !model || detailCollectionsLoaded || (activeTab !== 'schedule' && activeTab !== 'more')) return;
+      if (!teamId || !model || detailCollectionsLoaded || detailCollectionsLoading || detailCollectionsError || (activeTab !== 'schedule' && activeTab !== 'more')) return;
+      setDetailCollectionsLoading(true);
+      setDetailCollectionsError('');
       try {
         const nextModel = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
         if (!cancelled) {
@@ -190,8 +205,12 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
           } : nextModel);
           setDetailCollectionsLoaded(true);
         }
-      } catch {
-        // Keep the lightweight model visible. The schedule or more tab can still surface its own empty state.
+      } catch (loadError: any) {
+        if (!cancelled) {
+          setDetailCollectionsError(loadError?.message || 'Unable to load team schedule and settings.');
+        }
+      } finally {
+        if (!cancelled) setDetailCollectionsLoading(false);
       }
     }
 
@@ -199,7 +218,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, auth.user, detailCollectionsLoaded, model, teamId]);
+  }, [activeTab, auth.user, detailCollectionsError, detailCollectionsLoaded, detailCollectionsLoading, detailCollectionsReloadVersion, model, teamId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -458,10 +477,20 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       </section>
 
       {activeTab === 'overview' ? <OverviewTab model={model} /> : null}
-      {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} onOpenStatTrackerConfigs={() => navigateToTab('more')} /> : null}
+      {activeTab === 'schedule' ? (
+        detailCollectionsLoading ? <InlineDeferredLoading copy="Loading team schedule…" /> : detailCollectionsError ? <DeferredCollectionsErrorState message={detailCollectionsError} onRetry={() => {
+          setDetailCollectionsError('');
+          setDetailCollectionsReloadVersion((current) => current + 1);
+        }} /> : <ScheduleTab model={model} auth={auth} onOpenStatTrackerConfigs={() => navigateToTab('more')} />
+      ) : null}
       {activeTab === 'roster' ? <RosterTab model={model} authUser={auth.user} onRefresh={refreshTeamDetail} rosterInviteLoading={rosterInviteLoading} rosterInviteError={rosterInviteError} rosterInviteSummaries={rosterInviteSummaries} onInviteCreated={refreshRosterInvites} trackingLoading={trackingLoading} trackingError={trackingError} trackingItems={trackingItems} onTrackingChanged={refreshTrackingItems} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} loading={insightsLoading} error={insightsError} /> : null}
-      {activeTab === 'more' ? <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} sponsorsLoading={sponsorsLoading} sponsorsError={sponsorsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
+      {activeTab === 'more' ? (
+        detailCollectionsLoading ? <InlineDeferredLoading copy="Loading team settings…" /> : detailCollectionsError ? <DeferredCollectionsErrorState message={detailCollectionsError} onRetry={() => {
+          setDetailCollectionsError('');
+          setDetailCollectionsReloadVersion((current) => current + 1);
+        }} /> : <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} sponsorsLoading={sponsorsLoading} sponsorsError={sponsorsError} onTeamDetailRefresh={refreshTeamDetail} />
+      ) : null}
     </div>
   );
 }
@@ -1766,6 +1795,17 @@ function formatConfigColumnSummary(columnCount: number, columnNames: string[]) {
   const preview = columnNames.slice(0, 3).join(', ');
   const remainder = columnCount - Math.min(columnNames.length, 3);
   return `${columnCount} column${columnCount === 1 ? '' : 's'}${preview ? ` · ${preview}${remainder > 0 ? ` +${remainder}` : ''}` : ''}`;
+}
+
+function DeferredCollectionsErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <section className="app-card p-4">
+      <InlineDeferredError title="Team detail unavailable" message={message} />
+      <button type="button" className="secondary-button mt-3 !min-h-9 text-xs" onClick={onRetry}>
+        Retry
+      </button>
+    </section>
+  );
 }
 
 function InlineDeferredLoading({ copy }: { copy: string }) {

--- a/apps/app/src/pages/TeamSettings.test.tsx
+++ b/apps/app/src/pages/TeamSettings.test.tsx
@@ -7,6 +7,7 @@ import type { AuthState } from '../lib/types';
 
 const teamDetailServiceMocks = vi.hoisted(() => ({
   loadParentTeamDetail: vi.fn(),
+  loadParentTeamDetailBootstrap: vi.fn(),
   updateTeamSettingsForApp: vi.fn()
 }));
 
@@ -89,7 +90,7 @@ describe('TeamSettings', () => {
       value: vi.fn(),
       writable: true
     });
-    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(managedModel);
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockResolvedValue(managedModel);
     teamDetailServiceMocks.updateTeamSettingsForApp.mockResolvedValue(undefined);
   });
 
@@ -98,7 +99,7 @@ describe('TeamSettings', () => {
   });
 
   it('blocks non-staff users from the direct edit route', async () => {
-    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockResolvedValue({
       ...managedModel,
       canManageTeam: false
     });
@@ -116,7 +117,7 @@ describe('TeamSettings', () => {
   });
 
   it('shows a retry path when the initial team settings load fails', async () => {
-    teamDetailServiceMocks.loadParentTeamDetail
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap
       .mockRejectedValueOnce(new Error('Unable to load team settings.'))
       .mockResolvedValueOnce(managedModel);
 
@@ -135,7 +136,7 @@ describe('TeamSettings', () => {
 
     expect(await screen.findByRole('heading', { name: 'Edit team' })).toBeTruthy();
     await waitFor(() => {
-      expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+      expect(teamDetailServiceMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -212,12 +213,12 @@ describe('TeamSettings', () => {
 
     expect(nameInput.value).toBe('Updated Bears');
     await waitFor(() => {
-      expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+      expect(teamDetailServiceMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledTimes(1);
     });
   });
 
   it('defaults legacy teams without visibility set to public on save', async () => {
-    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockResolvedValue({
       ...managedModel,
       team: {
         ...managedModel.team,
@@ -253,7 +254,7 @@ describe('TeamSettings', () => {
     const teamOneLoad = createDeferred<typeof managedModel>();
     const teamTwoLoad = createDeferred<typeof managedModel>();
 
-    teamDetailServiceMocks.loadParentTeamDetail.mockImplementation((requestedTeamId: string) => {
+    teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockImplementation((requestedTeamId: string) => {
       if (requestedTeamId === 'team-1') return teamOneLoad.promise;
       if (requestedTeamId === 'team-2') return teamTwoLoad.promise;
       throw new Error(`Unexpected team id: ${requestedTeamId}`);
@@ -294,5 +295,19 @@ describe('TeamSettings', () => {
       expect((screen.getByPlaceholderText('Team name') as HTMLInputElement).value).toBe('Wolves');
       expect((screen.getByPlaceholderText('Basketball') as HTMLInputElement).value).toBe('Soccer');
     });
+  });
+
+  it('loads edit settings from the lightweight bootstrap path', async () => {
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1/edit']}>
+        <Routes>
+          <Route path="/teams/:teamId/edit" element={<TeamSettings auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Edit team' })).toBeTruthy();
+    expect(teamDetailServiceMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledTimes(1);
+    expect(teamDetailServiceMocks.loadParentTeamDetail).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/pages/TeamSettings.tsx
+++ b/apps/app/src/pages/TeamSettings.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, Camera, Loader2, RefreshCw, Save } from 'lucide-react';
-import { loadParentTeamDetail, updateTeamSettingsForApp } from '../lib/teamDetailService';
+import { loadParentTeamDetailBootstrap, updateTeamSettingsForApp } from '../lib/teamDetailService';
 import { normalizeOptionalHttpUrl, parseTeamLivestreamInput } from '../lib/teamLinks';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
 import type { AuthState } from '../lib/types';
@@ -44,7 +44,7 @@ export function TeamSettings({ auth }: { auth: AuthState }) {
     activeLoadIdRef.current = loadId;
 
     return runPrimaryLoad(
-      () => loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false }),
+      () => loadParentTeamDetailBootstrap(teamId, auth.user),
       {
         errorMessage: 'Unable to load team settings.',
         rethrow: false,

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -491,7 +491,11 @@ async function mockHomePlayerModules(page) {
                     return [];
                 }
 
-                export async function loadParentTeamDetail() {
+                export async function loadParentTeamDetailBootstrap(teamId) {
+                    return loadParentTeamDetail(teamId);
+                }
+
+                export async function loadParentTeamDetail(teamId = 'team-1') {
                     const nextDate = new Date('2100-06-01T18:00:00Z');
                     return {
                         team: {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -363,6 +363,10 @@ async function mockSearchModules(page) {
                     return [];
                 }
 
+                export async function loadParentTeamDetailBootstrap(teamId) {
+                    return loadParentTeamDetail(teamId);
+                }
+
                 export async function loadParentTeamDetail(teamId) {
                     const isRockets = teamId === 'team-2';
                     return {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -338,6 +338,10 @@ async function mockTeamsModules(page, { scenario = '' } = {}) {
                     return [];
                 }
 
+                export async function loadParentTeamDetailBootstrap(teamId) {
+                    return loadParentTeamDetail(teamId);
+                }
+
                 export async function loadParentTeamDetail(teamId) {
                     if (teamId === 'team-empty') {
                         return {

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -7,6 +7,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 const teamDetailMocks = vi.hoisted(() => ({
     addRosterPlayerForApp: vi.fn(),
     loadParentTeamDetail: vi.fn(),
+    loadParentTeamDetailBootstrap: vi.fn(),
     loadRosterFieldDefinitionsForApp: vi.fn(),
     loadTeamDetailInsights: vi.fn(),
     loadTeamDetailSponsors: vi.fn(),
@@ -43,6 +44,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
     addRosterPlayerForApp: teamDetailMocks.addRosterPlayerForApp,
     loadParentTeamDetail: teamDetailMocks.loadParentTeamDetail,
+    loadParentTeamDetailBootstrap: teamDetailMocks.loadParentTeamDetailBootstrap,
     loadRosterFieldDefinitionsForApp: teamDetailMocks.loadRosterFieldDefinitionsForApp,
     loadTeamDetailInsights: teamDetailMocks.loadTeamDetailInsights,
     loadTeamDetailSponsors: teamDetailMocks.loadTeamDetailSponsors,
@@ -310,7 +312,8 @@ beforeEach(() => {
         summary: 'Team default reminder window: 24 hours before event start.'
     });
     teamDetailMocks.loadTeamStaffPermissions.mockResolvedValue(null);
-    teamDetailMocks.loadParentTeamDetail.mockResolvedValue(coreModel());
+    teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValue(coreModel());
+    teamDetailMocks.loadParentTeamDetail.mockResolvedValue(model());
     teamDetailMocks.loadTeamDetailInsights.mockResolvedValue(deferredInsightsModel());
     teamDetailMocks.loadTeamDetailSponsors.mockResolvedValue(deferredSponsorsModel());
 });
@@ -328,7 +331,7 @@ describe('React app TeamDetail page', () => {
     it('loads parent-facing team.html features with team and player photos', async () => {
         const { container } = await renderTeamDetail();
 
-        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledWith('team-1', auth.user, { includeDeferredData: false });
+        expect(teamDetailMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledWith('team-1', auth.user);
         expect(container.textContent).toContain('Bears');
         expect(container.querySelector('img[src="https://img.example.test/team.png"]')).toBeTruthy();
         expect(container.textContent).toContain('Season record (2100)');
@@ -369,6 +372,7 @@ describe('React app TeamDetail page', () => {
         const fanModel = model();
         fanModel.team.id = 'team 1/blue';
         fanModel.team.name = 'Bears & Wolves';
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(fanModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(fanModel);
         parentToolsMocks.buildPrivateTeamCalendarFeedUrl.mockReturnValue('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
 
@@ -397,6 +401,7 @@ describe('React app TeamDetail page', () => {
         const fanModel = model();
         fanModel.team.id = 'team 1/blue';
         fanModel.team.name = 'Bears & Wolves';
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(fanModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(fanModel);
 
         const { container } = await renderTeamDetail();
@@ -422,6 +427,7 @@ describe('React app TeamDetail page', () => {
         ];
         hiddenModel.recentResults = [];
         hiddenModel.nextEvent = hiddenModel.upcomingEvents[0];
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(hiddenModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(hiddenModel);
         const hidden = await renderTeamDetail();
         await clickButton(hidden.container, 'More');
@@ -451,6 +457,7 @@ describe('React app TeamDetail page', () => {
         managerModel.canManageTeam = true;
         managerModel.team.id = 'team 1/blue';
         managerModel.team.name = 'Bears & Wolves';
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(managerModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
 
         const { container } = await renderTeamDetail();
@@ -470,6 +477,7 @@ describe('React app TeamDetail page', () => {
         expect(container.textContent).toContain('Widget link copied.');
 
         const parentModel = model();
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(parentModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(parentModel);
         const hidden = await renderTeamDetail();
         await clickButton(hidden.container, 'More');
@@ -486,6 +494,7 @@ describe('React app TeamDetail page', () => {
             hasExplicitReminderHours: true,
             summary: 'Team default reminder window: 72 hours before event start.'
         };
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(managerModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel).mockResolvedValueOnce({
             ...managerModel,
             team: {
@@ -522,6 +531,7 @@ describe('React app TeamDetail page', () => {
         expect(container.textContent).toContain('Team default reminder window: 48 hours before event start.');
 
         const parentModel = model();
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(parentModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(parentModel);
         const hidden = await renderTeamDetail();
         await clickButton(hidden.container, 'More');
@@ -532,6 +542,7 @@ describe('React app TeamDetail page', () => {
         const managerModel = model();
         managerModel.canManageTeam = true;
         managerModel.staffPermissions = null;
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(managerModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
         let resolveStaffPermissions;
         teamDetailMocks.loadTeamStaffPermissions.mockImplementationOnce(() => new Promise((resolve) => {
@@ -580,18 +591,18 @@ describe('React app TeamDetail page', () => {
     it('loads deferred insights and sponsors once, then reuses them across tab switches', async () => {
         const { container } = await renderTeamDetail();
 
-        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+        expect(teamDetailMocks.loadParentTeamDetail).not.toHaveBeenCalled();
         expect(teamDetailMocks.loadTeamDetailInsights).not.toHaveBeenCalled();
         expect(teamDetailMocks.loadTeamDetailSponsors).not.toHaveBeenCalled();
 
         await clickButton(container, 'Insights');
-        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+        expect(teamDetailMocks.loadParentTeamDetail).not.toHaveBeenCalled();
         expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
         expect(container.textContent).toContain('Bring ball');
 
         await clickButton(container, 'Overview');
         await clickButton(container, 'Insights');
-        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+        expect(teamDetailMocks.loadParentTeamDetail).not.toHaveBeenCalled();
         expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
 
         await clickButton(container, 'More');
@@ -694,6 +705,7 @@ describe('React app TeamDetail page', () => {
             { id: 'game-2', type: 'game', title: 'at Tigers', date: new Date('2100-06-03T18:00:00Z'), location: 'North Gym', opponent: 'Tigers', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false, statTrackerConfigId: '', statTrackerConfigLabel: 'No config assigned', statTrackerConfigBaseType: '', statTrackerConfigExists: false, statTrackerConfigIsBasketball: false }
         ];
         managerModel.nextEvent = managerModel.upcomingEvents[0];
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(managerModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
         scheduleServiceMocks.loadPreview.mockResolvedValueOnce({
             missingPlayerCount: 3,
@@ -762,6 +774,7 @@ describe('React app TeamDetail page', () => {
             columnNames: ['PTS', 'REB', 'AST', 'STL'],
             assignedUpcomingGames: [{ gameId: 'game-1', title: 'vs. Falcons', date: new Date('2100-06-01T18:00:00Z') }]
         }];
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(managerModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
 
         const { container } = await renderTeamDetail(managerAuth);
@@ -777,6 +790,7 @@ describe('React app TeamDetail page', () => {
         expect(container.textContent).toContain('vs. Falcons · Tue, Jun 1');
         expect(container.textContent).toContain('Missing config assignments');
 
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(model());
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(model());
         const hidden = await renderTeamDetail();
         await clickButton(hidden.container, 'Schedule');
@@ -788,6 +802,7 @@ describe('React app TeamDetail page', () => {
     it('hides inline RSVP reminders for parents and events with no missing players', async () => {
         const parentModel = model();
         parentModel.canManageTeam = false;
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(parentModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(parentModel);
 
         const { container } = await renderTeamDetail();
@@ -816,6 +831,7 @@ describe('React app TeamDetail page', () => {
         emptyModel.trackingSummaries = [];
         emptyModel.sponsors = [];
         emptyModel.counts = { games: 0, practices: 0, completedGames: 0 };
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(emptyModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(emptyModel);
         teamDetailMocks.loadTeamDetailInsights.mockResolvedValueOnce({ leaderboards: [], trackingSummaries: [] });
         teamDetailMocks.loadTeamDetailSponsors.mockResolvedValueOnce({ sponsors: [] });
@@ -839,7 +855,7 @@ describe('React app TeamDetail page', () => {
     });
 
     it('shows the team unavailable state with a route back to teams', async () => {
-        teamDetailMocks.loadParentTeamDetail.mockRejectedValueOnce(new Error('No team access'));
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockRejectedValueOnce(new Error('No team access'));
         const { container } = await renderTeamDetail();
 
         expect(container.textContent).toContain('Team unavailable');

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -331,7 +331,8 @@ describe('React app TeamDetail page', () => {
     it('loads parent-facing team.html features with team and player photos', async () => {
         const { container } = await renderTeamDetail();
 
-        expect(teamDetailMocks.loadParentTeamDetailBootstrap).toHaveBeenCalledWith('team-1', auth.user);
+        expect(teamDetailMocks.loadParentTeamDetailBootstrap).not.toHaveBeenCalled();
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledWith('team-1', auth.user, { includeDeferredData: false });
         expect(container.textContent).toContain('Bears');
         expect(container.querySelector('img[src="https://img.example.test/team.png"]')).toBeTruthy();
         expect(container.textContent).toContain('Season record (2100)');
@@ -591,18 +592,18 @@ describe('React app TeamDetail page', () => {
     it('loads deferred insights and sponsors once, then reuses them across tab switches', async () => {
         const { container } = await renderTeamDetail();
 
-        expect(teamDetailMocks.loadParentTeamDetail).not.toHaveBeenCalled();
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailInsights).not.toHaveBeenCalled();
         expect(teamDetailMocks.loadTeamDetailSponsors).not.toHaveBeenCalled();
 
         await clickButton(container, 'Insights');
-        expect(teamDetailMocks.loadParentTeamDetail).not.toHaveBeenCalled();
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
         expect(container.textContent).toContain('Bring ball');
 
         await clickButton(container, 'Overview');
         await clickButton(container, 'Insights');
-        expect(teamDetailMocks.loadParentTeamDetail).not.toHaveBeenCalled();
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
 
         await clickButton(container, 'More');
@@ -855,7 +856,7 @@ describe('React app TeamDetail page', () => {
     });
 
     it('shows the team unavailable state with a route back to teams', async () => {
-        teamDetailMocks.loadParentTeamDetailBootstrap.mockRejectedValueOnce(new Error('No team access'));
+        teamDetailMocks.loadParentTeamDetail.mockRejectedValueOnce(new Error('No team access'));
         const { container } = await renderTeamDetail();
 
         expect(container.textContent).toContain('Team unavailable');

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -7,6 +7,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 const teamDetailMocks = vi.hoisted(() => ({
     addRosterPlayerForApp: vi.fn(),
     loadParentTeamDetail: vi.fn(),
+    loadParentTeamDetailBootstrap: vi.fn(),
     loadRosterFieldDefinitionsForApp: vi.fn(),
     loadTeamDetailInsights: vi.fn(),
     loadTeamDetailSponsors: vi.fn(),
@@ -97,6 +98,7 @@ function makeModel(staffPermissions) {
 }
 
 async function renderTeamDetail(staffPermissions) {
+    teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValue(makeModel(staffPermissions));
     teamDetailMocks.loadParentTeamDetail.mockResolvedValue(makeModel(staffPermissions));
     teamDetailMocks.loadTeamStaffPermissions.mockResolvedValue(staffPermissions);
     const container = document.createElement('div');


### PR DESCRIPTION
Closes #3155

## What changed
- added a lightweight `loadParentTeamDetailBootstrap` path that loads only the team document and roster for initial Team Detail overview and Team Settings entry
- taught the shared team-detail snapshot cache to distinguish between bootstrap data and fully hydrated games/config data
- updated Team Detail to defer the full games/config load until a schedule-dependent surface is opened
- updated Team Settings to use the lightweight bootstrap path
- added regression coverage at both service and page level to lock in the loader call behavior

## Root Cause
The shared base snapshot loader always fetched games and stat-tracker configs up front, and both Team Detail overview and Team Settings reused that broad loader. As a result, `includeDeferredData: false` still paid for full collection reads and normalization work before those screens needed schedule, standings, or config data.

## Prevention / Learning
When a screen only needs bootstrap metadata, do not route it through a shared "full detail" loader. Keep bootstrap and deferred data paths explicit, and add call-count assertions in tests so UI mocks cannot hide unnecessary collection reads.

## Regression Tests
- `apps/app/src/lib/teamDetailService.test.ts` proves the bootstrap path skips games/config reads and the deferred detail path loads them when requested
- `apps/app/src/pages/TeamDetail.test.tsx` proves overview uses the lightweight bootstrap and only triggers full detail loading after opening Schedule
- `apps/app/src/pages/TeamSettings.test.tsx` proves Edit Team initializes through the lightweight bootstrap path
- focused validation run: `cd apps/app && npx vitest run src/pages/TeamDetail.test.tsx src/pages/TeamSettings.test.tsx src/lib/teamDetailService.test.ts`