### PR TITLE
Add app CSS production smoke coverage

### DIFF
--- a/tests/smoke/app-production-bootstrap.spec.js
+++ b/tests/smoke/app-production-bootstrap.spec.js
@@ -15,6 +15,7 @@ function appUrl(hashPath = '/auth') {
 test('production React app boots from deployed /app bundle', async ({ page }) => {
     const fatalErrors = [];
     const failedAssets = [];
+    const stylesheetResponses = [];
 
     page.on('pageerror', (error) => {
         fatalErrors.push(error.message);
@@ -26,15 +27,62 @@ test('production React app boots from deployed /app bundle', async ({ page }) =>
         }
     });
 
+    page.on('response', (response) => {
+        const request = response.request();
+        if (request.resourceType() === 'stylesheet') {
+            stylesheetResponses.push({
+                status: response.status(),
+                url: response.url()
+            });
+        }
+    });
+
     await page.goto(appUrl('/auth'), { waitUntil: 'domcontentloaded' });
 
     await expect(page).toHaveTitle(/ALL PLAYS APP/i);
     await expect(page.locator('#root')).not.toBeEmpty();
     await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Continue with Google' })).toBeVisible();
+    const googleButton = page.getByRole('button', { name: 'Continue with Google' });
+    await expect(googleButton).toBeVisible();
     await expect(page.locator('input[type="email"]')).toBeVisible();
     await expect(page.locator('input[type="password"]')).toBeVisible();
 
+    const badStylesheetResponses = stylesheetResponses
+        .filter(({ status }) => status >= 400)
+        .map(({ status, url }) => `${status} ${url}`);
+    const googleButtonStyles = await googleButton.evaluate((element) => {
+        const style = window.getComputedStyle(element);
+        return {
+            backgroundColor: style.backgroundColor,
+            borderColor: style.borderColor,
+            borderStyle: style.borderStyle,
+            borderWidth: style.borderWidth,
+            minHeight: style.minHeight
+        };
+    });
+    const tailwindIconStyles = await page.locator('.bg-primary-50').first().evaluate((element) => {
+        const style = window.getComputedStyle(element);
+        return {
+            backgroundColor: style.backgroundColor,
+            height: style.height,
+            width: style.width
+        };
+    });
+
     expect(fatalErrors).toEqual([]);
     expect(failedAssets).toEqual([]);
+    expect(stylesheetResponses.length).toBeGreaterThan(0);
+    expect(badStylesheetResponses).toEqual([]);
+    expect(googleButtonStyles).toMatchObject({
+        backgroundColor: 'rgb(238, 242, 255)',
+        borderColor: 'rgb(199, 210, 254)',
+        borderStyle: 'solid',
+        borderWidth: '1px',
+        minHeight: '40px'
+    });
+    expect(tailwindIconStyles).toMatchObject({
+        backgroundColor: 'rgb(238, 242, 255)',
+        height: '44px',
+        width: '44px'
+    });
 });


### PR DESCRIPTION
Closes #3576

## What changed
- Extended the production `/app` bootstrap smoke to collect stylesheet responses and fail on any CSS response with HTTP status `>= 400`.
- Added runtime computed-style assertions proving the auth page receives applied app CSS and Tailwind utility output.

## Root Cause
The production app bootstrap smoke only observed Playwright `requestfailed` events and visible auth controls, so a stylesheet request returning an HTTP error status or a page rendering without applied generated CSS could still pass.

## Prevention / Learning
Production boot smoke coverage for generated CSS should verify both stylesheet response health and computed styles from rendered app CSS/Tailwind UI, not just DOM visibility.

## Regression Tests
- `npm run app:build`
- `SMOKE_APP_BOOT_URL=http://127.0.0.1:4173 npx playwright test tests/smoke/app-production-bootstrap.spec.js --config=playwright.smoke.config.js --reporter=line`

## Recurrence Risk
Low: the focused smoke now fails when CSS is missing, HTTP-erroring, or not applied to the auth UI.