### PR TITLE
Enforce chat fallback attachment limits

### DIFF
--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -32,6 +32,7 @@ export function validateFirebaseRulesCi() {
     const firebaseJson = JSON.parse(readText('firebase.json'));
     const firestoreRules = readText('firestore.rules');
     const storageRules = readText('storage.rules');
+    const chatFallbackRules = extractMatchBlock(storageRules, 'match /stat-sheets/team-chat/{teamId}/{conversationId}/{userId}/{fileName}');
     const legacyGameClipRules = extractMatchBlock(storageRules, 'match /game-clips/{fileName} {');
     const collectionGroupGamesHelper = (firestoreRules.match(/function canReadCollectionGroupGameDocument\(teamPath, data\) \{[\s\S]*?\n\s*}/) || [''])[0];
     const gameEventsRules = (firestoreRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/) || [''])[0];
@@ -102,6 +103,11 @@ export function validateFirebaseRulesCi() {
     assertIncludes(storageRules, 'request.resource.contentType.matches(\'video/.*\')', 'Scoped Storage video content-type rules');
     assertIncludes(storageRules, 'match /game-clips/{fileName} {', 'Legacy Storage game clip rules');
     assertIncludes(legacyGameClipRules, 'allow get, create, delete: if false;', 'Legacy Storage deny-all rule');
+    assertIncludes(storageRules, 'function isAllowedChatAttachmentUpload(contentType, size)', 'Chat fallback attachment upload helper');
+    assertIncludes(storageRules, 'size <= 5 * 1024 * 1024', 'Chat fallback attachment size limit');
+    assertIncludes(storageRules, 'contentType.matches(\'image/.*\')', 'Chat fallback image content-type rules');
+    assertIncludes(storageRules, 'contentType.matches(\'video/.*\')', 'Chat fallback video content-type rules');
+    assertIncludes(chatFallbackRules, 'isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);', 'Chat fallback create upload guard');
 
     assertIncludes(regressionGuards, 'npm run ci:firebase-rules', 'Regression guard workflow');
     assertIncludes(regressionGuards, 'npm run test:smoke:team-fallback', 'Regression guard workflow');

--- a/storage.rules
+++ b/storage.rules
@@ -103,6 +103,13 @@ service firebase.storage {
         contentType.matches('video/.*');
     }
 
+    function isAllowedChatAttachmentUpload(contentType, size) {
+      return size > 0 &&
+        size <= 5 * 1024 * 1024 &&
+        (contentType.matches('image/.*') ||
+         contentType.matches('video/.*'));
+    }
+
     function canReadAthleteProfileMedia(userId, profileId) {
       let profilePath = /databases/(default)/documents/athleteProfiles/$(profileId);
       return (isSignedIn() && request.auth.uid == userId) ||
@@ -138,8 +145,7 @@ service firebase.storage {
       allow list: if false;
       allow create: if canAccessChatAttachment(teamId, conversationId) &&
         request.auth.uid == userId &&
-        request.resource.size > 0 &&
-        request.resource.size <= 20 * 1024 * 1024;
+        isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);
       allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
       allow update: if false;
     }

--- a/tests/unit/fallback-media-storage.test.js
+++ b/tests/unit/fallback-media-storage.test.js
@@ -29,6 +29,18 @@ function canAccessChatAttachment({ authUid, conversationId = 'team', isTeamAdmin
         (conversationId === 'team' || isTeamAdmin || isParticipant);
 }
 
+function isAllowedChatAttachmentUpload({ size, contentType }) {
+    return size > 0 &&
+        size <= 5 * 1024 * 1024 &&
+        (contentType.startsWith('image/') || contentType.startsWith('video/'));
+}
+
+function canCreateChatFallback({ authUid, pathUserId, conversationId = 'team', isTeamAdmin = false, isTeamParent = false, isParticipant = false, size = 1024, contentType = 'image/png' }) {
+    return canAccessChatAttachment({ authUid, conversationId, isTeamAdmin, isTeamParent, isParticipant }) &&
+        authUid === pathUserId &&
+        isAllowedChatAttachmentUpload({ size, contentType });
+}
+
 function canCreateScopedFallback({ authUid, pathUserId, conversationId = 'team', isTeamAdmin = false, isTeamParent = false, isParticipant = false }) {
     return canAccessChatAttachment({ authUid, conversationId, isTeamAdmin, isTeamParent, isParticipant }) && authUid === pathUserId;
 }
@@ -64,6 +76,7 @@ describe('fallback media paths and Storage rules', () => {
         expect(rules).toContain("('user:' + request.auth.uid) in participantIds");
         expect(rules).toContain("('email:' + request.auth.token.email.lower()) in participantIds");
         expect(chatFallbackRules).toContain('request.auth.uid == userId');
+        expect(chatFallbackRules).toContain('isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);');
         expect(chatFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
         expect(legacyChatFallbackRules).toContain('allow get: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
         expect(legacyChatFallbackRules).toContain('allow create: if false;');
@@ -80,6 +93,48 @@ describe('fallback media paths and Storage rules', () => {
         expect(canCreateScopedFallback({ authUid: 'parent-2', pathUserId: 'parent-1', isTeamParent: true })).toBe(false);
         expect(canDeleteScopedFallback({ authUid: 'coach-1', pathUserId: 'parent-1', isTeamAdmin: true })).toBe(true);
         expect(canDeleteScopedFallback({ authUid: 'parent-2', pathUserId: 'parent-1' })).toBe(false);
+    });
+
+    it('restricts fallback chat creates to image/video uploads no larger than 5 MB', () => {
+        expect(rules).toContain('function isAllowedChatAttachmentUpload(contentType, size)');
+        expect(rules).toContain("contentType.matches('image/.*')");
+        expect(rules).toContain("contentType.matches('video/.*')");
+        expect(rules).toContain('size <= 5 * 1024 * 1024');
+        expect(chatFallbackRules).not.toContain('request.resource.size <= 20 * 1024 * 1024');
+
+        expect(canCreateChatFallback({
+            authUid: 'parent-1',
+            pathUserId: 'parent-1',
+            conversationId: 'direct-1',
+            isTeamParent: true,
+            isParticipant: true,
+            size: 5 * 1024 * 1024,
+            contentType: 'image/jpeg'
+        })).toBe(true);
+
+        expect(canCreateChatFallback({
+            authUid: 'parent-1',
+            pathUserId: 'parent-1',
+            isTeamParent: true,
+            size: 512 * 1024,
+            contentType: 'video/mp4'
+        })).toBe(true);
+
+        expect(canCreateChatFallback({
+            authUid: 'parent-1',
+            pathUserId: 'parent-1',
+            isTeamParent: true,
+            size: 1024,
+            contentType: 'text/plain'
+        })).toBe(false);
+
+        expect(canCreateChatFallback({
+            authUid: 'parent-1',
+            pathUserId: 'parent-1',
+            isTeamParent: true,
+            size: (5 * 1024 * 1024) + 1,
+            contentType: 'image/png'
+        })).toBe(false);
     });
 
     it('denies unrelated signed-in users from scoped game clip reads and deletes', () => {


### PR DESCRIPTION
Closes #3524

## What changed
- Added a scoped Storage rules helper for fallback chat attachment uploads.
- Enforced image/* or video/* content types and a 5 MB maximum on `stat-sheets/team-chat/{teamId}/{conversationId}/{userId}/{fileName}` creates.
- Preserved existing read/delete scoping for chat fallback attachments.
- Added focused unit assertions and Firebase rules validation guards for the chat fallback media invariant.

## Root Cause
The scoped fallback chat Storage create rule preserved conversation and uploader access checks but reused the broader fallback size-only upload invariant, so server-side fallback uploads did not enforce the client chat attachment media-type allowlist or 5 MB product limit.

## Prevention / Learning
When adding or hardening fallback Storage paths, carry over both authorization and product-level content invariants from the primary/client path. Rules tests should cover allowed uploads and denied uploads for type and size, not just actor scoping.

## Regression Tests
- `npx vitest run tests/unit/fallback-media-storage.test.js --reporter=verbose`
- `npm run ci:firebase-rules`

## Recurrence Risk
Low. The chat fallback create path now delegates to a focused helper, and both unit and rules validation checks assert the MIME and size boundaries.