### PR TITLE
Lazy-load Profile push services

### DIFF
--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -177,6 +177,8 @@ describe('Profile', () => {
 
     expect(source).toContain("import type { PushNotificationPrimerContext, PushNotificationPermissionStatus } from '../lib/pushService';");
     expect(source).toContain("import('../lib/pushService')");
+    expect(source).toContain("pushServiceRequest = import('../lib/pushService').catch((error) => {");
+    expect(source).toContain('pushServiceRequest = null;');
     expect(pushStaticImports).toEqual([
       "import type { PushNotificationPrimerContext, PushNotificationPermissionStatus } from '../lib/pushService';"
     ]);

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -166,6 +167,33 @@ describe('Profile', () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it('keeps push service value APIs behind the Alerts dynamic import boundary', () => {
+    const source = readFileSync('src/pages/Profile.tsx', 'utf8');
+    const pushStaticImports = source
+      .match(/import[\s\S]*?from ['"][^'"]+['"];?/g)
+      ?.filter((statement) => statement.includes("from '../lib/pushService'")) || [];
+
+    expect(source).toContain("import type { PushNotificationPrimerContext, PushNotificationPermissionStatus } from '../lib/pushService';");
+    expect(source).toContain("import('../lib/pushService')");
+    expect(pushStaticImports).toEqual([
+      "import type { PushNotificationPrimerContext, PushNotificationPermissionStatus } from '../lib/pushService';"
+    ]);
+  });
+
+  it('does not check push permission status until Alerts is opened', async () => {
+    renderProfile();
+
+    expect(await screen.findByRole('heading', { name: 'Your Account' })).toBeTruthy();
+    expect(pushServiceMocks.getPushNotificationPermissionStatus).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /^Alerts$/ }));
+
+    expect(await screen.findByText('Notification preferences')).toBeTruthy();
+    await waitFor(() => {
+      expect(pushServiceMocks.getPushNotificationPermissionStatus).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('keeps mobile profile section buttons in a two-column grid so Alerts stays reachable', async () => {

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -81,7 +81,10 @@ let pushServiceRequest: Promise<PushServiceModule> | null = null;
 
 function loadPushService() {
   if (!pushServiceRequest) {
-    pushServiceRequest = import('../lib/pushService');
+    pushServiceRequest = import('../lib/pushService').catch((error) => {
+      pushServiceRequest = null;
+      throw error;
+    });
   }
   return pushServiceRequest;
 }

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -36,14 +36,6 @@ import {
   saveNotificationPreferences,
   saveProfileDocument
 } from '../lib/profileService';
-import {
-  enablePushNotificationsForUser,
-  getPushNotificationPermissionStatus,
-  openPushNotificationSettings,
-  runPushNotificationPrimer,
-  type PushNotificationPrimerContext,
-  type PushNotificationPermissionStatus
-} from '../lib/pushService';
 import { buildAppAcceptInviteUrl } from '../lib/inviteUrls';
 import { createLogger } from '../lib/logger';
 import { sharePublicUrl } from '../lib/publicActions';
@@ -53,6 +45,7 @@ import { useViewLoadTimer } from '../lib/viewLoadTiming';
 import { NOTIFICATION_PREFERENCE_GROUPS } from '../lib/adapters/legacyProfile';
 import type { AccessCodeRecord, NotificationCategory, NotificationPreferences, NotificationTeam, ProfileDocument } from '../lib/profileService';
 import type { ProfilePhotoSource } from '../lib/profilePhotoService';
+import type { PushNotificationPrimerContext, PushNotificationPermissionStatus } from '../lib/pushService';
 import type { AuthState } from '../lib/types';
 
 type Tone = 'neutral' | 'success' | 'error';
@@ -83,6 +76,15 @@ const profileSections: Array<{ id: ProfileSectionId; label: string }> = [
   { id: 'invites', label: 'Invites' },
   { id: 'security', label: 'Security' }
 ];
+type PushServiceModule = typeof import('../lib/pushService');
+let pushServiceRequest: Promise<PushServiceModule> | null = null;
+
+function loadPushService() {
+  if (!pushServiceRequest) {
+    pushServiceRequest = import('../lib/pushService');
+  }
+  return pushServiceRequest;
+}
 
 function getProfileSectionRoute(section: ProfileSectionId) {
   return section === 'account' ? '/profile' : `/profile?section=${section}`;
@@ -251,7 +253,8 @@ export function Profile({ auth }: { auth: AuthState }) {
     }
 
     try {
-      const nextStatus = await getPushNotificationPermissionStatus();
+      const pushService = await loadPushService();
+      const nextStatus = await pushService.getPushNotificationPermissionStatus();
       setPushPermissionStatus(nextStatus);
       return nextStatus;
     } catch (error) {
@@ -930,7 +933,8 @@ export function Profile({ auth }: { auth: AuthState }) {
     setNotificationStatus(null);
 
     try {
-      const currentPermissionStatus = pushPermissionStatus || await getPushNotificationPermissionStatus();
+      const pushService = await loadPushService();
+      const currentPermissionStatus = pushPermissionStatus || await pushService.getPushNotificationPermissionStatus();
 
       setPushPermissionStatus(currentPermissionStatus);
 
@@ -952,7 +956,7 @@ export function Profile({ auth }: { auth: AuthState }) {
         return;
       }
 
-      await enablePushNotificationsForUser(user.uid);
+      await pushService.enablePushNotificationsForUser(user.uid);
       await refreshPushPermissionStatus({ silent: true });
       setNotificationStatus({ message: 'Push is enabled on this device.', tone: 'success' });
     } catch (error: any) {
@@ -965,7 +969,8 @@ export function Profile({ auth }: { auth: AuthState }) {
 
   const openDeviceSettingsForPush = async (statusMessage = 'Open device settings, allow notifications, then return here. We will refresh this screen when you come back.') => {
     setNotificationStatus({ message: statusMessage, tone: 'neutral' });
-    await openPushNotificationSettings();
+    const pushService = await loadPushService();
+    await pushService.openPushNotificationSettings();
   };
 
   const confirmPushPrimer = async (context: PushNotificationPrimerContext, permissionStatus: PushNotificationPermissionStatus | null) => {
@@ -973,7 +978,8 @@ export function Profile({ auth }: { auth: AuthState }) {
       return true;
     }
 
-    const accepted = await runPushNotificationPrimer(context);
+    const pushService = await loadPushService();
+    const accepted = await pushService.runPushNotificationPrimer(context);
     if (!accepted) {
       setNotificationStatus({ message: 'Push setup was skipped. You can turn notifications on later from Alerts.', tone: 'neutral' });
     }
@@ -996,7 +1002,8 @@ export function Profile({ auth }: { auth: AuthState }) {
     setNotificationStatus(null);
 
     try {
-      const currentPermissionStatus = pushPermissionStatus || await getPushNotificationPermissionStatus();
+      const pushService = await loadPushService();
+      const currentPermissionStatus = pushPermissionStatus || await pushService.getPushNotificationPermissionStatus();
 
       setPushPermissionStatus(currentPermissionStatus);
 
@@ -1027,7 +1034,7 @@ export function Profile({ auth }: { auth: AuthState }) {
         ...gameDayDefaultPreferences
       });
 
-      await enablePushNotificationsForUser(user.uid);
+      await pushService.enablePushNotificationsForUser(user.uid);
       await refreshPushPermissionStatus({ silent: true });
       const saved = await saveNotificationPreferences(user.uid, teamId, nextPreferences);
       setNotificationPreferences(saved);

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -50,6 +50,7 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             notificationSaves: [],
             notificationLoads: [],
             push: 0,
+            pushModuleLoads: 0,
             accessCodes: [],
             openPushSettings: 0
         };
@@ -357,6 +358,8 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             status: 200,
             contentType: 'application/javascript',
             body: `
+                window.__appProfileCalls.pushModuleLoads += 1;
+
                 export async function addPushNotificationOpenListener() {
                     return async () => {};
                 }
@@ -643,6 +646,7 @@ test('profile exposes account, notification, invite, verification, password, upl
     await page.goto(appUrl(baseURL, '/profile'), { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByRole('heading', { name: 'Your Account' })).toBeVisible();
+    await expect.poll(async () => page.evaluate(() => window.__appProfileCalls.pushModuleLoads)).toBe(0);
     await page.locator('input[type="file"]').setInputFiles({
         name: 'avatar.png',
         mimeType: 'image/png',
@@ -658,6 +662,7 @@ test('profile exposes account, notification, invite, verification, password, upl
     const alertsTab = page.getByRole('button', { name: 'Alerts', exact: true });
     await alertsTab.click();
     await expect(alertsTab).toHaveAttribute('aria-pressed', 'true');
+    await expect.poll(async () => page.evaluate(() => window.__appProfileCalls.pushModuleLoads)).toBe(1);
     await expect(page.getByText('Per-team alerts for live chat, score updates, and schedule changes.')).toBeVisible();
     await expect(page.getByLabel('Team')).toHaveValue('team-1');
     const gameDayAlertsButton = page.getByRole('button', { name: 'Turn on game-day alerts' });

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -310,7 +310,8 @@ describe('React app auth/profile capability parity', () => {
         expect(handlerStart).toBeGreaterThanOrEqual(0);
         expectContains(enablePushOnDevice, [
             "setBusy('push-device')",
-            'await enablePushNotificationsForUser(user.uid);',
+            'const pushService = await loadPushService();',
+            'await pushService.enablePushNotificationsForUser(user.uid);',
             'Push is enabled on this device.',
             'Failed to enable push on this device.'
         ]);
@@ -333,7 +334,8 @@ describe('React app auth/profile capability parity', () => {
         expect(turnOnGameDayAlerts).toContain('? notificationPreferences');
         expect(turnOnGameDayAlerts).toContain(': await loadNotificationPreferencesOnce(user.uid, teamId));');
         expect(turnOnGameDayAlerts).toContain('...currentPreferences,');
-        expect(turnOnGameDayAlerts.indexOf('await enablePushNotificationsForUser(user.uid);')).toBeLessThan(
+        expect(turnOnGameDayAlerts).toContain('const pushService = await loadPushService();');
+        expect(turnOnGameDayAlerts.indexOf('await pushService.enablePushNotificationsForUser(user.uid);')).toBeLessThan(
             turnOnGameDayAlerts.indexOf('saveNotificationPreferences(user.uid, teamId, nextPreferences)')
         );
         expect(turnOnGameDayAlerts).toContain('setNotificationPreferencesByTeamId((current) => ({ ...current, [teamId]: saved }));');


### PR DESCRIPTION
Closes #3599

## What changed
- Replaced Profile's static pushService value imports with a cached dynamic `import('../lib/pushService')` loader.
- Kept push permission and primer types as type-only imports.
- Updated Alerts push handlers to load pushService only after Alerts-gated code paths run.
- Added component and smoke regression coverage for the import boundary.

## Root Cause
`Profile.tsx` statically imported Alerts-only pushService value APIs, so rendering the default Account section loaded push notification dependencies before the user opened Alerts.

## Prevention / Learning
Hidden-tab and tab-specific mobile services should sit behind the active-section guard with a cached dynamic loader. Keep shared type references as type-only imports so route chunks do not pull optional runtime dependencies.

## Regression Tests
- `cd apps/app && npx vitest run src/pages/Profile.test.tsx --reporter=verbose` passed.
- `npm run app:build` passed.
- Added `Profile.test.tsx` source-level import-boundary coverage.
- Added `Profile.test.tsx` Account-vs-Alerts permission-call coverage.
- Extended `tests/smoke/app-auth-profile.spec.js` to count pushService module requests on Account vs Alerts.
- Targeted local smoke was attempted, but the local Vite smoke harness did not reach mocked route headings even for an unchanged auth smoke case, so it was not used as the gate.