### PR TITLE
Add projected playing time interop regression tests

### DIFF
--- a/apps/app/src/lib/gameDayLineupBuilder.test.ts
+++ b/apps/app/src/lib/gameDayLineupBuilder.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   assignLineupPlayer,
+  buildProjectedPlayingTimeSummary,
   buildRoundRobinLineup,
   getLineupSlotKey,
   getOrderedLineupPeriods,
@@ -97,6 +98,100 @@ describe('gameDayLineupBuilder', () => {
     });
   });
 
+  it('preserves non-overridden whole-period minutes when timed current-shape overrides are mixed in', () => {
+    const summary = buildProjectedPlayingTimeSummary('soccer-9v9', {
+      formationId: 'soccer-9v9',
+      numPeriods: 2,
+      periodDuration: 30,
+      subTimes: [14],
+      lineups: {
+        'H1-keeper': 'p1',
+        "H1 14'-keeper": 'p2',
+        'H2-keeper': 'p1',
+        'H1-right-defense': 'p3',
+        'H2-right-defense': 'p3',
+        'H1-sweeper': 'p4',
+        'H2-sweeper': 'p4',
+        'H1-left-defense': 'p5',
+        'H2-left-defense': 'p5',
+        'H1-left-mid': 'p6',
+        'H2-left-mid': 'p6',
+        'H1-center-mid-1': 'p7',
+        'H2-center-mid-1': 'p7',
+        'H1-center-mid-2': 'p8',
+        'H2-center-mid-2': 'p8',
+        'H1-right-mid': 'p9',
+        'H2-right-mid': 'p9',
+        'H1-striker': 'p10',
+        'H2-striker': 'p10'
+      }
+    }, [
+      { id: 'p1', name: 'Alex Keeper', number: '1' },
+      { id: 'p2', name: 'Bailey Sub', number: '2' },
+      { id: 'p3', name: 'Casey Right Defense', number: '3' },
+      { id: 'p4', name: 'Devon Sweeper', number: '4' },
+      { id: 'p5', name: 'Emery Left Defense', number: '5' },
+      { id: 'p6', name: 'Finley Left Mid', number: '6' },
+      { id: 'p7', name: 'Gray Center Mid', number: '7' },
+      { id: 'p8', name: 'Harper Center Mid', number: '8' },
+      { id: 'p9', name: 'Indy Right Mid', number: '9' },
+      { id: 'p10', name: 'Jules Striker', number: '10' }
+    ]);
+
+    expect(summary.find((row) => row.playerId === 'p1')).toMatchObject({
+      minutes: 46,
+      status: 'balanced'
+    });
+    expect(summary.find((row) => row.playerId === 'p2')).toMatchObject({
+      minutes: 14,
+      status: 'under-utilized'
+    });
+  });
+
+  it('calculates legacy planner interval totals and status labels exactly', () => {
+    const summary = buildProjectedPlayingTimeSummary('soccer-9v9', {
+      formationId: 'soccer-9v9',
+      numPeriods: 2,
+      periodDuration: 20,
+      subTimes: [7, 14],
+      lineups: {
+        ...buildLegacyIntervalAssignments('keeper', 'p1', ['1-7', '1-20', '2-20']),
+        ...buildLegacyIntervalAssignments('keeper', 'p2', ['1-14', '2-14']),
+        ...buildLegacyIntervalAssignments('keeper', 'p3', ['2-7']),
+        ...buildLegacyIntervalAssignments('right-defense', 'p1'),
+        ...buildLegacyIntervalAssignments('sweeper', 'p1'),
+        ...buildLegacyIntervalAssignments('left-defense', 'p2'),
+        ...buildLegacyIntervalAssignments('left-mid', 'p2', ['1-7', '1-14', '2-7']),
+        ...buildLegacyIntervalAssignments('center-mid-1', 'p3'),
+        ...buildLegacyIntervalAssignments('center-mid-2', 'p4'),
+        ...buildLegacyIntervalAssignments('right-mid', 'p5'),
+        ...buildLegacyIntervalAssignments('striker', 'p5')
+      }
+    }, [
+      { id: 'p1', name: 'Alex Keeper', number: '1' },
+      { id: 'p2', name: 'Bailey Utility', number: '2' },
+      { id: 'p3', name: 'Casey Mid', number: '3' },
+      { id: 'p4', name: 'Devon Center Mid', number: '4' },
+      { id: 'p5', name: 'Emery Attack', number: '5' }
+    ]);
+
+    expect(summary.find((row) => row.playerId === 'p1')).toMatchObject({
+      minutes: 99,
+      targetMinutes: 72,
+      status: 'over-utilized'
+    });
+    expect(summary.find((row) => row.playerId === 'p2')).toMatchObject({
+      minutes: 75,
+      targetMinutes: 72,
+      status: 'balanced'
+    });
+    expect(summary.find((row) => row.playerId === 'p3')).toMatchObject({
+      minutes: 47,
+      targetMinutes: 72,
+      status: 'under-utilized'
+    });
+  });
+
   it('builds a balanced local fallback lineup across all periods', () => {
     const plan = buildRoundRobinLineup(['Q1', 'Q2'], LINEUP_FORMATIONS['basketball-5v5'].positions, [
       { id: 'p1', name: 'Avery Smith', number: '1' },
@@ -108,3 +203,7 @@ describe('gameDayLineupBuilder', () => {
     expect(plan[getLineupSlotKey('Q2', 'pg')]).toBe('p2');
   });
 });
+
+function buildLegacyIntervalAssignments(positionId: string, playerId: string, intervalKeys = ['1-7', '1-14', '1-20', '2-7', '2-14', '2-20']) {
+  return Object.fromEntries(intervalKeys.map((intervalKey) => [`${intervalKey}-${positionId}`, playerId]));
+}


### PR DESCRIPTION
Closes #3233

## What changed
- added app-level regression coverage for `buildProjectedPlayingTimeSummary()` in `apps/app/src/lib/gameDayLineupBuilder.test.ts`
- covered current-shape soccer Game Day lineups that mix whole-period assignments with a timed override like `H1 14'-keeper`
- covered legacy planner interval keys with `subTimes` and asserted exact projected-minute totals plus `balanced`, `under-utilized`, and `over-utilized` status labels

## Root Cause
The projected playing time panel depended on legacy lineup normalization plus interval expansion across mixed whole-period and timed keys, but the app helper had no regression test at that boundary. That made it possible for minute-total or status-label regressions in mixed-key Game Day drafts to ship quietly without failing app tests.

## Prevention / Learning
Whenever app UI math depends on legacy interop helpers, add regression coverage at the app helper boundary with both current-shape and legacy draft keys. For Game Day lineup math, always test exact minute totals and coach-facing status labels together, not just normalized slot output.

## Regression Tests
- `cd apps/app && npx vitest run src/lib/gameDayLineupBuilder.test.ts --reporter=verbose`
- current-shape mixed whole-period plus timed override case asserts keeper minutes stay on non-overridden intervals and move only on the overridden interval
- legacy planner interval case asserts exact minute totals and expected projected-playing-time status labels

## Recurrence Risk
Low. The app test suite now locks the mixed-key projected-minute math at the same helper boundary used by `ScheduleEventDetail`.