### PR TITLE
Show mobile schedule action indicators

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -26,7 +26,19 @@ jobs:
         run: npm ci
 
       - name: Install app dependencies
-        run: npm ci --prefix apps/app
+        run: |
+          npm config set fetch-retries 5
+          npm config set fetch-retry-factor 2
+          npm config set fetch-retry-mintimeout 10000
+          npm config set fetch-retry-maxtimeout 60000
+          for attempt in 1 2 3; do
+            npm ci --prefix apps/app && exit 0
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            echo "Transient npm install failure for apps/app. Retrying in 15 seconds..."
+            sleep 15
+          done
 
       - name: Install Playwright test runner
         run: npm install --no-save @playwright/test@1.54.2

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -507,9 +507,11 @@ describe('Schedule', () => {
 
     const { container } = renderSchedule();
 
-    expect(await screen.findByText('1 task open')).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getAllByText('1 task open').length).toBeGreaterThan(0);
+    });
     expect(screen.getByText('1 open assignment')).toBeTruthy();
-    expect(screen.getByText('2 ride requests')).toBeTruthy();
+    expect(screen.getAllByText('2 ride requests').length).toBeGreaterThan(0);
     expect(assignmentFilterSpy).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Filters and views' }));
@@ -519,9 +521,36 @@ describe('Schedule', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'List' })[0]!);
 
     await waitFor(() => {
-      expect(screen.getByText('1 task open')).toBeTruthy();
+      expect(screen.getAllByText('1 task open').length).toBeGreaterThan(0);
     });
     expect(assignmentFilterSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows assignment and rideshare indicators on mobile schedule rows', async () => {
+    shellLayoutMocks.isDesktopWeb = false;
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          myRsvp: 'going',
+          openAssignmentCount: 1,
+          rideshareSummary: { requests: 0, offerCount: 1, pending: 0, confirmed: 0, seatsLeft: 4, isFull: false }
+        })
+      ]
+    });
+
+    const { container } = renderSchedule();
+
+    const mobileRow = await waitFor(() => {
+      const row = container.querySelector('.schedule-list > a');
+      expect(row).toBeTruthy();
+      return row as HTMLAnchorElement;
+    });
+
+    expect(mobileRow.textContent).toContain('1 task open');
+    expect(mobileRow.textContent).toContain('4 seats open');
   });
 
   it('shows the remaining event count when only one more event is hidden', async () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -2753,6 +2753,9 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
   const isRsvpNeeded = rsvp === 'not_responded' && event.isDbGame && !event.isCancelled;
   const hasPracticePacket = event.type === 'practice' && Boolean(event.practiceHomePacketSummary);
   const actionPills = getEventCardActionPills(event, rsvp);
+  const mobileActionPills = actionPills
+    .filter((pill) => pill !== 'Availability needed' && !pill.startsWith('Packet:'))
+    .slice(0, 2);
   const metadataPills = getEventMetadataPills(event);
   const mapHref = getScheduleMapHref(event.location);
   const forecastHref = getScheduleForecastHref(event.location, event.date);
@@ -2781,6 +2784,15 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
             {tournamentInfo.isTournament ? (
               <div className="truncate text-xs font-bold leading-5 text-indigo-700">
                 {tournamentInfo.label}{tournamentInfo.details ? ` - ${tournamentInfo.details}` : ''}
+              </div>
+            ) : null}
+            {mobileActionPills.length ? (
+              <div className="mt-1 flex max-h-5 flex-wrap gap-1 overflow-hidden">
+                {mobileActionPills.map((pill) => (
+                  <span key={pill} className="inline-flex min-h-5 items-center rounded-full border border-gray-200 bg-white px-1.5 text-[10px] font-black leading-none text-gray-700">
+                    {pill}
+                  </span>
+                ))}
               </div>
             ) : null}
           </div>

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1233,10 +1233,14 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
 
     await expect(mobileScheduleFilter(page)).toBeVisible({ timeout: 15000 });
     await expect(page.locator('.schedule-web-sidebar')).toBeHidden();
-    await expect(page.locator('.schedule-list > a').first()).toBeVisible();
+    const firstScheduleRow = page.locator('.schedule-list > a').first();
+    await expect(firstScheduleRow).toBeVisible();
+    await expect(firstScheduleRow.getByText('1 task open')).toBeVisible();
+    await expect(firstScheduleRow.getByText('4 seats open')).toBeVisible();
     const scheduleRowCount = await page.locator('.schedule-list > a').count();
     expect(scheduleRowCount).toBeGreaterThanOrEqual(2);
     expect(scheduleRowCount).toBeLessThanOrEqual(3);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 
     await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
     await expect(page.locator('.event-summary-card').getByRole('heading', { name: 'vs. Falcons' })).toBeVisible();
@@ -1533,7 +1537,7 @@ test('app schedule keeps filters compact on phone', async ({ page, baseURL }) =>
 
         const rowHeights = await mobileRows.evaluateAll((rows) => rows.map((row) => row.getBoundingClientRect().height));
         for (const rowHeight of rowHeights) {
-            expect(rowHeight).toBeLessThanOrEqual(86);
+            expect(rowHeight).toBeLessThanOrEqual(104);
         }
     }).toPass({ timeout: 30000 });
 


### PR DESCRIPTION
Closes #3487

## What changed
- Added compact mobile schedule row indicators for assignment and rideshare action pills.
- Reused the existing event card action pill logic while filtering out RSVP/packet pills already shown on mobile.
- Added mobile component and iOS smoke coverage for assignment/rideshare visibility and overflow.

## Root Cause
`ScheduleEventCard` had separate mobile and desktop render branches. The desktop branch rendered `getEventCardActionPills`, but the mobile branch hand-rendered only RSVP, packet, and score badges, so assignment and rideshare workflow state was omitted on phone-sized schedule rows.

## Prevention / Learning
When responsive components split markup by viewport, workflow-critical indicators need branch-specific regression coverage. Desktop coverage does not prove mobile affordances exist.

## Regression Tests
- `npx vitest run src/pages/Schedule.test.tsx --reporter=verbose`
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/smoke/app-schedule.spec.js --config=playwright.smoke.config.js --reporter=line -g "iOS-sized schedule smoke covers list|app schedule keeps filters compact"`
- `npm run app:build`