### PR TITLE
Add app production CSS pipeline test

### DIFF
--- a/tests/unit/app-production-css-pipeline.test.js
+++ b/tests/unit/app-production-css-pipeline.test.js
@@ -1,0 +1,48 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const appRoot = path.join(repoRoot, 'apps/app');
+
+function buildAppCss() {
+    const outDir = mkdtempSync(path.join(tmpdir(), 'allplays-app-css-'));
+
+    try {
+        execFileSync(
+            path.join(appRoot, 'node_modules/.bin/vite'),
+            ['build', '--outDir', outDir, '--emptyOutDir'],
+            {
+                cwd: appRoot,
+                encoding: 'utf8',
+                stdio: 'pipe'
+            }
+        );
+
+        const assetsDir = path.join(outDir, 'assets');
+        const cssAsset = readdirSync(assetsDir).find((file) => file.endsWith('.css'));
+
+        expect(cssAsset).toBeTruthy();
+
+        return readFileSync(path.join(assetsDir, cssAsset), 'utf8');
+    } finally {
+        rmSync(outDir, { recursive: true, force: true });
+    }
+}
+
+describe('app production CSS pipeline', () => {
+    it('compiles Tailwind utilities and mobile shell CSS through Vite PostCSS', () => {
+        const css = buildAppCss();
+
+        expect(css).toContain('.bg-primary-600');
+        expect(css).not.toContain('@tailwind');
+        expect(css).toContain('.safe-top');
+        expect(css).toContain('env(safe-area-inset-top)');
+        expect(css).toContain('.safe-bottom');
+        expect(css).toContain('env(safe-area-inset-bottom)');
+        expect(css).toContain('.app-search-overlay');
+        expect(css).toContain('--app-search-keyboard-inset');
+    }, 30000);
+});


### PR DESCRIPTION
Closes #3435

## What changed
- Added a focused Vitest regression test that runs the app Vite production build into a temporary output directory.
- The test reads the emitted CSS asset and verifies Tailwind utilities are generated, raw `@tailwind` directives are gone, and mobile safe-area/app search CSS survives compilation.

## Root Cause
The app PostCSS/Tailwind production pipeline was only covered by source/config inspections, so Vite could stop loading `apps/app/postcss.config.js` or emitting required Tailwind/mobile CSS while unit tests still passed.

## Prevention / Learning
For build-pipeline-owned CSS, add at least one production-build regression that reads emitted assets and asserts generated utilities plus critical hand-authored mobile shell rules survive compilation.

## Regression Tests
- `npx vitest run tests/unit/app-production-css-pipeline.test.js --reporter=verbose`
- `npx vitest run tests/unit/app-tailwind-config.test.js tests/unit/app-capacitor-native-config.test.js tests/unit/app-production-css-pipeline.test.js --reporter=verbose`

## Recurrence Risk
Low. The new test exercises the real Vite/PostCSS output path and checks both Tailwind generation and critical mobile shell CSS.