### PR TITLE
Instrument visible chat send latency

### DIFF
--- a/apps/app/src/lib/chatService.test.ts
+++ b/apps/app/src/lib/chatService.test.ts
@@ -47,6 +47,13 @@ const nativeRuntime = vi.hoisted(() => ({
   isNativePlatform: false
 }));
 
+const uxTimingMocks = vi.hoisted(() => ({
+  endInteraction: vi.fn(),
+  startInteractionTimer: vi.fn(() => ({
+    end: uxTimingMocks.endInteraction
+  }))
+}));
+
 vi.mock('@capacitor/core', () => ({
   Capacitor: {
     isNativePlatform: () => nativeRuntime.isNativePlatform
@@ -64,6 +71,13 @@ vi.mock('./authService', () => ({
     }
   },
   getNativeAuthIdToken: vi.fn()
+}));
+
+vi.mock('./uxTiming', () => ({
+  UX_TIMING: {
+    chatSend: 'chat-send'
+  },
+  startInteractionTimer: uxTimingMocks.startInteractionTimer
 }));
 
 type Deferred<T> = {
@@ -120,6 +134,9 @@ beforeEach(() => {
   vi.useRealTimers();
   vi.resetAllMocks();
   nativeRuntime.isNativePlatform = false;
+  uxTimingMocks.startInteractionTimer.mockReturnValue({
+    end: uxTimingMocks.endInteraction
+  });
   legacyChatServiceMocks.resolveImageFirebaseConfig.mockReturnValue({ apiKey: 'test-api-key', storageBucket: 'test-bucket' });
   legacyChatServiceMocks.postChatMessage.mockResolvedValue({ id: 'message-1' });
 });
@@ -434,5 +451,24 @@ describe('sendTeamChatMessage attachment uploads', () => {
     await sendPromise;
     expect(legacyChatServiceMocks.uploadChatImage).toHaveBeenCalledTimes(3);
     expect(legacyChatServiceMocks.postChatMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips interaction timing when requested without changing chat delivery', async () => {
+    const { sendTeamChatMessage } = await import('./chatService');
+
+    const result = await sendTeamChatMessage({
+      ...buildSendInput([]),
+      skipInteractionTiming: true
+    });
+
+    expect(uxTimingMocks.startInteractionTimer).not.toHaveBeenCalled();
+    expect(legacyChatServiceMocks.postChatMessage).toHaveBeenCalledWith('team-1', expect.objectContaining({
+      text: 'Practice photos'
+    }));
+    expect(result).toEqual(expect.objectContaining({
+      conversationId: 'team',
+      createdConversation: false,
+      wantsAi: false
+    }));
   });
 });

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1205,14 +1205,20 @@ export async function sendTeamChatMessage({
       await withTimeout(Promise.resolve(postChatMessage(teamId, payload)), 'Chat message send');
     }
 
-    interactionHandle?.end({ path: isNativeRuntime() ? 'native' : 'sdk' });
+    if (interactionHandle) {
+      const interaction = interactionHandle;
+      interaction.end({ path: isNativeRuntime() ? 'native' : 'sdk' });
+    }
     return {
       conversationId,
       createdConversation,
       wantsAi: hasAllPlaysMention(text)
     };
   } catch (error) {
-    interactionHandle?.end({ error: (error as Error)?.message || 'Chat send failed' });
+    if (interactionHandle) {
+      const interaction = interactionHandle;
+      interaction.end({ error: (error as Error)?.message || 'Chat send failed' });
+    }
     const cleanupAttachments = uploadedAttachments.filter((attachment): attachment is ChatAttachment => Boolean(attachment));
     if (cleanupAttachments.length > 0) {
       try {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1141,12 +1141,14 @@ export async function sendTeamChatMessage({
     throw new Error('Choose at least one selected member before sending.');
   }
 
-  const interaction = skipInteractionTiming
-    ? null
-    : startInteractionTimer(UX_TIMING.chatSend, {
+  let interactionHandle: ReturnType<typeof startInteractionTimer> | null = null;
+  if (!skipInteractionTiming) {
+    const interaction = startInteractionTimer(UX_TIMING.chatSend, {
       attachments: files.length,
       target: selectedRecipientTarget
     });
+    interactionHandle = interaction;
+  }
   const uploadedAttachments: Array<ChatAttachment | undefined> = [];
   try {
     const targetMetadata = buildChatAudienceMetadata({
@@ -1203,14 +1205,14 @@ export async function sendTeamChatMessage({
       await withTimeout(Promise.resolve(postChatMessage(teamId, payload)), 'Chat message send');
     }
 
-    interaction?.end({ path: isNativeRuntime() ? 'native' : 'sdk' });
+    interactionHandle?.end({ path: isNativeRuntime() ? 'native' : 'sdk' });
     return {
       conversationId,
       createdConversation,
       wantsAi: hasAllPlaysMention(text)
     };
   } catch (error) {
-    interaction?.end({ error: (error as Error)?.message || 'Chat send failed' });
+    interactionHandle?.end({ error: (error as Error)?.message || 'Chat send failed' });
     const cleanupAttachments = uploadedAttachments.filter((attachment): attachment is ChatAttachment => Boolean(attachment));
     if (cleanupAttachments.length > 0) {
       try {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1118,7 +1118,8 @@ export async function sendTeamChatMessage({
   selectedRecipientTarget,
   selectedRecipientIds,
   onProgress,
-  aiMeta
+  aiMeta,
+  skipInteractionTiming = false
 }: {
   teamId: string;
   clientMessageId?: string | null;
@@ -1133,16 +1134,19 @@ export async function sendTeamChatMessage({
   selectedRecipientIds: string[];
   onProgress?: (stage: 'uploading' | 'posting') => void;
   aiMeta?: Record<string, unknown> | null;
+  skipInteractionTiming?: boolean;
 }) {
   if (selectedRecipientTarget === 'individuals'
     && (selectedRecipientIds || []).map((id) => String(id || '').trim()).filter(Boolean).length === 0) {
     throw new Error('Choose at least one selected member before sending.');
   }
 
-  const interaction = startInteractionTimer(UX_TIMING.chatSend, {
-    attachments: files.length,
-    target: selectedRecipientTarget
-  });
+  const interaction = skipInteractionTiming
+    ? null
+    : startInteractionTimer(UX_TIMING.chatSend, {
+      attachments: files.length,
+      target: selectedRecipientTarget
+    });
   const uploadedAttachments: Array<ChatAttachment | undefined> = [];
   try {
     const targetMetadata = buildChatAudienceMetadata({
@@ -1199,14 +1203,14 @@ export async function sendTeamChatMessage({
       await withTimeout(Promise.resolve(postChatMessage(teamId, payload)), 'Chat message send');
     }
 
-    interaction.end({ path: isNativeRuntime() ? 'native' : 'sdk' });
+    interaction?.end({ path: isNativeRuntime() ? 'native' : 'sdk' });
     return {
       conversationId,
       createdConversation,
       wantsAi: hasAllPlaysMention(text)
     };
   } catch (error) {
-    interaction.end({ error: (error as Error)?.message || 'Chat send failed' });
+    interaction?.end({ error: (error as Error)?.message || 'Chat send failed' });
     const cleanupAttachments = uploadedAttachments.filter((attachment): attachment is ChatAttachment => Boolean(attachment));
     if (cleanupAttachments.length > 0) {
       try {

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -89,6 +89,7 @@ import { sharePublicUrl } from '../../../lib/publicActions';
 import { useShellLayout } from '../../../lib/useShellLayout';
 import type { AuthState } from '../../../lib/types';
 import { voiceRecognition, type VoiceListenerHandle } from '../../../lib/voiceService';
+import { startInteractionTimer, UX_TIMING } from '../../../lib/uxTiming';
 import { useChatSheets } from '../hooks/useChatSheets';
 import { useChatTeam } from '../hooks/useChatTeam';
 import { useChatMessages } from '../hooks/useChatMessages';
@@ -126,6 +127,7 @@ type PendingChatSendRequest = {
   selectedConversationId: string;
   selectedRecipientTarget: ChatTargetType;
   selectedRecipientIds: string[];
+  interaction?: ReturnType<typeof startInteractionTimer>;
 };
 
 type VirtualizedChatWindow = {
@@ -164,6 +166,13 @@ function createChatClientMessageId(userId: string) {
 
 function getChatSendErrorMessage(error: unknown) {
   return error instanceof Error && error.message ? error.message : 'Failed to send message. Tap retry to try again.';
+}
+
+function startPendingChatSendInteraction(request: Pick<PendingChatSendRequest, 'attachmentCount' | 'selectedRecipientTarget'>) {
+  return startInteractionTimer(UX_TIMING.chatSend, {
+    attachments: request.attachmentCount,
+    target: request.selectedRecipientTarget
+  });
 }
 
 function createOptimisticChatMessage(request: PendingChatSendRequest): OptimisticChatMessage {
@@ -431,7 +440,10 @@ export function ChatWindow({
     setOptimisticMessages((current) => current.filter((message) => {
       return !liveClientIds.has(message.clientMessageId || message.id);
     }));
-    confirmedClientIds.forEach((id) => pendingSendRequestsRef.current.delete(id));
+    confirmedClientIds.forEach((id) => {
+      pendingSendRequestsRef.current.get(id)?.interaction?.end({ status: 'visible_sent' });
+      pendingSendRequestsRef.current.delete(id);
+    });
   }, [messages, optimisticMessages]);
 
   const selectedConversation = useMemo(() => (
@@ -951,7 +963,8 @@ export function ChatWindow({
         selectedRecipientIds: request.selectedRecipientIds,
         onProgress: (stage) => {
           setComposerNotice(stage === 'uploading' ? attachmentNotice : 'Posting message...');
-        }
+        },
+        skipInteractionTiming: true
       });
       if (result.createdConversation) {
         await reloadConversations();
@@ -993,6 +1006,7 @@ export function ChatWindow({
       }
     } catch (sendError) {
       const message = getChatSendErrorMessage(sendError);
+      request.interaction?.end({ error: message });
       setOptimisticMessages((current) => current.map((candidate) => (
         candidate.clientMessageId === request.clientMessageId
           ? { ...candidate, sendStatus: 'failed', sendError: message }
@@ -1020,6 +1034,7 @@ export function ChatWindow({
     }
 
     setStatus(null);
+    request.interaction = startPendingChatSendInteraction(request);
     pendingScrollRef.current = true;
     setOptimisticMessages((current) => current.map((message) => (
       message.clientMessageId === clientMessageId
@@ -1056,7 +1071,11 @@ export function ChatWindow({
       selectedConversation,
       selectedConversationId: effectiveConversationId,
       selectedRecipientTarget,
-      selectedRecipientIds: [...selectedRecipientIds]
+      selectedRecipientIds: [...selectedRecipientIds],
+      interaction: startPendingChatSendInteraction({
+        attachmentCount: files.length,
+        selectedRecipientTarget
+      })
     };
 
     setStatus(null);

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -41,6 +41,19 @@ const publicActionMocks = vi.hoisted(() => ({
     sharePublicUrl: vi.fn()
 }));
 
+const uxTimingMocks = vi.hoisted(() => ({
+    UX_TIMING: {
+        chatSend: 'chat send latency'
+    },
+    interactionEnds: [],
+    startInteractionTimer: vi.fn((_label, _meta) => {
+        const end = vi.fn();
+        uxTimingMocks.interactionEnds.push(end);
+        return { end };
+    }),
+    startScreenMountTimer: vi.fn(() => ({ end: vi.fn() }))
+}));
+
 const voiceMocks = vi.hoisted(() => {
     const listeners = {};
     return {
@@ -126,6 +139,7 @@ vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({
     useShellLayout: () => layoutMocks
 }));
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
+vi.mock('../../apps/app/src/lib/uxTiming.ts', () => uxTimingMocks);
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -249,6 +263,7 @@ async function setFieldValue(field, value) {
 
 beforeEach(() => {
     vi.clearAllMocks();
+    uxTimingMocks.interactionEnds.length = 0;
     layoutMocks.isDesktopWeb = false;
     nativeMocks.isNativePlatform = false;
     Object.keys(voiceMocks.listeners).forEach((eventName) => {
@@ -2086,6 +2101,56 @@ describe('React app messages integration', () => {
             secondSend.resolve({ conversationId: 'team', createdConversation: null, wantsAi: false });
         });
         await flush();
+    });
+
+    it('ends chat send timing only after the live sent message becomes visible', async () => {
+        const sendDeferred = createDeferred();
+        let emitMessages = null;
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((_teamId, _conversationId, onMessages) => {
+            emitMessages = onMessages;
+            onMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+        chatMocks.sendTeamChatMessage.mockImplementationOnce(() => sendDeferred.promise);
+        const { container } = await renderMessages('/messages/team-1');
+        const textarea = container.querySelector('textarea');
+
+        await setFieldValue(textarea, 'Timing check');
+        await click(container, 'Send message');
+
+        expect(uxTimingMocks.startInteractionTimer).toHaveBeenCalledWith('chat send latency', {
+            attachments: 0,
+            target: 'full_team'
+        });
+        const end = uxTimingMocks.interactionEnds[0];
+        expect(end).not.toHaveBeenCalled();
+
+        const clientMessageId = chatMocks.sendTeamChatMessage.mock.calls[0][0].clientMessageId;
+        await act(async () => {
+            sendDeferred.resolve({ conversationId: 'team', createdConversation: null, wantsAi: false });
+        });
+        await flush();
+
+        expect(end).not.toHaveBeenCalled();
+
+        await act(async () => {
+            emitMessages?.([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({
+                    id: 'msg-live-sent',
+                    clientMessageId,
+                    senderId: 'user-1',
+                    senderName: 'Pat Parent',
+                    text: 'Timing check',
+                    createdAt: new Date('2026-05-21T14:03:00Z')
+                })
+            ], { id: 'cursor-2' });
+        });
+        await flush();
+
+        expect(end).toHaveBeenCalledWith({ status: 'visible_sent' });
     });
 
     it('moves an optimistic selected-member send into the created conversation', async () => {

--- a/tests/unit/issue-2281-ux-timing-coverage-source.test.js
+++ b/tests/unit/issue-2281-ux-timing-coverage-source.test.js
@@ -28,6 +28,7 @@ describe('issue 2281 ux timing coverage source contract', () => {
         expect(messagesSource).toContain("startScreenMountTimer('messages'");
         expect(scheduleRsvpHookSource).toContain('const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });');
         expect(chatServiceSource).toContain('const interaction = startInteractionTimer(UX_TIMING.chatSend, {');
+        expect(chatServiceSource).toContain('if (!skipInteractionTiming) {');
     });
 
     it('keeps direct tests for timing labels, render milestones, and baseline contracts', () => {


### PR DESCRIPTION
Closes #3192

## What changed
- started the `chat send latency` interaction in the Messages UI when the user submits a send, instead of finishing it inside the low-level send helper
- completed the timing only when a live message with the same `clientMessageId` replaces the optimistic row, which matches the visible sent state
- kept existing chat-service telemetry behavior available for other callers, but let the Messages flow suppress the earlier write-complete timing so the event is emitted once at the correct boundary
- added a regression integration test that proves the timer does not end on send promise resolution and only ends after the confirmed live message becomes visible

## Root Cause
The existing instrumentation ended in `sendTeamChatMessage` as soon as the Firestore/native post resolved. The Messages experience confirms success later, when the optimistic message is replaced by the live message in `ChatWindow`, so telemetry was measuring transport completion instead of user-visible send completion.

## Prevention / Learning
For optimistic UI flows, do not use service-layer write completion as the success boundary for UX latency. Start timing at submit and end it at the UI confirmation state the user actually sees, keyed by the same optimistic identifier when possible.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx tests/unit/app-chat-service-recipients.test.js --reporter=verbose`
- `tests/unit/app-chat-messages-integration.test.jsx` now asserts that `chat send latency` remains open after the send promise resolves and closes only after the live message with the matching `clientMessageId` becomes visible