### PR TITLE
Run app colocated tests in CI (and fix the mocks #3289 broke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,6 @@ jobs:
 
       - name: Lint app
         run: npm --prefix apps/app run lint -- --quiet
+
+      - name: Test app
+        run: npm --prefix apps/app run test:ci

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -16,6 +16,7 @@
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "test": "vitest",
+    "test:ci": "vitest run --retry=2 --reporter=dot",
     "test:coverage": "vitest run --coverage",
     "preview": "vite preview --host 0.0.0.0"
   },

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -31,7 +31,8 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 
 const uxTimingMocks = vi.hoisted(() => ({
   recordFirstMeaningfulRender: vi.fn(),
-  startScreenMountTimer: vi.fn(() => ({ end: vi.fn() }))
+  startScreenMountTimer: vi.fn(() => ({ end: vi.fn() })),
+  startUxTimer: vi.fn(() => ({ end: vi.fn(), cancel: vi.fn() }))
 }));
 
 vi.mock('../components/PageSkeletons', () => ({

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -51,7 +51,8 @@ vi.mock('../lib/telemetry', () => ({
 }));
 vi.mock('../lib/uxTiming', () => ({
   recordFirstMeaningfulRender: uxTimingMocks.recordFirstMeaningfulRender,
-  startScreenMountTimer: vi.fn(() => ({ end: uxTimingMocks.end }))
+  startScreenMountTimer: vi.fn(() => ({ end: uxTimingMocks.end })),
+  startUxTimer: vi.fn(() => ({ end: vi.fn(), cancel: vi.fn() }))
 }));
 vi.mock('../lib/useShellLayout', () => ({
   useShellLayout: () => ({ isDesktopWeb: shellLayoutMocks.isDesktopWeb })

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -105,6 +105,8 @@ import { ScheduleEventDetail, getAvailabilityNoteSaveState, parseEventDetailSect
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const mountedRoots = [];
+
 const auth = {
     user: {
         uid: 'user-1',
@@ -190,6 +192,8 @@ async function renderDetail(initialEntry) {
             )
         ));
     });
+
+    mountedRoots.push({ container, root });
 
     return { container, root };
 }
@@ -322,7 +326,14 @@ beforeEach(() => {
     window.scrollTo = vi.fn();
 });
 
-afterEach(() => {
+afterEach(async () => {
+    while (mountedRoots.length > 0) {
+        const mounted = mountedRoots.pop();
+        await act(async () => {
+            mounted.root.unmount();
+        });
+        mounted.container.remove();
+    }
     vi.useRealTimers();
     document.body.innerHTML = '';
 });


### PR DESCRIPTION
## Gap (systemic)
The app's **colocated test suite (`apps/app/src/**/*.test`) is never run in CI.** The `unit-tests` job runs only `tests/unit`; `app-quality` only typechecks + lints. So an entire tier of app unit tests is unverified.

**Consequence, found while auditing:** #3289 ("Add app workflow performance telemetry") added `startUxTimer` view-load instrumentation to `Schedule.tsx`/`Home.tsx` but didn't update those pages' colocated test mocks — breaking **38 tests** (`No "startUxTimer" export is defined on the mock`) that **merged undetected** because CI doesn't run them.

## Fix
- Add `startUxTimer` to the `uxTiming` mock in `Schedule.test.tsx` and `Home.test.tsx` (restores the 38 tests).
- Add an app `test:ci` script and a **"Test app" step** to the `app-quality` CI job so the colocated suite runs on every PR.
- The script uses `vitest run --retry=2`: a couple of tests are flaky under full-suite concurrency (e.g. `ScheduleEventDetail`), and retry absorbs that while **real** breakage still fails every attempt. (Flaky tests can be hardened incrementally — one was already fixed in #3294.)

## Verification
- Full app suite **green 807/807 across repeated runs** with `test:ci`.
- `ci.yml` YAML validated; new step indentation matches existing steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)