### PR TITLE
Show created family share links immediately

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ParentTools, type ParentToolId } from './ParentTools';
 import type { AuthState } from '../lib/types';
-import { openPublicUrl } from '../lib/publicActions';
+import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
     buildParentScheduleIcs: vi.fn(),
@@ -226,6 +226,7 @@ describe('ParentTools access', () => {
     afterEach(() => {
         delete globalThis.__ALLPLAYS_PARENT_TOOLS_RENDER_TRACKER__;
         delete globalThis.__ALLPLAYS_PARENT_TOOLS_PANEL_LOAD_TRACKER__;
+        Reflect.deleteProperty(navigator, 'clipboard');
         cleanup();
     });
 
@@ -658,6 +659,61 @@ describe('ParentTools access', () => {
         expect(screen.getByText('Grandma')).toBeTruthy();
         expect(screen.getByText('https://allplays.ai/family.html?token=token-1')).toBeTruthy();
         expect(screen.getByRole('button', { name: 'Copy' })).toBeTruthy();
+    });
+
+    it('shows a created family link when clipboard copy and refresh recovery miss it', async () => {
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: {
+                writeText: vi.fn().mockRejectedValue(new Error('Clipboard unavailable.'))
+            }
+        });
+        parentToolsServiceMocks.loadFamilyShareModel.mockResolvedValue({
+            children: [
+                {
+                    teamId: 'team-1',
+                    playerId: 'player-1',
+                    playerName: 'Sam Player'
+                }
+            ],
+            tokens: [
+                {
+                    id: 'token-1',
+                    label: 'Grandma',
+                    url: 'https://allplays.ai/family.html?token=token-1',
+                    childCount: 1,
+                    extraCalendarUrls: []
+                }
+            ]
+        });
+        parentToolsServiceMocks.createParentFamilyShare.mockResolvedValue({
+            tokenId: 'token-2',
+            url: 'https://allplays.ai/family.html?token=token-2'
+        });
+
+        renderParentTools(['/parent-tools/share'], false, linkedAuth);
+
+        expect(await screen.findByText('Grandma')).toBeTruthy();
+        fireEvent.change(screen.getByPlaceholderText('Label, like Grandma or babysitter'), { target: { value: 'Aunt Chris' } });
+        fireEvent.change(screen.getByPlaceholderText('Optional external calendar feed URLs, one per line'), { target: { value: 'https://calendar.example.test/feed.ics' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create share link' }));
+
+        expect(await screen.findByText('https://allplays.ai/family.html?token=token-2')).toBeTruthy();
+        expect(screen.getByText('Copy is not available in this browser.')).toBeTruthy();
+        expect(parentToolsServiceMocks.createParentFamilyShare).toHaveBeenCalledWith(linkedAuth.user, 'Aunt Chris', ['https://calendar.example.test/feed.ics']);
+        expect(parentToolsServiceMocks.loadFamilyShareModel).toHaveBeenCalledTimes(2);
+        expect(screen.getByText('Aunt Chris')).toBeTruthy();
+        expect((screen.getByPlaceholderText('Label, like Grandma or babysitter') as HTMLInputElement).value).toBe('');
+        expect((screen.getByPlaceholderText('Optional external calendar feed URLs, one per line') as HTMLTextAreaElement).value).toBe('');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Share newly created family link' }));
+        await waitFor(() => {
+            expect(sharePublicUrl).toHaveBeenCalledWith({
+                title: 'ALL PLAYS family page',
+                text: 'Aunt Chris',
+                url: 'https://allplays.ai/family.html?token=token-2'
+            });
+        });
     });
 
     it('opens reusable team fee checkout links when legacy fee payloads omit paymentAction', async () => {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -716,6 +716,59 @@ describe('ParentTools access', () => {
         });
     });
 
+    it('clears the created family link panel after revoking that token', async () => {
+        const children = [
+            {
+                teamId: 'team-1',
+                playerId: 'player-1',
+                playerName: 'Sam Player'
+            }
+        ];
+        const createdToken = {
+            id: 'token-2',
+            label: 'Aunt Chris',
+            url: 'https://allplays.ai/family.html?token=token-2',
+            childCount: 1,
+            extraCalendarUrls: []
+        };
+        parentToolsServiceMocks.loadFamilyShareModel
+            .mockResolvedValueOnce({
+                children,
+                tokens: []
+            })
+            .mockResolvedValueOnce({
+                children,
+                tokens: [createdToken]
+            })
+            .mockResolvedValueOnce({
+                children,
+                tokens: []
+            });
+        parentToolsServiceMocks.createParentFamilyShare.mockResolvedValue({
+            tokenId: 'token-2',
+            url: createdToken.url
+        });
+        parentToolsServiceMocks.revokeParentFamilyShare.mockResolvedValue(undefined);
+
+        renderParentTools(['/parent-tools/share'], false, linkedAuth);
+
+        await screen.findByText('No family links');
+        fireEvent.change(screen.getByPlaceholderText('Label, like Grandma or babysitter'), { target: { value: 'Aunt Chris' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create share link' }));
+
+        expect(await screen.findByText('New family link')).toBeTruthy();
+        expect(await screen.findByRole('button', { name: 'Revoke' })).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Revoke link' }));
+
+        await waitFor(() => {
+            expect(parentToolsServiceMocks.revokeParentFamilyShare).toHaveBeenCalledWith('token-2');
+            expect(screen.queryByText('New family link')).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Copy newly created family link' })).toBeNull();
+            expect(screen.queryByRole('button', { name: 'Share newly created family link' })).toBeNull();
+        });
+    });
+
     it('opens reusable team fee checkout links when legacy fee payloads omit paymentAction', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -769,6 +769,64 @@ describe('ParentTools access', () => {
         });
     });
 
+    it('clears the created family link panel when the signed-in parent changes', async () => {
+        const children = [
+            {
+                teamId: 'team-1',
+                playerId: 'player-1',
+                playerName: 'Sam Player'
+            }
+        ];
+        const otherLinkedAuth: AuthState = {
+            ...linkedAuth,
+            user: linkedAuth.user ? {
+                ...linkedAuth.user,
+                uid: 'parent-2',
+                email: 'other-parent@example.com'
+            } : null
+        };
+        parentToolsServiceMocks.loadFamilyShareModel.mockImplementation(async (user) => ({
+            children,
+            tokens: user?.uid === 'parent-2' ? [
+                {
+                    id: 'token-9',
+                    label: 'Other family',
+                    url: 'https://allplays.ai/family.html?token=token-9',
+                    childCount: 1,
+                    extraCalendarUrls: []
+                }
+            ] : []
+        }));
+        parentToolsServiceMocks.createParentFamilyShare.mockResolvedValue({
+            tokenId: 'token-2',
+            url: 'https://allplays.ai/family.html?token=token-2'
+        });
+
+        const view = renderParentTools(['/parent-tools/share'], false, linkedAuth);
+
+        await screen.findByText('No family links');
+        fireEvent.change(screen.getByPlaceholderText('Label, like Grandma or babysitter'), { target: { value: 'Aunt Chris' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Create share link' }));
+
+        expect(await screen.findByText('https://allplays.ai/family.html?token=token-2')).toBeTruthy();
+
+        view.rerender(
+            <MemoryRouter initialEntries={['/parent-tools/share']}>
+                <Routes>
+                    <Route path="/parent-tools/:toolId" element={<ParentToolsRoute authState={otherLinkedAuth} />} />
+                </Routes>
+            </MemoryRouter>
+        );
+
+        await waitFor(() => {
+            expect(parentToolsServiceMocks.loadFamilyShareModel).toHaveBeenCalledWith(otherLinkedAuth.user);
+            expect(screen.queryByText('https://allplays.ai/family.html?token=token-2')).toBeNull();
+            expect(screen.queryByText('New family link')).toBeNull();
+        });
+        expect(await screen.findByText('Other family')).toBeTruthy();
+        expect(screen.getByText('https://allplays.ai/family.html?token=token-9')).toBeTruthy();
+    });
+
     it('opens reusable team fee checkout links when legacy fee payloads omit paymentAction', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -9,6 +9,7 @@ type CreatedFamilyShareLink = {
     tokenId: string;
     url: string;
     label: string;
+    ownerUid: string;
 };
 
 export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
@@ -30,6 +31,8 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     const saving = saveOperation.loading;
     const loadError = loadOperation.error;
     const saveError = saveOperation.error;
+    const activeUserUid = auth.user?.uid || '';
+    const visibleCreatedLink = createdLink?.ownerUid === activeUserUid ? createdLink : null;
 
     const refresh = useCallback(async () => {
         clearLoadError();
@@ -50,6 +53,10 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
         void refresh();
     }, [auth.user?.uid, refresh, refreshVersion]);
 
+    useEffect(() => {
+        setCreatedLink(null);
+    }, [auth.user?.uid]);
+
     const create = async (event: FormEvent) => {
         event.preventDefault();
         clearSaveError();
@@ -63,7 +70,8 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                     setCreatedLink({
                         tokenId: result.tokenId,
                         url: result.url,
-                        label: createdLabel
+                        label: createdLabel,
+                        ownerUid: activeUserUid
                     });
                     setMessage('Family link created.');
                     setLabel('');
@@ -130,17 +138,17 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                         Create share link
                     </button>
                 </form>
-                {createdLink ? (
+                {visibleCreatedLink ? (
                     <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3">
                         <div className="text-xs font-black uppercase text-emerald-800">New family link</div>
-                        <div className="mt-1 text-sm font-black text-gray-950">{createdLink.label}</div>
-                        <div className="mt-2 break-all rounded-xl border border-emerald-200 bg-white p-3 text-xs font-semibold text-gray-700">{createdLink.url}</div>
+                        <div className="mt-1 text-sm font-black text-gray-950">{visibleCreatedLink.label}</div>
+                        <div className="mt-2 break-all rounded-xl border border-emerald-200 bg-white p-3 text-xs font-semibold text-gray-700">{visibleCreatedLink.url}</div>
                         <div className="mt-3 grid grid-cols-2 gap-2">
-                            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" aria-label="Copy newly created family link" onClick={() => copyText(createdLink.url, setMessage)}>
+                            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" aria-label="Copy newly created family link" onClick={() => copyText(visibleCreatedLink.url, setMessage)}>
                                 <Copy className="h-4 w-4" aria-hidden="true" />
                                 Copy
                             </button>
-                            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" aria-label="Share newly created family link" onClick={() => sharePublicUrl({ title: 'ALL PLAYS family page', text: createdLink.label || 'Family schedule', url: createdLink.url })}>
+                            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" aria-label="Share newly created family link" onClick={() => sharePublicUrl({ title: 'ALL PLAYS family page', text: visibleCreatedLink.label || 'Family schedule', url: visibleCreatedLink.url })}>
                                 <Share2 className="h-4 w-4" aria-hidden="true" />
                                 Share
                             </button>

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -5,6 +5,12 @@ import { sharePublicUrl } from '../../lib/publicActions';
 import type { AuthState } from '../../lib/types';
 import { EmptyState, LoadingBlock, RetryableStatus, Status, ToolHeader, copyText, splitLines, useParentToolAsyncOperation } from './shared';
 
+type CreatedFamilyShareLink = {
+    tokenId: string;
+    url: string;
+    label: string;
+};
+
 export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
     const [tokens, setTokens] = useState<FamilyShareTokenCard[]>([]);
     const [children, setChildren] = useState<any[]>([]);
@@ -12,6 +18,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
     const [calendarText, setCalendarText] = useState('');
     const [editingTokenId, setEditingTokenId] = useState('');
     const [pendingRevokeToken, setPendingRevokeToken] = useState<FamilyShareTokenCard | null>(null);
+    const [createdLink, setCreatedLink] = useState<CreatedFamilyShareLink | null>(null);
     const [message, setMessage] = useState('');
     const loadOperation = useParentToolAsyncOperation();
     const saveOperation = useParentToolAsyncOperation();
@@ -47,11 +54,17 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
         event.preventDefault();
         clearSaveError();
         setMessage('');
+        const createdLabel = label || 'Family share';
         await runSave(
-            () => createParentFamilyShare(auth.user, label || 'Family share', splitLines(calendarText)),
+            () => createParentFamilyShare(auth.user, createdLabel, splitLines(calendarText)),
             'Unable to create family share link.',
             {
                 onSuccess: async (result) => {
+                    setCreatedLink({
+                        tokenId: result.tokenId,
+                        url: result.url,
+                        label: createdLabel
+                    });
                     setMessage('Family link created.');
                     setLabel('');
                     setCalendarText('');
@@ -116,6 +129,23 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                         Create share link
                     </button>
                 </form>
+                {createdLink ? (
+                    <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3">
+                        <div className="text-xs font-black uppercase text-emerald-800">New family link</div>
+                        <div className="mt-1 text-sm font-black text-gray-950">{createdLink.label}</div>
+                        <div className="mt-2 break-all rounded-xl border border-emerald-200 bg-white p-3 text-xs font-semibold text-gray-700">{createdLink.url}</div>
+                        <div className="mt-3 grid grid-cols-2 gap-2">
+                            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" aria-label="Copy newly created family link" onClick={() => copyText(createdLink.url, setMessage)}>
+                                <Copy className="h-4 w-4" aria-hidden="true" />
+                                Copy
+                            </button>
+                            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" aria-label="Share newly created family link" onClick={() => sharePublicUrl({ title: 'ALL PLAYS family page', text: createdLink.label || 'Family schedule', url: createdLink.url })}>
+                                <Share2 className="h-4 w-4" aria-hidden="true" />
+                                Share
+                            </button>
+                        </div>
+                    </div>
+                ) : null}
             </section>
 
             {!loadError && (loading ? <LoadingBlock label="Loading share links" /> : (

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -83,6 +83,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
             'Unable to revoke family share link.',
             {
                 onSuccess: async () => {
+                    setCreatedLink((current) => current?.tokenId === tokenId ? null : current);
                     setMessage('Family link revoked.');
                     await refresh();
                 },

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -187,6 +187,7 @@ async function mockParentToolsModules(page) {
         window.__playerLoads = [];
         window.__downloads = [];
         window.__familyCreates = [];
+        window.__clipboardShouldFail = false;
         window.__mediaUploads = [];
         window.__mediaLinks = [];
         window.__mediaDeletes = [];
@@ -194,6 +195,7 @@ async function mockParentToolsModules(page) {
             configurable: true,
             value: {
                 writeText: async (value) => {
+                    if (window.__clipboardShouldFail) throw new Error('Clipboard unavailable.');
                     window.__copiedText = String(value);
                 }
             }
@@ -518,8 +520,15 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await page.getByRole('button', { name: 'Share' }).first().click();
     await expect(page.getByText('Family share')).toBeVisible();
     await page.getByPlaceholder(/Label/).fill('Grandpa');
+    await page.evaluate(() => {
+        window.__clipboardShouldFail = true;
+    });
     await page.getByRole('button', { name: /Create share link/ }).click();
     await expect.poll(() => page.evaluate(() => window.__familyCreates.at(-1))).toEqual({ label: 'Grandpa', urls: [] });
+    await expect(page.getByText('https://allplays.ai/family.html?token=token-2')).toBeVisible();
+    await page.getByRole('button', { name: 'Share newly created family link' }).click();
+    await expect.poll(() => page.evaluate(() => window.__sharedUrls.at(-1)?.url)).toBe('https://allplays.ai/family.html?token=token-2');
+    await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 
     await page.getByRole('button', { name: 'Register' }).click();
     await expect(page.getByText('Summer Camp')).toBeVisible();


### PR DESCRIPTION
Closes #3534

## What changed
- Added a post-create success panel in Parent Tools > Share that stores and renders the returned family share URL immediately.
- Added Copy and Share actions for the newly created link independent of the refreshed token list.
- Kept the existing refresh path so loaded token cards continue to behave unchanged.

## Root Cause
FamilyShareTool discarded the createParentFamilyShare return value after attempting clipboard copy, so mobile parents depended on clipboard success or an eventually consistent refreshed token list to recover the new URL.

## Prevention / Learning
After create actions that return a user-actionable URL or recovery credential, persist and render the returned value immediately before optional clipboard/share/reload side effects.

## Regression Tests
- `npx vitest run src/pages/ParentTools.test.tsx --reporter=verbose`
- `SMOKE_APP_BASE_URL=http://localhost:5174 npx playwright test tests/smoke/app-parent-tools.spec.js --config=playwright.smoke.config.js --reporter=line`
- `npm run app:build`