### PR TITLE
Split staff registration review route chunk

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -32,7 +32,7 @@ const Messages = lazy(() => import('./pages/Messages').then((module) => ({ defau
 const Officials = lazy(() => import('./pages/Officials').then((module) => ({ default: module.Officials })));
 const ParentTools = lazy(() => import('./pages/ParentTools').then((module) => ({ default: module.ParentTools })));
 const RegistrationDetail = lazy(() => import('./pages/RegistrationDetail').then((module) => ({ default: module.RegistrationDetail })));
-const TeamRegistrationReview = lazy(() => import('./pages/RegistrationDetail').then((module) => ({ default: module.TeamRegistrationReview })));
+const TeamRegistrationReview = lazy(() => import('./pages/TeamRegistrationReview').then((module) => ({ default: module.TeamRegistrationReview })));
 const PlayerDetail = lazy(() => import('./pages/PlayerDetail').then((module) => ({ default: module.PlayerDetail })));
 const PrivateAiChat = lazy(() => import('./pages/PrivateAiChat').then((module) => ({ default: module.PrivateAiChat })));
 const Profile = lazy(() => import('./pages/Profile').then((module) => ({ default: module.Profile })));

--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -2,7 +2,8 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { RegistrationDetail, TeamRegistrationReview } from './RegistrationDetail';
+import { RegistrationDetail } from './RegistrationDetail';
+import { TeamRegistrationReview } from './TeamRegistrationReview';
 import type { AuthState } from '../lib/types';
 
 const parentRegistrationsServiceMocks = vi.hoisted(() => ({

--- a/apps/app/src/pages/TeamRegistrationReview.tsx
+++ b/apps/app/src/pages/TeamRegistrationReview.tsx
@@ -1,16 +1,24 @@
 import { useEffect, useMemo, useRef, useState, type InputHTMLAttributes, type SyntheticEvent } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
-import { AlertCircle, CheckCircle2, ChevronLeft, ExternalLink, Loader2, Send, Ticket, type LucideIcon } from 'lucide-react';
+import { AlertCircle, CheckCircle2, ChevronLeft, ExternalLink, Loader2, Send, Ticket, UserPlus, XCircle, type LucideIcon } from 'lucide-react';
 import { openPublicUrl } from '../lib/publicActions';
 import {
+  acceptTeamRegistrationOfferForApp,
+  approveTeamRegistrationForApp,
   cancelRegistrationCheckout,
+  extendTeamRegistrationOfferForApp,
   initiateRegistrationCheckout,
   loadParentRegistrationDetail,
   loadParentRegistrations,
   loadPublicRegistrationDetail,
+  loadStaffRegistrationDetail,
+  loadTeamRegistrationQueuePage,
+  loadTeamRegistrationRosterPlayers,
+  rejectTeamRegistrationForApp,
   submitOfflineRegistration,
   type ParentRegistrationCard,
-  type ParentRegistrationDetailModel
+  type ParentRegistrationDetailModel,
+  type TeamRegistrationQueueModel
 } from '../lib/parentRegistrationsService';
 import {
   calculateRegistrationFeeSnapshot,
@@ -39,10 +47,14 @@ export function selectInitialRegistrationOption(form: ParentRegistrationCard | n
 }
 
 export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthState; publicAccess?: boolean }) {
-  return <RegistrationDetailPage auth={auth} publicAccess={publicAccess} />;
+  return <RegistrationDetailPage auth={auth} publicAccess={publicAccess} staffReview={false} />;
 }
 
-function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthState; publicAccess?: boolean }) {
+export function TeamRegistrationReview({ auth }: { auth: AuthState }) {
+  return <RegistrationDetailPage auth={auth} publicAccess={false} staffReview />;
+}
+
+function RegistrationDetailPage({ auth, publicAccess = false, staffReview = false }: { auth: AuthState; publicAccess?: boolean; staffReview?: boolean }) {
   const params = useParams();
   const [searchParams] = useSearchParams();
   const teamId = publicAccess ? (searchParams.get('teamId') || '') : (params.teamId || '');
@@ -69,6 +81,13 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
   const [quantity, setQuantity] = useState(1);
   const [selectedPaymentPlanId, setSelectedPaymentPlanId] = useState('pay_full');
   const [currentPublicCheckoutCapability, setCurrentPublicCheckoutCapability] = useState(returnPublicCheckoutCapability);
+  const [queue, setQueue] = useState<TeamRegistrationQueueModel | null>(null);
+  const [selectedReviewId, setSelectedReviewId] = useState('');
+  const [selectedMergePlayerId, setSelectedMergePlayerId] = useState('');
+  const [lastDoc, setLastDoc] = useState<any>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [waitlistedLastDoc, setWaitlistedLastDoc] = useState<any>(null);
+  const [waitlistedHasMore, setWaitlistedHasMore] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
   const formRef = useRef<HTMLFormElement | null>(null);
   const cancelledCheckoutReleaseKeyRef = useRef('');
@@ -79,19 +98,46 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
       setLoading(true);
       setError('');
       try {
-        const nextForm = await loadRegistrationForm(auth.user, teamId, formId, publicAccess);
+        const nextForm = await loadRegistrationForm(auth.user, teamId, formId, publicAccess, staffReview);
         if (cancelled) return;
         if (!nextForm) {
           setError('Registration form not found or not active.');
           setForm(null);
           return;
         }
-        if (nextForm.isPublished === false) {
+        if (!staffReview && nextForm.isPublished === false) {
           setError('This linked registration form is not published right now.');
           setForm(null);
           return;
         }
         setForm(nextForm);
+        if (staffReview) {
+          const [nextPage, waitlistedPage, rosterPlayers] = await Promise.all([
+            loadTeamRegistrationQueuePage(teamId, formId),
+            loadTeamRegistrationQueuePage(teamId, formId, { status: 'waitlisted' }),
+            loadTeamRegistrationRosterPlayers(auth.user, teamId).catch(() => [])
+          ]);
+          if (cancelled) return;
+          const nextQueue: TeamRegistrationQueueModel = {
+            reviews: nextPage.reviews,
+            rosterPlayers,
+            waitlistedReviews: waitlistedPage.reviews,
+            totalWaitlisted: getTotalWaitlistedCount(nextForm.registrationOptionCounts, waitlistedPage.reviews.length)
+          };
+          setQueue(nextQueue);
+          setLastDoc(nextPage.lastDoc);
+          setHasMore(nextPage.hasMore);
+          setWaitlistedLastDoc(waitlistedPage.lastDoc);
+          setWaitlistedHasMore(waitlistedPage.hasMore);
+          const firstReviewId = nextQueue.reviews[0]?.id || nextQueue.waitlistedReviews?.[0]?.id || '';
+          setSelectedReviewId((current) => current && [...nextQueue.reviews, ...(nextQueue.waitlistedReviews || [])].some((review) => review.id === current) ? current : firstReviewId);
+        } else {
+          setQueue(null);
+          setLastDoc(null);
+          setHasMore(false);
+          setWaitlistedLastDoc(null);
+          setWaitlistedHasMore(false);
+        }
         const initialOptions = (Array.isArray(nextForm.options) && nextForm.options.length) ? nextForm.options : getActiveRegistrationOptions(nextForm, nextForm.registrationOptionCounts || {});
         const initialOptionId = selectInitialRegistrationOption(nextForm, initialOptions);
         setSelectedOptionId((current) => {
@@ -109,7 +155,7 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
     return () => {
       cancelled = true;
     };
-  }, [auth.user?.uid, teamId, formId, publicAccess, reloadKey]);
+  }, [auth.user?.uid, teamId, formId, publicAccess, reloadKey, staffReview]);
 
   const activeOptions: any[] = useMemo(() => form ? ((Array.isArray(form.options) && form.options.length) ? form.options : getActiveRegistrationOptions(form, form.registrationOptionCounts || {})) : [], [form]);
   const paymentPlanChoices: any[] = useMemo(() => form ? ((Array.isArray(form.paymentPlans) && form.paymentPlans.length) ? form.paymentPlans : getPaymentPlanChoices(form)) : [], [form]);
@@ -135,8 +181,35 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
     const paidInstallmentCount = paymentPlanId === 'installments' ? Math.max(1, successfulPaidInstallmentCount) : 0;
     return buildRegistrationPaymentPlanSummary(form, displayFeeSnapshot, paymentPlanId, paidInstallmentCount);
   }, [displayFeeSnapshot, form, isPaymentSuccessReturn, selectedPaymentPlanId, successfulPaidInstallmentCount, successfulPaymentPlanId]);
+  const selectedReview = useMemo(() => {
+    const allReviews = [...(queue?.reviews || []), ...(queue?.waitlistedReviews || [])];
+    return allReviews.find((review) => review.id === selectedReviewId) || allReviews[0] || null;
+  }, [queue, selectedReviewId]);
+  const waitlistedReviews = useMemo(() => queue?.waitlistedReviews || (queue?.reviews || []).filter((review) => review.status === 'waitlisted'), [queue]);
+  const totalWaitlisted = queue?.totalWaitlisted ?? waitlistedReviews.length;
+  const canApproveSelectedReview = selectedReview ? ['pending', 'offer-accepted'].includes(selectedReview.status) : false;
+  const canPromoteSelectedReview = selectedReview?.status === 'waitlisted';
+  const canAcceptOfferSelectedReview = selectedReview?.status === 'offer-extended';
+  const canDeclineSelectedReview = selectedReview ? ['pending', 'waitlisted', 'offer-extended', 'offer-accepted'].includes(selectedReview.status) : false;
+  const selectedReviewOptionAvailability = useMemo(() => {
+    if (!form || !selectedReview) return '';
+    const reviewOptionId = String(selectedReview.selectedOption?.id || selectedReview.selectedOption?.countKey || '');
+    const reviewOptionTitle = String(selectedReview.selectedOptionLabel || '').trim();
+    const reviewOption = (form.options || []).find((option: any) => (
+      String(option?.id || '') === reviewOptionId
+      || String(option?.countKey || '') === reviewOptionId
+      || String(option?.title || '').trim() === reviewOptionTitle
+    ));
+    return reviewOption ? formatOptionAvailability(reviewOption, form.registrationOptionCounts || {}) : '';
+  }, [form, selectedReview]);
+
   useEffect(() => {
-    if (returnStatus !== 'cancelled' || (!returnPublicCheckoutCapability && !returnRegistrationId)) return;
+    if (!selectedReview) return;
+    setSelectedMergePlayerId(selectedReview.linkedPlayerId || '');
+  }, [selectedReview?.id]);
+
+  useEffect(() => {
+    if (staffReview || returnStatus !== 'cancelled' || (!returnPublicCheckoutCapability && !returnRegistrationId)) return;
 
     const releaseAuthority = returnPublicCheckoutCapability || `${returnRegistrationId}:${returnCheckoutAttemptToken}`;
     if (!releaseAuthority) return;
@@ -162,7 +235,7 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
     }).catch(() => {
       // Keep the retry path available even if release cleanup fails.
     });
-  }, [formId, returnCheckoutAttemptToken, returnPublicCheckoutCapability, returnRegistrationId, returnStatus, retryPaymentRequested, teamId]);
+  }, [formId, returnCheckoutAttemptToken, returnPublicCheckoutCapability, returnRegistrationId, returnStatus, retryPaymentRequested, staffReview, teamId]);
 
   useEffect(() => {
     setCurrentPublicCheckoutCapability(returnPublicCheckoutCapability);
@@ -283,8 +356,260 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
     }
   };
 
+  const handleApprove = async () => {
+    if (!selectedReview || saving) return;
+    setSaving(true);
+    setError('');
+    setMessage('');
+    try {
+      await approveTeamRegistrationForApp(auth.user, teamId, formId, selectedReview.id, {
+        playerId: selectedMergePlayerId || undefined
+      });
+      setMessage('Registration approved. Roster and parent links were updated using the legacy approval flow.');
+      setReloadKey((current) => current + 1);
+    } catch (actionError: any) {
+      setError(actionError?.message || 'Registration could not be approved.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDecline = async () => {
+    if (!selectedReview || saving) return;
+    setSaving(true);
+    setError('');
+    setMessage('');
+    try {
+      await rejectTeamRegistrationForApp(auth.user, teamId, formId, selectedReview.id);
+      setMessage('Registration declined.');
+      setReloadKey((current) => current + 1);
+    } catch (actionError: any) {
+      setError(actionError?.message || 'Registration could not be declined.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handlePromote = async () => {
+    if (!selectedReview || saving) return;
+    setSaving(true);
+    setError('');
+    setMessage('');
+    try {
+      await extendTeamRegistrationOfferForApp(auth.user, teamId, formId, selectedReview.id);
+      setMessage('Waitlist offer extended using the legacy registration flow.');
+      setReloadKey((current) => current + 1);
+    } catch (actionError: any) {
+      setError(actionError?.message || 'Waitlist offer could not be extended.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAcceptOffer = async () => {
+    if (!selectedReview || saving) return;
+    setSaving(true);
+    setError('');
+    setMessage('');
+    try {
+      await acceptTeamRegistrationOfferForApp(auth.user, teamId, formId, selectedReview.id);
+      setMessage('Waitlist offer marked accepted. This registration can now be approved to the roster.');
+      setReloadKey((current) => current + 1);
+    } catch (actionError: any) {
+      setError(actionError?.message || 'Waitlist offer could not be marked accepted.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleLoadMore = async () => {
+    if (!lastDoc || !hasMore || saving) return;
+    setSaving(true);
+    setError('');
+    try {
+      const nextPage = await loadTeamRegistrationQueuePage(teamId, formId, { afterDoc: lastDoc });
+      setQueue((current: TeamRegistrationQueueModel | null) => current ? { ...current, reviews: [...current.reviews, ...nextPage.reviews] } : { reviews: nextPage.reviews, rosterPlayers: [] });
+      setLastDoc(nextPage.lastDoc);
+      setHasMore(nextPage.hasMore);
+    } catch (loadError: any) {
+      setError(loadError?.message || 'Unable to load more registrations.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleLoadMoreWaitlisted = async () => {
+    if (!waitlistedLastDoc || !waitlistedHasMore || saving) return;
+    setSaving(true);
+    setError('');
+    try {
+      const nextPage = await loadTeamRegistrationQueuePage(teamId, formId, { status: 'waitlisted', afterDoc: waitlistedLastDoc });
+      setQueue((current: TeamRegistrationQueueModel | null) => current ? {
+        ...current,
+        waitlistedReviews: [...(current.waitlistedReviews || []), ...nextPage.reviews]
+      } : { reviews: [], rosterPlayers: [], waitlistedReviews: nextPage.reviews });
+      setWaitlistedLastDoc(nextPage.lastDoc);
+      setWaitlistedHasMore(nextPage.hasMore);
+    } catch (loadError: any) {
+      setError(loadError?.message || 'Unable to load more waitlisted applicants.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (loading) return <LoadingBlock label="Loading registration" />;
   if (!form) return <EmptyState icon={Ticket} title="Registration unavailable" detail={error || 'This registration form could not be loaded.'} actionLabel={error ? 'Retry' : ''} onAction={error ? () => setReloadKey((current) => current + 1) : undefined} />;
+
+  if (staffReview) {
+    return (
+      <div className="space-y-3">
+        <section className="app-card overflow-hidden">
+          <div className="flex items-center gap-3 px-3 py-3 sm:px-4">
+            <Link to={`/teams/${encodeURIComponent(teamId)}`} className="ghost-button !h-9 !min-h-9 !w-9 !flex-none !p-0" aria-label="Back to team" title="Back to team">
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            </Link>
+            <div className="min-w-0 flex-1">
+              <div className="app-label">Registration review</div>
+              <h1 className="truncate text-xl font-black leading-tight text-gray-950">{form.programName}</h1>
+              <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">{form.teamName}{form.season ? ` - ${form.season}` : ''}</p>
+            </div>
+            {form.url ? (
+              <button type="button" className="secondary-button !min-h-9 text-xs" onClick={() => openPublicUrl(form.url)}>
+                <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                Legacy review
+              </button>
+            ) : null}
+          </div>
+        </section>
+
+        {message ? <Status tone="success" message={message} /> : null}
+        {error ? <Status tone="error" message={error} /> : null}
+
+        <section className="grid gap-3 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <div className="app-card p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-black text-gray-950">Applications</div>
+                <div className="text-xs font-semibold text-gray-500">Submitted registrations and their current review state.</div>
+              </div>
+              <button type="button" className="ghost-button !min-h-9 text-xs" onClick={() => setReloadKey((current) => current + 1)} disabled={loading || saving}>Refresh</button>
+            </div>
+            <div className="mt-3 grid gap-2">
+              {waitlistedReviews.length ? (
+                <div className="rounded-2xl border border-amber-200 bg-amber-50 p-3">
+                  <div className="text-sm font-black text-amber-950">Waitlisted applicants ({totalWaitlisted})</div>
+                  <div className="mt-1 text-xs font-semibold text-amber-800">Promote a waitlisted applicant into the same offer and payment path used on the legacy site.</div>
+                  <div className="mt-3 grid gap-2" data-waitlist-list>
+                    {waitlistedReviews.map((review) => (
+                      <button
+                        key={`waitlist-${review.id}`}
+                        type="button"
+                        onClick={() => setSelectedReviewId(review.id)}
+                        className={`rounded-2xl border p-3 text-left ${selectedReview?.id === review.id ? 'border-amber-300 bg-white' : 'border-amber-200 bg-white/80'}`}
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-black text-gray-950">{review.participantName}</div>
+                            <div className="truncate text-xs font-semibold text-gray-500">{review.guardianLabel || 'Guardian details unavailable'}</div>
+                          </div>
+                          <StatusPill value={review.status} />
+                        </div>
+                        <div className="mt-2 text-xs font-semibold text-gray-500">{review.selectedOptionLabel || 'No option selected'} · {review.paymentLabel}</div>
+                      </button>
+                    ))}
+                  </div>
+                  {waitlistedHasMore ? (
+                    <button type="button" className="secondary-button mt-3 w-full text-xs" onClick={handleLoadMoreWaitlisted} disabled={saving}>
+                      {saving ? <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" /> : null}
+                      Load more waitlisted applicants
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+              {queue?.reviews.length ? queue.reviews.map((review) => (
+                <button
+                  key={review.id}
+                  type="button"
+                  onClick={() => setSelectedReviewId(review.id)}
+                  className={`rounded-2xl border p-3 text-left ${selectedReview?.id === review.id ? 'border-primary-300 bg-primary-50' : 'border-gray-200 bg-white'}`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-black text-gray-950">{review.participantName}</div>
+                      <div className="truncate text-xs font-semibold text-gray-500">{review.guardianLabel || 'Guardian details unavailable'}</div>
+                    </div>
+                    <StatusPill value={review.status} />
+                  </div>
+                  <div className="mt-2 text-xs font-semibold text-gray-500">{review.selectedOptionLabel || 'No option selected'} · {review.paymentLabel}</div>
+                </button>
+              )) : <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No applications are available for this form yet.</div>}
+              {hasMore ? (
+                <button type="button" className="secondary-button w-full text-xs" onClick={handleLoadMore} disabled={saving}>
+                  {saving ? <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" /> : null}
+                  Load more
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="app-card p-4">
+            {selectedReview ? (
+              <div className="grid gap-4">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <h2 className="text-lg font-black text-gray-950">{selectedReview.participantName}</h2>
+                    <StatusPill value={selectedReview.status} />
+                  </div>
+                  <div className="mt-1 text-sm font-semibold text-gray-500">{selectedReview.selectedOptionLabel || 'No option selected'} · {selectedReview.paymentLabel}</div>
+                </div>
+
+                <DetailBlock title="Participant details" values={selectedReview.participant} />
+                <DetailBlock title="Guardian details" values={selectedReview.guardian} />
+
+                <div className="grid gap-2 rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-700">
+                  <div className="flex items-center justify-between gap-3"><span>Waiver accepted</span><span className="font-black text-gray-950">{selectedReview.waiverAccepted ? 'Yes' : 'No'}</span></div>
+                  {selectedReviewOptionAvailability ? <div className="flex items-center justify-between gap-3"><span>Current capacity</span><span className="text-right font-black text-gray-950">{selectedReviewOptionAvailability}</span></div> : null}
+                  {selectedReview.decisionNote ? <div className="flex items-start justify-between gap-3"><span>Decision note</span><span className="text-right font-black text-gray-950">{selectedReview.decisionNote}</span></div> : null}
+                </div>
+
+                {canApproveSelectedReview ? (
+                  <label className="min-w-0">
+                    <span className="app-label">Merge into existing roster player</span>
+                    <select className="auth-input mt-1" aria-label="Merge into existing roster player" value={selectedMergePlayerId} onChange={(event) => setSelectedMergePlayerId(event.target.value)} disabled={saving}>
+                      <option value="">Create a new roster player</option>
+                      {(queue?.rosterPlayers || []).map((player) => <option key={player.id} value={player.id}>{player.number ? `#${player.number} ` : ''}{player.name}</option>)}</select>
+                  </label>
+                ) : null}
+
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {canPromoteSelectedReview ? (
+                    <button type="button" className="primary-button" onClick={handlePromote} disabled={saving}>
+                      {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Send className="h-4 w-4" aria-hidden="true" />}
+                      Promote from waitlist
+                    </button>
+                  ) : canAcceptOfferSelectedReview ? (
+                    <button type="button" className="primary-button" onClick={handleAcceptOffer} disabled={saving}>
+                      {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <CheckCircle2 className="h-4 w-4" aria-hidden="true" />}
+                      Mark accepted
+                    </button>
+                  ) : (
+                    <button type="button" className="primary-button" onClick={handleApprove} disabled={saving || !canApproveSelectedReview}>
+                      {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <UserPlus className="h-4 w-4" aria-hidden="true" />}
+                      Approve application
+                    </button>
+                  )}
+                  <button type="button" className="secondary-button !border-rose-200 !text-rose-700 hover:!bg-rose-50" onClick={handleDecline} disabled={saving || !canDeclineSelectedReview}>
+                    <XCircle className="h-4 w-4" aria-hidden="true" />
+                    Decline application
+                  </button>
+                </div>
+              </div>
+            ) : <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">Choose an application to review.</div>}
+          </div>
+        </section>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3">
@@ -466,6 +791,14 @@ function normalizeRegistrationReturnStatus(value: string | null) {
   return '';
 }
 
+function getTotalWaitlistedCount(registrationOptionCounts: Record<string, any> | undefined, fallback = 0) {
+  const total = Object.values(registrationOptionCounts || {}).reduce((sum, counts) => {
+    const nextCount = Number((counts as Record<string, any>)?.waitlisted || 0);
+    return sum + (Number.isFinite(nextCount) ? nextCount : 0);
+  }, 0);
+  return total > 0 ? total : fallback;
+}
+
 function collectFieldValues(formElement: HTMLFormElement | null, group: string, fallback: Record<string, string>) {
   const values = { ...fallback };
   formElement?.querySelectorAll(`[data-field-group="${group}"]`).forEach((field) => {
@@ -492,7 +825,11 @@ function validate(form: ParentRegistrationCard, participant: Record<string, stri
   return errors;
 }
 
-async function loadRegistrationForm(user: any, teamId: string, formId: string, publicAccess = false): Promise<ParentRegistrationCard | null> {
+async function loadRegistrationForm(user: any, teamId: string, formId: string, publicAccess = false, staffReview = false): Promise<ParentRegistrationCard | null> {
+  if (staffReview) {
+    const detail: ParentRegistrationDetailModel = await loadStaffRegistrationDetail(user, teamId, formId);
+    return toRegistrationCardFromDetail(detail, teamId, formId);
+  }
   if (publicAccess) {
     const detail: ParentRegistrationDetailModel = await loadPublicRegistrationDetail(teamId, formId);
     return toRegistrationCardFromDetail(detail, teamId, formId);
@@ -681,4 +1018,43 @@ function formatDueDateLabel(value: string) {
 
 function formatMoney(cents: number, currency = 'USD') {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: currency || 'USD' }).format((Number(cents) || 0) / 100);
+}
+
+function StatusPill({ value }: { value: string }) {
+  const status = String(value || 'pending').trim().toLowerCase();
+  const label = status.replace(/-/g, ' ');
+  const className = status === 'approved'
+    ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+    : status === 'declined' || status === 'rejected'
+      ? 'border-rose-200 bg-rose-50 text-rose-700'
+      : status === 'waitlisted' || status === 'offer-extended' || status === 'offer-accepted'
+        ? 'border-amber-200 bg-amber-50 text-amber-700'
+        : 'border-sky-200 bg-sky-50 text-sky-700';
+  return <span className={`inline-flex rounded-full border px-2 py-1 text-[11px] font-black uppercase tracking-wide ${className}`}>{label}</span>;
+}
+
+function DetailBlock({ title, values }: { title: string; values: Record<string, any> }) {
+  const entries = Object.entries(values || {}).filter(([, value]) => String(value ?? '').trim());
+  return (
+    <div className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+      <div className="text-sm font-black text-gray-950">{title}</div>
+      <div className="mt-3 grid gap-2">
+        {entries.length ? entries.map(([key, value]) => (
+          <div key={key} className="flex items-start justify-between gap-3 text-sm font-semibold text-gray-700">
+            <span className="text-gray-500">{formatReviewFieldLabel(key)}</span>
+            <span className="text-right font-black text-gray-950">{String(value)}</span>
+          </div>
+        )) : <div className="text-sm font-semibold text-gray-500">No submitted values.</div>}
+      </div>
+    </div>
+  );
+}
+
+function formatReviewFieldLabel(value: string) {
+  return String(value || '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_.-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^./, (char) => char.toUpperCase());
 }

--- a/apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts
+++ b/apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts
@@ -25,4 +25,30 @@ describe('Parent Tools focused service imports', () => {
         expect(source).toContain("../lib/parentRegistrationsService");
         expect(source).not.toContain("../lib/parentToolsService");
     });
+
+    it('keeps staff registration review imports out of the parent registration detail module', () => {
+        const parentSource = readFileSync(resolve(__dirname, '..', 'RegistrationDetail.tsx'), 'utf8');
+        const staffSource = readFileSync(resolve(__dirname, '..', 'TeamRegistrationReview.tsx'), 'utf8');
+        const staffOnlyImports = [
+            'loadStaffRegistrationDetail',
+            'loadTeamRegistrationQueuePage',
+            'loadTeamRegistrationRosterPlayers',
+            'approveTeamRegistrationForApp',
+            'rejectTeamRegistrationForApp',
+            'extendTeamRegistrationOfferForApp'
+        ];
+
+        staffOnlyImports.forEach((staffOnlyImport) => {
+            expect(parentSource).not.toContain(staffOnlyImport);
+            expect(staffSource).toContain(staffOnlyImport);
+        });
+    });
+
+    it('lazy-loads staff registration review from a distinct route module', () => {
+        const source = readFileSync(resolve(__dirname, '..', '..', 'App.tsx'), 'utf8');
+
+        expect(source).toContain("import('./pages/RegistrationDetail')");
+        expect(source).toContain("import('./pages/TeamRegistrationReview')");
+        expect(source.indexOf("import('./pages/RegistrationDetail')")).not.toBe(source.indexOf("import('./pages/TeamRegistrationReview')"));
+    });
 });

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -319,7 +319,8 @@
                 "registration.html"
             ],
             "appPages": [
-                "apps/app/src/pages/RegistrationDetail.tsx"
+                "apps/app/src/pages/RegistrationDetail.tsx",
+                "apps/app/src/pages/TeamRegistrationReview.tsx"
             ],
             "cloudFunctions": [
                 "cancelStripeRegistrationCheckout",

--- a/tests/unit/app-registration-detail.test.jsx
+++ b/tests/unit/app-registration-detail.test.jsx
@@ -68,7 +68,8 @@ vi.mock('../../apps/app/src/lib/parentRegistrationsService.ts', () => parentRegi
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionsMocks);
 vi.mock('@legacy/registration-flow.js', () => registrationFlowMocks);
 
-import { RegistrationDetail, TeamRegistrationReview, selectInitialRegistrationOption } from '../../apps/app/src/pages/RegistrationDetail.tsx';
+import { RegistrationDetail, selectInitialRegistrationOption } from '../../apps/app/src/pages/RegistrationDetail.tsx';
+import { TeamRegistrationReview } from '../../apps/app/src/pages/TeamRegistrationReview.tsx';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 


### PR DESCRIPTION
Closes #3494

## What changed
- Lazy-load `TeamRegistrationReview` from its own `./pages/TeamRegistrationReview` route module.
- Removed staff review queue/action imports and rendering paths from the parent/public `RegistrationDetail` module.
- Updated registration detail tests to import the staff review component from the new module.
- Added static import-contract coverage that prevents staff-only registration review functions from returning to the parent route module and verifies distinct lazy route imports.

## Root Cause
The parent/public registration detail route and staff registration review route were exported from the same lazy-loaded module, so Vite had to ship staff-only queue loading and approve/reject/extend code with the parent registration form route.

## Prevention / Learning
Performance-sensitive role-specific workflows need a route-module import boundary, not just runtime conditionals. Add static import-contract tests for lazy route splits so hidden admin/staff paths do not leak into parent/public chunks again.

## Regression Tests
- `npx vitest run apps/app/src/pages/RegistrationDetail.test.tsx apps/app/src/pages/parent-tools/parentToolServiceImports.test.ts --reporter=verbose`
- `npm run app:build`
- Verified built `RegistrationDetail-*.js` does not contain staff-only service names.