### PR TITLE
Preserve certificate batch in website handoff

### DIFF
--- a/apps/app/src/pages/TeamCertificates.test.tsx
+++ b/apps/app/src/pages/TeamCertificates.test.tsx
@@ -226,7 +226,7 @@ describe('TeamCertificates', () => {
     });
   });
 
-  it('creates drafts, generates editable narratives, and does not hand off to the website', async () => {
+  it('creates drafts, generates editable narratives, and keeps the saved batch for website handoff', async () => {
     render(
       <MemoryRouter initialEntries={['/teams/team-1/certificates']}>
         <Routes>
@@ -249,6 +249,12 @@ describe('TeamCertificates', () => {
       drafts: [expect.objectContaining({ certificateId: 'cert-1' })]
     }));
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open website' }));
+
+    await waitFor(() => {
+      expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/certificates.html#teamId=team-1&batchId=batch-1');
+    });
   });
 
   it('requires explicit review confirmation before publishing generated awards', async () => {

--- a/apps/app/src/pages/TeamCertificates.tsx
+++ b/apps/app/src/pages/TeamCertificates.tsx
@@ -91,6 +91,10 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
   }, [drafts, previewPlayerId]);
 
   const exportableDrafts = useMemo(() => drafts.filter((draft) => draft.includeInExport !== false), [drafts]);
+  const certificateStudioUrl = useMemo(() => {
+    const batchId = drafts[0]?.batchId || '';
+    return getCertificateStudioUrl(teamId, batchId);
+  }, [drafts, teamId]);
 
   useEffect(() => {
     if (!previewRef.current || !shared || !model || (!previewPlayer && !previewDraft)) return;
@@ -132,7 +136,7 @@ export function TeamCertificates({ auth }: { auth: AuthState }) {
 
   const onOpenWebsite = async () => {
     if (!teamId) return;
-    await openPublicUrl(getCertificateStudioUrl(teamId));
+    await openPublicUrl(certificateStudioUrl);
   };
 
   const updateDraft = (draftId: string, patch: Partial<CertificateAwardDraft>) => {

--- a/tests/unit/issue-1997-awards-publish-export-source.test.js
+++ b/tests/unit/issue-1997-awards-publish-export-source.test.js
@@ -63,7 +63,7 @@ describe('issue 1997 awards publish export source contract', () => {
         expect(certificateAwardServiceTestSource).toContain('uses the legacy certificate narrative prompt verbatim');
         expect(certificateAwardServiceTestSource).toContain('publishes the same certificate payload shape parent certificate reads expect');
         expect(certificateAwardServiceTestSource).toContain('keeps drafts safe when AI fails and does not publish without confirmation');
-        expect(teamCertificatesTestSource).toContain('creates drafts, generates editable narratives, and does not hand off to the website');
+        expect(teamCertificatesTestSource).toContain('creates drafts, generates editable narratives, and keeps the saved batch for website handoff');
         expect(teamCertificatesTestSource).toContain('requires explicit review confirmation before publishing generated awards');
         expect(teamCertificatesTestSource).toContain('shows export failures without changing the drafted award');
     });


### PR DESCRIPTION
Closes #3239

## What changed
- updated `TeamCertificates` to reuse the created certificate batch id when building the "Open website" handoff URL
- kept the pre-draft escape hatch behavior unchanged so the button still opens the generic team studio before any batch exists
- extended the existing page test to verify that, after draft creation, the website handoff includes `batchId`

## Root Cause
`TeamCertificates` always built the website URL from `teamId` alone, even after `saveCertificateDraftsForApp(...)` had already created a saved batch and returned draft state containing that batch id. That dropped the persisted batch context during the app-to-website handoff.

## Prevention / Learning
When a flow creates persisted work and then offers a cross-surface handoff, the handoff URL must be derived from the latest saved entity context, not rebuilt from a generic route helper with only parent identifiers. Regression tests should cover both pre-save and post-save handoff behavior.

## Regression Tests
- `npx vitest run src/pages/TeamCertificates.test.tsx --reporter=verbose`
- updated `apps/app/src/pages/TeamCertificates.test.tsx` to assert that "Open website" opens `https://allplays.ai/certificates.html#teamId=team-1&batchId=batch-1` after drafts are created