### PR TITLE
Hide single-option registration picker

### DIFF
--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -92,7 +92,7 @@ function renderParentRegistration() {
 
 describe('RegistrationDetail payment notice', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    Object.values(parentToolsServiceMocks).forEach((mock) => mock.mockReset());
     openPublicUrlMock.mockReset();
   });
 
@@ -168,6 +168,62 @@ describe('RegistrationDetail payment notice', () => {
     expect(openPublicUrlMock).toHaveBeenCalledWith('https://stripe.example/checkout');
   });
 
+  it('hides the registration option selector when exactly one active option exists and still submits that option', async () => {
+    parentToolsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail({
+      options: [{ id: 'option-1', title: 'Varsity', capacity: 12, active: true }],
+      form: {
+        registrationOptionCounts: {
+          'option-1': { enrolled: 4 }
+        }
+      }
+    }));
+    parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValue({
+      status: 'pending',
+      registrationId: 'registration-1'
+    });
+
+    renderParentRegistration();
+
+    expect(await screen.findByLabelText('Selected registration option')).toBeTruthy();
+    expect(screen.getByText('Varsity')).toBeTruthy();
+    expect(screen.getByText('8 spots left')).toBeTruthy();
+    expect(screen.queryByLabelText('Registration option')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit registration' }));
+
+    await waitFor(() => expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+      'team-1',
+      'form-1',
+      expect.objectContaining({
+        selectedOptionId: 'option-1',
+        selectedOption: expect.objectContaining({ id: 'option-1', title: 'Varsity' })
+      })
+    ));
+  });
+
+  it('keeps the selector for multiple active options', async () => {
+    parentToolsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail({
+      options: [
+        { id: 'option-1', title: 'Varsity', capacity: 12, active: true },
+        { id: 'option-2', title: 'Junior Varsity', capacity: 12, active: true }
+      ],
+      form: {
+        registrationOptionCounts: {
+          'option-1': { enrolled: 4 },
+          'option-2': { enrolled: 6 }
+        }
+      }
+    }));
+
+    renderParentRegistration();
+
+    const optionSelect = await screen.findByLabelText('Registration option');
+    expect(optionSelect).toBeTruthy();
+    expect(screen.queryByLabelText('Selected registration option')).toBeNull();
+    expect(screen.getByRole('option', { name: 'Varsity' })).toBeTruthy();
+    expect(screen.getByRole('option', { name: 'Junior Varsity' })).toBeTruthy();
+  });
+
   it('shows the first installment due now plus the remaining schedule before checkout', async () => {
     parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       onlineCheckout: true,
@@ -232,7 +288,7 @@ describe('RegistrationDetail payment notice', () => {
     expect(screen.getByText('Your installment payment was received. Here is what remains on your payment schedule.')).toBeTruthy();
     expect(screen.getByLabelText('Remaining installment schedule')).toBeTruthy();
     expect(screen.getByText('Remaining balance')).toBeTruthy();
-    expect(screen.getByText('$41.68')).toBeTruthy();
+    expect(screen.getAllByText('$41.68')).toHaveLength(2);
     expect(screen.queryByText('Installment 2 · Due Jul 31, 2026')).toBeNull();
     expect(screen.getByText('Installment 3 · Due Aug 30, 2026')).toBeTruthy();
   });

--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RegistrationDetail } from './RegistrationDetail';
 import type { AuthState } from '../lib/types';
@@ -84,6 +84,30 @@ function renderParentRegistration() {
     <MemoryRouter initialEntries={['/parent-tools/registrations/team-1/form-1']}>
       <Routes>
         <Route path="/parent-tools/registrations/:teamId/:formId" element={<RegistrationDetail auth={auth} />} />
+        <Route path="/parent-tools/registrations" element={<div>Registrations</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function RouteSwapButton({ to }: { to: string }) {
+  const navigate = useNavigate();
+  return <button type="button" onClick={() => navigate(to)}>Swap route</button>;
+}
+
+function renderParentRegistrationWithRouteSwap() {
+  return render(
+    <MemoryRouter initialEntries={['/parent-tools/registrations/team-1/form-1']}>
+      <Routes>
+        <Route
+          path="/parent-tools/registrations/:teamId/:formId"
+          element={(
+            <>
+              <RouteSwapButton to="/parent-tools/registrations/team-1/form-2" />
+              <RegistrationDetail auth={auth} />
+            </>
+          )}
+        />
         <Route path="/parent-tools/registrations" element={<div>Registrations</div>} />
       </Routes>
     </MemoryRouter>
@@ -222,6 +246,52 @@ describe('RegistrationDetail payment notice', () => {
     expect(screen.queryByLabelText('Selected registration option')).toBeNull();
     expect(screen.getByRole('option', { name: 'Varsity' })).toBeTruthy();
     expect(screen.getByRole('option', { name: 'Junior Varsity' })).toBeTruthy();
+  });
+
+  it('resets a reused route to the new single active option before submit', async () => {
+    parentToolsServiceMocks.loadParentRegistrationDetail
+      .mockResolvedValueOnce(buildDetail({
+        options: [{ id: 'option-1', title: 'Varsity', capacity: 12, active: true }],
+        form: {
+          registrationOptionCounts: {
+            'option-1': { enrolled: 4 }
+          }
+        }
+      }))
+      .mockResolvedValueOnce(buildDetail({
+        form: {
+          programName: 'Fall Camp',
+          registrationOptionCounts: {
+            'option-2': { enrolled: 2 }
+          }
+        },
+        options: [{ id: 'option-2', title: 'Junior Varsity', capacity: 10, active: true }]
+      }));
+    parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValue({
+      status: 'pending',
+      registrationId: 'registration-2'
+    });
+
+    renderParentRegistrationWithRouteSwap();
+
+    expect(await screen.findByText('Varsity')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Swap route' }));
+
+    expect(await screen.findByText('Fall Camp')).toBeTruthy();
+    expect(screen.getByText('Junior Varsity')).toBeTruthy();
+    expect(screen.queryByLabelText('Registration option')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit registration' }));
+
+    await waitFor(() => expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+      'team-1',
+      'form-2',
+      expect.objectContaining({
+        selectedOptionId: 'option-2',
+        selectedOption: expect.objectContaining({ id: 'option-2', title: 'Junior Varsity' })
+      })
+    ));
   });
 
   it('shows the first installment due now plus the remaining schedule before checkout', async () => {

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -138,7 +138,9 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
   const activeOptions: any[] = useMemo(() => form ? ((Array.isArray(form.options) && form.options.length) ? form.options : getActiveRegistrationOptions(form, form.registrationOptionCounts || {})) : [], [form]);
   const paymentPlanChoices: any[] = useMemo(() => form ? ((Array.isArray(form.paymentPlans) && form.paymentPlans.length) ? form.paymentPlans : getPaymentPlanChoices(form)) : [], [form]);
   const showPaymentPlanSelector = paymentPlanChoices.length > 1;
-  const selectedOption = activeOptions.find((option) => option.id === selectedOptionId) || null;
+  const showRegistrationOptionSelector = activeOptions.length > 1;
+  const singleActiveOption = activeOptions.length === 1 ? activeOptions[0] : null;
+  const selectedOption = activeOptions.find((option) => option.id === selectedOptionId) || singleActiveOption || null;
   const placement = useMemo(() => {
     if (!form || !requiresRegistrationOption(form) || !selectedOptionId) return null;
     return decideRegistrationPlacement({ form, selectedOptionId, counts: form.registrationOptionCounts || {} });
@@ -227,7 +229,8 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     const currentParticipant = collectFieldValues(formRef.current, 'participant', participant);
     const currentGuardian = collectFieldValues(formRef.current, 'guardian', guardian);
     const currentWaiverAccepted = Boolean((formRef.current?.querySelector('[data-waiver-field]') as HTMLInputElement | null)?.checked ?? waiverAccepted);
-    const currentSelectedOptionId = String((formRef.current?.querySelector('[data-selected-option]') as HTMLSelectElement | null)?.value || selectedOptionId);
+    const selectedOptionInput = formRef.current?.querySelector('[data-selected-option]') as HTMLSelectElement | null;
+    const currentSelectedOptionId = selectedOptionInput ? String(selectedOptionInput.value) : selectedOptionId;
     const currentQuantity = hasQuantityDiscount ? Math.max(1, Number((formRef.current?.querySelector('[data-quantity-field]') as HTMLInputElement | null)?.value || quantity) || 1) : 1;
     const currentSelectedPaymentPlanId = String((formRef.current?.querySelector('[data-payment-plan]') as HTMLSelectElement | null)?.value || selectedPaymentPlanId);
     const currentSelectedOption = activeOptions.find((option) => option.id === currentSelectedOptionId) || selectedOption;
@@ -621,19 +624,24 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
           <FieldGroup title="Participant information" fields={form.participantFields || []} values={participant} errors={fieldErrors} prefix="participant" onChange={updateParticipant} disabled={saving} />
           <FieldGroup title="Guardian information" fields={form.guardianFields || []} values={guardian} errors={fieldErrors} prefix="guardian" onChange={updateGuardian} disabled={saving} />
 
-          {activeOptions.length ? (
+          {showRegistrationOptionSelector ? (
             <fieldset className="grid gap-2">
               <legend className="text-sm font-black text-gray-950">Registration options</legend>
               <label className="min-w-0">
                 <span className="app-label">Registration option</span>
                 <select className="auth-input mt-1" data-selected-option value={selectedOptionId} onChange={(event) => setSelectedOptionId(event.target.value)} disabled={saving}>
                   <option value="">Select an option</option>
-                  {activeOptions.map((option) => <option key={option.id} value={option.id}>{option.title}</option>)}
-                </select>
+                  {activeOptions.map((option) => <option key={option.id} value={option.id}>{option.title}</option>)}</select>
               </label>
               {selectedOption ? <div className="text-xs font-semibold text-gray-500">{formatOptionAvailability(selectedOption, form.registrationOptionCounts || {})}</div> : null}
               {fieldErrors.selectedOption ? <InlineError message={fieldErrors.selectedOption} /> : null}
             </fieldset>
+          ) : singleActiveOption ? (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 p-3" aria-label="Selected registration option">
+              <div className="app-label">Registration option</div>
+              <div className="mt-1 text-sm font-black text-gray-950">{singleActiveOption.title}</div>
+              <div className="mt-1 text-xs font-semibold text-gray-500">{formatOptionAvailability(singleActiveOption, form.registrationOptionCounts || {})}</div>
+            </div>
           ) : null}
 
           {hasQuantityDiscount ? (

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -122,7 +122,11 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
         }
         const initialOptions = (Array.isArray(nextForm.options) && nextForm.options.length) ? nextForm.options : getActiveRegistrationOptions(nextForm, nextForm.registrationOptionCounts || {});
         const initialOptionId = selectInitialRegistrationOption(nextForm, initialOptions);
-        setSelectedOptionId((current) => current || initialOptionId);
+        setSelectedOptionId((current) => {
+          if (!current) return initialOptionId;
+          if (initialOptions.length === 1) return initialOptionId;
+          return initialOptions.some((option) => option?.id === current) ? current : initialOptionId;
+        });
       } catch (loadError: any) {
         if (!cancelled) setError(loadError?.message || 'Unable to load registration form.');
       } finally {

--- a/tests/unit/app-parent-tools-registration.test.jsx
+++ b/tests/unit/app-parent-tools-registration.test.jsx
@@ -124,9 +124,10 @@ describe('React app registration detail', () => {
         expect(serviceMocks.loadParentRegistrationDetail).toHaveBeenCalledWith(auth.user, 'team-1', 'form-1');
         expect(container.textContent).toContain('Guardian information');
         expect(container.textContent).toContain('Waiver');
-        expect(container.textContent).toContain('Selected registration option');
-        expect(container.textContent).toContain('Registration option');
-        expect(container.textContent).toContain('5 spots left');
+        const selectedOptionSummary = container.querySelector('[aria-label="Selected registration option"]');
+        expect(selectedOptionSummary).toBeTruthy();
+        expect(selectedOptionSummary?.textContent).toContain('Registration option');
+        expect(selectedOptionSummary?.textContent).toContain('5 spots left');
         expect(container.textContent).toContain('$120.00');
         expect(container.textContent).toContain('Installment plan');
         expect(container.querySelector('label[for="participant-name"]')).toBeTruthy();

--- a/tests/unit/app-parent-tools-registration.test.jsx
+++ b/tests/unit/app-parent-tools-registration.test.jsx
@@ -124,13 +124,14 @@ describe('React app registration detail', () => {
         expect(serviceMocks.loadParentRegistrationDetail).toHaveBeenCalledWith(auth.user, 'team-1', 'form-1');
         expect(container.textContent).toContain('Guardian information');
         expect(container.textContent).toContain('Waiver');
-        expect(container.textContent).toContain('Registration options');
+        expect(container.textContent).toContain('Selected registration option');
+        expect(container.textContent).toContain('Registration option');
         expect(container.textContent).toContain('5 spots left');
         expect(container.textContent).toContain('$120.00');
         expect(container.textContent).toContain('Installment plan');
         expect(container.querySelector('label[for="participant-name"]')).toBeTruthy();
         expect(container.querySelector('#participant-name')).toBeTruthy();
-        expect(container.querySelector('legend')?.textContent).toContain('Registration options');
+        expect(container.querySelector('legend')).toBeNull();
 
         await clickButton(container, 'Legacy form');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/registration.html?teamId=team-1&formId=form-1');

--- a/tests/unit/app-registration-detail.test.jsx
+++ b/tests/unit/app-registration-detail.test.jsx
@@ -214,6 +214,21 @@ async function clickButton(container, text) {
   await flush();
 }
 
+async function ensureRegistrationOptionResolved(container, optionLabel = 'Option 1') {
+  const selector = Array.from(container.querySelectorAll('select')).find(
+    (el) => el.labels && Array.from(el.labels).some((label) => label.textContent.includes('Registration option'))
+  );
+  if (selector) {
+    await changeInputValue(container, 'Registration option', 'opt-1');
+    return;
+  }
+
+  const summary = container.querySelector('[aria-label="Selected registration option"]');
+  if (!summary) throw new Error('Registration option selector or summary not found.');
+  expect(summary.textContent).toContain('Registration option');
+  expect(summary.textContent).toContain(optionLabel);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   registrationFlowMocks.decideRegistrationPlacement.mockImplementation((params) => ({
@@ -923,7 +938,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1'); // Assuming select is handled by option value
+    await ensureRegistrationOptionResolved(container); // Assuming select is handled by option value
 
     await clickButton(container, 'Submit registration');
 
@@ -952,7 +967,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Submit registration');
 
     expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
@@ -992,7 +1007,7 @@ describe('RegistrationDetail page', () => {
 
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await changeInputValue(container, 'Payment plan', 'installments');
     await clickButton(container, 'Submit registration');
 
@@ -1043,7 +1058,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
 
     await clickButton(container, 'Submit registration');
 
@@ -1064,7 +1079,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
 
     await clickButton(container, 'Submit registration');
 
@@ -1100,7 +1115,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
 
     await clickButton(container, 'Pay registration with Stripe');
 
@@ -1178,7 +1193,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
     await waitForText(container, 'Registration submitted. You have been added to the waitlist.');
@@ -1211,7 +1226,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
     await waitForText(container, 'Registration created, but checkout could not be opened. Stripe session failed.');
@@ -1244,7 +1259,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
     await waitForText(container, 'Registration created, but checkout could not be opened. Popup blocked.');
@@ -1400,7 +1415,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
     expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
@@ -1454,7 +1469,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
     expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
@@ -1521,7 +1536,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await changeInputValue(container, 'I accept the waiver.', true);
-    await changeInputValue(container, 'Registration option', 'opt-1');
+    await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
     expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(


### PR DESCRIPTION
Closes #3277

## What changed
- hide the registration-option `<select>` when the form has exactly one active option
- show that lone option as read-only context with its current availability instead
- keep the existing selector path for forms with multiple active options
- add focused `RegistrationDetail` coverage for the single-option and multi-option flows
- tighten submit handling so an explicitly empty option field is not silently replaced by the previous selection

## Root Cause
`RegistrationDetail` treated any non-empty active-options list as a reason to render the chooser, even when the page had already auto-selected the only viable option. That exposed a fake decision in the common single-option flow. Separately, the submit path used a logical-OR fallback when reading the option field, which could mask an intentionally empty value by restoring the prior selection.

## Prevention / Learning
When the data model collapses a workflow to one valid choice, the UI should present that choice as read-only context instead of forcing a redundant control. Also, form-submit code should distinguish between a missing field and an explicitly blank value so validation can reason about real user state.

## Regression Tests
- `apps/app/src/pages/RegistrationDetail.test.tsx` verifies a single active option hides the selector and still submits that option id.
- `apps/app/src/pages/RegistrationDetail.test.tsx` verifies multiple active options still render the selector.
- Validation run: `cd apps/app && npx vitest run src/pages/RegistrationDetail.test.tsx --reporter=verbose`