### PR TITLE
Add expired family share link regression coverage

### DIFF
--- a/test-family-sharing.html
+++ b/test-family-sharing.html
@@ -199,9 +199,21 @@
         }
 
         // Token validation logic from family.html init()
+        function toDateSafe(value) {
+            if (!value) return null;
+            const d = value?.toDate ? value.toDate() : new Date(value);
+            return Number.isNaN(d?.getTime?.()) ? null : d;
+        }
+
+        function isFamilyShareTokenExpired(token) {
+            const expiresAt = toDateSafe(token?.expiresAt);
+            return Boolean(expiresAt && expiresAt.getTime() <= Date.now());
+        }
+
         function isTokenValid(token) {
             if (!token) return false;
             if (token.active === false) return false;
+            if (isFamilyShareTokenExpired(token)) return false;
             return true;
         }
 
@@ -697,6 +709,20 @@
 
         test('Token validation', 'token with active=true is valid', () => {
             assertTrue(isTokenValid({ id: 'tok1', active: true, ownerUserId: 'u1' }), 'Active token should be valid');
+        });
+
+        test('Token validation', 'expired token is invalid', () => {
+            assertFalse(
+                isTokenValid({ id: 'tok1', active: true, ownerUserId: 'u1', expiresAt: new Date(Date.now() - HOUR).toISOString() }),
+                'Expired token should be invalid even when active=true'
+            );
+        });
+
+        test('Token validation', 'future expiresAt token remains valid', () => {
+            assertTrue(
+                isTokenValid({ id: 'tok1', active: true, ownerUserId: 'u1', expiresAt: new Date(Date.now() + HOUR).toISOString() }),
+                'Future expiry should not block a healthy token'
+            );
         });
 
         test('Token validation', 'token without active field is valid (legacy/new)', () => {

--- a/tests/unit/family-share-expiry-init.test.js
+++ b/tests/unit/family-share-expiry-init.test.js
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import { JSDOM } from 'jsdom';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+function readFamilyPage() {
+    return readFileSync(path.join(repoRoot, 'family.html'), 'utf8');
+}
+
+function extractFamilyModuleScript(source) {
+    const matches = [...source.matchAll(/<script type="module">([\s\S]*?)<\/script>/g)];
+    const moduleScript = matches.at(-1)?.[1];
+    if (!moduleScript) {
+        throw new Error('Could not find family module script');
+    }
+
+    return moduleScript.replace(/^\s*import[\s\S]*?;\s*$/gm, '');
+}
+
+async function flushAsyncWork() {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createHarness({ token, url = 'https://example.test/family.html?token=share-token' }) {
+    const familyPage = readFamilyPage();
+    const moduleScript = extractFamilyModuleScript(familyPage);
+    const dom = new JSDOM(familyPage, {
+        url,
+        runScripts: 'outside-only'
+    });
+
+    const mocks = {
+        getFamilyShareToken: vi.fn().mockResolvedValue(token),
+        resolveFamilyShareTokenChildren: vi.fn().mockResolvedValue([]),
+        getTeam: vi.fn().mockResolvedValue({ name: 'Team Rocket', calendarUrls: [] }),
+        getGames: vi.fn().mockResolvedValue([]),
+        getTrackedCalendarEventUids: vi.fn().mockResolvedValue([]),
+        resolveScheduleWatchCta: vi.fn().mockReturnValue(null),
+        renderHeader: vi.fn(),
+        renderFooter: vi.fn(),
+        escapeHtml: (value = '') => String(value)
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;'),
+        fetchAndParseCalendar: vi.fn().mockResolvedValue([]),
+        extractOpponent: vi.fn().mockReturnValue('Opponent'),
+        isPracticeEvent: vi.fn().mockReturnValue(false),
+        expandRecurrence: vi.fn().mockReturnValue([]),
+        getCalendarEventTrackingId: vi.fn().mockReturnValue(null),
+        isTrackedCalendarEvent: vi.fn().mockReturnValue(false),
+        alert: vi.fn(),
+        console: {
+            error: vi.fn(),
+            warn: vi.fn(),
+            log: vi.fn()
+        }
+    };
+
+    const context = vm.createContext({
+        ...mocks,
+        window: dom.window,
+        document: dom.window.document,
+        navigator: dom.window.navigator,
+        location: dom.window.location,
+        URL: dom.window.URL,
+        URLSearchParams: dom.window.URLSearchParams,
+        Blob: dom.window.Blob,
+        setTimeout,
+        clearTimeout,
+        Date,
+        Promise,
+        Map,
+        Array,
+        Object,
+        String,
+        Number,
+        Boolean,
+        Math,
+        JSON,
+        globalThis: {}
+    });
+
+    vm.runInContext(moduleScript, context);
+
+    return {
+        dom,
+        document: dom.window.document,
+        mocks
+    };
+}
+
+describe('family share page init expiry handling', () => {
+    it('shows the explicit expired-link message and stops before loading family data', async () => {
+        const harness = createHarness({
+            token: {
+                id: 'share-token',
+                active: true,
+                label: 'Grandma Share',
+                expiresAt: new Date(Date.now() - 60_000).toISOString(),
+                children: [{ teamId: 'team-1', playerId: 'player-1', teamName: 'Rockets', playerName: 'Ava' }]
+            }
+        });
+
+        await flushAsyncWork();
+
+        expect(harness.mocks.getFamilyShareToken).toHaveBeenCalledWith('share-token');
+        expect(harness.document.getElementById('page-loading').classList.contains('hidden')).toBe(true);
+        expect(harness.document.getElementById('page-error').classList.contains('hidden')).toBe(false);
+        expect(harness.document.getElementById('page-error-title').textContent).toBe('This link has expired');
+        expect(harness.document.getElementById('page-error-detail').textContent).toBe('Ask the parent to create a new family share link. Expired links never load player, team, or schedule details.');
+        expect(harness.document.getElementById('page-main').classList.contains('hidden')).toBe(true);
+        expect(harness.mocks.renderHeader).not.toHaveBeenCalled();
+        expect(harness.mocks.getTeam).not.toHaveBeenCalled();
+    });
+
+    it('continues through init for a valid non-expired token', async () => {
+        const harness = createHarness({
+            token: {
+                id: 'share-token',
+                active: true,
+                label: 'Grandma Share',
+                expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+                children: [{ teamId: 'team-1', playerId: 'player-1', teamName: 'Rockets', playerName: 'Ava' }],
+                extraCalendarUrls: []
+            }
+        });
+
+        await flushAsyncWork();
+        await flushAsyncWork();
+
+        expect(harness.mocks.renderHeader).toHaveBeenCalled();
+        expect(harness.mocks.getTeam).toHaveBeenCalledWith('team-1');
+        expect(harness.document.getElementById('page-error').classList.contains('hidden')).toBe(true);
+        expect(harness.document.getElementById('page-loading').classList.contains('hidden')).toBe(true);
+        expect(harness.document.getElementById('page-main').classList.contains('hidden')).toBe(false);
+        expect(harness.document.getElementById('page-title').textContent).toBe('Grandma Share');
+        expect(harness.document.getElementById('players-list').textContent).toContain('Ava');
+        expect(harness.document.title).toBe('Grandma Share - ALL PLAYS');
+    });
+});


### PR DESCRIPTION
Closes #3280

## What changed
- added a focused Vitest jsdom regression test for `family.html` init handling of expired and non-expired share tokens
- updated `test-family-sharing.html` so its mirrored token-validation helper now matches the real `expiresAt` guard in `family.html`
- added manual-suite cases for expired and future-dated tokens so the dedicated family-sharing page no longer drifts on this branch

## Root Cause
The dedicated family-sharing test suite had drifted from production logic. Its mirrored token-validity helper only rejected missing or revoked tokens, so `family.html`'s later `expiresAt` gate and user-facing expired-link state were never exercised.

## Prevention / Learning
When a legacy test page mirrors production access-gate logic, keep every first-paint validity branch aligned, especially time-based states like expiry. Back that mirrored helper with an automated DOM-level init test so future copy drift is caught quickly.

## Regression Tests
- `npx vitest run tests/unit/family-share-expiry-init.test.js --reporter=verbose`
- manual suite coverage in `test-family-sharing.html` for expired and future-dated tokens

## Recurrence Risk
Low. The expired-link branch and the healthy-link pass-through branch are now both covered, and the dedicated family-sharing suite matches the real page guard again.