### PR TITLE
Render direct team chat before conversations hydrate

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -536,6 +536,39 @@ describe('ChatWindow virtualization', () => {
   });
 });
 
+describe('ChatWindow deferred conversation hydration', () => {
+  it('renders the active thread before conversations finish hydrating and keeps it visible afterward', async () => {
+    mockChatTeamState.loadingContext = false;
+    mockChatTeamState.conversations = [];
+    mockChatTeamState.selectedConversationId = 'team';
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Composer')).toBeVisible();
+    expect(document.querySelectorAll('.message-bubble').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Loading')).toBeNull();
+
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] }
+    ];
+
+    rerender(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(document.querySelectorAll('.message-bubble').length).toBeGreaterThan(0));
+    expect(screen.getByText('Composer')).toBeVisible();
+    expect(screen.queryByText('Loading')).toBeNull();
+  });
+});
+
 describe('ChatWindow conversation switching', () => {
   it('keeps staff chat reachable from the conversation selector without audience-sheet staff routing', () => {
     mockChatSheetsState.showConversationSheet = true;

--- a/apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx
+++ b/apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx
@@ -108,7 +108,36 @@ describe('useChatTeam', () => {
         await waitFor(() => expect(loadChatTeamContext).toHaveBeenCalledTimes(1));
     });
 
-    it('ends blocking load after team context while conversations hydrate in the background', async () => {
+    it('ends blocking load after team context while the default conversation hydrates in the background', async () => {
+        let resolveConversations: ((value: ChatConversation[]) => void) | null = null;
+        vi.mocked(loadChatTeamContext).mockResolvedValue({
+            team: { id: 'team-1', name: 'Bears' },
+            profile: {},
+            canModerate: true
+        });
+        vi.mocked(loadChatConversations).mockImplementation(() => new Promise((resolve) => {
+            resolveConversations = resolve;
+        }));
+
+        render(<TeamProbe teamId="team-1" />);
+
+        await waitFor(() => expect(screen.getByTestId('team-name').textContent).toBe('Bears'));
+        await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+        expect(screen.getByTestId('selected-conversation').textContent).toBe(DEFAULT_TEAM_CONVERSATION_ID);
+        expect(screen.getByTestId('conversation-count').textContent).toBe('0');
+
+        await act(async () => {
+            resolveConversations?.([
+                { id: DEFAULT_TEAM_CONVERSATION_ID, type: 'team', isDefault: true },
+                { id: 'staff', type: 'group', name: 'Staff only' }
+            ]);
+        });
+
+        await waitFor(() => expect(screen.getByTestId('conversation-count').textContent).toBe('2'));
+        expect(screen.getByTestId('selected-conversation').textContent).toBe(DEFAULT_TEAM_CONVERSATION_ID);
+    });
+
+    it('keeps blocking load for non-default conversations until conversation metadata hydrates', async () => {
         let resolveConversations: ((value: ChatConversation[]) => void) | null = null;
         vi.mocked(loadChatTeamContext).mockResolvedValue({
             team: { id: 'team-1', name: 'Bears' },
@@ -122,7 +151,7 @@ describe('useChatTeam', () => {
         render(<TeamProbe teamId="team-1" preferredConversationId="staff" />);
 
         await waitFor(() => expect(screen.getByTestId('team-name').textContent).toBe('Bears'));
-        await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+        expect(screen.getByTestId('loading').textContent).toBe('true');
         expect(screen.getByTestId('selected-conversation').textContent).toBe('staff');
         expect(screen.getByTestId('conversation-count').textContent).toBe('0');
 
@@ -133,7 +162,8 @@ describe('useChatTeam', () => {
             ]);
         });
 
-        await waitFor(() => expect(screen.getByTestId('conversation-count').textContent).toBe('2'));
+        await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+        expect(screen.getByTestId('conversation-count').textContent).toBe('2');
         expect(screen.getByTestId('selected-conversation').textContent).toBe('staff');
     });
 

--- a/apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx
+++ b/apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChatTeam } from '../useChatTeam';
 import { DEFAULT_TEAM_CONVERSATION_ID } from '../../../../lib/chatLogic';
-import { loadChatConversations, loadChatTeamContext } from '../../../../lib/chatService';
+import { loadChatConversations, loadChatTeamContext, type ChatConversation } from '../../../../lib/chatService';
 import type { AuthState } from '../../../../lib/types';
 
 vi.mock('../../../../lib/chatService', () => ({
@@ -106,6 +106,35 @@ describe('useChatTeam', () => {
         rerender(<TeamProbeWithUser authUser={secondUser} />);
 
         await waitFor(() => expect(loadChatTeamContext).toHaveBeenCalledTimes(1));
+    });
+
+    it('ends blocking load after team context while conversations hydrate in the background', async () => {
+        let resolveConversations: ((value: ChatConversation[]) => void) | null = null;
+        vi.mocked(loadChatTeamContext).mockResolvedValue({
+            team: { id: 'team-1', name: 'Bears' },
+            profile: {},
+            canModerate: true
+        });
+        vi.mocked(loadChatConversations).mockImplementation(() => new Promise((resolve) => {
+            resolveConversations = resolve;
+        }));
+
+        render(<TeamProbe teamId="team-1" preferredConversationId="staff" />);
+
+        await waitFor(() => expect(screen.getByTestId('team-name').textContent).toBe('Bears'));
+        await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+        expect(screen.getByTestId('selected-conversation').textContent).toBe('staff');
+        expect(screen.getByTestId('conversation-count').textContent).toBe('0');
+
+        await act(async () => {
+            resolveConversations?.([
+                { id: DEFAULT_TEAM_CONVERSATION_ID, type: 'team', isDefault: true },
+                { id: 'staff', type: 'group', name: 'Staff only' }
+            ]);
+        });
+
+        await waitFor(() => expect(screen.getByTestId('conversation-count').textContent).toBe('2'));
+        expect(screen.getByTestId('selected-conversation').textContent).toBe('staff');
     });
 
     it('switches conversations immediately when the selected id changes', async () => {

--- a/apps/app/src/pages/messages/hooks/useChatTeam.ts
+++ b/apps/app/src/pages/messages/hooks/useChatTeam.ts
@@ -5,7 +5,7 @@ import {
   type ChatConversation,
   type ChatTeam
 } from '../../../lib/chatService';
-import { DEFAULT_TEAM_CONVERSATION_ID } from '../../../lib/chatLogic';
+import { DEFAULT_TEAM_CONVERSATION_ID, isDefaultTeamConversation } from '../../../lib/chatLogic';
 import type { AuthState } from '../../../lib/types';
 
 type UseChatTeamParams = {
@@ -30,10 +30,12 @@ export function useChatTeam({ teamId, user, inboxTeam, preferredConversationId =
 
     async function loadContext() {
       if (!user) return;
+      const nextConversationId = preferredConversationId || DEFAULT_TEAM_CONVERSATION_ID;
+      const shouldBlockOnConversationHydration = !isDefaultTeamConversation(nextConversationId);
       setLoadingContext(true);
       setError(null);
       setConversations([]);
-      setSelectedConversationId(preferredConversationId || DEFAULT_TEAM_CONVERSATION_ID);
+      setSelectedConversationId(nextConversationId);
       onTeamReset?.();
 
       try {
@@ -42,7 +44,9 @@ export function useChatTeam({ teamId, user, inboxTeam, preferredConversationId =
         setTeam(context.team);
         setProfile(context.profile);
         setCanModerate(context.canModerate);
-        setLoadingContext(false);
+        if (!shouldBlockOnConversationHydration) {
+          setLoadingContext(false);
+        }
 
         try {
           const loadedConversations = await loadChatConversations(teamId, user, context.team, context.canModerate);
@@ -57,9 +61,11 @@ export function useChatTeam({ teamId, user, inboxTeam, preferredConversationId =
             }
             return DEFAULT_TEAM_CONVERSATION_ID;
           });
+          setLoadingContext(false);
         } catch {
           if (!cancelled) {
             setConversations([]);
+            setLoadingContext(false);
           }
         }
       } catch (loadError: any) {

--- a/apps/app/src/pages/messages/hooks/useChatTeam.ts
+++ b/apps/app/src/pages/messages/hooks/useChatTeam.ts
@@ -32,6 +32,7 @@ export function useChatTeam({ teamId, user, inboxTeam, preferredConversationId =
       if (!user) return;
       setLoadingContext(true);
       setError(null);
+      setConversations([]);
       setSelectedConversationId(preferredConversationId || DEFAULT_TEAM_CONVERSATION_ID);
       onTeamReset?.();
 
@@ -41,24 +42,31 @@ export function useChatTeam({ teamId, user, inboxTeam, preferredConversationId =
         setTeam(context.team);
         setProfile(context.profile);
         setCanModerate(context.canModerate);
-        const loadedConversations = await loadChatConversations(teamId, user, context.team, context.canModerate);
-        if (cancelled) return;
-        setConversations(loadedConversations);
-        setSelectedConversationId((current: string) => {
-          if (loadedConversations.some((conversation) => conversation.id === current)) {
-            return current;
+        setLoadingContext(false);
+
+        try {
+          const loadedConversations = await loadChatConversations(teamId, user, context.team, context.canModerate);
+          if (cancelled) return;
+          setConversations(loadedConversations);
+          setSelectedConversationId((current: string) => {
+            if (loadedConversations.some((conversation) => conversation.id === current)) {
+              return current;
+            }
+            if (preferredConversationId && loadedConversations.some((conversation) => conversation.id === preferredConversationId)) {
+              return preferredConversationId;
+            }
+            return DEFAULT_TEAM_CONVERSATION_ID;
+          });
+        } catch {
+          if (!cancelled) {
+            setConversations([]);
           }
-          if (preferredConversationId && loadedConversations.some((conversation) => conversation.id === preferredConversationId)) {
-            return preferredConversationId;
-          }
-          return DEFAULT_TEAM_CONVERSATION_ID;
-        });
+        }
       } catch (loadError: any) {
         if (!cancelled) {
           setError(loadError?.message || 'Unable to load team chat.');
+          setLoadingContext(false);
         }
-      } finally {
-        if (!cancelled) setLoadingContext(false);
       }
     }
 

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -252,6 +252,9 @@ async function mockMessagesModules(page, options = {}) {
                 }
 
                 export async function loadChatConversations() {
+                    if (${options.conversationDelayMs || 0} > 0) {
+                        await new Promise((resolve) => setTimeout(resolve, ${options.conversationDelayMs || 0}));
+                    }
                     return [
                         { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
                         { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
@@ -501,6 +504,22 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
         userId: 'user-1',
         conversationId: 'team'
     });
+});
+
+test('messages team thread renders before deferred conversation hydration finishes', async ({ page, baseURL }) => {
+    await mockMessagesModules(page, { conversationDelayMs: 1500 });
+    await page.goto(appUrl(baseURL, '/messages/team-1'), { waitUntil: 'domcontentloaded' });
+
+    await waitForMessagesRoute(page, page.getByPlaceholder('Message Bears'));
+    await expect(page.getByText('Bring both jerseys.')).toBeVisible();
+    await expect(page.getByText('Latest ride update.')).toBeVisible();
+    await expect(page.getByPlaceholder('Message Bears')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Team chat' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Team chat' }).click();
+    await expect(page.getByRole('dialog', { name: 'Conversations' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Staff only Group conversation' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('Latest ride update.')).toBeVisible();
 });
 
 test('messages inbox stays interactive while previews hydrate on inbox and desktop routes', async ({ page, baseURL }) => {


### PR DESCRIPTION
Closes #3270

## What changed
- Split `useChatTeam` bootstrap into blocking and deferred phases so `loadingContext` clears immediately after `loadChatTeamContext(...)` succeeds.
- Kept `loadChatConversations(...)` as a background hydration step that updates conversation chips and preferred/staff conversation selection after the thread is already visible.
- Added regression coverage for the hook, the chat window, and the smoke harness path that delays conversation loading.

## Root Cause
The direct-thread bootstrap treated conversation metadata as blocking route state. `useChatTeam` awaited `loadChatConversations(...)` before clearing `loadingContext`, so `ChatWindow` kept returning the full messages skeleton even though team context and the message subscription path were already ready.

## Prevention / Learning
For chat routes, unblock first render as soon as the minimum thread contract is satisfied, then hydrate secondary UI like conversation pickers and moderation metadata separately. If a later async dependency is not required by the message subscription itself, it should not own the route-level loading gate.

## Regression Tests
- Added a `useChatTeam` test that proves blocking loading ends after team context resolves while conversations continue hydrating in the background.
- Added a `ChatWindow` regression test that keeps the thread/composer visible before and after deferred conversation hydration.
- Added a smoke spec case for delayed `loadChatConversations` on `/messages/team-1`.
- Ran:
  - `npm --prefix apps/app test -- --run src/pages/messages/hooks/__tests__/useChatTeam.test.tsx src/pages/messages/components/ChatWindow.virtualization.test.tsx`
  - `npm run app:build`