### PR TITLE
Clear live events on statsheet replacement

### DIFF
--- a/js/track-statsheet-apply.js
+++ b/js/track-statsheet-apply.js
@@ -97,6 +97,15 @@ export function buildTrackStatsheetApplyPlan({
             awayScore: Number(awayScore || 0) || 0,
             opponentStats,
             status: 'completed',
+            liveStatus: 'completed',
+            liveHasData: false,
+            liveClockMs: 0,
+            liveClockRunning: false,
+            liveClockPeriod: 'Q1',
+            liveLineup: {
+                onCourt: [],
+                bench: []
+            },
             statSheetPhotoUrl: statSheetPhotoUrl || null
         }
     };

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -103,6 +103,15 @@ describe('track statsheet apply helpers', () => {
                     }
                 },
                 status: 'completed',
+                liveStatus: 'completed',
+                liveHasData: false,
+                liveClockMs: 0,
+                liveClockRunning: false,
+                liveClockPeriod: 'Q1',
+                liveLineup: {
+                    onCourt: [],
+                    bench: []
+                },
                 statSheetPhotoUrl: 'https://img.test/statsheet.png'
             }
         });
@@ -149,6 +158,15 @@ describe('track statsheet apply helpers', () => {
                     }
                 },
                 status: 'completed',
+                liveStatus: 'completed',
+                liveHasData: false,
+                liveClockMs: 0,
+                liveClockRunning: false,
+                liveClockPeriod: 'Q1',
+                liveLineup: {
+                    onCourt: [],
+                    bench: []
+                },
                 statSheetPhotoUrl: null
             }
         });
@@ -183,8 +201,20 @@ describe('track statsheet apply helpers', () => {
         ]);
     });
 
-    it('clears private player stats when replacing previously tracked game data', () => {
+    it('clears all tracked and live state when replacing previously tracked game data', () => {
         expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
-        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
+        expect(trackStatsheetSource).toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
+        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| liveEventsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(liveEventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
+        expect(buildTrackStatsheetApplyPlan().gameUpdate).toMatchObject({
+            liveStatus: 'completed',
+            liveHasData: false,
+            liveClockMs: 0,
+            liveClockRunning: false,
+            liveClockPeriod: 'Q1',
+            liveLineup: {
+                onCourt: [],
+                bench: []
+            }
+        });
     });
 });

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -201,10 +201,11 @@ describe('track statsheet apply helpers', () => {
         ]);
     });
 
-    it('clears all tracked and live state when replacing previously tracked game data', () => {
+    it('clears mutable tracked state without deleting immutable live events', () => {
         expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
-        expect(trackStatsheetSource).toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
-        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| liveEventsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(liveEventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
+        expect(trackStatsheetSource).not.toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
+        expect(trackStatsheetSource).not.toContain('liveEventsSnap.docs.map');
+        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(eventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(statsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
         expect(buildTrackStatsheetApplyPlan().gameUpdate).toMatchObject({
             liveStatus: 'completed',
             liveHasData: false,

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -201,11 +201,10 @@ describe('track statsheet apply helpers', () => {
         ]);
     });
 
-    it('clears mutable tracked state without deleting immutable live events', () => {
+    it('clears tracked, live, and private player state when replacing previously tracked game data', () => {
         expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
-        expect(trackStatsheetSource).not.toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
-        expect(trackStatsheetSource).not.toContain('liveEventsSnap.docs.map');
-        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(eventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(statsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
+        expect(trackStatsheetSource).toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
+        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| liveEventsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(eventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(statsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(liveEventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
         expect(buildTrackStatsheetApplyPlan().gameUpdate).toMatchObject({
             liveStatus: 'completed',
             liveHasData: false,

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -782,9 +782,8 @@ RETURN JSON:
         applyStatus.textContent = 'Checking existing game data…';
         const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
-        const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
         const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
-        if (eventsSnap.size > 0 || statsSnap.size > 0 || liveEventsSnap.size > 0 || privateStatsSnap.size > 0) {
+        if (eventsSnap.size > 0 || statsSnap.size > 0 || privateStatsSnap.size > 0) {
           const confirmClear = confirm('This game already has tracked data. Replace it with the stat sheet results?');
           if (!confirmClear) {
             applyStatus.textContent = 'Cancelled.';
@@ -793,7 +792,6 @@ RETURN JSON:
           applyStatus.textContent = 'Clearing existing stats…';
           await Promise.all(eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
           await Promise.all(statsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
-          await Promise.all(liveEventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
           await Promise.all(privateStatsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
         }
 

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -205,7 +205,7 @@
     import { checkAuth } from './js/auth.js?v=41';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
     import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=9';
-    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=4';
+    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=5';
     import { getApp } from './js/vendor/firebase-app.js';
     import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
@@ -782,8 +782,9 @@ RETURN JSON:
         applyStatus.textContent = 'Checking existing game data…';
         const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
+        const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
         const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
-        if (eventsSnap.size > 0 || statsSnap.size > 0 || privateStatsSnap.size > 0) {
+        if (eventsSnap.size > 0 || statsSnap.size > 0 || liveEventsSnap.size > 0 || privateStatsSnap.size > 0) {
           const confirmClear = confirm('This game already has tracked data. Replace it with the stat sheet results?');
           if (!confirmClear) {
             applyStatus.textContent = 'Cancelled.';
@@ -792,6 +793,7 @@ RETURN JSON:
           applyStatus.textContent = 'Clearing existing stats…';
           await Promise.all(eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
           await Promise.all(statsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
+          await Promise.all(liveEventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
           await Promise.all(privateStatsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
         }
 

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -782,8 +782,9 @@ RETURN JSON:
         applyStatus.textContent = 'Checking existing game data…';
         const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
+        const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
         const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
-        if (eventsSnap.size > 0 || statsSnap.size > 0 || privateStatsSnap.size > 0) {
+        if (eventsSnap.size > 0 || statsSnap.size > 0 || liveEventsSnap.size > 0 || privateStatsSnap.size > 0) {
           const confirmClear = confirm('This game already has tracked data. Replace it with the stat sheet results?');
           if (!confirmClear) {
             applyStatus.textContent = 'Cancelled.';
@@ -792,6 +793,7 @@ RETURN JSON:
           applyStatus.textContent = 'Clearing existing stats…';
           await Promise.all(eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
           await Promise.all(statsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
+          await Promise.all(liveEventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
           await Promise.all(privateStatsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
         }
 


### PR DESCRIPTION
Closes #3517

## What changed
- Statsheet replacement now checks `liveEvents` when deciding whether existing tracked data must be replaced.
- Confirmed replacement deletes stale `liveEvents` alongside `events`, `aggregatedStats`, and `privatePlayerStats`.
- Statsheet apply updates now reset live tracking metadata so resume/live-view flows do not reuse stale clock or lineup state.

## Root Cause
The statsheet replacement path only treated `events`, `aggregatedStats`, and `privatePlayerStats` as tracked data. `liveEvents` and live tracker metadata were omitted even though live tracker resume and live game views consume them as persisted tracked state.

## Prevention / Learning
Any workflow that replaces tracked game data must enumerate every persisted tracking source consumed by resume, replay, or live-view flows. Regression coverage should assert both subcollection cleanup and metadata reset.

## Regression Tests
- `npx vitest run tests/unit/track-statsheet-apply.test.js --reporter=verbose`