### PR TITLE
Respect public team access in mobile browse results

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -8,6 +8,7 @@ import { PublicTeamSearch } from './PublicTeamSearch';
 import { getPublicTeamsPage } from '../lib/publicTeamsService';
 import { openPublicUrl } from '../lib/publicActions';
 import { ParentHomeTeam } from '../lib/homeLogic';
+import { getTeamWebsiteHashHref } from '../lib/teamNavigation';
 
 vi.mock('../lib/publicTeamsService', () => ({
     getPublicTeamsPage: vi.fn() as MockInstance<(args?: { searchText?: string; cursor?: unknown | null; pageSize?: number }) => Promise<{ teams: ParentHomeTeam[]; nextCursor: unknown | null }>>,
@@ -251,7 +252,7 @@ describe('PublicTeamSearch', () => {
         expect(openPublicUrl).not.toHaveBeenCalled();
     });
 
-    it('routes to the app team page when only web access is available', async () => {
+    it('opens the website team page when only web access is available', async () => {
         renderSearch();
 
         fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
@@ -260,10 +261,10 @@ describe('PublicTeamSearch', () => {
         const newYorkCard = screen.getByText('New York Knicks').closest('article');
         expect(newYorkCard).toBeTruthy();
 
-        fireEvent.click(within(newYorkCard as HTMLElement).getByRole('button', { name: 'View team' }));
+        fireEvent.click(within(newYorkCard as HTMLElement).getByRole('button', { name: 'Open website team page' }));
 
-        expect(openPublicUrl).not.toHaveBeenCalled();
-        expect(screen.getByTestId('location-probe').textContent).toBe('/teams/team-nyc-1');
+        expect(openPublicUrl).toHaveBeenCalledWith(getTeamWebsiteHashHref('team.html', 'team-nyc-1'));
+        expect(screen.getByTestId('location-probe').textContent).toBe('/teams');
     });
 
     it('renders an unavailable state when neither app nor web access exists', async () => {

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -4,6 +4,8 @@ import { Search, XCircle, Loader2, Users } from 'lucide-react';
 import { type ParentHomeTeam } from '../lib/homeLogic';
 import { TeamAvatar, TeamLauncherChip, Status } from '../pages/Teams';
 import { getPublicTeamsPage } from '../lib/publicTeamsService';
+import { openPublicUrl } from '../lib/publicActions';
+import { getTeamWebsiteHashHref } from '../lib/teamNavigation';
 import { resolveZip } from '../lib/utils';
 
 export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = false }: { autoBrowseOnMount?: boolean; showBackLink?: boolean }) {
@@ -78,12 +80,15 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
     setNextCursor(null);
   };
 
-  const handleOpenTeam = useCallback((team: ParentHomeTeam) => {
-    if (!team.appAccess && !team.webAccess) {
+  const handleOpenTeam = useCallback(async (team: ParentHomeTeam) => {
+    if (team.appAccess) {
+      navigate(`/teams/${encodeURIComponent(team.teamId)}`);
       return;
     }
 
-    navigate(`/teams/${encodeURIComponent(team.teamId)}`);
+    if (team.webAccess) {
+      await openPublicUrl(getTeamWebsiteHashHref('team.html', team.teamId));
+    }
   }, [navigate]);
 
   useEffect(() => {
@@ -225,7 +230,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
 
 function PublicTeamCard({ team, onOpenTeam }: { team: ParentHomeTeam; onOpenTeam: (team: ParentHomeTeam) => void | Promise<void> }) {
   const isActionable = Boolean(team.appAccess || team.webAccess);
-  const actionLabel = 'View team';
+  const actionLabel = team.appAccess ? 'View team' : 'Open website team page';
 
   return (
     <article className={`min-w-0 rounded-2xl border bg-white p-3 shadow-sm ${isActionable ? 'border-gray-200' : 'border-gray-200/80 bg-gray-50'}`}>


### PR DESCRIPTION
Closes #3250

## What changed
- Updated `PublicTeamSearch` to branch on access mode instead of treating every actionable public team as a native app route.
- Kept `appAccess:true` teams on the native `/teams/:teamId` path.
- Changed `appAccess:false` and `webAccess:true` teams to open the public website team page via `openPublicUrl(getTeamWebsiteHashHref('team.html', teamId))`.
- Updated the web-only CTA copy to `Open website team page` so the destination is clear before tapping.
- Tightened the component regression test to assert website-open behavior for web-only teams and native navigation for app-access teams.

## Root Cause
`PublicTeamSearch` collapsed `appAccess` and `webAccess` into one generic actionable state. Once either flag was true, `handleOpenTeam` always navigated to `/teams/:teamId`, so web-only public teams were incorrectly sent into the member-oriented in-app team screen.

## Prevention / Learning
When a discovery surface exposes multiple public access modes, do not collapse them into one generic CTA or route. Branch navigation and button copy directly from the explicit access flags so the UI reflects the actual destination and permission model.

## Regression Tests
- `npx vitest run src/components/PublicTeamSearch.test.tsx --reporter=verbose`
- `apps/app/src/components/PublicTeamSearch.test.tsx` now verifies that a web-only public team calls `openPublicUrl(...)` and does not change router location, while an app-access team still navigates to `/teams/:teamId`.