### PR TITLE
Add real edit-config access smoke coverage

### DIFF
--- a/tests/smoke/edit-config-access-control.spec.js
+++ b/tests/smoke/edit-config-access-control.spec.js
@@ -1,0 +1,201 @@
+import { test, expect } from '@playwright/test';
+
+const UTILS_STUB = `
+export function renderHeader() {}
+export function renderFooter() {}
+export function getUrlParams() {
+    return { teamId: 'team-a' };
+}
+`;
+
+const TEAM_ADMIN_BANNER_STUB = `
+export function renderTeamAdminBanner(container, { team, active = 'stats', unreadCount = 0 } = {}) {
+    container.innerHTML = '<div data-testid="team-admin-banner">' + (team?.name || 'Unknown Team') + '|' + active + '|' + unreadCount + '</div>';
+}
+`;
+
+const STAT_LEADERBOARDS_STUB = `
+export function parseAdvancedStatDefinitions(input) {
+    if (!input || !String(input).trim()) return [];
+    return String(input)
+        .split('\\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+            const [head] = line.split('|');
+            const [label, statId = ''] = head.split('=');
+            return {
+                id: statId.trim(),
+                label: label.trim(),
+                acronym: label.trim(),
+                type: 'base'
+            };
+        });
+}
+
+export function validateStatDefinitionsForPublicLeaderboards() {
+    return { valid: true, errors: [] };
+}
+`;
+
+const STAT_CONFIG_PRESETS_STUB = `
+const presets = {
+    blank: { name: 'Custom Stat Schema', baseType: 'Custom', columns: [], statDefinitions: [] },
+    basketball: { name: 'Basketball Standard', baseType: 'Basketball', columns: ['PTS', 'REB', 'AST'], statDefinitions: [{ id: 'pts', label: 'PTS', topStat: true }] },
+    soccer: { name: 'Soccer Standard', baseType: 'Soccer', columns: ['GOALS', 'SHOTS'], statDefinitions: [{ id: 'goals', label: 'GOALS', topStat: true }] }
+};
+
+export function getStatConfigPresetOptions() {
+    return [
+        { id: 'blank', label: 'Blank Slate', description: 'Start empty' },
+        { id: 'basketball', label: 'Basketball Standard', description: 'Hoops' },
+        { id: 'soccer', label: 'Soccer Standard', description: 'Soccer' }
+    ];
+}
+
+export function getStatConfigPresetById(id) {
+    return JSON.parse(JSON.stringify(presets[id] || presets.blank));
+}
+
+export function serializeAdvancedStatDefinitions(config) {
+    return (config?.statDefinitions || [])
+        .filter((definition) => definition?.formula || definition?.topStat)
+        .map((definition) => {
+            let line = definition.label + '=' + definition.id;
+            if (definition.formula) line += '|formula=' + definition.formula;
+            if (definition.topStat) line += '|topStat=true';
+            return line;
+        })
+        .join('\\n');
+}
+`;
+
+function buildAuthStub(user) {
+    return `
+export function checkAuth(callback) {
+    callback(${JSON.stringify(user)});
+}
+`;
+}
+
+function buildDbStub(team) {
+    return `
+const configs = [{
+    id: 'cfg-1',
+    name: 'Existing Config',
+    baseType: 'Basketball',
+    columns: ['PTS', 'REB', 'AST'],
+    statDefinitions: [
+        { id: 'pts', label: 'PTS', type: 'base' },
+        { id: 'reb', label: 'REB', type: 'base' },
+        { id: 'ast', label: 'AST', type: 'base' }
+    ]
+}];
+
+export async function getTeam(teamId) {
+    return ${JSON.stringify(team)};
+}
+
+export async function getUserTeams() {
+    return [];
+}
+
+export async function getConfigs() {
+    return configs.map((config) => ({
+        ...config,
+        columns: [...config.columns],
+        statDefinitions: config.statDefinitions.map((definition) => ({ ...definition }))
+    }));
+}
+
+export async function createConfig() {
+    throw new Error('not implemented in test');
+}
+
+export async function updateConfig() {
+    throw new Error('not implemented in test');
+}
+
+export async function deleteConfig() {
+    throw new Error('not implemented in test');
+}
+
+export async function resetTeamStatConfigs() {
+    throw new Error('not implemented in test');
+}
+
+export async function getUnreadChatCount() {
+    return 0;
+}
+`;
+}
+
+async function mockDependencies(page, { user, team }) {
+    await page.route('https://www.googletagmanager.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: ''
+    }));
+    await page.route('**/dashboard.html', (route) => route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<!doctype html><html><body><h1>Dashboard</h1></body></html>'
+    }));
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: buildDbStub(team) }));
+    await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
+    await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: buildAuthStub(user) }));
+    await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
+    await page.route('**/js/stat-leaderboards.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_LEADERBOARDS_STUB }));
+    await page.route('**/js/stat-config-presets.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_CONFIG_PRESETS_STUB }));
+}
+
+test('team coach with case-different auth email can open stat config editor with real access checks', async ({ page, baseURL }) => {
+    await mockDependencies(page, {
+        user: {
+            uid: 'coach-1',
+            email: 'Coach@Example.com',
+            displayName: 'Coach Casey'
+        },
+        team: {
+            id: 'team-a',
+            name: 'Team A',
+            ownerId: 'owner-1',
+            adminEmails: ['coach@example.com']
+        }
+    });
+
+    await page.goto(`${baseURL}/edit-config.html#teamId=team-a`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/edit-config\.html#teamId=team-a$/);
+    await expect(page.locator('#team-name-display')).toHaveText('Team A');
+    await expect(page.locator('#config-list')).toContainText('Existing Config');
+    await expect(page.locator('#add-config-form')).toBeVisible();
+});
+
+test('legacy-normalized coach is denied and redirected by real stat config access checks', async ({ page, baseURL }) => {
+    await mockDependencies(page, {
+        user: {
+            uid: 'coach-1',
+            email: 'coach@example.com',
+            displayName: 'Coach Casey'
+        },
+        team: {
+            id: 'team-a',
+            name: 'Team A',
+            ownerId: 'owner-1',
+            adminEmails: [' Coach@Example.com ']
+        }
+    });
+
+    const dialogs = [];
+    page.on('dialog', async (dialog) => {
+        dialogs.push(dialog.message());
+        await dialog.accept();
+    });
+
+    await page.goto(`${baseURL}/edit-config.html#teamId=team-a`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(/dashboard\.html$/);
+    await expect(page.locator('h1')).toHaveText('Dashboard');
+    expect(dialogs).toEqual(['Team not found or access denied.']);
+});


### PR DESCRIPTION
Closes #3275

## What changed
- added `tests/smoke/edit-config-access-control.spec.js`
- covered the real `js/edit-config-access.js` path for a team coach whose auth email casing differs from `team.adminEmails`
- covered the real deny path for a legacy-normalized coach record that passes normalized team-admin lookup but fails the Firestore-compatible exact-write check, asserting the alert and redirect to `dashboard.html`

## Root Cause
The only browser coverage for `edit-config.html` stubbed `getEditConfigAccessDecision()` to always allow access. That masked regressions in the real authorization path, including the mismatch between normalized team-admin detection in `team-access.js` and the exact `adminEmails.includes(lowercasedAuthEmail)` write check in `edit-config-access.js`.

## Prevention / Learning
Do not rely on a browser test that stubs a privileged access helper as the sole coverage for a protected workflow. Keep at least one real-module browser test for both allow and deny decisions anywhere client-side authorization gates a page.

## Regression Tests
- `npx playwright test tests/smoke/edit-config-access-control.spec.js --config=playwright.smoke.config.js --reporter=line`

## Recurrence Risk
Low. The new smoke spec now exercises both the real coach allow path and the real denial path that depends on rules-compatible config-write access, which was the gap that let this bug class hide.