### PR TITLE
Paginate schedule packet rows

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -606,6 +606,29 @@ describe('Schedule', () => {
     expect(screen.queryByRole('button', { name: 'Show 1 more' })).toBeNull();
   });
 
+  it('does not show packet pagination when only non-packet past events are hidden', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        ...Array.from({ length: 5 }, (_, index) => buildPracticePacketEvent(index + 1, {
+          date: new Date(Date.UTC(2025, 5, index + 1, 18, 0, 0))
+        })),
+        ...Array.from({ length: 25 }, (_, index) => buildScheduleEvent(index + 6, {
+          date: new Date(Date.UTC(2025, 5, index + 6, 18, 0, 0))
+        }))
+      ]
+    });
+
+    renderSchedule('/schedule?filter=past-all&view=packets');
+
+    expect(await screen.findByText('Practice Packet 5')).toBeTruthy();
+    expect(screen.getByText('All visible packets are handled')).toBeTruthy();
+    expect(screen.queryByText('Showing 5 of 5 packets')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Show 10 more' })).toBeNull();
+  });
+
   it('applies schedule team and view query params on direct links', async () => {
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
       children: [

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -139,6 +139,22 @@ function buildScheduleEvent(index: number, overrides: Partial<ParentScheduleEven
   };
 }
 
+function buildPracticePacketEvent(index: number, overrides: Partial<ParentScheduleEvent> = {}): ParentScheduleEvent {
+  const date = new Date(Date.UTC(2100, 5, index, 18, 0, 0));
+  return buildScheduleEvent(index, {
+    eventKey: `team-1::practice-${index}::player-1::${date.toISOString()}::practice`,
+    id: `practice-${index}`,
+    type: 'practice',
+    isDbGame: false,
+    date,
+    opponent: null,
+    title: `Practice Packet ${index}`,
+    practiceHomePacketSummary: `${index} drills`,
+    practicePacketCompletions: [],
+    ...overrides
+  });
+}
+
 function buildStaffScheduleResult() {
   return {
     children: [
@@ -565,6 +581,29 @@ describe('Schedule', () => {
 
     expect(await screen.findByText('Showing 20 of 21 events')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Show 1 more' })).toBeTruthy();
+  });
+
+  it('paginates practice packet rows while keeping the all-packet summary count', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: Array.from({ length: 21 }, (_, index) => buildPracticePacketEvent(index + 1))
+    });
+
+    renderSchedule('/schedule?view=packets');
+
+    expect(await screen.findByText('21 practice packets need review')).toBeTruthy();
+    expect(screen.getByText('Showing 20 of 21 packets')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Show 1 more' })).toBeTruthy();
+    expect(screen.getByText('Practice Packet 20')).toBeTruthy();
+    expect(screen.queryByText('Practice Packet 21')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show 1 more' }));
+
+    expect(await screen.findByText('Practice Packet 21')).toBeTruthy();
+    expect(screen.getByText('21 practice packets need review')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Show 1 more' })).toBeNull();
   });
 
   it('applies schedule team and view query params on direct links', async () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -554,6 +554,19 @@ export function Schedule({ auth }: { auth: AuthState }) {
       setVisibleListCount((current) => current + listPageSize);
     }
   };
+  const handleShowMorePackets = async () => {
+    if (visibleListCount < packetRows.length) {
+      setVisibleListCount((current) => Math.min(current + listPageSize, packetRows.length));
+      return;
+    }
+    if (filter !== 'past-all' || !pastHistoryHasMore || loadingPastHistory) {
+      return;
+    }
+    const loaded = await loadPastSchedulePage();
+    if (loaded) {
+      setVisibleListCount((current) => current + listPageSize);
+    }
+  };
   const parentLinkedPlayerIds = useMemo(() => new Set(children.map((child) => child.playerId)), [children]);
   const teamOptions = useMemo(() => getParentScheduleTeamOptions(events, children), [children, events]);
   const packetRows = useMemo(() => getPracticePacketRows(visibleEvents), [visibleEvents]);
@@ -1490,7 +1503,14 @@ export function Schedule({ auth }: { auth: AuthState }) {
               onDayClose={() => setSelectedDay(null)}
             />
           ) : view === 'packets' ? (
-            <PracticePacketsPanel rows={packetRows} />
+            <PracticePacketsPanel
+              rows={packetRows}
+              visibleCount={visibleListCount}
+              pageSize={listPageSize}
+              canShowMore={canLoadMorePastHistory || visibleListCount < packetRows.length}
+              loadingMore={filter === 'past-all' && loadingPastHistory}
+              onShowMore={handleShowMorePackets}
+            />
           ) : view === 'compact' ? (
             <CompactScheduleList
               events={listEntries}
@@ -2692,7 +2712,14 @@ function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, load
   );
 }
 
-function PracticePacketsPanel({ rows }: { rows: PracticePacketScheduleRow[] }) {
+function PracticePacketsPanel({ rows, visibleCount, pageSize, canShowMore, loadingMore, onShowMore }: {
+  rows: PracticePacketScheduleRow[];
+  visibleCount: number;
+  pageSize: number;
+  canShowMore: boolean;
+  loadingMore: boolean;
+  onShowMore: () => void;
+}) {
   if (!rows.length) {
     return (
       <div className="app-card p-8 text-center">
@@ -2704,6 +2731,8 @@ function PracticePacketsPanel({ rows }: { rows: PracticePacketScheduleRow[] }) {
   }
 
   const readyCount = rows.filter((row) => row.needsAction).length;
+  const renderedRows = rows.slice(0, visibleCount);
+  const remainingCount = Math.max(rows.length - renderedRows.length, 0);
 
   return (
     <section className="space-y-3">
@@ -2716,7 +2745,7 @@ function PracticePacketsPanel({ rows }: { rows: PracticePacketScheduleRow[] }) {
         </div>
       </div>
       <div className="schedule-list overflow-hidden rounded-xl border border-gray-200 bg-white shadow-app sm:space-y-3 sm:overflow-visible sm:border-0 sm:bg-transparent sm:shadow-none">
-        {rows.map((row) => (
+        {renderedRows.map((row) => (
           <Link key={`${row.event.eventKey}-packet`} to={getGenericEventDetailPath(row.event)} className="block border-b border-gray-100 px-3 py-3 transition last:border-b-0 hover:bg-gray-50 sm:rounded-xl sm:border sm:border-blue-100 sm:bg-white sm:shadow-sm sm:hover:border-blue-200 sm:hover:bg-blue-50">
             <div className="flex items-center justify-between gap-3">
               <div className="min-w-0">
@@ -2738,6 +2767,16 @@ function PracticePacketsPanel({ rows }: { rows: PracticePacketScheduleRow[] }) {
           </Link>
         ))}
       </div>
+      {canShowMore ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-3 text-center shadow-sm">
+          <div className="text-xs font-bold text-gray-500">
+            Showing {renderedRows.length} of {rows.length} packets
+          </div>
+          <button type="button" className="secondary-button mt-2 min-h-9 px-3 py-2 text-xs" onClick={onShowMore} disabled={loadingMore}>
+            {loadingMore ? 'Loading more…' : `Show ${Math.min(pageSize, remainingCount || pageSize)} more`}
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -539,7 +539,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
 
   const calendarEntries = useMemo(() => getCalendarScheduleEntries(visibleEvents), [visibleEvents]);
   const listEntries = calendarEntries;
+  const packetRows = useMemo(() => getPracticePacketRows(visibleEvents), [visibleEvents]);
   const canLoadMorePastHistory = filter === 'past-all' && (pastHistoryHasMore || visibleListCount < listEntries.length);
+  const canLoadMorePacketRows = (filter === 'past-all' && pastHistoryHasMore) || visibleListCount < packetRows.length;
 
   const handleShowMore = async () => {
     if (visibleListCount < listEntries.length) {
@@ -569,7 +571,6 @@ export function Schedule({ auth }: { auth: AuthState }) {
   };
   const parentLinkedPlayerIds = useMemo(() => new Set(children.map((child) => child.playerId)), [children]);
   const teamOptions = useMemo(() => getParentScheduleTeamOptions(events, children), [children, events]);
-  const packetRows = useMemo(() => getPracticePacketRows(visibleEvents), [visibleEvents]);
   const selectedDayEntries = useMemo(() => {
     if (!selectedDay) return [];
     return calendarEntries.filter((event) =>
@@ -1507,7 +1508,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
               rows={packetRows}
               visibleCount={visibleListCount}
               pageSize={listPageSize}
-              canShowMore={canLoadMorePastHistory || visibleListCount < packetRows.length}
+              canShowMore={canLoadMorePacketRows}
               loadingMore={filter === 'past-all' && loadingPastHistory}
               onShowMore={handleShowMorePackets}
             />


### PR DESCRIPTION
Closes #3542

## What changed
- Wired the packets schedule view into the existing visible-count/page-size pagination contract.
- Updated `PracticePacketsPanel` to render only `rows.slice(0, visibleCount)` and show the same Show more footer pattern as list and compact views.
- Kept packet summary counts based on all matching packet rows.

## Root Cause
`PracticePacketsPanel` rendered `rows.map(...)` over the full packet row set and was not passed the pagination props used by the list and compact schedule views.

## Prevention / Learning
Every Schedule view that maps filtered event-derived rows should accept the shared pagination contract, slice before rendering, and keep summary counters based on the full filtered data set.

## Regression Tests
- Added Schedule coverage with 21 packet-eligible practices to verify first render is capped at 20 rows, Show more reveals the final packet, and the all-packet summary remains 21.
- Ran `cd apps/app && npx vitest run src/pages/Schedule.test.tsx --reporter=verbose`.