### PR TITLE
Show draft selection for new Private AI chats

### DIFF
--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -59,6 +59,8 @@ const starterPrompts = [
 ];
 
 const isDraftConversationId = (conversationId: string) => conversationId === DRAFT_PRIVATE_AI_CONVERSATION_ID;
+const draftConversationLabel = 'New chat';
+const draftConversationPreview = 'Start typing. This draft will save after your first message.';
 
 const resolveActiveConversationId = (
   currentConversationId: string,
@@ -293,7 +295,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
       if (nextConversationId !== activeConversationId) {
         setActiveConversationId(nextConversationId);
       }
-      await refreshConversations(false);
+      await refreshConversations(false, nextConversationId);
     } catch (error: any) {
       setMessages((current) => current.filter((message) => message.id !== optimisticUser.id));
       setDraft(trimmedText);
@@ -471,6 +473,8 @@ function PrivateAiConversationList({
   onNewConversation: () => void;
   compact?: boolean;
 }) {
+  const showDraftConversation = isDraftConversationId(activeConversationId);
+
   if (compact) {
     return (
       <section className="private-ai-conversation-strip" aria-label="AI conversations">
@@ -479,7 +483,19 @@ function PrivateAiConversationList({
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
             Loading
           </span>
-        ) : conversations.length ? conversations.map((conversation) => (
+        ) : null}
+        {!loading && showDraftConversation ? (
+          <button
+            type="button"
+            className="private-ai-conversation-chip private-ai-conversation-chip-active"
+            onClick={() => onSelect(DRAFT_PRIVATE_AI_CONVERSATION_ID)}
+            aria-pressed={true}
+          >
+            <MessageCircle className="h-4 w-4" aria-hidden="true" />
+            <span>{draftConversationLabel}</span>
+          </button>
+        ) : null}
+        {!loading && conversations.length ? conversations.map((conversation) => (
           <button
             key={conversation.id}
             type="button"
@@ -490,9 +506,10 @@ function PrivateAiConversationList({
             <MessageCircle className="h-4 w-4" aria-hidden="true" />
             <span>{conversation.title}</span>
           </button>
-        )) : (
+        )) : null}
+        {!loading && !showDraftConversation && !conversations.length ? (
           <span className="private-ai-conversation-chip private-ai-conversation-chip-muted">No saved chats</span>
-        )}
+        ) : null}
       </section>
     );
   }
@@ -521,6 +538,17 @@ function PrivateAiConversationList({
             Loading chats
           </div>
         ) : null}
+        {!loading && showDraftConversation ? (
+          <button
+            type="button"
+            className="private-ai-conversation-button private-ai-conversation-button-active"
+            onClick={() => onSelect(DRAFT_PRIVATE_AI_CONVERSATION_ID)}
+            aria-pressed={true}
+          >
+            <span className="private-ai-conversation-title">{draftConversationLabel}</span>
+            <span className="private-ai-conversation-preview">{draftConversationPreview}</span>
+          </button>
+        ) : null}
         {!loading && conversations.length ? conversations.map((conversation) => (
           <button
             key={conversation.id}
@@ -535,7 +563,7 @@ function PrivateAiConversationList({
             </span>
           </button>
         )) : null}
-        {!loading && !conversations.length ? (
+        {!loading && !showDraftConversation && !conversations.length ? (
           <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-3 py-4 text-sm font-bold text-gray-500">
             Start a private chat and it will stay here for later.
           </div>

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -225,4 +225,18 @@ test.describe('private AI chat', () => {
         const voiceBox = await voiceButton.boundingBox();
         expect(voiceBox.y).toBeGreaterThan(textareaBox.y + textareaBox.height - 2);
     });
+
+    test('mobile conversation strip shows the active draft after tapping new chat', async ({ page, baseURL }) => {
+        await mockPrivateAiModules(page);
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
+
+        await openPrivateAi(page);
+        await page.getByRole('button', { name: 'New AI chat' }).click();
+
+        const draftChip = page.locator('.private-ai-conversation-chip').filter({ hasText: 'New chat' });
+        await expect(draftChip).toBeVisible();
+        await expect(draftChip).toHaveAttribute('aria-pressed', 'true');
+        await expect(page.locator('.private-ai-conversation-strip')).toContainText('Recent chat');
+    });
 });

--- a/tests/unit/app-private-ai-integration.test.jsx
+++ b/tests/unit/app-private-ai-integration.test.jsx
@@ -176,6 +176,21 @@ describe('private AI chat page', () => {
         expect(container.querySelector('textarea').value).toBe('');
     });
 
+    it('shows a selected draft conversation row on desktop before first send', async () => {
+        layoutMocks.isDesktopWeb = true;
+        privateAiMocks.loadPrivateAiMessages.mockResolvedValueOnce([]);
+
+        const { container } = await renderPrivateAi();
+
+        await click(Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('New')));
+
+        const draftRow = Array.from(container.querySelectorAll('.private-ai-conversation-button')).find((button) => button.textContent.includes('New chat'));
+        expect(draftRow).toBeTruthy();
+        expect(draftRow.getAttribute('aria-pressed')).toBe('true');
+        expect(draftRow.textContent).toContain('Start typing. This draft will save after your first message.');
+        expect(container.textContent).toContain('Recent chat');
+    });
+
     it('renders starter prompts in the empty mobile welcome state', async () => {
         layoutMocks.isDesktopWeb = false;
         privateAiMocks.loadPrivateAiMessages.mockResolvedValueOnce([]);
@@ -201,7 +216,7 @@ describe('private AI chat page', () => {
         expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'What do I need to handle today?', 'default');
     });
 
-    it('starts a blank draft and only saves after the first send', async () => {
+    it('starts a blank draft, shows the active mobile chip, and only saves after the first send', async () => {
         privateAiMocks.loadPrivateAiMessages
             .mockResolvedValueOnce([])
             .mockResolvedValueOnce([
@@ -289,11 +304,20 @@ describe('private AI chat page', () => {
         expect(container.textContent).toContain('What do you need from ALL PLAYS?');
         expect(textarea.value).toBe('First draft question');
 
+        const draftChip = Array.from(container.querySelectorAll('.private-ai-conversation-chip')).find((button) => button.textContent.includes('New chat'));
+        expect(draftChip).toBeTruthy();
+        expect(draftChip.getAttribute('aria-pressed')).toBe('true');
+        expect(container.textContent).toContain('Saved chat');
+
         await click(container.querySelector('button[aria-label="Send AI message"]'));
 
         expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'First draft question', '__draft__');
         expect(container.textContent).toContain('First draft question');
         expect(privateAiMocks.loadPrivateAiConversations).toHaveBeenCalledTimes(3);
+        expect(Array.from(container.querySelectorAll('.private-ai-conversation-chip')).some((button) => button.textContent.includes('New chat'))).toBe(false);
+        const savedChip = Array.from(container.querySelectorAll('.private-ai-conversation-chip')).find((button) => button.textContent.includes('First draft question'));
+        expect(savedChip).toBeTruthy();
+        expect(savedChip.getAttribute('aria-pressed')).toBe('true');
     });
 
     it('shows service errors without losing the typed message', async () => {


### PR DESCRIPTION
Closes #3170

## What changed
- Added an explicit selected `New chat` draft item to the Private AI conversation navigation on both mobile and desktop whenever the active conversation is `__draft__`.
- Kept saved conversations visible beneath the draft item so users can switch back without persisting or renaming the draft early.
- Fixed the post-send refresh path so the temporary draft selection is replaced by the newly persisted conversation id and title after the first message.
- Extended unit coverage for desktop draft visibility, mobile draft visibility, and the draft-to-persisted transition.
- Added a focused smoke assertion for the mobile draft strip state after tapping `New AI chat`.

## Root Cause
The page treated `__draft__` as a real active state for message loading, but the conversation navigation rendered only saved conversations, so the active draft had no visible selected row or chip. The send flow also refreshed conversations using the render-time `activeConversationId` closure, which could preserve the transient draft id instead of the newly created persisted conversation id.

## Prevention / Learning
When a feature uses a transient sentinel id like `__draft__`, every navigation surface and refresh helper must explicitly model that transient state. After creating a persisted record from a transient state, follow-up refreshes should receive the resolved next id directly instead of relying on stale component state from the current render.

## Regression Tests
### Run
- `npx vitest run tests/unit/app-private-ai-integration.test.jsx --reporter=verbose`
- `npm run app:build`

### Added coverage
- Desktop unit assertion for a visible selected `New chat` draft row before first send.
- Mobile unit assertion for a visible selected `New chat` draft chip before first send and replacement with the saved conversation after send.
- Mobile smoke assertion that tapping `New AI chat` shows an active `New chat` chip in the conversation strip.