### PR TITLE
Keep blank public team searches search-only

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -88,6 +88,21 @@ describe('PublicTeamSearch', () => {
         expect(getPublicTeamsPage).not.toHaveBeenCalled();
     });
 
+    it('does not browse all teams when the search button is clicked with an empty or whitespace-only query', async () => {
+        renderSearch();
+
+        const searchButton = screen.getByRole('button', { name: 'Search public teams' });
+        const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
+
+        fireEvent.click(searchButton);
+        fireEvent.change(searchInput, { target: { value: '   ' } });
+        fireEvent.click(searchButton);
+
+        await waitFor(() => expect(getPublicTeamsPage).not.toHaveBeenCalled());
+        expect(screen.getByText('Search for public teams near you')).toBeTruthy();
+        expect(screen.queryByText('Atlanta United')).toBeNull();
+    });
+
     it('filters teams by search text when search is submitted', async () => {
         (getPublicTeamsPage as import('vitest').Mock).mockResolvedValueOnce({ teams: [mockTeams[0]], nextCursor: null });
         renderSearch();
@@ -107,6 +122,12 @@ describe('PublicTeamSearch', () => {
             .mockResolvedValueOnce({ teams: [mockTeams[0]], nextCursor: 'cursor-2' })
             .mockResolvedValueOnce({ teams: [mockTeams[1]], nextCursor: null });
         renderSearch();
+
+        const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
+        fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter', charCode: 13 });
+        fireEvent.change(searchInput, { target: { value: '   ' } });
+        fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter', charCode: 13 });
+        expect(getPublicTeamsPage).not.toHaveBeenCalled();
 
         fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
 

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -52,7 +52,12 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
   }, []);
 
   const handleSearch = () => {
-    void fetchPublicTeams({ searchText: searchQuery.trim() || undefined });
+    const trimmedQuery = searchQuery.trim();
+    if (!trimmedQuery) {
+      return;
+    }
+
+    void fetchPublicTeams({ searchText: trimmedQuery });
   };
 
   const handleBrowseAll = () => {


### PR DESCRIPTION
Closes #3237

## What changed
- Guarded `PublicTeamSearch.handleSearch()` so empty or whitespace-only input returns early instead of triggering a fetch.
- Preserved the existing filtered search behavior for non-empty queries.
- Added component coverage for blank Search clicks, blank Enter submissions, and the explicit Browse all path.

## Root Cause
`PublicTeamSearch.handleSearch()` trimmed blank input to `undefined` and still passed it into `fetchPublicTeams()`. In this component, `undefined` means an unfiltered browse request, so the primary Search action silently switched workflows from search to browse.

## Prevention / Learning
When a UI has separate Search and Browse actions, blank or whitespace-only search submissions should be treated as a no-op, not normalized into the browse code path. Add regression coverage for both button click and Enter key submission so both entry points stay aligned.

## Regression Tests
- `npx vitest run apps/app/src/components/PublicTeamSearch.test.tsx --reporter=dot`
- Added a component test proving Search does not call `getPublicTeamsPage` for empty or whitespace-only input.
- Extended the browse-all test to prove Enter on an empty or whitespace-only query also does not call `getPublicTeamsPage`, while Browse all still does.

## Recurrence Risk
Low. The shared search handler now rejects blank queries before any fetch, and focused tests cover both blank submission paths plus the explicit browse path.