### PR TITLE
Share Game Hub scoring roster load

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1224,7 +1224,9 @@ describe('ScheduleEventDetail assignments', () => {
         expect(screen.getByTestId('live-game-clock-panel')).toBeTruthy();
       });
 
-      expect(setIntervalSpy.mock.calls.filter(([, delay]) => delay === 1000)).toHaveLength(1);
+      await waitFor(() => {
+        expect(setIntervalSpy.mock.calls.filter(([, delay]) => delay === 1000)).toHaveLength(1);
+      });
       const initialHeaderClock = readClockSeconds(screen.getByLabelText('Live game clock').textContent);
       const initialPanelClock = readClockSeconds(screen.getByTestId('live-game-clock-panel').textContent);
       expect(initialHeaderClock).not.toBeNull();
@@ -1251,12 +1253,95 @@ describe('ScheduleEventDetail assignments', () => {
       expect(updatedHeaderClock).toBeGreaterThanOrEqual((initialHeaderClock ?? 0) + 1);
       expect(screen.getByTestId('live-score-editor').innerHTML).toBe(scoreEditorMarkup);
       expect(screen.getByTestId('game-day-foul-panel').innerHTML).toBe(foulTrackerMarkup);
-      expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledTimes(2);
+      expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledTimes(1);
       expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(1);
     } finally {
       setIntervalSpy.mockRestore();
     }
   }, 15000);
+
+  it('shares one loaded scoring roster between score and foul game hub panels', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        canUpdateScore: true,
+        liveClockPeriod: 'Q1',
+        gamePlan: { numPeriods: 4 }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([
+      { id: 'p1', name: 'Avery Smith', number: '12', points: 10, fouls: 1 }
+    ]);
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([
+      { id: 'f1', eventId: 'f1', type: 'stat', statKey: 'fouls', value: 6, period: 'Q1', isOpponent: false }
+    ]);
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
+
+    renderScheduleEventDetailWithRouteControls();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '#12 Avery Smith plus 2 points' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: '#12 Avery Smith add foul' })).toBeTruthy();
+      expect(screen.getByText('6 team fouls this period')).toBeTruthy();
+    });
+
+    expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledTimes(1);
+    expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledWith('team-1', 'game-1');
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the shared scoring roster once when switching game hub events', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockImplementation(async (_user, { eventId }) => ({
+      events: [eventId === 'game-2'
+        ? buildEvent({
+            eventKey: 'team-1::game-2::player-1::2026-06-05T18:00:00.000Z::game',
+            id: 'game-2',
+            opponent: 'Lions',
+            liveStatus: 'live',
+            canUpdateScore: true,
+            liveClockPeriod: 'Q1',
+            gamePlan: { numPeriods: 4 }
+          })
+        : buildEvent({
+            liveStatus: 'live',
+            canUpdateScore: true,
+            liveClockPeriod: 'Q1',
+            gamePlan: { numPeriods: 4 }
+          })],
+      children: []
+    }));
+    scheduleServiceMocks.loadHomeScoringPlayers.mockImplementation(async (_teamId, gameId) => (
+      gameId === 'game-2'
+        ? [{ id: 'p2', name: 'Jordan Lee', number: '7', points: 4, fouls: 0 }]
+        : [{ id: 'p1', name: 'Avery Smith', number: '12', points: 10, fouls: 1 }]
+    ));
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
+
+    renderScheduleEventDetailWithRouteControls();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '#12 Avery Smith plus 2 points' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: '#12 Avery Smith add foul' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch game' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '#7 Jordan Lee plus 2 points' })).toBeTruthy();
+      expect(screen.getByRole('button', { name: '#7 Jordan Lee add foul' })).toBeTruthy();
+    });
+
+    expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledTimes(2);
+    expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenNthCalledWith(1, 'team-1', 'game-1');
+    expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenNthCalledWith(2, 'team-1', 'game-2');
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(2);
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenNthCalledWith(1, 'team-1', 'game-1');
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenNthCalledWith(2, 'team-1', 'game-2');
+  });
 
   it('links staff scorekeepers from the app game hub to the standard tracker route', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1292,6 +1292,37 @@ describe('ScheduleEventDetail assignments', () => {
     expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps foul entry disabled when foul history fails to load', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        canUpdateScore: true,
+        liveClockPeriod: 'Q1',
+        gamePlan: { numPeriods: 4 }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([
+      { id: 'p1', name: 'Avery Smith', number: '12', points: 10, fouls: 1 }
+    ]);
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockRejectedValue(new Error('History unavailable'));
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
+
+    renderScheduleEventDetailWithRouteControls();
+
+    await waitFor(() => {
+      expect(screen.getByText('Foul history could not be loaded. Refresh before recording fouls.')).toBeTruthy();
+    });
+
+    const addFoulButton = screen.getByRole('button', { name: '#12 Avery Smith add foul' });
+    expect(addFoulButton).toHaveProperty('disabled', true);
+
+    fireEvent.click(addFoulButton);
+
+    expect(scheduleServiceMocks.recordPlayerGameStat).not.toHaveBeenCalled();
+  });
+
   it('invalidates the shared scoring roster once when switching game hub events', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockImplementation(async (_user, { eventId }) => ({
       events: [eventId === 'game-2'

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -190,6 +190,7 @@ import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';
 export { getAvailabilityNoteSaveState } from '../components/schedule/AvailabilityPanels';
 
 type EventDetailSectionId = ScheduleEventDetailSectionId;
+type HomeScoringPlayersUpdater = (players: ScheduleHomeScoringPlayer[]) => ScheduleHomeScoringPlayer[];
 
 const eventDetailSectionIds = new Set<EventDetailSectionId>(['availability', 'rideshare', 'assignments', 'game']);
 
@@ -1406,6 +1407,8 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
   const [openPanels, setOpenPanels] = useState<Record<string, boolean>>({});
+  const [homeScoringPlayers, setHomeScoringPlayers] = useState<ScheduleHomeScoringPlayer[]>([]);
+  const [loadingHomeScoringPlayers, setLoadingHomeScoringPlayers] = useState(false);
   const statusLabel = getEventStatusLabel(event);
   const scoreLabel = getScoreLabel(event);
   const isPractice = event.type === 'practice';
@@ -1424,6 +1427,35 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
   useEffect(() => {
     setOpenPanels({});
   }, [event.eventKey]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!canUpdateScore) {
+      setHomeScoringPlayers([]);
+      setLoadingHomeScoringPlayers(false);
+      return undefined;
+    }
+    async function loadPlayers() {
+      setLoadingHomeScoringPlayers(true);
+      try {
+        const players = await loadHomeScoringPlayers(event.teamId, event.id);
+        if (!cancelled) setHomeScoringPlayers(Array.isArray(players) ? players : []);
+      } catch (error) {
+        console.warn('[schedule-event-detail] Unable to load home scoring players:', error);
+        if (!cancelled) setHomeScoringPlayers([]);
+      } finally {
+        if (!cancelled) setLoadingHomeScoringPlayers(false);
+      }
+    }
+    void loadPlayers();
+    return () => {
+      cancelled = true;
+    };
+  }, [canUpdateScore, event.teamId, event.id, event.eventKey]);
+
+  const updateHomeScoringPlayers = useCallback((updater: HomeScoringPlayersUpdater) => {
+    setHomeScoringPlayers(updater);
+  }, []);
 
   const togglePanel = useCallback((panelId: string) => {
     setOpenPanels((current) => ({
@@ -1535,8 +1567,25 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
               Standard tracker
             </Link>
           ) : null}
-          {canUpdateScore ? <LiveScoreEditor auth={auth} event={event} onScoreUpdated={onScoreUpdated} /> : null}
-          {canUpdateScore ? <GameDayFoulTrackerPanel auth={auth} event={event} /> : null}
+          {canUpdateScore ? (
+            <LiveScoreEditor
+              auth={auth}
+              event={event}
+              homePlayers={homeScoringPlayers}
+              loadingHomePlayers={loadingHomeScoringPlayers}
+              onHomePlayersUpdated={updateHomeScoringPlayers}
+              onScoreUpdated={onScoreUpdated}
+            />
+          ) : null}
+          {canUpdateScore ? (
+            <GameDayFoulTrackerPanel
+              auth={auth}
+              event={event}
+              homePlayers={homeScoringPlayers}
+              loadingHomePlayers={loadingHomeScoringPlayers}
+              onHomePlayersUpdated={updateHomeScoringPlayers}
+            />
+          ) : null}
 
           {!isPractice ? (
             <LazyGameHubPanel
@@ -3004,15 +3053,13 @@ function getBonusState(teamFouls: number) {
   };
 }
 
-function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; event: ParentScheduleEvent; onScoreUpdated: (homeScore: number, awayScore: number) => void }) {
+function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, onHomePlayersUpdated, onScoreUpdated }: { auth: AuthState; event: ParentScheduleEvent; homePlayers: ScheduleHomeScoringPlayer[]; loadingHomePlayers: boolean; onHomePlayersUpdated: (updater: HomeScoringPlayersUpdater) => void; onScoreUpdated: (homeScore: number, awayScore: number) => void }) {
   const autosaveDelayMs = 700;
   const savedHomeScore = Math.max(0, Number(event.homeScore ?? 0));
   const savedAwayScore = Math.max(0, Number(event.awayScore ?? 0));
   const [homeScore, setHomeScore] = useState(savedHomeScore);
   const [awayScore, setAwayScore] = useState(savedAwayScore);
   const [previousScoreSnapshots, setPreviousScoreSnapshots] = useState<ScoreSnapshot[]>([]);
-  const [homePlayers, setHomePlayers] = useState<ScheduleHomeScoringPlayer[]>([]);
-  const [loadingHomePlayers, setLoadingHomePlayers] = useState(false);
   const [playerScoringId, setPlayerScoringId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [autosaveScheduled, setAutosaveScheduled] = useState(false);
@@ -3047,26 +3094,6 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
     setAutosaveScheduled(false);
     lastSavedScoreRef.current = { eventKey: event.eventKey, homeScore: savedHomeScore, awayScore: savedAwayScore };
   }, [event.eventKey, savedHomeScore, savedAwayScore]);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadPlayers() {
-      setLoadingHomePlayers(true);
-      try {
-        const players = await loadHomeScoringPlayers(event.teamId, event.id);
-        if (!cancelled) setHomePlayers(Array.isArray(players) ? players : []);
-      } catch (error) {
-        console.warn('[schedule-event-detail] Unable to load home scoring players:', error);
-        if (!cancelled) setHomePlayers([]);
-      } finally {
-        if (!cancelled) setLoadingHomePlayers(false);
-      }
-    }
-    loadPlayers();
-    return () => {
-      cancelled = true;
-    };
-  }, [event.teamId, event.id, event.eventKey]);
 
   const dirty = homeScore !== savedHomeScore || awayScore !== savedAwayScore;
   const adjust = (side: 'home' | 'away', delta: number) => {
@@ -3181,7 +3208,7 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
       setAwayScore(result.awayScore);
       pendingLocalSaveRef.current = { homeScore: result.homeScore, awayScore: result.awayScore };
       onScoreUpdated(result.homeScore, result.awayScore);
-      setHomePlayers((players) => players.map((candidate) => (
+      onHomePlayersUpdated((players) => players.map((candidate) => (
         candidate.id === player.id ? { ...candidate, points: result.playerPoints } : candidate
       )));
       setPreviousScoreSnapshots([]);
@@ -3265,8 +3292,7 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
   );
 }
 
-function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
-  const [homePlayers, setHomePlayers] = useState<ScheduleHomeScoringPlayer[]>([]);
+function GameDayFoulTrackerPanel({ auth, event, homePlayers, loadingHomePlayers, onHomePlayersUpdated }: { auth: AuthState; event: ParentScheduleEvent; homePlayers: ScheduleHomeScoringPlayer[]; loadingHomePlayers: boolean; onHomePlayersUpdated: (updater: HomeScoringPlayersUpdater) => void }) {
   const [loading, setLoading] = useState(false);
   const [savingPlayerId, setSavingPlayerId] = useState<string | null>(null);
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
@@ -3281,28 +3307,23 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
 
   useEffect(() => {
     let cancelled = false;
-    async function loadPlayers() {
+    async function loadLiveEvents() {
       setLoading(true);
       try {
         const { loadGameDayLiveEventsForApp } = await loadScheduleGameDayService();
-        const [players, loadedLiveEvents] = await Promise.all([
-          loadHomeScoringPlayers(event.teamId, event.id),
-          loadGameDayLiveEventsForApp(event.teamId, event.id)
-        ]);
+        const loadedLiveEvents = await loadGameDayLiveEventsForApp(event.teamId, event.id);
         if (cancelled) return;
-        setHomePlayers(Array.isArray(players) ? players : []);
         setLiveEvents(Array.isArray(loadedLiveEvents) ? loadedLiveEvents : []);
       } catch (error) {
         if (!cancelled) {
           console.warn('[schedule-event-detail] Unable to load foul tracker state:', error);
-          setHomePlayers([]);
           setLiveEvents([]);
         }
       } finally {
         if (!cancelled) setLoading(false);
       }
     }
-    void loadPlayers();
+    void loadLiveEvents();
     return () => {
       cancelled = true;
     };
@@ -3332,7 +3353,7 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
         playerName: player.name,
         playerNumber: player.number
       }, auth.user);
-      setHomePlayers((players) => players.map((candidate) => (
+      onHomePlayersUpdated((players) => players.map((candidate) => (
         candidate.id === player.id ? { ...candidate, fouls: result.playerStatTotal } : candidate
       )));
       setLiveEvents((entries) => [...entries, result.liveEvent]);
@@ -3362,7 +3383,7 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
         value: 1,
         teamSide: event.isHome === false ? 'away' : 'home'
       }, auth.user);
-      setHomePlayers((players) => players.map((candidate) => (
+      onHomePlayersUpdated((players) => players.map((candidate) => (
         candidate.id === latest.playerId ? { ...candidate, fouls: result.playerStatTotal } : candidate
       )));
       setLiveEvents((entries) => result.liveEvent ? [...entries, result.liveEvent] : entries);
@@ -3415,7 +3436,7 @@ function GameDayFoulTrackerPanel({ auth, event }: { auth: AuthState; event: Pare
             );
           })}
         </div>
-      ) : !loading ? <div className="mt-3 text-xs font-semibold text-gray-500">No active team roster players found.</div> : null}
+      ) : !(loading || loadingHomePlayers) ? <div className="mt-3 text-xs font-semibold text-gray-500">No active team roster players found.</div> : null}
       <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
         <div className="text-xs font-semibold text-gray-500">Team fouls reset when the live clock advances to a new period.</div>
         <button

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -3298,10 +3298,12 @@ function GameDayFoulTrackerPanel({ auth, event, homePlayers, loadingHomePlayers,
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [liveEvents, setLiveEvents] = useState<any[]>(() => Array.isArray(event.liveEvents) ? event.liveEvents : []);
   const [recordedFouls, setRecordedFouls] = useState<PlayerGameStatResult[]>([]);
+  const [foulHistoryLoadFailed, setFoulHistoryLoadFailed] = useState(false);
 
   useEffect(() => {
     setLiveEvents(Array.isArray(event.liveEvents) ? event.liveEvents : []);
     setRecordedFouls([]);
+    setFoulHistoryLoadFailed(false);
     setStatus(null);
   }, [event.eventKey, event.liveEvents]);
 
@@ -3309,6 +3311,7 @@ function GameDayFoulTrackerPanel({ auth, event, homePlayers, loadingHomePlayers,
     let cancelled = false;
     async function loadLiveEvents() {
       setLoading(true);
+      setFoulHistoryLoadFailed(false);
       try {
         const { loadGameDayLiveEventsForApp } = await loadScheduleGameDayService();
         const loadedLiveEvents = await loadGameDayLiveEventsForApp(event.teamId, event.id);
@@ -3318,6 +3321,8 @@ function GameDayFoulTrackerPanel({ auth, event, homePlayers, loadingHomePlayers,
         if (!cancelled) {
           console.warn('[schedule-event-detail] Unable to load foul tracker state:', error);
           setLiveEvents([]);
+          setFoulHistoryLoadFailed(true);
+          setStatus({ tone: 'error', message: 'Foul history could not be loaded. Refresh before recording fouls.' });
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -3339,9 +3344,10 @@ function GameDayFoulTrackerPanel({ auth, event, homePlayers, loadingHomePlayers,
     }, 0)
   ), [activePeriod, liveEvents]);
   const bonusState = getBonusState(homeTeamFouls);
+  const foulEntryDisabled = loading || foulHistoryLoadFailed;
 
   const recordFoul = async (player: ScheduleHomeScoringPlayer) => {
-    if (!auth.user || savingPlayerId) return;
+    if (!auth.user || savingPlayerId || foulEntryDisabled) return;
     setSavingPlayerId(player.id);
     setStatus(null);
     try {
@@ -3427,7 +3433,7 @@ function GameDayFoulTrackerPanel({ auth, event, homePlayers, loadingHomePlayers,
                   type="button"
                   className="primary-button mt-3 min-h-11 w-full px-4 text-sm disabled:opacity-60"
                   onClick={() => recordFoul(player)}
-                  disabled={busy || Boolean(savingPlayerId)}
+                  disabled={busy || Boolean(savingPlayerId) || foulEntryDisabled}
                   aria-label={`${label} add foul`}
                 >
                   {busy ? 'Saving foul' : '+ Foul'}


### PR DESCRIPTION
Closes #3496

## What changed
- Lifted the home scoring roster load into `GameHubSection` so `LiveScoreEditor` and `GameDayFoulTrackerPanel` share one event-scoped roster result.
- Kept foul tracker live-event history loading separate, since that panel still needs foul history for team bonus state.
- Preserved local score, +2, player foul, and undo-foul state updates by routing roster mutations through the shared parent state.

## Root Cause
`LiveScoreEditor` and `GameDayFoulTrackerPanel` were always-mounted siblings, and each independently called `loadHomeScoringPlayers(event.teamId, event.id)` during first render for the same team/game. That duplicated roster and aggregated-stat hydration before scorekeepers interacted with the Game Hub.

## Prevention / Learning
For always-mounted sibling panels that need the same expensive event-scoped data, lift the load/cache to the shared parent and pass state down. Keep panel-specific history loads separate and test both call counts and event-key invalidation.

## Regression Tests
- Updated the live Game Hub stability test to expect one `loadHomeScoringPlayers` call instead of two.
- Added coverage that score and foul panels both render from the same loaded roster without separate roster loads.
- Added coverage that switching to another event invalidates the shared roster and refetches once for the new game.
- Ran focused Vitest coverage: `npm --prefix apps/app exec vitest run src/pages/ScheduleEventDetail.test.tsx -- -t "shares one loaded scoring roster|invalidates the shared scoring roster|uses a single live clock ticker|tracks player fouls" --reporter=verbose`.
- Ran compiler/build validation: `npm run app:build`.