### PR TITLE
Skip dev-server app smoke specs in production suite

### DIFF
--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
 test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
 

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 const telemetryEndpoint = 'https://telemetry.example.test/collectTelemetry';

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 function appUrl(baseURL, hashPath) {

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
 
 test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');

--- a/tests/smoke/app-performance-timers.spec.js
+++ b/tests/smoke/app-performance-timers.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
 test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app performance timer smoke tests');
 

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 function appUrl(baseURL, hashPath) {
     const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
     const url = new URL('/', appBaseURL);

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
 test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
 

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -1,6 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { buildUrl } from './helpers/boot-path.js';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 function appUrl(baseURL, hashPath) {
     const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
     const url = new URL(buildUrl(appBaseURL, '/'));

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test';
 
+test.skip(
+    process.env.SMOKE_SUITE === 'production',
+    'Module-mocked app specs need the Vite dev server; production runs cover the deployed bundle via app-production-bootstrap.spec.js'
+);
+
 function appUrl(baseURL, hashPath) {
     const defaultBaseURL = 'http://localhost:3000/'; // A safe default for local testing
     const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL || defaultBaseURL;


### PR DESCRIPTION
## Summary
- Gate the nine module-mocked app smoke spec files (`app-auth-profile`, `app-home-player`, `app-messages`, `app-parent-tools`, `app-performance-timers`, `app-private-ai`, `app-schedule`, `app-search`, `app-teams`) behind `SMOKE_SUITE !== 'production'`.
- These specs stub app service modules by intercepting `/src/lib/*.ts` requests — URLs that only exist on the Vite dev server used by `preview-smoke`. Against `https://allplays.ai/app/` (built bundle) the mocks never engage, so the specs time out on every run. **`scheduled-prod-smoke` has not had a green run since May 23** (verified via the Actions API); the latest run failed 35 tests, 32 of them from these files.
- Production coverage of the deployed bundle is unchanged: `app-production-bootstrap.spec.js` still boots `SMOKE_APP_BOOT_URL` and asserts the app renders with no fatal errors or failed assets, and the legacy page-registry boot checks still run.

## Validation
- `SMOKE_SUITE=production` against `https://allplays.ai`: all 57 tests in the gated files now skip.
- `SMOKE_SUITE=preview` against a local Vite dev server: `app-home-player.spec.js` runs for real — 8/8 passed (gate does not affect PR preview smoke).
- Remaining legacy failures from the last scheduled run (`static-hosting-bootstrap` player details, `edit-config-access-control`, `team-fallback-regressions`) all pass when re-run against prod with the CI vars — they were transient mid-deploy flakes, not structural.
- Full production suite re-run against prod with this change is in progress locally; results in PR comments if anything surfaces.

## Manual test steps
- After merge, watch the next `scheduled-prod-smoke` run (every 15 min) — it should go green for the first time since May 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)