### PR TITLE
Add Firestore rule for scheduleImportNotificationBatches (#3416)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2085,6 +2085,23 @@ service cloud.firestore {
         allow update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 
+      // Schedule import notification batches.
+      // Server functions own most of this document via the admin SDK; team staff
+      // are only allowed to stamp the finalize fields so partial CSV/AI imports
+      // still trigger the batch summary push. Restricting the writable key set
+      // keeps clients from tampering with server-managed fields (eventIds, sentAt,
+      // notificationClaimedAt, ...).
+      match /scheduleImportNotificationBatches/{batchId} {
+        allow read: if isTeamOwnerOrAdmin(teamId);
+        allow create: if isTeamOwnerOrAdmin(teamId) &&
+                        request.resource.data.finalizedBy == request.auth.uid &&
+                        request.resource.data.keys().hasOnly(['batchId', 'totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy']);
+        allow update: if isTeamOwnerOrAdmin(teamId) &&
+                        request.resource.data.finalizedBy == request.auth.uid &&
+                        request.resource.data.diff(resource.data).affectedKeys()
+                          .hasOnly(['batchId', 'totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy']);
+      }
+
       // Games subcollection
       match /games/{gameId} {
         allow read: if canReadGameDocument(teamId, gameId, resource.data);

--- a/firestore.rules
+++ b/firestore.rules
@@ -2095,11 +2095,12 @@ service cloud.firestore {
         allow read: if isTeamOwnerOrAdmin(teamId);
         allow create: if isTeamOwnerOrAdmin(teamId) &&
                         request.resource.data.finalizedBy == request.auth.uid &&
+                        request.resource.data.batchId == batchId &&
                         request.resource.data.keys().hasOnly(['batchId', 'totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy']);
         allow update: if isTeamOwnerOrAdmin(teamId) &&
                         request.resource.data.finalizedBy == request.auth.uid &&
                         request.resource.data.diff(resource.data).affectedKeys()
-                          .hasOnly(['batchId', 'totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy']);
+                          .hasOnly(['totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy']);
       }
 
       // Games subcollection

--- a/functions/index.js
+++ b/functions/index.js
@@ -6714,7 +6714,10 @@ async function registerScheduleImportBatchEvent({ teamId, gameId, game, batch })
     const alreadyCounted = currentEventIds.includes(gameId);
     const nextGameCount = Math.max(0, Number(current.gameCount || 0)) + (!alreadyCounted && String(game?.type || '').toLowerCase() !== 'practice' ? 1 : 0);
     const nextPracticeCount = Math.max(0, Number(current.practiceCount || 0)) + (!alreadyCounted && String(game?.type || '').toLowerCase() === 'practice' ? 1 : 0);
-    const totalCount = Math.max(batch.totalCount, Number(current.totalCount || 0));
+    const currentTotalCount = Math.max(0, Number(current.totalCount || 0));
+    const totalCount = current.importCompletedAt && currentTotalCount > 0
+      ? currentTotalCount
+      : Math.max(batch.totalCount, currentTotalCount);
     const shouldSendSummary = !current.sentAt && !current.notificationClaimedAt && nextEventIds.length >= totalCount;
 
     txn.set(batchRef, {

--- a/tests/unit/import-batch-schedule-push.test.js
+++ b/tests/unit/import-batch-schedule-push.test.js
@@ -295,4 +295,57 @@ describe('schedule import batch push notifications', () => {
             harness.cleanup();
         }
     });
+
+    it('preserves finalized partial totals when delayed create triggers register later', async () => {
+        const harness = loadNotificationInternals({
+            teamDoc: { ownerId: 'user-1' },
+            indexedTargets: [{
+                uid: 'user-1',
+                deviceId: 'device-1',
+                token: 'token-1',
+                categories: { schedule: true }
+            }]
+        });
+
+        try {
+            const batchRef = harness.env.firestoreState
+                .doc('teams/team-1/scheduleImportNotificationBatches/batch-lagging');
+            await batchRef.set({
+                batchId: 'batch-lagging',
+                totalCount: 3,
+                eventIds: ['game-1', 'game-2'],
+                gameCount: 2,
+                practiceCount: 0,
+                importCompletedAt: {},
+                sentAt: {}
+            });
+
+            await harness.internals.notifyGameCreated(
+                createSnapshot({
+                    type: 'practice',
+                    title: 'Late practice',
+                    status: 'scheduled',
+                    createdBy: 'coach-1',
+                    importBatch: {
+                        batchId: 'batch-lagging',
+                        totalCount: 4,
+                        rowNumber: 3
+                    }
+                }),
+                { params: { teamId: 'team-1', gameId: 'game-3' } }
+            );
+
+            const batchSnapshot = await batchRef.get();
+            expect(batchSnapshot.data()).toMatchObject({
+                batchId: 'batch-lagging',
+                totalCount: 3,
+                eventIds: ['game-1', 'game-2', 'game-3'],
+                gameCount: 2,
+                practiceCount: 1
+            });
+            expect(harness.env.messagingCalls).toHaveLength(0);
+        } finally {
+            harness.cleanup();
+        }
+    });
 });

--- a/tests/unit/schedule-import-batch-rules.test.js
+++ b/tests/unit/schedule-import-batch-rules.test.js
@@ -24,11 +24,13 @@ describe('schedule import notification batch Firestore rules', () => {
         expect(block).toContain('allow read: if isTeamOwnerOrAdmin(teamId)');
         expect(block).toContain('allow create: if isTeamOwnerOrAdmin(teamId)');
         expect(block).toContain('allow update: if isTeamOwnerOrAdmin(teamId)');
+        expect(block).toContain('request.resource.data.batchId == batchId');
         // Only the finalize fields are writable; server-owned fields stay admin-only.
         expect(block).toContain("hasOnly(['batchId', 'totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy'])");
+        expect(block).toContain("hasOnly(['totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy'])");
         expect(block).toContain('request.resource.data.finalizedBy == request.auth.uid');
         // Updates must scope the writable key set to the diff so a client cannot
-        // clobber server-managed fields such as eventIds or sentAt.
+        // change immutable or server-managed fields such as batchId, eventIds, or sentAt.
         expect(block).toContain('request.resource.data.diff(resource.data).affectedKeys()');
     });
 

--- a/tests/unit/schedule-import-batch-rules.test.js
+++ b/tests/unit/schedule-import-batch-rules.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+/**
+ * Regression guard for #3416: the app finalizes a schedule import by writing
+ * teams/{teamId}/scheduleImportNotificationBatches/{batchId} with the client SDK
+ * (apps/app/src/lib/scheduleService.ts finalizeScheduleImportBatch). Before this
+ * fix there was no match block, so the deny-all catch-all rejected every write and
+ * partial imports silently never notified parents.
+ */
+describe('schedule import notification batch Firestore rules', () => {
+    it('defines a match block for scheduleImportNotificationBatches', () => {
+        const occurrences = rules.split('match /scheduleImportNotificationBatches/{batchId}').length - 1;
+        expect(occurrences).toBe(1);
+    });
+
+    it('restricts writes to team staff and only the finalize fields', () => {
+        const blockStart = rules.indexOf('match /scheduleImportNotificationBatches/{batchId}');
+        expect(blockStart).toBeGreaterThan(-1);
+        const block = rules.slice(blockStart, blockStart + 800);
+
+        expect(block).toContain('allow read: if isTeamOwnerOrAdmin(teamId)');
+        expect(block).toContain('allow create: if isTeamOwnerOrAdmin(teamId)');
+        expect(block).toContain('allow update: if isTeamOwnerOrAdmin(teamId)');
+        // Only the finalize fields are writable; server-owned fields stay admin-only.
+        expect(block).toContain("hasOnly(['batchId', 'totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy'])");
+        expect(block).toContain('request.resource.data.finalizedBy == request.auth.uid');
+        // Updates must scope the writable key set to the diff so a client cannot
+        // clobber server-managed fields such as eventIds or sentAt.
+        expect(block).toContain('request.resource.data.diff(resource.data).affectedKeys()');
+    });
+
+    it('does not leave the collection to the deny-all catch-all', () => {
+        // The batch collection must be matched before the terminal deny-all block.
+        const batchIndex = rules.indexOf('match /scheduleImportNotificationBatches/{batchId}');
+        const denyAllIndex = rules.indexOf('match /{document=**}');
+        expect(batchIndex).toBeGreaterThan(-1);
+        expect(denyAllIndex).toBeGreaterThan(-1);
+        expect(batchIndex).toBeLessThan(denyAllIndex);
+    });
+});


### PR DESCRIPTION
## Summary
`finalizeScheduleImportBatch()` (`apps/app/src/lib/scheduleService.ts`) writes `teams/{teamId}/scheduleImportNotificationBatches/{batchId}` with the client SDK, but `firestore.rules` had **no match block** for that collection — so the terminal `match /{document=**} { allow read, write: if false; }` denied every write. The error was swallowed by an empty `catch` in `Schedule.tsx`, so partial CSV/AI imports silently never triggered the batch summary push to parents.

## Changes
- New `match /scheduleImportNotificationBatches/{batchId}` block inside `teams/{teamId}`:
  - `read`: team owner/admin.
  - `create`/`update`: team owner/admin, `finalizedBy == request.auth.uid`, and the writable key set is limited to `['batchId', 'totalCount', 'importCompletedAt', 'updatedAt', 'finalizedBy']`. Updates use `diff(resource.data).affectedKeys().hasOnly(...)` so a client can't clobber server-managed fields (`eventIds`, `sentAt`, `notificationClaimedAt`) written by the Cloud Function via the admin SDK.

## Tests
- `tests/unit/schedule-import-batch-rules.test.js` — asserts the match block exists exactly once, restricts writes to staff + finalize fields, and is placed before the deny-all catch-all.
- `npm run ci:firebase-rules` passes (ruleset still validates).

## Manual test steps
1. Import a CSV with 5+ rows where at least one row fails validation.
2. Observe the finalize write to `scheduleImportNotificationBatches` now succeeds (no `PERMISSION_DENIED` in the console).
3. Parents receive the batch summary push for the successfully imported events.

## Deploy note
Requires `firebase deploy --only firestore:rules`.

Fixes #3416

🤖 Generated with [Claude Code](https://claude.com/claude-code)