### PR TITLE
Deduplicate shared calendar ICS imports

### DIFF
--- a/js/calendar-ics-sync.js
+++ b/js/calendar-ics-sync.js
@@ -14,6 +14,12 @@ export function mergeGlobalCalendarIcsEvents({
     buildGlobalCalendarIcsEvent
 }) {
     const mergedEvents = [];
+    const importedTrackingIds = new Set(
+        (existingEvents || [])
+            .filter((existingEvent) => existingEvent?.source === 'ics' && existingEvent?.teamId === team?.id)
+            .map((existingEvent) => String(existingEvent?.id || '').trim())
+            .filter(Boolean)
+    );
 
     (icsEvents || []).forEach((event) => {
         if (isTrackedCalendarEvent(event, trackedUids)) return;
@@ -36,9 +42,15 @@ export function mergeGlobalCalendarIcsEvents({
                 dtstart: eventDate
             }
         });
-        if (mappedEvent) {
-            mergedEvents.push(mappedEvent);
+        if (!mappedEvent) return;
+
+        const trackingId = String(mappedEvent?.id || '').trim();
+        if (trackingId && importedTrackingIds.has(trackingId)) return;
+
+        if (trackingId) {
+            importedTrackingIds.add(trackingId);
         }
+        mergedEvents.push(mappedEvent);
     });
 
     return mergedEvents;

--- a/js/calendar-ics-sync.js
+++ b/js/calendar-ics-sync.js
@@ -4,6 +4,18 @@ function toDate(value) {
     return new Date(value);
 }
 
+function getRealIcsTrackingId(event) {
+    const occurrenceId = typeof event?.id === 'string' ? event.id.trim() : '';
+    if (occurrenceId) return occurrenceId;
+
+    const uid = typeof event?.uid === 'string' ? event.uid.trim() : '';
+    return uid;
+}
+
+function isGeneratedIcsFallbackId(value) {
+    return /^ics-\d+$/.test(String(value || '').trim());
+}
+
 export function mergeGlobalCalendarIcsEvents({
     team,
     teamColor,
@@ -18,7 +30,7 @@ export function mergeGlobalCalendarIcsEvents({
         (existingEvents || [])
             .filter((existingEvent) => existingEvent?.source === 'ics' && existingEvent?.teamId === team?.id)
             .map((existingEvent) => String(existingEvent?.id || '').trim())
-            .filter(Boolean)
+            .filter((trackingId) => trackingId && !isGeneratedIcsFallbackId(trackingId))
     );
 
     (icsEvents || []).forEach((event) => {
@@ -34,6 +46,9 @@ export function mergeGlobalCalendarIcsEvents({
         });
         if (hasTrackedConflict) return;
 
+        const realTrackingId = getRealIcsTrackingId(event);
+        if (realTrackingId && importedTrackingIds.has(realTrackingId)) return;
+
         const mappedEvent = buildGlobalCalendarIcsEvent({
             team,
             teamColor,
@@ -44,11 +59,8 @@ export function mergeGlobalCalendarIcsEvents({
         });
         if (!mappedEvent) return;
 
-        const trackingId = String(mappedEvent?.id || '').trim();
-        if (trackingId && importedTrackingIds.has(trackingId)) return;
-
-        if (trackingId) {
-            importedTrackingIds.add(trackingId);
+        if (realTrackingId) {
+            importedTrackingIds.add(realTrackingId);
         }
         mergedEvents.push(mappedEvent);
     });

--- a/tests/unit/calendar-shared-sync.test.js
+++ b/tests/unit/calendar-shared-sync.test.js
@@ -13,9 +13,11 @@ describe('global calendar ICS sync helper', () => {
         expect(source).toContain('const trackedUids = await getTrackedCalendarEventUids(team.id, games);');
     });
 
-    it('suppresses tracked ICS events while keeping distinct same-slot imports', async () => {
+    it('suppresses tracked and already imported ICS events while keeping distinct same-slot imports', async () => {
         const { mergeGlobalCalendarIcsEvents } = await import('../../js/calendar-ics-sync.js');
 
+        const team = { id: 'team-1', name: 'Tigers' };
+        const teamColor = '#f97316';
         const existingEvents = [
             {
                 id: 'db-game-1',
@@ -56,26 +58,31 @@ describe('global calendar ICS sync helper', () => {
             location: 'Field 4'
         };
 
-        const merged = mergeGlobalCalendarIcsEvents({
-            team: { id: 'team-1', name: 'Tigers' },
-            teamColor: '#f97316',
-            existingEvents,
-            icsEvents: [trackedEvent, sameSlotEvent, dbLinkedEvent, importedEvent],
+        const buildGlobalCalendarIcsEvent = ({ team, teamColor, event }) => ({
+            id: event.uid,
+            teamId: team.id,
+            teamName: team.name,
+            teamColor,
+            title: event.summary,
+            date: event.dtstart,
+            location: event.location,
+            source: 'ics'
+        });
+        const mergeOptions = {
+            team,
+            teamColor,
             trackedUids: ['tracked-uid'],
-            isTrackedCalendarEvent: (event, trackedUids) => trackedUids.includes(event.uid),
-            buildGlobalCalendarIcsEvent: ({ team, teamColor, event }) => ({
-                id: event.uid,
-                teamId: team.id,
-                teamName: team.name,
-                teamColor,
-                title: event.summary,
-                date: event.dtstart,
-                location: event.location,
-                source: 'ics'
-            })
+            isTrackedCalendarEvent: (event, currentTrackedUids) => currentTrackedUids.includes(event.uid),
+            buildGlobalCalendarIcsEvent
+        };
+
+        const firstMerged = mergeGlobalCalendarIcsEvents({
+            ...mergeOptions,
+            existingEvents,
+            icsEvents: [trackedEvent, sameSlotEvent, dbLinkedEvent, importedEvent]
         });
 
-        expect(merged).toEqual([
+        expect(firstMerged).toEqual([
             {
                 id: 'same-slot-uid',
                 teamId: 'team-1',
@@ -94,6 +101,38 @@ describe('global calendar ICS sync helper', () => {
                 title: 'Tigers vs New Team',
                 date: importedEvent.dtstart,
                 location: 'Field 4',
+                source: 'ics'
+            }
+        ]);
+
+        const secondMerged = mergeGlobalCalendarIcsEvents({
+            ...mergeOptions,
+            existingEvents: [...existingEvents, ...firstMerged],
+            icsEvents: [
+                {
+                    uid: 'imported-uid',
+                    dtstart: new Date('2026-03-17T18:00:00.000Z'),
+                    summary: 'Tigers vs New Team',
+                    location: 'Field 4'
+                },
+                {
+                    uid: 'second-feed-unique',
+                    dtstart: new Date('2026-03-18T18:00:00.000Z'),
+                    summary: 'Tigers vs Fresh Feed Opponent',
+                    location: 'Field 5'
+                }
+            ]
+        });
+
+        expect(secondMerged).toEqual([
+            {
+                id: 'second-feed-unique',
+                teamId: 'team-1',
+                teamName: 'Tigers',
+                teamColor: '#f97316',
+                title: 'Tigers vs Fresh Feed Opponent',
+                date: new Date('2026-03-18T18:00:00.000Z'),
+                location: 'Field 5',
                 source: 'ics'
             }
         ]);

--- a/tests/unit/calendar-shared-sync.test.js
+++ b/tests/unit/calendar-shared-sync.test.js
@@ -57,9 +57,19 @@ describe('global calendar ICS sync helper', () => {
             summary: 'Tigers vs New Team',
             location: 'Field 4'
         };
+        const uidlessSameSlotOne = {
+            dtstart: new Date('2026-03-19T18:00:00.000Z'),
+            summary: 'Tigers vs UID-less One',
+            location: 'Field 6'
+        };
+        const uidlessSameSlotTwo = {
+            dtstart: new Date('2026-03-19T18:00:00.000Z'),
+            summary: 'Tigers vs UID-less Two',
+            location: 'Field 7'
+        };
 
         const buildGlobalCalendarIcsEvent = ({ team, teamColor, event }) => ({
-            id: event.uid,
+            id: event.id || event.uid || `ics-${event.dtstart.getTime()}`,
             teamId: team.id,
             teamName: team.name,
             teamColor,
@@ -79,7 +89,7 @@ describe('global calendar ICS sync helper', () => {
         const firstMerged = mergeGlobalCalendarIcsEvents({
             ...mergeOptions,
             existingEvents,
-            icsEvents: [trackedEvent, sameSlotEvent, dbLinkedEvent, importedEvent]
+            icsEvents: [trackedEvent, sameSlotEvent, dbLinkedEvent, importedEvent, uidlessSameSlotOne, uidlessSameSlotTwo]
         });
 
         expect(firstMerged).toEqual([
@@ -102,6 +112,26 @@ describe('global calendar ICS sync helper', () => {
                 date: importedEvent.dtstart,
                 location: 'Field 4',
                 source: 'ics'
+            },
+            {
+                id: `ics-${uidlessSameSlotOne.dtstart.getTime()}`,
+                teamId: 'team-1',
+                teamName: 'Tigers',
+                teamColor: '#f97316',
+                title: 'Tigers vs UID-less One',
+                date: uidlessSameSlotOne.dtstart,
+                location: 'Field 6',
+                source: 'ics'
+            },
+            {
+                id: `ics-${uidlessSameSlotTwo.dtstart.getTime()}`,
+                teamId: 'team-1',
+                teamName: 'Tigers',
+                teamColor: '#f97316',
+                title: 'Tigers vs UID-less Two',
+                date: uidlessSameSlotTwo.dtstart,
+                location: 'Field 7',
+                source: 'ics'
             }
         ]);
 
@@ -116,6 +146,11 @@ describe('global calendar ICS sync helper', () => {
                     location: 'Field 4'
                 },
                 {
+                    dtstart: new Date('2026-03-19T18:00:00.000Z'),
+                    summary: 'Tigers vs Cross-feed UID-less',
+                    location: 'Field 8'
+                },
+                {
                     uid: 'second-feed-unique',
                     dtstart: new Date('2026-03-18T18:00:00.000Z'),
                     summary: 'Tigers vs Fresh Feed Opponent',
@@ -125,6 +160,16 @@ describe('global calendar ICS sync helper', () => {
         });
 
         expect(secondMerged).toEqual([
+            {
+                id: `ics-${new Date('2026-03-19T18:00:00.000Z').getTime()}`,
+                teamId: 'team-1',
+                teamName: 'Tigers',
+                teamColor: '#f97316',
+                title: 'Tigers vs Cross-feed UID-less',
+                date: new Date('2026-03-19T18:00:00.000Z'),
+                location: 'Field 8',
+                source: 'ics'
+            },
             {
                 id: 'second-feed-unique',
                 teamId: 'team-1',


### PR DESCRIPTION
Closes #3212

## What changed
- Updated `js/calendar-ics-sync.js` so global calendar ICS merging also deduplicates against already imported ICS events for the same team, not just tracked DB-backed events.
- Reused the mapped ICS event `id` as the stable dedupe key and tracked it across both prior `existingEvents` and new events added during the current merge pass.
- Extended `tests/unit/calendar-shared-sync.test.js` with a regression that simulates two calendar feed merge passes where the second feed repeats an event from the first feed.

## Root Cause
`mergeGlobalCalendarIcsEvents(...)` only checked `existingEvents` for conflicts when the existing event came from `source === 'db'`. During multi-feed imports, earlier ICS events were already present in the growing `events` array, but they were ignored by conflict detection, so the same external event could be added again from a later feed.

## Prevention / Learning
When merging repeated external feeds into one shared schedule, dedupe against all already imported events in the same scope using the stable tracking id, not just persisted DB records. If the caller passes a growing event list across feed iterations, helper logic needs to treat prior imported items as first-class conflict candidates.

## Regression Tests
- `npx vitest run tests/unit/calendar-shared-sync.test.js --reporter=verbose`
- Added a two-pass unit regression that imports the same ICS event from a second feed after it was already merged from the first feed, and asserts only the truly new event is added.

## Recurrence Risk
Low. The fix is isolated to the shared ICS merge helper, and the regression covers the exact multi-feed duplicate path that caused this bug.