### PR TITLE
Chunk notification device sync

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -136,6 +136,8 @@ if (admin.apps.length === 0) {
 const firestore = admin.firestore();
 const TEAM_MEDIA_NOTIFICATION_BATCH_WINDOW_MS = 60 * 60 * 1000;
 const TEAM_MEDIA_NOTIFICATION_DISPATCH_LIMIT = 50;
+const FIRESTORE_BATCH_SAFE_WRITE_LIMIT = 450;
+const NOTIFICATION_RECIPIENT_DEVICE_SYNC_CONCURRENCY = 5;
 const checkStripeWebhookRateLimit = createInMemoryRateLimiter({
   windowMs: 60_000,
   maxRequests: 120,
@@ -4256,6 +4258,64 @@ function normalizeNotificationDeviceRecord(deviceId, raw) {
   };
 }
 
+function createBoundedFirestoreBatchWriter(limit = FIRESTORE_BATCH_SAFE_WRITE_LIMIT) {
+  const safeLimit = Number.isInteger(limit) && limit > 0 && limit <= 500 ? limit : FIRESTORE_BATCH_SAFE_WRITE_LIMIT;
+  let batch = firestore.batch();
+  let operationCount = 0;
+  const commits = [];
+
+  const commitCurrentBatch = () => {
+    if (operationCount <= 0) return;
+    const batchToCommit = batch;
+    commits.push(() => batchToCommit.commit());
+    batch = firestore.batch();
+    operationCount = 0;
+  };
+
+  const addOperation = (operation) => {
+    if (operationCount >= safeLimit) {
+      commitCurrentBatch();
+    }
+    operation(batch);
+    operationCount += 1;
+  };
+
+  return {
+    set(ref, value, options) {
+      addOperation((currentBatch) => currentBatch.set(ref, value, options));
+    },
+    delete(ref) {
+      addOperation((currentBatch) => currentBatch.delete(ref));
+    },
+    update(ref, value) {
+      addOperation((currentBatch) => currentBatch.update(ref, value));
+    },
+    async commit() {
+      commitCurrentBatch();
+      for (const commit of commits) {
+        await commit();
+      }
+    }
+  };
+}
+
+async function runWithConcurrencyLimit(items, limit, worker) {
+  const values = Array.from(items || []);
+  const concurrency = Math.max(1, Math.min(Number.isInteger(limit) ? limit : 1, values.length || 1));
+  let nextIndex = 0;
+  const results = new Array(values.length);
+
+  await Promise.all(Array.from({ length: concurrency }, async () => {
+    while (nextIndex < values.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await worker(values[currentIndex], currentIndex);
+    }
+  }));
+
+  return results;
+}
+
 async function getNotificationTargetTeamAccessMap(uid, teamIds) {
   const uniqueTeamIds = Array.from(new Set((Array.isArray(teamIds) ? teamIds : []).map((teamId) => String(teamId || '').trim()).filter(Boolean)));
   if (!uid || !uniqueTeamIds.length) return new Map();
@@ -4285,7 +4345,7 @@ async function syncNotificationTargetsForPreference(uid, teamId, preferences) {
   if (devicesSnap.empty) return;
 
   const teamAccessMap = await getNotificationTargetTeamAccessMap(uid, [teamId]);
-  const batch = firestore.batch();
+  const batch = createBoundedFirestoreBatchWriter();
   devicesSnap.docs.forEach((deviceSnap) => {
     const device = normalizeNotificationDeviceRecord(deviceSnap.id, deviceSnap.data());
     const indexRefs = buildTeamNotificationIndexRefs(teamId, uid, deviceSnap.id);
@@ -4318,7 +4378,7 @@ async function syncNotificationTargetsForDevice(uid, deviceId, rawDevice) {
   if (prefsSnap.empty) return;
 
   const teamAccessMap = await getNotificationTargetTeamAccessMap(uid, prefsSnap.docs.map((prefSnap) => prefSnap.id));
-  const batch = firestore.batch();
+  const batch = createBoundedFirestoreBatchWriter();
   prefsSnap.docs.forEach((prefSnap) => {
     const indexRefs = buildTeamNotificationIndexRefs(prefSnap.id, uid, deviceId);
     const preferences = normalizeNotificationPreferences(prefSnap.data());
@@ -4566,7 +4626,11 @@ exports.syncTeamNotificationRecipientsOnDeviceWrite = functions.firestore
     const userSnap = await firestore.doc(`users/${context.params.uid}`).get();
     const user = userSnap.exists ? (userSnap.data() || {}) : null;
     const teamIds = await getNotificationRecipientTeamIdsForUser(user, context.params.uid);
-    await Promise.all(teamIds.map((teamId) => syncNotificationRecipientForTeamUser(teamId, context.params.uid, { userData: user })));
+    await runWithConcurrencyLimit(
+      teamIds,
+      NOTIFICATION_RECIPIENT_DEVICE_SYNC_CONCURRENCY,
+      (teamId) => syncNotificationRecipientForTeamUser(teamId, context.params.uid, { userData: user })
+    );
     return null;
   });
 
@@ -7027,6 +7091,10 @@ exports._internal = {
   isFeeDueReminderCandidateEligible,
   buildFeeReminderNotificationBody,
   resolveEligibleFeeReminderRecipient,
+  FIRESTORE_BATCH_SAFE_WRITE_LIMIT,
+  NOTIFICATION_RECIPIENT_DEVICE_SYNC_CONCURRENCY,
+  createBoundedFirestoreBatchWriter,
+  runWithConcurrencyLimit,
   syncNotificationRecipientForTeamUser,
   syncNotificationRecipientsForUserChange,
   syncNotificationRecipientsForTeamChange

--- a/functions/test/notification-recipient-index.test.js
+++ b/functions/test/notification-recipient-index.test.js
@@ -98,9 +98,14 @@ function loadNotificationRecipientIndexEnv({
     preferenceDocs = {},
     deviceDocs = {},
     authUsersByEmail = {},
-    initialRecipientDocs = {}
+    initialRecipientDocs = {},
+    maxBatchCommitOps = 450,
+    teamDocGetDelayMs = 0
 } = {}) {
     const deletedPaths = [];
+    const batchCommitSizes = [];
+    let activeTeamDocGets = 0;
+    let maxActiveTeamDocGets = 0;
     const docStore = new Map();
 
     for (const [path, value] of Object.entries(initialRecipientDocs)) {
@@ -123,6 +128,10 @@ function loadNotificationRecipientIndexEnv({
         return (deviceDocs[uid] || []).find((entry) => String(entry.id || '').trim() === String(deviceId || '').trim()) || null;
     }
 
+    function delay(ms) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
     function doc(path) {
         return {
             path,
@@ -134,6 +143,12 @@ function loadNotificationRecipientIndexEnv({
 
                 const teamMatch = path.match(/^teams\/([^/]+)$/);
                 if (teamMatch) {
+                    activeTeamDocGets += 1;
+                    maxActiveTeamDocGets = Math.max(maxActiveTeamDocGets, activeTeamDocGets);
+                    if (teamDocGetDelayMs > 0) {
+                        await delay(teamDocGetDelayMs);
+                    }
+                    activeTeamDocGets -= 1;
                     const team = teamDocs[teamMatch[1]];
                     return makeDocSnapshot(this, team, team !== undefined);
                 }
@@ -360,6 +375,11 @@ function loadNotificationRecipientIndexEnv({
                     ops.push(() => ref.update(value));
                 },
                 async commit() {
+                    batchCommitSizes.push(ops.length);
+                    assert.ok(
+                        ops.length <= maxBatchCommitOps,
+                        `Firestore batch exceeded safe test limit: ${ops.length} > ${maxBatchCommitOps}`
+                    );
                     for (const op of ops) {
                         await op();
                     }
@@ -425,6 +445,10 @@ function loadNotificationRecipientIndexEnv({
         moduleExports,
         internals: moduleExports._internal,
         deletedPaths,
+        batchCommitSizes,
+        getMaxActiveTeamDocGets() {
+            return maxActiveTeamDocGets;
+        },
         getDoc(path) {
             return clone(docStore.get(path));
         },
@@ -581,6 +605,99 @@ test('device writes refresh token lists for every team the user belongs to', asy
         assert.equal(env.getDoc('teams/team-1/notificationRecipients/parent-1')?.tokens?.length, 2);
         assert.deepEqual(env.getDoc('teams/team-2/notificationRecipients/parent-1')?.roles, ['staff']);
         assert.deepEqual(env.getDoc('teams/team-2/notificationRecipients/parent-1')?.tokens?.map((entry) => entry.token).sort(), ['token-a', 'token-b']);
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('device target sync chunks writes below the Firestore batch limit', async () => {
+    const teamCount = 501;
+    const teamDocs = {};
+    const preferenceDocs = {};
+    const parentTeamIds = [];
+
+    for (let index = 0; index < teamCount; index += 1) {
+        const teamId = `team-${index}`;
+        teamDocs[teamId] = { ownerId: `coach-${index}`, adminEmails: [] };
+        preferenceDocs[`users/parent-1/notificationPreferences/${teamId}`] = { schedule: true };
+        parentTeamIds.push(teamId);
+    }
+
+    const env = loadNotificationRecipientIndexEnv({
+        teamDocs,
+        userDocs: {
+            'parent-1': { email: 'parent@example.com', parentTeamIds }
+        },
+        preferenceDocs,
+        deviceDocs: {
+            'parent-1': [
+                { id: 'device-a', token: 'token-a', platform: 'ios' }
+            ]
+        }
+    });
+
+    try {
+        await env.moduleExports.syncTeamNotificationTargetsOnDeviceWrite(
+            makeChange(
+                { id: 'device-a', path: 'users/parent-1/notificationDevices/device-a' },
+                null,
+                { token: 'token-a', platform: 'ios' }
+            ),
+            { params: { uid: 'parent-1', deviceId: 'device-a' } }
+        );
+
+        assert.equal(env.batchCommitSizes.length, 2);
+        assert.deepEqual(env.batchCommitSizes, [450, 51]);
+        assert.equal(env.getDoc('teams/team-0/notificationTargets/parent-1__device-a')?.token, 'token-a');
+        assert.equal(env.getDoc('teams/team-500/notificationTargets/parent-1__device-a')?.token, 'token-a');
+    } finally {
+        env.cleanup();
+    }
+});
+
+test('device recipient sync refreshes many teams with bounded concurrency', async () => {
+    const teamCount = 25;
+    const teamDocs = {};
+    const parentTeamIds = [];
+
+    for (let index = 0; index < teamCount; index += 1) {
+        const teamId = `team-${index}`;
+        teamDocs[teamId] = { ownerId: `coach-${index}`, adminEmails: [] };
+        parentTeamIds.push(teamId);
+    }
+
+    const env = loadNotificationRecipientIndexEnv({
+        teamDocs,
+        userDocs: {
+            'parent-1': { email: 'parent@example.com', parentTeamIds }
+        },
+        preferenceDocs: Object.fromEntries(parentTeamIds.map((teamId) => [
+            `users/parent-1/notificationPreferences/${teamId}`,
+            { schedule: true }
+        ])),
+        deviceDocs: {
+            'parent-1': [
+                { id: 'device-a', token: 'token-a', platform: 'ios' },
+                { id: 'device-b', token: 'token-b', platform: 'android' }
+            ]
+        },
+        teamDocGetDelayMs: 5
+    });
+
+    try {
+        await env.moduleExports.syncTeamNotificationRecipientsOnDeviceWrite(
+            makeChange(
+                { id: 'device-b', path: 'users/parent-1/notificationDevices/device-b' },
+                null,
+                { token: 'token-b', platform: 'android' }
+            ),
+            { params: { uid: 'parent-1', deviceId: 'device-b' } }
+        );
+
+        assert.equal(env.getMaxActiveTeamDocGets(), env.internals.NOTIFICATION_RECIPIENT_DEVICE_SYNC_CONCURRENCY);
+        for (const teamId of parentTeamIds) {
+            assert.deepEqual(env.getDoc(`teams/${teamId}/notificationRecipients/parent-1`)?.tokens?.map((entry) => entry.token).sort(), ['token-a', 'token-b']);
+        }
     } finally {
         env.cleanup();
     }


### PR DESCRIPTION
Closes #3539

## What changed
- Added a bounded Firestore batch writer for notification target sync, capped at 450 writes per commit.
- Updated device target sync to split 501+ team preference writes across multiple commits.
- Updated device recipient sync to refresh many team recipient docs through a concurrency-limited worker pool.
- Extended notification recipient index tests with high-cardinality device-write coverage and batch-size/concurrency instrumentation.

## Root Cause
Device push registration/refresh fanned out across every team preference and membership for a user, but target writes were queued into one Firestore WriteBatch and recipient refreshes used unbounded Promise.all. Users on hundreds of teams could exceed Firestore's 500-write batch limit or create excessive concurrent Firestore work during normal Profile push setup.

## Prevention / Learning
Any device, membership, or preference sync that fans out by team count must explicitly bound Firestore batch size and async concurrency. Regression tests need high-cardinality fixtures, not just the two-team happy path.

## Regression Tests
- `npx vitest run functions/test/notification-recipient-index.test.js --environment node --reporter=verbose`
- `npm run test:notifications` from `functions/`

## Recurrence Risk
Low. The affected device-write paths now use shared bounds, and tests fail if batch commits exceed the safe limit or recipient sync concurrency escapes the cap.