### PR TITLE
[codex] Improve app alert notifications

### DIFF
--- a/apps/app/src/lib/firebaseAuthRuntime.test.ts
+++ b/apps/app/src/lib/firebaseAuthRuntime.test.ts
@@ -1,19 +1,26 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const legacySdkMock = vi.hoisted(() => {
-  const resolvedConfig = { projectId: 'primary-project' };
+const firebaseAuthSdk = vi.hoisted(() => {
+  const resolvedConfig = {
+    apiKey: 'api-key',
+    authDomain: 'example.firebaseapp.com',
+    projectId: 'example',
+    messagingSenderId: 'sender',
+    appId: 'app-id'
+  };
+
   return {
     resolvedConfig,
     applyActionCode: vi.fn(),
     confirmPasswordReset: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),
-    getApps: vi.fn<() => Array<{ name: string }>>(() => []),
-    getAuth: vi.fn((app: unknown) => ({ app })),
+    getApps: vi.fn<() => Array<{ name?: string }>>(() => []),
+    getAuth: vi.fn((app: unknown) => ({ app, auth: true })),
     getRedirectResult: vi.fn(),
     GoogleAuthProvider: class {},
-    indexedDBLocalPersistence: {},
-    initializeApp: vi.fn(() => ({ name: '[DEFAULT]', initialized: true })),
+    indexedDBLocalPersistence: { type: 'indexedDBLocalPersistence' },
+    initializeApp: vi.fn(() => ({ name: '[DEFAULT]', created: true })),
     initializeAuth: vi.fn(),
     isSignInWithEmailLink: vi.fn(),
     onAuthStateChanged: vi.fn(),
@@ -30,33 +37,44 @@ const legacySdkMock = vi.hoisted(() => {
   };
 });
 
-vi.mock('./adapters/legacyFirebaseAuthSdk', () => legacySdkMock);
+vi.mock('./adapters/legacyFirebaseAuthSdk', () => firebaseAuthSdk);
+
+vi.mock('./logger', () => ({
+  createLogger: vi.fn(() => ({
+    warn: vi.fn()
+  }))
+}));
 
 describe('firebaseAuthRuntime', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    firebaseAuthSdk.getApps.mockReturnValue([]);
+    firebaseAuthSdk.initializeApp.mockReturnValue({ name: '[DEFAULT]', created: true });
+    firebaseAuthSdk.getAuth.mockImplementation((app: unknown) => ({ app, auth: true }));
+    firebaseAuthSdk.resolvePrimaryFirebaseConfig.mockResolvedValue(firebaseAuthSdk.resolvedConfig);
   });
 
   it('initializes the default app when only named apps are registered', async () => {
     // The image-upload project registers a named app while the primary config
-    // fetch is still awaiting. getApp() on a registry with no '[DEFAULT]' app
-    // throws app/no-app and killed the whole module graph (blank screen).
-    legacySdkMock.getApps.mockReturnValue([{ name: 'game-flow-img' }]);
+    // fetch is still awaiting. Only reuse '[DEFAULT]' so named apps cannot
+    // break the auth runtime during startup.
+    firebaseAuthSdk.getApps.mockReturnValue([{ name: 'game-flow-img' }]);
 
-    await import('./firebaseAuthRuntime');
+    const runtime = await import('./firebaseAuthRuntime');
 
-    expect(legacySdkMock.initializeApp).toHaveBeenCalledWith(legacySdkMock.resolvedConfig);
-    expect(legacySdkMock.getAuth).toHaveBeenCalledWith({ name: '[DEFAULT]', initialized: true });
+    expect(firebaseAuthSdk.initializeApp).toHaveBeenCalledWith(firebaseAuthSdk.resolvedConfig);
+    expect(firebaseAuthSdk.getAuth).toHaveBeenCalledWith({ name: '[DEFAULT]', created: true });
+    expect(runtime.auth).toEqual({ app: { name: '[DEFAULT]', created: true }, auth: true });
   });
 
   it('reuses an existing default app', async () => {
-    const defaultApp = { name: '[DEFAULT]' };
-    legacySdkMock.getApps.mockReturnValue([{ name: 'game-flow-img' }, defaultApp]);
+    const existingDefaultApp = { name: '[DEFAULT]' };
+    firebaseAuthSdk.getApps.mockReturnValue([{ name: 'game-flow-img' }, existingDefaultApp]);
 
     await import('./firebaseAuthRuntime');
 
-    expect(legacySdkMock.initializeApp).not.toHaveBeenCalled();
-    expect(legacySdkMock.getAuth).toHaveBeenCalledWith(defaultApp);
+    expect(firebaseAuthSdk.initializeApp).not.toHaveBeenCalled();
+    expect(firebaseAuthSdk.getAuth).toHaveBeenCalledWith(existingDefaultApp);
   });
 });

--- a/apps/app/src/lib/pushService.test.ts
+++ b/apps/app/src/lib/pushService.test.ts
@@ -20,6 +20,7 @@ const profileServiceMocks = {
 };
 
 const legacyPushMocks = {
+    canUsePushNotifications: vi.fn(),
     registerPushNotifications: vi.fn()
 };
 
@@ -68,6 +69,7 @@ describe('pushService permission states', () => {
         firebaseMessagingMocks.checkPermissions.mockResolvedValue({ receive: 'prompt' });
         firebaseMessagingMocks.requestPermissions.mockResolvedValue({ receive: 'prompt' });
         profileServiceMocks.saveNotificationDeviceToken.mockResolvedValue(undefined);
+        legacyPushMocks.canUsePushNotifications.mockResolvedValue(true);
         legacyPushMocks.registerPushNotifications.mockResolvedValue({ token: 'web-token' });
         vi.doMock('@capacitor/core', () => ({
             Capacitor: capacitorState
@@ -231,6 +233,30 @@ describe('pushService permission states', () => {
             canPrompt: false,
             canOpenSettings: false
         });
+    });
+
+    it('maps Firebase Messaging unsupported web browsers to unsupported state before prompting', async () => {
+        capacitorState.isNativePlatform.mockReturnValue(false);
+        capacitorState.getPlatform.mockReturnValue('web');
+        setWebPushSupport('default');
+        legacyPushMocks.canUsePushNotifications.mockResolvedValue(false);
+        const { enablePushNotificationsForUser, getPushNotificationPermissionStatus } = await loadPushService();
+
+        await expect(getPushNotificationPermissionStatus()).resolves.toEqual({
+            state: 'unsupported',
+            isNative: false,
+            platform: 'web',
+            canPrompt: false,
+            canOpenSettings: false
+        });
+        await expect(enablePushNotificationsForUser('user-1')).rejects.toMatchObject({
+            code: 'push-unsupported',
+            permissionStatus: {
+                state: 'unsupported',
+                platform: 'web'
+            }
+        });
+        expect(legacyPushMocks.registerPushNotifications).not.toHaveBeenCalled();
     });
 
     it('registers web push with the configured VAPID key', async () => {

--- a/apps/app/src/lib/pushService.test.ts
+++ b/apps/app/src/lib/pushService.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const capacitorState = {
     isNativePlatform: vi.fn(),
@@ -19,6 +19,10 @@ const profileServiceMocks = {
     saveNotificationDeviceToken: vi.fn()
 };
 
+const legacyPushMocks = {
+    registerPushNotifications: vi.fn()
+};
+
 const locationAssignMock = vi.fn();
 let localStorageEntries: Map<string, string>;
 
@@ -26,10 +30,35 @@ async function loadPushService() {
     return await import('./pushService');
 }
 
+function setWebPushSupport(permission: NotificationPermission = 'default') {
+    Object.defineProperty(window, 'PushManager', {
+        configurable: true,
+        value: function PushManager() {}
+    });
+    Object.defineProperty(navigator, 'serviceWorker', {
+        configurable: true,
+        value: {}
+    });
+    Object.defineProperty(window, 'Notification', {
+        configurable: true,
+        value: {
+            permission,
+            requestPermission: vi.fn(async () => permission)
+        }
+    });
+}
+
+function clearWebPushSupport() {
+    Reflect.deleteProperty(window, 'PushManager');
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+    Reflect.deleteProperty(window, 'Notification');
+}
+
 describe('pushService permission states', () => {
     beforeEach(() => {
         vi.resetModules();
         vi.clearAllMocks();
+        vi.stubEnv('VITE_ALLPLAYS_FCM_VAPID_KEY', 'test-vapid-key');
         capacitorState.isNativePlatform.mockReturnValue(true);
         capacitorState.getPlatform.mockReturnValue('ios');
         firebaseMessagingMocks.isSupported.mockResolvedValue({ isSupported: true });
@@ -39,6 +68,7 @@ describe('pushService permission states', () => {
         firebaseMessagingMocks.checkPermissions.mockResolvedValue({ receive: 'prompt' });
         firebaseMessagingMocks.requestPermissions.mockResolvedValue({ receive: 'prompt' });
         profileServiceMocks.saveNotificationDeviceToken.mockResolvedValue(undefined);
+        legacyPushMocks.registerPushNotifications.mockResolvedValue({ token: 'web-token' });
         vi.doMock('@capacitor/core', () => ({
             Capacitor: capacitorState
         }));
@@ -50,6 +80,7 @@ describe('pushService permission states', () => {
             rememberPendingPushRoute: vi.fn(),
             resolvePushNotificationRoute: vi.fn()
         }));
+        vi.doMock('@legacy/push-notifications.js', () => legacyPushMocks);
         Object.defineProperty(window, 'location', {
             configurable: true,
             value: {
@@ -73,6 +104,11 @@ describe('pushService permission states', () => {
                 })
             }
         });
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        clearWebPushSupport();
     });
 
     it('maps granted native permissions to enabled state', async () => {
@@ -140,9 +176,52 @@ describe('pushService permission states', () => {
         });
     });
 
-    it('maps non-native shells to unsupported state for settings recovery UI', async () => {
+    it('maps web default permissions to prompt state for browser registration', async () => {
         capacitorState.isNativePlatform.mockReturnValue(false);
         capacitorState.getPlatform.mockReturnValue('web');
+        setWebPushSupport('default');
+        const { getPushNotificationPermissionStatus } = await loadPushService();
+
+        await expect(getPushNotificationPermissionStatus()).resolves.toEqual({
+            state: 'prompt',
+            isNative: false,
+            platform: 'web',
+            canPrompt: true,
+            canOpenSettings: false
+        });
+    });
+
+    it('maps granted and denied web permissions without opening device settings', async () => {
+        capacitorState.isNativePlatform.mockReturnValue(false);
+        capacitorState.getPlatform.mockReturnValue('web');
+        setWebPushSupport('granted');
+        let service = await loadPushService();
+
+        await expect(service.getPushNotificationPermissionStatus()).resolves.toEqual({
+            state: 'enabled',
+            isNative: false,
+            platform: 'web',
+            canPrompt: false,
+            canOpenSettings: false
+        });
+
+        vi.resetModules();
+        setWebPushSupport('denied');
+        service = await loadPushService();
+
+        await expect(service.getPushNotificationPermissionStatus()).resolves.toEqual({
+            state: 'blocked',
+            isNative: false,
+            platform: 'web',
+            canPrompt: false,
+            canOpenSettings: false
+        });
+    });
+
+    it('maps unsupported web browsers to unsupported state', async () => {
+        capacitorState.isNativePlatform.mockReturnValue(false);
+        capacitorState.getPlatform.mockReturnValue('web');
+        clearWebPushSupport();
         const { getPushNotificationPermissionStatus } = await loadPushService();
 
         await expect(getPushNotificationPermissionStatus()).resolves.toEqual({
@@ -151,6 +230,45 @@ describe('pushService permission states', () => {
             platform: 'web',
             canPrompt: false,
             canOpenSettings: false
+        });
+    });
+
+    it('registers web push with the configured VAPID key', async () => {
+        capacitorState.isNativePlatform.mockReturnValue(false);
+        capacitorState.getPlatform.mockReturnValue('web');
+        setWebPushSupport('default');
+        const { enablePushNotificationsForUser } = await loadPushService();
+
+        await expect(enablePushNotificationsForUser('user-1')).resolves.toEqual({
+            token: 'web-token',
+            platform: 'web'
+        });
+
+        expect(legacyPushMocks.registerPushNotifications).toHaveBeenCalledWith({ vapidKey: 'test-vapid-key' });
+        expect(profileServiceMocks.saveNotificationDeviceToken).toHaveBeenCalledWith('user-1', {
+            token: 'web-token',
+            platform: 'web',
+            userAgent: navigator.userAgent || ''
+        });
+    });
+
+    it('throws a blocked permission error when the browser prompt is denied', async () => {
+        capacitorState.isNativePlatform.mockReturnValue(false);
+        capacitorState.getPlatform.mockReturnValue('web');
+        setWebPushSupport('default');
+        legacyPushMocks.registerPushNotifications.mockImplementation(async () => {
+            setWebPushSupport('denied');
+            throw new Error('Notification permission was not granted.');
+        });
+        const { enablePushNotificationsForUser } = await loadPushService();
+
+        await expect(enablePushNotificationsForUser('user-1')).rejects.toMatchObject({
+            code: 'push-permission-blocked',
+            permissionStatus: {
+                state: 'blocked',
+                platform: 'web',
+                canOpenSettings: false
+            }
         });
     });
 

--- a/apps/app/src/lib/pushService.ts
+++ b/apps/app/src/lib/pushService.ts
@@ -140,7 +140,7 @@ export async function enablePushNotificationsForUser(userId: string): Promise<Pu
   }
 
   if (!Capacitor.isNativePlatform()) {
-    const permissionStatus = getWebPushPermissionStatus();
+    const permissionStatus = await getWebPushPermissionStatus();
     if (permissionStatus.state === 'unsupported') {
       throw new PushPermissionError('Push notifications are not supported in this browser.', 'push-unsupported', permissionStatus);
     }
@@ -153,7 +153,7 @@ export async function enablePushNotificationsForUser(userId: string): Promise<Pu
     try {
       ({ token } = await registerPushNotifications(webPushVapidKey ? { vapidKey: webPushVapidKey } : {}));
     } catch (error) {
-      const statusAfterAttempt = getWebPushPermissionStatus();
+      const statusAfterAttempt = await getWebPushPermissionStatus();
       if (statusAfterAttempt.state === 'blocked') {
         throw new PushPermissionError(webPushBlockedMessage, 'push-permission-blocked', statusAfterAttempt);
       }
@@ -249,7 +249,7 @@ export async function runPushNotificationPrimer(
 
 export async function getPushNotificationPermissionStatus(): Promise<PushNotificationPermissionStatus> {
   if (!Capacitor.isNativePlatform()) {
-    return getWebPushPermissionStatus();
+    return await getWebPushPermissionStatus();
   }
 
   const platform = Capacitor.getPlatform();
@@ -303,8 +303,13 @@ function isWebPushSupported(): boolean {
     && 'PushManager' in window;
 }
 
-function getWebPushPermissionStatus(): PushNotificationPermissionStatus {
+async function getWebPushPermissionStatus(): Promise<PushNotificationPermissionStatus> {
   if (!isWebPushSupported()) {
+    return buildPushPermissionStatus('unsupported', 'web');
+  }
+  const { canUsePushNotifications } = await import('@legacy/push-notifications.js');
+  const firebaseMessagingSupported = await canUsePushNotifications();
+  if (!firebaseMessagingSupported) {
     return buildPushPermissionStatus('unsupported', 'web');
   }
   if (Notification.permission === 'granted') {

--- a/apps/app/src/lib/pushService.ts
+++ b/apps/app/src/lib/pushService.ts
@@ -50,6 +50,8 @@ type PushRegistrationResult = {
 };
 
 const nativePushTimeoutMs = 15000;
+const webPushVapidKey = String(import.meta.env?.VITE_ALLPLAYS_FCM_VAPID_KEY || '').trim();
+const webPushBlockedMessage = 'Notifications are blocked for this site in your browser. Allow notifications in your browser site settings, then try again.';
 const iosNotificationSettingsUrl = 'app-settings:';
 const androidNotificationSettingsUrl = 'intent:#Intent;action=android.settings.APP_NOTIFICATION_SETTINGS;S.extra_app_package=ai.allplays.lite;end';
 const androidAppSettingsUrl = 'app-settings:';
@@ -138,8 +140,25 @@ export async function enablePushNotificationsForUser(userId: string): Promise<Pu
   }
 
   if (!Capacitor.isNativePlatform()) {
+    const permissionStatus = getWebPushPermissionStatus();
+    if (permissionStatus.state === 'unsupported') {
+      throw new PushPermissionError('Push notifications are not supported in this browser.', 'push-unsupported', permissionStatus);
+    }
+    if (permissionStatus.state === 'blocked') {
+      throw new PushPermissionError(webPushBlockedMessage, 'push-permission-blocked', permissionStatus);
+    }
+
     const { registerPushNotifications } = await import('@legacy/push-notifications.js');
-    const { token } = await registerPushNotifications();
+    let token = '';
+    try {
+      ({ token } = await registerPushNotifications(webPushVapidKey ? { vapidKey: webPushVapidKey } : {}));
+    } catch (error) {
+      const statusAfterAttempt = getWebPushPermissionStatus();
+      if (statusAfterAttempt.state === 'blocked') {
+        throw new PushPermissionError(webPushBlockedMessage, 'push-permission-blocked', statusAfterAttempt);
+      }
+      throw error;
+    }
     await saveNotificationDeviceToken(userId, {
       token,
       platform: 'web',
@@ -230,7 +249,7 @@ export async function runPushNotificationPrimer(
 
 export async function getPushNotificationPermissionStatus(): Promise<PushNotificationPermissionStatus> {
   if (!Capacitor.isNativePlatform()) {
-    return buildPushPermissionStatus('unsupported', 'web');
+    return getWebPushPermissionStatus();
   }
 
   const platform = Capacitor.getPlatform();
@@ -271,8 +290,30 @@ function buildPushPermissionStatus(state: PushNotificationPermissionState, platf
     isNative: platform !== 'web',
     platform,
     canPrompt: state === 'prompt',
-    canOpenSettings: state === 'blocked'
+    canOpenSettings: state === 'blocked' && platform !== 'web'
   };
+}
+
+function isWebPushSupported(): boolean {
+  return typeof window !== 'undefined'
+    && window.isSecureContext !== false
+    && typeof Notification !== 'undefined'
+    && typeof navigator !== 'undefined'
+    && 'serviceWorker' in navigator
+    && 'PushManager' in window;
+}
+
+function getWebPushPermissionStatus(): PushNotificationPermissionStatus {
+  if (!isWebPushSupported()) {
+    return buildPushPermissionStatus('unsupported', 'web');
+  }
+  if (Notification.permission === 'granted') {
+    return buildPushPermissionStatus('enabled', 'web');
+  }
+  if (Notification.permission === 'denied') {
+    return buildPushPermissionStatus('blocked', 'web');
+  }
+  return buildPushPermissionStatus('prompt', 'web');
 }
 
 function getPushNotificationPrimerCopy(context: PushNotificationPrimerContext): PushNotificationPrimerCopy {

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -48,7 +48,7 @@ const pushServiceMocks = vi.hoisted(() => ({
     canOpenSettings: false
   })),
   openPushNotificationSettings: vi.fn(async () => undefined),
-  runPushNotificationPrimer: vi.fn(async () => ({ completed: false, status: 'skipped' }))
+  runPushNotificationPrimer: vi.fn(async () => true)
 }));
 
 vi.mock('../lib/authService', () => authServiceMocks);
@@ -141,6 +141,16 @@ function createDeferredPromise<T>() {
 describe('Profile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([{ id: 'team-1', name: 'Blue Team' }]);
+    pushServiceMocks.getPushNotificationPermissionStatus.mockResolvedValue({
+      state: 'prompt',
+      isNative: false,
+      platform: 'web',
+      canPrompt: true,
+      canOpenSettings: false
+    });
+    pushServiceMocks.runPushNotificationPrimer.mockResolvedValue(true);
     Object.defineProperty(window, 'scrollTo', {
       value: vi.fn(),
       writable: true
@@ -209,6 +219,41 @@ describe('Profile', () => {
     await waitFor(() => {
       expect(screen.queryByText('Loading alerts for Blue Team…')).toBeNull();
     });
+  });
+
+  it('shows browser-specific recovery when web notifications are blocked', async () => {
+    pushServiceMocks.getPushNotificationPermissionStatus.mockResolvedValue({
+      state: 'blocked',
+      isNative: false,
+      platform: 'web',
+      canPrompt: false,
+      canOpenSettings: false
+    });
+
+    renderProfile('/profile?section=alerts');
+
+    expect(await screen.findByText('Notifications are blocked in this browser')).toBeTruthy();
+    expect(screen.getByText('Notifications are blocked in this browser. Allow notifications in site settings, then check again.')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Check browser settings again' }).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Open device settings' })).toBeNull();
+  });
+
+  it('enables web game-day alerts through push registration and preference save', async () => {
+    renderProfile('/profile?section=alerts');
+
+    expect(await screen.findByLabelText('Live Score')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Turn on game-day alerts' }));
+
+    await waitFor(() => {
+      expect(pushServiceMocks.runPushNotificationPrimer).toHaveBeenCalledWith('game_day_alerts');
+      expect(pushServiceMocks.enablePushNotificationsForUser).toHaveBeenCalledWith('user-1');
+      expect(profileServiceMocks.saveNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1', expect.objectContaining({
+        liveScore: true,
+        schedule: true
+      }));
+    });
+    expect(await screen.findByText('Game-day alerts are on for this team.')).toBeTruthy();
   });
 
   it('ignores stale initial alert preferences after switching teams mid-load', async () => {

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -180,9 +180,10 @@ export function Profile({ auth }: { auth: AuthState }) {
   const selectedTeamPreferencesHydrated = Boolean(selectedTeamId) && Object.prototype.hasOwnProperty.call(notificationPreferencesByTeamId, selectedTeamId);
   const selectedTeamPreferencesError = selectedTeamId ? notificationPreferenceErrorsByTeamId[selectedTeamId] || '' : '';
   const selectedTeamPreferencesLoading = alertsReady && Boolean(selectedTeamId) && !selectedTeamPreferencesHydrated && !selectedTeamPreferencesError;
-  const nativePushEnabled = isNative && pushPermissionStatus?.state === 'enabled';
-  const nativePushBlocked = isNative && pushPermissionStatus?.state === 'blocked';
-  const nativePushUnsupported = isNative && pushPermissionStatus?.state === 'unsupported';
+  const pushEnabled = pushPermissionStatus?.state === 'enabled';
+  const pushBlocked = pushPermissionStatus?.state === 'blocked';
+  const pushUnsupported = pushPermissionStatus?.state === 'unsupported';
+  const pushBlockedInBrowser = pushBlocked && !pushPermissionStatus?.canOpenSettings;
   const profileSectionRoute = getProfileSectionRoute(activeProfileSection);
   const profileSectionReady = !loading && (
     activeProfileSection === 'alerts'
@@ -239,7 +240,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   }, []);
 
   const refreshPushPermissionStatus = useCallback(async (options: { silent?: boolean } = {}) => {
-    if (!isNative || activeProfileSection !== 'alerts') {
+    if (activeProfileSection !== 'alerts') {
       setPushPermissionStatus(null);
       setPushPermissionLoading(false);
       return null;
@@ -257,8 +258,8 @@ export function Profile({ auth }: { auth: AuthState }) {
       logger.warn('Unable to load push permission state.', { error });
       setPushPermissionStatus({
         state: 'unsupported',
-        isNative: true,
-        platform: 'native',
+        isNative,
+        platform: isNative ? 'native' : 'web',
         canPrompt: false,
         canOpenSettings: false
       });
@@ -409,7 +410,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   }, [refreshPushPermissionStatus]);
 
   useEffect(() => {
-    if (!isNative || activeProfileSection !== 'alerts') {
+    if (activeProfileSection !== 'alerts') {
       return;
     }
 
@@ -427,7 +428,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       window.removeEventListener('focus', refreshOnReturn);
       document.removeEventListener('visibilitychange', refreshOnReturn);
     };
-  }, [activeProfileSection, isNative, refreshPushPermissionStatus]);
+  }, [activeProfileSection, refreshPushPermissionStatus]);
 
   useEffect(() => {
     let cancelled = false;
@@ -929,12 +930,22 @@ export function Profile({ auth }: { auth: AuthState }) {
     setNotificationStatus(null);
 
     try {
-      const currentPermissionStatus = isNative
-        ? (pushPermissionStatus || await getPushNotificationPermissionStatus())
-        : null;
+      const currentPermissionStatus = pushPermissionStatus || await getPushNotificationPermissionStatus();
 
-      if (currentPermissionStatus) {
-        setPushPermissionStatus(currentPermissionStatus);
+      setPushPermissionStatus(currentPermissionStatus);
+
+      if (currentPermissionStatus.state === 'blocked') {
+        if (currentPermissionStatus.canOpenSettings) {
+          await openDeviceSettingsForPush();
+        } else {
+          setNotificationStatus({ message: 'Notifications are blocked in this browser. Allow notifications in site settings, then check again.', tone: 'error' });
+        }
+        return;
+      }
+
+      if (currentPermissionStatus.state === 'unsupported') {
+        setNotificationStatus({ message: 'Push notifications are not supported in this browser or device.', tone: 'error' });
+        return;
       }
 
       if (!(await confirmPushPrimer('profile_device_push', currentPermissionStatus))) {
@@ -985,21 +996,21 @@ export function Profile({ auth }: { auth: AuthState }) {
     setNotificationStatus(null);
 
     try {
-      const currentPermissionStatus = isNative
-        ? (pushPermissionStatus || await getPushNotificationPermissionStatus())
-        : null;
+      const currentPermissionStatus = pushPermissionStatus || await getPushNotificationPermissionStatus();
 
-      if (currentPermissionStatus) {
-        setPushPermissionStatus(currentPermissionStatus);
-      }
+      setPushPermissionStatus(currentPermissionStatus);
 
       if (currentPermissionStatus?.state === 'blocked') {
-        await openDeviceSettingsForPush('Notifications are turned off in device settings. Open device settings to finish turning on game-day alerts.');
+        if (currentPermissionStatus.canOpenSettings) {
+          await openDeviceSettingsForPush('Notifications are turned off in device settings. Open device settings to finish turning on game-day alerts.');
+        } else {
+          setNotificationStatus({ message: 'Notifications are blocked in this browser. Allow notifications in site settings, then check again.', tone: 'error' });
+        }
         return;
       }
 
       if (currentPermissionStatus?.state === 'unsupported') {
-        setNotificationStatus({ message: 'Push notifications are not supported on this device.', tone: 'error' });
+        setNotificationStatus({ message: 'Push notifications are not supported in this browser or device.', tone: 'error' });
         return;
       }
 
@@ -1417,19 +1428,31 @@ export function Profile({ auth }: { auth: AuthState }) {
                   ))}
                 </select>
               </label>
-              {isNative ? <NativePushPermissionCard permissionStatus={pushPermissionStatus} loading={pushPermissionLoading} onOpenSettings={openDeviceSettingsForPush} onRefresh={() => void refreshPushPermissionStatus()} /> : null}
+              <PushPermissionCard
+                permissionStatus={pushPermissionStatus}
+                loading={pushPermissionLoading}
+                onOpenSettings={openDeviceSettingsForPush}
+                onRefresh={() => void refreshPushPermissionStatus()}
+              />
               <div className="rounded-2xl border border-gray-200 bg-white p-3">
                 <div className="text-sm font-black text-gray-900">Device push</div>
                 <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">
-                  {nativePushEnabled
+                  {pushEnabled
                     ? 'Notifications are already allowed on this device. Refresh registration if this device recently changed accounts.'
-                    : nativePushBlocked
-                      ? 'Notifications are turned off in device settings. Open settings to re-enable them for ALL PLAYS.'
-                      : nativePushUnsupported
-                        ? 'This device does not support push notifications in the native shell.'
+                    : pushBlockedInBrowser
+                      ? 'Notifications are blocked in this browser. Allow notifications in site settings, then check again.'
+                      : pushBlocked
+                        ? 'Notifications are turned off in device settings. Open settings to re-enable them for ALL PLAYS.'
+                        : pushUnsupported
+                          ? 'This browser or device does not support push notifications.'
                         : 'Register this device for push notifications without changing team alert preferences.'}
                 </p>
-                {nativePushUnsupported ? null : nativePushBlocked ? (
+                {pushUnsupported ? null : pushBlockedInBrowser ? (
+                  <button type="button" className="secondary-button mt-3" onClick={() => void refreshPushPermissionStatus()}>
+                    <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                    Check browser settings again
+                  </button>
+                ) : pushBlocked ? (
                   <button type="button" className="secondary-button mt-3" onClick={() => void openDeviceSettingsForPush()}>
                     <Upload className="h-4 w-4" aria-hidden="true" />
                     Open device settings
@@ -1437,20 +1460,31 @@ export function Profile({ auth }: { auth: AuthState }) {
                 ) : (
                   <button type="button" className="secondary-button mt-3" onClick={enablePushOnDevice} disabled={busy === 'push-device' || !user}>
                     {busy === 'push-device' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Upload className="h-4 w-4" aria-hidden="true" />}
-                    {nativePushEnabled ? 'Refresh push registration' : 'Enable push on this device'}
+                    {pushEnabled ? 'Refresh push registration' : 'Enable push on this device'}
                   </button>
                 )}
               </div>
               <div className="rounded-2xl border border-primary-100 bg-primary-50 p-3">
                 <div className="text-sm font-black text-primary-900">Game-day alerts</div>
                 <p className="mt-1 text-sm font-semibold leading-6 text-primary-800">
-                  {nativePushBlocked
-                    ? 'Notifications are blocked in device settings. Open settings, allow notifications, then return here to finish game-day alerts.'
+                  {pushBlockedInBrowser
+                    ? 'Notifications are blocked in this browser. Allow notifications in site settings, then check again before turning on game-day alerts.'
+                    : pushBlocked
+                      ? 'Notifications are blocked in device settings. Open settings, allow notifications, then return here to finish game-day alerts.'
                     : 'One tap enables push on this device and turns on schedule changes and live score updates for the selected team.'}
                 </p>
-                <button type="button" className="primary-button mt-3" onClick={nativePushBlocked ? () => void openDeviceSettingsForPush('Notifications are turned off in device settings. Open device settings to finish turning on game-day alerts.') : turnOnGameDayAlerts} disabled={busy === 'game-day-alerts' || !selectedTeamId || !selectedTeamPreferencesHydrated}>
+                <button
+                  type="button"
+                  className="primary-button mt-3"
+                  onClick={pushBlockedInBrowser
+                    ? () => void refreshPushPermissionStatus()
+                    : pushBlocked
+                      ? () => void openDeviceSettingsForPush('Notifications are turned off in device settings. Open device settings to finish turning on game-day alerts.')
+                      : turnOnGameDayAlerts}
+                  disabled={busy === 'game-day-alerts' || !selectedTeamId || !selectedTeamPreferencesHydrated}
+                >
                   {busy === 'game-day-alerts' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Upload className="h-4 w-4" aria-hidden="true" />}
-                  {nativePushBlocked ? 'Open device settings to finish alerts' : 'Turn on game-day alerts'}
+                  {pushBlockedInBrowser ? 'Check browser settings again' : pushBlocked ? 'Open device settings to finish alerts' : 'Turn on game-day alerts'}
                 </button>
               </div>
             </div>
@@ -1697,7 +1731,7 @@ function PreferenceToggle({ label, checked, onChange }: { label: string; checked
   );
 }
 
-function NativePushPermissionCard({
+function PushPermissionCard({
   permissionStatus,
   loading,
   onOpenSettings,
@@ -1713,7 +1747,7 @@ function NativePushPermissionCard({
       <div className="rounded-2xl border border-gray-200 bg-gray-50 p-3" role="status" aria-live="polite">
         <div className="flex items-center gap-2 text-sm font-black text-gray-900">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-          Checking device notification access…
+          Checking notification access…
         </div>
       </div>
     );
@@ -1727,12 +1761,24 @@ function NativePushPermissionCard({
     return (
       <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-3">
         <div className="text-sm font-black text-emerald-900">Push is allowed on this device</div>
-        <p className="mt-1 text-sm font-semibold leading-6 text-emerald-800">ALL PLAYS can request push registration here without sending you back through the OS permission prompt.</p>
+        <p className="mt-1 text-sm font-semibold leading-6 text-emerald-800">ALL PLAYS can refresh push registration here without sending you back through a permission prompt.</p>
       </div>
     );
   }
 
   if (permissionStatus.state === 'blocked') {
+    if (!permissionStatus.canOpenSettings) {
+      return (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 p-3">
+          <div className="text-sm font-black text-amber-900">Notifications are blocked in this browser</div>
+          <p className="mt-1 text-sm font-semibold leading-6 text-amber-800">ALL PLAYS cannot show the browser prompt again until notifications are allowed from this site&apos;s browser settings.</p>
+          <button type="button" className="ghost-button mt-3" onClick={onRefresh}>
+            Check again
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="rounded-2xl border border-amber-200 bg-amber-50 p-3">
         <div className="text-sm font-black text-amber-900">Notifications are off in device settings</div>
@@ -1752,8 +1798,8 @@ function NativePushPermissionCard({
   if (permissionStatus.state === 'unsupported') {
     return (
       <div className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
-        <div className="text-sm font-black text-gray-900">Push is unavailable on this device</div>
-        <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">This native shell cannot register for push notifications right now.</p>
+        <div className="text-sm font-black text-gray-900">Push is unavailable here</div>
+        <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">This browser or device cannot register for push notifications right now.</p>
       </div>
     );
   }
@@ -1761,7 +1807,7 @@ function NativePushPermissionCard({
   return (
     <div className="rounded-2xl border border-primary-100 bg-primary-50 p-3">
       <div className="text-sm font-black text-primary-900">Allow notifications to finish setup</div>
-      <p className="mt-1 text-sm font-semibold leading-6 text-primary-800">The next step will show the iPhone or Android notification prompt. After you allow notifications, ALL PLAYS can finish device registration here.</p>
+      <p className="mt-1 text-sm font-semibold leading-6 text-primary-800">{permissionStatus.isNative ? 'The next step will show the iPhone or Android notification prompt.' : 'The next step will show the browser notification prompt.'} After you allow notifications, ALL PLAYS can finish device registration here.</p>
     </div>
   );
 }

--- a/apps/app/src/vite-env.d.ts
+++ b/apps/app/src/vite-env.d.ts
@@ -2,3 +2,7 @@
 
 declare module '*.js';
 declare module '*.cjs';
+
+interface ImportMetaEnv {
+  readonly VITE_ALLPLAYS_FCM_VAPID_KEY?: string;
+}

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -9,6 +9,13 @@
         "google.com"
       ]
     },
+    "FirebaseMessaging": {
+      "presentationOptions": [
+        "badge",
+        "sound",
+        "alert"
+      ]
+    },
     "SplashScreen": {
       "launchAutoHide": false,
       "launchShowDuration": 0,

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -346,7 +346,8 @@ describe('React app auth/profile capability parity', () => {
         expectContains(pushService, [
             'if (!Capacitor.isNativePlatform()) {',
             "await import('@legacy/push-notifications.js')",
-            'const { token } = await registerPushNotifications();',
+            'webPushVapidKey ? { vapidKey: webPushVapidKey } : {}',
+            'await registerPushNotifications(webPushVapidKey ? { vapidKey: webPushVapidKey } : {})',
             'await saveNotificationDeviceToken(userId, {',
             "platform: 'web'",
             'FirebaseMessaging.requestPermissions()',


### PR DESCRIPTION
## Summary
- Enable web push registration in the app with browser permission handling, optional VAPID key wiring, and browser-specific recovery UX.
- Add Firebase Messaging foreground presentation options for native iOS/Android shells.
- Fix app Firebase bootstrap when a named Firebase app exists before the default app, and add regression coverage.
- Add focused coverage for blocked browser notifications, web game-day alert enablement, and native REST auth storage fixture stability.

## Validation
- `npm run test:ci` in `apps/app` — 111 files, 902 tests passed
- `npm run app:build`
- `npx vitest run tests/unit/notification-delivery-metadata.test.js --reporter=verbose`
- `npx cap sync`
- Android debug build: `ANDROID_HOME=/Users/paulsnider/Library/Android/sdk JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :app:assembleDebug`
- iOS simulator build: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/App/App.xcodeproj -scheme App -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- Authenticated web smoke on `#/profile?section=alerts` with `[REDACTED_EMAIL]` showed browser-blocked notification recovery UX correctly