### PR TITLE
Add one-off certificate save and reopen coverage

### DIFF
--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -1046,6 +1046,7 @@ function buildCertificatePayload(draft, status = draft.status || 'draft') {
         backgroundOpacity: state.shared.backgroundOpacity,
         watermarkImageRef: state.shared.watermarkImageRef || null,
         watermarkOpacity: state.shared.watermarkOpacity,
+        includeInExport: draft.includeInExport !== false,
         exportedPngUrl: draft.exportedPngUrl || null,
         exportedPdfUrl: draft.exportedPdfUrl || null,
         status
@@ -1442,7 +1443,7 @@ function createDraftFromSavedCertificate(certificate, index = 0) {
         descriptionSource: certificate?.descriptionSource || 'manual',
         descriptionStatus: certificate?.descriptionStatus || (description ? 'ready' : 'pending'),
         statsWindow: certificate?.statsWindow || state.shared?.statsWindow || 10,
-        includeInExport: true,
+        includeInExport: certificate?.includeInExport !== false,
         errorMessage: null,
         status: certificate?.status || 'draft',
         exportedPngUrl: certificate?.exportedPngUrl || null,

--- a/tests/smoke/certificates-workflow.spec.js
+++ b/tests/smoke/certificates-workflow.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test('certificates demo workflow creates, edits, exports, and prints', async ({ page, baseURL }) => {
+async function stubCertificateBrowserApis(page) {
     await page.addInitScript(() => {
         window.__certificatePrintCalls = 0;
         window.__certificatePrintSheetCount = 0;
@@ -20,6 +20,10 @@ test('certificates demo workflow creates, edits, exports, and prints', async ({ 
             window.__certificatePrintImageCount = document.querySelectorAll('#cert-print-root .cert-print-image').length;
         };
     });
+}
+
+test('certificates demo workflow creates, edits, exports, and prints', async ({ page, baseURL }) => {
+    await stubCertificateBrowserApis(page);
 
     await page.goto(`${baseURL}/certificates.html?demo=1#teamId=demo-junior-current`, { waitUntil: 'networkidle' });
     await expect(page.getByRole('heading', { name: 'Awards & Certificates' })).toBeVisible();
@@ -207,4 +211,56 @@ test('certificates demo workflow creates, edits, exports, and prints', async ({ 
         page.locator('#cert-zip-btn').click()
     ]);
     expect(zipDownload.suggestedFilename()).toBe('junior-current-certificates.zip');
+});
+
+test('one-off certificates save, reopen, export, and print with custom data intact', async ({ page, baseURL }) => {
+    await stubCertificateBrowserApis(page);
+
+    await page.goto(`${baseURL}/certificates.html?demo=1#teamId=demo-junior-current`, { waitUntil: 'networkidle' });
+    await expect(page.getByRole('heading', { name: 'Awards & Certificates' })).toBeVisible();
+
+    await page.locator('#cert-custom-recipient-btn').click();
+    await expect(page.locator('#cert-review-grid tbody tr')).toHaveCount(1);
+
+    await page.locator('[data-draft-field="recipientName"]').fill('Coach Choice');
+    await page.locator('[data-draft-field="awardTitle"]').fill('Leadership Award');
+    await page.locator('[data-draft-field="description"]').fill('Closed out the season with steady leadership.');
+    await page.locator('[data-draft-field="includeInExport"]').uncheck();
+    await expect(page.locator('[data-draft-field="includeInExport"]')).not.toBeChecked();
+    await expect(page.locator('#cert-review-preview .cert-recipient-name')).toContainText('Coach Choice');
+
+    await page.locator('#cert-save-drafts-btn').click();
+    await expect(page.locator('#cert-alert')).toContainText('Demo drafts saved for this session.');
+    await expect(page.locator('[data-open-batch]')).toHaveCount(1);
+    await expect(page.locator('[data-open-certificate]')).toHaveCount(1);
+
+    await page.locator('[data-open-certificate]').first().click();
+    await expect(page.locator('#cert-alert')).toContainText('Saved certificate opened for editing');
+    await expect(page.locator('[data-draft-field="recipientName"]')).toHaveValue('Coach Choice');
+    await expect(page.locator('[data-draft-field="awardTitle"]')).toHaveValue('Leadership Award');
+    await expect(page.locator('[data-draft-field="description"]')).toHaveValue('Closed out the season with steady leadership.');
+    await expect(page.locator('[data-draft-field="includeInExport"]')).not.toBeChecked();
+
+    await page.locator('[data-draft-field="includeInExport"]').check();
+    await page.locator('#cert-save-drafts-btn').click();
+    await expect(page.locator('#cert-alert')).toContainText('Demo drafts saved for this session.');
+
+    await page.locator('[data-open-batch]').first().click();
+    await expect(page.locator('#cert-alert')).toContainText('Saved run opened for editing');
+    await expect(page.locator('[data-draft-field="recipientName"]')).toHaveValue('Coach Choice');
+    await expect(page.locator('[data-draft-field="awardTitle"]')).toHaveValue('Leadership Award');
+    await expect(page.locator('[data-draft-field="description"]')).toHaveValue('Closed out the season with steady leadership.');
+    await expect(page.locator('[data-draft-field="includeInExport"]')).toBeChecked();
+
+    const [pngDownload] = await Promise.all([
+        page.waitForEvent('download'),
+        page.locator('#cert-png-btn').click()
+    ]);
+    expect(pngDownload.suggestedFilename()).toContain('coach-choice');
+
+    await page.locator('#cert-print-btn').click();
+    await expect.poll(() => page.evaluate(() => window.__certificatePrintCalls)).toBe(1);
+    await expect.poll(() => page.evaluate(() => window.__certificatePrintSheetCount)).toBe(1);
+    await expect.poll(() => page.evaluate(() => window.__certificatePrintImageCount)).toBe(1);
+    await expect(page.locator('#cert-review-preview .cert-recipient-name')).toContainText('Coach Choice');
 });

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -1,8 +1,144 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 function readRepoFile(relativePath) {
     return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+function extractFunction(source, signature) {
+    const start = source.indexOf(signature);
+    if (start === -1) {
+        throw new Error(`Unable to find ${signature}`);
+    }
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, index + 1);
+        }
+    }
+
+    throw new Error(`Unable to extract ${signature}`);
+}
+
+function createCertificateStudioHarness() {
+    const studio = readRepoFile('js/certificates/studio.js');
+    const snippets = [
+        'function buildCertificatePayload',
+        'function createDraftFromSavedCertificate',
+        'function saveDraftsToLocalHistory',
+        'async function openSavedBatch',
+        'async function openSavedCertificate',
+        'function startCustomCertificate'
+    ].map((signature) => extractFunction(studio, signature)).join('\n\n');
+
+    const deps = {
+        state: {
+            demoMode: false,
+            certificatePersistenceUnavailable: false,
+            teamId: 'team-1',
+            team: { name: 'Demo Team' },
+            shared: {
+                templateId: 'banner',
+                colorMode: 'custom',
+                customColors: { accentColor: '#123456' },
+                teamNameOverride: 'Demo Team',
+                statsWindow: 10,
+                seasonLabel: 'Fall 2026',
+                footerUrl: 'allplays.ai',
+                fonts: { heading: 'classic', recipient: 'classic', body: 'friendly' },
+                signers: [],
+                foregroundImageRef: null,
+                backgroundImageRef: null,
+                backgroundOpacity: 18,
+                watermarkImageRef: null,
+                watermarkOpacity: 12,
+                awardTitle: 'Team MVP'
+            },
+            drafts: [],
+            savedCertificates: [],
+            savedBatches: [],
+            selectedPlayerIds: new Set(),
+            selectedDraftId: null,
+            descriptionGeneration: null,
+            mode: 'setup'
+        },
+        truncateCertificateDescription: (value) => String(value || '').slice(0, 350),
+        resolveColors: (shared) => shared.customColors,
+        normalizeSigners: (signers) => signers || [],
+        clonePlain: (value) => JSON.parse(JSON.stringify(value || null)),
+        buildSharedFromSavedSource: (defaults = {}, certificate = {}) => ({
+            templateId: certificate.templateId || defaults.templateId || 'banner',
+            colorMode: certificate.colorMode || defaults.colorMode || 'custom',
+            customColors: certificate.colors || defaults.customColors || {},
+            teamNameOverride: certificate.teamNameOverride || defaults.teamNameOverride || 'Demo Team',
+            awardTitle: certificate.awardTitle || defaults.awardTitle || '',
+            statsWindow: certificate.statsWindow || defaults.statsWindow || 10,
+            seasonLabel: certificate.seasonLabel || defaults.seasonLabel || '',
+            footerUrl: certificate.footerUrl || defaults.footerUrl || '',
+            fonts: certificate.fonts || defaults.fonts || {},
+            signers: certificate.signers || defaults.signers || [],
+            foregroundImageRef: certificate.foregroundImageRef || defaults.foregroundImageRef || null,
+            backgroundImageRef: certificate.backgroundImageRef || defaults.backgroundImageRef || null,
+            backgroundOpacity: certificate.backgroundOpacity ?? defaults.backgroundOpacity ?? 18,
+            watermarkImageRef: certificate.watermarkImageRef || defaults.watermarkImageRef || null,
+            watermarkOpacity: certificate.watermarkOpacity ?? defaults.watermarkOpacity ?? 12
+        }),
+        renderReview: vi.fn(),
+        showAlert: vi.fn(),
+        getCertificateBatch: vi.fn(),
+        getCertificate: vi.fn(),
+        isPermissionError: () => false
+    };
+
+    deps.loadCertificatesForSavedBatch = async (batch) => batch.generatedCertificateIds.map((id) => {
+        const certificate = deps.state.savedCertificates.find((item) => item.id === id);
+        return certificate || null;
+    }).filter(Boolean);
+
+    return new Function('deps', `
+        const state = deps.state;
+        const truncateCertificateDescription = deps.truncateCertificateDescription;
+        const resolveColors = deps.resolveColors;
+        const normalizeSigners = deps.normalizeSigners;
+        const clonePlain = deps.clonePlain;
+        const buildSharedFromSavedSource = deps.buildSharedFromSavedSource;
+        const renderReview = deps.renderReview;
+        const showAlert = deps.showAlert;
+        const loadCertificatesForSavedBatch = deps.loadCertificatesForSavedBatch;
+        const getCertificateBatch = deps.getCertificateBatch;
+        const getCertificate = deps.getCertificate;
+        const isPermissionError = deps.isPermissionError;
+        const upsertSavedCertificate = (certificate) => {
+            if (!certificate?.id) return;
+            state.savedCertificates = [
+                certificate,
+                ...state.savedCertificates.filter((item) => item.id !== certificate.id)
+            ];
+        };
+        const upsertSavedBatch = (batch) => {
+            if (!batch?.id) return;
+            state.savedBatches = [
+                batch,
+                ...state.savedBatches.filter((item) => item.id !== batch.id)
+            ];
+        };
+        ${snippets}
+        return {
+            state,
+            buildCertificatePayload,
+            createDraftFromSavedCertificate,
+            saveDraftsToLocalHistory,
+            openSavedBatch,
+            openSavedCertificate,
+            startCustomCertificate
+        };
+    `)(deps);
 }
 
 describe('awards and certificates workflow wiring', () => {
@@ -122,6 +258,82 @@ describe('awards and certificates workflow wiring', () => {
         expect(reviewGridBody).toContain('disabled aria-disabled="true" title="Descriptions are still generating"');
         expect(reviewGridBody).toContain('<button id="cert-publish-btn"');
         expect(reviewGridBody).toContain('${publishDisabledAttrs}>Publish certificates</button>');
+    });
+
+    it('persists one-off certificate drafts with stable ids and restores export selection on reopen', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-28T04:24:16Z'));
+
+        try {
+            const timestamp = Date.now();
+            const harness = createCertificateStudioHarness();
+            harness.startCustomCertificate();
+
+            expect(harness.state.drafts).toHaveLength(1);
+            expect(harness.state.drafts[0]).toMatchObject({
+                batchId: null,
+                certificateId: null,
+                playerId: null,
+                includeInExport: true,
+                recipientName: 'Custom Recipient'
+            });
+
+            harness.state.drafts[0].recipientName = 'Coach Choice';
+            harness.state.drafts[0].awardTitle = 'Leadership Award';
+            harness.state.drafts[0].description = 'Closed out the season with steady leadership.';
+            harness.state.drafts[0].includeInExport = false;
+
+            expect(harness.buildCertificatePayload(harness.state.drafts[0], 'draft')).toMatchObject({
+                batchId: null,
+                playerId: null,
+                recipientName: 'Coach Choice',
+                awardTitle: 'Leadership Award',
+                includeInExport: false,
+                status: 'draft'
+            });
+
+            harness.saveDraftsToLocalHistory('draft');
+
+            const expectedBatchId = `local-batch-${timestamp}`;
+            const expectedCertificateId = `local-cert-${expectedBatchId}-custom-${timestamp}`;
+
+            expect(harness.state.savedBatches).toHaveLength(1);
+            expect(harness.state.savedCertificates).toHaveLength(1);
+            expect(harness.state.drafts[0].batchId).toBe(expectedBatchId);
+            expect(harness.state.drafts[0].certificateId).toBe(expectedCertificateId);
+            expect(harness.state.savedBatches[0].selectedPlayerIds).toEqual([]);
+            expect(harness.state.savedCertificates[0]).toMatchObject({
+                id: expectedCertificateId,
+                batchId: expectedBatchId,
+                playerId: null,
+                recipientName: 'Coach Choice',
+                awardTitle: 'Leadership Award',
+                includeInExport: false
+            });
+
+            await harness.openSavedCertificate(harness.state.savedCertificates[0].id);
+            expect(harness.state.drafts).toHaveLength(1);
+            expect(harness.state.drafts[0]).toMatchObject({
+                certificateId: expectedCertificateId,
+                batchId: expectedBatchId,
+                playerId: null,
+                recipientName: 'Coach Choice',
+                awardTitle: 'Leadership Award',
+                includeInExport: false
+            });
+            expect([...harness.state.selectedPlayerIds]).toEqual([]);
+
+            await harness.openSavedBatch(harness.state.savedBatches[0].id);
+            expect(harness.state.drafts).toHaveLength(1);
+            expect(harness.state.drafts[0]).toMatchObject({
+                playerId: null,
+                recipientName: 'Coach Choice',
+                includeInExport: false
+            });
+            expect([...harness.state.selectedPlayerIds]).toEqual([]);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('adds coach and parent navigation without exposing certificates on the public team page', () => {


### PR DESCRIPTION
Closes #3253

## What changed
- Persisted `includeInExport` in the saved certificate payload so one-off drafts keep their export-selection state through save and reopen.
- Restored `includeInExport` from saved certificate data instead of forcing reopened drafts back to `true`.
- Added a focused unit harness that round-trips a one-off draft with `playerId=null` and `batchId=null`, verifies stable ids are assigned on save, confirms `selectedPlayerIds` stays empty, and checks reopen behavior for both saved certificate and saved batch paths.
- Added Playwright smoke coverage for the real coach flow: create one-off certificate, edit recipient and text, save, reopen, export PNG, and print.

## Root Cause
The one-off certificate path reused the normal save and reopen pipeline, but `buildCertificatePayload()` did not persist `includeInExport` and `createDraftFromSavedCertificate()` hard-coded reopened drafts back to `includeInExport: true`. Existing coverage only checked that the one-off entry point existed, so the null `playerId` and `batchId` branch never exercised the broken save and reopen contract.

## Prevention / Learning
When a workflow has a distinct draft shape, especially nullable ids or custom-only branches, the regression test needs to round-trip the full persisted payload, not just assert that the button or starter function exists. For coach-facing draft flows, treat every mutable UI field as part of the save and reopen contract.

## Regression Tests
- `npx vitest run tests/unit/certificates-workflow.test.js --reporter=verbose`
- `SMOKE_BASE_URL=http://127.0.0.1:8011 npx playwright test tests/smoke/certificates-workflow.spec.js --config=playwright.smoke.config.js --reporter=line`