### PR TITLE
Prevent unbounded inbox fallback

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -343,6 +343,29 @@ describe('AppShell', () => {
       expect(subscribeToNotificationInboxMock).toHaveBeenCalledTimes(1);
     });
 
+    const onItems = subscribeToNotificationInboxMock.mock.calls[0]?.[1] as ((items: NotificationInboxItem[]) => void) | undefined;
+    act(() => {
+      onItems?.([
+        {
+          id: 'cached-notification',
+          category: 'team_message',
+          type: 'team_message',
+          title: 'Team update',
+          body: '',
+          text: 'Cached notification',
+          appRoute: '/messages',
+          conversationId: '',
+          createdAt: null,
+          readAt: null,
+        },
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-inbox-sheet-state').textContent).toBe('ready');
+    });
+    expect(screen.getByText('Cached notification')).toBeTruthy();
+
     const onError = subscribeToNotificationInboxMock.mock.calls[0]?.[2] as ((error: unknown) => void) | undefined;
     act(() => {
       onError?.(new Error('offline'));
@@ -351,6 +374,7 @@ describe('AppShell', () => {
     await waitFor(() => {
       expect(screen.getByTestId('notification-inbox-sheet-state').textContent).toBe('error');
     });
+    expect(screen.getByText('Cached notification')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry notifications' }));
 

--- a/apps/app/src/lib/notificationInboxService.test.ts
+++ b/apps/app/src/lib/notificationInboxService.test.ts
@@ -83,45 +83,39 @@ describe('notificationInboxService', () => {
         expect(primaryUnsubscribe).toHaveBeenCalledTimes(1);
     });
 
-    it('falls back to the full inbox snapshot when the ordered inbox query fails', () => {
+    it('subscribes to the ordered limited inbox snapshot', () => {
         const callback = vi.fn();
         const primaryUnsubscribe = vi.fn();
-        const fallbackUnsubscribe = vi.fn();
         const inboxCollection = { kind: 'inboxCollection' };
         const primaryQuery = { kind: 'primaryInboxQuery' };
         vi.mocked(collection).mockReturnValueOnce(inboxCollection as never);
         vi.mocked(query).mockReturnValueOnce(primaryQuery as never);
-        vi.mocked(onSnapshot)
-            .mockImplementationOnce((_query, _onNext, onError) => {
-                onError?.(new Error('The query requires an index.'));
-                return primaryUnsubscribe;
-            })
-            .mockImplementationOnce((_query, onNext) => {
-                onNext({
-                    docs: [
-                        {
-                            id: 'older',
-                            data: () => ({
-                                category: 'schedule',
-                                title: 'Older update',
-                                body: 'Earlier item',
-                                createdAt: { seconds: 10 },
-                                readAt: null
-                            })
-                        },
-                        {
-                            id: 'newer',
-                            data: () => ({
-                                type: 'team_message',
-                                text: 'Fresh message',
-                                createdAt: { toDate: () => new Date('2026-06-26T12:00:00Z') },
-                                readAt: null
-                            })
-                        }
-                    ]
-                } as never);
-                return fallbackUnsubscribe;
-            });
+        vi.mocked(onSnapshot).mockImplementationOnce((_query, onNext) => {
+            onNext({
+                docs: [
+                    {
+                        id: 'newest',
+                        data: () => ({
+                            category: 'schedule',
+                            title: 'Newest update',
+                            body: 'Latest item',
+                            createdAt: { seconds: 20 },
+                            readAt: null
+                        })
+                    },
+                    {
+                        id: 'older',
+                        data: () => ({
+                            type: 'team_message',
+                            text: 'Earlier message',
+                            createdAt: { seconds: 10 },
+                            readAt: null
+                        })
+                    }
+                ]
+            } as never);
+            return primaryUnsubscribe;
+        });
 
         const unsubscribe = subscribeToNotificationInbox('user-123', callback);
 
@@ -129,15 +123,74 @@ describe('notificationInboxService', () => {
         expect(orderBy).toHaveBeenCalledWith('createdAt', 'desc');
         expect(limit).toHaveBeenCalledWith(50);
         expect(query).toHaveBeenCalledWith(inboxCollection, { kind: 'orderBy' }, { kind: 'limit' });
-        expect(onSnapshot).toHaveBeenNthCalledWith(1, primaryQuery, expect.any(Function), expect.any(Function));
-        expect(onSnapshot).toHaveBeenNthCalledWith(2, inboxCollection, expect.any(Function), expect.any(Function));
+        expect(onSnapshot).toHaveBeenCalledTimes(1);
+        expect(onSnapshot).toHaveBeenCalledWith(primaryQuery, expect.any(Function), expect.any(Function));
         expect(callback).toHaveBeenCalledWith([
-            expect.objectContaining({ id: 'newer', text: 'Fresh message' }),
-            expect.objectContaining({ id: 'older', text: 'Older update: Earlier item' })
+            expect.objectContaining({ id: 'newest', text: 'Newest update: Latest item' }),
+            expect.objectContaining({ id: 'older', text: 'Earlier message' })
         ]);
 
         unsubscribe();
         expect(primaryUnsubscribe).toHaveBeenCalledTimes(1);
-        expect(fallbackUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports ordered inbox query errors without attaching a raw full-inbox fallback', () => {
+        const callback = vi.fn();
+        const onError = vi.fn();
+        const primaryUnsubscribe = vi.fn();
+        const inboxCollection = { kind: 'inboxCollection' };
+        const primaryQuery = { kind: 'primaryInboxQuery' };
+        const orderedQueryError = new Error('The query requires an index.');
+        vi.mocked(collection).mockReturnValueOnce(inboxCollection as never);
+        vi.mocked(query).mockReturnValueOnce(primaryQuery as never);
+        vi.mocked(onSnapshot).mockImplementationOnce((_query, _onNext, onSnapshotError) => {
+            onSnapshotError?.(orderedQueryError);
+            return primaryUnsubscribe;
+        });
+
+        const unsubscribe = subscribeToNotificationInbox('user-123', callback, onError);
+
+        expect(orderBy).toHaveBeenCalledWith('createdAt', 'desc');
+        expect(limit).toHaveBeenCalledWith(50);
+        expect(query).toHaveBeenCalledWith(inboxCollection, { kind: 'orderBy' }, { kind: 'limit' });
+        expect(onSnapshot).toHaveBeenCalledTimes(1);
+        expect(onSnapshot).toHaveBeenCalledWith(primaryQuery, expect.any(Function), expect.any(Function));
+        expect(callback).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledWith(orderedQueryError);
+
+        unsubscribe();
+        expect(primaryUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not map a large raw fallback snapshot after an ordered inbox query error', () => {
+        const callback = vi.fn();
+        const onError = vi.fn();
+        const primaryUnsubscribe = vi.fn();
+        const largeRawFallbackSnapshot = {
+            docs: Array.from({ length: 1000 }, (_, index) => ({
+                id: `notification-${index}`,
+                data: vi.fn(() => ({
+                    category: 'team_message',
+                    text: `Notification ${index}`,
+                    createdAt: { seconds: index },
+                    readAt: null
+                }))
+            }))
+        };
+        vi.mocked(collection).mockReturnValueOnce({ kind: 'inboxCollection' } as never);
+        vi.mocked(query).mockReturnValueOnce({ kind: 'primaryInboxQuery' } as never);
+        vi.mocked(onSnapshot).mockImplementationOnce((_query, _onNext, onSnapshotError) => {
+            onSnapshotError?.(new Error('permission denied'));
+            return primaryUnsubscribe;
+        });
+
+        subscribeToNotificationInbox('user-123', callback, onError);
+
+        expect(onSnapshot).toHaveBeenCalledTimes(1);
+        for (const docSnap of largeRawFallbackSnapshot.docs) {
+            expect(docSnap.data).not.toHaveBeenCalled();
+        }
+        expect(callback).not.toHaveBeenCalled();
+        expect(onError).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -63,35 +63,6 @@ function mapNotificationInboxSnapshot(snapshot: QuerySnapshot<DocumentData>): No
     });
 }
 
-function getCreatedAtTime(value: unknown): number {
-    if (value instanceof Date) {
-        const time = value.getTime();
-        return Number.isFinite(time) ? time : 0;
-    }
-    if (value && typeof value === 'object') {
-        const timestamp = value as { toDate?: () => Date; seconds?: number; nanoseconds?: number };
-        if (typeof timestamp.toDate === 'function') {
-            const time = timestamp.toDate().getTime();
-            return Number.isFinite(time) ? time : 0;
-        }
-        if (typeof timestamp.seconds === 'number') {
-            return (timestamp.seconds * 1000) + (typeof timestamp.nanoseconds === 'number' ? timestamp.nanoseconds / 1000000 : 0);
-        }
-    }
-    if (typeof value === 'number') {
-        return Number.isFinite(value) ? value : 0;
-    }
-    if (typeof value === 'string') {
-        const time = Date.parse(value);
-        return Number.isFinite(time) ? time : 0;
-    }
-    return 0;
-}
-
-function sortNotificationInboxItems(items: NotificationInboxItem[]): NotificationInboxItem[] {
-    return [...items].sort((left, right) => getCreatedAtTime(right.createdAt) - getCreatedAtTime(left.createdAt));
-}
-
 /**
  * Subscribe to the unread notification count only.
  * Returns an unsubscribe function.
@@ -141,34 +112,22 @@ export function subscribeToNotificationInbox(
         limit(notificationInboxLimit)
     );
 
-    let fallbackUnsubscribe: (() => void) | null = null;
     const primaryUnsubscribe = onSnapshot(
         q,
         (snapshot: QuerySnapshot<DocumentData>) => {
             callback(mapNotificationInboxSnapshot(snapshot));
         },
         (error: unknown) => {
-            logger.warn('Inbox ordered query failed; falling back to unordered inbox snapshot.', { error });
-            if (fallbackUnsubscribe) return;
-            fallbackUnsubscribe = onSnapshot(
-                inboxRef,
-                (snapshot: QuerySnapshot<DocumentData>) => {
-                    callback(sortNotificationInboxItems(mapNotificationInboxSnapshot(snapshot)).slice(0, notificationInboxLimit));
-                },
-                (fallbackError: unknown) => {
-                    if (onError) {
-                        onError(fallbackError);
-                    } else {
-                        logger.error('Failed to subscribe to notification inbox.', { error: fallbackError });
-                    }
-                }
-            );
+            if (onError) {
+                onError(error);
+            } else {
+                logger.error('Failed to subscribe to notification inbox.', { error });
+            }
         }
     );
 
     return () => {
         primaryUnsubscribe();
-        fallbackUnsubscribe?.();
     };
 }
 

--- a/tests/unit/app-notification-inbox-review.test.tsx
+++ b/tests/unit/app-notification-inbox-review.test.tsx
@@ -169,7 +169,7 @@ describe('Notification inbox review regressions', () => {
         });
     });
 
-    it('falls back before logging Firestore subscription errors when no error callback is provided', () => {
+    it('logs Firestore subscription errors without attaching an unbounded fallback when no error callback is provided', () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
         const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
         const subscriptionError = new Error('subscription failed');
@@ -179,18 +179,11 @@ describe('Notification inbox review regressions', () => {
         const errorHandler = firebaseMocks.onSnapshot.mock.calls[0][2] as (error: unknown) => void;
         errorHandler(subscriptionError);
 
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-            '[notification-inbox-service] Inbox ordered query failed; falling back to unordered inbox snapshot.',
-            { error: { name: 'Error', message: 'subscription failed' } }
-        );
-
-        const fallbackError = new Error('fallback failed');
-        const fallbackErrorHandler = firebaseMocks.onSnapshot.mock.calls[1][2] as (error: unknown) => void;
-        fallbackErrorHandler(fallbackError);
-
+        expect(firebaseMocks.onSnapshot).toHaveBeenCalledTimes(1);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
         expect(consoleErrorSpy).toHaveBeenCalledWith(
             '[notification-inbox-service] Failed to subscribe to notification inbox.',
-            { error: { name: 'Error', message: 'fallback failed' } }
+            { error: { name: 'Error', message: 'subscription failed' } }
         );
     });
 


### PR DESCRIPTION
Closes #3588

## What changed
- Removed the raw unordered `notificationInbox` fallback listener from `subscribeToNotificationInbox`.
- Ordered inbox failures now surface through `onError`, allowing AppShell to keep cached items or show the existing retry/error state.
- Updated focused service and AppShell regression coverage for the bounded query and retry behavior.

## Root Cause
`subscribeToNotificationInbox` handled ordered-query failures by attaching a second `onSnapshot` directly to `users/{uid}/notificationInbox` without `orderBy` or `limit`, then mapping, sorting, and slicing all documents client-side before rendering the visible 50 items.

## Prevention / Learning
Firestore fallback paths for high-cardinality user collections must preserve the same server-side bounds as the primary query. If the bounded query fails, surface the error and keep cached UI state instead of replacing server limits with client sorting.

## Regression Tests
- `npx vitest run src/lib/notificationInboxService.test.ts src/components/AppShell.test.tsx --reporter=verbose`
- `npm run typecheck`