### PR TITLE
Limit Team Media grid rendering

### DIFF
--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { TeamMedia } from './TeamMedia';
+import { TeamMedia, getSelectedVisibleTeamMediaItems, getVisibleTeamMediaWindow } from './TeamMedia';
 import type { AuthState } from '../lib/types';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
@@ -73,6 +73,20 @@ function createModel(overrides: Record<string, any> = {}) {
   };
 }
 
+function createMediaItems(count: number, type: 'photo' | 'file' = 'photo', start = 1) {
+  return Array.from({ length: count }, (_, index) => {
+    const itemNumber = start + index;
+    const padded = String(itemNumber).padStart(2, '0');
+    return {
+      id: `${type}-${padded}`,
+      title: `${type === 'photo' ? 'Photo' : 'File'} ${padded}`,
+      type,
+      url: `https://example.com/${type}-${padded}.${type === 'photo' ? 'jpg' : 'pdf'}`,
+      uploadedBy: 'coach-1'
+    };
+  });
+}
+
 function renderTeamMedia(customAuth: AuthState = auth) {
   return render(
     <MemoryRouter initialEntries={['/teams/team-1/media']}>
@@ -111,6 +125,22 @@ describe('TeamMedia bulk delete', () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+  });
+
+  it('derives visible media windows and selected items with bounded Set lookups', () => {
+    const items = createMediaItems(4);
+
+    expect(getVisibleTeamMediaWindow(items, 2, true)).toEqual({
+      renderedItems: items.slice(0, 2),
+      canShowMoreLoaded: true,
+      canLoadMoreRemote: false
+    });
+    expect(getVisibleTeamMediaWindow(items.slice(0, 2), 2, true)).toEqual({
+      renderedItems: items.slice(0, 2),
+      canShowMoreLoaded: false,
+      canLoadMoreRemote: true
+    });
+    expect(getSelectedVisibleTeamMediaItems(items, new Set(['photo-02', 'photo-02', 'missing']))).toEqual([items[1]]);
   });
 
   it('retries a retryable media load failure from the shared error state', async () => {
@@ -190,6 +220,120 @@ describe('TeamMedia bulk delete', () => {
     expect(await screen.findByText('Delete failed.')).toBeTruthy();
     expect(selectPhotoOne.checked).toBe(true);
     expect(screen.getByText('1 selected in this view')).toBeTruthy();
+  });
+
+  it('limits large loaded albums to the visible item window and reveals the next window on demand', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(createModel({
+      folders: [
+        {
+          id: 'album-1',
+          name: 'Game day',
+          visibility: 'team',
+          itemCount: 72,
+          itemsLoaded: true,
+          itemsHasMore: false,
+          items: createMediaItems(72)
+        }
+      ]
+    }));
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    expect(screen.getByText('1 albums - 72 items')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'All72' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Photos72' })).toBeTruthy();
+    expect(screen.getByText('Photo 01')).toBeTruthy();
+    expect(screen.getByText('Photo 24')).toBeTruthy();
+    expect(screen.queryByText('Photo 25')).toBeNull();
+    expect(screen.queryByText('Photo 72')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+
+    expect(screen.getByText('Photo 25')).toBeTruthy();
+    expect(screen.getByText('Photo 48')).toBeTruthy();
+    expect(screen.queryByText('Photo 49')).toBeNull();
+  });
+
+  it('resets the visible window when filtering media types', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(createModel({
+      folders: [
+        {
+          id: 'album-1',
+          name: 'Game day',
+          visibility: 'team',
+          itemCount: 60,
+          itemsLoaded: true,
+          itemsHasMore: false,
+          items: [
+            ...createMediaItems(36, 'photo'),
+            ...createMediaItems(24, 'file')
+          ]
+        }
+      ]
+    }));
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+    expect(screen.getByText('Photo 36')).toBeTruthy();
+    expect(screen.getByText('File 12')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Photos36' }));
+
+    expect(screen.getByText('Photo 24')).toBeTruthy();
+    expect(screen.queryByText('Photo 25')).toBeNull();
+    expect(screen.queryByText('Photo 36')).toBeNull();
+    expect(screen.queryByText('File 01')).toBeNull();
+  });
+
+  it('bulk deletes only selected visible items after filtering a loaded album', async () => {
+    const files = createMediaItems(30, 'file');
+    parentToolsServiceMocks.loadTeamMediaForApp
+      .mockResolvedValueOnce(createModel({
+        folders: [
+          {
+            id: 'album-1',
+            name: 'Game day',
+            visibility: 'team',
+            itemCount: 30,
+            itemsLoaded: true,
+            itemsHasMore: false,
+            items: files
+          }
+        ]
+      }))
+      .mockResolvedValueOnce(createModel({
+        folders: [
+          {
+            id: 'album-1',
+            name: 'Game day',
+            visibility: 'team',
+            itemCount: 29,
+            itemsLoaded: true,
+            itemsHasMore: false,
+            items: files.slice(1)
+          }
+        ]
+      }));
+    parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp.mockResolvedValue(undefined);
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    fireEvent.click(screen.getByRole('button', { name: 'Files30' }));
+    expect(screen.getByText('File 24')).toBeTruthy();
+    expect(screen.queryByText('File 25')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Select File 01'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete selected' }));
+
+    expect(parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp).toHaveBeenCalledWith('team-1', [
+      expect.objectContaining({ id: 'file-01' })
+    ]);
+    expect(parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp.mock.calls[0][1]).toHaveLength(1);
+    expect(await screen.findByText('1 media item deleted.')).toBeTruthy();
   });
 
   it('posts a photo to the default team conversation', async () => {

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -52,6 +52,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [model, setModel] = useState<TeamMediaModel | null>(null);
   const [activeFolderId, setActiveFolderId] = useState('');
   const [selectedMediaType, setSelectedMediaType] = useState<MediaTypeFilter>('all');
+  const [visibleMediaCount, setVisibleMediaCount] = useState(TEAM_MEDIA_VISIBLE_WINDOW_SIZE);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [linkTitle, setLinkTitle] = useState('');
   const [linkUrl, setLinkUrl] = useState('');
@@ -148,9 +149,14 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         cursorsByFolderId: { [folderToLoad.id]: folderToLoad.itemsNextCursor },
         append: true
       });
+      setVisibleMediaCount((current) => current + TEAM_MEDIA_VISIBLE_WINDOW_SIZE);
     } finally {
       setLoadingMoreFolderId('');
     }
+  };
+
+  const handleShowMoreLoadedItems = () => {
+    setVisibleMediaCount((current) => current + TEAM_MEDIA_VISIBLE_WINDOW_SIZE);
   };
 
   const handleRenameItem = async (item: TeamMediaItem, nextTitle: string) => {
@@ -302,20 +308,35 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const loadedItems = useMemo(() => model?.folders.flatMap((folder) => folder.items.map((item) => ({ ...item, folderName: folder.name || 'Album' }))) || [], [model]);
   const mediaTypeCounts = useMemo(() => getMediaTypeCounts(activeFolder?.items || []), [activeFolder]);
   const filteredItems = useMemo(() => (activeFolder?.items || []).filter((item) => matchesMediaTypeFilter(item, selectedMediaType)), [activeFolder, selectedMediaType]);
-  const visibleItemIds = useMemo(() => filteredItems.map((item) => item.id).filter(Boolean), [filteredItems]);
-  const selectedItems = useMemo(() => filteredItems.filter((item) => selectedIds.includes(item.id)), [filteredItems, selectedIds]);
+  const visibleMediaWindow = useMemo(
+    () => getVisibleTeamMediaWindow(filteredItems, visibleMediaCount, Boolean(activeFolder?.itemsHasMore)),
+    [activeFolder?.itemsHasMore, filteredItems, visibleMediaCount]
+  );
+  const visibleItems = visibleMediaWindow.renderedItems;
+  const visibleItemIds = useMemo(() => visibleItems.map((item) => item.id).filter(Boolean), [visibleItems]);
+  const visibleItemIdSet = useMemo(() => new Set(visibleItemIds), [visibleItemIds]);
+  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const selectedItems = useMemo(() => getSelectedVisibleTeamMediaItems(visibleItems, selectedIdSet), [selectedIdSet, visibleItems]);
   const selectedCount = selectedItems.length;
   const selectedMediaTypeLabel = MEDIA_TYPE_FILTERS.find((filter) => filter.id === selectedMediaType)?.label || 'All';
   const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
   const featured = activeFolder ? getFolderCoverMedia(activeFolder) || loadedItems[0] || null : loadedItems[0] || null;
+  const alternateFolders = useMemo(() => (model?.folders || []).filter((folder) => folder.id && folder.id !== activeFolder?.id), [activeFolder?.id, model]);
 
   useEffect(() => {
-    setSelectedIds((current) => current.filter((itemId) => visibleItemIds.includes(itemId)));
-  }, [visibleItemIds]);
+    setSelectedIds((current) => current.filter((itemId) => visibleItemIdSet.has(itemId)));
+  }, [visibleItemIdSet]);
+
+  useEffect(() => {
+    setVisibleMediaCount(TEAM_MEDIA_VISIBLE_WINDOW_SIZE);
+  }, [activeFolder?.id, selectedMediaType]);
 
   const toggleItemSelection = (itemId: string, checked: boolean) => {
     if (!itemId || !model?.canManage) return;
-    setSelectedIds((current) => checked ? current.includes(itemId) ? current : [...current, itemId] : current.filter((selectedId) => selectedId !== itemId));
+    setSelectedIds((current) => {
+      const currentSet = new Set(current);
+      return checked ? currentSet.has(itemId) ? current : [...current, itemId] : current.filter((selectedId) => selectedId !== itemId);
+    });
   };
 
   const handleBulkDelete = async () => {
@@ -604,6 +625,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               onClick={() => {
                 setSelectedMediaType('all');
                 setSelectedIds([]);
+                setVisibleMediaCount(TEAM_MEDIA_VISIBLE_WINDOW_SIZE);
                 if (folder.itemsLoaded || folder.items.length) {
                   setActiveFolderId(folder.id);
                   return;
@@ -734,6 +756,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               onClick={() => {
                 setSelectedMediaType(filter.id);
                 setSelectedIds([]);
+                setVisibleMediaCount(TEAM_MEDIA_VISIBLE_WINDOW_SIZE);
               }}
               aria-pressed={selectedMediaType === filter.id}
             >
@@ -763,7 +786,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
           </div>
         ) : null}
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {filteredItems.length ? filteredItems.map((item) => (
+          {filteredItems.length ? visibleItems.map((item) => (
             <TeamMediaItemCard
               key={item.id}
               item={item}
@@ -771,11 +794,11 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               canManage={model.canManage}
               canPostToChat={model.canPostChat && model.canContribute && Boolean(auth.user)}
               currentUserId={auth.user?.uid || ''}
-              folders={model.folders}
+              alternateFolders={alternateFolders}
               currentFolderId={activeFolder?.id || ''}
               deleting={deletingItemId === item.id}
               selectable={model.canManage}
-              selected={selectedIds.includes(item.id)}
+              selected={selectedIdSet.has(item.id)}
               renaming={renamingItemId === item.id}
               moving={movingItemId === item.id}
               settingCover={coverItemId === item.id}
@@ -791,17 +814,17 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
         </div>
-        {activeFolder?.itemsHasMore ? (
+        {visibleMediaWindow.canShowMoreLoaded || visibleMediaWindow.canLoadMoreRemote ? (
           <div className="mt-3 flex justify-center">
             <button
               type="button"
               className="ghost-button justify-center disabled:opacity-60"
-              onClick={handleLoadMoreItems}
-              disabled={loadingMoreFolderId === activeFolder.id}
-              aria-disabled={loadingMoreFolderId === activeFolder.id}
+              onClick={visibleMediaWindow.canShowMoreLoaded ? handleShowMoreLoadedItems : handleLoadMoreItems}
+              disabled={loadingMoreFolderId === activeFolder?.id}
+              aria-disabled={loadingMoreFolderId === activeFolder?.id}
             >
-              {loadingMoreFolderId === activeFolder.id ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
-              {loadingMoreFolderId === activeFolder.id ? 'Loading more' : 'Load more'}
+              {loadingMoreFolderId === activeFolder?.id ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+              {loadingMoreFolderId === activeFolder?.id ? 'Loading more' : visibleMediaWindow.canShowMoreLoaded ? 'Show more' : 'Load more'}
             </button>
           </div>
         ) : null}
@@ -827,6 +850,20 @@ const MEDIA_TYPE_FILTERS: { id: MediaTypeFilter; label: string }[] = [
 ];
 const MAX_PHOTO_UPLOAD_BYTES = 10 * 1024 * 1024;
 const PHOTO_UPLOAD_CONCURRENCY = 3;
+const TEAM_MEDIA_VISIBLE_WINDOW_SIZE = 24;
+
+export function getVisibleTeamMediaWindow<T>(items: T[], visibleCount: number, itemsHasMore: boolean) {
+  const safeVisibleCount = Math.max(0, Math.floor(Number(visibleCount) || 0));
+  return {
+    renderedItems: items.slice(0, safeVisibleCount),
+    canShowMoreLoaded: items.length > safeVisibleCount,
+    canLoadMoreRemote: items.length <= safeVisibleCount && Boolean(itemsHasMore)
+  };
+}
+
+export function getSelectedVisibleTeamMediaItems<T extends { id: string }>(items: T[], selectedIdSet: ReadonlySet<string>) {
+  return items.filter((item) => selectedIdSet.has(item.id));
+}
 
 function isSupportedPhotoUpload(file: File) {
   return Boolean(file?.type?.startsWith('image/')) && Number(file.size || 0) > 0 && Number(file.size || 0) <= MAX_PHOTO_UPLOAD_BYTES;
@@ -941,7 +978,7 @@ function TeamMediaItemCard({
   canManage,
   canPostToChat,
   currentUserId,
-  folders,
+  alternateFolders,
   currentFolderId,
   deleting,
   selectable,
@@ -962,7 +999,7 @@ function TeamMediaItemCard({
   canManage: boolean;
   canPostToChat: boolean;
   currentUserId: string;
-  folders: TeamMediaFolder[];
+  alternateFolders: TeamMediaFolder[];
   currentFolderId: string;
   deleting: boolean;
   selectable: boolean;
@@ -986,7 +1023,6 @@ function TeamMediaItemCard({
   const [draftTitle, setDraftTitle] = useState(title);
   const [postCaption, setPostCaption] = useState('');
   const [moveFolderId, setMoveFolderId] = useState('');
-  const alternateFolders = folders.filter((folder) => folder.id && folder.id !== currentFolderId);
   const canMove = canManage && alternateFolders.length > 0;
   const selectedMoveFolderId = moveFolderId && moveFolderId !== currentFolderId ? moveFolderId : '';
   const canRename = canManage || item.uploadedBy === currentUserId;


### PR DESCRIPTION
Closes #3537

## What changed
- Added a 24-item client-side visible window for the active Team Media grid while preserving album item counts and media type counts.
- Added a Show more path for already-loaded items and kept the existing remote Load more path for server pagination.
- Switched render-derived selection lookups to Set semantics and scoped selected bulk actions to currently visible filtered items.
- Memoized alternate move-folder options instead of recomputing them per rendered card.

## Root Cause
TeamMedia appended server-paged items into a growing `folder.items` array, then derived filtered items, selected items, and rendered cards from the full loaded array. Selection checks used `selectedIds.includes(...)` during render-derived paths, so work scaled with both loaded item count and selected count.

## Prevention / Learning
For paged client-rendered collections, keep a bounded visible render window independent of loaded/cache size and use Set membership for selected/active ID checks in render-derived paths.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/TeamMedia.test.tsx --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Low. The focused tests now cover large loaded albums, filter window resets, visible-only bulk delete scope, helper window flags, and Set-based selected lookup behavior.