### PR TITLE
Preserve official directory fields

### DIFF
--- a/js/officiating-slots.js
+++ b/js/officiating-slots.js
@@ -1,3 +1,10 @@
+function normalizeDelimitedStrings(value) {
+    const values = Array.isArray(value) ? value : String(value || '').split(',');
+    return Array.from(new Set(values
+        .map((item) => String(item || '').trim())
+        .filter(Boolean)));
+}
+
 export function normalizeOfficialsDirectory(officials = []) {
     if (!Array.isArray(officials)) return [];
     return officials
@@ -8,7 +15,10 @@ export function normalizeOfficialsDirectory(officials = []) {
             return {
                 id,
                 name,
-                email: String(official?.email || '').trim()
+                email: String(official?.email || '').trim(),
+                phone: String(official?.phone || '').trim(),
+                roles: normalizeDelimitedStrings(official?.roles),
+                tags: normalizeDelimitedStrings(official?.tags)
             };
         })
         .filter(Boolean)

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -43,6 +43,30 @@ describe('officiating slots', () => {
         ]);
     });
 
+    it('preserves structured official directory fields for phone-only reload edits', () => {
+        const officials = normalizeOfficialsDirectory([
+            {
+                id: 'pat-ref',
+                name: ' Pat Ref ',
+                phone: ' 555-123-4567 ',
+                roles: [' Referee ', 'Referee', 'Umpire'],
+                tags: ' Varsity, Playoffs, Varsity ',
+                email: ''
+            }
+        ]);
+
+        expect(officials).toEqual([
+            {
+                id: 'pat-ref',
+                name: 'Pat Ref',
+                email: '',
+                phone: '555-123-4567',
+                roles: ['Referee', 'Umpire'],
+                tags: ['Varsity', 'Playoffs']
+            }
+        ]);
+    });
+
     it('reports unstaffed, partially staffed, and fully staffed states', () => {
         expect(getOfficiatingCoverageState([])).toBe('unstaffed');
         expect(getOfficiatingCoverageState([{ position: 'Umpire' }])).toBe('unstaffed');


### PR DESCRIPTION
Closes #3585

## What changed
- Updated `normalizeOfficialsDirectory` to preserve `phone`, `roles`, and `tags` when loading officials.
- Normalized role/tag lists with trimming and de-duping so edit forms reload clean structured values.
- Added a regression test for a phone-only official with roles and tags after directory normalization.

## Root Cause
`normalizeOfficialsDirectory` projected persisted official records down to only `id`, `name`, and `email`. `edit-schedule.html` then rendered and edited that reduced object, so phone-only officials lost their contact, role, and tag data after reload and failed validation on simple edits.

## Prevention / Learning
When a read-side normalizer feeds an edit form, preserve every persisted field required by that form. Add regression coverage at the projection boundary for phone-only structured records, not only email-based records.

## Regression Tests
- `npx vitest run tests/unit/officiating-slots.test.js --reporter=verbose`

## Recurrence Risk
Low: the normalized official directory shape is now covered by an adjacent unit regression for phone-only officials with roles and tags.