### PR TITLE
Bound chat recipient profile hydration

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -72,6 +72,7 @@ const chatUploadTimeoutMs = 25000;
 const chatAttachmentUploadConcurrency = 3;
 const chatPreviewCacheTtlMs = 20 * 1000;
 const deferredInboxPreviewConcurrency = 3;
+export const CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY = 8;
 const imageUploadSessionKey = 'allplays-chat-image-upload-session';
 const logger = createLogger('chat-service');
 
@@ -1816,31 +1817,45 @@ async function loadChatRecipientProfiles(players: any): Promise<Map<string, Reco
     return new Map();
   }
 
-  const entries = await Promise.all([...uniqueParents.entries()].map(async ([recipientId, parent]) => {
-    const userId = compactString(parent?.userId);
-    const email = compactString(parent?.email).toLowerCase();
-    try {
-      if (userId) {
-        const profile = await withTimeout(Promise.resolve(getUserProfile(userId)), 'Chat recipient profile load', 2500)
-          .catch(async (error) => {
-            if (!isNativeRuntime()) throw error;
-            return nativeGetDocument(`users/${encodeURIComponent(userId)}`);
-          });
-        return [recipientId, profile || {}] as const;
+  const parentEntries = [...uniqueParents.entries()];
+  const entries: (readonly [string, Record<string, any>])[] = new Array(parentEntries.length);
+  let nextParentIndex = 0;
+
+  async function hydrateNextParent() {
+    while (nextParentIndex < parentEntries.length) {
+      const entryIndex = nextParentIndex;
+      nextParentIndex += 1;
+      const [recipientId, parent] = parentEntries[entryIndex];
+      const userId = compactString(parent?.userId);
+      const email = compactString(parent?.email).toLowerCase();
+      try {
+        if (userId) {
+          const profile = await withTimeout(Promise.resolve(getUserProfile(userId)), 'Chat recipient profile load', 2500)
+            .catch(async (error) => {
+              if (!isNativeRuntime()) throw error;
+              return nativeGetDocument(`users/${encodeURIComponent(userId)}`);
+            });
+          entries[entryIndex] = [recipientId, profile || {}] as const;
+          continue;
+        }
+        if (email) {
+          const profile = await withTimeout(Promise.resolve(getUserByEmail(email)), 'Chat recipient profile load', 2500)
+            .catch(async (error) => {
+              if (!isNativeRuntime()) throw error;
+              return nativeGetUserByEmail(email);
+            });
+          entries[entryIndex] = [recipientId, profile || {}] as const;
+          continue;
+        }
+      } catch (error) {
+        logger.warn('Failed to hydrate chat recipient profile.', { error });
       }
-      if (email) {
-        const profile = await withTimeout(Promise.resolve(getUserByEmail(email)), 'Chat recipient profile load', 2500)
-          .catch(async (error) => {
-            if (!isNativeRuntime()) throw error;
-            return nativeGetUserByEmail(email);
-          });
-        return [recipientId, profile || {}] as const;
-      }
-    } catch (error) {
-      logger.warn('Failed to hydrate chat recipient profile.', { error });
+      entries[entryIndex] = [recipientId, {}] as const;
     }
-    return [recipientId, {}] as const;
-  }));
+  }
+
+  const workerCount = Math.min(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY, parentEntries.length);
+  await Promise.all(Array.from({ length: workerCount }, () => hydrateNextParent()));
 
   return new Map(entries);
 }

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1822,21 +1822,11 @@ async function loadChatRecipientProfiles(players: any): Promise<Map<string, Reco
   let nextParentIndex = 0;
 
   async function hydrateChatRecipientProfile<T>(lookupPromise: Promise<T>, fallbackLookup: () => Promise<T>): Promise<T> {
-    let lookupSettled = false;
-    const trackedLookup = lookupPromise.finally(() => {
-      lookupSettled = true;
-    });
-    try {
-      return await withTimeout(trackedLookup, 'Chat recipient profile load', 2500)
-        .catch(async (error) => {
-          if (!isNativeRuntime()) throw error;
-          return fallbackLookup();
-        });
-    } finally {
-      if (!lookupSettled) {
-        await trackedLookup.catch(() => undefined);
-      }
-    }
+    return withTimeout(lookupPromise, 'Chat recipient profile load', 2500)
+      .catch(async (error) => {
+        if (!isNativeRuntime()) throw error;
+        return fallbackLookup();
+      });
   }
 
   async function hydrateNextParent() {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1821,6 +1821,24 @@ async function loadChatRecipientProfiles(players: any): Promise<Map<string, Reco
   const entries: (readonly [string, Record<string, any>])[] = new Array(parentEntries.length);
   let nextParentIndex = 0;
 
+  async function hydrateChatRecipientProfile<T>(lookupPromise: Promise<T>, fallbackLookup: () => Promise<T>): Promise<T> {
+    let lookupSettled = false;
+    const trackedLookup = lookupPromise.finally(() => {
+      lookupSettled = true;
+    });
+    try {
+      return await withTimeout(trackedLookup, 'Chat recipient profile load', 2500)
+        .catch(async (error) => {
+          if (!isNativeRuntime()) throw error;
+          return fallbackLookup();
+        });
+    } finally {
+      if (!lookupSettled) {
+        await trackedLookup.catch(() => undefined);
+      }
+    }
+  }
+
   async function hydrateNextParent() {
     while (nextParentIndex < parentEntries.length) {
       const entryIndex = nextParentIndex;
@@ -1830,20 +1848,18 @@ async function loadChatRecipientProfiles(players: any): Promise<Map<string, Reco
       const email = compactString(parent?.email).toLowerCase();
       try {
         if (userId) {
-          const profile = await withTimeout(Promise.resolve(getUserProfile(userId)), 'Chat recipient profile load', 2500)
-            .catch(async (error) => {
-              if (!isNativeRuntime()) throw error;
-              return nativeGetDocument(`users/${encodeURIComponent(userId)}`);
-            });
+          const profile = await hydrateChatRecipientProfile(
+            Promise.resolve(getUserProfile(userId)),
+            () => nativeGetDocument(`users/${encodeURIComponent(userId)}`)
+          );
           entries[entryIndex] = [recipientId, profile || {}] as const;
           continue;
         }
         if (email) {
-          const profile = await withTimeout(Promise.resolve(getUserByEmail(email)), 'Chat recipient profile load', 2500)
-            .catch(async (error) => {
-              if (!isNativeRuntime()) throw error;
-              return nativeGetUserByEmail(email);
-            });
+          const profile = await hydrateChatRecipientProfile(
+            Promise.resolve(getUserByEmail(email)),
+            () => nativeGetUserByEmail(email)
+          );
           entries[entryIndex] = [recipientId, profile || {}] as const;
           continue;
         }

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearAppDataCache } from '../../apps/app/src/lib/appDataCache.ts';
 
 const dbMocks = vi.hoisted(() => ({
@@ -82,6 +82,10 @@ beforeEach(() => {
     dbMocks.getChatMessages.mockResolvedValue([]);
     dbMocks.sendTeamEmail.mockResolvedValue({ recipientCount: 8, status: 'queued' });
     dbMocks.getSentTeamEmails.mockResolvedValue([]);
+});
+
+afterEach(() => {
+    vi.useRealTimers();
 });
 
 describe('React app chat recipient service', () => {
@@ -316,6 +320,66 @@ describe('React app chat recipient service', () => {
                 id: 'email:guardian-37@example.com',
                 name: 'guardian-37@example.com',
                 email: 'guardian-37@example.com'
+            })
+        ]));
+    });
+
+    it('keeps timed-out profile lookups occupying worker slots until the backend request settles', async () => {
+        vi.useFakeTimers();
+        const missingLabelParents = Array.from({ length: 9 }, (_, index) => ({
+            id: `player-${index}`,
+            name: `Player ${index}`,
+            parents: [{ userId: `parent-${index}` }]
+        }));
+        dbMocks.getPlayers.mockResolvedValue(missingLabelParents);
+
+        const pendingLookups = [];
+        dbMocks.getUserProfile.mockImplementation((userId) => {
+            let resolveLookup;
+            const promise = new Promise((resolve) => {
+                resolveLookup = resolve;
+            });
+            pendingLookups.push({
+                userId,
+                resolve: resolveLookup
+            });
+            return promise;
+        });
+
+        const {
+            CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY,
+            loadChatRecipientOptions
+        } = await import('../../apps/app/src/lib/chatService.ts');
+        const optionsPromise = loadChatRecipientOptions('team-1');
+
+        await vi.waitFor(() => {
+            expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY);
+        });
+
+        await vi.advanceTimersByTimeAsync(2500);
+        await Promise.resolve();
+
+        expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY);
+
+        pendingLookups[0].resolve({ fullName: 'Hydrated parent-0', email: 'parent-0@example.com' });
+        await vi.waitFor(() => {
+            expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY + 1);
+        });
+
+        pendingLookups.slice(1).forEach((lookup, index) => {
+            lookup.resolve({
+                fullName: `Hydrated parent-${index + 1}`,
+                email: `parent-${index + 1}@example.com`
+            });
+        });
+
+        const options = await optionsPromise;
+
+        expect(options).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'user:parent-8',
+                name: 'Hydrated parent-8',
+                email: 'parent-8@example.com'
             })
         ]));
     });

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -324,7 +324,7 @@ describe('React app chat recipient service', () => {
         ]));
     });
 
-    it('keeps timed-out profile lookups occupying worker slots until the backend request settles', async () => {
+    it('returns fallback recipient options when profile lookups never settle', async () => {
         vi.useFakeTimers();
         const missingLabelParents = Array.from({ length: 9 }, (_, index) => ({
             id: `player-${index}`,
@@ -333,18 +333,7 @@ describe('React app chat recipient service', () => {
         }));
         dbMocks.getPlayers.mockResolvedValue(missingLabelParents);
 
-        const pendingLookups = [];
-        dbMocks.getUserProfile.mockImplementation((userId) => {
-            let resolveLookup;
-            const promise = new Promise((resolve) => {
-                resolveLookup = resolve;
-            });
-            pendingLookups.push({
-                userId,
-                resolve: resolveLookup
-            });
-            return promise;
-        });
+        dbMocks.getUserProfile.mockImplementation(() => new Promise(() => {}));
 
         const {
             CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY,
@@ -357,29 +346,21 @@ describe('React app chat recipient service', () => {
         });
 
         await vi.advanceTimersByTimeAsync(2500);
-        await Promise.resolve();
-
-        expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY);
-
-        pendingLookups[0].resolve({ fullName: 'Hydrated parent-0', email: 'parent-0@example.com' });
         await vi.waitFor(() => {
             expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY + 1);
         });
 
-        pendingLookups.slice(1).forEach((lookup, index) => {
-            lookup.resolve({
-                fullName: `Hydrated parent-${index + 1}`,
-                email: `parent-${index + 1}@example.com`
-            });
-        });
+        await vi.advanceTimersByTimeAsync(2500);
 
         const options = await optionsPromise;
 
+        expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(9);
+        expect(options).toHaveLength(18);
         expect(options).toEqual(expect.arrayContaining([
             expect.objectContaining({
                 id: 'user:parent-8',
-                name: 'Hydrated parent-8',
-                email: 'parent-8@example.com'
+                name: 'Guardian',
+                detail: 'Guardian for Player 8'
             })
         ]));
     });

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -225,6 +225,101 @@ describe('React app chat recipient service', () => {
         ]));
     });
 
+    it('bounds missing-label parent profile hydration and preserves fallback options', async () => {
+        const missingLabelParents = Array.from({ length: 50 }, (_, index) => {
+            const parent = index < 25
+                ? { userId: `parent-${index}`, email: `parent-${index}@example.com` }
+                : { email: `guardian-${index}@example.com` };
+            return {
+                id: `player-${index}`,
+                name: `Player ${index}`,
+                parents: [parent]
+            };
+        });
+        dbMocks.getPlayers.mockResolvedValue(missingLabelParents);
+
+        const pendingLookups = [];
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const trackLookup = (key, profile) => {
+            inFlight += 1;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            let resolveLookup;
+            let rejectLookup;
+            const promise = new Promise((resolve, reject) => {
+                resolveLookup = resolve;
+                rejectLookup = reject;
+            }).finally(() => {
+                inFlight -= 1;
+            });
+            pendingLookups.push({
+                key,
+                profile,
+                resolve: resolveLookup,
+                reject: rejectLookup
+            });
+            return promise;
+        };
+        dbMocks.getUserProfile.mockImplementation((userId) => trackLookup(userId, {
+            fullName: `Hydrated ${userId}`,
+            email: `${userId}@profile.example.com`
+        }));
+        dbMocks.getUserByEmail.mockImplementation((email) => trackLookup(email, {
+            fullName: `Hydrated ${email}`,
+            email
+        }));
+
+        const {
+            CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY,
+            loadChatRecipientOptions
+        } = await import('../../apps/app/src/lib/chatService.ts');
+        const optionsPromise = loadChatRecipientOptions('team-1');
+
+        await vi.waitFor(() => {
+            expect(pendingLookups).toHaveLength(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY);
+        });
+        expect(maxInFlight).toBe(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY);
+
+        for (let index = 0; index < missingLabelParents.length; index += 1) {
+            await vi.waitFor(() => {
+                expect(pendingLookups.length).toBeGreaterThan(0);
+            });
+            const lookup = pendingLookups.shift();
+            if (lookup.key === 'guardian-37@example.com') {
+                lookup.reject(new Error('profile lookup failed'));
+            } else {
+                lookup.resolve(lookup.profile);
+            }
+            await Promise.resolve();
+            await Promise.resolve();
+            expect(maxInFlight).toBeLessThanOrEqual(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY);
+        }
+
+        const options = await optionsPromise;
+
+        expect(dbMocks.getUserProfile).toHaveBeenCalledTimes(25);
+        expect(dbMocks.getUserByEmail).toHaveBeenCalledTimes(25);
+        expect(maxInFlight).toBeLessThanOrEqual(CHAT_RECIPIENT_PROFILE_LOOKUP_CONCURRENCY);
+        expect(options).toHaveLength(100);
+        expect(options).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                id: 'user:parent-0',
+                name: 'Hydrated parent-0',
+                email: 'parent-0@example.com'
+            }),
+            expect.objectContaining({
+                id: 'email:guardian-25@example.com',
+                name: 'Hydrated guardian-25@example.com',
+                email: 'guardian-25@example.com'
+            }),
+            expect.objectContaining({
+                id: 'email:guardian-37@example.com',
+                name: 'guardian-37@example.com',
+                email: 'guardian-37@example.com'
+            })
+        ]));
+    });
+
     it('builds the inbox from parent, coach, and admin team access with unread and preview data', async () => {
         dbMocks.getUserProfile.mockResolvedValue({
             email: 'parent@example.com',


### PR DESCRIPTION
Closes #3600

## What changed
- Added an explicit 8-request concurrency cap for missing-label chat recipient profile hydration.
- Replaced the unbounded `Promise.all` fan-out with a bounded worker queue that preserves de-dupe, fallback behavior, and result ordering.
- Added a 50-parent deferred-promise regression test covering userId-backed parents, email-backed parents, concurrency limits, and lookup failure fallback.

## Root Cause
`loadChatRecipientProfiles` de-duped missing-label parents, but then used `Promise.all` across every remaining parent profile lookup. Large rosters could start all `getUserProfile` and `getUserByEmail` calls concurrently, creating avoidable Firestore/API pressure during recipient loading.

## Prevention / Learning
Any roster, recipient, notification, or message fan-out path needs a cardinality check and a bounded worker queue when the number of async lookups can scale with team size. High-count deferred-promise tests should assert max in-flight work, not just final output.

## Regression Tests
- `npx vitest run tests/unit/app-chat-service-recipients.test.js --reporter=dot`

## Recurrence Risk
Low. The affected fan-out now has a named cap and a regression test that would fail if unbounded concurrency returns.