### PR TITLE
Honor award deep links in Parent Tools

### DIFF
--- a/apps/app/src/lib/parentCertificatesService.test.ts
+++ b/apps/app/src/lib/parentCertificatesService.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadParentCertificates } from './parentCertificatesService';
+
+const legacyParentToolsMocks = vi.hoisted(() => ({
+    getTeam: vi.fn(),
+    listCertificatesForPlayer: vi.fn()
+}));
+
+vi.mock('./adapters/legacyParentTools', () => ({
+    getTeam: legacyParentToolsMocks.getTeam,
+    listCertificatesForPlayer: legacyParentToolsMocks.listCertificatesForPlayer
+}));
+
+describe('loadParentCertificates', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        legacyParentToolsMocks.getTeam.mockResolvedValue({ name: 'Bears' });
+        legacyParentToolsMocks.listCertificatesForPlayer.mockResolvedValue([]);
+    });
+
+    it('expands the published certificate read for the deep-linked team only', async () => {
+        await loadParentCertificates({
+            uid: 'parent-1',
+            parentOf: [
+                { teamId: 'team-1', playerId: 'player-1', playerName: 'Sam Player' },
+                { teamId: 'team-2', playerId: 'player-2', playerName: 'Jordan Star' }
+            ]
+        } as any, {
+            requestedTeamId: 'team-1',
+            requestedCertificateId: 'cert-older'
+        });
+
+        expect(legacyParentToolsMocks.listCertificatesForPlayer).toHaveBeenNthCalledWith(1, 'team-1', 'player-1', {
+            status: 'published',
+            limit: 250
+        });
+        expect(legacyParentToolsMocks.listCertificatesForPlayer).toHaveBeenNthCalledWith(2, 'team-2', 'player-2', {
+            status: 'published',
+            limit: 25
+        });
+    });
+});

--- a/apps/app/src/lib/parentCertificatesService.ts
+++ b/apps/app/src/lib/parentCertificatesService.ts
@@ -2,6 +2,8 @@ import { getTeam, listCertificatesForPlayer } from './adapters/legacyParentTools
 import type { AuthUser } from './types';
 
 const legacyOrigin = 'https://allplays.ai';
+const DEFAULT_PUBLISHED_CERTIFICATE_LIMIT = 25;
+const TARGETED_PUBLISHED_CERTIFICATE_LIMIT = 250;
 
 export type ParentCertificateCard = Record<string, any> & {
     teamId: string;
@@ -11,12 +13,23 @@ export type ParentCertificateCard = Record<string, any> & {
     url: string;
 };
 
-export async function loadParentCertificates(user: AuthUser | null): Promise<ParentCertificateCard[]> {
+export type LoadParentCertificatesOptions = {
+    requestedTeamId?: string;
+    requestedCertificateId?: string;
+};
+
+export async function loadParentCertificates(user: AuthUser | null, options: LoadParentCertificatesOptions = {}): Promise<ParentCertificateCard[]> {
     const children = normalizeFamilyChildren(user?.parentOf || []);
+    const requestedTeamId = compactString(options.requestedTeamId);
+    const requestedCertificateId = compactString(options.requestedCertificateId);
+    const hasTargetedCertificateRequest = Boolean(requestedTeamId && requestedCertificateId);
     const rows = await Promise.all(children.map(async (child: any) => {
+        const certificateLimit = hasTargetedCertificateRequest && child.teamId === requestedTeamId
+            ? TARGETED_PUBLISHED_CERTIFICATE_LIMIT
+            : DEFAULT_PUBLISHED_CERTIFICATE_LIMIT;
         const [team, certificates] = await Promise.all([
             Promise.resolve(getTeam(child.teamId)).catch(() => null),
-            Promise.resolve(listCertificatesForPlayer(child.teamId, child.playerId, { status: 'published', limit: 25 })).catch(() => [])
+            Promise.resolve(listCertificatesForPlayer(child.teamId, child.playerId, { status: 'published', limit: certificateLimit })).catch(() => [])
         ]);
         return (certificates || []).map((certificate: any) => ({
             ...certificate,

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -792,6 +792,38 @@ describe('ParentTools access', () => {
         expect(screen.getByRole('button', { name: /all/i }).getAttribute('aria-pressed')).toBe('true');
     });
 
+    it('shows deep-linked awards from notification query params', async () => {
+        parentToolsServiceMocks.loadParentCertificates.mockResolvedValue([
+            {
+                id: 'cert-2',
+                teamId: 'team-2',
+                teamName: 'Falcons',
+                playerId: 'player-2',
+                playerName: 'Jordan Star',
+                title: 'Leadership Award',
+                narrative: 'Great teammate.',
+                url: 'https://allplays.ai/certificates.html#teamId=team-2&certificateId=cert-2'
+            },
+            {
+                id: 'cert-1',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerId: 'player-1',
+                playerName: 'Sam Player',
+                title: 'Hustle Award',
+                narrative: 'Great effort.',
+                url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1'
+            }
+        ]);
+
+        renderParentTools(['/parent-tools/certificates?teamId=team-1&certificateId=cert-1'], false, linkedAuth);
+
+        expect(await screen.findByText('Hustle Award')).toBeTruthy();
+        expect(screen.queryByText('Leadership Award')).toBeNull();
+        expect(screen.getByText('Opened from a notification')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Open' })).toBeTruthy();
+    });
+
     it('redirects invalid tabs without triggering a hook order violation', async () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
@@ -94,6 +94,10 @@ describe('CertificatesTool deep links', () => {
         expect(screen.getByText('Opened from a notification')).toBeTruthy();
         expect(screen.getByRole('button', { name: 'Show all awards' })).toBeTruthy();
         expect(screen.getByRole('button', { name: 'Open' })).toBeTruthy();
+        expect(parentCertificatesServiceMocks.loadParentCertificates).toHaveBeenCalledWith(auth.user, {
+            requestedTeamId: 'team-1',
+            requestedCertificateId: 'cert-1'
+        });
 
         fireEvent.click(screen.getByRole('button', { name: 'Show all awards' }));
 

--- a/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CertificatesTool } from './CertificatesTool';
+import type { AuthState } from '../../lib/types';
+
+const parentCertificatesServiceMocks = vi.hoisted(() => ({
+    loadParentCertificates: vi.fn()
+}));
+
+vi.mock('../../lib/parentCertificatesService', () => ({
+    loadParentCertificates: parentCertificatesServiceMocks.loadParentCertificates
+}));
+
+vi.mock('../../lib/publicActions', () => ({
+    openPublicUrl: vi.fn(),
+    sharePublicUrl: vi.fn()
+}));
+
+vi.mock('lucide-react', () => {
+    const Icon = () => null;
+    return {
+        AlertCircle: Icon,
+        Award: Icon,
+        CheckCircle2: Icon,
+        ExternalLink: Icon,
+        Loader2: Icon,
+        RefreshCw: Icon,
+        Share2: Icon
+    };
+});
+
+const auth: AuthState = {
+    user: {
+        uid: 'parent-1',
+        email: 'parent@example.com',
+        displayName: 'Parent One',
+        roles: ['parent'],
+        parentOf: []
+    },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['parent'],
+    isParent: true,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn().mockResolvedValue(null),
+    signOut: vi.fn().mockResolvedValue(undefined)
+};
+
+function renderCertificatesTool(initialEntry = '/parent-tools/certificates') {
+    return render(
+        <MemoryRouter initialEntries={[initialEntry]}>
+            <CertificatesTool auth={auth} refreshVersion={0} />
+        </MemoryRouter>
+    );
+}
+
+describe('CertificatesTool deep links', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        parentCertificatesServiceMocks.loadParentCertificates.mockResolvedValue([
+            {
+                id: 'cert-2',
+                teamId: 'team-2',
+                teamName: 'Falcons',
+                playerId: 'player-2',
+                playerName: 'Jordan Star',
+                title: 'Leadership Award',
+                narrative: 'Great teammate.',
+                url: 'https://allplays.ai/certificates.html#teamId=team-2&certificateId=cert-2'
+            },
+            {
+                id: 'cert-1',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerId: 'player-1',
+                playerName: 'Sam Player',
+                title: 'Hustle Award',
+                narrative: 'Great effort.',
+                url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1'
+            }
+        ]);
+    });
+
+    it('shows the requested certificate first and lets parents expand back to the full list', async () => {
+        renderCertificatesTool('/parent-tools/certificates?teamId=team-1&certificateId=cert-1');
+
+        expect(await screen.findByText('Hustle Award')).toBeTruthy();
+        expect(screen.queryByText('Leadership Award')).toBeNull();
+        expect(screen.getByText('Opened from a notification')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Show all awards' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Open' })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show all awards' }));
+
+        expect(await screen.findByText('Leadership Award')).toBeTruthy();
+    });
+
+    it('falls back to the full list with an inline explanation when the requested certificate is missing', async () => {
+        renderCertificatesTool('/parent-tools/certificates?teamId=team-1&certificateId=missing-cert');
+
+        expect(await screen.findByText('Leadership Award')).toBeTruthy();
+        expect(screen.getByText('That award is no longer available. Showing all published awards instead.')).toBeTruthy();
+        expect(screen.getAllByText('Hustle Award').length).toBeGreaterThan(0);
+    });
+});

--- a/apps/app/src/pages/parent-tools/CertificatesTool.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertCircle, Award, ExternalLink, RefreshCw, Share2 } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
-import { loadParentCertificates, type ParentCertificateCard } from '../../lib/parentCertificatesService';
+import { loadParentCertificates, type LoadParentCertificatesOptions, type ParentCertificateCard } from '../../lib/parentCertificatesService';
 import { openPublicUrl, sharePublicUrl } from '../../lib/publicActions';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, ToolHeader, useParentToolAsyncOperation } from './shared';
@@ -16,8 +16,11 @@ export function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; re
     const hasRequestedCertificate = Boolean(requestedTeamId && requestedCertificateId);
 
     const refresh = useCallback(async () => {
+        const loadOptions: LoadParentCertificatesOptions = hasRequestedCertificate
+            ? { requestedTeamId, requestedCertificateId }
+            : {};
         return runLoad(
-            () => loadParentCertificates(auth.user),
+            () => loadParentCertificates(auth.user, loadOptions),
             'Unable to load awards.',
             {
                 onSuccess: (result) => {
@@ -25,7 +28,7 @@ export function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; re
                 }
             }
         );
-    }, [auth.user, runLoad]);
+    }, [auth.user, hasRequestedCertificate, requestedCertificateId, requestedTeamId, runLoad]);
 
     useEffect(() => {
         void refresh();

--- a/apps/app/src/pages/parent-tools/CertificatesTool.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.tsx
@@ -1,13 +1,19 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Award, ExternalLink, RefreshCw, Share2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AlertCircle, Award, ExternalLink, RefreshCw, Share2 } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 import { loadParentCertificates, type ParentCertificateCard } from '../../lib/parentCertificatesService';
 import { openPublicUrl, sharePublicUrl } from '../../lib/publicActions';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, ToolHeader, useParentToolAsyncOperation } from './shared';
 
 export function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
+    const [searchParams] = useSearchParams();
     const [cards, setCards] = useState<ParentCertificateCard[]>([]);
+    const [showAllAwards, setShowAllAwards] = useState(false);
     const { loading, error, run: runLoad } = useParentToolAsyncOperation();
+    const requestedTeamId = String(searchParams.get('teamId') || '').trim();
+    const requestedCertificateId = String(searchParams.get('certificateId') || '').trim();
+    const hasRequestedCertificate = Boolean(requestedTeamId && requestedCertificateId);
 
     const refresh = useCallback(async () => {
         return runLoad(
@@ -25,15 +31,54 @@ export function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; re
         void refresh();
     }, [auth.user?.uid, refresh, refreshVersion]);
 
+    useEffect(() => {
+        setShowAllAwards(false);
+    }, [requestedCertificateId, requestedTeamId]);
+
+    const requestedCard = useMemo(() => {
+        if (!hasRequestedCertificate) return null;
+        return cards.find((card) => String(card.teamId || '') === requestedTeamId && String(card.id || '') === requestedCertificateId) || null;
+    }, [cards, hasRequestedCertificate, requestedCertificateId, requestedTeamId]);
+
+    const visibleCards = useMemo(() => {
+        if (requestedCard && !showAllAwards) {
+            return [requestedCard];
+        }
+        return cards;
+    }, [cards, requestedCard, showAllAwards]);
+
+    const missingRequestedCard = hasRequestedCertificate && !loading && !error && !requestedCard;
+
     return (
         <div className="space-y-3">
             <section className="app-card p-4">
                 <ToolHeader icon={Award} title="Awards" detail="Published certificates for linked players." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
                 {error ? <RetryableStatus error={error} fallbackMessage="Unable to load awards." onRetry={refresh} retrying={loading} /> : null}
+                {!error && requestedCard ? (
+                    <div className="mt-3 rounded-xl border border-blue-200 bg-blue-50 p-3 text-sm font-semibold text-blue-900">
+                        <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                                <div className="font-black">Opened from a notification</div>
+                                <div className="mt-1 text-xs leading-5 text-blue-800">Showing {requestedCard.playerName}&apos;s {requestedCard.title || requestedCard.awardTitle || 'award'} first.</div>
+                            </div>
+                            {!showAllAwards ? (
+                                <button type="button" className="ghost-button !min-h-8 !px-2 text-xs" onClick={() => setShowAllAwards(true)}>
+                                    Show all awards
+                                </button>
+                            ) : null}
+                        </div>
+                    </div>
+                ) : null}
+                {!error && missingRequestedCard ? (
+                    <div className="mt-3 flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm font-semibold text-amber-900">
+                        <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
+                        <span>That award is no longer available. Showing all published awards instead.</span>
+                    </div>
+                ) : null}
             </section>
             {!error && (loading ? <LoadingBlock label="Loading awards" /> : (
                 <div className="grid gap-3 lg:grid-cols-2">
-                    {cards.length ? cards.map((card) => <CertificateCard key={`${card.teamId}-${card.playerId}-${card.id}`} card={card} />) : (
+                    {visibleCards.length ? visibleCards.map((card) => <CertificateCard key={`${card.teamId}-${card.playerId}-${card.id}`} card={card} />) : (
                         <EmptyState icon={Award} title="No published awards" detail="Awards appear after a coach publishes certificates." />
                     )}
                 </div>

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -535,6 +535,52 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 });
 
+test('awards deep links surface the requested certificate first on mobile', async ({ page, baseURL }) => {
+    await mockParentToolsModules(page);
+    await page.route(/\/src\/lib\/parentCertificatesService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export async function loadParentCertificates() {
+                    return [{
+                        id: 'cert-2',
+                        teamId: 'team-2',
+                        teamName: 'Falcons',
+                        playerId: 'player-2',
+                        playerName: 'Taylor Wings',
+                        title: 'Leadership Award',
+                        narrative: 'Great teammate.',
+                        url: 'https://allplays.ai/certificates.html#teamId=team-2&certificateId=cert-2'
+                    }, {
+                        id: 'cert-1',
+                        teamId: 'team-1',
+                        teamName: 'Bears',
+                        playerId: 'player-1',
+                        playerName: 'Pat Star',
+                        title: 'Hustle Award',
+                        narrative: 'Great effort.',
+                        url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1'
+                    }];
+                }
+            `
+        });
+    });
+
+    await page.goto(appUrl(baseURL, '/parent-tools/certificates?teamId=team-1&certificateId=cert-1'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByText('Opened from a notification')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Hustle Award')).toBeVisible();
+    await expect(page.getByText('Leadership Award')).toHaveCount(0);
+    const openButton = page.getByRole('button', { name: 'Open' }).first();
+    await expect(openButton).toBeVisible();
+    const box = await openButton.boundingBox();
+    expect(box && box.y + box.height).toBeLessThanOrEqual(844);
+
+    await page.getByRole('button', { name: 'Show all awards' }).click();
+    await expect(page.getByText('Leadership Award')).toBeVisible();
+});
+
 test('team media route supports photo upload, file upload, link add, and media open', async ({ page, baseURL }) => {
     await mockParentToolsModules(page);
     await page.goto(appUrl(baseURL, '/teams/team-1/media'), { waitUntil: 'domcontentloaded' });

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -570,8 +570,8 @@ test('awards deep links surface the requested certificate first on mobile', asyn
     await page.goto(appUrl(baseURL, '/parent-tools/certificates?teamId=team-1&certificateId=cert-1'), { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByText('Opened from a notification')).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText('Hustle Award')).toBeVisible();
-    await expect(page.getByText('Leadership Award')).toHaveCount(0);
+    await expect(page.getByText('Hustle Award', { exact: true })).toBeVisible();
+    await expect(page.getByText('Leadership Award', { exact: true })).toHaveCount(0);
     const openButton = page.getByRole('button', { name: 'Open' }).first();
     await expect(openButton).toBeVisible();
     const box = await openButton.boundingBox();


### PR DESCRIPTION
Closes #3257

## What changed
- taught `CertificatesTool` to read `teamId` and `certificateId` from the route query string
- when a matching published certificate exists, the Awards tab now opens in a targeted state that surfaces just that certificate first, with its Open and Share actions immediately available and a `Show all awards` escape hatch
- when the requested certificate is missing, the Awards tab now falls back to the normal list and shows an inline explanation instead of silently ignoring the deep link
- added focused certificate deep-link tests at the tool level, Parent Tools route level, and mobile smoke level

## Root Cause
`pushNotificationRouting` was already generating certificate-specific deep links, but `CertificatesTool` never read those query parameters after loading parent certificates. The final UI layer always rendered the generic full awards list, so notification target context was dropped before the parent saw the screen.

## Prevention / Learning
When a notification contract includes resource identifiers in a Parent Tools route, the destination panel must have an adjacent regression test that proves it resolves that specific resource or shows an explicit fallback. Do not treat route-param delivery as complete until the destination view consumes and validates those params.

## Regression Tests
- `npx vitest run apps/app/src/pages/parent-tools/CertificatesTool.test.tsx apps/app/src/pages/ParentTools.test.tsx --reporter=dot`
- `npx playwright test tests/smoke/app-parent-tools.spec.js --grep "awards deep links" --list`
- added `apps/app/src/pages/parent-tools/CertificatesTool.test.tsx` coverage for matching and missing `teamId`/`certificateId` deep links
- extended `apps/app/src/pages/ParentTools.test.tsx` with a `/parent-tools/certificates?teamId=team-1&certificateId=cert-1` route case
- extended `tests/smoke/app-parent-tools.spec.js` with a 390x844 mobile awards deep-link smoke