### PR TITLE
Remove invalid single-field registrations index blocking prod deploys

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -400,13 +400,6 @@
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "submittedAt", "order": "DESCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "registrations",
-      "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "submittedAt", "order": "DESCENDING" }
-      ]
     }
   ],
   "fieldOverrides": [


### PR DESCRIPTION
- Removes the `registrations` / `submittedAt DESC` single-field entry from `firestore.indexes.json`. Firestore rejects explicit single-field indexes with HTTP 400 ("this index is not necessary, configure using single field index controls"), so every `deploy-prod` run has aborted at the index-deploy step — before Firestore rules are released.
- This was the second stacked deploy blocker after the `_internal-*` functions-name fix (#3468): runs now get past functions packaging but die here, which is why the deployed ruleset is still the June 12 release (prod still denies `notificationInbox` reads and `rsvpNotes` writes).
- Safe to remove: single-field ordering is served by Firestore's automatic indexes, and the `status ASC, submittedAt DESC` composite used by the registration review-queue pagination (#2177) remains. `tests/unit/db-registration-review-pagination.test.js` still passes.

Manual test steps:
- `npm run test:unit:ci` — 3779/3779 pass.
- After merge, watch `deploy-prod` and confirm it reaches "released rules" / hosting deploy; verify the notifications bell loads in the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)