### PR TITLE
Default assignments to actionable slots

### DIFF
--- a/apps/app/src/components/schedule/AssignmentsSection.tsx
+++ b/apps/app/src/components/schedule/AssignmentsSection.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AlertCircle, CheckCircle2, ClipboardCheck, RefreshCw } from 'lucide-react';
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronUp, ClipboardCheck, RefreshCw } from 'lucide-react';
 import {
   claimParentScheduleAssignmentSlot,
   loadParentScheduleAssignments,
   releaseParentScheduleAssignmentClaim
 } from '../../lib/scheduleService';
 import {
+  isScheduleAssignmentClaimedByUser,
   isScheduleAssignmentOpen,
   type ScheduleAssignment
 } from '../../lib/scheduleLogic';
@@ -26,6 +27,7 @@ export function AssignmentsSection() {
   const [busyRole, setBusyRole] = useState<string | null>(null);
   const [assignmentStatus, setAssignmentStatus] = useState<string | null>(null);
   const [assignmentError, setAssignmentError] = useState<string | null>(null);
+  const [showFilledAssignments, setShowFilledAssignments] = useState(false);
 
   const handleAssignmentsChanged = useCallback((nextAssignments: ScheduleAssignment[]) => {
     updateEvents((current) => current.map((entry) => (
@@ -91,6 +93,22 @@ export function AssignmentsSection() {
   };
 
   const openCount = assignments.filter(isScheduleAssignmentOpen).length;
+  const userId = auth.user?.uid || '';
+  const actionableAssignments = assignments.filter((assignment) => (
+    isScheduleAssignmentOpen(assignment) || isScheduleAssignmentClaimedByUser(assignment, userId)
+  ));
+  const filledAssignments = assignments.filter((assignment) => !actionableAssignments.includes(assignment));
+  const shouldShowFilledAssignments = !actionableAssignments.length || showFilledAssignments;
+
+  useEffect(() => {
+    if (!filledAssignments.length) {
+      setShowFilledAssignments(false);
+      return;
+    }
+    if (!actionableAssignments.length) {
+      setShowFilledAssignments(true);
+    }
+  }, [actionableAssignments.length, filledAssignments.length]);
 
   return (
     <section className="app-card overflow-hidden p-0">
@@ -114,17 +132,49 @@ export function AssignmentsSection() {
         {assignmentStatus ? <Status tone="success" message={assignmentStatus} /> : null}
         {assignmentError ? <div className="mt-2"><Status tone="error" message={assignmentError} /></div> : null}
         <div className="mt-2 space-y-2">
-          {assignments.length ? assignments.map((assignment, index) => (
-            <AssignmentCard
-              key={`${assignment.role || 'assignment'}-${index}`}
-              assignment={assignment}
-              userId={auth.user?.uid || ''}
-              busy={busyRole === String(assignment.role || '').trim()}
-              disabled={Boolean(busyRole) || !event.isDbGame || event.isCancelled}
-              onClaim={() => claimSlot(assignment)}
-              onRelease={() => releaseSlot(assignment)}
-            />
-          )) : (
+          {assignments.length ? (
+            <>
+              {(actionableAssignments.length ? actionableAssignments : filledAssignments).map((assignment, index) => (
+                <AssignmentCard
+                  key={`${assignment.role || 'assignment'}-${index}`}
+                  assignment={assignment}
+                  userId={userId}
+                  busy={busyRole === String(assignment.role || '').trim()}
+                  disabled={Boolean(busyRole) || !event.isDbGame || event.isCancelled}
+                  onClaim={() => claimSlot(assignment)}
+                  onRelease={() => releaseSlot(assignment)}
+                />
+              ))}
+              {filledAssignments.length && actionableAssignments.length ? (
+                <div className="pt-2">
+                  <button
+                    type="button"
+                    className="inline-flex min-h-9 items-center gap-2 rounded-full border border-gray-200 bg-white px-3 text-xs font-black text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700"
+                    aria-expanded={shouldShowFilledAssignments}
+                    onClick={() => setShowFilledAssignments((current) => !current)}
+                  >
+                    {shouldShowFilledAssignments ? <ChevronUp className="h-4 w-4" aria-hidden="true" /> : <ChevronDown className="h-4 w-4" aria-hidden="true" />}
+                    {shouldShowFilledAssignments ? 'Hide filled assignments' : `Show filled assignments (${filledAssignments.length})`}
+                  </button>
+                  {shouldShowFilledAssignments ? (
+                    <div className="mt-3 space-y-2">
+                      {filledAssignments.map((assignment, index) => (
+                        <AssignmentCard
+                          key={`${assignment.role || 'filled-assignment'}-filled-${index}`}
+                          assignment={assignment}
+                          userId={userId}
+                          busy={busyRole === String(assignment.role || '').trim()}
+                          disabled={Boolean(busyRole) || !event.isDbGame || event.isCancelled}
+                          onClaim={() => claimSlot(assignment)}
+                          onRelease={() => releaseSlot(assignment)}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </>
+          ) : (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">None posted</div>
           )}
         </div>

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -2083,6 +2083,82 @@ describe('ScheduleEventDetail assignments', () => {
     });
   });
 
+  it('shows actionable assignments before deferring filled roles behind a secondary reveal', async () => {
+    const assignments = [
+      { role: 'Snacks', value: '', claimable: true, claim: null },
+      { role: 'Drinks', value: '', claimable: true, claim: { id: 'Drinks', claimedByUserId: 'coach-1', claimedByName: 'Coach Carter' } },
+      { role: 'Setup', value: '', claimable: true, claim: { id: 'Setup', claimedByUserId: 'other-parent', claimedByName: 'Taylor' } },
+      { role: 'Scorebook', value: 'Jamie', claimable: false, claim: null }
+    ];
+
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ assignments })],
+      children: []
+    });
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue(assignments);
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Assignments' }).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Assignments' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('4 posted · 1 open')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Snacks')).toBeTruthy();
+    expect(screen.getByText('Drinks')).toBeTruthy();
+    expect(screen.queryByText('Setup')).toBeNull();
+    expect(screen.queryByText('Scorebook')).toBeNull();
+
+    const disclosure = screen.getByRole('button', { name: 'Show filled assignments (2)' });
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(disclosure);
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup')).toBeTruthy();
+    });
+    expect(screen.getByText('Scorebook')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Hide filled assignments' })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('shows filled assignments immediately when no actionable slots exist', async () => {
+    const assignments = [
+      { role: 'Setup', value: '', claimable: true, claim: { id: 'Setup', claimedByUserId: 'other-parent', claimedByName: 'Taylor' } },
+      { role: 'Scorebook', value: 'Jamie', claimable: false, claim: null }
+    ];
+
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ assignments })],
+      children: []
+    });
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue(assignments);
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Assignments' }).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Assignments' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('2 posted · 0 open')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Setup')).toBeTruthy();
+    expect(screen.getByText('Scorebook')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Show filled assignments/i })).toBeNull();
+  });
+
   it('refreshes assignment cards after claim and release actions mutate the loaded array in place', async () => {
     const assignments = [
       { role: 'Snacks', value: '', claimable: true, claim: null },
@@ -2120,6 +2196,13 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getByText('4 posted · 1 open')).toBeTruthy();
     });
 
+    fireEvent.click(screen.getByRole('button', { name: 'Show filled assignments (2)' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Setup')).toBeTruthy();
+    });
+    expect(screen.getByText('Scorebook')).toBeTruthy();
+
     const snacksCard = screen.getByText('Snacks').closest('article');
     expect(snacksCard).toBeTruthy();
     fireEvent.click(within(snacksCard as HTMLElement).getByRole('button', { name: 'Sign up' }));
@@ -2131,10 +2214,13 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getByText('4 posted · 0 open')).toBeTruthy();
     });
     await waitFor(() => {
-      expect(within(snacksCard as HTMLElement).getByText('You')).toBeTruthy();
+      expect(within(screen.getByText('Snacks').closest('article') as HTMLElement).getByText('You')).toBeTruthy();
     });
+    expect(screen.getByRole('button', { name: 'Hide filled assignments' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Setup')).toBeTruthy();
+    expect(screen.getByText('Scorebook')).toBeTruthy();
 
-    fireEvent.click(within(snacksCard as HTMLElement).getByRole('button', { name: 'Release' }));
+    fireEvent.click(within(screen.getByText('Snacks').closest('article') as HTMLElement).getByRole('button', { name: 'Release' }));
 
     await waitFor(() => {
       expect(screen.getByText('Snacks released.')).toBeTruthy();
@@ -2143,8 +2229,11 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getByText('4 posted · 1 open')).toBeTruthy();
     });
     await waitFor(() => {
-      expect(within(snacksCard as HTMLElement).getByRole('button', { name: 'Sign up' })).toBeTruthy();
+      expect(within(screen.getByText('Snacks').closest('article') as HTMLElement).getByRole('button', { name: 'Sign up' })).toBeTruthy();
     });
+    expect(screen.getByRole('button', { name: 'Hide filled assignments' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Setup')).toBeTruthy();
+    expect(screen.getByText('Scorebook')).toBeTruthy();
   });
 });
 

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -2117,7 +2117,7 @@ describe('ScheduleEventDetail assignments', () => {
     expect(screen.queryByText('Scorebook')).toBeNull();
 
     const disclosure = screen.getByRole('button', { name: 'Show filled assignments (2)' });
-    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false');
 
     fireEvent.click(disclosure);
 
@@ -2125,7 +2125,7 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getByText('Setup')).toBeTruthy();
     });
     expect(screen.getByText('Scorebook')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Hide filled assignments' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Hide filled assignments' }).getAttribute('aria-expanded')).toBe('true');
   });
 
   it('shows filled assignments immediately when no actionable slots exist', async () => {
@@ -2216,7 +2216,7 @@ describe('ScheduleEventDetail assignments', () => {
     await waitFor(() => {
       expect(within(screen.getByText('Snacks').closest('article') as HTMLElement).getByText('You')).toBeTruthy();
     });
-    expect(screen.getByRole('button', { name: 'Hide filled assignments' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Hide filled assignments' }).getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByText('Setup')).toBeTruthy();
     expect(screen.getByText('Scorebook')).toBeTruthy();
 
@@ -2231,7 +2231,7 @@ describe('ScheduleEventDetail assignments', () => {
     await waitFor(() => {
       expect(within(screen.getByText('Snacks').closest('article') as HTMLElement).getByRole('button', { name: 'Sign up' })).toBeTruthy();
     });
-    expect(screen.getByRole('button', { name: 'Hide filled assignments' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Hide filled assignments' }).getAttribute('aria-expanded')).toBe('true');
     expect(screen.getByText('Setup')).toBeTruthy();
     expect(screen.getByText('Scorebook')).toBeTruthy();
   });
@@ -2281,7 +2281,7 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     expect(screen.queryByTestId('staff-rsvp-row-p3')).toBeNull();
 
     const disclosure = screen.getByRole('button', { name: 'Show responded players (1 going · 1 maybe · 1 out · 0 missing)' });
-    expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false');
 
     fireEvent.click(disclosure);
 
@@ -2290,7 +2290,7 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     });
     expect(screen.getByTestId('staff-rsvp-row-p2')).toBeTruthy();
     expect(screen.getByTestId('staff-rsvp-row-p3')).toBeTruthy();
-    expect(screen.getByRole('button', { name: 'Hide responded players' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Hide responded players' }).getAttribute('aria-expanded')).toBe('true');
   });
 
   it('lets staff override a responded player after expanding and refreshes the counts', async () => {

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1340,6 +1340,8 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
     await expect(assignmentsSection.getByText('Scorebook: Jamie')).toBeVisible();
     await expect(assignmentsSection.getByText('Drinks')).toBeVisible();
     await expect(assignmentsSection.getByText('You')).toBeVisible();
+    await expect(assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' })).toBeVisible();
+    await assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' }).click();
     await expect(assignmentsSection.getByText('Setup')).toBeVisible();
     await expect(assignmentsSection.getByText('Taylor')).toBeVisible();
     await assignmentsSection.locator('article').filter({ hasText: 'Snacks' }).getByRole('button', { name: 'Sign up' }).click();
@@ -1482,6 +1484,8 @@ test('app schedule assignments supports parent sign up and release', async ({ pa
     await expect(assignmentsSection.getByText('Scorebook: Jamie')).toBeVisible();
     await expect(snacksCard.getByRole('button', { name: 'Sign up' })).toBeVisible();
     await expect(drinksCard.getByText('You')).toBeVisible();
+    await expect(assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' })).toBeVisible();
+    await assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' }).click();
     await expect(setupCard.getByText('Taylor')).toBeVisible();
 
     await snacksCard.getByRole('button', { name: 'Sign up' }).click();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1337,13 +1337,14 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
     const assignmentsSection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Assignments' }) });
     await expect(assignmentsSection.getByText('4 posted · 1 open')).toBeVisible();
     await expect(assignmentsSection.getByText('Snacks')).toBeVisible();
-    await expect(assignmentsSection.getByText('Scorebook: Jamie')).toBeVisible();
     await expect(assignmentsSection.getByText('Drinks')).toBeVisible();
     await expect(assignmentsSection.getByText('You')).toBeVisible();
+    await expect(assignmentsSection.getByText('Scorebook: Jamie')).toHaveCount(0);
     await expect(assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' })).toBeVisible();
     await assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' }).click();
     await expect(assignmentsSection.getByText('Setup')).toBeVisible();
     await expect(assignmentsSection.getByText('Taylor')).toBeVisible();
+    await expect(assignmentsSection.getByText('Scorebook: Jamie')).toBeVisible();
     await assignmentsSection.locator('article').filter({ hasText: 'Snacks' }).getByRole('button', { name: 'Sign up' }).click();
     await expect(assignmentsSection.getByText('Snacks claimed.')).toBeVisible();
     expect(await page.evaluate(() => window.__scheduleCalls.assignments.some((call) => call.action === 'claim' && call.role === 'Snacks'))).toBe(true);
@@ -1481,12 +1482,13 @@ test('app schedule assignments supports parent sign up and release', async ({ pa
     const setupCard = assignmentsSection.locator('article').filter({ hasText: 'Setup' });
 
     await expect(assignmentsSection.getByText('4 posted · 1 open')).toBeVisible();
-    await expect(assignmentsSection.getByText('Scorebook: Jamie')).toBeVisible();
+    await expect(assignmentsSection.getByText('Scorebook: Jamie')).toHaveCount(0);
     await expect(snacksCard.getByRole('button', { name: 'Sign up' })).toBeVisible();
     await expect(drinksCard.getByText('You')).toBeVisible();
     await expect(assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' })).toBeVisible();
     await assignmentsSection.getByRole('button', { name: 'Show filled assignments (2)' }).click();
     await expect(setupCard.getByText('Taylor')).toBeVisible();
+    await expect(assignmentsSection.getByText('Scorebook: Jamie')).toBeVisible();
 
     await snacksCard.getByRole('button', { name: 'Sign up' }).click();
     await expect(assignmentsSection.getByText('Snacks claimed.')).toBeVisible();


### PR DESCRIPTION
Closes #3287

## What changed
- Split `AssignmentsSection` into an actionable-first view that shows open slots plus the current user's claimed slot before any filled assignments.
- Added a secondary disclosure for taken-by-others and fixed-value assignments, with the filled count shown on the trigger.
- Auto-expanded filled assignments when no actionable slots exist, and preserved the disclosure state across claim/release refreshes.
- Extended `ScheduleEventDetail` tests to cover mixed assignment rendering, the no-actionable fallback, and claim/release refresh behavior with the filled section expanded.

## Root Cause
`AssignmentsSection` computed `openCount` but still rendered the raw `assignments` array directly, so the UI never separated the primary parent action path from contextual filled roles even though the route already deep-links parents into Assignments when open slots exist.

## Prevention / Learning
When a workflow intentionally routes users into a primary action tab, render actionable items separately from contextual or completed items instead of relying on card styling alone. Add regression coverage for both the default visible subset and post-mutation disclosure behavior so refreshes cannot quietly collapse the wrong content back into a flat list.

## Regression Tests
- `apps/app/src/pages/ScheduleEventDetail.test.tsx` verifies that a mixed assignment set only shows open plus self-claimed cards until the filled disclosure is expanded.
- `apps/app/src/pages/ScheduleEventDetail.test.tsx` verifies that filled assignments are visible by default when no actionable slots exist.
- `apps/app/src/pages/ScheduleEventDetail.test.tsx` verifies that claim/release refreshes keep the actionable area correct and preserve access to the filled disclosure.

## Recurrence Risk
Low. The mixed-state, empty-actionable, and claim/release refresh cases are now covered by focused UI regression tests around the exact workflow that previously stayed flat.