### PR TITLE
Add in-place retry for message thread loads

### DIFF
--- a/apps/app/src/lib/chatService.test.ts
+++ b/apps/app/src/lib/chatService.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { mapChatConversationDocument, mapChatMessageDocument, mapChatMessageRecord, mapChatMessageRecords } from './firestore/mappers';
@@ -470,5 +471,32 @@ describe('sendTeamChatMessage attachment uploads', () => {
       createdConversation: null,
       wantsAi: false
     }));
+  });
+});
+
+describe('subscribeToTeamChatMessages', () => {
+  it('forwards async Firestore listener errors to the caller', async () => {
+    const unsubscribe = vi.fn();
+    const onMessages = vi.fn();
+    const onError = vi.fn();
+    legacyChatServiceMocks.subscribeToChatMessages.mockReturnValue(unsubscribe);
+
+    const { subscribeToTeamChatMessages } = await import('./chatService');
+    const subscription = subscribeToTeamChatMessages('team-1', 'team', onMessages, onError);
+
+    expect(legacyChatServiceMocks.subscribeToChatMessages).toHaveBeenCalledWith(
+      'team-1',
+      { limit: 50, conversationId: 'team' },
+      expect.any(Function),
+      onError
+    );
+
+    const forwardedOnError = legacyChatServiceMocks.subscribeToChatMessages.mock.calls[0][3];
+    const listenerError = new Error('Firestore listener failed');
+    forwardedOnError(listenerError);
+
+    expect(onError).toHaveBeenCalledWith(listenerError);
+    subscription.unsubscribe();
+    expect(unsubscribe).toHaveBeenCalled();
   });
 });

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1057,7 +1057,7 @@ export function subscribeToTeamChatMessages(
         const mappedMessages = mapChatMessageRecords(messages);
         onMessages(mappedMessages, oldestDoc);
       }
-    });
+    }, onError);
   } catch (error: any) {
     if (!isNativeRuntime()) {
       onError?.(error);

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -409,6 +409,7 @@ export function ChatWindow({
     loadingMessages,
     loadingOlder,
     error: messagesError,
+    retryMessages,
     loadOlderMessages: loadOlderChatMessages,
     initialSnapshotLoadedRef
   } = useChatMessages({
@@ -454,6 +455,7 @@ export function ChatWindow({
     preferTopWindow: olderMessages.length > 0 && messageViewportState.scrollTop <= 0
   }), [messageLayout, messageViewportState.scrollTop, messageViewportState.viewportHeight, olderMessages.length, visibleMessages]);
   const error = teamError || messagesError;
+  const canRetryMessagesError = Boolean(messagesError && !teamError);
 
   const handleMessageRowHeightChange = useCallback((messageId: string, height: number) => {
     if (!messageId || !Number.isFinite(height) || height <= 0) return;
@@ -1547,7 +1549,15 @@ export function ChatWindow({
     return (
       <section className={`chat-window app-card p-5 ${embedded ? 'chat-window-embedded' : ''}`}>
         <div className="text-base font-black text-rose-700">{error}</div>
-        <button type="button" className="secondary-button mt-4" onClick={() => navigate('/messages')}>Back to messages</button>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {canRetryMessagesError ? (
+            <button type="button" className="primary-button" onClick={retryMessages}>
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              Retry
+            </button>
+          ) : null}
+          <button type="button" className="secondary-button" onClick={() => navigate('/messages')}>Back to messages</button>
+        </div>
       </section>
     );
   }

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -227,8 +227,11 @@ vi.mock('../hooks/useChatMessages', async () => {
   const React = await import('react');
   return {
     useChatMessages: () => {
+      const [phase, setPhase] = React.useState<'error' | 'loading' | 'ready'>('error');
+      const [olderMessages, setOlderMessages] = React.useState<ChatMessage[]>([]);
+      const [loadingOlder, setLoadingOlder] = React.useState(false);
+
       if (mockThreadLoadScenario === 'retrySuccess') {
-        const [phase, setPhase] = React.useState<'error' | 'loading' | 'ready'>('error');
         return {
           messages: phase === 'ready' ? [buildMessage('recovered-message', 999)] : [],
           olderMessages: [],
@@ -245,8 +248,6 @@ vi.mock('../hooks/useChatMessages', async () => {
         };
       }
 
-      const [olderMessages, setOlderMessages] = React.useState<ChatMessage[]>([]);
-      const [loadingOlder, setLoadingOlder] = React.useState(false);
       return {
         messages: [...olderMessages, ...liveMessages],
         olderMessages,

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -17,11 +17,15 @@ import {
   buildVirtualizedChatWindowFromLayout
 } from './ChatWindow';
 
+const mockRouter = vi.hoisted(() => ({
+  navigate: vi.fn()
+}));
 const normalizeChatReactionsSpy = vi.fn();
 const getMessageAttachmentsSpy = vi.fn();
 const mockShellLayoutState = { isDesktopWeb: false };
 type MockActiveChatSheet = 'conversation' | 'audience' | 'media' | 'attach' | 'link' | 'email' | null;
 let useStatefulChatSheets = false;
+let mockThreadLoadScenario: 'normal' | 'retrySuccess' = 'normal';
 const mockChatSheetsState = {
   showConversationSheet: false,
   showAudienceSheet: false,
@@ -135,7 +139,7 @@ vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
     ...actual,
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockRouter.navigate,
     Link: ({ children, ...props }: any) => <a {...props}>{children}</a>
   };
 });
@@ -223,6 +227,24 @@ vi.mock('../hooks/useChatMessages', async () => {
   const React = await import('react');
   return {
     useChatMessages: () => {
+      if (mockThreadLoadScenario === 'retrySuccess') {
+        const [phase, setPhase] = React.useState<'error' | 'loading' | 'ready'>('error');
+        return {
+          messages: phase === 'ready' ? [buildMessage('recovered-message', 999)] : [],
+          olderMessages: [],
+          hasMoreMessages: false,
+          loadingMessages: phase === 'loading',
+          loadingOlder: false,
+          error: phase === 'error' ? 'Unable to load chat messages.' : null,
+          retryMessages: () => {
+            setPhase('loading');
+            window.setTimeout(() => setPhase('ready'), 0);
+          },
+          loadOlderMessages: async () => {},
+          initialSnapshotLoadedRef: { current: phase === 'ready' }
+        };
+      }
+
       const [olderMessages, setOlderMessages] = React.useState<ChatMessage[]>([]);
       const [loadingOlder, setLoadingOlder] = React.useState(false);
       return {
@@ -232,6 +254,7 @@ vi.mock('../hooks/useChatMessages', async () => {
         loadingMessages: false,
         loadingOlder,
         error: null,
+        retryMessages: () => {},
         loadOlderMessages: async () => {
           setLoadingOlder(true);
           scrollHeightValue = 3000;
@@ -275,6 +298,8 @@ class MockResizeObserver {
 
 beforeEach(() => {
   useStatefulChatSheets = false;
+  mockThreadLoadScenario = 'normal';
+  mockRouter.navigate.mockReset();
   mockShellLayoutState.isDesktopWeb = false;
   mockChatSheetsState.showConversationSheet = false;
   mockChatSheetsState.showAudienceSheet = false;
@@ -497,6 +522,27 @@ describe('ChatWindow virtualization', () => {
     expect(bubbleCount).toBeGreaterThan(0);
     expect(bubbleCount).toBeLessThan(100);
     expect(bubbleCount).toBeLessThan(liveMessages.length);
+  });
+
+  it('offers in-place retry for a failed message subscription and keeps back navigation available', async () => {
+    mockThreadLoadScenario = 'retrySuccess';
+    render(
+      <MemoryRouter initialEntries={['/messages/team-1']}>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Unable to load chat messages.')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Back to messages' }));
+    expect(mockRouter.navigate).toHaveBeenCalledWith('/messages');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(screen.getByText('Loading messages...')).toBeVisible();
+    await waitFor(() => expect(screen.getByText('Message recovered-message')).toBeVisible());
+    expect(screen.getByText('Composer')).toBeVisible();
+    expect(mockRouter.navigate).toHaveBeenCalledTimes(1);
   });
 
   it('replaces an open conversation sheet when the media gallery opens', async () => {

--- a/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
+++ b/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
@@ -61,13 +61,16 @@ function MessagesProbe({
             <div data-testid="loading-older">{String(state.loadingOlder)}</div>
             <div data-testid="message-ids">{state.messages.map((item) => item.id).join(',')}</div>
             <div data-testid="has-more">{String(state.hasMoreMessages)}</div>
+            <div data-testid="error">{state.error || ''}</div>
             <button type="button" onClick={() => void state.loadOlderMessages().catch(onLoadOlderError)}>Load older</button>
+            <button type="button" onClick={state.retryMessages}>Retry</button>
         </div>
     );
 }
 
 describe('useChatMessages', () => {
     let liveCallback: ((messages: ChatMessage[], oldestDoc: unknown | null) => void) | undefined;
+    let errorCallback: ((error: Error) => void) | undefined;
     let unsubscribe: () => void;
 
     afterEach(() => {
@@ -77,9 +80,11 @@ describe('useChatMessages', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         liveCallback = undefined;
+        errorCallback = undefined;
         unsubscribe = vi.fn() as () => void;
-        vi.mocked(subscribeToTeamChatMessages).mockImplementation((_teamId, _conversationId, onMessages) => {
+        vi.mocked(subscribeToTeamChatMessages).mockImplementation((_teamId, _conversationId, onMessages, onError) => {
             liveCallback = onMessages;
+            errorCallback = onError;
             return { unsubscribe };
         });
     });
@@ -168,6 +173,35 @@ describe('useChatMessages', () => {
         rerender(<MessagesProbeWithUser authUser={secondUser} />);
 
         await waitFor(() => expect(subscribeToTeamChatMessages).toHaveBeenCalledTimes(1));
+    });
+
+    it('retries a failed live subscription for the same team and conversation', async () => {
+        const onMessagesReset = vi.fn();
+        render(<MessagesProbe conversationId="staff" onMessagesReset={onMessagesReset} />);
+
+        act(() => {
+            errorCallback?.(new Error('Subscription failed'));
+        });
+
+        await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+        expect(screen.getByTestId('error').textContent).toBe('Subscription failed');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+        expect(screen.getByTestId('loading').textContent).toBe('true');
+        expect(screen.getByTestId('error').textContent).toBe('');
+        expect(screen.getByTestId('message-ids').textContent).toBe('');
+        await waitFor(() => expect(subscribeToTeamChatMessages).toHaveBeenCalledTimes(2));
+        expect(unsubscribe).toHaveBeenCalled();
+        expect(onMessagesReset).toHaveBeenCalledTimes(3);
+        expect(subscribeToTeamChatMessages).toHaveBeenLastCalledWith('team-1', 'staff', expect.any(Function), expect.any(Function));
+
+        act(() => {
+            liveCallback?.([message('recovered', 30)], { cursor: 'recovered' });
+        });
+
+        await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+        expect(screen.getByTestId('message-ids').textContent).toBe('recovered');
     });
 
     it('resets the loading state when loading older messages fails and still rejects to the caller', async () => {

--- a/apps/app/src/pages/messages/hooks/useChatMessages.ts
+++ b/apps/app/src/pages/messages/hooks/useChatMessages.ts
@@ -39,6 +39,7 @@ export function useChatMessages({
   const [loadingMessages, setLoadingMessages] = useState(true);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [retryVersion, setRetryVersion] = useState(0);
   const initialSnapshotLoadedRef = useRef(false);
   const conversationId = normalizeConversationId(selectedConversationId);
 
@@ -79,7 +80,20 @@ export function useChatMessages({
     return () => {
       subscription.unsubscribe();
     };
-  }, [conversationId, onBeforeLiveUpdate, onLiveUpdateState, onMarkRead, onMessagesReset, team?.id, teamId, user?.uid]);
+  }, [conversationId, onBeforeLiveUpdate, onLiveUpdateState, onMarkRead, onMessagesReset, retryVersion, team?.id, teamId, user?.uid]);
+
+  const retryMessages = useCallback(() => {
+    if (!team || !user) return;
+    setLoadingMessages(true);
+    setError(null);
+    setOlderMessages([]);
+    setLiveMessages([]);
+    setLiveOldestDoc(null);
+    setHasMoreMessages(false);
+    initialSnapshotLoadedRef.current = false;
+    onMessagesReset?.();
+    setRetryVersion((current) => current + 1);
+  }, [onMessagesReset, team, user]);
 
   const loadOlderMessages = useCallback(async () => {
     if (loadingOlder || !hasMoreMessages) return;
@@ -105,6 +119,7 @@ export function useChatMessages({
     loadingOlder,
     error,
     setError,
+    retryMessages,
     loadOlderMessages,
     initialSnapshotLoadedRef
   };

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -87,7 +87,8 @@ async function mockMessagesModules(page, options = {}) {
             edits: [],
             deletes: [],
             reads: [],
-            ai: []
+            ai: [],
+            subscriptions: []
         };
         if (speech) {
             class MockSpeechRecognition {
@@ -272,8 +273,22 @@ async function mockMessagesModules(page, options = {}) {
                     ];
                 }
 
-                export function subscribeToTeamChatMessages(teamId, conversationId, onMessages) {
-                    ${options.threadMessagesScript || buildDefaultThreadMessagesScript()}
+                export function subscribeToTeamChatMessages(teamId, conversationId, onMessages, onError) {
+                    window.__chatCalls.subscriptions.push({ teamId, conversationId });
+                    if (${Boolean(options.failFirstThreadLoad)}) {
+                        window.__threadSubscriptionAttempts = (window.__threadSubscriptionAttempts || 0) + 1;
+                        if (window.__threadSubscriptionAttempts <= ${options.failFirstThreadLoadAttempts || 1}) {
+                            setTimeout(() => onError(new Error('Unable to load chat messages.')), 0);
+                            return { unsubscribe: () => {} };
+                        }
+                    }
+                    if (${options.threadMessagesDelayMs || 0} > 0) {
+                        setTimeout(() => {
+                            ${options.threadMessagesScript || buildDefaultThreadMessagesScript()}
+                        }, ${options.threadMessagesDelayMs || 0});
+                    } else {
+                        ${options.threadMessagesScript || buildDefaultThreadMessagesScript()}
+                    }
                     return { unsubscribe: () => {} };
                 }
 
@@ -520,6 +535,25 @@ test('messages team thread renders before deferred conversation hydration finish
     await expect(page.getByRole('dialog', { name: 'Conversations' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Staff only Group conversation' })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('Latest ride update.')).toBeVisible();
+});
+
+test('messages team thread retries a failed subscription in place on mobile', async ({ page, baseURL }) => {
+    await mockMessagesModules(page, { failFirstThreadLoad: true, threadMessagesDelayMs: 1000 });
+    await page.goto(appUrl(baseURL, '/messages/team-1'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 30000 });
+    await expect(page.getByText('Unable to load chat messages.')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Retry' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back to messages' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Retry' }).click();
+
+    await expect(page.getByText('Loading messages...')).toBeVisible();
+    await expect(page.getByText('Bring both jerseys.')).toBeVisible();
+    await expect(page.getByPlaceholder('Message Bears')).toBeVisible();
+    await expect(page).toHaveURL(/#\/messages\/team-1$/);
+    await expect.poll(() => page.evaluate(() => window.__chatCalls.subscriptions.length)).toBeGreaterThanOrEqual(2);
+    await expect.poll(() => page.evaluate(() => window.__chatCalls.subscriptions.at(-1))).toEqual({ teamId: 'team-1', conversationId: 'team' });
 });
 
 test('messages inbox stays interactive while previews hydrate on inbox and desktop routes', async ({ page, baseURL }) => {


### PR DESCRIPTION
Closes #3451

## What changed
- Added a `retryMessages` trigger to `useChatMessages` that clears the prior subscription error, resets thread loading state, and re-subscribes to the active `teamId` and conversation.
- Updated `ChatWindow` to show `Retry` beside `Back to messages` for message subscription errors while leaving team-context errors back-only.
- Added hook, component, and mobile smoke coverage for fail-first subscription recovery without leaving `/messages/team-1`.

## Root Cause
`useChatMessages` converted `subscribeToTeamChatMessages` failures into terminal error state without exposing a retry/reload trigger for the active subscription. `ChatWindow` then collapsed `teamError || messagesError` into one route-level error card with only `Back to messages`, forcing users to leave and re-enter the thread.

## Prevention / Learning
Route-level async subscription errors need an in-place retry path that resets loading/error state and reuses the current route scope. Future message-like surfaces should test error, loading, retry, and recovered states as separate invariants.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/messages/hooks/__tests__/useChatMessages.test.tsx src/pages/messages/components/ChatWindow.virtualization.test.tsx --reporter=verbose`
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/smoke/app-messages.spec.js -g "retries a failed subscription"`
- `npm run app:build`