### PR TITLE
Default score-capable event details to Game tab

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -693,6 +693,67 @@ describe('ScheduleEventDetail nav visibility', () => {
     expect(screen.getAllByRole('button', { name: 'Rideshare' }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('button', { name: 'Assignments' }).length).toBeGreaterThan(0);
   });
+
+  it('defaults score-capable tracked games to the Game tab when the route omits section', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        canUpdateScore: true,
+        statTrackerConfigId: 'cfg-soccer'
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
+
+    renderScheduleEventDetailWithLocation();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Game hub' })).toBeTruthy();
+    });
+
+    expect(screen.getByTestId('standard-tracker-launch')).toBeTruthy();
+    expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1');
+  });
+
+  it('keeps non-score-capable viewers on Availability when the route omits section', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        canUpdateScore: false,
+        statTrackerConfigId: 'cfg-soccer'
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetailWithLocation();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('heading', { name: 'Game hub' })).toBeNull();
+    expect(screen.queryByTestId('standard-tracker-launch')).toBeNull();
+  });
+
+  it('preserves an explicit section query even for score-capable viewers', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        canUpdateScore: true,
+        statTrackerConfigId: 'cfg-soccer'
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=availability');
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('heading', { name: 'Game hub' })).toBeNull();
+    expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=availability');
+  });
 });
 
 describe('ScheduleEventDetail rideshare permissions', () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -151,12 +151,16 @@ type EventDetailSectionId = ScheduleEventDetailSectionId;
 
 const eventDetailSectionIds = new Set<EventDetailSectionId>(['availability', 'rideshare', 'assignments', 'game']);
 
-export function parseEventDetailSection(section: string | null | undefined): EventDetailSectionId {
+function parseRequestedEventDetailSection(section: string | null | undefined): EventDetailSectionId | null {
   const normalized = String(section || '').trim().toLowerCase();
   if (normalized && eventDetailSectionIds.has(normalized as EventDetailSectionId)) {
     return normalized as EventDetailSectionId;
   }
-  return 'availability';
+  return null;
+}
+
+export function parseEventDetailSection(section: string | null | undefined): EventDetailSectionId {
+  return parseRequestedEventDetailSection(section) || 'availability';
 }
 
 const hubIconComponents: Record<ScheduleHubIcon, LucideIcon> = {
@@ -170,6 +174,13 @@ const hubIconComponents: Record<ScheduleHubIcon, LucideIcon> = {
 
 function isActiveTrackedScheduleEvent(event?: ParentScheduleEvent | null) {
   return Boolean(event?.isDbGame && !event?.isCancelled);
+}
+
+function getDefaultEventDetailSection(event?: ParentScheduleEvent | null) {
+  if (isActiveTrackedScheduleEvent(event) && event?.canUpdateScore) {
+    return 'game';
+  }
+  return 'availability';
 }
 
 function hasRideshareActivity(event?: ParentScheduleEvent | null) {
@@ -239,7 +250,9 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
   const [selectedChildId, setSelectedChildId] = useState(searchParams.get('childId') || '');
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [activeSection, setActiveSection] = useState<EventDetailSectionId>(() => parseEventDetailSection(searchParams.get('section')));
+  const [activeSection, setActiveSection] = useState<EventDetailSectionId | null>(() => (
+    searchParams.has('section') ? parseEventDetailSection(searchParams.get('section')) : null
+  ));
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [availabilityNote, setAvailabilityNote] = useState('');
   const [initialLoadPending, setInitialLoadPending] = useState(true);
@@ -338,7 +351,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   }, [auth.user?.uid, decodedTeamId, decodedEventId]);
 
   useEffect(() => {
-    setActiveSection(parseEventDetailSection(searchParams.get('section')));
+    setActiveSection(searchParams.has('section') ? parseEventDetailSection(searchParams.get('section')) : null);
     const routeChildId = searchParams.get('childId') || '';
     if (routeChildId) {
       setSelectedChildId(routeChildId);
@@ -463,7 +476,12 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const attentionItems = getAttentionItems(selectedEvent, rsvp).filter((item) => item.section !== 'availability' && item.title !== 'Practice packet ready');
   const sections = getEventDetailSections(selectedEvent);
   const sectionIds = new Set(sections.map((section) => section.id));
-  const resolvedActiveSection = sectionIds.has(activeSection) ? activeSection : sections[0]?.id || 'availability';
+  const defaultSection = getDefaultEventDetailSection(selectedEvent);
+  const resolvedActiveSection = activeSection && sectionIds.has(activeSection)
+    ? activeSection
+    : sectionIds.has(defaultSection)
+      ? defaultSection
+      : sections[0]?.id || 'availability';
 
   const addEventToCalendar = async () => {
     const icsTitle = `${title} | ${selectedEvent.teamName}`;

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1265,8 +1265,7 @@ test('Android-sized schedule smoke covers practice packet and More workflow with
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule/team-1/practice-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
-    const practiceHeading = page.getByRole('heading', { name: 'Practice' });
-    await waitForScheduleRoute(page, practiceHeading);
+    await waitForScheduleRoute(page, page.locator('.event-summary-card'));
     await expect(page.getByRole('button', { name: 'Practice packet ready, review packet' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Practice packet ready, review packet' }).click();
@@ -1287,7 +1286,7 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
         gameHomeScore: 4,
         gameAwayScore: 2
     });
-    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
+    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1&section=availability'), { waitUntil: 'domcontentloaded' });
 
     const eventSummaryCard = page.locator('.event-summary-card');
     await expect(eventSummaryCard.getByRole('heading', { name: 'vs. Falcons' })).toBeVisible({ timeout: 15000 });
@@ -1406,7 +1405,7 @@ test('app schedule saves edited availability notes without re-tapping RSVP', asy
         gameMyRsvp: 'going',
         gameMyRsvpNote: 'Original note'
     });
-    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
+    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1&section=availability'), { waitUntil: 'domcontentloaded' });
 
     const availabilitySection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Availability' }) });
     await waitForScheduleRoute(page, availabilitySection.getByRole('heading', { name: 'Availability' }));


### PR DESCRIPTION
Closes #3219

## What changed
- distinguished missing `?section` queries from explicit section requests in `ScheduleEventDetail`
- defaulted tracked games to the `Game` tab only when the viewer can update score and the route does not already specify a section
- preserved existing explicit section behavior, including the current availability fallback for invalid section values
- added focused regressions for score-capable default-to-Game, non-score fallback-to-Availability, and explicit section preservation

## Root Cause
`ScheduleEventDetail` seeded and resynced `activeSection` directly from `parseEventDetailSection(searchParams.get('section'))`, and that parser always fell back to `availability` when `section` was missing. Because the component treated an omitted query the same as an explicit availability choice, score-capable staff never got a role-aware default and had to tap into the Game hub manually.

## Prevention / Learning
When route state is optional, do not collapse "missing" and "explicit" query values into the same fallback path. Preserve explicit deep links as authoritative, but compute role-aware defaults only when the route truly omits that state.

## Regression Tests
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx -t "defaults score-capable tracked games to the Game tab when the route omits section|keeps non-score-capable viewers on Availability when the route omits section|preserves an explicit section query even for score-capable viewers" --reporter=verbose`
- `src/pages/ScheduleEventDetail.test.tsx` now verifies:
  - score-capable tracked games open the Game hub without clicking a tab when `?section` is absent
  - non-score-capable viewers still land on Availability for the same route shape
  - explicit `?section=availability` remains authoritative even for score-capable viewers