### PR TITLE
[codex] Fix production app smoke gating

### DIFF
--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -1,12 +1,14 @@
 import { expect, test } from '@playwright/test';
 
+const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
+test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
+
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 const telemetryEndpoint = 'https://telemetry.example.test/collectTelemetry';
 
 function appUrl(baseURL, hashPath) {
-    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
-    const url = new URL('/', appBaseURL);
+    const url = new URL('/', appBaseUrl || baseURL);
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -1,10 +1,12 @@
 import { expect, test } from '@playwright/test';
 
+const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
+test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
+
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 function appUrl(baseURL, hashPath) {
-    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
-    const url = new URL('/', appBaseURL);
+    const url = new URL('/', appBaseUrl || baseURL);
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -1,8 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
+test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
+
 function appUrl(baseURL, hashPath) {
-    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
-    const url = new URL('/', appBaseURL);
+    const url = new URL('/', appBaseUrl || baseURL);
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { buildUrl } from './helpers/boot-path.js';
 
+const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
+test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
+
 function appUrl(baseURL, hashPath) {
-    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
-    const url = new URL(buildUrl(appBaseURL, '/'));
+    const url = new URL(buildUrl(appBaseUrl || baseURL, '/'));
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -1,9 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
+test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
+
 function appUrl(baseURL, hashPath) {
-    const defaultBaseURL = 'http://localhost:3000/'; // A safe default for local testing
-    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL || defaultBaseURL;
-    const url = new URL('/', appBaseURL);
+    const url = new URL('/', appBaseUrl || baseURL);
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/unit/prod-smoke-workflow.test.js
+++ b/tests/unit/prod-smoke-workflow.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readWorkflow(path) {
+    return readFileSync(path, 'utf8');
+}
+
+describe('production smoke workflow configuration', () => {
+    it('uses the deployed app boot smoke without enabling Vite-mocked app specs', () => {
+        [
+            '.github/workflows/scheduled-prod-smoke.yml',
+            '.github/workflows/post-deploy-smoke.yml'
+        ].forEach((workflowPath) => {
+            const workflow = readWorkflow(workflowPath);
+
+            expect(workflow).toContain('SMOKE_BASE_URL: https://allplays.ai');
+            expect(workflow).toContain('SMOKE_APP_BOOT_URL: https://allplays.ai/app/');
+            expect(workflow).not.toContain('SMOKE_APP_BASE_URL:');
+        });
+    });
+
+    it('keeps Vite-mocked React app smoke specs gated behind SMOKE_APP_BASE_URL', () => {
+        [
+            'tests/smoke/app-home-player.spec.js',
+            'tests/smoke/app-messages.spec.js',
+            'tests/smoke/app-private-ai.spec.js',
+            'tests/smoke/app-search.spec.js',
+            'tests/smoke/app-teams.spec.js'
+        ].forEach((specPath) => {
+            const spec = readWorkflow(specPath);
+
+            expect(spec).toContain("const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';");
+            expect(spec).toContain("test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');");
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Gate Vite-mocked React app smoke specs behind an explicit `SMOKE_APP_BASE_URL`.
- Keep production smoke focused on the deployed `/app/` boot check via `SMOKE_APP_BOOT_URL` instead of accidentally running dev-server module mocks against production.
- Add a unit guard covering the production smoke workflow config and the app smoke spec gates.

## Root Cause
The scheduled production smoke job only sets `SMOKE_BASE_URL` and `SMOKE_APP_BOOT_URL`. Five React app specs fell back to `SMOKE_BASE_URL`, so they loaded the legacy root during production runs and failed looking for mocked app headings. Those specs also depend on `/src/lib/...` Vite module interception, so they should only run when `SMOKE_APP_BASE_URL` points at a dev/preview app server.

## Validation
- `npx vitest run tests/unit/prod-smoke-workflow.test.js --reporter=verbose`
- `SMOKE_BASE_URL=https://allplays.ai SMOKE_APP_BOOT_URL=https://allplays.ai/app/ SMOKE_SUITE=production npx playwright test tests/smoke/app-home-player.spec.js tests/smoke/app-messages.spec.js tests/smoke/app-private-ai.spec.js tests/smoke/app-search.spec.js tests/smoke/app-teams.spec.js tests/smoke/app-production-bootstrap.spec.js --config=playwright.smoke.config.js --reporter=line` -> 31 skipped, 1 passed
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5175 npx playwright test tests/smoke/app-home-player.spec.js --config=playwright.smoke.config.js --reporter=line --grep "parent core player drill-in sends workflow timer|parent core workflows emit baseline timers|requested app workflows emit DB-ready view load baseline timers"` -> 3 passed
