### PR TITLE
Sanitize roster rollover player payloads

### DIFF
--- a/js/team-rollover.js
+++ b/js/team-rollover.js
@@ -9,6 +9,30 @@ const ROLLOVER_OMITTED_PLAYER_FIELDS = new Set([
 
 ]);
 
+const ROLLOVER_SENSITIVE_PLAYER_FIELDS = new Set([
+    'medicalInfo', 'medical_info', 'medicalNotes', 'medical_notes',
+    'emergencyContact', 'emergency_contact', 'emergencyContactName', 'emergencyContactPhone',
+    'parents', 'parent', 'parentEmail', 'parentPhone', 'parentRelation',
+    'guardian', 'guardians', 'guardianEmail', 'guardianPhone', 'guardianRelation',
+    'householdContact', 'householdContacts', 'householdEmail', 'householdPhone', 'householdRelation'
+]);
+
+const ROLLOVER_ROSTER_FIELD_SOURCES = new Set([
+    'rosterFieldValues',
+    'customFields',
+    'profileFields',
+    'extraFields'
+]);
+
+function omitSensitiveRosterFields(source = {}) {
+    const copy = {};
+    Object.entries(source).forEach(([key, value]) => {
+        if (ROLLOVER_SENSITIVE_PLAYER_FIELDS.has(key)) return;
+        copy[key] = value;
+    });
+    return copy;
+}
+
 export function buildRolloverPlayerCopy(sourcePlayer, sourceTeamId, rolledOverAt) {
     if (!sourcePlayer || typeof sourcePlayer !== 'object') {
         throw new Error('Source player is required');
@@ -17,6 +41,11 @@ export function buildRolloverPlayerCopy(sourcePlayer, sourceTeamId, rolledOverAt
     const copy = {};
     Object.entries(sourcePlayer).forEach(([key, value]) => {
         if (ROLLOVER_OMITTED_PLAYER_FIELDS.has(key)) return;
+        if (ROLLOVER_SENSITIVE_PLAYER_FIELDS.has(key)) return;
+        if (ROLLOVER_ROSTER_FIELD_SOURCES.has(key) && value && typeof value === 'object' && !Array.isArray(value)) {
+            copy[key] = omitSensitiveRosterFields(value);
+            return;
+        }
         copy[key] = value;
     });
 

--- a/js/team-rollover.js
+++ b/js/team-rollover.js
@@ -33,6 +33,22 @@ function omitSensitiveRosterFields(source = {}) {
     return copy;
 }
 
+function isPlainRosterMap(value) {
+    return value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function omitSensitiveProfileRosterFields(profile = {}) {
+    const copy = {};
+    Object.entries(profile).forEach(([key, value]) => {
+        if ((key === 'rosterFields' || key === 'customFields') && isPlainRosterMap(value)) {
+            copy[key] = omitSensitiveRosterFields(value);
+            return;
+        }
+        copy[key] = value;
+    });
+    return copy;
+}
+
 export function buildRolloverPlayerCopy(sourcePlayer, sourceTeamId, rolledOverAt) {
     if (!sourcePlayer || typeof sourcePlayer !== 'object') {
         throw new Error('Source player is required');
@@ -42,8 +58,12 @@ export function buildRolloverPlayerCopy(sourcePlayer, sourceTeamId, rolledOverAt
     Object.entries(sourcePlayer).forEach(([key, value]) => {
         if (ROLLOVER_OMITTED_PLAYER_FIELDS.has(key)) return;
         if (ROLLOVER_SENSITIVE_PLAYER_FIELDS.has(key)) return;
-        if (ROLLOVER_ROSTER_FIELD_SOURCES.has(key) && value && typeof value === 'object' && !Array.isArray(value)) {
+        if (ROLLOVER_ROSTER_FIELD_SOURCES.has(key) && isPlainRosterMap(value)) {
             copy[key] = omitSensitiveRosterFields(value);
+            return;
+        }
+        if (key === 'profile' && isPlainRosterMap(value)) {
+            copy[key] = omitSensitiveProfileRosterFields(value);
             return;
         }
         copy[key] = value;

--- a/tests/unit/team-rollover.test.js
+++ b/tests/unit/team-rollover.test.js
@@ -100,6 +100,17 @@ describe('team rollover player copy', () => {
                 height: '5-8',
                 medicalInfo: 'asthma'
             },
+            profile: {
+                nickname: 'Sam',
+                rosterFields: {
+                    graduationYear: '2030',
+                    medicalNotes: 'uses inhaler'
+                },
+                customFields: {
+                    bats: 'right',
+                    parentEmail: 'parent@example.com'
+                }
+            },
             createdAt: { old: true },
             updatedAt: { old: true }
         }, 'team-old', rolledOverAt);
@@ -112,6 +123,15 @@ describe('team rollover player copy', () => {
             active: true,
             rosterFieldValues: {
                 height: '5-8'
+            },
+            profile: {
+                nickname: 'Sam',
+                rosterFields: {
+                    graduationYear: '2030'
+                },
+                customFields: {
+                    bats: 'right'
+                }
             },
             sourceTeamId: 'team-old',
             sourcePlayerId: 'player-1',
@@ -160,6 +180,16 @@ describe('team rollover player copy', () => {
                     rosterFieldValues: {
                         school: 'Central',
                         guardianPhone: '555-9999'
+                    },
+                    profile: {
+                        rosterFields: {
+                            graduationYear: '2030',
+                            emergencyContactPhone: '555-0000'
+                        },
+                        customFields: {
+                            throws: 'right',
+                            householdEmail: 'household@example.com'
+                        }
                     }
                 },
                 {
@@ -190,6 +220,10 @@ describe('team rollover player copy', () => {
             active: true,
             number: '12',
             rosterFieldValues: { school: 'Central' },
+            profile: {
+                rosterFields: { graduationYear: '2030' },
+                customFields: { throws: 'right' }
+            },
             sourceTeamId: 'team-old',
             sourcePlayerId: 'player-1'
         });
@@ -204,6 +238,8 @@ describe('team rollover player copy', () => {
         expect(harness.batch.setCalls[0].payload).not.toHaveProperty('emergencyContact');
         expect(harness.batch.setCalls[0].payload).not.toHaveProperty('medicalInfo');
         expect(harness.batch.setCalls[0].payload.rosterFieldValues).not.toHaveProperty('guardianPhone');
+        expect(harness.batch.setCalls[0].payload.profile.rosterFields).not.toHaveProperty('emergencyContactPhone');
+        expect(harness.batch.setCalls[0].payload.profile.customFields).not.toHaveProperty('householdEmail');
         expect(harness.batch.setCalls[1].payload).not.toHaveProperty('parentEmail');
         expect(harness.batch.setCalls[1].payload).not.toHaveProperty('householdContact');
         expect(harness.batch.setCalls[1].payload.customFields).not.toHaveProperty('emergencyContactName');

--- a/tests/unit/team-rollover.test.js
+++ b/tests/unit/team-rollover.test.js
@@ -1,8 +1,93 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { buildRolloverPlayerCopy } from '../../js/team-rollover.js';
 
+function readDbSource() {
+    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+}
+
+function extractFunction(source, signature) {
+    const start = source.indexOf(signature);
+    expect(start, `Expected function signature to exist: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    const parenStart = source.indexOf('(', start);
+    expect(parenStart, `Expected opening paren for: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    let parenDepth = 1;
+    let parenEnd = -1;
+    for (let i = parenStart + 1; i < source.length; i += 1) {
+        const ch = source[i];
+        if (ch === '(') parenDepth += 1;
+        if (ch === ')') parenDepth -= 1;
+        if (parenDepth === 0) {
+            parenEnd = i;
+            break;
+        }
+    }
+
+    expect(parenEnd, `Expected closing paren for: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    const braceStart = source.indexOf('{', parenEnd);
+    expect(braceStart, `Expected opening brace for: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    let depth = 1;
+    for (let i = braceStart + 1; i < source.length; i += 1) {
+        const ch = source[i];
+        if (ch === '{') depth += 1;
+        if (ch === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, i + 1);
+        }
+    }
+
+    throw new Error(`Could not extract function for signature: ${signature}`);
+}
+
+function buildRolloverDbHarness({ players = [] } = {}) {
+    const source = readDbSource();
+    const assertFnSource = extractFunction(source, 'function assertNoSensitivePlayerFields(');
+    const copyFnSource = extractFunction(source, 'export async function copySelectedPlayersForTeamRollover(')
+        .replace('export async function copySelectedPlayersForTeamRollover', 'async function copySelectedPlayersForTeamRollover');
+    const batch = {
+        setCalls: [],
+        set(ref, payload) {
+            this.setCalls.push({ ref, payload });
+        },
+        commit: async () => {
+            batch.committed = true;
+        },
+        committed: false
+    };
+    const deps = {
+        buildRolloverPlayerCopy,
+        collection: (_db, path) => ({ path }),
+        db: {},
+        doc: (collectionRef) => ({ path: `${collectionRef.path}/auto-${batch.setCalls.length + 1}` }),
+        getPlayers: async () => players,
+        Timestamp: { now: () => ({ marker: `ts-${batch.setCalls.length}` }) },
+        writeBatch: () => {
+            deps.batchCreated = true;
+            return batch;
+        },
+        batchCreated: false
+    };
+
+    const factory = new Function('deps', `
+        const { buildRolloverPlayerCopy, collection, db, doc, getPlayers, Timestamp, writeBatch } = deps;
+        ${assertFnSource}
+        ${copyFnSource}
+        return { copySelectedPlayersForTeamRollover };
+    `);
+
+    return {
+        batch,
+        deps,
+        ...factory(deps)
+    };
+}
+
 describe('team rollover player copy', () => {
-    it('preserves supported public player and family fields with source audit metadata', () => {
+    it('preserves supported public player fields with source audit metadata', () => {
         const rolledOverAt = { marker: 'now' };
         const copy = buildRolloverPlayerCopy({
             id: 'player-1',
@@ -11,7 +96,10 @@ describe('team rollover player copy', () => {
             position: 'Guard',
             photoUrl: 'https://example.test/player.png',
             active: false,
-            parents: [{ userId: 'parent-1', email: 'parent@example.com', relation: 'Mom' }],
+            rosterFieldValues: {
+                height: '5-8',
+                medicalInfo: 'asthma'
+            },
             createdAt: { old: true },
             updatedAt: { old: true }
         }, 'team-old', rolledOverAt);
@@ -22,14 +110,16 @@ describe('team rollover player copy', () => {
             position: 'Guard',
             photoUrl: 'https://example.test/player.png',
             active: true,
-            parents: [{ userId: 'parent-1', email: 'parent@example.com', relation: 'Mom' }],
+            rosterFieldValues: {
+                height: '5-8'
+            },
             sourceTeamId: 'team-old',
             sourcePlayerId: 'player-1',
             rolledOverAt
         });
     });
 
-    it('copies medical and emergency contact info during rollover', () => {
+    it('omits private family, medical, and emergency contact info during rollover', () => {
         const medicalInfo = { allergies: 'peanuts' };
         const emergencyContact = { name: 'Jane Doe', phone: '555-1234' };
         const copy = buildRolloverPlayerCopy({
@@ -37,16 +127,105 @@ describe('team rollover player copy', () => {
             name: 'Sam Player',
             medicalInfo,
             emergencyContact,
+            parents: [{ userId: 'parent-1', email: 'parent@example.com', relation: 'Mom' }],
+            guardianEmail: 'guardian@example.com',
+            householdContact: { name: 'Family Contact' },
             sourceTeamId: 'older-team',
             sourcePlayerId: 'older-player',
             rolledOverAt: { old: true },
             deactivatedAt: { old: true }
         }, 'team-old', { marker: 'now' });
 
-        expect(copy).toHaveProperty('medicalInfo', medicalInfo);
-        expect(copy).toHaveProperty('emergencyContact', emergencyContact);
+        expect(copy).not.toHaveProperty('medicalInfo');
+        expect(copy).not.toHaveProperty('emergencyContact');
+        expect(copy).not.toHaveProperty('parents');
+        expect(copy).not.toHaveProperty('guardianEmail');
+        expect(copy).not.toHaveProperty('householdContact');
         expect(copy).not.toHaveProperty('deactivatedAt');
         expect(copy.sourceTeamId).toBe('team-old');
         expect(copy.sourcePlayerId).toBe('player-1');
+    });
+
+    it('writes sanitized public player payloads through the rollover copy path', async () => {
+        const harness = buildRolloverDbHarness({
+            players: [
+                {
+                    id: 'player-1',
+                    name: 'Sam Player',
+                    active: true,
+                    number: '12',
+                    parents: [{ userId: 'parent-1', email: 'parent@example.com' }],
+                    emergencyContact: { name: 'Jane Doe', phone: '555-1234' },
+                    medicalInfo: { allergies: 'peanuts' },
+                    rosterFieldValues: {
+                        school: 'Central',
+                        guardianPhone: '555-9999'
+                    }
+                },
+                {
+                    id: 'player-2',
+                    name: 'Taylor Player',
+                    active: true,
+                    parentEmail: 'parent2@example.com',
+                    householdContact: { name: 'Household Contact' },
+                    customFields: {
+                        jerseySize: 'M',
+                        emergencyContactName: 'Alex'
+                    }
+                }
+            ]
+        });
+
+        await expect(harness.copySelectedPlayersForTeamRollover('team-old', 'team-new', ['player-1', 'player-2']))
+            .resolves.toEqual({ copiedCount: 2 });
+
+        expect(harness.batch.committed).toBe(true);
+        expect(harness.batch.setCalls).toHaveLength(2);
+        expect(harness.batch.setCalls.map(call => call.ref.path)).toEqual([
+            'teams/team-new/players/auto-1',
+            'teams/team-new/players/auto-2'
+        ]);
+        expect(harness.batch.setCalls[0].payload).toMatchObject({
+            name: 'Sam Player',
+            active: true,
+            number: '12',
+            rosterFieldValues: { school: 'Central' },
+            sourceTeamId: 'team-old',
+            sourcePlayerId: 'player-1'
+        });
+        expect(harness.batch.setCalls[1].payload).toMatchObject({
+            name: 'Taylor Player',
+            active: true,
+            customFields: { jerseySize: 'M' },
+            sourceTeamId: 'team-old',
+            sourcePlayerId: 'player-2'
+        });
+        expect(harness.batch.setCalls[0].payload).not.toHaveProperty('parents');
+        expect(harness.batch.setCalls[0].payload).not.toHaveProperty('emergencyContact');
+        expect(harness.batch.setCalls[0].payload).not.toHaveProperty('medicalInfo');
+        expect(harness.batch.setCalls[0].payload.rosterFieldValues).not.toHaveProperty('guardianPhone');
+        expect(harness.batch.setCalls[1].payload).not.toHaveProperty('parentEmail');
+        expect(harness.batch.setCalls[1].payload).not.toHaveProperty('householdContact');
+        expect(harness.batch.setCalls[1].payload.customFields).not.toHaveProperty('emergencyContactName');
+    });
+
+    it('does not create a partial batch when a selected rollover player is missing', async () => {
+        const harness = buildRolloverDbHarness({
+            players: [
+                {
+                    id: 'player-1',
+                    name: 'Sam Player',
+                    active: true,
+                    medicalInfo: { allergies: 'peanuts' }
+                }
+            ]
+        });
+
+        await expect(harness.copySelectedPlayersForTeamRollover('team-old', 'team-new', ['player-1', 'missing-player']))
+            .rejects.toThrow('One or more selected players could not be found on the source team. Refresh and try again.');
+
+        expect(harness.deps.batchCreated).toBe(false);
+        expect(harness.batch.setCalls).toHaveLength(0);
+        expect(harness.batch.committed).toBe(false);
     });
 });


### PR DESCRIPTION
Closes #3536

## What changed
- Sanitized team rollover player copies so public roster docs exclude private family, emergency contact, household, guardian, and medical fields.
- Added focused rollover tests for the real `copySelectedPlayersForTeamRollover` batch path and missing-player failure path.

## Root Cause
`buildRolloverPlayerCopy` copied realistic source roster records into the public player payload before `copySelectedPlayersForTeamRollover` validated them, so private family, emergency contact, and medical fields could reach the public-doc assertion and break rollover at write time.

## Prevention / Learning
Any workflow that copies player records into public roster docs must sanitize against the public/private player split before batching writes. Tests should exercise the persistence helper boundary, not only the pure copy helper or UI wiring mocks.

## Regression Tests
- `npx vitest run tests/unit/team-rollover.test.js --reporter=verbose`

## Recurrence Risk
Low: the helper now strips the forbidden fields and the focused test covers the db rollover batch contract with realistic sensitive source data.