### PR TITLE
Fix replay seek stats reconciliation

### DIFF
--- a/js/live-game.js
+++ b/js/live-game.js
@@ -2204,6 +2204,8 @@ function seekReplay(targetMs) {
   state.eventIds = new Set();
   state.stats = {};
   state.opponentStats = {};
+  state.onCourt = [];
+  state.bench = [];
   state.homeScore = 0;
   state.awayScore = 0;
   state.period = getDefaultLivePeriod({ game: state.game, team: state.team });
@@ -2212,6 +2214,9 @@ function seekReplay(targetMs) {
   state.replayChatIndex = 0;
   state.replayReactionIndex = 0;
   state.chatMessages = [];
+  state.lastStatChange = null;
+  state.scoringRun = { team: null, points: 0 };
+  state.lastRunAnnounced = 0;
 
   if (els.playsFeed) els.playsFeed.innerHTML = '';
   if (els.chatMessages) {
@@ -2230,6 +2235,8 @@ function seekReplay(targetMs) {
 
   advanceReplayStreams(targetMs);
   renderScoreboard();
+  renderStats();
+  renderLineup();
   if (els.replayCurrent) els.replayCurrent.textContent = formatClock(targetMs);
 }
 

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -551,6 +551,9 @@ async function bootReplayPage({ replayEvents }) {
         replayControls: ensureElement('replay-controls'),
         replayStartRebaseCalls,
         seekReplay: moduleInstance.seekReplay,
+        opponentStats: ensureElement('opponent-stats'),
+        lineupOnCourt: ensureElement('lineup-oncourt'),
+        lineupBench: ensureElement('lineup-bench'),
         state: moduleInstance.state
     };
 }
@@ -609,6 +612,42 @@ describe('live game replay initialization', () => {
         });
         expect(page.state.replayStartTime).toBe(12345);
         expect(page.state.gameClockMs).toBe(30_000);
+    });
+
+    it('reconciles stats and lineup when seeking before replay events', async () => {
+        const page = await bootReplayPage({
+            replayEvents: [
+                {
+                    id: 'event-1',
+                    type: 'stat',
+                    statKey: 'pts',
+                    value: 2,
+                    playerId: 'player-1',
+                    period: 'Q1',
+                    gameClockMs: 10_000,
+                    description: 'Basket',
+                    createdAt: { toMillis: () => 10_000 }
+                }
+            ]
+        });
+
+        page.state.stats = { 'player-1': { pts: 2 } };
+        page.state.opponentStats = { 'opp-1': { name: 'Future Opponent', pts: 2 } };
+        page.state.onCourt = ['player-1'];
+        page.state.bench = ['player-2'];
+        page.opponentStats.innerHTML = '<div>Future Opponent 2 PTS</div>';
+        page.lineupOnCourt.innerHTML = '<div>Future Player 2 PTS</div>';
+        page.lineupBench.innerHTML = '<div>Future Bench</div>';
+
+        page.seekReplay(0);
+
+        expect(page.state.stats).toEqual({});
+        expect(page.state.opponentStats).toEqual({});
+        expect(page.state.onCourt).toEqual([]);
+        expect(page.state.bench).toEqual([]);
+        expect(page.opponentStats.innerHTML).toBe('');
+        expect(page.lineupOnCourt.innerHTML).toBe('');
+        expect(page.lineupBench.innerHTML).toBe('');
     });
 
     it('applies the same replay chat lockout whether replay events exist or not', async () => {


### PR DESCRIPTION
Closes #3565

## What changed
- Reset replay-derived lineup, stat highlight, and scoring-run state when the replay scrubber seeks.
- Rerender stats and lineup after rebuilding the replay window, including the path where no events exist at the target timestamp.
- Added focused regression coverage for seeking back before future stat/lineup events.

## Root Cause
`seekReplay()` cleared replay event, score, chat, home stats, and opponent stats state, but it did not clear lineup-derived state or force the Stats and lineup DOM to rerender after the reset. When seeking backward before any replay events were processed, the scoreboard and feed rewound while the previously rendered future stats/lineup DOM stayed visible.

## Prevention / Learning
Replay seek paths must reconcile every replay-derived UI surface, not only the scoreboard and play feed. Regression tests for scrubber behavior should seed stale DOM, seek to a timestamp with no replay events, and assert all derived panels clear.

## Regression Tests
- `npx vitest run tests/unit/live-game-replay-init.test.js --reporter=verbose`