### PR TITLE
Track RSVP latency through visible success state

### DIFF
--- a/apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx
+++ b/apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx
@@ -161,6 +161,21 @@ describe('useScheduleEventRsvp', () => {
         expect(screen.getByTestId('submitting').textContent).toBe('');
     });
 
+    it('treats a null RSVP summary as a successful submission', async () => {
+        vi.mocked(submitParentScheduleRsvp).mockResolvedValue(null as any);
+
+        renderProbe('Running late');
+        fireEvent.click(screen.getByRole('button', { name: 'Submit going' }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Avery Smith marked going.')).toBeTruthy();
+        });
+        expect(screen.getByTestId('current-rsvp').textContent).toBe('going');
+        expect(startInteractionTimer).toHaveBeenCalledWith(UX_TIMING.rsvpTap, { response: 'going' });
+        expect(rsvpInteractionEnd).toHaveBeenCalledWith();
+        expect(rsvpInteractionEnd).not.toHaveBeenCalledWith({ error: 'RSVP submit failed' });
+    });
+
     it('rolls back optimistic RSVP state when the save fails', async () => {
         vi.mocked(submitParentScheduleRsvp).mockRejectedValue(new Error('Unable to save RSVP.'));
 

--- a/apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx
+++ b/apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx
@@ -3,12 +3,23 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useState } from 'react';
 import { submitParentScheduleRsvp } from '../../lib/scheduleService';
+import { UX_TIMING } from '../../lib/uxTiming';
 import { useScheduleEventRsvp } from './useScheduleEventRsvp';
 import { ScheduleEventDetailProvider, useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
 import type { AuthState } from '../../lib/types';
 
 vi.mock('../../lib/scheduleService', () => ({
     submitParentScheduleRsvp: vi.fn()
+}));
+
+const rsvpInteractionEnd = vi.fn();
+const startInteractionTimer = vi.fn((_label?: string, _meta?: Record<string, unknown>) => ({ end: rsvpInteractionEnd }));
+
+vi.mock('../../lib/uxTiming', () => ({
+    UX_TIMING: {
+        rsvpTap: 'rsvp tap latency'
+    },
+    startInteractionTimer: (label: string, meta?: Record<string, unknown>) => startInteractionTimer(label, meta)
 }));
 
 const auth: AuthState = {
@@ -142,6 +153,10 @@ describe('useScheduleEventRsvp', () => {
         });
         await waitFor(() => {
             expect(screen.getByText('Avery Smith marked going.')).toBeTruthy();
+        });
+        expect(startInteractionTimer).toHaveBeenCalledWith(UX_TIMING.rsvpTap, { response: 'going' });
+        await waitFor(() => {
+            expect(rsvpInteractionEnd).toHaveBeenCalledWith();
         });
         expect(screen.getByTestId('submitting').textContent).toBe('');
     });

--- a/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
+++ b/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
@@ -3,6 +3,7 @@ import { toAppServiceError } from '../../lib/appErrors';
 import { submitParentScheduleRsvp } from '../../lib/scheduleService';
 import { useAsyncOperation } from '../../lib/useAsyncOperation';
 import { normalizeRsvpResponse, type ParentScheduleEvent, type RsvpResponse } from '../../lib/scheduleLogic';
+import { UX_TIMING, startInteractionTimer } from '../../lib/uxTiming';
 import { useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
 
 function getRsvpErrorMessage(error: unknown) {
@@ -28,6 +29,16 @@ function buildOptimisticRsvpSummary(summary: ParentScheduleEvent['rsvpSummary'],
   return nextSummary as ParentScheduleEvent['rsvpSummary'];
 }
 
+function waitForVisibleState() {
+  return new Promise<void>((resolve) => {
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => resolve());
+      return;
+    }
+    setTimeout(resolve, 0);
+  });
+}
+
 export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: string }) {
   const { auth, event, updateEvents } = useScheduleEventDetailContext();
   const [submitting, setSubmitting] = useState<RsvpResponse | null>(null);
@@ -40,6 +51,7 @@ export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: s
     const currentUser = auth.user;
     if (!currentUser || !canSubmit) return;
 
+    const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });
     const previousRsvp = normalizeRsvpResponse(event.myRsvp);
     const previousNote = String(event.myRsvpNote || '').trim();
     const note = String(availabilityNote || '').trim();
@@ -58,7 +70,7 @@ export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: s
       };
     }));
 
-    await run(async () => {
+    const result = await run(async () => {
       const summary = await submitParentScheduleRsvp(event, currentUser, response, note);
 
       updateEvents((current) => current.map((currentEvent) => {
@@ -76,6 +88,7 @@ export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: s
       setMessage(noteOnlySave
         ? `${event.childName} availability note saved.`
         : `${event.childName} marked ${response.replace('_', ' ')}.`);
+      return summary;
     }, {
       getErrorMessage: getRsvpErrorMessage,
       onError: () => {
@@ -97,6 +110,13 @@ export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: s
       onFinally: () => setSubmitting(null),
       rethrow: false
     });
+
+    await waitForVisibleState();
+    if (result) {
+      interaction.end();
+      return;
+    }
+    interaction.end({ error: 'RSVP submit failed' });
   };
 
   return {

--- a/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
+++ b/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
@@ -88,7 +88,7 @@ export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: s
       setMessage(noteOnlySave
         ? `${event.childName} availability note saved.`
         : `${event.childName} marked ${response.replace('_', ' ')}.`);
-      return summary;
+      return { ok: true as const };
     }, {
       getErrorMessage: getRsvpErrorMessage,
       onError: () => {
@@ -112,7 +112,7 @@ export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: s
     });
 
     await waitForVisibleState();
-    if (result) {
+    if (result?.ok) {
       interaction.end();
       return;
     }

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -82,7 +82,7 @@ import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailability
 import { buildTrackerEventDocument } from './statTrackingEvent';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
-import { startInteractionTimer, startUxTimer, UX_TIMING } from './uxTiming';
+import { startUxTimer } from './uxTiming';
 import {
   getNextRideConfirmedSeatCount,
   getScheduleRideshareSummary,
@@ -3780,25 +3780,19 @@ export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user:
     throw new Error('Select a child before submitting RSVP.');
   }
 
-  const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });
   try {
-    const result = await withTimeout(Promise.resolve(submitRsvpForPlayer(event.teamId, event.id, user.uid, {
+    return await withTimeout(Promise.resolve(submitRsvpForPlayer(event.teamId, event.id, user.uid, {
       displayName: user.displayName || user.email,
       playerId: event.childId,
       response,
       note: compactString(note) || null
     })), 'RSVP submit');
-    interaction.end({ path: 'sdk' });
-    return result;
   } catch (error) {
     if (!isNativeRuntime()) {
-      interaction.end({ error: (error as Error)?.message || 'RSVP submit failed' });
       throw error;
     }
     logScheduleWarning('Falling back to REST RSVP submit.', 'parent-rsvp-submit', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id, childId: event.childId });
-    const fallback = await nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note, event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
-    interaction.end({ path: 'rest' });
-    return fallback;
+    return nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note, event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
   }
 }
 

--- a/tests/unit/app-performance-baseline-contract.test.js
+++ b/tests/unit/app-performance-baseline-contract.test.js
@@ -88,13 +88,13 @@ describe('app performance baseline contract', () => {
     });
 
     it('records RSVP and chat-send interaction latency around the write paths', () => {
-        const scheduleService = readRepoFile('apps/app/src/lib/scheduleService.ts');
+        const scheduleRsvpHook = readRepoFile('apps/app/src/hooks/schedule/useScheduleEventRsvp.ts');
         const chatService = readRepoFile('apps/app/src/lib/chatService.ts');
 
-        expect(scheduleService).toContain("import { startInteractionTimer, startUxTimer, UX_TIMING } from './uxTiming';");
-        expect(scheduleService).toContain('const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });');
-        expect(scheduleService).toContain("interaction.end({ path: 'sdk' });");
-        expect(scheduleService).toContain("interaction.end({ path: 'rest' });");
+        expect(scheduleRsvpHook).toContain("import { UX_TIMING, startInteractionTimer } from '../../lib/uxTiming';");
+        expect(scheduleRsvpHook).toContain('const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });');
+        expect(scheduleRsvpHook).toContain('interaction.end();');
+        expect(scheduleRsvpHook).toContain("interaction.end({ error: 'RSVP submit failed' });");
         expect(chatService).toContain("import { startInteractionTimer, UX_TIMING } from './uxTiming';");
         expect(chatService).toContain('const interaction = startInteractionTimer(UX_TIMING.chatSend, {');
         expect(chatService).toContain("interaction.end({ path: isNativeRuntime() ? 'native' : 'sdk' });");

--- a/tests/unit/app-performance-measurement-initiative-source-contract.test.js
+++ b/tests/unit/app-performance-measurement-initiative-source-contract.test.js
@@ -15,7 +15,7 @@ const mainSource = readSource('apps/app/src/main.tsx');
 const homeSource = readSource('apps/app/src/pages/Home.tsx');
 const scheduleSource = readSource('apps/app/src/pages/Schedule.tsx');
 const messagesSource = readSource('apps/app/src/pages/Messages.tsx');
-const scheduleServiceSource = readSource('apps/app/src/lib/scheduleService.ts');
+const scheduleRsvpHookSource = readSource('apps/app/src/hooks/schedule/useScheduleEventRsvp.ts');
 const chatServiceSource = readSource('apps/app/src/lib/chatService.ts');
 
 describe('app performance measurement initiative source contract', () => {
@@ -86,10 +86,10 @@ describe('app performance measurement initiative source contract', () => {
     });
 
     it('keeps RSVP and chat send latency timers around their write paths', () => {
-        expect(scheduleServiceSource).toContain("import { startInteractionTimer, startUxTimer, UX_TIMING } from './uxTiming';");
-        expect(scheduleServiceSource).toContain('const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });');
-        expect(scheduleServiceSource).toContain("interaction.end({ path: 'sdk' });");
-        expect(scheduleServiceSource).toContain("interaction.end({ path: 'rest' });");
+        expect(scheduleRsvpHookSource).toContain("import { UX_TIMING, startInteractionTimer } from '../../lib/uxTiming';");
+        expect(scheduleRsvpHookSource).toContain('const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });');
+        expect(scheduleRsvpHookSource).toContain('interaction.end();');
+        expect(scheduleRsvpHookSource).toContain("interaction.end({ error: 'RSVP submit failed' });");
 
         expect(chatServiceSource).toContain("import { startInteractionTimer, UX_TIMING } from './uxTiming';");
         expect(chatServiceSource).toContain('const interaction = startInteractionTimer(UX_TIMING.chatSend, {');

--- a/tests/unit/issue-2281-ux-timing-coverage-source.test.js
+++ b/tests/unit/issue-2281-ux-timing-coverage-source.test.js
@@ -7,7 +7,7 @@ const performanceContractSource = readFileSync(new URL('./app-performance-baseli
 const homeSource = readFileSync(new URL('../../apps/app/src/pages/Home.tsx', import.meta.url), 'utf8');
 const scheduleSource = readFileSync(new URL('../../apps/app/src/pages/Schedule.tsx', import.meta.url), 'utf8');
 const messagesSource = readFileSync(new URL('../../apps/app/src/pages/Messages.tsx', import.meta.url), 'utf8');
-const scheduleServiceSource = readFileSync(new URL('../../apps/app/src/lib/scheduleService.ts', import.meta.url), 'utf8');
+const scheduleRsvpHookSource = readFileSync(new URL('../../apps/app/src/hooks/schedule/useScheduleEventRsvp.ts', import.meta.url), 'utf8');
 const chatServiceSource = readFileSync(new URL('../../apps/app/src/lib/chatService.ts', import.meta.url), 'utf8');
 
 describe('issue 2281 ux timing coverage source contract', () => {
@@ -26,7 +26,7 @@ describe('issue 2281 ux timing coverage source contract', () => {
         expect(scheduleSource).toContain("startScreenMountTimer('schedule'");
         expect(scheduleSource).toContain("recordFirstMeaningfulRender('schedule'");
         expect(messagesSource).toContain("startScreenMountTimer('messages'");
-        expect(scheduleServiceSource).toContain('const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });');
+        expect(scheduleRsvpHookSource).toContain('const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });');
         expect(chatServiceSource).toContain('const interaction = startInteractionTimer(UX_TIMING.chatSend, {');
     });
 


### PR DESCRIPTION
Closes #3191

## What changed
- moved RSVP interaction timing out of `submitParentScheduleRsvp` and into `useScheduleEventRsvp`, where the success message is actually set for the visible UI state
- wait one paint before ending the RSVP span so telemetry reflects tap-to-visible-success timing instead of tap-to-service-response timing
- added a focused hook regression test that verifies the stable RSVP timing event is started and ended on the successful RSVP path

## Root Cause
The RSVP latency span ended inside the service layer as soon as the save request resolved. The visible success state is rendered later in the hook via `setMessage(...)`, so telemetry was measuring backend completion, not user-visible confirmation.

## Prevention / Learning
For UX latency metrics, end the span in the UI layer that commits the visible success or error state. Do not close user-perceived interaction timers in lower-level services when the UI confirmation happens later.

## Regression Tests
- `npx vitest run src/hooks/schedule/useScheduleEventRsvp.test.tsx --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Low. The timing boundary now lives next to the RSVP success UI state and the focused hook test will fail if that event name or completion path drifts back to the service layer.