### PR TITLE
Bound officials game read by date instead of full scan (#3420)

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -1273,7 +1273,14 @@ describe('official assignments app service', () => {
     ]);
     expect(result.assignments.map((item) => item.gameId)).not.toContain('game-past');
     expect(result.assignments.map((item) => item.gameId)).not.toContain('game-cancelled');
-    expect(getGames).toHaveBeenCalledWith('team-alpha');
+    // Regression for #3420: the officials load must bound the game read by date instead
+    // of scanning the full games collection. The start date is a small look-behind so
+    // same-day / in-progress games stay in range.
+    expect(getGames).toHaveBeenCalledWith('team-alpha', { startDate: expect.any(Date) });
+    const [, range] = vi.mocked(getGames).mock.calls[0] as [string, { startDate: Date }];
+    expect(range.startDate).toBeInstanceOf(Date);
+    expect(range.startDate.getTime()).toBeLessThanOrEqual(Date.now());
+    expect(range.startDate.getTime()).toBeGreaterThan(Date.now() - 48 * 60 * 60 * 1000);
   });
 
   it('hides officials access when no official link matches the signed-in user', async () => {
@@ -1306,7 +1313,7 @@ describe('official assignments app service', () => {
     ]);
     expect(result.assignments.map((item) => item.kind)).toEqual(['assigned']);
     expect(getTeam).toHaveBeenCalledWith('team-alpha', { includeInactive: true });
-    expect(getGames).toHaveBeenCalledWith('team-alpha');
+    expect(getGames).toHaveBeenCalledWith('team-alpha', { startDate: expect.any(Date) });
   });
 
   it('delegates accept, decline, and claim writes to legacy officiating actions', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -5279,6 +5279,10 @@ function extractTeamIdFromOfficialRefPath(path: string) {
   return teamIndex >= 0 ? compactString(parts[teamIndex + 1]) : '';
 }
 
+// Look-behind buffer for the officials game query so same-day / in-progress games stay
+// in range while still bounding the read (avoids scanning a team's full game history).
+const officialAssignmentsLookBehindMs = 24 * 60 * 60 * 1000;
+
 function isUpcomingOfficialGame(game: any, now = new Date()) {
   const date = normalizeScheduleDate(game?.date);
   const status = compactString(game?.status).toLowerCase();
@@ -5354,10 +5358,15 @@ export async function loadOfficialAssignments(user: AuthUser, options: { teamId?
   }
 
   const now = new Date();
+  // Only upcoming games are ever surfaced (isUpcomingOfficialGame requires date >= now),
+  // so bound the read to a small look-behind window instead of scanning the team's entire
+  // game history on every officials load. The look-behind keeps in-progress / same-day games
+  // (whose stored date is the start time) in range; the filter below still trims to upcoming.
+  const officialGamesSince = new Date(now.getTime() - officialAssignmentsLookBehindMs);
   const teamResults = await Promise.all(teamIds.map(async (teamId) => {
     const [team, games] = await Promise.all([
       getTeam(teamId, { includeInactive: true }).catch(() => null),
-      getGames(teamId).catch(() => [])
+      getGames(teamId, { startDate: officialGamesSince }).catch(() => [])
     ]);
     const canClaim = isEligibleOpenOfficiatingSlotParticipant(team || {}, userProfile as Record<string, any>, user);
     const teamName = compactString(team?.name) || 'Team';


### PR DESCRIPTION
## Summary
The officials/assignments loader (`loadOfficialAssignments`) read the **entire** `games` collection for every linked team with `getGames(teamId)` (no date range), then discarded all but upcoming games client-side via `isUpcomingOfficialGame`. For a team with a long history that's a full-collection Firestore read on every officials load — cost and latency scaling with total history, not the handful of upcoming games, and multiplied across every linked team.

## Changes
- Pass a look-behind-bounded `startDate` to `getGames(teamId, { startDate })`. `getGames` already applies the range server-side (`where('date', '>=', ...)`) with a client-side fallback when indexes are unavailable.
- Look-behind window is 24h (`officialAssignmentsLookBehindMs`) so same-day / in-progress games (whose stored `date` is the start time) stay in range; `isUpcomingOfficialGame` still trims the result to strictly upcoming, so **the surfaced assignments are unchanged**.

## Tests
`src/lib/scheduleService.test.ts` (81 passing):
- Existing officials tests updated to assert `getGames` is now called with `{ startDate }`.
- New assertions verify the `startDate` is a `Date` in the recent past (≤ now, within the last 48h), locking in the bounded read.
- `tsc --noEmit` clean.

## Manual test steps
1. Sign in as an official linked to a team with lots of historical games.
2. Open the officials screen.
3. Confirm the same upcoming assignments appear, and the Firestore read for games is date-bounded (network panel shows a ranged query rather than a full-collection fetch).

Fixes #3420

🤖 Generated with [Claude Code](https://claude.com/claude-code)