### PR TITLE
Flush pending game plan autosaves before switching games

### DIFF
--- a/game-plan.html
+++ b/game-plan.html
@@ -304,7 +304,7 @@
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent } from './js/utils.js?v=11';
         import { checkAuth } from './js/auth.js?v=37';
         import { getTeamAccessInfo } from './js/team-access.js';
-        import { createAutoSaveController } from './js/game-plan-autosave.js?v=1';
+        import { createAutoSaveController } from './js/game-plan-autosave.js?v=2';
         import { buildGamePlanIntervals } from './js/game-plan-intervals.js?v=2';
         import { normalizeLineupsForGamePlanPlanner } from './js/game-plan-interop.js?v=2';
 
@@ -645,6 +645,8 @@
         }
 
         async function loadGame(game) {
+            await autoSave.flush(currentTeamId, currentGameId, gamePlan, currentGame);
+
             currentGameId = game.id;
             currentGame = game;
 
@@ -670,7 +672,6 @@
             intervalsCache = [];
             lastSelectedPlayerId = null;
             dragSourceCellKey = null;
-            autoSave.cancel();
             const saveStatusEl = document.getElementById('save-status');
             const saveStatusText = document.getElementById('save-status-text');
             const saveStatusDot = document.getElementById('save-status-dot');

--- a/js/game-plan-autosave.js
+++ b/js/game-plan-autosave.js
@@ -64,7 +64,11 @@ export function createAutoSaveController({ updateGame, onStatusChange, delay = 1
         }
 
         if (activeSavePromise) {
-            await activeSavePromise;
+            try {
+                await activeSavePromise;
+            } catch (err) {
+                // executeSave already reports active-save failures through status updates.
+            }
         }
     }
 

--- a/js/game-plan-autosave.js
+++ b/js/game-plan-autosave.js
@@ -9,29 +9,69 @@
 export function createAutoSaveController({ updateGame, onStatusChange, delay = 1500 } = {}) {
     let timer = null;
     let hasPendingSave = false;
+    let pendingPayload = null;
+    let activeSavePromise = null;
 
     async function executeSave(teamId, gameId, gamePlan) {
+        if (!gameId) {
+            return;
+        }
+
         onStatusChange?.('saving');
-        try {
+        activeSavePromise = (async () => {
             await updateGame(teamId, gameId, { gamePlan });
+        })();
+
+        try {
+            await activeSavePromise;
             hasPendingSave = false;
             onStatusChange?.('saved');
         } catch (err) {
             console.error('Auto-save failed:', err);
             onStatusChange?.('error');
+        } finally {
+            activeSavePromise = null;
         }
     }
 
     function scheduleSave(teamId, gameId, gamePlan, game) {
         if (!gameId || game?.isCalendar || game?.isSharedGame) return;
         hasPendingSave = true;
+        pendingPayload = { teamId, gameId, gamePlan };
         onStatusChange?.('unsaved');
         clearTimeout(timer);
-        timer = setTimeout(() => executeSave(teamId, gameId, gamePlan), delay);
+        timer = setTimeout(() => {
+            timer = null;
+            const payload = pendingPayload;
+            pendingPayload = null;
+            if (payload) {
+                return executeSave(payload.teamId, payload.gameId, payload.gamePlan);
+            }
+            return undefined;
+        }, delay);
+    }
+
+    async function flush(teamId, gameId, gamePlan, game) {
+        if (!gameId || game?.isCalendar || game?.isSharedGame) return;
+
+        if (timer) {
+            clearTimeout(timer);
+            timer = null;
+            const payload = pendingPayload ?? { teamId, gameId, gamePlan };
+            pendingPayload = null;
+            await executeSave(payload.teamId, payload.gameId, payload.gamePlan);
+            return;
+        }
+
+        if (activeSavePromise) {
+            await activeSavePromise;
+        }
     }
 
     function cancel() {
         clearTimeout(timer);
+        timer = null;
+        pendingPayload = null;
         hasPendingSave = false;
     }
 
@@ -39,5 +79,5 @@ export function createAutoSaveController({ updateGame, onStatusChange, delay = 1
         return hasPendingSave;
     }
 
-    return { scheduleSave, cancel, isPending };
+    return { scheduleSave, flush, cancel, isPending };
 }

--- a/tests/unit/game-plan-autosave.test.js
+++ b/tests/unit/game-plan-autosave.test.js
@@ -131,6 +131,51 @@ describe('createAutoSaveController', () => {
         });
     });
 
+    describe('flush', () => {
+        it('writes a pending debounced save immediately', async () => {
+            const gamePlan = { lineups: { '1-7-pg': 'player-1' } };
+
+            autoSave.scheduleSave('team-1', 'game-1', gamePlan, {});
+            await autoSave.flush('team-1', 'game-1', gamePlan, {});
+
+            expect(updateGame).toHaveBeenCalledTimes(1);
+            expect(updateGame).toHaveBeenCalledWith('team-1', 'game-1', { gamePlan });
+            expect(autoSave.isPending()).toBe(false);
+        });
+
+        it('uses the latest pending payload when flushing after rapid edits', async () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: { a: 'player-1' } }, {});
+            const latestPlan = { lineups: { a: 'player-2' } };
+
+            autoSave.scheduleSave('team-1', 'game-1', latestPlan, {});
+            await autoSave.flush('team-1', 'game-1', { stale: true }, {});
+
+            expect(updateGame).toHaveBeenCalledTimes(1);
+            expect(updateGame).toHaveBeenCalledWith('team-1', 'game-1', { gamePlan: latestPlan });
+        });
+
+        it('waits for an active save instead of issuing a duplicate write', async () => {
+            let resolveSave;
+            updateGame.mockImplementation(() => new Promise((resolve) => {
+                resolveSave = resolve;
+            }));
+
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            const timerRun = vi.runAllTimersAsync();
+            await vi.advanceTimersByTimeAsync(1500);
+
+            const flushPromise = autoSave.flush('team-1', 'game-1', { lineups: {} }, {});
+            expect(updateGame).toHaveBeenCalledTimes(1);
+
+            resolveSave();
+            await flushPromise;
+            await timerRun;
+
+            expect(updateGame).toHaveBeenCalledTimes(1);
+            expect(autoSave.isPending()).toBe(false);
+        });
+    });
+
     describe('onStatusChange optional', () => {
         it('does not throw when onStatusChange is not provided', async () => {
             const bare = createAutoSaveController({ updateGame, delay: 1500 });

--- a/tests/unit/game-plan-autosave.test.js
+++ b/tests/unit/game-plan-autosave.test.js
@@ -5,15 +5,18 @@ describe('createAutoSaveController', () => {
     let updateGame;
     let onStatusChange;
     let autoSave;
+    let consoleErrorSpy;
 
     beforeEach(() => {
         vi.useFakeTimers();
         updateGame = vi.fn().mockResolvedValue(undefined);
         onStatusChange = vi.fn();
         autoSave = createAutoSaveController({ updateGame, onStatusChange, delay: 1500 });
+        consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     });
 
     afterEach(() => {
+        consoleErrorSpy.mockRestore();
         vi.useRealTimers();
     });
 
@@ -173,6 +176,27 @@ describe('createAutoSaveController', () => {
 
             expect(updateGame).toHaveBeenCalledTimes(1);
             expect(autoSave.isPending()).toBe(false);
+        });
+
+        it('swallows active save failures after surfacing the error state', async () => {
+            let rejectSave;
+            updateGame.mockImplementation(() => new Promise((_, reject) => {
+                rejectSave = reject;
+            }));
+
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            const timerRun = vi.runAllTimersAsync();
+            await vi.advanceTimersByTimeAsync(1500);
+
+            const flushPromise = autoSave.flush('team-1', 'game-1', { lineups: {} }, {});
+            expect(updateGame).toHaveBeenCalledTimes(1);
+
+            rejectSave(new Error('network'));
+            await expect(flushPromise).resolves.toBeUndefined();
+            await timerRun;
+
+            expect(onStatusChange).toHaveBeenCalledWith('error');
+            expect(autoSave.isPending()).toBe(true);
         });
     });
 

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -105,6 +105,7 @@ function buildHarness(overrides = {}) {
         renderPlayingTimeSummary: vi.fn(),
         updatePlanSummary: vi.fn(),
         autoSave: {
+            flush: vi.fn().mockResolvedValue(undefined),
             cancel: vi.fn(),
             isPending: vi.fn().mockReturnValue(false),
             scheduleSave: vi.fn()
@@ -298,7 +299,7 @@ describe('game plan game switching', () => {
         });
     });
 
-    it('cancels any pending auto-save when switching games', async () => {
+    it('flushes any pending auto-save before switching games', async () => {
         const { harness, deps } = buildHarness();
 
         await harness.loadGame({
@@ -313,8 +314,9 @@ describe('game plan game switching', () => {
             date: '2026-04-05T19:00:00.000Z'
         });
 
-        // autoSave.cancel should be called once per loadGame call
-        expect(deps.autoSave.cancel).toHaveBeenCalledTimes(2);
+        expect(deps.autoSave.flush).toHaveBeenNthCalledWith(1, 'team-1', null, deps.gamePlan, null);
+        expect(deps.autoSave.flush).toHaveBeenNthCalledWith(2, 'team-1', 'game-a', expect.objectContaining({ lineups: {} }), expect.objectContaining({ id: 'game-a' }));
+        expect(deps.autoSave.cancel).not.toHaveBeenCalled();
     });
 
     it('disables saving for calendar games and shows an explanatory note', async () => {


### PR DESCRIPTION
Closes #3167

## What changed
- Added `flush()` to the Game Plan autosave controller so a pending debounced save can be persisted immediately.
- Updated `loadGame()` to flush the current game's pending autosave before replacing in-memory state with the newly selected game.
- Bumped the `game-plan-autosave.js` cache-bust import version in `game-plan.html`.
- Added focused regression coverage for autosave flush behavior and for Game Plan switch wiring.

## Root Cause
Game Plan debounced lineup writes in memory, but switching games always called `autoSave.cancel()` before loading the next game. If a coach switched inside the debounce window, that canceled the timer and cleared the pending flag without ever saving the first game's edits.

## Prevention / Learning
When a workflow debounces persistence for record-scoped editing, any navigation that swaps the active record must flush or otherwise explicitly resolve pending writes before replacing local state. Canceling a debounce is safe only when the pending data is no longer user-visible or has already been persisted.

## Regression Tests
- `tests/unit/game-plan-autosave.test.js`
  - verifies `flush()` writes pending debounced edits immediately
  - verifies `flush()` uses the latest pending payload after rapid edits
  - verifies `flush()` waits for an active save instead of issuing a duplicate write
- `tests/unit/game-plan-switching.test.js`
  - verifies game switching flushes the current game's pending autosave before loading the next game
- Validation run:
  - `npx vitest run tests/unit/game-plan-autosave.test.js tests/unit/game-plan-switching.test.js --reporter=verbose`