### PR TITLE
Lazy-load Team Drills AI coach

### DIFF
--- a/apps/app/src/lib/teamDrillsService.test.ts
+++ b/apps/app/src/lib/teamDrillsService.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildPracticeAiCoachPrompt, filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite } from './teamDrillsService';
+import { buildPracticeAiCoachPrompt } from './practiceAiCoachService';
+import { filterDrillSummaries, loadFavoriteDrills, loadTeamDrillLibraryPage, setTeamDrillFavorite } from './teamDrillsService';
 
 const dbMocks = vi.hoisted(() => ({
   addDrillFavorite: vi.fn(),

--- a/apps/app/src/lib/teamDrillsService.ts
+++ b/apps/app/src/lib/teamDrillsService.ts
@@ -1,9 +1,6 @@
 import { addDrillFavorite, DRILL_LEVELS, DRILL_TYPES, getDrill, getDrillFavorites, getDrills, getPublishedDrills, getTeam, hasFullTeamAccess, removeDrillFavorite } from './adapters/legacyTeamDrills';
 import type { AuthUser } from './types';
 
-export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';
-export type { PracticeAiCoachPrompt, PracticeAiCoachPromptInput } from './practiceAiCoachService';
-
 const drillLibraryPageSize = 12;
 
 export type TeamDrillSummary = {

--- a/apps/app/src/pages/TeamDrills.test.tsx
+++ b/apps/app/src/pages/TeamDrills.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,7 +25,8 @@ const teamDrillsServiceMocks = vi.hoisted(() => ({
 }));
 
 const practiceAiCoachServiceMocks = vi.hoisted(() => ({
-  generatePracticeAiCoachPlan: vi.fn()
+  generatePracticeAiCoachPlan: vi.fn(),
+  moduleLoadCount: 0
 }));
 
 const practiceTimelineServiceMocks = vi.hoisted(() => ({
@@ -38,7 +40,10 @@ const publicActionsMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../lib/teamDrillsService', () => teamDrillsServiceMocks);
-vi.mock('../lib/practiceAiCoachService', () => practiceAiCoachServiceMocks);
+vi.mock('../lib/practiceAiCoachService', () => {
+  practiceAiCoachServiceMocks.moduleLoadCount += 1;
+  return practiceAiCoachServiceMocks;
+});
 vi.mock('../lib/practiceTimelineService', () => practiceTimelineServiceMocks);
 vi.mock('../lib/publicActions', () => publicActionsMocks);
 
@@ -105,6 +110,7 @@ function renderTeamDrills() {
 describe('TeamDrills', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    practiceAiCoachServiceMocks.moduleLoadCount = 0;
     teamDrillsServiceMocks.loadTeamDrillLibraryPage.mockResolvedValue(createPage({
       drills: [
         createDrill(),
@@ -170,6 +176,13 @@ describe('TeamDrills', () => {
     vi.restoreAllMocks();
   });
 
+  it('keeps the AI coach service behind a dynamic import on the route', () => {
+    const source = readFileSync('src/pages/TeamDrills.tsx', 'utf8');
+
+    expect(source).not.toMatch(/import\s*\{[^}]*generatePracticeAiCoachPlan[^}]*\}\s*from\s*['"]\.\.\/lib\/practiceAiCoachService['"]/);
+    expect(source).toContain("import('../lib/practiceAiCoachService')");
+  });
+
   it('passes search and filter selections into the bounded community drill query', async () => {
     renderTeamDrills();
 
@@ -217,16 +230,21 @@ describe('TeamDrills', () => {
     renderTeamDrills();
 
     expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    expect(practiceAiCoachServiceMocks.moduleLoadCount).toBe(0);
+    expect(practiceAiCoachServiceMocks.generatePracticeAiCoachPlan).not.toHaveBeenCalled();
+
     fireEvent.change(screen.getByLabelText('Practice event ID'), { target: { value: 'practice-1' } });
     fireEvent.click(screen.getByRole('button', { name: 'Load practice' }));
 
     await waitFor(() => expect(practiceTimelineServiceMocks.loadPracticeTimelineModel).toHaveBeenCalledWith('team-1', 'practice-1', auth.user));
     expect(await screen.findByText('Current timeline: 1 block · 10 min')).toBeTruthy();
+    expect(practiceAiCoachServiceMocks.moduleLoadCount).toBe(0);
 
     fireEvent.change(screen.getByLabelText('Practice focus'), { target: { value: '60 minute shooting plan' } });
     fireEvent.change(screen.getByLabelText('Coach skill level'), { target: { value: 'Intermediate' } });
     fireEvent.click(screen.getByRole('button', { name: 'Generate proposal' }));
 
+    await waitFor(() => expect(practiceAiCoachServiceMocks.moduleLoadCount).toBe(1));
     await waitFor(() => expect(practiceAiCoachServiceMocks.generatePracticeAiCoachPlan).toHaveBeenCalledWith(expect.objectContaining({
       teamName: 'Bears',
       sport: 'Soccer',

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Link, Navigate, useParams, useSearchParams } from 'react-router-dom';
 import { ChevronLeft, ExternalLink, Heart, Loader2, Save, Search, Shield, Sparkles } from 'lucide-react';
 import { DRILL_LEVELS, DRILL_TYPES, DRILL_TYPE_COLORS } from '../lib/adapters/legacyDrills';
-import { generatePracticeAiCoachPlan, type PracticeAiCoachPlanResult } from '../lib/practiceAiCoachService';
+import type { PracticeAiCoachPlanResult } from '../lib/practiceAiCoachService';
 import { getPracticeTimelineTotalMinutes, loadPracticeTimelineModel, savePracticeTimelineForApp, type PracticeTimelineBlock, type PracticeTimelineModel } from '../lib/practiceTimelineService';
 import { isRetryableAppServiceError, toAppServiceError } from '../lib/appErrors';
 import { openPublicUrl } from '../lib/publicActions';
@@ -14,6 +14,10 @@ type DrillTab = 'community' | 'favorites';
 
 const drillTypeOptions = DRILL_TYPES as string[];
 const drillLevelOptions = DRILL_LEVELS as string[];
+
+function loadPracticeAiCoachService() {
+  return import('../lib/practiceAiCoachService');
+}
 
 function mergeUniqueDrills(drills: TeamDrillSummary[]) {
   return Array.from(new Map(drills.map((drill) => [drill.id, drill])).values());
@@ -241,6 +245,7 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
     setCoachProposal(null);
     try {
       const favoriteContextDrills = (favoriteDrills || communityDrills.filter((drill) => favoriteIds.includes(drill.id))).slice(0, 10);
+      const { generatePracticeAiCoachPlan } = await loadPracticeAiCoachService();
       const result = await generatePracticeAiCoachPlan({
         teamName: practiceModel.teamName || teamName,
         sport: practiceModel.teamSport || teamSport,

--- a/tests/unit/issue-1986-drills-ai-coach-source.test.js
+++ b/tests/unit/issue-1986-drills-ai-coach-source.test.js
@@ -11,7 +11,7 @@ const starterDrillsTestSource = readFileSync(new URL('./practice-starter-drills.
 
 describe('issue 1986 drills AI coach source contract', () => {
     it('keeps the practice AI coach prompt grounded in team context and favorite drills', () => {
-        expect(teamDrillsServiceSource).toContain("export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';");
+        expect(teamDrillsServiceSource).not.toContain("export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';");
         expect(practiceAiCoachServiceSource).toContain('export type PracticeAiCoachPromptInput');
         expect(practiceAiCoachServiceSource).toContain('export function buildPracticeAiCoachPrompt');
         expect(practiceAiCoachServiceSource).toContain('You are ALL PLAYS AI coach');

--- a/tests/unit/issue-1986-drills-ai-coach-source.test.js
+++ b/tests/unit/issue-1986-drills-ai-coach-source.test.js
@@ -12,6 +12,7 @@ const starterDrillsTestSource = readFileSync(new URL('./practice-starter-drills.
 describe('issue 1986 drills AI coach source contract', () => {
     it('keeps the practice AI coach prompt grounded in team context and favorite drills', () => {
         expect(teamDrillsServiceSource).not.toContain("export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';");
+        expect(teamDrillsServiceSource).not.toContain('buildPracticeAiCoachPrompt');
         expect(practiceAiCoachServiceSource).toContain('export type PracticeAiCoachPromptInput');
         expect(practiceAiCoachServiceSource).toContain('export function buildPracticeAiCoachPrompt');
         expect(practiceAiCoachServiceSource).toContain('You are ALL PLAYS AI coach');

--- a/tests/unit/issue-2026-team-drills-picker-source.test.js
+++ b/tests/unit/issue-2026-team-drills-picker-source.test.js
@@ -22,7 +22,7 @@ describe('issue 2026 team drills picker source contract', () => {
     it('keeps drill service pagination and AI practice-coach prompt inputs available', () => {
         expect(teamDrillsServiceSource).toContain('const drillLibraryPageSize = 12;');
         expect(teamDrillsServiceSource).toContain('export function filterDrillSummaries');
-        expect(teamDrillsServiceSource).toContain("export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';");
+        expect(teamDrillsServiceSource).not.toContain("export { buildPracticeAiCoachPrompt } from './practiceAiCoachService';");
         expect(practiceAiCoachServiceSource).toContain('export function buildPracticeAiCoachPrompt');
         expect(practiceAiCoachServiceSource).toContain('drillLibraryCatalog');
         expect(teamDrillsServiceSource).toContain('export async function loadTeamDrillLibraryPage');


### PR DESCRIPTION
Closes #3598

## What changed
- Moved Team Drills AI proposal generation to a dynamic `practiceAiCoachService` import inside the Generate proposal path.
- Removed the `teamDrillsService` prompt-builder re-export so drill-library imports no longer pull the AI coach module.
- Updated prompt-builder tests to import `practiceAiCoachService` directly.

## Root Cause
`TeamDrills.tsx` statically imported `generatePracticeAiCoachPlan`, and `teamDrillsService` re-exported the prompt builder from `practiceAiCoachService`, creating eager module edges from the common drill-browsing route/service path into optional AI coach code.

## Prevention / Learning
Optional route workflows should be loaded at the user action boundary, with shared types kept type-only. Common library services should not re-export optional heavy workflow modules used only by secondary flows.

## Regression Tests
- `TeamDrills.test.tsx` asserts the route has no static value import from `../lib/practiceAiCoachService` and keeps the dynamic import.
- `TeamDrills.test.tsx` verifies initial render and Load practice do not load/call the AI coach module, then Generate proposal dynamically loads and calls it.
- `teamDrillsService.test.ts` imports the prompt builder directly from `practiceAiCoachService`.

Test run:
`npx vitest run src/pages/TeamDrills.test.tsx src/lib/teamDrillsService.test.ts src/lib/practiceAiCoachService.test.ts --reporter=verbose`