### PR TITLE
Add schedule loading redesign spec

### DIFF
--- a/spec/schedule-loading-redesign/design.md
+++ b/spec/schedule-loading-redesign/design.md
@@ -1,0 +1,162 @@
+# Design: Schedule Loading Redesign
+
+## Overview
+
+This design implements the requirements in [requirements.md](./requirements.md): move external calendar (ICS) ingestion server-side into a scheduled Cloud Function that reconciles feeds into Firestore event docs, remove the client ICS fetch from the schedule load path, make every visible schedule event a real Firestore doc, and make practice attendance work uniformly regardless of event origin.
+
+Research for this design was conducted directly against the codebase and production data (read-only, via the `_migration` service account):
+
+- `apps/app/src/lib/scheduleService.ts` — `loadParentSchedule` → `buildTeamSchedule` fetches ICS inline per team (`fetchAndParseCalendar`), expands recurring practice masters client-side into synthetic `masterId__YYYY-MM-DD` IDs, and on native falls back from the Firebase SDK (5s timeout per read) to REST calls that list whole collections.
+- `js/utils.js` `fetchAndParseCalendar` — Cloud Function attempt → direct fetch → 4 CORS-proxy fallbacks, 5s timeout each (worst case ~30s per dead feed, per load).
+- `functions/calendar-ics-fetch-core.cjs` + `exports.fetchCalendarIcs` — server-side ICS fetch with SSRF guards, ICS validation, and a 5-minute in-memory cache already exists; there are currently **no scheduled functions** in `functions/index.js`.
+- `js/calendar-ics-sync.js` (legacy) and `isTrackedCalendarEvent` (app) — both clients already suppress client-fetched ICS events when a DB doc carries a matching `calendarEventUid`. This is the backward-compatibility hinge.
+- Production audit (account with 5 teams, 59 games, 3 calendar URLs): 2 of 4 practice sessions are orphans keyed by ICS UIDs (`madison-futsal-winter2-5@sniderfamily`), unreachable by the app's `isDbGame` guard.
+
+## Architecture
+
+### Sync pipeline (Phase 2)
+
+```mermaid
+sequenceDiagram
+    participant Sched as Cloud Scheduler (hourly)
+    participant Fn as syncTeamCalendars (Function)
+    participant Feed as External ICS host
+    participant FS as Firestore
+
+    Sched->>Fn: onRun
+    Fn->>FS: query teams where calendarUrls != []
+    loop each (team, calendarUrl)
+        Fn->>FS: read calendarSyncs/{urlHash} (etag, contentHash)
+        Fn->>Feed: GET (If-None-Match / If-Modified-Since)
+        alt 304 / hash unchanged
+            Fn->>FS: update lastFetchedAt only
+        else changed
+            Fn->>Fn: parse ICS, expand RRULEs in horizon
+            Fn->>FS: read synced event docs for this calendar
+            Fn->>Fn: diff (create / patch source fields / cancel missing)
+            Fn->>FS: batched writes (≤500/batch)
+            Fn->>FS: update calendarSyncs (contentHash, lastSuccessAt, counts)
+        end
+    end
+    Fn->>FS: set syncStatus/global.lastSweepAt
+```
+
+Entry points sharing one reconcile core:
+
+1. `syncTeamCalendars` — `functions.pubsub.schedule('every 60 minutes')`. Sweeps all teams (req 1.1, 1.2).
+2. `syncTeamCalendarNow` — HTTPS callable, `(teamId, calendarUrl)`. Auth: team staff only. Used by on-open staleness revalidation (req 1.3) and the settings "Sync now" button (req 1.4).
+3. Both wrap `functions/calendar-sync-core.cjs` (new, pure CJS module, unit-testable like the existing `*-core.cjs` modules), which itself reuses `calendar-ics-fetch-core.cjs` for fetching/validation (req 1.6).
+
+### Client read path (after Phase 2)
+
+```mermaid
+flowchart LR
+    A[Schedule screen] --> B["1 windowed query per team\nteams/{id}/games where date >= windowStart"]
+    B --> C[Render immediately]
+    A -.async, non-blocking.-> D{calendarSyncs stale > 15 min?}
+    D -- yes --> E[call syncTeamCalendarNow]
+    E --> F[Firestore snapshot/refresh picks up changes]
+```
+
+No ICS fetch, no proxy chain, no cross-source merging in the client. Calendar events are just game docs with `source: 'calendar'`.
+
+### Data model
+
+```mermaid
+erDiagram
+    TEAM ||--o{ GAME : "games/"
+    TEAM ||--o{ CALENDAR_SYNC : "calendarSyncs/"
+    TEAM ||--o{ PRACTICE_SESSION : "practiceSessions/"
+    GAME ||--o| PRACTICE_SESSION : "sessionId == eventId"
+
+    GAME {
+        string id "ics-{urlHash8}-{uidKey} for synced docs"
+        string source "'calendar' | 'db' | ..."
+        string calendarEventUid "ICS UID (suppression key for both clients)"
+        string calendarUrlHash "which feed owns this doc"
+        string sourceRevision "SEQUENCE:DTSTAMP"
+        string seriesId "for materialized occurrences"
+        string instanceDate "YYYY-MM-DD for occurrences"
+        string status "'cancelled' with cancelReason on removal"
+    }
+    CALENDAR_SYNC {
+        string id "sha256(url) first 16 hex"
+        string url
+        timestamp lastFetchedAt
+        timestamp lastSuccessAt
+        string etag
+        string contentHash
+        string lastError
+        map lastRunCounts "created/updated/cancelled"
+    }
+```
+
+**Doc ID scheme for synced events:** `ics-{urlHash8}-{uidKey}` where `urlHash8` = first 8 hex of sha256(normalized calendar URL) and `uidKey` = the UID sanitized (`/` → `_`), truncated with a sha1 suffix if > 120 chars. RRULE occurrences append `__{instanceDate}`. Deterministic IDs make every sync run idempotent (req 2.1) and namespace per feed so two teams importing the same calendar stay independent (edge case 2).
+
+**Source-owned vs app-owned fields (req 2.3):** the sync writes only this allowlist: `date`, `end`, `location`, `title`, `opponent` (parsed), `type`, `status` + `cancelReason` (cancellation only), `source`, `calendarEventUid`, `calendarUrlHash`, `sourceRevision`, `updatedAt`. Everything else (`statTrackerConfigId`, `arrivalTime`, `notes`, `kitColor`, `assignments`, `gamePlan`, scores, …) is never touched. Patches use `update()` with explicit field paths, never `set()` without merge.
+
+**Practice sessions (req 4.2, 4.3):** session doc ID == event ID. `saveStaffPracticeAttendance` uses `set(doc(practiceSessions/{eventId}), payload, { merge: true })` — idempotent, no query-then-create race. Reads resolve by exact ID first, falling back to the legacy `eventId ==` query only for pre-migration docs. Nearest-date fuzzy matching is removed for writes.
+
+### Reconcile algorithm (calendar-sync-core.cjs)
+
+For one (team, calendarUrl):
+
+1. Fetch ICS via `calendar-ics-fetch-core`; on invalid/empty ICS, record `lastError` and stop — never touch event docs (req 2.9).
+2. Parse; expand RRULEs within horizon `[now − 30d, now + 12mo]`; apply `RECURRENCE-ID` exceptions (req 2.7).
+3. Load current synced docs: `games where calendarUrlHash == urlHash8`, plus legacy-linked docs `where calendarEventUid in feedUids` (chunked `in` queries) to adopt docs created by the legacy manual import (req 2.8).
+4. Diff:
+   - UID not in DB → **create** (req 2.2).
+   - UID in DB, `sourceRevision` or field-hash differs → **patch allowlist** (req 2.3, 2.4).
+   - UID cancelled in feed → patch `status: 'cancelled'` (req 2.6).
+   - Doc's UID absent from feed → increment `missingCount`; at 1 → `status: 'cancelled'`, `cancelReason: 'removed-from-calendar'`; at ≥3 AND future-dated AND no attached data → delete (req 2.5).
+   - Doc present again after cancellation → un-cancel and reset `missingCount`.
+5. Commit in batches of ≤500 writes; update `calendarSyncs` with counts and hashes (req 6.3).
+
+### Attendance flow (Phase 1 + 2)
+
+- Drop the `isDbGame` guard in `assertPracticeAttendanceManagementEvent` for practice events that have any Firestore-backed identity; after Phase 2 every visible practice is doc-backed, so the guard reduces to "is a practice + is staff" (req 4.1).
+- Phase 1 interim: calendar practices without docs key their session to `calendarEventUid` (matching how legacy pages historically wrote the orphan sessions), so attendance works even before server sync ships.
+- `loadStaffPracticeAttendance` no longer throws "not linked to a session yet"; a missing session yields an empty roster-based attendance sheet, and the first save creates the session (req 4.2).
+
+### Schedule load performance changes (Phase 1)
+
+1. **Async calendar merge (req 3.2):** `loadParentSchedule` returns DB-backed events immediately; a second emission (callback/async iterator consumed by `Schedule.tsx` / `homeService`) merges calendar events when the fetch settles. Cap the client proxy chain at 1 fallback.
+2. **Native REST windows (req 3.3):** replace `nativeListScheduleEventDocuments('teams/{id}/games')` full-collection listing with `:runQuery` structuredQuery date filters (the `nativeRunQuery` helper already exists in `scheduleService.ts`); same for `practiceSessions`.
+3. **Scope pruning (req 3.4):** `resolveParentScheduleChildren` checks `isTeamActive` before per-player reads (already partially true) and passes the loaded team doc into `buildTeamSchedule` to eliminate the duplicate `loadTeam` read.
+4. **Materialized in-app recurrences (req 3.5, Phase 2):** on series create/edit, write occurrence docs (`seriesId`, `instanceDate`, ID `masterId__YYYY-MM-DD` — same shape as today's synthetic IDs so existing session links keep working); remove `expandRecurrence` from the read path. A migration materializes existing series.
+5. **Denormalized summaries (req 3.6, Phase 3):** Firestore triggers on `rsvps`, `rideOffers`, `assignmentClaims`, and session `attendance` maintain `rsvpSummary` / `rideshareSummary` / `openAssignmentCount` / `attendanceSummary` on the parent game doc. `hydrateEventDetails` then runs only on the detail screen.
+
+### Firestore rules
+
+- `calendarSyncs` subcollection: read for team staff (settings banner, req 6.1); writes only via Admin SDK (no client write rule).
+- Synced event docs live in `teams/{teamId}/games` — existing game rules apply unchanged.
+- Session-ID-as-event-ID writes are already covered by existing `practiceSessions` staff-write rules.
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| Feed down / timeout | `calendarSyncs.lastError` set; event docs untouched; schedule renders last-good data (req 6.1, 2.9) |
+| Feed returns truncated/empty ICS | Rejected by `BEGIN:VCALENDAR` validation → treated as fetch failure, not as "all events removed" (edge case 1) |
+| One calendar fails mid-sweep | Per-calendar try/catch; sweep continues; failure isolated to that feed |
+| Function timeout on huge feeds | 300s `runWith` timeout; batched writes are idempotent, next run resumes cleanly (deterministic IDs) |
+| Unstable feed UIDs | Remove+add; cancelled originals keep history; one-time migration heuristic (same team + start time within 60s) may link replacements (edge case 6) |
+| Scheduler silently stops (bad deploy) | `syncStatus/global.lastSweepAt` freshness asserted in `scheduled-prod-smoke` → red check (req 6.2) |
+| Client callable fails | On-open revalidation is fire-and-forget; UI never blocks or errors on it |
+
+## Design Decisions
+
+1. **Sync into `games`, not a new `events` collection** — both clients and Firestore rules already read/enforce `games`; the existing `calendarEventUid` suppression in both clients gives zero-change backward compatibility (req 5.1–5.3). A new collection would require rules, both read paths, and a data migration for no benefit.
+2. **Cancel-don't-delete** — protects attendance/RSVP history against feed truncation and provider outages; deletion is opt-in narrow (future + no data + 3 misses).
+3. **UID-based identity over date matching** — moved events keep their doc, so attached data follows automatically; this specifically fixes today's wrong-occurrence fuzzy matching.
+4. **Session ID == event ID** — removes the query-then-create race and the fuzzy resolver; legacy fallback query keeps old sessions readable until migrated.
+5. **Hourly + on-open hybrid cadence** — hourly bounds worst-case staleness cheaply (conditional fetches); on-open revalidation gives seconds-level freshness exactly when someone cares, without the client ever blocking on it.
+
+## Testing Strategy
+
+1. **`calendar-sync-core.cjs` unit tests** (`tests/unit/`, Vitest, like existing `*-core` tests): create / patch-allowlist (app-owned fields preserved) / cancel-on-missing / un-cancel / delete-guard / RRULE horizon + RECURRENCE-ID / invalid-ICS rejection / UID sanitization / legacy-doc adoption via `calendarEventUid`. Fixture ICS files checked in.
+2. **App unit tests** (`apps/app`, colocated): async two-phase schedule load emission; native REST `runQuery` fallback shape; attendance auto-create-on-save (`set` + merge, deterministic ID); calendar-practice attendance no longer blocked; exact-ID session resolution with legacy fallback.
+3. **Regression tests (bug-fix rule):** failing-before tests for the "not linked to a session yet" dead end and the nearest-date wrong-occurrence match.
+4. **Functions deployability:** extend `tests/unit/functions-deployable-exports.test.js` to cover the new scheduled/callable exports (guards the known deploy-prod failure mode).
+5. **Smoke** (`tests/smoke/` + prod smoke workflow): schedule boots with a team whose calendar URL is unreachable (no spinner hang); `scheduled-prod-smoke` asserts `lastSweepAt` freshness.
+6. **Migration scripts** (`_migration/`): dry-run mode printing planned re-links (orphan sessions → synced docs) before writing; audited with the same service-account pattern used for this design's research.

--- a/spec/schedule-loading-redesign/design.md
+++ b/spec/schedule-loading-redesign/design.md
@@ -45,7 +45,7 @@ Entry points sharing one reconcile core:
 
 1. `syncTeamCalendars` — `functions.pubsub.schedule('every 60 minutes')`. Sweeps all teams (req 1.1, 1.2).
 2. `syncTeamCalendarNow` — HTTPS callable, `(teamId, calendarUrl)`. Auth: team staff only. Used by on-open staleness revalidation (req 1.3) and the settings "Sync now" button (req 1.4).
-3. Both wrap `functions/calendar-sync-core.cjs` (new, pure CJS module, unit-testable like the existing `*-core.cjs` modules), which itself reuses `calendar-ics-fetch-core.cjs` for fetching/validation (req 1.6).
+3. Both wrap `functions/calendar-sync-core.cjs` (new, pure CJS module, unit-testable like the existing `*-core.cjs` modules), which fetches feeds only through the existing guarded `exports.fetchCalendarIcs` path or an extracted shared guarded helper that preserves `normalizeTargetUrl`, `fetchWithTimeout`, `BEGIN:VCALENDAR` validation, and `calendar-ics-fetch-core.cjs` cache semantics (req 1.6).
 
 ### Client read path (after Phase 2)
 
@@ -70,9 +70,9 @@ erDiagram
     GAME ||--o| PRACTICE_SESSION : "sessionId == eventId"
 
     GAME {
-        string id "ics-{urlHash8}-{uidKey} for synced docs"
+        string id "ics-{urlHash8}-{trackingKey} for synced docs"
         string source "'calendar' | 'db' | ..."
-        string calendarEventUid "ICS UID (suppression key for both clients)"
+        string calendarEventUid "single-event UID or recurring occurrence tracking id"
         string calendarUrlHash "which feed owns this doc"
         string sourceRevision "SEQUENCE:DTSTAMP"
         string seriesId "for materialized occurrences"
@@ -91,24 +91,24 @@ erDiagram
     }
 ```
 
-**Doc ID scheme for synced events:** `ics-{urlHash8}-{uidKey}` where `urlHash8` = first 8 hex of sha256(normalized calendar URL) and `uidKey` = the UID sanitized (`/` → `_`), truncated with a sha1 suffix if > 120 chars. RRULE occurrences append `__{instanceDate}`. Deterministic IDs make every sync run idempotent (req 2.1) and namespace per feed so two teams importing the same calendar stay independent (edge case 2).
+**Tracking ID and doc ID scheme for synced events:** compute the same tracking id the clients use today: `getCalendarEventTrackingId(event)` returns the occurrence id for recurring ICS instances (for example `uid__2026-03-10T23:00:00.000Z`) and falls back to the raw UID only for non-recurring/single events. Store that exact value in `calendarEventUid`. Firestore doc ID is `ics-{urlHash8}-{trackingKey}` where `urlHash8` = first 8 hex of sha256(normalized calendar URL) and `trackingKey` = the tracking id sanitized (`/` -> `_`), truncated with a sha1 suffix if > 120 chars. Deterministic IDs make every sync run idempotent (req 2.1) and namespace per feed so two teams importing the same calendar stay independent (edge case 2).
 
 **Source-owned vs app-owned fields (req 2.3):** the sync writes only this allowlist: `date`, `end`, `location`, `title`, `opponent` (parsed), `type`, `status` + `cancelReason` (cancellation only), `source`, `calendarEventUid`, `calendarUrlHash`, `sourceRevision`, `updatedAt`. Everything else (`statTrackerConfigId`, `arrivalTime`, `notes`, `kitColor`, `assignments`, `gamePlan`, scores, …) is never touched. Patches use `update()` with explicit field paths, never `set()` without merge.
 
-**Practice sessions (req 4.2, 4.3):** session doc ID == event ID. `saveStaffPracticeAttendance` uses `set(doc(practiceSessions/{eventId}), payload, { merge: true })` — idempotent, no query-then-create race. Reads resolve by exact ID first, falling back to the legacy `eventId ==` query only for pre-migration docs. Nearest-date fuzzy matching is removed for writes.
+**Practice sessions (req 4.2, 4.3):** session doc ID == event ID. `saveStaffPracticeAttendance` uses an idempotent merge write to `doc(practiceSessions/{eventId})`, but the created payload must preserve the existing document shape: `attendance: normalizedAttendance`, `attendancePlayers`, and `aiContext.attendanceSummary` at the root. Do not write raw `players` / `checkedInCount` / `rosterSize` at the practice-session root. Reads resolve by exact ID first, falling back to the legacy `eventId ==` query only for pre-migration docs. Nearest-date fuzzy matching is removed for writes.
 
 ### Reconcile algorithm (calendar-sync-core.cjs)
 
 For one (team, calendarUrl):
 
-1. Fetch ICS via `calendar-ics-fetch-core`; on invalid/empty ICS, record `lastError` and stop — never touch event docs (req 2.9).
-2. Parse; expand RRULEs within horizon `[now − 30d, now + 12mo]`; apply `RECURRENCE-ID` exceptions (req 2.7).
-3. Load current synced docs: `games where calendarUrlHash == urlHash8`, plus legacy-linked docs `where calendarEventUid in feedUids` (chunked `in` queries) to adopt docs created by the legacy manual import (req 2.8).
+1. Fetch ICS via the shared guarded fetch implementation used by `exports.fetchCalendarIcs` (or call that HTTPS function from server code only if no helper has been extracted); on invalid/empty ICS, record `lastError` and stop — never touch event docs (req 2.9).
+2. Parse; expand RRULEs within horizon `[now − 30d, now + 12mo]`; apply `RECURRENCE-ID` exceptions (req 2.7); compute `trackingId = getCalendarEventTrackingId(event)` for each expanded event and use it for doc ID generation, `calendarEventUid`, dedupe, and legacy adoption.
+3. Load current synced docs: `games where calendarUrlHash == urlHash8`, plus legacy-linked docs `where calendarEventUid in feedTrackingIds` (chunked `in` queries) to adopt docs created by the legacy manual import (req 2.8).
 4. Diff:
-   - UID not in DB → **create** (req 2.2).
-   - UID in DB, `sourceRevision` or field-hash differs → **patch allowlist** (req 2.3, 2.4).
-   - UID cancelled in feed → patch `status: 'cancelled'` (req 2.6).
-   - Doc's UID absent from feed → increment `missingCount`; at 1 → `status: 'cancelled'`, `cancelReason: 'removed-from-calendar'`; at ≥3 AND future-dated AND no attached data → delete (req 2.5).
+   - Tracking id not in DB → **create** (req 2.2).
+   - Tracking id in DB, `sourceRevision` or field-hash differs → **patch allowlist** (req 2.3, 2.4).
+   - Tracking id cancelled in feed → patch `status: 'cancelled'` (req 2.6).
+   - Doc's tracking id absent from feed → increment `missingCount`; at 1 → `status: 'cancelled'`, `cancelReason: 'removed-from-calendar'`; at ≥3 AND future-dated AND no attached data → delete (req 2.5).
    - Doc present again after cancellation → un-cancel and reset `missingCount`.
 5. Commit in batches of ≤500 writes; update `calendarSyncs` with counts and hashes (req 6.3).
 
@@ -121,7 +121,7 @@ For one (team, calendarUrl):
 ### Schedule load performance changes (Phase 1)
 
 1. **Async calendar merge (req 3.2):** `loadParentSchedule` returns DB-backed events immediately; a second emission (callback/async iterator consumed by `Schedule.tsx` / `homeService`) merges calendar events when the fetch settles. Cap the client proxy chain at 1 fallback.
-2. **Native REST windows (req 3.3):** replace `nativeListScheduleEventDocuments('teams/{id}/games')` full-collection listing with `:runQuery` structuredQuery date filters (the `nativeRunQuery` helper already exists in `scheduleService.ts`); same for `practiceSessions`.
+2. **Native REST windows (req 3.3):** replace `nativeListScheduleEventDocuments('teams/{id}/games')` full-collection listing with parent-scoped `:runQuery` structuredQuery date filters posted to `/documents/teams/{teamId}:runQuery` (or the equivalent parent-path endpoint), not the root `/documents:runQuery`; same for `practiceSessions`. The existing `nativeRunQuery` helper in `scheduleService.ts` currently targets root collections and must be extended or wrapped so `from: [{ collectionId: 'games' }]` is scoped to the team document.
 3. **Scope pruning (req 3.4):** `resolveParentScheduleChildren` checks `isTeamActive` before per-player reads (already partially true) and passes the loaded team doc into `buildTeamSchedule` to eliminate the duplicate `loadTeam` read.
 4. **Materialized in-app recurrences (req 3.5, Phase 2):** on series create/edit, write occurrence docs (`seriesId`, `instanceDate`, ID `masterId__YYYY-MM-DD` — same shape as today's synthetic IDs so existing session links keep working); remove `expandRecurrence` from the read path. A migration materializes existing series.
 5. **Denormalized summaries (req 3.6, Phase 3):** Firestore triggers on `rsvps`, `rideOffers`, `assignmentClaims`, and session `attendance` maintain `rsvpSummary` / `rideshareSummary` / `openAssignmentCount` / `attendanceSummary` on the parent game doc. `hydrateEventDetails` then runs only on the detail screen.
@@ -154,8 +154,8 @@ For one (team, calendarUrl):
 
 ## Testing Strategy
 
-1. **`calendar-sync-core.cjs` unit tests** (`tests/unit/`, Vitest, like existing `*-core` tests): create / patch-allowlist (app-owned fields preserved) / cancel-on-missing / un-cancel / delete-guard / RRULE horizon + RECURRENCE-ID / invalid-ICS rejection / UID sanitization / legacy-doc adoption via `calendarEventUid`. Fixture ICS files checked in.
-2. **App unit tests** (`apps/app`, colocated): async two-phase schedule load emission; native REST `runQuery` fallback shape; attendance auto-create-on-save (`set` + merge, deterministic ID); calendar-practice attendance no longer blocked; exact-ID session resolution with legacy fallback.
+1. **`calendar-sync-core.cjs` unit tests** (`tests/unit/`, Vitest, like existing `*-core` tests): create / patch-allowlist (app-owned fields preserved) / cancel-on-missing / un-cancel / delete-guard / RRULE horizon + RECURRENCE-ID / invalid-ICS rejection / tracking-id sanitization / recurring occurrence `calendarEventUid` values / legacy-doc adoption via `calendarEventUid`. Fixture ICS files checked in.
+2. **App unit tests** (`apps/app`, colocated): async two-phase schedule load emission; parent-scoped native REST `runQuery` fallback shape; attendance auto-create-on-save (merge to deterministic ID while preserving nested `attendance` shape); calendar-practice attendance no longer blocked; exact-ID session resolution with legacy fallback.
 3. **Regression tests (bug-fix rule):** failing-before tests for the "not linked to a session yet" dead end and the nearest-date wrong-occurrence match.
 4. **Functions deployability:** extend `tests/unit/functions-deployable-exports.test.js` to cover the new scheduled/callable exports (guards the known deploy-prod failure mode).
 5. **Smoke** (`tests/smoke/` + prod smoke workflow): schedule boots with a team whose calendar URL is unreachable (no spinner hang); `scheduled-prod-smoke` asserts `lastSweepAt` freshness.

--- a/spec/schedule-loading-redesign/requirements.md
+++ b/spec/schedule-loading-redesign/requirements.md
@@ -1,0 +1,127 @@
+# Feature: Schedule Loading Redesign
+
+## Introduction
+
+Schedule loading in the ALL PLAYS app (`apps/app`) is slow and attendance marking is unreliable because the schedule is assembled client-side from four inconsistent sources: `teams/{teamId}/games` docs, recurring series masters expanded in the client into synthetic `masterId__YYYY-MM-DD` IDs, external ICS calendar events fetched live during every load, and orphan `practiceSessions` docs. Investigation of a real account (5 teams, 59 game docs, 3 external calendars) confirmed:
+
+- Every schedule load fetches and parses external ICS feeds inline, with a fallback chain (Cloud Function → direct fetch → 4 CORS proxies, 5s timeout each) that can add ~30 seconds per dead feed.
+- The native (Capacitor) read path falls back from the Firebase SDK (5s timeout per read) to REST calls that list entire collections and filter client-side.
+- Attendance is blocked for calendar-imported practices (`isDbGame` guard), dead-ends on DB practices with no pre-created session ("not linked to a session yet"), and uses nearest-date fuzzy matching that can attach attendance to the wrong recurring occurrence. Production data contains orphaned sessions keyed by ICS UIDs (e.g. `madison-futsal-winter2-5@sniderfamily`) that the app can no longer reach.
+
+This feature moves calendar data server-side (a scheduled Cloud Function syncs ICS feeds into Firestore event docs), removes the client ICS fetch from the load path, makes every visible schedule event a real Firestore doc, and makes attendance work uniformly across all practice sources. Both the legacy site and the React app read the same collections and already suppress client-fetched ICS events when a doc with a matching `calendarEventUid` exists, so the sync is backward compatible with both clients by design.
+
+## User Stories
+
+1. As a parent, I want the schedule screen to render immediately from the database, so that I am not blocked by slow or dead external calendar feeds.
+2. As a coach, I want to mark attendance on any practice — created in-app, recurring, or imported from a calendar — so that I do not have to know where an event came from.
+3. As a coach, I want edits to my team's external calendar (add / move / cancel a practice) to appear in everyone's app automatically, so that I only maintain the schedule in one place.
+4. As a coach, I want attendance, RSVPs, and packets to stay attached to a practice when its time changes in the external calendar, so that history is never orphaned.
+5. As a team admin, I want to see when a calendar feed last synced and whether it is failing, so that a broken feed is visible to the person who can fix it instead of silently degrading everyone's schedule.
+6. As a user of the legacy site, I want synced calendar events to appear exactly once (no duplicates alongside client-fetched ICS events), so that both apps stay consistent during the transition.
+
+## Requirements (EARS)
+
+### 1. Server-side calendar sync
+
+1.1. WHEN the scheduled sync job runs (Cloud Scheduler, every 60 minutes), THE SYSTEM SHALL iterate all teams with non-empty `calendarUrls` and reconcile each feed into Firestore event docs.
+
+1.2. WHEN fetching a feed, THE SYSTEM SHALL use conditional requests (`ETag` / `If-Modified-Since`) and a stored content hash, and SHALL skip reconciliation when the feed is unchanged.
+
+1.3. WHEN a user opens the schedule and a team calendar's `lastFetchedAt` is older than a staleness threshold (default 15 minutes), THE SYSTEM SHALL trigger an on-demand sync for that calendar in the background without blocking rendering.
+
+1.4. WHEN a team admin taps "Sync now" in calendar settings, THE SYSTEM SHALL sync that calendar immediately (`forceRefresh` semantics).
+
+1.5. THE SYSTEM SHALL persist per-calendar sync state in a `calendarSyncs` document: `lastFetchedAt`, `etag`, `contentHash`, `lastError`, `lastSuccessAt`.
+
+1.6. THE SYSTEM SHALL reuse the existing server-side fetch core (`functions/calendar-ics-fetch-core.cjs` SSRF guards, ICS validation) for all sync fetches.
+
+### 2. Reconciliation semantics
+
+2.1. THE SYSTEM SHALL use the ICS `UID` (plus `RECURRENCE-ID` for exceptions) as event identity, with a deterministic Firestore doc ID derived from the calendar URL hash and UID.
+
+2.2. WHEN a new UID appears in a feed, THE SYSTEM SHALL create an event doc with `source: 'calendar'`, `calendarEventUid`, and the feed's `SEQUENCE`/`DTSTAMP` as `sourceRevision`.
+
+2.3. WHEN an existing UID's content changes, THE SYSTEM SHALL patch only source-owned fields (date, end, location, title/summary, cancelled status) and SHALL NOT modify app-owned fields (`statTrackerConfigId`, `arrivalTime`, `notes`, `kitColor`, assignments, `gamePlan`).
+
+2.4. WHEN an event's date or time changes in the feed, THE SYSTEM SHALL update the existing doc in place so attendance, RSVPs, and practice sessions remain attached.
+
+2.5. WHEN a UID disappears from a feed, THE SYSTEM SHALL mark the event doc `status: 'cancelled'` with `cancelReason: 'removed-from-calendar'` and SHALL NOT delete it. Hard deletion MAY occur only for future events with no attached data (no RSVPs, sessions, or attendance) after 3 consecutive syncs missing.
+
+2.6. WHEN a feed event carries `STATUS:CANCELLED` or a `[CANCELED]` summary marker, THE SYSTEM SHALL mark the event doc cancelled.
+
+2.7. WHEN a feed event has an `RRULE`, THE SYSTEM SHALL expand occurrences server-side within a bounded horizon (past 30 days to future 12 months) into occurrence docs keyed `uid__instanceDate`, applying `RECURRENCE-ID` exceptions as per-occurrence patches, and SHALL roll the horizon forward on each scheduled run.
+
+2.8. WHEN a game doc already exists with `calendarEventUid` equal to a feed UID (e.g. created by the legacy manual import), THE SYSTEM SHALL patch that doc rather than creating a duplicate.
+
+2.9. WHEN a feed returns invalid or empty ICS, THE SYSTEM SHALL record the error on the `calendarSyncs` doc and SHALL leave all previously synced event docs untouched.
+
+### 3. Schedule load performance
+
+3.1. THE SYSTEM SHALL NOT fetch or parse ICS feeds in the client schedule load path (`buildTeamSchedule` in `apps/app/src/lib/scheduleService.ts`) once server sync is live for a team.
+
+3.2. WHILE server sync is not yet live (Phase 1), THE SYSTEM SHALL render database events immediately and merge client-fetched calendar events asynchronously after first paint.
+
+3.3. WHEN the native (Capacitor) runtime falls back to Firestore REST, THE SYSTEM SHALL use `:runQuery` with date-range filters instead of listing entire collections.
+
+3.4. THE SYSTEM SHALL skip inactive teams before performing per-player validation reads in `resolveParentScheduleChildren`, and SHALL NOT read the same team document twice per load.
+
+3.5. WHEN recurring in-app practice series are created or edited (Phase 2), THE SYSTEM SHALL materialize occurrence docs within a bounded horizon instead of expanding recurrence client-side with synthetic IDs.
+
+3.6. THE SYSTEM SHALL denormalize per-event summary fields (`attendanceSummary`, `rideshareSummary`, `openAssignmentCount`, in addition to the existing `rsvpSummary`) onto event docs via Firestore triggers (Phase 3), so that the schedule list view requires zero subcollection reads.
+
+### 4. Attendance on all practice events
+
+4.1. WHEN a staff member opens attendance for any practice event backed by a Firestore doc, THE SYSTEM SHALL allow marking attendance regardless of the event's origin (in-app, recurring occurrence, or calendar sync).
+
+4.2. WHEN attendance is first marked for a practice with no linked session, THE SYSTEM SHALL create the practice session automatically using a deterministic session ID equal to the event ID, via an idempotent merge write (no query-then-create race).
+
+4.3. THE SYSTEM SHALL resolve practice sessions by exact event ID only, and SHALL NOT use nearest-date fuzzy matching for new writes.
+
+4.4. WHEN migrating (Phase 2), THE SYSTEM SHALL re-link existing orphan practice sessions whose `eventId` is an ICS UID to the corresponding synced event docs, preserving recorded attendance.
+
+### 5. Backward compatibility (legacy site + React app)
+
+5.1. THE SYSTEM SHALL stamp every synced event doc with `calendarEventUid` so the existing suppression logic in both clients (legacy `js/calendar-ics-sync.js` merge; app `isTrackedCalendarEvent`) hides duplicate client-fetched ICS events without client changes.
+
+5.2. WHEN the sync is live, events synced from calendars SHALL appear exactly once in both the legacy site and the React app.
+
+5.3. THE SYSTEM SHALL leave the legacy manual "import from calendar" flow functional during transition; docs it creates SHALL be recognized by the sync via `calendarEventUid` (see 2.8).
+
+### 6. Observability and failure visibility
+
+6.1. WHEN a calendar sync fails, THE SYSTEM SHALL surface "last synced X ago / failing since Y" to team admins in calendar settings, and SHALL NOT degrade schedule rendering for any user.
+
+6.2. THE SYSTEM SHALL stamp a global `lastSweepAt` timestamp on each scheduled run, and the production smoke workflow SHALL assert its freshness so a broken deploy is a red check rather than silently stale schedules.
+
+6.3. THE SYSTEM SHALL record sync outcomes (created / updated / cancelled counts, duration) per run for debugging.
+
+## Edge Cases
+
+1. A feed temporarily serves truncated or empty content during a host outage — cancel-don't-delete (2.5) plus invalid-ICS rejection (2.9) prevent data loss.
+2. Two teams import the same external calendar — doc IDs are namespaced by calendar URL hash per team, so events sync independently per team.
+3. An ICS event moves across the recurrence horizon boundary — the rolling horizon (2.7) picks it up on the next scheduled run.
+4. A coach edits an app-owned field on a synced event, then the feed changes the same event — source-owned/app-owned field split (2.3) preserves the coach's edit.
+5. A user opens the schedule while an on-demand sync is running — the client renders last-known-good docs; snapshot listeners (Phase 3) or the next refresh pick up changes.
+6. Feed UIDs are unstable (some providers regenerate UIDs) — treated as remove + add; cancelled originals retain history, and the migration heuristic (same team, same start time within 60s) MAY link replacements once.
+7. The Cloud Scheduler job stops running after a failed deploy — smoke freshness check (6.2) turns red.
+
+## UX Constraints
+
+1. Schedule first paint MUST NOT wait on any external network fetch other than Firestore.
+2. Worst-case calendar staleness is the scheduler interval (60 minutes); user-visible staleness after pull-to-refresh MUST be seconds, not minutes.
+3. Attendance marking MUST never show "not linked to a session yet" or "attendance opens after this event is tracked" for any practice visible in the schedule (once Phase 2 is complete).
+4. No breaking changes to RSVPs, ride shares, lineups, or live tracking flows.
+
+## Success Criteria
+
+1. Cold schedule load for a multi-team account with external calendars completes without any client-side ICS fetch (Phase 2) and renders first content in under 2 seconds on a warm connection.
+2. Attendance can be marked on 100% of practice events visible in the schedule, including calendar-imported and recurring occurrences.
+3. A calendar edit (add / move / cancel) propagates to all users within 60 minutes automatically and within seconds on manual refresh.
+4. Zero duplicate events across legacy and React app during and after rollout.
+5. Existing orphan ICS-UID sessions are re-linked with attendance history intact.
+
+## Phasing
+
+1. **Phase 1 (client-only quick wins):** async calendar merge after first paint (3.2), native REST `runQuery` windows (3.3), inactive-team and duplicate-read elimination (3.4), auto-create session on attendance mark (4.2), attendance for calendar practices keyed by `calendarEventUid`.
+2. **Phase 2 (server sync + canonical events):** scheduled + on-demand + manual sync (§1, §2), materialized recurring occurrences (3.5), orphan session migration (4.4), remove client ICS fetch from the React app load path (3.1).
+3. **Phase 3 (denormalized summaries):** trigger-maintained summary fields (3.6), snapshot listeners for live updates, remove client ICS fetch from legacy pages.

--- a/spec/schedule-loading-redesign/requirements.md
+++ b/spec/schedule-loading-redesign/requirements.md
@@ -33,15 +33,15 @@ This feature moves calendar data server-side (a scheduled Cloud Function syncs I
 
 1.5. THE SYSTEM SHALL persist per-calendar sync state in a `calendarSyncs` document: `lastFetchedAt`, `etag`, `contentHash`, `lastError`, `lastSuccessAt`.
 
-1.6. THE SYSTEM SHALL reuse the existing server-side fetch core (`functions/calendar-ics-fetch-core.cjs` SSRF guards, ICS validation) for all sync fetches.
+1.6. THE SYSTEM SHALL reuse the existing guarded server-side ICS fetch path for all sync fetches: either call/extract the logic currently inline in `exports.fetchCalendarIcs` (`normalizeTargetUrl` + `fetchWithTimeout` + `BEGIN:VCALENDAR` validation) and wrap it with the cache helpers from `functions/calendar-ics-fetch-core.cjs`, or first move that guarded logic into a shared function module used by both `fetchCalendarIcs` and the sync. The sync SHALL NOT fetch arbitrary `calendarUrls` through a new unguarded HTTP client.
 
 ### 2. Reconciliation semantics
 
-2.1. THE SYSTEM SHALL use the ICS `UID` (plus `RECURRENCE-ID` for exceptions) as event identity, with a deterministic Firestore doc ID derived from the calendar URL hash and UID.
+2.1. THE SYSTEM SHALL use the shared calendar tracking id as event identity: raw ICS `UID` for single events and `getCalendarEventTrackingId(event)` / `uid__occurrenceStart` for recurring occurrences and `RECURRENCE-ID` exceptions. Firestore doc IDs SHALL be deterministic and derived from the calendar URL hash plus that tracking id.
 
-2.2. WHEN a new UID appears in a feed, THE SYSTEM SHALL create an event doc with `source: 'calendar'`, `calendarEventUid`, and the feed's `SEQUENCE`/`DTSTAMP` as `sourceRevision`.
+2.2. WHEN a new tracking id appears in a feed, THE SYSTEM SHALL create an event doc with `source: 'calendar'`, `calendarEventUid` set to the tracking id, and the feed's `SEQUENCE`/`DTSTAMP` as `sourceRevision`.
 
-2.3. WHEN an existing UID's content changes, THE SYSTEM SHALL patch only source-owned fields (date, end, location, title/summary, cancelled status) and SHALL NOT modify app-owned fields (`statTrackerConfigId`, `arrivalTime`, `notes`, `kitColor`, assignments, `gamePlan`).
+2.3. WHEN an existing tracking id's content changes, THE SYSTEM SHALL patch only source-owned fields (date, end, location, title/summary, cancelled status) and SHALL NOT modify app-owned fields (`statTrackerConfigId`, `arrivalTime`, `notes`, `kitColor`, assignments, `gamePlan`).
 
 2.4. WHEN an event's date or time changes in the feed, THE SYSTEM SHALL update the existing doc in place so attendance, RSVPs, and practice sessions remain attached.
 
@@ -49,9 +49,9 @@ This feature moves calendar data server-side (a scheduled Cloud Function syncs I
 
 2.6. WHEN a feed event carries `STATUS:CANCELLED` or a `[CANCELED]` summary marker, THE SYSTEM SHALL mark the event doc cancelled.
 
-2.7. WHEN a feed event has an `RRULE`, THE SYSTEM SHALL expand occurrences server-side within a bounded horizon (past 30 days to future 12 months) into occurrence docs keyed `uid__instanceDate`, applying `RECURRENCE-ID` exceptions as per-occurrence patches, and SHALL roll the horizon forward on each scheduled run.
+2.7. WHEN a feed event has an `RRULE`, THE SYSTEM SHALL expand occurrences server-side within a bounded horizon (past 30 days to future 12 months) into occurrence docs keyed by the same occurrence tracking id used by `getCalendarEventTrackingId(event)` (for example `uid__2026-03-10T23:00:00.000Z`), applying `RECURRENCE-ID` exceptions as per-occurrence patches, and SHALL roll the horizon forward on each scheduled run.
 
-2.8. WHEN a game doc already exists with `calendarEventUid` equal to a feed UID (e.g. created by the legacy manual import), THE SYSTEM SHALL patch that doc rather than creating a duplicate.
+2.8. WHEN a game doc already exists with `calendarEventUid` equal to a feed tracking id (e.g. created by the legacy manual import), THE SYSTEM SHALL patch that doc rather than creating a duplicate.
 
 2.9. WHEN a feed returns invalid or empty ICS, THE SYSTEM SHALL record the error on the `calendarSyncs` doc and SHALL leave all previously synced event docs untouched.
 
@@ -81,7 +81,7 @@ This feature moves calendar data server-side (a scheduled Cloud Function syncs I
 
 ### 5. Backward compatibility (legacy site + React app)
 
-5.1. THE SYSTEM SHALL stamp every synced event doc with `calendarEventUid` so the existing suppression logic in both clients (legacy `js/calendar-ics-sync.js` merge; app `isTrackedCalendarEvent`) hides duplicate client-fetched ICS events without client changes.
+5.1. THE SYSTEM SHALL stamp every synced event doc with `calendarEventUid` equal to the same tracking id produced by `getCalendarEventTrackingId(event)` so the existing suppression logic in both clients (legacy `js/calendar-ics-sync.js` merge; app `isTrackedCalendarEvent`) hides duplicate client-fetched ICS events without client changes. Recurring occurrence docs SHALL NOT store only the raw UID.
 
 5.2. WHEN the sync is live, events synced from calendars SHALL appear exactly once in both the legacy site and the React app.
 

--- a/spec/schedule-loading-redesign/tasks.md
+++ b/spec/schedule-loading-redesign/tasks.md
@@ -1,0 +1,107 @@
+# Tasks: Schedule Loading Redesign
+
+Execute one task at a time with `/spec-execute-task`; stop for review after each. Every task lists the requirements it implements (see [requirements.md](./requirements.md)) and follows the design in [design.md](./design.md). Write the failing test first where a test is listed.
+
+## Phase 1 — Client quick wins (no schema change)
+
+- [ ] 1. Fix the attendance "not linked to a session yet" dead end
+  - In `apps/app/src/lib/scheduleService.ts`, change `saveStaffPracticeAttendance` to write via `set(doc(teams/{teamId}/practiceSessions/{eventId}), payload, { merge: true })` (native path: PATCH to the deterministic path), creating the session on first mark with `sessionId == eventId`.
+  - Change `loadStaffPracticeAttendance` to return an empty roster-based sheet instead of throwing when no session exists.
+  - Resolve sessions by exact event ID first; keep the `eventId ==` query as legacy fallback for reads only.
+  - Tests: regression unit test that fails on current code (load throws / save requires pre-existing session); test that save with no session creates doc at deterministic ID; test legacy-fallback read still finds old query-keyed sessions.
+  - _Requirements: 4.2, 4.3_
+
+- [ ] 2. Allow attendance on calendar-imported practices
+  - In `assertPracticeAttendanceManagementEvent`, permit practice events with `sourceType === 'calendar'` (key the session to `calendarEventUid` via task 1's deterministic-ID path); keep staff-only and practice-only guards.
+  - Surface the attendance panel for these events in `apps/app/src/pages/ScheduleEventDetail.tsx`.
+  - Tests: unit test that a calendar practice event loads/saves attendance; regression test that the old "attendance opens after this event is tracked" block is gone for calendar practices.
+  - _Requirements: 4.1_
+
+- [ ] 3. Remove client-side session fuzzy matching for writes
+  - Delete nearest-date matching from the write path; `resolvePracticeSessionForEvent` remains read-only display fallback, exact-ID and `masterId__` prefix matches only.
+  - Tests: unit test that a recurring occurrence never writes attendance to a different occurrence's session.
+  - _Requirements: 4.3_
+
+- [ ] 4. Make the schedule render before calendar fetches complete
+  - Restructure `loadParentSchedule` / `buildTeamSchedule` so DB events return immediately and ICS-derived events merge via a second async emission consumed by `Schedule.tsx` and `homeService.ts`; cap the client proxy fallback chain at one proxy.
+  - Tests: unit test that first emission contains DB events with no `fetchAndParseCalendar` call awaited; test merged second emission dedups tracked UIDs; smoke test that schedule boots with an unreachable calendar URL configured.
+  - _Requirements: 3.2, UX 1_
+
+- [ ] 5. Use windowed `:runQuery` in the native REST fallback
+  - Replace full-collection `nativeListScheduleEventDocuments`/`nativeListCollection` fallbacks for `games` and `practiceSessions` with structuredQuery date-range filters (extend the existing `nativeRunQuery` helper to support range operators).
+  - Tests: unit tests asserting the structuredQuery payload shape (collection, field filters, date bounds) for both collections.
+  - _Requirements: 3.3_
+
+- [ ] 6. Prune redundant reads in scope resolution
+  - Skip per-player validation reads for inactive teams in `resolveParentScheduleChildren`; thread the already-loaded team doc into `buildTeamSchedule` to remove the duplicate team read.
+  - Tests: unit test with a mocked inactive team asserting zero player reads; test that `buildTeamSchedule` performs one team read per team per load.
+  - _Requirements: 3.4_
+
+## Phase 2 — Server-side calendar sync and canonical events
+
+- [ ] 7. Create `functions/calendar-sync-core.cjs` (pure reconcile module)
+  - Implement parse → RRULE horizon expansion (past 30d / future 12mo, RECURRENCE-ID exceptions) → diff (create / allowlist patch / cancel-on-missing with `missingCount` / un-cancel / guarded delete) → batched write plan. Deterministic doc IDs `ics-{urlHash8}-{uidKey}` with UID sanitization; adoption of legacy docs via `calendarEventUid` lookup; invalid/empty ICS rejection leaves docs untouched.
+  - Tests (fixture ICS files in `tests/unit/`): each diff branch; app-owned fields preserved on patch; two teams sharing one feed stay namespaced; truncated feed causes zero writes.
+  - _Requirements: 2.1–2.9, 1.6_
+
+- [ ] 8. Add the `syncTeamCalendars` scheduled function
+  - `functions.pubsub.schedule('every 60 minutes')`, 300s timeout: sweep teams with `calendarUrls`, conditional fetch (ETag/If-Modified-Since + `contentHash`) via `calendar-ics-fetch-core.cjs`, run the reconcile core, persist `calendarSyncs/{urlHash}` state (`lastFetchedAt`, `lastSuccessAt`, `etag`, `contentHash`, `lastError`, `lastRunCounts`) and `syncStatus/global.lastSweepAt`. Per-calendar try/catch isolation.
+  - Tests: extend `tests/unit/functions-deployable-exports.test.js` for the new export (no `_internal` collision); unit tests for conditional-fetch skip and per-calendar failure isolation.
+  - _Requirements: 1.1, 1.2, 1.5, 6.2, 6.3_
+
+- [ ] 9. Add the `syncTeamCalendarNow` callable and client staleness trigger
+  - Callable validates team-staff auth, syncs one (teamId, calendarUrl). App: on schedule open, if `calendarSyncs.lastFetchedAt` > 15 min old, fire-and-forget the callable; "Sync now" button in team calendar settings calls it with `forceRefresh`.
+  - Tests: callable rejects non-staff; client trigger fires only when stale and never blocks or fails the schedule load.
+  - _Requirements: 1.3, 1.4_
+
+- [ ] 10. Firestore rules and indexes for sync state
+  - `firestore.rules`: team staff may read `teams/{teamId}/calendarSyncs/*`; no client writes. Add any composite index needed for `games where calendarUrlHash ==` (verify against `firestore.indexes.json` single-field rules — avoid the known invalid-index deploy failure).
+  - Tests: unit test asserting rules text includes the new match block; deploy-safety check for indexes file.
+  - _Requirements: 6.1, 1.5_
+
+- [ ] 11. Calendar sync status UI in team settings
+  - Show "last synced X ago" / "failing since Y — {lastError}" from `calendarSyncs` next to each calendar URL in the app team settings, with the Sync now button (task 9).
+  - Tests: component test for fresh, stale, and failing states.
+  - _Requirements: 6.1_
+
+- [ ] 12. Remove the client ICS fetch from the React app load path
+  - When every `calendarUrls` entry for a team has a `calendarSyncs` doc with a successful sync, skip `fetchAndParseCalendar` entirely in `buildTeamSchedule` (synced docs arrive via the normal games query; existing `isTrackedCalendarEvent` suppression covers the transition).
+  - Tests: unit test that no calendar fetch occurs when sync state is present and healthy; events appear exactly once.
+  - _Requirements: 3.1, 5.1, 5.2_
+
+- [ ] 13. Migration: re-link orphan ICS-UID practice sessions
+  - `_migration/relink-calendar-practice-sessions.js` (Admin SDK, dry-run default): for each session whose `eventId` matches no game doc, link to the synced doc by `calendarEventUid`, else by the one-time heuristic (same team, start within 60s); report unmatched.
+  - Tests: unit test the matching logic as a pure function with the audited production shapes (`madison-futsal-*@sniderfamily` style UIDs).
+  - _Requirements: 4.4, 5.3_
+
+- [ ] 14. Materialize in-app recurring practice occurrences
+  - On series create/edit in `scheduleService.ts`, write occurrence docs (ID `masterId__YYYY-MM-DD`, `seriesId`, `instanceDate`) over the bounded horizon; remove `expandRecurrence` from read paths; `_migration/materialize-recurring-occurrences.js` backfills existing series (dry-run default). Keep occurrence-override/cancel flows writing to the occurrence docs.
+  - Tests: create/edit produces expected docs; read path no longer calls `expandRecurrence`; occurrence cancel/override round-trips; migration dry-run output on fixture series.
+  - _Requirements: 3.5_
+
+- [ ] 15. Assert sync freshness in production smoke
+  - `scheduled-prod-smoke` reads `syncStatus/global.lastSweepAt` and fails if older than 3 hours.
+  - Tests: workflow-level check plus a unit test for the freshness comparator.
+  - _Requirements: 6.2_
+
+## Phase 3 — Denormalized summaries and cleanup
+
+- [ ] 16. Trigger-maintained event summary fields
+  - Firestore triggers on `rsvps`, `rideOffers`, `assignmentClaims` writes and session `attendance` updates maintain `rsvpSummary`, `rideshareSummary`, `openAssignmentCount`, `attendanceSummary` on the parent game doc (pure `*-core.cjs` module + thin trigger exports).
+  - Tests: core-module unit tests per summary; deployable-exports test extended.
+  - _Requirements: 3.6_
+
+- [ ] 17. Drop list-view hydration fan-out
+  - `loadParentSchedule` list views read summaries from event docs; `hydrateEventDetails` (rsvps/offers/claims subcollection reads) runs only for the event-detail screen.
+  - Tests: unit test that list load performs zero subcollection reads; detail screen still hydrates.
+  - _Requirements: 3.6, UX 1_
+
+- [ ] 18. Live schedule updates via snapshot listeners
+  - Replace pull-to-refresh full reloads with `onSnapshot` listeners on the windowed per-team games queries (web SDK path; native keeps timed refresh).
+  - Tests: unit test listener wiring and teardown on unmount/team change.
+  - _Requirements: 1.3 (freshness), UX 2_
+
+- [ ] 19. Remove the client ICS fetch from legacy pages
+  - Behind the same sync-health check as task 12, skip `fetchAndParseCalendar` in the six legacy consumers (team.html, calendar.html, family.html, parent-dashboard.html, edit-schedule.html, game-plan.html); retire the manual calendar import on edit-schedule.html in favor of "Sync now".
+  - Tests: unit tests for page wiring changes; smoke specs for each page booting with a calendar-configured team.
+  - _Requirements: 3.1, 5.2, 5.3_

--- a/spec/schedule-loading-redesign/tasks.md
+++ b/spec/schedule-loading-redesign/tasks.md
@@ -5,7 +5,7 @@ Execute one task at a time with `/spec-execute-task`; stop for review after each
 ## Phase 1 — Client quick wins (no schema change)
 
 - [ ] 1. Fix the attendance "not linked to a session yet" dead end
-  - In `apps/app/src/lib/scheduleService.ts`, change `saveStaffPracticeAttendance` to write via `set(doc(teams/{teamId}/practiceSessions/{eventId}), payload, { merge: true })` (native path: PATCH to the deterministic path), creating the session on first mark with `sessionId == eventId`.
+  - In `apps/app/src/lib/scheduleService.ts`, change `saveStaffPracticeAttendance` to write via `set(doc(teams/{teamId}/practiceSessions/{eventId}), { attendance: normalizedAttendance, attendancePlayers, aiContext: { attendanceSummary } }, { merge: true })` (native path: PATCH to the deterministic path), creating the session on first mark with `sessionId == eventId` while preserving the existing nested attendance document shape.
   - Change `loadStaffPracticeAttendance` to return an empty roster-based sheet instead of throwing when no session exists.
   - Resolve sessions by exact event ID first; keep the `eventId ==` query as legacy fallback for reads only.
   - Tests: regression unit test that fails on current code (load throws / save requires pre-existing session); test that save with no session creates doc at deterministic ID; test legacy-fallback read still finds old query-keyed sessions.
@@ -28,8 +28,8 @@ Execute one task at a time with `/spec-execute-task`; stop for review after each
   - _Requirements: 3.2, UX 1_
 
 - [ ] 5. Use windowed `:runQuery` in the native REST fallback
-  - Replace full-collection `nativeListScheduleEventDocuments`/`nativeListCollection` fallbacks for `games` and `practiceSessions` with structuredQuery date-range filters (extend the existing `nativeRunQuery` helper to support range operators).
-  - Tests: unit tests asserting the structuredQuery payload shape (collection, field filters, date bounds) for both collections.
+  - Replace full-collection `nativeListScheduleEventDocuments`/`nativeListCollection` fallbacks for `games` and `practiceSessions` with structuredQuery date-range filters posted to the team parent path (`/documents/teams/{teamId}:runQuery`, or equivalent parent-scoped endpoint), not the root `/documents:runQuery`. Extend or wrap the existing `nativeRunQuery` helper to support parent paths plus range operators.
+  - Tests: unit tests asserting the structuredQuery payload shape (parent path, collection, field filters, date bounds) for both collections.
   - _Requirements: 3.3_
 
 - [ ] 6. Prune redundant reads in scope resolution
@@ -40,12 +40,12 @@ Execute one task at a time with `/spec-execute-task`; stop for review after each
 ## Phase 2 — Server-side calendar sync and canonical events
 
 - [ ] 7. Create `functions/calendar-sync-core.cjs` (pure reconcile module)
-  - Implement parse → RRULE horizon expansion (past 30d / future 12mo, RECURRENCE-ID exceptions) → diff (create / allowlist patch / cancel-on-missing with `missingCount` / un-cancel / guarded delete) → batched write plan. Deterministic doc IDs `ics-{urlHash8}-{uidKey}` with UID sanitization; adoption of legacy docs via `calendarEventUid` lookup; invalid/empty ICS rejection leaves docs untouched.
-  - Tests (fixture ICS files in `tests/unit/`): each diff branch; app-owned fields preserved on patch; two teams sharing one feed stay namespaced; truncated feed causes zero writes.
+  - Implement parse → RRULE horizon expansion (past 30d / future 12mo, RECURRENCE-ID exceptions) → tracking-id computation matching `getCalendarEventTrackingId(event)` → diff (create / allowlist patch / cancel-on-missing with `missingCount` / un-cancel / guarded delete) → batched write plan. Deterministic doc IDs `ics-{urlHash8}-{trackingKey}` with tracking-id sanitization; `calendarEventUid` stores the tracking id (raw UID only for non-recurring events, occurrence id for recurring instances); adoption of legacy docs via `calendarEventUid` lookup; invalid/empty ICS rejection leaves docs untouched.
+  - Tests (fixture ICS files in `tests/unit/`): each diff branch; app-owned fields preserved on patch; recurring occurrences store distinct tracking IDs in `calendarEventUid`; two teams sharing one feed stay namespaced; truncated feed causes zero writes.
   - _Requirements: 2.1–2.9, 1.6_
 
 - [ ] 8. Add the `syncTeamCalendars` scheduled function
-  - `functions.pubsub.schedule('every 60 minutes')`, 300s timeout: sweep teams with `calendarUrls`, conditional fetch (ETag/If-Modified-Since + `contentHash`) via `calendar-ics-fetch-core.cjs`, run the reconcile core, persist `calendarSyncs/{urlHash}` state (`lastFetchedAt`, `lastSuccessAt`, `etag`, `contentHash`, `lastError`, `lastRunCounts`) and `syncStatus/global.lastSweepAt`. Per-calendar try/catch isolation.
+  - `functions.pubsub.schedule('every 60 minutes')`, 300s timeout: sweep teams with `calendarUrls`, conditional fetch (ETag/If-Modified-Since + `contentHash`) via the guarded fetch implementation currently inline in `exports.fetchCalendarIcs` (`normalizeTargetUrl`, `fetchWithTimeout`, `BEGIN:VCALENDAR` validation) plus the `calendar-ics-fetch-core.cjs` cache helpers, run the reconcile core, persist `calendarSyncs/{urlHash}` state (`lastFetchedAt`, `lastSuccessAt`, `etag`, `contentHash`, `lastError`, `lastRunCounts`) and `syncStatus/global.lastSweepAt`. Per-calendar try/catch isolation.
   - Tests: extend `tests/unit/functions-deployable-exports.test.js` for the new export (no `_internal` collision); unit tests for conditional-fetch skip and per-calendar failure isolation.
   - _Requirements: 1.1, 1.2, 1.5, 6.2, 6.3_
 


### PR DESCRIPTION
## Summary
- Add `/spec/schedule-loading-redesign/` (requirements, design, tasks) for redesigning schedule loading and calendar sync
- **Problem (verified against code + production data):** schedule loads fetch external ICS feeds inline with up to ~30s of proxy fallbacks per dead feed; native REST fallback lists whole collections; attendance is blocked or dead-ends depending on whether a practice came from a game doc, a client-expanded recurring series, or an imported calendar — production has orphaned attendance sessions keyed by ICS UIDs the app can no longer reach
- **Requirements:** EARS-format groups covering server-side calendar sync (hourly scheduled + on-open + manual triggers), reconciliation semantics (UID identity, source-owned vs app-owned fields, cancel-don't-delete), load-path performance, attendance on all practice events, legacy/React-app backward compatibility, and sync observability
- **Design:** scheduled Cloud Function reconciles ICS feeds into `teams/{teamId}/games` docs with deterministic IDs; both clients' existing `calendarEventUid` suppression makes rollout backward compatible with zero client changes; practice session ID becomes the event ID (removes fuzzy matching and the create race); includes Mermaid diagrams, error-handling table, and testing strategy
- **Tasks:** 19 checkbox tasks in 3 phases — Phase 1 client quick wins (attendance dead-end fixes, render-before-calendar-fetch, windowed native queries), Phase 2 server sync + migrations, Phase 3 denormalized summaries + legacy cleanup

## Test plan
- [ ] Spec-only change — no code paths affected; CI should stay green
- [ ] Review requirements/design/tasks for accuracy against `apps/app/src/lib/scheduleService.ts`, `js/utils.js`, and `functions/calendar-ics-fetch-core.cjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)