### PR TITLE
Fix blank family-share page: bump db.js cache version (#3232 gap)

### DIFF
--- a/family.html
+++ b/family.html
@@ -173,7 +173,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getFamilyShareToken, resolveFamilyShareTokenChildren, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=74';
+    import { getFamilyShareToken, resolveFamilyShareTokenChildren, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=76';
     import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';
     import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=14';
 

--- a/tests/unit/family-share-db-cache-bust.test.js
+++ b/tests/unit/family-share-db-cache-bust.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+// Regression for the #3232 gap (Codex P1, unaddressed at merge): family.html
+// imports the newly added `resolveFamilyShareTokenChildren` export from db.js but
+// kept the old `?v=74` cache key. Clients/CDNs holding a cached db.js?v=74 from
+// before the export was added would fail the named import and render a blank
+// family-share page. The import's cache-bust version must be >= 75 (the version
+// at/after which the export exists).
+
+function read(rel) {
+    return readFileSync(new URL(`../../${rel}`, import.meta.url), 'utf8');
+}
+
+describe('family-share db.js cache-busting', () => {
+    const html = read('family.html');
+
+    it('family.html imports resolveFamilyShareTokenChildren from db.js', () => {
+        expect(html).toMatch(/import\s*\{[^}]*\bresolveFamilyShareTokenChildren\b[^}]*\}\s*from\s*'\.\/js\/db\.js\?v=\d+'/);
+    });
+
+    it('the db.js import is not pinned to a pre-export cache version', () => {
+        const match = html.match(/resolveFamilyShareTokenChildren[^}]*\}\s*from\s*'\.\/js\/db\.js\?v=(\d+)'/);
+        expect(match, 'db.js import with the export should exist').toBeTruthy();
+        const version = Number(match[1]);
+        expect(version).toBeGreaterThanOrEqual(75);
+    });
+
+    it('the export actually exists in js/db.js', () => {
+        expect(read('js/db.js')).toMatch(/export\s+(async\s+)?function\s+resolveFamilyShareTokenChildren\b|export\s*\{[^}]*\bresolveFamilyShareTokenChildren\b/);
+    });
+});


### PR DESCRIPTION
## Gap
Auditing yesterday's (2026-06-27) merges, **#3232** ("[codex] Fix legacy family share player loading") merged with an **unresolved Codex P1** that was never addressed (it predates the review-settle gate, so the review landed after merge).

The P1: \`family.html\` imports the **newly added** \`resolveFamilyShareTokenChildren\` export from \`./js/db.js?v=74\`, but the cache version wasn't bumped. A browser/CDN holding a cached \`db.js?v=74\` from *before* the export was added fails the named import — module load aborts before \`init()\`, so the family-share page renders **blank/broken** even for tokens with stored children.

## Fix
- Bump \`family.html\`'s db.js import to \`?v=76\` (past the current max of 75) so clients fetch the db.js that contains the export. \`family.html\` is the only importer of this export.
- Add a regression test (\`tests/unit/family-share-db-cache-bust.test.js\`) that fails on any pre-export (<75) version and verifies the export exists in db.js.

## Verification
- New test passes on the fix, fails on the stale \`?v=74\` (verified both ways).
- Family-share unit suites green.

## Note (separate, pre-existing — not in this PR)
\`tests/unit/app-team-media.test.jsx\` (chat-posting "in-flight" tests) is **flaky under full-suite concurrency** (passes 21/21 in isolation). Not a regression from yesterday; flagging for a dedicated stabilization follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)