### PR TITLE
Stabilize flaky TeamMedia chat-posting tests

### DIFF
--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "11aaa7f8bd2952068c14a56f58e487c6d5a0e0fea3b0079d55e332a1a58f0bf2",
+  "originHash" : "b43de2bb2e418767b6490ce41b7a304bf11005eee89cdb9a2df8986e157af9f3",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -121,15 +121,18 @@ function selectValue(select, value) {
 }
 
 async function waitForAssertion(assertion) {
+  // Polls until the assertion passes, returning immediately on success. The
+  // budget is generous (≈3s) so it stays reliable under full-suite concurrency
+  // where the event loop is contended; a passing assertion never waits.
   let lastError;
-  for (let attempt = 0; attempt < 50; attempt += 1) {
+  for (let attempt = 0; attempt < 150; attempt += 1) {
     try {
       assertion();
       return;
     } catch (error) {
       lastError = error;
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 20));
       });
     }
   }
@@ -546,9 +549,11 @@ describe('React app TeamMedia team chat posting', () => {
     await act(async () => {
       resolveSend({ conversationId: 'team', createdConversation: null, wantsAi: false });
     });
-    await act(async () => {});
 
-    expect(container.textContent).toContain('Photo posted to team chat.');
+    // Poll for the settled success state instead of assuming a fixed number of
+    // act flushes — the resolve -> state update -> re-render chain can take more
+    // microtask ticks under concurrency.
+    await waitForAssertion(() => expect(container.textContent).toContain('Photo posted to team chat.'));
     expect(container.querySelector('[aria-label="Caption for team chat"]')).toBeNull();
 
     await act(async () => root.unmount());


### PR DESCRIPTION
## Gap
Surfaced while auditing yesterday's merges: `tests/unit/app-team-media.test.jsx` "team chat posting" tests **pass 21/21 in isolation but fail intermittently under full-suite concurrency** — a contended event loop, not a code regression. Flaky tests undermine CI reliability (and can mask real failures).

## Root cause
- `waitForAssertion` had a tight poll budget (50×10ms ≈ 500ms), insufficient under full-suite load.
- The "disables ... while the send is in flight" test asserted the post-resolve success state **synchronously** after a fixed 2 `act()` flushes, so when the resolve → `setState` → re-render chain needed more microtask ticks under contention, it failed.

## Fix
- Widen `waitForAssertion` to ≈3s. It returns immediately on success, so passing assertions never wait — the budget only helps the slow/contended case.
- Make the in-flight test poll for the settled success state via `waitForAssertion` instead of assuming a fixed flush count.
- No production code change; test-only.

## Verification
- **Full suite green 5/5 consecutive runs** (`npx vitest run tests/unit`, 3634/3634) — previously failed ~every full-suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)