### PR TITLE
Split registration detail off parent tools service

### DIFF
--- a/apps/app/src/lib/parentRegistrationsService.ts
+++ b/apps/app/src/lib/parentRegistrationsService.ts
@@ -1,11 +1,30 @@
 import {
+    acceptTeamRegistrationOffer,
+    approveTeamRegistration,
     calculateRegistrationFeeSnapshot,
+    cancelStripeRegistrationCheckout,
+    createRegistrationCheckoutSession,
+    db,
+    doc,
+    extendTeamRegistrationOffer,
+    functions,
     getActiveRegistrationOptions,
+    getDoc,
+    getPaymentPlanChoices,
+    getPlayers,
+    getRegistrationGuardianDrafts,
     getRegistrationPaymentNotice,
+    getRegistrationPlayerDraft,
+    getRegistrationSubmittedData,
     getTeam,
+    getTeamRegistrationForm,
     hasOnlineRegistrationCheckout,
+    httpsCallable,
     listPublishedTeamRegistrationForms,
-    normalizeRegistrationForm
+    listTeamRegistrationReviewsPage,
+    normalizeRegistrationForm,
+    normalizeRegistrationStatus,
+    rejectTeamRegistration
 } from './adapters/legacyParentTools';
 import { formatCurrencyFromCents as formatCurrency } from './money';
 import type { AuthUser } from './types';
@@ -39,6 +58,48 @@ export type ParentRegistrationCard = Record<string, any> & {
     appUrl?: string;
 };
 
+export type ParentRegistrationDetailModel = {
+    teamName: string;
+    isPublished: boolean;
+    onlineCheckout: boolean;
+    legacyUrl: string;
+    form: Record<string, any>;
+    options: Array<Record<string, any>>;
+    feeSnapshot: Record<string, any>;
+    paymentNotice: string;
+    paymentPlans: Array<Record<string, any>>;
+};
+
+export type TeamRegistrationRosterPlayer = {
+    id: string;
+    name: string;
+    number?: string;
+};
+
+export type TeamRegistrationReviewCard = Record<string, any> & {
+    id: string;
+    status: string;
+    participantName: string;
+    guardianLabel: string;
+    guardianEmails: string[];
+    participant: Record<string, any>;
+    guardian: Record<string, any>;
+    submittedData: Record<string, any>;
+    submittedAt: unknown;
+    selectedOptionLabel: string;
+    paymentLabel: string;
+    waiverAccepted: boolean;
+    linkedPlayerId: string;
+    decisionNote: string;
+};
+
+export type TeamRegistrationQueueModel = {
+    reviews: TeamRegistrationReviewCard[];
+    rosterPlayers: TeamRegistrationRosterPlayer[];
+    waitlistedReviews?: TeamRegistrationReviewCard[];
+    totalWaitlisted?: number;
+};
+
 export async function loadParentRegistrations(user: AuthUser | null): Promise<ParentRegistrationCard[]> {
     const teamIds = getLinkedTeamIds(user);
     const cards = await Promise.all(teamIds.map(async (teamId) => {
@@ -51,6 +112,231 @@ export async function loadParentRegistrations(user: AuthUser | null): Promise<Pa
     return cards.flat()
         .filter((card): card is ParentRegistrationCard => Boolean(card))
         .sort((a, b) => a.teamName.localeCompare(b.teamName) || a.programName.localeCompare(b.programName));
+}
+
+export async function submitOfflineRegistration(teamId: string, formId: string, submission: Record<string, any>) {
+    if (!teamId || !formId || !submission) throw new Error('Registration submission is incomplete.');
+
+    const submitPublicRegistration = httpsCallable(functions, 'submitPublicRegistration');
+    try {
+        const result = await submitPublicRegistration({
+            teamId,
+            formId,
+            participant: submission.participant,
+            guardian: submission.guardian,
+            waiverAccepted: submission.waiverAccepted,
+            selectedOptionId: submission.selectedOptionId || submission.selectedOption?.id || '',
+            selectedPaymentPlanId: submission.selectedPaymentPlanId || 'pay_full',
+            quantity: submission.quantity || submission.feeSnapshot?.quantity || 1,
+            checkoutAttemptToken: submission.checkoutAttemptToken || ''
+        });
+        return result?.data || {};
+    } catch (error: any) {
+        const code = String(error?.code || '').replace(/^functions\//, '');
+        const details = error?.details || {};
+        if (details.reason === 'option-full' || details.reason === 'missing-option' || code === 'failed-precondition' || code === 'invalid-argument' || code === 'resource-exhausted') {
+            throw new Error(error?.message || 'Registration could not be submitted.');
+        }
+        throw error;
+    }
+}
+
+export async function loadTeamRegistrationQueuePage(
+    teamId: string,
+    formId: string,
+    options: { status?: string; pageSize?: number; afterDoc?: any } = {}
+): Promise<{ reviews: TeamRegistrationReviewCard[]; lastDoc: any; hasMore: boolean }> {
+    const { status = 'all', pageSize = 25, afterDoc = null } = options;
+    const { registrations, lastDoc, hasMore } = await listTeamRegistrationReviewsPage(teamId, formId, { status, pageSize, afterDoc });
+    return {
+        reviews: (registrations || []).map((review: any) => toTeamRegistrationReviewCard(review)),
+        lastDoc,
+        hasMore
+    };
+}
+
+export async function loadTeamRegistrationRosterPlayers(
+    user: AuthUser | null,
+    teamId: string
+): Promise<TeamRegistrationRosterPlayer[]> {
+    if (!canManageTeamRegistrations(user, teamId)) {
+        throw new Error('Admin access is required to review registrations.');
+    }
+    const rosterPlayers = await Promise.resolve(getPlayers(teamId)).catch(() => []);
+    return (rosterPlayers || []).map((player: any) => ({
+        id: compactString(player.id),
+        name: compactString(player.name) || 'Player',
+        number: compactString(player.number)
+    }));
+}
+
+export async function approveTeamRegistrationForApp(
+    user: AuthUser | null,
+    teamId: string,
+    formId: string,
+    registrationId: string,
+    options: { playerId?: string; decisionNote?: string } = {}
+) {
+    if (!canManageTeamRegistrations(user, teamId)) {
+        throw new Error('Admin access is required to approve registrations.');
+    }
+    return approveTeamRegistration(teamId, formId, registrationId, options);
+}
+
+export async function rejectTeamRegistrationForApp(
+    user: AuthUser | null,
+    teamId: string,
+    formId: string,
+    registrationId: string,
+    decisionNote = ''
+) {
+    if (!canManageTeamRegistrations(user, teamId)) {
+        throw new Error('Admin access is required to decline registrations.');
+    }
+    return rejectTeamRegistration(teamId, formId, registrationId, decisionNote);
+}
+
+export async function extendTeamRegistrationOfferForApp(
+    user: AuthUser | null,
+    teamId: string,
+    formId: string,
+    registrationId: string,
+    decisionNote = ''
+) {
+    if (!canManageTeamRegistrations(user, teamId)) {
+        throw new Error('Admin access is required to manage waitlist registrations.');
+    }
+    return extendTeamRegistrationOffer(teamId, formId, registrationId, decisionNote);
+}
+
+export async function acceptTeamRegistrationOfferForApp(
+    user: AuthUser | null,
+    teamId: string,
+    formId: string,
+    registrationId: string,
+    decisionNote = ''
+) {
+    if (!canManageTeamRegistrations(user, teamId)) {
+        throw new Error('Admin access is required to manage waitlist registrations.');
+    }
+    return acceptTeamRegistrationOffer(teamId, formId, registrationId, decisionNote);
+}
+
+export async function loadParentRegistrationDetail(
+    user: AuthUser | null,
+    teamId: string,
+    formId: string
+): Promise<ParentRegistrationDetailModel> {
+    if (!user?.uid || !teamId || !formId) {
+        throw new Error('Team and form are required.');
+    }
+    if (!getLinkedTeamIds(user).includes(teamId)) {
+        throw new Error('Registration is not linked to your family.');
+    }
+    return loadRegistrationDetailModel(teamId, formId);
+}
+
+export async function loadStaffRegistrationDetail(
+    user: AuthUser | null,
+    teamId: string,
+    formId: string
+): Promise<ParentRegistrationDetailModel> {
+    if (!canManageTeamRegistrations(user, teamId)) {
+        throw new Error('Admin access is required to review registrations.');
+    }
+    return loadRegistrationDetailModel(teamId, formId);
+}
+
+export async function loadPublicRegistrationDetail(
+    teamId: string,
+    formId: string
+): Promise<ParentRegistrationDetailModel> {
+    if (!teamId || !formId) {
+        throw new Error('Team and form are required.');
+    }
+
+    const formSnap = await Promise.resolve(getDoc(doc(db, 'teams', teamId, 'registrationForms', formId))).catch(() => null);
+    const form = formSnap?.exists?.() ? { id: formId, ...(formSnap.data() || {}) } : null;
+    if (!form) throw new Error('Registration form not found.');
+
+    const normalizedForm = normalizeRegistrationForm(form, { teamId, formId });
+    if (!normalizedForm.published || normalizedForm.status === 'closed' || normalizedForm.status === 'archived') {
+        throw new Error('This registration form is not available right now.');
+    }
+
+    const feeSnapshot = calculateRegistrationFeeSnapshot(normalizedForm, { now: new Date() });
+    const paymentPlans = getPaymentPlanChoices(normalizedForm);
+    const paymentNotice = getRegistrationPaymentNotice(normalizedForm);
+    const onlineCheckout = hasOnlineRegistrationCheckout(normalizedForm);
+    const legacyUrl = getRegistrationUrl(teamId, formId);
+
+    return {
+        teamName: getPublicRegistrationTeamName(form),
+        isPublished: true,
+        onlineCheckout,
+        legacyUrl,
+        form: normalizedForm,
+        options: getActiveRegistrationOptions(normalizedForm, normalizedForm.registrationOptionCounts || {}),
+        feeSnapshot,
+        paymentNotice,
+        paymentPlans
+    };
+}
+
+export async function initiateRegistrationCheckout(
+    teamId: string,
+    formId: string,
+    registrationId: string,
+    selectedOptionId: string,
+    paymentPlanId: string,
+    quantity: number,
+    amountCents: number,
+    currency: string,
+    options: { checkoutAttemptToken?: string; retryPayment?: boolean; publicCheckoutCapability?: string } = {}
+): Promise<{ success: true; checkoutUrl: string }> {
+    if (!teamId || !formId || (!registrationId && !options.publicCheckoutCapability) || !paymentPlanId || !quantity || !amountCents || !currency) {
+        throw new Error('Missing required fields for checkout.');
+    }
+
+    const result = await createRegistrationCheckoutSession(
+        teamId,
+        formId,
+        registrationId,
+        selectedOptionId,
+        paymentPlanId,
+        quantity,
+        amountCents,
+        currency,
+        options.checkoutAttemptToken,
+        options.retryPayment,
+        options.publicCheckoutCapability
+    );
+
+    if (!result?.checkoutUrl) {
+        throw new Error('Failed to get checkout URL.');
+    }
+
+    return { success: true, checkoutUrl: result.checkoutUrl };
+}
+
+export async function cancelRegistrationCheckout(
+    teamId: string,
+    formId: string,
+    registrationId: string,
+    checkoutAttemptToken = '',
+    publicCheckoutCapability = ''
+) {
+    if (!teamId || !formId || (!registrationId && !publicCheckoutCapability)) {
+        throw new Error('Missing required fields for checkout cancellation.');
+    }
+
+    return cancelStripeRegistrationCheckout({
+        teamId,
+        formId,
+        registrationId,
+        checkoutAttemptToken,
+        publicCheckoutCapability
+    });
 }
 
 function getLegacyUrl(path: string, params: Record<string, string> = {}) {
@@ -95,11 +381,115 @@ function toRegistrationCard(team: any, form: any): ParentRegistrationCard | null
     };
 }
 
+async function loadRegistrationDetailModel(teamId: string, formId: string): Promise<ParentRegistrationDetailModel> {
+    if (!teamId || !formId) {
+        throw new Error('Team and form are required.');
+    }
+    const [team, form] = await Promise.all([
+        Promise.resolve(getTeam(teamId)).catch(() => null),
+        Promise.resolve(getTeamRegistrationForm(teamId, formId)).catch(() => null)
+    ]);
+
+    if (!form) throw new Error('Registration form not found.');
+    if (!team) throw new Error('Team not found.');
+
+    const normalizedForm = normalizeRegistrationForm(form, { teamId, formId });
+    const feeSnapshot = calculateRegistrationFeeSnapshot(normalizedForm, { now: new Date() });
+    const paymentPlans = getPaymentPlanChoices(normalizedForm);
+    const paymentNotice = getRegistrationPaymentNotice(normalizedForm);
+    const onlineCheckout = hasOnlineRegistrationCheckout(normalizedForm);
+    const legacyUrl = getRegistrationUrl(teamId, formId);
+
+    return {
+        teamName: compactString(team.name) || 'Team',
+        isPublished: normalizedForm.published && normalizedForm.status !== 'closed' && normalizedForm.status !== 'archived',
+        onlineCheckout,
+        legacyUrl,
+        form: normalizedForm,
+        options: getActiveRegistrationOptions(normalizedForm, normalizedForm.registrationOptionCounts || {}),
+        feeSnapshot,
+        paymentNotice,
+        paymentPlans
+    };
+}
+
+function getPublicRegistrationTeamName(form: Record<string, any>) {
+    return compactString(form.teamName || form.team?.name || form.organizationName || form.clubName) || 'Team';
+}
+
+function toTeamRegistrationReviewCard(review: any): TeamRegistrationReviewCard {
+    const normalizedStatus = normalizeRegistrationStatus(review?.status || 'pending');
+    const submittedData = asObject(getRegistrationSubmittedData(review));
+    const participant = {
+        ...asObject(review?.participant),
+        ...asObject(submittedData.participant)
+    };
+    const guardian = {
+        ...asObject(review?.guardian),
+        ...asObject(submittedData.guardian)
+    };
+    const guardians = getRegistrationGuardianDrafts(review) as Array<Record<string, any>>;
+    const playerDraft = getRegistrationPlayerDraft(review);
+    const feeSnapshot = asObject(review?.feeSnapshot);
+    const selectedOption = asObject(review?.selectedOption);
+    const paymentState = compactString(
+        review?.paymentStatus
+        || feeSnapshot.paymentStatus
+        || review?.checkoutStatus
+        || review?.paymentState
+        || review?.payment?.status
+    );
+    const paymentAmount = Number(
+        review?.balanceDueCents
+        ?? review?.paymentPlan?.remainingBalanceCents
+        ?? feeSnapshot.finalAmountDueCents
+        ?? feeSnapshot.amountDueCents
+        ?? feeSnapshot.feeAmountCents
+        ?? review?.feeAmountCents
+    );
+    const paymentStateLabel = paymentState.replace(/_/g, ' ');
+
+    return {
+        ...review,
+        id: compactString(review?.id),
+        status: normalizedStatus,
+        participantName: compactString(review?.reviewSummary?.playerName || playerDraft.name || participant.name) || 'Unnamed player',
+        guardianLabel: compactString(review?.reviewSummary?.guardianLabel || guardians.map((entry) => entry.email || entry.name).filter(Boolean).join(', ')),
+        guardianEmails: guardians.map((entry) => compactString(entry.email)).filter(Boolean),
+        participant,
+        guardian,
+        submittedData,
+        submittedAt: review?.reviewSummary?.submittedAt || review?.submittedAt || review?.createdAt || null,
+        selectedOptionLabel: compactString(selectedOption.title || selectedOption.label || review?.selectedOptionLabel || review?.selectedOptionId),
+        paymentLabel: paymentState
+            ? `${paymentStateLabel}${Number.isFinite(paymentAmount) ? ` · ${formatCurrency(paymentAmount, feeSnapshot.currency || review?.currency || 'USD')}` : ''}`
+            : (Number.isFinite(paymentAmount) ? formatCurrency(paymentAmount, feeSnapshot.currency || review?.currency || 'USD') : 'Not recorded'),
+        waiverAccepted: Boolean(
+            review?.waiverAccepted
+            ?? submittedData.waiverAccepted
+            ?? submittedData.waiver
+            ?? review?.waiver?.accepted
+        ),
+        linkedPlayerId: compactString(review?.linkedPlayerId),
+        decisionNote: compactString(review?.decisionNote)
+    };
+}
+
 function getLinkedTeamIds(user: AuthUser | null) {
     return [...new Set([
-        ...(Array.isArray(user?.parentOf) ? user!.parentOf.map((entry: any) => compactString(entry.teamId)) : []),
-        ...(Array.isArray(user?.coachOf) ? user!.coachOf.map(compactString) : [])
+        ...(Array.isArray(user?.parentOf) ? user.parentOf.map((entry: any) => compactString(entry.teamId)) : []),
+        ...(Array.isArray(user?.coachOf) ? user.coachOf.map(compactString) : [])
     ].filter(Boolean))];
+}
+
+function canManageTeamRegistrations(user: AuthUser | null, teamId: string) {
+    if (!teamId || !user) return false;
+    if (Array.isArray(user.roles) && user.roles.some((role) => role === 'admin' || role === 'platformAdmin')) return true;
+    return Array.isArray(user.coachOf) && user.coachOf.map(compactString).includes(teamId);
+}
+
+function asObject(value: unknown): Record<string, any> {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, any> : {};
 }
 
 function compactString(value: unknown) {

--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -2,20 +2,27 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { RegistrationDetail } from './RegistrationDetail';
+import { RegistrationDetail, TeamRegistrationReview } from './RegistrationDetail';
 import type { AuthState } from '../lib/types';
 
-const parentToolsServiceMocks = vi.hoisted(() => ({
+const parentRegistrationsServiceMocks = vi.hoisted(() => ({
+  acceptTeamRegistrationOfferForApp: vi.fn(),
+  approveTeamRegistrationForApp: vi.fn(),
   cancelRegistrationCheckout: vi.fn(),
+  extendTeamRegistrationOfferForApp: vi.fn(),
   initiateRegistrationCheckout: vi.fn(),
   loadParentRegistrationDetail: vi.fn(),
   loadPublicRegistrationDetail: vi.fn(),
   loadParentRegistrations: vi.fn(),
+  loadStaffRegistrationDetail: vi.fn(),
+  loadTeamRegistrationQueuePage: vi.fn(),
+  loadTeamRegistrationRosterPlayers: vi.fn(),
+  rejectTeamRegistrationForApp: vi.fn(),
   submitOfflineRegistration: vi.fn()
 }));
 const openPublicUrlMock = vi.hoisted(() => vi.fn());
 
-vi.mock('../lib/parentToolsService', () => parentToolsServiceMocks);
+vi.mock('../lib/parentRegistrationsService', () => parentRegistrationsServiceMocks);
 vi.mock('../lib/publicActions', () => ({
   openPublicUrl: openPublicUrlMock
 }));
@@ -90,6 +97,17 @@ function renderParentRegistration() {
   );
 }
 
+function renderStaffRegistrationReview() {
+  return render(
+    <MemoryRouter initialEntries={['/teams/team-1/registrations/form-1/review']}>
+      <Routes>
+        <Route path="/teams/:teamId/registrations/:formId/review" element={<TeamRegistrationReview auth={{ ...auth, user: { ...auth.user!, roles: ['coach'], coachOf: ['team-1'] } as any, roles: ['coach'], isParent: false, isCoach: true }} />} />
+        <Route path="/teams/:teamId" element={<div>Team detail</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 function RouteSwapButton({ to }: { to: string }) {
   const navigate = useNavigate();
   return <button type="button" onClick={() => navigate(to)}>Swap route</button>;
@@ -116,7 +134,7 @@ function renderParentRegistrationWithRouteSwap() {
 
 describe('RegistrationDetail payment notice', () => {
   beforeEach(() => {
-    Object.values(parentToolsServiceMocks).forEach((mock) => mock.mockReset());
+    Object.values(parentRegistrationsServiceMocks).forEach((mock) => mock.mockReset());
     openPublicUrlMock.mockReset();
   });
 
@@ -125,7 +143,7 @@ describe('RegistrationDetail payment notice', () => {
   });
 
   it('renders the payment section for public online checkout forms', async () => {
-    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       paymentNotice: 'Payment will be collected in Stripe before your registration is complete.',
       onlineCheckout: true
     }));
@@ -138,42 +156,42 @@ describe('RegistrationDetail payment notice', () => {
   });
 
   it('hides the payment section when no notice exists for authenticated parent forms', async () => {
-    parentToolsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail());
+    parentRegistrationsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail());
 
     renderParentRegistration();
 
     expect(await screen.findByRole('button', { name: 'Submit registration' })).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'Payment' })).toBeNull();
-    expect(parentToolsServiceMocks.loadParentRegistrationDetail).toHaveBeenCalledWith(auth.user, 'team-1', 'form-1');
+    expect(parentRegistrationsServiceMocks.loadParentRegistrationDetail).toHaveBeenCalledWith(auth.user, 'team-1', 'form-1');
   });
 
   it('shows retry guidance and releases cancelled checkout attempts on Stripe cancel returns', async () => {
-    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       paymentNotice: 'Payment will be collected in Stripe before your registration is complete.',
       onlineCheckout: true
     }));
-    parentToolsServiceMocks.cancelRegistrationCheckout.mockResolvedValue({ released: true, nextPublicCheckoutCapability: 'cap-2' });
+    parentRegistrationsServiceMocks.cancelRegistrationCheckout.mockResolvedValue({ released: true, nextPublicCheckoutCapability: 'cap-2' });
 
     renderPublicRegistration('/registration?teamId=team-1&formId=form-1&publicCheckoutCapability=cap-1&retryPayment=1&status=cancelled');
 
     expect(await screen.findByText('Stripe payment was cancelled. You can retry payment for this registration.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Retry payment with Stripe' })).toBeTruthy();
-    await waitFor(() => expect(parentToolsServiceMocks.cancelRegistrationCheckout).toHaveBeenCalledWith('team-1', 'form-1', '', '', 'cap-1'));
+    await waitFor(() => expect(parentRegistrationsServiceMocks.cancelRegistrationCheckout).toHaveBeenCalledWith('team-1', 'form-1', '', '', 'cap-1'));
   });
 
   it('retries Stripe checkout without creating a duplicate registration', async () => {
-    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       onlineCheckout: true,
       paymentNotice: 'Pay online.'
     }));
-    parentToolsServiceMocks.cancelRegistrationCheckout.mockResolvedValue({ released: true, nextPublicCheckoutCapability: 'cap-2' });
-    parentToolsServiceMocks.initiateRegistrationCheckout.mockResolvedValue({ success: true, checkoutUrl: 'https://stripe.example/checkout' });
+    parentRegistrationsServiceMocks.cancelRegistrationCheckout.mockResolvedValue({ released: true, nextPublicCheckoutCapability: 'cap-2' });
+    parentRegistrationsServiceMocks.initiateRegistrationCheckout.mockResolvedValue({ success: true, checkoutUrl: 'https://stripe.example/checkout' });
 
     renderPublicRegistration('/registration?teamId=team-1&formId=form-1&publicCheckoutCapability=cap-1&retryPayment=1&status=cancelled');
 
     fireEvent.click(await screen.findByRole('button', { name: 'Retry payment with Stripe' }));
 
-    await waitFor(() => expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+    await waitFor(() => expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       '',
@@ -188,12 +206,12 @@ describe('RegistrationDetail payment notice', () => {
         publicCheckoutCapability: 'cap-2'
       }
     ));
-    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
     expect(openPublicUrlMock).toHaveBeenCalledWith('https://stripe.example/checkout');
   });
 
   it('hides the registration option selector when exactly one active option exists and still submits that option', async () => {
-    parentToolsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail({
       options: [{ id: 'option-1', title: 'Varsity', capacity: 12, active: true }],
       form: {
         registrationOptionCounts: {
@@ -201,7 +219,7 @@ describe('RegistrationDetail payment notice', () => {
         }
       }
     }));
-    parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValue({
+    parentRegistrationsServiceMocks.submitOfflineRegistration.mockResolvedValue({
       status: 'pending',
       registrationId: 'registration-1'
     });
@@ -215,7 +233,7 @@ describe('RegistrationDetail payment notice', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit registration' }));
 
-    await waitFor(() => expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+    await waitFor(() => expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       expect.objectContaining({
@@ -226,7 +244,7 @@ describe('RegistrationDetail payment notice', () => {
   });
 
   it('keeps the selector for multiple active options', async () => {
-    parentToolsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail({
       options: [
         { id: 'option-1', title: 'Varsity', capacity: 12, active: true },
         { id: 'option-2', title: 'Junior Varsity', capacity: 12, active: true }
@@ -249,7 +267,7 @@ describe('RegistrationDetail payment notice', () => {
   });
 
   it('resets a reused route to the new single active option before submit', async () => {
-    parentToolsServiceMocks.loadParentRegistrationDetail
+    parentRegistrationsServiceMocks.loadParentRegistrationDetail
       .mockResolvedValueOnce(buildDetail({
         options: [{ id: 'option-1', title: 'Varsity', capacity: 12, active: true }],
         form: {
@@ -267,7 +285,7 @@ describe('RegistrationDetail payment notice', () => {
         },
         options: [{ id: 'option-2', title: 'Junior Varsity', capacity: 10, active: true }]
       }));
-    parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValue({
+    parentRegistrationsServiceMocks.submitOfflineRegistration.mockResolvedValue({
       status: 'pending',
       registrationId: 'registration-2'
     });
@@ -284,7 +302,7 @@ describe('RegistrationDetail payment notice', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit registration' }));
 
-    await waitFor(() => expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+    await waitFor(() => expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
       'team-1',
       'form-2',
       expect.objectContaining({
@@ -295,7 +313,7 @@ describe('RegistrationDetail payment notice', () => {
   });
 
   it('shows the first installment due now plus the remaining schedule before checkout', async () => {
-    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       onlineCheckout: true,
       paymentNotice: 'Pay online.',
       paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }, { id: 'installments', title: 'Monthly installments' }],
@@ -323,7 +341,7 @@ describe('RegistrationDetail payment notice', () => {
   });
 
   it('replaces the form with a success confirmation after Stripe success returns', async () => {
-    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       onlineCheckout: true,
       paymentNotice: 'Pay online.'
     }));
@@ -337,7 +355,7 @@ describe('RegistrationDetail payment notice', () => {
   });
 
   it('shows remaining installments after a successful installment payment', async () => {
-    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
       onlineCheckout: true,
       paymentNotice: 'Pay online.',
       paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }, { id: 'installments', title: 'Monthly installments' }],
@@ -362,5 +380,55 @@ describe('RegistrationDetail payment notice', () => {
     expect(within(remainingSchedule).getAllByText('$41.68')).toHaveLength(2);
     expect(screen.queryByText('Installment 2 · Due Jul 31, 2026')).toBeNull();
     expect(screen.getByText('Installment 3 · Due Aug 30, 2026')).toBeTruthy();
+  });
+
+  it('loads the staff review workflow from the focused registration service and approves a pending registration', async () => {
+    parentRegistrationsServiceMocks.loadStaffRegistrationDetail.mockResolvedValue(buildDetail({
+      form: {
+        registrationOptionCounts: {
+          'opt-1': { enrolled: 4, waitlisted: 0 }
+        }
+      },
+      options: [{ id: 'opt-1', title: 'Full week', capacityLimit: 20, waitlistEnabled: true }]
+    }));
+    parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage
+      .mockResolvedValueOnce({
+        reviews: [{
+          id: 'review-1',
+          status: 'pending',
+          participantName: 'Pat Star',
+          guardianLabel: 'Parent One',
+          participant: { name: 'Pat Star' },
+          guardian: { email: 'parent@example.com' },
+          selectedOption: { id: 'opt-1' },
+          selectedOptionLabel: 'Full week',
+          paymentLabel: '$75.00',
+          waiverAccepted: true,
+          linkedPlayerId: '',
+          decisionNote: ''
+        }],
+        lastDoc: null,
+        hasMore: false
+      })
+      .mockResolvedValueOnce({ reviews: [], lastDoc: null, hasMore: false });
+    parentRegistrationsServiceMocks.loadTeamRegistrationRosterPlayers.mockResolvedValue([
+      { id: 'player-1', name: 'Pat Star', number: '9' }
+    ]);
+    parentRegistrationsServiceMocks.approveTeamRegistrationForApp.mockResolvedValue({ success: true });
+
+    renderStaffRegistrationReview();
+
+    expect(await screen.findByText('Applications')).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Pat Star' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve application' }));
+
+    await waitFor(() => expect(parentRegistrationsServiceMocks.approveTeamRegistrationForApp).toHaveBeenCalledWith(
+      expect.objectContaining({ uid: 'parent-1' }),
+      'team-1',
+      'form-1',
+      'review-1',
+      { playerId: undefined }
+    ));
   });
 });

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -1,13 +1,25 @@
 import { useEffect, useMemo, useRef, useState, type InputHTMLAttributes, type SyntheticEvent } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import * as parentToolsService from '../lib/parentToolsService';
 import { AlertCircle, CheckCircle2, ChevronLeft, ExternalLink, Loader2, Send, Ticket, UserPlus, XCircle, type LucideIcon } from 'lucide-react';
 import { openPublicUrl } from '../lib/publicActions';
-import type {
-  ParentRegistrationCard,
-  ParentRegistrationDetailModel,
-  TeamRegistrationQueueModel
-} from '../lib/parentToolsService';
+import {
+  acceptTeamRegistrationOfferForApp,
+  approveTeamRegistrationForApp,
+  cancelRegistrationCheckout,
+  extendTeamRegistrationOfferForApp,
+  initiateRegistrationCheckout,
+  loadParentRegistrationDetail,
+  loadParentRegistrations,
+  loadPublicRegistrationDetail,
+  loadStaffRegistrationDetail,
+  loadTeamRegistrationQueuePage,
+  loadTeamRegistrationRosterPlayers,
+  rejectTeamRegistrationForApp,
+  submitOfflineRegistration,
+  type ParentRegistrationCard,
+  type ParentRegistrationDetailModel,
+  type TeamRegistrationQueueModel
+} from '../lib/parentRegistrationsService';
 import {
   calculateRegistrationFeeSnapshot,
   decideRegistrationPlacement,
@@ -99,9 +111,9 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
         setForm(nextForm);
         if (staffReview) {
           const [nextPage, waitlistedPage, rosterPlayers] = await Promise.all([
-            (parentToolsService as any).loadTeamRegistrationQueuePage(teamId, formId) as Promise<{ reviews: any[]; lastDoc: any; hasMore: boolean }>,
-            (parentToolsService as any).loadTeamRegistrationQueuePage(teamId, formId, { status: 'waitlisted' }) as Promise<{ reviews: any[]; lastDoc: any; hasMore: boolean }>,
-            (parentToolsService as any).loadTeamRegistrationRosterPlayers(auth.user, teamId).catch(() => [])
+            loadTeamRegistrationQueuePage(teamId, formId),
+            loadTeamRegistrationQueuePage(teamId, formId, { status: 'waitlisted' }),
+            loadTeamRegistrationRosterPlayers(auth.user, teamId).catch(() => [])
           ]);
           if (cancelled) return;
           const nextQueue: TeamRegistrationQueueModel = {
@@ -204,7 +216,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
       ? 'Stripe payment was cancelled. You can retry payment for this registration.'
       : 'Stripe payment was cancelled.');
 
-    void parentToolsService.cancelRegistrationCheckout(
+    void cancelRegistrationCheckout(
       teamId,
       formId,
       returnRegistrationId,
@@ -266,7 +278,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
             setError('We could not restore your previous checkout attempt. Please restart registration or contact the organizer.');
             return;
           }
-          const checkout = await parentToolsService.initiateRegistrationCheckout(
+          const checkout = await initiateRegistrationCheckout(
             form.teamId,
             form.id,
             currentPublicCheckoutCapability ? '' : returnRegistrationId,
@@ -287,7 +299,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
         }
       }
 
-      const result = await parentToolsService.submitOfflineRegistration(form.teamId, form.id, {
+      const result = await submitOfflineRegistration(form.teamId, form.id, {
         participant: currentParticipant,
         guardian: currentGuardian,
         waiverAccepted: currentWaiverAccepted,
@@ -306,7 +318,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
       const checkoutFeeSnapshot = serverFeeSnapshot || currentFeeSnapshot;
       if (form.onlineCheckout && Number(checkoutFeeSnapshot.finalAmountDueCents || 0) > 0) {
         try {
-          const checkout = await parentToolsService.initiateRegistrationCheckout(
+          const checkout = await initiateRegistrationCheckout(
             form.teamId,
             form.id,
             result.registrationId,
@@ -344,7 +356,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     setError('');
     setMessage('');
     try {
-      await (parentToolsService as any).approveTeamRegistrationForApp(auth.user, teamId, formId, selectedReview.id, {
+      await approveTeamRegistrationForApp(auth.user, teamId, formId, selectedReview.id, {
         playerId: selectedMergePlayerId || undefined
       });
       setMessage('Registration approved. Roster and parent links were updated using the legacy approval flow.');
@@ -362,7 +374,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     setError('');
     setMessage('');
     try {
-      await (parentToolsService as any).rejectTeamRegistrationForApp(auth.user, teamId, formId, selectedReview.id);
+      await rejectTeamRegistrationForApp(auth.user, teamId, formId, selectedReview.id);
       setMessage('Registration declined.');
       setReloadKey((current) => current + 1);
     } catch (actionError: any) {
@@ -378,7 +390,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     setError('');
     setMessage('');
     try {
-      await (parentToolsService as any).extendTeamRegistrationOfferForApp(auth.user, teamId, formId, selectedReview.id);
+      await extendTeamRegistrationOfferForApp(auth.user, teamId, formId, selectedReview.id);
       setMessage('Waitlist offer extended using the legacy registration flow.');
       setReloadKey((current) => current + 1);
     } catch (actionError: any) {
@@ -394,7 +406,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     setError('');
     setMessage('');
     try {
-      await (parentToolsService as any).acceptTeamRegistrationOfferForApp(auth.user, teamId, formId, selectedReview.id);
+      await acceptTeamRegistrationOfferForApp(auth.user, teamId, formId, selectedReview.id);
       setMessage('Waitlist offer marked accepted. This registration can now be approved to the roster.');
       setReloadKey((current) => current + 1);
     } catch (actionError: any) {
@@ -409,7 +421,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     setSaving(true);
     setError('');
     try {
-      const nextPage = await (parentToolsService as any).loadTeamRegistrationQueuePage(teamId, formId, { afterDoc: lastDoc }) as { reviews: any[]; lastDoc: any; hasMore: boolean };
+      const nextPage = await loadTeamRegistrationQueuePage(teamId, formId, { afterDoc: lastDoc });
       setQueue((current: TeamRegistrationQueueModel | null) => current ? { ...current, reviews: [...current.reviews, ...nextPage.reviews] } : { reviews: nextPage.reviews, rosterPlayers: [] });
       setLastDoc(nextPage.lastDoc);
       setHasMore(nextPage.hasMore);
@@ -784,25 +796,22 @@ function validate(form: ParentRegistrationCard, participant: Record<string, stri
 
 async function loadRegistrationForm(user: any, teamId: string, formId: string, publicAccess = false, staffReview = false): Promise<ParentRegistrationCard | null> {
   if (staffReview) {
-    const detail: ParentRegistrationDetailModel = await (parentToolsService as any).loadStaffRegistrationDetail(user, teamId, formId);
+    const detail: ParentRegistrationDetailModel = await loadStaffRegistrationDetail(user, teamId, formId);
     return toRegistrationCardFromDetail(detail, teamId, formId);
   }
   if (publicAccess) {
-    const detail: ParentRegistrationDetailModel = await (parentToolsService as any).loadPublicRegistrationDetail(teamId, formId);
+    const detail: ParentRegistrationDetailModel = await loadPublicRegistrationDetail(teamId, formId);
     return toRegistrationCardFromDetail(detail, teamId, formId);
   }
 
   try {
-    const loadDetail = (parentToolsService as any).loadParentRegistrationDetail;
-    if (typeof loadDetail === 'function') {
-      const detail: ParentRegistrationDetailModel = await loadDetail(user, teamId, formId);
-      return toRegistrationCardFromDetail(detail, teamId, formId);
-    }
+    const detail: ParentRegistrationDetailModel = await loadParentRegistrationDetail(user, teamId, formId);
+    return toRegistrationCardFromDetail(detail, teamId, formId);
   } catch (error: any) {
     if (!String(error?.message || '').includes('loadParentRegistrationDetail')) throw error;
   }
 
-  const forms = await parentToolsService.loadParentRegistrations(user);
+  const forms = await loadParentRegistrations(user);
   return forms.find((candidate: ParentRegistrationCard) => candidate.teamId === teamId && candidate.id === formId) || null;
 }
 

--- a/apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts
+++ b/apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts
@@ -18,4 +18,11 @@ describe('Parent Tools focused service imports', () => {
         expect(source).toContain(focusedImport);
         expect(source).not.toContain("../../lib/parentToolsService");
     });
+
+    it('RegistrationDetail imports only the focused registrations service module', () => {
+        const source = readFileSync(resolve(__dirname, '..', 'RegistrationDetail.tsx'), 'utf8');
+
+        expect(source).toContain("../lib/parentRegistrationsService");
+        expect(source).not.toContain("../lib/parentToolsService");
+    });
 });

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -103,6 +103,15 @@ const parentRegistrationsServiceMock = `
             url: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1'
         }];
     }
+    export async function submitOfflineRegistration() {
+        return { status: 'pending', registrationId: 'registration-1' };
+    }
+    export async function initiateRegistrationCheckout() {
+        return { success: true, checkoutUrl: 'https://pay.example.test/registration-checkout' };
+    }
+    export async function cancelRegistrationCheckout() {
+        return { released: true };
+    }
     export async function loadParentRegistrationDetail() {
         return {
             teamName: 'Bears',
@@ -382,43 +391,6 @@ async function mockParentToolsModules(page) {
                 }
                 export async function revokeParentFamilyShare() {}
                 export async function updateParentFamilyShareCalendars() {}
-                export async function loadParentRegistrations() {
-                    return [{
-                        id: 'form-1',
-                        teamId: 'team-1',
-                        teamName: 'Bears',
-                        programName: 'Summer Camp',
-                        description: 'Skills week',
-                        season: 'Summer',
-                        feeLabel: '$75.00',
-                        paymentNotice: 'Online checkout available.',
-                        onlineCheckout: true,
-                        options: [{ id: 'opt-1' }],
-                        url: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1'
-                    }];
-                }
-                export async function loadParentRegistrationDetail() {
-                    return {
-                        teamName: 'Bears',
-                        isPublished: true,
-                        onlineCheckout: true,
-                        legacyUrl: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1',
-                        form: {
-                            programName: 'Summer Camp',
-                            description: 'Skills week',
-                            season: 'Summer',
-                            currency: 'USD',
-                            participantFields: [],
-                            guardianFields: [],
-                            waiverText: '',
-                            registrationOptionCounts: {}
-                        },
-                        options: [{ id: 'opt-1', title: 'Full week', description: 'Skills week', capacityLimit: 20, waitlistEnabled: true }],
-                        feeSnapshot: { finalAmountDueCents: 7500 },
-                        paymentNotice: 'Online checkout available.',
-                        paymentPlans: []
-                    };
-                }
                 export async function loadParentCertificates() {
                     return [{
                         id: 'cert-1',
@@ -527,6 +499,10 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await expect(page.getByRole('link', { name: /Review/ })).toBeVisible();
     await page.getByRole('button', { name: /Legacy form/ }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://allplays.ai/registration.html?teamId=team-1&formId=form-1');
+    await page.getByRole('link', { name: /Review/ }).click();
+    await expect(page.getByRole('button', { name: 'Pay registration with Stripe' })).toBeVisible();
+    await page.getByRole('button', { name: 'Pay registration with Stripe' }).click();
+    await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pay.example.test/registration-checkout');
 
     await page.getByRole('button', { name: 'Awards' }).click();
     await expect(page.getByText('Hustle Award')).toBeVisible();

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -112,7 +112,7 @@ const parentRegistrationsServiceMock = `
     export async function cancelRegistrationCheckout() {
         return { released: true };
     }
-    export async function loadParentRegistrationDetail() {
+    function buildRegistrationDetail() {
         return {
             teamName: 'Bears',
             isPublished: true,
@@ -133,6 +133,33 @@ const parentRegistrationsServiceMock = `
             paymentNotice: 'Online checkout available.',
             paymentPlans: []
         };
+    }
+    export async function loadParentRegistrationDetail() {
+        return buildRegistrationDetail();
+    }
+    export async function loadPublicRegistrationDetail() {
+        return buildRegistrationDetail();
+    }
+    export async function loadStaffRegistrationDetail() {
+        return buildRegistrationDetail();
+    }
+    export async function loadTeamRegistrationQueuePage() {
+        return { reviews: [], lastDoc: null, hasMore: false, totalWaitlisted: 0 };
+    }
+    export async function loadTeamRegistrationRosterPlayers() {
+        return [];
+    }
+    export async function approveTeamRegistrationForApp() {
+        return { success: true };
+    }
+    export async function rejectTeamRegistrationForApp() {
+        return { success: true };
+    }
+    export async function extendTeamRegistrationOfferForApp() {
+        return { success: true };
+    }
+    export async function acceptTeamRegistrationOfferForApp() {
+        return { success: true };
     }
 `;
 
@@ -504,7 +531,7 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await page.getByRole('button', { name: 'Pay registration with Stripe' }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pay.example.test/registration-checkout');
 
-    await page.getByRole('button', { name: 'Awards' }).click();
+    await page.goto(appUrl(baseURL, '/parent-tools/certificates'), { waitUntil: 'domcontentloaded' });
     await expect(page.getByText('Hustle Award')).toBeVisible();
     await page.getByRole('button', { name: 'Share' }).last().click();
     await expect.poll(() => page.evaluate(() => window.__sharedUrls.at(-1)?.url)).toBe('https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1');

--- a/tests/unit/app-parent-tools-registration.test.jsx
+++ b/tests/unit/app-parent-tools-registration.test.jsx
@@ -5,7 +5,19 @@ import { createRoot } from 'react-dom/client';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const serviceMocks = vi.hoisted(() => ({
-    loadParentRegistrationDetail: vi.fn()
+    acceptTeamRegistrationOfferForApp: vi.fn(),
+    approveTeamRegistrationForApp: vi.fn(),
+    cancelRegistrationCheckout: vi.fn(),
+    extendTeamRegistrationOfferForApp: vi.fn(),
+    initiateRegistrationCheckout: vi.fn(),
+    loadParentRegistrationDetail: vi.fn(),
+    loadParentRegistrations: vi.fn(),
+    loadPublicRegistrationDetail: vi.fn(),
+    loadStaffRegistrationDetail: vi.fn(),
+    loadTeamRegistrationQueuePage: vi.fn(),
+    loadTeamRegistrationRosterPlayers: vi.fn(),
+    rejectTeamRegistrationForApp: vi.fn(),
+    submitOfflineRegistration: vi.fn(),
 }));
 
 const publicActionMocks = vi.hoisted(() => ({
@@ -14,7 +26,18 @@ const publicActionMocks = vi.hoisted(() => ({
 
 // Mock registration-flow.js
 const registrationFlowMocks = vi.hoisted(() => ({
+  buildPendingRegistrationRecord: vi.fn((params = {}) => ({
+    id: 'pending-registration-1',
+    status: params.status || 'pending',
+    participant: params.participant || {},
+    guardian: params.guardian || {},
+  })),
+  getActiveRegistrationOptions: vi.fn((form = {}) => form.registrationOptions || form.options || []),
+  getPaymentPlanChoices: vi.fn(() => [{ id: 'pay_full', type: 'pay_full', title: 'Pay in full' }]),
+  getRegistrationPaymentNotice: vi.fn(() => ''),
+  hasOnlineRegistrationCheckout: vi.fn(() => true),
   hasQuantityDiscountRule: vi.fn(() => false),
+  normalizeRegistrationForm: vi.fn((form = {}) => form),
   requiresRegistrationOption: vi.fn(() => true),
   decideRegistrationPlacement: vi.fn((params) => ({
     status: 'pending',
@@ -37,7 +60,7 @@ const registrationFlowMocks = vi.hoisted(() => ({
   ])),
 }));
 
-vi.mock('../../apps/app/src/lib/parentToolsService.ts', () => serviceMocks);
+vi.mock('../../apps/app/src/lib/parentRegistrationsService.ts', () => serviceMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 vi.mock('../../js/registration-flow.js', () => registrationFlowMocks);
 

--- a/tests/unit/app-registration-detail.test.jsx
+++ b/tests/unit/app-registration-detail.test.jsx
@@ -4,8 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
-// Mock parentToolsService
-const parentToolsServiceMocks = vi.hoisted(() => ({
+// Mock parentRegistrationsService
+const parentRegistrationsServiceMocks = vi.hoisted(() => ({
   loadParentRegistrations: vi.fn(),
   loadStaffRegistrationDetail: vi.fn(),
   loadTeamRegistrationQueue: vi.fn(),
@@ -27,6 +27,11 @@ const publicActionsMocks = vi.hoisted(() => ({
 
 // Mock registration-flow.js
 const registrationFlowMocks = vi.hoisted(() => ({
+  buildPendingRegistrationRecord: vi.fn((params) => ({
+    ...params,
+    id: 'mock-pending-reg-id',
+    status: params.status || 'pending',
+  })),
   buildRegistrationRecord: vi.fn((params) => ({
     ...params,
     id: 'mock-reg-id',
@@ -59,7 +64,7 @@ const registrationFlowMocks = vi.hoisted(() => ({
   hasQuantityDiscountRule: vi.fn(() => false), // Default mock for new helper
 }));
 
-vi.mock('../../apps/app/src/lib/parentToolsService.ts', () => parentToolsServiceMocks);
+vi.mock('../../apps/app/src/lib/parentRegistrationsService.ts', () => parentRegistrationsServiceMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionsMocks);
 vi.mock('@legacy/registration-flow.js', () => registrationFlowMocks);
 
@@ -241,7 +246,7 @@ beforeEach(() => {
   registrationFlowMocks.getActiveRegistrationOptions.mockReturnValue([{ id: 'opt-1', title: 'Option 1', capacityLimit: 10 }]);
   registrationFlowMocks.requiresRegistrationOption.mockReturnValue(true);
   registrationFlowMocks.hasQuantityDiscountRule.mockReturnValue(false);
-  parentToolsServiceMocks.loadParentRegistrations.mockResolvedValue([
+  parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValue([
     {
       id: 'form-1',
       teamId: 'team-1',
@@ -261,7 +266,7 @@ beforeEach(() => {
       discountRules: [], // Default to no quantity discounts for most tests
     },
   ]);
-  parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue({
+  parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue({
     teamName: 'Public Bears',
     isPublished: true,
     onlineCheckout: false,
@@ -282,7 +287,7 @@ beforeEach(() => {
     paymentNotice: '',
     paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }],
   });
-  parentToolsServiceMocks.loadStaffRegistrationDetail.mockResolvedValue({
+  parentRegistrationsServiceMocks.loadStaffRegistrationDetail.mockResolvedValue({
     teamName: 'Coach Bears',
     isPublished: true,
     onlineCheckout: false,
@@ -303,7 +308,7 @@ beforeEach(() => {
     paymentNotice: '',
     paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }],
   });
-  parentToolsServiceMocks.loadTeamRegistrationQueue.mockResolvedValue({
+  parentRegistrationsServiceMocks.loadTeamRegistrationQueue.mockResolvedValue({
     reviews: [{
       id: 'reg-1',
       status: 'pending',
@@ -322,21 +327,21 @@ beforeEach(() => {
     }],
     rosterPlayers: [{ id: 'player-9', name: 'Riley Runner', number: '12' }],
   });
-  parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValue({
+  parentRegistrationsServiceMocks.submitOfflineRegistration.mockResolvedValue({
     success: true,
     status: 'pending',
     registrationId: 'new-reg-1',
     feeSnapshot: { finalAmountDueCents: 10000, currency: 'USD' },
   });
-  parentToolsServiceMocks.initiateRegistrationCheckout.mockResolvedValue({
+  parentRegistrationsServiceMocks.initiateRegistrationCheckout.mockResolvedValue({
     success: true,
     checkoutUrl: 'https://checkout.stripe.com/c/pay-reg-1',
   });
-  parentToolsServiceMocks.acceptTeamRegistrationOfferForApp.mockResolvedValue({ success: true });
-  parentToolsServiceMocks.approveTeamRegistrationForApp.mockResolvedValue({ success: true });
-  parentToolsServiceMocks.extendTeamRegistrationOfferForApp.mockResolvedValue({ success: true });
-  parentToolsServiceMocks.rejectTeamRegistrationForApp.mockResolvedValue({ success: true });
-  parentToolsServiceMocks.loadTeamRegistrationQueuePage.mockImplementation(async (_teamId, _formId, options = {}) => {
+  parentRegistrationsServiceMocks.acceptTeamRegistrationOfferForApp.mockResolvedValue({ success: true });
+  parentRegistrationsServiceMocks.approveTeamRegistrationForApp.mockResolvedValue({ success: true });
+  parentRegistrationsServiceMocks.extendTeamRegistrationOfferForApp.mockResolvedValue({ success: true });
+  parentRegistrationsServiceMocks.rejectTeamRegistrationForApp.mockResolvedValue({ success: true });
+  parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage.mockImplementation(async (_teamId, _formId, options = {}) => {
     if (options?.status === 'waitlisted') {
       return {
         reviews: [],
@@ -365,10 +370,10 @@ beforeEach(() => {
       hasMore: false,
     };
   });
-  parentToolsServiceMocks.loadTeamRegistrationRosterPlayers.mockResolvedValue([
+  parentRegistrationsServiceMocks.loadTeamRegistrationRosterPlayers.mockResolvedValue([
     { id: 'player-9', name: 'Riley Runner', number: '12' }
   ]);
-  parentToolsServiceMocks.cancelRegistrationCheckout.mockResolvedValue(undefined);
+  parentRegistrationsServiceMocks.cancelRegistrationCheckout.mockResolvedValue(undefined);
   publicActionsMocks.openPublicUrl.mockResolvedValue(undefined);
 });
 
@@ -415,23 +420,23 @@ describe('RegistrationDetail page', () => {
     await waitForText(container, 'Travel Tryouts');
     await waitForText(container, 'Riley Runner');
 
-    expect(parentToolsServiceMocks.loadStaffRegistrationDetail).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.loadStaffRegistrationDetail).toHaveBeenCalledWith(
       expect.objectContaining({ uid: 'user-1' }),
       'team-coach',
       'form-review'
     );
-    expect(parentToolsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
+    expect(parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
       1,
       'team-coach',
       'form-review'
     );
-    expect(parentToolsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
+    expect(parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
       2,
       'team-coach',
       'form-review',
       { status: 'waitlisted' }
     );
-    expect(parentToolsServiceMocks.loadTeamRegistrationRosterPlayers).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.loadTeamRegistrationRosterPlayers).toHaveBeenCalledWith(
       expect.objectContaining({ uid: 'user-1' }),
       'team-coach'
     );
@@ -441,7 +446,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Merge into existing roster player', 'player-9');
     await clickButton(container, 'Approve application');
 
-    expect(parentToolsServiceMocks.approveTeamRegistrationForApp).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.approveTeamRegistrationForApp).toHaveBeenCalledWith(
       expect.objectContaining({ uid: 'user-1' }),
       'team-coach',
       'form-review',
@@ -452,7 +457,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('allows staff review for closed registration forms', async () => {
-    parentToolsServiceMocks.loadStaffRegistrationDetail.mockResolvedValueOnce({
+    parentRegistrationsServiceMocks.loadStaffRegistrationDetail.mockResolvedValueOnce({
       teamName: 'Coach Bears',
       isPublished: false,
       onlineCheckout: false,
@@ -481,12 +486,12 @@ describe('RegistrationDetail page', () => {
     await waitForText(container, 'Riley Runner');
 
     expect(container.textContent).not.toContain('This linked registration form is not published right now.');
-    expect(parentToolsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
+    expect(parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
       1,
       'team-coach',
       'form-review'
     );
-    expect(parentToolsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
+    expect(parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
       2,
       'team-coach',
       'form-review',
@@ -495,7 +500,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('loads waitlisted applicants separately when they fall outside the first all-status page', async () => {
-    parentToolsServiceMocks.loadStaffRegistrationDetail.mockResolvedValueOnce({
+    parentRegistrationsServiceMocks.loadStaffRegistrationDetail.mockResolvedValueOnce({
       teamName: 'Coach Bears',
       isPublished: true,
       onlineCheckout: false,
@@ -518,7 +523,7 @@ describe('RegistrationDetail page', () => {
       paymentNotice: '',
       paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }],
     });
-    parentToolsServiceMocks.loadTeamRegistrationQueuePage
+    parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage
       .mockResolvedValueOnce({
         reviews: [{
           id: 'reg-pending',
@@ -586,12 +591,12 @@ describe('RegistrationDetail page', () => {
     expect(container.textContent).toContain('Pending Parker');
     expect(container.textContent).toContain('Riley Runner');
     expect(container.textContent).toContain('Avery Ace');
-    expect(parentToolsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
+    expect(parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
       1,
       'team-coach',
       'form-review'
     );
-    expect(parentToolsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
+    expect(parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage).toHaveBeenNthCalledWith(
       2,
       'team-coach',
       'form-review',
@@ -600,7 +605,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('lists waitlisted applicants in order and promotes them through the legacy waitlist flow', async () => {
-    parentToolsServiceMocks.loadStaffRegistrationDetail.mockResolvedValueOnce({
+    parentRegistrationsServiceMocks.loadStaffRegistrationDetail.mockResolvedValueOnce({
       teamName: 'Coach Bears',
       isPublished: true,
       onlineCheckout: false,
@@ -623,7 +628,7 @@ describe('RegistrationDetail page', () => {
       paymentNotice: '',
       paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }],
     });
-    parentToolsServiceMocks.loadTeamRegistrationQueuePage
+    parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage
       .mockResolvedValueOnce({
         reviews: [
           {
@@ -815,7 +820,7 @@ describe('RegistrationDetail page', () => {
 
     await clickButton(container, 'Promote from waitlist');
 
-    expect(parentToolsServiceMocks.extendTeamRegistrationOfferForApp).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.extendTeamRegistrationOfferForApp).toHaveBeenCalledWith(
       expect.objectContaining({ uid: 'user-1' }),
       'team-coach',
       'form-review',
@@ -826,7 +831,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('marks extended waitlist offers accepted through the legacy waitlist flow', async () => {
-    parentToolsServiceMocks.loadTeamRegistrationQueuePage
+    parentRegistrationsServiceMocks.loadTeamRegistrationQueuePage
       .mockResolvedValueOnce({
         reviews: [{
           id: 'reg-offer-1',
@@ -862,7 +867,7 @@ describe('RegistrationDetail page', () => {
 
     await clickButton(container, 'Mark accepted');
 
-    expect(parentToolsServiceMocks.acceptTeamRegistrationOfferForApp).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.acceptTeamRegistrationOfferForApp).toHaveBeenCalledWith(
       expect.objectContaining({ uid: 'user-1' }),
       'team-coach',
       'form-review',
@@ -872,7 +877,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('defaults the selected option to the first option with available capacity', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -916,19 +921,19 @@ describe('RegistrationDetail page', () => {
     const { container } = await renderPublicRegistrationDetail();
     await waitForText(container, 'Open Clinic');
 
-    expect(parentToolsServiceMocks.loadPublicRegistrationDetail).toHaveBeenCalledWith('team-public', 'form-public');
-    expect(parentToolsServiceMocks.loadParentRegistrations).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.loadPublicRegistrationDetail).toHaveBeenCalledWith('team-public', 'form-public');
+    expect(parentRegistrationsServiceMocks.loadParentRegistrations).not.toHaveBeenCalled();
     expect(container.textContent).toContain('Public Bears');
     expect(container.textContent).not.toContain('Back to registrations');
   });
 
   it('blocks submit for unavailable public registration links', async () => {
-    parentToolsServiceMocks.loadPublicRegistrationDetail.mockRejectedValueOnce(new Error('This registration form is not available right now.'));
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockRejectedValueOnce(new Error('This registration form is not available right now.'));
     const { container } = await renderPublicRegistrationDetail();
 
     await waitForText(container, 'This registration form is not available right now.');
     expect(container.textContent).toContain('Registration unavailable');
-    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
   });
 
   it('renders the form and handles submission successfully', async () => {
@@ -942,8 +947,8 @@ describe('RegistrationDetail page', () => {
 
     await clickButton(container, 'Submit registration');
 
-    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledTimes(1);
-    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledTimes(1);
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       expect.objectContaining({
@@ -970,7 +975,7 @@ describe('RegistrationDetail page', () => {
     await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Submit registration');
 
-    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       expect.objectContaining({
@@ -980,7 +985,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('shows the payment plan selector for multiple choices and submits the selected plan', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1011,7 +1016,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'Payment plan', 'installments');
     await clickButton(container, 'Submit registration');
 
-    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       expect.objectContaining({
@@ -1026,21 +1031,21 @@ describe('RegistrationDetail page', () => {
 
     await clickButton(container, 'Submit registration');
     await waitForText(container, 'Participant Name is required.');
-    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
 
     await changeInputValue(container, 'Participant Name', 'Test Participant');
     await clickButton(container, 'Submit registration');
     await waitForText(container, 'Guardian Name is required.');
-    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
 
     await changeInputValue(container, 'Guardian Name', 'Test Guardian');
     await clickButton(container, 'Submit registration');
     await waitForText(container, 'Accept the waiver to submit.');
-    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
   });
 
   it('shows a waitlisted message if placement status is waitlisted', async () => {
-    parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValueOnce({
+    parentRegistrationsServiceMocks.submitOfflineRegistration.mockResolvedValueOnce({
       success: true,
       status: 'waitlisted',
       registrationId: 'new-reg-waitlisted',
@@ -1084,11 +1089,11 @@ describe('RegistrationDetail page', () => {
     await clickButton(container, 'Submit registration');
 
     await waitForText(container, 'Option is full and not accepting waitlist registrations.');
-    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
   });
 
   it('launches Stripe checkout for online checkout forms', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1119,8 +1124,8 @@ describe('RegistrationDetail page', () => {
 
     await clickButton(container, 'Pay registration with Stripe');
 
-    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledTimes(1);
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledTimes(1);
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       'new-reg-1',
@@ -1137,7 +1142,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('keeps online checkout validation before creating a registration', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1159,13 +1164,13 @@ describe('RegistrationDetail page', () => {
     await clickButton(container, 'Pay registration with Stripe');
 
     await waitForText(container, 'Participant Name is required.');
-    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).not.toHaveBeenCalled();
     expect(publicActionsMocks.openPublicUrl).not.toHaveBeenCalled();
   });
 
   it('does not launch checkout for waitlisted online checkout registrations', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1181,7 +1186,7 @@ describe('RegistrationDetail page', () => {
         waiverText: 'I agree to the terms and conditions.',
       },
     ]);
-    parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValueOnce({
+    parentRegistrationsServiceMocks.submitOfflineRegistration.mockResolvedValueOnce({
       success: true,
       status: 'waitlisted',
       registrationId: 'new-reg-waitlisted',
@@ -1197,12 +1202,12 @@ describe('RegistrationDetail page', () => {
     await clickButton(container, 'Pay registration with Stripe');
 
     await waitForText(container, 'Registration submitted. You have been added to the waitlist.');
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).not.toHaveBeenCalled();
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).not.toHaveBeenCalled();
     expect(publicActionsMocks.openPublicUrl).not.toHaveBeenCalled();
   });
 
   it('shows a post-registration error when checkout creation fails', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1218,7 +1223,7 @@ describe('RegistrationDetail page', () => {
         waiverText: 'I agree to the terms and conditions.',
       },
     ]);
-    parentToolsServiceMocks.initiateRegistrationCheckout.mockRejectedValueOnce(new Error('Stripe session failed.'));
+    parentRegistrationsServiceMocks.initiateRegistrationCheckout.mockRejectedValueOnce(new Error('Stripe session failed.'));
 
     const { container } = await renderRegistrationDetail();
     await waitForText(container, 'Pay registration with Stripe');
@@ -1235,7 +1240,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('shows a post-registration error when checkout URL opening fails', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1263,7 +1268,7 @@ describe('RegistrationDetail page', () => {
     await clickButton(container, 'Pay registration with Stripe');
 
     await waitForText(container, 'Registration created, but checkout could not be opened. Popup blocked.');
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledTimes(1);
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledTimes(1);
   });
 
   it('supports online checkout forms without registration options', async () => {
@@ -1273,7 +1278,7 @@ describe('RegistrationDetail page', () => {
       .mockReturnValueOnce(false)
       .mockReturnValueOnce(false);
     registrationFlowMocks.getActiveRegistrationOptions.mockReturnValueOnce([]);
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1298,7 +1303,7 @@ describe('RegistrationDetail page', () => {
     await changeInputValue(container, 'I accept the waiver.', true);
     await clickButton(container, 'Pay registration with Stripe');
 
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       'new-reg-1',
@@ -1316,7 +1321,7 @@ describe('RegistrationDetail page', () => {
 
   it('renders fee summary rows and updates them when quantity changes', async () => {
     registrationFlowMocks.hasQuantityDiscountRule.mockReturnValueOnce(true);
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1353,7 +1358,7 @@ describe('RegistrationDetail page', () => {
 
   it('does not let a loaded fee snapshot freeze the displayed quantity total', async () => {
     registrationFlowMocks.hasQuantityDiscountRule.mockReturnValueOnce(true);
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1386,7 +1391,7 @@ describe('RegistrationDetail page', () => {
   });
 
   it('uses the server-returned registration fee for checkout', async () => {
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1402,7 +1407,7 @@ describe('RegistrationDetail page', () => {
         waiverText: 'I agree to the terms and conditions.',
       },
     ]);
-    parentToolsServiceMocks.submitOfflineRegistration.mockResolvedValueOnce({
+    parentRegistrationsServiceMocks.submitOfflineRegistration.mockResolvedValueOnce({
       success: true,
       status: 'pending',
       registrationId: 'new-reg-1',
@@ -1418,7 +1423,7 @@ describe('RegistrationDetail page', () => {
     await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       'new-reg-1',
@@ -1445,7 +1450,7 @@ describe('RegistrationDetail page', () => {
 
   it('passes quantity=1 to submission and checkout when Quantity is hidden', async () => {
     registrationFlowMocks.hasQuantityDiscountRule.mockReturnValueOnce(false);
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1472,14 +1477,14 @@ describe('RegistrationDetail page', () => {
     await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
-    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       expect.objectContaining({
         quantity: 1, // Should be 1 because hasQuantityDiscountRule is false
       })
     );
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       'new-reg-1',
@@ -1496,7 +1501,7 @@ describe('RegistrationDetail page', () => {
 
   it('renders Quantity and updates fee summary when an active quantity discount rule exists', async () => {
     registrationFlowMocks.hasQuantityDiscountRule.mockReturnValueOnce(true);
-    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+    parentRegistrationsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
       {
         id: 'form-1',
         teamId: 'team-1',
@@ -1539,14 +1544,14 @@ describe('RegistrationDetail page', () => {
     await ensureRegistrationOptionResolved(container);
     await clickButton(container, 'Pay registration with Stripe');
 
-    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       expect.objectContaining({
         quantity: 2, // Should be 2 because hasQuantityDiscountRule is true and input was changed
       })
     );
-    expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+    expect(parentRegistrationsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
       'team-1',
       'form-1',
       'new-reg-1',


### PR DESCRIPTION
Closes #3216

## What changed
- Extended `apps/app/src/lib/parentRegistrationsService.ts` to own the registration-detail route surface: parent/public/staff detail loads, checkout submit/cancel/initiate actions, and staff review queue helpers.
- Updated `apps/app/src/pages/RegistrationDetail.tsx` to import only `../lib/parentRegistrationsService` instead of the monolithic `../lib/parentToolsService` module.
- Updated `apps/app/src/pages/RegistrationDetail.test.tsx` to mock the focused registration service and added staff-review coverage alongside the existing parent/public checkout coverage.
- Added a source-contract guard in `apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts` so `RegistrationDetail.tsx` fails test if it ever reintroduces `../lib/parentToolsService`.
- Updated `tests/smoke/app-parent-tools.spec.js` so the mobile Parent Tools registration flow uses the focused registration service mock and continues through the review/checkout path.

## Root Cause
`RegistrationDetail.tsx` imported `parentToolsService`, which is a broad aggregation module with many unrelated Parent Tools adapters loaded at module scope. Because the registration-detail route is lazy-loaded, that single import pulled an oversized dependency graph into a focused registration workflow.

## Prevention / Learning
When a route already belongs to a focused feature boundary, extend that focused feature service for adjacent detail and action APIs instead of importing a cross-feature aggregate module. Add a source-contract test at the route level any time bundle-scope boundaries matter so regressions fail before review.

## Regression Tests
- `npx vitest run src/pages/RegistrationDetail.test.tsx src/pages/parent-tools/parentToolServiceImports.test.ts --reporter=verbose`
- Added component-level coverage for parent, public, and staff-review registration detail flows using the focused registration service mock.
- Added an import guard that fails if `RegistrationDetail.tsx` imports `../lib/parentToolsService` again.
- Updated the mobile smoke spec path in `tests/smoke/app-parent-tools.spec.js` to exercise the focused registration review/checkout flow with the new mock surface.