### PR TITLE
Cover Team Media photo retry reset

### DIFF
--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -881,9 +881,12 @@ function getFileUploadMessage(uploaded: number, failed: number) {
   return `${uploadedLabel}.`;
 }
 
+let uploadQueueSequence = 0;
+
 function createUploadQueueItem(file: File, kind: 'photo' | 'file', index: number): UploadQueueItem {
+  uploadQueueSequence += 1;
   return {
-    id: `${kind}-${file.name || 'upload'}-${file.size || 0}-${index}`,
+    id: `${kind}-${file.name || 'upload'}-${file.size || 0}-${index}-${uploadQueueSequence}`,
     kind,
     name: file.name || `Untitled ${kind}`,
     status: 'uploading',

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -451,6 +451,47 @@ describe('React app TeamMedia upload flow', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('clears the photo picker after failed uploads so the same image can be retried', async () => {
+    parentToolsServiceMocks.uploadParentTeamMediaPhoto
+      .mockRejectedValueOnce(new Error('storage/retry'))
+      .mockResolvedValueOnce({
+        id: 'uploaded-photo-retry',
+        title: 'tipoff.jpg',
+        type: 'photo',
+        url: 'https://example.test/tipoff.jpg',
+      });
+
+    const { container, root } = await renderTeamMedia(uploadableModel());
+    const photoInput = container.querySelector('input[accept="image/*"]');
+    const file = new File(['first'], 'tipoff.jpg', { type: 'image/jpeg' });
+
+    Object.defineProperty(photoInput, 'value', {
+      configurable: true,
+      writable: true,
+      value: 'C\\fakepath\\tipoff.jpg',
+    });
+    changeFiles(photoInput, [file]);
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenCalledTimes(1);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(1, 'team-1', 'folder-1', file);
+    expect(photoInput.value).toBe('');
+    expect(container.textContent).toContain('No photos uploaded. Choose image files that are 10 MB or smaller.');
+
+    photoInput.value = 'C\\fakepath\\tipoff.jpg';
+    changeFiles(photoInput, [file]);
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenCalledTimes(2);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(2, 'team-1', 'folder-1', file);
+    expect(container.textContent).toContain('tipoff.jpg');
+    expect((container.textContent.match(/Uploaded/g) || []).length).toBe(1);
+    expect((container.textContent.match(/Upload failed\./g) || []).length).toBe(1);
+    expect(container.textContent).toContain('1 photo uploaded.');
+
+    await act(async () => root.unmount());
+  });
 });
 
 describe('React app TeamMedia team chat posting', () => {


### PR DESCRIPTION
Closes #3579

## What changed
- Added a focused Team Media unit regression for failed photo uploads clearing the hidden image input.
- Asserted same-file retry calls `uploadParentTeamMediaPhoto` again with the same team, folder, and `File`.
- Made upload queue item IDs unique per attempt so retrying the same file keeps the failed row isolated from the successful retry row.

## Root Cause
Team Media upload queue item IDs were derived only from file kind, name, size, and selection index. Retrying the same failed photo generated the same queue ID, so retry state could collide with the previous failed attempt. The photo path also lacked the document path's regression coverage for input clearing and same-file retry.

## Prevention / Learning
For hidden file input workflows, cover failure recovery per upload type: input value reset, same-file reselection, service call arguments, and per-attempt UI state isolation.

## Regression Tests
- `npx vitest run tests/unit/app-team-media.test.jsx --reporter=verbose`