### PR TITLE
Chunk team media album deletes

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -1263,17 +1263,40 @@ export async function updateTeamMediaFolder(teamId, folderId, draft = {}) {
 
 export async function deleteTeamMediaFolder(teamId, folderId) {
     if (!teamId || !folderId) throw new Error('Album is required.');
-    const folderItems = await getTeamMediaItems(teamId, folderId);
-    const batch = writeBatch(db);
-    batch.delete(doc(db, `teams/${teamId}/mediaFolders`, folderId));
+    const snapshot = await getDocs(query(getTeamMediaItemsRef(teamId), where('folderId', '==', folderId)));
+    const folderItems = snapshot.docs
+        .map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }))
+        .filter((item) => item.deleted !== true && item.folderId === folderId);
+    const batches = [];
+    const createBatch = () => {
+        const batch = writeBatch(db);
+        batches.push({ batch, writeCount: 0 });
+        return batches[batches.length - 1];
+    };
+    let currentBatch = null;
+    const getCurrentBatch = () => {
+        if (!currentBatch || currentBatch.writeCount >= 450) {
+            currentBatch = createBatch();
+        }
+        return currentBatch;
+    };
+
     folderItems.forEach((item) => {
-        batch.update(doc(db, `teams/${teamId}/mediaItems`, item.id), {
+        currentBatch = getCurrentBatch();
+        currentBatch.batch.update(doc(db, `teams/${teamId}/mediaItems`, item.id), {
             deleted: true,
             deletedAt: serverTimestamp(),
             updatedAt: serverTimestamp()
         });
+        currentBatch.writeCount += 1;
     });
-    await batch.commit();
+    currentBatch = getCurrentBatch();
+    currentBatch.batch.delete(doc(db, `teams/${teamId}/mediaFolders`, folderId));
+    currentBatch.writeCount += 1;
+
+    for (const { batch } of batches) {
+        await batch.commit();
+    }
 }
 
 export async function createTeamMediaLink(teamId, folderId, media = {}) {

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem
-} from './db.js?v=81';
+} from './db.js?v=82';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,

--- a/team-media.html
+++ b/team-media.html
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=10"></script>
+    <script type="module" src="js/team-media.js?v=11"></script>
 </body>
 </html>

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const folderState = vi.hoisted(() => ({ nextMediaOrder: 0 }));
 const addDocState = vi.hoisted(() => ({ nextId: 1 }));
+const batchState = vi.hoisted(() => ({ batches: [] }));
 const firebaseMocks = vi.hoisted(() => ({
     addDoc: vi.fn(async (_collectionRef, data) => ({ id: `media-${addDocState.nextId++}`, data })),
     collection: vi.fn((_db, path) => ({ path })),
@@ -110,6 +111,18 @@ describe('team media db ordering', () => {
         vi.clearAllMocks();
         folderState.nextMediaOrder = 0;
         addDocState.nextId = 1;
+        batchState.batches = [];
+        firebaseMocks.writeBatch.mockImplementation(() => {
+            const batch = {
+                deletes: [],
+                updates: [],
+                delete: vi.fn((docRef) => batch.deletes.push(docRef)),
+                update: vi.fn((docRef, payload) => batch.updates.push({ docRef, payload })),
+                commit: vi.fn(async () => undefined)
+            };
+            batchState.batches.push(batch);
+            return batch;
+        });
         uploadTaskQueue.length = 0;
         global.fetch = vi.fn(async () => ({
             ok: true,
@@ -304,6 +317,48 @@ describe('team media db ordering', () => {
         expect(items[0]).not.toHaveProperty('url');
         expect(items[0]).not.toHaveProperty('src');
         expect(items[0]).not.toHaveProperty('downloadUrl');
+    });
+
+    it('soft-deletes large albums in multiple metadata-only batches without resolving storage URLs', async () => {
+        const docs = Array.from({ length: 501 }, (_, index) => ({
+            id: `media-${index + 1}`,
+            data: () => ({
+                folderId: 'folder-large',
+                type: index % 2 === 0 ? 'photo' : 'file',
+                storagePath: `team-media/team-1/folder-large/user-1/media-${index + 1}`,
+                order: index,
+                deleted: false
+            })
+        }));
+        firebaseMocks.getDocs.mockResolvedValueOnce({ docs });
+
+        const { deleteTeamMediaFolder } = await import('../../js/db.js');
+        await deleteTeamMediaFolder('team-1', 'folder-large');
+
+        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(1);
+        expect(firebaseMocks.where).toHaveBeenCalledWith('folderId', '==', 'folder-large');
+        expect(firebaseMocks.getDownloadURL).not.toHaveBeenCalled();
+        expect(firebaseMocks.writeBatch).toHaveBeenCalledTimes(2);
+        expect(batchState.batches.map((batch) => batch.commit)).toEqual([
+            expect.any(Function),
+            expect.any(Function)
+        ]);
+        expect(batchState.batches[0].commit).toHaveBeenCalledTimes(1);
+        expect(batchState.batches[1].commit).toHaveBeenCalledTimes(1);
+        expect(batchState.batches[0].deletes).toEqual([]);
+        expect(batchState.batches[1].deletes).toEqual([{ path: 'teams/team-1/mediaFolders/folder-large' }]);
+        const updates = batchState.batches.flatMap((batch) => batch.updates);
+        expect(updates).toHaveLength(501);
+        expect(batchState.batches[0].updates).toHaveLength(450);
+        expect(batchState.batches[1].updates).toHaveLength(51);
+        expect(updates.map((entry) => entry.docRef.path)).toEqual(
+            docs.map((itemDoc) => `teams/team-1/mediaItems/${itemDoc.id}`)
+        );
+        expect(updates[0].payload).toEqual({
+            deleted: true,
+            deletedAt: 'server-ts',
+            updatedAt: 'server-ts'
+        });
     });
 
     it('returns bounded media item pages with stable folder order and cursor metadata', async () => {

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -281,6 +281,7 @@ describe('team media db ordering', () => {
     });
 
     it('drops persisted storage urls when fresh authorization cannot be resolved', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
         firebaseMocks.getDocs.mockResolvedValueOnce({
             docs: [{
                 id: 'media-stale',
@@ -298,25 +299,34 @@ describe('team media db ordering', () => {
         firebaseMocks.getDownloadURL.mockRejectedValueOnce(new Error('storage/unauthorized'));
 
         const { getTeamMediaItems } = await import('../../js/db.js');
-        const items = await getTeamMediaItems('team-1', 'folder-1');
+        let items;
+        try {
+            items = await getTeamMediaItems('team-1', 'folder-1');
 
-        expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
-            { path: 'teams/team-1/mediaItems/media-stale' },
-            {
-                url: 'DELETE_FIELD',
-                src: 'DELETE_FIELD',
-                updatedAt: 'server-ts'
-            }
-        );
-        expect(items).toEqual([
-            expect.objectContaining({
-                id: 'media-stale',
-                storagePath: 'team-media/team-1/folder-1/user-1/stale.jpg'
-            })
-        ]);
-        expect(items[0]).not.toHaveProperty('url');
-        expect(items[0]).not.toHaveProperty('src');
-        expect(items[0]).not.toHaveProperty('downloadUrl');
+            expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
+                { path: 'teams/team-1/mediaItems/media-stale' },
+                {
+                    url: 'DELETE_FIELD',
+                    src: 'DELETE_FIELD',
+                    updatedAt: 'server-ts'
+                }
+            );
+            expect(warnSpy).toHaveBeenCalledWith(
+                'Unable to resolve authorized team media download URL:',
+                expect.any(Error)
+            );
+            expect(items).toEqual([
+                expect.objectContaining({
+                    id: 'media-stale',
+                    storagePath: 'team-media/team-1/folder-1/user-1/stale.jpg'
+                })
+            ]);
+            expect(items[0]).not.toHaveProperty('url');
+            expect(items[0]).not.toHaveProperty('src');
+            expect(items[0]).not.toHaveProperty('downloadUrl');
+        } finally {
+            warnSpy.mockRestore();
+        }
     });
 
     it('soft-deletes large albums in multiple metadata-only batches without resolving storage URLs', async () => {

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=81', () => {
+vi.mock('../../js/db.js?v=82', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-legacy-upload-forms.test.js
+++ b/tests/unit/team-media-legacy-upload-forms.test.js
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=81', () => ({
+vi.mock('../../js/db.js?v=82', () => ({
     getTeam: mocks.getTeam,
     getTeamMediaFolders: mocks.getTeamMediaFolders,
     getTeamMediaItemsPage: mocks.getTeamMediaItemsPage,

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -24,7 +24,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=10"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=11"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
@@ -36,7 +36,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toContain("from './db.js?v=81'");
+        expect(pageJs).toContain("from './db.js?v=82'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');
@@ -45,6 +45,8 @@ describe('team media entry point', () => {
         expect(pageJs).toContain('getMediaPermissionMessage');
         expect(pageJs).toContain('updateTeamMediaFolder');
         expect(pageJs).toContain('deleteTeamMediaFolder');
+        expect(pageJs).toContain('await deleteTeamMediaFolder(state.teamId, folder.id);');
+        expect(pageJs).toContain("}, 'Album deleted.');");
         expect(pageJs).toContain('canReadTeamMediaAlbum');
         expect(pageJs).toContain('bulkDeleteTeamMediaItems');
         expect(pageJs).toContain('setTeamMediaAlbumCover');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -38,6 +38,22 @@ describe('team media page wiring', () => {
         expect(source).toContain('data-load-more-media');
     });
 
+    it('keeps jsdom team media db mocks aligned with the runtime db import', () => {
+        const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
+        const dbImportVersion = source.match(/from '\.\/db\.js\?v=(\d+)'/)?.[1];
+
+        expect(dbImportVersion).toBe('82');
+
+        for (const testFile of [
+            'tests/unit/team-media-item-rename.test.js',
+            'tests/unit/team-media-legacy-upload-forms.test.js'
+        ]) {
+            const testSource = fs.readFileSync(path.join(repoRoot, testFile), 'utf8');
+            expect(testSource).toContain(`vi.mock('../../js/db.js?v=${dbImportVersion}'`);
+            expect(testSource).not.toContain("vi.mock('../../js/db.js?v=81'");
+        }
+    });
+
     it('keeps media reads member-scoped and uploads explicitly approved', () => {
         const rules = fs.readFileSync(path.join(repoRoot, 'firestore.rules'), 'utf8');
         expect(rules).toContain('match /mediaFolders/{folderId}');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -20,11 +20,11 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=10"');
+        expect(page).toContain('src="js/team-media.js?v=11"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=81'");
+        expect(source).toContain("from './db.js?v=82'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=41';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');


### PR DESCRIPTION
Closes #3497

## What changed
- Reworked `deleteTeamMediaFolder` to use a metadata-only folder item query instead of the gallery read path.
- Chunked media item soft-delete writes into Firestore batches below the 500-write limit.
- Kept the folder delete as a single write in the final batch so retries can continue cleaning up items if a later commit fails.
- Bumped the team media cache keys for the changed `db.js` import path.

## Root Cause
`deleteTeamMediaFolder` reused `getTeamMediaItems`, which resolved Storage download URLs for every item, then attempted to delete the folder and soft-delete all media items in one Firestore `writeBatch`. Albums with 500+ items exceeded the client batch limit and failed in the admin delete flow.

## Prevention / Learning
High-cardinality delete paths should use metadata-only reads and chunk Firestore writes below platform limits. Do not reuse rich display/gallery read paths for delete-only workflows.

## Regression Tests
- `tests/unit/team-media-db-ordering.test.js` seeds 501 media item docs, verifies multiple batch commits, confirms all item ids are soft-deleted, and asserts `getDownloadURL` is not called.
- `tests/unit/team-media-page.test.js` keeps the album delete handler routed through `deleteTeamMediaFolder` and the success alert path.
- `tests/unit/team-media-wiring.test.js` verifies the cache-busted team media module and `db.js` dependency.

Validation:
- `npx vitest run tests/unit/team-media-db-ordering.test.js tests/unit/team-media-page.test.js tests/unit/team-media-wiring.test.js --reporter=verbose --testTimeout=15000`
- `node scripts/check-critical-cache-bust.mjs`