### PR TITLE
Add Team Operations help search coverage

### DIFF
--- a/tests/unit/app-help-knowledge-service.test.js
+++ b/tests/unit/app-help-knowledge-service.test.js
@@ -186,4 +186,39 @@ describe('app help knowledge service', () => {
             })
         ]));
     });
+
+    it('keeps Team Operations household revocation guidance searchable for parents', async () => {
+        const { searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+        const results = searchHelpKnowledge({
+            query: 'revoke household contact access invite tokens',
+            roles: ['parent'],
+            limit: 5
+        });
+
+        expect(results).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'team-operations',
+                file: 'help-team-operations.html',
+                snippet: expect.stringMatching(/membership revoked|invite tokens/i)
+            })
+        ]));
+    });
+
+    it('keeps Team Operations officials directory guidance searchable for coaches', async () => {
+        const { getHelpKnowledgeDocs, searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+        const results = searchHelpKnowledge({
+            query: 'officials directory edit schedule',
+            roles: ['coach'],
+            limit: 5
+        });
+        const teamOperationsDoc = getHelpKnowledgeDocs().find((doc) => doc.id === 'team-operations');
+
+        expect(results).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'team-operations',
+                file: 'help-team-operations.html'
+            })
+        ]));
+        expect(teamOperationsDoc?.text).toMatch(/Maintain an officials directory in edit-schedule\.html/i);
+    });
 });

--- a/tests/unit/app-help-portal.test.jsx
+++ b/tests/unit/app-help-portal.test.jsx
@@ -236,4 +236,28 @@ describe('HelpPortal', () => {
 
         await act(async () => root.unmount());
     });
+
+    it('searches the real help index and opens Team Operations Top Stat guidance in-app', async () => {
+        const realHelpService = await vi.importActual('../../apps/app/src/lib/helpKnowledgeService.ts');
+        realHelpService.resetHelpKnowledgeCachesForTests();
+        helpMocks.getHelpKnowledgeDocs.mockImplementation(realHelpService.getHelpKnowledgeDocs);
+        helpMocks.searchHelpKnowledge.mockImplementation(realHelpService.searchHelpKnowledge);
+
+        const { container, root } = await renderHelp();
+
+        await setInputValue(
+            container.querySelector('input[aria-label="Search help articles"]'),
+            'Top Stat public leaderboard visibility'
+        );
+
+        const teamOperationsLink = container.querySelector('a[href="/help/team-operations"]');
+        expect(teamOperationsLink).toBeTruthy();
+
+        await clickElement(teamOperationsLink);
+
+        expect(container.textContent).toContain('Team Operations');
+        expect(container.textContent).toMatch(/Stats marked as public leaderboard Top Stats must have public-player visibility/i);
+
+        await act(async () => root.unmount());
+    });
 });


### PR DESCRIPTION
Closes #3568

## What changed
- Added real `searchHelpKnowledge` coverage for Team Operations household revocation terms.
- Added real `searchHelpKnowledge` coverage for coach-facing officials directory schedule terms.
- Added a HelpPortal in-app integration path that delegates to the real help knowledge service, searches Top Stat visibility terms, opens Team Operations, and verifies the production article guidance renders.

## Root Cause
Team Operations content existed in the production help index, but tests only verified broad document inclusion and mocked HelpPortal behavior. That left critical ownership guidance searchable/renderable paths unprotected against index or portal drift.

## Prevention / Learning
For packaged help workflows, pair production-index search assertions with at least one in-app portal path using the real help service for critical user guidance terms.

## Regression Tests
- `npx vitest run tests/unit/app-help-knowledge-service.test.js --reporter=dot`
- `npx vitest run tests/unit/app-help-portal.test.jsx --reporter=dot`

## Recurrence Risk
Low. The key parent, coach, and Top Stat Team Operations discovery paths now have targeted real-index coverage.