### PR TITLE
Lazy-load player video clips

### DIFF
--- a/apps/app/src/lib/chatLogic.ts
+++ b/apps/app/src/lib/chatLogic.ts
@@ -120,6 +120,11 @@ export function formatChatTime(value: any) {
   return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 }
 
+export function buildChatViewportSignature(scrollHeight: number, clientHeight: number, scrollTop: number) {
+  const distanceFromBottom = Math.max(0, scrollHeight - clientHeight - scrollTop);
+  return `${scrollHeight}:${clientHeight}:${distanceFromBottom}`;
+}
+
 export function formatChatDay(value: any) {
   const date = toChatDate(value);
   if (!date) return '';

--- a/apps/app/src/lib/playerService.test.ts
+++ b/apps/app/src/lib/playerService.test.ts
@@ -830,6 +830,18 @@ describe('loadParentPlayerDetail custom roster fields', () => {
     });
     expect(result).toEqual(clips.slice(0, 8));
   });
+
+  it('surfaces video clip game fetch failures to the caller', async () => {
+    legacyPlayerDbMocks.getGames.mockRejectedValue(new Error('Game fetch failed.'));
+
+    await expect(loadParentPlayerVideoClips({
+      uid: 'parent-1',
+      email: 'parent@example.com',
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    } as any, 'team-1', 'player-1')).rejects.toThrow('Game fetch failed.');
+
+    expect(legacyPlayerProfileMocks.collectPlayerVideoClips).not.toHaveBeenCalled();
+  });
 });
 
 describe('loadParentPlayerAthleteProfile', () => {

--- a/apps/app/src/lib/playerService.test.ts
+++ b/apps/app/src/lib/playerService.test.ts
@@ -83,6 +83,7 @@ import {
   loadParentPlayerAthleteProfile,
   loadParentPlayerDetail,
   loadParentPlayerDetailWithAthleteProfile,
+  loadParentPlayerVideoClips,
   normalizeAthleteProfileHighlightClipUrl,
   saveParentAthleteProfileDraft,
   savePlayerCustomRosterFieldValues,
@@ -719,6 +720,18 @@ describe('loadParentPlayerDetail custom roster fields', () => {
     expect(JSON.stringify(detail.customRosterFields)).not.toContain('YM');
   });
 
+  it('does not load team games or collect clips for the initial detail payload', async () => {
+    const detail = await loadParentPlayerDetail({
+      uid: 'parent-1',
+      email: 'parent@example.com',
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    } as any, 'team-1', 'player-1');
+
+    expect(legacyPlayerDbMocks.getGames).not.toHaveBeenCalled();
+    expect(legacyPlayerProfileMocks.collectPlayerVideoClips).not.toHaveBeenCalled();
+    expect(detail.clips).toEqual([]);
+  });
+
   it('includes parent-visible private roster field values for linked parents', async () => {
     legacyPlayerDbMocks.getRosterFieldDefinitions.mockResolvedValue([
       { key: 'nickname', label: 'Nickname', type: 'text', visibility: 'team', sortOrder: 1 },
@@ -788,6 +801,34 @@ describe('loadParentPlayerDetail custom roster fields', () => {
       expect.objectContaining({ key: 'nickname', value: 'Rocket' })
     ]);
     expect(detail.customRosterFields.some((field) => field.key === 'jerseySize')).toBe(false);
+  });
+
+  it('loads video clips on demand and limits the player clips to 8', async () => {
+    const games = [{ id: 'game-1' }, { id: 'game-2' }];
+    const clips = Array.from({ length: 9 }, (_, index) => ({
+      id: `clip-${index + 1}`,
+      title: `Clip ${index + 1}`,
+      gameDate: '',
+      playLabel: '',
+      url: `https://video.example/clip-${index + 1}.mp4`,
+      thumbnailUrl: '',
+      gameLabel: 'Game'
+    }));
+    legacyPlayerDbMocks.getGames.mockResolvedValue(games);
+    legacyPlayerProfileMocks.collectPlayerVideoClips.mockReturnValue(clips as any);
+
+    const result = await loadParentPlayerVideoClips({
+      uid: 'parent-1',
+      email: 'parent@example.com',
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    } as any, 'team-1', 'player-1');
+
+    expect(legacyPlayerDbMocks.getGames).toHaveBeenCalledWith('team-1');
+    expect(legacyPlayerProfileMocks.collectPlayerVideoClips).toHaveBeenCalledWith(games, {
+      teamId: 'team-1',
+      playerId: 'player-1'
+    });
+    expect(result).toEqual(clips.slice(0, 8));
   });
 });
 

--- a/apps/app/src/lib/playerService.test.ts
+++ b/apps/app/src/lib/playerService.test.ts
@@ -831,6 +831,42 @@ describe('loadParentPlayerDetail custom roster fields', () => {
     expect(result).toEqual(clips.slice(0, 8));
   });
 
+  it('allows profile-hydrated parent links to load video clips on demand', async () => {
+    const games = [{ id: 'game-1' }];
+    const clips = [{
+      id: 'clip-1',
+      title: 'Fast break',
+      gameDate: '',
+      playLabel: '',
+      url: 'https://video.example/clip-1.mp4',
+      thumbnailUrl: '',
+      gameLabel: 'Game'
+    }];
+    scheduleServiceMocks.loadParentPlayerSchedule.mockResolvedValue({
+      children: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Sam Player' }],
+      events: []
+    });
+    legacyPlayerDbMocks.getGames.mockResolvedValue(games);
+    legacyPlayerProfileMocks.collectPlayerVideoClips.mockReturnValue(clips as any);
+
+    const result = await loadParentPlayerVideoClips({
+      uid: 'parent-1',
+      email: 'parent@example.com',
+      parentOf: []
+    } as any, 'team-1', 'player-1');
+
+    expect(scheduleServiceMocks.loadParentPlayerSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ uid: 'parent-1' }),
+      { teamId: 'team-1', playerId: 'player-1' }
+    );
+    expect(legacyPlayerDbMocks.getGames).toHaveBeenCalledWith('team-1');
+    expect(legacyPlayerProfileMocks.collectPlayerVideoClips).toHaveBeenCalledWith(games, {
+      teamId: 'team-1',
+      playerId: 'player-1'
+    });
+    expect(result).toEqual(clips);
+  });
+
   it('surfaces video clip game fetch failures to the caller', async () => {
     legacyPlayerDbMocks.getGames.mockRejectedValue(new Error('Game fetch failed.'));
 

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -59,6 +59,8 @@ import { loadParentPlayerSchedule, type ParentScheduleChild } from './scheduleSe
 import { clearAppDataCache } from './appDataCache';
 import type { AuthUser } from './types';
 
+export type { PlayerVideoClip };
+
 export type ParentPlayerStatRow = {
   event: ParentScheduleEvent;
   stats: Record<string, unknown>;
@@ -200,7 +202,6 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
 
   const [
     players,
-    games,
     certificates,
     trackingItems,
     trackingStatuses,
@@ -212,7 +213,6 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     statOptions
   ] = await Promise.all([
     getPlayers(resolvedTeamId, { includeInactive: true }).catch(() => []),
-    getGames(resolvedTeamId).catch(() => []),
     listCertificatesForPlayer(resolvedTeamId, resolvedPlayerId, { status: 'published', limit: 5 }).catch(() => []),
     getPublicTrackingItems(resolvedTeamId).catch(() => []),
     getPlayerTrackingStatuses(resolvedTeamId, [resolvedPlayerId]).catch(() => []),
@@ -248,11 +248,6 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     stats: await getAggregatedStatsForPlayer(resolvedTeamId, event.id, resolvedPlayerId).catch(() => ({})) || {}
   })));
 
-  const clips = collectPlayerVideoClips(games, {
-    teamId: resolvedTeamId,
-    playerId: resolvedPlayerId
-  }).slice(0, 8);
-
   const trackingSummary = getVisiblePlayerTrackingSummary({
     items: trackingItems,
     statuses: trackingStatuses,
@@ -283,7 +278,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
       openAssignments: upcoming.reduce((total, event) => total + getOpenScheduleAssignments(event.assignments).length, 0)
     },
     statRows,
-    clips,
+    clips: [],
     certificates: Array.isArray(certificates) ? certificates : [],
     trackingSummary,
     privateProfile: normalizePrivateProfile(privateProfile),
@@ -300,6 +295,26 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
       resolvedPlayerId
     )
   };
+}
+
+export async function loadParentPlayerVideoClips(user: AuthUser | null, teamId: string, playerId: string): Promise<PlayerVideoClip[]> {
+  if (!user?.uid) {
+    throw new Error('Player details require a signed-in user.');
+  }
+
+  const resolvedTeamId = decodeURIComponent(teamId || '');
+  const resolvedPlayerId = decodeURIComponent(playerId || '');
+  const team = await getTeam(resolvedTeamId, { includeInactive: true });
+  const access = buildPlayerAccess(user, resolvedTeamId, resolvedPlayerId, team);
+  if (!access.isLinkedParent && !access.isTeamStaff) {
+    throw new Error('This player is not linked to your account.');
+  }
+
+  const games = await getGames(resolvedTeamId).catch(() => []);
+  return collectPlayerVideoClips(games, {
+    teamId: resolvedTeamId,
+    playerId: resolvedPlayerId
+  }).slice(0, 8);
 }
 
 export async function loadParentPlayerAthleteProfile(user: AuthUser | null, teamId: string, playerId: string): Promise<ParentAthleteProfileData> {

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -310,7 +310,7 @@ export async function loadParentPlayerVideoClips(user: AuthUser | null, teamId: 
     throw new Error('This player is not linked to your account.');
   }
 
-  const games = await getGames(resolvedTeamId).catch(() => []);
+  const games = await getGames(resolvedTeamId);
   return collectPlayerVideoClips(games, {
     teamId: resolvedTeamId,
     playerId: resolvedPlayerId

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -302,11 +302,15 @@ export async function loadParentPlayerVideoClips(user: AuthUser | null, teamId: 
     throw new Error('Player details require a signed-in user.');
   }
 
-  const resolvedTeamId = decodeURIComponent(teamId || '');
-  const resolvedPlayerId = decodeURIComponent(playerId || '');
+  const schedule = await loadParentPlayerSchedule(user, { teamId, playerId });
+  const linkedChild = findLinkedChild(schedule.children, teamId, playerId);
+  const requestedTeamId = decodeURIComponent(teamId || '');
+  const requestedPlayerId = decodeURIComponent(playerId || '');
+  const resolvedTeamId = linkedChild?.teamId || requestedTeamId;
+  const resolvedPlayerId = linkedChild?.playerId || requestedPlayerId;
   const team = await getTeam(resolvedTeamId, { includeInactive: true });
   const access = buildPlayerAccess(user, resolvedTeamId, resolvedPlayerId, team);
-  if (!access.isLinkedParent && !access.isTeamStaff) {
+  if (!linkedChild && !access.isLinkedParent && !access.isTeamStaff) {
     throw new Error('This player is not linked to your account.');
   }
 

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -24,7 +24,10 @@ import {
   loadParentFeesForApp,
   loadParentRegistrations
 } from './parentToolsService';
-import { loadParentPlayerDetailWithAthleteProfile } from './playerService';
+import {
+  loadParentPlayerDetailWithAthleteProfile,
+  loadParentPlayerVideoClips
+} from './playerService';
 import {
   formatEventDateLabel,
   formatEventTimeLabel,
@@ -351,10 +354,17 @@ export async function runPrivateAiTool(user: AuthUser, call: PrivateAiToolCall):
         if (!player) {
           return { name, ok: false, error: 'No matching player was found for this account.' };
         }
+        const [detail, clips] = await Promise.all([
+          loadParentPlayerDetailWithAthleteProfile(user, player.teamId, player.playerId),
+          loadParentPlayerVideoClips(user, player.teamId, player.playerId)
+        ]);
         return {
           name,
           ok: true,
-          data: summarizePlayerDevelopment(await loadParentPlayerDetailWithAthleteProfile(user, player.teamId, player.playerId))
+          data: summarizePlayerDevelopment({
+            ...detail,
+            clips
+          })
         };
       }
       case 'get_fees':

--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -356,7 +356,7 @@ export async function runPrivateAiTool(user: AuthUser, call: PrivateAiToolCall):
         }
         const [detail, clips] = await Promise.all([
           loadParentPlayerDetailWithAthleteProfile(user, player.teamId, player.playerId),
-          loadParentPlayerVideoClips(user, player.teamId, player.playerId)
+          loadParentPlayerVideoClips(user, player.teamId, player.playerId).catch(() => [])
         ]);
         return {
           name,

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -16,6 +16,7 @@ function createDeferred<T>() {
 const playerServiceMocks = vi.hoisted(() => ({
   loadParentPlayerAthleteProfile: vi.fn(),
   loadParentPlayerDetail: vi.fn(),
+  loadParentPlayerVideoClips: vi.fn(),
   markParentPlayerIncentivePaid: vi.fn(),
   retireParentPlayerIncentiveRule: vi.fn(),
   saveParentAthleteProfileDraft: vi.fn(),
@@ -157,6 +158,7 @@ describe('PlayerDetail athlete profile season selection', () => {
     vi.clearAllMocks();
     playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData());
     playerServiceMocks.loadParentPlayerAthleteProfile.mockResolvedValue(buildDetailData().athleteProfile);
+    playerServiceMocks.loadParentPlayerVideoClips.mockResolvedValue([]);
     playerServiceMocks.saveParentAthleteProfileDraft.mockResolvedValue({
       shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1'
     });
@@ -208,6 +210,43 @@ describe('PlayerDetail athlete profile season selection', () => {
 
     await waitFor(() => {
       expect(playerServiceMocks.loadParentPlayerAthleteProfile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('lazy-loads video clips once when the Video Clips report opens', async () => {
+    playerServiceMocks.loadParentPlayerVideoClips.mockResolvedValue([
+      {
+        id: 'clip-1',
+        title: 'Fast break finish',
+        gameDate: '2026-01-15',
+        playLabel: 'Score',
+        url: 'https://video.example/clip-1.mp4',
+        thumbnailUrl: '',
+        gameLabel: 'Comets vs Storm'
+      }
+    ]);
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    expect(playerServiceMocks.loadParentPlayerVideoClips).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
+    expect(playerServiceMocks.loadParentPlayerVideoClips).not.toHaveBeenCalled();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Video Clips' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(1);
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledWith(auth.user, 'team-current', 'player-current');
+    });
+    expect(await screen.findByText('Fast break finish')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Game Stats' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Video Clips' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -250,6 +250,47 @@ describe('PlayerDetail athlete profile season selection', () => {
     });
   });
 
+  it('does not auto-retry failed video clip loads until the user retries', async () => {
+    playerServiceMocks.loadParentPlayerVideoClips
+      .mockRejectedValueOnce(new Error('Clip network failed.'))
+      .mockResolvedValueOnce([
+        {
+          id: 'clip-1',
+          title: 'Putback score',
+          gameDate: '2026-01-15',
+          playLabel: 'Score',
+          url: 'https://video.example/clip-1.mp4',
+          thumbnailUrl: '',
+          gameLabel: 'Comets vs Storm'
+        }
+      ]);
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Video Clips' }));
+
+    expect(await screen.findByText('Clip network failed.')).toBeTruthy();
+    await waitFor(() => {
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Game Stats' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Video Clips' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry clips' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText('Putback score')).toBeTruthy();
+  });
+
   it('shows a retryable player detail error state and reloads on retry', async () => {
     playerServiceMocks.loadParentPlayerDetail
       .mockRejectedValueOnce(new Error('Player detail unavailable.'))

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 function createDeferred<T>() {
@@ -153,6 +153,27 @@ function renderPlayerDetail() {
   );
 }
 
+function PlayerDetailWithRouteSwitcher() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate('/players/team-next/player-next')}>Next player route</button>
+      <PlayerDetail auth={auth} />
+    </>
+  );
+}
+
+function renderPlayerDetailWithRouteSwitcher() {
+  return render(
+    <MemoryRouter initialEntries={['/players/team-current/player-current']}>
+      <Routes>
+        <Route path="/players/:teamId/:playerId" element={<PlayerDetailWithRouteSwitcher />} />
+        <Route path="/home" element={<div>Home</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe('PlayerDetail athlete profile season selection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -247,6 +268,63 @@ describe('PlayerDetail athlete profile season selection', () => {
 
     await waitFor(() => {
       expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not preload clips when navigating to another player after clips were opened', async () => {
+    playerServiceMocks.loadParentPlayerDetail
+      .mockResolvedValueOnce(buildDetailData())
+      .mockResolvedValueOnce(buildDetailData({
+        child: {
+          teamId: 'team-next',
+          teamName: 'Next Team',
+          playerId: 'player-next',
+          playerName: 'Jordan Player'
+        },
+        player: {
+          id: 'player-next',
+          teamId: 'team-next',
+          teamName: 'Next Team',
+          name: 'Jordan Player',
+          number: '24',
+          photoUrl: ''
+        },
+        team: { id: 'team-next', name: 'Next Team' }
+      }));
+    playerServiceMocks.loadParentPlayerVideoClips.mockResolvedValue([
+      {
+        id: 'clip-1',
+        title: 'Fast break finish',
+        gameDate: '2026-01-15',
+        playLabel: 'Score',
+        url: 'https://video.example/clip-1.mp4',
+        thumbnailUrl: '',
+        gameLabel: 'Comets vs Storm'
+      }
+    ]);
+
+    renderPlayerDetailWithRouteSwitcher();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Video Clips' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(1);
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledWith(auth.user, 'team-current', 'player-current');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next player route' }));
+
+    await screen.findByText('Jordan Player');
+    expect(playerServiceMocks.loadParentPlayerDetail).toHaveBeenLastCalledWith(auth.user, 'team-next', 'player-next');
+    expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Video Clips' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenCalledTimes(2);
+      expect(playerServiceMocks.loadParentPlayerVideoClips).toHaveBeenLastCalledWith(auth.user, 'team-next', 'player-next');
     });
   });
 

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -332,7 +332,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
     if (!auth.user?.uid) {
       return null;
     }
-    if ((videoClipsLoaded || videoClipsLoading) && !force) {
+    if ((videoClipsLoaded || videoClipsLoading || videoClipsError) && !force) {
       return null;
     }
 

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -416,7 +416,13 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
     }
   };
 
-  const refreshPlayer = async ({ showLoading = data === null }: { showLoading?: boolean } = {}) => {
+  const refreshPlayer = async ({
+    showLoading = data === null,
+    reloadVideoClips = videoClipsLoaded
+  }: {
+    showLoading?: boolean;
+    reloadVideoClips?: boolean;
+  } = {}) => {
     const fullPageLoading = showLoading || data === null;
     if (fullPageLoading) {
       setLoading(true);
@@ -431,7 +437,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
       setAthleteProfileLoaded(nextAthleteProfileLoaded);
       setAthleteProfileError(null);
       setVideoClipsError(null);
-      if (videoClipsLoaded) {
+      if (reloadVideoClips) {
         await loadVideoClips({
           nextTeamId: nextData.child.teamId,
           nextPlayerId: nextData.child.playerId,
@@ -471,7 +477,7 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
     setVideoClipsLoaded(false);
     setVideoClipsLoading(false);
     setVideoClipsError(null);
-    refreshPlayer({ showLoading: true });
+    refreshPlayer({ showLoading: true, reloadVideoClips: false });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, teamId, playerId]);
 

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -35,6 +35,7 @@ import {
 import {
   loadParentPlayerAthleteProfile,
   loadParentPlayerDetail,
+  loadParentPlayerVideoClips,
   markParentPlayerIncentivePaid,
   retireParentPlayerIncentiveRule,
   savePlayerCustomRosterFieldValues,
@@ -50,7 +51,8 @@ import {
   type AthleteProfileHighlightClipUpload,
   type ParentAthleteProfileData,
   type ParentPlayerDetailData,
-  type ParentPlayerStatRow
+  type ParentPlayerStatRow,
+  type PlayerVideoClip
 } from '../lib/playerService';
 import { DetailLoadErrorState } from '../components/DetailLoadErrorState';
 import { getEventDetailPath } from '../lib/homeLogic';
@@ -312,7 +314,59 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
   const [athleteProfileLoaded, setAthleteProfileLoaded] = useState(false);
   const [athleteProfileLoading, setAthleteProfileLoading] = useState(false);
   const [athleteProfileError, setAthleteProfileError] = useState<AppServiceError | null>(null);
+  const [videoClipsLoaded, setVideoClipsLoaded] = useState(false);
+  const [videoClipsLoading, setVideoClipsLoading] = useState(false);
+  const [videoClipsError, setVideoClipsError] = useState<AppServiceError | null>(null);
   const athleteProfileRequestKeyRef = useRef('');
+  const videoClipsRequestKeyRef = useRef('');
+
+  const loadVideoClips = async ({
+    nextTeamId,
+    nextPlayerId,
+    force = false
+  }: {
+    nextTeamId: string;
+    nextPlayerId: string;
+    force?: boolean;
+  }): Promise<PlayerVideoClip[] | null> => {
+    if (!auth.user?.uid) {
+      return null;
+    }
+    if ((videoClipsLoaded || videoClipsLoading) && !force) {
+      return null;
+    }
+
+    const requestKey = `${nextTeamId}::${nextPlayerId}`;
+    videoClipsRequestKeyRef.current = requestKey;
+    setVideoClipsLoading(true);
+    setVideoClipsError(null);
+    try {
+      const clips = await loadParentPlayerVideoClips(auth.user, nextTeamId, nextPlayerId);
+      if (videoClipsRequestKeyRef.current !== requestKey) {
+        return null;
+      }
+      setData((current) => {
+        if (!current || current.child.teamId !== nextTeamId || current.child.playerId !== nextPlayerId) {
+          return current;
+        }
+        return {
+          ...current,
+          clips
+        };
+      });
+      setVideoClipsLoaded(true);
+      return clips;
+    } catch (loadError: any) {
+      if (videoClipsRequestKeyRef.current === requestKey) {
+        setVideoClipsError(toAppServiceError(loadError, 'Unable to load video clips.'));
+      }
+      return null;
+    } finally {
+      if (videoClipsRequestKeyRef.current === requestKey) {
+        setVideoClipsLoading(false);
+      }
+    }
+  };
 
   const loadAthleteProfile = async ({
     nextTeamId,
@@ -376,6 +430,14 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
       setData(nextData);
       setAthleteProfileLoaded(nextAthleteProfileLoaded);
       setAthleteProfileError(null);
+      setVideoClipsError(null);
+      if (videoClipsLoaded) {
+        await loadVideoClips({
+          nextTeamId: nextData.child.teamId,
+          nextPlayerId: nextData.child.playerId,
+          force: true
+        });
+      }
       if (athleteProfileLoaded && !nextAthleteProfileLoaded) {
         const nextAthleteProfile = await loadAthleteProfile({
           nextTeamId: nextData.child.teamId,
@@ -402,9 +464,13 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
 
   useEffect(() => {
     athleteProfileRequestKeyRef.current = '';
+    videoClipsRequestKeyRef.current = '';
     setAthleteProfileLoaded(false);
     setAthleteProfileLoading(false);
     setAthleteProfileError(null);
+    setVideoClipsLoaded(false);
+    setVideoClipsLoading(false);
+    setVideoClipsError(null);
     refreshPlayer({ showLoading: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, teamId, playerId]);
@@ -513,7 +579,22 @@ export function PlayerDetail({ auth }: { auth: AuthState }) {
       {error ? <Status tone="error" message={error.message} /> : null}
       {activeSection === 'overview' ? <OverviewSection data={data} /> : null}
       {activeSection === 'schedule' ? <PlayerScheduleSection events={data.events} /> : null}
-      {activeSection === 'performance' ? <ReportsSection data={data} /> : null}
+      {activeSection === 'performance' ? (
+        <ReportsSection
+          data={data}
+          videoClipsLoading={videoClipsLoading}
+          videoClipsError={videoClipsError}
+          onVideoClipsOpen={() => loadVideoClips({
+            nextTeamId: data.child.teamId,
+            nextPlayerId: data.child.playerId
+          })}
+          onRetryVideoClips={() => loadVideoClips({
+            nextTeamId: data.child.teamId,
+            nextPlayerId: data.child.playerId,
+            force: true
+          })}
+        />
+      ) : null}
       {activeSection === 'profile' ? (
         <PlayerProfileSection
           data={data}
@@ -596,9 +677,28 @@ const reportPanels: Array<{ id: ReportPanelId; label: string }> = [
   { id: 'clips', label: 'Video Clips' }
 ];
 
-function ReportsSection({ data }: { data: ParentPlayerDetailData }) {
+function ReportsSection({
+  data,
+  videoClipsLoading,
+  videoClipsError,
+  onVideoClipsOpen,
+  onRetryVideoClips
+}: {
+  data: ParentPlayerDetailData;
+  videoClipsLoading: boolean;
+  videoClipsError: AppServiceError | null;
+  onVideoClipsOpen: () => void;
+  onRetryVideoClips: () => void;
+}) {
   const [activePanel, setActivePanel] = useState<ReportPanelId>('games');
   const trackingRows = Array.isArray(data.trackingSummary) ? data.trackingSummary[0]?.items || [] : [];
+
+  useEffect(() => {
+    if (activePanel === 'clips') {
+      onVideoClipsOpen();
+    }
+  }, [activePanel, onVideoClipsOpen]);
+
   return (
     <div className="player-section-content space-y-4">
       <section className="app-card p-4">
@@ -630,7 +730,14 @@ function ReportsSection({ data }: { data: ParentPlayerDetailData }) {
           {activePanel === 'games' ? <GameStatsPanel rows={data.statRows} /> : null}
           {activePanel === 'season' ? <SeasonAveragesPanel rows={data.statRows} /> : null}
           {activePanel === 'events' ? <GameEventsPanel events={data.events} /> : null}
-          {activePanel === 'clips' ? <ClipsPanel clips={data.clips} /> : null}
+          {activePanel === 'clips' ? (
+            <ClipsPanel
+              clips={data.clips}
+              loading={videoClipsLoading}
+              error={videoClipsError}
+              onRetry={onRetryVideoClips}
+            />
+          ) : null}
         </div>
       </section>
 
@@ -689,7 +796,35 @@ function GameEventsPanel({ events }: { events: ParentScheduleEvent[] }) {
   );
 }
 
-function ClipsPanel({ clips }: { clips: Array<Record<string, any>> }) {
+function ClipsPanel({
+  clips,
+  loading,
+  error,
+  onRetry
+}: {
+  clips: Array<Record<string, any>>;
+  loading: boolean;
+  error: AppServiceError | null;
+  onRetry: () => void;
+}) {
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">
+        <Loader2 className="mr-2 inline h-4 w-4 animate-spin text-primary-600" aria-hidden="true" />
+        Loading video clips...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-rose-200 bg-rose-50 p-3">
+        <div className="text-sm font-black text-rose-900">{error.message}</div>
+        <button type="button" className="mt-2 text-xs font-black text-rose-700" onClick={onRetry}>Retry clips</button>
+      </div>
+    );
+  }
+
   return (
     <div className="grid gap-2 sm:grid-cols-2">
       {clips.length ? clips.map((clip) => (

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -55,6 +55,7 @@ import {
   MAX_CHAT_MEDIA_SIZE,
   buildChatAudienceMetadata,
   buildChatMentionSuggestions,
+  buildChatViewportSignature,
   buildEmailAudienceMetadata,
   buildChatMediaShareDetails,
   chatReactions,
@@ -1824,10 +1825,7 @@ export function ChatWindow({
   );
 }
 
-export function buildChatViewportSignature(scrollHeight: number, clientHeight: number, scrollTop: number) {
-  const distanceFromBottom = Math.max(0, scrollHeight - clientHeight - scrollTop);
-  return `${scrollHeight}:${clientHeight}:${distanceFromBottom}`;
-}
+export { buildChatViewportSignature };
 
 export function getSafeMessageAttachments(message: ChatMessage): SafeChatAttachment[] {
   return getMessageAttachments(message).filter((attachment): attachment is SafeChatAttachment => (

--- a/player.html
+++ b/player.html
@@ -424,22 +424,26 @@
         async function loadPlayerGameData(teamId, games, playerId, playerName) {
             return Promise.all(games.map(async (game) => {
                 const gameId = game.id;
-                const statsSnapshot = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
                 const teamStatsByPlayerId = {};
                 let selectedPlayerStats = null;
 
-                statsSnapshot.forEach((docSnap) => {
-                    const statData = docSnap.data() || {};
-                    const playerStats = statData.stats || {};
-                    teamStatsByPlayerId[docSnap.id] = playerStats;
+                try {
+                    const statsSnapshot = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
+                    statsSnapshot.forEach((docSnap) => {
+                        const statData = docSnap.data() || {};
+                        const playerStats = statData.stats || {};
+                        teamStatsByPlayerId[docSnap.id] = playerStats;
 
-                    if (docSnap.id === playerId && hasPlayerProfileParticipation(statData)) {
-                        selectedPlayerStats = {
-                            stats: playerStats,
-                            timeMs: typeof statData.timeMs === 'number' ? statData.timeMs : 0
-                        };
-                    }
-                });
+                        if (docSnap.id === playerId && hasPlayerProfileParticipation(statData)) {
+                            selectedPlayerStats = {
+                                stats: playerStats,
+                                timeMs: typeof statData.timeMs === 'number' ? statData.timeMs : 0
+                            };
+                        }
+                    });
+                } catch (error) {
+                    console.warn('Player stats unavailable for game:', gameId, error);
+                }
 
                 if (!selectedPlayerStats) {
                     return {
@@ -454,15 +458,20 @@
                     collection(db, `teams/${teamId}/games/${gameId}/events`),
                     orderBy('timestamp', 'asc')
                 );
-                const eventsSnapshot = await getDocs(eventsQuery);
-                const events = eventsSnapshot.docs
-                    .map((docSnap) => docSnap.data())
-                    .filter((event) => event.playerId === playerId || (event.text && event.text.includes(playerName)))
-                    .map((event) => ({
-                        ...event,
-                        gameId,
-                        opponent: game.opponent || 'Opponent'
-                    }));
+                let events = [];
+                try {
+                    const eventsSnapshot = await getDocs(eventsQuery);
+                    events = eventsSnapshot.docs
+                        .map((docSnap) => docSnap.data())
+                        .filter((event) => event.playerId === playerId || (event.text && event.text.includes(playerName)))
+                        .map((event) => ({
+                            ...event,
+                            gameId,
+                            opponent: game.opponent || 'Opponent'
+                        }));
+                } catch (error) {
+                    console.warn('Player events unavailable for game:', gameId, error);
+                }
 
                 return {
                     gameId,

--- a/scripts/build-help-workflow-html-loop.mjs
+++ b/scripts/build-help-workflow-html-loop.mjs
@@ -529,6 +529,7 @@ function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const pickActiveFromViewport = () => {
@@ -594,16 +595,28 @@ function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
         window.addEventListener('scroll', () => {
-          window.requestAnimationFrame(() => setActive(null));
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
         }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {

--- a/scripts/build-help-workflow-html-loop.mjs
+++ b/scripts/build-help-workflow-html-loop.mjs
@@ -585,7 +585,9 @@ function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => setActive(null));
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/scripts/build-help-workflow-html-loop.mjs
+++ b/scripts/build-help-workflow-html-loop.mjs
@@ -531,13 +531,30 @@ function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
         let mobileWrapper = null;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = (activeId) => {
-          let active = sectionById.get(activeId) || headings[0];
-          if (!sectionById.has(activeId)) {
-            for (const h of headings) {
-              if (h.getBoundingClientRect().top <= 140) active = h;
+        const pickActiveFromViewport = () => {
+          const activationLine = Math.min(180, Math.max(120, window.innerHeight * 0.22));
+          let active = headings[0];
+          let nearest = headings[0];
+          let nearestDistance = Number.POSITIVE_INFINITY;
+
+          for (const h of headings) {
+            const top = h.getBoundingClientRect().top;
+            const distance = Math.abs(top - activationLine);
+            if (distance < nearestDistance) {
+              nearest = h;
+              nearestDistance = distance;
             }
+            if (top <= activationLine) active = h;
           }
+
+          if (nearest && nearest !== active && nearest.getBoundingClientRect().top > 0 && nearestDistance <= 140) {
+            return nearest;
+          }
+
+          return active;
+        };
+        const setActive = (activeId) => {
+          const active = sectionById.get(activeId) || pickActiveFromViewport();
           allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -972,6 +972,10 @@ async function mockHomePlayerModules(page) {
                     };
                 }
 
+                export async function loadParentPlayerVideoClips() {
+                    return [{ title: 'Fast break', url: 'https://video.example.test/clip', gameLabel: 'vs. Falcons' }];
+                }
+
                 export async function updateParentPlayerEditableProfile() {}
                 export async function savePlayerCustomRosterFieldValues() {}
                 export async function saveStaffPlayerRosterDetails() { return { updatedFields: [] }; }

--- a/tests/smoke/help-workflow-pages.spec.js
+++ b/tests/smoke/help-workflow-pages.spec.js
@@ -106,6 +106,7 @@ test.describe('help topic and workflow pages', () => {
         const desktopPrerequisitesLink = page.locator('.wf-sidebar #workflow-toc a[href="#prerequisites"]');
         await expect(mobilePrerequisitesLink).toHaveClass(/is-active/);
         await expect(desktopPrerequisitesLink).toHaveClass(/is-active/);
+        await page.waitForTimeout(120);
 
         const targetSection = page.locator('.help-workflow-body h2#common-questions');
         await targetSection.evaluate((element) => element.scrollIntoView());

--- a/tests/unit/app-chat-messages-scroll-signature.test.js
+++ b/tests/unit/app-chat-messages-scroll-signature.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildChatViewportSignature } from '../../apps/app/src/pages/Messages.tsx';
+import { buildChatViewportSignature } from '../../apps/app/src/lib/chatLogic.ts';
 
 describe('buildChatViewportSignature', () => {
     it('changes when the viewport height changes even if message height stays the same', () => {

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -30,6 +30,7 @@ const socialMocks = vi.hoisted(() => ({
 
 const playerMocks = vi.hoisted(() => ({
     loadParentPlayerDetail: vi.fn(),
+    loadParentPlayerVideoClips: vi.fn(),
     markParentPlayerIncentivePaid: vi.fn(),
     retireParentPlayerIncentiveRule: vi.fn(),
     saveParentAthleteProfileDraft: vi.fn(),
@@ -513,6 +514,9 @@ beforeEach(() => {
             builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-1&playerId=player-1&profileId=profile-1'
         }
     });
+    playerMocks.loadParentPlayerVideoClips.mockResolvedValue([
+        { title: 'Fast break', url: 'https://video.example.test/clip', gameLabel: 'vs. Falcons' }
+    ]);
     playerMocks.updateParentPlayerEditableProfile.mockResolvedValue();
     playerMocks.saveParentAthleteProfileDraft.mockResolvedValue({
         shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1'

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -62,6 +62,7 @@ vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
 
 import {
     loadParentPlayerDetail,
+    loadParentPlayerVideoClips,
     normalizeAthleteProfileHighlightClipUrl,
     saveParentAthleteProfileDraft,
     saveParentPlayerIncentiveRule,
@@ -207,7 +208,7 @@ beforeEach(() => {
 });
 
 describe('React app parent player detail service', () => {
-    it('loads a team-scoped linked player with schedule actions, stats, clips, certificates, and tracking', async () => {
+    it('loads a team-scoped linked player with schedule actions, stats, certificates, and tracking without eager clips', async () => {
         const detail = await loadParentPlayerDetail(user(), 'team-1', 'player-1');
 
         expect(scheduleMocks.loadParentPlayerSchedule).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-1' }), {
@@ -216,7 +217,7 @@ describe('React app parent player detail service', () => {
         });
         expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1', { includeInactive: true });
         expect(dbMocks.getPlayers).toHaveBeenCalledWith('team-1', { includeInactive: true });
-        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1');
+        expect(dbMocks.getGames).not.toHaveBeenCalled();
         expect(dbMocks.getAggregatedStatsForPlayer).toHaveBeenCalledWith('team-1', 'game-final', 'player-1');
         expect(dbMocks.getPlayerPrivateProfile).toHaveBeenCalledWith('team-1', 'player-1');
         expect(dbMocks.listCertificatesForPlayer).toHaveBeenCalledWith('team-1', 'player-1', { status: 'published', limit: 5 });
@@ -225,10 +226,7 @@ describe('React app parent player detail service', () => {
         expect(incentiveMocks.getPaidGames).toHaveBeenCalledWith('user-1', 'player-1');
         expect(incentiveMocks.getCapSetting).toHaveBeenCalledWith('user-1', 'player-1');
         expect(incentiveMocks.getStatOptionsForTeam).toHaveBeenCalledWith('team-1');
-        expect(profileStatMocks.collectPlayerVideoClips).toHaveBeenCalledWith(expect.any(Array), {
-            teamId: 'team-1',
-            playerId: 'player-1'
-        });
+        expect(profileStatMocks.collectPlayerVideoClips).not.toHaveBeenCalled();
         expect(trackingMocks.getVisiblePlayerTrackingSummary).toHaveBeenCalledWith({
             items: [{ id: 'item-1', title: 'Bring ball' }],
             statuses: [{ playerId: 'player-1', itemId: 'item-1', status: 'complete' }],
@@ -254,7 +252,7 @@ describe('React app parent player detail service', () => {
             event: expect.objectContaining({ id: 'game-final' }),
             stats: { pts: 12, reb: 4 }
         });
-        expect(detail.clips).toHaveLength(1);
+        expect(detail.clips).toEqual([]);
         expect(detail.certificates).toEqual([{ id: 'cert-1', title: 'Hustle Award' }]);
         expect(detail.trackingSummary).toEqual([{ playerId: 'player-1', items: [{ id: 'item-1', title: 'Bring ball', isComplete: true }] }]);
         expect(detail.privateProfile).toEqual({
@@ -282,6 +280,14 @@ describe('React app parent player detail service', () => {
                 }
             ]
         });
+
+        const clips = await loadParentPlayerVideoClips(user(), 'team-1', 'player-1');
+        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1');
+        expect(profileStatMocks.collectPlayerVideoClips).toHaveBeenCalledWith([{ id: 'game-final', clips: [] }], {
+            teamId: 'team-1',
+            playerId: 'player-1'
+        });
+        expect(clips).toEqual([{ title: 'Fast break', url: 'https://video.example.test/clip', gameLabel: 'vs. Falcons' }]);
     });
 
     it('falls back to the legacy player-only route and blocks unlinked players', async () => {

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -50,9 +50,11 @@ const teamMocks = vi.hoisted(() => ({
 
 const playerMocks = vi.hoisted(() => {
     const loadParentPlayerDetailWithAthleteProfile = vi.fn();
+    const loadParentPlayerVideoClips = vi.fn();
     return {
         loadParentPlayerDetail: loadParentPlayerDetailWithAthleteProfile,
-        loadParentPlayerDetailWithAthleteProfile
+        loadParentPlayerDetailWithAthleteProfile,
+        loadParentPlayerVideoClips
     };
 });
 
@@ -178,6 +180,7 @@ beforeEach(async () => {
         certificates: [],
         clips: []
     });
+    playerMocks.loadParentPlayerVideoClips.mockResolvedValue([]);
     toolsMocks.loadParentFeesForApp.mockResolvedValue([]);
     toolsMocks.loadParentRegistrations.mockResolvedValue([]);
     toolsMocks.loadParentCertificates.mockResolvedValue([]);
@@ -366,6 +369,9 @@ describe('private AI service', () => {
     });
 
     it('uses linked player detail data for player development coaching answers', async () => {
+        playerMocks.loadParentPlayerVideoClips.mockResolvedValueOnce([
+            { id: 'clip-1', title: 'Fast break', url: 'https://video.example.test/fast-break.mp4' }
+        ]);
         const { runPrivateAiTool } = await import('../../apps/app/src/lib/privateAiService.ts');
 
         await expect(runPrivateAiTool(authUser, { name: 'get_player_development', args: { playerName: 'ave' } })).resolves.toMatchObject({
@@ -381,10 +387,18 @@ describe('private AI service', () => {
                 incentives: expect.objectContaining({
                     totalEarnedCents: 800,
                     unpaidCents: 200
-                })
+                }),
+                clips: [
+                    expect.objectContaining({
+                        id: 'clip-1',
+                        title: 'Fast break',
+                        url: 'https://video.example.test/fast-break.mp4'
+                    })
+                ]
             })
         });
         expect(playerMocks.loadParentPlayerDetailWithAthleteProfile).toHaveBeenCalledWith(authUser, 'team-1', 'player-1');
+        expect(playerMocks.loadParentPlayerVideoClips).toHaveBeenCalledWith(authUser, 'team-1', 'player-1');
     });
 
     it('opts all-range AI schedule lookups into full history loads', async () => {

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -401,6 +401,24 @@ describe('private AI service', () => {
         expect(playerMocks.loadParentPlayerVideoClips).toHaveBeenCalledWith(authUser, 'team-1', 'player-1');
     });
 
+    it('keeps player development answers available when optional video clips fail to load', async () => {
+        playerMocks.loadParentPlayerVideoClips.mockRejectedValueOnce(new Error('Games unavailable'));
+        const { runPrivateAiTool } = await import('../../apps/app/src/lib/privateAiService.ts');
+
+        await expect(runPrivateAiTool(authUser, { name: 'get_player_development', args: { playerName: 'ave' } })).resolves.toMatchObject({
+            ok: true,
+            data: expect.objectContaining({
+                player: expect.objectContaining({
+                    id: 'player-1',
+                    name: 'Avery'
+                }),
+                clips: []
+            })
+        });
+        expect(playerMocks.loadParentPlayerDetailWithAthleteProfile).toHaveBeenCalledWith(authUser, 'team-1', 'player-1');
+        expect(playerMocks.loadParentPlayerVideoClips).toHaveBeenCalledWith(authUser, 'team-1', 'player-1');
+    });
+
     it('opts all-range AI schedule lookups into full history loads', async () => {
         const { runPrivateAiTool } = await import('../../apps/app/src/lib/privateAiService.ts');
 

--- a/tests/unit/player-public-load-performance.test.js
+++ b/tests/unit/player-public-load-performance.test.js
@@ -14,4 +14,10 @@ describe('player public page load performance', () => {
         expect(source).toContain('const gameTeamStats = gameLoadResults.find((entry) => entry.gameId === selectedGameId)?.statsByPlayerId || {};');
         expect(source).not.toContain('const teamStatsSnapshot = await getDocs(collection(db, `teams/${teamId}/games/${selectedGameId}/aggregatedStats`));');
     });
+
+    it('keeps the public profile bootable when optional per-game reads are denied', () => {
+        expect(source).toContain("console.warn('Player stats unavailable for game:', gameId, error);");
+        expect(source).toContain("console.warn('Player events unavailable for game:', gameId, error);");
+        expect(source).toContain('playerGameStats: null,');
+    });
 });

--- a/tests/unit/workflow-mobile-toc-active-state.test.js
+++ b/tests/unit/workflow-mobile-toc-active-state.test.js
@@ -8,6 +8,7 @@ function readRepoFile(relativePath) {
 function expectMobileTocActiveStateSupport(source) {
     expect(source).toContain(".filter((h) => h.id !== 'in-this-article');");
     expect(source).toContain('const allLinks = [...links];');
+    expect(source).toContain('let preserveHashActiveUntil = 0;');
     expect(source).toContain('const ensureMobileToc = () => {');
     expect(source).toContain('if (!mobileToc || mobileWrapper || window.innerWidth >= 1024) return;');
     expect(source).toContain("const mobileLinks = Array.from(list.querySelectorAll('a'));");
@@ -21,8 +22,13 @@ function expectMobileTocActiveStateSupport(source) {
     expect(source).toContain("window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));");
     expect(source).toContain('const syncHashActiveAfterResize = () => {');
     expect(source).toContain("if (!window.location.hash) return;");
+    expect(source).toContain('preserveHashActiveUntil = performance.now() + 120;');
+    expect(source).toContain('const activeHash = window.location.hash.slice(1);');
+    expect(source).toContain('window.setTimeout(() => {');
+    expect(source).toContain('preserveHashActiveUntil = 0;');
     expect(source).toContain("window.requestAnimationFrame(() => {");
-    expect(source).toContain("window.requestAnimationFrame(() => setActive(null));");
+    expect(source).toContain('performance.now() < preserveHashActiveUntil');
+    expect(source).toContain('setActive(null);');
     expect(source).toContain("window.addEventListener('resize', () => {");
     expect(source).toContain('syncHashActiveAfterResize();');
     expect(source).not.toContain("links.forEach((a) => a.classList.toggle('is-active'");

--- a/tests/unit/workflow-mobile-toc-active-state.test.js
+++ b/tests/unit/workflow-mobile-toc-active-state.test.js
@@ -19,6 +19,7 @@ function expectMobileTocActiveStateSupport(source) {
     expect(source).toContain('const syncHashActiveAfterResize = () => {');
     expect(source).toContain("if (!window.location.hash) return;");
     expect(source).toContain("window.requestAnimationFrame(() => {");
+    expect(source).toContain("window.requestAnimationFrame(() => setActive(null));");
     expect(source).toContain("window.addEventListener('resize', () => {");
     expect(source).toContain('syncHashActiveAfterResize();');
     expect(source).not.toContain("links.forEach((a) => a.classList.toggle('is-active'");

--- a/tests/unit/workflow-mobile-toc-active-state.test.js
+++ b/tests/unit/workflow-mobile-toc-active-state.test.js
@@ -13,6 +13,9 @@ function expectMobileTocActiveStateSupport(source) {
     expect(source).toContain("const mobileLinks = Array.from(list.querySelectorAll('a'));");
     expect(source).toContain('allLinks.push(...mobileLinks);');
     expect(source).toContain('addLinkHandlers(mobileLinks);');
+    expect(source).toContain('const pickActiveFromViewport = () => {');
+    expect(source).toContain('const activationLine = Math.min(180, Math.max(120, window.innerHeight * 0.22));');
+    expect(source).toContain('nearestDistance <= 140');
     expect(source).toContain("allLinks.forEach((a) => a.classList.toggle('is-active'");
     expect(source).toContain('const addLinkHandlers = (tocLinks) => {');
     expect(source).toContain("window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));");

--- a/workflow-admin-ops.html
+++ b/workflow-admin-ops.html
@@ -396,6 +396,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -444,15 +445,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-awards-certificates.html
+++ b/workflow-awards-certificates.html
@@ -294,6 +294,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
           let active = sectionById.get(activeId) || headings[0];
@@ -336,13 +337,27 @@
         };
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
         addLinkHandlers(links);
         ensureMobileToc();
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-choose-home-dashboard.html
+++ b/workflow-choose-home-dashboard.html
@@ -417,6 +417,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -465,15 +466,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-communication.html
+++ b/workflow-communication.html
@@ -452,6 +452,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -500,15 +501,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-fees-payments.html
+++ b/workflow-fees-payments.html
@@ -335,6 +335,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
           let active = sectionById.get(activeId) || headings[0];
@@ -377,13 +378,27 @@
         };
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
         addLinkHandlers(links);
         ensureMobileToc();
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-game-day.html
+++ b/workflow-game-day.html
@@ -543,6 +543,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -591,15 +592,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-getting-started.html
+++ b/workflow-getting-started.html
@@ -457,6 +457,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -505,15 +506,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-join-team.html
+++ b/workflow-join-team.html
@@ -448,6 +448,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -496,15 +497,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-live-tracker.html
+++ b/workflow-live-tracker.html
@@ -422,6 +422,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
           let active = sectionById.get(activeId) || headings[0];
@@ -464,13 +465,27 @@
         };
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
         addLinkHandlers(links);
         ensureMobileToc();
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-live-watch-replay.html
+++ b/workflow-live-watch-replay.html
@@ -474,6 +474,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const pickActiveFromViewport = () => {
@@ -539,16 +540,28 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
         window.addEventListener('scroll', () => {
-          window.requestAnimationFrame(() => setActive(null));
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
         }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {

--- a/workflow-live-watch-replay.html
+++ b/workflow-live-watch-replay.html
@@ -476,13 +476,30 @@
         let mobileWrapper = null;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = (activeId) => {
-          let active = sectionById.get(activeId) || headings[0];
-          if (!sectionById.has(activeId)) {
-            for (const h of headings) {
-              if (h.getBoundingClientRect().top <= 140) active = h;
+        const pickActiveFromViewport = () => {
+          const activationLine = Math.min(180, Math.max(120, window.innerHeight * 0.22));
+          let active = headings[0];
+          let nearest = headings[0];
+          let nearestDistance = Number.POSITIVE_INFINITY;
+
+          for (const h of headings) {
+            const top = h.getBoundingClientRect().top;
+            const distance = Math.abs(top - activationLine);
+            if (distance < nearestDistance) {
+              nearest = h;
+              nearestDistance = distance;
             }
+            if (top <= activationLine) active = h;
           }
+
+          if (nearest && nearest !== active && nearest.getBoundingClientRect().top > 0 && nearestDistance <= 140) {
+            return nearest;
+          }
+
+          return active;
+        };
+        const setActive = (activeId) => {
+          const active = sectionById.get(activeId) || pickActiveFromViewport();
           allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 

--- a/workflow-live-watch-replay.html
+++ b/workflow-live-watch-replay.html
@@ -530,7 +530,9 @@
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => setActive(null));
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -496,13 +496,30 @@
         let mobileWrapper = null;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = (activeId) => {
-          let active = sectionById.get(activeId) || headings[0];
-          if (!sectionById.has(activeId)) {
-            for (const h of headings) {
-              if (h.getBoundingClientRect().top <= 140) active = h;
+        const pickActiveFromViewport = () => {
+          const activationLine = Math.min(180, Math.max(120, window.innerHeight * 0.22));
+          let active = headings[0];
+          let nearest = headings[0];
+          let nearestDistance = Number.POSITIVE_INFINITY;
+
+          for (const h of headings) {
+            const top = h.getBoundingClientRect().top;
+            const distance = Math.abs(top - activationLine);
+            if (distance < nearestDistance) {
+              nearest = h;
+              nearestDistance = distance;
             }
+            if (top <= activationLine) active = h;
           }
+
+          if (nearest && nearest !== active && nearest.getBoundingClientRect().top > 0 && nearestDistance <= 140) {
+            return nearest;
+          }
+
+          return active;
+        };
+        const setActive = (activeId) => {
+          const active = sectionById.get(activeId) || pickActiveFromViewport();
           allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -550,7 +550,9 @@
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => setActive(null));
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -494,6 +494,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const pickActiveFromViewport = () => {
@@ -559,16 +560,28 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
         window.addEventListener('scroll', () => {
-          window.requestAnimationFrame(() => setActive(null));
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
         }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {

--- a/workflow-registration.html
+++ b/workflow-registration.html
@@ -315,6 +315,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
           let active = sectionById.get(activeId) || headings[0];
@@ -357,13 +358,27 @@
         };
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
         addLinkHandlers(links);
         ensureMobileToc();
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-roster.html
+++ b/workflow-roster.html
@@ -569,6 +569,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -617,15 +618,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-schedule.html
+++ b/workflow-schedule.html
@@ -619,6 +619,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -667,15 +668,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-team-media.html
+++ b/workflow-team-media.html
@@ -323,6 +323,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
           let active = sectionById.get(activeId) || headings[0];
@@ -365,13 +366,27 @@
         };
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
         addLinkHandlers(links);
         ensureMobileToc();
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-team-setup.html
+++ b/workflow-team-setup.html
@@ -574,6 +574,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -622,15 +623,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();

--- a/workflow-track-game.html
+++ b/workflow-track-game.html
@@ -481,6 +481,7 @@
         });
         const allLinks = [...links];
         let mobileWrapper = null;
+        let preserveHashActiveUntil = 0;
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
         const setActive = (activeId) => {
@@ -529,15 +530,29 @@
 
         const syncHashActiveAfterResize = () => {
           if (!window.location.hash) return;
+          preserveHashActiveUntil = performance.now() + 120;
+          const activeHash = window.location.hash.slice(1);
           window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(() => setActive(window.location.hash.slice(1)));
+            window.requestAnimationFrame(() => setActive(activeHash));
           });
+          window.setTimeout(() => {
+            setActive(activeHash);
+            preserveHashActiveUntil = 0;
+          }, 80);
         };
 
         addLinkHandlers(links);
         ensureMobileToc();
 
-        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('scroll', () => {
+          window.requestAnimationFrame(() => {
+            if (window.location.hash && performance.now() < preserveHashActiveUntil) {
+              setActive(window.location.hash.slice(1));
+              return;
+            }
+            setActive(null);
+          });
+        }, { passive: true });
         window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
         window.addEventListener('resize', () => {
           ensureMobileToc();


### PR DESCRIPTION
Closes #3486

## What changed
- Removed team game-history fetching from the initial PlayerDetail payload.
- Added `loadParentPlayerVideoClips` to hydrate clips only when needed.
- Wired Reports > Video Clips to lazy-load once, show loading/error/empty states, and cache clips on the current detail page.

## Root Cause
`loadParentPlayerDetail` bundled optional clip hydration into the required player detail payload. That forced `getGames(resolvedTeamId)` to read the full team game history before the default Overview could render, even though clips are only needed in Reports > Video Clips.

## Prevention / Learning
Keep hidden or secondary panels behind explicit lazy loaders with local loading, error, and cache state. First-paint services should fetch only data required by the default view.

## Regression Tests
- `npx vitest run src/lib/playerService.test.ts --reporter=verbose`
- `npx vitest run src/pages/PlayerDetail.test.tsx --reporter=verbose`
- `npm run app:build`