### PR TITLE
Remove staff audience option from message composer

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -28,7 +28,6 @@ import {
 import {
   deleteTeamChatMessage,
   editTeamChatMessage,
-  ensureStaffChatConversation,
   loadChatRecipientOptions,
   loadSentTeamEmails,
   loadTeamEmailDrafts,
@@ -157,7 +156,6 @@ const messageRevisionSignatureCache = new WeakMap<ChatMessage, string>();
 
 const allTargetOptions: Array<{ value: ChatTargetType; label: string; description: string }> = [
   { value: 'full_team', label: 'Full team', description: 'Visible to everyone in this team chat.' },
-  { value: 'staff', label: 'Staff only', description: 'Moves this into a staff conversation.' },
   { value: 'individuals', label: 'Selected members', description: 'Starts a direct or group conversation.' }
 ];
 
@@ -851,25 +849,6 @@ export function ChatWindow({
         switchConversation(DEFAULT_TEAM_CONVERSATION_ID);
       }
       closeAudienceSheet();
-      return;
-    }
-
-    if (target === 'staff') {
-      if (!auth.user || !team) return;
-      try {
-        const staffConversation = await ensureStaffChatConversation(teamId, auth.user, conversations);
-        setConversations((current) => (
-          current.some((conversation) => conversation.id === staffConversation.id)
-            ? current
-            : [...current, staffConversation]
-        ));
-        if (selectedConversationId !== staffConversation.id) {
-          switchConversation(staffConversation.id);
-        }
-        closeAudienceSheet();
-      } catch (staffError: any) {
-        setStatus({ tone: 'error', message: staffError?.message || 'Unable to open staff chat.' });
-      }
     }
   };
 

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -456,20 +456,18 @@ export function ChatWindow({
   const selectedConversation = useMemo(() => (
     conversations.find((conversation) => conversation.id === effectiveConversationId) || conversations[0] || null
   ), [conversations, effectiveConversationId]);
-  const conversationSheetConversations = useMemo(() => {
+  const conversationSheetConversations = useMemo<ChatConversation[]>(() => {
     if (!canModerate || conversations.some((conversation) => isStaffConversation(conversation))) {
       return conversations;
     }
-    return [
-      ...conversations,
-      {
-        id: STAFF_CONVERSATION_PLACEHOLDER_ID,
-        type: 'group',
-        name: 'Staff only',
-        participantIds: [],
-        participantRoles: ['staff']
-      }
-    ];
+    const staffPlaceholderConversation = {
+      id: STAFF_CONVERSATION_PLACEHOLDER_ID,
+      type: 'group',
+      name: 'Staff only',
+      participantIds: [],
+      participantRoles: ['staff']
+    } satisfies ChatConversation;
+    return [...conversations, staffPlaceholderConversation];
   }, [canModerate, conversations]);
   const audienceMetadata = useMemo(() => buildChatAudienceMetadata({
     selectedConversation,

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -28,6 +28,7 @@ import {
 import {
   deleteTeamChatMessage,
   editTeamChatMessage,
+  ensureStaffChatConversation,
   loadChatRecipientOptions,
   loadSentTeamEmails,
   loadTeamEmailDrafts,
@@ -75,6 +76,7 @@ import {
   insertChatMention,
   isChatComposerLinkSafe,
   isDefaultTeamConversation,
+  isStaffConversation,
   isSafeChatMediaUrl,
   mergeChatMessageLists,
   normalizeChatReactions,
@@ -158,6 +160,7 @@ const allTargetOptions: Array<{ value: ChatTargetType; label: string; descriptio
   { value: 'full_team', label: 'Full team', description: 'Visible to everyone in this team chat.' },
   { value: 'individuals', label: 'Selected members', description: 'Starts a direct or group conversation.' }
 ];
+const STAFF_CONVERSATION_PLACEHOLDER_ID = '__staff_conversation__';
 
 function createChatClientMessageId(userId: string) {
   const randomPart = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
@@ -453,6 +456,21 @@ export function ChatWindow({
   const selectedConversation = useMemo(() => (
     conversations.find((conversation) => conversation.id === effectiveConversationId) || conversations[0] || null
   ), [conversations, effectiveConversationId]);
+  const conversationSheetConversations = useMemo(() => {
+    if (!canModerate || conversations.some((conversation) => isStaffConversation(conversation))) {
+      return conversations;
+    }
+    return [
+      ...conversations,
+      {
+        id: STAFF_CONVERSATION_PLACEHOLDER_ID,
+        type: 'group',
+        name: 'Staff only',
+        participantIds: [],
+        participantRoles: ['staff']
+      }
+    ];
+  }, [canModerate, conversations]);
   const audienceMetadata = useMemo(() => buildChatAudienceMetadata({
     selectedConversation,
     selectedConversationId: effectiveConversationId,
@@ -836,6 +854,32 @@ export function ChatWindow({
     setReactionMessageId('');
     setActionMessageId('');
     closeConversationSheet();
+  };
+
+  const ensureAndSwitchStaffConversation = async () => {
+    if (!auth.user || !team) return;
+    try {
+      const staffConversation = await ensureStaffChatConversation(teamId, auth.user, conversations);
+      setConversations((current) => (
+        current.some((conversation) => conversation.id === staffConversation.id)
+          ? current
+          : [...current, staffConversation]
+      ));
+      if (selectedConversationId !== staffConversation.id) {
+        switchConversation(staffConversation.id);
+      }
+      closeConversationSheet();
+    } catch (staffError: any) {
+      setStatus({ tone: 'error', message: staffError?.message || 'Unable to open staff chat.' });
+    }
+  };
+
+  const handleConversationSelect = (conversationId: string) => {
+    if (conversationId === STAFF_CONVERSATION_PLACEHOLDER_ID) {
+      void ensureAndSwitchStaffConversation();
+      return;
+    }
+    switchConversation(conversationId);
   };
 
   const handleAudienceTargetChange = async (target: ChatTargetType) => {
@@ -1643,10 +1687,10 @@ export function ChatWindow({
 
       {showConversationSheet ? (
         <ConversationSheet
-          conversations={conversations}
+          conversations={conversationSheetConversations}
           team={team || {}}
           selectedConversationId={effectiveConversationId}
-          onSelect={switchConversation}
+          onSelect={handleConversationSelect}
           onClose={closeConversationSheet}
         />
       ) : null}

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -555,6 +555,35 @@ describe('ChatWindow conversation switching', () => {
     expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
     expect(ensureStaffChatConversation).not.toHaveBeenCalled();
   });
+
+  it('creates the staff conversation from the selector when a team has never opened it', async () => {
+    mockChatSheetsState.showConversationSheet = true;
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
+    ];
+    vi.mocked(ensureStaffChatConversation).mockResolvedValue({
+      id: 'staff-conversation',
+      type: 'group',
+      name: 'Staff only',
+      participantIds: [],
+      participantRoles: ['staff']
+    } as ChatConversation);
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Staff only.*Group conversation/i }));
+
+    await waitFor(() => {
+      expect(ensureStaffChatConversation).toHaveBeenCalledWith('team-1', auth.user, [
+        { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
+      ]);
+    });
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
+  });
 });
 
 describe('AudienceSheet recipient search', () => {

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ChatMessage } from '../../../lib/chatService';
+import { ensureStaffChatConversation, type ChatMessage } from '../../../lib/chatService';
 import type { AuthState } from '../../../lib/types';
 import {
   AudienceSheet,
@@ -19,6 +19,40 @@ import {
 
 const normalizeChatReactionsSpy = vi.fn();
 const getMessageAttachmentsSpy = vi.fn();
+const mockShellLayoutState = { isDesktopWeb: false };
+const mockChatSheetsState = {
+  showConversationSheet: false,
+  showAudienceSheet: false,
+  showMediaGallery: false,
+  showAttachSheet: false,
+  showLinkSheet: false,
+  showEmailSheet: false,
+  openConversationSheet: vi.fn(),
+  closeConversationSheet: vi.fn(),
+  openAudienceSheet: vi.fn(),
+  closeAudienceSheet: vi.fn(),
+  openMediaGallery: vi.fn(),
+  closeMediaGallery: vi.fn(),
+  openAttachSheet: vi.fn(),
+  closeAttachSheet: vi.fn(),
+  openLinkSheet: vi.fn(),
+  closeLinkSheet: vi.fn(),
+  openEmailSheet: vi.fn(),
+  closeEmailSheet: vi.fn()
+};
+const mockChatTeamState = {
+  team: { id: 'team-1', name: 'Bears' },
+  profile: { fullName: 'Pat Parent' },
+  canModerate: true,
+  conversations: [{ id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }],
+  setConversations: vi.fn(),
+  selectedConversationId: 'team',
+  setSelectedConversationId: vi.fn(),
+  loadingContext: false,
+  error: null,
+  reloadConversations: vi.fn(),
+  switchConversation: vi.fn(() => true)
+};
 
 vi.mock('../../../lib/chatLogic', async () => {
   const actual = await vi.importActual<typeof import('../../../lib/chatLogic')>('../../../lib/chatLogic');
@@ -101,7 +135,7 @@ vi.mock('../../../lib/publicActions', () => ({
 }));
 
 vi.mock('../../../lib/useShellLayout', () => ({
-  useShellLayout: () => ({ isDesktopWeb: false })
+  useShellLayout: () => mockShellLayoutState
 }));
 
 vi.mock('../../../lib/voiceService', () => ({
@@ -131,42 +165,11 @@ vi.mock('../../../lib/chatService', () => ({
 }));
 
 vi.mock('../hooks/useChatSheets', () => ({
-  useChatSheets: () => ({
-    showConversationSheet: false,
-    showAudienceSheet: false,
-    showMediaGallery: false,
-    showAttachSheet: false,
-    showLinkSheet: false,
-    showEmailSheet: false,
-    openConversationSheet: vi.fn(),
-    closeConversationSheet: vi.fn(),
-    openAudienceSheet: vi.fn(),
-    closeAudienceSheet: vi.fn(),
-    openMediaGallery: vi.fn(),
-    closeMediaGallery: vi.fn(),
-    openAttachSheet: vi.fn(),
-    closeAttachSheet: vi.fn(),
-    openLinkSheet: vi.fn(),
-    closeLinkSheet: vi.fn(),
-    openEmailSheet: vi.fn(),
-    closeEmailSheet: vi.fn()
-  })
+  useChatSheets: () => mockChatSheetsState
 }));
 
 vi.mock('../hooks/useChatTeam', () => ({
-  useChatTeam: () => ({
-    team: { id: 'team-1', name: 'Bears' },
-    profile: { fullName: 'Pat Parent' },
-    canModerate: true,
-    conversations: [{ id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }],
-    setConversations: vi.fn(),
-    selectedConversationId: 'team',
-    setSelectedConversationId: vi.fn(),
-    loadingContext: false,
-    error: null,
-    reloadConversations: vi.fn(),
-    switchConversation: vi.fn(() => true)
-  })
+  useChatTeam: () => mockChatTeamState
 }));
 
 vi.mock('../hooks/useChatMessages', async () => {
@@ -222,6 +225,38 @@ class MockResizeObserver {
   observe() {}
   disconnect() {}
 }
+
+beforeEach(() => {
+  mockShellLayoutState.isDesktopWeb = false;
+  mockChatSheetsState.showConversationSheet = false;
+  mockChatSheetsState.showAudienceSheet = false;
+  mockChatSheetsState.showMediaGallery = false;
+  mockChatSheetsState.showAttachSheet = false;
+  mockChatSheetsState.showLinkSheet = false;
+  mockChatSheetsState.showEmailSheet = false;
+  Object.values(mockChatSheetsState).forEach((value) => {
+    if (typeof value === 'function' && 'mockReset' in value) {
+      value.mockReset();
+    }
+  });
+  mockChatTeamState.team = { id: 'team-1', name: 'Bears' };
+  mockChatTeamState.profile = { fullName: 'Pat Parent' };
+  mockChatTeamState.canModerate = true;
+  mockChatTeamState.conversations = [{ id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }];
+  mockChatTeamState.selectedConversationId = 'team';
+  mockChatTeamState.loadingContext = false;
+  mockChatTeamState.error = null;
+  mockChatTeamState.setConversations.mockReset();
+  mockChatTeamState.setSelectedConversationId.mockReset();
+  mockChatTeamState.reloadConversations.mockReset();
+  mockChatTeamState.switchConversation.mockReset();
+  mockChatTeamState.switchConversation.mockReturnValue(true);
+  vi.mocked(ensureStaffChatConversation).mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
 
 describe('ChatWindow virtualization', () => {
   beforeEach(() => {
@@ -489,6 +524,27 @@ describe('ChatWindow virtualization', () => {
   });
 });
 
+describe('ChatWindow conversation switching', () => {
+  it('keeps staff chat reachable from the conversation selector without audience-sheet staff routing', () => {
+    mockChatSheetsState.showConversationSheet = true;
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] }
+    ];
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Staff only/i })[0]);
+
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
+    expect(ensureStaffChatConversation).not.toHaveBeenCalled();
+  });
+});
+
 describe('AudienceSheet recipient search', () => {
   function getRecipientCheckbox(name: string) {
     return screen.getByText(name).closest('label')?.querySelector('input') as HTMLInputElement;
@@ -521,6 +577,26 @@ describe('AudienceSheet recipient search', () => {
     return render(<AudienceSheetHarness />);
   }
 
+  it('shows only full team and selected members as audience choices', () => {
+    render(
+      <AudienceSheet
+        selectedTarget="full_team"
+        selectedRecipientIds={[]}
+        recipientOptions={[]}
+        recipientOptionsLoading={false}
+        recipientOptionsError={null}
+        onTargetChange={vi.fn() as any}
+        onRecipientsChange={vi.fn()}
+        onRetryRecipientOptions={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /Full team/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /Selected members/i })).not.toBeNull();
+    expect(screen.queryByRole('button', { name: /Staff only/i })).toBeNull();
+  });
+
   it('filters recipient options immediately by name or detail text', () => {
     renderAudienceSheet();
 
@@ -528,43 +604,43 @@ describe('AudienceSheet recipient search', () => {
       target: { value: 'guardian for sam' }
     });
 
-    expect(screen.getByText('Taylor Guardian')).toBeInTheDocument();
-    expect(screen.queryByText('Sam Player')).not.toBeInTheDocument();
-    expect(screen.queryByText('Casey Center')).not.toBeInTheDocument();
+    expect(screen.getByText('Taylor Guardian')).not.toBeNull();
+    expect(screen.queryByText('Sam Player')).toBeNull();
+    expect(screen.queryByText('Casey Center')).toBeNull();
   });
 
   it('keeps selected recipients pinned and checked while filtering and after clearing search', () => {
     renderAudienceSheet(['player-sam']);
 
-    expect(getRecipientCheckbox('Sam Player')).toBeChecked();
-    expect(screen.getByText('Selected')).toBeInTheDocument();
+    expect(getRecipientCheckbox('Sam Player').checked).toBe(true);
+    expect(screen.getByText('Selected')).not.toBeNull();
 
     fireEvent.change(screen.getByPlaceholderText('Search by member or guardian name'), {
       target: { value: 'zzz' }
     });
 
-    expect(getRecipientCheckbox('Sam Player')).toBeChecked();
-    expect(screen.getByText('No recipients match that search yet.')).toBeInTheDocument();
+    expect(getRecipientCheckbox('Sam Player').checked).toBe(true);
+    expect(screen.getByText('No recipients match that search yet.')).not.toBeNull();
 
     fireEvent.change(screen.getByPlaceholderText('Search by member or guardian name'), {
       target: { value: '' }
     });
 
-    expect(getRecipientCheckbox('Sam Player')).toBeChecked();
-    expect(screen.queryByText('No recipients match that search yet.')).not.toBeInTheDocument();
+    expect(getRecipientCheckbox('Sam Player').checked).toBe(true);
+    expect(screen.queryByText('No recipients match that search yet.')).toBeNull();
   });
 
   it('blocks Done with no selected recipients and allows it after choosing a filtered recipient', () => {
     renderAudienceSheet();
 
-    const doneButton = screen.getByRole('button', { name: 'Done' });
-    expect(doneButton).toBeDisabled();
+    const doneButton = screen.getByRole('button', { name: 'Done' }) as HTMLButtonElement;
+    expect(doneButton.disabled).toBe(true);
 
     fireEvent.change(screen.getByPlaceholderText('Search by member or guardian name'), {
       target: { value: 'casey' }
     });
     fireEvent.click(getRecipientCheckbox('Casey Center'));
 
-    expect(doneButton).not.toBeDisabled();
+    expect(doneButton.disabled).toBe(false);
   });
 });

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ensureStaffChatConversation, type ChatMessage } from '../../../lib/chatService';
+import { ensureStaffChatConversation, type ChatConversation, type ChatMessage } from '../../../lib/chatService';
 import type { AuthState } from '../../../lib/types';
 import {
   AudienceSheet,
@@ -40,7 +40,19 @@ const mockChatSheetsState = {
   openEmailSheet: vi.fn(),
   closeEmailSheet: vi.fn()
 };
-const mockChatTeamState = {
+const mockChatTeamState: {
+  team: { id: string; name: string };
+  profile: { fullName: string };
+  canModerate: boolean;
+  conversations: ChatConversation[];
+  setConversations: ReturnType<typeof vi.fn>;
+  selectedConversationId: string;
+  setSelectedConversationId: ReturnType<typeof vi.fn>;
+  loadingContext: boolean;
+  error: string | null;
+  reloadConversations: ReturnType<typeof vi.fn>;
+  switchConversation: ReturnType<typeof vi.fn>;
+} = {
   team: { id: 'team-1', name: 'Bears' },
   profile: { fullName: 'Pat Parent' },
   canModerate: true,

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -575,6 +575,7 @@ describe('ChatWindow conversation switching', () => {
       </MemoryRouter>
     );
 
+    expect(screen.getByRole('button', { name: /Staff only.*Group conversation/i })).not.toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /Staff only.*Group conversation/i }));
 
     await waitFor(() => {

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -253,7 +253,8 @@ async function mockMessagesModules(page, options = {}) {
 
                 export async function loadChatConversations() {
                     return [
-                        { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] }
+                        { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
+                        { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
                     ];
                 }
 
@@ -467,7 +468,13 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await page.getByPlaceholder('Message Bears').fill('');
 
     await page.getByRole('button', { name: /Audience: Full team/ }).click();
-    await page.getByRole('button', { name: 'Staff only' }).click();
+    await expect(page.getByRole('button', { name: 'Staff only' })).toBeHidden();
+    await page.getByRole('button', { name: 'Close Message audience' }).click();
+
+    await page.getByRole('button', { name: 'Team chat' }).click();
+    const conversationsDialog = page.getByRole('dialog', { name: 'Conversations' });
+    await expect(conversationsDialog).toBeVisible();
+    await conversationsDialog.getByRole('button', { name: 'Staff only Group conversation' }).click();
 
     await page.getByPlaceholder('Message Bears').fill('@ALL PLAYS who needs RSVP help?');
     await page.getByRole('button', { name: 'Send message' }).click();

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1533,17 +1533,15 @@ describe('React app messages integration', () => {
         expect(recipientLabels.some((label) => label.includes('Coach Jamie'))).toBe(false);
     });
 
-    it('keeps staff targeting contextual and sends the selected audience metadata', async () => {
-        const { container } = await renderMessages('/messages/team-1');
+    it('keeps staff conversation targeting contextual and sends the selected audience metadata', async () => {
+        chatMocks.loadChatConversations.mockResolvedValueOnce([
+            { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
+            { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
+        ]);
 
-        await click(container, 'Audience: Full team');
-        await click(container, 'Staff only');
+        const { container } = await renderMessages('/messages/team-1?conversationId=staff-conversation');
 
-        expect(chatMocks.ensureStaffChatConversation).toHaveBeenCalledWith(
-            'team-1',
-            auth.user,
-            [{ id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] }]
-        );
+        expect(chatMocks.ensureStaffChatConversation).not.toHaveBeenCalled();
         expect(container.textContent).toContain('Staff only');
 
         const textarea = container.querySelector('textarea');
@@ -1767,18 +1765,21 @@ describe('React app messages integration', () => {
         expect(buttonByText(container, 'Save draft').disabled).toBe(true);
         expect(container.textContent).toContain('Draft saving is available only for Selected members.');
 
-        await click(container, 'Close');
-        await click(container, 'Audience: Full team');
-        await click(container, 'Staff only');
-        await click(container, 'Team Email');
+        chatMocks.loadChatConversations.mockResolvedValueOnce([
+            { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
+            { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
+        ]);
+        const staffView = await renderMessages('/messages/team-1?conversationId=staff-conversation');
 
-        emailDialog = container.querySelector('[role="dialog"][aria-label="Team Email"]');
+        await click(staffView.container, 'Team Email');
+
+        emailDialog = staffView.container.querySelector('[role="dialog"][aria-label="Team Email"]');
         subjectInput = emailDialog.querySelector('input[placeholder="Team update"]');
         bodyInput = emailDialog.querySelector('textarea[placeholder="Write the email body..."]');
         await setFieldValue(subjectInput, 'Staff schedule');
         await setFieldValue(bodyInput, 'Film at 6.');
-        expect(buttonByText(container, 'Save draft').disabled).toBe(true);
-        expect(container.textContent).toContain('Draft saving is available only for Selected members.');
+        expect(buttonByText(staffView.container, 'Save draft').disabled).toBe(true);
+        expect(staffView.container.textContent).toContain('Draft saving is available only for Selected members.');
     });
 
     it('opens photo, video, and link actions from the attachment button', async () => {


### PR DESCRIPTION
Closes #3265

## What changed
- removed the **Staff only** option from the message audience sheet so it now shows only **Full team** and **Selected members**
- deleted the audience-sheet code path that called `ensureStaffChatConversation(...)` and switched threads from inside the composer
- added focused `ChatWindow` regression coverage to verify staff chat is still reachable through conversation switching and that the reduced audience option set still preserves selected-member search and Done-state behavior

## Root Cause
The chat composer modeled **Staff only** as a peer audience target even though staff messaging is already represented as its own conversation. That duplicated a conversation-switching action inside the audience sheet and tied audience changes to `ensureStaffChatConversation(...)`, creating two different UI paths for the same staff-only outcome.

## Prevention / Learning
When a destination already exists as a first-class conversation, keep it in conversation-selection UI and do not duplicate it as an in-thread audience target. Audience sheets should only represent targeting choices that stay within the current compose workflow.

## Regression Tests
- `npx vitest run apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx --reporter=verbose`
- added coverage that `AudienceSheet` renders only **Full team** and **Selected members**
- added coverage that `ChatWindow` still switches to the staff thread through the conversation selector without calling `ensureStaffChatConversation(...)`
- kept recipient search and Done-state validation coverage passing with the reduced audience options

## Recurrence Risk
Low. The duplicate staff path is removed and the targeted component tests now lock both the audience option list and the staff-conversation access path.