### PR TITLE
Return explicit single-game tournament save errors

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -468,6 +468,30 @@ describe('scheduled tournament writes', () => {
     }));
   });
 
+  it('throws an explicit error when a single-game tournament save returns no id', async () => {
+    vi.mocked(addGame).mockResolvedValueOnce(undefined as any);
+
+    await expect(createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z'),
+          location: 'Main Gym',
+          arrivalTime: new Date('2026-06-24T18:00:00.000Z'),
+          isHome: true,
+          notes: 'Bring dark jerseys'
+        }
+      ]
+    }, coachUser)).rejects.toThrow('Tournament game save failed because no game id was returned.');
+
+    expect(addGame).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects tournament blocks without required metadata or child games', async () => {
     await expect(createScheduledTournamentBlockForApp('team-1', {
       divisionName: '',

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -492,6 +492,33 @@ describe('scheduled tournament writes', () => {
     expect(addGame).toHaveBeenCalledTimes(1);
   });
 
+  it('does not fall back to REST when a native single-game tournament save resolves without an id', async () => {
+    (globalThis as any).window = { location: { protocol: 'capacitor:' }, setTimeout, clearTimeout } as any;
+    (globalThis as any).fetch = vi.fn();
+    vi.mocked(addGame).mockResolvedValueOnce(undefined as any);
+
+    await expect(createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z'),
+          location: 'Main Gym',
+          arrivalTime: new Date('2026-06-24T18:00:00.000Z'),
+          isHome: true,
+          notes: 'Bring dark jerseys'
+        }
+      ]
+    }, coachUser)).rejects.toThrow('Tournament game save failed because no game id was returned.');
+
+    expect(addGame).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   it('rejects tournament blocks without required metadata or child games', async () => {
     await expect(createScheduledTournamentBlockForApp('team-1', {
       divisionName: '',

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1670,10 +1670,14 @@ export async function createScheduledTournamentBlockForApp(teamId: string, input
     throw new Error('Tournament adapter could not build a complete legacy payload.');
   }
 
+  const requiresExplicitSingleGameFailure = payloads.length === 1;
   const createdIds: string[] = [];
   for (const payload of payloads) {
     try {
       const createdId = await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Scheduled tournament game create');
+      if (requiresExplicitSingleGameFailure && !compactString(createdId)) {
+        throw new Error('Tournament game save failed because no game id was returned.');
+      }
       createdIds.push(createdId || '');
     } catch (error) {
       if (!isNativeRuntime()) throw error;
@@ -1682,7 +1686,11 @@ export async function createScheduledTournamentBlockForApp(teamId: string, input
         ...payload,
         createdAt: new Date()
       });
-      createdIds.push(doc?.id || '');
+      const createdId = compactString(doc?.id);
+      if (requiresExplicitSingleGameFailure && !createdId) {
+        throw new Error('Tournament game save failed because no game id was returned.');
+      }
+      createdIds.push(createdId);
     }
   }
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1673,12 +1673,9 @@ export async function createScheduledTournamentBlockForApp(teamId: string, input
   const requiresExplicitSingleGameFailure = payloads.length === 1;
   const createdIds: string[] = [];
   for (const payload of payloads) {
+    let createdId = '';
     try {
-      const createdId = await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Scheduled tournament game create');
-      if (requiresExplicitSingleGameFailure && !compactString(createdId)) {
-        throw new Error('Tournament game save failed because no game id was returned.');
-      }
-      createdIds.push(createdId || '');
+      createdId = compactString(await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Scheduled tournament game create'));
     } catch (error) {
       if (!isNativeRuntime()) throw error;
       logScheduleWarning('Falling back to REST scheduled tournament game create.', 'scheduled-tournament-game-create', error, { fallback: 'rest', teamId: normalizedTeamId });
@@ -1686,12 +1683,12 @@ export async function createScheduledTournamentBlockForApp(teamId: string, input
         ...payload,
         createdAt: new Date()
       });
-      const createdId = compactString(doc?.id);
-      if (requiresExplicitSingleGameFailure && !createdId) {
-        throw new Error('Tournament game save failed because no game id was returned.');
-      }
-      createdIds.push(createdId);
+      createdId = compactString(doc?.id);
     }
+    if (requiresExplicitSingleGameFailure && !createdId) {
+      throw new Error('Tournament game save failed because no game id was returned.');
+    }
+    createdIds.push(createdId);
   }
 
   return createdIds;


### PR DESCRIPTION
Closes #3199

## What changed
- Added a scoped guard in `createScheduledTournamentBlockForApp()` so the single-game tournament save path throws an explicit error when the legacy `addGame()` call returns no created game id.
- Applied the same explicit-id check to the native REST fallback for that same single-game workflow.
- Added a regression test covering the missing-id failure case so the caller no longer receives a silent success.

## Root Cause
The single-game tournament save flow treated a falsy `addGame()` result as success by coercing it to an empty string and returning it in `createdIds`, so the caller had no explicit signal that no tournament game was actually persisted.

## Prevention / Learning
When a create workflow uses a returned document id as proof of persistence, a missing id must be treated as a hard failure, not normalized into a superficially successful result. Add a focused regression test for that invariant anywhere a legacy adapter can resolve without throwing.

## Regression Tests
- `cd apps/app && npx vitest run src/lib/scheduleService.test.ts --reporter=dot`
- Added coverage for `throws an explicit error when a single-game tournament save returns no id` in `apps/app/src/lib/scheduleService.test.ts`

## Recurrence Risk
Low. The fix is narrowly scoped to the single-game tournament save workflow and the regression test now enforces the missing-id failure contract.