### PR TITLE
Harden live game chat payload rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2147,6 +2147,35 @@ service cloud.firestore {
         }
 
         // Live Chat subcollection - game-specific chat for live viewers
+        function isValidLiveChatCreate(data) {
+          return data.keys().hasOnly([
+                   'text', 'senderId', 'senderName', 'senderPhotoUrl', 'isAnonymous', 'createdAt'
+                 ]) &&
+                 data.keys().hasAll(['text', 'senderId', 'createdAt']) &&
+                 data.senderId == request.auth.uid &&
+                 data.createdAt == request.time &&
+                 data.text is string &&
+                 data.text.size() > 0 &&
+                 data.text.size() <= 2000 &&
+                 (!('senderName' in data) ||
+                   (data.senderName is string &&
+                    data.senderName.size() > 0 &&
+                    data.senderName.size() <= 80)) &&
+                 (!('senderPhotoUrl' in data) ||
+                   data.senderPhotoUrl == null ||
+                   (data.senderPhotoUrl is string &&
+                    data.senderPhotoUrl.size() <= 2048)) &&
+                 (!('isAnonymous' in data) || data.isAnonymous is bool);
+        }
+
+        function isValidLiveReactionCreate(data) {
+          return data.keys().hasOnly(['type', 'senderId', 'createdAt']) &&
+                 data.keys().hasAll(['type', 'senderId', 'createdAt']) &&
+                 data.senderId == request.auth.uid &&
+                 data.createdAt == request.time &&
+                 data.type in ['fire', 'clap', 'wow', 'heart', 'hundred'];
+        }
+
         match /liveChat/{messageId} {
           allow read: if canReadGameSubcollectionDocument(teamId, gameId);
           allow create: if isSignedIn()
@@ -2155,11 +2184,7 @@ service cloud.firestore {
                  isShareableGameDocument(
                    get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)).data
                  )))
-            && request.resource.data.keys().hasAll(['text', 'senderId'])
-            && request.resource.data.senderId == request.auth.uid
-            && request.resource.data.text is string
-            && request.resource.data.text.size() > 0
-            && request.resource.data.text.size() <= 2000;
+            && isValidLiveChatCreate(request.resource.data);
           allow update: if false;  // Messages are immutable
           allow delete: if isTeamOwnerOrAdmin(teamId);  // Moderation only
         }
@@ -2173,8 +2198,7 @@ service cloud.firestore {
                  isShareableGameDocument(
                    get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)).data
                  )))
-            && request.resource.data.keys().hasAll(['type', 'senderId'])
-            && request.resource.data.senderId == request.auth.uid;
+            && isValidLiveReactionCreate(request.resource.data);
           allow update, delete: if false;  // Reactions are immutable
         }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -2158,6 +2158,7 @@ service cloud.firestore {
                  data.text.size() > 0 &&
                  data.text.size() <= 2000 &&
                  (!('senderName' in data) ||
+                   data.senderName == null ||
                    (data.senderName is string &&
                     data.senderName.size() > 0 &&
                     data.senderName.size() <= 80)) &&

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -2300,9 +2300,7 @@ async function generateAiResponse(question) {
       senderId: state.user?.uid || null,
       senderName: 'ALL PLAYS',
       senderPhotoUrl: null,
-      isAnonymous: false,
-      ai: true,
-      aiQuestion: question
+      isAnonymous: false
     });
   } catch (error) {
     console.warn('AI response failed:', error);
@@ -2311,9 +2309,7 @@ async function generateAiResponse(question) {
       senderId: state.user?.uid || null,
       senderName: 'ALL PLAYS',
       senderPhotoUrl: null,
-      isAnonymous: false,
-      ai: true,
-      aiQuestion: question
+      isAnonymous: false
     });
   } finally {
     hideAiThinking();

--- a/tests/unit/firestore-live-chat-auth.test.js
+++ b/tests/unit/firestore-live-chat-auth.test.js
@@ -93,6 +93,7 @@ describe('firestore rules — liveChat authentication requirements', () => {
             "data.keys().hasOnly([\n                   'text', 'senderId', 'senderName', 'senderPhotoUrl', 'isAnonymous', 'createdAt'\n                 ])"
         );
         expect(liveChatValidatorBlock).toContain('data.createdAt == request.time');
+        expect(liveChatValidatorBlock).toContain('data.senderName == null');
         expect(liveChatValidatorBlock).toContain('data.senderName.size() <= 80');
         expect(liveChatValidatorBlock).toContain('data.senderPhotoUrl.size() <= 2048');
         expect(liveChatValidatorBlock).toContain("!('isAnonymous' in data) || data.isAnonymous is bool");

--- a/tests/unit/firestore-live-chat-auth.test.js
+++ b/tests/unit/firestore-live-chat-auth.test.js
@@ -36,6 +36,8 @@ function extractMatchBlock(source, collectionPattern) {
 const liveEventsBlock = extractMatchBlock(rulesSource, 'match /liveEvents/{eventId}');
 const liveChatBlock = extractMatchBlock(rulesSource, 'match /liveChat/{messageId}');
 const liveReactionsBlock = extractMatchBlock(rulesSource, 'match /liveReactions/{reactionId}');
+const liveChatValidatorBlock = extractMatchBlock(rulesSource, 'function isValidLiveChatCreate(data)');
+const liveReactionValidatorBlock = extractMatchBlock(rulesSource, 'function isValidLiveReactionCreate(data)');
 
 describe('firestore rules — live game read visibility helpers', () => {
     it('keeps live events, chat, and reactions behind the shared game visibility helper', () => {
@@ -72,17 +74,30 @@ describe('firestore rules — liveChat authentication requirements', () => {
     });
 
     it('validates that liveChat create requires text and senderId fields', () => {
-        expect(liveChatBlock).toContain("hasAll(['text', 'senderId'])");
+        expect(liveChatBlock).toContain('isValidLiveChatCreate(request.resource.data)');
+        expect(liveChatValidatorBlock).toContain("data.keys().hasAll(['text', 'senderId', 'createdAt'])");
     });
 
     it('validates that liveChat create checks senderId matches auth uid', () => {
-        expect(liveChatBlock).toContain('request.resource.data.senderId == request.auth.uid');
+        expect(liveChatValidatorBlock).toContain('data.senderId == request.auth.uid');
     });
 
     it('validates liveChat text field is a non-empty string capped at 2000 chars', () => {
-        expect(liveChatBlock).toContain('request.resource.data.text is string');
-        expect(liveChatBlock).toContain('request.resource.data.text.size() > 0');
-        expect(liveChatBlock).toContain('request.resource.data.text.size() <= 2000');
+        expect(liveChatValidatorBlock).toContain('data.text is string');
+        expect(liveChatValidatorBlock).toContain('data.text.size() > 0');
+        expect(liveChatValidatorBlock).toContain('data.text.size() <= 2000');
+    });
+
+    it('limits liveChat creates to the approved client payload shape', () => {
+        expect(liveChatValidatorBlock).toContain(
+            "data.keys().hasOnly([\n                   'text', 'senderId', 'senderName', 'senderPhotoUrl', 'isAnonymous', 'createdAt'\n                 ])"
+        );
+        expect(liveChatValidatorBlock).toContain('data.createdAt == request.time');
+        expect(liveChatValidatorBlock).toContain('data.senderName.size() <= 80');
+        expect(liveChatValidatorBlock).toContain('data.senderPhotoUrl.size() <= 2048');
+        expect(liveChatValidatorBlock).toContain("!('isAnonymous' in data) || data.isAnonymous is bool");
+        expect(liveChatValidatorBlock).not.toContain("'ai'");
+        expect(liveChatValidatorBlock).not.toContain("'aiQuestion'");
     });
 });
 
@@ -97,10 +112,18 @@ describe('firestore rules — liveReactions authentication requirements', () => 
     });
 
     it('validates that liveReactions create requires type and senderId fields', () => {
-        expect(liveReactionsBlock).toContain("hasAll(['type', 'senderId'])");
+        expect(liveReactionsBlock).toContain('isValidLiveReactionCreate(request.resource.data)');
+        expect(liveReactionValidatorBlock).toContain("data.keys().hasAll(['type', 'senderId', 'createdAt'])");
     });
 
     it('validates that liveReactions create checks senderId matches auth uid', () => {
-        expect(liveReactionsBlock).toContain('request.resource.data.senderId == request.auth.uid');
+        expect(liveReactionValidatorBlock).toContain('data.senderId == request.auth.uid');
+    });
+
+    it('limits liveReactions creates to request-time supported reaction payloads', () => {
+        expect(liveReactionValidatorBlock).toContain("data.keys().hasOnly(['type', 'senderId', 'createdAt'])");
+        expect(liveReactionValidatorBlock).toContain('data.createdAt == request.time');
+        expect(liveReactionValidatorBlock).toContain("data.type in ['fire', 'clap', 'wow', 'heart', 'hundred']");
+        expect(liveReactionValidatorBlock).not.toContain("'metadata'");
     });
 });

--- a/tests/unit/live-game-auth-required-ui.test.js
+++ b/tests/unit/live-game-auth-required-ui.test.js
@@ -29,4 +29,17 @@ describe('live game auth-required chat and reactions', () => {
         expect(source).toContain('senderId: state.user?.uid || null');
         expect(source).toContain('if (!state.user) return;');
     });
+
+    it('keeps client-created ALL PLAYS bot chat writes inside the approved chat payload shape', () => {
+        const source = readFile('js/live-game.js');
+        const generateAiResponseStart = source.indexOf('async function generateAiResponse(question)');
+        const buildAiPromptStart = source.indexOf('function buildAiPrompt(question)');
+        const generateAiResponseSource = source.slice(generateAiResponseStart, buildAiPromptStart);
+
+        expect(generateAiResponseSource).toContain("senderName: 'ALL PLAYS'");
+        expect(generateAiResponseSource).toContain('senderPhotoUrl: null');
+        expect(generateAiResponseSource).toContain('isAnonymous: false');
+        expect(generateAiResponseSource).not.toContain('ai: true');
+        expect(generateAiResponseSource).not.toContain('aiQuestion');
+    });
 });


### PR DESCRIPTION
Closes #3443

## What changed
- Added focused Firestore validators for liveChat and liveReactions create payloads.
- liveChat now requires an allowlisted shape, authenticated senderId, request-time createdAt, bounded text/display fields, and rejects reserved AI/system metadata.
- liveReactions now only allows type, senderId, createdAt, with type restricted to fire, clap, wow, heart, and hundred.
- Removed reserved ai/aiQuestion metadata from the legacy client-created ALL PLAYS bot chat writes so they stay inside the approved payload shape.

## Root Cause
liveChat and liveReactions create rules authenticated the writer but only checked minimum required fields. Because js/db.js spreads caller-provided payloads before adding serverTimestamp(), arbitrary client metadata could be persisted and then trusted by the live viewer UI.

## Prevention / Learning
Shared viewer-facing Firestore writes need complete allowlisted create shapes at the rules boundary, request.time timestamp enforcement, bounded user-controlled strings, and explicit rejection of reserved/system metadata. Client helpers should also avoid writing fields the rules reserve.

## Regression Tests
- npx vitest run tests/unit/firestore-live-chat-auth.test.js tests/unit/live-game-auth-required-ui.test.js --reporter=verbose
- npm run ci:firebase-rules