### PR TITLE
Keep mobile chat notifications reachable

### DIFF
--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -248,6 +248,29 @@ export function AppShell({ auth, children }: AppShellProps) {
     navigate(workflow.href);
   };
 
+  const renderNotificationTrigger = (className: string, iconOnly = false) => (
+    <button
+      type="button"
+      className={className}
+      onClick={() => setInboxOpen(true)}
+      aria-label="Notifications"
+      title="Notifications"
+      data-testid="app-shell-notifications-trigger"
+    >
+      <Bell className="h-5 w-5" aria-hidden="true" />
+      {iconOnly ? <span className="sr-only">Notifications</span> : null}
+      {unreadCount > 0 && (
+        <span
+          className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-500 px-1 text-[10px] font-black text-white"
+          aria-label={`${unreadCount} unread`}
+          data-testid="notification-unread-badge"
+        >
+          {unreadCount > 99 ? '99+' : unreadCount}
+        </span>
+      )}
+    </button>
+  );
+
   return (
     <div className={isDesktopWeb ? `desktop-app-page ${isDesktopMessages ? 'desktop-app-page-messages' : ''}` : `app-page ${isMobileChatDetail ? 'app-page-chat-detail' : ''} ${isAiRoute ? 'app-page-ai' : ''}`}>
       <div className="sr-only" role="status" aria-live="polite" aria-atomic="true" aria-label="Notification status" data-testid="app-shell-notification-status">
@@ -282,25 +305,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                   <Sparkles className="h-5 w-5" aria-hidden="true" />
                   AI
                 </button>
-                <button
-                  type="button"
-                  className="ghost-button !h-10 !min-h-10 relative"
-                  onClick={() => setInboxOpen(true)}
-                  aria-label="Notifications"
-                  title="Notifications"
-                  data-testid="app-shell-notifications-trigger"
-                >
-                  <Bell className="h-5 w-5" aria-hidden="true" />
-                  {unreadCount > 0 && (
-                    <span
-                      className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-500 px-1 text-[10px] font-black text-white"
-                      aria-label={`${unreadCount} unread`}
-                      data-testid="notification-unread-badge"
-                    >
-                      {unreadCount > 99 ? '99+' : unreadCount}
-                    </span>
-                  )}
-                </button>
+                {renderNotificationTrigger('ghost-button !h-10 !min-h-10 relative')}
                 <button
                   type="button"
                   className="ghost-button !h-10 !min-h-10"
@@ -358,6 +363,12 @@ export function AppShell({ auth, children }: AppShellProps) {
         </>
       ) : (
         <>
+          {isMobileChatDetail ? (
+            <div className="pointer-events-none fixed inset-x-0 top-0 z-30 flex justify-end px-3 safe-top">
+              {renderNotificationTrigger('ghost-button pointer-events-auto !h-10 !min-h-10 !w-10 !p-0 relative', true)}
+            </div>
+          ) : null}
+
           {!isMobileChatDetail ? <header className="safe-top sticky top-0 z-40 border-b border-gray-200 bg-white/95 backdrop-blur">
             <div className="mx-auto flex max-w-5xl items-center gap-3 px-4 pb-3">
               <button
@@ -385,26 +396,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                   <Sparkles className="h-5 w-5" aria-hidden="true" />
                   <span className="sr-only">Private AI</span>
                 </button>
-                <button
-                  type="button"
-                  className="ghost-button !h-10 !min-h-10 !w-10 !p-0 relative"
-                  onClick={() => setInboxOpen(true)}
-                  aria-label="Notifications"
-                  title="Notifications"
-                  data-testid="app-shell-notifications-trigger"
-                >
-                  <Bell className="h-5 w-5" aria-hidden="true" />
-                  <span className="sr-only">Notifications</span>
-                  {unreadCount > 0 && (
-                    <span
-                      className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-500 px-1 text-[10px] font-black text-white"
-                      aria-label={`${unreadCount} unread`}
-                      data-testid="notification-unread-badge"
-                    >
-                      {unreadCount > 99 ? '99+' : unreadCount}
-                    </span>
-                  )}
-                </button>
+                {renderNotificationTrigger('ghost-button !h-10 !min-h-10 !w-10 !p-0 relative', true)}
                 <button
                   type="button"
                   className="ghost-button !h-10 !min-h-10 !w-10 !p-0"

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1485,7 +1485,7 @@ export function ChatWindow({
 
   return (
     <div className={`chat-window ${embedded ? 'chat-window-embedded' : 'chat-window-mobile'}`}>
-      <section className={`chat-topbar ${embedded ? 'rounded-xl' : 'safe-top sticky top-0'} z-20 border border-gray-200 bg-white/95 px-3 py-3 shadow-app backdrop-blur`}>
+      <section className={`chat-topbar ${embedded ? 'rounded-xl' : 'safe-top sticky top-0'} ${!embedded && !isDesktopWeb ? 'pr-16' : ''} z-20 border border-gray-200 bg-white/95 px-3 py-3 shadow-app backdrop-blur`}>
         <div className="flex items-center gap-2">
           {!embedded ? (
             <Link to="/messages" className="ghost-button !h-10 !min-h-10 !w-10 !p-0" aria-label="Back to messages">

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -145,6 +145,45 @@ async function mockMessagesModules(page, options = {}) {
         });
     });
 
+    await page.route(/\/src\/lib\/notificationInboxService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                const notificationItems = [
+                    {
+                        id: 'notif-1',
+                        text: 'Game starts in 30 minutes',
+                        type: 'game_alert',
+                        appRoute: '/schedule/game-1',
+                        readAt: null
+                    }
+                ];
+
+                export function subscribeToUnreadNotificationCount(_uid, onCount, _onError) {
+                    onCount(notificationItems.filter((item) => !item.readAt).length);
+                    return () => {};
+                }
+
+                export function subscribeToNotificationInbox(_uid, onItems, _onError) {
+                    onItems(notificationItems);
+                    return () => {};
+                }
+
+                export async function markNotificationRead(_uid, itemId) {
+                    const item = notificationItems.find((entry) => entry.id === itemId);
+                    if (item) item.readAt = new Date().toISOString();
+                }
+
+                export async function markAllNotificationsRead() {
+                    notificationItems.forEach((item) => {
+                        item.readAt = new Date().toISOString();
+                    });
+                }
+            `
+        });
+    });
+
     await page.route(/\/src\/lib\/chatService\.ts(\?.*)?$/, async (route) => {
         await route.fulfill({
             status: 200,
@@ -381,6 +420,14 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     expect(mobileFrame.composerHeight).toBeLessThan(132);
     expect(mobileFrame.textareaHeight).toBeLessThanOrEqual(50);
     expect(mobileFrame.toolbarMarginTop).toBeLessThanOrEqual(8);
+    const notificationTrigger = page.getByTestId('app-shell-notifications-trigger');
+    await expect(notificationTrigger).toBeVisible();
+    await expect(page.getByTestId('notification-unread-badge')).toHaveText('1');
+    await notificationTrigger.click();
+    await expect(page.getByRole('dialog', { name: 'Notifications' })).toBeVisible();
+    await page.getByRole('button', { name: 'Close notifications' }).click();
+    await expect(page.getByRole('dialog', { name: 'Notifications' })).toBeHidden();
+    await expect(page).toHaveURL(/#\/messages\/team-1$/);
     await expect(page.getByRole('button', { name: /Audience: Full team/ })).toBeVisible();
 
     await page.getByRole('button', { name: 'Add attachment' }).click();

--- a/tests/unit/app-notification-bell.test.tsx
+++ b/tests/unit/app-notification-bell.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from '../../apps/app/src/components/AppShell';
 import type { AuthState } from '../../apps/app/src/lib/types';
@@ -117,16 +117,35 @@ const auth: AuthState = {
     signOut: vi.fn(),
 };
 
-function renderShell(isDesktop = true) {
+function LocationDisplay() {
+    const location = useLocation();
+    return <div data-testid="current-route">{location.pathname}</div>;
+}
+
+function renderShell(isDesktop = true, initialPath = '/home') {
     useShellLayoutMock.mockReturnValue({ isDesktopWeb: isDesktop });
     return render(
-        <MemoryRouter initialEntries={['/home']}>
+        <MemoryRouter initialEntries={[initialPath]}>
             <Routes>
                 <Route
                     path="/home"
                     element={
                         <AppShell auth={auth}>
-                            <div>Home content</div>
+                            <>
+                                <div>Home content</div>
+                                <LocationDisplay />
+                            </>
+                        </AppShell>
+                    }
+                />
+                <Route
+                    path="/messages/:teamId"
+                    element={
+                        <AppShell auth={auth}>
+                            <>
+                                <div>Chat thread content</div>
+                                <LocationDisplay />
+                            </>
                         </AppShell>
                     }
                 />
@@ -166,6 +185,58 @@ describe('Notification bell in AppShell', () => {
         renderShell(false);
         const bellButton = screen.getByTestId('app-shell-notifications-trigger');
         expect(bellButton.getAttribute('aria-label')).toBe('Notifications');
+    });
+
+    it('keeps the notification trigger available on mobile chat detail routes and returns to the same thread after closing the inbox', async () => {
+        let onUnreadError: ((error: unknown) => void) | undefined;
+        inboxServiceMocks.subscribeToUnreadNotificationCount.mockImplementation(
+            (_uid: string, onCount: (count: number) => void, onError?: (error: unknown) => void) => {
+                onUnreadError = onError;
+                return vi.fn();
+            }
+        );
+
+        renderShell(false, '/messages/team-1');
+
+        await waitFor(() => {
+            expect(inboxServiceMocks.subscribeToUnreadNotificationCount).toHaveBeenCalledWith(
+                'user-1',
+                expect.any(Function),
+                expect.any(Function)
+            );
+        });
+
+        const bellButton = screen.getByTestId('app-shell-notifications-trigger');
+        expect(bellButton.getAttribute('aria-label')).toBe('Notifications');
+        expect(screen.getByTestId('current-route').textContent).toBe('/messages/team-1');
+        expect(screen.queryByTestId('notification-unread-badge')).toBeNull();
+
+        act(() => {
+            onUnreadError?.(new Error('offline'));
+        });
+
+        expect(screen.getByTestId('app-shell-notifications-trigger')).toBeTruthy();
+
+        act(() => {
+            const onCount = inboxServiceMocks.subscribeToUnreadNotificationCount.mock.calls[0]?.[1] as ((count: number) => void) | undefined;
+            onCount?.(3);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('notification-unread-badge').textContent).toBe('3');
+        });
+
+        fireEvent.click(screen.getByTestId('app-shell-notifications-trigger'));
+        await waitFor(() => {
+            expect(screen.getByRole('dialog', { name: 'Notifications' })).toBeTruthy();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close notifications' }));
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', { name: 'Notifications' })).toBeNull();
+        });
+        expect(screen.getByTestId('current-route').textContent).toBe('/messages/team-1');
+        expect(screen.getByText('Chat thread content')).toBeTruthy();
     });
 
     it('subscribes to unread counts on mount and defers the full inbox until opened', async () => {


### PR DESCRIPTION
Closes #3203

## What changed
- added a shared AppShell notification trigger renderer and reused it for desktop, standard mobile, and mobile chat-detail routes
- rendered a persistent mobile chat-detail notification trigger as a safe-area-aware floating control so `/messages/:teamId` keeps the bell and unread badge even when the mobile header is suppressed
- added mobile chat-detail regression coverage in the notification bell unit test and extended the mobile messages smoke flow to open and close the notification inbox without leaving the active thread
- added right-side spacing in the mobile chat top bar so the new trigger does not crowd existing chat controls

## Root Cause
AppShell only rendered the notification bell inside the normal mobile header branch. Mobile chat-detail routes intentionally skip that header, so `/messages/:teamId` removed the only inbox trigger and unread badge with no replacement control.

## Prevention / Learning
When AppShell hides a global affordance for a route-specific mobile layout, treat that as a routing contract change. Add a route-level regression test for the hidden-header path and provide an alternate trigger in the surviving shell chrome before shipping.

## Regression Tests
- `npx vitest run tests/unit/app-notification-bell.test.tsx --reporter=verbose`
- `SMOKE_BASE_URL=http://127.0.0.1:4174 npx playwright test tests/smoke/app-messages.spec.js --config=playwright.smoke.config.js --grep "messages inbox and team chat exercise real migrated chat UX"`