### PR TITLE
Show final games in scoreboard widget

### DIFF
--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -43,4 +43,15 @@ describe('scoreboard widget embed', () => {
         expect(source).toContain("window.addEventListener('beforeunload', clearRefreshTimer);");
         expect(source).toContain('Read-only public scoreboard');
     });
+
+    it('treats legacy final games as completed recent results', () => {
+        const source = readPage('widget-scoreboard.html');
+
+        expect(source).toContain("const status = normalizeStatus(game?.status);");
+        expect(source).toContain("return liveStatus === 'completed' || status === 'completed' || status === 'final';");
+        expect(source).toContain('.filter((game) => game._date && (isLive(game) || game._date >= now || (isCompleted(game) && game._date >= recentCutoff)))');
+        expect(source).toContain("if (isCompleted(game)) return 'Final';");
+        expect(source).toContain('game.html?teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(gameId)}');
+        expect(source).toContain('const showScore = isLive(game) || isCompleted(game);');
+    });
 });

--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -48,7 +48,7 @@ describe('scoreboard widget embed', () => {
         const source = readPage('widget-scoreboard.html');
 
         expect(source).toContain("const status = normalizeStatus(game?.status);");
-        expect(source).toContain("return liveStatus === 'completed' || status === 'completed' || status === 'final';");
+        expect(source).toContain("return liveStatus === 'completed' || liveStatus === 'final' || status === 'completed' || status === 'final';");
         expect(source).toContain('.filter((game) => game._date && (isLive(game) || game._date >= now || (isCompleted(game) && game._date >= recentCutoff)))');
         expect(source).toContain("if (isCompleted(game)) return 'Final';");
         expect(source).toContain('game.html?teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(gameId)}');

--- a/widget-scoreboard.html
+++ b/widget-scoreboard.html
@@ -66,7 +66,7 @@
         function isCompleted(game) {
             const liveStatus = normalizeStatus(game?.liveStatus);
             const status = normalizeStatus(game?.status);
-            return liveStatus === 'completed' || status === 'completed' || status === 'final';
+            return liveStatus === 'completed' || liveStatus === 'final' || status === 'completed' || status === 'final';
         }
 
         function isLive(game) {

--- a/widget-scoreboard.html
+++ b/widget-scoreboard.html
@@ -64,7 +64,9 @@
         }
 
         function isCompleted(game) {
-            return normalizeStatus(game?.liveStatus) === 'completed' || normalizeStatus(game?.status) === 'completed';
+            const liveStatus = normalizeStatus(game?.liveStatus);
+            const status = normalizeStatus(game?.status);
+            return liveStatus === 'completed' || status === 'completed' || status === 'final';
         }
 
         function isLive(game) {


### PR DESCRIPTION
Closes #3506

## What changed
- Updated the scoreboard widget completed-game predicate to treat legacy `status: 'final'` games as completed.
- Added a focused regression test asserting final-status games flow through the recent-results path as Final results with score and details routing.

## Root Cause
`widget-scoreboard.html` duplicated completed-game status logic and only accepted `completed`, while other app surfaces already treat `final` as a completed/final state. The recent-results filter depends on `isCompleted(game)`, so recent scored games with `status: 'final'` were excluded.

## Prevention / Learning
When filtering completed games in public widgets or schedule surfaces, use the full canonical final-state set already supported elsewhere: `status: 'completed'`, `status: 'final'`, and `liveStatus: 'completed'`.

## Regression Tests
- `npx vitest run tests/unit/scoreboard-widget.test.js --reporter=verbose`