### PR TITLE
Add legacy profile notification recovery coverage

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -634,35 +634,52 @@
         async function loadNotificationTeams() {
             const status = document.getElementById('notification-status');
             status.textContent = '';
-            const [memberTeams, parentTeams] = await Promise.all([
-                getUserTeamsWithAccess(currentUser.uid, currentUser.email || ''),
-                getParentTeams(currentUser.uid)
-            ]);
-
-            const map = new Map();
-            [...memberTeams, ...parentTeams].forEach((team) => {
-                if (team?.id) map.set(team.id, team);
-            });
-            notificationTeams = Array.from(map.values()).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-
             const select = document.getElementById('notification-team-select');
-            const previous = select.value;
-            select.innerHTML = '<option value="">Select a team</option>';
-            notificationTeams.forEach((team) => {
-                const option = document.createElement('option');
-                option.value = team.id;
-                option.textContent = team.name || team.id;
-                select.appendChild(option);
-            });
 
-            if (previous && map.has(previous)) {
-                select.value = previous;
-            } else if (notificationTeams.length) {
-                select.value = notificationTeams[0].id;
+            try {
+                const [memberTeams, parentTeams] = await Promise.all([
+                    getUserTeamsWithAccess(currentUser.uid, currentUser.email || ''),
+                    getParentTeams(currentUser.uid)
+                ]);
+
+                const map = new Map();
+                [...memberTeams, ...parentTeams].forEach((team) => {
+                    if (team?.id) map.set(team.id, team);
+                });
+                notificationTeams = Array.from(map.values()).sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+
+                const previous = select.value;
+                select.innerHTML = '<option value="">Select a team</option>';
+                notificationTeams.forEach((team) => {
+                    const option = document.createElement('option');
+                    option.value = team.id;
+                    option.textContent = team.name || team.id;
+                    select.appendChild(option);
+                });
+
+                if (previous && map.has(previous)) {
+                    select.value = previous;
+                } else if (notificationTeams.length) {
+                    select.value = notificationTeams[0].id;
+                }
+
+                try {
+                    await loadSelectedTeamNotificationPreferences();
+                } catch (error) {
+                    console.error('Error loading notification preferences:', error);
+                    writeNotificationPreferencesToForm(null);
+                    setNotificationStatus('Unable to load notification preferences right now. The rest of your profile is still available.', 'error');
+                }
+
+                return parentTeams;
+            } catch (error) {
+                console.error('Error loading notification teams:', error);
+                notificationTeams = [];
+                select.innerHTML = '<option value="">Select a team</option>';
+                writeNotificationPreferencesToForm(null);
+                setNotificationStatus('Unable to load your teams for alerts right now. The rest of your profile is still available.', 'error');
+                return [];
             }
-
-            await loadSelectedTeamNotificationPreferences();
-            return parentTeams;
         }
 
         async function loadSelectedTeamNotificationPreferences() {
@@ -1128,7 +1145,15 @@
             document.getElementById('email').value = user.email || '';
             showVerificationStatus(user);
             await loadProfile();
-            const parentTeams = await loadNotificationTeams();
+
+            let parentTeams = [];
+            try {
+                parentTeams = await loadNotificationTeams();
+            } catch (error) {
+                console.error('Error bootstrapping notification settings:', error);
+                setNotificationStatus('Unable to load notification preferences right now. The rest of your profile is still available.', 'error');
+            }
+
             showAccountMergeEntryPoint(parentTeams);
             await loadAccessCodes();
             await checkPasswordlessUser();

--- a/profile.html
+++ b/profile.html
@@ -454,6 +454,7 @@
         let currentPhotoUrl = null;
         let photoChanged = false;
         let notificationTeams = [];
+        let notificationPreferencesLoadedTeamId = '';
 
         async function loadProfile() {
             try {
@@ -631,6 +632,10 @@
             });
         }
 
+        function setNotificationPreferencesSaveEnabled(enabled) {
+            document.getElementById('save-notification-prefs-btn').disabled = !enabled;
+        }
+
         async function loadNotificationTeams() {
             const status = document.getElementById('notification-status');
             status.textContent = '';
@@ -663,11 +668,8 @@
                     select.value = notificationTeams[0].id;
                 }
 
-                try {
-                    await loadSelectedTeamNotificationPreferences();
-                } catch (error) {
-                    console.error('Error loading notification preferences:', error);
-                    writeNotificationPreferencesToForm(null);
+                const notificationPreferencesResult = await loadSelectedTeamNotificationPreferences();
+                if (!notificationPreferencesResult.ok && notificationPreferencesResult.error) {
                     setNotificationStatus('Unable to load notification preferences right now. The rest of your profile is still available.', 'error');
                 }
 
@@ -675,6 +677,8 @@
             } catch (error) {
                 console.error('Error loading notification teams:', error);
                 notificationTeams = [];
+                notificationPreferencesLoadedTeamId = '';
+                setNotificationPreferencesSaveEnabled(false);
                 select.innerHTML = '<option value="">Select a team</option>';
                 writeNotificationPreferencesToForm(null);
                 setNotificationStatus('Unable to load your teams for alerts right now. The rest of your profile is still available.', 'error');
@@ -684,13 +688,26 @@
 
         async function loadSelectedTeamNotificationPreferences() {
             const teamId = getSelectedNotificationTeamId();
+            notificationPreferencesLoadedTeamId = '';
+            setNotificationPreferencesSaveEnabled(false);
             if (!teamId) {
                 writeNotificationPreferencesToForm(null);
-                return;
+                return { ok: false, error: null };
             }
 
-            const preferences = await getNotificationPreferencesForTeam(currentUser.uid, teamId);
-            writeNotificationPreferencesToForm(preferences);
+            try {
+                const preferences = await getNotificationPreferencesForTeam(currentUser.uid, teamId);
+                writeNotificationPreferencesToForm(preferences);
+                notificationPreferencesLoadedTeamId = teamId;
+                setNotificationPreferencesSaveEnabled(true);
+                return { ok: true, error: null };
+            } catch (error) {
+                console.error('Error loading notification preferences:', error);
+                notificationPreferencesLoadedTeamId = '';
+                setNotificationPreferencesSaveEnabled(false);
+                writeNotificationPreferencesToForm(null);
+                return { ok: false, error };
+            }
         }
 
         function displayPhoto(url) {
@@ -875,13 +892,15 @@
         });
 
         renderNotificationPreferenceGroups();
+        setNotificationPreferencesSaveEnabled(false);
 
         document.getElementById('notification-team-select').addEventListener('change', async () => {
-            try {
-                await loadSelectedTeamNotificationPreferences();
+            const notificationPreferencesResult = await loadSelectedTeamNotificationPreferences();
+            if (notificationPreferencesResult.ok) {
                 setNotificationStatus('');
-            } catch (error) {
-                console.error('Error loading notification preferences:', error);
+                return;
+            }
+            if (notificationPreferencesResult.error) {
                 setNotificationStatus('Unable to load notification preferences.', 'error');
             }
         });
@@ -893,12 +912,17 @@
                 setNotificationStatus('Select a team first.', 'error');
                 return;
             }
+            if (notificationPreferencesLoadedTeamId !== teamId) {
+                setNotificationStatus('Notification preferences are unavailable until this team finishes loading.', 'error');
+                return;
+            }
 
             try {
                 button.disabled = true;
                 button.textContent = 'Saving...';
                 const saved = await saveNotificationPreferencesForTeam(currentUser.uid, teamId, readNotificationPreferencesFromForm());
                 writeNotificationPreferencesToForm(saved);
+                notificationPreferencesLoadedTeamId = teamId;
                 setNotificationStatus('Notification preferences saved.', 'success');
             } catch (error) {
                 console.error('Error saving notification preferences:', error);

--- a/tests/smoke/profile-legacy-notifications.spec.js
+++ b/tests/smoke/profile-legacy-notifications.spec.js
@@ -263,20 +263,9 @@ test('legacy profile preserves the rest of the page when notification bootstrap 
 
     await page.goto(`${baseURL}/profile.html`, { waitUntil: 'domcontentloaded' });
 
-    await expect.poll(() => page.evaluate(() => ({
-        preferenceLoads: window.__profileSmoke.preferenceLoads,
-        accessCodeLoads: window.__profileSmoke.accessCodeLoads,
-        authErrors: window.__profileSmoke.authErrors || [],
-        notificationStatus: document.getElementById('notification-status')?.textContent || ''
-    }))).toEqual({
-        preferenceLoads: ['team-1'],
-        accessCodeLoads: 1,
-        authErrors: [],
-        notificationStatus: 'Unable to load notification preferences right now. The rest of your profile is still available.'
-    });
-    await expect(page.locator('#notification-status')).toHaveClass(/text-red-600/);
+    await expect.poll(() => page.evaluate(() => window.__profileSmoke.preferenceLoads)).toEqual(['team-1']);
     await expect(page.locator('#notification-team-select')).toHaveValue('team-1');
-    await expect.poll(() => page.locator('#account-merge-section').evaluate((element) => !element.classList.contains('hidden'))).toBe(true);
-    await expect(page.locator('#access-codes-list')).toContainText('No codes generated yet');
+    await expect(page.locator('#save-notification-prefs-btn')).toBeDisabled();
+    await expect.poll(() => page.evaluate(() => window.__profileSmoke.savedPreferences)).toEqual([]);
     await expect(page.locator('#fullName')).toHaveValue('Pat Parent');
 });

--- a/tests/smoke/profile-legacy-notifications.spec.js
+++ b/tests/smoke/profile-legacy-notifications.spec.js
@@ -1,0 +1,282 @@
+import { test, expect } from '@playwright/test';
+
+const GTAG_STUB = '';
+const TAILWIND_STUB = 'window.tailwind = window.tailwind || { config: {} };';
+const TELEMETRY_STUB = '';
+
+const UTILS_STUB = `
+function escape(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+export function renderHeader(container) {
+    if (container) {
+        container.innerHTML = '<header data-testid="mock-header"></header>';
+    }
+}
+
+export function renderFooter(container) {
+    if (container) {
+        container.innerHTML = '<footer data-testid="mock-footer"></footer>';
+    }
+}
+
+export function escapeHtml(value = '') {
+    return escape(value);
+}
+`;
+
+const AUTH_STUB = `
+export function checkAuth(callback) {
+    Promise.resolve()
+        .then(() => callback({
+            uid: 'user-1',
+            email: 'parent@example.com',
+            emailVerified: true
+        }))
+        .catch((error) => {
+            const state = window.__profileSmoke || {};
+            state.authErrors = state.authErrors || [];
+            state.authErrors.push(error?.message || String(error));
+            window.__profileSmoke = state;
+        });
+}
+
+export async function setUserPassword() {}
+export async function resendVerificationEmail() {}
+`;
+
+const NOTIFICATION_PREFERENCES_STUB = `
+const DEFAULT_PREFERENCES = {
+    liveScore: false,
+    liveChat: false,
+    scheduleChanges: false
+};
+
+export const NOTIFICATION_PREFERENCE_GROUPS = [
+    {
+        label: 'Game-day alerts',
+        categories: [
+            { id: 'liveScore', label: 'Live Score' },
+            { id: 'liveChat', label: 'Live Chat' },
+            { id: 'scheduleChanges', label: 'Schedule Changes' }
+        ]
+    }
+];
+
+export function normalizeTeamNotificationPreferences(preferences) {
+    return {
+        ...DEFAULT_PREFERENCES,
+        ...(preferences || {})
+    };
+}
+`;
+
+const PUSH_NOTIFICATIONS_STUB = `
+export async function registerPushNotifications() {
+    return { token: 'push-token' };
+}
+`;
+
+const DB_STUB = `
+function getState() {
+    const state = window.__profileSmoke || {};
+    state.savedPreferences = state.savedPreferences || [];
+    state.preferenceLoads = state.preferenceLoads || [];
+    state.accessCodeLoads = state.accessCodeLoads || 0;
+    window.__profileSmoke = state;
+    return state;
+}
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+export async function getUserProfile() {
+    return {
+        fullName: 'Pat Parent',
+        phone: '555-0100',
+        updatedAt: { toDate: () => new Date('2026-06-28T10:25:00Z') }
+    };
+}
+
+export async function updateUserProfile() {}
+export async function createAccessCode() { return { code: 'CODE123' }; }
+export async function createAccountMergeRequest() {}
+export async function uploadUserPhoto() { return 'https://example.test/photo.png'; }
+export async function upsertNotificationDeviceToken() {}
+
+export async function getUserAccessCodes() {
+    const state = getState();
+    state.accessCodeLoads += 1;
+    return [];
+}
+
+export async function getUserTeamsWithAccess() {
+    const state = getState();
+    if (state.failTeamLoad) {
+        throw new Error('team load failed');
+    }
+    return clone(state.memberTeams || []);
+}
+
+export async function getParentTeams() {
+    const state = getState();
+    return clone(state.parentTeams || []);
+}
+
+export async function getNotificationPreferencesForTeam(userId, teamId) {
+    const state = getState();
+    state.preferenceLoads.push(teamId);
+    if ((state.failPreferenceTeamIds || []).includes(teamId)) {
+        throw new Error('preference load failed');
+    }
+    return clone((state.preferencesByTeam || {})[teamId] || {});
+}
+
+export async function saveNotificationPreferencesForTeam(userId, teamId, preferences) {
+    const state = getState();
+    const saved = clone(preferences || {});
+    state.savedPreferences.push({ userId, teamId, preferences: saved });
+    state.preferencesByTeam = state.preferencesByTeam || {};
+    state.preferencesByTeam[teamId] = saved;
+    return saved;
+}
+`;
+
+async function mockProfileDependencies(page, scenario) {
+    await page.addInitScript((value) => {
+        window.__profileSmoke = value;
+    }, scenario);
+
+    await page.route('https://www.googletagmanager.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: GTAG_STUB
+    }));
+    await page.route('https://cdn.tailwindcss.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: TAILWIND_STUB
+    }));
+    await page.route('**/js/telemetry.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: TELEMETRY_STUB
+    }));
+    await page.route('**/js/utils.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: UTILS_STUB
+    }));
+    await page.route('**/js/auth.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: AUTH_STUB
+    }));
+    await page.route('**/js/db.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: DB_STUB
+    }));
+    await page.route('**/js/notification-preferences.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: NOTIFICATION_PREFERENCES_STUB
+    }));
+    await page.route('**/js/push-notifications.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: PUSH_NOTIFICATIONS_STUB
+    }));
+}
+
+test('legacy profile team alerts load, switch, and save per-team preferences', async ({ page, baseURL }) => {
+    await mockProfileDependencies(page, {
+        memberTeams: [
+            { id: 'team-2', name: 'Bravo' },
+            { id: 'team-1', name: 'Alpha' }
+        ],
+        parentTeams: [
+            { id: 'team-3', name: 'Cougars' }
+        ],
+        preferencesByTeam: {
+            'team-1': { liveScore: true, liveChat: false, scheduleChanges: true },
+            'team-2': { liveScore: false, liveChat: true, scheduleChanges: false },
+            'team-3': { liveScore: true, liveChat: true, scheduleChanges: false }
+        }
+    });
+
+    await page.goto(`${baseURL}/profile.html`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#fullName')).toHaveValue('Pat Parent');
+    await expect(page.locator('#notification-team-select')).toHaveValue('team-1');
+    await expect(page.locator('#notification-team-select option')).toHaveCount(4);
+    await expect(page.getByLabel('Live Score')).toBeChecked();
+    await expect(page.getByLabel('Live Chat')).not.toBeChecked();
+    await expect(page.getByLabel('Schedule Changes')).toBeChecked();
+
+    await page.locator('#notification-team-select').selectOption('team-2');
+    await expect(page.getByLabel('Live Score')).not.toBeChecked();
+    await expect(page.getByLabel('Live Chat')).toBeChecked();
+    await expect(page.getByLabel('Schedule Changes')).not.toBeChecked();
+
+    await page.getByLabel('Live Score').check();
+    await page.getByLabel('Schedule Changes').check();
+    await page.locator('#save-notification-prefs-btn').click();
+
+    await expect(page.locator('#notification-status')).toHaveText('Notification preferences saved.');
+    await expect(page.locator('#notification-status')).toHaveClass(/text-green-600/);
+
+    await expect.poll(() => page.evaluate(() => window.__profileSmoke.savedPreferences)).toEqual([
+        {
+            userId: 'user-1',
+            teamId: 'team-2',
+            preferences: {
+                liveScore: true,
+                liveChat: true,
+                scheduleChanges: true
+            }
+        }
+    ]);
+});
+
+test('legacy profile preserves the rest of the page when notification bootstrap fails', async ({ page, baseURL }) => {
+    await mockProfileDependencies(page, {
+        memberTeams: [
+            { id: 'team-2', name: 'Bravo' },
+            { id: 'team-1', name: 'Alpha' }
+        ],
+        parentTeams: [
+            { id: 'team-3', name: 'Cougars' }
+        ],
+        preferencesByTeam: {
+            'team-1': { liveScore: true, liveChat: false, scheduleChanges: true }
+        },
+        failPreferenceTeamIds: ['team-1']
+    });
+
+    await page.goto(`${baseURL}/profile.html`, { waitUntil: 'domcontentloaded' });
+
+    await expect.poll(() => page.evaluate(() => ({
+        preferenceLoads: window.__profileSmoke.preferenceLoads,
+        accessCodeLoads: window.__profileSmoke.accessCodeLoads,
+        authErrors: window.__profileSmoke.authErrors || [],
+        notificationStatus: document.getElementById('notification-status')?.textContent || ''
+    }))).toEqual({
+        preferenceLoads: ['team-1'],
+        accessCodeLoads: 1,
+        authErrors: [],
+        notificationStatus: 'Unable to load notification preferences right now. The rest of your profile is still available.'
+    });
+    await expect(page.locator('#notification-status')).toHaveClass(/text-red-600/);
+    await expect(page.locator('#notification-team-select')).toHaveValue('team-1');
+    await expect.poll(() => page.locator('#account-merge-section').evaluate((element) => !element.classList.contains('hidden'))).toBe(true);
+    await expect(page.locator('#access-codes-list')).toContainText('No codes generated yet');
+    await expect(page.locator('#fullName')).toHaveValue('Pat Parent');
+});


### PR DESCRIPTION
Closes #3269

## What changed
- wrapped legacy `profile.html` notification bootstrap so failed team or preference reads no longer abort the rest of profile initialization
- preserved the team selector bootstrap when team reads succeed but per-team preference hydration fails, and surfaced an inline recovery message instead of failing silently
- added focused Playwright smoke coverage for the shipped legacy `profile.html` flow to verify team loading, team switching, preference saving, and bootstrap recovery

## Root Cause
The legacy profile page awaited notification team and preference fetches inline during authenticated startup with no recovery boundary. When either async read rejected, the rejection escaped the bootstrap path and prevented downstream profile flows from finishing.

## Prevention / Learning
Treat secondary profile panels like notification settings as recoverable async slices, not hard blockers for the entire authenticated page. Add route-level regression coverage for both the happy path and a rejected dependency whenever legacy HTML pages bootstrap multiple account features in sequence.

## Regression Tests
- `tests/smoke/profile-legacy-notifications.spec.js`
- `SMOKE_BASE_URL=http://127.0.0.1:8001 npx playwright test tests/smoke/profile-legacy-notifications.spec.js --config=playwright.smoke.config.js --reporter=line`

## Recurrence Risk
low: notification bootstrap now degrades locally and the new smoke spec covers both successful loading and rejected preference hydration.