### PR TITLE
Fix selected certificate publishing

### DIFF
--- a/certificates.html
+++ b/certificates.html
@@ -97,7 +97,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/certificates/studio.js?v=10"></script>
+    <script type="module" src="./js/certificates/studio.js?v=11"></script>
 </body>
 
 </html>

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -282,6 +282,10 @@ function getSelectedDrafts() {
     return state.drafts.filter((draft) => draft.includeInExport !== false);
 }
 
+function getDraftsForSaveStatus(status) {
+    return status === 'published' ? getSelectedDrafts() : state.drafts;
+}
+
 function getSelectedDraft() {
     return state.drafts.find((draft) => draft.id === state.selectedDraftId) || state.drafts[0] || createPreviewDraft(state.roster, state.shared);
 }
@@ -1471,18 +1475,21 @@ function saveDraftsToLocalHistory(status) {
     const prefix = state.demoMode ? 'demo' : 'local';
     const existingBatchId = state.drafts.find((draft) => draft.batchId)?.batchId;
     const batchId = existingBatchId || `${prefix}-batch-${Date.now()}`;
+    const draftsToSave = getDraftsForSaveStatus(status);
     const ids = [];
 
-    state.drafts.forEach((draft) => {
+    draftsToSave.forEach((draft) => {
         draft.status = status;
         draft.batchId = draft.batchId || batchId;
         draft.certificateId = draft.certificateId || `${prefix}-cert-${batchId}-${draft.id}`;
-        ids.push(draft.certificateId);
         upsertSavedCertificate({
             id: draft.certificateId,
             ...buildCertificatePayload(draft, status),
             updatedAt: new Date().toISOString()
         });
+    });
+    state.drafts.forEach((draft) => {
+        if (draft.certificateId) ids.push(draft.certificateId);
     });
 
     upsertSavedBatch({
@@ -1642,7 +1649,7 @@ function renderDescriptionProgress() {
 }
 
 function getPublishBlockedDrafts() {
-    return state.drafts.filter((draft) => draft.descriptionStatus !== 'ready');
+    return getSelectedDrafts().filter((draft) => draft.descriptionStatus !== 'ready');
 }
 
 function formatPublishBlockedDraftNames(drafts) {
@@ -1651,6 +1658,11 @@ function formatPublishBlockedDraftNames(drafts) {
 
 function guardPublishableDraftDescriptions(status) {
     if (status !== 'published') return true;
+    if (!getSelectedDrafts().length) {
+        showAlert('Select at least one certificate before publishing.', 'warning');
+        renderReviewGrid();
+        return false;
+    }
     const blockedDrafts = getPublishBlockedDrafts();
     if (!blockedDrafts.length) return true;
     showAlert(`Review or fix certificates marked Needs review or Error before publishing: ${formatPublishBlockedDraftNames(blockedDrafts)}.`, 'error');
@@ -1896,6 +1908,7 @@ async function saveDrafts(status) {
     }
 
     try {
+        const draftsToSave = getDraftsForSaveStatus(status);
         let batchId = state.drafts.find((draft) => draft.batchId)?.batchId || null;
         if (!batchId) {
             batchId = await createCertificateBatch(state.teamId, {
@@ -1910,7 +1923,7 @@ async function saveDrafts(status) {
         }
 
         const ids = [];
-        for (const draft of state.drafts) {
+        for (const draft of draftsToSave) {
             draft.status = status;
             const payload = buildCertificatePayload(draft, status);
             if (draft.certificateId) {
@@ -1918,8 +1931,10 @@ async function saveDrafts(status) {
             } else {
                 draft.certificateId = await createCertificate(state.teamId, payload);
             }
-            ids.push(draft.certificateId);
         }
+        state.drafts.forEach((draft) => {
+            if (draft.certificateId) ids.push(draft.certificateId);
+        });
         if (batchId) {
             await updateCertificateBatch(state.teamId, batchId, {
                 generatedCertificateIds: ids,

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -29,6 +29,8 @@ function extractFunction(source, signature) {
 function createCertificateStudioHarness() {
     const studio = readRepoFile('js/certificates/studio.js');
     const snippets = [
+        'function getSelectedDrafts',
+        'function getDraftsForSaveStatus',
         'function buildCertificatePayload',
         'function createDraftFromSavedCertificate',
         'function getPublishBlockedDrafts',
@@ -37,7 +39,9 @@ function createCertificateStudioHarness() {
         'function saveDraftsToLocalHistory',
         'async function openSavedBatch',
         'async function openSavedCertificate',
-        'function startCustomCertificate'
+        'function startCustomCertificate',
+        'async function waitForActiveRegeneration',
+        'async function saveDrafts'
     ].map((signature) => extractFunction(studio, signature)).join('\n\n');
 
     const deps = {
@@ -95,8 +99,23 @@ function createCertificateStudioHarness() {
         renderReview: vi.fn(),
         renderReviewGrid: vi.fn(),
         showAlert: vi.fn(),
+        renderSidebar: vi.fn(),
         getCertificateBatch: vi.fn(),
         getCertificate: vi.fn(),
+        createCertificateBatch: vi.fn(async () => 'batch-1'),
+        createCertificate: vi.fn(async (_teamId, payload) => `created-${payload.playerId || payload.recipientName}`),
+        updateCertificate: vi.fn(async () => undefined),
+        updateCertificateBatch: vi.fn(async () => undefined),
+        setCertificateDefaults: vi.fn(async () => undefined),
+        listCertificates: vi.fn(async () => []),
+        listCertificateBatches: vi.fn(async () => []),
+        loadOptionalCertificateResource: async (_label, loader, fallback) => {
+            try {
+                return await loader();
+            } catch {
+                return fallback;
+            }
+        },
         isPermissionError: () => false
     };
 
@@ -115,9 +134,18 @@ function createCertificateStudioHarness() {
         const renderReview = deps.renderReview;
         const renderReviewGrid = deps.renderReviewGrid;
         const showAlert = deps.showAlert;
+        const renderSidebar = deps.renderSidebar;
         const loadCertificatesForSavedBatch = deps.loadCertificatesForSavedBatch;
         const getCertificateBatch = deps.getCertificateBatch;
         const getCertificate = deps.getCertificate;
+        const createCertificateBatch = deps.createCertificateBatch;
+        const createCertificate = deps.createCertificate;
+        const updateCertificate = deps.updateCertificate;
+        const updateCertificateBatch = deps.updateCertificateBatch;
+        const setCertificateDefaults = deps.setCertificateDefaults;
+        const listCertificates = deps.listCertificates;
+        const listCertificateBatches = deps.listCertificateBatches;
+        const loadOptionalCertificateResource = deps.loadOptionalCertificateResource;
         const isPermissionError = deps.isPermissionError;
         const upsertSavedCertificate = (certificate) => {
             if (!certificate?.id) return;
@@ -144,9 +172,13 @@ function createCertificateStudioHarness() {
             formatPublishBlockedDraftNames,
             guardPublishableDraftDescriptions,
             saveDraftsToLocalHistory,
+            saveDrafts,
             openSavedBatch,
             openSavedCertificate,
-            startCustomCertificate
+            startCustomCertificate,
+            createCertificate,
+            updateCertificate,
+            updateCertificateBatch
         };
     `)(deps);
 }
@@ -169,7 +201,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(html).toContain('Start new run');
         expect(html).toContain('View saved work');
         expect(html).toContain('Create one-off certificate');
-        expect(html).toContain('./js/certificates/studio.js?v=10');
+        expect(html).toContain('./js/certificates/studio.js?v=11');
         expect(studio).toContain("from './templates.js?v=2'");
         expect(studio).toContain("from './renderer.js?v=2'");
         expect(studio).toContain("from './aiDescriptions.js?v=4'");
@@ -273,7 +305,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(reviewGridBody).toContain('${publishDisabledAttrs}>Publish certificates</button>');
     });
 
-    it('blocks website certificate publishing until every description is ready', () => {
+    it('blocks website certificate publishing until every selected description is ready', () => {
         const harness = createCertificateStudioHarness();
         harness.state.drafts = [
             {
@@ -296,14 +328,75 @@ describe('awards and certificates workflow wiring', () => {
             }
         ];
 
-        expect(harness.getPublishBlockedDrafts().map((draft) => draft.recipientName)).toEqual(['Sam Star', 'Lee Star']);
+        expect(harness.getPublishBlockedDrafts().map((draft) => draft.recipientName)).toEqual(['Sam Star']);
         expect(harness.guardPublishableDraftDescriptions('draft')).toBe(true);
         expect(harness.guardPublishableDraftDescriptions('published')).toBe(false);
         expect(harness.showAlert).toHaveBeenCalledWith(
-            'Review or fix certificates marked Needs review or Error before publishing: Sam Star, Lee Star.',
+            'Review or fix certificates marked Needs review or Error before publishing: Sam Star.',
             'error'
         );
         expect(harness.renderReviewGrid).toHaveBeenCalled();
+    });
+
+    it('publishes only selected legacy certificate drafts while preserving batch metadata', async () => {
+        const harness = createCertificateStudioHarness();
+        harness.state.drafts = [
+            {
+                id: 'draft-1',
+                batchId: 'batch-1',
+                certificateId: 'cert-1',
+                playerId: 'player-1',
+                recipientName: 'Pat Star',
+                descriptionStatus: 'ready',
+                description: 'Pat brought energy to every match.',
+                includeInExport: true,
+                status: 'draft'
+            },
+            {
+                id: 'draft-2',
+                batchId: 'batch-1',
+                certificateId: 'cert-2',
+                playerId: 'player-2',
+                recipientName: 'Sam Star',
+                descriptionStatus: 'ready',
+                description: 'Sam led the group with effort.',
+                includeInExport: false,
+                status: 'draft'
+            },
+            {
+                id: 'draft-3',
+                batchId: 'batch-1',
+                certificateId: null,
+                playerId: 'player-3',
+                recipientName: 'Lee Star',
+                descriptionStatus: 'ready',
+                description: 'Lee made steady progress.',
+                includeInExport: true,
+                status: 'draft'
+            }
+        ];
+
+        await harness.saveDrafts('published');
+
+        expect(harness.updateCertificate).toHaveBeenCalledTimes(1);
+        expect(harness.updateCertificate).toHaveBeenCalledWith(
+            'team-1',
+            'cert-1',
+            expect.objectContaining({ recipientName: 'Pat Star', status: 'published' }),
+            { action: 'published' }
+        );
+        expect(harness.createCertificate).toHaveBeenCalledTimes(1);
+        expect(harness.createCertificate).toHaveBeenCalledWith(
+            'team-1',
+            expect.objectContaining({ recipientName: 'Lee Star', status: 'published' })
+        );
+        expect(harness.state.drafts[0].status).toBe('published');
+        expect(harness.state.drafts[1]).toMatchObject({ certificateId: 'cert-2', status: 'draft' });
+        expect(harness.state.drafts[2]).toMatchObject({ certificateId: 'created-player-3', status: 'published' });
+        expect(harness.updateCertificateBatch).toHaveBeenCalledWith('team-1', 'batch-1', expect.objectContaining({
+            generatedCertificateIds: ['cert-1', 'cert-2', 'created-player-3'],
+            status: 'published'
+        }));
     });
 
     it('persists one-off certificate drafts with stable ids and restores export selection on reopen', async () => {


### PR DESCRIPTION
Closes #3601

## What changed
- Updated the legacy certificate studio publish path to save/publish only drafts selected by the review table checkbox.
- Kept batch metadata intact by retaining existing certificate ids for unchecked drafts without rewriting them as published.
- Scoped publish readiness checks to selected drafts and added a no-selection guard.
- Bumped the certificates studio module cache version.

## Root Cause
The legacy certificate studio treated `includeInExport` as the user's selection control, but `saveDrafts('published')` iterated `state.drafts` and assigned `status = 'published'` to every draft. That crossed the parent visibility boundary for unchecked certificates.

## Prevention / Learning
Any publish path with a user selection boundary must derive write candidates from the same selected collection used by preview/export controls, while preserving broader batch metadata separately.

## Regression Tests
- `npx vitest run tests/unit/certificates-workflow.test.js --reporter=verbose`
- Added coverage that executes the legacy save path and verifies unchecked drafts are not updated or marked published.
- Updated publish-blocking coverage so unchecked drafts with review issues do not block selected certificate publishing.

## Recurrence Risk
Low. The focused unit test now exercises the exact legacy persistence path that caused the visibility leak.