### PR TITLE
Security: escape legacy markup XSS + harden invite-code RNG

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -2056,7 +2056,7 @@
             const previewWrap = document.getElementById('player-photo-preview');
             const thumb = document.getElementById('player-photo-thumb');
             if (editingPhotoUrl) {
-                thumb.innerHTML = `<img src="${editingPhotoUrl}" alt="${player.name}" class="w-full h-full object-cover">`;
+                thumb.innerHTML = `<img src="${escapeHtml(editingPhotoUrl)}" alt="${escapeHtml(player.name || '')}" class="w-full h-full object-cover">`;
             } else {
                 thumb.innerHTML = `
                     <svg class="w-full h-full text-gray-400 p-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -2407,7 +2407,7 @@ EXAMPLES:
                                         <span class="text-xs font-bold text-green-700 uppercase">➕ Add</span>
                                     </div>
                                     <div class="text-sm">
-                                        <input type="text" value="${player.name}"
+                                        <input type="text" value="${escapeHtml(player.name)}"
                                             onchange="updatePlayerOperation(${index}, 'name', this.value)"
                                             class="font-semibold bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1"
                                             placeholder="Player Name">

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2522,7 +2522,7 @@
                         <div class="text-sm text-gray-600">
                             ${mapLink(practice.location) ? `<a class="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer" href="${mapLink(practice.location)}">${practice.location || 'TBD'}</a>` : (practice.location || 'TBD')}
                         </div>
-                        ${practice.notes ? `<div class="text-sm text-gray-500 mt-1">${practice.notes}</div>` : ''}
+                        ${practice.notes ? `<div class="text-sm text-gray-500 mt-1">${escapeHtml(practice.notes)}</div>` : ''}
                         ${planSummary}
                     </div>
                     <div class="flex space-x-2">
@@ -4845,7 +4845,7 @@ PARSING RULES:
                                         </span>
                                     </div>
                                     <div class="text-sm">
-                                        <input type="text" value="${game.opponent}"
+                                        <input type="text" value="${escapeHtml(game.opponent)}"
                                             onchange="updateOperation(${index}, 'opponent', this.value)"
                                             class="font-semibold bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1">
                                         <input type="datetime-local" value="${formatIsoForInput(date)}"

--- a/edit-team.html
+++ b/edit-team.html
@@ -1256,8 +1256,8 @@
                 const checked = !isSameSource || previouslySelectedEmails.has(entry.email) ? ' checked' : '';
                 return `
                 <label class="flex items-center gap-2">
-                    <input type="checkbox" class="rollover-staff-email h-3.5 w-3.5 text-amber-600 border-gray-300 rounded" value="${entry.email}"${checked}>
-                    <span>${entry.email}</span>
+                    <input type="checkbox" class="rollover-staff-email h-3.5 w-3.5 text-amber-600 border-gray-300 rounded" value="${escapeHtml(entry.email)}"${checked}>
+                    <span>${escapeHtml(entry.email)}</span>
                 </label>
             `;
             }).join('');
@@ -1516,7 +1516,7 @@
 
                 if (team.photoUrl) {
                     currentPhotoUrl = team.photoUrl;
-                    document.getElementById('photo-preview').innerHTML = `<img src="${team.photoUrl}" class="w-full h-full object-cover">`;
+                    document.getElementById('photo-preview').innerHTML = `<img src="${escapeHtml(team.photoUrl)}" class="w-full h-full object-cover">`;
                 }
 
                 // Update management links

--- a/game-plan.html
+++ b/game-plan.html
@@ -301,7 +301,7 @@
 
     <script type="module">
         import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=74';
-        import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent } from './js/utils.js?v=14';
+        import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml } from './js/utils.js?v=14';
         import { checkAuth } from './js/auth.js?v=37';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { createAutoSaveController } from './js/game-plan-autosave.js?v=2';
@@ -748,7 +748,7 @@
                         <div class="w-10 h-10 mx-auto rounded-full bg-gradient-to-br from-primary-100 to-primary-200 flex items-center justify-center border-2 border-primary-300 mb-1">
                             <span class="font-bold text-primary-700 text-sm">${p.number || '?'}</span>
                         </div>
-                        <div class="text-xs font-semibold text-gray-900 truncate">${p.name}</div>
+                        <div class="text-xs font-semibold text-gray-900 truncate">${escapeHtml(p.name)}</div>
                     </div>
                 `).join('');
 
@@ -845,7 +845,7 @@
                 <tr class="hover:bg-gray-50">
                     <td class="px-4 py-3 text-sm font-semibold text-gray-900 sticky left-0 bg-white z-10 border-r border-gray-300">
                         <div class="flex items-center justify-between gap-2">
-                            <span>${position.name}</span>
+                            <span>${escapeHtml(position.name)}</span>
                             <button class="fill-row-btn text-xs text-primary-700 hover:text-primary-900 bg-primary-50 px-2 py-1 rounded"
                                     data-position="${position.id}"
                                     title="Fill empty cells in this row with last selected player">Fill</button>
@@ -880,7 +880,7 @@
                                         ${changedFromPrevCell && !prevPosition ? '<span class="absolute -top-1 -right-1 text-[10px] bg-amber-500 text-white px-1 rounded">chg</span>' : ''}
                                         ${prevPosition ? '<span class="text-xs mr-0.5">↔</span>' : ''}
                                         <span class="font-bold text-xs">#${player.number || '?'}</span>
-                                        <span class="text-xs font-semibold">${player.name}</span>
+                                        <span class="text-xs font-semibold">${escapeHtml(player.name)}</span>
                                         <span class="text-xs">×</span>
                                     </div>
                                 ` : `
@@ -993,7 +993,7 @@
                          draggable="true"
                          data-player-id="${p.id}">
                         <span class="font-bold text-xs text-gray-700">#${p.number || '?'}</span>
-                        <span class="text-xs text-gray-800">${p.name}</span>
+                        <span class="text-xs text-gray-800">${escapeHtml(p.name)}</span>
                     </div>
                 `).join('') || '<span class="text-gray-400 text-xs">All assigned</span>';
 
@@ -1098,7 +1098,7 @@
                                         <span class="text-sm font-bold text-${statusColor}-700">${p.number || '?'}</span>
                                     </div>
                                     <div>
-                                        <span class="font-semibold text-gray-900">${p.name}</span>
+                                        <span class="font-semibold text-gray-900">${escapeHtml(p.name)}</span>
                                         <div class="text-xs text-${statusColor}-600 font-medium">${statusText}</div>
                                     </div>
                                 </div>

--- a/js/family-plan.js
+++ b/js/family-plan.js
@@ -12,10 +12,16 @@ function normalizeStatus(value) {
 }
 
 function generateHouseholdInviteCode() {
+    // Household invite codes become access codes for family-plan linking, so use a
+    // cryptographically secure RNG — a non-crypto PRNG is predictable from observed
+    // outputs. The 32-char alphabet divides 256 evenly, so byte % length is unbiased.
     const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    const cryptoApi = globalThis.crypto || globalThis.msCrypto;
+    const randomValues = new Uint8Array(8);
+    cryptoApi.getRandomValues(randomValues);
     let code = '';
-    for (let i = 0; i < 8; i += 1) {
-        code += chars.charAt(Math.floor(Math.random() * chars.length));
+    for (let i = 0; i < randomValues.length; i += 1) {
+        code += chars.charAt(randomValues[i] % chars.length);
     }
     return code;
 }

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -815,7 +815,7 @@ function renderOpponents() {
         <div class="flex items-center gap-2 min-w-0">
           ${o.photoUrl || o.name ? avatarHtml({ name: o.name, photoUrl: o.photoUrl }, 'h-6 w-6', 'text-[10px]') : ''}
           ${o.number ? `<span class="text-[10px] font-bold text-slate-500 shrink-0">#${escapeHtml(o.number)}</span>` : ''}
-          <input data-opp-edit="${o.id}" value="${o.name}" class="flex-1 min-w-0 text-xs px-2 py-1 rounded border border-slate/10 font-semibold" placeholder="Player name">
+          <input data-opp-edit="${escapeHtml(o.id)}" value="${escapeHtml(o.name)}" class="flex-1 min-w-0 text-xs px-2 py-1 rounded border border-slate/10 font-semibold" placeholder="Player name">
         </div>
         <div class="text-[11px] text-slate-500">${quickLineWithFouls || 'No stats yet'}</div>
         <div class="grid grid-cols-3 gap-1 text-[11px] font-semibold">

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -280,7 +280,7 @@ function renderOpponents() {
 
     return `
       <div class="border border-slate/10 rounded-xl p-2 bg-white space-y-1">
-        <input data-opp-edit="${o.id}" value="${o.name}" class="w-full text-xs px-2 py-1 rounded border border-slate/10 font-semibold">
+        <input data-opp-edit="${escapeHtml(o.id)}" value="${escapeHtml(o.name)}" class="w-full text-xs px-2 py-1 rounded border border-slate/10 font-semibold">
         <div class="text-[11px] text-slate-500">${quickLineWithFouls || 'No stats yet'}</div>
         <div class="grid grid-cols-3 gap-1 text-[11px] font-semibold">
           ${oppBtns} ${oppBtn(o.id, 'fouls', 1, 'FLS')} <button data-opp-del="${o.id}" class="text-[11px] text-red-600">Remove</button>

--- a/player.html
+++ b/player.html
@@ -1185,7 +1185,7 @@
              
              const preview = document.getElementById('edit-photo-preview');
              if (currentPlayer.photoUrl) {
-                 preview.innerHTML = `<img src="${currentPlayer.photoUrl}" class="w-full h-full object-cover">`;
+                 preview.innerHTML = `<img src="${escapeHtml(currentPlayer.photoUrl)}" class="w-full h-full object-cover">`;
              } else {
                  preview.innerHTML = '';
              }

--- a/tests/unit/family-plan-invite-code-randomness.test.js
+++ b/tests/unit/family-plan-invite-code-randomness.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Security regression guard (CWE-338): household invite codes become access
+// codes for family-plan linking, so they must be generated with a
+// cryptographically secure RNG. Math.random() is predictable from observed
+// outputs and must never be used for these codes.
+
+function readFamilyPlanSource() {
+    return readFileSync(new URL('../../js/family-plan.js', import.meta.url), 'utf8');
+}
+
+function extractFunction(source, name) {
+    const start = source.indexOf(`function ${name}(`);
+    expect(start, `${name} should exist`).toBeGreaterThan(-1);
+    // Capture up to the next top-level function declaration.
+    const rest = source.slice(start + 1);
+    const next = rest.indexOf('\nfunction ');
+    return next === -1 ? source.slice(start) : source.slice(start, start + 1 + next);
+}
+
+describe('household invite code randomness', () => {
+    const body = extractFunction(readFamilyPlanSource(), 'generateHouseholdInviteCode');
+
+    it('uses a cryptographically secure RNG', () => {
+        expect(body).toContain('getRandomValues');
+    });
+
+    it('does not use Math.random for the invite code', () => {
+        expect(body).not.toContain('Math.random');
+    });
+
+    it('uses a 32-char alphabet so byte % length is unbiased', () => {
+        const match = body.match(/const chars = '([^']+)'/);
+        expect(match, 'alphabet literal should be present').toBeTruthy();
+        const alphabet = match[1];
+        expect(alphabet.length).toBe(32);
+        // 256 divides evenly by the alphabet length -> no modulo bias.
+        expect(256 % alphabet.length).toBe(0);
+        // No ambiguous characters (I/O/0/1) in the alphabet.
+        expect(/[IO01]/.test(alphabet)).toBe(false);
+    });
+});

--- a/tests/unit/game-plan-playing-time-summary.test.js
+++ b/tests/unit/game-plan-playing-time-summary.test.js
@@ -93,6 +93,9 @@ function buildHarness(overrides = {}) {
         const FORMATIONS = deps.FORMATIONS;
         const document = deps.document;
         const buildGamePlanIntervals = deps.buildGamePlanIntervals;
+        const escapeHtml = (unsafe) => unsafe === null || unsafe === undefined ? '' : String(unsafe)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#039;');
         let intervalsCache = [];
         const recentAssignments = new Map();
         let draggedPlayerId = null;

--- a/tests/unit/xss-no-unescaped-interpolation-guard.test.js
+++ b/tests/unit/xss-no-unescaped-interpolation-guard.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Security guard: prevent stored-XSS regressions in the legacy vanilla-JS site.
+//
+// The legacy pages build markup with template literals and assign it via
+// innerHTML. Any user-controlled field interpolated directly into markup
+// context — element text `>${x.name}<` or an attribute value `="${x.name}"` —
+// must be wrapped in escapeHtml() (js/utils.js). This test fails if a new
+// unescaped interpolation of a known user-data field is introduced.
+//
+// Scope: production root *.html (test-*.html excluded) and js/**/*.js.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+// Fields that carry user-entered, stored content (Firestore-backed). Matching
+// is intentionally conservative — these are the realistic XSS carriers.
+const USER_DATA_FIELDS = [
+    'name',
+    'email',
+    'displayName',
+    'senderName',
+    'authorName',
+    'playerName',
+    'teamName',
+    'opponent',
+    'notes',
+    'note',
+    'comment',
+    'description',
+    'photoUrl',
+    'title'
+];
+
+const fieldAlternation = USER_DATA_FIELDS.join('|');
+// An interpolation in markup context: preceded by `>` (element text) or `="`
+// (attribute value), referencing a user-data field as the final property.
+const MARKUP_INTERP = new RegExp(
+    `(>|=")\\$\\{([^{}]*\\.(?:${fieldAlternation}))[a-zA-Z0-9_?]*\\}`,
+    'g'
+);
+
+function listLegacyFiles() {
+    const htmlFiles = readdirSync(repoRoot)
+        .filter((name) => name.endsWith('.html') && !name.startsWith('test'))
+        .map((name) => path.join(repoRoot, name));
+
+    const jsDir = path.join(repoRoot, 'js');
+    const walk = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) return walk(full);
+        if (entry.name.endsWith('.js') && !entry.name.includes('.test.')) return [full];
+        return [];
+    });
+
+    return [...htmlFiles, ...walk(jsDir)];
+}
+
+function findUnescapedSinks(source) {
+    const offenders = [];
+    for (const match of source.matchAll(MARKUP_INTERP)) {
+        const expression = match[2];
+        // Safe if the value is escaped (or is a runtime Error message, which is
+        // not user-stored content and surfaces only in dev error toasts).
+        if (expression.includes('escapeHtml(')) continue;
+        if (/\b(error|err|e)\.(message|name)$/.test(expression)) continue;
+        const line = source.slice(0, match.index).split('\n').length;
+        offenders.push(`${expression} (line ${line})`);
+    }
+    return offenders;
+}
+
+describe('legacy XSS guard: no unescaped user-data interpolation in markup', () => {
+    const files = listLegacyFiles();
+
+    it('scans a meaningful number of legacy files', () => {
+        // Sanity check so a broken glob does not silently pass.
+        expect(files.length).toBeGreaterThan(20);
+    });
+
+    for (const file of files) {
+        const relative = path.relative(repoRoot, file);
+        it(`has no unescaped user-data sinks in ${relative}`, () => {
+            const offenders = findUnescapedSinks(readFileSync(file, 'utf8'));
+            expect(offenders, `Unescaped user-data interpolation(s) in ${relative}: ${offenders.join(', ')}. Wrap with escapeHtml().`).toEqual([]);
+        });
+    }
+});

--- a/tests/unit/xss-roster-name-escaping.test.js
+++ b/tests/unit/xss-roster-name-escaping.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Security regression guard: user-controlled roster names (player.name / p.name)
+// and photo URLs are stored data and must be HTML-escaped before being placed
+// into innerHTML template literals, otherwise a name like
+// `" onerror="alert(1)` yields stored XSS. See escapeHtml in js/utils.js.
+
+function read(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('roster name XSS escaping', () => {
+    it('escapes the edited player photo preview src/alt in edit-roster.html', () => {
+        const source = read('edit-roster.html');
+        expect(source).toContain('src="${escapeHtml(editingPhotoUrl)}" alt="${escapeHtml(player.name || \'\')}"');
+        // The raw, unescaped sink must be gone.
+        expect(source).not.toContain('src="${editingPhotoUrl}" alt="${player.name}"');
+    });
+
+    it('imports escapeHtml and escapes every player-name interpolation in game-plan.html', () => {
+        const source = read('game-plan.html');
+        expect(source).toMatch(/import\s*\{[^}]*\bescapeHtml\b[^}]*\}\s*from\s*'\.\/js\/utils\.js/);
+
+        // No bare ${p.name} / ${player.name} should remain inside markup templates.
+        expect(source).not.toMatch(/>\$\{p\.name\}</);
+        expect(source).not.toMatch(/>\$\{player\.name\}</);
+
+        // The escaped forms are present.
+        expect(source).toContain('${escapeHtml(p.name)}');
+        expect(source).toContain('${escapeHtml(player.name)}');
+    });
+});


### PR DESCRIPTION
## Summary
Security pass across the codebase. Two fix classes, plus an audit that confirmed the server-side surface is solid.

### Stored XSS — unescaped user data in legacy `innerHTML` templates
User-entered roster/team data was interpolated into `innerHTML` template literals without escaping (a name like `" onerror="alert(1)` would execute). All wrapped in `escapeHtml` (from `js/utils.js`):
- `edit-roster.html` — player photo preview + edited-player name input
- `edit-schedule.html` — practice notes, opponent name input
- `edit-team.html` — staff emails (×2), team photo preview
- `game-plan.html` — player/position names across lineup, sub-matrix, playing-time views (+`escapeHtml` import)
- `player.html` — player photo preview
- `js/live-tracker.js`, `js/track-basketball.js` — opponent name inputs

### Insecure randomness (CWE-338)
`generateHouseholdInviteCode()` (`js/family-plan.js`) built codes with `Math.random()`. These become family-plan **access codes**, so they must not be predictable — switched to `crypto.getRandomValues` (32-char alphabet divides 256 evenly → no modulo bias).

## Tests
- **`xss-no-unescaped-interpolation-guard`** — scans all 251 production legacy files and fails on any unescaped user-data interpolation in markup context. This guard already caught one sink (`edit-team.html` `team.photoUrl`) that manual review missed.
- **`xss-roster-name-escaping`** — regression for the roster-name sinks.
- **`family-plan-invite-code-randomness`** — asserts a CSPRNG + unbiased 32-char alphabet.
- Provided `escapeHtml` in the game-plan render test harness.
- **Full suite: 3595/3595 unit tests pass.**

## Audited and confirmed secure (no changes needed)
- **Firestore rules:** no privilege escalation (`isAdmin`/`parentTeamIds`/`playerKeys` immutable from client); team `ownerId` immutable; chat enforces `senderId == auth.uid`; public reads limited to non-sensitive config.
- **Storage rules:** deny-by-default, size + content-type limits, per-path access checks.
- **Cloud Functions:** Stripe webhook signature-verified on `rawBody`; CORS uses a strict origin allowlist (no `Allow-Credentials`); the one wildcard `*` is a token-bearer endpoint; SSRF endpoint is deploy-time config; prototype-pollution sinks guarded by `hasOwnProperty`; public endpoints rate-limited.
- **React app:** deep-link/push routing rejects `//` (no open redirect); chat HTML goes through DOMPurify; no secrets in localStorage.
- **No** committed secrets, `eval`, or ReDoS-prone regexes.

## Known follow-ups (not in this PR)
- `functions/` has 9 moderate **transitive** npm vulns (under `firebase-admin@12`); resolving them needs a breaking `firebase-admin` 12→14 + `firebase-functions` 5→7 migration (v7 removes `functions.config()`, used here) — should be its own PR with deploy testing.
- Design question: team **admins** (not just owners) can edit `adminEmails`. This is currently by design (`hasFullTeamAccess` grants admins full management); flagged in case owner-only admin management is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)