### PR TITLE
Normalize search route preload matching

### DIFF
--- a/apps/app/src/lib/searchRoutePreload.test.ts
+++ b/apps/app/src/lib/searchRoutePreload.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import {
+  preloadSearchRoute,
+  resolveSearchRoutePreloader
+} from './searchRoutePreload';
+
+describe('searchRoutePreload', () => {
+  it('matches query-string search routes by pathname while preserving navigation routes', async () => {
+    const homePreloader = resolveSearchRoutePreloader('/home');
+    const authPreloader = resolveSearchRoutePreloader('/auth');
+
+    expect(resolveSearchRoutePreloader('/home?section=feed')).toBe(homePreloader);
+    expect(resolveSearchRoutePreloader('/auth?mode=signup')).toBe(authPreloader);
+    await expect(preloadSearchRoute('/home?section=feed')).resolves.toBe(true);
+  });
+
+  it('keeps existing plain-path route preload coverage intact', () => {
+    expect(resolveSearchRoutePreloader('/teams')).toBeTypeOf('function');
+    expect(resolveSearchRoutePreloader('/teams/browse')).toBeTypeOf('function');
+    expect(resolveSearchRoutePreloader('/players/team-1/player-1')).toBeTypeOf('function');
+    expect(resolveSearchRoutePreloader('/help/parent-fees')).toBeTypeOf('function');
+  });
+
+  it('does not match unknown routes after normalization', async () => {
+    expect(resolveSearchRoutePreloader('/unknown?section=feed')).toBeNull();
+    await expect(preloadSearchRoute('/unknown?section=feed')).resolves.toBe(false);
+  });
+});

--- a/apps/app/src/lib/searchRoutePreload.ts
+++ b/apps/app/src/lib/searchRoutePreload.ts
@@ -5,7 +5,6 @@ const routePreloaders: Array<{ pattern: RegExp; load: () => Promise<unknown> }> 
   { pattern: /^\/messages(?:\/[^/]+)?$/, load: () => import('../pages/Messages') },
   { pattern: /^\/teams\/browse$/, load: () => import('../pages/PublicTeamsBrowse') },
   { pattern: /^\/teams$/, load: () => import('../pages/Teams') },
-  { pattern: /^\/teams\/browse$/, load: () => import('../pages/PublicTeamsBrowse') },
   { pattern: /^\/teams\/[^/]+$/, load: () => import('../pages/TeamDetail') },
   { pattern: /^\/teams\/[^/]+\/edit$/, load: () => import('../pages/TeamSettings') },
   { pattern: /^\/teams\/[^/]+\/fees(?:\/[^/]+)?$/, load: () => import('../pages/TeamFees') },
@@ -27,7 +26,8 @@ const routePreloaders: Array<{ pattern: RegExp; load: () => Promise<unknown> }> 
 ];
 
 export function resolveSearchRoutePreloader(route: string) {
-  return routePreloaders.find(({ pattern }) => pattern.test(route))?.load ?? null;
+  const pathname = route.split(/[?#]/, 1)[0];
+  return routePreloaders.find(({ pattern }) => pattern.test(pathname))?.load ?? null;
 }
 
 export async function preloadSearchRoute(route: string) {

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -137,6 +137,13 @@ async function clickButton(container, text) {
     await flush();
 }
 
+async function hoverButton(container, text) {
+    await act(async () => {
+        buttonByText(container, text).dispatchEvent(new MouseEvent('mouseover', { bubbles: true, cancelable: true }));
+    });
+    await flush();
+}
+
 async function pressDialogKey(container, key) {
     const dialog = container.querySelector('[role="dialog"]');
     if (!dialog) throw new Error('Search dialog not found');
@@ -591,6 +598,18 @@ describe('React app shell search', () => {
         expect(routePreloadMocks.preloadSearchRoute).toHaveBeenCalledTimes(1);
     });
 
+    it('preloads query-string app action routes on hover', async () => {
+        const { container } = await renderShell();
+
+        await clickButton(container, 'Search');
+        await fillSearch(container, 'feed');
+        expect(container.textContent).toContain('Social Feed');
+
+        await hoverButton(container, 'Social Feed');
+
+        expect(routePreloadMocks.preloadSearchRoute).toHaveBeenCalledWith('/home?section=feed');
+    });
+
     it('opens the add workflow launcher with native and website actions', async () => {
         const { container } = await renderShell();
 
@@ -662,6 +681,7 @@ describe('React app shell search', () => {
         expect(homeMocks.loadParentHomeSummary).not.toHaveBeenCalled();
 
         await clickButton(container, 'Get Started');
+        expect(routePreloadMocks.preloadSearchRoute).toHaveBeenCalledWith('/auth?mode=signup');
         expect(container.querySelector('[data-testid="route"]').textContent).toBe('/auth?mode=signup');
     });
 


### PR DESCRIPTION
Closes #3529

## What changed
- Normalize app-search preload route matching to pathname before applying preload regexes.
- Preserve full query-string routes for dialog navigation and preload calls.
- Removed the duplicate `/teams/browse` preloader entry.

## Root Cause
`resolveSearchRoutePreloader` matched anchored regexes against the full route string, so `/home?section=feed` and `/auth?mode=signup` did not match `/^\/home$/` or `/^\/auth$/`.

## Prevention / Learning
When app routes use query params for view state, route-map, preload, and cache lookup keys should normalize to pathname while navigation preserves the full URL.

## Regression Tests
- `apps/app/src/lib/searchRoutePreload.test.ts` covers query-string normalization, existing plain-path preload routes, and unknown-route false/null behavior.
- `tests/unit/app-search-integration.test.jsx` covers query-string action preloading for Social Feed hover and Get Started navigation.

## Recurrence Risk
Low. The lookup invariant is now centralized in the resolver and covered by focused tests.

## Validation
- `cd apps/app && npx vitest run src/lib/searchRoutePreload.test.ts src/components/AppSearchDialog.test.tsx --reporter=verbose`
- `npx vitest run tests/unit/app-search-integration.test.jsx tests/unit/app-search-service.test.js --reporter=verbose`