### PR TITLE
Validate single-game tournament payloads before writes

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -485,6 +485,85 @@ describe('scheduled tournament writes', () => {
       games: []
     }, coachUser)).rejects.toThrow('Tournament blocks require at least one game.');
   });
+
+  it('fails fast on invalid child games before any tournament writes occur', async () => {
+    await expect(createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z')
+        },
+        {
+          opponent: '',
+          startDate: new Date('2026-06-25T18:30:00.000Z'),
+          endDate: new Date('2026-06-25T20:00:00.000Z')
+        } as any
+      ]
+    }, coachUser)).rejects.toThrow('Games require an opponent.');
+
+    await expect(createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z')
+        },
+        {
+          opponent: 'Lions',
+          startDate: 'not-a-date',
+          endDate: new Date('2026-06-25T20:00:00.000Z')
+        } as any
+      ]
+    }, coachUser)).rejects.toThrow('Game start time is invalid.');
+
+    expect(addGame).not.toHaveBeenCalled();
+  });
+
+  it('rejects incomplete legacy tournament payloads before any writes occur', async () => {
+    vi.mocked(buildLegacyTournamentGameDocuments).mockReturnValueOnce([
+      {
+        type: 'game',
+        opponent: 'Tigers',
+        competitionType: 'tournament',
+        tournament: {
+          divisionName: '10U Gold',
+          bracketName: 'Gold Bracket',
+          roundName: 'Semifinal',
+          poolName: 'Pool A'
+        }
+      }
+    ] as any);
+
+    await expect(createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z')
+        },
+        {
+          opponent: 'Lions',
+          startDate: new Date('2026-06-25T18:30:00.000Z'),
+          endDate: new Date('2026-06-25T20:00:00.000Z')
+        }
+      ]
+    }, coachUser)).rejects.toThrow('Tournament adapter could not build a complete legacy payload.');
+
+    expect(addGame).not.toHaveBeenCalled();
+  });
 });
 
 describe('scheduled practice writes', () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1661,10 +1661,14 @@ export async function createScheduledTournamentBlockForApp(teamId: string, input
     throw new Error('Tournament blocks require at least one game.');
   }
 
-  const payloads = buildLegacyTournamentGameDocuments(games.map((game) => buildScheduledGamePayload({
+  const validatedGames = games.map((game) => buildScheduledGamePayload({
     ...game,
     competitionType: 'tournament'
-  }, user as AuthUser)), tournament);
+  }, user as AuthUser));
+  const payloads = buildLegacyTournamentGameDocuments(validatedGames, tournament);
+  if (payloads.length !== validatedGames.length) {
+    throw new Error('Tournament adapter could not build a complete legacy payload.');
+  }
 
   const createdIds: string[] = [];
   for (const payload of payloads) {


### PR DESCRIPTION
Closes #3195

## What changed
- Pre-validated every single-game tournament child payload before any legacy tournament write starts.
- Added an explicit adapter guard that rejects incomplete legacy tournament payload sets instead of allowing partial downstream writes.
- Added regression coverage for missing opponent, invalid game start time, and incomplete legacy adapter output so failed validation never calls `addGame()`.

## Root Cause
`createScheduledTournamentBlockForApp()` trusted the legacy tournament adapter output without asserting that it produced a complete payload set for every requested child game. That left the all-or-nothing invariant implicit instead of enforced at the adapter boundary.

## Prevention / Learning
For multi-document adapters, validate every child input first and assert output cardinality before the first persistence call. Do not rely on downstream mappers or filters to preserve all-or-nothing behavior.

## Regression Tests
- `npm test -- --run src/lib/scheduleService.test.ts -t "scheduled tournament writes"`
- Added coverage that missing opponent and invalid dates throw explicit errors before any tournament write occurs.
- Added coverage that incomplete legacy adapter output throws before any tournament write occurs.