### PR TITLE
Preserve legacy team permissions on edit

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -625,6 +625,8 @@
         let pendingAdminInviteEmails = [];
         let confirmedTeamMembers = [];
         let teamPermissions = normalizeTeamPermissions();
+        let loadedTeamHasTeamPermissions = false;
+        let teamPermissionsTouched = false;
         let rolloverSourceTeams = [];
         let rolloverAccessPreview = null;
         let currentRegistrationSource = null;
@@ -1378,6 +1380,7 @@
 
             list.querySelectorAll(`.${kind}-member-checkbox`).forEach((input) => {
                 input.addEventListener('change', () => {
+                    teamPermissionsTouched = true;
                     const current = new Set(getPermissionState(kind).memberIds);
                     if (input.checked) {
                         current.add(input.value);
@@ -1451,6 +1454,7 @@
 
         ['scorekeeping', 'streaming'].forEach((kind) => {
             document.getElementById(`${kind}AccessMode`).addEventListener('change', (event) => {
+                teamPermissionsTouched = true;
                 teamPermissions = normalizeTeamPermissions({
                     ...teamPermissions,
                     [kind]: {
@@ -1461,6 +1465,10 @@
                 renderPermissionMemberList(kind);
             });
         });
+
+        function shouldPersistTeamPermissions() {
+            return !currentTeamId || loadedTeamHasTeamPermissions || teamPermissionsTouched;
+        }
 
         function syncStreamVolunteerPanel() {
             const mode = document.getElementById('streamAccessMode').value;
@@ -1538,6 +1546,7 @@
                     teamId: initialTeamId,
                     getTeamAccessCodes
                 });
+                loadedTeamHasTeamPermissions = Object.prototype.hasOwnProperty.call(team, 'teamPermissions');
                 teamPermissions = normalizeTeamPermissions(team.teamPermissions);
                 await loadConfirmedTeamMembers(initialTeamId);
                 streamVolunteerEmails = normalizeStreamVolunteerEmailList(team.streamVolunteerEmails);
@@ -2018,7 +2027,7 @@
                         }
                     } : {}),
                     ...(rolloverStaffUpdate ? { accessRolloverAudit: rolloverStaffUpdate.accessRolloverAudit } : {}),
-                    teamPermissions: normalizeTeamPermissions(teamPermissions),
+                    ...(shouldPersistTeamPermissions() ? { teamPermissions: normalizeTeamPermissions(teamPermissions) } : {}),
                     streamAccessMode: document.getElementById('streamAccessMode').value,
                     streamVolunteerEmails: normalizedStreamVolunteerEmails,
                     defaultAssignments: getDefaultAssignmentsFromForm(),

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -692,6 +692,76 @@ describe('edit team admin access persistence', () => {
         }
     });
 
+    it('does not backfill team permissions when saving an unrelated edit to a legacy team', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Legacy Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: '',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: []
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            env.elements.get('name').value = 'Legacy Sharks Updated';
+
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls).toHaveLength(1);
+            expect(env.state.updateCalls[0].teamData.name).toBe('Legacy Sharks Updated');
+            expect(env.state.updateCalls[0].teamData).not.toHaveProperty('teamPermissions');
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('persists team permissions for legacy teams after the permissions UI is changed', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Legacy Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: '',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: []
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            env.elements.get('scorekeepingAccessMode').value = 'selected';
+            await env.elements.get('scorekeepingAccessMode').dispatchEvent(new MockEvent('change'));
+
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls).toHaveLength(1);
+            expect(env.state.updateCalls[0].teamData.teamPermissions).toMatchObject({
+                scorekeeping: { mode: 'selected', memberIds: [] },
+                streaming: { mode: 'all_confirmed', memberIds: [] },
+                videography: { mode: 'selected', memberIds: [] }
+            });
+        } finally {
+            env.cleanup();
+        }
+    });
+
     it('blocks Sports Connect roster import until a stored provider snapshot exists', () => {
         const html = readFileSync(new URL('../../edit-roster.html', import.meta.url), 'utf8');
 


### PR DESCRIPTION
Closes #3501

## What changed
- Preserves missing `teamPermissions` when saving unrelated edits to legacy teams.
- Persists normalized permissions only when the team already had `teamPermissions`, a new team is created, or the Team Permissions UI is explicitly changed.
- Added regression coverage for legacy no-op permission saves and explicit permission edits.

## Root Cause
Edit Team normalized a missing `teamPermissions` field into default `all_confirmed` scorekeeping and streaming permissions during load, then always wrote that normalized object on save. That converted legacy absence into delegated live-game access during unrelated edits.

## Prevention / Learning
Do not persist normalized defaults for optional access-control fields unless the field already exists or the user explicitly edits that permission surface. Regression tests should assert legacy absence stays absent on unrelated saves.

## Regression Tests
- `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js --reporter=verbose`