### PR TITLE
Stabilize public team search loading state

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -118,6 +118,54 @@ describe('PublicTeamSearch', () => {
         expect(screen.getByRole('button', { name: 'Clear public team search' })).toBeTruthy();
     });
 
+    it('shows the submitted query in the loading copy before filtered results resolve', async () => {
+        let resolveSearch: ((value: { teams: ParentHomeTeam[]; nextCursor: unknown | null }) => void) | null = null;
+        (getPublicTeamsPage as import('vitest').Mock).mockImplementationOnce(() => new Promise((resolve) => {
+            resolveSearch = resolve;
+        }));
+        renderSearch();
+
+        const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
+        fireEvent.change(searchInput, { target: { value: 'atlanta' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
+
+        expect(screen.getByText('Loading public teams')).toBeTruthy();
+        expect(screen.getByText('Searching public teams for "atlanta".')).toBeTruthy();
+        expect(screen.queryByText('Browsing teams across all regions.')).toBeNull();
+
+        if (!resolveSearch) {
+            throw new Error('Expected public team search request to be captured before resolving it.');
+        }
+
+        (resolveSearch as (value: { teams: ParentHomeTeam[]; nextCursor: unknown | null }) => void)({ teams: [mockTeams[0]], nextCursor: null });
+        await waitFor(() => expect(screen.getByText('Atlanta United')).toBeTruthy());
+    });
+
+    it('suppresses duplicate same-query submissions while the search is loading', async () => {
+        let resolveSearch: ((value: { teams: ParentHomeTeam[]; nextCursor: unknown | null }) => void) | null = null;
+        (getPublicTeamsPage as import('vitest').Mock).mockImplementationOnce(() => new Promise((resolve) => {
+            resolveSearch = resolve;
+        }));
+        renderSearch();
+
+        const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
+        const searchButton = screen.getByRole('button', { name: 'Search public teams' });
+        fireEvent.change(searchInput, { target: { value: 'atlanta' } });
+        fireEvent.click(searchButton);
+        fireEvent.click(searchButton);
+        fireEvent.keyDown(searchInput, { key: 'Enter', code: 'Enter', charCode: 13 });
+
+        expect(getPublicTeamsPage).toHaveBeenCalledTimes(1);
+        expect(searchButton).toBeDisabled();
+
+        if (!resolveSearch) {
+            throw new Error('Expected public team search request to be captured before resolving it.');
+        }
+
+        (resolveSearch as (value: { teams: ParentHomeTeam[]; nextCursor: unknown | null }) => void)({ teams: [mockTeams[0]], nextCursor: null });
+        await waitFor(() => expect(screen.getByText('Atlanta United')).toBeTruthy());
+    });
+
     it('loads all public teams only when browse all is used and can load the next page', async () => {
         (getPublicTeamsPage as import('vitest').Mock)
             .mockResolvedValueOnce({ teams: [mockTeams[0]], nextCursor: 'cursor-2' })
@@ -322,6 +370,8 @@ describe('PublicTeamSearch', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
 
         await waitFor(() => expect(getPublicTeamsPage).toHaveBeenNthCalledWith(2, { searchText: 'atlanta', cursor: null }));
+        expect(screen.getByText('Searching public teams for "atlanta".')).toBeTruthy();
+        expect(screen.queryByText('Browsing teams across all regions.')).toBeNull();
 
         if (!resolveSearch || !resolveBrowseAll) {
             throw new Error('Expected both public team requests to be captured before resolving them.');
@@ -334,6 +384,33 @@ describe('PublicTeamSearch', () => {
         (resolveBrowseAll as (value: { teams: ParentHomeTeam[]; nextCursor: unknown | null }) => void)({ teams: [], nextCursor: null });
         await waitFor(() => expect(screen.getByText('Atlanta Fire')).toBeTruthy());
         expect(searchInput.value).toBe('atlanta');
+    });
+
+    it('clears pending filtered search state and ignores the stale response', async () => {
+        let resolveSearch: ((value: { teams: ParentHomeTeam[]; nextCursor: unknown | null }) => void) | null = null;
+        (getPublicTeamsPage as import('vitest').Mock).mockImplementationOnce(() => new Promise((resolve) => {
+            resolveSearch = resolve;
+        }));
+        renderSearch();
+
+        const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
+        fireEvent.change(searchInput, { target: { value: 'atlanta' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
+        expect(screen.getByText('Searching public teams for "atlanta".')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Clear public team search' }));
+
+        expect(searchInput.value).toBe('');
+        expect(screen.getByText('Search for public teams near you')).toBeTruthy();
+        expect(screen.queryByText('Searching public teams for "atlanta".')).toBeNull();
+
+        if (!resolveSearch) {
+            throw new Error('Expected public team search request to be captured before resolving it.');
+        }
+
+        (resolveSearch as (value: { teams: ParentHomeTeam[]; nextCursor: unknown | null }) => void)({ teams: [mockTeams[0]], nextCursor: null });
+        await waitFor(() => expect(screen.queryByText('Atlanta United')).toBeNull());
+        expect(screen.getByText('Search for public teams near you')).toBeTruthy();
     });
 
     it('can auto-browse on mount for the dedicated discovery route', async () => {

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -8,6 +8,13 @@ import { openPublicUrl } from '../lib/publicActions';
 import { getTeamWebsiteHashHref } from '../lib/teamNavigation';
 import { resolveZip } from '../lib/utils';
 
+type PendingSearchMode = 'browse' | 'search';
+
+function publicTeamRequestKey(searchText?: string | null) {
+  const trimmedSearchText = searchText?.trim();
+  return trimmedSearchText ? `search:${trimmedSearchText}` : 'browse';
+}
+
 export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = false }: { autoBrowseOnMount?: boolean; showBackLink?: boolean }) {
   const navigate = useNavigate();
   const [searchQuery, setSearchQuery] = useState<string>('');
@@ -15,28 +22,35 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
   const [activeSearchQuery, setActiveSearchQuery] = useState<string | null>(null);
+  const [pendingSearchQuery, setPendingSearchQuery] = useState<string | null>(null);
+  const [pendingMode, setPendingMode] = useState<PendingSearchMode | null>(null);
+  const [pendingRequestKey, setPendingRequestKey] = useState<string | null>(null);
   const [hasSearched, setHasSearched] = useState<boolean>(false);
   const [nextCursor, setNextCursor] = useState<unknown | null>(null);
   const autoBrowseTriggeredRef = useRef(false);
   const latestRequestIdRef = useRef(0);
 
   const fetchPublicTeams = useCallback(async ({ searchText, cursor = null, append = false }: { searchText?: string; cursor?: unknown | null; append?: boolean } = {}) => {
+    const submittedSearchText = searchText?.trim() || undefined;
     const requestId = latestRequestIdRef.current + 1;
     latestRequestIdRef.current = requestId;
 
     setLoading(true);
     if (!append) {
       setError('');
+      setPendingSearchQuery(submittedSearchText || null);
+      setPendingMode(submittedSearchText ? 'search' : 'browse');
+      setPendingRequestKey(publicTeamRequestKey(submittedSearchText));
     }
     setHasSearched(true);
     try {
-      const result = await getPublicTeamsPage({ searchText, cursor });
+      const result = await getPublicTeamsPage({ searchText: submittedSearchText, cursor });
       if (requestId !== latestRequestIdRef.current) {
         return;
       }
       setPublicTeams((current) => append ? [...current, ...result.teams] : result.teams);
       setNextCursor(result.nextCursor);
-      setActiveSearchQuery(searchText || null);
+      setActiveSearchQuery(submittedSearchText || null);
     } catch (err: any) {
       if (requestId !== latestRequestIdRef.current) {
         return;
@@ -49,6 +63,9 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
     } finally {
       if (requestId === latestRequestIdRef.current) {
         setLoading(false);
+        setPendingSearchQuery(null);
+        setPendingMode(null);
+        setPendingRequestKey(null);
       }
     }
   }, []);
@@ -56,6 +73,9 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
   const handleSearch = () => {
     const trimmedQuery = searchQuery.trim();
     if (!trimmedQuery) {
+      return;
+    }
+    if (loading && pendingRequestKey === publicTeamRequestKey(trimmedQuery)) {
       return;
     }
 
@@ -72,11 +92,16 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
   };
 
   const handleClear = () => {
+    latestRequestIdRef.current += 1;
     setSearchQuery('');
     setPublicTeams([]);
     setError('');
     setActiveSearchQuery(null);
+    setPendingSearchQuery(null);
+    setPendingMode(null);
+    setPendingRequestKey(null);
     setHasSearched(false);
+    setLoading(false);
     setNextCursor(null);
   };
 
@@ -112,6 +137,12 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
     return groups;
   }, [publicTeams]);
 
+  const trimmedSearchQuery = searchQuery.trim();
+  const isDuplicatePendingSearch = loading && Boolean(trimmedSearchQuery) && pendingRequestKey === publicTeamRequestKey(trimmedSearchQuery);
+  const loadingStatusCopy = pendingMode === 'search' && pendingSearchQuery
+    ? `Searching public teams for "${pendingSearchQuery}".`
+    : 'Browsing teams across all regions.';
+
   return (
     <section className="app-card p-3 sm:p-4 space-y-4">
       <div className="flex items-center justify-between gap-3">
@@ -145,7 +176,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
           type="button"
           className="primary-button !min-h-10 !px-3 text-sm"
           onClick={handleSearch}
-          disabled={loading && !searchQuery.trim()}
+          disabled={loading && (!trimmedSearchQuery || isDuplicatePendingSearch)}
           aria-label="Search public teams"
         >
           {loading ? (
@@ -155,12 +186,11 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
           )}
           <span className="hidden sm:inline">Search</span>
         </button>
-        {searchQuery || activeSearchQuery ? (
+        {searchQuery || activeSearchQuery || pendingSearchQuery ? (
           <button
             type="button"
             className="ghost-button !min-h-10 !px-3 text-sm"
             onClick={handleClear}
-            disabled={loading}
             aria-label="Clear public team search"
           >
             <XCircle className="h-4 w-4" aria-hidden="true" />
@@ -187,7 +217,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
         <div className="app-card p-6 text-center">
           <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
           <div className="mt-3 text-sm font-black text-gray-900">Loading public teams</div>
-          <div className="mt-1 text-xs font-semibold text-gray-500">{activeSearchQuery ? `Searching public teams for "${activeSearchQuery}".` : 'Browsing teams across all regions.'}</div>
+          <div className="mt-1 text-xs font-semibold text-gray-500">{loadingStatusCopy}</div>
         </div>
       ) : error ? (
         <Status tone="error" message={error} />

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -453,10 +453,11 @@ async function mockTeamsModules(page, { scenario = '' } = {}) {
     });
 }
 
-async function mockPublicTeamsBrowseModule(page) {
-    await page.addInitScript(() => {
+async function mockPublicTeamsBrowseModule(page, { slowSearch = false } = {}) {
+    await page.addInitScript(({ shouldSlowSearch }) => {
         window.__publicTeamSearchCalls = [];
-    });
+        window.__slowPublicTeamSearch = shouldSlowSearch;
+    }, { shouldSlowSearch: slowSearch });
 
     await page.route(/\/src\/lib\/publicTeamsService\.ts(\?.*)?$/, async (route) => {
         await route.fulfill({
@@ -518,6 +519,9 @@ async function mockPublicTeamsBrowseModule(page) {
 
                 export async function getPublicTeamsPage({ searchText, cursor = null } = {}) {
                     window.__publicTeamSearchCalls.push({ searchText, cursor });
+                    if (searchText === 'atlanta' && cursor === null && window.__slowPublicTeamSearch) {
+                        await new Promise((resolve) => setTimeout(resolve, 1000));
+                    }
                     if (searchText === 'atlanta' && cursor === null) {
                         return { teams: firstPage, nextCursor: 'search-page-2' };
                     }
@@ -600,7 +604,7 @@ test.describe('mobile My Teams', () => {
 
     test('browse teams paginates searched results on mobile without clearing the query', async ({ page, baseURL }) => {
         await mockTeamsModules(page, { scenario: 'empty' });
-        await mockPublicTeamsBrowseModule(page);
+        await mockPublicTeamsBrowseModule(page, { slowSearch: true });
         await page.goto(appUrl(baseURL, '/teams/browse'), { waitUntil: 'domcontentloaded' });
 
         await expect(page.getByRole('heading', { name: 'Discover Public Teams' })).toBeVisible();
@@ -608,6 +612,9 @@ test.describe('mobile My Teams', () => {
         await searchInput.fill('atlanta');
         await page.getByRole('button', { name: 'Search public teams' }).click();
 
+        await expect(page.getByText('Searching public teams for "atlanta".')).toBeVisible();
+        await expect(page.getByText('Browsing teams across all regions.')).toHaveCount(0);
+        await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
         await expect(page.getByText('Atlanta Fire')).toBeVisible();
         await expect(page.getByRole('button', { name: 'Load more teams' })).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__publicTeamSearchCalls.at(-1))).toEqual({ searchText: 'atlanta', cursor: null });


### PR DESCRIPTION
Closes #3448

## What changed
- Added explicit pending public-team search state and request keys so loading copy reflects the submitted query before results resolve.
- Suppressed duplicate same-query Search submissions while allowing a changed query to supersede an in-flight browse/search.
- Made Clear reset pending state and invalidate stale in-flight responses.
- Added component regression coverage plus a focused mobile smoke assertion for slow public-team search loading copy and overflow.

## Root Cause
PublicTeamSearch used activeSearchQuery, which represents the last completed result set, to render in-flight loading copy. The component also had no submitted request key, so a non-empty query stayed tappable during loading and could enqueue duplicate same-query requests.

## Prevention / Learning
For async search UI, keep in-flight submission state separate from completed result state. Key requests by submitted intent so loading labels, duplicate suppression, Clear, and stale-response handling all use the same request identity.

## Regression Tests
- `npm run test:ci -- PublicTeamSearch.test.tsx` passed: 17 tests.
- Added deferred-promise coverage for filtered loading copy before resolution.
- Added duplicate same-query submit suppression coverage.
- Extended auto-browse supersession coverage to assert the typed query pending state while browse-all is unresolved.
- Added Clear coverage to ensure pending state resets and stale responses are ignored.
- Extended `tests/smoke/app-teams.spec.js` for mobile slow-search loading copy and no horizontal overflow.

Smoke note: the focused Playwright smoke command was attempted, but the local app dev server fails before React mounts because this workspace cannot resolve `@tailwindcss/postcss` from `apps/app/postcss.config.js`.