### PR TITLE
Fix parent dashboard action escaping

### DIFF
--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -2664,11 +2664,11 @@
                                 class="inline-flex items-center gap-1.5 text-xs font-semibold text-primary-700 bg-primary-50 px-3 py-1.5 rounded-lg hover:bg-primary-100 transition border border-primary-200">
                                 Athlete Profile
                             </a>
-                            <button onclick="openInviteCoParentModal('${escapeAttr(child.teamId)}', '${escapeAttr(child.playerId)}', '${escapeAttr(child.playerName)}')"
+                            <button onclick="openInviteCoParentModal(${escapeJsArgAttr(child.teamId)}, ${escapeJsArgAttr(child.playerId)}, ${escapeJsArgAttr(child.playerName)})"
                                 class="inline-flex items-center gap-1.5 text-xs font-semibold text-indigo-700 bg-indigo-50 px-3 py-1.5 rounded-lg hover:bg-indigo-100 transition border border-indigo-200">
                                 👨‍👩‍👧‍👦 Invite Co-Parent
                             </button>
-                            <button onclick="openIncentivesPanel('${escapeAttr(child.playerId)}', '${escapeAttr(child.playerName)}', '${escapeAttr(child.teamId)}')"
+                            <button onclick="openIncentivesPanel(${escapeJsArgAttr(child.playerId)}, ${escapeJsArgAttr(child.playerName)}, ${escapeJsArgAttr(child.teamId)})"
                                 class="inline-flex items-center gap-1.5 text-xs font-semibold text-amber-700 bg-amber-50 px-3 py-1.5 rounded-lg hover:bg-amber-100 transition border border-amber-200">
                                 💰 Incentives
                             </button>
@@ -2819,7 +2819,7 @@
                             const earnedCents = incentivesEarningsCache.get(cacheKey);
                             if (game.type === 'game' && game.isDbGame && !game.isCancelled && earnedCents !== undefined && earnedCents !== 0) {
                                 const isPositive = earnedCents >= 0;
-                                return `<button onclick="openIncentivesPanel('${escapeAttr(game.childId)}', '${escapeAttr(game.childName || '')}', '${escapeAttr(game.teamId)}')"
+                                return `<button onclick="openIncentivesPanel(${escapeJsArgAttr(game.childId)}, ${escapeJsArgAttr(game.childName || '')}, ${escapeJsArgAttr(game.teamId)})"
                                     class="inline-flex items-center gap-1 text-xs font-semibold ${isPositive ? 'text-green-700 bg-green-50 border-green-200' : 'text-red-600 bg-red-50 border-red-200'} px-2 py-0.5 rounded-full mt-1 mr-1 border hover:opacity-80 transition">
                                     💰 ${isPositive ? '+' : ''}${formatCents(earnedCents, { sign: false })} earned →
                                 </button>`;

--- a/tests/unit/parent-dashboard-player-action-wiring.test.js
+++ b/tests/unit/parent-dashboard-player-action-wiring.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readParentDashboardSource() {
+    return readFileSync(new URL('../../parent-dashboard.html', import.meta.url), 'utf8');
+}
+
+describe('parent dashboard player action wiring', () => {
+    it('serializes My Players action onclick arguments as JavaScript strings before HTML escaping', () => {
+        const html = readParentDashboardSource();
+
+        expect(html).toContain('function escapeJsArgAttr(value)');
+        expect(html).toContain("return escapeAttr(JSON.stringify(String(value ?? '')));");
+        expect(html).toContain('openInviteCoParentModal(${escapeJsArgAttr(child.teamId)}, ${escapeJsArgAttr(child.playerId)}, ${escapeJsArgAttr(child.playerName)})');
+        expect(html).toContain('openIncentivesPanel(${escapeJsArgAttr(child.playerId)}, ${escapeJsArgAttr(child.playerName)}, ${escapeJsArgAttr(child.teamId)})');
+        expect(html).not.toContain("openInviteCoParentModal('${escapeAttr(child.teamId)}', '${escapeAttr(child.playerId)}', '${escapeAttr(child.playerName)}')");
+        expect(html).not.toContain("openIncentivesPanel('${escapeAttr(child.playerId)}', '${escapeAttr(child.playerName)}', '${escapeAttr(child.teamId)}')");
+    });
+
+    it('serializes schedule earnings incentive action arguments the same way', () => {
+        const html = readParentDashboardSource();
+
+        expect(html).toContain("openIncentivesPanel(${escapeJsArgAttr(game.childId)}, ${escapeJsArgAttr(game.childName || '')}, ${escapeJsArgAttr(game.teamId)})");
+        expect(html).not.toContain("openIncentivesPanel('${escapeAttr(game.childId)}', '${escapeAttr(game.childName || '')}', '${escapeAttr(game.teamId)}')");
+    });
+});


### PR DESCRIPTION
Closes #3538

## What changed
- Updated Parent Dashboard Invite Co-Parent and Incentives inline handlers to use `escapeJsArgAttr` for JavaScript string arguments.
- Applied the same safe argument serialization to the schedule earnings Incentives action.
- Added focused regression coverage for the affected Parent Dashboard action wiring.

## Root Cause
Parent Dashboard rendered user-controlled player names inside single-quoted inline `onclick` arguments using only HTML attribute escaping. Browsers decode `&#39;` before JavaScript parses the handler, so names like `O'Connor` terminated the string and caused a syntax error.

## Prevention / Learning
When user-controlled text is placed in inline JavaScript handlers, serialize it as a JavaScript string with `JSON.stringify` before HTML attribute escaping. Tests should assert the exact rendering/event path, not just generic HTML escaping.

## Regression Tests
- `npx vitest run tests/unit/parent-dashboard-player-action-wiring.test.js tests/unit/parent-dashboard-rideshare-wiring.test.js --reporter=verbose`
- Added `tests/unit/parent-dashboard-player-action-wiring.test.js` to guard Invite Co-Parent and Incentives handler serialization.