### PR TITLE
Fix dashboard chat unread badges

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -188,7 +188,20 @@
                 // Fetch unread chat counts for all teams
                 const allTeams = [...fullAccessTeams, ...parentOnlyTeams];
                 const teamIds = allTeams.map(t => t.id);
-                const unreadCounts = teamIds.length > 0 ? await getUnreadChatCounts(user.uid, teamIds) : {};
+                const unreadLookupUser = {
+                    ...user,
+                    uid: user.uid,
+                    email: user.email || user.profileEmail || profile?.email || null
+                };
+                const conversationLookupByTeam = allTeams.reduce((acc, team) => {
+                    acc[team.id] = {
+                        user: unreadLookupUser,
+                        team,
+                        canModerate: team._access === 'full'
+                    };
+                    return acc;
+                }, {});
+                const unreadCounts = teamIds.length > 0 ? await getUnreadChatCounts(user.uid, teamIds, { conversationLookupByTeam }) : {};
 
                 function renderTeamCard(team) {
                     const hasFullAccess = team._access === 'full';

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -1562,7 +1562,24 @@
                 // Get unique team IDs and fetch unread counts
                 const teamIds = [...new Set(data.children.map(c => c.teamId).filter(Boolean))];
                 await ensureParentTeamAccess(user.uid, teamIds);
-                const unreadCounts = await getUnreadChatCounts(user.uid, teamIds);
+                const unreadLookupUser = {
+                    ...user,
+                    uid: user.uid,
+                    email: user.email || null
+                };
+                const conversationLookupByTeam = teamIds.reduce((acc, teamId) => {
+                    const child = data.children.find(c => c.teamId === teamId) || {};
+                    acc[teamId] = {
+                        user: unreadLookupUser,
+                        team: {
+                            id: teamId,
+                            name: child.teamName || child.team?.name || 'Team'
+                        },
+                        canModerate: false
+                    };
+                    return acc;
+                }, {});
+                const unreadCounts = await getUnreadChatCounts(user.uid, teamIds, { conversationLookupByTeam });
                 renderTeamChats(data.children, unreadCounts);
                 await renderFamilyPlanSection(document.getElementById('family-plan-card'), user, { playerLinks: data.children || [] });
                 await loadParentTeamFees(user.uid, data.children);

--- a/tests/unit/dashboard-chat-unread-wiring.test.js
+++ b/tests/unit/dashboard-chat-unread-wiring.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('dashboard chat unread wiring', () => {
+    it('passes participant and moderator lookup context from the coach dashboard', () => {
+        const html = readRepoFile('dashboard.html');
+
+        expect(html).toContain('const unreadLookupUser = {');
+        expect(html).toContain('email: user.email || user.profileEmail || profile?.email || null');
+        expect(html).toContain('const conversationLookupByTeam = allTeams.reduce((acc, team) => {');
+        expect(html).toContain("canModerate: team._access === 'full'");
+        expect(html).toContain('await getUnreadChatCounts(user.uid, teamIds, { conversationLookupByTeam })');
+        expect(html).not.toContain('await getUnreadChatCounts(user.uid, teamIds) : {}');
+    });
+
+    it('passes participant lookup context from the parent dashboard', () => {
+        const html = readRepoFile('parent-dashboard.html');
+
+        expect(html).toContain('const unreadLookupUser = {');
+        expect(html).toContain('email: user.email || null');
+        expect(html).toContain('const conversationLookupByTeam = teamIds.reduce((acc, teamId) => {');
+        expect(html).toContain('canModerate: false');
+        expect(html).toContain('await getUnreadChatCounts(user.uid, teamIds, { conversationLookupByTeam })');
+        expect(html).not.toContain('const unreadCounts = await getUnreadChatCounts(user.uid, teamIds);');
+    });
+});


### PR DESCRIPTION
Closes #3471

## What changed
- Wired coach/admin dashboard unread badge calls to pass `conversationLookupByTeam` with user, team, and moderator context.
- Wired parent dashboard unread badge calls to pass participant lookup context for each linked team.
- Added focused regression coverage that blocks the old two-argument unread count calls on both dashboards.

## Root Cause
Legacy dashboard unread badge calls passed only `userId` and `teamIds`, so `getUnreadChatCounts` had no user/team conversation lookup context. That made `getChatConversations` receive a null user, skip participant queries, and count only the default team-wide chat.

## Prevention / Learning
Any surface that shows aggregate team chat unread badges must pass `conversationLookupByTeam` or preloaded `conversationIdsByTeam`; otherwise targeted conversations silently collapse to the default channel.

## Regression Tests
- `npx vitest run tests/unit/dashboard-chat-unread-wiring.test.js tests/unit/db-unread-chat-counts.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`

## Recurrence Risk
Low. The affected dashboard wiring is now covered by a focused source regression test, and the existing unread-count helper tests still cover aggregation behavior.