### PR TITLE
Cache schedule open assignment counts

### DIFF
--- a/apps/app/src/lib/performanceInstrumentation.test.ts
+++ b/apps/app/src/lib/performanceInstrumentation.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const capacitorMock = vi.hoisted(() => ({
@@ -79,6 +80,13 @@ describe('performanceInstrumentation', () => {
       num: 4
     }));
     expect(firebasePerformanceMock.stopTrace).toHaveBeenCalledWith({ traceName: 'ap_workflow_schedule_import' });
+  });
+
+  it('lets Vite resolve the Firebase Performance dynamic import', () => {
+    const source = readFileSync('src/lib/performanceInstrumentation.ts', 'utf8');
+
+    expect(source).toContain("import('@capacitor-firebase/performance')");
+    expect(source).not.toContain('@vite-ignore');
   });
 
   it('records completed spans without requiring a live trace', async () => {

--- a/apps/app/src/lib/performanceInstrumentation.ts
+++ b/apps/app/src/lib/performanceInstrumentation.ts
@@ -27,7 +27,6 @@ const MAX_ATTRIBUTE_VALUE_LENGTH = 100;
 let sequence = 0;
 let firebasePerformancePromise: Promise<FirebasePerformanceRef | null> | null = null;
 const activeFirebaseTraceCounts = new Map<string, number>();
-const FIREBASE_PERFORMANCE_MODULE_ID = '@capacitor-firebase/performance';
 
 export function now() {
   return typeof performance !== 'undefined' && typeof performance.now === 'function'
@@ -129,7 +128,7 @@ function measure(name: string, startMark: string, endMark: string) {
 async function loadFirebasePerformance(): Promise<FirebasePerformanceRef | null> {
   if (!isPerformanceExportEnabled()) return null;
   if (!firebasePerformancePromise) {
-    firebasePerformancePromise = import(/* @vite-ignore */ FIREBASE_PERFORMANCE_MODULE_ID)
+    firebasePerformancePromise = import('@capacitor-firebase/performance')
       .then((module) => ({ api: module.FirebasePerformance }))
       .catch((error) => {
         logger.debug('Firebase Performance unavailable.', { error });

--- a/apps/app/src/lib/performanceInstrumentation.ts
+++ b/apps/app/src/lib/performanceInstrumentation.ts
@@ -27,6 +27,7 @@ const MAX_ATTRIBUTE_VALUE_LENGTH = 100;
 let sequence = 0;
 let firebasePerformancePromise: Promise<FirebasePerformanceRef | null> | null = null;
 const activeFirebaseTraceCounts = new Map<string, number>();
+const FIREBASE_PERFORMANCE_MODULE_ID = '@capacitor-firebase/performance';
 
 export function now() {
   return typeof performance !== 'undefined' && typeof performance.now === 'function'
@@ -128,7 +129,7 @@ function measure(name: string, startMark: string, endMark: string) {
 async function loadFirebasePerformance(): Promise<FirebasePerformanceRef | null> {
   if (!isPerformanceExportEnabled()) return null;
   if (!firebasePerformancePromise) {
-    firebasePerformancePromise = import('@capacitor-firebase/performance')
+    firebasePerformancePromise = import(/* @vite-ignore */ FIREBASE_PERFORMANCE_MODULE_ID)
       .then((module) => ({ api: module.FirebasePerformance }))
       .catch((error) => {
         logger.debug('Firebase Performance unavailable.', { error });

--- a/apps/app/src/lib/scheduleLogic.test.ts
+++ b/apps/app/src/lib/scheduleLogic.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { countOpenScheduleAssignments, getCalendarScheduleEntries, type ParentScheduleEvent } from './scheduleLogic';
+
+function buildParentScheduleEvent(overrides: Partial<ParentScheduleEvent> = {}): ParentScheduleEvent {
+  const assignments = Array.isArray(overrides.assignments) ? overrides.assignments : [];
+  return {
+    eventKey: 'team-1::event-1::player-1::2100-06-01T18:00:00.000Z::game',
+    id: 'event-1',
+    teamId: 'team-1',
+    teamName: 'Bears',
+    type: 'game',
+    date: new Date('2100-06-01T18:00:00.000Z'),
+    location: 'Main Gym',
+    opponent: 'Rivals',
+    childId: 'player-1',
+    childName: 'Pat',
+    isDbGame: true,
+    isCancelled: false,
+    assignments,
+    openAssignmentCount: countOpenScheduleAssignments(assignments),
+    ...overrides
+  };
+}
+
+describe('schedule open assignment counts', () => {
+  it('counts only claimable assignments that are still unclaimed and unfilled', () => {
+    expect(countOpenScheduleAssignments([
+      { role: 'Snack bar', claimable: true, value: '' },
+      { role: 'Bench help', claimable: true, claim: { claimedByUserId: 'parent-2' } },
+      { role: 'Water', claimable: true, value: 'Filled' },
+      { role: 'Setup', claimable: false, value: '' },
+      { role: '', claimable: true, value: '' }
+    ])).toBe(1);
+  });
+
+  it('preserves cached open assignment counts on grouped calendar entries', () => {
+    const sharedAssignments = [
+      { role: 'Snack bar', claimable: true, value: '' },
+      { role: 'Bench help', claimable: true, claim: { claimedByUserId: 'parent-2' } }
+    ];
+
+    const entries = getCalendarScheduleEntries([
+      buildParentScheduleEvent({
+        assignments: sharedAssignments,
+        openAssignmentCount: 1
+      }),
+      buildParentScheduleEvent({
+        eventKey: 'team-1::event-1::player-2::2100-06-01T18:00:00.000Z::game',
+        childId: 'player-2',
+        childName: 'Sam',
+        assignments: sharedAssignments,
+        openAssignmentCount: 1,
+        myRsvp: 'going'
+      })
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.openAssignmentCount).toBe(1);
+    expect(entries[0]?.childIds).toEqual(['player-1', 'player-2']);
+  });
+});

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -193,6 +193,7 @@ export type ParentScheduleEvent = {
   rsvpSummary?: ScheduleRsvpSummary | null;
   rideshareSummary?: ScheduleRideSummary | null;
   assignments: ScheduleAssignment[];
+  openAssignmentCount: number;
   availabilityLocked?: boolean;
   availabilityCutoffLabel?: string;
   availabilityPreferences?: Record<string, unknown> | null;
@@ -770,11 +771,21 @@ export function getOpenScheduleAssignments(assignments: Array<Partial<ScheduleAs
     .filter(isScheduleAssignmentOpen);
 }
 
-export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'rideshareSummary' | 'isDbGame' | 'isCancelled' | 'myRsvp'>): ScheduleEventDetailSection | '' {
+export function countOpenScheduleAssignments(assignments: Array<Partial<ScheduleAssignment>> = []) {
+  return getOpenScheduleAssignments(assignments).length;
+}
+
+export function getEventOpenAssignmentCount(event: Pick<ParentScheduleEvent, 'openAssignmentCount' | 'assignments'> | Pick<CalendarScheduleEntry, 'openAssignmentCount' | 'assignments'>) {
+  return Number.isFinite(event.openAssignmentCount)
+    ? Math.max(0, Number(event.openAssignmentCount))
+    : countOpenScheduleAssignments(event.assignments);
+}
+
+export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'openAssignmentCount' | 'rideshareSummary' | 'isDbGame' | 'isCancelled' | 'myRsvp'>): ScheduleEventDetailSection | '' {
   if (event.type === 'game' && event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded') return 'availability';
   // Practice packets render in the shared game/report tab inside ScheduleEventDetail.
   if (event.type === 'practice' && event.practiceHomePacketSummary) return PRACTICE_PACKET_DETAIL_SECTION;
-  if (getOpenScheduleAssignments(event.assignments).length > 0) return 'assignments';
+  if (getEventOpenAssignmentCount(event) > 0) return 'assignments';
   const rideSummary = event.rideshareSummary;
   if (rideSummary && (rideSummary.requests > 0 || rideSummary.pending > 0 || rideSummary.seatsLeft > 0)) return 'rideshare';
   return '';
@@ -1183,6 +1194,7 @@ export function getCalendarScheduleEntries(events: ParentScheduleEvent[]): Calen
         myRsvp: normalizeRsvpResponse(event.myRsvp)
       });
     }
+    entry.openAssignmentCount = getEventOpenAssignmentCount(entry);
   });
 
   return [...byKey.values()].sort((a, b) => a.date.getTime() - b.date.getTime());

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -174,7 +174,7 @@ vi.mock('./appDataCache', () => ({
 
 import { addGame, addPractice, broadcastLiveEvent, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getTeam, getTeams, listRideOffersForEvent, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
 import { getNativeAuthIdToken } from './authService';
-import { expandRecurrence, fetchAndParseCalendar, isTeamActive } from './adapters/legacyScheduleHelpers';
+import { expandRecurrence, fetchAndParseCalendar, isTeamActive, mergeAssignmentsWithClaims } from './adapters/legacyScheduleHelpers';
 import { getCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
@@ -1023,6 +1023,7 @@ describe('parent schedule detail hydration', () => {
       isDbGame: true,
       isCancelled: false,
       assignments: [],
+      openAssignmentCount: 0,
       availabilityPreferences: {},
       myRsvp: 'not_responded',
       myRsvpNote: null,
@@ -1051,6 +1052,7 @@ describe('parent schedule detail hydration', () => {
     });
     vi.mocked(listRideOffersForEvent).mockResolvedValue([] as any);
     vi.mocked(getAssignmentClaims).mockResolvedValue({} as any);
+    vi.mocked(mergeAssignmentsWithClaims).mockImplementation((assignments: any[]) => assignments);
   });
 
   it('eagerly hydrates only near-term Home events without preloading duplicate RSVP summaries', async () => {
@@ -1072,6 +1074,24 @@ describe('parent schedule detail hydration', () => {
       total: 1
     });
     expect(futureEvent.myRsvp).toBe('not_responded');
+  });
+
+  it('refreshes cached open assignment counts after assignment claim hydration', async () => {
+    const nearEvent = buildHydrationEvent('near-game', new Date(Date.now() + 24 * 60 * 60 * 1000));
+    nearEvent.assignments = [{ role: 'Scoreboard', claimable: true, value: '' }];
+    nearEvent.openAssignmentCount = 1;
+    const claimedAssignments = [{ role: 'Scoreboard', claimable: true, value: '', claim: { claimedByUserId: 'parent-2' } }];
+    vi.mocked(getAssignmentClaims).mockResolvedValue({ scoreboard: { claimedByUserId: 'parent-2' } } as any);
+    vi.mocked(mergeAssignmentsWithClaims).mockReturnValue(claimedAssignments as any);
+
+    await hydrateParentScheduleDetails({ children: [], events: [nearEvent] }, user);
+
+    expect(mergeAssignmentsWithClaims).toHaveBeenCalledWith(
+      [{ role: 'Scoreboard', claimable: true, value: '' }],
+      { scoreboard: { claimedByUserId: 'parent-2' } }
+    );
+    expect(nearEvent.assignments).toBe(claimedAssignments);
+    expect(nearEvent.openAssignmentCount).toBe(0);
   });
 
   it('preserves denormalized RSVP summaries without preloading duplicate summaries', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2341,7 +2341,7 @@ describe('native parent schedule Firestore mapping', () => {
                   mapValue: {
                     fields: {
                       role: { stringValue: 'Scoreboard' },
-                      value: { stringValue: 'Open' }
+                      claimable: { booleanValue: true }
                     }
                   }
                 }
@@ -2377,6 +2377,7 @@ describe('native parent schedule Firestore mapping', () => {
       status: 'scheduled',
       liveClockMs: 120000,
       liveClockRunning: true,
+      openAssignmentCount: 1,
       sourceType: 'registration'
     });
     expect(result.events[0].date).toEqual(new Date('2026-06-20T18:00:00.000Z'));

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3268,6 +3268,7 @@ async function hydrateEventDetails(events: ParentScheduleEvent[], user: AuthUser
     const summary = firstEvent.rsvpSummary || summarizeRsvps(rsvps);
     const rideshareSummary = getEventRideshareSummary(offers) as ScheduleRideSummary;
     const assignments = mergeAssignmentsWithClaims(firstEvent.assignments, claims) as ScheduleAssignment[];
+    const openAssignmentCount = countOpenScheduleAssignments(assignments);
     const preferences = firstEvent.availabilityPreferences || {};
     const isTeamAdmin = matchingEvents.some((event) => event.isTeamAdmin === true);
     const availabilityNotesVisible = canViewAvailabilityNotes(preferences, isTeamAdmin);
@@ -3279,6 +3280,7 @@ async function hydrateEventDetails(events: ParentScheduleEvent[], user: AuthUser
       event.rsvpSummary = summary;
       event.rideshareSummary = rideshareSummary;
       event.assignments = assignments;
+      event.openAssignmentCount = openAssignmentCount;
       event.availabilityNotesVisible = availabilityNotesVisible;
       event.availabilityNotes = availabilityNotes;
     });

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -85,6 +85,7 @@ import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { startUxTimer } from './uxTiming';
 import {
+  countOpenScheduleAssignments,
   getNextRideConfirmedSeatCount,
   getScheduleRideshareSummary,
   getScheduleTitle,
@@ -2782,6 +2783,7 @@ function createScheduleEvent(input: {
     rsvpSummary: input.rsvpSummary || null,
     rideshareSummary: null,
     assignments: Array.isArray(input.assignments) ? input.assignments : [],
+    openAssignmentCount: countOpenScheduleAssignments(Array.isArray(input.assignments) ? input.assignments : []),
     availabilityLocked: isAvailabilityLocked(input.date, availabilityPreferences),
     availabilityCutoffLabel: formatAvailabilityCutoff(availabilityPreferences),
     availabilityPreferences,

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -133,8 +133,8 @@ function buildScheduleEvent(index: number, overrides: Partial<ParentScheduleEven
   const assignments = Array.isArray(event.assignments) ? event.assignments : [];
   return {
     ...event,
-    openAssignmentCount: typeof event.openAssignmentCount === 'number'
-      ? event.openAssignmentCount
+    openAssignmentCount: typeof overrides.openAssignmentCount === 'number'
+      ? overrides.openAssignmentCount
       : assignments.filter((assignment: any) => assignment?.claimable && !assignment?.claim && !assignment?.value).length
   };
 }

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -49,6 +49,11 @@ vi.mock('../lib/telemetry', () => ({
   recordAppWorkflowTiming: vi.fn(),
   startAppInitialLoadTimer: vi.fn(() => initialLoadTelemetryMocks)
 }));
+vi.mock('../lib/performanceInstrumentation', () => ({
+  now: vi.fn(() => 0),
+  startPerformanceSpan: vi.fn(() => ({ startedAt: 0, end: vi.fn() })),
+  recordCompletedPerformanceSpan: vi.fn()
+}));
 vi.mock('../lib/uxTiming', () => ({
   recordFirstMeaningfulRender: uxTimingMocks.recordFirstMeaningfulRender,
   startScreenMountTimer: vi.fn(() => ({ end: uxTimingMocks.end })),
@@ -104,7 +109,7 @@ function RouteProbe() {
 }
 
 function buildScheduleEvent(index: number, overrides: Record<string, unknown> = {}) {
-  return {
+  const event = {
     eventKey: `team-1::event-${index}::player-1::2100-06-${String(index).padStart(2, '0')}T18:00:00.000Z::game`,
     id: `event-${index}`,
     teamId: 'team-1',
@@ -121,6 +126,14 @@ function buildScheduleEvent(index: number, overrides: Record<string, unknown> = 
     myRsvp: 'not_responded' as const,
     assignments: [],
     ...overrides
+  };
+
+  const assignments = Array.isArray(event.assignments) ? event.assignments : [];
+  return {
+    ...event,
+    openAssignmentCount: typeof event.openAssignmentCount === 'number'
+      ? event.openAssignmentCount
+      : assignments.filter((assignment: any) => assignment?.claimable && !assignment?.claim && !assignment?.value).length
   };
 }
 
@@ -465,6 +478,48 @@ describe('Schedule', () => {
 
     expect(queueLinks).toContain('/schedule/team-1/event-1?childId=player-1&section=assignments');
     expect(queueLinks).toContain('/schedule/team-1/event-2?childId=player-1&section=rideshare');
+  });
+
+  it('reuses cached open assignment counts across schedule summaries and view changes', async () => {
+    shellLayoutMocks.isDesktopWeb = true;
+    const assignments = [
+      { role: 'Snack bar', claimable: true, value: '' },
+      { role: 'Bench help', claimable: true, claim: { claimedByUserId: 'parent-2' } },
+      { role: 'Water', claimable: true, value: 'Filled' }
+    ];
+    const assignmentFilterSpy = vi.spyOn(assignments, 'filter');
+
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          myRsvp: 'going',
+          assignments,
+          openAssignmentCount: 1,
+          rideshareSummary: { requests: 2, pending: 0, seatsLeft: 0 }
+        })
+      ]
+    });
+
+    const { container } = renderSchedule();
+
+    expect(await screen.findByText('1 task open')).toBeTruthy();
+    expect(screen.getByText('1 open assignment')).toBeTruthy();
+    expect(screen.getByText('2 ride requests')).toBeTruthy();
+    expect(assignmentFilterSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters and views' }));
+    expect(container.querySelector('.schedule-control-panel')?.textContent || '').toContain('1Tasks');
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Calendar' })[0]!);
+    fireEvent.click(screen.getAllByRole('button', { name: 'List' })[0]!);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 task open')).toBeTruthy();
+    });
+    expect(assignmentFilterSpy).not.toHaveBeenCalled();
   });
 
   it('shows the remaining event count when only one more event is hidden', async () => {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Schedule, getGenericEventDetailPath } from './Schedule';
+import type { ParentScheduleEvent } from '../lib/scheduleLogic';
 import type { AuthState } from '../lib/types';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
@@ -108,8 +109,8 @@ function RouteProbe() {
   return <div data-testid="route-probe">{location.pathname}{location.search}</div>;
 }
 
-function buildScheduleEvent(index: number, overrides: Record<string, unknown> = {}) {
-  const event = {
+function buildScheduleEvent(index: number, overrides: Partial<ParentScheduleEvent> = {}): ParentScheduleEvent {
+  const event: ParentScheduleEvent = {
     eventKey: `team-1::event-${index}::player-1::2100-06-${String(index).padStart(2, '0')}T18:00:00.000Z::game`,
     id: `event-${index}`,
     teamId: 'team-1',
@@ -125,6 +126,7 @@ function buildScheduleEvent(index: number, overrides: Record<string, unknown> = 
     isCancelled: false,
     myRsvp: 'not_responded' as const,
     assignments: [],
+    openAssignmentCount: 0,
     ...overrides
   };
 
@@ -406,7 +408,7 @@ describe('Schedule', () => {
       isTeamStaff: false,
       myRsvp: 'going',
       assignments: [],
-      rideshareSummary: { requests: 1, pending: 0, seatsLeft: 0 }
+      rideshareSummary: { requests: 1, offerCount: 0, pending: 0, confirmed: 0, seatsLeft: 0, isFull: false }
     }) as any, true)).toBe('/schedule/team-1/event-1?childId=player-1&section=rideshare');
     expect(getGenericEventDetailPath(buildScheduleEvent(1, {
       id: 'practice-1',
@@ -458,7 +460,7 @@ describe('Schedule', () => {
           date: new Date('2100-06-02T18:00:00.000Z'),
           myRsvp: 'going',
           assignments: [],
-          rideshareSummary: { requests: 1, pending: 0, seatsLeft: 0 }
+          rideshareSummary: { requests: 1, offerCount: 0, pending: 0, confirmed: 0, seatsLeft: 0, isFull: false }
         })
       ]
     });
@@ -498,7 +500,7 @@ describe('Schedule', () => {
           myRsvp: 'going',
           assignments,
           openAssignmentCount: 1,
-          rideshareSummary: { requests: 2, pending: 0, seatsLeft: 0 }
+          rideshareSummary: { requests: 2, offerCount: 0, pending: 0, confirmed: 0, seatsLeft: 0, isFull: false }
         })
       ]
     });

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -22,6 +22,7 @@ import {
   formatEventDateLabel,
   formatEventTimeLabel,
   getCalendarScheduleEntries,
+  getEventOpenAssignmentCount,
   getGenericEventDetailPath,
   getParentScheduleTeamOptions,
   getScheduleEventDetailPath,
@@ -2208,12 +2209,12 @@ type ScheduleWebInsights = {
   rideRequests: number;
 };
 
-function buildScheduleWebInsights(events: ParentScheduleEvent[]): ScheduleWebInsights {
+function buildScheduleWebInsights(events: Array<ParentScheduleEvent | CalendarScheduleEntry>): ScheduleWebInsights {
   return events.reduce<ScheduleWebInsights>((insights, event) => {
     if (!insights.nextEvent && !event.isCancelled) insights.nextEvent = event;
     if (event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded') insights.rsvpNeeded += 1;
     if (event.type === 'practice' && event.practiceHomePacketSummary) insights.packetsReady += 1;
-    insights.openAssignments += event.assignments.filter((assignment) => assignment.claimable && !assignment.claim && !assignment.value).length;
+    insights.openAssignments += getEventOpenAssignmentCount(event);
     insights.rideRequests += event.rideshareSummary?.requests || 0;
     return insights;
   }, {
@@ -2843,7 +2844,7 @@ function getScheduleChildLabel(event: ParentScheduleEvent | CalendarScheduleEntr
 function getEventPrimaryActionText(event: ParentScheduleEvent, rsvp: RsvpResponse) {
   if (rsvp === 'not_responded' && event.isDbGame && !event.isCancelled) return 'Set availability';
   if (event.type === 'practice' && event.practiceHomePacketSummary) return 'Review packet';
-  if (getOpenAssignmentCount(event) > 0) return 'Review assignments';
+  if (getEventOpenAssignmentCount(event) > 0) return 'Review assignments';
   if ((event.rideshareSummary?.requests || 0) > 0) return 'Check ride requests';
   return event.type === 'practice' ? 'Open practice' : 'Open game';
 }
@@ -2852,7 +2853,7 @@ function getEventActionSummary(event: ParentScheduleEvent) {
   const rsvp = normalizeRsvpResponse(event.myRsvp);
   if (rsvp === 'not_responded' && event.isDbGame && !event.isCancelled) return `RSVP needed for ${event.childName}`;
   if (event.type === 'practice' && event.practiceHomePacketSummary) return `Packet ready: ${event.practiceHomePacketSummary}`;
-  const openAssignments = getOpenAssignmentCount(event);
+  const openAssignments = getEventOpenAssignmentCount(event);
   if (openAssignments > 0) return `${openAssignments} open ${openAssignments === 1 ? 'assignment' : 'assignments'}`;
   const rideRequests = event.rideshareSummary?.requests || 0;
   if (rideRequests > 0) return `${rideRequests} ride ${rideRequests === 1 ? 'request' : 'requests'}`;
@@ -2863,7 +2864,7 @@ function getEventCardActionPills(event: ParentScheduleEvent | CalendarScheduleEn
   const pills: string[] = [];
   if (rsvp === 'not_responded' && event.isDbGame && !event.isCancelled) pills.push('Availability needed');
   if (event.type === 'practice' && event.practiceHomePacketSummary) pills.push(`Packet: ${event.practiceHomePacketSummary}`);
-  const openAssignments = getOpenAssignmentCount(event);
+  const openAssignments = getEventOpenAssignmentCount(event);
   if (openAssignments > 0) pills.push(`${openAssignments} task${openAssignments === 1 ? '' : 's'} open`);
   const seatsLeft = event.rideshareSummary?.seatsLeft || 0;
   const rideRequests = event.rideshareSummary?.requests || 0;
@@ -2891,10 +2892,6 @@ function getScoreLabel(event: ParentScheduleEvent | CalendarScheduleEntry) {
   const isPastScheduledResult = event.date.getTime() < Date.now() - pastScheduleCutoffMs;
   if (!isCompleted && !isPastScheduledResult) return '';
   return `${event.homeScore}-${event.awayScore}`;
-}
-
-function getOpenAssignmentCount(event: ParentScheduleEvent | CalendarScheduleEntry) {
-  return event.assignments.filter((assignment) => assignment.claimable && !assignment.claim && !assignment.value).length;
 }
 
 function CalendarSchedule({ month, entries, selectedDay, selectedDayEntries, preferGameHubForStaff, onMonthChange, onDaySelect, onDayClose }: {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -2731,6 +2731,7 @@ function buildTeamReminderScheduleEvent(event: TeamDetailEvent, model: TeamDetai
     homeScore: event.homeScore,
     awayScore: event.awayScore,
     assignments: [],
+    openAssignmentCount: 0,
     isTeamStaff: true,
     isTeamRsvpReminderManager: true
   };

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -26,6 +26,15 @@ const layoutState = vi.hoisted(() => ({
 }));
 
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
+vi.mock('@capacitor-firebase/performance', () => ({
+    FirebasePerformance: {
+        startTrace: vi.fn().mockResolvedValue(undefined),
+        stopTrace: vi.fn().mockResolvedValue(undefined),
+        putAttribute: vi.fn().mockResolvedValue(undefined),
+        putMetric: vi.fn().mockResolvedValue(undefined),
+        record: vi.fn().mockResolvedValue(undefined)
+    }
+}));
 vi.mock('../../apps/app/src/lib/uxTiming.ts', () => ({
     recordFirstMeaningfulRender: vi.fn(),
     startScreenMountTimer: vi.fn(() => ({ end: vi.fn() })),

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -97,6 +97,15 @@ const publicActionMocks = vi.hoisted(() => ({
     sharePublicUrl: vi.fn()
 }));
 
+vi.mock('@capacitor-firebase/performance', () => ({
+    FirebasePerformance: {
+        startTrace: vi.fn().mockResolvedValue(undefined),
+        stopTrace: vi.fn().mockResolvedValue(undefined),
+        putAttribute: vi.fn().mockResolvedValue(undefined),
+        putMetric: vi.fn().mockResolvedValue(undefined),
+        record: vi.fn().mockResolvedValue(undefined)
+    }
+}));
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
 vi.mock('../../apps/app/src/lib/gameReportService.ts', () => reportMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);


### PR DESCRIPTION
Closes #3217

## What changed
- added a cached `openAssignmentCount` to normalized `ParentScheduleEvent` records and reused it through grouped `CalendarScheduleEntry` rows
- added shared schedule-logic helpers so Schedule consumers read the cached count instead of re-filtering `event.assignments`
- updated Schedule insights, action summary text, primary actions, and event card pills to consume the cached count
- added focused regression coverage for normalization/grouping, native schedule mapping, and Schedule view/filter toggles

## Root Cause
The Schedule render path recalculated open assignment counts from raw `assignments` arrays in multiple helpers on every render. Because event shaping never stored the derived value, list rows, insights, and the attention queue repeatedly scanned the same assignment arrays for the same visible events.

## Prevention / Learning
When a derived UI value is consumed by multiple render-path helpers, compute it once at normalization/grouping boundaries and carry it forward as typed data. Future Schedule work should treat repeated array filtering inside render helpers as a performance smell and move that derivation into shared shaping logic with regression coverage.

## Regression Tests
- `npx vitest run src/lib/scheduleLogic.test.ts src/lib/scheduleService.test.ts src/pages/Schedule.test.tsx --reporter=verbose`
- verified `countOpenScheduleAssignments` only counts claimable unclaimed unfilled assignments
- verified grouped calendar entries preserve cached assignment counts
- verified Schedule insights, queue text, and event pills keep the same visible counts while filter/view changes do not trigger assignment-array `filter` recomputation for the same event set

## Recurrence Risk
Low. The derived count now has a single normalization source and focused tests cover both shaping and the main Schedule render consumers.