### PR TITLE
Fix admin search across paginated records

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -708,7 +708,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="js/admin.js?v=7"></script>
+    <script type="module" src="js/admin.js?v=8"></script>
 </body>
 
 </html>

--- a/js/admin-search.js
+++ b/js/admin-search.js
@@ -1,0 +1,11 @@
+export function normalizeAdminSearchTerm(value = '') {
+    return String(value || '').trim().toLowerCase();
+}
+
+export function hasAdminGlobalSearchTerm(value = '') {
+    return normalizeAdminSearchTerm(value).length > 0;
+}
+
+export function selectAdminSearchCollection({ searchTerm = '', pageItems = [], globalItems = [] } = {}) {
+    return hasAdminGlobalSearchTerm(searchTerm) ? globalItems : pageItems;
+}

--- a/js/admin-search.js
+++ b/js/admin-search.js
@@ -9,3 +9,8 @@ export function hasAdminGlobalSearchTerm(value = '') {
 export function selectAdminSearchCollection({ searchTerm = '', pageItems = [], globalItems = [] } = {}) {
     return hasAdminGlobalSearchTerm(searchTerm) ? globalItems : pageItems;
 }
+
+export function selectAdminItemById({ id = '', pageItems = [], globalItems = [], fallbackItems = [] } = {}) {
+    const itemId = String(id || '');
+    return [...pageItems, ...globalItems, ...fallbackItems].find((item) => String(item?.id || '') === itemId) || null;
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -40,6 +40,11 @@ import {
 } from './admin-user-official-links.js?v=2';
 import { buildAdminTeamOfficialsSummary } from './admin-team-officials.js?v=1';
 import {
+    hasAdminGlobalSearchTerm,
+    normalizeAdminSearchTerm,
+    selectAdminSearchCollection
+} from './admin-search.js?v=1';
+import {
     buildTrackedWorkflowLoadSummary,
     buildTelemetryPerformanceSummary,
     formatPerformanceDuration
@@ -47,6 +52,8 @@ import {
 
 let allTeams = [];
 let allUsers = [];
+let globalSearchTeams = [];
+let globalSearchUsers = [];
 let dashboardTeams = [];
 let dashboardUsers = [];
 let officialUserLookup = new Map();
@@ -80,6 +87,10 @@ let loadedGamesPageKey = '';
 let loadedDashboardGamesKey = '';
 let loadedTeamsOfficialsPageKey = '';
 let loadedUsersOfficialsKey = '';
+let globalSearchTeamsLoaded = false;
+let globalSearchUsersLoaded = false;
+let globalSearchTeamsPromise = null;
+let globalSearchUsersPromise = null;
 
 function getCurrentTeamPage() {
     return teamPageState.pages[teamPageState.currentIndex] || [];
@@ -117,6 +128,69 @@ function applyCurrentTeamPage() {
 
 function applyCurrentUsersPage() {
     allUsers = getCurrentUsersPage();
+}
+
+function resetGlobalAdminSearchCollections() {
+    globalSearchTeams = [];
+    globalSearchUsers = [];
+    globalSearchTeamsLoaded = false;
+    globalSearchUsersLoaded = false;
+    globalSearchTeamsPromise = null;
+    globalSearchUsersPromise = null;
+}
+
+async function ensureGlobalAdminTeamsForSearch() {
+    if (globalSearchTeamsLoaded) return globalSearchTeams;
+    if (!globalSearchTeamsPromise) {
+        globalSearchTeamsPromise = getTeams({ includeInactive: true })
+            .then((teams) => {
+                globalSearchTeams = Array.isArray(teams) ? teams : [];
+                globalSearchTeamsLoaded = true;
+                return globalSearchTeams;
+            })
+            .finally(() => {
+                globalSearchTeamsPromise = null;
+            });
+    }
+    return globalSearchTeamsPromise;
+}
+
+async function ensureGlobalAdminUsersForSearch() {
+    if (globalSearchUsersLoaded) return globalSearchUsers;
+    if (!globalSearchUsersPromise) {
+        globalSearchUsersPromise = getAllUsers()
+            .then((users) => {
+                globalSearchUsers = Array.isArray(users) ? users : [];
+                globalSearchUsersLoaded = true;
+                return globalSearchUsers;
+            })
+            .finally(() => {
+                globalSearchUsersPromise = null;
+            });
+    }
+    return globalSearchUsersPromise;
+}
+
+async function getAdminTeamsForSearch(searchTerm = '') {
+    if (hasAdminGlobalSearchTerm(searchTerm)) {
+        await ensureGlobalAdminTeamsForSearch();
+    }
+    return selectAdminSearchCollection({
+        searchTerm,
+        pageItems: allTeams,
+        globalItems: globalSearchTeams
+    });
+}
+
+async function getAdminUsersForSearch(searchTerm = '') {
+    if (hasAdminGlobalSearchTerm(searchTerm)) {
+        await ensureGlobalAdminUsersForSearch();
+    }
+    return selectAdminSearchCollection({
+        searchTerm,
+        pageItems: allUsers,
+        globalItems: globalSearchUsers
+    });
 }
 
 function setTeamsPage(page, nextCursor, index = 0) {
@@ -245,6 +319,7 @@ async function loadData() {
         dashboardGameStatsByTeamId = new Map();
         dashboardTeams = [];
         dashboardUsers = [];
+        resetGlobalAdminSearchCollections();
         officialUserLookup = new Map();
         officialsByTeamId = new Map();
 
@@ -405,6 +480,10 @@ async function loadGameStatsForTeams(teams = allTeams, { scope = 'page' } = {}) 
 async function loadDashboardData() {
     dashboardTeams = await getTeams({ includeInactive: true });
     dashboardUsers = await getAllUsers();
+    globalSearchTeams = dashboardTeams;
+    globalSearchUsers = dashboardUsers;
+    globalSearchTeamsLoaded = true;
+    globalSearchUsersLoaded = true;
     await loadGameStatsForTeams(dashboardTeams, { scope: 'dashboard' });
 }
 
@@ -1602,9 +1681,14 @@ async function saveRegistrationForm(event) {
     }
 }
 
-function renderCurrentTeamsView() {
-    const term = (document.getElementById('search-teams')?.value || '').toLowerCase();
-    const filtered = getVisibleTeams().filter((team) =>
+async function renderCurrentTeamsView() {
+    const term = normalizeAdminSearchTerm(document.getElementById('search-teams')?.value || '');
+    const teams = await getAdminTeamsForSearch(term);
+    const latestTerm = normalizeAdminSearchTerm(document.getElementById('search-teams')?.value || '');
+    if (term !== latestTerm) return;
+
+    const visibleTeams = showInactiveTeams ? teams : teams.filter(isTeamActive);
+    const filtered = visibleTeams.filter((team) =>
         !term
         || (team.name || '').toLowerCase().includes(term)
         || (team.sport || '').toLowerCase().includes(term)
@@ -1612,10 +1696,14 @@ function renderCurrentTeamsView() {
     renderTeams(filtered);
 }
 
-function renderCurrentUsersView() {
-    const term = (document.getElementById('search-users')?.value || '').toLowerCase();
+async function renderCurrentUsersView() {
+    const term = normalizeAdminSearchTerm(document.getElementById('search-users')?.value || '');
     const officialFilter = document.getElementById('filter-users-official-status')?.value || 'all';
-    const filtered = allUsers.filter((u) => {
+    const users = await getAdminUsersForSearch(term);
+    const latestTerm = normalizeAdminSearchTerm(document.getElementById('search-users')?.value || '');
+    if (term !== latestTerm) return;
+
+    const filtered = users.filter((u) => {
         const officialSummary = getOfficialUserSummary(u, officialUserLookup);
         if (officialFilter === 'officials' && !officialSummary) return false;
         if (officialFilter === 'non-officials' && officialSummary) return false;

--- a/js/admin.js
+++ b/js/admin.js
@@ -42,6 +42,7 @@ import { buildAdminTeamOfficialsSummary } from './admin-team-officials.js?v=1';
 import {
     hasAdminGlobalSearchTerm,
     normalizeAdminSearchTerm,
+    selectAdminItemById,
     selectAdminSearchCollection
 } from './admin-search.js?v=1';
 import {
@@ -120,6 +121,15 @@ function getDashboardTeams() {
 
 function getDashboardUsers() {
     return dashboardUsers.length ? dashboardUsers : allUsers;
+}
+
+function getAdminTeamById(teamId) {
+    return selectAdminItemById({
+        id: teamId,
+        pageItems: allTeams,
+        globalItems: globalSearchTeams,
+        fallbackItems: dashboardTeams
+    });
 }
 
 function applyCurrentTeamPage() {
@@ -1258,7 +1268,7 @@ function getOfficialsAdminDraft() {
 }
 
 window.openOfficialsAdmin = async function (teamId) {
-    activeOfficialsTeam = allTeams.find((team) => team.id === teamId) || null;
+    activeOfficialsTeam = getAdminTeamById(teamId);
     if (!activeOfficialsTeam) return;
 
     document.getElementById('officials-admin-team-name').textContent = activeOfficialsTeam.name || 'Team';
@@ -1395,7 +1405,7 @@ function renderUsers(users) {
 }
 
 window.deleteTeamAdmin = async function (teamId, teamName) {
-    const team = allTeams.find((entry) => entry.id === teamId) || null;
+    const team = getAdminTeamById(teamId);
     if (!canCurrentUserDeactivateTeam(team)) {
         alert('Team deactivation is only available to the team owner in the dashboard workflow.');
         return;
@@ -1414,7 +1424,7 @@ window.deleteTeamAdmin = async function (teamId, teamName) {
 };
 
 window.openRegistrationFormsAdmin = async function (teamId) {
-    activeRegistrationTeam = allTeams.find(team => team.id === teamId) || null;
+    activeRegistrationTeam = getAdminTeamById(teamId);
     if (!activeRegistrationTeam) return;
 
     document.getElementById('registration-team-name').textContent = activeRegistrationTeam.name || 'Team';
@@ -1702,6 +1712,10 @@ async function renderCurrentUsersView() {
     const users = await getAdminUsersForSearch(term);
     const latestTerm = normalizeAdminSearchTerm(document.getElementById('search-users')?.value || '');
     if (term !== latestTerm) return;
+
+    await loadVisibleOfficialUserLinks(users);
+    const refreshedTerm = normalizeAdminSearchTerm(document.getElementById('search-users')?.value || '');
+    if (term !== refreshedTerm) return;
 
     const filtered = users.filter((u) => {
         const officialSummary = getOfficialUserSummary(u, officialUserLookup);

--- a/tests/unit/admin-search.test.js
+++ b/tests/unit/admin-search.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+    hasAdminGlobalSearchTerm,
+    normalizeAdminSearchTerm,
+    selectAdminSearchCollection
+} from '../../js/admin-search.js';
+
+describe('admin search collection selection', () => {
+    it('keeps empty searches scoped to the current paginated page', () => {
+        const pageItems = [{ id: 'team-1', name: 'Aardvarks' }];
+        const globalItems = [{ id: 'team-99', name: 'Zebras' }];
+
+        expect(selectAdminSearchCollection({ searchTerm: '', pageItems, globalItems })).toBe(pageItems);
+        expect(selectAdminSearchCollection({ searchTerm: '   ', pageItems, globalItems })).toBe(pageItems);
+    });
+
+    it('uses the collection-wide cache when admins enter a search term', () => {
+        const pageItems = [{ id: 'user-1', email: 'alpha@example.com' }];
+        const globalItems = [{ id: 'user-99', email: 'zeta@example.com' }];
+
+        expect(selectAdminSearchCollection({ searchTerm: 'zeta', pageItems, globalItems })).toBe(globalItems);
+    });
+
+    it('normalizes whitespace and casing before deciding whether search is global', () => {
+        expect(normalizeAdminSearchTerm('  Team Z  ')).toBe('team z');
+        expect(hasAdminGlobalSearchTerm('  Team Z  ')).toBe(true);
+        expect(hasAdminGlobalSearchTerm('\n\t')).toBe(false);
+    });
+});

--- a/tests/unit/admin-search.test.js
+++ b/tests/unit/admin-search.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     hasAdminGlobalSearchTerm,
     normalizeAdminSearchTerm,
+    selectAdminItemById,
     selectAdminSearchCollection
 } from '../../js/admin-search.js';
 
@@ -25,5 +26,26 @@ describe('admin search collection selection', () => {
         expect(normalizeAdminSearchTerm('  Team Z  ')).toBe('team z');
         expect(hasAdminGlobalSearchTerm('  Team Z  ')).toBe(true);
         expect(hasAdminGlobalSearchTerm('\n\t')).toBe(false);
+    });
+
+    it('resolves row actions against global search results outside the current page', () => {
+        const pageItems = [{ id: 'team-1', name: 'Current page' }];
+        const globalItems = [{ id: 'team-99', name: 'Search result' }];
+        const fallbackItems = [{ id: 'team-100', name: 'Dashboard cached' }];
+
+        expect(selectAdminItemById({ id: 'team-99', pageItems, globalItems, fallbackItems })).toBe(globalItems[0]);
+        expect(selectAdminItemById({ id: 'team-100', pageItems, globalItems, fallbackItems })).toBe(fallbackItems[0]);
+        expect(selectAdminItemById({ id: 'missing', pageItems, globalItems, fallbackItems })).toBeNull();
+    });
+
+    it('documents that non-empty user searches use the global lookup source', () => {
+        const pageUsers = [{ id: 'user-1', email: 'page@example.com' }];
+        const globalUsers = [{ id: 'user-99', email: 'official@example.com' }];
+
+        expect(selectAdminSearchCollection({
+            searchTerm: 'official',
+            pageItems: pageUsers,
+            globalItems: globalUsers
+        })).toBe(globalUsers);
     });
 });

--- a/tests/unit/admin-user-official-links.test.js
+++ b/tests/unit/admin-user-official-links.test.js
@@ -123,4 +123,18 @@ describe('admin users official links', () => {
         expect(adminJs).toContain("await loadVisibleOfficialUserLinks(getCurrentUsersPage());");
         expect(adminJs).toContain('await ensureCurrentUsersOfficialsLoaded();');
     });
+
+    it('loads official lookups for the active user search result source before filtering and rendering badges', () => {
+        const adminJs = readSource('js/admin.js');
+        const renderUsersView = adminJs.slice(
+            adminJs.indexOf('async function renderCurrentUsersView()'),
+            adminJs.indexOf('async function loadNextTeamsPage()')
+        );
+
+        expect(renderUsersView).toContain('const users = await getAdminUsersForSearch(term);');
+        expect(renderUsersView).toContain('await loadVisibleOfficialUserLinks(users);');
+        expect(renderUsersView.indexOf('await loadVisibleOfficialUserLinks(users);')).toBeLessThan(
+            renderUsersView.indexOf('const filtered = users.filter')
+        );
+    });
 });


### PR DESCRIPTION
Closes #3502

## What changed
- Updated admin team and user search so non-empty search terms use a collection-wide cache instead of only the active 25-row page.
- Kept empty browsing scoped to the current paginated page so initial admin load behavior stays unchanged.
- Reused the dashboard-loaded full team/user collections for search and added a one-flight fallback fetch if search runs before that cache is ready.
- Bumped the admin page script cache key.

## Root Cause
`allTeams` and `allUsers` are reassigned to the current paginated page, and the admin search inputs filtered those page-scoped arrays directly. Any team or user outside the active 25-record slice was invisible to search until the admin manually paged to it.

## Prevention / Learning
Admin search over paginated collections must explicitly choose page-local browsing for empty terms and a collection-wide or server-side source for non-empty terms. Cover that source-selection invariant with focused regression tests.

## Regression Tests
- `npx vitest run tests/unit/admin-search.test.js tests/unit/admin-bootstrap.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`