### PR TITLE
Fix app typecheck broken on master (TS2556 in uxTiming.test)

### DIFF
--- a/apps/app/src/lib/uxTiming.test.ts
+++ b/apps/app/src/lib/uxTiming.test.ts
@@ -16,7 +16,9 @@ vi.mock('./telemetry', () => ({
 
 vi.mock('./performanceInstrumentation', () => ({
   now: vi.fn(() => 150),
-  startPerformanceSpan: (...args: unknown[]) => startPerformanceSpan(...args),
+  // The local mock is typed (label: string); cast the passthrough spread to a
+  // tuple so it satisfies that parameter (runtime still forwards every arg).
+  startPerformanceSpan: (...args: unknown[]) => startPerformanceSpan(...(args as [string])),
   recordCompletedPerformanceSpan: (...args: unknown[]) => recordCompletedPerformanceSpan(...args)
 }));
 


### PR DESCRIPTION
## Urgent: master's app typecheck is currently broken
`#3297` changed `startUxTimer`'s return type, which shifted inference so the `performanceInstrumentation` mock's `startPerformanceSpan(...args)` passthrough no longer satisfied the local mock's `(label: string)` parameter → **TS2556**. Because `app-quality` (which runs `tsc --noEmit`) is **not a required check**, #3297 merged with it red and left `master` failing `tsc`.

Confirmed: `tsc --noEmit` is clean on `84fde70a~1` and errors on master.

## Fix
Cast the passthrough spread to a `[string]` tuple (runtime still forwards every arg). Restores `tsc --noEmit` to clean; `uxTiming.test.ts` still passes (8/8); eslint clean.

## Follow-up (separate)
This slipped because `app-quality` isn't a required status check — see the related effort to **run app tests in CI (#3298)** and the recommendation to make `app-quality` a required check so typecheck/lint failures block merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)