### PR TITLE
Lazy-load Messages chat AI code

### DIFF
--- a/apps/app/src/lib/adapters/legacyChatAi.ts
+++ b/apps/app/src/lib/adapters/legacyChatAi.ts
@@ -1,0 +1,7 @@
+import { getApp as legacyGetApp } from '@legacy/vendor/firebase-app.js';
+import { getAI as legacyGetAI, getGenerativeModel as legacyGetGenerativeModel, GoogleAIBackend as LegacyGoogleAIBackend } from '@legacy/vendor/firebase-ai.js';
+
+export const getApp = legacyGetApp as (...args: any[]) => any;
+export const getAI = legacyGetAI as (...args: any[]) => any;
+export const getGenerativeModel = legacyGetGenerativeModel as (...args: any[]) => any;
+export const GoogleAIBackend = LegacyGoogleAIBackend as new (...args: any[]) => unknown;

--- a/apps/app/src/lib/adapters/legacyChatService.ts
+++ b/apps/app/src/lib/adapters/legacyChatService.ts
@@ -2,7 +2,6 @@
  * Bindings re-exported as-is so existing js/* test mocks apply via the @legacy alias. */
 import * as legacyDb from '@legacy/db.js';
 import { getApp as legacy_getApp } from '@legacy/vendor/firebase-app.js';
-import { getAI as legacy_getAI, getGenerativeModel as legacy_getGenerativeModel, GoogleAIBackend as legacy_GoogleAIBackend } from '@legacy/vendor/firebase-ai.js';
 import { resolveImageFirebaseConfig as legacy_resolveImageFirebaseConfig } from '@legacy/firebase-runtime-config.js';
 import { isTeamActive as legacy_isTeamActive } from '@legacy/team-visibility.js';
 
@@ -47,8 +46,5 @@ export const clearChatMuted = (...args: any[]) => callLegacyDb('clearChatMuted',
 export const uploadChatImage = (...args: any[]) => callLegacyDb('uploadChatImage', args);
 export const upsertChatConversation = (...args: any[]) => callLegacyDb('upsertChatConversation', args);
 export const getApp = legacy_getApp as (...args: any[]) => any;
-export const getAI = legacy_getAI as (...args: any[]) => any;
-export const getGenerativeModel = legacy_getGenerativeModel as (...args: any[]) => any;
-export const GoogleAIBackend = legacy_GoogleAIBackend as new (...args: any[]) => unknown;
 export const resolveImageFirebaseConfig = legacy_resolveImageFirebaseConfig as (...args: any[]) => any;
 export const isTeamActive = legacy_isTeamActive as (...args: any[]) => any;

--- a/apps/app/src/lib/chatAiService.ts
+++ b/apps/app/src/lib/chatAiService.ts
@@ -1,0 +1,256 @@
+import {
+  getAI,
+  getApp,
+  getGenerativeModel,
+  GoogleAIBackend
+} from './adapters/legacyChatAi';
+import {
+  getAggregatedStatsForGames,
+  getGameEvents,
+  getGames,
+  getPlayers,
+  postChatMessage
+} from './adapters/legacyChatService';
+import type { ChatConversation } from './chatService';
+import {
+  buildChatAudienceMetadata,
+  type ChatTargetType
+} from './chatLogic';
+import type { AuthUser } from './types';
+
+const aiStatsGamesLimit = 10;
+const aiGamesContextLimit = 20;
+const aiEventsGamesLimit = 3;
+const aiEventsPerGameLimit = 25;
+const CHAT_AI_RESET_EVENT = 'allplays-chat-ai-reset';
+
+let aiModelCache: any = null;
+
+export function resetChatAiModel() {
+  aiModelCache = null;
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener(CHAT_AI_RESET_EVENT, resetChatAiModel);
+}
+
+function toDate(value: any) {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (value?.toDate) return value.toDate();
+  if (typeof value?.seconds === 'number') return new Date(value.seconds * 1000);
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function truncateText(text: unknown, maxLen: number) {
+  const clean = String(text || '').trim();
+  if (clean.length <= maxLen) return clean || null;
+  return `${clean.slice(0, maxLen).trim()}...`;
+}
+
+function isCompletedGame(game: any) {
+  const status = String(game?.status || '').toLowerCase();
+  if (status === 'final' || status === 'completed') return true;
+  const homeScore = Number(game?.homeScore || 0);
+  const awayScore = Number(game?.awayScore || 0);
+  return homeScore > 0 || awayScore > 0;
+}
+
+function shouldFetchStats(question: string) {
+  return /(stats|scorer|score|points|rebounds|assists|goals|saves|leader|leading|top|better|improv|improve|development|progress|player\s*#?\s*\d+)/i.test(question);
+}
+
+function shouldFetchEvents(question: string) {
+  return /(play\s*by\s*play|play-by-play|timeline|game\s*log|event\s*log|events|possessions|highlights|what happened|sequence)/i.test(question);
+}
+
+function serializeGame(game: any) {
+  const date = toDate(game?.date);
+  return {
+    id: game?.id || null,
+    date: date ? date.toISOString() : null,
+    opponent: game?.opponent || null,
+    location: game?.location || null,
+    status: game?.status || null,
+    homeScore: game?.homeScore ?? null,
+    awayScore: game?.awayScore ?? null,
+    summary: truncateText(game?.summary, 700)
+  };
+}
+
+function findMatchedPlayer(question: string, players: any[]) {
+  const match = question.match(/player\s*#?\s*(\d{1,3})/i);
+  if (!match) return null;
+  const target = String(Number(match[1]));
+  return players.find((player) => String(player.number ?? '') === target) || null;
+}
+
+async function buildAiContext(teamId: string, team: Record<string, any>, question: string, { fetchStats, fetchEvents }: { fetchStats: boolean; fetchEvents: boolean }) {
+  const [players, games] = await Promise.all([
+    getPlayers(teamId, { includeInactive: true }),
+    getGames(teamId)
+  ]);
+  const playersById = new Map((players || []).map((player: any) => [player.id, player]));
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+  const gamesWithDates = (games || [])
+    .map((game: any) => ({ ...game, _date: toDate(game.date) }))
+    .filter((game: any) => game._date);
+
+  const upcomingGames = gamesWithDates
+    .filter((game: any) => game._date >= cutoff)
+    .sort((a: any, b: any) => a._date.getTime() - b._date.getTime())
+    .slice(0, 10)
+    .map(serializeGame);
+
+  const recentGames = gamesWithDates
+    .filter((game: any) => game._date < cutoff)
+    .sort((a: any, b: any) => b._date.getTime() - a._date.getTime())
+    .slice(0, aiGamesContextLimit)
+    .map(serializeGame);
+
+  let statsSummary = null;
+  if (fetchStats) {
+    const completedGames = gamesWithDates
+      .filter(isCompletedGame)
+      .sort((a: any, b: any) => b._date.getTime() - a._date.getTime())
+      .slice(0, aiStatsGamesLimit);
+    const totals = await getAggregatedStatsForGames(teamId, completedGames.map((game: any) => game.id));
+    statsSummary = {
+      gamesUsed: completedGames.map(serializeGame),
+      totalsByPlayer: Object.entries(totals || {}).map(([playerId, stats]) => ({
+        id: playerId,
+        name: (playersById.get(playerId) as any)?.name || 'Unknown',
+        number: (playersById.get(playerId) as any)?.number || null,
+        stats
+      }))
+    };
+  }
+
+  let eventsSummary = null;
+  if (fetchEvents) {
+    const recentCompleted = gamesWithDates
+      .filter(isCompletedGame)
+      .sort((a: any, b: any) => b._date.getTime() - a._date.getTime())
+      .slice(0, aiEventsGamesLimit);
+    const eventsByGame = await Promise.all(recentCompleted.map(async (game: any) => {
+      const events = await getGameEvents(teamId, game.id, { limit: aiEventsPerGameLimit });
+      return {
+        game: serializeGame(game),
+        events: (events || []).slice().reverse().map((event: any) => {
+          const player = event.playerId ? playersById.get(event.playerId) as any : null;
+          return {
+            id: event.id,
+            timestamp: event.timestamp ?? null,
+            period: event.period ?? null,
+            gameTime: event.gameTime ?? null,
+            text: event.text || null,
+            type: event.type || null,
+            playerId: event.playerId || null,
+            playerName: player?.name || null,
+            playerNumber: player?.number ?? null,
+            statKey: event.statKey || null,
+            value: event.value ?? null,
+            isOpponent: event.isOpponent === true
+          };
+        })
+      };
+    }));
+    eventsSummary = {
+      gamesUsed: recentCompleted.map(serializeGame),
+      eventsByGame
+    };
+  }
+
+  const matchedPlayer = findMatchedPlayer(question, players || []);
+  return {
+    team: {
+      id: teamId,
+      name: team?.name || null,
+      sport: team?.sport || null
+    },
+    players: (players || []).map((player: any) => ({
+      id: player.id,
+      name: player.name || null,
+      number: player.number || null
+    })),
+    matchedPlayer: matchedPlayer ? {
+      id: matchedPlayer.id,
+      name: matchedPlayer.name || null,
+      number: matchedPlayer.number ?? null
+    } : null,
+    gamesUpcoming: upcomingGames,
+    gamesRecent: recentGames,
+    stats: statsSummary,
+    playByPlay: eventsSummary
+  };
+}
+
+async function getAiModel() {
+  if (aiModelCache) return aiModelCache;
+  const firebaseApp = getApp();
+  const ai = getAI(firebaseApp, { backend: new GoogleAIBackend() });
+  aiModelCache = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+  return aiModelCache;
+}
+
+export async function sendAllPlaysChatAnswer({
+  teamId,
+  team,
+  user,
+  question,
+  selectedConversation,
+  selectedConversationId,
+  selectedRecipientTarget,
+  selectedRecipientIds
+}: {
+  teamId: string;
+  team: Record<string, any>;
+  user: AuthUser;
+  question: string;
+  selectedConversation?: ChatConversation | null;
+  selectedConversationId: string;
+  selectedRecipientTarget: ChatTargetType;
+  selectedRecipientIds: string[];
+}) {
+  const fetchStats = shouldFetchStats(question);
+  const fetchEvents = shouldFetchEvents(question);
+  const context = await buildAiContext(teamId, team, question, { fetchStats, fetchEvents });
+  const prompt = `You are ALL PLAYS, a sports management expert for youth teams.\n` +
+    `You are speaking to coaches, admins, and parents.\n` +
+    `Use ONLY the provided DATA to answer. If the data is insufficient, say so.\n` +
+    `Respond in a clear, readable format with short paragraphs or bullet points.\n` +
+    `Limit to at most 6 bullets total. Use *bold* only for short labels.\n\n` +
+    `QUESTION:\n${question}\n\nDATA (JSON):\n${JSON.stringify(context)}\n`;
+  const model = await getAiModel();
+  const result = await model.generateContent(prompt);
+  const responseText = result.response.text();
+  const targetMetadata = buildChatAudienceMetadata({
+    selectedConversation,
+    selectedConversationId,
+    selectedRecipientTarget,
+    selectedRecipientIds
+  });
+  await postChatMessage(teamId, {
+    text: responseText,
+    senderId: user.uid,
+    senderName: null,
+    senderEmail: null,
+    senderPhotoUrl: null,
+    ai: true,
+    aiName: 'ALL PLAYS',
+    aiQuestion: question,
+    conversationId: selectedConversationId,
+    ...targetMetadata,
+    aiMeta: {
+      statsGameLimit: aiStatsGamesLimit,
+      gamesContextLimit: aiGamesContextLimit,
+      statsRequested: fetchStats,
+      eventsGameLimit: aiEventsGamesLimit,
+      eventsPerGameLimit: aiEventsPerGameLimit,
+      eventsRequested: fetchEvents,
+      statsRequestSource: 'heuristic'
+    }
+  });
+}

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1,20 +1,13 @@
 import { isNativeRuntime } from './nativeRuntime';
 import {
-  GoogleAIBackend,
   canAccessTeamChat,
   canModerateChat,
   clearChatMuted,
   deleteChatMessage,
   deleteUploadedChatAttachments,
   editChatMessage,
-  getAI,
-  getAggregatedStatsForGames,
-  getApp,
   getChatConversations,
   getChatMessages,
-  getGameEvents,
-  getGames,
-  getGenerativeModel,
   getParentTeams,
   getPlayers,
   getSentTeamEmails,
@@ -80,10 +73,6 @@ const chatAttachmentUploadConcurrency = 3;
 const chatPreviewCacheTtlMs = 20 * 1000;
 const deferredInboxPreviewConcurrency = 3;
 const imageUploadSessionKey = 'allplays-chat-image-upload-session';
-const aiStatsGamesLimit = 10;
-const aiGamesContextLimit = 20;
-const aiEventsGamesLimit = 3;
-const aiEventsPerGameLimit = 25;
 const logger = createLogger('chat-service');
 
 export type ChatTeam = {
@@ -189,10 +178,12 @@ type ImageUploadSession = {
   expirationTime: number;
 };
 
-let aiModelCache: any = null;
+export const CHAT_AI_RESET_EVENT = 'allplays-chat-ai-reset';
 
 export function resetChatAiModel() {
-  aiModelCache = null;
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(CHAT_AI_RESET_EVENT));
+  }
 }
 
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
@@ -1861,218 +1852,6 @@ function toDate(value: any) {
   if (typeof value?.seconds === 'number') return new Date(value.seconds * 1000);
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;
-}
-
-function truncateText(text: unknown, maxLen: number) {
-  const clean = String(text || '').trim();
-  if (clean.length <= maxLen) return clean || null;
-  return `${clean.slice(0, maxLen).trim()}...`;
-}
-
-function isCompletedGame(game: any) {
-  const status = String(game?.status || '').toLowerCase();
-  if (status === 'final' || status === 'completed') return true;
-  const homeScore = Number(game?.homeScore || 0);
-  const awayScore = Number(game?.awayScore || 0);
-  return homeScore > 0 || awayScore > 0;
-}
-
-function shouldFetchStats(question: string) {
-  return /(stats|scorer|score|points|rebounds|assists|goals|saves|leader|leading|top|better|improv|improve|development|progress|player\s*#?\s*\d+)/i.test(question);
-}
-
-function shouldFetchEvents(question: string) {
-  return /(play\s*by\s*play|play-by-play|timeline|game\s*log|event\s*log|events|possessions|highlights|what happened|sequence)/i.test(question);
-}
-
-function serializeGame(game: any) {
-  const date = toDate(game?.date);
-  return {
-    id: game?.id || null,
-    date: date ? date.toISOString() : null,
-    opponent: game?.opponent || null,
-    location: game?.location || null,
-    status: game?.status || null,
-    homeScore: game?.homeScore ?? null,
-    awayScore: game?.awayScore ?? null,
-    summary: truncateText(game?.summary, 700)
-  };
-}
-
-function findMatchedPlayer(question: string, players: any[]) {
-  const match = question.match(/player\s*#?\s*(\d{1,3})/i);
-  if (!match) return null;
-  const target = String(Number(match[1]));
-  return players.find((player) => String(player.number ?? '') === target) || null;
-}
-
-async function buildAiContext(teamId: string, team: Record<string, any>, question: string, { fetchStats, fetchEvents }: { fetchStats: boolean; fetchEvents: boolean }) {
-  const [players, games] = await Promise.all([
-    getPlayers(teamId, { includeInactive: true }),
-    getGames(teamId)
-  ]);
-  const playersById = new Map((players || []).map((player: any) => [player.id, player]));
-  const now = new Date();
-  const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
-  const gamesWithDates = (games || [])
-    .map((game: any) => ({ ...game, _date: toDate(game.date) }))
-    .filter((game: any) => game._date);
-
-  const upcomingGames = gamesWithDates
-    .filter((game: any) => game._date >= cutoff)
-    .sort((a: any, b: any) => a._date.getTime() - b._date.getTime())
-    .slice(0, 10)
-    .map(serializeGame);
-
-  const recentGames = gamesWithDates
-    .filter((game: any) => game._date < cutoff)
-    .sort((a: any, b: any) => b._date.getTime() - a._date.getTime())
-    .slice(0, aiGamesContextLimit)
-    .map(serializeGame);
-
-  let statsSummary = null;
-  if (fetchStats) {
-    const completedGames = gamesWithDates
-      .filter(isCompletedGame)
-      .sort((a: any, b: any) => b._date.getTime() - a._date.getTime())
-      .slice(0, aiStatsGamesLimit);
-    const totals = await getAggregatedStatsForGames(teamId, completedGames.map((game: any) => game.id));
-    statsSummary = {
-      gamesUsed: completedGames.map(serializeGame),
-      totalsByPlayer: Object.entries(totals || {}).map(([playerId, stats]) => ({
-        id: playerId,
-        name: (playersById.get(playerId) as any)?.name || 'Unknown',
-        number: (playersById.get(playerId) as any)?.number || null,
-        stats
-      }))
-    };
-  }
-
-  let eventsSummary = null;
-  if (fetchEvents) {
-    const recentCompleted = gamesWithDates
-      .filter(isCompletedGame)
-      .sort((a: any, b: any) => b._date.getTime() - a._date.getTime())
-      .slice(0, aiEventsGamesLimit);
-    const eventsByGame = await Promise.all(recentCompleted.map(async (game: any) => {
-      const events = await getGameEvents(teamId, game.id, { limit: aiEventsPerGameLimit });
-      return {
-        game: serializeGame(game),
-        events: (events || []).slice().reverse().map((event: any) => {
-          const player = event.playerId ? playersById.get(event.playerId) as any : null;
-          return {
-            id: event.id,
-            timestamp: event.timestamp ?? null,
-            period: event.period ?? null,
-            gameTime: event.gameTime ?? null,
-            text: event.text || null,
-            type: event.type || null,
-            playerId: event.playerId || null,
-            playerName: player?.name || null,
-            playerNumber: player?.number ?? null,
-            statKey: event.statKey || null,
-            value: event.value ?? null,
-            isOpponent: event.isOpponent === true
-          };
-        })
-      };
-    }));
-    eventsSummary = {
-      gamesUsed: recentCompleted.map(serializeGame),
-      eventsByGame
-    };
-  }
-
-  const matchedPlayer = findMatchedPlayer(question, players || []);
-  return {
-    team: {
-      id: teamId,
-      name: team?.name || null,
-      sport: team?.sport || null
-    },
-    players: (players || []).map((player: any) => ({
-      id: player.id,
-      name: player.name || null,
-      number: player.number || null
-    })),
-    matchedPlayer: matchedPlayer ? {
-      id: matchedPlayer.id,
-      name: matchedPlayer.name || null,
-      number: matchedPlayer.number ?? null
-    } : null,
-    gamesUpcoming: upcomingGames,
-    gamesRecent: recentGames,
-    stats: statsSummary,
-    playByPlay: eventsSummary
-  };
-}
-
-async function getAiModel() {
-  if (aiModelCache) return aiModelCache;
-  const firebaseApp = getApp();
-  const ai = getAI(firebaseApp, { backend: new GoogleAIBackend() });
-  aiModelCache = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
-  return aiModelCache;
-}
-
-export async function sendAllPlaysChatAnswer({
-  teamId,
-  team,
-  user,
-  question,
-  selectedConversation,
-  selectedConversationId,
-  selectedRecipientTarget,
-  selectedRecipientIds
-}: {
-  teamId: string;
-  team: Record<string, any>;
-  user: AuthUser;
-  question: string;
-  selectedConversation?: ChatConversation | null;
-  selectedConversationId: string;
-  selectedRecipientTarget: ChatTargetType;
-  selectedRecipientIds: string[];
-}) {
-  const fetchStats = shouldFetchStats(question);
-  const fetchEvents = shouldFetchEvents(question);
-  const context = await buildAiContext(teamId, team, question, { fetchStats, fetchEvents });
-  const prompt = `You are ALL PLAYS, a sports management expert for youth teams.\n` +
-    `You are speaking to coaches, admins, and parents.\n` +
-    `Use ONLY the provided DATA to answer. If the data is insufficient, say so.\n` +
-    `Respond in a clear, readable format with short paragraphs or bullet points.\n` +
-    `Limit to at most 6 bullets total. Use *bold* only for short labels.\n\n` +
-    `QUESTION:\n${question}\n\nDATA (JSON):\n${JSON.stringify(context)}\n`;
-  const model = await getAiModel();
-  const result = await model.generateContent(prompt);
-  const responseText = result.response.text();
-  const targetMetadata = buildChatAudienceMetadata({
-    selectedConversation,
-    selectedConversationId,
-    selectedRecipientTarget,
-    selectedRecipientIds
-  });
-  await postChatMessage(teamId, {
-    text: responseText,
-    senderId: user.uid,
-    senderName: null,
-    senderEmail: null,
-    senderPhotoUrl: null,
-    ai: true,
-    aiName: 'ALL PLAYS',
-    aiQuestion: question,
-    conversationId: selectedConversationId,
-    ...targetMetadata,
-    aiMeta: {
-      statsGameLimit: aiStatsGamesLimit,
-      gamesContextLimit: aiGamesContextLimit,
-      statsRequested: fetchStats,
-      eventsGameLimit: aiEventsGamesLimit,
-      eventsPerGameLimit: aiEventsPerGameLimit,
-      eventsRequested: fetchEvents,
-      statsRequestSource: 'heuristic'
-    }
-  });
 }
 
 export function getChatInboxPreview(message: ChatMessage | null) {

--- a/apps/app/src/pages/messages/components/ChatWindow.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.test.tsx
@@ -1,11 +1,29 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { APP_BACK_DISMISS_EVENT } from '../../../lib/nativeBackButton';
-import { Sheet } from './ChatWindow';
+import { Sheet, sendLazyAllPlaysChatAnswer } from './ChatWindow';
+
+const chatAiServiceMocks = vi.hoisted(() => ({
+  sendAllPlaysChatAnswer: vi.fn()
+}));
+
+vi.mock('../../../lib/chatAiService', () => chatAiServiceMocks);
+
+function resolveAppSourcePath(relativePath: string) {
+  const cwd = process.cwd();
+  const appRoot = cwd.endsWith('/apps/app') || cwd.endsWith('\\apps\\app')
+    ? cwd
+    : resolve(cwd, 'apps/app');
+  return resolve(appRoot, relativePath);
+}
 
 afterEach(() => {
   cleanup();
+  vi.clearAllMocks();
 });
 
 describe('Messages Sheet native back behavior', () => {
@@ -41,5 +59,47 @@ describe('Messages Sheet native back behavior', () => {
     window.dispatchEvent(event);
 
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('Messages ALL PLAYS lazy loading', () => {
+  it('keeps the AI answer module behind the wantsAi send branch', () => {
+    const sourcePath = resolveAppSourcePath('src/pages/messages/components/ChatWindow.tsx');
+    const source = readFileSync(sourcePath, 'utf8');
+    const chatServiceImport = source.match(/import \{[\s\S]*?\} from '..\/..\/..\/lib\/chatService';/)?.[0] || '';
+    const chatServiceSource = readFileSync(resolveAppSourcePath('src/lib/chatService.ts'), 'utf8');
+    const legacyChatServiceSource = readFileSync(resolveAppSourcePath('src/lib/adapters/legacyChatService.ts'), 'utf8');
+
+    expect(chatServiceImport).not.toContain('sendAllPlaysChatAnswer');
+    expect(source).toContain("await import('../../../lib/chatAiService')");
+    expect(source.indexOf('if (result.wantsAi)')).toBeLessThan(source.indexOf('await sendLazyAllPlaysChatAnswer({'));
+    expect(chatServiceSource).not.toContain('getAI');
+    expect(chatServiceSource).not.toContain('getGenerativeModel');
+    expect(chatServiceSource).not.toContain('GoogleAIBackend');
+    expect(legacyChatServiceSource).not.toContain('firebase-ai');
+  });
+
+  it('loads and calls the AI module only through the lazy answer helper', async () => {
+    const input = {
+      teamId: 'team-1',
+      team: { id: 'team-1', name: 'Bears' },
+      user: { uid: 'user-1', email: 'coach@example.test', displayName: 'Coach Taylor', roles: ['coach'] as const },
+      question: 'who needs RSVP help?',
+      selectedConversation: { id: 'staff-conversation', participantRoles: ['staff'] },
+      selectedConversationId: 'staff-conversation',
+      selectedRecipientTarget: 'staff' as const,
+      selectedRecipientIds: ['user:coach-1']
+    };
+
+    await sendLazyAllPlaysChatAnswer(input as any);
+
+    expect(chatAiServiceMocks.sendAllPlaysChatAnswer).toHaveBeenCalledTimes(1);
+    expect(chatAiServiceMocks.sendAllPlaysChatAnswer).toHaveBeenCalledWith(expect.objectContaining({
+      teamId: 'team-1',
+      question: 'who needs RSVP help?',
+      selectedConversationId: 'staff-conversation',
+      selectedRecipientTarget: 'staff',
+      selectedRecipientIds: ['user:coach-1']
+    }));
   });
 });

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -38,7 +38,6 @@ import {
   unmuteTeamChat,
   saveTeamEmailDraft,
   saveTeamEmailTemplate,
-  sendAllPlaysChatAnswer,
   sendTeamChatMessage,
   sendTeamEmailMessage,
   toggleTeamChatReaction,
@@ -94,6 +93,7 @@ import { useViewLoadTimer } from '../../../lib/viewLoadTiming';
 import type { AuthState } from '../../../lib/types';
 import { voiceRecognition, type VoiceListenerHandle } from '../../../lib/voiceService';
 import { startInteractionTimer, UX_TIMING } from '../../../lib/uxTiming';
+import type { sendAllPlaysChatAnswer } from '../../../lib/chatAiService';
 import { useChatSheets } from '../hooks/useChatSheets';
 import { useChatTeam } from '../hooks/useChatTeam';
 import { useChatMessages } from '../hooks/useChatMessages';
@@ -163,6 +163,11 @@ const allTargetOptions: Array<{ value: ChatTargetType; label: string; descriptio
   { value: 'individuals', label: 'Selected members', description: 'Starts a direct or group conversation.' }
 ];
 const STAFF_CONVERSATION_PLACEHOLDER_ID = '__staff_conversation__';
+
+export async function sendLazyAllPlaysChatAnswer(input: Parameters<typeof sendAllPlaysChatAnswer>[0]) {
+  const chatAiService = await import('../../../lib/chatAiService');
+  return chatAiService.sendAllPlaysChatAnswer(input);
+}
 
 function createChatClientMessageId(userId: string) {
   const randomPart = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
@@ -1039,7 +1044,7 @@ export function ChatWindow({
         } else {
           setAiThinking(true);
           try {
-            await sendAllPlaysChatAnswer({
+            await sendLazyAllPlaysChatAnswer({
               teamId,
               team: request.team,
               user: request.user,

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -88,6 +88,7 @@ async function mockMessagesModules(page, options = {}) {
             deletes: [],
             reads: [],
             ai: [],
+            chatAiModuleRequests: [],
             subscriptions: []
         };
         if (speech) {
@@ -308,10 +309,6 @@ async function mockMessagesModules(page, options = {}) {
                     return { conversationId: 'team', createdConversation: null, wantsAi: input.text.includes('@ALL PLAYS') };
                 }
 
-                export async function sendAllPlaysChatAnswer(input) {
-                    window.__chatCalls.ai.push(input.question);
-                }
-
                 export async function toggleTeamChatReaction(teamId, messageId, reactionKey, userId, conversationId) {
                     window.__chatCalls.reactions.push({ teamId, messageId, reactionKey, userId, conversationId });
                     return true;
@@ -380,6 +377,25 @@ async function mockMessagesModules(page, options = {}) {
                         size: file.size || 0,
                         url: 'https://media.example.test/' + file.name
                     };
+                }
+            `
+        });
+    });
+
+    await page.route(/\/src\/lib\/chatAiService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                window.__chatCalls.chatAiModuleRequests.push(new URL(import.meta.url).pathname);
+
+                export async function sendAllPlaysChatAnswer(input) {
+                    window.__chatCalls.ai.push({
+                        question: input.question,
+                        selectedConversationId: input.selectedConversationId,
+                        selectedRecipientTarget: input.selectedRecipientTarget,
+                        selectedRecipientIds: input.selectedRecipientIds
+                    });
                 }
             `
         });
@@ -489,6 +505,17 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await expect(page.getByRole('button', { name: 'Staff only' })).toBeHidden();
     await page.getByRole('button', { name: 'Close Message audience' }).click();
 
+    await page.getByPlaceholder('Message Bears').fill('See you at practice');
+    await page.getByRole('button', { name: 'Send message' }).click();
+    await expect.poll(() => page.evaluate(() => window.__chatCalls.sends[0])).toMatchObject({
+        text: 'See you at practice',
+        selectedConversationId: 'team',
+        selectedRecipientTarget: 'full_team',
+        selectedRecipientIds: [],
+        fileCount: 0
+    });
+    await expect.poll(() => page.evaluate(() => window.__chatCalls.chatAiModuleRequests)).toEqual([]);
+
     await page.getByRole('button', { name: 'Team chat' }).click();
     const conversationsDialog = page.getByRole('dialog', { name: 'Conversations' });
     await expect(conversationsDialog).toBeVisible();
@@ -499,6 +526,14 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
 
     await expect.poll(() => page.evaluate(() => window.__chatCalls.sends)).toEqual([
         {
+            text: 'See you at practice',
+            selectedConversationId: 'team',
+            selectedConversationRoles: [],
+            selectedRecipientTarget: 'full_team',
+            selectedRecipientIds: [],
+            fileCount: 0
+        },
+        {
             text: '@ALL PLAYS who needs RSVP help?',
             selectedConversationId: 'staff-conversation',
             selectedConversationRoles: ['staff'],
@@ -507,7 +542,13 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
             fileCount: 0
         }
     ]);
-    await expect.poll(() => page.evaluate(() => window.__chatCalls.ai)).toEqual(['who needs RSVP help?']);
+    await expect.poll(() => page.evaluate(() => window.__chatCalls.chatAiModuleRequests.length)).toBe(1);
+    await expect.poll(() => page.evaluate(() => window.__chatCalls.ai)).toEqual([{
+        question: 'who needs RSVP help?',
+        selectedConversationId: 'team',
+        selectedRecipientTarget: 'full_team',
+        selectedRecipientIds: []
+    }]);
 
     await page.getByRole('button', { name: 'Add reaction' }).last().click();
     await expect(page.locator('.chat-reaction-picker-above')).toBeVisible();

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -528,7 +528,7 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
         {
             text: 'See you at practice',
             selectedConversationId: 'team',
-            selectedConversationRoles: [],
+            selectedConversationRoles: ['team'],
             selectedRecipientTarget: 'full_team',
             selectedRecipientIds: [],
             fileCount: 0
@@ -551,7 +551,7 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     }]);
 
     await page.getByRole('button', { name: 'Add reaction' }).last().click();
-    await expect(page.locator('.chat-reaction-picker-above')).toBeVisible();
+    await expect(page.locator('.chat-reaction-picker')).toBeVisible();
     await page.getByRole('button', { name: 'Like' }).click();
     await expect.poll(() => page.evaluate(() => window.__chatCalls.reactions[0])).toMatchObject({
         teamId: 'team-1',

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -386,6 +386,7 @@ describe('React app auth/profile capability parity', () => {
             readProjectFile('apps/app/src/pages/messages/components/ChatWindow.tsx')
         ].join('\n');
         const chatService = readProjectFile('apps/app/src/lib/chatService.ts');
+        const chatAiService = readProjectFile('apps/app/src/lib/chatAiService.ts');
         const chatLogic = readProjectFile('apps/app/src/lib/chatLogic.ts');
 
         expectContains(legacyTeamChat, [
@@ -424,10 +425,12 @@ describe('React app auth/profile capability parity', () => {
             'upsertChatConversation',
             'uploadTeamChatAttachment',
             'deleteUploadedChatAttachments',
-            'sendAllPlaysChatAnswer',
-            'getGenerativeModel',
             'nativeUploadChatMedia',
             'nativePostChatMessage'
+        ]);
+        expectContains(chatAiService, [
+            'sendAllPlaysChatAnswer',
+            'getGenerativeModel'
         ]);
         expectContains(chatLogic, [
             'formatChatMessageHtml',

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -136,6 +136,9 @@ vi.mock('../../apps/app/src/lib/voiceService.ts', () => ({
     voiceRecognition: voiceMocks
 }));
 vi.mock('../../apps/app/src/lib/chatService.ts', () => chatMocks);
+vi.mock('../../apps/app/src/lib/chatAiService.ts', () => ({
+    sendAllPlaysChatAnswer: chatMocks.sendAllPlaysChatAnswer
+}));
 vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({
     useShellLayout: () => layoutMocks
 }));

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -136,7 +136,7 @@ vi.mock('../../apps/app/src/lib/voiceService.ts', () => ({
     voiceRecognition: voiceMocks
 }));
 vi.mock('../../apps/app/src/lib/chatService.ts', () => chatMocks);
-vi.mock('../../apps/app/src/lib/chatAiService.ts', () => ({
+vi.mock('../../apps/app/src/lib/chatAiService', () => ({
     sendAllPlaysChatAnswer: chatMocks.sendAllPlaysChatAnswer
 }));
 vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({


### PR DESCRIPTION
Closes #3464

## What changed
- Moved ALL PLAYS assistant answer generation into `chatAiService`, behind a dynamic import from `ChatWindow`.
- Split Firebase AI bindings into `legacyChatAi` so the core chat adapter and `chatService` no longer import `firebase-ai`.
- Added regression coverage for the lazy boundary and updated the Messages smoke mock to prove normal sends do not request the AI module before an @ALL PLAYS prompt.

## Root Cause
`ChatWindow` statically imported `sendAllPlaysChatAnswer` from `chatService`, while `chatService` statically imported Firebase AI bindings from the core legacy chat adapter. That made `@legacy/vendor/firebase-ai.js` reachable during normal Messages route load even when users only read or send regular chat messages.

## Prevention / Learning
Rare AI/vendor-heavy paths should live in dedicated lazy modules. Route-level services must not import AI SDK bindings unless the route needs that path on initial render, and source-contract tests should guard that boundary.

## Regression Tests
- `npm exec --prefix apps/app -- vitest run apps/app/src/pages/messages/components/ChatWindow.test.tsx apps/app/src/lib/chatService.test.ts tests/unit/app-auth-profile-capabilities.test.js --reporter=verbose`
- `npm run --prefix apps/app typecheck`
- Attempted `npx playwright test tests/smoke/app-messages.spec.js --config=playwright.smoke.config.js --reporter=line`, but local smoke failed because no server was listening on `127.0.0.1:4173`.
- Attempted `npm run app:build`, but local build failed before bundling on missing local dependency `@tailwindcss/postcss` from `apps/app/postcss.config.js`.