### PR TITLE
Lock social post update scope

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1104,6 +1104,21 @@ service cloud.firestore {
              request.resource.data.get('updatedAt', resource.data.get('updatedAt', null)) is timestamp;
     }
 
+    function isSocialPostAuthorHideUpdateValid() {
+      return resource.data.get('authorId', '') == request.auth.uid &&
+             isSocialPostScopeImmutable() &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'hidden',
+               'hiddenBy',
+               'hiddenAt',
+               'updatedAt'
+             ]) &&
+             request.resource.data.get('hidden', false) == true &&
+             request.resource.data.get('hiddenBy', '') == request.auth.uid &&
+             request.resource.data.get('hiddenAt', resource.data.get('hiddenAt', null)) is timestamp &&
+             request.resource.data.get('updatedAt', resource.data.get('updatedAt', null)) is timestamp;
+    }
+
     function isSocialPostModeratorUpdateValid() {
       return canModerateSocialPost(resource.data) &&
              isSocialPostScopeImmutable() &&
@@ -1542,6 +1557,7 @@ service cloud.firestore {
       allow update: if isSignedIn() &&
                     (
                       isSocialPostAuthorContentUpdateValid() ||
+                      isSocialPostAuthorHideUpdateValid() ||
                       isSocialPostModeratorUpdateValid()
                     );
       allow delete: if isSignedIn() &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -1070,6 +1070,60 @@ service cloud.firestore {
              );
     }
 
+    function socialPostImmutableScopeFields() {
+      return [
+        'authorId',
+        'teamId',
+        'teamIds',
+        'visibility',
+        'visibleUserIds',
+        'createdAt',
+        'snapshot'
+      ];
+    }
+
+    function isSocialPostScopeImmutable() {
+      return !request.resource.data.diff(resource.data).affectedKeys().hasAny(socialPostImmutableScopeFields());
+    }
+
+    function isSocialPostAuthorContentUpdateValid() {
+      return resource.data.get('authorId', '') == request.auth.uid &&
+             isSocialPostScopeImmutable() &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'title',
+               'detail',
+               'caption',
+               'media',
+               'updatedAt'
+             ]) &&
+             request.resource.data.get('title', '') is string &&
+             request.resource.data.get('title', '').size() > 0 &&
+             request.resource.data.get('detail', '') is string &&
+             request.resource.data.get('caption', '') is string &&
+             request.resource.data.get('media', []) is list &&
+             request.resource.data.get('updatedAt', resource.data.get('updatedAt', null)) is timestamp;
+    }
+
+    function isSocialPostModeratorUpdateValid() {
+      return canModerateSocialPost(resource.data) &&
+             isSocialPostScopeImmutable() &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'hidden',
+               'hiddenBy',
+               'hiddenAt',
+               'reportCount',
+               'lastReportedBy',
+               'lastReportedAt',
+               'moderationStatus',
+               'moderationReason',
+               'moderatedBy',
+               'moderatedAt',
+               'updatedAt'
+             ]) &&
+             request.resource.data.get('hidden', resource.data.get('hidden', false)) is bool &&
+             request.resource.data.get('updatedAt', resource.data.get('updatedAt', null)) is timestamp;
+    }
+
     function canAccessFriendship(data) {
       return isSignedIn() &&
              data.get('memberIds', []) is list &&
@@ -1486,8 +1540,10 @@ service cloud.firestore {
       allow read: if canReadSocialPost(resource.data);
       allow create: if isSocialPostCreatePayloadValid(request.resource.data);
       allow update: if isSignedIn() &&
-                    request.resource.data.get('authorId', resource.data.get('authorId', '')) == resource.data.get('authorId', '') &&
-                    (resource.data.get('authorId', '') == request.auth.uid || canModerateSocialPost(resource.data));
+                    (
+                      isSocialPostAuthorContentUpdateValid() ||
+                      isSocialPostModeratorUpdateValid()
+                    );
       allow delete: if isSignedIn() &&
                     (resource.data.get('authorId', '') == request.auth.uid || canModerateSocialPost(resource.data));
 

--- a/tests/unit/app-social-rules.test.js
+++ b/tests/unit/app-social-rules.test.js
@@ -51,6 +51,14 @@ function isAuthorSocialPostContentUpdateValid({ actorId, authorId, affectedKeys 
         hasOnly(affectedKeys, authorSocialPostContentFields);
 }
 
+function isAuthorSocialPostHideUpdateValid({ actorId, authorId, affectedKeys, hidden, hiddenBy }) {
+    return actorId === authorId &&
+        !hasAny(affectedKeys, immutableSocialPostScopeFields) &&
+        hasOnly(affectedKeys, ['hidden', 'hiddenBy', 'hiddenAt', 'updatedAt']) &&
+        hidden === true &&
+        hiddenBy === actorId;
+}
+
 function isModeratorSocialPostUpdateValid({ canModerate, affectedKeys }) {
     return canModerate &&
         !hasAny(affectedKeys, immutableSocialPostScopeFields) &&
@@ -66,6 +74,7 @@ describe('React app social Firestore rules', () => {
         expect(source).toContain('function canModerateSocialPost(data)');
         expect(source).toContain('function socialPostImmutableScopeFields()');
         expect(source).toContain('function isSocialPostAuthorContentUpdateValid()');
+        expect(source).toContain('function isSocialPostAuthorHideUpdateValid()');
         expect(source).toContain('function isSocialPostModeratorUpdateValid()');
         expect(source).toContain('match /socialPosts/{postId}');
         expect(source).toContain('match /comments/{commentId}');
@@ -122,6 +131,49 @@ describe('React app social Firestore rules', () => {
             actorId: 'author-1',
             authorId: 'author-1',
             affectedKeys: ['visibleUserIds', 'visibility', 'updatedAt']
+        })).toBe(false);
+    });
+
+    it('allows authors to hide their own social posts without moderator permissions', () => {
+        const source = rulesSource();
+
+        expect(source).toContain('isSocialPostAuthorHideUpdateValid() ||');
+        expect(source).toContain("request.resource.data.get('hidden', false) == true");
+        expect(source).toContain("request.resource.data.get('hiddenBy', '') == request.auth.uid");
+        expect(isAuthorSocialPostHideUpdateValid({
+            actorId: 'author-1',
+            authorId: 'author-1',
+            affectedKeys: ['hidden', 'hiddenBy', 'hiddenAt', 'updatedAt'],
+            hidden: true,
+            hiddenBy: 'author-1'
+        })).toBe(true);
+        expect(isAuthorSocialPostHideUpdateValid({
+            actorId: 'author-1',
+            authorId: 'author-1',
+            affectedKeys: ['hidden', 'hiddenBy', 'hiddenAt', 'updatedAt'],
+            hidden: true,
+            hiddenBy: 'other-user'
+        })).toBe(false);
+        expect(isAuthorSocialPostHideUpdateValid({
+            actorId: 'author-1',
+            authorId: 'author-1',
+            affectedKeys: ['hidden', 'hiddenBy', 'hiddenAt', 'updatedAt'],
+            hidden: false,
+            hiddenBy: 'author-1'
+        })).toBe(false);
+        expect(isAuthorSocialPostHideUpdateValid({
+            actorId: 'author-1',
+            authorId: 'author-1',
+            affectedKeys: ['hidden', 'hiddenBy', 'hiddenAt', 'teamIds', 'updatedAt'],
+            hidden: true,
+            hiddenBy: 'author-1'
+        })).toBe(false);
+        expect(isAuthorSocialPostHideUpdateValid({
+            actorId: 'author-1',
+            authorId: 'other-author',
+            affectedKeys: ['hidden', 'hiddenBy', 'hiddenAt', 'updatedAt'],
+            hidden: true,
+            hiddenBy: 'author-1'
         })).toBe(false);
     });
 

--- a/tests/unit/app-social-rules.test.js
+++ b/tests/unit/app-social-rules.test.js
@@ -5,6 +5,58 @@ function rulesSource() {
     return readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 }
 
+const immutableSocialPostScopeFields = [
+    'authorId',
+    'teamId',
+    'teamIds',
+    'visibility',
+    'visibleUserIds',
+    'createdAt',
+    'snapshot'
+];
+
+const authorSocialPostContentFields = [
+    'title',
+    'detail',
+    'caption',
+    'media',
+    'updatedAt'
+];
+
+const moderatorSocialPostFields = [
+    'hidden',
+    'hiddenBy',
+    'hiddenAt',
+    'reportCount',
+    'lastReportedBy',
+    'lastReportedAt',
+    'moderationStatus',
+    'moderationReason',
+    'moderatedBy',
+    'moderatedAt',
+    'updatedAt'
+];
+
+function hasOnly(values, allowed) {
+    return values.every((value) => allowed.includes(value));
+}
+
+function hasAny(values, candidates) {
+    return values.some((value) => candidates.includes(value));
+}
+
+function isAuthorSocialPostContentUpdateValid({ actorId, authorId, affectedKeys }) {
+    return actorId === authorId &&
+        !hasAny(affectedKeys, immutableSocialPostScopeFields) &&
+        hasOnly(affectedKeys, authorSocialPostContentFields);
+}
+
+function isModeratorSocialPostUpdateValid({ canModerate, affectedKeys }) {
+    return canModerate &&
+        !hasAny(affectedKeys, immutableSocialPostScopeFields) &&
+        hasOnly(affectedKeys, moderatorSocialPostFields);
+}
+
 describe('React app social Firestore rules', () => {
     it('adds least-privilege collections for social posts, reactions, comments, reports, and friendships', () => {
         const source = rulesSource();
@@ -12,6 +64,9 @@ describe('React app social Firestore rules', () => {
         expect(source).toContain('function canReadSocialPost(data)');
         expect(source).toContain('function isSocialPostCreatePayloadValid(data)');
         expect(source).toContain('function canModerateSocialPost(data)');
+        expect(source).toContain('function socialPostImmutableScopeFields()');
+        expect(source).toContain('function isSocialPostAuthorContentUpdateValid()');
+        expect(source).toContain('function isSocialPostModeratorUpdateValid()');
         expect(source).toContain('match /socialPosts/{postId}');
         expect(source).toContain('match /comments/{commentId}');
         expect(source).toContain('match /reactions/{userId}');
@@ -37,5 +92,59 @@ describe('React app social Firestore rules', () => {
         expect(source).toContain("(isOwner(userId) && isOwnerUserUpdatePayloadValid())");
         expect(source).toContain('allow read: if isGlobalAdmin() || isOwner(userId);');
         expect(source).not.toContain('allow read: if true;  // Public profiles');
+    });
+
+    it('locks author social post updates to content fields without changing original visibility scope', () => {
+        const source = rulesSource();
+
+        for (const field of immutableSocialPostScopeFields) {
+            expect(source).toContain(`'${field}'`);
+            expect(isAuthorSocialPostContentUpdateValid({
+                actorId: 'author-1',
+                authorId: 'author-1',
+                affectedKeys: [field]
+            })).toBe(false);
+        }
+
+        expect(source).toContain('!request.resource.data.diff(resource.data).affectedKeys().hasAny(socialPostImmutableScopeFields())');
+        expect(source).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly([\n               'title',");
+        expect(isAuthorSocialPostContentUpdateValid({
+            actorId: 'author-1',
+            authorId: 'author-1',
+            affectedKeys: ['title', 'detail', 'caption', 'media', 'updatedAt']
+        })).toBe(true);
+        expect(isAuthorSocialPostContentUpdateValid({
+            actorId: 'author-1',
+            authorId: 'author-1',
+            affectedKeys: ['teamId', 'teamIds', 'updatedAt']
+        })).toBe(false);
+        expect(isAuthorSocialPostContentUpdateValid({
+            actorId: 'author-1',
+            authorId: 'author-1',
+            affectedKeys: ['visibleUserIds', 'visibility', 'updatedAt']
+        })).toBe(false);
+    });
+
+    it('keeps moderator social post updates limited to hide and report metadata', () => {
+        const source = rulesSource();
+
+        expect(source).toContain('canModerateSocialPost(resource.data)');
+        expect(source).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly([\n               'hidden',");
+        expect(isModeratorSocialPostUpdateValid({
+            canModerate: true,
+            affectedKeys: ['hidden', 'hiddenBy', 'hiddenAt', 'updatedAt']
+        })).toBe(true);
+        expect(isModeratorSocialPostUpdateValid({
+            canModerate: true,
+            affectedKeys: ['reportCount', 'lastReportedBy', 'lastReportedAt', 'updatedAt']
+        })).toBe(true);
+        expect(isModeratorSocialPostUpdateValid({
+            canModerate: true,
+            affectedKeys: ['hidden', 'teamIds', 'updatedAt']
+        })).toBe(false);
+        expect(isModeratorSocialPostUpdateValid({
+            canModerate: false,
+            affectedKeys: ['hidden', 'hiddenBy', 'hiddenAt', 'updatedAt']
+        })).toBe(false);
     });
 });

--- a/tests/unit/app-social-service.test.js
+++ b/tests/unit/app-social-service.test.js
@@ -274,4 +274,24 @@ describe('React app social service', () => {
             thumbnailUrl: null
         });
     });
+
+    it('hides social posts with moderation fields only', async () => {
+        const { hideSocialPost } = await import('../../apps/app/src/lib/socialService.ts');
+
+        await hideSocialPost('post-1', user);
+
+        expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({ path: ['socialPosts', 'post-1'] }),
+            {
+                hidden: true,
+                hiddenBy: 'user-1',
+                hiddenAt: { __serverTimestamp: true },
+                updatedAt: { __serverTimestamp: true }
+            }
+        );
+        expect(firebaseMocks.updateDoc.mock.calls[0][1]).not.toHaveProperty('teamId');
+        expect(firebaseMocks.updateDoc.mock.calls[0][1]).not.toHaveProperty('teamIds');
+        expect(firebaseMocks.updateDoc.mock.calls[0][1]).not.toHaveProperty('visibility');
+        expect(firebaseMocks.updateDoc.mock.calls[0][1]).not.toHaveProperty('visibleUserIds');
+    });
 });


### PR DESCRIPTION
Closes #3586

## What changed
- Split `socialPosts` update rules into author content edits and moderator metadata updates.
- Froze post scope fields after creation: `authorId`, `teamId`, `teamIds`, `visibility`, `visibleUserIds`, `createdAt`, and `snapshot`.
- Added focused regression coverage for author edit allow/deny behavior, moderator hide/report metadata, and the app hide payload.

## Root Cause
`socialPosts` update authorization checked the existing document author/moderator relationship but did not constrain mutable visibility and team discovery fields in `request.resource.data`, allowing an author to retarget a post after the create-time team access check.

## Prevention / Learning
For Firestore documents with create-time authorization scope, split update rules by actor workflow and freeze all discovery/scope fields after creation. Allowlist affected fields for each update path instead of relying on old-document authorization alone.

## Regression Tests
- `npx vitest run tests/unit/app-social-rules.test.js tests/unit/app-social-service.test.js --reporter=verbose`
- `npm run ci:firebase-rules`