### PR TITLE
Harden parent invite redemption rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -137,8 +137,10 @@ service cloud.firestore {
              request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
              resource.data.used == false &&
              resource.data.get('revoked', false) != true &&
+             resource.data.get('active', true) != false &&
              resource.data.get('status', 'active') != 'removed' &&
              resource.data.get('status', 'active') != 'cancelled' &&
+             resource.data.get('status', 'active') != 'revoked' &&
              (resource.data.get('expiresAt', null) == null ||
               (resource.data.expiresAt is timestamp && resource.data.expiresAt > request.time)) &&
              (!('email' in resource.data) ||

--- a/firestore.rules
+++ b/firestore.rules
@@ -135,6 +135,18 @@ service cloud.firestore {
       return resource.data.get('type', null) == 'parent_invite' &&
              request.resource.data.get('type', resource.data.get('type', null)) == 'parent_invite' &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
+             resource.data.used == false &&
+             resource.data.get('revoked', false) != true &&
+             resource.data.get('status', 'active') != 'removed' &&
+             resource.data.get('status', 'active') != 'cancelled' &&
+             (resource.data.get('expiresAt', null) == null ||
+              (resource.data.expiresAt is timestamp && resource.data.expiresAt > request.time)) &&
+             (!('email' in resource.data) ||
+              resource.data.email == null ||
+              resource.data.email == '' ||
+              (resource.data.email is string &&
+               request.auth.token.email is string &&
+               request.auth.token.email.lower() == resource.data.email.lower())) &&
              request.resource.data.used == true &&
              request.resource.data.usedBy == request.auth.uid &&
              request.resource.data.usedAt is timestamp;

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -80,8 +80,10 @@ describe('access code Firestore rules', () => {
     it('requires parent_invite redemption to use an active invite owned by the signed-in email', () => {
         expect(parentInviteRedemptionRule).toContain('resource.data.used == false');
         expect(parentInviteRedemptionRule).toContain("resource.data.get('revoked', false) != true");
+        expect(parentInviteRedemptionRule).toContain("resource.data.get('active', true) != false");
         expect(parentInviteRedemptionRule).toContain("resource.data.get('status', 'active') != 'removed'");
         expect(parentInviteRedemptionRule).toContain("resource.data.get('status', 'active') != 'cancelled'");
+        expect(parentInviteRedemptionRule).toContain("resource.data.get('status', 'active') != 'revoked'");
         expect(parentInviteRedemptionRule).toContain("resource.data.get('expiresAt', null) == null");
         expect(parentInviteRedemptionRule).toContain('resource.data.expiresAt > request.time');
         expect(parentInviteRedemptionRule).toContain("!('email' in resource.data)");
@@ -96,6 +98,8 @@ describe('access code Firestore rules', () => {
         const authorizationGuards = parentInviteRedemptionRule.slice(affectedKeysIndex);
         expect(authorizationGuards).toContain('resource.data.used == false');
         expect(authorizationGuards).toContain("resource.data.get('revoked', false) != true");
+        expect(authorizationGuards).toContain("resource.data.get('active', true) != false");
+        expect(authorizationGuards).toContain("resource.data.get('status', 'active') != 'revoked'");
         expect(authorizationGuards).toContain('request.auth.token.email.lower() == resource.data.email.lower()');
     });
 

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -5,6 +5,8 @@ import { resolve } from 'node:path';
 const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
 const accessCodeMatch = rules.match(/match \/accessCodes\/\{codeId\} \{[\s\S]*?\n\s*\}/);
 const accessCodeRules = accessCodeMatch?.[0] || '';
+const parentInviteRedemptionMatch = rules.match(/function isParentInviteRedemptionUpdate\(\) \{[\s\S]*?\n    \}/);
+const parentInviteRedemptionRule = parentInviteRedemptionMatch?.[0] || '';
 
 describe('access code Firestore rules', () => {
     it('removes the public accessCodes read loophole and scopes raw access to authorized users', () => {
@@ -73,6 +75,28 @@ describe('access code Firestore rules', () => {
         expect(accessCodeRules).toContain("resource.data.get('type', null) != 'parent_invite'");
         expect(accessCodeRules).toContain("resource.data.get('type', null) != 'household_invite'");
         expect(accessCodeRules).not.toContain("resource.data.type != 'parent_invite'");
+    });
+
+    it('requires parent_invite redemption to use an active invite owned by the signed-in email', () => {
+        expect(parentInviteRedemptionRule).toContain('resource.data.used == false');
+        expect(parentInviteRedemptionRule).toContain("resource.data.get('revoked', false) != true");
+        expect(parentInviteRedemptionRule).toContain("resource.data.get('status', 'active') != 'removed'");
+        expect(parentInviteRedemptionRule).toContain("resource.data.get('status', 'active') != 'cancelled'");
+        expect(parentInviteRedemptionRule).toContain("resource.data.get('expiresAt', null) == null");
+        expect(parentInviteRedemptionRule).toContain('resource.data.expiresAt > request.time');
+        expect(parentInviteRedemptionRule).toContain("!('email' in resource.data)");
+        expect(parentInviteRedemptionRule).toContain('request.auth.token.email is string');
+        expect(parentInviteRedemptionRule).toContain('request.auth.token.email.lower() == resource.data.email.lower()');
+    });
+
+    it('does not let parent_invite redemption rely only on writable key narrowing', () => {
+        const affectedKeysIndex = parentInviteRedemptionRule.indexOf("affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
+        expect(affectedKeysIndex).toBeGreaterThanOrEqual(0);
+
+        const authorizationGuards = parentInviteRedemptionRule.slice(affectedKeysIndex);
+        expect(authorizationGuards).toContain('resource.data.used == false');
+        expect(authorizationGuards).toContain("resource.data.get('revoked', false) != true");
+        expect(authorizationGuards).toContain('request.auth.token.email.lower() == resource.data.email.lower()');
     });
 
     it('requires household_invite creation to match an organizer-owned family membership and linked parent scope', () => {


### PR DESCRIPTION
Closes #3535

## What changed
- Tightened `isParentInviteRedemptionUpdate()` so direct parent invite redemption now requires the source invite to be unused, unrevoked, non-removed/non-cancelled, and unexpired when `expiresAt` is present.
- Required signed-in auth email to match `resource.data.email` for email-bound parent invites while preserving code-only redemption when no invite email is present.
- Added focused unit guards so parent invite redemption cannot regress to writable-key narrowing only.

## Root Cause
The Firestore rule for parent invite redemption only limited the updated fields and trusted client-side validation for invited-email and active-state checks. A direct `accessCodes` update could therefore consume an email-bound or inactive invite without satisfying the intended authorization boundary.

## Prevention / Learning
Invite and token redemption rules must independently enforce actor ownership, unused state, revocation/removal state, and expiry at the mutation boundary. Client-side checks are useful UX, not security controls.

## Regression Tests
- `npx vitest run tests/unit/access-code-rules.test.js tests/unit/access-code-atomic-redemption-guard.test.js --reporter=verbose`
- `npm run ci:firebase-rules`

## Recurrence Risk
Low. The exact server-side predicate now carries the missing authorization checks, and adjacent unit tests fail if redemption relies only on affected-key narrowing again.