### PR TITLE
Fix leaked Firebase Performance span on abandoned view loads (#3289 gap)

### DIFF
--- a/apps/app/src/lib/uxTiming.test.ts
+++ b/apps/app/src/lib/uxTiming.test.ts
@@ -1,8 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const recordAppUxTiming = vi.fn();
+const performanceSpanEnd = vi.fn();
+const startPerformanceSpan = vi.fn((label: string) => ({
+  label,
+  traceName: `trace:${label}`,
+  startedAt: 100,
+  end: performanceSpanEnd
+}));
+const recordCompletedPerformanceSpan = vi.fn();
+
 vi.mock('./telemetry', () => ({
   recordAppUxTiming: (...args: unknown[]) => recordAppUxTiming(...args)
+}));
+
+vi.mock('./performanceInstrumentation', () => ({
+  now: vi.fn(() => 150),
+  startPerformanceSpan: (...args: unknown[]) => startPerformanceSpan(...args),
+  recordCompletedPerformanceSpan: (...args: unknown[]) => recordCompletedPerformanceSpan(...args)
 }));
 
 import {
@@ -20,6 +35,9 @@ import {
 describe('uxTiming', () => {
   beforeEach(() => {
     recordAppUxTiming.mockClear();
+    performanceSpanEnd.mockClear();
+    startPerformanceSpan.mockClear();
+    recordCompletedPerformanceSpan.mockClear();
     resetFirstMeaningfulRenderForTests();
     vi.spyOn(console, 'info').mockImplementation(() => {});
   });
@@ -55,6 +73,19 @@ describe('uxTiming', () => {
       category: 'interaction',
       response: 'going',
       path: 'sdk'
+    });
+  });
+
+  it('marks canceled spans as abandoned in Firebase-safe metadata', () => {
+    const timer = startUxTimer('schedule load', { route: 'schedule' });
+    timer.cancel({ source: 'unmount' });
+
+    expect(recordAppUxTiming).not.toHaveBeenCalled();
+    expect(performanceSpanEnd).toHaveBeenCalledWith({
+      route: 'schedule',
+      source: 'unmount',
+      abandoned: true,
+      outcome: 'abandoned'
     });
   });
 

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -57,7 +57,7 @@ export function startUxTimer(label: string, baseMeta: Record<string, unknown> = 
       // leaked count makes later spans with the same label look already-active,
       // so startFirebaseTrace skips them and they never export. Intentionally
       // does NOT record a completed UX timing.
-      performanceSpan.end({ ...baseMeta, ...meta, abandoned: true });
+      performanceSpan.end({ ...baseMeta, ...meta, abandoned: true, outcome: 'abandoned' });
     }
   };
 }

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -49,6 +49,15 @@ export function startUxTimer(label: string, baseMeta: Record<string, unknown> = 
       const mergedMeta = { ...baseMeta, ...readMeta, ...meta };
       recordUxTiming(label, performanceSpan.startedAt, mergedMeta, { recordPerformance: false });
       performanceSpan.end(mergedMeta);
+    },
+    cancel(meta: Record<string, unknown> = {}) {
+      // The timed view/interaction was abandoned (e.g. the user navigated away,
+      // or the timing key changed, before it became ready). End the underlying
+      // performance span so its active Firebase-trace count is released — a
+      // leaked count makes later spans with the same label look already-active,
+      // so startFirebaseTrace skips them and they never export. Intentionally
+      // does NOT record a completed UX timing.
+      performanceSpan.end({ ...baseMeta, ...meta, abandoned: true });
     }
   };
 }

--- a/apps/app/src/lib/viewLoadTiming.test.tsx
+++ b/apps/app/src/lib/viewLoadTiming.test.tsx
@@ -6,9 +6,11 @@ import { useViewLoadTimer, getViewLoadTimingLabel } from './viewLoadTiming';
 
 const uxTimingMocks = vi.hoisted(() => {
   const timerEnd = vi.fn<(meta?: Record<string, unknown>) => void>();
+  const timerCancel = vi.fn<(meta?: Record<string, unknown>) => void>();
   return {
     timerEnd,
-    startUxTimer: vi.fn<(label: string, baseMeta?: Record<string, unknown>) => { end: typeof timerEnd }>(() => ({ end: timerEnd }))
+    timerCancel,
+    startUxTimer: vi.fn<(label: string, baseMeta?: Record<string, unknown>) => { end: typeof timerEnd; cancel: typeof timerCancel }>(() => ({ end: timerEnd, cancel: timerCancel }))
   };
 });
 
@@ -32,6 +34,7 @@ describe('viewLoadTiming', () => {
   beforeEach(() => {
     uxTimingMocks.startUxTimer.mockClear();
     uxTimingMocks.timerEnd.mockClear();
+    uxTimingMocks.timerCancel.mockClear();
   });
 
   afterEach(() => {
@@ -62,5 +65,35 @@ describe('viewLoadTiming', () => {
     const view = render(<TestViewTimer ready={false} resetKey="a" />);
     view.rerender(<TestViewTimer ready={false} resetKey="b" />);
     expect(uxTimingMocks.startUxTimer).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels (does not complete) an abandoned timer when the view unmounts before ready', () => {
+    const view = render(<TestViewTimer ready={false} />);
+    expect(uxTimingMocks.startUxTimer).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+
+    expect(uxTimingMocks.timerCancel).toHaveBeenCalledTimes(1);
+    expect(uxTimingMocks.timerEnd).not.toHaveBeenCalled();
+  });
+
+  it('cancels the previous timer when the key changes before ready', () => {
+    const view = render(<TestViewTimer ready={false} resetKey="a" />);
+    view.rerender(<TestViewTimer ready={false} resetKey="b" />);
+
+    expect(uxTimingMocks.timerCancel).toHaveBeenCalledTimes(1);
+    expect(uxTimingMocks.timerEnd).not.toHaveBeenCalled();
+  });
+
+  it('does not cancel a timer that completed normally before unmount', async () => {
+    const view = render(<TestViewTimer ready={false} />);
+    view.rerender(<TestViewTimer ready />);
+    await waitFor(() => {
+      expect(uxTimingMocks.timerEnd).toHaveBeenCalledTimes(1);
+    });
+
+    view.unmount();
+
+    expect(uxTimingMocks.timerCancel).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/lib/viewLoadTiming.ts
+++ b/apps/app/src/lib/viewLoadTiming.ts
@@ -47,7 +47,13 @@ export function useViewLoadTimer({
 
     return () => {
       if (activeKeyRef.current === key) {
+        // If the view is left (or its timing key changes) before `ready` flips
+        // true, the started span was never ended. Cancel it so the active
+        // Firebase-trace count is released; otherwise the leak blocks later
+        // loads of the same label from exporting.
+        const pendingTimer = timerRef.current;
         timerRef.current = null;
+        pendingTimer?.cancel?.({ route, viewName });
       }
     };
     // getBaseMeta is intentionally sampled only when a new timing key starts.


### PR DESCRIPTION
## Gap
Auditing yesterday's/today's merges, **#3289** ("[codex] Add app workflow performance telemetry") merged with an **unresolved Codex P1** (its review landed ~3 min after merge — see the gate fix below).

The P1 (`viewLoadTiming.ts:46`): `useViewLoadTimer`'s cleanup only dropped the timer ref when a view was left or its timing key changed **before `ready`**. Since `startUxTimer` starts a Firebase Performance span immediately, that span was **never ended** — leaking the active-trace count. And because `startFirebaseTrace` skips starting a real trace when a label's count is already `> 0`, the leak made **later loads of the same label never export**.

## Fix
- Add `cancel()` to `startUxTimer` — ends the underlying performance span (releasing the active-trace count) **without** recording a completed UX timing; tags the span `abandoned: true`.
- Call `timer.cancel()` in the cleanup path when the timer hasn't completed.
- Regression tests: cancels on unmount-before-ready and on key change; does **not** cancel after a normal completion (verified the tests fail on the pre-fix cleanup).

## Verification
- App timing/perf suites green (uxTiming, viewLoadTiming, performanceInstrumentation, performanceWiring, workflowTiming).
- `tsc --noEmit` clean.

## Related
The reason #3289 merged before its review was a **fail-open bug in the merge-prep review-settle gate** (transient commit-date fetch → proceed). That's been fixed server-side to fail closed, so this class of "merged before review" won't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)