### PR TITLE
Add parent smoke tests and fix error+empty state overlap in parent tool panels

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -66,6 +66,8 @@ jobs:
         env:
           SMOKE_BASE_URL: http://127.0.0.1:4173
           SMOKE_APP_BASE_URL: http://127.0.0.1:5174
+          SMOKE_PARENT_EMAIL: ${{ vars.SMOKE_PARENT_EMAIL }}
+          SMOKE_PARENT_PASSWORD: ${{ secrets.SMOKE_PARENT_PASSWORD }}
           SMOKE_SUITE: preview
           SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
           SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -626,6 +626,39 @@ describe('ParentTools access', () => {
         expect(parentToolsServiceMocks.loadParentHouseholdInviteModel).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps loaded family share links visible when a save action fails', async () => {
+        parentToolsServiceMocks.loadFamilyShareModel.mockResolvedValue({
+            children: [
+                {
+                    teamId: 'team-1',
+                    playerId: 'player-1',
+                    playerName: 'Sam Player'
+                }
+            ],
+            tokens: [
+                {
+                    id: 'token-1',
+                    label: 'Grandma',
+                    url: 'https://allplays.ai/family.html?token=token-1',
+                    childCount: 1,
+                    extraCalendarUrls: []
+                }
+            ]
+        });
+        parentToolsServiceMocks.revokeParentFamilyShare.mockRejectedValue(new Error('Unable to revoke family share link.'));
+
+        renderParentTools(['/parent-tools/share'], false, linkedAuth);
+
+        expect(await screen.findByText('Grandma')).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Revoke link' }));
+
+        expect(await screen.findByText('Unable to revoke family share link.')).toBeTruthy();
+        expect(screen.getByText('Grandma')).toBeTruthy();
+        expect(screen.getByText('https://allplays.ai/family.html?token=token-1')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Copy' })).toBeTruthy();
+    });
+
     it('opens reusable team fee checkout links when legacy fee payloads omit paymentAction', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {

--- a/apps/app/src/pages/parent-tools/CalendarTool.tsx
+++ b/apps/app/src/pages/parent-tools/CalendarTool.tsx
@@ -22,7 +22,8 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
     const clearFeedError = feedOperation.clearError;
     const loading = loadOperation.loading;
     const exporting = exportOperation.loading;
-    const error = loadOperation.error ?? exportOperation.error ?? feedOperation.error;
+    const loadError = loadOperation.error;
+    const error = loadError ?? exportOperation.error ?? feedOperation.error;
 
     const refresh = useCallback(async (options: { force?: boolean } = {}) => {
         clearLoadError();
@@ -116,7 +117,7 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
                 </div>
             </section>
 
-            {loading ? <LoadingBlock label="Loading calendar teams" /> : (
+            {!loadError && (loading ? <LoadingBlock label="Loading calendar teams" /> : (
                 <section className="grid gap-3 lg:grid-cols-2">
                     {teams.length ? teams.map((team) => (
                         <div key={team.teamId} className="app-card p-4">
@@ -135,7 +136,7 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
                         </div>
                     )) : <div className="app-card p-5 text-center"><CalendarDays className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" /><div className="mt-3 text-sm font-black text-gray-950">No team schedules</div><div className="mt-1 text-xs font-semibold text-gray-500">Schedules appear after a player or team is linked.</div></div>}
                 </section>
-            )}
+            ))}
         </div>
     );
 }

--- a/apps/app/src/pages/parent-tools/CertificatesTool.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.tsx
@@ -31,13 +31,13 @@ export function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; re
                 <ToolHeader icon={Award} title="Awards" detail="Published certificates for linked players." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
                 {error ? <RetryableStatus error={error} fallbackMessage="Unable to load awards." onRetry={refresh} retrying={loading} /> : null}
             </section>
-            {loading ? <LoadingBlock label="Loading awards" /> : (
+            {!error && (loading ? <LoadingBlock label="Loading awards" /> : (
                 <div className="grid gap-3 lg:grid-cols-2">
                     {cards.length ? cards.map((card) => <CertificateCard key={`${card.teamId}-${card.playerId}-${card.id}`} card={card} />) : (
                         <EmptyState icon={Award} title="No published awards" detail="Awards appear after a coach publishes certificates." />
                     )}
                 </div>
-            )}
+            ))}
         </div>
     );
 }

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -116,7 +116,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                 </form>
             </section>
 
-            {loading ? <LoadingBlock label="Loading share links" /> : (
+            {!error && (loading ? <LoadingBlock label="Loading share links" /> : (
                 <div className="grid gap-3 lg:grid-cols-2">
                     {tokens.length ? tokens.map((token) => (
                         <FamilyTokenCard
@@ -133,7 +133,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                         />
                     )) : <EmptyState icon={Share2} title="No family links" detail="Create a link when someone needs schedule access without a full account." />}
                 </div>
-            )}
+            ))}
 
             {pendingRevokeToken ? (
                 <div className="fixed inset-0 z-50 flex items-end justify-center bg-gray-950/40 px-4 py-5 sm:items-center" role="presentation">

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -21,7 +21,8 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     const clearSaveError = saveOperation.clearError;
     const loading = loadOperation.loading;
     const saving = saveOperation.loading;
-    const error = loadOperation.error ?? saveOperation.error;
+    const loadError = loadOperation.error;
+    const saveError = saveOperation.error;
 
     const refresh = useCallback(async () => {
         clearLoadError();
@@ -99,7 +100,8 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
         <div className="space-y-3">
             <section className="app-card p-4">
                 <ToolHeader icon={Share2} title="Family share" detail="Share a private family page with relatives and caregivers." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
-                {error ? <RetryableStatus error={error} fallbackMessage="Unable to load family share links." onRetry={loading ? undefined : refresh} retrying={loading} /> : null}
+                {loadError ? <RetryableStatus error={loadError} fallbackMessage="Unable to load family share links." onRetry={loading ? undefined : refresh} retrying={loading} /> : null}
+                {saveError ? <RetryableStatus error={saveError} fallbackMessage="Unable to save family share changes." /> : null}
                 {message ? <Status tone="success" message={message} /> : null}
                 <div className="mt-3 flex flex-wrap gap-1.5">
                     {children.length ? children.map((child) => (
@@ -116,7 +118,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                 </form>
             </section>
 
-            {!error && (loading ? <LoadingBlock label="Loading share links" /> : (
+            {!loadError && (loading ? <LoadingBlock label="Loading share links" /> : (
                 <div className="grid gap-3 lg:grid-cols-2">
                     {tokens.length ? tokens.map((token) => (
                         <FamilyTokenCard

--- a/apps/app/src/pages/parent-tools/FeesTool.tsx
+++ b/apps/app/src/pages/parent-tools/FeesTool.tsx
@@ -117,7 +117,7 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
             </section>
 
             {error ? <RetryableStatus error={error} fallbackMessage="Unable to load fees." onRetry={refresh} retrying={loading} /> : null}
-            {loading ? <LoadingBlock label="Loading fees" /> : (
+            {!error && (loading ? <LoadingBlock label="Loading fees" /> : (
                 <div className="grid gap-3 lg:grid-cols-2">
                     {visibleFees.length ? visibleFees.map((fee) => {
                         const feeKey = getFeeCardKey(fee);
@@ -126,7 +126,7 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
                         <EmptyState icon={DollarSign} title="No fees in this view" detail="Paid and canceled items are available under All." />
                     )}
                 </div>
-            )}
+            ))}
         </div>
     );
 }

--- a/apps/app/src/pages/parent-tools/RegistrationsTool.tsx
+++ b/apps/app/src/pages/parent-tools/RegistrationsTool.tsx
@@ -32,13 +32,13 @@ export function RegistrationsTool({ auth, refreshVersion }: { auth: AuthState; r
                 <ToolHeader icon={Ticket} title="Registrations" detail="Published team registration forms linked to your family." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
                 {error ? <RetryableStatus error={error} fallbackMessage="Unable to load registrations." onRetry={refresh} retrying={loading} /> : null}
             </section>
-            {loading ? <LoadingBlock label="Loading registrations" /> : (
+            {!error && (loading ? <LoadingBlock label="Loading registrations" /> : (
                 <div className="grid gap-3 lg:grid-cols-2">
                     {cards.length ? cards.map((card) => <RegistrationCard key={`${card.teamId}-${card.id}`} card={card} />) : (
                         <EmptyState icon={Ticket} title="No open registrations" detail="Published registration forms will appear here." />
                     )}
                 </div>
-            )}
+            ))}
         </div>
     );
 }

--- a/apps/app/src/pages/parent-tools/family-share-regression.test.ts
+++ b/apps/app/src/pages/parent-tools/family-share-regression.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(currentDir, 'FamilyShareTool.tsx'), 'utf8');
+
+describe('FamilyShareTool regression guards', () => {
+    it('keeps save failures separate from load failures', () => {
+        expect(source).toContain('const loadError = loadOperation.error;');
+        expect(source).toContain('const saveError = saveOperation.error;');
+        expect(source).toContain('{saveError ? <RetryableStatus error={saveError} fallbackMessage="Unable to save family share changes." /> : null}');
+        expect(source).toContain('{!loadError && (loading ? <LoadingBlock label="Loading share links" /> : (');
+    });
+});

--- a/tests/smoke/app-parent-live.spec.js
+++ b/tests/smoke/app-parent-live.spec.js
@@ -18,8 +18,10 @@ const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
 const parentEmail = process.env.SMOKE_PARENT_EMAIL || '';
 const parentPassword = process.env.SMOKE_PARENT_PASSWORD || '';
 const hasParentCredentials = Boolean(parentEmail && parentPassword);
+const missingParentCredentials = Boolean(appBaseUrl) && !hasParentCredentials;
 
 test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for live parent smoke tests');
+test.skip(missingParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for live parent smoke tests');
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 function appUrl(baseURL, hashPath) {
@@ -33,6 +35,9 @@ function appUrl(baseURL, hashPath) {
  * The auth route is #/auth; after success the app redirects to /teams (admin) or /home.
  */
 async function signIn(page, baseURL) {
+    if (!hasParentCredentials) {
+        throw new Error('SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for live parent smoke tests');
+    }
     await page.goto(appUrl(baseURL, '/auth'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
 

--- a/tests/smoke/app-parent-live.spec.js
+++ b/tests/smoke/app-parent-live.spec.js
@@ -4,8 +4,8 @@
  *
  * Requires:
  *   SMOKE_APP_BASE_URL=http://localhost:5174
- *   SMOKE_PARENT_EMAIL  (default: paul@paulsnider.net)
- *   SMOKE_PARENT_PASSWORD (default: looser)
+ *   SMOKE_PARENT_EMAIL
+ *   SMOKE_PARENT_PASSWORD
  *
  * Run:
  *   SMOKE_APP_BASE_URL=http://localhost:5174 \
@@ -15,8 +15,9 @@
 import { expect, test } from '@playwright/test';
 
 const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
-const parentEmail = process.env.SMOKE_PARENT_EMAIL || 'paul@paulsnider.net';
-const parentPassword = process.env.SMOKE_PARENT_PASSWORD || 'looser';
+const parentEmail = process.env.SMOKE_PARENT_EMAIL || '';
+const parentPassword = process.env.SMOKE_PARENT_PASSWORD || '';
+const hasParentCredentials = Boolean(parentEmail && parentPassword);
 
 test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for live parent smoke tests');
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
@@ -71,6 +72,7 @@ test('live: app boots without a blank white screen', async ({ page, baseURL }) =
 // AUTH — sign in with email/password completes successfully
 // ---------------------------------------------------------------------------
 test('live: parent can sign in and land on a protected page', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     const hash = new URL(page.url()).hash;
     // Should land on /teams (admin) or /home or /schedule — never /auth
@@ -83,6 +85,7 @@ test('live: parent can sign in and land on a protected page', async ({ page, bas
 // SCHEDULE — parent can see schedule
 // ---------------------------------------------------------------------------
 test('live: schedule page boots and shows content without crash', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -102,6 +105,7 @@ test('live: schedule page boots and shows content without crash', async ({ page,
 // PARENT TOOLS — access panel renders "Family workflows" heading
 // ---------------------------------------------------------------------------
 test('live: parent tools access panel boots and shows family workflows heading', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/parent-tools/access'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -116,6 +120,7 @@ test('live: parent tools access panel boots and shows family workflows heading',
 // FEES — fees panel boots
 // ---------------------------------------------------------------------------
 test('live: parent fees panel boots without error', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/parent-tools/fees'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -139,6 +144,7 @@ test('live: parent fees panel boots without error', async ({ page, baseURL }) =>
 // CALENDAR — calendar panel boots
 // ---------------------------------------------------------------------------
 test('live: parent calendar panel boots without crash', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/parent-tools/calendar'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -160,6 +166,7 @@ test('live: parent calendar panel boots without crash', async ({ page, baseURL }
 // SHARE — family share panel boots
 // ---------------------------------------------------------------------------
 test('live: parent share panel boots without crash', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/parent-tools/share'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -178,6 +185,7 @@ test('live: parent share panel boots without crash', async ({ page, baseURL }) =
 // HOUSEHOLD — household panel boots
 // ---------------------------------------------------------------------------
 test('live: parent household panel boots without crash', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/parent-tools/household'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -189,6 +197,7 @@ test('live: parent household panel boots without crash', async ({ page, baseURL 
 // CERTIFICATES / AWARDS — awards panel boots
 // ---------------------------------------------------------------------------
 test('live: parent awards panel boots without crash', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/parent-tools/certificates'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -206,6 +215,7 @@ test('live: parent awards panel boots without crash', async ({ page, baseURL }) 
 // NAVIGATION — tab switching within parent tools
 // ---------------------------------------------------------------------------
 test('live: parent tools tab navigation works across tabs', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/parent-tools/access'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
@@ -227,6 +237,7 @@ test('live: parent tools tab navigation works across tabs', async ({ page, baseU
 // RSVP — schedule event detail has RSVP section
 // ---------------------------------------------------------------------------
 test('live: schedule RSVP button opens response panel without crash', async ({ page, baseURL }) => {
+    test.skip(!hasParentCredentials, 'SMOKE_PARENT_EMAIL and SMOKE_PARENT_PASSWORD are required for authenticated parent smoke tests');
     await signIn(page, baseURL);
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });

--- a/tests/smoke/app-parent-live.spec.js
+++ b/tests/smoke/app-parent-live.spec.js
@@ -1,0 +1,258 @@
+/**
+ * Live smoke tests for parent workflows — authenticates with real Firebase credentials
+ * and exercises the parent tools hub against the dev server.
+ *
+ * Requires:
+ *   SMOKE_APP_BASE_URL=http://localhost:5174
+ *   SMOKE_PARENT_EMAIL  (default: paul@paulsnider.net)
+ *   SMOKE_PARENT_PASSWORD (default: looser)
+ *
+ * Run:
+ *   SMOKE_APP_BASE_URL=http://localhost:5174 \
+ *     npx playwright test tests/smoke/app-parent-live.spec.js \
+ *     --config=playwright.smoke.config.js --reporter=line
+ */
+import { expect, test } from '@playwright/test';
+
+const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
+const parentEmail = process.env.SMOKE_PARENT_EMAIL || 'paul@paulsnider.net';
+const parentPassword = process.env.SMOKE_PARENT_PASSWORD || 'looser';
+
+test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for live parent smoke tests');
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+function appUrl(baseURL, hashPath) {
+    const url = new URL('/', appBaseUrl || baseURL);
+    url.hash = hashPath;
+    return url.toString();
+}
+
+/**
+ * Sign in and wait for Firebase auth to fully resolve.
+ * The auth route is #/auth; after success the app redirects to /teams (admin) or /home.
+ */
+async function signIn(page, baseURL) {
+    await page.goto(appUrl(baseURL, '/auth'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    const emailField = page.getByLabel('Email');
+    const passwordField = page.getByLabel('Password');
+    await expect(emailField).toBeVisible({ timeout: 10000 });
+    await emailField.fill(parentEmail);
+    await passwordField.fill(parentPassword);
+
+    // Click the submit Sign in button (second one, inside the form)
+    await page.getByRole('button', { name: 'Sign in' }).last().click();
+
+    // Wait for successful redirect away from /auth AND for the URL to stabilize
+    // (the app auto-navigates admin users from /teams → /teams/:teamId after sign-in)
+    await expect(async () => {
+        const hash = new URL(page.url()).hash;
+        expect(hash).not.toMatch(/^#\/(auth|sign-in)/);
+    }).toPass({ timeout: 20000 });
+
+    // Allow any post-login navigation effects to settle before the caller navigates
+    await page.waitForTimeout(1500);
+}
+
+// ---------------------------------------------------------------------------
+// BOOT — app loads and renders something sensible
+// ---------------------------------------------------------------------------
+test('live: app boots without a blank white screen', async ({ page, baseURL }) => {
+    await page.goto(appUrl(baseURL, '/auth'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+    // Auth page should always be reachable and show sign-in form
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible({ timeout: 10000 });
+    // No horizontal overflow
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 2)).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// AUTH — sign in with email/password completes successfully
+// ---------------------------------------------------------------------------
+test('live: parent can sign in and land on a protected page', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    const hash = new URL(page.url()).hash;
+    // Should land on /teams (admin) or /home or /schedule — never /auth
+    expect(hash).not.toMatch(/^#\/(auth|sign-in)/);
+    // App shell nav should be present
+    await expect(page.locator('nav, [role="navigation"]').first()).toBeVisible({ timeout: 10000 });
+});
+
+// ---------------------------------------------------------------------------
+// SCHEDULE — parent can see schedule
+// ---------------------------------------------------------------------------
+test('live: schedule page boots and shows content without crash', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    await expect(async () => {
+        // Could be a schedule heading, empty state, or event cards
+        const hasSchedule = await page.getByText(/schedule/i).first().isVisible().catch(() => false);
+        const hasContent = await page.locator('[class*="card"],[class*="event"],[class*="game"]').first().isVisible().catch(() => false);
+        const hasEmpty = await page.getByText(/no (upcoming|games|events)/i).first().isVisible().catch(() => false);
+        expect(hasSchedule || hasContent || hasEmpty).toBe(true);
+    }).toPass({ timeout: 20000 });
+
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 2)).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// PARENT TOOLS — access panel renders "Family workflows" heading
+// ---------------------------------------------------------------------------
+test('live: parent tools access panel boots and shows family workflows heading', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/parent-tools/access'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 25000 });
+    // Access tab should always be present (use aria-pressed to distinguish tab button)
+    await expect(page.locator('button[aria-pressed]', { hasText: 'Access' }).first()).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 2)).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// FEES — fees panel boots
+// ---------------------------------------------------------------------------
+test('live: parent fees panel boots without error', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/parent-tools/fees'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    // Wait for family workflows heading (parent tools shell)
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 25000 });
+
+    // Fees panel: either fee records, empty state, or access-locked redirect
+    await expect(async () => {
+        const hasFees = await page.getByText(/fees|team dues|balance/i).first().isVisible().catch(() => false);
+        const hasEmpty = await page.getByText(/no (fees|open|dues)/i).first().isVisible().catch(() => false);
+        const hasLockedMsg = await page.getByText(/request access|no linked players/i).first().isVisible().catch(() => false);
+        const hasLoading = await page.getByText(/loading/i).first().isVisible().catch(() => false);
+        expect(hasFees || hasEmpty || hasLockedMsg || hasLoading).toBe(true);
+    }).toPass({ timeout: 15000 });
+
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 2)).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// CALENDAR — calendar panel boots
+// ---------------------------------------------------------------------------
+test('live: parent calendar panel boots without crash', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/parent-tools/calendar'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 25000 });
+
+    await expect(async () => {
+        const hasCalendar = await page.getByText('Calendar tools').isVisible().catch(() => false);
+        const hasNoSchedules = await page.getByText('No team schedules').isVisible().catch(() => false);
+        const hasDownload = await page.getByRole('button', { name: /download/i }).isVisible().catch(() => false);
+        const hasLocked = await page.getByText(/request access/i).first().isVisible().catch(() => false);
+        expect(hasCalendar || hasNoSchedules || hasDownload || hasLocked).toBe(true);
+    }).toPass({ timeout: 20000 });
+
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 2)).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// SHARE — family share panel boots
+// ---------------------------------------------------------------------------
+test('live: parent share panel boots without crash', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/parent-tools/share'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 25000 });
+
+    await expect(async () => {
+        const hasShare = await page.getByText('Family share').isVisible().catch(() => false);
+        const hasNoLinks = await page.getByText('No family links').isVisible().catch(() => false);
+        const hasLocked = await page.getByText(/request access/i).first().isVisible().catch(() => false);
+        expect(hasShare || hasNoLinks || hasLocked).toBe(true);
+    }).toPass({ timeout: 20000 });
+});
+
+// ---------------------------------------------------------------------------
+// HOUSEHOLD — household panel boots
+// ---------------------------------------------------------------------------
+test('live: parent household panel boots without crash', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/parent-tools/household'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 25000 });
+});
+
+// ---------------------------------------------------------------------------
+// CERTIFICATES / AWARDS — awards panel boots
+// ---------------------------------------------------------------------------
+test('live: parent awards panel boots without crash', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/parent-tools/certificates'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 25000 });
+
+    await expect(async () => {
+        const hasAward = await page.getByText(/award|certificate|hustle|no awards|nothing yet/i).first().isVisible().catch(() => false);
+        const hasLocked = await page.getByText(/request access/i).first().isVisible().catch(() => false);
+        expect(hasAward || hasLocked).toBe(true);
+    }).toPass({ timeout: 15000 });
+});
+
+// ---------------------------------------------------------------------------
+// NAVIGATION — tab switching within parent tools
+// ---------------------------------------------------------------------------
+test('live: parent tools tab navigation works across tabs', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/parent-tools/access'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 25000 });
+
+    const tabsToTest = ['Fees', 'Calendar', 'Awards'];
+    for (const tabLabel of tabsToTest) {
+        const tab = page.getByRole('button', { name: tabLabel });
+        if (await tab.isVisible().catch(() => false)) {
+            await tab.click();
+            // Loading spinner clears and some heading is visible
+            await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 10000 });
+            expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 2)).toBe(true);
+        }
+    }
+});
+
+// ---------------------------------------------------------------------------
+// RSVP — schedule event detail has RSVP section
+// ---------------------------------------------------------------------------
+test('live: schedule RSVP button opens response panel without crash', async ({ page, baseURL }) => {
+    await signIn(page, baseURL);
+    await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 15000 });
+
+    // Wait for schedule to load
+    await expect(async () => {
+        const notLoading = await page.getByText('Loading ALL PLAYS').isHidden().catch(() => false);
+        expect(notLoading).toBe(true);
+        const hasContent = await page.getByRole('heading').first().isVisible().catch(() => false);
+        expect(hasContent).toBe(true);
+    }).toPass({ timeout: 20000 });
+
+    const rsvpButton = page.getByRole('button', { name: /rsvp|going|attending/i }).first();
+    const hasRsvp = await rsvpButton.isVisible({ timeout: 8000 }).catch(() => false);
+
+    if (!hasRsvp) {
+        // No upcoming events for this account — skip gracefully
+        return;
+    }
+
+    await rsvpButton.click();
+    await expect(async () => {
+        const hasOptions = await page.getByRole('button', { name: /yes|no|maybe|going|not going/i }).first().isVisible().catch(() => false);
+        const hasPanel = await page.getByText(/rsvp|attendance|response/i).first().isVisible().catch(() => false);
+        expect(hasOptions || hasPanel).toBe(true);
+    }).toPass({ timeout: 10000 });
+
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 2)).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Add `tests/smoke/app-parent-live.spec.js` — 11 live Playwright smoke tests that authenticate with real Firebase credentials and exercise all parent tool panels (access, fees, calendar, share, household, awards, RSVP). Tests are opt-in via `SMOKE_APP_BASE_URL` env var and skip in standard CI.
- Fix a bug where parent tool panels rendered both an error/retry block AND an empty state simultaneously when a data load fails. Affected `FeesTool`, `CertificatesTool`, `RegistrationsTool`, `FamilyShareTool`, and `CalendarTool`. Fix: gate the list/empty-state block on `!error` so only the error+retry shows on failure.

## How the bug was found

The fees panel was visually confirmed (via Playwright + real Firebase auth) to show "Unable to load fees." and "No fees in this view" at the same time. The same structural pattern existed across all five panels.

## Test plan

- [ ] Run existing unit tests: `npm test` (2 pre-existing failures in `app-team-media.test.jsx`, unrelated)
- [ ] Run live smoke tests against the dev server:
  ```
  SMOKE_APP_BASE_URL=http://localhost:5174 SMOKE_BASE_URL=http://localhost:5174 \
    npx playwright test tests/smoke/app-parent-live.spec.js \
    --config=playwright.smoke.config.js --reporter=line
  ```
- [ ] Manually trigger a fee load failure (no linked players) and confirm only the error/retry block renders

## Notes

The `signIn()` helper uses a 1500ms `waitForTimeout` after auth to allow admin users' automatic `/teams → /teams/:teamId` redirect to settle before tests navigate to a parent tools route. This is a known timing workaround for the post-login navigation cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)