### PR TITLE
Deduplicate parent certificate team reads

### DIFF
--- a/apps/app/src/lib/parentCertificatesService.test.ts
+++ b/apps/app/src/lib/parentCertificatesService.test.ts
@@ -18,6 +18,33 @@ describe('loadParentCertificates', () => {
         legacyParentToolsMocks.listCertificatesForPlayer.mockResolvedValue([]);
     });
 
+    it('reuses one team read for linked children on the same team', async () => {
+        legacyParentToolsMocks.listCertificatesForPlayer
+            .mockResolvedValueOnce([{ id: 'cert-1', title: 'Hustle Award' }])
+            .mockResolvedValueOnce([{ id: 'cert-2', title: 'Leadership Award' }]);
+
+        const cards = await loadParentCertificates({
+            uid: 'parent-1',
+            parentOf: [
+                { teamId: 'team-1', playerId: 'player-1', playerName: 'Sam Player' },
+                { teamId: 'team-1', playerId: 'player-2', playerName: 'Jordan Star' }
+            ]
+        } as any);
+
+        expect(legacyParentToolsMocks.getTeam).toHaveBeenCalledTimes(1);
+        expect(legacyParentToolsMocks.getTeam).toHaveBeenCalledWith('team-1');
+        expect(legacyParentToolsMocks.listCertificatesForPlayer).toHaveBeenCalledTimes(2);
+        expect(legacyParentToolsMocks.listCertificatesForPlayer).toHaveBeenNthCalledWith(1, 'team-1', 'player-1', {
+            status: 'published',
+            limit: 25
+        });
+        expect(legacyParentToolsMocks.listCertificatesForPlayer).toHaveBeenNthCalledWith(2, 'team-1', 'player-2', {
+            status: 'published',
+            limit: 25
+        });
+        expect(cards.map((card) => card.playerId)).toEqual(['player-1', 'player-2']);
+    });
+
     it('expands the published certificate read for the deep-linked team only', async () => {
         await loadParentCertificates({
             uid: 'parent-1',
@@ -38,5 +65,36 @@ describe('loadParentCertificates', () => {
             status: 'published',
             limit: 25
         });
+        expect(legacyParentToolsMocks.getTeam).toHaveBeenCalledTimes(2);
+        expect(legacyParentToolsMocks.getTeam).toHaveBeenNthCalledWith(1, 'team-1');
+        expect(legacyParentToolsMocks.getTeam).toHaveBeenNthCalledWith(2, 'team-2');
+    });
+
+    it('falls back to child team names when team metadata has no usable name', async () => {
+        legacyParentToolsMocks.getTeam.mockResolvedValue({});
+        legacyParentToolsMocks.listCertificatesForPlayer.mockResolvedValueOnce([{ id: 'cert-1', title: 'Hustle Award' }]);
+
+        const cards = await loadParentCertificates({
+            uid: 'parent-1',
+            parentOf: [
+                { teamId: 'team-1', teamName: 'Family Bears', playerId: 'player-1', playerName: 'Sam Player' }
+            ]
+        } as any);
+
+        expect(cards[0].teamName).toBe('Family Bears');
+    });
+
+    it('falls back to child team names when team metadata fails to load', async () => {
+        legacyParentToolsMocks.getTeam.mockRejectedValue(new Error('team read failed'));
+        legacyParentToolsMocks.listCertificatesForPlayer.mockResolvedValueOnce([{ id: 'cert-1', title: 'Hustle Award' }]);
+
+        const cards = await loadParentCertificates({
+            uid: 'parent-1',
+            parentOf: [
+                { teamId: 'team-1', teamName: 'Family Bears', playerId: 'player-1', playerName: 'Sam Player' }
+            ]
+        } as any);
+
+        expect(cards[0].teamName).toBe('Family Bears');
     });
 });

--- a/apps/app/src/lib/parentCertificatesService.ts
+++ b/apps/app/src/lib/parentCertificatesService.ts
@@ -23,12 +23,19 @@ export async function loadParentCertificates(user: AuthUser | null, options: Loa
     const requestedTeamId = compactString(options.requestedTeamId);
     const requestedCertificateId = compactString(options.requestedCertificateId);
     const hasTargetedCertificateRequest = Boolean(requestedTeamId && requestedCertificateId);
+    const teamReads = new Map<string, Promise<any>>();
+    const readTeam = (teamId: string) => {
+        if (!teamReads.has(teamId)) {
+            teamReads.set(teamId, Promise.resolve(getTeam(teamId)).catch(() => null));
+        }
+        return teamReads.get(teamId)!;
+    };
     const rows = await Promise.all(children.map(async (child: any) => {
         const certificateLimit = hasTargetedCertificateRequest && child.teamId === requestedTeamId
             ? TARGETED_PUBLISHED_CERTIFICATE_LIMIT
             : DEFAULT_PUBLISHED_CERTIFICATE_LIMIT;
         const [team, certificates] = await Promise.all([
-            Promise.resolve(getTeam(child.teamId)).catch(() => null),
+            readTeam(child.teamId),
             Promise.resolve(listCertificatesForPlayer(child.teamId, child.playerId, { status: 'published', limit: certificateLimit })).catch(() => [])
         ]);
         return (certificates || []).map((certificate: any) => ({

--- a/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
@@ -111,4 +111,36 @@ describe('CertificatesTool deep links', () => {
         expect(screen.getByText('That award is no longer available. Showing all published awards instead.')).toBeTruthy();
         expect(screen.getAllByText('Hustle Award').length).toBeGreaterThan(0);
     });
+
+    it('renders multiple award cards from the same team', async () => {
+        parentCertificatesServiceMocks.loadParentCertificates.mockResolvedValueOnce([
+            {
+                id: 'cert-1',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerId: 'player-1',
+                playerName: 'Sam Player',
+                title: 'Hustle Award',
+                narrative: 'Great effort.',
+                url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1'
+            },
+            {
+                id: 'cert-2',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerId: 'player-2',
+                playerName: 'Jordan Star',
+                title: 'Leadership Award',
+                narrative: 'Great teammate.',
+                url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-2'
+            }
+        ]);
+
+        renderCertificatesTool();
+
+        expect(await screen.findByText('Hustle Award')).toBeTruthy();
+        expect(screen.getByText('Leadership Award')).toBeTruthy();
+        expect(screen.getByText('Sam Player - Bears')).toBeTruthy();
+        expect(screen.getByText('Jordan Star - Bears')).toBeTruthy();
+    });
 });

--- a/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CertificatesTool } from './CertificatesTool';
@@ -136,11 +136,12 @@ describe('CertificatesTool deep links', () => {
             }
         ]);
 
-        renderCertificatesTool();
+        const { container } = renderCertificatesTool();
+        const currentRender = within(container);
 
-        expect(await screen.findByText('Hustle Award')).toBeTruthy();
-        expect(screen.getByText('Leadership Award')).toBeTruthy();
-        expect(screen.getByText('Sam Player - Bears')).toBeTruthy();
-        expect(screen.getByText('Jordan Star - Bears')).toBeTruthy();
+        expect(await currentRender.findByText('Hustle Award')).toBeTruthy();
+        expect(currentRender.getByText('Leadership Award')).toBeTruthy();
+        expect(currentRender.getByText('Sam Player - Bears')).toBeTruthy();
+        expect(currentRender.getByText('Jordan Star - Bears')).toBeTruthy();
     });
 });


### PR DESCRIPTION
Closes #3446

## What changed
- Added a per-call team metadata promise cache in `loadParentCertificates` keyed by `teamId`.
- Kept `listCertificatesForPlayer` calls per linked child and preserved the targeted 250 certificate limit for deep-linked teams.
- Added unit coverage for same-team deduplication, distinct team reads, deep-link limits, and team name fallback behavior.
- Added CertificatesTool coverage proving multiple awards from the same team still render.

## Root Cause
`loadParentCertificates` called `getTeam(child.teamId)` inside each per-child task, so siblings on the same team triggered duplicate team metadata reads on the parent-visible Awards loading path.

## Prevention / Learning
When a loader fans out per child but also needs shared parent/team metadata, cache shared reads per invocation by stable ID while keeping truly child-specific reads per child.

## Regression Tests
- `npm test -- parentCertificatesService.test.ts CertificatesTool.test.tsx --run`
- `npm run typecheck`

## Recurrence Risk
Low. The cache is scoped to one service call, certificate query behavior is unchanged, and focused tests now assert the duplicate-read invariant.