### PR TITLE
Add Help Watch Chat deep-link coverage

### DIFF
--- a/help-watch-chat.html
+++ b/help-watch-chat.html
@@ -78,11 +78,22 @@
         gameId: context.get('gameId') || ''
       };
 
-      const resolveRouteTemplate = (template) => template
+      const removeEmptyHashParameters = (route) => {
+        const [base, hash] = route.split('#');
+        if (hash === undefined) {
+          return route;
+        }
+
+        const parameters = hash
+          .split('&')
+          .filter((parameter) => parameter !== 'teamId=' && parameter !== 'gameId=');
+
+        return parameters.length > 0 ? `${base}#${parameters.join('&')}` : base;
+      };
+
+      const resolveRouteTemplate = (template) => removeEmptyHashParameters(template
         .replaceAll('{teamId}', encodeURIComponent(values.teamId))
-        .replaceAll('{gameId}', encodeURIComponent(values.gameId))
-        .replace(/#teamId=$/, '')
-        .replace(/&gameId=$/, '');
+        .replaceAll('{gameId}', encodeURIComponent(values.gameId)));
 
       document.querySelectorAll('[data-help-context-link]').forEach((link) => {
         link.href = resolveRouteTemplate(link.dataset.routeTemplate || link.getAttribute('href'));

--- a/help-watch-chat.html
+++ b/help-watch-chat.html
@@ -21,6 +21,24 @@
           <li><strong>Coach/Admin:</strong> Configure stream source and game live status.</li>
           <li><strong>Parent/Member:</strong> Consume view-only watching experience.</li>
         </ul>
+        <div class="mt-4 flex flex-wrap gap-2" aria-label="Watch navigation">
+          <a
+            class="inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
+            href="team.html"
+            data-help-context-link
+            data-guide-id="watch-game"
+            data-quick-link-label="Team Page"
+            data-route-template="team.html#teamId={teamId}"
+          >Team Page</a>
+          <a
+            class="inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
+            href="live-game.html"
+            data-help-context-link
+            data-guide-id="watch-game"
+            data-quick-link-label="Game Viewer"
+            data-route-template="live-game.html#teamId={teamId}&gameId={gameId}"
+          >Game Viewer</a>
+        </div>
       </article>
 
       <article class="bg-white rounded-xl border border-slate-200 p-5">
@@ -30,6 +48,16 @@
           <li><strong>Coach/Admin:</strong> Send operational game-day and scheduling updates.</li>
           <li><strong>Parent:</strong> Parent communication and acknowledgments.</li>
         </ul>
+        <div class="mt-4 flex flex-wrap gap-2" aria-label="Chat navigation">
+          <a
+            class="inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
+            href="team-chat.html"
+            data-help-context-link
+            data-guide-id="team-chat-basics"
+            data-quick-link-label="Open Team Chat"
+            data-route-template="team-chat.html#teamId={teamId}"
+          >Team Chat</a>
+        </div>
       </article>
 
       <article class="bg-white rounded-xl border border-slate-200 p-5">
@@ -42,5 +70,24 @@
       </article>
     </section>
   </main>
+  <script>
+    (() => {
+      const context = new URLSearchParams(window.location.search);
+      const values = {
+        teamId: context.get('teamId') || '',
+        gameId: context.get('gameId') || ''
+      };
+
+      const resolveRouteTemplate = (template) => template
+        .replaceAll('{teamId}', encodeURIComponent(values.teamId))
+        .replaceAll('{gameId}', encodeURIComponent(values.gameId))
+        .replace(/#teamId=$/, '')
+        .replace(/&gameId=$/, '');
+
+      document.querySelectorAll('[data-help-context-link]').forEach((link) => {
+        link.href = resolveRouteTemplate(link.dataset.routeTemplate || link.getAttribute('href'));
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/tests/smoke/help-workflow-pages.spec.js
+++ b/tests/smoke/help-workflow-pages.spec.js
@@ -44,6 +44,24 @@ test.describe('help topic and workflow pages', () => {
         });
     }
 
+    test('help-watch-chat exposes context-aware watch and chat deep links', async ({ page, baseURL }) => {
+        await assertPageBootsWithoutFatalErrors(page, {
+            baseURL,
+            path: '/help-watch-chat.html?context=team&teamId=team-123&gameId=game-456&role=parent',
+            titlePatterns: [/Help/i],
+            skipDefaultForbiddenTexts: true,
+            requiredSelectors: [
+                'a[data-help-context-link][data-quick-link-label="Team Page"]',
+                'a[data-help-context-link][data-quick-link-label="Game Viewer"]',
+                'a[data-help-context-link][data-quick-link-label="Open Team Chat"]'
+            ]
+        });
+
+        await expect(page.getByRole('link', { name: 'Team Page' })).toHaveAttribute('href', 'team.html#teamId=team-123');
+        await expect(page.getByRole('link', { name: 'Game Viewer' })).toHaveAttribute('href', 'live-game.html#teamId=team-123&gameId=game-456');
+        await expect(page.getByRole('link', { name: 'Team Chat' })).toHaveAttribute('href', 'team-chat.html#teamId=team-123');
+    });
+
     for (const file of workflowPages) {
         test(`${file} boots with generated workflow navigation`, async ({ page, baseURL }) => {
             await assertPageBootsWithoutFatalErrors(page, {

--- a/tests/unit/help-center.test.js
+++ b/tests/unit/help-center.test.js
@@ -14,6 +14,15 @@ function readRepoFile(relativePath) {
     return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
 }
 
+function getHelpWatchChatContextLinks() {
+    const helpPage = readRepoFile('help-watch-chat.html');
+    return [...helpPage.matchAll(/<a\b[^>]*data-help-context-link[^>]*>/g)].map(([anchor]) => ({
+        guideId: anchor.match(/\bdata-guide-id="([^"]+)"/)?.[1],
+        quickLinkLabel: anchor.match(/\bdata-quick-link-label="([^"]+)"/)?.[1],
+        routeTemplate: anchor.match(/\bdata-route-template="([^"]+)"/)?.[1]
+    }));
+}
+
 describe('help center deep workflow coverage', () => {
     it('normalizes role aliases and defaults unknown to member', () => {
         expect(normalizeHelpRole('admins')).toBe('administrator');
@@ -84,5 +93,24 @@ describe('help center deep workflow coverage', () => {
         expect(helpPage).toContain('@ALL PLAYS');
         expect(helpPage).toContain('Use the recipient picker, not @ mentions');
         expect(helpPage).not.toContain('Use targeted mentions');
+    });
+
+    it('keeps Help Watch Chat CTAs aligned with watch and team-chat quick links', () => {
+        const pageLinksByGuideAndLabel = new Map(
+            getHelpWatchChatContextLinks().map((link) => [`${link.guideId}:${link.quickLinkLabel}`, link.routeTemplate])
+        );
+
+        const requiredQuickLinks = [
+            ['watch-game', 'Team Page'],
+            ['watch-game', 'Game Viewer'],
+            ['team-chat-basics', 'Open Team Chat']
+        ];
+
+        requiredQuickLinks.forEach(([guideId, label]) => {
+            const guide = getGuideById('parent', guideId);
+            const quickLink = guide.quickLinks.find((link) => link.label === label);
+
+            expect(pageLinksByGuideAndLabel.get(`${guideId}:${label}`)).toBe(quickLink.url);
+        });
     });
 });

--- a/tests/unit/help-center.test.js
+++ b/tests/unit/help-center.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
 import {
     normalizeHelpRole,
     getHelpGuidesForRole,
@@ -21,6 +22,13 @@ function getHelpWatchChatContextLinks() {
         quickLinkLabel: anchor.match(/\bdata-quick-link-label="([^"]+)"/)?.[1],
         routeTemplate: anchor.match(/\bdata-route-template="([^"]+)"/)?.[1]
     }));
+}
+
+function renderHelpWatchChat(url) {
+    return new JSDOM(readRepoFile('help-watch-chat.html'), {
+        url,
+        runScripts: 'dangerously'
+    }).window.document;
 }
 
 describe('help center deep workflow coverage', () => {
@@ -108,9 +116,21 @@ describe('help center deep workflow coverage', () => {
 
         requiredQuickLinks.forEach(([guideId, label]) => {
             const guide = getGuideById('parent', guideId);
+            expect(guide, `Guide "${guideId}" should exist for parent help`).toBeDefined();
+            expect(Array.isArray(guide.quickLinks), `Guide "${guideId}" should define quick links`).toBe(true);
+
             const quickLink = guide.quickLinks.find((link) => link.label === label);
+            expect(quickLink, `Guide "${guideId}" should include quick link "${label}"`).toBeDefined();
 
             expect(pageLinksByGuideAndLabel.get(`${guideId}:${label}`)).toBe(quickLink.url);
         });
+    });
+
+    it('removes empty Help Watch Chat context parameters from CTA links', () => {
+        const document = renderHelpWatchChat('https://allplays.test/help-watch-chat.html?role=parent');
+
+        expect(document.querySelector('[data-quick-link-label="Team Page"]')?.getAttribute('href')).toBe('team.html');
+        expect(document.querySelector('[data-quick-link-label="Game Viewer"]')?.getAttribute('href')).toBe('live-game.html');
+        expect(document.querySelector('[data-quick-link-label="Open Team Chat"]')?.getAttribute('href')).toBe('team-chat.html');
     });
 });


### PR DESCRIPTION
Closes #3499

## What changed
- Added actionable Help Watch Chat CTAs for Team Page, Game Viewer, and Team Chat.
- The CTAs now resolve team/game context from the page query string into the expected hash deep links.
- Added focused Playwright smoke coverage for the parent team/game context path.
- Added a unit/static contract test tying the page CTA route templates to `watch-game` and `team-chat-basics` quickLinks.

## Root Cause
Help Watch Chat listed `team.html`, `live-game.html`, and `team-chat.html` as static code text, so generic help-page boot tests could pass even when users had no actionable navigation and team/game context was not preserved.

## Prevention / Learning
Static help workflow pages that reference app routes should expose real CTAs and have both resolved-link smoke coverage plus a static contract against the shared help-center quickLinks.

## Regression Tests
- `npx vitest run tests/unit/help-center.test.js --reporter=verbose`
- `npx playwright test tests/smoke/help-workflow-pages.spec.js --config=playwright.smoke.config.js --grep "help-watch-chat exposes context-aware" --reporter=line`

## Recurrence Risk
Low. The workflow now has direct smoke coverage for resolved deep links and a quickLink alignment contract to catch route drift.