### PR TITLE
Defer legacy calendar RSVP hydration

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -184,7 +184,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=81';
+        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvps } from './js/db.js?v=81';
         import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent } from './js/utils.js?v=14';
         import { mergeGlobalCalendarIcsEvents } from './js/calendar-ics-sync.js?v=1';
         import { requireAuth, checkAuth } from './js/auth.js?v=41';
@@ -208,6 +208,7 @@
         let activeDayDetail = null;
         let linkedPlayersByTeam = new Map();
         let calendarTeams = [];
+        const rsvpHydrationCache = new Map();
         const teamColors = {};
         const colorPalette = ['#6366f1', '#ec4899', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6', '#06b6d4', '#f97316'];
 
@@ -244,14 +245,56 @@
             return Array.isArray(linkedPlayersByTeam.get(teamId)) ? linkedPlayersByTeam.get(teamId) : [];
         }
 
-        function parseTeamGameKey(key) {
-            const delimiter = '::';
-            const delimiterIndex = key.indexOf(delimiter);
-            if (delimiterIndex === -1) return [key, ''];
-            return [
-                key.slice(0, delimiterIndex),
-                key.slice(delimiterIndex + delimiter.length)
-            ];
+        function getDbRsvpEvents(events) {
+            const seen = new Set();
+            return (events || []).filter((ev) => {
+                if (ev?.source !== 'db') return false;
+                if (ev.type !== 'game' && ev.type !== 'practice') return false;
+                if (ev.status === 'cancelled') return false;
+                const key = `${ev.teamId}::${ev.id}`;
+                if (seen.has(key)) return false;
+                seen.add(key);
+                return true;
+            });
+        }
+
+        async function hydrateRsvpEvents(events, { includeNotes = false } = {}) {
+            const dbEvents = getDbRsvpEvents(events);
+            if (dbEvents.length === 0) return;
+
+            await Promise.all(dbEvents.map(async (eventForPrefs) => {
+                const key = `${eventForPrefs.teamId}::${eventForPrefs.id}`;
+                let cached = rsvpHydrationCache.get(key);
+                if (!cached) {
+                    cached = (async () => {
+                        const linkedPlayerIds = getLinkedPlayersForTeam(eventForPrefs.teamId).map((player) => player.playerId).filter(Boolean);
+                        const [myRsvp, rsvps] = await Promise.all([
+                            getMyRsvp(eventForPrefs.teamId, eventForPrefs.id, currentUserId, linkedPlayerIds),
+                            includeNotes && eventForPrefs.notesVisible ? getRsvps(eventForPrefs.teamId, eventForPrefs.id) : Promise.resolve([])
+                        ]);
+                        return {
+                            myRsvp: myRsvp ? myRsvp.response : null,
+                            availabilityNotes: buildAvailabilityNoteRows(rsvps, eventForPrefs.availabilityPreferences, !!eventForPrefs.isTeamAdmin)
+                        };
+                    })();
+                    rsvpHydrationCache.set(key, cached);
+                }
+
+                try {
+                    const hydration = await cached;
+                    applyRsvpHydration(allEvents, eventForPrefs.teamId, eventForPrefs.id, {
+                        myRsvp: hydration.myRsvp,
+                        summary: null
+                    });
+                    allEvents.forEach((ev) => {
+                        if (ev.teamId === eventForPrefs.teamId && ev.id === eventForPrefs.id) {
+                            ev.availabilityNotes = hydration.availabilityNotes;
+                        }
+                    });
+                } catch (_) {
+                    rsvpHydrationCache.delete(key);
+                }
+            }));
         }
 
         function renderCalendarChildScope(teamId) {
@@ -484,48 +527,6 @@
                 const results = await Promise.all(loadPromises);
                 allEvents = results.flat().sort((a, b) => a.date - b.date);
 
-                // Fetch current user's RSVP for DB schedule events (games + practices).
-                const dbEvents = allEvents.filter(ev => ev.source === 'db' && (ev.type === 'game' || ev.type === 'practice') && ev.status !== 'cancelled');
-                const uniqueGameKeys = [...new Set(dbEvents.map(ev => `${ev.teamId}::${ev.id}`))];
-                const unsummarizedByTeam = new Map();
-                uniqueGameKeys.forEach((key) => {
-                    const [teamId, gameId] = parseTeamGameKey(key);
-                    const shouldLoadSummary = allEvents.some((ev) => ev.teamId === teamId && ev.id === gameId && !ev.rsvpSummary);
-                    if (!shouldLoadSummary) return;
-                    if (!unsummarizedByTeam.has(teamId)) unsummarizedByTeam.set(teamId, []);
-                    unsummarizedByTeam.get(teamId).push(gameId);
-                });
-
-                const summaryMapsByTeam = new Map();
-                await Promise.all(Array.from(unsummarizedByTeam.entries()).map(async ([teamId, gameIds]) => {
-                    try {
-                        summaryMapsByTeam.set(teamId, await getRsvpSummaries(teamId, gameIds));
-                    } catch (_) {
-                        summaryMapsByTeam.set(teamId, new Map());
-                    }
-                }));
-
-                await Promise.all(uniqueGameKeys.map(async (key) => {
-                    const [teamId, gameId] = parseTeamGameKey(key);
-                    try {
-                        const eventForPrefs = allEvents.find(ev => ev.teamId === teamId && ev.id === gameId);
-                        const linkedPlayerIds = getLinkedPlayersForTeam(teamId).map((player) => player.playerId).filter(Boolean);
-                        const [myRsvp, rsvps] = await Promise.all([
-                            getMyRsvp(teamId, gameId, currentUserId, linkedPlayerIds),
-                            eventForPrefs?.notesVisible ? getRsvps(teamId, gameId) : Promise.resolve([])
-                        ]);
-                        const summary = summaryMapsByTeam.get(teamId)?.get(gameId) || null;
-                        const availabilityNotes = buildAvailabilityNoteRows(rsvps, eventForPrefs?.availabilityPreferences, !!eventForPrefs?.isTeamAdmin);
-                        applyRsvpHydration(allEvents, teamId, gameId, {
-                            myRsvp: myRsvp ? myRsvp.response : null,
-                            summary
-                        });
-                        allEvents.forEach((ev) => {
-                            if (ev.teamId === teamId && ev.id === gameId) ev.availabilityNotes = availabilityNotes;
-                        });
-                    } catch (_) {}
-                }));
-
                 applyFilters();
             } catch (error) {
                 console.error('Calendar init error:', error);
@@ -718,22 +719,17 @@
             container.innerHTML = html;
         }
 
-        function openDayDetail(year, month, day) {
-            activeDayDetail = { year, month, day };
+        function getDayDetailEvents(year, month, day) {
             const dayStart = new Date(year, month, day);
             const dayEnd = new Date(year, month, day, 23, 59, 59);
-            const dayEvents = allEvents.filter(ev => {
+            return allEvents.filter(ev => {
                 if (currentTypeFilter !== 'all' && ev.type !== currentTypeFilter) return false;
                 if (currentTeamFilter && ev.teamId !== currentTeamFilter) return false;
                 return ev.date >= dayStart && ev.date <= dayEnd;
             });
+        }
 
-            const modal = document.getElementById('day-modal');
-            const title = document.getElementById('day-modal-title');
-            const content = document.getElementById('day-modal-content');
-
-            title.textContent = dayStart.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
-
+        function renderDayDetailEvents(dayEvents, content) {
             if (dayEvents.length === 0) {
                 content.innerHTML = '<p class="text-gray-500 text-center py-8">No events on this day.</p>';
             } else {
@@ -760,8 +756,26 @@
                     </div>`;
                 }).join('');
             }
+        }
+
+        async function openDayDetail(year, month, day) {
+            activeDayDetail = { year, month, day };
+            const dayStart = new Date(year, month, day);
+            const dayEvents = getDayDetailEvents(year, month, day);
+
+            const modal = document.getElementById('day-modal');
+            const title = document.getElementById('day-modal-title');
+            const content = document.getElementById('day-modal-content');
+
+            title.textContent = dayStart.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+            renderDayDetailEvents(dayEvents, content);
 
             modal.classList.remove('hidden');
+
+            await hydrateRsvpEvents(dayEvents, { includeNotes: true });
+            if (activeDayDetail?.year === year && activeDayDetail?.month === month && activeDayDetail?.day === day && !modal.classList.contains('hidden')) {
+                renderDayDetailEvents(getDayDetailEvents(year, month, day), content);
+            }
         }
 
         function closeDayModal() {
@@ -796,7 +810,13 @@
                 applyFilters();
                 const dayModal = document.getElementById('day-modal');
                 if (currentView === 'calendar' && activeDayDetail && dayModal && !dayModal.classList.contains('hidden')) {
-                    openDayDetail(activeDayDetail.year, activeDayDetail.month, activeDayDetail.day);
+                    const cacheKey = `${teamId}::${gameId}`;
+                    const existingHydration = await Promise.resolve(rsvpHydrationCache.get(cacheKey)).catch(() => null);
+                    rsvpHydrationCache.set(cacheKey, Promise.resolve({
+                        ...(existingHydration || {}),
+                        myRsvp: response
+                    }));
+                    await openDayDetail(activeDayDetail.year, activeDayDetail.month, activeDayDetail.day);
                 }
             } catch (err) {
                 alert('Failed to submit RSVP: ' + (err?.message || err));

--- a/calendar.html
+++ b/calendar.html
@@ -328,7 +328,7 @@
             if (currentView !== 'detailed' && currentView !== 'compact') return;
             const token = ++renderedRsvpHydrationToken;
             const view = currentView;
-            await hydrateRsvpEvents(filteredEvents, { includeMissingSummary: true });
+            await hydrateRsvpEvents(filteredEvents, { includeMissingSummary: true, includeNotes: view === 'detailed' });
             if (token !== renderedRsvpHydrationToken || currentView !== view) return;
             if (view === 'detailed') renderDetailed();
             else renderCompact();

--- a/calendar.html
+++ b/calendar.html
@@ -294,12 +294,18 @@
                     cached.rsvps = getRsvps(eventForPrefs.teamId, eventForPrefs.id);
                 }
 
+                const myRsvpPromise = cached.myRsvp;
+                const summaryCachePromise = cached.summary;
+                const summaryPromise = summaryCachePromise || Promise.resolve(null);
+                const rsvpsPromise = includeNotes && eventForPrefs.notesVisible ? (cached.rsvps || Promise.resolve([])) : Promise.resolve([]);
+
                 try {
                     const [myRsvp, summary, rsvps] = await Promise.all([
-                        cached.myRsvp,
-                        cached.summary || Promise.resolve(null),
-                        includeNotes && eventForPrefs.notesVisible ? (cached.rsvps || Promise.resolve([])) : Promise.resolve([])
+                        myRsvpPromise,
+                        summaryPromise,
+                        rsvpsPromise
                     ]);
+                    if (cached.myRsvp !== myRsvpPromise || cached.summary !== summaryCachePromise) return;
                     applyRsvpHydration(allEvents, eventForPrefs.teamId, eventForPrefs.id, {
                         myRsvp,
                         summary

--- a/calendar.html
+++ b/calendar.html
@@ -269,6 +269,12 @@
             return cached;
         }
 
+        function updateRsvpHydrationCache(teamId, gameId, response, summary) {
+            const cached = getRsvpHydrationCacheEntry(teamId, gameId);
+            cached.myRsvp = Promise.resolve(response);
+            if (summary) cached.summary = Promise.resolve(summary);
+        }
+
         async function hydrateRsvpEvents(events, { includeNotes = false, includeMissingSummary = false } = {}) {
             const dbEvents = getDbRsvpEvents(events);
             if (dbEvents.length === 0) return;
@@ -833,12 +839,10 @@
                         if (summary) ev.rsvpSummary = summary;
                     }
                 });
+                updateRsvpHydrationCache(teamId, gameId, response, summary);
                 applyFilters();
                 const dayModal = document.getElementById('day-modal');
                 if (currentView === 'calendar' && activeDayDetail && dayModal && !dayModal.classList.contains('hidden')) {
-                    const existingHydration = getRsvpHydrationCacheEntry(teamId, gameId);
-                    existingHydration.myRsvp = Promise.resolve(response);
-                    if (summary) existingHydration.summary = Promise.resolve(summary);
                     await openDayDetail(activeDayDetail.year, activeDayDetail.month, activeDayDetail.day);
                 }
             } catch (err) {

--- a/calendar.html
+++ b/calendar.html
@@ -184,7 +184,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvps } from './js/db.js?v=81';
+        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=81';
         import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent } from './js/utils.js?v=14';
         import { mergeGlobalCalendarIcsEvents } from './js/calendar-ics-sync.js?v=1';
         import { requireAuth, checkAuth } from './js/auth.js?v=41';
@@ -209,6 +209,7 @@
         let linkedPlayersByTeam = new Map();
         let calendarTeams = [];
         const rsvpHydrationCache = new Map();
+        let renderedRsvpHydrationToken = 0;
         const teamColors = {};
         const colorPalette = ['#6366f1', '#ec4899', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6', '#06b6d4', '#f97316'];
 
@@ -258,43 +259,67 @@
             });
         }
 
-        async function hydrateRsvpEvents(events, { includeNotes = false } = {}) {
+        function getRsvpHydrationCacheEntry(teamId, gameId) {
+            const key = `${teamId}::${gameId}`;
+            let cached = rsvpHydrationCache.get(key);
+            if (!cached) {
+                cached = {};
+                rsvpHydrationCache.set(key, cached);
+            }
+            return cached;
+        }
+
+        async function hydrateRsvpEvents(events, { includeNotes = false, includeMissingSummary = false } = {}) {
             const dbEvents = getDbRsvpEvents(events);
             if (dbEvents.length === 0) return;
 
             await Promise.all(dbEvents.map(async (eventForPrefs) => {
-                const key = `${eventForPrefs.teamId}::${eventForPrefs.id}`;
-                let cached = rsvpHydrationCache.get(key);
-                if (!cached) {
-                    cached = (async () => {
-                        const linkedPlayerIds = getLinkedPlayersForTeam(eventForPrefs.teamId).map((player) => player.playerId).filter(Boolean);
-                        const [myRsvp, rsvps] = await Promise.all([
-                            getMyRsvp(eventForPrefs.teamId, eventForPrefs.id, currentUserId, linkedPlayerIds),
-                            includeNotes && eventForPrefs.notesVisible ? getRsvps(eventForPrefs.teamId, eventForPrefs.id) : Promise.resolve([])
-                        ]);
-                        return {
-                            myRsvp: myRsvp ? myRsvp.response : null,
-                            availabilityNotes: buildAvailabilityNoteRows(rsvps, eventForPrefs.availabilityPreferences, !!eventForPrefs.isTeamAdmin)
-                        };
-                    })();
-                    rsvpHydrationCache.set(key, cached);
+                const cached = getRsvpHydrationCacheEntry(eventForPrefs.teamId, eventForPrefs.id);
+                if (!cached.myRsvp) {
+                    const linkedPlayerIds = getLinkedPlayersForTeam(eventForPrefs.teamId).map((player) => player.playerId).filter(Boolean);
+                    cached.myRsvp = getMyRsvp(eventForPrefs.teamId, eventForPrefs.id, currentUserId, linkedPlayerIds)
+                        .then((myRsvp) => myRsvp ? myRsvp.response : null);
+                }
+                if (includeMissingSummary && !eventForPrefs.rsvpSummary && !cached.summary) {
+                    cached.summary = getRsvpSummaries(eventForPrefs.teamId, [eventForPrefs.id])
+                        .then((summaries) => summaries?.get(eventForPrefs.id) || null);
+                }
+                if (includeNotes && eventForPrefs.notesVisible && !cached.rsvps) {
+                    cached.rsvps = getRsvps(eventForPrefs.teamId, eventForPrefs.id);
                 }
 
                 try {
-                    const hydration = await cached;
+                    const [myRsvp, summary, rsvps] = await Promise.all([
+                        cached.myRsvp,
+                        cached.summary || Promise.resolve(null),
+                        includeNotes && eventForPrefs.notesVisible ? (cached.rsvps || Promise.resolve([])) : Promise.resolve([])
+                    ]);
                     applyRsvpHydration(allEvents, eventForPrefs.teamId, eventForPrefs.id, {
-                        myRsvp: hydration.myRsvp,
-                        summary: null
+                        myRsvp,
+                        summary
                     });
-                    allEvents.forEach((ev) => {
-                        if (ev.teamId === eventForPrefs.teamId && ev.id === eventForPrefs.id) {
-                            ev.availabilityNotes = hydration.availabilityNotes;
-                        }
-                    });
+                    if (includeNotes && eventForPrefs.notesVisible) {
+                        const availabilityNotes = buildAvailabilityNoteRows(rsvps, eventForPrefs.availabilityPreferences, !!eventForPrefs.isTeamAdmin);
+                        allEvents.forEach((ev) => {
+                            if (ev.teamId === eventForPrefs.teamId && ev.id === eventForPrefs.id) {
+                                ev.availabilityNotes = availabilityNotes;
+                            }
+                        });
+                    }
                 } catch (_) {
-                    rsvpHydrationCache.delete(key);
+                    rsvpHydrationCache.delete(`${eventForPrefs.teamId}::${eventForPrefs.id}`);
                 }
             }));
+        }
+
+        async function hydrateRenderedRsvpEvents() {
+            if (currentView !== 'detailed' && currentView !== 'compact') return;
+            const token = ++renderedRsvpHydrationToken;
+            const view = currentView;
+            await hydrateRsvpEvents(filteredEvents, { includeMissingSummary: true });
+            if (token !== renderedRsvpHydrationToken || currentView !== view) return;
+            if (view === 'detailed') renderDetailed();
+            else renderCompact();
         }
 
         function renderCalendarChildScope(teamId) {
@@ -577,6 +602,7 @@
             else if (currentView === 'calendar') renderCalendarGrid();
 
             document.getElementById('month-nav').classList.toggle('hidden', currentView !== 'calendar');
+            hydrateRenderedRsvpEvents();
         }
 
         // ===== DETAILED LIST VIEW =====
@@ -772,7 +798,7 @@
 
             modal.classList.remove('hidden');
 
-            await hydrateRsvpEvents(dayEvents, { includeNotes: true });
+            await hydrateRsvpEvents(dayEvents, { includeNotes: true, includeMissingSummary: true });
             if (activeDayDetail?.year === year && activeDayDetail?.month === month && activeDayDetail?.day === day && !modal.classList.contains('hidden')) {
                 renderDayDetailEvents(getDayDetailEvents(year, month, day), content);
             }
@@ -810,12 +836,9 @@
                 applyFilters();
                 const dayModal = document.getElementById('day-modal');
                 if (currentView === 'calendar' && activeDayDetail && dayModal && !dayModal.classList.contains('hidden')) {
-                    const cacheKey = `${teamId}::${gameId}`;
-                    const existingHydration = await Promise.resolve(rsvpHydrationCache.get(cacheKey)).catch(() => null);
-                    rsvpHydrationCache.set(cacheKey, Promise.resolve({
-                        ...(existingHydration || {}),
-                        myRsvp: response
-                    }));
+                    const existingHydration = getRsvpHydrationCacheEntry(teamId, gameId);
+                    existingHydration.myRsvp = Promise.resolve(response);
+                    if (summary) existingHydration.summary = Promise.resolve(summary);
                     await openDayDetail(activeDayDetail.year, activeDayDetail.month, activeDayDetail.day);
                 }
             } catch (err) {

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -99,8 +99,8 @@ const URL = deps.URL;
 const Blob = deps.Blob;
 ` + match[1]
         .replace(
-            /import \{ getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps \} from '\.\/js\/db\.js\?v=\d+';/,
-            'const { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } = deps.db;'
+            /import \{ getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvps \} from '\.\/js\/db\.js\?v=\d+';/,
+            'const { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvps } = deps.db;'
         )
         .replace(
             /import \{ renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent \} from '\.\/js\/utils\.js\?v=\d+';/,
@@ -214,6 +214,7 @@ function createEnvironment() {
 
 function createDeps(submitRecorder, overrides = {}) {
     const getMyRsvpCalls = [];
+    const getRsvpsCalls = [];
     const eventDate = overrides.eventDate || new Date('2026-03-15T18:00:00.000Z');
     const initialSummary = overrides.initialSummary || { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 };
     const updatedSummary = overrides.updatedSummary || { going: 1, maybe: 1, notGoing: 0, notResponded: 0, total: 2 };
@@ -278,11 +279,9 @@ function createDeps(submitRecorder, overrides = {}) {
                 getMyRsvpCalls.push({ teamId, gameId, userId, playerIds });
                 return overrides.myRsvp || null;
             },
-            async getRsvpSummaries() {
-                return new Map([['game-1', initialSummary]]);
-            },
-            async getRsvps() {
-                return [];
+            async getRsvps(teamId, gameId) {
+                getRsvpsCalls.push({ teamId, gameId });
+                return overrides.rsvps || [];
             }
         },
         utils: {
@@ -399,8 +398,12 @@ function createDeps(submitRecorder, overrides = {}) {
             }
         },
         availabilityPreferences: {
-            buildAvailabilityNoteRows() { return []; },
-            canViewAvailabilityNotes() { return false; },
+            buildAvailabilityNoteRows(rsvps) {
+                return (rsvps || [])
+                    .filter((rsvp) => rsvp.note)
+                    .map((rsvp) => ({ displayName: rsvp.displayName || 'Player', note: rsvp.note }));
+            },
+            canViewAvailabilityNotes() { return !!overrides.notesVisible; },
             formatAvailabilityCutoff() { return 'No cutoff'; },
             isAvailabilityLocked() { return false; },
             normalizeAvailabilityPreferences() { return { cutoffMinutesBeforeStart: 0, noteVisibility: 'admins' }; }
@@ -423,7 +426,8 @@ function createDeps(submitRecorder, overrides = {}) {
         eventDate,
         initialSummary,
         updatedSummary,
-        getMyRsvpCalls
+        getMyRsvpCalls,
+        getRsvpsCalls
     };
 }
 
@@ -445,8 +449,53 @@ async function bootCalendar(overrides = {}) {
 }
 
 describe('calendar day modal RSVP refresh', () => {
-    it('hydrates calendar RSVP state from linked player RSVP docs', async () => {
-        const { elements, getMyRsvpCalls, window } = await bootCalendar({
+    it('keeps initial calendar boot summary-only for off-screen RSVP data', async () => {
+        const eventDate = new Date('2026-03-15T18:00:00.000Z');
+        const games = Array.from({ length: 25 }, (_, index) => ({
+            id: `game-${index + 1}`,
+            type: 'game',
+            opponent: `Opponent ${index + 1}`,
+            date: new Date(eventDate.getTime() + index * 86400000).toISOString(),
+            location: 'North Field',
+            status: 'scheduled',
+            rsvpSummary: { going: index, maybe: 0, notGoing: 0, notResponded: 1, total: index + 1 }
+        }));
+        const { elements, getMyRsvpCalls, getRsvpsCalls, window } = await bootCalendar({ eventDate, games });
+
+        expect(getMyRsvpCalls).toEqual([]);
+        expect(getRsvpsCalls).toEqual([]);
+
+        window.setTimeRange('all');
+
+        expect(elements.get('calendar-content').innerHTML).toContain('0 going · 0 maybe · 0 can\'t go · 1 no response');
+        expect(elements.get('calendar-content').innerHTML).toContain('24 going · 0 maybe · 0 can\'t go · 1 no response');
+    });
+
+    it('hydrates day-detail RSVP state from linked player RSVP docs only for the selected day', async () => {
+        const selectedDate = new Date('2026-03-15T18:00:00.000Z');
+        const offscreenDate = new Date('2026-04-20T18:00:00.000Z');
+        const { elements, getMyRsvpCalls, getRsvpsCalls, window } = await bootCalendar({
+            eventDate: selectedDate,
+            games: [
+                {
+                    id: 'game-1',
+                    type: 'game',
+                    opponent: 'Lions',
+                    date: selectedDate.toISOString(),
+                    location: 'North Field',
+                    status: 'scheduled',
+                    rsvpSummary: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+                },
+                {
+                    id: 'game-2',
+                    type: 'game',
+                    opponent: 'Bears',
+                    date: offscreenDate.toISOString(),
+                    location: 'South Field',
+                    status: 'scheduled',
+                    rsvpSummary: { going: 0, maybe: 1, notGoing: 0, notResponded: 1, total: 2 }
+                }
+            ],
             parentOf: [
                 { teamId: 'team-1', playerId: 'player-1', playerName: 'Avery' },
                 { teamId: 'team-1', playerId: 'player-2', playerName: 'Blake' }
@@ -459,23 +508,51 @@ describe('calendar day modal RSVP refresh', () => {
             }
         });
 
-        expect(getMyRsvpCalls).toContainEqual({
+        await window.openDayDetail(selectedDate.getUTCFullYear(), selectedDate.getUTCMonth(), selectedDate.getUTCDate());
+
+        expect(getMyRsvpCalls).toEqual([{
             teamId: 'team-1',
             gameId: 'game-1',
             userId: 'user-1',
             playerIds: ['player-1', 'player-2']
+        }]);
+        expect(getRsvpsCalls).toEqual([]);
+
+        expect(elements.get('day-modal-content').innerHTML).toContain('bg-green-600 text-white border-green-600');
+        expect(elements.get('day-modal-content').innerHTML).not.toContain('Bears');
+    });
+
+    it('uses the day-detail RSVP hydration cache when reopening the same day', async () => {
+        const eventDate = new Date('2026-03-15T18:00:00.000Z');
+        const { getMyRsvpCalls, getRsvpsCalls, window } = await bootCalendar({
+            eventDate,
+            notesVisible: true,
+            myRsvp: {
+                id: 'user-1__player-1',
+                userId: 'user-1',
+                playerId: 'player-1',
+                response: 'maybe'
+            },
+            rsvps: [
+                {
+                    displayName: 'Avery',
+                    note: 'Running late'
+                }
+            ]
         });
 
-        window.setTimeRange('all');
+        await window.openDayDetail(eventDate.getUTCFullYear(), eventDate.getUTCMonth(), eventDate.getUTCDate());
+        await window.openDayDetail(eventDate.getUTCFullYear(), eventDate.getUTCMonth(), eventDate.getUTCDate());
 
-        expect(elements.get('calendar-content').innerHTML).toContain('bg-green-600 text-white border-green-600');
+        expect(getMyRsvpCalls).toHaveLength(1);
+        expect(getRsvpsCalls).toEqual([{ teamId: 'team-1', gameId: 'game-1' }]);
     });
 
     it('keeps the day-detail modal open and refreshes RSVP state after a save', async () => {
         const { elements, submitRecorder, updatedSummary, eventDate, window } = await bootCalendar();
 
         window.setView('calendar');
-        window.openDayDetail(eventDate.getUTCFullYear(), eventDate.getUTCMonth(), eventDate.getUTCDate());
+        await window.openDayDetail(eventDate.getUTCFullYear(), eventDate.getUTCMonth(), eventDate.getUTCDate());
 
         const beforeHtml = elements.get('day-modal-content').innerHTML;
         expect(beforeHtml).toContain('submitCalendarRsvpFromButton');

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -515,6 +515,53 @@ describe('calendar day modal RSVP refresh', () => {
         expect(elements.get('calendar-content').innerHTML).toContain('bg-green-600 text-white border-green-600');
     });
 
+    it('keeps detailed RSVP saves from being overwritten by cached hydration', async () => {
+        const eventDate = new Date();
+        const { elements, getMyRsvpCalls, submitRecorder, updatedSummary, window } = await bootCalendar({
+            eventDate,
+            games: [
+                {
+                    id: 'game-1',
+                    type: 'game',
+                    opponent: 'Lions',
+                    date: eventDate.toISOString(),
+                    location: 'North Field',
+                    status: 'scheduled',
+                    rsvpSummary: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+                }
+            ],
+            myRsvp: {
+                id: 'user-1__player-1',
+                userId: 'user-1',
+                playerId: 'player-1',
+                response: 'going'
+            }
+        });
+
+        await flushCalendarHydration();
+        expect(elements.get('calendar-content').innerHTML).toContain('bg-green-600 text-white border-green-600');
+
+        await window.submitCalendarRsvp('team-1', 'game-1', 'maybe');
+        await flushCalendarHydration();
+
+        expect(submitRecorder.calls).toEqual([
+            {
+                teamId: 'team-1',
+                gameId: 'game-1',
+                currentUserId: 'user-1',
+                payload: {
+                    displayName: 'Parent User',
+                    playerIds: ['player-1'],
+                    response: 'maybe'
+                }
+            }
+        ]);
+        expect(getMyRsvpCalls).toHaveLength(1);
+        expect(elements.get('calendar-content').innerHTML).toContain('bg-yellow-500 text-white border-yellow-500');
+        expect(elements.get('calendar-content').innerHTML).not.toContain('bg-green-600 text-white border-green-600');
+        expect(elements.get('calendar-content').innerHTML).toContain(`${updatedSummary.going} going · ${updatedSummary.maybe} maybe · ${updatedSummary.notGoing} can't go · ${updatedSummary.notResponded} no response`);
+    });
+
     it('hydrates day-detail RSVP state from linked player RSVP docs only for the selected day', async () => {
         const selectedDate = new Date('2026-03-15T18:00:00.000Z');
         const offscreenDate = new Date('2026-04-20T18:00:00.000Z');

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -562,6 +562,46 @@ describe('calendar day modal RSVP refresh', () => {
         expect(elements.get('calendar-content').innerHTML).toContain(`${updatedSummary.going} going · ${updatedSummary.maybe} maybe · ${updatedSummary.notGoing} can't go · ${updatedSummary.notResponded} no response`);
     });
 
+    it('ignores stale in-flight RSVP hydration after a detailed RSVP save', async () => {
+        const eventDate = new Date();
+        let resolveMyRsvp;
+        const pendingMyRsvp = new Promise((resolve) => {
+            resolveMyRsvp = resolve;
+        });
+        const { elements, submitRecorder, window } = await bootCalendar({
+            eventDate,
+            games: [
+                {
+                    id: 'game-1',
+                    type: 'game',
+                    opponent: 'Lions',
+                    date: eventDate.toISOString(),
+                    location: 'North Field',
+                    status: 'scheduled',
+                    rsvpSummary: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+                }
+            ],
+            myRsvp: pendingMyRsvp
+        });
+
+        await window.submitCalendarRsvp('team-1', 'game-1', 'maybe');
+        expect(submitRecorder.calls).toHaveLength(1);
+        expect(elements.get('calendar-content').innerHTML).toContain('bg-yellow-500 text-white border-yellow-500');
+
+        resolveMyRsvp({
+            id: 'user-1__player-1',
+            userId: 'user-1',
+            playerId: 'player-1',
+            response: 'going'
+        });
+        await flushCalendarHydration();
+        await flushCalendarHydration();
+        window.setTimeRange('all');
+
+        expect(elements.get('calendar-content').innerHTML).toContain('bg-yellow-500 text-white border-yellow-500');
+        expect(elements.get('calendar-content').innerHTML).not.toContain('bg-green-600 text-white border-green-600');
+    });
+
     it('hydrates day-detail RSVP state from linked player RSVP docs only for the selected day', async () => {
         const selectedDate = new Date('2026-03-15T18:00:00.000Z');
         const offscreenDate = new Date('2026-04-20T18:00:00.000Z');

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -515,6 +515,38 @@ describe('calendar day modal RSVP refresh', () => {
         expect(elements.get('calendar-content').innerHTML).toContain('bg-green-600 text-white border-green-600');
     });
 
+    it('hydrates visible detailed availability notes without opening the day modal', async () => {
+        const eventDate = new Date();
+        const { elements, getRsvpsCalls } = await bootCalendar({
+            eventDate,
+            notesVisible: true,
+            rsvps: [
+                {
+                    displayName: 'Avery',
+                    note: 'Running late'
+                }
+            ],
+            games: [
+                {
+                    id: 'game-1',
+                    type: 'game',
+                    opponent: 'Lions',
+                    date: eventDate.toISOString(),
+                    location: 'North Field',
+                    status: 'scheduled',
+                    rsvpSummary: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+                }
+            ]
+        });
+
+        await flushCalendarHydration();
+
+        expect(getRsvpsCalls).toEqual([{ teamId: 'team-1', gameId: 'game-1' }]);
+        expect(elements.get('calendar-content').innerHTML).toContain('Avery:');
+        expect(elements.get('calendar-content').innerHTML).toContain('Running late');
+        expect(elements.get('day-modal').classList.contains('hidden')).toBe(true);
+    });
+
     it('keeps detailed RSVP saves from being overwritten by cached hydration', async () => {
         const eventDate = new Date();
         const { elements, getMyRsvpCalls, submitRecorder, updatedSummary, window } = await bootCalendar({

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -99,8 +99,8 @@ const URL = deps.URL;
 const Blob = deps.Blob;
 ` + match[1]
         .replace(
-            /import \{ getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvps \} from '\.\/js\/db\.js\?v=\d+';/,
-            'const { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvps } = deps.db;'
+            /import \{ getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps \} from '\.\/js\/db\.js\?v=\d+';/,
+            'const { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } = deps.db;'
         )
         .replace(
             /import \{ renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent \} from '\.\/js\/utils\.js\?v=\d+';/,
@@ -214,6 +214,7 @@ function createEnvironment() {
 
 function createDeps(submitRecorder, overrides = {}) {
     const getMyRsvpCalls = [];
+    const getRsvpSummariesCalls = [];
     const getRsvpsCalls = [];
     const eventDate = overrides.eventDate || new Date('2026-03-15T18:00:00.000Z');
     const initialSummary = overrides.initialSummary || { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 };
@@ -278,6 +279,10 @@ function createDeps(submitRecorder, overrides = {}) {
             async getMyRsvp(teamId, gameId, userId, playerIds) {
                 getMyRsvpCalls.push({ teamId, gameId, userId, playerIds });
                 return overrides.myRsvp || null;
+            },
+            async getRsvpSummaries(teamId, gameIds) {
+                getRsvpSummariesCalls.push({ teamId, gameIds });
+                return overrides.rsvpSummaries || new Map([['game-1', initialSummary]]);
             },
             async getRsvps(teamId, gameId) {
                 getRsvpsCalls.push({ teamId, gameId });
@@ -427,6 +432,7 @@ function createDeps(submitRecorder, overrides = {}) {
         initialSummary,
         updatedSummary,
         getMyRsvpCalls,
+        getRsvpSummariesCalls,
         getRsvpsCalls
     };
 }
@@ -446,6 +452,10 @@ async function bootCalendar(overrides = {}) {
     });
 
     return { ...env, ...deps, submitRecorder };
+}
+
+async function flushCalendarHydration() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('calendar day modal RSVP refresh', () => {
@@ -469,6 +479,40 @@ describe('calendar day modal RSVP refresh', () => {
 
         expect(elements.get('calendar-content').innerHTML).toContain('0 going · 0 maybe · 0 can\'t go · 1 no response');
         expect(elements.get('calendar-content').innerHTML).toContain('24 going · 0 maybe · 0 can\'t go · 1 no response');
+    });
+
+    it('hydrates visible detailed RSVP controls from saved RSVP docs', async () => {
+        const eventDate = new Date();
+        const { elements, getMyRsvpCalls } = await bootCalendar({
+            eventDate,
+            games: [
+                {
+                    id: 'game-1',
+                    type: 'game',
+                    opponent: 'Lions',
+                    date: eventDate.toISOString(),
+                    location: 'North Field',
+                    status: 'scheduled',
+                    rsvpSummary: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+                }
+            ],
+            myRsvp: {
+                id: 'user-1__player-1',
+                userId: 'user-1',
+                playerId: 'player-1',
+                response: 'going'
+            }
+        });
+
+        await flushCalendarHydration();
+
+        expect(getMyRsvpCalls).toEqual([{
+            teamId: 'team-1',
+            gameId: 'game-1',
+            userId: 'user-1',
+            playerIds: ['player-1']
+        }]);
+        expect(elements.get('calendar-content').innerHTML).toContain('bg-green-600 text-white border-green-600');
     });
 
     it('hydrates day-detail RSVP state from linked player RSVP docs only for the selected day', async () => {
@@ -520,6 +564,36 @@ describe('calendar day modal RSVP refresh', () => {
 
         expect(elements.get('day-modal-content').innerHTML).toContain('bg-green-600 text-white border-green-600');
         expect(elements.get('day-modal-content').innerHTML).not.toContain('Bears');
+    });
+
+    it('loads missing RSVP summaries for selected day events', async () => {
+        const selectedDate = new Date('2026-03-15T18:00:00.000Z');
+        const fallbackSummary = { going: 2, maybe: 1, notGoing: 0, notResponded: 3, total: 6 };
+        const { elements, getRsvpSummariesCalls, window } = await bootCalendar({
+            eventDate: selectedDate,
+            games: [
+                {
+                    id: 'game-1',
+                    type: 'practice',
+                    title: 'Practice',
+                    date: selectedDate.toISOString(),
+                    location: 'North Field',
+                    status: 'scheduled',
+                    rsvpSummary: null
+                }
+            ],
+            icsEvents: [],
+            rsvpSummaries: new Map([['game-1', fallbackSummary]])
+        });
+
+        await window.openDayDetail(selectedDate.getUTCFullYear(), selectedDate.getUTCMonth(), selectedDate.getUTCDate());
+
+        expect(getRsvpSummariesCalls).toContainEqual({
+            teamId: 'team-1',
+            gameIds: ['game-1']
+        });
+        expect(elements.get('day-modal-content').innerHTML).toContain('2 going · 1 maybe · 0 can\'t go · 3 no response');
+        expect(elements.get('day-modal-content').innerHTML).not.toContain('No RSVPs yet.');
     });
 
     it('uses the day-detail RSVP hydration cache when reopening the same day', async () => {


### PR DESCRIPTION
Closes #3493

## What changed
- Removed initial legacy calendar RSVP fan-out across every loaded DB event.
- Kept initial calendar rendering summary-only using denormalized `game.rsvpSummary` when present.
- Added day-modal RSVP hydration scoped to the selected day’s DB events.
- Added a per-team/game hydration cache so reopening the same day does not repeat RSVP reads.
- Preserved RSVP submit behavior by updating local `myRsvp` and `rsvpSummary` before rerendering the open day modal.

## Root Cause
`calendar.html` built a unique key for every non-cancelled DB game/practice across all accessible teams during boot, then awaited `getMyRsvp` and sometimes `getRsvps`/`getRsvpSummaries` for all of them before initial render. That made page-load Firestore reads scale with the full accessible schedule and linked-player count, including historical and off-screen events.

## Prevention / Learning
Calendar and schedule surfaces should separate first-paint data from secondary per-user/full-detail data. Render from denormalized event fields first, then lazy-load user-specific RSVP state and full RSVP rows only for the selected visible scope, with a cache keyed by team/game.

## Regression Tests
- `npx vitest run tests/unit/calendar-day-modal-rsvp.test.js --reporter=verbose`
- Added coverage proving initial boot does not call `getMyRsvp`/`getRsvps` for many loaded events.
- Added coverage proving day-modal hydration only fetches the selected day’s DB events and passes linked player ids.
- Added coverage proving reopening the same day uses the hydration cache.