### PR TITLE
Defer schedule game day services

### DIFF
--- a/apps/app/src/lib/scheduleGameDayService.ts
+++ b/apps/app/src/lib/scheduleGameDayService.ts
@@ -1,0 +1,19 @@
+export {
+  loadAutoFilledLineupDraftPreviewForApp,
+  publishGamePlanForApp,
+  publishLiveScoreUpdateEvent,
+  recordPlayerGameStat,
+  recordPlayerScoringStat,
+  undoRecordedPlayerGameStat,
+  saveScheduledGameLineupDraftForApp,
+  completeGameWrapupForApp,
+  loadGameDayLiveEventsForApp,
+  saveGameDaySubstitutionForApp,
+  updateLiveGameClockState,
+  buildLiveGameClockPeriods,
+  resolveLiveGameClockSnapshot,
+  type LineupDraftPreviewResult,
+  type PlayerGameStatResult
+} from './scheduleService';
+
+export { LINEUP_FORMATIONS, getLineupPublishStatus, hasLineupDraft } from './gameDayLineupPublish';

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -116,17 +116,7 @@ import {
   type ScheduleRideOffer,
   type ScheduleRideSummary
 } from './scheduleLogic';
-import {
-  LINEUP_FORMATIONS,
-  buildAutoFilledLineupDraft,
-  buildLineupPublishPayload,
-  buildLineupPublishMessage,
-  countLineupChanges,
-  getLineupFormation,
-  type AutoFilledLineupPlayer,
-  type GamePlanPublishPayloadInput
-} from './gameDayLineupPublish';
-import { sendTeamChatMessage } from './chatService';
+import type { AutoFilledLineupPlayer, GamePlanPublishPayloadInput } from './gameDayLineupPublish';
 import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
 import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
 import { toAppServiceError } from './appErrors';
@@ -149,6 +139,7 @@ const parentHomeHydrationLookBehindMs = 12 * 60 * 60 * 1000;
 // an explicit full-history load. Tune here if season length assumptions change.
 const defaultScheduleHistoryWindowMs = 400 * 24 * 60 * 60 * 1000;
 const logger = createLogger('schedule-service');
+type GameDayLineupPublishModule = typeof import('./gameDayLineupPublish');
 
 function logScheduleWarning(message: string, operation: string, error: unknown, context: Record<string, unknown> = {}) {
   logger.warn(message, {
@@ -530,8 +521,8 @@ function normalizeLineupAssignments(lineups: Record<string, unknown> | null | un
   }, {});
 }
 
-function buildManualLineupDraft(formationId: string, lineups: Record<string, string>, previousGamePlan: Record<string, any> | null | undefined) {
-  const formation = getLineupFormation(formationId);
+function buildManualLineupDraft(lineupModule: GameDayLineupPublishModule, formationId: string, lineups: Record<string, string>, previousGamePlan: Record<string, any> | null | undefined) {
+  const formation = lineupModule.getLineupFormation(formationId);
   if (!formation) {
     throw new Error('Select a supported formation before saving a lineup draft.');
   }
@@ -555,8 +546,8 @@ function buildManualLineupDraft(formationId: string, lineups: Record<string, str
   };
 }
 
-function buildLineupDraftPreview(formationId: string, availablePlayers: AutoFilledLineupPlayer[], goingPlayers: AutoFilledLineupPlayer[], gamePlan: Record<string, any> | null | undefined): LineupDraftPreviewResult {
-  const formation = getLineupFormation(formationId);
+function buildLineupDraftPreview(lineupModule: GameDayLineupPublishModule, formationId: string, availablePlayers: AutoFilledLineupPlayer[], goingPlayers: AutoFilledLineupPlayer[], gamePlan: Record<string, any> | null | undefined): LineupDraftPreviewResult {
+  const formation = lineupModule.getLineupFormation(formationId);
   if (!formation) {
     throw new Error('Select a supported formation before saving a lineup draft.');
   }
@@ -569,7 +560,7 @@ function buildLineupDraftPreview(formationId: string, availablePlayers: AutoFill
     };
   } else {
     try {
-      draft = buildAutoFilledLineupDraft({ formationId, goingPlayers, previousGamePlan: gamePlan || {} });
+      draft = lineupModule.buildAutoFilledLineupDraft({ formationId, goingPlayers, previousGamePlan: gamePlan || {} });
     } catch (error: any) {
       if (!String(error?.message || '').includes('No Going players')) throw error;
     }
@@ -604,14 +595,15 @@ function assertLineupDraftEvent(event: ParentScheduleEvent, user: AuthUser | nul
 
 export async function loadAutoFilledLineupDraftPreviewForApp(event: ParentScheduleEvent, user: AuthUser | null, formationId: string): Promise<LineupDraftPreviewResult> {
   assertLineupDraftEvent(event, user);
-  if (!LINEUP_FORMATIONS[compactString(formationId)]) {
+  const lineupModule = await import('./gameDayLineupPublish');
+  if (!lineupModule.LINEUP_FORMATIONS[compactString(formationId)]) {
     throw new Error('Select a supported formation before saving a lineup draft.');
   }
   const [players, rsvps] = await Promise.all([
     loadPlayers(event.teamId),
     loadRsvps(event.teamId, event.id)
   ]);
-  return buildLineupDraftPreview(formationId, getAvailableLineupPlayers(players), getGoingLineupPlayers(players, rsvps), event.gamePlan || {});
+  return buildLineupDraftPreview(lineupModule, formationId, getAvailableLineupPlayers(players), getGoingLineupPlayers(players, rsvps), event.gamePlan || {});
 }
 
 export async function saveScheduledGameLineupDraftForApp(
@@ -621,6 +613,7 @@ export async function saveScheduledGameLineupDraftForApp(
   options?: { lineups?: Record<string, string> | null }
 ): Promise<LineupDraftPreviewResult> {
   assertLineupDraftEvent(event, user);
+  const lineupModule = await import('./gameDayLineupPublish');
   const [players, rsvps] = await Promise.all([
     loadPlayers(event.teamId),
     loadRsvps(event.teamId, event.id)
@@ -632,8 +625,8 @@ export async function saveScheduledGameLineupDraftForApp(
     ? normalizeLineupAssignments(options.lineups)
     : null;
   const nextGamePlan = hasLineupOverride
-    ? buildManualLineupDraft(formationId, overrideLineups || {}, event.gamePlan || {})
-    : buildAutoFilledLineupDraft({ formationId, goingPlayers, previousGamePlan: event.gamePlan || {} });
+    ? buildManualLineupDraft(lineupModule, formationId, overrideLineups || {}, event.gamePlan || {})
+    : lineupModule.buildAutoFilledLineupDraft({ formationId, goingPlayers, previousGamePlan: event.gamePlan || {} });
   const payload: Record<string, unknown> = { gamePlan: nextGamePlan };
 
   try {
@@ -644,7 +637,7 @@ export async function saveScheduledGameLineupDraftForApp(
     await nativePatchDocument(`teams/${encodeURIComponent(event.teamId)}/games/${encodeURIComponent(event.id)}`, payload);
   }
 
-  return buildLineupDraftPreview(formationId, availablePlayers, goingPlayers, nextGamePlan);
+  return buildLineupDraftPreview(lineupModule, formationId, availablePlayers, goingPlayers, nextGamePlan);
 }
 
 export async function publishGamePlanForApp(event: ParentScheduleEvent, user: AuthUser): Promise<PublishGamePlanResult> {
@@ -659,12 +652,13 @@ export async function publishGamePlanForApp(event: ParentScheduleEvent, user: Au
   }
 
   const { teamId, id: gameId } = event;
+  const lineupModule = await import('./gameDayLineupPublish');
   const currentTeamPlayers = await loadPlayers(teamId);
   const recipientPlayerIds = uniqueNonEmptyStrings(currentTeamPlayers.map((p: any) => p.id));
   const recipientParentIds = uniqueNonEmptyStrings(currentTeamPlayers.flatMap(getPlayerParentUserIds));
 
   const previousGamePlan = event.gamePlan;
-  const nextGamePlan = buildLineupPublishPayload({
+  const nextGamePlan = lineupModule.buildLineupPublishPayload({
     previousGamePlan,
     publishedBy: user.uid,
     publishedByName: user.displayName || user.email || 'Coach',
@@ -685,13 +679,14 @@ export async function publishGamePlanForApp(event: ParentScheduleEvent, user: Au
     await nativePatchDocument(`teams/${encodeURIComponent(teamId)}/games/${encodeURIComponent(gameId)}`, payload);
   }
 
-  const changedAssignments = countLineupChanges(
+  const changedAssignments = lineupModule.countLineupChanges(
     previousGamePlan?.publishedLineups,
     nextGamePlan.publishedLineups
   );
 
   let notificationError: string | null = null;
   try {
+    const { sendTeamChatMessage } = await import('./chatService');
     await sendTeamChatMessage({
       teamId: event.teamId,
       user,
@@ -699,7 +694,7 @@ export async function publishGamePlanForApp(event: ParentScheduleEvent, user: Au
         fullName: user.displayName || null,
         photoUrl: user.photoUrl || null
       },
-      text: buildLineupPublishMessage({
+      text: lineupModule.buildLineupPublishMessage({
         opponentName: event.opponent || event.title || null,
         publishedVersion: nextGamePlan.publishedVersion,
         changedAssignments
@@ -5238,6 +5233,7 @@ export async function sendStaffRsvpReminder(event: ParentScheduleEvent, user: Au
   }
 
   const emailResult = await sendPublicRsvpReminderEmailsNativeSafe(event);
+  const { sendTeamChatMessage } = await import('./chatService');
   await sendTeamChatMessage({
     teamId: event.teamId,
     user,

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1345,6 +1345,81 @@ describe('ScheduleEventDetail assignments', () => {
     expect(screen.getAllByText(/LIVE · Q2/i).length).toBeGreaterThan(0);
   });
 
+  it('preserves elapsed running clock time while the game-day service import is loading', async () => {
+    const updatedAt = new Date(Date.now() - 30_000).toISOString();
+    const updateLiveGameClockState = vi.fn(async (_teamId, _gameId, payload) => ({
+      liveClockMs: payload.liveClockMs,
+      liveClockRunning: payload.liveClockRunning,
+      liveClockPeriod: payload.liveClockPeriod,
+      period: payload.liveClockPeriod,
+      liveClockUpdatedAt: new Date(),
+      liveStatus: 'live'
+    }));
+    let resolveImporter: (module: any) => void = () => {};
+    const importerPromise = new Promise<any>((resolve) => {
+      resolveImporter = resolve;
+    });
+    const importer = vi.fn(() => importerPromise);
+    setScheduleGameDayServiceImporterForTest(importer);
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        canUpdateScore: true,
+        liveClockMs: 60_000,
+        liveClockRunning: true,
+        liveClockPeriod: 'Q1',
+        liveClockUpdatedAt: updatedAt,
+        gamePlan: { numPeriods: 4 }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
+
+    try {
+      renderScheduleEventDetailWithRouteControls();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('live-game-clock-panel')).toBeTruthy();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Pause clock' }));
+
+      expect(updateLiveGameClockState).not.toHaveBeenCalled();
+
+      resolveImporter({
+        loadAutoFilledLineupDraftPreviewForApp: vi.fn(() => Promise.resolve({ availablePlayers: [], goingPlayers: [], gamePlan: null })),
+        publishGamePlanForApp: vi.fn(),
+        publishLiveScoreUpdateEvent: vi.fn(),
+        recordPlayerGameStat: vi.fn(),
+        recordPlayerScoringStat: vi.fn(),
+        undoRecordedPlayerGameStat: vi.fn(),
+        saveScheduledGameLineupDraftForApp: vi.fn(),
+        completeGameWrapupForApp: vi.fn(),
+        loadGameDayLiveEventsForApp: vi.fn(() => Promise.resolve([])),
+        saveGameDaySubstitutionForApp: vi.fn(),
+        updateLiveGameClockState,
+        buildLiveGameClockPeriods: vi.fn(() => ['Q1', 'Q2', 'Q3', 'Q4']),
+        resolveLiveGameClockSnapshot: vi.fn(),
+        LINEUP_FORMATIONS: {},
+        getLineupPublishStatus: vi.fn(() => 'Lineup draft is not published.'),
+        hasLineupDraft: vi.fn(() => false)
+      });
+
+      await waitFor(() => {
+        expect(updateLiveGameClockState).toHaveBeenCalledWith('team-1', 'game-1', expect.objectContaining({
+          liveClockMs: expect.any(Number),
+          liveClockRunning: false,
+          liveClockPeriod: 'Q1'
+        }), auth.user);
+      });
+      expect(updateLiveGameClockState.mock.calls[0][2].liveClockMs).toBeGreaterThanOrEqual(89_000);
+    } finally {
+      setScheduleGameDayServiceImporterForTest();
+    }
+  });
+
   it('tracks player fouls, shows bonus state, and resets team fouls by period', async () => {
     scheduleServiceMocks.updateLiveGameClockState.mockResolvedValueOnce({
       liveClockMs: 0,

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -94,6 +94,37 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('../lib/scheduleGameDayService', () => ({
+  loadAutoFilledLineupDraftPreviewForApp: scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp,
+  publishGamePlanForApp: scheduleServiceMocks.publishGamePlanForApp,
+  publishLiveScoreUpdateEvent: scheduleServiceMocks.publishLiveScoreUpdateEvent,
+  recordPlayerGameStat: scheduleServiceMocks.recordPlayerGameStat,
+  recordPlayerScoringStat: scheduleServiceMocks.recordPlayerScoringStat,
+  undoRecordedPlayerGameStat: scheduleServiceMocks.undoRecordedPlayerGameStat,
+  saveScheduledGameLineupDraftForApp: scheduleServiceMocks.saveScheduledGameLineupDraftForApp,
+  completeGameWrapupForApp: scheduleServiceMocks.completeGameWrapupForApp,
+  loadGameDayLiveEventsForApp: scheduleServiceMocks.loadGameDayLiveEventsForApp,
+  saveGameDaySubstitutionForApp: scheduleServiceMocks.saveGameDaySubstitutionForApp,
+  updateLiveGameClockState: scheduleServiceMocks.updateLiveGameClockState,
+  buildLiveGameClockPeriods: scheduleServiceMocks.buildLiveGameClockPeriods,
+  resolveLiveGameClockSnapshot: scheduleServiceMocks.resolveLiveGameClockSnapshot,
+  LINEUP_FORMATIONS: {
+    'basketball-5v5': {
+      id: 'basketball-5v5',
+      name: 'Basketball 5v5',
+      numPeriods: 4,
+      positions: [
+        { id: 'pg', name: 'PG' },
+        { id: 'sg', name: 'SG' },
+        { id: 'sf', name: 'SF' },
+        { id: 'pf', name: 'PF' },
+        { id: 'c', name: 'C' }
+      ]
+    }
+  },
+  getLineupPublishStatus: vi.fn((gamePlan: any) => gamePlan?.isPublished ? 'Published lineup is current.' : 'Lineup draft is not published.'),
+  hasLineupDraft: vi.fn((gamePlan: any) => Boolean(gamePlan?.lineups && Object.keys(gamePlan.lineups).length))
+}));
 const publicActionMocks = vi.hoisted(() => ({
   exportCalendarIcsFile: vi.fn(),
   openPublicUrl: vi.fn(),
@@ -204,7 +235,9 @@ import {
   loadGameWrapupServiceModule,
   loadLegacyScheduleHelpersModule,
   loadPracticeTimelineServiceModule,
+  loadScheduleGameDayService,
   loadStatsheetImportServiceModule,
+  setScheduleGameDayServiceImporterForTest,
   shouldAutosaveGeneratedLineupDraft,
   shouldAutosaveLineupDraft,
   shouldPersistLineupDraft
@@ -362,7 +395,12 @@ function buildLiveChatMessages(count: number) {
 
 describe('ScheduleEventDetail deferred game hub loaders', () => {
   it('keeps closed game hub implementation modules out of the route static imports', () => {
-    const source = readFileSync('src/pages/ScheduleEventDetail.tsx', 'utf8');
+    let source = '';
+    try {
+      source = readFileSync('src/pages/ScheduleEventDetail.tsx', 'utf8');
+    } catch {
+      source = readFileSync('apps/app/src/pages/ScheduleEventDetail.tsx', 'utf8');
+    }
 
     [
       '../lib/gameDayLineupBuilder',
@@ -370,7 +408,9 @@ describe('ScheduleEventDetail deferred game hub loaders', () => {
       '../lib/practiceTimelineService',
       '../lib/statsheetImportService',
       '../lib/adapters/legacyScheduleHelpers',
-      '../components/schedule/GameReportSections'
+      '../components/schedule/GameReportSections',
+      '../lib/scheduleGameDayService',
+      '../lib/gameDayLineupPublish'
     ].forEach((modulePath) => {
       expect(source).not.toMatch(new RegExp(`import\\s+(?!type\\b)[^;]+from ['"]${modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`));
     });
@@ -383,7 +423,8 @@ describe('ScheduleEventDetail deferred game hub loaders', () => {
       { load: loadPracticeTimelineServiceModule, exportName: 'loadPracticeTimelineModel' },
       { load: loadStatsheetImportServiceModule, exportName: 'loadTrackStatsheetContextForApp' },
       { load: loadLegacyScheduleHelpersModule, exportName: 'getSubstitutionOptions' },
-      { load: loadGameReportSectionsModule, exportName: 'GameReportSections' }
+      { load: loadGameReportSectionsModule, exportName: 'GameReportSections' },
+      { load: loadScheduleGameDayService, exportName: 'loadAutoFilledLineupDraftPreviewForApp' }
     ];
 
     for (const { load, exportName } of loaders) {
@@ -392,6 +433,36 @@ describe('ScheduleEventDetail deferred game hub loaders', () => {
       expect(secondLoad).toBe(firstLoad);
       await expect(firstLoad).resolves.toHaveProperty(exportName);
     }
+  });
+
+  it('caches the lazy game-day schedule service import across panels', async () => {
+    const importer = vi.fn(async () => ({
+      loadAutoFilledLineupDraftPreviewForApp: vi.fn(),
+      publishGamePlanForApp: vi.fn(),
+      publishLiveScoreUpdateEvent: vi.fn(),
+      recordPlayerGameStat: vi.fn(),
+      recordPlayerScoringStat: vi.fn(),
+      undoRecordedPlayerGameStat: vi.fn(),
+      saveScheduledGameLineupDraftForApp: vi.fn(),
+      completeGameWrapupForApp: vi.fn(),
+      loadGameDayLiveEventsForApp: vi.fn(),
+      saveGameDaySubstitutionForApp: vi.fn(),
+      updateLiveGameClockState: vi.fn(),
+      buildLiveGameClockPeriods: vi.fn(),
+      resolveLiveGameClockSnapshot: vi.fn(),
+      LINEUP_FORMATIONS: {},
+      getLineupPublishStatus: vi.fn(),
+      hasLineupDraft: vi.fn()
+    }) as any);
+    setScheduleGameDayServiceImporterForTest(importer);
+
+    const firstLoad = loadScheduleGameDayService();
+    const secondLoad = loadScheduleGameDayService();
+
+    expect(secondLoad).toBe(firstLoad);
+    await firstLoad;
+    expect(importer).toHaveBeenCalledTimes(1);
+    setScheduleGameDayServiceImporterForTest();
   });
 });
 
@@ -871,6 +942,32 @@ describe('ScheduleEventDetail nav visibility', () => {
 
     expect(screen.queryByRole('heading', { name: 'Game hub' })).toBeNull();
     expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=availability');
+  });
+
+  it('does not import game-day service for availability or rideshare initial renders', async () => {
+    const importer = vi.fn(async () => ({}) as any);
+    setScheduleGameDayServiceImporterForTest(importer);
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        canUpdateScore: true,
+        rideshareSummary: { offerCount: 1, seatsLeft: 2, requests: 0, pending: 0, confirmed: 0, isFull: false }
+      })],
+      children: []
+    });
+
+    const availabilityRender = renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=availability');
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+    });
+    expect(importer).not.toHaveBeenCalled();
+    availabilityRender.unmount();
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=rideshare');
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Rideshare' })).toBeTruthy();
+    });
+    expect(importer).not.toHaveBeenCalled();
+    setScheduleGameDayServiceImporterForTest();
   });
 });
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2863,15 +2863,22 @@ function LiveGameClockPanel({ auth, event, onLiveClockUpdated }: { auth: AuthSta
     Number((event.gamePlan as Record<string, any> | null | undefined)?.numPeriods) === 4 ? ['Q1', 'Q2', 'Q3', 'Q4'] : ['H1', 'H2']
   ), [event.gamePlan]);
   const periods = useMemo(() => gameDayService?.buildLiveGameClockPeriods(event as Record<string, any>) || fallbackPeriods, [event, fallbackPeriods, gameDayService]);
-  const clockState = useMemo(() => (
-    gameDayService?.resolveLiveGameClockSnapshot(event as Record<string, any>, clockNow) || {
-      persistedClockMs: Math.max(0, Number(event.liveClockMs || 0)),
-      effectiveClockMs: Math.max(0, Number(event.liveClockMs || 0)),
+  const clockState = useMemo(() => {
+    const serviceSnapshot = gameDayService?.resolveLiveGameClockSnapshot(event as Record<string, any>, clockNow);
+    if (serviceSnapshot) return serviceSnapshot;
+
+    const persistedClockMs = Math.max(0, Number(event.liveClockMs || 0));
+    const parsedUpdatedAt = event.liveClockUpdatedAt ? new Date(event.liveClockUpdatedAt as any) : clockNow;
+    const updatedAt = Number.isFinite(parsedUpdatedAt.getTime()) ? parsedUpdatedAt : clockNow;
+    const elapsedClockMs = event.liveClockRunning === true ? Math.max(0, clockNow.getTime() - updatedAt.getTime()) : 0;
+    return {
+      persistedClockMs,
+      effectiveClockMs: persistedClockMs + elapsedClockMs,
       running: event.liveClockRunning === true,
       period: event.liveClockPeriod || (event as Record<string, any>).period || periods[0] || 'H1',
-      updatedAt: event.liveClockUpdatedAt ? new Date(event.liveClockUpdatedAt as any) : clockNow
-    }
-  ), [event, clockNow, periods, gameDayService]);
+      updatedAt
+    };
+  }, [event, clockNow, periods, gameDayService]);
   const activePeriodIndex = Math.max(0, periods.indexOf(clockState.period));
   const activePeriod = periods[activePeriodIndex] || clockState.period;
   const hasNextPeriod = activePeriodIndex < periods.length - 1;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -18,24 +18,11 @@ import {
   loadStaffPracticeAttendance,
   loadParentScheduleEventDetail,
   resolveCachedParentScheduleEvents,
-  loadAutoFilledLineupDraftPreviewForApp,
   markParentPracticePacketComplete,
-  publishGamePlanForApp,
   loadHomeScoringPlayers,
-  publishLiveScoreUpdateEvent,
-  recordPlayerGameStat,
-  recordPlayerScoringStat,
-  undoRecordedPlayerGameStat,
-  saveScheduledGameLineupDraftForApp,
   saveStaffPracticeAttendance,
   saveStaffPracticePacket,
-  completeGameWrapupForApp,
-  loadGameDayLiveEventsForApp,
-  saveGameDaySubstitutionForApp,
   updateGameScore,
-  updateLiveGameClockState,
-  buildLiveGameClockPeriods,
-  resolveLiveGameClockSnapshot,
   createStaffRsvpAvailabilityLoader,
   type PracticeAttendancePlayer,
   type StaffPracticeAttendance,
@@ -44,10 +31,8 @@ import {
   type ParentPracticePacket,
   type ParentPracticePacketChild,
   type ScheduleHomeScoringPlayer,
-  type PlayerGameStatResult,
-  type LineupDraftPreviewResult
 } from '../lib/scheduleService';
-import { LINEUP_FORMATIONS, getLineupPublishStatus, hasLineupDraft } from '../lib/gameDayLineupPublish';
+import type { PlayerGameStatResult, LineupDraftPreviewResult } from '../lib/scheduleGameDayService';
 import { exportCalendarIcsFile, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { buildParentScheduleEventIcs } from '../lib/parentToolsService';
 import {
@@ -112,6 +97,7 @@ type PracticeTimelineServiceModule = typeof import('../lib/practiceTimelineServi
 type StatsheetImportServiceModule = typeof import('../lib/statsheetImportService');
 type LegacyScheduleHelpersModule = typeof import('../lib/adapters/legacyScheduleHelpers');
 type GameReportSectionsModule = typeof import('../components/schedule/GameReportSections');
+type ScheduleGameDayServiceModule = typeof import('../lib/scheduleGameDayService');
 
 // Module-level promise caches — each module loads at most once per session
 let liveGameChatModulePromise: Promise<LiveGameChatModule> | null = null;
@@ -122,6 +108,8 @@ let practiceTimelineServiceModulePromise: Promise<PracticeTimelineServiceModule>
 let statsheetImportServiceModulePromise: Promise<StatsheetImportServiceModule> | null = null;
 let legacyScheduleHelpersModulePromise: Promise<LegacyScheduleHelpersModule> | null = null;
 let gameReportSectionsModulePromise: Promise<GameReportSectionsModule> | null = null;
+let scheduleGameDayServiceModulePromise: Promise<ScheduleGameDayServiceModule> | null = null;
+let scheduleGameDayServiceImporter = () => import('../lib/scheduleGameDayService');
 
 function loadLiveGameChatModule() {
   if (!liveGameChatModulePromise) {
@@ -177,6 +165,18 @@ export function loadGameReportSectionsModule() {
     gameReportSectionsModulePromise = import('../components/schedule/GameReportSections');
   }
   return gameReportSectionsModulePromise;
+}
+
+export function loadScheduleGameDayService() {
+  if (!scheduleGameDayServiceModulePromise) {
+    scheduleGameDayServiceModulePromise = scheduleGameDayServiceImporter();
+  }
+  return scheduleGameDayServiceModulePromise;
+}
+
+export function setScheduleGameDayServiceImporterForTest(importer?: () => Promise<ScheduleGameDayServiceModule>) {
+  scheduleGameDayServiceModulePromise = null;
+  scheduleGameDayServiceImporter = importer || (() => import('../lib/scheduleGameDayService'));
 }
 
 const DeferredGameReportSections = lazy(() => (
@@ -283,7 +283,9 @@ export function shouldAutosaveLineupDraft(isDirty: boolean, formationId: string,
 }
 
 export function shouldAutosaveGeneratedLineupDraft(existingGamePlan: Record<string, any> | null | undefined, previewGamePlan: Record<string, any> | null | undefined) {
-  return !hasLineupDraft(existingGamePlan) && hasLineupDraft(previewGamePlan);
+  const hasExistingDraft = Boolean(existingGamePlan?.lineups && typeof existingGamePlan.lineups === 'object' && Object.keys(existingGamePlan.lineups).length);
+  const hasPreviewDraft = Boolean(previewGamePlan?.lineups && typeof previewGamePlan.lineups === 'object' && Object.keys(previewGamePlan.lineups).length);
+  return !hasExistingDraft && hasPreviewDraft;
 }
 
 export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
@@ -2077,6 +2079,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
 
       if (nextHomeScore !== previousScore.homeScore || nextAwayScore !== previousScore.awayScore) {
         try {
+          const { publishLiveScoreUpdateEvent } = await loadScheduleGameDayService();
           await publishLiveScoreUpdateEvent(event.teamId, event.id, { homeScore: nextHomeScore, awayScore: nextAwayScore }, auth.user, previousScore);
         } catch (publishError) {
           console.warn('[schedule-event-detail] Wrap-up score saved but live play-by-play posting failed:', publishError);
@@ -2109,6 +2112,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
         awayScore: nextAwayScore,
         postGameNotes: trimmedNotes
       });
+      const { completeGameWrapupForApp } = await loadScheduleGameDayService();
       await completeGameWrapupForApp(event.teamId, event.id, {
         ...completionPayload,
         summary: finalSummary,
@@ -2355,11 +2359,17 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
     let cancelled = false;
     setLoading(true);
     Promise.all([
-      loadAutoFilledLineupDraftPreviewForApp(event, auth.user, formationId),
-      loadGameDayLiveEventsForApp(event.teamId, event.id),
+      loadScheduleGameDayService(),
       loadGameDayLineupBuilderModule()
     ])
-      .then(([preview, loadedLiveEvents, builder]) => {
+      .then(async ([gameDayService, builder]) => {
+        const [preview, loadedLiveEvents] = await Promise.all([
+          gameDayService.loadAutoFilledLineupDraftPreviewForApp(event, auth.user, formationId),
+          gameDayService.loadGameDayLiveEventsForApp(event.teamId, event.id)
+        ]);
+        return { preview, loadedLiveEvents, builder };
+      })
+      .then(({ preview, loadedLiveEvents, builder }) => {
         if (cancelled) return;
         const loadedPlayers = builder.buildLineupEditorPlayers(preview?.availablePlayers || [], preview?.goingPlayers || []);
         setPlayers(loadedPlayers.map((player) => ({ id: player.id, name: player.name, number: player.number || null })));
@@ -2420,6 +2430,7 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
     setSaving(true);
     setStatus(null);
     try {
+      const { saveGameDaySubstitutionForApp } = await loadScheduleGameDayService();
       const saved = await saveGameDaySubstitutionForApp(event.teamId, event.id, auth.user, {
         rotationPlan: result.rotationPlan,
         rotationActual: result.rotationActual,
@@ -2513,6 +2524,7 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
 }
 
 function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: AuthState; event: ParentScheduleEvent; onGamePlanSaved: (gamePlan: Record<string, any>) => void }) {
+  const [gameDayService, setGameDayService] = useState<ScheduleGameDayServiceModule | null>(null);
   const [lineupBuilderModule, setLineupBuilderModule] = useState<GameDayLineupBuilderModule | null>(null);
   const [formationId, setFormationId] = useState(event.gamePlan?.formationId || '');
   const [preview, setPreview] = useState<LineupDraftPreviewResult | null>(null);
@@ -2528,7 +2540,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   const latestDraftRef = useRef<Record<string, string>>({});
   const latestPreviewRef = useRef<LineupDraftPreviewResult | null>(null);
 
-  const formation = LINEUP_FORMATIONS[formationId] || null;
+  const formation = gameDayService?.LINEUP_FORMATIONS[formationId] || null;
   const lineupPeriods = useMemo(() => (
     lineupBuilderModule ? lineupBuilderModule.getOrderedLineupPeriods(formationId, preview?.gamePlan || event.gamePlan || null) : []
   ), [lineupBuilderModule, formationId, preview?.gamePlan, event.gamePlan]);
@@ -2536,12 +2548,18 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
     lineupBuilderModule ? lineupBuilderModule.buildLineupEditorPlayers(preview?.availablePlayers || [], preview?.goingPlayers || []) : []
   ), [lineupBuilderModule, preview?.availablePlayers, preview?.goingPlayers]);
   const playerById = useMemo(() => new Map(editorPlayers.map((player) => [player.id, player])), [editorPlayers]);
-  const hasSavedDraft = hasLineupDraft(preview?.gamePlan ?? event.gamePlan);
+  const hasSavedDraft = gameDayService?.hasLineupDraft(preview?.gamePlan ?? event.gamePlan) || false;
   const hasDraft = Object.keys(draftLineups).length > 0 || (!dirtyRef.current && hasSavedDraft);
-  const statusCopy = getLineupPublishStatus(event.gamePlan);
+  const statusCopy = gameDayService?.getLineupPublishStatus(event.gamePlan) || null;
 
   useEffect(() => {
-    void loadGameDayLineupBuilderModule().then(setLineupBuilderModule);
+    void Promise.all([
+      loadScheduleGameDayService(),
+      loadGameDayLineupBuilderModule()
+    ]).then(([service, builder]) => {
+      setGameDayService(service);
+      setLineupBuilderModule(builder);
+    });
   }, []);
 
   useEffect(() => {
@@ -2565,11 +2583,16 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
 
     setLoadingPreview(true);
     Promise.all([
-      loadAutoFilledLineupDraftPreviewForApp(event, auth.user, formationId),
+      loadScheduleGameDayService(),
       loadGameDayLineupBuilderModule()
     ])
-      .then(([result, builder]) => {
+      .then(async ([service, builder]) => {
+        const result = await service.loadAutoFilledLineupDraftPreviewForApp(event, auth.user, formationId);
+        return { result, builder, service };
+      })
+      .then(({ result, builder, service }) => {
         if (cancelled) return;
+        setGameDayService(service);
         setPreview(result);
         latestPreviewRef.current = result;
         const seeded = builder.buildLineupEditorAssignments(formationId, result.gamePlan || event.gamePlan || null);
@@ -2599,6 +2622,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
     setSaving(true);
     if (reason !== 'autosave') setStatus(null);
     try {
+      const { saveScheduledGameLineupDraftForApp } = await loadScheduleGameDayService();
       const result = await saveScheduledGameLineupDraftForApp(event, auth.user, formationId, { lineups });
       setPreview(result);
       latestPreviewRef.current = result;
@@ -2669,6 +2693,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
     if (!saved) return;
     setPublishing(true);
     try {
+      const { publishGamePlanForApp } = await loadScheduleGameDayService();
       const result = await publishGamePlanForApp({ ...event, gamePlan: latestPreviewRef.current?.gamePlan || event.gamePlan }, auth.user);
       onGamePlanSaved(result.gamePlan);
       const version = Number.parseInt(String(result.gamePlan?.publishedVersion || ''), 10) || 0;
@@ -2697,7 +2722,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
             disabled={!auth.user || event.isCancelled || saving || publishing}
           >
             <option value="">Select formation</option>
-            {Object.values(LINEUP_FORMATIONS).map((option) => (
+            {Object.values(gameDayService?.LINEUP_FORMATIONS || {}).map((option) => (
               <option key={option.id} value={option.id}>{option.name}</option>
             ))}
           </select>
@@ -2828,10 +2853,25 @@ type ScoreSnapshot = {
 
 function LiveGameClockPanel({ auth, event, onLiveClockUpdated }: { auth: AuthState; event: ParentScheduleEvent; onLiveClockUpdated: (payload: Partial<ParentScheduleEvent> & { period?: string | null }) => void }) {
   const clockNow = useLiveGameClockNow();
+  const [gameDayService, setGameDayService] = useState<ScheduleGameDayServiceModule | null>(null);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
-  const periods = useMemo(() => buildLiveGameClockPeriods(event as Record<string, any>), [event]);
-  const clockState = useMemo(() => resolveLiveGameClockSnapshot(event as Record<string, any>, clockNow), [event, clockNow]);
+  useEffect(() => {
+    void loadScheduleGameDayService().then(setGameDayService);
+  }, []);
+  const fallbackPeriods = useMemo(() => (
+    Number((event.gamePlan as Record<string, any> | null | undefined)?.numPeriods) === 4 ? ['Q1', 'Q2', 'Q3', 'Q4'] : ['H1', 'H2']
+  ), [event.gamePlan]);
+  const periods = useMemo(() => gameDayService?.buildLiveGameClockPeriods(event as Record<string, any>) || fallbackPeriods, [event, fallbackPeriods, gameDayService]);
+  const clockState = useMemo(() => (
+    gameDayService?.resolveLiveGameClockSnapshot(event as Record<string, any>, clockNow) || {
+      persistedClockMs: Math.max(0, Number(event.liveClockMs || 0)),
+      effectiveClockMs: Math.max(0, Number(event.liveClockMs || 0)),
+      running: event.liveClockRunning === true,
+      period: event.liveClockPeriod || (event as Record<string, any>).period || periods[0] || 'H1',
+      updatedAt: event.liveClockUpdatedAt ? new Date(event.liveClockUpdatedAt as any) : clockNow
+    }
+  ), [event, clockNow, periods, gameDayService]);
   const activePeriodIndex = Math.max(0, periods.indexOf(clockState.period));
   const activePeriod = periods[activePeriodIndex] || clockState.period;
   const hasNextPeriod = activePeriodIndex < periods.length - 1;
@@ -2849,6 +2889,7 @@ function LiveGameClockPanel({ auth, event, onLiveClockUpdated }: { auth: AuthSta
     setSaving(true);
     setStatus(null);
     try {
+      const { updateLiveGameClockState } = await loadScheduleGameDayService();
       const payload = await updateLiveGameClockState(event.teamId, event.id, {
         liveClockMs: clockState.effectiveClockMs,
         liveClockRunning: next.running,
@@ -3069,6 +3110,7 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
         return;
       }
       try {
+        const { publishLiveScoreUpdateEvent } = await loadScheduleGameDayService();
         await publishLiveScoreUpdateEvent(event.teamId, event.id, { homeScore: nextHomeScore, awayScore: nextAwayScore }, auth.user, previousScore);
         setStatus({ tone: 'success', message: mode === 'autosave' ? 'Score autosaved and posted to live play-by-play.' : 'Score saved and posted to live play-by-play.' });
       } catch (publishError) {
@@ -3120,6 +3162,7 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
     setPlayerScoringId(player.id);
     setStatus(null);
     try {
+      const { recordPlayerScoringStat } = await loadScheduleGameDayService();
       const result = await recordPlayerScoringStat(event.teamId, event.id, player.id, {
         statKey: 'pts',
         value: 2,
@@ -3234,6 +3277,7 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
     async function loadPlayers() {
       setLoading(true);
       try {
+        const { loadGameDayLiveEventsForApp } = await loadScheduleGameDayService();
         const [players, loadedLiveEvents] = await Promise.all([
           loadHomeScoringPlayers(event.teamId, event.id),
           loadGameDayLiveEventsForApp(event.teamId, event.id)
@@ -3257,7 +3301,7 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
     };
   }, [event.teamId, event.id, event.eventKey]);
 
-  const activePeriod = useMemo(() => resolveLiveGameClockSnapshot(event as Record<string, any>).period || event.liveClockPeriod || (event as Record<string, any>).period || 'Q1', [event]);
+  const activePeriod = event.liveClockPeriod || (event as Record<string, any>).period || 'Q1';
   const homeTeamFouls = useMemo(() => Math.max(0,
     (Array.isArray(liveEvents) ? liveEvents : []).reduce((total, entry) => {
       if (entry?.type !== 'stat' || entry?.isOpponent === true) return total;
@@ -3273,6 +3317,7 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
     setSavingPlayerId(player.id);
     setStatus(null);
     try {
+      const { recordPlayerGameStat } = await loadScheduleGameDayService();
       const result = await recordPlayerGameStat(event.teamId, event.id, player.id, {
         statKey: 'fouls',
         value: 1,
@@ -3299,6 +3344,7 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
     setSavingPlayerId(latest.playerId);
     setStatus(null);
     try {
+      const { undoRecordedPlayerGameStat } = await loadScheduleGameDayService();
       const result = await undoRecordedPlayerGameStat(event.teamId, event.id, {
         trackerEventId: latest.trackerEventId,
         liveEventId: latest.liveEventId,

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -212,8 +212,8 @@ async function renderDetail(initialEntry) {
     return { container, root };
 }
 
-async function waitForText(container, text) {
-    for (let index = 0; index < 100; index += 1) {
+async function waitForText(container, text, attempts = 100) {
+    for (let index = 0; index < attempts; index += 1) {
         if (container.textContent.includes(text)) return;
         await act(async () => {
             if (vi.isFakeTimers()) {
@@ -1037,7 +1037,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await clickButton(container, 'Game');
         await waitForText(container, 'Lineup builder');
         await clickButton(container, 'Lineup builder');
-        await waitForText(container, 'No lineup draft is available yet.');
+        await waitForText(container, 'No lineup draft is available yet.', 500);
 
         expect(container.querySelector('#game-hub-lineup-formation')).not.toBeNull();
         expect(buttonByText(container, 'Publish lineup').disabled).toBe(true);
@@ -1059,7 +1059,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
             select.value = 'basketball-5v5';
             select.dispatchEvent(new Event('change', { bubbles: true }));
         });
-        await waitForText(container, '#1 Avery');
+        await waitForText(container, '#1 Avery', 500);
         await act(async () => {
             await new Promise((resolve) => setTimeout(resolve, 900));
         });

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -227,6 +227,21 @@ async function waitForText(container, text) {
     throw new Error(`Timed out waiting for text: ${text}`);
 }
 
+async function waitForMockCall(mock, label) {
+    for (let index = 0; index < 100; index += 1) {
+        if (mock.mock.calls.length > 0) return;
+        await act(async () => {
+            if (vi.isFakeTimers()) {
+                await vi.advanceTimersByTimeAsync(1);
+                await Promise.resolve();
+                return;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+    }
+    throw new Error(`Timed out waiting for mock call: ${label}`);
+}
+
 function buttonByText(container, text) {
     const button = Array.from(container.querySelectorAll('button')).find((candidate) => (
         candidate.textContent.trim() === text || candidate.getAttribute('aria-label') === text
@@ -833,6 +848,8 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await clickButton(container, 'Game');
         await waitForText(container, 'Live score');
 
+        await waitForMockCall(scheduleMocks.buildLiveGameClockPeriods, 'buildLiveGameClockPeriods');
+        await waitForMockCall(scheduleMocks.resolveLiveGameClockSnapshot, 'resolveLiveGameClockSnapshot');
         expect(scheduleMocks.buildLiveGameClockPeriods).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }));
         expect(scheduleMocks.resolveLiveGameClockSnapshot).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), expect.any(Date));
 


### PR DESCRIPTION
Closes #3491

## What changed
- Added a lazy `scheduleGameDayService` boundary for Game Hub-only schedule helpers and lineup constants.
- Updated `ScheduleEventDetail` so availability and rideshare initial renders do not import Game Hub service helpers.
- Lazy-loaded lineup/live score/wrap-up/substitution/foul helper calls from Game Hub panels through one cached service import.
- Removed eager `gameDayLineupPublish` and `chatService` runtime imports from `scheduleService` by loading them only inside the workflows that need them.
- Added regression coverage for static import boundaries, cached lazy loading, and availability/rideshare no-import behavior.

## Root Cause
`ScheduleEventDetail` deferred Game Hub UI panels, but still statically imported Game Hub-only schedule service helpers and lineup constants. `scheduleService` also loaded lineup publishing and chat dependencies at module initialization, so the initial event detail route paid for game-day code before parents opened Game Hub tools.

## Prevention / Learning
When deferring hidden app panels, split both the component and service import boundaries. Add source-level and behavior-level tests that prove initial route paths do not statically import or invoke hidden-panel service modules.

## Regression Tests
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx --reporter=verbose`
- `npx vitest run src/lib/scheduleService.test.ts --reporter=verbose`
- `npx tsc --noEmit`
- `npm --prefix apps/app run build`

Build output includes deferred chunks such as `scheduleGameDayService-jypeKpRm.js`, `gameDayLineupPublish-BEtloCjR.js`, and separate `chatService` chunks.