### PR TITLE
Move admin invite redemption server-side

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -156,7 +156,8 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=41';
-        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=81';
+        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=81';
+        import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';
         import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -155,7 +155,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=41';
+        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=42';
         import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=81';
         import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';
         import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';

--- a/apps/app/src/lib/adapters/legacyAuth.ts
+++ b/apps/app/src/lib/adapters/legacyAuth.ts
@@ -31,6 +31,7 @@ export type LegacyAuthDbModule = {
 
 export type LegacyAdminInviteModule = {
   redeemAdminInviteAcceptance: (...args: any[]) => Promise<unknown>;
+  redeemAdminInviteAtomically: (...args: any[]) => Promise<unknown>;
 };
 
 export type LegacyInviteRedemptionResult = {

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -1291,16 +1291,18 @@ export async function redeemInviteForUser(userId: string, code: string, authEmai
 
   const [
     dbModule,
+    { redeemAdminInviteAtomically },
     { createInviteProcessor }
   ] = await Promise.all([
     loadLegacyAuthDb(),
+    loadLegacyAdminInvite(),
     loadLegacyInviteFlow()
   ]);
   const processInvite = createInviteProcessor({
     validateAccessCode: dbModule.validateAccessCode,
     redeemParentInvite: dbModule.redeemParentInvite,
     redeemHouseholdInvite: dbModule.redeemHouseholdInvite,
-    redeemAdminInviteAtomically: dbModule.redeemAdminInviteAtomically,
+    redeemAdminInviteAtomically,
     updateUserProfile: dbModule.updateUserProfile,
     updateTeam: dbModule.updateTeam,
     getTeam: dbModule.getTeam,

--- a/edit-team.html
+++ b/edit-team.html
@@ -577,7 +577,7 @@
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth, sendInviteEmail } from './js/auth.js?v=41';
+        import { checkAuth, sendInviteEmail } from './js/auth.js?v=42';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=3';

--- a/firestore.rules
+++ b/firestore.rules
@@ -1676,11 +1676,13 @@ service cloud.firestore {
                         isHouseholdInviteRedemptionUpdate() ||
                         isHouseholdInviteRevocationUpdate() ||
                         // Allow marking as used only if setting these specific fields
-                        (resource.data.get('type', null) != 'parent_invite' &&
+                        (resource.data.get('type', null) != 'admin_invite' &&
+                         resource.data.get('type', null) != 'parent_invite' &&
                          resource.data.get('type', null) != 'household_invite' &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
                          request.resource.data.usedBy == request.auth.uid) ||
-                        (resource.data.get('type', null) != 'parent_invite' &&
+                        (resource.data.get('type', null) != 'admin_invite' &&
+                         resource.data.get('type', null) != 'parent_invite' &&
                          resource.data.get('type', null) != 'household_invite' &&
                          resource.data.generatedBy == request.auth.uid &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt'])));

--- a/functions/index.js
+++ b/functions/index.js
@@ -2336,6 +2336,89 @@ exports.redeemCoParentInvite = functions.https.onCall(async (data, context) => {
   return responsePayload;
 });
 
+exports.redeemAdminInvite = functions.https.onCall(async (data, context) => {
+  if (!context.auth?.uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in before accepting an admin invite.');
+  }
+
+  const userId = normalizeFirestoreId(data?.userId || context.auth.uid, 'userId');
+  if (userId !== context.auth.uid) {
+    throw new functions.https.HttpsError('permission-denied', 'You can only accept an invite for your own account.');
+  }
+
+  const codeId = normalizeFirestoreId(data?.codeId, 'codeId');
+  const codeRef = firestore.doc(`accessCodes/${codeId}`);
+  let responsePayload = null;
+
+  await firestore.runTransaction(async (transaction) => {
+    const codeSnap = await transaction.get(codeRef);
+    if (!codeSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Admin invite could not be found.');
+    }
+
+    const codeData = codeSnap.data() || {};
+    if (codeData.type !== 'admin_invite') {
+      throw new functions.https.HttpsError('failed-precondition', 'Not an admin invite code.');
+    }
+    if (codeData.used || codeData.revoked === true || codeData.active === false || ['removed', 'cancelled', 'revoked'].includes(codeData.status)) {
+      throw new functions.https.HttpsError('failed-precondition', 'Admin invite is no longer available.');
+    }
+    if (isParentInviteExpired(codeData.expiresAt)) {
+      throw new functions.https.HttpsError('failed-precondition', 'Admin invite has expired.');
+    }
+
+    const invitedEmail = normalizeParentInviteEmail(codeData.email);
+    if (!invitedEmail) {
+      throw new functions.https.HttpsError('failed-precondition', 'Admin invite is missing an invited email.');
+    }
+
+    const teamId = normalizeFirestoreId(codeData.teamId, 'teamId');
+    const teamRef = firestore.doc(`teams/${teamId}`);
+    const userRef = firestore.doc(`users/${userId}`);
+    const [teamSnap, userSnap] = await Promise.all([
+      transaction.get(teamRef),
+      transaction.get(userRef)
+    ]);
+
+    if (!teamSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Team not found.');
+    }
+
+    const teamData = teamSnap.data() || {};
+    const userData = userSnap.exists ? userSnap.data() || {} : {};
+    const signedInEmail = normalizeParentInviteEmail(context.auth.token?.email || userData.email);
+    if (!signedInEmail || invitedEmail !== signedInEmail) {
+      throw new functions.https.HttpsError('permission-denied', `This invite was sent to ${invitedEmail}. Sign in with that email to accept it.`);
+    }
+
+    const now = admin.firestore.Timestamp.now();
+
+    transaction.set(teamRef, {
+      adminEmails: appendUniqueValue(teamData.adminEmails, invitedEmail),
+      updatedAt: now
+    }, { merge: true });
+    transaction.set(userRef, {
+      coachOf: appendUniqueValue(userData.coachOf, teamId),
+      roles: appendUniqueValue(userData.roles, 'coach'),
+      updatedAt: now
+    }, { merge: true });
+    transaction.update(codeRef, {
+      used: true,
+      usedBy: userId,
+      usedAt: now
+    });
+
+    responsePayload = {
+      success: true,
+      codeId,
+      teamId,
+      teamName: teamData.name || codeData.teamName || null
+    };
+  });
+
+  return responsePayload;
+});
+
 exports.validateAccessCodeForAcceptance = functions.https.onCall(async (data, context) => {
   const code = String(data?.code || '').trim().toUpperCase();
   if (!code) {

--- a/js/admin-invite.js
+++ b/js/admin-invite.js
@@ -1,4 +1,26 @@
-import { redeemAdminInviteAtomicPersistence } from './db.js?v=81';
+import { functions, httpsCallable } from './firebase.js?v=20';
+
+export async function redeemAdminInviteCallablePersistence({
+    userId,
+    userEmail,
+    codeId
+}) {
+    const callable = httpsCallable(functions, 'redeemAdminInvite');
+    const result = await callable({
+        userId,
+        userEmail,
+        codeId
+    });
+    return result?.data || result;
+}
+
+export async function redeemAdminInviteAtomically(codeId, userId, fallbackEmail = null) {
+    return redeemAdminInviteCallablePersistence({
+        userId,
+        userEmail: fallbackEmail,
+        codeId
+    });
+}
 
 export async function redeemAdminInviteAcceptance({
     userId,
@@ -6,7 +28,7 @@ export async function redeemAdminInviteAcceptance({
     codeId = null,
     getTeam,
     getUserProfile,
-    redeemAdminInviteAtomicPersistence: redeemAdminInviteAtomicPersistenceOverride = redeemAdminInviteAtomicPersistence
+    redeemAdminInviteAtomicPersistence: redeemAdminInviteAtomicPersistenceOverride = redeemAdminInviteCallablePersistence
 }) {
     if (!userId) throw new Error('Missing userId');
     if (!codeId) throw new Error('Missing codeId');

--- a/js/admin.js
+++ b/js/admin.js
@@ -19,7 +19,7 @@ import {
 } from './db.js?v=81';
 import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp, getCountFromServer, query, where } from './firebase.js?v=20';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=41';
+import { checkAuth } from './auth.js?v=42';
 import { DEFAULT_ADMIN_PAGE_SIZE, loadAdminCollectionPage, loadInitialAdminBootstrap } from './admin-bootstrap.js?v=1';
 import {
     adminRegistrationDefaults,

--- a/js/auth.js
+++ b/js/auth.js
@@ -17,7 +17,7 @@ import {
 } from './firebase.js?v=20';
 import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=81';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=6';
-import { redeemAdminInviteAcceptance } from './admin-invite.js?v=5';
+import { redeemAdminInviteAcceptance } from './admin-invite.js?v=6';
 import { mergeApprovedParentMembershipRequests } from './parent-membership-utils.js?v=2';
 
 async function cleanupFailedNewUser(user, context) {

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -20,7 +20,7 @@ import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, 
 import { hasFullTeamAccess } from './team-access.js?v=1';
 import { buildScoreLinkedClipRecord, isScoredPlayEvent, validateGameClipFile } from './game-clips.js?v=1';
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
-import { checkAuth } from './auth.js?v=41';
+import { checkAuth } from './auth.js?v=42';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { createPlayAnnouncer } from './live-game-announcer.js?v=1';
 import {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -2,7 +2,7 @@
 import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=81';
 import { db } from './firebase.js?v=20';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
-import { checkAuth } from './auth.js?v=41';
+import { checkAuth } from './auth.js?v=42';
 import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=20';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -2,7 +2,7 @@
 import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=81';
 import { db } from './firebase.js?v=20';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=41';
+import { checkAuth } from './auth.js?v=42';
 import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=20';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/utils.js
+++ b/js/utils.js
@@ -176,10 +176,9 @@ export function renderHeader(container, user) {
       navProfile.classList.add('hidden');
     }
 
-    // Shared header logout intentionally stays pinned to auth.js?v=40.
-    // Broader auth consumer cache busting moved to auth.js?v=40.
+    // Keep shared-header logout on the same auth bundle as page consumers.
     navLogout.addEventListener('click', async () => {
-      const { logout } = await import('./auth.js?v=40');
+      const { logout } = await import('./auth.js?v=42');
       await logout();
       window.location.href = 'index.html';
     });

--- a/login.html
+++ b/login.html
@@ -97,7 +97,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=41';
+        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=42';
         import { getUserProfile } from './js/db.js?v=81';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -133,6 +133,7 @@
                 "autoAcceptParentInviteForExistingUser",
                 "confirmParentAccountMerge",
                 "previewAccountMerge",
+                "redeemAdminInvite",
                 "redeemCoParentInvite",
                 "validateAccessCodeForAcceptance"
             ],

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -238,6 +238,18 @@ export async function markAccessCodeAsUsed() {
 }
 `;
 
+const ACCEPT_INVITE_ADMIN_INVITE_STUB = `
+export async function redeemAdminInviteAtomically(codeId, userId, authEmail) {
+    console.log('redeemAdminInviteAtomically called with:', { codeId, userId, authEmail });
+    window.__acceptInviteCalls.push({ type: 'redeem', codeId, userId, authEmail });
+    return {
+        success: true,
+        teamId: 'team-1',
+        teamName: 'Tigers'
+    };
+}
+`;
+
 const ACCEPT_INVITE_AUTH_STUB = `
 export function isEmailSignInLink() {
     return false;
@@ -306,6 +318,7 @@ async function mockAcceptInviteDependencies(page) {
     await page.addInitScript(() => { window.__acceptInviteCalls = []; console.log('__acceptInviteCalls initialized on window'); });
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ACCEPT_INVITE_DB_STUB }));
     await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ACCEPT_INVITE_AUTH_STUB }));
+    await page.route(/\/js\/admin-invite\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ACCEPT_INVITE_ADMIN_INVITE_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: SHARED_UTILS_STUB }));
 }
 

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -105,7 +105,7 @@ const URLSearchParams = deps.URLSearchParams;
 const setTimeout = deps.setTimeout;
 ` + match[1]
         .replace(
-            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=41';",
+            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=42';",
             'const { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } = deps.auth;'
         )
         .replace(

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -3,7 +3,8 @@ import { readFileSync } from 'node:fs';
 import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from '../../js/accept-invite-flow.js';
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=81';";
+const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=81';";
+const ACCEPT_INVITE_ADMIN_IMPORT = "import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';";
 
 class MockClassList {
     constructor(initial = []) {
@@ -109,7 +110,11 @@ const setTimeout = deps.setTimeout;
         )
         .replace(
             ACCEPT_INVITE_DB_IMPORT,
-            'const { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } = deps.db;'
+            'const { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } = deps.db;'
+        )
+        .replace(
+            ACCEPT_INVITE_ADMIN_IMPORT,
+            'const { redeemAdminInviteAtomically } = deps.db;'
         )
         .replace(
             "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';",

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -74,7 +74,18 @@ describe('access code Firestore rules', () => {
         expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'updatedAt'])");
         expect(accessCodeRules).toContain("resource.data.get('type', null) != 'parent_invite'");
         expect(accessCodeRules).toContain("resource.data.get('type', null) != 'household_invite'");
+        expect(accessCodeRules).toContain("resource.data.get('type', null) != 'admin_invite'");
         expect(accessCodeRules).not.toContain("resource.data.type != 'parent_invite'");
+    });
+
+    it('excludes admin_invite documents from generic used-field redemption updates', () => {
+        const genericUsedUpdateIndex = accessCodeRules.indexOf("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
+        expect(genericUsedUpdateIndex).toBeGreaterThanOrEqual(0);
+
+        const genericUsedUpdateBranch = accessCodeRules.slice(genericUsedUpdateIndex - 280, genericUsedUpdateIndex + 220);
+        expect(genericUsedUpdateBranch).toContain("resource.data.get('type', null) != 'admin_invite'");
+        expect(genericUsedUpdateBranch).toContain("resource.data.get('type', null) != 'parent_invite'");
+        expect(genericUsedUpdateBranch).toContain("resource.data.get('type', null) != 'household_invite'");
     });
 
     it('requires parent_invite redemption to use an active invite owned by the signed-in email', () => {

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -20,8 +20,8 @@ describe('admin dashboard statistics scope', () => {
         const adminHtml = fs.readFileSync('admin.html', 'utf8');
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
 
-        expect(adminJs).toContain("import { checkAuth } from './auth.js?v=41';");
-        expect(adminJs).not.toContain("import { checkAuth } from './auth.js?v=40';");
+        expect(adminJs).toContain("import { checkAuth } from './auth.js?v=42';");
+        expect(adminJs).not.toContain("import { checkAuth } from './auth.js?v=41';");
         expect(adminJs).toContain('loadInitialAdminBootstrap({');
         expect(adminJs).toContain('getTeamsPage: getAdminTeamsPage');
         expect(adminJs).toContain('getUsersPage: getAdminUsersPage');

--- a/tests/unit/admin-invite-server-authoritative.test.js
+++ b/tests/unit/admin-invite-server-authoritative.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('admin invite server-authoritative redemption', () => {
+    it('exposes a callable that validates invite identity and mutates team, user, and access code in one transaction', () => {
+        const functionsSource = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
+        const handlerIndex = functionsSource.indexOf('exports.redeemAdminInvite');
+        expect(handlerIndex).toBeGreaterThanOrEqual(0);
+
+        const handlerSource = functionsSource.slice(handlerIndex, handlerIndex + 5200);
+        expect(handlerSource).toContain('functions.https.onCall');
+        expect(handlerSource).toContain('firestore.runTransaction(async (transaction) =>');
+        expect(handlerSource).toContain("codeData.type !== 'admin_invite'");
+        expect(handlerSource).toContain('codeData.used');
+        expect(handlerSource).toContain('isParentInviteExpired(codeData.expiresAt)');
+        expect(handlerSource).toContain('invitedEmail !== signedInEmail');
+        expect(handlerSource).toContain('context.auth.token?.email || userData.email');
+        expect(handlerSource).not.toContain('data?.userEmail || data?.authEmail');
+        expect(handlerSource).toContain('userId !== context.auth.uid');
+        expect(handlerSource).toContain('adminEmails: appendUniqueValue');
+        expect(handlerSource).toContain('coachOf: appendUniqueValue');
+        expect(handlerSource).toContain("roles: appendUniqueValue(userData.roles, 'coach')");
+        expect(handlerSource).toContain('transaction.update(codeRef');
+        expect(handlerSource).toContain('used: true');
+        expect(handlerSource).toContain('usedBy: userId');
+        expect(handlerSource).toContain('usedAt: now');
+    });
+
+    it('routes legacy and React invite acceptance through the callable-backed adapter', () => {
+        const adminInviteSource = readFileSync(resolve(process.cwd(), 'js/admin-invite.js'), 'utf8');
+        const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
+        const appAuthSource = readFileSync(resolve(process.cwd(), 'apps/app/src/lib/authService.ts'), 'utf8');
+
+        expect(adminInviteSource).toContain("httpsCallable(functions, 'redeemAdminInvite')");
+        expect(acceptInviteSource).toContain("import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';");
+        expect(appAuthSource).toContain('{ redeemAdminInviteAtomically }');
+        expect(appAuthSource).toContain('redeemAdminInviteAtomically,');
+        expect(appAuthSource).not.toContain('redeemAdminInviteAtomically: dbModule.redeemAdminInviteAtomically');
+    });
+});

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -72,7 +72,7 @@ describe('admin invite signup cache busting', () => {
 
     it('bumps the shared header logout import with auth.js consumers', () => {
         const utilsSource = readFileSync(resolve(process.cwd(), 'js/utils.js'), 'utf8');
-        const logoutImportMatches = utilsSource.match(/const \{ logout \} = await import\('\.\/auth\.js\?v=40'\);/g) || [];
+        const logoutImportMatches = utilsSource.match(/const \{ logout \} = await import\('\.\/auth\.js\?v=42'\);/g) || [];
 
         expect(logoutImportMatches).toHaveLength(1);
         expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=24');");

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -51,13 +51,13 @@ describe('admin invite signup cache busting', () => {
 
     it('bumps auth module consumers after signup flow changes', () => {
         const authConsumers = {
-            'login.html': 'auth.js?v=41',
-            'accept-invite.html': 'auth.js?v=41',
-            'edit-team.html': 'auth.js?v=41',
-            'js/admin.js': 'auth.js?v=41',
-            'js/live-game.js': 'auth.js?v=41',
-            'js/live-tracker.js': 'auth.js?v=41',
-            'js/track-basketball.js': 'auth.js?v=41'
+            'login.html': 'auth.js?v=42',
+            'accept-invite.html': 'auth.js?v=42',
+            'edit-team.html': 'auth.js?v=42',
+            'js/admin.js': 'auth.js?v=42',
+            'js/live-game.js': 'auth.js?v=42',
+            'js/live-tracker.js': 'auth.js?v=42',
+            'js/track-basketball.js': 'auth.js?v=42'
         };
 
         for (const [relativePath, expectedVersion] of Object.entries(authConsumers)) {
@@ -66,8 +66,8 @@ describe('admin invite signup cache busting', () => {
         }
 
         const editTeamSource = readFileSync(resolve(process.cwd(), 'edit-team.html'), 'utf8');
-        expect(editTeamSource).toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=41';");
-        expect(editTeamSource).not.toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=38';");
+        expect(editTeamSource).toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=42';");
+        expect(editTeamSource).not.toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=39';");
     });
 
     it('bumps the shared header logout import with auth.js consumers', () => {
@@ -75,8 +75,8 @@ describe('admin invite signup cache busting', () => {
         const logoutImportMatches = utilsSource.match(/const \{ logout \} = await import\('\.\/auth\.js\?v=40'\);/g) || [];
 
         expect(logoutImportMatches).toHaveLength(1);
-        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=23');");
-        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=39');");
+        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=24');");
+        expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=40');");
     });
 
     it('does not leave deployed source consumers pinned to stale auth or db wrappers', () => {

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -31,7 +31,7 @@ describe('admin invite signup cache busting', () => {
         const authSource = readFileSync(resolve(process.cwd(), 'js/auth.js'), 'utf8');
 
         expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=6';");
-        expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=5';");
+        expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=6';");
         expect(authSource).toContain("from './db.js?v=81';");
     });
 
@@ -39,7 +39,10 @@ describe('admin invite signup cache busting', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=81';"
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=81';"
+        );
+        expect(acceptInviteSource).toContain(
+            "import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';"
         );
         expect(acceptInviteSource).toContain(
             "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';"

--- a/tests/unit/admin-invite.test.js
+++ b/tests/unit/admin-invite.test.js
@@ -1,18 +1,44 @@
 import { describe, it, expect, vi } from 'vitest';
 
-const dbMocks = vi.hoisted(() => ({
-    redeemAdminInviteAtomicPersistence: vi.fn()
+const firebaseMocks = vi.hoisted(() => ({
+    functions: {},
+    httpsCallable: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=81', () => dbMocks);
+vi.mock('../../js/firebase.js?v=20', () => firebaseMocks);
 
-const { redeemAdminInviteAcceptance } = await import('../../js/admin-invite.js');
+const { redeemAdminInviteAcceptance, redeemAdminInviteAtomically } = await import('../../js/admin-invite.js');
 
 describe('admin invite acceptance', () => {
+    it('routes direct admin invite redemption through the server callable', async () => {
+        const callable = vi.fn().mockResolvedValue({
+            data: {
+                success: true,
+                teamId: 'team-1',
+                teamName: 'Sharks'
+            }
+        });
+        firebaseMocks.httpsCallable.mockReturnValue(callable);
+
+        const result = await redeemAdminInviteAtomically('code-1', 'user-1', 'Admin@Example.com');
+
+        expect(firebaseMocks.httpsCallable).toHaveBeenCalledWith(firebaseMocks.functions, 'redeemAdminInvite');
+        expect(callable).toHaveBeenCalledWith({
+            userId: 'user-1',
+            userEmail: 'Admin@Example.com',
+            codeId: 'code-1'
+        });
+        expect(result).toEqual({
+            success: true,
+            teamId: 'team-1',
+            teamName: 'Sharks'
+        });
+    });
+
     it('delegates signup admin redemption to atomic persistence', async () => {
         const getTeam = vi.fn().mockResolvedValue({ id: 'team-1', name: 'Sharks' });
         const getUserProfile = vi.fn().mockResolvedValue({ coachOf: ['team-0'], roles: ['parent'] });
-        const redeemAdminInviteAtomicPersistence = dbMocks.redeemAdminInviteAtomicPersistence.mockResolvedValue({
+        const redeemAdminInviteAtomicPersistence = vi.fn().mockResolvedValue({
             success: true,
             teamId: 'team-1'
         });

--- a/tests/unit/app-email-signup-invite-redemption.test.ts
+++ b/tests/unit/app-email-signup-invite-redemption.test.ts
@@ -19,5 +19,6 @@ describe('React app email signup invite redemption dependencies', () => {
     const adapterSource = readFileSync(resolve(process.cwd(), 'apps/app/src/lib/adapters/legacyAuth.ts'), 'utf8');
 
     expect(adapterSource).toContain('redeemCoParentInvite: (...args: any[]) => Promise<unknown>;');
+    expect(adapterSource).toContain('redeemAdminInviteAtomically: (...args: any[]) => Promise<unknown>;');
   });
 });

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -41,7 +41,7 @@ vi.mock('../../js/db.js?v=81', () => ({
     addTeamAdminEmail: vi.fn()
 }));
 
-vi.mock('../../js/admin-invite.js?v=5', () => ({
+vi.mock('../../js/admin-invite.js?v=6', () => ({
     redeemAdminInviteAcceptance: redeemAdminInviteAcceptanceMock
 }));
 

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -47,7 +47,7 @@ vi.mock('../../js/signup-flow.js?v=6', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));
 
-vi.mock('../../js/admin-invite.js?v=5', () => ({
+vi.mock('../../js/admin-invite.js?v=6', () => ({
     redeemAdminInviteAcceptance: vi.fn()
 }));
 

--- a/tests/unit/auth-google-popup-fallback.test.js
+++ b/tests/unit/auth-google-popup-fallback.test.js
@@ -39,7 +39,7 @@ vi.mock('../../js/signup-flow.js?v=6', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));
 
-vi.mock('../../js/admin-invite.js?v=5', () => ({
+vi.mock('../../js/admin-invite.js?v=6', () => ({
     redeemAdminInviteAcceptance: vi.fn()
 }));
 

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -39,7 +39,7 @@ vi.mock('../../js/db.js?v=81', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=6', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));
-vi.mock('../../js/admin-invite.js?v=5', () => ({
+vi.mock('../../js/admin-invite.js?v=6', () => ({
     redeemAdminInviteAcceptance: vi.fn()
 }));
 

--- a/tests/unit/auth-send-invite-email-no-localstorage.test.js
+++ b/tests/unit/auth-send-invite-email-no-localstorage.test.js
@@ -36,7 +36,7 @@ vi.mock('../../js/db.js?v=81', () => ({
     listMyParentMembershipRequests: vi.fn()
 }));
 
-vi.mock('../../js/admin-invite.js?v=5', () => ({
+vi.mock('../../js/admin-invite.js?v=6', () => ({
     redeemAdminInviteAcceptance: vi.fn()
 }));
 

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -39,7 +39,7 @@ const dbMocks = vi.hoisted(() => ({
 
 vi.mock('../../js/firebase.js?v=20', () => firebaseMocks);
 vi.mock('../../js/db.js?v=81', () => dbMocks);
-vi.mock('../../js/admin-invite.js?v=5', () => ({
+vi.mock('../../js/admin-invite.js?v=6', () => ({
     redeemAdminInviteAcceptance: vi.fn()
 }));
 


### PR DESCRIPTION
Closes #3485

## What changed
- Added a `redeemAdminInvite` callable that validates the authenticated user, invite type, invited email, unused state, expiration, and target team before atomically writing `teams.adminEmails`, `users.coachOf`/`roles`, and `accessCodes.used*`.
- Routed legacy and React invite acceptance through the callable-backed admin invite adapter.
- Tightened Firestore rules so `admin_invite` can no longer use the generic `used/usedBy/usedAt` access-code update branch.
- Added focused regression coverage for rules, callable contract, legacy wiring, React adapter typing, and cache-busted invite paths.

## Root Cause
The `accessCodes` update rule excluded `parent_invite` and `household_invite` from generic redemption updates but not `admin_invite`, while admin invite email validation was enforced in client flow and client-side persistence paths instead of a single server-authoritative boundary.

## Prevention / Learning
For typed invite or access-grant records, the server/rules boundary must reject generic mutation paths for every privileged type, and tests must assert the denied actor path in addition to the happy path.

## Regression Tests
- `npx vitest run tests/unit/access-code-rules.test.js tests/unit/admin-invite.test.js tests/unit/admin-invite-server-authoritative.test.js tests/unit/admin-invite-signup-cache-busting.test.js tests/unit/accept-invite-page.test.js tests/unit/app-email-signup-invite-redemption.test.ts --reporter=verbose`
- `npx vitest run tests/unit/auth-signup-parent-invite.test.js tests/unit/auth-send-invite-email-no-localstorage.test.js tests/unit/auth-google-admin-invite-cleanup.test.js tests/unit/auth-google-parent-invite-cleanup.test.js tests/unit/auth-google-popup-fallback.test.js tests/unit/auth-parent-membership-sync.test.js --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Low. The generic rules branch now excludes `admin_invite`, and both legacy and app redemption paths route through the callable-backed adapter.