### PR TITLE
Simplify Private AI first-run prompt

### DIFF
--- a/apps/app/src/pages/PrivateAiChat.test.tsx
+++ b/apps/app/src/pages/PrivateAiChat.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrivateAiChat } from './PrivateAiChat';
+import type { AuthState } from '../lib/types';
+
+const privateAiServiceMocks = vi.hoisted(() => ({
+    loadPrivateAiConversations: vi.fn(),
+    loadPrivateAiMessages: vi.fn(),
+    sendPrivateAiMessage: vi.fn()
+}));
+
+vi.mock('../lib/privateAiService', () => ({
+    DEFAULT_PRIVATE_AI_CONVERSATION_ID: 'default',
+    DRAFT_PRIVATE_AI_CONVERSATION_ID: '__draft__',
+    loadPrivateAiConversations: privateAiServiceMocks.loadPrivateAiConversations,
+    loadPrivateAiMessages: privateAiServiceMocks.loadPrivateAiMessages,
+    sendPrivateAiMessage: privateAiServiceMocks.sendPrivateAiMessage
+}));
+vi.mock('../lib/chatLogic', () => ({
+    formatChatDay: () => 'Today',
+    formatChatMessageHtml: (text: string) => text,
+    formatChatTime: () => '1:00 PM'
+}));
+vi.mock('../lib/dictation', () => ({
+    appendDictationTranscript: vi.fn(),
+    collectFinalDictationTranscript: vi.fn(),
+    getDictationErrorMessage: vi.fn(),
+    getSpeechRecognitionConstructor: vi.fn(() => null),
+    isCapacitorNativeRuntime: vi.fn(() => false),
+    startNativeSpeechDictation: vi.fn()
+}));
+vi.mock('../lib/useShellLayout', () => ({
+    useShellLayout: () => ({
+        isDesktop: true,
+        isNative: false,
+        isDesktopWeb: true
+    })
+}));
+vi.mock('lucide-react', () => {
+    const Icon = () => null;
+    return {
+        ChevronRight: Icon,
+        ChevronsDown: Icon,
+        Loader2: Icon,
+        MessageCircle: Icon,
+        Mic: Icon,
+        Plus: Icon,
+        RefreshCw: Icon,
+        Send: Icon,
+        ShieldCheck: Icon,
+        Sparkles: Icon
+    };
+});
+
+const auth: AuthState = {
+    user: {
+        uid: 'user-1',
+        email: 'coach@example.com',
+        displayName: 'Coach Example',
+        roles: ['coach'],
+        parentOf: []
+    },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['coach'],
+    isParent: false,
+    isCoach: true,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn()
+};
+
+function renderChat() {
+    return render(<PrivateAiChat auth={auth} />);
+}
+
+describe('PrivateAiChat', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Object.defineProperty(window, 'scrollTo', {
+            value: vi.fn(),
+            writable: true
+        });
+        Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+            value: vi.fn(),
+            writable: true
+        });
+        privateAiServiceMocks.loadPrivateAiConversations.mockResolvedValue([]);
+        privateAiServiceMocks.loadPrivateAiMessages.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('shows one default first-run action and defers advanced prompts behind expansion', async () => {
+        renderChat();
+
+        expect(await screen.findByText('What do you need from ALL PLAYS?')).toBeTruthy();
+
+        const railCard = screen.getByText('Ask about').closest('section');
+        expect(railCard).toBeTruthy();
+        if (!railCard) {
+            throw new Error('Ask about card not found');
+        }
+
+        expect(within(railCard).getByRole('button', { name: 'What do I need to handle today?' })).toBeTruthy();
+        expect(within(railCard).queryByRole('button', { name: 'Who still needs an RSVP?' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'What is my next game?' })).toBeNull();
+
+        const expandButtons = screen.getAllByRole('button', { name: 'More ways to ask' });
+        fireEvent.click(expandButtons[0]!);
+
+        expect(await within(railCard).findByRole('button', { name: 'Who still needs an RSVP?' })).toBeTruthy();
+        expect(within(railCard).getByRole('button', { name: 'What is my next game?' })).toBeTruthy();
+        expect(within(railCard).getByRole('button', { name: 'Show unread team messages' })).toBeTruthy();
+    });
+
+    it('sends the primary first-run action through the existing send flow and preserves optimistic chat behavior', async () => {
+        let resolveSend!: (value: {
+            userMessage: { id: string; role: 'user'; text: string; createdAt: Date; conversationId: string };
+            assistantMessage: { id: string; role: 'assistant'; text: string; createdAt: Date; conversationId: string; toolNames: string[] };
+            toolResults: [];
+        }) => void;
+        privateAiServiceMocks.sendPrivateAiMessage.mockImplementationOnce(() => new Promise((resolve) => {
+            resolveSend = resolve;
+        }));
+        privateAiServiceMocks.loadPrivateAiConversations
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([
+                {
+                    id: 'conversation-1',
+                    title: 'What do I need to handle today?',
+                    createdAt: new Date('2026-06-27T13:18:00Z'),
+                    updatedAt: new Date('2026-06-27T13:18:01Z'),
+                    lastMessagePreview: 'What do I need to handle today?'
+                }
+            ]);
+        privateAiServiceMocks.loadPrivateAiMessages.mockImplementation(async (_user, _limit, conversationId) => {
+            if (conversationId === 'conversation-1') {
+                return [
+                    {
+                        id: 'server-user-1',
+                        role: 'user',
+                        text: 'What do I need to handle today?',
+                        createdAt: new Date('2026-06-27T13:18:00Z'),
+                        conversationId: 'conversation-1'
+                    },
+                    {
+                        id: 'server-assistant-1',
+                        role: 'assistant',
+                        text: 'Here is your summary.',
+                        createdAt: new Date('2026-06-27T13:18:01Z'),
+                        conversationId: 'conversation-1',
+                        toolNames: ['get_home']
+                    }
+                ];
+            }
+            return [];
+        });
+
+        renderChat();
+
+        expect(await screen.findByText('What do you need from ALL PLAYS?')).toBeTruthy();
+        fireEvent.click(screen.getAllByRole('button', { name: 'What do I need to handle today?' })[0]!);
+
+        await waitFor(() => {
+            expect(privateAiServiceMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'What do I need to handle today?', 'default');
+        });
+        expect(screen.getAllByText('What do I need to handle today?').length).toBeGreaterThan(0);
+
+        resolveSend({
+            userMessage: {
+                id: 'server-user-1',
+                role: 'user',
+                text: 'What do I need to handle today?',
+                createdAt: new Date('2026-06-27T13:18:00Z'),
+                conversationId: 'conversation-1'
+            },
+            assistantMessage: {
+                id: 'server-assistant-1',
+                role: 'assistant',
+                text: 'Here is your summary.',
+                createdAt: new Date('2026-06-27T13:18:01Z'),
+                conversationId: 'conversation-1',
+                toolNames: ['get_home']
+            },
+            toolResults: []
+        });
+
+        expect(await screen.findByText('Here is your summary.')).toBeTruthy();
+        await waitFor(() => {
+            expect(privateAiServiceMocks.loadPrivateAiMessages).toHaveBeenCalledWith(auth.user, undefined, 'conversation-1');
+        });
+    });
+});

--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject } from 'react';
 import {
   ChevronRight,
+  ChevronsDown,
   Loader2,
   MessageCircle,
   Mic,
@@ -57,6 +58,10 @@ const starterPrompts = [
   'Show unread team messages',
   'Who still needs an RSVP?'
 ];
+
+const primaryStarterPrompt = starterPrompts[0];
+const secondaryStarterPrompts = starterPrompts.slice(1);
+const secondarySuggestedPrompts = suggestedPrompts.filter((prompt) => prompt !== primaryStarterPrompt);
 
 const isDraftConversationId = (conversationId: string) => conversationId === DRAFT_PRIVATE_AI_CONVERSATION_ID;
 const draftConversationLabel = 'New chat';
@@ -392,21 +397,33 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
             />
 
             <section className="app-card p-3">
-              <div className="app-label">Ask about</div>
-              <div className="mt-2 space-y-2">
-                {suggestedPrompts.map((prompt) => (
-                  <button
-                    key={prompt}
-                    type="button"
-                    className="private-ai-prompt-button"
-                    onClick={() => sendSuggestion(prompt)}
-                    disabled={sending}
-                  >
-                    <span>{prompt}</span>
-                    <ChevronRight className="h-4 w-4 flex-none" aria-hidden="true" />
-                  </button>
-                ))}
-              </div>
+              {!messages.length ? (
+                <PromptSection
+                  title="Ask about"
+                  primaryPrompt={primaryStarterPrompt}
+                  secondaryPrompts={secondarySuggestedPrompts}
+                  onPrompt={sendSuggestion}
+                  disabled={sending}
+                />
+              ) : (
+                <>
+                  <div className="app-label">Ask about</div>
+                  <div className="mt-2 space-y-2">
+                    {suggestedPrompts.map((prompt) => (
+                      <button
+                        key={prompt}
+                        type="button"
+                        className="private-ai-prompt-button"
+                        onClick={() => sendSuggestion(prompt)}
+                        disabled={sending}
+                      >
+                        <span>{prompt}</span>
+                        <ChevronRight className="h-4 w-4 flex-none" aria-hidden="true" />
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
             </section>
           </aside>
           <div className="messages-chat-pane min-w-0">
@@ -699,6 +716,77 @@ function PrivateAiThread({
   );
 }
 
+function PromptSection({
+  title,
+  primaryPrompt,
+  secondaryPrompts,
+  onPrompt,
+  disabled,
+  variant = 'rail'
+}: {
+  title?: string;
+  primaryPrompt: string;
+  secondaryPrompts: string[];
+  onPrompt: (prompt: string) => void;
+  disabled: boolean;
+  variant?: 'rail' | 'welcome';
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const isWelcome = variant === 'welcome';
+  const primaryButtonClass = isWelcome ? 'private-ai-starter-prompt private-ai-starter-prompt-primary' : 'private-ai-prompt-button';
+  const secondaryButtonClass = isWelcome ? 'private-ai-starter-prompt' : 'private-ai-prompt-button';
+
+  return (
+    <div>
+      {title ? <div className="app-label">{title}</div> : null}
+      <div className={isWelcome ? 'private-ai-starter-prompts' : 'mt-2 space-y-2'} aria-label={isWelcome ? 'Starter prompts' : undefined}>
+        <button
+          type="button"
+          className={primaryButtonClass}
+          onClick={() => onPrompt(primaryPrompt)}
+          disabled={disabled}
+        >
+          <span>{primaryPrompt}</span>
+          {isWelcome ? <Send className="h-3.5 w-3.5 flex-none" aria-hidden="true" /> : <ChevronRight className="h-4 w-4 flex-none" aria-hidden="true" />}
+        </button>
+      </div>
+      {secondaryPrompts.length ? (
+        <div className={isWelcome ? 'mt-3' : 'mt-2'}>
+          <button
+            type="button"
+            className={isWelcome ? 'ghost-button !min-h-10 !px-3 text-sm font-bold' : 'ghost-button !min-h-9 !px-2 text-sm font-bold'}
+            onClick={() => setExpanded((current) => !current)}
+            aria-expanded={expanded}
+            aria-controls={`secondary-prompts-${variant}`}
+          >
+            <ChevronsDown className={`h-4 w-4 ${expanded ? 'rotate-180' : ''}`} aria-hidden="true" />
+            More ways to ask
+          </button>
+          {expanded ? (
+            <div
+              id={`secondary-prompts-${variant}`}
+              className={isWelcome ? 'private-ai-starter-prompts mt-3' : 'mt-2 space-y-2'}
+            >
+              {secondaryPrompts.map((prompt) => (
+                <button
+                  key={prompt}
+                  type="button"
+                  className={secondaryButtonClass}
+                  onClick={() => onPrompt(prompt)}
+                  disabled={disabled}
+                >
+                  <span>{prompt}</span>
+                  {isWelcome ? <Send className="h-3.5 w-3.5 flex-none" aria-hidden="true" /> : <ChevronRight className="h-4 w-4 flex-none" aria-hidden="true" />}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function PrivateAiWelcome({
   sending,
   onStarterPrompt
@@ -715,19 +803,14 @@ function PrivateAiWelcome({
       <div className="mt-1 text-sm font-semibold leading-6 text-gray-500">
         Ask about your teams, schedule, messages, fees, player development, coaching ideas, registrations, and profile.
       </div>
-      <div className="private-ai-starter-prompts" aria-label="Starter prompts">
-        {starterPrompts.map((prompt) => (
-          <button
-            key={prompt}
-            type="button"
-            className="private-ai-starter-prompt"
-            onClick={() => onStarterPrompt(prompt)}
-            disabled={sending}
-          >
-            <span>{prompt}</span>
-            <Send className="h-3.5 w-3.5 flex-none" aria-hidden="true" />
-          </button>
-        ))}
+      <div className="mt-4">
+        <PromptSection
+          primaryPrompt={primaryStarterPrompt}
+          secondaryPrompts={secondaryStarterPrompts}
+          onPrompt={onStarterPrompt}
+          disabled={sending}
+          variant="welcome"
+        />
       </div>
     </div>
   );

--- a/tests/unit/app-private-ai-integration.test.jsx
+++ b/tests/unit/app-private-ai-integration.test.jsx
@@ -168,13 +168,17 @@ describe('private AI chat page', () => {
 
         expect(container.querySelector('.messages-two-pane')).toBeTruthy();
         expect(container.textContent).toContain('What do I need to handle today?');
-        expect(container.textContent).toContain('More ways to ask');
-        expect(container.textContent).not.toContain('Who still needs an RSVP?');
 
-        const expandButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('More ways to ask'));
+        const initialButtons = Array.from(container.querySelectorAll('button'));
+        expect(initialButtons.some((button) => button.textContent.includes('More ways to ask'))).toBe(true);
+        expect(initialButtons.some((button) => button.textContent.includes('Who still needs an RSVP?'))).toBe(false);
+
+        const expandButton = initialButtons.find((button) => button.textContent.includes('More ways to ask'));
+        expect(expandButton).toBeTruthy();
         await click(expandButton);
 
         const suggestion = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Who still needs an RSVP?'));
+        expect(suggestion).toBeTruthy();
         await click(suggestion);
 
         expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'Who still needs an RSVP?', 'default');
@@ -205,12 +209,15 @@ describe('private AI chat page', () => {
         expect(container.querySelector('.messages-two-pane')).toBeFalsy();
         expect(container.textContent).toContain('What do you need from ALL PLAYS?');
         expect(container.textContent).toContain('What do I need to handle today?');
-        expect(container.textContent).toContain('More ways to ask');
-        expect(container.textContent).not.toContain('What is my next game?');
-        expect(container.textContent).not.toContain('Show unread team messages');
-        expect(container.textContent).not.toContain('Who still needs an RSVP?');
 
-        const expandButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('More ways to ask'));
+        const initialButtons = Array.from(container.querySelectorAll('button'));
+        expect(initialButtons.some((button) => button.textContent.includes('More ways to ask'))).toBe(true);
+        expect(initialButtons.some((button) => button.textContent.includes('What is my next game?'))).toBe(false);
+        expect(initialButtons.some((button) => button.textContent.includes('Show unread team messages'))).toBe(false);
+        expect(initialButtons.some((button) => button.textContent.includes('Who still needs an RSVP?'))).toBe(false);
+
+        const expandButton = initialButtons.find((button) => button.textContent.includes('More ways to ask'));
+        expect(expandButton).toBeTruthy();
         await click(expandButton);
 
         expect(container.textContent).toContain('What is my next game?');

--- a/tests/unit/app-private-ai-integration.test.jsx
+++ b/tests/unit/app-private-ai-integration.test.jsx
@@ -168,6 +168,11 @@ describe('private AI chat page', () => {
 
         expect(container.querySelector('.messages-two-pane')).toBeTruthy();
         expect(container.textContent).toContain('What do I need to handle today?');
+        expect(container.textContent).toContain('More ways to ask');
+        expect(container.textContent).not.toContain('Who still needs an RSVP?');
+
+        const expandButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('More ways to ask'));
+        await click(expandButton);
 
         const suggestion = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Who still needs an RSVP?'));
         await click(suggestion);
@@ -200,6 +205,14 @@ describe('private AI chat page', () => {
         expect(container.querySelector('.messages-two-pane')).toBeFalsy();
         expect(container.textContent).toContain('What do you need from ALL PLAYS?');
         expect(container.textContent).toContain('What do I need to handle today?');
+        expect(container.textContent).toContain('More ways to ask');
+        expect(container.textContent).not.toContain('What is my next game?');
+        expect(container.textContent).not.toContain('Show unread team messages');
+        expect(container.textContent).not.toContain('Who still needs an RSVP?');
+
+        const expandButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('More ways to ask'));
+        await click(expandButton);
+
         expect(container.textContent).toContain('What is my next game?');
         expect(container.textContent).toContain('Show unread team messages');
         expect(container.textContent).toContain('Who still needs an RSVP?');


### PR DESCRIPTION
Closes #3229

## What changed
- changed the empty Private AI welcome state to lead with a single primary action: `What do I need to handle today?`
- moved the remaining starter prompts behind a `More ways to ask` expander so they stay available without competing with the default path
- applied the same first-run treatment to the desktop left rail, while keeping the full prompt list available again after a conversation has started
- added focused page tests for the empty-state prompt hierarchy and the primary action send flow, including optimistic first-message behavior

## Root Cause
`PrivateAiChat` hard-coded multiple starter prompts at equal visual weight in both the empty welcome state and the desktop rail. That meant first-run users saw a flat stack of competing options instead of one opinionated default action, and there was no UI state that deferred advanced prompts until the user explicitly asked for them.

## Prevention / Learning
For first-run assistant entry points, treat prompt suggestions as a hierarchy, not a list. Lead with one primary default action, defer secondary prompts behind an explicit affordance, and add a page-level regression test that proves advanced prompts stay hidden until expansion.

## Regression Tests
- `npm --prefix apps/app test -- --run src/pages/PrivateAiChat.test.tsx`
- `apps/app/src/pages/PrivateAiChat.test.tsx` verifies only the primary first-run action is visible by default and secondary prompts appear only after `More ways to ask`
- `apps/app/src/pages/PrivateAiChat.test.tsx` verifies clicking the primary action calls the existing send flow with `What do I need to handle today?` and preserves optimistic first-message behavior