### PR TITLE
Bound native schedule fallback reads

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2566,6 +2566,74 @@ describe('native parent schedule Firestore mapping', () => {
     });
   });
 
+  it('wraps native game fallback start-only filters in a composite filter', async () => {
+    const startDate = new Date('2026-06-01T00:00:00.000Z');
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ([])
+    } as any);
+
+    await loadParentSchedule({ uid: 'parent-1', email: 'parent@example.com', roles: [] } as any, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      scheduleRangeByTeam: {
+        'team-1': { startDate }
+      }
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [, requestInit] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(requestInit.body));
+    expect(body.structuredQuery.where).toEqual({
+      compositeFilter: {
+        op: 'AND',
+        filters: [
+          {
+            fieldFilter: {
+              field: { fieldPath: 'date' },
+              op: 'GREATER_THAN_OR_EQUAL',
+              value: { timestampValue: startDate.toISOString() }
+            }
+          }
+        ]
+      }
+    });
+  });
+
+  it('wraps native game fallback end-only filters in a composite filter', async () => {
+    const endDate = new Date('2026-06-30T23:59:59.000Z');
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ([])
+    } as any);
+
+    await loadParentSchedule({ uid: 'parent-1', email: 'parent@example.com', roles: [] } as any, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      scheduleRangeByTeam: {
+        'team-1': { endDate }
+      }
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [, requestInit] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(requestInit.body));
+    expect(body.structuredQuery.where).toEqual({
+      compositeFilter: {
+        op: 'AND',
+        filters: [
+          {
+            fieldFilter: {
+              field: { fieldPath: 'date' },
+              op: 'LESS_THAN_OR_EQUAL',
+              value: { timestampValue: endDate.toISOString() }
+            }
+          }
+        ]
+      }
+    });
+  });
+
   it('drops malformed Firestore schedule event records at the mapper boundary', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValue({
       ok: true,

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2486,7 +2486,8 @@ describe('native parent schedule Firestore mapping', () => {
 
     const result = await loadParentSchedule({ uid: 'parent-1', email: 'parent@example.com', roles: [] } as any, {
       hydrateDetails: false,
-      expandStaffPlayers: false
+      expandStaffPlayers: false,
+      includePastGames: true
     });
 
     expect(result.events).toHaveLength(1);
@@ -2497,6 +2498,72 @@ describe('native parent schedule Firestore mapping', () => {
       isDbGame: true
     });
     expect(fetchAndParseCalendar).toHaveBeenCalledWith('https://calendar.example.com/team-1.ics');
+  });
+
+  it('queries native game fallback by date range instead of listing the full games collection', async () => {
+    const startDate = new Date('2026-06-01T00:00:00.000Z');
+    const endDate = new Date('2026-06-30T23:59:59.000Z');
+    vi.mocked(globalThis.fetch).mockImplementation(async (input: any, init?: RequestInit) => {
+      const requestUrl = String(input);
+      expect(requestUrl).toContain('/documents/teams/team-1:runQuery');
+      expect(requestUrl).not.toContain('/documents/teams/team-1/games');
+      expect(init?.method).toBe('POST');
+      return {
+        ok: true,
+        json: async () => ([
+          {
+            document: {
+              name: 'projects/allplays-test/databases/(default)/documents/teams/team-1/games/game-in-range',
+              fields: {
+                date: { timestampValue: '2026-06-20T18:00:00.000Z' },
+                opponent: { stringValue: 'Tigers' },
+                location: { stringValue: 'Main Gym' }
+              }
+            }
+          }
+        ])
+      } as any;
+    });
+
+    const result = await loadParentSchedule({ uid: 'parent-1', email: 'parent@example.com', roles: [] } as any, {
+      hydrateDetails: false,
+      expandStaffPlayers: false,
+      scheduleRangeByTeam: {
+        'team-1': { startDate, endDate }
+      }
+    });
+
+    expect(result.events.map((event) => event.id)).toEqual(['game-in-range']);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [, requestInit] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(String(requestInit.body));
+    expect(body).toMatchObject({
+      structuredQuery: {
+        from: [{ collectionId: 'games' }],
+        where: {
+          compositeFilter: {
+            op: 'AND',
+            filters: [
+              {
+                fieldFilter: {
+                  field: { fieldPath: 'date' },
+                  op: 'GREATER_THAN_OR_EQUAL',
+                  value: { timestampValue: startDate.toISOString() }
+                }
+              },
+              {
+                fieldFilter: {
+                  field: { fieldPath: 'date' },
+                  op: 'LESS_THAN_OR_EQUAL',
+                  value: { timestampValue: endDate.toISOString() }
+                }
+              }
+            ]
+          }
+        },
+        orderBy: [{ field: { fieldPath: 'date' }, direction: 'ASCENDING' }]
+      }
+    });
   });
 
   it('drops malformed Firestore schedule event records at the mapper boundary', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -874,6 +874,51 @@ async function nativeListScheduleEventDocuments(path: string): Promise<ScheduleE
   return mapScheduleEventDocuments((payload.documents || []) as NativeFirestoreDocument[]);
 }
 
+async function nativeQueryScheduleEventDocuments(teamId: string, range: ScheduleDateRange): Promise<ScheduleEventFirestoreRecord[]> {
+  const filters = [
+    range.startDate
+      ? {
+          fieldFilter: {
+            field: { fieldPath: 'date' },
+            op: 'GREATER_THAN_OR_EQUAL',
+            value: encodeFirestoreValue(range.startDate)
+          }
+        }
+      : null,
+    range.endDate
+      ? {
+          fieldFilter: {
+            field: { fieldPath: 'date' },
+            op: 'LESS_THAN_OR_EQUAL',
+            value: encodeFirestoreValue(range.endDate)
+          }
+        }
+      : null
+  ].filter(Boolean) as Array<Record<string, unknown>>;
+  const where = filters.length === 1
+    ? filters[0]
+    : {
+        compositeFilter: {
+          op: 'AND',
+          filters
+        }
+      };
+  const payload = await nativeFirestoreRequest(`/teams/${encodeURIComponent(teamId)}:runQuery`, {
+    method: 'POST',
+    body: JSON.stringify({
+      structuredQuery: {
+        from: [{ collectionId: 'games' }],
+        where,
+        orderBy: [{ field: { fieldPath: 'date' }, direction: 'ASCENDING' }]
+      }
+    })
+  });
+
+  return Array.isArray(payload)
+    ? mapScheduleEventDocuments(payload.map((entry) => entry?.document).filter(Boolean) as NativeFirestoreDocument[])
+    : [];
+}
+
 const nativeDeleteFieldSentinel = { __deleteField: true };
 
 function escapeFirestoreFieldPathSegment(segment: string) {
@@ -2434,7 +2479,9 @@ async function loadGames(teamId: string, range: ScheduleDateRange = {}): Promise
     `games ${teamId}`,
     async () => mapScheduleEventRecords(await getGames(teamId, range)),
     async () => {
-      const docs = await nativeListScheduleEventDocuments(`teams/${encodeURIComponent(teamId)}/games`);
+      const docs = (range.startDate || range.endDate)
+        ? await nativeQueryScheduleEventDocuments(teamId, range)
+        : await nativeListScheduleEventDocuments(`teams/${encodeURIComponent(teamId)}/games`);
       const windowed = (range.startDate || range.endDate)
         ? docs.filter((doc) => isEventWithinRange(doc, range))
         : docs;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -895,14 +895,12 @@ async function nativeQueryScheduleEventDocuments(teamId: string, range: Schedule
         }
       : null
   ].filter(Boolean) as Array<Record<string, unknown>>;
-  const where = filters.length === 1
-    ? filters[0]
-    : {
-        compositeFilter: {
-          op: 'AND',
-          filters
-        }
-      };
+  const where = {
+    compositeFilter: {
+      op: 'AND',
+      filters
+    }
+  };
   const payload = await nativeFirestoreRequest(`/teams/${encodeURIComponent(teamId)}:runQuery`, {
     method: 'POST',
     body: JSON.stringify({


### PR DESCRIPTION
Closes #3544

## What changed
- Added a native Firestore REST `runQuery` helper for ranged team game reads under `teams/{teamId}`.
- `loadGames` now uses structured queries with `date` range filters and `orderBy date` when `startDate` or `endDate` is present.
- Kept unbounded full-history native fallback on the existing collection list path.

## Root Cause
The native REST fallback for `loadGames` used the full `teams/{teamId}/games` collection list endpoint and applied schedule range constraints only after the network read, unlike the primary Firestore query path.

## Prevention / Learning
When a primary Firestore path accepts query bounds, native REST fallbacks must preserve equivalent server-side constraints with `structuredQuery` / `runQuery` before client-side safety filtering.

## Regression Tests
- `npm --prefix apps/app test -- --run src/lib/scheduleService.test.ts`
- Added native fallback coverage proving ranged `loadParentSchedule` uses `teams/{teamId}:runQuery` with date filters and `orderBy date`, and does not call the full games collection list endpoint.

## Recurrence Risk
Low. The exact native fallback path now has focused regression coverage for the bounded query contract.