### PR TITLE
Gate report replay action by availability

### DIFF
--- a/game.html
+++ b/game.html
@@ -399,7 +399,7 @@
         import { splitPlayerStatsByVisibility } from './js/stat-leaderboards.js?v=2';
         import { formatGameReportEventTimestamp, resolveReportStatColumns, resolveOpponentReportStatColumns } from './js/game-report-stats.js?v=2';
         import { normalizeStatKey, resolvePostGameStatFields, resolvePostGameTeamStatFields, resolvePostGameEditorDidNotPlay, buildCompletedGamePlayerStatsPayload, buildCompletedGameTeamStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=4';
-        import { buildHighlightShareUrl, normalizeGameRecapHighlightClips } from './js/live-game-video.js?v=3';
+        import { buildHighlightShareUrl, normalizeGameRecapHighlightClips, resolveReplayVideoOptions } from './js/live-game-video.js?v=3';
 
         let currentUser = null;
         let canManageStatSheet = false;
@@ -434,6 +434,51 @@
             toast.textContent = message;
             document.body.appendChild(toast);
             setTimeout(() => toast.remove(), 2000);
+        }
+
+        function renderReplayReportAction({ teamId, gameId, game }) {
+            const gameCompleted = game?.status === 'completed' || game?.liveStatus === 'completed';
+            if (!gameCompleted) return '';
+
+            const replayOptions = resolveReplayVideoOptions({
+                game,
+                isReplay: true
+            });
+
+            if (replayOptions.hasVideo) {
+                return `
+                    <a href="live-game.html?teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}&replay=true"
+                       class="inline-flex items-center gap-2 bg-teal-500 text-white px-5 py-2 rounded-full font-semibold shadow hover:bg-teal-600 transition">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                        Watch Replay
+                    </a>
+                `;
+            }
+
+            const replayState = replayOptions.replayState || {
+                status: 'unavailable',
+                title: 'Replay unavailable'
+            };
+            const stateLabel = replayState.status === 'processing'
+                ? 'Replay Processing'
+                : replayState.status === 'failed'
+                    ? 'Replay Failed'
+                    : 'Replay Unavailable';
+            const stateClasses = replayState.status === 'processing'
+                ? 'bg-amber-50 text-amber-700 border-amber-200'
+                : replayState.status === 'failed'
+                    ? 'bg-red-50 text-red-700 border-red-200'
+                    : 'bg-gray-50 text-gray-600 border-gray-200';
+
+            return `
+                <span class="inline-flex items-center gap-2 px-5 py-2 rounded-full font-semibold shadow border ${stateClasses}"
+                      aria-label="${escapeHtml(replayState.title || stateLabel)}">
+                    ${escapeHtml(stateLabel)}
+                </span>
+            `;
         }
 
         function insightToneClasses(tone) {
@@ -1375,6 +1420,7 @@ Write the match report now:`;
                 // Render Header
                 const scoreView = resolveGameReportScoreView(game);
                 const { teamScore, opponentScore, isWin, isLoss, isTie } = scoreView;
+                const replayReportAction = renderReplayReportAction({ teamId, gameId, game });
 
                 document.getElementById('game-header').innerHTML = `
                     <div class="inline-flex items-center gap-2 mb-4">
@@ -1415,16 +1461,7 @@ Write the match report now:`;
                         </div>
                     </div>
                     <div class="flex flex-wrap justify-center gap-3 mb-4">
-                    ${game.liveStatus === 'completed' ? `
-                        <a href="live-game.html?teamId=${teamId}&gameId=${gameId}&replay=true"
-                           class="inline-flex items-center gap-2 bg-teal-500 text-white px-5 py-2 rounded-full font-semibold shadow hover:bg-teal-600 transition">
-                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                            </svg>
-                            Watch Replay
-                        </a>
-                    ` : ''}
+                    ${replayReportAction}
                     ${game.liveStatus === 'live' ? `
                         <a href="live-game.html?teamId=${teamId}&gameId=${gameId}"
                            class="inline-flex items-center gap-2 bg-red-500 text-white px-5 py-2 rounded-full font-semibold shadow hover:bg-red-600 transition">

--- a/game.html
+++ b/game.html
@@ -436,11 +436,12 @@
             setTimeout(() => toast.remove(), 2000);
         }
 
-        function renderReplayReportAction({ teamId, gameId, game }) {
+        function renderReplayReportAction({ teamId, gameId, game, team }) {
             const gameCompleted = game?.status === 'completed' || game?.liveStatus === 'completed';
             if (!gameCompleted) return '';
 
             const replayOptions = resolveReplayVideoOptions({
+                team,
                 game,
                 isReplay: true
             });
@@ -1420,7 +1421,7 @@ Write the match report now:`;
                 // Render Header
                 const scoreView = resolveGameReportScoreView(game);
                 const { teamScore, opponentScore, isWin, isLoss, isTie } = scoreView;
-                const replayReportAction = renderReplayReportAction({ teamId, gameId, game });
+                const replayReportAction = renderReplayReportAction({ teamId, gameId, game, team: resolvedTeam });
 
                 document.getElementById('game-header').innerHTML = `
                     <div class="inline-flex items-center gap-2 mb-4">

--- a/tests/unit/game-report-replay-action.test.js
+++ b/tests/unit/game-report-replay-action.test.js
@@ -11,7 +11,9 @@ describe('game report replay action', () => {
         const html = readRepoFile('game.html');
 
         expect(html).toContain('resolveReplayVideoOptions');
-        expect(html).toContain('renderReplayReportAction({ teamId, gameId, game })');
+        expect(html).toContain('renderReplayReportAction({ teamId, gameId, game, team })');
+        expect(html).toMatch(/resolveReplayVideoOptions\(\{\s*team,\s*game,\s*isReplay: true\s*\}\)/);
+        expect(html).toContain('renderReplayReportAction({ teamId, gameId, game, team: resolvedTeam })');
         expect(html).toContain('if (replayOptions.hasVideo)');
         expect(html).not.toContain("${game.liveStatus === 'completed' ? `");
     });
@@ -56,5 +58,25 @@ describe('game report replay action', () => {
         expect(unavailable.replayState?.status).toBe('unavailable');
         expect(ready.hasVideo).toBe(true);
         expect(ready.replayState).toBeNull();
+    });
+
+    it('allows completed reports to link replay viewing when the loaded team has a usable stream embed', () => {
+        const youtube = resolveReplayVideoOptions({
+            team: { youtubeVideoId: 'abcdefghijk' },
+            game: { liveStatus: 'completed' },
+            isReplay: true
+        });
+        const twitch = resolveReplayVideoOptions({
+            team: { twitchChannel: 'allplays' },
+            game: { status: 'completed' },
+            isReplay: true
+        });
+
+        expect(youtube.hasVideo).toBe(true);
+        expect(youtube.mode).toBe('embed');
+        expect(youtube.sourceUrl).toContain('youtube.com/embed/abcdefghijk');
+        expect(twitch.hasVideo).toBe(true);
+        expect(twitch.mode).toBe('embed');
+        expect(twitch.sourceUrl).toContain('player.twitch.tv');
     });
 });

--- a/tests/unit/game-report-replay-action.test.js
+++ b/tests/unit/game-report-replay-action.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolveReplayVideoOptions } from '../../js/live-game-video.js';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('game report replay action', () => {
+    it('gates the report replay action on usable replay media instead of completed status alone', () => {
+        const html = readRepoFile('game.html');
+
+        expect(html).toContain('resolveReplayVideoOptions');
+        expect(html).toContain('renderReplayReportAction({ teamId, gameId, game })');
+        expect(html).toContain('if (replayOptions.hasVideo)');
+        expect(html).not.toContain("${game.liveStatus === 'completed' ? `");
+    });
+
+    it('uses explicit non-clickable replay states for completed games without watchable replay media', () => {
+        const processing = resolveReplayVideoOptions({
+            game: {
+                liveStatus: 'completed',
+                replayVideo: { status: 'processing' }
+            },
+            isReplay: true
+        });
+        const failed = resolveReplayVideoOptions({
+            game: {
+                liveStatus: 'completed',
+                replayVideo: { status: 'failed' }
+            },
+            isReplay: true
+        });
+        const unavailable = resolveReplayVideoOptions({
+            game: {
+                liveStatus: 'completed'
+            },
+            isReplay: true
+        });
+        const ready = resolveReplayVideoOptions({
+            game: {
+                liveStatus: 'completed',
+                replayVideo: {
+                    status: 'ready',
+                    url: 'https://cdn.example.com/game-1.mp4'
+                }
+            },
+            isReplay: true
+        });
+
+        expect(processing.hasVideo).toBe(false);
+        expect(processing.replayState?.status).toBe('processing');
+        expect(failed.hasVideo).toBe(false);
+        expect(failed.replayState?.status).toBe('failed');
+        expect(unavailable.hasVideo).toBe(false);
+        expect(unavailable.replayState?.status).toBe('unavailable');
+        expect(ready.hasVideo).toBe(true);
+        expect(ready.replayState).toBeNull();
+    });
+});


### PR DESCRIPTION
Closes #3490

## What changed
- Updated `game.html` to reuse `resolveReplayVideoOptions` before rendering the postgame replay action.
- Shows `Watch Replay` only when a usable replay video exists.
- Shows non-clickable `Replay Processing`, `Replay Failed`, or `Replay Unavailable` states when playback is not ready.

## Root Cause
`game.html` rendered the postgame `Watch Replay` link from `game.liveStatus === 'completed'` alone, without checking replay processing status or whether a replay video URL existed.

## Prevention / Learning
Postgame replay/share CTAs must use the shared replay availability contract and explicitly represent ready, processing, failed, and unavailable states before linking users to playback.

## Regression Tests
- `npx vitest run tests/unit/game-report-replay-action.test.js --reporter=verbose`
- `npx vitest run tests/unit/live-game-video.test.js --reporter=verbose`