### PR TITLE
Preserve Browse Teams search pagination

### DIFF
--- a/teams.html
+++ b/teams.html
@@ -164,10 +164,10 @@
       setSearchPending(true);
       try {
         const discovery = await discoverPublicTeams(locationFilter
-          ? { searchText: locationFilter, pageSize: 24 }
+          ? { searchText: locationFilter, cursor, pageSize: 24 }
           : { cursor, pageSize: 24 });
         const allTeams = discovery.teams || [];
-        browseCursor = locationFilter ? null : (discovery.nextCursor || null);
+        browseCursor = discovery.nextCursor || null;
         // Defense in depth: the query only requests public teams, and this keeps
         // private teams hidden if a stale helper or local test double returns one.
         const teams = allTeams.filter(t => t.isPublic === true);
@@ -287,11 +287,11 @@
         container.innerHTML = markup;
 
         renderLoadMoreButton(container, {
-          canLoadMore: !locationFilter && Boolean(browseCursor),
+          canLoadMore: Boolean(browseCursor),
           onClick: async () => {
             const nextCursor = browseCursor;
             if (!nextCursor) return;
-            await loadTeams('', { cursor: nextCursor, append: true });
+            await loadTeams(getLocationSearchValue(), { cursor: nextCursor, append: true });
           }
         });
 

--- a/teams.html
+++ b/teams.html
@@ -118,6 +118,7 @@
     const searchButton = document.getElementById('search-button');
     const clearSearchButton = document.getElementById('clear-search-button');
     let browseCursor = null;
+    let activeLocationFilter = '';
     let renderedTeams = [];
 
     function getLocationSearchValue() {
@@ -291,7 +292,7 @@
           onClick: async () => {
             const nextCursor = browseCursor;
             if (!nextCursor) return;
-            await loadTeams(getLocationSearchValue(), { cursor: nextCursor, append: true });
+            await loadTeams(activeLocationFilter, { cursor: nextCursor, append: true });
           }
         });
 
@@ -324,13 +325,15 @@
 
     searchForm.addEventListener('submit', async (event) => {
       event.preventDefault();
+      activeLocationFilter = getLocationSearchValue();
       browseCursor = null;
       renderedTeams = [];
-      await loadTeams(getLocationSearchValue());
+      await loadTeams(activeLocationFilter);
     });
 
     clearSearchButton.addEventListener('click', async () => {
       locationSearchInput.value = '';
+      activeLocationFilter = '';
       browseCursor = null;
       renderedTeams = [];
       await loadTeams();

--- a/tests/smoke/teams-location-search.spec.js
+++ b/tests/smoke/teams-location-search.spec.js
@@ -16,6 +16,9 @@ const pages = {
   ],
   kansas: [
     { id: 'current', name: 'Kansas City Current', sport: 'Soccer', description: 'Midwest club', isPublic: true, zip: '64102', city: 'Kansas City', state: 'MO' }
+  ],
+  kansasNext: [
+    { id: 'kc-wave', name: 'KC Wave', sport: 'Soccer', description: 'Second search page', isPublic: true, city: 'Kansas City', state: 'KS' }
   ]
 };
 
@@ -31,7 +34,13 @@ export async function discoverPublicTeams(options = {}) {
     }
     return { teams: pages.browse, nextCursor: 'page-2' };
   }
-  return { teams: filter.includes('kansas') ? pages.kansas : [], nextCursor: null };
+  if (filter.includes('kansas')) {
+    if (options.cursor === 'search-page-2') {
+      return { teams: pages.kansasNext, nextCursor: null };
+    }
+    return { teams: pages.kansas, nextCursor: 'search-page-2' };
+  }
+  return { teams: [], nextCursor: null };
 }
 
 export async function getTeams() {
@@ -68,7 +77,7 @@ export async function resolveZip() {
 }
 `;
 
-test('browse teams location search uses bounded discovery and clear restores browse page', async ({ page, baseURL }) => {
+test('browse teams location search paginates filtered results and clear restores browse page', async ({ page, baseURL }) => {
     await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route('**/js/db.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route('**/js/telemetry.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: '' }));
@@ -89,7 +98,15 @@ test('browse teams location search uses bounded discovery and clear restores bro
 
     await expect(page.getByText('Kansas City Current')).toBeVisible();
     await expect(page.getByText('Alpha Soccer')).toHaveCount(0);
-    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ searchText: 'Kansas', pageSize: 24 });
+    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ searchText: 'Kansas', cursor: null, pageSize: 24 });
+    await expect(page.getByRole('button', { name: 'Load more teams' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Load more teams' }).click();
+
+    await expect(page.getByText('Kansas City Current')).toBeVisible();
+    await expect(page.getByText('KC Wave')).toBeVisible();
+    await expect(page.getByText('Alpha Soccer')).toHaveCount(0);
+    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ searchText: 'Kansas', cursor: 'search-page-2', pageSize: 24 });
     await expect.poll(() => page.evaluate(() => window.__runtimeZipFallbackCalls)).toBe(0);
     expect(new URL(page.url()).pathname).toMatch(/\/teams\.html$/);
 

--- a/tests/smoke/teams-location-search.spec.js
+++ b/tests/smoke/teams-location-search.spec.js
@@ -101,6 +101,7 @@ test('browse teams location search paginates filtered results and clear restores
     await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ searchText: 'Kansas', cursor: null, pageSize: 24 });
     await expect(page.getByRole('button', { name: 'Load more teams' })).toBeVisible();
 
+    await page.locator('#location-search-input').fill('Chicago');
     await page.getByRole('button', { name: 'Load more teams' }).click();
 
     await expect(page.getByText('Kansas City Current')).toBeVisible();

--- a/tests/unit/teams-html-escaping.test.js
+++ b/tests/unit/teams-html-escaping.test.js
@@ -39,6 +39,18 @@ describe('teams page HTML escaping', () => {
         expect(source).toContain("locationSearchInput.value = '';");
     });
 
+    it('preserves filtered discovery cursors for load more and clear resets back to browse mode', () => {
+        const source = readTeamsPage();
+
+        expect(source).toContain('? { searchText: locationFilter, cursor, pageSize: 24 }');
+        expect(source).toContain('browseCursor = discovery.nextCursor || null;');
+        expect(source).toContain('canLoadMore: Boolean(browseCursor),');
+        expect(source).toContain("await loadTeams(getLocationSearchValue(), { cursor: nextCursor, append: true });");
+        expect(source).toContain("browseCursor = null;");
+        expect(source).toContain("renderedTeams = [];");
+        expect(source).toContain('await loadTeams();');
+    });
+
     // This test now relies on the actual rendering logic in teams.html
     // and the `escapeHtml` and `getSafeImageUrl` functions being correctly applied.
     // Since we're importing the functions directly, we're testing their behavior,

--- a/tests/unit/teams-html-escaping.test.js
+++ b/tests/unit/teams-html-escaping.test.js
@@ -29,7 +29,7 @@ describe('teams page HTML escaping', () => {
 
         expect(source).toContain("searchForm.addEventListener('submit'");
         expect(source).toContain('event.preventDefault();');
-        expect(source).toContain('await loadTeams(getLocationSearchValue());');
+        expect(source).toContain('await loadTeams(activeLocationFilter);');
         expect(source).toContain('discoverPublicTeams(locationFilter');
         expect(source).toContain('function getStoredLocationLabel(team)');
         expect(source).toContain('.filter((team) => !getStoredLocationLabel(team))');
@@ -43,9 +43,12 @@ describe('teams page HTML escaping', () => {
         const source = readTeamsPage();
 
         expect(source).toContain('? { searchText: locationFilter, cursor, pageSize: 24 }');
+        expect(source).toContain("let activeLocationFilter = '';");
         expect(source).toContain('browseCursor = discovery.nextCursor || null;');
         expect(source).toContain('canLoadMore: Boolean(browseCursor),');
-        expect(source).toContain("await loadTeams(getLocationSearchValue(), { cursor: nextCursor, append: true });");
+        expect(source).toContain("await loadTeams(activeLocationFilter, { cursor: nextCursor, append: true });");
+        expect(source).toContain("activeLocationFilter = getLocationSearchValue();");
+        expect(source).toContain("activeLocationFilter = '';");
         expect(source).toContain("browseCursor = null;");
         expect(source).toContain("renderedTeams = [];");
         expect(source).toContain('await loadTeams();');


### PR DESCRIPTION
Closes #3235

## What changed
- preserved `discoverPublicTeams` cursors during location-filtered Browse Teams searches instead of dropping them after page 1
- showed the existing `Load more teams` control whenever a public-team cursor exists, including active search mode
- kept `Load more` requests pinned to the current search text so page 2 appends filtered results instead of reverting to unfiltered browse
- added focused regression coverage in both smoke and page-level unit tests for filtered pagination and clear-state reset behavior

## Root Cause
`teams.html` treated location-filtered discovery as single-page only. It nulled `discoverPublicTeams().nextCursor` whenever `searchText` was present and only rendered `Load more teams` for the unfiltered browse state, so the backend's existing paginated search contract could never surface in the UI.

## Prevention / Learning
When a page reuses the same discovery helper for filtered and unfiltered browsing, preserve the pagination contract in both modes. Add a regression test that clicks into page 2 while asserting the active filter stays applied and that Clear resets both rendered state and cursor state back to default browse mode.

## Regression Tests
- `npx vitest run tests/unit/teams-html-escaping.test.js --reporter=verbose`
- `SMOKE_BASE_URL=http://127.0.0.1:8017 npx playwright test tests/smoke/teams-location-search.spec.js --config=playwright.smoke.config.js`