### PR TITLE
Hide dead-end event detail tabs

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -637,6 +637,64 @@ describe('ScheduleEventDetail route state', () => {
 
 });
 
+describe('ScheduleEventDetail nav visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('hides rideshare and assignments tabs for inactive events with no related data', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isDbGame: false,
+        isCancelled: true,
+        rideshareSummary: { offerCount: 0, seatsLeft: 0, requests: 0, pending: 0, confirmed: 0, isFull: false },
+        assignments: []
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetailWithLocation();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Rideshare' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Assignments' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Availability' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+  });
+
+  it('keeps rideshare and assignments tabs when inactive events still have related data', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isDbGame: false,
+        isCancelled: true,
+        rideshareSummary: { offerCount: 1, seatsLeft: 0, requests: 0, pending: 0, confirmed: 1, isFull: true },
+        assignments: [{ role: 'Snacks', value: '', claimable: true, claim: null }]
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+    });
+
+    expect(screen.getAllByRole('button', { name: 'Rideshare' }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole('button', { name: 'Assignments' }).length).toBeGreaterThan(0);
+  });
+});
+
 describe('ScheduleEventDetail rideshare permissions', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -168,14 +168,37 @@ const hubIconComponents: Record<ScheduleHubIcon, LucideIcon> = {
   users: Users
 };
 
+function isActiveTrackedScheduleEvent(event?: ParentScheduleEvent | null) {
+  return Boolean(event?.isDbGame && !event?.isCancelled);
+}
+
+function hasRideshareActivity(event?: ParentScheduleEvent | null) {
+  const summary = event?.rideshareSummary;
+  if (!summary) return false;
+  return [summary.offerCount, summary.requests, summary.pending, summary.confirmed, summary.seatsLeft]
+    .some((value) => Number(value || 0) > 0);
+}
+
+function hasAssignmentsPosted(event?: ParentScheduleEvent | null) {
+  return Array.isArray(event?.assignments) && event.assignments.length > 0;
+}
+
 function getEventDetailSections(event?: ParentScheduleEvent | null): Array<{ id: EventDetailSectionId; label: string; shortLabel?: string }> {
   const eventLabel = event?.type === 'practice' ? 'More' : 'Game';
-  return [
-    { id: 'availability', label: 'Availability' },
-    { id: 'rideshare', label: 'Rideshare' },
-    { id: 'assignments', label: 'Assignments', shortLabel: 'Tasks' },
-    { id: 'game', label: eventLabel }
+  const sections: Array<{ id: EventDetailSectionId; label: string; shortLabel?: string }> = [
+    { id: 'availability', label: 'Availability' }
   ];
+
+  if (isActiveTrackedScheduleEvent(event) || hasRideshareActivity(event)) {
+    sections.push({ id: 'rideshare', label: 'Rideshare' });
+  }
+
+  if (isActiveTrackedScheduleEvent(event) || hasAssignmentsPosted(event)) {
+    sections.push({ id: 'assignments', label: 'Assignments', shortLabel: 'Tasks' });
+  }
+
+  sections.push({ id: 'game', label: eventLabel });
+  return sections;
 }
 
 function getScheduleEventDetailLoadErrorMessage(error: AppServiceError, hasExistingEvent: boolean) {
@@ -439,6 +462,8 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const hasPracticePacket = selectedEvent.type === 'practice' && Boolean(selectedEvent.practiceHomePacketSummary);
   const attentionItems = getAttentionItems(selectedEvent, rsvp).filter((item) => item.section !== 'availability' && item.title !== 'Practice packet ready');
   const sections = getEventDetailSections(selectedEvent);
+  const sectionIds = new Set(sections.map((section) => section.id));
+  const resolvedActiveSection = sectionIds.has(activeSection) ? activeSection : sections[0]?.id || 'availability';
 
   const addEventToCalendar = async () => {
     const icsTitle = `${title} | ${selectedEvent.teamName}`;
@@ -517,7 +542,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
               className="event-workflow-nav event-nav-desktop mt-3"
               includeBaseClass={false}
               sections={sections}
-              activeSection={activeSection}
+              activeSection={resolvedActiveSection}
               hasPracticePacket={hasPracticePacket}
               onSelect={selectSection}
             />
@@ -533,7 +558,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
         <EventSectionNav
           className="event-nav-mobile sticky top-24 z-30 w-full max-w-full bg-gray-50/95 py-1 backdrop-blur sm:py-2"
           sections={sections}
-          activeSection={activeSection}
+          activeSection={resolvedActiveSection}
           hasPracticePacket={hasPracticePacket}
           onSelect={selectSection}
         />
@@ -543,7 +568,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
         {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
         {error ? <Status tone="error" message={error} /> : null}
 
-        {activeSection === 'availability' ? (
+        {resolvedActiveSection === 'availability' ? (
           <AvailabilitySection
             event={selectedEvent}
             rsvp={rsvp}
@@ -553,9 +578,9 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
             onSelectSection={selectSection}
           />
         ) : null}
-        {activeSection === 'rideshare' ? <RideshareSection /> : null}
-        {activeSection === 'assignments' ? <AssignmentsSection /> : null}
-        {activeSection === 'game' ? <GameHubSection key={selectedEvent.eventKey} auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onLiveClockUpdated={handleLiveClockUpdated} onWrapupCompleted={handleWrapupCompleted} onStatsheetImported={handleStatsheetImported} onGameCancelled={handleGameCancelled} onPracticeOccurrenceCancelled={handlePracticeOccurrenceCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
+        {resolvedActiveSection === 'rideshare' ? <RideshareSection /> : null}
+        {resolvedActiveSection === 'assignments' ? <AssignmentsSection /> : null}
+        {resolvedActiveSection === 'game' ? <GameHubSection key={selectedEvent.eventKey} auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onLiveClockUpdated={handleLiveClockUpdated} onWrapupCompleted={handleWrapupCompleted} onStatsheetImported={handleStatsheetImported} onGameCancelled={handleGameCancelled} onPracticeOccurrenceCancelled={handlePracticeOccurrenceCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
       </div>
       </div>
     </ScheduleEventDetailProvider>


### PR DESCRIPTION
Closes #3163

## What changed
- updated `ScheduleEventDetail` to build the top nav from event state instead of always rendering Rideshare and Assignments
- kept Rideshare visible when the event is an active tracked event or existing rideshare activity is present
- kept Assignments visible when the event is an active tracked event or assignments have already been posted
- added a safe fallback so the detail page renders the first available section if a hidden tab was previously selected
- added focused regression coverage for hidden-tab and keep-visible cases

## Root Cause
`ScheduleEventDetail` hard-coded Rideshare and Assignments into the event-detail nav, so inactive or untracked events still exposed tabs whose sections could only render disabled-state messaging.

## Prevention / Learning
For optional workflow tabs, derive nav visibility from the same actionability and data-presence rules as the section content. Do not ship static nav entries for features that only lead to explanatory empty or disabled states.

## Regression Tests
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx`
- added coverage that hides Rideshare and Assignments for inactive events with no rideshare activity and no assignments
- added coverage that keeps those tabs visible when inactive events still have rideshare data or posted assignments