### PR TITLE
Security: escape number/title/name fields the XSS guard missed

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -2092,7 +2092,7 @@ ${JSON.stringify({
                                 <button onclick="moveCanvasBlock(${i}, 1)" ${i >= state.canvasBlocks.length - 1 ? 'disabled' : ''} class="text-gray-300 hover:text-gray-500 disabled:opacity-30 disabled:cursor-not-allowed" title="Move down">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
                                 </button>
-                                <input type="number" value="${b.duration}" min="1" max="60" class="w-10 text-center text-sm font-bold text-gray-500 border-none bg-transparent focus:bg-primary-50 focus:outline-none rounded" onchange="window._updateBlockDur(${i}, this.value)">
+                                <input type="number" value="${escapeHtml(b.duration)}" min="1" max="60" class="w-10 text-center text-sm font-bold text-gray-500 border-none bg-transparent focus:bg-primary-50 focus:outline-none rounded" onchange="window._updateBlockDur(${i}, this.value)">
                                 <span class="text-xs text-gray-400">min</span>
                                 <button onclick="toggleCanvasBlockEdit(${i})" class="text-gray-300 hover:text-primary-500" title="Edit">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
@@ -2179,11 +2179,11 @@ ${JSON.stringify({
                 <div class="flex flex-wrap items-center gap-3 mt-2 ml-0 sm:ml-7">
                     <div class="flex items-center gap-1">
                         <label class="text-[10px] text-gray-500">Groups:</label>
-                        <input type="number" value="${b.groupCount || 2}" min="1" max="10" class="w-10 text-center text-xs border border-gray-200 rounded px-1 py-0.5" onchange="updateStructureField(${i}, 'groupCount', parseInt(this.value))">
+                        <input type="number" value="${escapeHtml(b.groupCount || 2)}" min="1" max="10" class="w-10 text-center text-xs border border-gray-200 rounded px-1 py-0.5" onchange="updateStructureField(${i}, 'groupCount', parseInt(this.value))">
                     </div>
                     <div class="flex items-center gap-1">
                         <label class="text-[10px] text-gray-500">Rotation:</label>
-                        <input type="number" value="${b.rotationTime || 5}" min="1" max="30" class="w-10 text-center text-xs border border-gray-200 rounded px-1 py-0.5" onchange="updateStructureField(${i}, 'rotationTime', parseInt(this.value))">
+                        <input type="number" value="${escapeHtml(b.rotationTime || 5)}" min="1" max="30" class="w-10 text-center text-xs border border-gray-200 rounded px-1 py-0.5" onchange="updateStructureField(${i}, 'rotationTime', parseInt(this.value))">
                         <span class="text-[10px] text-gray-400">min</span>
                     </div>
                 </div>` : '';
@@ -2830,7 +2830,7 @@ ${JSON.stringify({
                 const isUser = msg.role === 'user';
                 return `
                     <div class="${isUser ? 'text-right' : 'text-left'}">
-                        <p class="text-[10px] ${isUser ? 'text-gray-500' : 'text-indigo-600'} font-semibold mb-0.5">${isUser ? (state.user?.displayName || 'Coach') : 'ALL PLAYS COACH'}</p>
+                        <p class="text-[10px] ${isUser ? 'text-gray-500' : 'text-indigo-600'} font-semibold mb-0.5">${isUser ? escapeHtml(state.user?.displayName || 'Coach') : 'ALL PLAYS COACH'}</p>
                         <div class="inline-block max-w-[95%] ${isUser ? 'bg-indigo-100 text-gray-800' : 'bg-gray-100 text-gray-700'} rounded-md px-2 py-1">
                             ${escapeHtml(msg.content || '')}
                         </div>

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -2411,7 +2411,7 @@ EXAMPLES:
                                             onchange="updatePlayerOperation(${index}, 'name', this.value)"
                                             class="font-semibold bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1"
                                             placeholder="Player Name">
-                                        <input type="text" value="${player.number || ''}"
+                                        <input type="text" value="${escapeHtml(player.number || '')}"
                                             onchange="updatePlayerOperation(${index}, 'number', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full"
                                             placeholder="Number (optional)">
@@ -2431,7 +2431,7 @@ EXAMPLES:
                                     <div class="text-sm">
                                         Player ID: ${op.playerId}<br>
                                         Changes: ${JSON.stringify(op.changes)}<br>
-                                        <span class="text-xs text-gray-600">${op.reason || ''}</span>
+                                        <span class="text-xs text-gray-600">${escapeHtml(op.reason || '')}</span>
                                     </div>
                                 </div>
                                 <button onclick="removePlayerOperation(${index})"
@@ -2447,7 +2447,7 @@ EXAMPLES:
                                     <div class="text-xs font-bold text-red-700 uppercase mb-1">⏸️ Deactivate</div>
                                     <div class="text-sm">
                                         Player ID: ${op.playerId}<br>
-                                        <span class="text-xs text-gray-600">${op.reason || 'Deactivate from active roster (preserve history)'}</span>
+                                        <span class="text-xs text-gray-600">${escapeHtml(op.reason || 'Deactivate from active roster (preserve history)')}</span>
                                     </div>
                                 </div>
                                 <button onclick="removePlayerOperation(${index})"
@@ -2463,7 +2463,7 @@ EXAMPLES:
                                     <div class="text-xs font-bold text-emerald-700 uppercase mb-1">▶️ Reactivate</div>
                                     <div class="text-sm">
                                         Player ID: ${op.playerId}<br>
-                                        <span class="text-xs text-gray-600">${op.reason || 'Reactivate to active roster'}</span>
+                                        <span class="text-xs text-gray-600">${escapeHtml(op.reason || 'Reactivate to active roster')}</span>
                                     </div>
                                 </div>
                                 <button onclick="removePlayerOperation(${index})"

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2518,7 +2518,7 @@
                             ${badges}
                         </div>
                         <div class="text-sm text-gray-500 font-semibold uppercase tracking-wide mb-1">${formatDate(practice.date)} • ${timeDisplay || formatTime(practice.date)}</div>
-                        <div class="text-lg font-bold text-gray-900">${practice.title || 'Practice'}</div>
+                        <div class="text-lg font-bold text-gray-900">${escapeHtml(practice.title || 'Practice')}</div>
                         <div class="text-sm text-gray-600">
                             ${mapLink(practice.location) ? `<a class="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer" href="${mapLink(practice.location)}">${practice.location || 'TBD'}</a>` : (practice.location || 'TBD')}
                         </div>
@@ -4868,7 +4868,7 @@ PARSING RULES:
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
                                         <textarea rows="2" placeholder="Notes"
                                             onchange="updateOperation(${index}, 'notes', this.value)"
-                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">${game.notes || ''}</textarea>
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">${escapeHtml(game.notes || '')}</textarea>
                                         <input type="text" value="${formatAssignmentsForInput(game.assignments)}" placeholder="Assignments: Role:Value; Role2:Value2"
                                             onchange="updateOperation(${index}, 'assignments', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
@@ -4889,7 +4889,7 @@ PARSING RULES:
                                     <div class="text-sm">
                                         Game ID: ${op.gameId}<br>
                                         Changes: ${JSON.stringify(op.changes)}<br>
-                                        <span class="text-xs text-gray-600">${op.reason || ''}</span>
+                                        <span class="text-xs text-gray-600">${escapeHtml(op.reason || '')}</span>
                                     </div>
                                 </div>
                                 <button onclick="removeOperation(${index})"
@@ -4905,7 +4905,7 @@ PARSING RULES:
                                     <div class="text-xs font-bold text-red-700 uppercase mb-1">🗑️ Delete</div>
                                     <div class="text-sm">
                                         Game ID: ${op.gameId}<br>
-                                        <span class="text-xs text-gray-600">${op.reason || 'Removed from schedule'}</span>
+                                        <span class="text-xs text-gray-600">${escapeHtml(op.reason || 'Removed from schedule')}</span>
                                     </div>
                                 </div>
                                 <button onclick="removeOperation(${index})"

--- a/edit-team.html
+++ b/edit-team.html
@@ -1275,7 +1275,7 @@
                 if (rolloverSourceTeams.length === 0) return;
 
                 sourceSelect.innerHTML = '<option value="">Do not copy access</option>' + rolloverSourceTeams.map((team) => `
-                    <option value="${team.id}">${team.name || 'Untitled team'}</option>
+                    <option value="${escapeHtml(team.id)}">${escapeHtml(team.name || 'Untitled team')}</option>
                 `).join('');
                 sourceSelect.addEventListener('change', renderRolloverAccessPreview);
                 panel.classList.remove('hidden');

--- a/game-plan.html
+++ b/game-plan.html
@@ -746,7 +746,7 @@
                          draggable="true"
                          data-player-id="${p.id}">
                         <div class="w-10 h-10 mx-auto rounded-full bg-gradient-to-br from-primary-100 to-primary-200 flex items-center justify-center border-2 border-primary-300 mb-1">
-                            <span class="font-bold text-primary-700 text-sm">${p.number || '?'}</span>
+                            <span class="font-bold text-primary-700 text-sm">${escapeHtml(p.number || '?')}</span>
                         </div>
                         <div class="text-xs font-semibold text-gray-900 truncate">${escapeHtml(p.name)}</div>
                     </div>
@@ -1095,7 +1095,7 @@
                             <div class="flex items-center justify-between mb-2">
                                 <div class="flex items-center gap-3">
                                     <div class="w-8 h-8 rounded-full bg-${statusColor}-100 flex items-center justify-center">
-                                        <span class="text-sm font-bold text-${statusColor}-700">${p.number || '?'}</span>
+                                        <span class="text-sm font-bold text-${statusColor}-700">${escapeHtml(p.number || '?')}</span>
                                     </div>
                                     <div>
                                         <span class="font-semibold text-gray-900">${escapeHtml(p.name)}</span>

--- a/registration.html
+++ b/registration.html
@@ -99,7 +99,7 @@
 
     <script type="module">
         import { db, doc, getDoc, getFunctions, httpsCallable } from './js/firebase.js?v=19';
-        import { renderHeader, renderFooter } from './js/utils.js?v=8';
+        import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { cancelStripeRegistrationCheckout, initiateStripeCheckout } from './js/stripe-service.js';
         import {
             calculateRegistrationFeeSnapshot,
@@ -459,7 +459,7 @@
             const snapshot = calculateRegistrationFeeSnapshot(form, { quantity: getRegistrationQuantity(), now: new Date() });
             container.innerHTML = formatFeeSnapshotLines(snapshot).map(line => `
                 <div class="flex justify-between gap-4 ${line.strong ? 'border-t border-indigo-200 pt-2 font-semibold text-gray-900' : 'text-gray-700'}">
-                    <span>${line.label}</span>
+                    <span>${escapeHtml(line.label)}</span>
                     <span>${formatFeeAmount(line.amountCents, snapshot.currency)}</span>
                 </div>
             `).join('');

--- a/tests/smoke/edit-roster-xss-escaping.spec.js
+++ b/tests/smoke/edit-roster-xss-escaping.spec.js
@@ -6,6 +6,7 @@ import { test, expect } from '@playwright/test';
 // genuinely exercises the fix at edit-roster.html:2410.
 
 const MALICIOUS_NAME = '"><img src=x onerror="window.__xssFired=true">';
+const MALICIOUS_NUMBER = '"><img src=y onerror="window.__xssFired=true">';
 
 // Real escapeHtml from js/utils.js — inlined so the stub does NOT neuter the fix.
 const UTILS_STUB = `
@@ -125,7 +126,7 @@ export function getGenerativeModel() {
                     text() {
                         return JSON.stringify({
                             operations: [
-                                { action: 'add', player: { name: ${JSON.stringify(MALICIOUS_NAME)}, number: '12' } }
+                                { action: 'add', player: { name: ${JSON.stringify(MALICIOUS_NAME)}, number: ${JSON.stringify(MALICIOUS_NUMBER)} } }
                             ]
                         });
                     }
@@ -163,11 +164,13 @@ test('malicious AI-imported player name is escaped in proposed changes (no XSS)'
     await expect(page.locator('#proposed-changes-section')).toBeVisible();
 
     const nameInput = page.locator('#proposed-changes-list input[placeholder="Player Name"]');
-    // The full payload is preserved as an inert input value (proves it was escaped
-    // into the attribute, not parsed as markup).
+    const numberInput = page.locator('#proposed-changes-list input[placeholder="Number (optional)"]');
+    // The full payloads are preserved as inert input values (proves both the name
+    // and the jersey number were escaped into the attribute, not parsed as markup).
     await expect(nameInput).toHaveValue(MALICIOUS_NAME);
+    await expect(numberInput).toHaveValue(MALICIOUS_NUMBER);
 
-    // No injected element and no fired handler.
+    // No injected element and no fired handler from either field.
     expect(await page.locator('#proposed-changes-list img').count()).toBe(0);
     expect(await page.evaluate(() => window.__xssFired)).toBeFalsy();
 });

--- a/tests/smoke/registration-public.spec.js
+++ b/tests/smoke/registration-public.spec.js
@@ -129,6 +129,14 @@ async function mockRegistrationModules(page, { form = registrationForm(), submit
                 export function renderFooter(container) {
                     if (container) container.innerHTML = '<footer data-test-id="mock-footer"></footer>';
                 }
+                export function escapeHtml(value) {
+                    return String(value ?? '')
+                        .replace(/&/g, '&amp;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;')
+                        .replace(/\"/g, '&quot;')
+                        .replace(/'/g, '&#39;');
+                }
             `
         });
     });

--- a/tests/unit/xss-no-unescaped-interpolation-guard.test.js
+++ b/tests/unit/xss-no-unescaped-interpolation-guard.test.js
@@ -71,22 +71,45 @@ function listLegacyFiles() {
     return [...htmlFiles, ...walk(jsDir)];
 }
 
+function getInterpolationExpression(interpolationMatch) {
+    return interpolationMatch.slice(interpolationMatch.indexOf('${') + 2, -1).trim();
+}
+
+function isSafeNumericReadout(interpolationMatch) {
+    const expression = getInterpolationExpression(interpolationMatch);
+    // Numeric readouts (e.g. ${String(x.description || '').length}) render a
+    // count, not the user string, so they are inert. Apply this only when the
+    // rendered expression itself is the numeric readout, not when a later
+    // fallback branch happens to reference a count.
+    return /^\s*(?:String\([^)]*\)|[^|()]+)\.(length|size|count)\s*(?:\|\|[^|]*)?\s*$/.test(expression);
+}
+
 function findUnescapedSinks(source) {
     const offenders = [];
     for (const match of source.matchAll(MARKUP_INTERP)) {
-        const expression = match[2];
+        const expression = getInterpolationExpression(match[0]);
         // Safe if the value is escaped (or is a runtime Error message, which is
         // not user-stored content and surfaces only in dev error toasts).
         if (expression.includes('escapeHtml(')) continue;
         if (/\b(error|err|e)\.(message|name)$/.test(expression)) continue;
-        // Numeric readouts (e.g. ${String(x.description || '').length}) render a
-        // count, not the user string, so they are inert.
-        if (/\.(length|size|count)\b/.test(match[0])) continue;
+        if (isSafeNumericReadout(match[0])) continue;
         const line = source.slice(0, match.index).split('\n').length;
         offenders.push(`${expression} (line ${line})`);
     }
     return offenders;
 }
+
+describe('findUnescapedSinks', () => {
+    it('allows numeric readouts when the rendered branch is a count', () => {
+        const offenders = findUnescapedSinks('<span>${String(player.description || \"\").length || 0}</span>');
+        expect(offenders).toEqual([]);
+    });
+
+    it('still flags unescaped user data when only the fallback is numeric', () => {
+        const offenders = findUnescapedSinks('<span>${row.name || totals.count}</span>');
+        expect(offenders).toEqual(['row.name || totals.count (line 1)']);
+    });
+});
 
 describe('legacy XSS guard: no unescaped user-data interpolation in markup', () => {
     const files = listLegacyFiles();

--- a/tests/unit/xss-no-unescaped-interpolation-guard.test.js
+++ b/tests/unit/xss-no-unescaped-interpolation-guard.test.js
@@ -31,14 +31,27 @@ const USER_DATA_FIELDS = [
     'comment',
     'description',
     'photoUrl',
-    'title'
+    'title',
+    // Added after a Codex review caught player.number rendering unescaped.
+    'number',
+    'jersey',
+    'reason',
+    'nickname',
+    'firstName',
+    'lastName',
+    'phone',
+    'address',
+    'school',
+    'grade'
 ];
 
 const fieldAlternation = USER_DATA_FIELDS.join('|');
 // An interpolation in markup context: preceded by `>` (element text) or `="`
-// (attribute value), referencing a user-data field as the final property.
+// (attribute value), referencing a user-data field as the final property. The
+// trailing `(?:\s*\|\|[^{}]*)?` matches `${ field || 'default' }` forms, which
+// an earlier version of this guard missed.
 const MARKUP_INTERP = new RegExp(
-    `(>|=")\\$\\{([^{}]*\\.(?:${fieldAlternation}))[a-zA-Z0-9_?]*\\}`,
+    `(>|=")\\$\\{([^{}]*\\.(?:${fieldAlternation}))[a-zA-Z0-9_?]*(?:\\s*\\|\\|[^{}]*)?\\}`,
     'g'
 );
 
@@ -66,6 +79,9 @@ function findUnescapedSinks(source) {
         // not user-stored content and surfaces only in dev error toasts).
         if (expression.includes('escapeHtml(')) continue;
         if (/\b(error|err|e)\.(message|name)$/.test(expression)) continue;
+        // Numeric readouts (e.g. ${String(x.description || '').length}) render a
+        // count, not the user string, so they are inert.
+        if (/\.(length|size|count)\b/.test(match[0])) continue;
         const line = source.slice(0, match.index).split('\n').length;
         offenders.push(`${expression} (line ${line})`);
     }


### PR DESCRIPTION
Follow-up to the merged security work. The Codex review on #3255 correctly flagged that the bulk-AI import still rendered `player.number` **unescaped** — and that exposed two blind spots in the XSS guard. This PR fixes both the sinks and the guard.

## Why the earlier guard missed these
1. **Field allowlist** didn't include `number` (jersey), `reason`, etc.
2. **Regex** didn't match `${ field || 'default' }` — the most common legacy form — so even listed fields slipped through.

Strengthening the guard immediately surfaced **9 unescaped sinks** (the original Codex one plus 8 more it now catches).

## Sinks fixed (stored/user/AI data → `innerHTML`)
- **Jersey numbers:** `edit-roster.html` (import preview input), `game-plan.html` (×2 lineup spans)
- **Notes / titles:** `edit-schedule.html` game notes `<textarea>` (breakout via `</textarea>`), practice title
- **AI-generated `op.reason`:** `edit-roster.html` (×3), `edit-schedule.html` (×2)
- **Team name/option:** `edit-team.html`
- **Drill block numbers + author name:** `drills.html` (duration/groupCount/rotationTime, `displayName`)
- **Registration fee line labels:** `registration.html` (admin-defined → shown to public registrants; added `escapeHtml` import)

## Guard hardening (`xss-no-unescaped-interpolation-guard`)
- Added `number`, `jersey`, `reason`, `nickname`, `firstName`, `lastName`, `phone`, `address`, `school`, `grade` to the user-data list.
- Match `${ field || 'default' }` forms.
- Skip numeric `.length`/`.size`/`.count` readouts (inert) to avoid false positives like `${String(x.description||'').length}`.

## Test (Codex's specific ask)
- Extended `edit-roster-xss-escaping` smoke test to feed a **malicious jersey number** and assert the number input is escaped too — not just the name.

## Verification
- **3629/3629 unit tests pass** (guard now green across 251 legacy files).
- Smoke test verified against headless Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)