### PR TITLE
Lazy-load user-content images in the app

### DIFF
--- a/apps/app/src/components/schedule/GameReportSectionContent.tsx
+++ b/apps/app/src/components/schedule/GameReportSectionContent.tsx
@@ -118,7 +118,7 @@ function PlayerPerformanceRow({ player, statKeys, statLabels, hasPlayingTime, te
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-3">
           <div className="flex h-10 w-10 flex-none items-center justify-center overflow-hidden rounded-full bg-gray-100 text-sm font-black text-gray-500">
-            {player.photoUrl ? <img src={player.photoUrl} alt="" className="h-full w-full object-cover" /> : player.playerName.slice(0, 1)}
+            {player.photoUrl ? <img src={player.photoUrl} alt="" loading="lazy" decoding="async" className="h-full w-full object-cover" /> : player.playerName.slice(0, 1)}
           </div>
           <div className="min-w-0">
             <div className="truncate text-sm font-black text-gray-950">#{player.number} {player.playerName}</div>

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -1376,7 +1376,7 @@ function FriendCard({
     <div className="rounded-xl border border-gray-200 bg-white p-3">
       <div className="flex items-start gap-3">
         {friend.photoUrl ? (
-          <img src={friend.photoUrl} alt="" className="h-10 w-10 flex-none rounded-full object-cover" />
+          <img src={friend.photoUrl} alt="" loading="lazy" decoding="async" className="h-10 w-10 flex-none rounded-full object-cover" />
         ) : (
           <div className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-gray-950 text-xs font-black text-white">{getFriendInitials(friend.name)}</div>
         )}

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -376,7 +376,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
             <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
           <div className="flex h-11 w-11 flex-none items-center justify-center overflow-hidden rounded-2xl bg-primary-50 text-base font-black text-primary-700">
-            {data.player.photoUrl ? <img src={data.player.photoUrl} alt={`${playerName} profile photo`} className="h-full w-full object-cover" /> : <span>{jersey || getInitials(playerName)}</span>}
+            {data.player.photoUrl ? <img src={data.player.photoUrl} alt={`${playerName} profile photo`} loading="lazy" decoding="async" className="h-full w-full object-cover" /> : <span>{jersey || getInitials(playerName)}</span>}
           </div>
           <div className="min-w-0 flex-1">
             <div className="app-label">Player</div>

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -501,7 +501,7 @@ function TeamHero({ model }: { model: TeamDetailModel }) {
     <section className="app-card overflow-hidden">
       <div className="relative h-32 bg-gray-950 sm:h-44">
         {team.photoUrl ? (
-          <img src={team.photoUrl} alt={`${team.name} team photo`} className="h-full w-full object-cover opacity-90" />
+          <img src={team.photoUrl} alt={`${team.name} team photo`} decoding="async" className="h-full w-full object-cover opacity-90" />
         ) : (
           <div className="flex h-full w-full items-center justify-center bg-[linear-gradient(135deg,#111827_0%,#4338ca_50%,#047857_100%)]">
             <span className="text-5xl font-black text-white">{getInitials(team.name)}</span>

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -733,7 +733,7 @@ function DrillDetailModal({
           <div className="mt-5">
             <div className="text-sm font-black text-gray-950">Media & diagrams</div>
             <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              {drill.diagramUrls.map((url, index) => <img key={`${url}-${index}`} src={url} alt={`${drill.title} diagram ${index + 1}`} className="w-full rounded-2xl border border-gray-200 object-cover" />)}
+              {drill.diagramUrls.map((url, index) => <img key={`${url}-${index}`} src={url} alt={`${drill.title} diagram ${index + 1}`} loading="lazy" decoding="async" className="w-full rounded-2xl border border-gray-200 object-cover" />)}
             </div>
           </div>
         ) : null}

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -543,7 +543,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
           <div className="flex h-11 w-11 flex-none items-center justify-center overflow-hidden rounded-2xl bg-primary-50 text-primary-700">
-            {isPhotoMediaItem(featured) ? <img src={featured.url} alt="" className="h-full w-full object-cover" /> : <ImageIcon className="h-5 w-5" aria-hidden="true" />}
+            {isPhotoMediaItem(featured) ? <img src={featured.url} alt="" loading="lazy" decoding="async" className="h-full w-full object-cover" /> : <ImageIcon className="h-5 w-5" aria-hidden="true" />}
           </div>
           <div className="min-w-0 flex-1">
             <div className="app-label">Team media</div>
@@ -890,7 +890,7 @@ function FolderCoverThumb({ folder, active }: { folder: TeamMediaFolder; active:
 
   return (
     <span className={`flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-full ${active ? 'bg-white/20 text-white' : 'bg-white text-gray-500'}`} aria-hidden="true">
-      {coverUrl ? <img src={coverUrl} alt="" className="h-full w-full object-cover" /> : <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />}
+      {coverUrl ? <img src={coverUrl} alt="" loading="lazy" decoding="async" className="h-full w-full object-cover" /> : <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />}
     </span>
   );
 }

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -235,7 +235,7 @@ export function TeamAvatar({ team }: { team: Pick<ChatTeam, 'name' | 'photoUrl' 
   return (
     <div className="relative flex h-11 w-11 flex-none items-center justify-center overflow-hidden rounded-xl border border-gray-200 bg-primary-50 text-primary-700 shadow-sm">
       {team.photoUrl ? (
-        <img src={team.photoUrl} alt={`${team.name} team photo`} className="h-full w-full object-cover" />
+        <img src={team.photoUrl} alt={`${team.name} team photo`} loading="lazy" decoding="async" className="h-full w-full object-cover" />
       ) : (
         <span className="text-base font-black">{team.name.charAt(0).toUpperCase()}</span>
       )}
@@ -2639,7 +2639,7 @@ export function MessageAvatar({ message, label }: { message: ChatMessage; label:
     return <img src="./logo_small.png" alt="ALL PLAYS assistant avatar" className="h-8 w-8 rounded-full border border-indigo-200 object-cover" />;
   }
   if (message.senderPhotoUrl) {
-    return <img src={message.senderPhotoUrl} alt={`${label} profile photo`} className="h-8 w-8 rounded-full object-cover" />;
+    return <img src={message.senderPhotoUrl} alt={`${label} profile photo`} loading="lazy" decoding="async" className="h-8 w-8 rounded-full object-cover" />;
   }
   return (
     <div className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-200 text-xs font-black text-gray-600">
@@ -3135,7 +3135,7 @@ function MediaGallerySheet({
                 <video controls preload="metadata" className="aspect-video w-full bg-black object-cover" src={entry.url} />
               ) : (
                 <a href={entry.url} target="_blank" rel="noopener noreferrer">
-                  <img src={entry.url} alt={entry.name || 'Chat media'} className="aspect-video w-full object-cover" />
+                  <img src={entry.url} alt={entry.name || 'Chat media'} loading="lazy" decoding="async" className="aspect-video w-full object-cover" />
                 </a>
               )}
               <div className="p-3">

--- a/tests/unit/app-image-lazy-loading.test.js
+++ b/tests/unit/app-image-lazy-loading.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Performance regression guard: user-content images (team/player photos, media
+// grids, drill diagrams, chat media, friend avatars) must defer offscreen
+// decoding so the image-heavy mobile views stay responsive. Since iOS/Android
+// share the same WebView bundle, these attributes benefit all three platforms.
+
+function read(relativePath) {
+    return readFileSync(new URL(`../../apps/app/${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('app image lazy loading', () => {
+    it('lazy-loads repeated roster photos in game report sections', () => {
+        const source = read('src/components/schedule/GameReportSectionContent.tsx');
+        expect(source).toContain('src={player.photoUrl} alt="" loading="lazy" decoding="async"');
+    });
+
+    it('lazy-loads team media grid images', () => {
+        const source = read('src/pages/TeamMedia.tsx');
+        expect(source).toContain('src={featured.url} alt="" loading="lazy" decoding="async"');
+        expect(source).toContain('src={coverUrl} alt="" loading="lazy" decoding="async"');
+    });
+
+    it('lazy-loads drill diagram images', () => {
+        const source = read('src/pages/TeamDrills.tsx');
+        expect(source).toContain('src={url} alt={`${drill.title} diagram ${index + 1}`} loading="lazy" decoding="async"');
+    });
+
+    it('lazy-loads friend avatars on the home feed', () => {
+        const source = read('src/pages/Home.tsx');
+        expect(source).toContain('src={friend.photoUrl} alt="" loading="lazy" decoding="async"');
+    });
+
+    it('lazy-loads chat sender avatars and inline media', () => {
+        const source = read('src/pages/messages/components/ChatWindow.tsx');
+        expect(source).toContain('src={message.senderPhotoUrl} alt={`${label} profile photo`} loading="lazy" decoding="async"');
+        expect(source).toContain('src={entry.url} alt={entry.name || \'Chat media\'} loading="lazy" decoding="async"');
+    });
+
+    it('async-decodes the team detail hero photo without blocking LCP via lazy', () => {
+        const source = read('src/pages/TeamDetail.tsx');
+        expect(source).toContain('alt={`${team.name} team photo`} decoding="async"');
+        // Hero banner stays eager so it is not deferred as the LCP element.
+        expect(source).not.toContain('alt={`${team.name} team photo`} loading="lazy"');
+    });
+});


### PR DESCRIPTION
## Summary
- Performance pass on the React/Capacitor app focused on image loading. The image-heavy mobile views (rosters, media grids, drill diagrams, chat, friend lists) were decoding remote user-content images eagerly on the main thread even when offscreen.
- Applied the repo's existing pattern (chat attachments already used `loading="lazy" decoding="async"`) consistently:
  - **`loading="lazy" decoding="async"`** on repeated/below-the-fold images — game-report roster photos, team media grid, drill diagrams, home friend avatars, chat sender avatars, chat inline media, player-detail avatar.
  - **`decoding="async"` only** on the TeamDetail hero banner (kept eager so it isn't deferred as the LCP element).
- iOS and Android share the `apps/app/dist` WebView bundle, so this benefits web, iOS, and Android equally.

## Manual test steps
- Open a team with photos, the team media grid, a drill with diagrams, and a chat thread with images on a phone-sized viewport; confirm images appear correctly and offscreen ones load as you scroll.
- Confirm the team detail hero banner still renders immediately.

## Testing
- `npx tsc --noEmit` clean
- New regression test `tests/unit/app-image-lazy-loading.test.js` (6/6 pass)
- Touched-page suites pass (2 pre-existing TeamDetail failures confirmed present on clean tree, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)