### PR TITLE
Keep game hub report tabs mounted on live updates

### DIFF
--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -27,9 +27,9 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
   } as any;
 }
 
-function buildReport(summary: string) {
+function buildReport(summary: string, gameOverrides: Record<string, unknown> = {}) {
   return {
-    game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38 },
+    game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38, ...gameOverrides },
     plays: [],
     summary,
     opponentRows: [],
@@ -76,6 +76,29 @@ describe('GameReportSections', () => {
     expect(screen.getByRole('button', { name: 'Players' }).className).toContain('bg-primary-600');
     expect(screen.getByRole('link', { name: /#1 Avery Smith/i })).toBeTruthy();
     expect(screen.queryByText('Loading report sections...')).toBeNull();
+  });
+
+  it('reloads the report when the same event transitions to a new live status', async () => {
+    gameReportServiceMocks.loadGameReportSections
+      .mockResolvedValueOnce(buildReport('Scheduled report.', { liveStatus: 'scheduled', status: 'scheduled' }))
+      .mockResolvedValueOnce(buildReport('Live report.', { liveStatus: 'live', status: 'live' }));
+
+    const { rerender } = render(<GameReportSections event={buildEvent({ liveStatus: 'scheduled', status: 'scheduled' })} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Scheduled report.')).toBeTruthy();
+    });
+
+    rerender(<GameReportSections event={buildEvent({ liveStatus: 'live', status: 'live' })} />);
+
+    expect(screen.getByText('Loading report sections...')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Live report.')).toBeTruthy();
+    });
+    expect(screen.queryByText('Scheduled report.')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Summary' }).className).toContain('bg-primary-600');
   });
 
   it('resets the panel when the event identity changes', async () => {

--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GameReportSections } from './GameReportSections';
+
+const gameReportServiceMocks = vi.hoisted(() => ({
+  loadGameReportSections: vi.fn()
+}));
+
+vi.mock('../../lib/gameReportService', () => gameReportServiceMocks);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function buildEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'game-1',
+    teamId: 'team-1',
+    liveStatus: 'live',
+    status: 'live',
+    homeScore: 41,
+    awayScore: 38,
+    ...overrides
+  } as any;
+}
+
+function buildReport(summary: string) {
+  return {
+    game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38 },
+    plays: [],
+    summary,
+    opponentRows: [],
+    opponentStatKeys: [],
+    teamInsights: [],
+    playerInsightRows: [],
+    highlightClips: [],
+    statSheetPhotoUrl: null,
+    teamStatKeys: [],
+    teamStats: {},
+    statKeys: ['pts'],
+    playerRows: [
+      { playerId: 'player-1', playerName: 'Avery Smith', number: '1', stats: { pts: 8 }, timeMs: 600000, didNotPlay: false }
+    ],
+    statLabels: { pts: 'PTS' },
+    hasPlayingTime: true,
+    team: { id: 'team-1' }
+  } as any;
+}
+
+describe('GameReportSections', () => {
+  it('keeps the active tab and loaded report mounted during same-event live score updates', async () => {
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('First report.'));
+
+    const { rerender } = render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('First report.')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Players' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /#1 Avery Smith/i })).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: 'Players' }).className).toContain('bg-primary-600');
+
+    rerender(<GameReportSections event={buildEvent({ liveStatus: 'halftime', homeScore: 42, awayScore: 40 })} />);
+
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByRole('button', { name: 'Players' }).className).toContain('bg-primary-600');
+    expect(screen.getByRole('link', { name: /#1 Avery Smith/i })).toBeTruthy();
+    expect(screen.queryByText('Loading report sections...')).toBeNull();
+  });
+
+  it('resets the panel when the event identity changes', async () => {
+    gameReportServiceMocks.loadGameReportSections
+      .mockResolvedValueOnce(buildReport('First report.'))
+      .mockResolvedValueOnce({
+        ...buildReport('Second report.'),
+        game: { id: 'game-2', liveStatus: 'completed', status: 'completed', homeScore: 55, awayScore: 44 }
+      });
+
+    const { rerender } = render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('First report.')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Players' }));
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /#1 Avery Smith/i })).toBeTruthy();
+    });
+
+    rerender(<GameReportSections event={buildEvent({ id: 'game-2', homeScore: 55, awayScore: 44, liveStatus: 'completed', status: 'completed' })} />);
+
+    expect(screen.getByText('Loading report sections...')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenNthCalledWith(2, 'team-1', 'game-2');
+      expect(screen.getByText('Second report.')).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: 'Summary' }).className).toContain('bg-primary-600');
+  });
+});

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -42,7 +42,7 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
     setReport(null);
     setActiveReportSection('summary');
     void refreshReport();
-  }, [event.liveStatus, event.status, event.homeScore, event.awayScore, refreshReport]);
+  }, [event.id, event.teamId, refreshReport]);
 
   useEffect(() => {
     if (!isLivePlaysRefreshEnabled) return undefined;

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -14,6 +14,7 @@ const gameReportSections: Array<{ id: GameReportSectionId; label: string }> = [
 ];
 
 const liveReportStatuses = new Set(['live', 'in_progress', 'in-progress', 'halftime']);
+const completedReportStatuses = new Set(['final', 'completed', 'complete']);
 const liveReportPollIntervalMs = 15000;
 
 export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
@@ -23,6 +24,7 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   const [reportError, setReportError] = useState<string | null>(null);
   const visibleReportSections = useMemo(() => getVisibleGameReportSections(report), [report]);
   const liveReportStatus = String(report?.game?.liveStatus || report?.game?.status || event.liveStatus || event.status || '').trim().toLowerCase();
+  const eventReportLoadStatus = normalizeGameReportLoadStatus(event.liveStatus || event.status);
   const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && liveReportStatuses.has(liveReportStatus);
 
   const refreshReport = useCallback(async (showLoading = true) => {
@@ -42,7 +44,7 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
     setReport(null);
     setActiveReportSection('summary');
     void refreshReport();
-  }, [event.id, event.teamId, refreshReport]);
+  }, [event.id, event.teamId, eventReportLoadStatus, refreshReport]);
 
   useEffect(() => {
     if (!isLivePlaysRefreshEnabled) return undefined;
@@ -128,6 +130,14 @@ function hasMediaReportData(report: GameReportData) {
 function shouldShowPlayByPlaySection(report: GameReportData) {
   const liveStatus = String(report.game?.liveStatus || report.game?.status || '').trim().toLowerCase();
   return report.plays.length > 0 || liveReportStatuses.has(liveStatus);
+}
+
+function normalizeGameReportLoadStatus(status: unknown) {
+  const normalized = String(status || '').trim().toLowerCase();
+  if (liveReportStatuses.has(normalized)) return 'live';
+  if (completedReportStatuses.has(normalized)) return 'completed';
+  if (!normalized || normalized === 'scheduled') return 'scheduled';
+  return normalized;
 }
 
 function getVisibleGameReportSections(report: GameReportData | null) {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -120,7 +120,15 @@ const chatServiceMocks = vi.hoisted(() => ({
 }));
 vi.mock('../lib/chatService', () => chatServiceMocks);
 vi.mock('../lib/publicActions', () => publicActionMocks);
-vi.mock('../lib/liveGameAnnouncer', () => ({ useLiveGameAnnouncer: vi.fn() }));
+const liveGameAnnouncerMocks = vi.hoisted(() => ({
+  useLiveGameAnnouncer: vi.fn(() => ({
+    supported: true,
+    enabled: false,
+    paused: false,
+    toggleEnabled: vi.fn()
+  }))
+}));
+vi.mock('../lib/liveGameAnnouncer', () => liveGameAnnouncerMocks);
 const liveGameChatServiceMocks = vi.hoisted(() => ({
   canUseLiveGameChat: vi.fn<(game: unknown, options?: unknown) => boolean>(() => true),
   getLiveGameChatNotice: vi.fn<(game: unknown, options?: unknown) => string | null>(() => null),
@@ -1643,6 +1651,78 @@ describe('ScheduleEventDetail assignments', () => {
     expect(chatServiceMocks.sendTeamChatMessage).not.toHaveBeenCalled();
     expect(screen.queryByText('Loading lineup builder…')).toBeNull();
     expect(screen.getByText('Score autosaved and posted to live play-by-play.')).toBeTruthy();
+  });
+
+  it('keeps report sections mounted during live score updates', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        status: 'live',
+        canUpdateScore: true,
+        isTeamStaff: true,
+        homeScore: 41,
+        awayScore: 38
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([
+      { id: 'p1', name: 'Avery Smith', number: '1', points: 10, fouls: 1 }
+    ]);
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue({
+      game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38 },
+      plays: [
+        { id: 'play-1', period: 'Q1', clock: '02:11', text: 'Avery Smith made a layup' }
+      ],
+      summary: 'Loaded on demand.',
+      opponentRows: [],
+      opponentStatKeys: [],
+      teamInsights: [],
+      playerInsightRows: [],
+      highlightClips: [],
+      statSheetPhotoUrl: null,
+      teamStatKeys: [],
+      teamStats: {},
+      statKeys: ['pts'],
+      playerRows: [
+        { playerId: 'player-1', playerName: 'Avery Smith', number: '1', stats: { pts: 8 }, timeMs: 600000, didNotPlay: false }
+      ],
+      statLabels: { pts: 'PTS' },
+      hasPlayingTime: true,
+      team: { id: 'team-1' }
+    } as any);
+    scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 42, awayScore: 38 });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Report sections' }));
+
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Loaded on demand.')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Avery Smith made a layup')).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: 'Plays' }).className).toContain('bg-primary-600');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Home score up' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 42, awayScore: 38 }, auth.user);
+    }, { timeout: 2000 });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Plays' }).className).toContain('bg-primary-600');
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Avery Smith made a layup')).toBeTruthy();
+    });
+    expect(screen.queryByText('Loading report sections...')).toBeNull();
   });
 
   it('keeps live substitutions loaded during live clock updates', async () => {


### PR DESCRIPTION
Closes #3267

## What changed
- Changed `GameReportSections` so its reset + blocking load effect keys off stable event identity (`teamId` + `event.id`) instead of volatile live score/status props.
- Kept the existing non-blocking live refresh path for the Plays tab intact, so same-game live updates no longer clear the loaded report or force the selected tab back to Summary.
- Added a focused component regression test for same-event rerenders and extended the Schedule Event Detail game hub test to prove report sections stay mounted during a live score update.

## Root Cause
`GameReportSections` treated live score and status prop changes as if they were a new event. Its initial-load effect depended on `liveStatus`, `status`, `homeScore`, and `awayScore`, so normal same-game scoring updates cleared `report`, reset `activeReportSection` to `summary`, and triggered another blocking `loadGameReportSections()` call.

## Prevention / Learning
When a screen already has a targeted live refresh path, blocking reset effects must be keyed only to stable entity identity. Same-entity rerender tests should explicitly cover live score/status prop churn so volatile display fields cannot accidentally behave like a remount trigger.

## Regression Tests
- `apps/app/src/components/schedule/GameReportSections.test.tsx`
  - proves same-event score/status rerenders preserve the active tab and do not trigger another blocking refresh
  - proves switching to a different event still resets and reloads correctly
- `apps/app/src/pages/ScheduleEventDetail.test.tsx`
  - opens Game hub > Report sections > Plays, performs a live score update, and verifies the Plays tab stays selected, prior content stays visible, and `loadGameReportSections` call count does not increase

## Recurrence Risk
Low. The reset path now keys off stable event identity, and both component-level and game-hub regression tests cover the exact same-event live update behavior that caused the reset.