### PR TITLE
Add substitution-only live tracker history coverage

### DIFF
--- a/tests/unit/live-tracker-finish.test.js
+++ b/tests/unit/live-tracker-finish.test.js
@@ -182,6 +182,46 @@ describe('live tracker finish completion plan', () => {
     expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(true);
   });
 
+  it('marks zero-stat players with substitution-only live tracker appearances as having appeared', () => {
+    const plan = buildFinishCompletionPlan({
+      requestedHome: 0,
+      requestedAway: 0,
+      liveHome: 0,
+      liveAway: 0,
+      scoreLogIsComplete: true,
+      log: [],
+      columns: ['PTS', 'REB', 'AST'],
+      roster: [
+        { id: 'p-zero', name: 'Zero Stat', num: '12' }
+      ],
+      statsByPlayerId: {
+        'p-zero': { pts: 0, reb: 0, ast: 0, fouls: 0, time: 0 }
+      },
+      activePlayerIds: ['p-other'],
+      substitutions: [
+        { out: 'p-other', in: 'p-zero' },
+        { out: 'p-zero', in: 'p-other' }
+      ],
+      opponentEntries: []
+    });
+
+    expect(plan.aggregatedStatsWrites).toEqual([
+      {
+        playerId: 'p-zero',
+        data: {
+          playerName: 'Zero Stat',
+          playerNumber: '12',
+          participated: true,
+          participationStatus: 'appeared',
+          participationSource: 'live-tracker-finish',
+          stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
+          timeMs: 0
+        }
+      }
+    ]);
+    expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(true);
+  });
+
   it('keeps live-tracker aggregates with real participation visible in player profile history', () => {
     const standardFinishAggregateDoc = {
       playerName: 'Zero Stat',

--- a/tests/unit/live-tracker-save-complete.test.js
+++ b/tests/unit/live-tracker-save-complete.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { commitFinishPlan, runSaveAndCompleteWorkflow } from '../../js/live-tracker-save-complete.js';
+import { hasPlayerProfileParticipation } from '../../js/player-profile-stats.js';
 
 function buildDocRef(...args) {
   if (args.length === 1) {
@@ -221,6 +222,41 @@ describe('live tracker save-and-complete workflow', () => {
         stats: { pts: 0, ast: 0, fouls: 0 }
       }
     });
+  });
+
+  it('preserves substitution-only zero-stat appearances in finish writes and player history visibility', async () => {
+    const harness = buildHarness();
+    harness.context.state.stats = {
+      'p-zero': { pts: 0, ast: 0, fouls: 0, time: 0 },
+      'p-other': { pts: 0, ast: 0, fouls: 0, time: 0 }
+    };
+    harness.context.state.onCourt = ['p-other'];
+    harness.context.state.subs = [
+      { out: 'p-other', in: 'p-zero' },
+      { out: 'p-zero', in: 'p-other' }
+    ];
+    harness.context.roster = [
+      { id: 'p-zero', name: 'Zero Stat', num: '12' },
+      { id: 'p-other', name: 'Other Player', num: '3' }
+    ];
+    harness.context.currentConfig = { columns: ['PTS', 'AST'] };
+
+    await runSaveAndCompleteWorkflow(harness.context);
+
+    const zeroStatWrite = harness.setCalls.find(({ ref }) => ref.path === 'teams/team-1/games/game-9/aggregatedStats/p-zero');
+    expect(zeroStatWrite).toEqual({
+      ref: { kind: 'doc', path: 'teams/team-1/games/game-9/aggregatedStats/p-zero' },
+      data: {
+        playerName: 'Zero Stat',
+        playerNumber: '12',
+        timeMs: 0,
+        participated: true,
+        participationStatus: 'appeared',
+        participationSource: 'live-tracker-finish',
+        stats: { pts: 0, ast: 0, fouls: 0 }
+      }
+    });
+    expect(hasPlayerProfileParticipation(zeroStatWrite.data)).toBe(true);
   });
 
   it('accepts only one in-flight finish submission and keeps the button disabled until commit settles', async () => {


### PR DESCRIPTION
Closes #3205

## What changed
- added a `buildFinishCompletionPlan` regression test for a zero-stat bench player whose only appearance evidence is substitution history
- added a `runSaveAndCompleteWorkflow` regression test that persists the same substitution-only case through aggregated stats writes
- asserted the saved aggregate still passes `hasPlayerProfileParticipation(...)` so the player remains visible on the player profile Games tab

## Root Cause
The live tracker finish code already treats substitutions as explicit appearance evidence, but the zero-stat regression coverage only exercised lineup-based `activePlayerIds` and recorded playing time. That left the substitution-only participation path unguarded, so a future refactor could silently reintroduce false did-not-play writes for players who checked in and later checked out without stats.

## Prevention / Learning
For participation and history filters, add one focused regression per independent appearance signal instead of assuming one happy-path zero-stat test covers the whole invariant. In this workflow that means separately guarding lineup presence, substitution history, and recorded time.

## Regression Tests
- `npx vitest run tests/unit/live-tracker-finish.test.js tests/unit/live-tracker-save-complete.test.js --reporter=verbose`
- `tests/unit/live-tracker-finish.test.js` now proves substitution-only history marks `participated:true`, `participationStatus:'appeared'`, and avoids `didNotPlay`
- `tests/unit/live-tracker-save-complete.test.js` now proves the workflow persists that aggregate and keeps it visible via `hasPlayerProfileParticipation(...)`

## Recurrence Risk
Low. The finish-plan unit test and the save-and-complete workflow test now both lock in the substitution-only zero-stat participation path at the two places where this regression would matter.