### PR TITLE
Tests: behavioral, integration & workflow coverage for security fixes

### DIFF
--- a/tests/smoke/edit-roster-xss-escaping.spec.js
+++ b/tests/smoke/edit-roster-xss-escaping.spec.js
@@ -1,0 +1,173 @@
+import { test, expect } from '@playwright/test';
+
+// Workflow/E2E security test: drive the edit-roster bulk-AI import flow with a
+// malicious player name and confirm the rendered proposed-changes input escapes
+// it (no injected node, no fired handler). Uses the REAL escapeHtml so this
+// genuinely exercises the fix at edit-roster.html:2410.
+
+const MALICIOUS_NAME = '"><img src=x onerror="window.__xssFired=true">';
+
+// Real escapeHtml from js/utils.js — inlined so the stub does NOT neuter the fix.
+const UTILS_STUB = `
+export function renderHeader() {}
+export function renderFooter() {}
+export function getUrlParams() {
+    return { teamId: 'team-1' };
+}
+export function escapeHtml(unsafe) {
+    if (unsafe === null || unsafe === undefined) return '';
+    return String(unsafe)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+`;
+
+const DB_STUB = `
+export async function getTeam(teamId) {
+    return { id: teamId, name: 'Test Team', ownerId: 'user-1', adminEmails: [] };
+}
+export async function getPlayers() { return []; }
+export async function addPlayer() {}
+export async function deactivatePlayer() {}
+export async function reactivatePlayer() {}
+export async function getGames() { return []; }
+export async function uploadPlayerPhoto() { return 'https://example.test/photo.png'; }
+export async function updatePlayer() {}
+export async function setPlayerPrivateRosterProfileFields() {}
+export async function inviteParent() { return {}; }
+export async function removeParentFromPlayer() {}
+export async function getAllUsers() { return []; }
+export async function getUnreadChatCount() { return 0; }
+export async function getRosterFieldDefinitions() { return []; }
+export async function saveRosterFieldDefinition() {}
+export async function disableRosterFieldDefinition() {}
+export async function reorderRosterFieldDefinitions() {}
+export async function listTeamParentMembershipRequests() { return []; }
+export async function approveParentMembershipRequest() {}
+export async function denyParentMembershipRequest() {}
+export async function listTeamRegistrationForms() { return []; }
+export async function listTeamRegistrationReviews() { return []; }
+export async function approveTeamRegistration() {}
+export async function rejectTeamRegistration() {}
+export async function extendTeamRegistrationOffer() {}
+export async function acceptTeamRegistrationOffer() {}
+export async function releaseTeamRegistrationWaitlist() {}
+export async function listTeamTrackingItems() { return []; }
+export async function createTeamTrackingItem() { return 'tracking-item-1'; }
+export async function listTeamTrackingStatuses() { return []; }
+export async function setTeamTrackingStatus() {}
+`;
+
+const AUTH_STUB = `
+export function checkAuth(callback) {
+    callback({ uid: 'user-1', email: 'coach@example.com', isAdmin: false });
+}
+export async function sendInviteEmail() {}
+`;
+
+const TEAM_ACCESS_STUB = `
+export function hasFullTeamAccess() { return true; }
+export function normalizeTeamPermissions() {
+    return { scorekeeping: { mode: 'all', memberIds: [] }, streaming: { mode: 'all', memberIds: [] } };
+}
+`;
+
+const TEAM_ADMIN_BANNER_STUB = `export function renderTeamAdminBanner() {}`;
+
+const FIREBASE_APP_STUB = `
+export function getApp() { return {}; }
+export function _getProvider() { return { isInitialized: () => false, getImmediate: () => ({}), get: () => Promise.resolve({}), initialize: () => ({}) }; }
+export function _registerComponent() {}
+export function _removeServiceInstance() {}
+export function registerVersion() {}
+export function _isFirebaseServerApp() { return false; }
+export const SDK_VERSION = 'test';
+`;
+
+const FIREBASE_STUB = `
+export const auth = { currentUser: { uid: 'user-1', email: 'coach@example.com' } };
+export const db = {};
+export const storage = {};
+export function onAuthStateChanged(_auth, callback) { callback(auth.currentUser); return () => {}; }
+export function collection() { return {}; }
+export function doc() { return {}; }
+export function getDoc() { return Promise.resolve({ exists: () => false, data: () => ({}) }); }
+export function getDocs() { return Promise.resolve({ docs: [], empty: true, forEach() {} }); }
+export function setDoc() { return Promise.resolve(); }
+export function updateDoc() { return Promise.resolve(); }
+export function addDoc() { return Promise.resolve({ id: 'doc-1' }); }
+export function deleteDoc() { return Promise.resolve(); }
+export function query() { return {}; }
+export function where() { return {}; }
+export function orderBy() { return {}; }
+export function limit() { return {}; }
+export function onSnapshot(_ref, next) { if (typeof next === 'function') next({ docs: [], empty: true, forEach() {} }); return () => {}; }
+export function serverTimestamp() { return new Date(); }
+export function writeBatch() { return { set() {}, update() {}, delete() {}, commit: () => Promise.resolve() }; }
+`;
+
+const FIREBASE_AI_STUB = `
+export class GoogleAIBackend {}
+export const Schema = {
+    object(value) { return value; },
+    array(value) { return value; },
+    string() { return { type: 'string' }; }
+};
+export function getAI() { return {}; }
+export function getGenerativeModel() {
+    return {
+        async generateContent() {
+            return {
+                response: {
+                    text() {
+                        return JSON.stringify({
+                            operations: [
+                                { action: 'add', player: { name: ${JSON.stringify(MALICIOUS_NAME)}, number: '12' } }
+                            ]
+                        });
+                    }
+                }
+            };
+        }
+    };
+}
+`;
+
+async function mockEditRosterDependencies(page) {
+    await page.route(/\/js\/telemetry\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: '' }));
+    await page.route(/\/js\/firebase\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_STUB }));
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
+    await page.route(/\/js\/utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
+    await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/team-access\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
+    await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
+    await page.route(/\/js\/vendor\/firebase-app\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
+    await page.route(/\/js\/vendor\/firebase-ai\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
+}
+
+test('malicious AI-imported player name is escaped in proposed changes (no XSS)', async ({ page, baseURL }) => {
+    page.on('dialog', (dialog) => dialog.accept());
+
+    await mockEditRosterDependencies(page);
+    await page.goto(`${baseURL}/edit-roster.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#team-name-display')).toHaveText('Test Team');
+
+    await page.click('#tab-bulk-ai');
+    await expect(page.locator('#content-bulk-ai')).toBeVisible();
+
+    await page.fill('#bulk-text-input', '#12 malicious');
+    await page.click('#process-ai-btn');
+    await expect(page.locator('#proposed-changes-section')).toBeVisible();
+
+    const nameInput = page.locator('#proposed-changes-list input[placeholder="Player Name"]');
+    // The full payload is preserved as an inert input value (proves it was escaped
+    // into the attribute, not parsed as markup).
+    await expect(nameInput).toHaveValue(MALICIOUS_NAME);
+
+    // No injected element and no fired handler.
+    expect(await page.locator('#proposed-changes-list img').count()).toBe(0);
+    expect(await page.evaluate(() => window.__xssFired)).toBeFalsy();
+});

--- a/tests/unit/chat-html-sanitizer-xss.test.js
+++ b/tests/unit/chat-html-sanitizer-xss.test.js
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { formatChatMessageHtml, __chatHtmlTestUtils } from '../../apps/app/src/lib/chatLogic.ts';
+
+const { sanitizeFormattedChatHtmlFallback } = __chatHtmlTestUtils;
+
+// Behavioral tests for the React chat HTML pipeline (the only dangerouslySetInnerHTML
+// path). formatChatMessageHtml escapes input, applies markdown-ish formatting, then
+// sanitizes. We assert XSS payloads never survive as live markup, through both the
+// DOMPurify path (jsdom) and the regex fallback.
+
+const XSS_PAYLOADS = [
+    '<script>window.__x=1</script>',
+    '<img src=x onerror=alert(1)>',
+    '<svg/onload=alert(1)>',
+    '<a href="javascript:alert(1)">click</a>',
+    '<iframe src="javascript:alert(1)"></iframe>',
+    '"><img src=x onerror=alert(1)>'
+];
+
+describe('formatChatMessageHtml XSS hardening', () => {
+    for (const payload of XSS_PAYLOADS) {
+        it(`neutralizes: ${payload.slice(0, 32)}`, () => {
+            const html = formatChatMessageHtml(payload);
+            // No LIVE tag survives (escaped text like "&lt;img ... onerror=&gt;"
+            // is inert and intentionally still contains those substrings).
+            expect(html).not.toMatch(/<script/i);
+            expect(html).not.toMatch(/<iframe/i);
+            expect(html).not.toMatch(/<img/i);
+            expect(html).not.toMatch(/<svg/i);
+            // Authoritative check: rendering into a real DOM creates no dangerous
+            // nodes and fires no handler.
+            const host = document.createElement('div');
+            host.innerHTML = html;
+            expect(host.querySelectorAll('script, iframe, svg, img')).toHaveLength(0);
+            expect(host.querySelector('[onerror], [onload], [onclick]')).toBeNull();
+        });
+    }
+
+    it('keeps legitimate text and auto-links http(s) URLs with safe rel', () => {
+        const html = formatChatMessageHtml('see https://allplays.ai for info');
+        expect(html).toContain('href="https://allplays.ai"');
+        expect(html).toContain('rel="noopener noreferrer"');
+        expect(html).toContain('target="_blank"');
+    });
+
+    it('does not linkify javascript: pseudo-URLs', () => {
+        const html = formatChatMessageHtml('javascript:alert(1)');
+        expect(html).not.toMatch(/href="javascript:/i);
+    });
+});
+
+describe('sanitizeFormattedChatHtmlFallback (DOMPurify-unavailable path)', () => {
+    it('drops disallowed tags entirely', () => {
+        expect(sanitizeFormattedChatHtmlFallback('<script>x</script>')).not.toMatch(/<script/i);
+        expect(sanitizeFormattedChatHtmlFallback('<iframe></iframe>')).not.toMatch(/<iframe/i);
+        expect(sanitizeFormattedChatHtmlFallback('<img src=x onerror=alert(1)>')).not.toMatch(/<img/i);
+    });
+
+    it('keeps a safe https anchor but strips event handlers', () => {
+        const out = sanitizeFormattedChatHtmlFallback('<a href="https://allplays.ai" target="_blank" rel="noopener noreferrer">x</a>');
+        expect(out).toContain('href="https://allplays.ai"');
+        expect(out).not.toMatch(/onclick=|onerror=/i);
+    });
+
+    it('rejects a javascript: anchor', () => {
+        const out = sanitizeFormattedChatHtmlFallback('<a href="javascript:alert(1)">x</a>');
+        expect(out).not.toMatch(/href="javascript:/i);
+    });
+});

--- a/tests/unit/escape-html-behavior.test.js
+++ b/tests/unit/escape-html-behavior.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from '../../js/utils.js';
+
+// Behavioral unit tests for the escaping primitive that every legacy XSS fix
+// relies on. The xss-no-unescaped-interpolation-guard test proves the sinks
+// call escapeHtml; these tests prove escapeHtml actually neutralizes payloads.
+
+describe('escapeHtml', () => {
+    it('escapes the five HTML-significant characters', () => {
+        expect(escapeHtml('<')).toBe('&lt;');
+        expect(escapeHtml('>')).toBe('&gt;');
+        expect(escapeHtml('&')).toBe('&amp;');
+        expect(escapeHtml('"')).toBe('&quot;');
+        expect(escapeHtml("'")).toBe('&#039;');
+    });
+
+    it('returns empty string for null/undefined', () => {
+        expect(escapeHtml(null)).toBe('');
+        expect(escapeHtml(undefined)).toBe('');
+    });
+
+    it('coerces non-strings without throwing', () => {
+        expect(escapeHtml(42)).toBe('42');
+        expect(escapeHtml(0)).toBe('0');
+        expect(escapeHtml(false)).toBe('false');
+    });
+
+    it('neutralizes element-context script injection', () => {
+        const out = escapeHtml('<script>alert(1)</script>');
+        expect(out).not.toContain('<script');
+        expect(out).not.toContain('</script>');
+        expect(out).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
+    it('neutralizes attribute-context breakout payloads', () => {
+        // A double-quote-terminated attribute cannot be escaped by these strings.
+        const payloads = [
+            '"><img src=x onerror=alert(1)>',
+            '" onmouseover="alert(1)',
+            "'><svg onload=alert(1)>",
+            '"><script>alert(document.cookie)</script>'
+        ];
+        for (const payload of payloads) {
+            const out = escapeHtml(payload);
+            // The quotes that would close an attribute are now entities.
+            expect(out).not.toContain('"');
+            expect(out).not.toContain("'");
+            // No live tag can survive.
+            expect(out).not.toContain('<img');
+            expect(out).not.toContain('<svg');
+            expect(out).not.toContain('<script');
+        }
+    });
+
+    it('does not double-decode or strip safe text', () => {
+        expect(escapeHtml('Jordan Reed')).toBe('Jordan Reed');
+        expect(escapeHtml('#23 — Guard')).toBe('#23 — Guard');
+    });
+
+    it('is safe to embed inside a real attribute value (jsdom round-trip)', () => {
+        // Set a real attribute via DOM API equivalence: the escaped value, when
+        // placed in markup, must not create extra nodes.
+        const malicious = '"><img src=x onerror=alert(1)>';
+        const markup = `<input value="${escapeHtml(malicious)}">`;
+        expect(markup).not.toContain('"><img');
+        expect(markup).toContain('&quot;&gt;&lt;img');
+    });
+});

--- a/tests/unit/family-plan-invite-code-behavior.test.js
+++ b/tests/unit/family-plan-invite-code-behavior.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Node env (default): import.meta.url is a file URL for readFileSync, and
+// Node 20 exposes globalThis.crypto (Web Crypto) for the real-RNG test.
+
+// Behavioral tests for generateHouseholdInviteCode (not exported, so extracted
+// and executed with an injected `globalThis` so we control the RNG). Verifies it
+// consumes the crypto RNG correctly and never falls back to a weak source.
+
+function extractGenerator() {
+    const source = readFileSync(new URL('../../js/family-plan.js', import.meta.url), 'utf8');
+    const match = source.match(/function generateHouseholdInviteCode\(\) \{[\s\S]*?\n\}/);
+    expect(match, 'generateHouseholdInviteCode should exist').toBeTruthy();
+    return match[0];
+}
+
+const ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+// Run the extracted function with a controllable globalThis.crypto.
+function runWith(getRandomValues) {
+    const fnSource = extractGenerator();
+    const factory = new Function('globalThis', `${fnSource}\nreturn generateHouseholdInviteCode();`);
+    return factory({ crypto: { getRandomValues } });
+}
+
+describe('generateHouseholdInviteCode behavior', () => {
+    it('requests 8 cryptographically secure bytes', () => {
+        const spy = vi.fn((arr) => arr.fill(0));
+        runWith(spy);
+        expect(spy).toHaveBeenCalledTimes(1);
+        const arg = spy.mock.calls[0][0];
+        expect(arg).toBeInstanceOf(Uint8Array);
+        expect(arg.length).toBe(8);
+    });
+
+    it('maps each byte to alphabet[byte % 32]', () => {
+        // Known bytes -> deterministic, verifiable output (no modulo bias at 32).
+        const bytes = [0, 1, 31, 32, 33, 255, 64, 100];
+        const code = runWith((arr) => { bytes.forEach((b, i) => { arr[i] = b; }); });
+        const expected = bytes.map((b) => ALPHABET[b % ALPHABET.length]).join('');
+        expect(code).toBe(expected);
+    });
+
+    it('produces an 8-char code using only the safe alphabet', () => {
+        const code = runWith((arr) => { for (let i = 0; i < arr.length; i += 1) arr[i] = i * 17; });
+        expect(code).toHaveLength(8);
+        expect([...code].every((ch) => ALPHABET.includes(ch))).toBe(true);
+        // No visually ambiguous characters.
+        expect(/[IO01]/.test(code)).toBe(false);
+    });
+
+    it('uses the real Web Crypto RNG when available (high uniqueness)', () => {
+        const fnSource = extractGenerator();
+        const factory = new Function('globalThis', `${fnSource}\nreturn generateHouseholdInviteCode();`);
+        const codes = new Set();
+        for (let i = 0; i < 200; i += 1) {
+            codes.add(factory(globalThis)); // real globalThis.crypto in jsdom
+        }
+        // Collisions would indicate a broken/weak RNG; expect near-perfect uniqueness.
+        expect(codes.size).toBeGreaterThan(195);
+    });
+});

--- a/tests/unit/xss-render-integration.test.js
+++ b/tests/unit/xss-render-integration.test.js
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { escapeHtml } from '../../js/utils.js';
+
+// Integration tests: render the exact markup shapes used by the fixed sinks
+// through a REAL DOM (jsdom) using the REAL escapeHtml, with malicious input,
+// then assert via DOM queries that no attacker-controlled node/handler is
+// created. This proves the end-to-end render path is safe, not just the string.
+
+const ATTACK_NAMES = [
+    '"><img src=x onerror="window.__xss=1">',
+    "'><svg onload=\"window.__xss=1\">",
+    '<script>window.__xss=1</script>',
+    'Bobby"><iframe src=javascript:window.__xss=1>'
+];
+
+function render(html) {
+    const host = document.createElement('div');
+    host.innerHTML = html;
+    return host;
+}
+
+describe('legacy XSS render integration', () => {
+    it('attribute context: player name in an input value creates no extra nodes', () => {
+        for (const name of ATTACK_NAMES) {
+            delete window.__xss;
+            // Mirrors edit-roster.html / edit-schedule.html input value sinks.
+            const host = render(`<input type="text" value="${escapeHtml(name)}">`);
+            const input = host.querySelector('input');
+            expect(input).toBeTruthy();
+            // The whole payload survives as the literal value (text), unparsed.
+            expect(input.getAttribute('value')).toBe(name);
+            // No injected elements, no fired handler.
+            expect(host.querySelectorAll('img, svg, script, iframe')).toHaveLength(0);
+            expect(window.__xss).toBeUndefined();
+        }
+    });
+
+    it('alt/src attribute context: photo preview creates only the intended img', () => {
+        for (const name of ATTACK_NAMES) {
+            delete window.__xss;
+            const url = 'https://cdn.test/p.png';
+            // Mirrors edit-roster.html / player.html photo preview sinks.
+            const host = render(`<img src="${escapeHtml(url)}" alt="${escapeHtml(name)}" class="x">`);
+            const imgs = host.querySelectorAll('img');
+            expect(imgs).toHaveLength(1); // exactly the intended one
+            expect(imgs[0].getAttribute('alt')).toBe(name);
+            expect(imgs[0].getAttribute('src')).toBe(url);
+            expect(host.querySelectorAll('script, iframe, svg')).toHaveLength(0);
+            expect(window.__xss).toBeUndefined();
+        }
+    });
+
+    it('element-text context: player name in a span renders as text only', () => {
+        for (const name of ATTACK_NAMES) {
+            delete window.__xss;
+            // Mirrors game-plan.html span sinks.
+            const host = render(`<span class="n">${escapeHtml(name)}</span>`);
+            const span = host.querySelector('span.n');
+            expect(span).toBeTruthy();
+            expect(span.textContent).toBe(name);
+            expect(host.querySelectorAll('img, svg, script, iframe')).toHaveLength(0);
+            expect(window.__xss).toBeUndefined();
+        }
+    });
+
+    it('regression: the unescaped form WOULD have injected (sanity that the test is meaningful)', () => {
+        delete window.__xss;
+        const name = '"><img src=x onerror="window.__xss=1">';
+        // Intentionally unescaped to confirm the assertions above can fail.
+        const host = render(`<input type="text" value="${name}">`);
+        // jsdom does not execute inline handlers, but the injected node exists.
+        expect(host.querySelectorAll('img').length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Follow-up to the merged security PR (#3254) — adds real behavioral/integration/E2E coverage on top of the source-assertion guards.

## Unit (behavioral)
- **`escape-html-behavior`** — `escapeHtml` escapes the five HTML-significant chars, returns `''` for null/undefined, coerces non-strings, and neutralizes element- and attribute-context breakout payloads.
- **`chat-html-sanitizer-xss`** — `formatChatMessageHtml` and the DOMPurify-unavailable regex fallback drop live `<script>/<iframe>/<img>/<svg>`, strip event handlers, and reject `javascript:` anchors; legitimate https links keep `rel="noopener noreferrer"`.
- **`family-plan-invite-code-behavior`** — extracts `generateHouseholdInviteCode` and runs it with an injected `globalThis`, asserting it requests 8 CSPRNG bytes via `Uint8Array(8)`, maps each byte to `alphabet[byte % 32]`, uses only the safe 32-char alphabet, and is near-perfectly unique over 200 runs with the real Web Crypto RNG.

## Integration (jsdom)
- **`xss-render-integration`** — renders the exact markup shapes the fixes use (input `value`, `img alt/src`, element text) with the **real** `escapeHtml` and malicious input into a real DOM, then asserts via DOM queries that no attacker node/handler is created. Includes a negative control proving the assertions can fail on unescaped input.

## Workflow (Playwright smoke)
- **`edit-roster-xss-escaping`** — drives the real edit-roster bulk-AI import flow with a malicious AI-returned player name (using the **real** `escapeHtml`, not the identity stub), and asserts the proposed-changes input holds the payload as an inert value with no injected `<img>` node and no fired `onerror` handler.

## Verification
- Full unit suite: **3621/3621 pass** (+26 new).
- Both the new and existing edit-roster smoke specs verified locally against headless Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)