### PR TITLE
Batch messages inbox preview updates

### DIFF
--- a/apps/app/src/pages/Messages.previewBatch.test.tsx
+++ b/apps/app/src/pages/Messages.previewBatch.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Messages } from './Messages';
+import type { ChatInboxPreviewUpdate, ChatTeam } from '../lib/chatService';
+import type { AuthState } from '../lib/types';
+import type { ReactNode } from 'react';
+
+const chatServiceMocks = vi.hoisted(() => ({
+  getChatInboxPreview: vi.fn((message: any) => message ? `${message.senderName}: ${message.text}` : 'No messages yet'),
+  loadChatInbox: vi.fn()
+}));
+
+vi.mock('../lib/chatService', () => chatServiceMocks);
+vi.mock('../lib/useShellLayout', () => ({
+  useShellLayout: () => ({ isDesktopWeb: false })
+}));
+vi.mock('../lib/useRefreshOnResume', () => ({
+  useRefreshOnResume: vi.fn()
+}));
+vi.mock('../lib/uxTiming', () => ({
+  startScreenMountTimer: vi.fn(() => ({ end: vi.fn() }))
+}));
+vi.mock('../lib/parentWorkflowTiming', () => ({
+  completeParentCoreWorkflowTimer: vi.fn()
+}));
+vi.mock('../components/PageSkeletons', () => ({
+  MessagesPageSkeleton: () => <div>Loading messages inbox</div>
+}));
+vi.mock('../components/PullToRefresh', () => ({
+  PullToRefresh: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}));
+vi.mock('./messages/components/ChatWindow', () => ({
+  ChatWindow: () => <div>Chat window</div>,
+  TeamAvatar: ({ team }: { team: ChatTeam }) => <div aria-hidden="true">{team.name.slice(0, 1)}</div>,
+  MessageAvatar: () => null,
+  StatusBanner: () => null,
+  buildChatViewportSignature: vi.fn(),
+  isSelectedConversation: vi.fn(),
+  mergeVisibleChatMessages: vi.fn(),
+  normalizeConversationId: vi.fn()
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'user-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent',
+    roles: ['parent']
+  },
+  profile: {},
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: async () => null,
+  signOut: async () => {}
+};
+
+function team(overrides: Partial<ChatTeam> = {}): ChatTeam {
+  return {
+    id: overrides.id || 'team-1',
+    name: overrides.name || 'Bears',
+    sport: overrides.sport || 'Basketball',
+    photoUrl: overrides.photoUrl || null,
+    active: overrides.active ?? true,
+    role: overrides.role || 'Admin',
+    canModerate: overrides.canModerate ?? true,
+    unreadCount: overrides.unreadCount ?? 0,
+    lastMessage: overrides.lastMessage ?? null,
+    preferredConversationId: overrides.preferredConversationId ?? null,
+    isMuted: overrides.isMuted ?? false
+  };
+}
+
+function preview(teamId: string, text: string, createdAt: string): ChatInboxPreviewUpdate {
+  return {
+    teamId,
+    lastMessage: {
+      id: `${teamId}-${text}`,
+      text,
+      senderId: 'coach-1',
+      senderName: 'Coach Jamie',
+      senderEmail: 'coach@example.com',
+      createdAt: new Date(createdAt),
+      reactions: {},
+      deleted: false
+    },
+    preferredConversationId: null,
+    isMuted: false
+  };
+}
+
+function renderMessages() {
+  return render(
+    <MemoryRouter initialEntries={['/messages']}>
+      <Messages auth={auth} />
+    </MemoryRouter>
+  );
+}
+
+describe('Messages deferred inbox preview batching', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    chatServiceMocks.loadChatInbox.mockReset();
+    chatServiceMocks.getChatInboxPreview.mockClear();
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 16);
+    window.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders placeholder inbox rows, then hydrates a burst of deferred previews through the batch flush', async () => {
+    chatServiceMocks.loadChatInbox.mockImplementation(async (_user, options) => {
+      window.setTimeout(() => {
+        options.onPreview(preview('team-1', 'Practice packet is posted.', '2026-06-15T04:00:00Z'));
+        options.onPreview(preview('team-2', 'Tournament schedule changed.', '2026-06-15T03:00:00Z'));
+        options.onPreview(preview('team-3', 'Lineup card is ready.', '2026-06-15T02:00:00Z'));
+      }, 0);
+      return {
+        teams: [
+          team({ id: 'team-1', name: 'Bears' }),
+          team({ id: 'team-2', name: 'Thunder', role: 'Parent', canModerate: false }),
+          team({ id: 'team-3', name: 'Falcons', role: 'Coach' })
+        ]
+      };
+    });
+
+    renderMessages();
+
+    expect(await screen.findByRole('link', { name: /Bears/ })).toHaveTextContent('No messages yet');
+    expect(screen.getByRole('button', { name: 'Refresh messages' })).toBeEnabled();
+    expect(screen.getByPlaceholderText('Search team chats')).toBeEnabled();
+
+    await waitFor(() => expect(screen.getByRole('link', { name: /Bears/ })).toHaveTextContent('Coach Jamie: Practice packet is posted.'));
+    expect(screen.getByRole('link', { name: /Thunder/ })).toHaveTextContent('Coach Jamie: Tournament schedule changed.');
+    expect(screen.getByRole('link', { name: /Falcons/ })).toHaveTextContent('Coach Jamie: Lineup card is ready.');
+  });
+
+  it('does not apply stale buffered previews after a newer inbox refresh supersedes the request', async () => {
+    chatServiceMocks.loadChatInbox
+      .mockImplementationOnce(async (_user, options) => {
+        window.setTimeout(() => {
+          options.onPreview(preview('team-1', 'Stale older request preview.', '2026-06-15T05:00:00Z'));
+        }, 25);
+        return { teams: [team({ id: 'team-1', name: 'Bears' })] };
+      })
+      .mockImplementationOnce(async (_user, options) => {
+        window.setTimeout(() => {
+          options.onPreview(preview('team-1', 'Current request preview.', '2026-06-15T04:00:00Z'));
+        }, 0);
+        return { teams: [team({ id: 'team-1', name: 'Bears' })] };
+      });
+
+    renderMessages();
+
+    expect(await screen.findByRole('link', { name: /Bears/ })).toHaveTextContent('No messages yet');
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh messages' }));
+
+    await waitFor(() => expect(screen.getByRole('link', { name: /Bears/ })).toHaveTextContent('Coach Jamie: Current request preview.'));
+    await new Promise((resolve) => window.setTimeout(resolve, 60));
+
+    expect(screen.getByRole('link', { name: /Bears/ })).toHaveTextContent('Coach Jamie: Current request preview.');
+    expect(screen.getByRole('link', { name: /Bears/ })).not.toHaveTextContent('Stale older request preview.');
+  });
+});

--- a/apps/app/src/pages/Messages.test.ts
+++ b/apps/app/src/pages/Messages.test.ts
@@ -29,10 +29,10 @@ function buildTeam(overrides: Partial<ChatTeam> = {}): ChatTeam {
 }
 
 describe('mergeInboxTeams', () => {
-  it('applies deferred previews collected during the active inbox load', () => {
-    const previewUpdate: ChatInboxPreviewUpdate = {
-      teamId: 'team-1',
-      lastMessage: {
+  function previewUpdate(overrides: Partial<ChatInboxPreviewUpdate> = {}): ChatInboxPreviewUpdate {
+    return {
+      teamId: overrides.teamId || 'team-1',
+      lastMessage: overrides.lastMessage ?? {
         id: 'msg-1',
         text: 'Practice packet is posted.',
         senderId: 'coach-1',
@@ -42,14 +42,79 @@ describe('mergeInboxTeams', () => {
         reactions: {},
         deleted: false,
       },
-      preferredConversationId: null,
-      isMuted: true,
+      preferredConversationId: overrides.preferredConversationId ?? null,
+      isMuted: overrides.isMuted ?? false,
     };
+  }
 
-    const merged = mergeInboxTeams([buildTeam()], new Map([[previewUpdate.teamId, previewUpdate]]));
+  it('applies deferred previews collected during the active inbox load', () => {
+    const update = previewUpdate({ isMuted: true });
+
+    const merged = mergeInboxTeams([buildTeam()], new Map([[update.teamId, update]]));
 
     expect(merged[0].lastMessage?.text).toBe('Practice packet is posted.');
     expect(merged[0].isMuted).toBe(true);
+  });
+
+  it('coalesces batched deferred previews, keeps the latest update per team, and sorts once by preview recency', () => {
+    const olderUpdate = previewUpdate({
+      teamId: 'team-1',
+      lastMessage: {
+        id: 'older',
+        text: 'Older Bears update.',
+        senderId: 'coach-1',
+        senderName: 'Coach Jamie',
+        senderEmail: 'coach@example.com',
+        createdAt: new Date('2026-06-15T01:00:00Z'),
+        reactions: {},
+        deleted: false,
+      },
+      preferredConversationId: 'staff-room',
+      isMuted: true,
+    });
+    const latestUpdate = previewUpdate({
+      teamId: 'team-1',
+      lastMessage: {
+        id: 'latest',
+        text: 'Latest Bears update wins.',
+        senderId: 'coach-1',
+        senderName: 'Coach Jamie',
+        senderEmail: 'coach@example.com',
+        createdAt: new Date('2026-06-15T04:00:00Z'),
+        reactions: {},
+        deleted: false,
+      },
+      preferredConversationId: null,
+      isMuted: false,
+    });
+    const thunderUpdate = previewUpdate({
+      teamId: 'team-2',
+      lastMessage: {
+        id: 'thunder',
+        text: 'Thunder checks in.',
+        senderId: 'coach-2',
+        senderName: 'Coach Morgan',
+        senderEmail: 'morgan@example.com',
+        createdAt: new Date('2026-06-15T03:00:00Z'),
+        reactions: {},
+        deleted: false,
+      },
+    });
+    const batchedUpdates = new Map<string, ChatInboxPreviewUpdate>();
+    batchedUpdates.set(olderUpdate.teamId, olderUpdate);
+    batchedUpdates.set(thunderUpdate.teamId, thunderUpdate);
+    batchedUpdates.set(latestUpdate.teamId, latestUpdate);
+
+    const merged = mergeInboxTeams([
+      buildTeam({ id: 'team-2', name: 'Thunder' }),
+      buildTeam({ id: 'team-1', name: 'Bears' }),
+    ], batchedUpdates);
+
+    expect(merged.map((team) => team.id)).toEqual(['team-1', 'team-2']);
+    expect(merged[0].lastMessage?.text).toBe('Latest Bears update wins.');
+    expect(merged[0].preferredConversationId).toBeNull();
+    expect(merged[0].isMuted).toBe(false);
+    expect(merged[1].lastMessage?.text).toBe('Thunder checks in.');
   });
 
   it('resets teams back to placeholder previews when a new inbox load has no deferred preview yet', () => {
@@ -138,7 +203,10 @@ describe('direct thread mount telemetry', () => {
     expect(source).toContain('const result = await loadChatInbox(auth.user, {');
     expect(source).toContain('includeLastMessages: false,');
     expect(source).toContain('onPreview: (previewUpdate) => {');
-    expect(source).toContain('setTeams((current) => mergeInboxPreview(current, previewUpdate));');
+    expect(source).toContain('pendingPreviewUpdates.set(previewUpdate.teamId, previewUpdate);');
+    expect(source).toContain('schedulePreviewFlush();');
+    expect(source).toContain('setTeams((current) => mergeInboxTeams(current, updates));');
+    expect(source).not.toContain('mergeInboxPreview');
   });
 
   it('keeps Messages email composer dispatches on the shared action creators', () => {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -56,6 +56,36 @@ export function Messages({ auth }: { auth: AuthState }) {
     if (!auth.user) return;
     const requestId = inboxRequestIdRef.current + 1;
     const previewUpdates = new Map<string, ChatInboxPreviewUpdate>();
+    const pendingPreviewUpdates = new Map<string, ChatInboxPreviewUpdate>();
+    let cancelScheduledPreviewFlush: (() => void) | null = null;
+    const flushPreviewUpdates = () => {
+      cancelScheduledPreviewFlush = null;
+      if (pendingPreviewUpdates.size === 0) return;
+      if (inboxRequestIdRef.current !== requestId) {
+        pendingPreviewUpdates.clear();
+        return;
+      }
+      const updates = new Map(pendingPreviewUpdates);
+      pendingPreviewUpdates.clear();
+      setTeams((current) => mergeInboxTeams(current, updates));
+    };
+    const schedulePreviewFlush = () => {
+      if (cancelScheduledPreviewFlush) return;
+      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+        const frameId = window.requestAnimationFrame(flushPreviewUpdates);
+        cancelScheduledPreviewFlush = () => window.cancelAnimationFrame(frameId);
+        return;
+      }
+      const timeoutId = globalThis.setTimeout(flushPreviewUpdates, 16);
+      cancelScheduledPreviewFlush = () => globalThis.clearTimeout(timeoutId);
+    };
+    const cancelPreviewFlush = () => {
+      if (cancelScheduledPreviewFlush) {
+        cancelScheduledPreviewFlush();
+        cancelScheduledPreviewFlush = null;
+      }
+      pendingPreviewUpdates.clear();
+    };
     const timer = startScreenMountTimer('messages', {
       mode: 'inbox',
       hasTeamRoute: Boolean(teamId)
@@ -69,10 +99,15 @@ export function Messages({ auth }: { auth: AuthState }) {
         onPreview: (previewUpdate) => {
           if (inboxRequestIdRef.current !== requestId) return;
           previewUpdates.set(previewUpdate.teamId, previewUpdate);
-          setTeams((current) => mergeInboxPreview(current, previewUpdate));
+          pendingPreviewUpdates.set(previewUpdate.teamId, previewUpdate);
+          schedulePreviewFlush();
         }
       });
-      if (inboxRequestIdRef.current !== requestId) return;
+      if (inboxRequestIdRef.current !== requestId) {
+        cancelPreviewFlush();
+        return;
+      }
+      cancelPreviewFlush();
       setTeams(mergeInboxTeams(result.teams, previewUpdates));
       const totalUnread = result.teams.reduce((sum, team) => sum + team.unreadCount, 0);
       completeParentCoreWorkflowTimer('messages', {
@@ -90,7 +125,11 @@ export function Messages({ auth }: { auth: AuthState }) {
         deferredPreviewUpdateCount: previewUpdates.size
       });
     } catch (loadError: any) {
-      if (inboxRequestIdRef.current !== requestId) return;
+      if (inboxRequestIdRef.current !== requestId) {
+        cancelPreviewFlush();
+        return;
+      }
+      cancelPreviewFlush();
       const message = loadError?.message || 'Unable to load messages.';
       setError(message);
       setTeams([]);
@@ -104,6 +143,8 @@ export function Messages({ auth }: { auth: AuthState }) {
     } finally {
       if (inboxRequestIdRef.current === requestId) {
         setLoading(false);
+      } else {
+        cancelPreviewFlush();
       }
     }
   }, [auth.user, teamId]);
@@ -456,25 +497,6 @@ export function mergeInboxTeams(nextTeams: ChatTeam[], previewUpdates: Map<strin
       isMuted: previewUpdate.isMuted
     };
   }));
-}
-
-function mergeInboxPreview(
-  teams: ChatTeam[],
-  previewUpdate: { teamId: string; lastMessage: ChatMessage | null; preferredConversationId: string | null; isMuted: boolean; }
-) {
-  let changed = false;
-  const nextTeams = teams.map((team) => {
-    if (team.id !== previewUpdate.teamId) return team;
-    changed = true;
-    return {
-      ...team,
-      lastMessage: previewUpdate.lastMessage,
-      preferredConversationId: previewUpdate.preferredConversationId,
-      isMuted: previewUpdate.isMuted
-    };
-  });
-  if (!changed) return teams;
-  return sortInboxTeams(nextTeams);
 }
 
 function updateInboxTeamMuteState(

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -228,18 +228,35 @@ async function mockMessagesModules(page, options = {}) {
                             canModerate: false,
                             unreadCount: 0,
                             lastMessage: options.includeLastMessages === false ? null : msg({ id: 'last-2', text: 'Tournament schedule changed.', senderName: 'Morgan' })
+                        },
+                        {
+                            id: 'team-3',
+                            name: 'Falcons',
+                            sport: 'Baseball',
+                            role: 'Coach',
+                            canModerate: true,
+                            unreadCount: 1,
+                            lastMessage: options.includeLastMessages === false ? null : msg({ id: 'last-3', text: 'Lineup card is ready.', senderName: 'Coach Lee' })
                         }
                     ];
                     if (options.includeLastMessages === false && options.onPreview) {
                         setTimeout(() => options.onPreview({
                             teamId: 'team-1',
                             lastMessage: msg({ id: 'last-1', text: 'Practice packet is posted.' }),
-                            preferredConversationId: null
+                            preferredConversationId: null,
+                            isMuted: false
                         }), ${options.previewDelayMs || 0});
                         setTimeout(() => options.onPreview({
                             teamId: 'team-2',
                             lastMessage: msg({ id: 'last-2', text: 'Tournament schedule changed.', senderName: 'Morgan' }),
-                            preferredConversationId: null
+                            preferredConversationId: null,
+                            isMuted: false
+                        }), ${options.previewDelayMs || 0});
+                        setTimeout(() => options.onPreview({
+                            teamId: 'team-3',
+                            lastMessage: msg({ id: 'last-3', text: 'Lineup card is ready.', senderName: 'Coach Lee' }),
+                            preferredConversationId: null,
+                            isMuted: true
                         }), ${options.previewDelayMs || 0});
                     }
                     return { teams };
@@ -606,7 +623,11 @@ test('messages inbox stays interactive while previews hydrate on inbox and deskt
     await expect(bearsInboxRow).toBeVisible();
     await expect(bearsInboxRow).toContainText('No messages yet');
     await expect(page.getByRole('button', { name: 'Refresh messages' })).toBeVisible();
+    await page.getByPlaceholder('Search team chats').fill('Falcons');
+    await expect(page.getByRole('link', { name: /Falcons/ }).first()).toBeVisible();
+    await page.getByPlaceholder('Search team chats').fill('');
     await expect(bearsInboxRow).toContainText('Coach Jamie: Practice packet is posted.', { timeout: 5000 });
+    await expect(page.getByRole('link', { name: /Falcons/ }).first()).toContainText('Coach Lee: Lineup card is ready.');
 
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto(appUrl(baseURL, '/messages/team-1'), { waitUntil: 'domcontentloaded' });
@@ -616,6 +637,7 @@ test('messages inbox stays interactive while previews hydrate on inbox and deskt
     await expect(page.locator('.messages-chat-pane')).toContainText('Bring both jerseys.');
     await expect(page.locator('.messages-list-pane')).toContainText('No messages yet');
     await expect(page.locator('.messages-list-pane')).toContainText('Coach Jamie: Practice packet is posted.', { timeout: 5000 });
+    await expect(page.locator('.messages-list-pane')).toContainText('Coach Lee: Lineup card is ready.');
 });
 
 test('messages selected-member, dictation, and validation flows stay usable on mobile', async ({ page, baseURL }) => {


### PR DESCRIPTION
Closes #3540

## What changed
- Buffered deferred Messages inbox preview callbacks in `refreshInbox` by `teamId` and flush them at most once per animation frame.
- Reused the existing active request guard so superseded inbox loads do not apply stale buffered previews.
- Extended unit, component, and smoke coverage for coalesced preview hydration, sort preservation, and stale request suppression.

## Root Cause
`Messages.refreshInbox` received deferred `ChatInboxPreviewUpdate` callbacks one team at a time and immediately called `setTeams((current) => mergeInboxPreview(current, previewUpdate))`. Each preview callback mapped and sorted the full inbox list, so large inboxes could trigger N full merge/sort/render passes during hydration.

## Prevention / Learning
For deferred fan-out hydration in React lists, buffer callback results by stable entity id and flush frame-sized batches behind the active request guard. Later updates for the same entity should win before React state is touched.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/Messages.test.ts src/pages/Messages.previewBatch.test.tsx --reporter=verbose`
- `cd apps/app && npx tsc --noEmit`
- `SMOKE_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/smoke/app-messages.spec.js --config=playwright.smoke.config.js --reporter=line`