### PR TITLE
Map single-game tournament blocks to legacy docs

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@legacy/db.js', () => ({
+    addGame: vi.fn(),
+    addPractice: vi.fn(),
+    broadcastLiveEvent: vi.fn(),
+    cancelOccurrence: vi.fn(),
+    clearOccurrenceOverride: vi.fn(),
+    cancelRideRequest: vi.fn(),
+    claimAssignmentSlot: vi.fn(),
+    claimOpenOfficiatingSlot: vi.fn(),
+    closeRideOffer: vi.fn(),
+    createRideOffer: vi.fn(),
+    getConfigs: vi.fn(),
+    getAssignmentClaims: vi.fn(),
+    getGame: vi.fn(),
+    getGames: vi.fn(),
+    getLiveEvents: vi.fn(),
+    getPlayers: vi.fn(),
+    getPracticePacketCompletions: vi.fn(),
+    getPracticeSession: vi.fn(),
+    getPracticeSessionByEvent: vi.fn(),
+    getPracticeSessions: vi.fn(),
+    getRsvpBreakdownByPlayer: vi.fn(),
+    getRsvpSummaries: vi.fn(),
+    getRsvps: vi.fn(),
+    getTeam: vi.fn(),
+    getTeams: vi.fn(),
+    postChatMessage: vi.fn(),
+    postSharedGameCancellationNotification: vi.fn(),
+    releaseAssignmentClaim: vi.fn(),
+    requestRideSpot: vi.fn(),
+    respondToOfficiatingAssignment: vi.fn(),
+    submitRsvpForPlayer: vi.fn(),
+    updateEvent: vi.fn(),
+    updateGame: vi.fn(),
+    updateOccurrence: vi.fn(),
+    updatePracticeAttendance: vi.fn(),
+    updatePracticeSession: vi.fn(),
+    updateRideRequestStatus: vi.fn(),
+    updateSeries: vi.fn(),
+    updateTeam: vi.fn(),
+    upsertPracticeSessionForEvent: vi.fn(),
+    upsertPracticePacketCompletion: vi.fn(),
+    listRideOffersForEvent: vi.fn()
+}));
+
+vi.mock('@legacy/firebase.js', () => ({
+    collection: vi.fn(),
+    collectionGroup: vi.fn(),
+    db: {},
+    doc: vi.fn(),
+    deleteField: vi.fn(),
+    getDoc: vi.fn(),
+    getDocs: vi.fn(),
+    increment: vi.fn(),
+    query: vi.fn(),
+    runTransaction: vi.fn(),
+    serverTimestamp: vi.fn(),
+    Timestamp: { fromDate: vi.fn((value: Date) => value) },
+    where: vi.fn()
+}));
+
+import { buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments } from './legacyScheduleDb';
+
+describe('legacyScheduleDb tournament mapping', () => {
+    it('maps a single-game tournament block to exactly one legacy-compatible game document', () => {
+        const basePayload = {
+            type: 'game',
+            opponent: 'Tigers',
+            date: new Date('2026-06-24T18:30:00.000Z'),
+            end: new Date('2026-06-24T20:00:00.000Z'),
+            location: 'Main Gym',
+            arrivalTime: new Date('2026-06-24T18:00:00.000Z'),
+            isHome: true,
+            notes: 'Bring dark jerseys',
+            assignments: [],
+            status: 'scheduled',
+            homeScore: 0,
+            awayScore: 0,
+            countsTowardSeasonRecord: true,
+            statTrackerConfigId: null,
+            createdBy: 'coach-1'
+        };
+        const tournament = {
+            divisionName: '10U Gold',
+            bracketName: 'Gold Bracket',
+            roundName: 'Semifinal',
+            poolName: 'Pool A'
+        };
+
+        const documents = buildLegacyTournamentGameDocuments([basePayload], tournament);
+
+        expect(documents).toEqual([
+            expect.objectContaining({
+                ...basePayload,
+                competitionType: 'tournament',
+                tournament
+            })
+        ]);
+        expect(documents).toHaveLength(1);
+    });
+
+    it('wraps legacy tournament metadata without mutating the base payload', () => {
+        const basePayload = {
+            type: 'game',
+            opponent: 'Lions',
+            competitionType: 'league'
+        };
+        const tournament = {
+            divisionName: '12U',
+            bracketName: 'Silver',
+            roundName: 'Final'
+        };
+
+        const document = buildLegacyTournamentGameDocument(basePayload, tournament);
+
+        expect(document).toEqual({
+            type: 'game',
+            opponent: 'Lions',
+            competitionType: 'tournament',
+            tournament
+        });
+        expect(basePayload).toEqual({
+            type: 'game',
+            opponent: 'Lions',
+            competitionType: 'league'
+        });
+    });
+});

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -144,6 +144,22 @@ export async function getTeams(options?: { includePrivate?: boolean }) {
     return await Promise.resolve(options === undefined ? legacyGetTeams() : legacyGetTeams(options));
 }
 
+export function buildLegacyTournamentGameDocument(payload: Record<string, unknown>, tournament: Record<string, unknown>) {
+    return {
+        ...payload,
+        competitionType: 'tournament',
+        tournament: {
+            ...tournament
+        }
+    };
+}
+
+export function buildLegacyTournamentGameDocuments(games: Array<Record<string, unknown> | null | undefined>, tournament: Record<string, unknown>) {
+    return games
+        .filter((game): game is Record<string, unknown> => Boolean(game && typeof game === 'object' && !Array.isArray(game)))
+        .map((game) => buildLegacyTournamentGameDocument(game, tournament));
+}
+
 export async function addGame(teamId: string, payload: Record<string, unknown>) {
     return await Promise.resolve(legacyAddGame(teamId, payload));
 }

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -44,6 +44,18 @@ vi.mock('./adapters/legacyScheduleDb', () => ({
   getTeams: vi.fn(),
   addGame: vi.fn(),
   addPractice: vi.fn(),
+  buildLegacyTournamentGameDocument: vi.fn((payload: Record<string, unknown>, tournament: Record<string, unknown>) => ({
+    ...payload,
+    competitionType: 'tournament',
+    tournament
+  })),
+  buildLegacyTournamentGameDocuments: vi.fn((games: Array<Record<string, unknown> | null | undefined>, tournament: Record<string, unknown>) => games
+    .filter((game): game is Record<string, unknown> => Boolean(game && typeof game === 'object' && !Array.isArray(game)))
+    .map((game) => ({
+      ...game,
+      competitionType: 'tournament',
+      tournament
+    }))),
   clearOccurrenceOverride: vi.fn(),
   createRideOffer: vi.fn(),
   claimAssignmentSlot: vi.fn(),
@@ -160,7 +172,7 @@ vi.mock('./appDataCache', () => ({
   getParentScheduleSummaryCacheKey: (userId: string) => `app-schedule-summary:${userId}`
 }));
 
-import { addGame, addPractice, broadcastLiveEvent, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getTeam, getTeams, listRideOffersForEvent, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
+import { addGame, addPractice, broadcastLiveEvent, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getTeam, getTeams, listRideOffersForEvent, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
 import { getNativeAuthIdToken } from './authService';
 import { expandRecurrence, fetchAndParseCalendar, isTeamActive } from './adapters/legacyScheduleHelpers';
 import { getCachedAppData, loadCachedAppData } from './appDataCache';
@@ -366,6 +378,23 @@ describe('scheduled tournament writes', () => {
     }, coachUser);
 
     expect(createdIds).toEqual(['game-1', 'game-2']);
+    expect(buildLegacyTournamentGameDocuments).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: 'game',
+        opponent: 'Tigers',
+        competitionType: 'tournament'
+      }),
+      expect.objectContaining({
+        type: 'game',
+        opponent: 'Lions',
+        competitionType: 'tournament'
+      })
+    ], {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A'
+    });
     expect(addGame).toHaveBeenCalledTimes(2);
     expect(addGame).toHaveBeenNthCalledWith(1, 'team-1', expect.objectContaining({
       type: 'game',
@@ -381,6 +410,54 @@ describe('scheduled tournament writes', () => {
     expect(addGame).toHaveBeenNthCalledWith(2, 'team-1', expect.objectContaining({
       type: 'game',
       opponent: 'Lions',
+      competitionType: 'tournament',
+      tournament: {
+        divisionName: '10U Gold',
+        bracketName: 'Gold Bracket',
+        roundName: 'Semifinal',
+        poolName: 'Pool A'
+      }
+    }));
+  });
+
+  it('maps a single-game tournament block to one legacy document and one write', async () => {
+    vi.mocked(addGame).mockResolvedValueOnce('game-1' as any);
+
+    const createdIds = await createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z'),
+          location: 'Main Gym',
+          arrivalTime: new Date('2026-06-24T18:00:00.000Z'),
+          isHome: true,
+          notes: 'Bring dark jerseys'
+        }
+      ]
+    }, coachUser);
+
+    expect(createdIds).toEqual(['game-1']);
+    expect(buildLegacyTournamentGameDocuments).toHaveBeenCalledWith([
+      expect.objectContaining({
+        type: 'game',
+        opponent: 'Tigers',
+        competitionType: 'tournament'
+      })
+    ], {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A'
+    });
+    expect(addGame).toHaveBeenCalledTimes(1);
+    expect(addGame).toHaveBeenCalledWith('team-1', expect.objectContaining({
+      type: 'game',
+      opponent: 'Tigers',
       competitionType: 'tournament',
       tournament: {
         divisionName: '10U Gold',

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -15,6 +15,7 @@ import {
   getTeams,
   addGame,
   addPractice,
+  buildLegacyTournamentGameDocuments,
   createRideOffer,
   claimAssignmentSlot,
   respondToOfficiatingAssignment,
@@ -1660,17 +1661,13 @@ export async function createScheduledTournamentBlockForApp(teamId: string, input
     throw new Error('Tournament blocks require at least one game.');
   }
 
-  const createdIds: string[] = [];
-  for (const game of games) {
-    const payload = {
-      ...buildScheduledGamePayload({
-        ...game,
-        competitionType: 'tournament'
-      }, user as AuthUser),
-      competitionType: 'tournament',
-      tournament
-    };
+  const payloads = buildLegacyTournamentGameDocuments(games.map((game) => buildScheduledGamePayload({
+    ...game,
+    competitionType: 'tournament'
+  }, user as AuthUser)), tournament);
 
+  const createdIds: string[] = [];
+  for (const payload of payloads) {
     try {
       const createdId = await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Scheduled tournament game create');
       createdIds.push(createdId || '');


### PR DESCRIPTION
Closes #3197

## What changed
- added typed legacy schedule adapter helpers to build tournament game document payloads instead of inlining that shape in the schedule service
- routed `createScheduledTournamentBlockForApp(...)` through the adapter mapping helper before the existing legacy save flow
- added focused regression coverage for:
  - adapter output shape for a single-game tournament block
  - single-game tournament save path emitting exactly one legacy document and one write

## Root Cause
The app schedule layer built tournament payloads inline inside `createScheduledTournamentBlockForApp(...)`, so there was no dedicated adapter contract or regression test proving that the single-game tournament path produced exactly one legacy-compatible document before entering the existing save flow.

## Prevention / Learning
When app form inputs must feed a legacy persistence contract, put the shape conversion behind a typed adapter helper and add an explicit one-item regression test that checks both payload shape and emitted document count.

## Regression Tests
- `npx vitest run src/lib/adapters/legacyScheduleDb.test.ts src/lib/scheduleService.test.ts --reporter=verbose`
- `src/lib/adapters/legacyScheduleDb.test.ts` verifies a single-game tournament block maps to exactly one legacy-compatible document
- `src/lib/scheduleService.test.ts` verifies the single-game tournament path performs exactly one mapped write