### PR TITLE
Add edit-config regression coverage for invalid Top Stats

### DIFF
--- a/tests/unit/edit-config-schema-workflow.test.js
+++ b/tests/unit/edit-config-schema-workflow.test.js
@@ -32,6 +32,27 @@ function extractFunction(source, functionName) {
     throw new Error(`Could not extract ${functionName} body`);
 }
 
+function extractSubmitHandlerBody(source) {
+    const marker = "document.getElementById('add-config-form').addEventListener('submit', async (e) => {";
+    const start = source.indexOf(marker);
+    if (start === -1) {
+        throw new Error('Could not find submit handler in edit-config.html');
+    }
+
+    const bodyStart = start + marker.length;
+    let depth = 1;
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(bodyStart, index);
+        }
+    }
+
+    throw new Error('Could not extract submit handler body');
+}
+
 describe('edit config schema workflow', () => {
     it('adds preset, import, edit, and reset controls to the stats config page', () => {
         const source = readEditConfigSource();
@@ -137,6 +158,93 @@ describe('edit config schema workflow', () => {
 
         expect(dom.window.document.getElementById('columns').value).toBe('PTS, REB');
         expect(dom.window.document.getElementById('advancedStatDefinitions').value).toBe('Deflections=DEF|group=Defense|visibility=public|scope=team');
+    });
+
+    it('blocks invalid top stat definitions during add or update and leaves the textarea unchanged', () => {
+        const source = readEditConfigSource();
+        const dom = new JSDOM(`<!doctype html><body>
+            <textarea id="advancedStatDefinitions">PTS=pts|visibility=public|scope=player|topStat=true</textarea>
+            <input id="statDefinitionLabel" value="Hustle">
+            <input id="statDefinitionId" value="hustle">
+            <input id="statDefinitionFormula" value="">
+            <input id="statDefinitionGroup" value="Defense">
+            <select id="statDefinitionFormat"><option value="number" selected>number</option></select>
+            <input id="statDefinitionPrecision" value="">
+            <select id="statDefinitionRankingOrder"><option value="desc" selected>desc</option></select>
+            <select id="statDefinitionVisibility"><option value="private" selected>private</option></select>
+            <select id="statDefinitionScope"><option value="team" selected>team</option></select>
+            <input id="statDefinitionTopStat" type="checkbox" checked>
+        </body>`);
+
+        const alerts = [];
+        const script = [
+            extractFunction(source, 'getStatDefinitionLineId'),
+            extractFunction(source, 'syncColumnsInputWithStatId'),
+            extractFunction(source, 'addOrUpdateStatDefinitionLine'),
+            'globalThis.__testHooks = { addOrUpdateStatDefinitionLine };'
+        ].join('\n');
+
+        const context = vm.createContext({
+            document: dom.window.document,
+            alert: (message) => alerts.push(message),
+            window: dom.window,
+            globalThis: {}
+        });
+        vm.runInContext(script, context);
+
+        context.globalThis.__testHooks.addOrUpdateStatDefinitionLine();
+
+        expect(alerts).toEqual([
+            'Hustle cannot be a Top Stat unless visibility is public and scope is player.'
+        ]);
+        expect(dom.window.document.getElementById('advancedStatDefinitions').value).toBe('PTS=pts|visibility=public|scope=player|topStat=true');
+    });
+
+    it('blocks saving invalid top stat definitions before createConfig or updateConfig runs', async () => {
+        const source = readEditConfigSource();
+        const alerts = [];
+        const calls = [];
+        const submitHandler = `async function __testSubmitHandler(e) {${extractSubmitHandlerBody(source)}}\nglobalThis.__testHooks = { __testSubmitHandler };`;
+
+        const context = vm.createContext({
+            editingConfigId: null,
+            currentTeamId: 'team-a',
+            getConfigWritePayload: () => ({
+                name: 'Invalid Config',
+                columns: ['PTS'],
+                statDefinitions: [
+                    { id: 'hustle', label: 'Hustle', visibility: 'private', scope: 'team', topStat: true }
+                ]
+            }),
+            validateStatDefinitionsForPublicLeaderboards: () => ({
+                valid: false,
+                errors: ['Hustle cannot be a Top Stat unless visibility is public and scope is player.']
+            }),
+            createConfig: async () => calls.push('create'),
+            updateConfig: async () => calls.push('update'),
+            resetFormState: () => calls.push('reset'),
+            loadConfigs: async () => calls.push('loadConfigs'),
+            loadImportConfigs: async () => calls.push('loadImportConfigs'),
+            alert: (message) => alerts.push(message),
+            console,
+            globalThis: {}
+        });
+        vm.runInContext(submitHandler, context);
+
+        const event = {
+            preventDefaultCalled: false,
+            preventDefault() {
+                this.preventDefaultCalled = true;
+            }
+        };
+
+        await context.globalThis.__testHooks.__testSubmitHandler(event);
+
+        expect(event.preventDefaultCalled).toBe(true);
+        expect(alerts).toEqual([
+            'Hustle cannot be a Top Stat unless visibility is public and scope is player.'
+        ]);
+        expect(calls).toEqual([]);
     });
 
     it('adds db helpers for updating and resetting stat tracker configs', () => {

--- a/tests/unit/edit-config-schema-workflow.test.js
+++ b/tests/unit/edit-config-schema-workflow.test.js
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
 
+import { validateStatDefinitionsForPublicLeaderboards } from '../../js/stat-leaderboards.js';
+
 function readEditConfigSource() {
     return readFileSync(new URL('../../edit-config.html', import.meta.url), 'utf8');
 }
@@ -216,10 +218,7 @@ describe('edit config schema workflow', () => {
                     { id: 'hustle', label: 'Hustle', visibility: 'private', scope: 'team', topStat: true }
                 ]
             }),
-            validateStatDefinitionsForPublicLeaderboards: () => ({
-                valid: false,
-                errors: ['Hustle cannot be a Top Stat unless visibility is public and scope is player.']
-            }),
+            validateStatDefinitionsForPublicLeaderboards,
             createConfig: async () => calls.push('create'),
             updateConfig: async () => calls.push('update'),
             resetFormState: () => calls.push('reset'),


### PR DESCRIPTION
Closes #3292

## What changed
- Added focused DOM workflow regressions in `tests/unit/edit-config-schema-workflow.test.js` for invalid Top Stat handling on `edit-config.html`.
- Covered the add/update stat-definition path to verify invalid private or team-scoped Top Stats trigger the alert and do not mutate `#advancedStatDefinitions`.
- Covered the submit/save path to verify invalid Top Stat definitions surface the leaderboard validation error and stop before `createConfig` or `updateConfig` runs.

## Root Cause
The runtime guards in `edit-config.html` were already present, but regression coverage never exercised those real page workflows. Existing coverage stopped at the pure validator helper, while the main smoke test stubbed `validateStatDefinitionsForPublicLeaderboards()` to always succeed, so a future regression in the page handlers could slip through unnoticed.

## Prevention / Learning
When a UI flow relies on both inline guard logic and a shared validator, add a regression that executes the real page handler, not just the helper. Avoid relying only on smoke tests that stub the validator on workflows where blocking behavior is the invariant.

## Regression Tests
- `npx vitest run tests/unit/edit-config-schema-workflow.test.js --reporter=verbose`
- `tests/unit/edit-config-schema-workflow.test.js`: blocks invalid Top Stat definitions during add or update and leaves the textarea unchanged
- `tests/unit/edit-config-schema-workflow.test.js`: blocks saving invalid Top Stat definitions before `createConfig` or `updateConfig` runs