### PR TITLE
Keep mobile chat search reachable

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { Link, MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
 import type { NotificationInboxItem } from '../lib/notificationInboxService';
@@ -112,6 +112,11 @@ const signedInAuth: AuthState = {
     roles: ['parent'],
   },
 };
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="current-route">{location.pathname}</div>;
+}
 
 describe('AppShell', () => {
   beforeEach(() => {
@@ -433,6 +438,29 @@ describe('AppShell', () => {
 
     const searchButton = screen.getByTestId('app-shell-search-trigger');
     expect(searchButton.getAttribute('aria-label')).toBe('Search');
+  });
+
+  it('opens search from a mobile message thread without leaving the thread', async () => {
+    useShellLayoutMock.mockReturnValue({ isDesktopWeb: false });
+
+    render(
+      <MemoryRouter initialEntries={['/messages/team-1']}>
+        <Routes>
+          <Route
+            path="/messages/:conversationId"
+            element={<AppShell auth={auth}><div>Thread<LocationDisplay /></div></AppShell>}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const searchButton = screen.getByTestId('app-shell-search-trigger');
+    expect(searchButton.getAttribute('aria-label')).toBe('Search');
+    expect(screen.getByTestId('current-route').textContent).toBe('/messages/team-1');
+
+    fireEvent.click(searchButton);
+    await waitFor(() => expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy());
+    expect(screen.getByTestId('current-route').textContent).toBe('/messages/team-1');
   });
 
   it('opens the search dialog immediately when the desktop search button is clicked', async () => {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -372,7 +372,18 @@ export function AppShell({ auth, children }: AppShellProps) {
       ) : (
         <>
           {isMobileChatDetail ? (
-            <div className="pointer-events-none fixed inset-x-0 top-0 z-30 flex justify-end px-3 safe-top">
+            <div className="pointer-events-none fixed inset-x-0 top-0 z-30 flex justify-end gap-2 px-3 safe-top">
+              <button
+                type="button"
+                className="ghost-button pointer-events-auto !h-10 !min-h-10 !w-10 !p-0"
+                onClick={() => setSearchOpen(true)}
+                aria-label="Search"
+                title="Search (Ctrl+K / Cmd+K)"
+                data-testid="app-shell-search-trigger"
+              >
+                <Search className="h-5 w-5" aria-hidden="true" />
+                <span className="sr-only">Search</span>
+              </button>
               {renderNotificationTrigger('ghost-button pointer-events-auto !h-10 !min-h-10 !w-10 !p-0 relative', true)}
             </div>
           ) : null}

--- a/apps/app/src/pages/messages/components/ChatWindow.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.test.tsx
@@ -63,6 +63,14 @@ describe('Messages Sheet native back behavior', () => {
 });
 
 describe('Messages ALL PLAYS lazy loading', () => {
+  it('reserves enough mobile chat topbar space for both shell overlay buttons', () => {
+    const sourcePath = resolveAppSourcePath('src/pages/messages/components/ChatWindow.tsx');
+    const source = readFileSync(sourcePath, 'utf8');
+
+    expect(source).toContain("${!embedded && !isDesktopWeb ? 'pr-28' : ''}");
+    expect(source).not.toContain("${!embedded && !isDesktopWeb ? 'pr-16' : ''}");
+  });
+
   it('keeps the AI answer module behind the wantsAi send branch', () => {
     const sourcePath = resolveAppSourcePath('src/pages/messages/components/ChatWindow.tsx');
     const source = readFileSync(sourcePath, 'utf8');

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1569,7 +1569,7 @@ export function ChatWindow({
 
   return (
     <div className={`chat-window ${embedded ? 'chat-window-embedded' : 'chat-window-mobile'}`}>
-      <section className={`chat-topbar ${embedded ? 'rounded-xl' : 'safe-top sticky top-0'} ${!embedded && !isDesktopWeb ? 'pr-16' : ''} z-20 border border-gray-200 bg-white/95 px-3 py-3 shadow-app backdrop-blur`}>
+      <section className={`chat-topbar ${embedded ? 'rounded-xl' : 'safe-top sticky top-0'} ${!embedded && !isDesktopWeb ? 'pr-28' : ''} z-20 border border-gray-200 bg-white/95 px-3 py-3 shadow-app backdrop-blur`}>
         <div className="flex items-center gap-2">
           {!embedded ? (
             <Link to="/messages" className="ghost-button !h-10 !min-h-10 !w-10 !p-0" aria-label="Back to messages">

--- a/tests/unit/app-notification-bell.test.tsx
+++ b/tests/unit/app-notification-bell.test.tsx
@@ -208,6 +208,8 @@ describe('Notification bell in AppShell', () => {
 
         const bellButton = screen.getByTestId('app-shell-notifications-trigger');
         expect(bellButton.getAttribute('aria-label')).toBe('Notifications');
+        const searchButton = screen.getByTestId('app-shell-search-trigger');
+        expect(searchButton.getAttribute('aria-label')).toBe('Search');
         expect(screen.getByTestId('current-route').textContent).toBe('/messages/team-1');
         expect(screen.queryByTestId('notification-unread-badge')).toBeNull();
 


### PR DESCRIPTION
Closes #3489

## What changed
- Added a compact 40px Search button beside Notifications in the mobile chat-detail top overlay.
- Reused the existing `setSearchOpen(true)` shell state and `app-shell-search-trigger` selector.
- Added focused regression coverage for `/messages/team-1` and the existing notification affordance.

## Root Cause
The mobile chat-detail AppShell branch replaced the standard mobile header with a route-specific overlay that rendered only Notifications, dropping the global Search trigger from `/messages/:conversationId` even though search state and dialog support already existed.

## Prevention / Learning
When a route-specific mobile shell hides or replaces a shared header, carry forward every global affordance that remains part of the app contract and add route-specific regression coverage for each retained affordance.

## Regression Tests
- `npx vitest run apps/app/src/components/AppShell.test.tsx tests/unit/app-notification-bell.test.tsx --reporter=verbose`
- `AppShell.test.tsx` verifies mobile `/messages/team-1` exposes Search, opens the search dialog, and keeps the route unchanged.
- `app-notification-bell.test.tsx` verifies Search and Notifications both remain available on mobile chat detail routes.

## Recurrence Risk
Low. The missing chat-detail affordance now has direct route-specific coverage, and the adjacent notification test protects both top overlay controls together.