### PR TITLE
[codex] Fix legacy family share player loading

### DIFF
--- a/family.html
+++ b/family.html
@@ -173,7 +173,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=74';
+    import { getFamilyShareToken, resolveFamilyShareTokenChildren, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=74';
     import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';
     import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=14';
 
@@ -216,6 +216,35 @@
       return Boolean(expiresAt && expiresAt.getTime() <= Date.now());
     }
 
+    function normalizeFamilyPageChildren(children = []) {
+      return (Array.isArray(children) ? children : [])
+        .map(child => {
+          const teamId = String(child?.teamId ?? '').trim();
+          const playerId = String(child?.playerId || child?.childId || '').trim();
+          return {
+            teamId,
+            teamName: String(child?.teamName || child?.team || '').trim(),
+            playerId,
+            playerName: String(child?.playerName || child?.childName || child?.name || '').trim(),
+            playerNumber: String(child?.playerNumber ?? child?.number ?? '').trim(),
+            playerPhotoUrl: child?.playerPhotoUrl || child?.photoUrl || null
+          };
+        })
+        .filter(child => child.teamId && child.playerId);
+    }
+
+    async function resolveFamilyPageChildren(token) {
+      const storedChildren = normalizeFamilyPageChildren(token?.children);
+      if (storedChildren.length > 0) return storedChildren;
+
+      try {
+        return normalizeFamilyPageChildren(await resolveFamilyShareTokenChildren(tokenId));
+      } catch (err) {
+        console.warn('[family] Failed to resolve legacy share token children:', err);
+        return [];
+      }
+    }
+
     async function init() {
       if (!tokenId) {
         showError();
@@ -254,7 +283,7 @@
 
       document.title = (token.label || 'Family Page') + ' - ALL PLAYS';
 
-      const children = Array.isArray(token.children) ? token.children : [];
+      const children = await resolveFamilyPageChildren(token);
 
       renderPlayers(children);
       renderTeams(children);

--- a/functions/family-share-core.cjs
+++ b/functions/family-share-core.cjs
@@ -1,0 +1,100 @@
+function compactString(value) {
+  return value == null ? '' : String(value).trim();
+}
+
+function toMillis(value) {
+  if (!value) return 0;
+  if (typeof value.toMillis === 'function') return value.toMillis();
+  const date = typeof value.toDate === 'function' ? value.toDate() : new Date(value);
+  const millis = date?.getTime?.();
+  return Number.isFinite(millis) ? millis : 0;
+}
+
+function isFamilyShareTokenReadable(token = {}, nowMs = Date.now()) {
+  if (!token || typeof token !== 'object') return false;
+  if (token.active === false || token.revoked === true || token.revokedAt) return false;
+  const expiresAtMs = toMillis(token.expiresAt);
+  return expiresAtMs === 0 || expiresAtMs > nowMs;
+}
+
+function isTeamActive(team = {}) {
+  const status = compactString(team.status).toLowerCase();
+  return team.active !== false &&
+    team.archived !== true &&
+    !['archived', 'inactive', 'disabled'].includes(status);
+}
+
+function parseParentPlayerKey(value) {
+  const [teamId, playerId] = compactString(value).split('::').map(compactString);
+  if (!teamId || !playerId) return null;
+  return { teamId, playerId };
+}
+
+function collectOwnerParentLinks(profile = {}) {
+  const linksByKey = new Map();
+
+  function addLink(raw = {}) {
+    const teamId = compactString(raw.teamId);
+    const playerId = compactString(raw.playerId || raw.childId);
+    if (!teamId || !playerId) return;
+    const key = `${teamId}::${playerId}`;
+    if (!linksByKey.has(key)) {
+      linksByKey.set(key, {
+        teamId,
+        teamName: compactString(raw.teamName || raw.team),
+        playerId,
+        playerName: compactString(raw.playerName || raw.childName || raw.name),
+        playerNumber: compactString(raw.playerNumber ?? raw.number),
+        playerPhotoUrl: compactString(raw.playerPhotoUrl || raw.photoUrl) || null
+      });
+    }
+  }
+
+  (Array.isArray(profile.parentOf) ? profile.parentOf : []).forEach(addLink);
+  (Array.isArray(profile.parentPlayerKeys) ? profile.parentPlayerKeys : [])
+    .map(parseParentPlayerKey)
+    .filter(Boolean)
+    .forEach(addLink);
+
+  return [...linksByKey.values()];
+}
+
+async function resolveFamilyShareChildrenFromOwnerProfile(profile = {}, loaders = {}) {
+  const loadTeam = loaders.loadTeam;
+  const loadPlayer = loaders.loadPlayer;
+  if (typeof loadTeam !== 'function' || typeof loadPlayer !== 'function') {
+    throw new TypeError('Family share child resolution requires team and player loaders.');
+  }
+
+  const children = [];
+  const links = collectOwnerParentLinks(profile);
+  const teamCache = new Map();
+
+  for (const link of links) {
+    if (!teamCache.has(link.teamId)) {
+      teamCache.set(link.teamId, await loadTeam(link.teamId));
+    }
+    const team = teamCache.get(link.teamId);
+    if (!team || !isTeamActive(team)) continue;
+
+    const player = await loadPlayer(link.teamId, link.playerId);
+    if (!player || player.active === false) continue;
+
+    children.push({
+      teamId: link.teamId,
+      teamName: compactString(team.name || link.teamName),
+      playerId: link.playerId,
+      playerName: compactString(player.name || link.playerName),
+      playerNumber: compactString(player.number ?? link.playerNumber),
+      playerPhotoUrl: compactString(player.photoUrl || link.playerPhotoUrl) || null
+    });
+  }
+
+  return children;
+}
+
+module.exports = {
+  collectOwnerParentLinks,
+  isFamilyShareTokenReadable,
+  resolveFamilyShareChildrenFromOwnerProfile
+};

--- a/functions/index.js
+++ b/functions/index.js
@@ -36,6 +36,10 @@ const {
   normalizeCalendarRequest
 } = require('./team-calendar-feed-core.cjs');
 const {
+  isFamilyShareTokenReadable,
+  resolveFamilyShareChildrenFromOwnerProfile
+} = require('./family-share-core.cjs');
+const {
   hashRsvpToken,
   createRawRsvpToken,
   normalizeRsvpTokenCreateInput,
@@ -3893,6 +3897,46 @@ exports.teamCalendarFeed = functions.https.onRequest(async (req, res) => {
     console.error('Failed to build team calendar feed:', error);
     res.status(500).send('Calendar feed failed');
   }
+});
+
+exports.resolveFamilyShareTokenChildren = functions.https.onCall(async (data) => {
+  const tokenId = String(data?.tokenId || '').trim();
+  if (!/^[a-f0-9]{40}$/i.test(tokenId)) {
+    throw new functions.https.HttpsError('invalid-argument', 'A valid family share token is required.');
+  }
+
+  const tokenSnap = await firestore.doc(`familyShareTokens/${tokenId}`).get();
+  if (!tokenSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Family share token not found.');
+  }
+
+  const token = tokenSnap.data() || {};
+  if (!isFamilyShareTokenReadable(token)) {
+    throw new functions.https.HttpsError('permission-denied', 'Family share token is no longer active.');
+  }
+
+  const ownerUserId = String(token.ownerUserId || '').trim();
+  if (!ownerUserId) {
+    return { children: [] };
+  }
+
+  const ownerSnap = await firestore.doc(`users/${ownerUserId}`).get();
+  if (!ownerSnap.exists) {
+    return { children: [] };
+  }
+
+  const children = await resolveFamilyShareChildrenFromOwnerProfile(ownerSnap.data() || {}, {
+    loadTeam: async (teamId) => {
+      const teamSnap = await firestore.doc(`teams/${teamId}`).get();
+      return teamSnap.exists ? { id: teamSnap.id, ...(teamSnap.data() || {}) } : null;
+    },
+    loadPlayer: async (teamId, playerId) => {
+      const playerSnap = await firestore.doc(`teams/${teamId}/players/${playerId}`).get();
+      return playerSnap.exists ? { id: playerSnap.id, ...(playerSnap.data() || {}) } : null;
+    }
+  });
+
+  return { children };
 });
 
 exports.fetchCalendarIcs = functions

--- a/functions/test/family-share-core.test.cjs
+++ b/functions/test/family-share-core.test.cjs
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  collectOwnerParentLinks,
+  isFamilyShareTokenReadable,
+  resolveFamilyShareChildrenFromOwnerProfile
+} = require('../family-share-core.cjs');
+
+test('family share token readability preserves active legacy tokens and blocks revoked or expired links', () => {
+  const nowMs = Date.parse('2026-06-27T12:00:00Z');
+
+  assert.equal(isFamilyShareTokenReadable({ active: true }, nowMs), true);
+  assert.equal(isFamilyShareTokenReadable({ active: false }, nowMs), false);
+  assert.equal(isFamilyShareTokenReadable({ revoked: true }, nowMs), false);
+  assert.equal(isFamilyShareTokenReadable({ revokedAt: { toDate: () => new Date('2026-06-01T00:00:00Z') } }, nowMs), false);
+  assert.equal(
+    isFamilyShareTokenReadable({ expiresAt: { toDate: () => new Date('2026-06-28T00:00:00Z') } }, nowMs),
+    true
+  );
+  assert.equal(
+    isFamilyShareTokenReadable({ expiresAt: { toDate: () => new Date('2026-06-26T00:00:00Z') } }, nowMs),
+    false
+  );
+});
+
+test('family share child resolver rebuilds public child rows from owner parent scope', async () => {
+  const profile = {
+    parentOf: [
+      {
+        teamId: 'team-1',
+        teamName: 'Old Bears',
+        playerId: 'player-1',
+        playerName: 'Old Pat',
+        playerNumber: '7',
+        playerPhotoUrl: 'old-photo.jpg'
+      }
+    ],
+    parentPlayerKeys: [
+      'team-1::player-1',
+      'team-2::player-2',
+      'team-3::inactive-player',
+      'team-archived::player-4'
+    ]
+  };
+
+  assert.deepEqual(collectOwnerParentLinks(profile).map((link) => `${link.teamId}::${link.playerId}`), [
+    'team-1::player-1',
+    'team-2::player-2',
+    'team-3::inactive-player',
+    'team-archived::player-4'
+  ]);
+
+  const teams = {
+    'team-1': { name: 'Bears' },
+    'team-2': { name: 'Hawks' },
+    'team-3': { name: 'Wolves' },
+    'team-archived': { name: 'Archived', archived: true }
+  };
+  const players = {
+    'team-1::player-1': { name: 'Pat Star', number: '9', photoUrl: 'pat.jpg' },
+    'team-2::player-2': { name: 'Avery Stone', number: '11', photoUrl: 'avery.jpg' },
+    'team-3::inactive-player': { name: 'Inactive', active: false },
+    'team-archived::player-4': { name: 'Archived Player' }
+  };
+
+  const children = await resolveFamilyShareChildrenFromOwnerProfile(profile, {
+    loadTeam: async (teamId) => teams[teamId] || null,
+    loadPlayer: async (teamId, playerId) => players[`${teamId}::${playerId}`] || null
+  });
+
+  assert.deepEqual(children, [
+    {
+      teamId: 'team-1',
+      teamName: 'Bears',
+      playerId: 'player-1',
+      playerName: 'Pat Star',
+      playerNumber: '9',
+      playerPhotoUrl: 'pat.jpg'
+    },
+    {
+      teamId: 'team-2',
+      teamName: 'Hawks',
+      playerId: 'player-2',
+      playerName: 'Avery Stone',
+      playerNumber: '11',
+      playerPhotoUrl: 'avery.jpg'
+    }
+  ]);
+});

--- a/js/db.js
+++ b/js/db.js
@@ -8915,6 +8915,14 @@ export async function getFamilyShareToken(tokenId) {
     return { id: snap.id, ...snap.data() };
 }
 
+export async function resolveFamilyShareTokenChildren(tokenId) {
+    const normalizedTokenId = String(tokenId || '').trim();
+    if (!normalizedTokenId) return [];
+    const callable = httpsCallable(functions, 'resolveFamilyShareTokenChildren');
+    const response = await callable({ tokenId: normalizedTokenId });
+    return normalizeFamilyShareChildren(response?.data?.children || []);
+}
+
 export async function listFamilyShareTokens(ownerUserId) {
     const q = query(
         collection(db, 'familyShareTokens'),

--- a/js/family-share-utils.js
+++ b/js/family-share-utils.js
@@ -18,14 +18,23 @@ export function normalizeFamilyShareCalendarUrls(urls = []) {
         });
 }
 
+function compactString(value) {
+    return value == null ? '' : String(value).trim();
+}
+
 export function normalizeFamilyShareChildren(children = []) {
     return (children || [])
-        .filter((child) => child?.teamId && child?.playerId)
-        .map((child) => ({
-            teamId: String(child.teamId || ''),
-            teamName: String(child.teamName || ''),
-            playerId: String(child.playerId || ''),
-            playerName: String(child.playerName || ''),
-            playerPhotoUrl: child.playerPhotoUrl || null
-        }));
+        .map((child) => {
+            const teamId = compactString(child?.teamId);
+            const playerId = compactString(child?.playerId || child?.childId);
+            return {
+                teamId,
+                teamName: compactString(child?.teamName || child?.team),
+                playerId,
+                playerName: compactString(child?.playerName || child?.childName || child?.name),
+                playerNumber: compactString(child?.playerNumber ?? child?.number),
+                playerPhotoUrl: child?.playerPhotoUrl || child?.photoUrl || null
+            };
+        })
+        .filter((child) => child.teamId && child.playerId);
 }

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -597,14 +597,17 @@
                 "notifyRideClaimUpdated",
                 "notifyRideOfferCancelled",
                 "notifyRideOfferCreated",
+                "resolveFamilyShareTokenChildren",
                 "sendPracticePacketDueTomorrowReminders"
             ],
             "unitTests": [
+                "functions/test/family-share-core.test.cjs",
                 "tests/unit/app-parent-tools-household-service.test.js",
                 "tests/unit/app-parent-tools-service.test.js",
                 "tests/unit/app-parent-tools-single-event-ics.test.ts",
                 "tests/unit/family-calendar-failures.test.js",
                 "tests/unit/family-plan.test.js",
+                "tests/unit/family-share-legacy-token.test.js",
                 "tests/unit/family-share-token-rules.test.js"
             ],
             "integrationTests": [

--- a/tests/unit/family-plan.test.js
+++ b/tests/unit/family-plan.test.js
@@ -451,7 +451,8 @@ describe('family plan helpers', () => {
 
     it('normalizes family share children and drops incomplete player links', () => {
         expect(normalizeFamilyShareChildren([
-            { teamId: 'team-1', teamName: 'Tigers', playerId: 'player-1', playerName: 'Sam', playerPhotoUrl: 'photo.jpg' },
+            { teamId: ' team-1 ', teamName: ' Tigers ', playerId: ' player-1 ', playerName: ' Sam ', playerNumber: ' 9 ', playerPhotoUrl: 'photo.jpg' },
+            { teamId: 'team-legacy', team: 'Legacy Team', childId: 'player-legacy', name: 'Legacy Player', number: 12, photoUrl: 'legacy.jpg' },
             { teamId: 'team-2', playerName: 'Missing player id' },
             { playerId: 'player-3', playerName: 'Missing team id' }
         ])).toEqual([
@@ -460,7 +461,16 @@ describe('family plan helpers', () => {
                 teamName: 'Tigers',
                 playerId: 'player-1',
                 playerName: 'Sam',
+                playerNumber: '9',
                 playerPhotoUrl: 'photo.jpg'
+            },
+            {
+                teamId: 'team-legacy',
+                teamName: 'Legacy Team',
+                playerId: 'player-legacy',
+                playerName: 'Legacy Player',
+                playerNumber: '12',
+                playerPhotoUrl: 'legacy.jpg'
             }
         ]);
     });

--- a/tests/unit/family-share-legacy-token.test.js
+++ b/tests/unit/family-share-legacy-token.test.js
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readRepoFile(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
+
+describe('legacy empty family share tokens', () => {
+    it('wires a callable fallback before rendering family page children', () => {
+        const familyPage = readRepoFile('family.html');
+        const dbSource = readRepoFile('js/db.js');
+
+        expect(dbSource).toContain('export async function resolveFamilyShareTokenChildren(tokenId)');
+        expect(dbSource).toContain("httpsCallable(functions, 'resolveFamilyShareTokenChildren')");
+        expect(dbSource).toContain('return normalizeFamilyShareChildren(response?.data?.children || []);');
+
+        expect(familyPage).toContain('getFamilyShareToken, resolveFamilyShareTokenChildren, getTeam');
+        expect(familyPage).toContain('function normalizeFamilyPageChildren(children = [])');
+        expect(familyPage).toContain('async function resolveFamilyPageChildren(token)');
+        expect(familyPage).toContain('const storedChildren = normalizeFamilyPageChildren(token?.children);');
+        expect(familyPage).toContain('if (storedChildren.length > 0) return storedChildren;');
+        expect(familyPage).toContain('return normalizeFamilyPageChildren(await resolveFamilyShareTokenChildren(tokenId));');
+        expect(familyPage).toContain('const children = await resolveFamilyPageChildren(token);');
+    });
+
+    it('registers a backend resolver that validates the bearer token before reading owner scope', () => {
+        const functionsSource = readRepoFile('functions/index.js');
+
+        expect(functionsSource).toContain('exports.resolveFamilyShareTokenChildren = functions.https.onCall');
+        expect(functionsSource).toContain('isFamilyShareTokenReadable(token)');
+        expect(functionsSource).toContain('firestore.doc(`users/${ownerUserId}`).get()');
+        expect(functionsSource).toContain('resolveFamilyShareChildrenFromOwnerProfile(ownerSnap.data() || {},');
+        expect(functionsSource).toContain('firestore.doc(`teams/${teamId}/players/${playerId}`).get()');
+    });
+});


### PR DESCRIPTION
## Summary
- Add a `resolveFamilyShareTokenChildren` callable that validates a family share bearer token, reads the owner's parent scope server-side, and returns only public-safe child rows.
- Update `family.html` to use stored token children first, then fall back to the callable for legacy tokens whose `children` array is empty.
- Broaden family-share child normalization for legacy/app field names and add regression coverage plus coverage-map registration.

## Root cause
The reported production URL loads a valid token document, but that document has `children: []`. The page was rendering exactly that empty array, so players, teams, filters, and schedule all appeared empty. Anonymous Firestore cannot safely read `users/{ownerUserId}`, so legacy empty tokens need a server-side resolver that checks token validity before reading owner/player data.

## Validation
- `npx vitest run tests/unit/family-plan.test.js tests/unit/family-share-legacy-token.test.js --reporter=verbose`
- `npm --prefix functions test`
- `npm run app:build`
- `npm test -- --run` (passed on rerun; an earlier run hit a transient `app-team-media` failure that passed in isolation)

## Deployment note
This fix requires deploying both the static site change and the new Firebase callable function for existing empty-token links to recover players.