### PR TITLE
Add mobile workflow TOC smoke coverage

### DIFF
--- a/tests/smoke/help-workflow-pages.spec.js
+++ b/tests/smoke/help-workflow-pages.spec.js
@@ -100,6 +100,7 @@ test.describe('help topic and workflow pages', () => {
 
         await expect(page.locator('#workflow-mobile-toc details')).toHaveCount(0);
         await page.setViewportSize({ width: 390, height: 844 });
+        await expect(page.locator('#workflow-mobile-toc details')).toHaveCount(1);
 
         const mobilePrerequisitesLink = page.locator('#workflow-mobile-toc a[href="#prerequisites"]');
         const desktopPrerequisitesLink = page.locator('.wf-sidebar #workflow-toc a[href="#prerequisites"]');

--- a/tests/smoke/help-workflow-pages.spec.js
+++ b/tests/smoke/help-workflow-pages.spec.js
@@ -14,6 +14,22 @@ function listRootPages(prefix) {
 
 const helpTopicPages = listRootPages('help-');
 const workflowPages = listRootPages('workflow-');
+const workflowTocPage = 'workflow-live-watch-replay.html';
+
+async function bootWorkflowPage(page, baseURL, path) {
+    await assertPageBootsWithoutFatalErrors(page, {
+        baseURL,
+        path,
+        titlePatterns: [/ALL PLAYS Help/i],
+        skipDefaultForbiddenTexts: true,
+        requiredSelectors: [
+            '[data-help-back-link]',
+            '#workflow-toc',
+            '#workflow-mobile-toc',
+            '.help-workflow-body h2[id]'
+        ]
+    });
+}
 
 test.describe('help topic and workflow pages', () => {
     for (const file of ['help.html', ...helpTopicPages]) {
@@ -52,20 +68,48 @@ test.describe('help topic and workflow pages', () => {
         await page.setViewportSize({ width: 390, height: 844 });
 
         for (const file of workflowPages) {
-            await assertPageBootsWithoutFatalErrors(page, {
-                baseURL,
-                path: `/${file}`,
-                titlePatterns: [/ALL PLAYS Help/i],
-                skipDefaultForbiddenTexts: true,
-                requiredSelectors: [
-                    '[data-help-back-link]',
-                    '#workflow-mobile-toc',
-                    '.help-workflow-body h2[id]'
-                ]
-            });
+            await bootWorkflowPage(page, baseURL, `/${file}`);
 
             await expect(page.locator('#workflow-mobile-toc')).toBeVisible();
             expect(await page.locator('#workflow-mobile-toc a').count(), `${file} should populate mobile TOC links`).toBeGreaterThan(0);
         }
+    });
+
+    test('mobile workflow table-of-contents links sync active state and collapse after click', async ({ page, baseURL }) => {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await bootWorkflowPage(page, baseURL, `/${workflowTocPage}`);
+
+        const mobileTocDetails = page.locator('#workflow-mobile-toc details');
+        const mobilePrerequisitesLink = page.locator('#workflow-mobile-toc a[href="#prerequisites"]');
+        const desktopPrerequisitesLink = page.locator('.wf-sidebar #workflow-toc a[href="#prerequisites"]');
+
+        await page.locator('#workflow-mobile-toc summary').click();
+        await expect(mobileTocDetails).toHaveJSProperty('open', true);
+
+        await mobilePrerequisitesLink.click();
+
+        await expect(page).toHaveURL(/#prerequisites$/);
+        await expect(mobilePrerequisitesLink).toHaveClass(/is-active/);
+        await expect(desktopPrerequisitesLink).toHaveClass(/is-active/);
+        await expect(mobileTocDetails).toHaveJSProperty('open', false);
+    });
+
+    test('workflow table-of-contents keeps hash active after mobile resize and updates on scroll', async ({ page, baseURL }) => {
+        await page.setViewportSize({ width: 1280, height: 900 });
+        await bootWorkflowPage(page, baseURL, `/${workflowTocPage}#prerequisites`);
+
+        await expect(page.locator('#workflow-mobile-toc details')).toHaveCount(0);
+        await page.setViewportSize({ width: 390, height: 844 });
+
+        const mobilePrerequisitesLink = page.locator('#workflow-mobile-toc a[href="#prerequisites"]');
+        const desktopPrerequisitesLink = page.locator('.wf-sidebar #workflow-toc a[href="#prerequisites"]');
+        await expect(mobilePrerequisitesLink).toHaveClass(/is-active/);
+        await expect(desktopPrerequisitesLink).toHaveClass(/is-active/);
+
+        const targetSection = page.locator('.help-workflow-body h2#common-questions');
+        await targetSection.evaluate((element) => element.scrollIntoView());
+        await expect(page.locator('#workflow-mobile-toc a[href="#common-questions"]')).toHaveClass(/is-active/);
+        await expect(page.locator('.wf-sidebar #workflow-toc a[href="#common-questions"]')).toHaveClass(/is-active/);
+        await expect(mobilePrerequisitesLink).not.toHaveClass(/is-active/);
     });
 });


### PR DESCRIPTION
Closes #3474

## What changed
- Added real-browser Playwright coverage for generated workflow mobile TOC interaction on `workflow-live-watch-replay.html`.
- Covered mobile link click, URL hash update, cloned mobile active state, desktop TOC active-state sync, and details collapse.
- Covered desktop hash load followed by mobile resize, lazy mobile TOC creation, hashed active state, and scroll-driven active-state movement.

## Root Cause
Generated workflow pages had real runtime behavior for cloned mobile TOC links, active-state synchronization, hash handling, resize creation, scroll updates, and details collapse, but adjacent smoke coverage only asserted that the mobile TOC existed and had links.

## Prevention / Learning
Responsive cloned navigation needs real-browser interaction coverage for both source and clone nodes: click, hash, resize, scroll, and collapsed-menu state on an actual generated page.

## Regression Tests
- `SMOKE_BASE_URL=http://127.0.0.1:8000 npx playwright test tests/smoke/help-workflow-pages.spec.js --config=playwright.smoke.config.js --reporter=line --grep "mobile workflow table-of-contents|keeps hash active"`
- `SMOKE_BASE_URL=http://127.0.0.1:8000 npx playwright test tests/smoke/help-workflow-pages.spec.js --config=playwright.smoke.config.js --reporter=line`