### PR TITLE
Disable Android backup to protect persisted Firebase session (#3417)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Defense-in-depth for #3417. The WebView persists a Firebase refresh/ID token in
+  localStorage (allplays-native-auth-session), so no app data may leave the device
+  via cloud backup or device-to-device transfer. allowBackup="false" already blocks
+  legacy backup; these rules keep Android 12+ cloud-backup and transfer disabled too.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </device-transfer>
+</data-extraction-rules>

--- a/tests/unit/app-capacitor-native-config.test.js
+++ b/tests/unit/app-capacitor-native-config.test.js
@@ -109,6 +109,7 @@ describe('Capacitor native config', () => {
         // data may be captured by backup or device transfer.
         expect(androidManifest).toContain('android:allowBackup="false"');
         expect(androidManifest).not.toContain('android:allowBackup="true"');
+        expect(androidManifest).toContain('android:fullBackupContent="false"');
         expect(androidManifest).toContain('android:dataExtractionRules="@xml/data_extraction_rules"');
 
         expect(extractionRules).toContain('<cloud-backup>');

--- a/tests/unit/app-capacitor-native-config.test.js
+++ b/tests/unit/app-capacitor-native-config.test.js
@@ -100,4 +100,21 @@ describe('Capacitor native config', () => {
         expect(iosEntitlements).toContain('com.apple.developer.associated-domains');
         expect(iosEntitlements).toContain('applinks:allplays.ai');
     });
+
+    it('disables Android backup so the persisted Firebase session cannot be exfiltrated via adb backup (#3417)', () => {
+        const androidManifest = readProjectFile('android/app/src/main/AndroidManifest.xml');
+        const extractionRules = readProjectFile('android/app/src/main/res/xml/data_extraction_rules.xml');
+
+        // The WebView stores a Firebase refresh/ID token in localStorage, so no app
+        // data may be captured by backup or device transfer.
+        expect(androidManifest).toContain('android:allowBackup="false"');
+        expect(androidManifest).not.toContain('android:allowBackup="true"');
+        expect(androidManifest).toContain('android:dataExtractionRules="@xml/data_extraction_rules"');
+
+        expect(extractionRules).toContain('<cloud-backup>');
+        expect(extractionRules).toContain('<device-transfer>');
+        expect(extractionRules).toContain('<exclude domain="root" />');
+        expect(extractionRules).toContain('<exclude domain="database" />');
+        expect(extractionRules).toContain('<exclude domain="sharedpref" />');
+    });
 });


### PR DESCRIPTION
## Summary
The Android app shipped with the default `android:allowBackup="true"`. Because the WebView persists a Firebase **refresh token** (non-expiring) and ID token in `localStorage` (`allplays-native-auth-session`, written in `apps/app/src/lib/authService.ts`), the full auth session was extractable from a non-rooted device via `adb backup` / Auto Backup / device-to-device transfer. An attacker with brief ADB access could then exchange the refresh token at `securetoken.googleapis.com` for fresh ID tokens indefinitely, independent of the original device.

## Changes
- `AndroidManifest.xml`: `android:allowBackup="false"`, `android:fullBackupContent="false"`, and `android:dataExtractionRules="@xml/data_extraction_rules"`.
- New `res/xml/data_extraction_rules.xml`: excludes all domains from both `cloud-backup` and `device-transfer` (Android 12+ defense-in-depth, forward-safe if `allowBackup` is ever flipped).
- Guard test in `tests/unit/app-capacitor-native-config.test.js` asserting backup stays disabled.

## Tests
`npx vitest run tests/unit/app-capacitor-native-config.test.js` → 5 passed.

## Manual test steps
1. Build a release APK.
2. `adb backup -f out.ab ai.allplays.lite` → backup is now empty/refused; the extracted archive no longer contains `allplays-native-auth-session`.

## Notes
- Kept the scope to the security fix. `minifyEnabled` (mentioned in the issue as optional) is intentionally left for a separate PR since enabling R8 needs Capacitor/Firebase keep-rules verification.
- Follow-up hardening worth considering: move the session out of WebView `localStorage` into Capacitor Secure Storage / Keychain-backed storage.

Fixes #3417

🤖 Generated with [Claude Code](https://claude.com/claude-code)