### PR TITLE
Remove deep chat bubble serialization on scroll

### DIFF
--- a/apps/app/src/lib/adapters/legacyChatLogic.ts
+++ b/apps/app/src/lib/adapters/legacyChatLogic.ts
@@ -1,3 +1,4 @@
+import type { ChatAttachmentFirestoreRecord, ChatMessageFirestoreRecord } from '../firestore/types';
 import { DEFAULT_TEAM_CONVERSATION_ID as legacyDefaultTeamConversationId, buildDefaultTeamConversation as legacyBuildDefaultTeamConversation, getConversationDisplayName as legacyGetConversationDisplayName, isDefaultTeamConversation as legacyIsDefaultTeamConversation } from '@legacy/team-chat-conversations.js';
 import { MAX_CHAT_MEDIA_SIZE as legacyMaxChatMediaSize, buildChatMediaShareDetails as legacyBuildChatMediaShareDetails, collectThreadMedia as legacyCollectThreadMedia, getChatMediaActionState as legacyGetChatMediaActionState, getChatMediaDownloadName as legacyGetChatMediaDownloadName, getMessageAttachments as legacyGetMessageAttachments, isSafeChatMediaUrl as legacyIsSafeChatMediaUrl } from '@legacy/team-chat-media.js';
 import { shouldRetryChatLastReadOnViewReturn as legacyShouldRetryChatLastReadOnViewReturn, shouldUpdateChatLastRead as legacyShouldUpdateChatLastRead } from '@legacy/team-chat-last-read.js';
@@ -15,7 +16,7 @@ export const buildChatMediaShareDetails = legacyBuildChatMediaShareDetails as (.
 export const collectThreadMedia = legacyCollectThreadMedia as (...args: any[]) => any;
 export const getChatMediaActionState = legacyGetChatMediaActionState as (...args: any[]) => any;
 export const getChatMediaDownloadName = legacyGetChatMediaDownloadName as (...args: any[]) => string;
-export const getMessageAttachments = legacyGetMessageAttachments as (...args: any[]) => any;
+export const getMessageAttachments = legacyGetMessageAttachments as (message: ChatMessageFirestoreRecord | null | undefined) => ChatAttachmentFirestoreRecord[];
 export const isSafeChatMediaUrl = legacyIsSafeChatMediaUrl as (...args: any[]) => boolean;
 export const shouldRetryChatLastReadOnViewReturn = legacyShouldRetryChatLastReadOnViewReturn as (...args: any[]) => boolean;
 export const shouldUpdateChatLastRead = legacyShouldUpdateChatLastRead as (...args: any[]) => boolean;

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -42,6 +42,7 @@ import {
   sendTeamChatMessage,
   sendTeamEmailMessage,
   toggleTeamChatReaction,
+  type ChatAttachment,
   type ChatConversation,
   type ChatMessage,
   type SentTeamEmail,
@@ -141,6 +142,10 @@ type VirtualizedChatWindow = {
 type VirtualizedChatLayout = {
   offsets: number[];
   totalHeight: number;
+};
+
+type SafeChatAttachment = ChatAttachment & {
+  url: string;
 };
 
 const CHAT_MESSAGE_INITIAL_WINDOW_COUNT = 40;
@@ -1765,6 +1770,12 @@ export function buildChatViewportSignature(scrollHeight: number, clientHeight: n
   return `${scrollHeight}:${clientHeight}:${distanceFromBottom}`;
 }
 
+export function getSafeMessageAttachments(message: ChatMessage): SafeChatAttachment[] {
+  return getMessageAttachments(message).filter((attachment): attachment is SafeChatAttachment => (
+    typeof attachment?.url === 'string' && isSafeChatMediaUrl(attachment.url)
+  ));
+}
+
 export function estimateChatMessageRowHeight(message: ChatMessage, previousMessage: ChatMessage | null = null) {
   const attachments = getMessageAttachments(message);
   const textLength = String(message.text || '').trim().length;
@@ -2413,10 +2424,7 @@ const MessageBubble = memo(function MessageBubble({
   const isDeleted = message.deleted === true;
   const isLocalSend = message.sendStatus === 'pending' || message.sendStatus === 'failed';
   const senderLabel = useMemo(() => getMessageSenderLabel(message, currentUserId), [currentUserId, message]);
-  const attachments = useMemo(
-    () => getMessageAttachments(message).filter((attachment: any) => isSafeChatMediaUrl(attachment.url)),
-    [message]
-  );
+  const attachments = useMemo(() => getSafeMessageAttachments(message), [message]);
   const reactions = useMemo(() => normalizeChatReactions(message), [message]);
   const messageHtml = useMemo(() => formatChatMessageHtml(message.text || ''), [message.text]);
   const createdAtLabel = useMemo(() => formatChatTime(message.createdAt), [message.createdAt]);
@@ -2666,7 +2674,7 @@ function InlineAttachmentVideo({ src, label }: { src: string; label: string }) {
   );
 }
 
-function MessageAttachments({ attachments, isOwn }: { attachments: any[]; isOwn: boolean }) {
+function MessageAttachments({ attachments, isOwn }: { attachments: SafeChatAttachment[]; isOwn: boolean }) {
   return (
     <div className={`mb-2 grid gap-2 ${attachments.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}>
       {attachments.map((attachment, index) => {

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -148,6 +148,7 @@ const CHAT_MESSAGE_WINDOW_OVERSCAN_PX = 480;
 const CHAT_MESSAGE_BASE_ESTIMATED_HEIGHT = 104;
 const CHAT_MESSAGE_DAY_DIVIDER_ESTIMATED_HEIGHT = 28;
 const CHAT_MESSAGE_ATTACHMENT_ESTIMATED_HEIGHT = 144;
+const messageRevisionSignatureCache = new WeakMap<ChatMessage, string>();
 
 const allTargetOptions: Array<{ value: ChatTargetType; label: string; description: string }> = [
   { value: 'full_team', label: 'Full team', description: 'Visible to everyone in this team chat.' },
@@ -2353,6 +2354,7 @@ const MessageList = memo(function MessageList({
             {showDay ? <div className="my-3 text-center text-[11px] font-black uppercase text-gray-400">{day}</div> : null}
             <MessageBubble
               message={message}
+              messageRevisionSignature={getMessageRevisionSignature(message)}
               currentUserId={currentUserId}
               canModerate={canModerate}
               actionsOpen={actionMessageId === message.id}
@@ -2377,6 +2379,7 @@ MessageList.displayName = 'MessageList';
 
 type MessageBubbleProps = {
   message: ChatMessage;
+  messageRevisionSignature: string;
   currentUserId: string;
   canModerate: boolean;
   actionsOpen: boolean;
@@ -2392,6 +2395,7 @@ type MessageBubbleProps = {
 
 const MessageBubble = memo(function MessageBubble({
   message,
+  messageRevisionSignature: _messageRevisionSignature,
   currentUserId,
   canModerate,
   actionsOpen,
@@ -2544,35 +2548,69 @@ function areMessageBubblePropsEqual(previous: MessageBubbleProps, next: MessageB
     && previous.actionsOpen === next.actionsOpen
     && previous.reactionsOpen === next.reactionsOpen
     && previous.preferReactionPickerAbove === next.preferReactionPickerAbove
+    && previous.messageRevisionSignature === next.messageRevisionSignature
     && previous.onActionMessage === next.onActionMessage
     && previous.onReactionMessage === next.onReactionMessage
     && previous.onToggleReaction === next.onToggleReaction
     && previous.onEdit === next.onEdit
     && previous.onDelete === next.onDelete
-    && previous.onRetrySend === next.onRetrySend
-    && areMessagesEquivalent(previous.message, next.message);
+    && previous.onRetrySend === next.onRetrySend;
 }
 
-function areMessagesEquivalent(previous: ChatMessage, next: ChatMessage) {
+export function areMessagesEquivalent(previous: ChatMessage, next: ChatMessage) {
   return previous === next || (
-    previous.id === next.id
-    && previous.clientMessageId === next.clientMessageId
-    && previous.text === next.text
-    && previous.ai === next.ai
-    && previous.deleted === next.deleted
-    && previous.sendStatus === next.sendStatus
-    && previous.sendError === next.sendError
-    && previous.attachmentCount === next.attachmentCount
-    && previous.senderId === next.senderId
-    && previous.senderName === next.senderName
-    && previous.senderEmail === next.senderEmail
-    && previous.senderPhotoUrl === next.senderPhotoUrl
-    && previous.aiName === next.aiName
-    && normalizeTimestampValue(previous.createdAt) === normalizeTimestampValue(next.createdAt)
-    && normalizeTimestampValue(previous.editedAt) === normalizeTimestampValue(next.editedAt)
-    && JSON.stringify(getMessageAttachments(previous)) === JSON.stringify(getMessageAttachments(next))
-    && JSON.stringify(normalizeChatReactions(previous)) === JSON.stringify(normalizeChatReactions(next))
+    getMessageRevisionSignature(previous) === getMessageRevisionSignature(next)
   );
+}
+
+export function getMessageRevisionSignature(message: ChatMessage) {
+  const cachedSignature = messageRevisionSignatureCache.get(message);
+  if (cachedSignature) {
+    return cachedSignature;
+  }
+
+  const attachmentSignature = getMessageAttachments(message)
+    .map((attachment) => [
+      attachment?.type || '',
+      attachment?.url || '',
+      attachment?.path || '',
+      attachment?.thumbnailUrl || '',
+      attachment?.name || '',
+      attachment?.mimeType || '',
+      attachment?.size ?? '',
+      normalizeTimestampValue(attachment?.uploadedAt)
+    ].join('\u001f'))
+    .join('\u001e');
+  const normalizedReactions = normalizeChatReactions(message);
+  const reactionSignature = chatReactions
+    .map(({ key }) => {
+      const users = normalizedReactions[key] || [];
+      return users.length ? `${key}:${users.join(',')}` : '';
+    })
+    .filter(Boolean)
+    .join('|');
+  const signature = [
+    message.id,
+    message.clientMessageId || '',
+    message.text || '',
+    message.ai === true ? '1' : '0',
+    message.deleted === true ? '1' : '0',
+    message.sendStatus || '',
+    message.sendError || '',
+    message.attachmentCount ?? '',
+    message.senderId || '',
+    message.senderName || '',
+    message.senderEmail || '',
+    message.senderPhotoUrl || '',
+    message.aiName || '',
+    normalizeTimestampValue(message.createdAt),
+    normalizeTimestampValue(message.editedAt),
+    attachmentSignature,
+    reactionSignature
+  ].join('\u001d');
+
+  messageRevisionSignatureCache.set(message, signature);
+  return signature;
 }
 
 function normalizeTimestampValue(value: unknown) {

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -9,10 +9,29 @@ import type { AuthState } from '../../../lib/types';
 import {
   AudienceSheet,
   ChatWindow,
+  areMessagesEquivalent,
   buildVirtualizedChatLayout,
   buildVirtualizedChatWindow,
   buildVirtualizedChatWindowFromLayout
 } from './ChatWindow';
+
+const normalizeChatReactionsSpy = vi.fn();
+const getMessageAttachmentsSpy = vi.fn();
+
+vi.mock('../../../lib/chatLogic', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/chatLogic')>('../../../lib/chatLogic');
+  return {
+    ...actual,
+    normalizeChatReactions: vi.fn((message: any) => {
+      normalizeChatReactionsSpy(message);
+      return actual.normalizeChatReactions(message);
+    }),
+    getMessageAttachments: vi.fn((message: any) => {
+      getMessageAttachmentsSpy(message);
+      return actual.getMessageAttachments(message);
+    })
+  };
+});
 
 const liveMessages = Array.from({ length: 220 }, (_, index) => buildMessage(`live-${index + 1}`, index + 101));
 const olderPage = Array.from({ length: 50 }, (_, index) => buildMessage(`older-${index + 1}`, index + 1));
@@ -239,6 +258,29 @@ describe('ChatWindow virtualization', () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    normalizeChatReactionsSpy.mockClear();
+    getMessageAttachmentsSpy.mockClear();
+  });
+
+  it('recognizes unchanged message content without JSON serialization', () => {
+    const previous = {
+      ...buildMessage('message-1', 1),
+      text: 'Same message',
+      attachments: [{ type: 'image', url: 'https://example.com/a.png', name: 'a.png', mimeType: 'image/png', size: 128 }],
+      reactions: { thumbs_up: ['user-1'], '👍': ['user-1'] },
+      editedAt: { seconds: 5 }
+    } as ChatMessage;
+    const next = {
+      ...previous,
+      attachments: [{ type: 'image', url: 'https://example.com/a.png', name: 'a.png', mimeType: 'image/png', size: 128 }],
+      reactions: { thumbs_up: ['user-1'] }
+    } as ChatMessage;
+    const stringifySpy = vi.spyOn(JSON, 'stringify');
+
+    expect(areMessagesEquivalent(previous, next)).toBe(true);
+    expect(stringifySpy).not.toHaveBeenCalled();
+
+    stringifySpy.mockRestore();
   });
 
   it('returns a bounded render slice and spacer heights for long message lists', () => {
@@ -383,6 +425,38 @@ describe('ChatWindow virtualization', () => {
         expect(bubbleCount).toBeLessThan(100);
       });
     }
+  });
+
+  it('avoids JSON serialization during scroll-only viewport updates for unchanged bubbles', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    const thread = container.querySelector('.chat-messages-scroll') as HTMLDivElement;
+    expect(thread).toBeTruthy();
+
+    thread.scrollTop = 180;
+    fireEvent.scroll(thread);
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.message-bubble').length).toBeGreaterThan(0);
+    });
+
+    const stringifySpy = vi.spyOn(JSON, 'stringify');
+
+    for (const scrollTop of [181, 182, 183]) {
+      thread.scrollTop = scrollTop;
+      fireEvent.scroll(thread);
+      await waitFor(() => {
+        expect(container.querySelectorAll('.message-bubble').length).toBeGreaterThan(0);
+      });
+    }
+
+    expect(stringifySpy).not.toHaveBeenCalled();
+
+    stringifySpy.mockRestore();
   });
 });
 

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -11,6 +11,7 @@ import {
   ChatWindow,
   areMessagesEquivalent,
   getMessageRevisionSignature,
+  getSafeMessageAttachments,
   buildVirtualizedChatLayout,
   buildVirtualizedChatWindow,
   buildVirtualizedChatWindowFromLayout
@@ -295,6 +296,20 @@ describe('ChatWindow virtualization', () => {
     } as ChatMessage;
 
     expect(getMessageRevisionSignature(message)).not.toBe(getMessageRevisionSignature(changedAttachmentMessage));
+  });
+
+  it('filters message attachments to safe media urls', () => {
+    const message = {
+      ...buildMessage('message-with-attachment', 10),
+      attachments: [
+        { type: 'image', url: 'https://example.com/a.png', name: 'a.png', mimeType: 'image/png', size: 128 },
+        { type: 'image', url: 'javascript:alert(1)', name: 'bad.png', mimeType: 'image/png', size: 128 }
+      ]
+    } as ChatMessage;
+
+    expect(getSafeMessageAttachments(message)).toMatchObject([
+      { type: 'image', url: 'https://example.com/a.png', name: 'a.png', mimeType: 'image/png', size: 128 }
+    ]);
   });
 
   it('returns a bounded render slice and spacer heights for long message lists', () => {

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -10,6 +10,7 @@ import {
   AudienceSheet,
   ChatWindow,
   areMessagesEquivalent,
+  getMessageRevisionSignature,
   buildVirtualizedChatLayout,
   buildVirtualizedChatWindow,
   buildVirtualizedChatWindowFromLayout
@@ -281,6 +282,19 @@ describe('ChatWindow virtualization', () => {
     expect(stringifySpy).not.toHaveBeenCalled();
 
     stringifySpy.mockRestore();
+  });
+
+  it('includes attachment fields in the message revision signature', () => {
+    const message = {
+      ...buildMessage('message-with-attachment', 10),
+      attachments: [{ type: 'image', url: 'https://example.com/a.png', name: 'a.png', mimeType: 'image/png', size: 128 }]
+    } as ChatMessage;
+    const changedAttachmentMessage = {
+      ...message,
+      attachments: [{ type: 'image', url: 'https://example.com/b.png', name: 'b.png', mimeType: 'image/png', size: 128 }]
+    } as ChatMessage;
+
+    expect(getMessageRevisionSignature(message)).not.toBe(getMessageRevisionSignature(changedAttachmentMessage));
   });
 
   it('returns a bounded render slice and spacer heights for long message lists', () => {


### PR DESCRIPTION
Closes #3223

## What changed
- replaced the `MessageBubble` memo comparator's deep attachment/reaction `JSON.stringify` checks with a cached primitive message revision signature
- computed the signature once per visible message before rendering each bubble, then compared that signature in `areMessageBubblePropsEqual`
- added regression coverage for equivalent message equality without JSON serialization and for repeated scroll-only viewport updates in long threads

## Root Cause
`MessageBubble` equality did deep attachment and reaction normalization plus `JSON.stringify` inside the memo comparator. Because `ChatWindow` updates viewport state on scroll, mounted bubbles paid that per-row comparison cost on scroll-driven parent renders even when message content was unchanged.

## Prevention / Learning
For virtualized or scroll-heavy lists, never put deep normalization or serialization inside a `React.memo` comparator. Use a cached or precomputed primitive revision key so scroll-only parent updates stay cheap.

## Regression Tests
- `npm test -- --run src/pages/messages/components/ChatWindow.virtualization.test.tsx`
- added `recognizes unchanged message content without JSON serialization`
- added `avoids JSON serialization during scroll-only viewport updates for unchanged bubbles`