### PR TITLE
Fix architecture review findings: access control, CI gaps, cache leaks, stat drift

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -2,25 +2,9 @@ name: mobile-build
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/mobile-build.yml"
-      - "apps/app/**"
-      - "android/**"
-      - "ios/**"
-      - "capacitor.config.json"
-      - "package.json"
-      - "package-lock.json"
   push:
     branches:
       - master
-    paths:
-      - ".github/workflows/mobile-build.yml"
-      - "apps/app/**"
-      - "android/**"
-      - "ios/**"
-      - "capacitor.config.json"
-      - "package.json"
-      - "package-lock.json"
   workflow_dispatch:
 
 concurrency:
@@ -28,7 +12,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect mobile-relevant changes
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual run — always building." >&2
+            echo "mobile=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          elif [ "$EVENT_NAME" = "push" ] && [ -n "$BEFORE_SHA" ] && git cat-file -e "$BEFORE_SHA" 2>/dev/null; then
+            CHANGED=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA")
+          else
+            # New branch / unknown before-sha (e.g. force push) — fall back to
+            # treating this as mobile-relevant so we don't silently skip a real
+            # native build.
+            echo "mobile=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:" >&2
+          echo "$CHANGED" >&2
+
+          if echo "$CHANGED" | grep -Eq '^(\.github/workflows/mobile-build\.yml|apps/app/|android/|ios/|capacitor\.config\.json|package\.json|package-lock\.json)'; then
+            echo "mobile=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "mobile=false" >> "$GITHUB_OUTPUT"
+          fi
+
   android-debug:
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -101,6 +135,8 @@ jobs:
           retention-days: 7
 
   ios-simulator:
+    needs: changes
+    if: needs.changes.outputs.mobile == 'true'
     runs-on: macos-15
 
     steps:
@@ -176,3 +212,33 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             CODE_SIGNING_ALLOWED=NO \
             build
+
+  # Single required status check with a stable name/context, regardless of
+  # whether this PR's changes actually triggered a native build. Branch
+  # protection requires this job (not the path-filtered android-debug/
+  # ios-simulator jobs) so a PR that never touches mobile paths isn't stuck
+  # waiting on a check that never runs, while a PR that does touch mobile
+  # paths can't merge with a red native build (the gap this job closes).
+  mobile-build:
+    needs: [changes, android-debug, ios-simulator]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check native build results
+        run: |
+          if [ "${{ needs.changes.outputs.mobile }}" != "true" ]; then
+            echo "No mobile-relevant changes — skipping native build requirement."
+            exit 0
+          fi
+
+          if [ "${{ needs.android-debug.result }}" != "success" ]; then
+            echo "android-debug build did not succeed (${{ needs.android-debug.result }})."
+            exit 1
+          fi
+
+          if [ "${{ needs.ios-simulator.result }}" != "success" ]; then
+            echo "ios-simulator build did not succeed (${{ needs.ios-simulator.result }})."
+            exit 1
+          fi
+
+          echo "Native builds succeeded."

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -226,6 +226,11 @@ jobs:
     steps:
       - name: Check native build results
         run: |
+          if [ "${{ needs.changes.result }}" != "success" ]; then
+            echo "changes job did not complete successfully (${{ needs.changes.result }}) — failing closed instead of assuming no mobile-relevant changes."
+            exit 1
+          fi
+
           if [ "${{ needs.changes.outputs.mobile }}" != "true" ]; then
             echo "No mobile-relevant changes — skipping native build requirement."
             exit 0

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -1,5 +1,4 @@
 import { lazy, ReactNode, Suspense, useEffect, useRef, useState } from 'react';
-import { Capacitor } from '@capacitor/core';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -15,6 +14,7 @@ import {
   type NativeBackButtonEvent
 } from './lib/nativeBackButton';
 import { addNativeDeepLinkListener } from './lib/nativeDeepLinkRouting';
+import { isNativeRuntime } from './lib/nativeRuntime';
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { readAuthBootstrapHint } from './lib/authBootstrapHint';
 import { getRouteForUser } from './lib/authService';
@@ -156,9 +156,7 @@ export default function App() {
       return;
     }
 
-    const isNativeRuntime = Capacitor.isNativePlatform()
-      || (typeof window !== 'undefined' && window.location.protocol === 'capacitor:');
-    if (!isNativeRuntime) {
+    if (!isNativeRuntime()) {
       return;
     }
 

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -238,7 +238,7 @@ export default function App() {
         <Route path="/players/:teamId/:playerId" element={<Protected auth={auth}><PlayerDetail auth={auth} /></Protected>} />
         <Route path="/players/:playerId" element={<Protected auth={auth}><PlayerDetail auth={auth} /></Protected>} />
         <Route path="/games/:gameId" element={<Protected auth={auth}><GameDetail auth={auth} /></Protected>} />
-        <Route path="/help" element={<Protected auth={auth}><HelpPortal /></Protected>} />
+        <Route path="/help" element={<Protected auth={auth}><HelpPortal auth={auth} /></Protected>} />
         <Route path="/help/:helpId" element={<Protected auth={auth}><HelpArticle /></Protected>} />
         <Route path="/profile" element={<Protected auth={auth}><Profile auth={auth} /></Protected>} />
         <Route path="/capabilities/:capabilityId" element={<Protected auth={auth}><CapabilityPage /></Protected>} />

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Capacitor } from '@capacitor/core';
 import { ChevronRight, Search, X } from 'lucide-react';
 import { derivePrimaryHelpRole } from '../lib/helpRoles';
+import { isNativeRuntime } from '../lib/nativeRuntime';
 import { openPublicUrl } from '../lib/publicActions';
 import { preloadSearchRoute } from '../lib/searchRoutePreload';
 import {
@@ -222,10 +222,9 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       return;
     }
 
-    const isNativeRuntime = Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:';
     const visualViewport = window.visualViewport;
 
-    if (!isNativeRuntime || !visualViewport) {
+    if (!isNativeRuntime() || !visualViewport) {
       setKeyboardInset(0);
       return;
     }

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -1,5 +1,6 @@
 import { Capacitor } from '@capacitor/core';
 import { FirebaseAuthentication } from '@capacitor-firebase/authentication';
+import { isNativeRuntime } from './nativeRuntime';
 import {
   auth,
   applyActionCode,
@@ -146,10 +147,6 @@ function normalizeEmail(email: string) {
 
 function normalizeCode(code: string | null | undefined) {
   return String(code || '').trim().toUpperCase();
-}
-
-function isNativeRuntime() {
-  return Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:';
 }
 
 function withTimeout<T>(promise: Promise<T>, message: string, timeoutMs = authTimeoutMs): Promise<T> {

--- a/apps/app/src/lib/badgeService.ts
+++ b/apps/app/src/lib/badgeService.ts
@@ -1,10 +1,5 @@
-import { Capacitor } from '@capacitor/core';
+import { isNativeRuntime } from './nativeRuntime';
 import type { NotificationInboxItem } from './notificationInboxService';
-
-function isNativeRuntime(): boolean {
-    const protocol = typeof window === 'undefined' ? '' : window.location.protocol;
-    return Capacitor.isNativePlatform() || protocol === 'capacitor:';
-}
 
 export function normalizeAppIconBadgeCount(count: unknown): number {
     const numericCount = typeof count === 'number' ? count : Number(count);

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -191,6 +191,10 @@ type ImageUploadSession = {
 
 let aiModelCache: any = null;
 
+export function resetChatAiModel() {
+  aiModelCache = null;
+}
+
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
   let timeoutId: number | undefined;
   const timeout = new Promise<T>((_, reject) => {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1,4 +1,4 @@
-import { Capacitor } from '@capacitor/core';
+import { isNativeRuntime } from './nativeRuntime';
 import {
   GoogleAIBackend,
   canAccessTeamChat,
@@ -190,10 +190,6 @@ type ImageUploadSession = {
 };
 
 let aiModelCache: any = null;
-
-function isNativeRuntime() {
-  return Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:';
-}
 
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
   let timeoutId: number | undefined;

--- a/apps/app/src/lib/gameDayLineupBuilder.ts
+++ b/apps/app/src/lib/gameDayLineupBuilder.ts
@@ -230,6 +230,10 @@ export function parseAiLineupPlan(
 
 let lineupAiModelCache: any = null;
 
+export function resetLineupAiModel() {
+  lineupAiModelCache = null;
+}
+
 export async function getLineupAiModel() {
   if (lineupAiModelCache) return lineupAiModelCache;
   const firebaseApp = getApp();

--- a/apps/app/src/lib/gameWrapupService.test.ts
+++ b/apps/app/src/lib/gameWrapupService.test.ts
@@ -34,13 +34,13 @@ import {
   buildAppWrapupCompletionPayload,
   buildGameWrapupEmailDraft,
   generateGameWrapupArtifactsForApp,
-  resetGameWrapupAiModelForTests
+  resetGameWrapupAiModel
 } from './gameWrapupService';
 
 describe('gameWrapupService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    resetGameWrapupAiModelForTests();
+    resetGameWrapupAiModel();
     dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Falcons', sport: 'Basketball' });
     dbMocks.getGame.mockResolvedValue({
       id: 'game-1',

--- a/apps/app/src/lib/gameWrapupService.ts
+++ b/apps/app/src/lib/gameWrapupService.ts
@@ -41,7 +41,7 @@ export type GameWrapupEmailDraft = {
 
 let aiModelCache: any = null;
 
-export function resetGameWrapupAiModelForTests() {
+export function resetGameWrapupAiModel() {
   aiModelCache = null;
 }
 

--- a/apps/app/src/lib/nativeAppearance.ts
+++ b/apps/app/src/lib/nativeAppearance.ts
@@ -1,5 +1,5 @@
-import { Capacitor } from '@capacitor/core';
 import { createLogger } from './logger';
+import { isNativeRuntime } from './nativeRuntime';
 
 const logger = createLogger('native');
 
@@ -29,8 +29,4 @@ export async function hideNativeSplashScreen() {
   } catch (error) {
     logger.warn('Unable to hide splash screen.', { error });
   }
-}
-
-function isNativeRuntime() {
-  return Capacitor.isNativePlatform() || (typeof window !== 'undefined' && window.location.protocol === 'capacitor:');
 }

--- a/apps/app/src/lib/nativeRuntime.test.ts
+++ b/apps/app/src/lib/nativeRuntime.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const capacitorCoreMock = vi.hoisted(() => ({
+    isNativePlatform: vi.fn(() => false)
+}));
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: capacitorCoreMock
+}));
+
+import { isNativeRuntime } from './nativeRuntime';
+
+describe('isNativeRuntime', () => {
+    const originalLocation = window.location;
+
+    beforeEach(() => {
+        capacitorCoreMock.isNativePlatform.mockReturnValue(false);
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', { value: originalLocation, writable: true, configurable: true });
+    });
+
+    it('returns true when Capacitor reports a native platform', () => {
+        capacitorCoreMock.isNativePlatform.mockReturnValue(true);
+        expect(isNativeRuntime()).toBe(true);
+    });
+
+    it('returns true when running under the capacitor: protocol even if Capacitor.isNativePlatform() misses it', () => {
+        capacitorCoreMock.isNativePlatform.mockReturnValue(false);
+        Object.defineProperty(window, 'location', {
+            value: { ...originalLocation, protocol: 'capacitor:' },
+            writable: true,
+            configurable: true
+        });
+
+        expect(isNativeRuntime()).toBe(true);
+    });
+
+    it('returns false in a regular web browser', () => {
+        capacitorCoreMock.isNativePlatform.mockReturnValue(false);
+        Object.defineProperty(window, 'location', {
+            value: { ...originalLocation, protocol: 'https:' },
+            writable: true,
+            configurable: true
+        });
+
+        expect(isNativeRuntime()).toBe(false);
+    });
+});

--- a/apps/app/src/lib/nativeRuntime.ts
+++ b/apps/app/src/lib/nativeRuntime.ts
@@ -1,0 +1,13 @@
+import { Capacitor } from '@capacitor/core';
+
+/**
+ * Single source of truth for "are we running inside the Capacitor native
+ * WebView" — Capacitor.isNativePlatform() alone misses the `capacitor:`
+ * protocol fallback some native builds boot through, so every call site
+ * needs both checks. Keeping this in one place avoids the two checks
+ * silently drifting apart across call sites.
+ */
+export function isNativeRuntime(): boolean {
+  if (Capacitor.isNativePlatform()) return true;
+  return typeof window !== 'undefined' && window.location.protocol === 'capacitor:';
+}

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -89,7 +89,7 @@ const maxAnswerCharacters = 2400;
 
 let aiModelCache: any = null;
 
-export function resetPrivateAiModelForTests() {
+export function resetPrivateAiModel() {
   aiModelCache = null;
 }
 

--- a/apps/app/src/lib/profilePhotoService.ts
+++ b/apps/app/src/lib/profilePhotoService.ts
@@ -7,6 +7,7 @@ import {
 import { Capacitor } from '@capacitor/core';
 import { resolveImageFirebaseConfig } from './adapters/legacyProfilePhotoDb';
 import { createLogger } from './logger';
+import { isNativeRuntime } from './nativeRuntime';
 import { uploadUserPhoto } from './adapters/legacyProfilePhotoDb';
 
 const profileTimeoutMs = 8000;
@@ -49,10 +50,6 @@ function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = profileT
       window.clearTimeout(timeoutId);
     }
   });
-}
-
-function isNativeRuntime() {
-  return Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:';
 }
 
 function isNativeCameraAvailable() {

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -572,7 +572,7 @@ function helpResultMatchesRole(resultRoles: string[] = [], helpRoleFilter: Exclu
   return normalizedRoles.includes('all') || normalizedRoles.includes(helpRoleFilter);
 }
 
-export function resetAppSearchCacheForTests() {
+export function resetAppSearchCache() {
   cachedTeams = null;
   cachedTeamsLoadedAt = 0;
   cachedTeamsUserKey = '';

--- a/apps/app/src/lib/statTrackingService.test.ts
+++ b/apps/app/src/lib/statTrackingService.test.ts
@@ -153,6 +153,81 @@ describe('statTrackingService', () => {
     expect(service.getEventLog()).toHaveLength(1);
   });
 
+  it('credits a team-configured custom scoring column, matching js/track-basketball.js and js/live-tracker.js getConfiguredPointsColumn() semantics', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['SCORE', 'REB', 'AST'], scoringColumn: 'SCORE' },
+      initialScore: { homeScore: 0, awayScore: 0 },
+      dependencies
+    });
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex SCORE +5',
+      playerName: 'Alex',
+      playerNumber: '4',
+      teamSide: 'home',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'SCORE',
+        value: 5,
+        isOpponent: false
+      }
+    }, { uid: 'coach-1' });
+
+    expect(service.getCurrentScore()).toEqual({ homeScore: 5, awayScore: 0 });
+  });
+
+  it('does not credit the default PTS column as score once a different column is configured as scoringColumn', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS', 'SCORE', 'REB'], scoringColumn: 'SCORE' },
+      initialScore: { homeScore: 0, awayScore: 0 },
+      dependencies
+    });
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex PTS +5',
+      playerName: 'Alex',
+      playerNumber: '4',
+      teamSide: 'home',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'PTS',
+        value: 5,
+        isOpponent: false
+      }
+    }, { uid: 'coach-1' });
+
+    expect(service.getCurrentScore()).toEqual({ homeScore: 0, awayScore: 0 });
+  });
+
+  it('falls back to the default PTS/POINTS/GOALS scoring keys when scoringColumn does not name a real column', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS', 'REB'], scoringColumn: 'DOES_NOT_EXIST' },
+      initialScore: { homeScore: 0, awayScore: 0 },
+      dependencies
+    });
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex PTS +5',
+      playerName: 'Alex',
+      playerNumber: '4',
+      teamSide: 'home',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'PTS',
+        value: 5,
+        isOpponent: false
+      }
+    }, { uid: 'coach-1' });
+
+    expect(service.getCurrentScore()).toEqual({ homeScore: 5, awayScore: 0 });
+  });
+
   it('accepts legacy custom stat column keys with punctuation', async () => {
     const dependencies = createDependencies();
     const service = createStatTrackingService({

--- a/apps/app/src/lib/statTrackingService.ts
+++ b/apps/app/src/lib/statTrackingService.ts
@@ -9,6 +9,7 @@ export type TrackerScoreState = {
 export type TrackerStatConfig = {
   columns?: string[];
   statDefinitions?: Array<{ id?: string; scope?: string; visibility?: string }>;
+  scoringColumn?: string;
 };
 
 export type TrackerLogEntry = {
@@ -72,7 +73,20 @@ function normalizeStatsNumber(value: unknown) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
-function isScoringStatKey(statKey: string) {
+// Mirrors js/track-basketball.js and js/live-tracker.js's getConfiguredPointsColumn():
+// a team's statTrackerConfig.scoringColumn (when it names an actual column) always
+// wins, so a custom scoring column name is honored consistently across all three
+// trackers instead of only the two legacy ones.
+function getConfiguredScoringStatKey(config: TrackerStatConfig = {}) {
+  const configured = normalizeStatKey(config.scoringColumn);
+  if (!configured) return '';
+  const columns = Array.isArray(config.columns) ? config.columns : [];
+  return columns.some((column) => normalizeStatKey(column) === configured) ? configured : '';
+}
+
+function isScoringStatKey(statKey: string, config: TrackerStatConfig = {}) {
+  const configuredScoringStatKey = getConfiguredScoringStatKey(config);
+  if (configuredScoringStatKey) return statKey === configuredScoringStatKey;
   return statKey === 'pts' || statKey === 'points' || statKey === 'goals' || statKey === 'goal';
 }
 
@@ -308,7 +322,7 @@ export function createStatTrackingService({
 
     const scoreBefore = { ...currentScore };
     const scoreAfter = { ...scoreBefore };
-    if (event.type === 'stat' && statKey && isScoringStatKey(statKey) && delta !== 0) {
+    if (event.type === 'stat' && statKey && isScoringStatKey(statKey, statConfig) && delta !== 0) {
       const scoreSide = input.teamSide === 'away' ? 'away' : 'home';
       if (scoreSide === 'away') {
         scoreAfter.awayScore = normalizeScoreValue(scoreAfter.awayScore + delta);

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -102,11 +102,13 @@ import {
   loadParentTeamDetail,
   loadParentTeamDetailBootstrap,
   loadTeamTrackingAdmin,
+  revokeTeamAdminAccessForApp,
   saveTeamTrackingItemForApp,
   setPlayerTrackingStatusForApp,
   updateTeamSettingsForApp
 } from './teamDetailService';
 import { computeNativeStandings } from '../../../../js/native-standings.js';
+import { hasFullTeamAccess } from '../../../../js/team-access.js';
 
 describe('createStatTrackerConfigForApp', () => {
   beforeEach(() => {
@@ -346,6 +348,50 @@ describe('tracking admin helpers', () => {
       updatedBy: 'coach-1',
       updatedByEmail: 'coach@example.com'
     }));
+  });
+});
+
+describe('canManageTeamAdmins adminEmails parity with legacy js/team-access.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Use the real legacy hasFullTeamAccess (not the file-level always-true mock) so this
+    // test actually exercises owner/adminEmails/isAdmin parity instead of trivially passing.
+    vi.mocked(hasFullTeamAccess).mockImplementation((user: any, team: any) => {
+      if (!user || !team) return false;
+      const isOwner = team.ownerId === user.uid;
+      const normalizedEmail = String(user.email || '').trim().toLowerCase();
+      const adminEmails = (Array.isArray(team.adminEmails) ? team.adminEmails : [])
+        .map((email: string) => String(email || '').trim().toLowerCase());
+      const isTeamAdmin = adminEmails.includes(normalizedEmail);
+      const isPlatformAdmin = user.isAdmin === true;
+      return isOwner || isTeamAdmin || isPlatformAdmin;
+    });
+    dbMocks.getTeam.mockResolvedValue({
+      id: 'team-1',
+      ownerId: 'owner-uid',
+      ownerEmail: 'owner@example.com',
+      adminEmails: ['teamadmin@example.com']
+    });
+    dbMocks.updateTeam.mockResolvedValue(undefined);
+    __resetTeamDetailBaseSnapshotCacheForTests();
+  });
+
+  it('allows a user listed in team.adminEmails (not owner, not isAdmin) to manage admins', async () => {
+    const teamAdminUser = { uid: 'admin-uid', email: 'teamadmin@example.com', roles: [] } as any;
+
+    await expect(
+      revokeTeamAdminAccessForApp('team-1', 'someoneelse@example.com', teamAdminUser)
+    ).resolves.toBeUndefined();
+    expect(dbMocks.updateTeam).toHaveBeenCalled();
+  });
+
+  it('denies a user who is neither owner, adminEmails member, isAdmin, isPlatformAdmin, nor admin-role', async () => {
+    const randomUser = { uid: 'random-uid', email: 'random@example.com', roles: [] } as any;
+
+    await expect(
+      revokeTeamAdminAccessForApp('team-1', 'teamadmin@example.com', randomUser)
+    ).rejects.toThrow('You do not have permission to manage admins for this team.');
+    expect(dbMocks.updateTeam).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -383,10 +383,11 @@ function invalidateTeamDetailBaseSnapshotCache(teamId: string) {
 
 function canManageTeamAdmins(user: AuthUser | null, team: any) {
   if (!user || !team) return false;
-  return cleanString(team?.ownerId) === cleanString(user?.uid)
-    || user?.isAdmin === true
+  // Delegates owner/adminEmails/isAdmin checks to the legacy source of truth
+  // (js/team-access.js) so this stays in sync with the legacy site instead of drifting.
+  return hasFullTeamAccess(user, team)
     || user?.isPlatformAdmin === true
-    || Array.isArray(user?.roles) && (user.roles.includes('admin') || user.roles.includes('platformAdmin'));
+    || (Array.isArray(user?.roles) && (user.roles.includes('admin') || user.roles.includes('platformAdmin')));
 }
 
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {

--- a/apps/app/src/lib/useAuth.test.ts
+++ b/apps/app/src/lib/useAuth.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const authServiceMocks = vi.hoisted(() => ({
+  observeFirebaseUser: vi.fn((callback: (user: unknown) => void) => {
+    callback(null);
+    return () => undefined;
+  }),
+  hydrateFirebaseUser: vi.fn(),
+  signOut: vi.fn(() => Promise.resolve())
+}));
+
+const cacheResetMocks = vi.hoisted(() => ({
+  resetAppSearchCache: vi.fn(),
+  resetChatAiModel: vi.fn(),
+  resetGameWrapupAiModel: vi.fn(),
+  resetPrivateAiModel: vi.fn(),
+  resetLineupAiModel: vi.fn()
+}));
+
+vi.mock('./authService', () => authServiceMocks);
+vi.mock('./searchService', () => ({ resetAppSearchCache: cacheResetMocks.resetAppSearchCache }));
+vi.mock('./chatService', () => ({ resetChatAiModel: cacheResetMocks.resetChatAiModel }));
+vi.mock('./gameWrapupService', () => ({ resetGameWrapupAiModel: cacheResetMocks.resetGameWrapupAiModel }));
+vi.mock('./privateAiService', () => ({ resetPrivateAiModel: cacheResetMocks.resetPrivateAiModel }));
+vi.mock('./gameDayLineupBuilder', () => ({ resetLineupAiModel: cacheResetMocks.resetLineupAiModel }));
+
+import { useAuth } from './useAuth';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useAuth signOut', () => {
+  it('clears every per-user module cache so a second user signing in on the same tab never sees stale cached data', async () => {
+    const { result } = renderHook(() => useAuth());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    expect(cacheResetMocks.resetAppSearchCache).toHaveBeenCalledTimes(1);
+    expect(cacheResetMocks.resetChatAiModel).toHaveBeenCalledTimes(1);
+    expect(cacheResetMocks.resetGameWrapupAiModel).toHaveBeenCalledTimes(1);
+    expect(cacheResetMocks.resetPrivateAiModel).toHaveBeenCalledTimes(1);
+    expect(cacheResetMocks.resetLineupAiModel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/lib/useAuth.ts
+++ b/apps/app/src/lib/useAuth.ts
@@ -3,8 +3,25 @@ import type { AuthState, AuthUser } from './types';
 import { clearAuthBootstrapHint, writeAuthBootstrapHint } from './authBootstrapHint';
 import { hydrateFirebaseUser, observeFirebaseUser, signOut } from './authService';
 import { createLogger } from './logger';
+import { resetChatAiModel } from './chatService';
+import { resetGameWrapupAiModel } from './gameWrapupService';
+import { resetLineupAiModel } from './gameDayLineupBuilder';
+import { resetPrivateAiModel } from './privateAiService';
+import { resetAppSearchCache } from './searchService';
 
 const logger = createLogger('app-auth');
+
+function clearPerUserCaches() {
+  // These module-level caches key on the signed-in user (search results, help
+  // roles) or hold generative-model handles tied to the session's Firebase
+  // app. Without this, a second user signing in on the same tab/device could
+  // briefly see the previous user's cached search results.
+  resetAppSearchCache();
+  resetChatAiModel();
+  resetGameWrapupAiModel();
+  resetPrivateAiModel();
+  resetLineupAiModel();
+}
 
 export function useAuth(): AuthState {
   const [user, setUser] = useState<AuthUser | null>(null);
@@ -86,6 +103,7 @@ export function useAuth(): AuthState {
     setUser(null);
     setProfile(null);
     clearAuthBootstrapHint();
+    clearPerUserCaches();
     setLoading(false);
     try {
       await cleanup;

--- a/apps/app/src/lib/useShellLayout.ts
+++ b/apps/app/src/lib/useShellLayout.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Capacitor } from '@capacitor/core';
+import { isNativeRuntime as readNativeRuntime } from './nativeRuntime';
 
 const desktopQuery = '(min-width: 1024px)';
 
@@ -10,10 +10,6 @@ type MediaQueryWithLegacyListeners = MediaQueryList & {
 
 function readDesktopMatch() {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia(desktopQuery).matches;
-}
-
-function readNativeRuntime() {
-  return typeof window !== 'undefined' && (Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:');
 }
 
 function subscribeToMediaQuery(media: MediaQueryWithLegacyListeners, listener: (event: MediaQueryListEvent) => void) {

--- a/apps/app/src/pages/HelpPortal.test.tsx
+++ b/apps/app/src/pages/HelpPortal.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { HelpPortal } from './HelpPortal';
+import type { AuthState } from '../lib/types';
+
+vi.mock('../lib/helpKnowledgeService', () => ({
+  getHelpKnowledgeDocs: () => [
+    { id: 'doc-parent', title: 'Parent guide', summary: 'For parents', roles: ['parent'] },
+    { id: 'doc-coach', title: 'Coach guide', summary: 'For coaches', roles: ['coach'] }
+  ],
+  searchHelpKnowledge: () => []
+}));
+
+function buildAuth(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    user: { uid: 'user-1', email: 'user@example.com', displayName: 'Test User', roles: [] },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: [],
+    isParent: false,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn(),
+    ...overrides
+  } as AuthState;
+}
+
+describe('HelpPortal', () => {
+  it('derives its default role filter from the auth prop instead of instantiating its own auth listener', () => {
+    render(
+      <MemoryRouter>
+        <HelpPortal auth={buildAuth({ isCoach: true })} />
+      </MemoryRouter>
+    );
+
+    // Only the coach-tagged doc should be visible by default for a coach user —
+    // proving the role filter came from the passed-in auth prop.
+    expect(screen.getByText('Coach guide')).toBeTruthy();
+    expect(screen.queryByText('Parent guide')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Coach' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('shows all articles for a signed-in user with no specific role', () => {
+    render(
+      <MemoryRouter>
+        <HelpPortal auth={buildAuth()} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Parent guide')).toBeTruthy();
+    expect(screen.getByText('Coach guide')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'All' }).getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/apps/app/src/pages/HelpPortal.tsx
+++ b/apps/app/src/pages/HelpPortal.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { LifeBuoy, Search } from 'lucide-react';
 import { getHelpKnowledgeDocs, searchHelpKnowledge } from '../lib/helpKnowledgeService';
 import { derivePrimaryHelpRole, type HelpRoleFilter } from '../lib/helpRoles';
-import { useAuth } from '../lib/useAuth';
+import type { AuthState } from '../lib/types';
 
 type HelpPortalRoleFilter = HelpRoleFilter;
 
@@ -22,9 +22,8 @@ const helpRoleOptions: Array<{ value: HelpPortalRoleFilter; label: string }> = [
   { value: 'member', label: 'Member' }
 ];
 
-export function HelpPortal() {
+export function HelpPortal({ auth }: { auth: AuthState }) {
   const location = useLocation();
-  const auth = useAuth();
   const defaultRoleFilter = derivePrimaryHelpRole(auth);
   const portalState = useMemo(() => normalizePortalState(location.state, defaultRoleFilter), [defaultRoleFilter, location.state]);
   const [query, setQuery] = useState(portalState.helpQuery);

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -343,13 +343,17 @@ describe('ParentTools access', () => {
         renderParentTools(['/parent-tools/access?teamId=missing-team']);
 
         await screen.findByText('Request player access');
-        await waitFor(() => expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1));
-        expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
-        expect(screen.getByRole('button', { name: 'Redeem code' })).toBeTruthy();
-
+        // Wait for the manual-request panel to actually render (only true once
+        // teams have loaded and the deep-link reconciliation effect has run) before
+        // asserting on its contents — asserting synchronously right after only the
+        // load call was observed races the state update under full-suite load and
+        // was intermittently failing in CI while passing in isolation.
         const teamSelect = await screen.findByRole('combobox', { name: 'Team' }) as HTMLSelectElement;
         expect(teamSelect.value).toBe('');
         expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
+        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
+        expect(screen.getByRole('button', { name: 'Redeem code' })).toBeTruthy();
         expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
     });
 

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -63,6 +63,27 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
 
     afterEach(() => cleanup());
 
+    it('opens the manual request form while deep-linked teams are still loading', async () => {
+        let resolveTeams: (teams: Array<{ id: string; name: string }>) => void = () => {};
+        accessServiceMocks.loadParentAccessTeams.mockReturnValue(new Promise((resolve) => {
+            resolveTeams = resolve;
+        }));
+
+        const view = renderTool('team-a');
+
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1));
+        await waitFor(() => {
+            const select = view.container.querySelector('#parent-access-team') as HTMLSelectElement | null;
+            expect(select).not.toBeNull();
+            expect(select?.disabled).toBe(true);
+            expect(select?.textContent).toContain('Loading public teams...');
+        });
+
+        await act(async () => {
+            resolveTeams([{ id: 'team-a', name: 'Team A' }]);
+        });
+    });
+
     it('switches to a newly deep-linked team while already mounted', async () => {
         renderTool('team-a');
         await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-a'));

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -117,6 +117,12 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [auth.user?.uid]);
 
     useEffect(() => {
+        if (!deepLinkedTeamId) return;
+        setManualRequestOpen(true);
+        setManualTeamsRequested(true);
+    }, [deepLinkedTeamId]);
+
+    useEffect(() => {
         if (!deepLinkedTeamId || teams.length || loadingTeams) return;
         void loadTeams();
     }, [deepLinkedTeamId, loadTeams, loadingTeams, teams.length]);

--- a/firestore.rules
+++ b/firestore.rules
@@ -627,13 +627,6 @@ service cloud.firestore {
              teamData.get('active', true) != false;
     }
 
-    // Lets anonymous spectators on public live-game views resolve a team's stat
-    // tracker config (sport/columns) without granting them broader team access.
-    function isPublicTeamForConfigRead(teamId) {
-      let teamPath = /databases/$(database)/documents/teams/$(teamId);
-      return exists(teamPath) && isPublicGameReadTeam(get(teamPath).data);
-    }
-
     function isShareableGameDocument(data) {
       let visibility = data.get('visibility', '');
       return visibility != 'private' &&
@@ -2362,10 +2355,17 @@ service cloud.firestore {
       }
 
       // Stat tracker configs subcollection
+      // Left open to anonymous reads (unlike rosterFields): live-game.js loads
+      // getConfigs(state.teamId) for the *specific* shareable/public game a
+      // replay link points to, but that read isn't scoped to a gameId — it's a
+      // team-wide collection query — and a game can be individually shareable
+      // (isShareableGameDocument) even when its team is inactive/non-public.
+      // Without knowing which game the client is loading, this rule can't
+      // reproduce that per-game exception, so requiring team-level public+active
+      // status here breaks replay links for exactly the teams that need it most.
+      // The data itself (sport type + column names) has no meaningful sensitivity.
       match /statTrackerConfigs/{configId} {
-        allow read: if isTeamOwnerOrAdmin(teamId) ||
-                       isParentForTeam(teamId) ||
-                       isPublicTeamForConfigRead(teamId);
+        allow read: if true;
         allow write: if isTeamOwnerOrAdmin(teamId);
       }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -627,6 +627,13 @@ service cloud.firestore {
              teamData.get('active', true) != false;
     }
 
+    // Lets anonymous spectators on public live-game views resolve a team's stat
+    // tracker config (sport/columns) without granting them broader team access.
+    function isPublicTeamForConfigRead(teamId) {
+      let teamPath = /databases/$(database)/documents/teams/$(teamId);
+      return exists(teamPath) && isPublicGameReadTeam(get(teamPath).data);
+    }
+
     function isShareableGameDocument(data) {
       let visibility = data.get('visibility', '');
       return visibility != 'private' &&
@@ -1691,24 +1698,6 @@ service cloud.firestore {
                        isTeamOwnerOrAdmin(resource.data.teamId);
     }
 
-    // Collection group rule for assigned team fee recipient records.
-    // Parents can only read records tied directly to their account or linked players.
-    match /{path=**}/feeRecipients/{recipientId} {
-      allow read: if resource.data.get('teamId', '') is string &&
-                     (isTeamFeeRecipientForCurrentParent(resource.data, resource.data.get('teamId', '')) ||
-                      isTeamOwnerOrAdmin(resource.data.get('teamId', '')));
-      allow create: if request.resource.data.get('teamId', '') is string &&
-                       hasNoPrivateTeamFeeBillingFields(request.resource.data) &&
-                       isTeamOwnerOrAdmin(request.resource.data.get('teamId', ''));
-      allow update: if resource.data.get('teamId', '') is string &&
-                       request.resource.data.get('teamId', '') == resource.data.get('teamId', '') &&
-                       hasNoIntroducedPrivateTeamFeeBillingFields() &&
-                       isTeamOwnerOrAdmin(resource.data.get('teamId', ''));
-      allow delete: if resource.data.get('teamId', '') is string &&
-                       isTeamOwnerOrAdmin(resource.data.get('teamId', ''));
-    }
-
-
     // Parent-managed athlete profiles with explicit public/private sharing.
     match /athleteProfiles/{profileId} {
       allow read: if resource.data.privacy == 'public' ||
@@ -1867,7 +1856,7 @@ service cloud.firestore {
       }
 
       match /rosterFields/{fieldId} {
-        allow read: if true;
+        allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 
@@ -2374,7 +2363,9 @@ service cloud.firestore {
 
       // Stat tracker configs subcollection
       match /statTrackerConfigs/{configId} {
-        allow read: if true;
+        allow read: if isTeamOwnerOrAdmin(teamId) ||
+                       isParentForTeam(teamId) ||
+                       isPublicTeamForConfigRead(teamId);
         allow write: if isTeamOwnerOrAdmin(teamId);
       }
 

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -259,6 +259,7 @@ describe('React app auth/profile capability parity', () => {
         const appPackageLock = readProjectFile('apps/app/package-lock.json');
         const profilePage = readProjectFile('apps/app/src/pages/Profile.tsx');
         const profilePhotoService = readProjectFile('apps/app/src/lib/profilePhotoService.ts');
+        const nativeRuntime = readProjectFile('apps/app/src/lib/nativeRuntime.ts');
         const androidManifest = readProjectFile('android/app/src/main/AndroidManifest.xml');
         const androidSettings = readProjectFile('android/capacitor.settings.gradle');
         const androidCapacitorBuild = readProjectFile('android/app/capacitor.build.gradle');
@@ -268,13 +269,19 @@ describe('React app auth/profile capability parity', () => {
         expectContains(rootPackageLock, ['"node_modules/@capacitor/camera"']);
         expectContains(appPackage, ['"@capacitor/camera":']);
         expectContains(appPackageLock, ['"node_modules/@capacitor/camera"']);
+        // Native-runtime detection is centralized in nativeRuntime.ts (not reimplemented
+        // per-file) so profilePhotoService just imports and calls it.
         expectContains(profilePhotoService, [
             "from '@capacitor/camera'",
-            'Capacitor.isNativePlatform() || window.location.protocol === \'capacitor:\'',
+            "isNativeRuntime } from './nativeRuntime'",
             'Camera.getPhoto',
             'CameraResultType.Uri',
             'CameraSource.Camera',
             'CameraSource.Photos'
+        ]);
+        expectContains(nativeRuntime, [
+            'Capacitor.isNativePlatform()',
+            "window.location.protocol === 'capacitor:'"
         ]);
         expectContains(profilePage, [
             "handleNativePhotoChoice('camera')",

--- a/tests/unit/app-help-article.test.jsx
+++ b/tests/unit/app-help-article.test.jsx
@@ -72,7 +72,10 @@ describe('HelpArticle', () => {
         );
         expect(appSource).toContain("const HelpArticle = lazy(() => import('./pages/HelpArticle').then((module) => ({ default: module.HelpArticle })));"
         );
-        expect(appSource).toContain('<Route path="/help" element={<Protected auth={auth}><HelpPortal /></Protected>} />');
+        // HelpPortal takes auth as a prop (like every other page) instead of calling
+        // useAuth() itself, so navigating here doesn't mount a second, redundant
+        // auth listener alongside the one App.tsx already set up.
+        expect(appSource).toContain('<Route path="/help" element={<Protected auth={auth}><HelpPortal auth={auth} /></Protected>} />');
         expect(appSource).toContain('<Route path="/help/:helpId" element={<Protected auth={auth}><HelpArticle /></Protected>} />');
     });
 

--- a/tests/unit/app-help-portal.test.jsx
+++ b/tests/unit/app-help-portal.test.jsx
@@ -26,9 +26,6 @@ const authMock = vi.hoisted(() => ({
 }));
 
 vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
-vi.mock('../../apps/app/src/lib/useAuth.ts', () => ({
-    useAuth: () => authMock.state
-}));
 
 import { HelpArticle } from '../../apps/app/src/pages/HelpArticle.tsx';
 import { HelpPortal } from '../../apps/app/src/pages/HelpPortal.tsx';
@@ -88,7 +85,7 @@ async function renderHelp(initialEntry = '/help', extraHelpContent = null) {
                 null,
                 React.createElement(Route, {
                     path: '/help',
-                    element: React.createElement(React.Fragment, null, extraHelpContent, React.createElement(HelpPortal))
+                    element: React.createElement(React.Fragment, null, extraHelpContent, React.createElement(HelpPortal, { auth: authMock.state }))
                 }),
                 React.createElement(Route, { path: '/help/:helpId', element: React.createElement(HelpArticle) })
             )

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -182,7 +182,7 @@ beforeEach(async () => {
     toolsMocks.loadParentRegistrations.mockResolvedValue([]);
     toolsMocks.loadParentCertificates.mockResolvedValue([]);
     const service = await import('../../apps/app/src/lib/privateAiService.ts');
-    service.resetPrivateAiModelForTests();
+    service.resetPrivateAiModel();
 });
 
 describe('private AI service', () => {

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -50,7 +50,7 @@ vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
 vi.mock('../../apps/app/src/lib/searchRoutePreload.ts', () => routePreloadMocks);
 
 import { AppShell } from '../../apps/app/src/components/AppShell.tsx';
-import { resetAppSearchCacheForTests } from '../../apps/app/src/lib/searchService.ts';
+import { resetAppSearchCache } from '../../apps/app/src/lib/searchService.ts';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -167,7 +167,7 @@ async function waitForText(container, text) {
 
 beforeEach(() => {
     vi.clearAllMocks();
-    resetAppSearchCacheForTests();
+    resetAppSearchCache();
     window.matchMedia = vi.fn(() => ({
         matches: false,
         media: '(min-width: 1024px)',
@@ -696,7 +696,7 @@ describe('React app shell search', () => {
         expect(container.textContent).toContain('Team search unavailable');
 
         await clickButton(container, 'Close search');
-        resetAppSearchCacheForTests();
+        resetAppSearchCache();
         homeMocks.loadParentHome.mockResolvedValueOnce({ teams: [] });
         firebaseMocks.getDocs.mockRejectedValue(Object.assign(new Error('Permission denied'), { code: 'permission-denied' }));
 
@@ -705,7 +705,7 @@ describe('React app shell search', () => {
         expect(container.textContent).toContain('Player search unavailable for this account.');
 
         await clickButton(container, 'Close search');
-        resetAppSearchCacheForTests();
+        resetAppSearchCache();
         homeMocks.loadParentHome.mockResolvedValueOnce({ teams: [] });
         firebaseMocks.getDocs.mockRejectedValue(Object.assign(new Error('not ready yet: create index'), { code: 'failed-precondition' }));
 

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -40,7 +40,7 @@ import {
     getKnownAppSearchTeams,
     getSearchHelpRoles,
     loadAppSearchTeams,
-    resetAppSearchCacheForTests,
+    resetAppSearchCache,
     scoreSearchText,
     searchAppTeams,
     searchAppPlayers,
@@ -92,7 +92,7 @@ beforeEach(() => {
     vi.clearAllMocks();
     firebaseMocks.getDoc.mockReset();
     dbMocks.discoverPublicTeams.mockResolvedValue({ teams: [], nextCursor: null });
-    resetAppSearchCacheForTests();
+    resetAppSearchCache();
     helpMocks.searchHelpKnowledge.mockReturnValue([]);
     homeMocks.loadParentHomeSummary.mockImplementation((...args) => homeMocks.loadParentHome(...args));
 });
@@ -755,7 +755,7 @@ describe('React app search service', () => {
         expect(homeMocks.loadParentHomeSummary).toHaveBeenCalledTimes(1);
         expect(first.map((team) => team.id)).toEqual(['team-home']);
 
-        resetAppSearchCacheForTests();
+        resetAppSearchCache();
         firebaseMocks.getDocs
             .mockRejectedValueOnce(new Error('direct access down'))
             .mockResolvedValueOnce({ docs: [] })

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -166,16 +166,34 @@ describe('React app team detail model', () => {
         expect(inviteAdmin).not.toHaveBeenCalled();
     });
 
-    it('requires owner or platform admin access before creating or revoking team admin access', async () => {
+    it('requires owner, adminEmails membership, or platform admin access before creating or revoking team admin access', async () => {
         getTeam.mockResolvedValue({ id: 'team-1', ownerId: 'owner-1', ownerEmail: 'owner@example.com', adminEmails: [' coach@example.com ', 'COACH@example.com '] });
         getPlayers.mockResolvedValue([]);
         getGames.mockResolvedValue([]);
         getConfigs.mockResolvedValue([]);
         updateTeam.mockResolvedValue(undefined);
+        inviteAdmin.mockResolvedValue({ code: 'CODE1', teamName: 'Bears', existingUser: false });
+        addTeamAdminEmail.mockResolvedValue(undefined);
+        sendInviteEmail.mockResolvedValue({ success: true });
 
-        await expect(inviteTeamAdminForApp('team-1', 'newcoach@example.com', { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'] })).rejects.toThrow('You do not have permission to manage admins for this team.');
-        await expect(revokeTeamAdminAccessForApp('team-1', 'coach@example.com', { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'] })).rejects.toThrow('You do not have permission to manage admins for this team.');
+        // A user with no relationship to the team at all (not owner, not in
+        // adminEmails, not platform admin) must still be rejected.
+        await expect(inviteTeamAdminForApp('team-1', 'newcoach@example.com', { uid: 'stranger-1', email: 'stranger@example.com', roles: [] })).rejects.toThrow('You do not have permission to manage admins for this team.');
+        await expect(revokeTeamAdminAccessForApp('team-1', 'coach@example.com', { uid: 'stranger-1', email: 'stranger@example.com', roles: [] })).rejects.toThrow('You do not have permission to manage admins for this team.');
 
+        // A user listed in team.adminEmails (but not owner/platformAdmin) has full team
+        // access on the legacy site (js/team-access.js hasFullTeamAccess, gating
+        // edit-team.html's admin management UI), so the app must allow it too instead
+        // of drifting into a narrower, owner/platform-admin-only check.
+        await expect(inviteTeamAdminForApp('team-1', 'newcoach@example.com', { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'] })).resolves.toMatchObject({ email: 'newcoach@example.com' });
+        await revokeTeamAdminAccessForApp('team-1', 'coach@example.com', { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'] });
+        expect(updateTeam).toHaveBeenCalledWith('team-1', {
+            adminEmails: [],
+            updatedAt: expect.any(Date)
+        });
+
+        updateTeam.mockClear();
+        getTeam.mockResolvedValue({ id: 'team-1', ownerId: 'owner-1', ownerEmail: 'owner@example.com', adminEmails: [' coach@example.com ', 'COACH@example.com '] });
         await revokeTeamAdminAccessForApp('team-1', ' Coach@Example.com ', { uid: 'owner-1', email: 'owner@example.com', roles: ['coach'] });
         expect(updateTeam).toHaveBeenCalledWith('team-1', {
             adminEmails: [],

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+describe('firestore.rules architecture fixes', () => {
+    // Duplicate-block regression coverage lives in tests/unit/team-fee-recipient-rules.test.js.
+    it('keeps feeRecipients access scoped to the fee recipient or team owner/admin', () => {
+        const start = rules.indexOf('match /{path=**}/feeRecipients/{recipientId}');
+        const end = rules.indexOf('\n    }', start) + '\n    }'.length;
+        const feeRecipientsRules = rules.slice(start, end);
+
+        expect(feeRecipientsRules).toContain('isTeamFeeRecipientForCurrentParent(resource.data, resource.data.teamId)');
+        expect(feeRecipientsRules).toContain('isTeamOwnerOrAdmin(resource.data.teamId)');
+    });
+
+    it('does not allow unauthenticated/public reads of roster field definitions', () => {
+        const start = rules.indexOf('match /rosterFields/{fieldId}');
+        const end = rules.indexOf('\n      }', start) + '\n      }'.length;
+        const rosterFieldsRules = rules.slice(start, end);
+
+        expect(rosterFieldsRules).not.toContain('allow read: if true;');
+        expect(rosterFieldsRules).toContain('allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);');
+    });
+
+    it('does not allow unauthenticated/public reads of stat tracker configs except for public teams', () => {
+        const start = rules.indexOf('match /statTrackerConfigs/{configId}');
+        const end = rules.indexOf('\n      }', start) + '\n      }'.length;
+        const statTrackerConfigRules = rules.slice(start, end);
+
+        expect(statTrackerConfigRules).not.toContain('allow read: if true;');
+        expect(statTrackerConfigRules).toContain('isTeamOwnerOrAdmin(teamId)');
+        expect(statTrackerConfigRules).toContain('isParentForTeam(teamId)');
+        expect(statTrackerConfigRules).toContain('isPublicTeamForConfigRead(teamId)');
+    });
+
+    it('gates the public stat tracker config fallback on the team being public and active', () => {
+        expect(rules).toContain('function isPublicTeamForConfigRead(teamId) {');
+        const start = rules.indexOf('function isPublicTeamForConfigRead(teamId) {');
+        const end = rules.indexOf('\n    }', start) + '\n    }'.length;
+        const helper = rules.slice(start, end);
+
+        expect(helper).toContain('isPublicGameReadTeam(get(teamPath).data)');
+    });
+});

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -23,23 +23,19 @@ describe('firestore.rules architecture fixes', () => {
         expect(rosterFieldsRules).toContain('allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);');
     });
 
-    it('does not allow unauthenticated/public reads of stat tracker configs except for public teams', () => {
+    it('keeps stat tracker configs publicly readable so shareable replay links keep working', () => {
+        // Codex caught a regression here: live-game.js loads getConfigs(state.teamId)
+        // for a specific shareable/public *game*, but that read isn't scoped to a
+        // gameId, and a game can be individually shareable even when its team is
+        // inactive/non-public (isShareableGameDocument, independent of team-level
+        // isPublic/active). Requiring team-level public+active status broke replay
+        // links for exactly the teams that need them. The data (sport type + column
+        // names) has no meaningful sensitivity, so it stays open.
         const start = rules.indexOf('match /statTrackerConfigs/{configId}');
         const end = rules.indexOf('\n      }', start) + '\n      }'.length;
         const statTrackerConfigRules = rules.slice(start, end);
 
-        expect(statTrackerConfigRules).not.toContain('allow read: if true;');
-        expect(statTrackerConfigRules).toContain('isTeamOwnerOrAdmin(teamId)');
-        expect(statTrackerConfigRules).toContain('isParentForTeam(teamId)');
-        expect(statTrackerConfigRules).toContain('isPublicTeamForConfigRead(teamId)');
-    });
-
-    it('gates the public stat tracker config fallback on the team being public and active', () => {
-        expect(rules).toContain('function isPublicTeamForConfigRead(teamId) {');
-        const start = rules.indexOf('function isPublicTeamForConfigRead(teamId) {');
-        const end = rules.indexOf('\n    }', start) + '\n    }'.length;
-        const helper = rules.slice(start, end);
-
-        expect(helper).toContain('isPublicGameReadTeam(get(teamPath).data)');
+        expect(statTrackerConfigRules).toContain('allow read: if true;');
+        expect(statTrackerConfigRules).toContain('allow write: if isTeamOwnerOrAdmin(teamId);');
     });
 });

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync(new URL('../../.github/workflows/mobile-build.yml', import.meta.url), 'utf8');
+
+describe('mobile-build CI workflow', () => {
+    it('always triggers on every pull request and master push (no path filter that could skip the required check)', () => {
+        // A `paths:` filter directly under `pull_request:`/`push:` would mean the
+        // workflow — and therefore the `mobile-build` required status check —
+        // never runs for PRs that don't touch those paths, permanently blocking
+        // merge (GitHub required checks that never post a status block forever).
+        const triggerSection = workflow.slice(workflow.indexOf('\non:'), workflow.indexOf('\nconcurrency:'));
+        expect(triggerSection).not.toContain('paths:');
+        expect(triggerSection).toContain('pull_request:');
+        expect(triggerSection).toContain('push:');
+        expect(triggerSection).toContain('workflow_dispatch:');
+    });
+
+    it('gates the expensive android/ios build jobs on a path-detection job instead of removing path awareness entirely', () => {
+        expect(workflow).toContain('changes:');
+        expect(workflow).toContain("outputs.mobile");
+        expect(workflow).toContain('android-debug/');
+        // The mobile-relevant path list moved from the trigger filter into the
+        // changes-detection job body.
+        expect(workflow).toContain('apps/app/');
+        expect(workflow).toContain('android/');
+        expect(workflow).toContain('ios/');
+        expect(workflow).toContain('capacitor\\.config\\.json');
+    });
+
+    it('skips the native builds themselves for non-mobile changes but always runs the required mobile-build gate job', () => {
+        const androidStart = workflow.indexOf('  android-debug:');
+        const androidSection = workflow.slice(androidStart, workflow.indexOf('  ios-simulator:'));
+        expect(androidSection).toContain('needs: changes');
+        expect(androidSection).toContain("if: needs.changes.outputs.mobile == 'true'");
+
+        const iosStart = workflow.indexOf('  ios-simulator:');
+        const iosSection = workflow.slice(iosStart, workflow.indexOf('  mobile-build:'));
+        expect(iosSection).toContain('needs: changes');
+        expect(iosSection).toContain("if: needs.changes.outputs.mobile == 'true'");
+
+        const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
+        expect(gateSection).toContain('needs: [changes, android-debug, ios-simulator]');
+        expect(gateSection).toContain('if: always()');
+    });
+
+    it('fails the required gate job when a mobile-relevant PR actually breaks native builds', () => {
+        const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
+        expect(gateSection).toContain("needs.android-debug.result }}\" != \"success\"");
+        expect(gateSection).toContain("needs.ios-simulator.result }}\" != \"success\"");
+        expect(gateSection).toContain('exit 1');
+    });
+});

--- a/tests/unit/mobile-build-workflow.test.js
+++ b/tests/unit/mobile-build-workflow.test.js
@@ -50,4 +50,20 @@ describe('mobile-build CI workflow', () => {
         expect(gateSection).toContain("needs.ios-simulator.result }}\" != \"success\"");
         expect(gateSection).toContain('exit 1');
     });
+
+    it('fails closed instead of silently skipping when the changes-detection job itself does not succeed', () => {
+        // Codex caught this: the gate job uses `if: always()`, so it also runs
+        // when `changes` fails (e.g. a checkout/diff error). In that case
+        // needs.changes.outputs.mobile is empty — not "true" — so without this
+        // check the gate would take the "no mobile changes" skip path and report
+        // success even though neither native build ran, exactly the gap this job
+        // exists to close.
+        const gateSection = workflow.slice(workflow.indexOf('  mobile-build:'));
+        const changesResultCheckIndex = gateSection.indexOf('needs.changes.result }}\" != \"success\"');
+        const mobileOutputCheckIndex = gateSection.indexOf('needs.changes.outputs.mobile }}\" != \"true\"');
+
+        expect(changesResultCheckIndex).toBeGreaterThan(-1);
+        expect(mobileOutputCheckIndex).toBeGreaterThan(-1);
+        expect(changesResultCheckIndex).toBeLessThan(mobileOutputCheckIndex);
+    });
 });

--- a/tests/unit/stat-tracking-scoring-column-parity.test.js
+++ b/tests/unit/stat-tracking-scoring-column-parity.test.js
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { createStatTrackingService } from '../../apps/app/src/lib/statTrackingService.ts';
+
+// ALL PLAYS has three independent stat-tracking implementations that must agree on
+// which stat column represents "points" for a given team's config: the mobile
+// beta tracker (js/track-basketball.js), the live game monitor (js/live-tracker.js),
+// and the React app's "standard tracker" (apps/app/src/lib/statTrackingService.ts).
+// They were never consolidated (see architecture review) because doing so safely
+// is a much larger effort than fits in one pass — this suite instead pins the one
+// invariant that actually matters across all three: given the same
+// statTrackerConfig, do they identify the same column as the scoring column?
+//
+// This caught a real bug during authoring: statTrackingService.ts ignored a
+// team's configured `scoringColumn` entirely (unlike both legacy trackers, which
+// respect it via getConfiguredPointsColumn()), so a custom scoring column name
+// would fail to update the live score in the React app's tracker only.
+
+function extractFunction(source, functionName, fileLabel) {
+    const signature = `function ${functionName}`;
+    const start = source.indexOf(signature);
+    if (start === -1) {
+        throw new Error(`Could not find ${functionName} in ${fileLabel}`);
+    }
+
+    let paramsDepth = 0;
+    let bodyStart = -1;
+    for (let index = start; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '(') paramsDepth += 1;
+        if (char === ')') paramsDepth = Math.max(0, paramsDepth - 1);
+        if (char === '{' && paramsDepth === 0) {
+            bodyStart = index;
+            break;
+        }
+    }
+    if (bodyStart === -1) {
+        throw new Error(`Could not find ${functionName} body start in ${fileLabel}`);
+    }
+
+    let depth = 0;
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, index + 1);
+        }
+    }
+
+    throw new Error(`Could not extract ${functionName} from ${fileLabel}`);
+}
+
+function runFunction(scriptParts, hookNames, contextValues = {}) {
+    const context = vm.createContext({
+        ...contextValues,
+        globalThis: {}
+    });
+    const hookAssignments = hookNames.map((name) => `${name}: typeof ${name} === 'function' ? ${name} : undefined`).join(', ');
+    vm.runInContext(scriptParts.join('\n'), context);
+    vm.runInContext(`globalThis.__testHooks = { ${hookAssignments} };`, context);
+    return context.globalThis.__testHooks;
+}
+
+function legacyIsPointsColumn(relativePath, currentConfig, statKey) {
+    const source = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+    const hooks = runFunction([
+        extractFunction(source, 'getConfiguredPointsColumn', relativePath),
+        extractFunction(source, 'isPointsColumn', relativePath)
+    ], ['isPointsColumn'], { currentConfig });
+
+    return hooks.isPointsColumn(statKey);
+}
+
+function createDependencies() {
+    return {
+        db: {},
+        doc: vi.fn((_db, ...segments) => ({ path: segments.join('/') })),
+        setDoc: vi.fn(async () => undefined),
+        deleteDoc: vi.fn(async () => undefined),
+        increment: vi.fn((value) => ({ __increment: value })),
+        updateGameScore: vi.fn(async () => undefined)
+    };
+}
+
+async function reactTrackerCreditsAsScore(statConfig, statKey) {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+        statConfig,
+        initialScore: { homeScore: 0, awayScore: 0 },
+        dependencies
+    });
+
+    await service.recordEvent('team-1', 'game-1', {
+        text: `#4 Alex ${statKey} +5`,
+        playerName: 'Alex',
+        playerNumber: '4',
+        teamSide: 'home',
+        undoData: {
+            type: 'stat',
+            playerId: 'player-1',
+            statKey,
+            value: 5,
+            isOpponent: false
+        }
+    }, { uid: 'coach-1' });
+
+    return service.getCurrentScore().homeScore === 5;
+}
+
+describe('stat-tracking scoring-column parity across all three trackers', () => {
+    const scenarios = [
+        {
+            label: 'default basketball config with no custom scoringColumn',
+            config: { columns: ['PTS', 'REB', 'AST'] },
+            scoringKey: 'PTS',
+            nonScoringKey: 'REB'
+        },
+        {
+            label: 'soccer-style config using GOALS as the default scoring column',
+            config: { columns: ['GOALS', 'ASSISTS', 'FOULS'] },
+            scoringKey: 'GOALS',
+            nonScoringKey: 'ASSISTS'
+        },
+        {
+            label: 'a team with a renamed custom scoring column configured',
+            config: { columns: ['SCORE', 'REB', 'AST'], scoringColumn: 'SCORE' },
+            scoringKey: 'SCORE',
+            nonScoringKey: 'REB'
+        },
+        {
+            label: 'a custom scoring column in a different case than the config columns entry',
+            config: { columns: ['Score', 'Reb', 'Ast'], scoringColumn: 'score' },
+            scoringKey: 'Score',
+            nonScoringKey: 'Reb'
+        }
+    ];
+
+    it.each(scenarios)('$label', async ({ config, scoringKey, nonScoringKey }) => {
+        const trackBasketballScores = legacyIsPointsColumn('../../js/track-basketball.js', config, scoringKey);
+        const liveTrackerScores = legacyIsPointsColumn('../../js/live-tracker.js', config, scoringKey);
+        const reactTrackerScores = await reactTrackerCreditsAsScore(config, scoringKey);
+
+        expect({ trackBasketballScores, liveTrackerScores, reactTrackerScores }).toEqual({
+            trackBasketballScores: true,
+            liveTrackerScores: true,
+            reactTrackerScores: true
+        });
+
+        const trackBasketballIgnoresOther = !legacyIsPointsColumn('../../js/track-basketball.js', config, nonScoringKey);
+        const liveTrackerIgnoresOther = !legacyIsPointsColumn('../../js/live-tracker.js', config, nonScoringKey);
+        const reactTrackerIgnoresOther = !(await reactTrackerCreditsAsScore(config, nonScoringKey));
+
+        expect({ trackBasketballIgnoresOther, liveTrackerIgnoresOther, reactTrackerIgnoresOther }).toEqual({
+            trackBasketballIgnoresOther: true,
+            liveTrackerIgnoresOther: true,
+            reactTrackerIgnoresOther: true
+        });
+    });
+});

--- a/tests/unit/team-fee-recipient-rules.test.js
+++ b/tests/unit/team-fee-recipient-rules.test.js
@@ -4,10 +4,17 @@ import { readFileSync } from 'node:fs';
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 
 describe('team fee recipient Firestore rules', () => {
+    it('defines the feeRecipients collection-group rule exactly once', () => {
+        // Regression guard: this rule was previously duplicated into two back-to-back
+        // match blocks with equivalent (but not identical) logic, which made the ruleset
+        // harder to audit. See tests/unit/firestore-rules-architecture-fixes.test.js.
+        const occurrences = rules.split('match /{path=**}/feeRecipients/{recipientId}').length - 1;
+        expect(occurrences).toBe(1);
+    });
+
     it('passes teamId to the parent recipient helper for collection-group reads', () => {
         expect(rules).toContain('function isTeamFeeRecipientForCurrentParent(data, teamId)');
         expect(rules).not.toContain('isTeamFeeRecipientForCurrentParent(resource.data) ||');
-        expect(rules).toContain("isTeamFeeRecipientForCurrentParent(resource.data, resource.data.get('teamId', ''))");
         expect(rules).toContain('isTeamFeeRecipientForCurrentParent(resource.data, resource.data.teamId)');
     });
 


### PR DESCRIPTION
## Summary
Seven fixes from an architecture review of the webapp/iOS/Android app, each in its own commit:

- **Access-control drift**: `canManageTeamAdmins()` in the React app hand-rolled its own owner/isAdmin check instead of delegating to the legacy `hasFullTeamAccess()`, so a user listed in `team.adminEmails` (not owner/platformAdmin) could manage admins on the legacy site but was denied in the app. Now delegates to the legacy check.
- **firestore.rules cleanup**: removed a dead-code duplicate `feeRecipients` rule block; tightened `rosterFields`/`statTrackerConfigs` from unauthenticated `allow read: if true` to team-scoped access (with a public-team fallback preserved for anonymous spectators on live game views).
- **Native-runtime detection**: `Capacitor.isNativePlatform() || location.protocol === 'capacitor:'` was reimplemented independently in 8 files; centralized into `lib/nativeRuntime.ts`.
- **Duplicate auth listener**: `/help` route didn't pass `auth` like every other route, so `HelpPortal` called `useAuth()` itself, mounting a second Firebase auth listener. Now takes `auth` as a prop.
- **CI gap**: `mobile-build.yml` only triggered on paths that touch native code, so it could never be added as a required status check (a required check that never posts blocks merge forever). Restructured with a path-detection job + an always-present `mobile-build` gate job, then added it to master's required status checks.
- **Stale cache leak on sign-out**: `searchService.ts` and four AI-model-handle caches were never cleared on sign-out, risking a second user on the same tab briefly seeing the previous user's cached search results. Wired into `useAuth`'s sign-out flow.
- **Stat-tracking parity tests**: added cross-implementation tests comparing the three independent stat-tracking implementations (`track-basketball.js`, `live-tracker.js`, `statTrackingService.ts`). This surfaced a real bug — the React tracker ignored a team's configured custom scoring column — which is now fixed.

## Test plan
- [x] Root unit suite: `npm test` — 578 files / 3733 tests passing
- [x] App unit suite: `cd apps/app && npx vitest run` — 110 files / 866 tests passing
- [x] Smoke suite: `npm run test:smoke` — 156 passed / 13 skipped (require real Firebase creds)
- [x] `npm run app:build` and `npm run app:check-bundle-size` — pass
- [x] TypeScript typecheck (`tsc --noEmit`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)