### PR TITLE
Remove calendar RSVP fan-out

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4423,48 +4423,6 @@ async function getCalendarTokenHolderUser(tokenData) {
   return { uid, ...(userSnap.data() || {}) };
 }
 
-async function loadMissingTeamCalendarRsvpSummaries(teamId, gameIds = []) {
-  const uniqueGameIds = [...new Set(gameIds.map((value) => String(value || '').trim()).filter(Boolean))];
-  if (!uniqueGameIds.length) return new Map();
-
-  const playersSnap = await firestore.collection(`teams/${teamId}/players`).get();
-  const activePlayerIds = new Set();
-  playersSnap.forEach((docSnap) => {
-    const player = docSnap.data() || {};
-    if (player.active !== false) activePlayerIds.add(docSnap.id);
-  });
-
-  const summaries = new Map();
-  await Promise.all(uniqueGameIds.map(async (gameId) => {
-    const rsvpsSnap = await firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`).get();
-    const responsesByPlayerId = new Map();
-    rsvpsSnap.forEach((docSnap) => {
-      const rsvp = docSnap.data() || {};
-      const response = normalizePublicRsvpResponse(rsvp.response);
-      if (!response) return;
-      const playerIds = getPublicRsvpPlayerIds(rsvp).filter((playerId) => activePlayerIds.has(playerId));
-      const respondedAtMs = getPublicRsvpResponseSortMs(rsvp, docSnap);
-      playerIds.forEach((playerId) => {
-        const existing = responsesByPlayerId.get(playerId);
-        if (!existing || respondedAtMs >= existing.respondedAtMs) {
-          responsesByPlayerId.set(playerId, { response, respondedAtMs });
-        }
-      });
-    });
-
-    const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0 };
-    responsesByPlayerId.forEach(({ response }) => {
-      if (response === 'going') summary.going += 1;
-      if (response === 'maybe') summary.maybe += 1;
-      if (response === 'not_going') summary.notGoing += 1;
-    });
-    summary.notResponded = Math.max(activePlayerIds.size - responsesByPlayerId.size, 0);
-    summaries.set(gameId, summary);
-  }));
-
-  return summaries;
-}
-
 function calendarTokenHasTeamAccess({ team, user, tokenData }) {
   if (!team || !tokenData) return false;
   const uid = user?.uid || tokenData.uid || tokenData.userId || tokenData.createdBy || null;
@@ -4519,14 +4477,8 @@ exports.teamCalendarFeed = functions.https.onRequest(async (req, res) => {
     }
 
     const eventsSnap = await firestore.collection(`teams/${teamId}/games`).orderBy('date').get();
-    const rawEvents = eventsSnap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }));
-    const missingSummaryGameIds = rawEvents
-      .filter((game) => !game.rsvpSummary || typeof game.rsvpSummary !== 'object')
-      .map((game) => game.id);
-    const rsvpSummaryByGameId = await loadMissingTeamCalendarRsvpSummaries(teamId, missingSummaryGameIds);
-    const events = rawEvents.map((game) => {
-      const liveRsvpSummary = rsvpSummaryByGameId.get(game.id);
-      if (liveRsvpSummary) game.rsvpSummary = liveRsvpSummary;
+    const events = eventsSnap.docs.map((docSnap) => {
+      const game = { id: docSnap.id, ...(docSnap.data() || {}) };
       game.officiating = Array.isArray(game.officiating) ? game.officiating : (Array.isArray(game.officials) ? game.officials : []);
       return game;
     });

--- a/functions/index.js
+++ b/functions/index.js
@@ -4423,48 +4423,6 @@ async function getCalendarTokenHolderUser(tokenData) {
   return { uid, ...(userSnap.data() || {}) };
 }
 
-async function loadTeamCalendarRsvpSummaries(teamId, gameIds = []) {
-  const uniqueGameIds = [...new Set(gameIds.map((value) => String(value || '').trim()).filter(Boolean))];
-  if (!uniqueGameIds.length) return new Map();
-
-  const playersSnap = await firestore.collection(`teams/${teamId}/players`).get();
-  const activePlayerIds = new Set();
-  playersSnap.forEach((docSnap) => {
-    const player = docSnap.data() || {};
-    if (player.active !== false) activePlayerIds.add(docSnap.id);
-  });
-
-  const summaries = new Map();
-  await Promise.all(uniqueGameIds.map(async (gameId) => {
-    const rsvpsSnap = await firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`).get();
-    const responsesByPlayerId = new Map();
-    rsvpsSnap.forEach((docSnap) => {
-      const rsvp = docSnap.data() || {};
-      const response = normalizePublicRsvpResponse(rsvp.response);
-      if (!response) return;
-      const playerIds = getPublicRsvpPlayerIds(rsvp).filter((playerId) => activePlayerIds.has(playerId));
-      const respondedAtMs = getPublicRsvpResponseSortMs(rsvp, docSnap);
-      playerIds.forEach((playerId) => {
-        const existing = responsesByPlayerId.get(playerId);
-        if (!existing || respondedAtMs >= existing.respondedAtMs) {
-          responsesByPlayerId.set(playerId, { response, respondedAtMs });
-        }
-      });
-    });
-
-    const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0 };
-    responsesByPlayerId.forEach(({ response }) => {
-      if (response === 'going') summary.going += 1;
-      if (response === 'maybe') summary.maybe += 1;
-      if (response === 'not_going') summary.notGoing += 1;
-    });
-    summary.notResponded = Math.max(activePlayerIds.size - responsesByPlayerId.size, 0);
-    summaries.set(gameId, summary);
-  }));
-
-  return summaries;
-}
-
 function calendarTokenHasTeamAccess({ team, user, tokenData }) {
   if (!team || !tokenData) return false;
   const uid = user?.uid || tokenData.uid || tokenData.userId || tokenData.createdBy || null;
@@ -4519,12 +4477,8 @@ exports.teamCalendarFeed = functions.https.onRequest(async (req, res) => {
     }
 
     const eventsSnap = await firestore.collection(`teams/${teamId}/games`).orderBy('date').get();
-    const rsvpSummaryByGameId = await loadTeamCalendarRsvpSummaries(teamId, eventsSnap.docs.map((docSnap) => docSnap.id));
     const events = eventsSnap.docs.map((docSnap) => {
       const game = { id: docSnap.id, ...(docSnap.data() || {}) };
-      const liveRsvpSummary = rsvpSummaryByGameId.get(game.id);
-      if (liveRsvpSummary) game.rsvpSummary = liveRsvpSummary;
-      // Assuming officiating details are directly on the game document
       game.officiating = Array.isArray(game.officiating) ? game.officiating : (Array.isArray(game.officials) ? game.officials : []);
       return game;
     });

--- a/functions/index.js
+++ b/functions/index.js
@@ -4423,6 +4423,48 @@ async function getCalendarTokenHolderUser(tokenData) {
   return { uid, ...(userSnap.data() || {}) };
 }
 
+async function loadMissingTeamCalendarRsvpSummaries(teamId, gameIds = []) {
+  const uniqueGameIds = [...new Set(gameIds.map((value) => String(value || '').trim()).filter(Boolean))];
+  if (!uniqueGameIds.length) return new Map();
+
+  const playersSnap = await firestore.collection(`teams/${teamId}/players`).get();
+  const activePlayerIds = new Set();
+  playersSnap.forEach((docSnap) => {
+    const player = docSnap.data() || {};
+    if (player.active !== false) activePlayerIds.add(docSnap.id);
+  });
+
+  const summaries = new Map();
+  await Promise.all(uniqueGameIds.map(async (gameId) => {
+    const rsvpsSnap = await firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`).get();
+    const responsesByPlayerId = new Map();
+    rsvpsSnap.forEach((docSnap) => {
+      const rsvp = docSnap.data() || {};
+      const response = normalizePublicRsvpResponse(rsvp.response);
+      if (!response) return;
+      const playerIds = getPublicRsvpPlayerIds(rsvp).filter((playerId) => activePlayerIds.has(playerId));
+      const respondedAtMs = getPublicRsvpResponseSortMs(rsvp, docSnap);
+      playerIds.forEach((playerId) => {
+        const existing = responsesByPlayerId.get(playerId);
+        if (!existing || respondedAtMs >= existing.respondedAtMs) {
+          responsesByPlayerId.set(playerId, { response, respondedAtMs });
+        }
+      });
+    });
+
+    const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0 };
+    responsesByPlayerId.forEach(({ response }) => {
+      if (response === 'going') summary.going += 1;
+      if (response === 'maybe') summary.maybe += 1;
+      if (response === 'not_going') summary.notGoing += 1;
+    });
+    summary.notResponded = Math.max(activePlayerIds.size - responsesByPlayerId.size, 0);
+    summaries.set(gameId, summary);
+  }));
+
+  return summaries;
+}
+
 function calendarTokenHasTeamAccess({ team, user, tokenData }) {
   if (!team || !tokenData) return false;
   const uid = user?.uid || tokenData.uid || tokenData.userId || tokenData.createdBy || null;
@@ -4477,8 +4519,14 @@ exports.teamCalendarFeed = functions.https.onRequest(async (req, res) => {
     }
 
     const eventsSnap = await firestore.collection(`teams/${teamId}/games`).orderBy('date').get();
-    const events = eventsSnap.docs.map((docSnap) => {
-      const game = { id: docSnap.id, ...(docSnap.data() || {}) };
+    const rawEvents = eventsSnap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }));
+    const missingSummaryGameIds = rawEvents
+      .filter((game) => !game.rsvpSummary || typeof game.rsvpSummary !== 'object')
+      .map((game) => game.id);
+    const rsvpSummaryByGameId = await loadMissingTeamCalendarRsvpSummaries(teamId, missingSummaryGameIds);
+    const events = rawEvents.map((game) => {
+      const liveRsvpSummary = rsvpSummaryByGameId.get(game.id);
+      if (liveRsvpSummary) game.rsvpSummary = liveRsvpSummary;
       game.officiating = Array.isArray(game.officiating) ? game.officiating : (Array.isArray(game.officials) ? game.officials : []);
       return game;
     });

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -144,25 +144,20 @@ describe('team calendar subscription feed', () => {
         expect(functionsSource).toContain('buildTeamCalendarIcs({ teamId, team, events })');
     });
 
-    it('hydrates missing private feed summaries from RSVP rows without exposing attendee rows', () => {
+    it('builds private feeds from stored game summaries without fallback RSVP scans', () => {
         const feedStart = functionsSource.indexOf('exports.teamCalendarFeed = functions.https.onRequest');
         const feedEnd = functionsSource.indexOf('exports.resolveFamilyShareTokenChildren', feedStart);
         const teamCalendarFeedSource = functionsSource.slice(feedStart, feedEnd);
-        const summaryHelperStart = functionsSource.indexOf('async function loadMissingTeamCalendarRsvpSummaries');
-        const summaryHelperEnd = functionsSource.indexOf('function calendarTokenHasTeamAccess', summaryHelperStart);
-        const summaryHelperSource = functionsSource.slice(summaryHelperStart, summaryHelperEnd);
 
         expect(teamCalendarFeedSource).toContain("firestore.collection(`teams/${teamId}/games`).orderBy('date').get()");
-        expect(teamCalendarFeedSource).toContain('const rawEvents = eventsSnap.docs.map');
-        expect(teamCalendarFeedSource).toContain("filter((game) => !game.rsvpSummary || typeof game.rsvpSummary !== 'object')");
-        expect(teamCalendarFeedSource).toContain('loadMissingTeamCalendarRsvpSummaries(teamId, missingSummaryGameIds)');
-        expect(teamCalendarFeedSource).toContain('game.rsvpSummary = liveRsvpSummary');
+        expect(teamCalendarFeedSource).toContain('const game = { id: docSnap.id, ...(docSnap.data() || {}) }');
         expect(teamCalendarFeedSource).toContain('buildTeamCalendarIcs({ teamId, team, events })');
+        expect(teamCalendarFeedSource).not.toContain('loadMissingTeamCalendarRsvpSummaries');
+        expect(teamCalendarFeedSource).not.toContain('loadTeamCalendarRsvpSummaries');
+        expect(teamCalendarFeedSource).not.toContain("firestore.collection(`teams/${teamId}/players`).get()");
+        expect(teamCalendarFeedSource).not.toContain("firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`).get()");
+        expect(teamCalendarFeedSource).not.toContain('responsesByPlayerId');
         expect(teamCalendarFeedSource).not.toContain('game.rsvps');
-        expect(summaryHelperSource).toContain('if (!uniqueGameIds.length) return new Map()');
-        expect(summaryHelperSource).toContain('firestore.collection(`teams/${teamId}/players`).get()');
-        expect(summaryHelperSource).toContain('firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`).get()');
-        expect(summaryHelperSource).toContain('responsesByPlayerId');
-        expect(summaryHelperSource).not.toContain('displayName');
+        expect(functionsSource).not.toContain('async function loadMissingTeamCalendarRsvpSummaries');
     });
 });

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -144,21 +144,19 @@ describe('team calendar subscription feed', () => {
         expect(functionsSource).toContain('buildTeamCalendarIcs({ teamId, team, events })');
     });
 
-    it('hydrates private feeds from live RSVP subcollection aggregates without exposing attendee rows', () => {
+    it('builds private feeds from game documents without per-game RSVP fan-out', () => {
         const feedStart = functionsSource.indexOf('exports.teamCalendarFeed = functions.https.onRequest');
         const feedEnd = functionsSource.indexOf('exports.resolveFamilyShareTokenChildren', feedStart);
         const teamCalendarFeedSource = functionsSource.slice(feedStart, feedEnd);
-        const summaryHelperStart = functionsSource.indexOf('async function loadTeamCalendarRsvpSummaries');
-        const summaryHelperEnd = functionsSource.indexOf('function calendarTokenHasTeamAccess', summaryHelperStart);
-        const summaryHelperSource = functionsSource.slice(summaryHelperStart, summaryHelperEnd);
 
         expect(teamCalendarFeedSource).toContain("firestore.collection(`teams/${teamId}/games`).orderBy('date').get()");
-        expect(teamCalendarFeedSource).toContain('loadTeamCalendarRsvpSummaries(teamId, eventsSnap.docs.map((docSnap) => docSnap.id))');
-        expect(teamCalendarFeedSource).toContain('game.rsvpSummary = liveRsvpSummary');
+        expect(teamCalendarFeedSource).toContain('const game = { id: docSnap.id, ...(docSnap.data() || {}) }');
+        expect(teamCalendarFeedSource).toContain('buildTeamCalendarIcs({ teamId, team, events })');
+        expect(teamCalendarFeedSource).not.toContain('loadTeamCalendarRsvpSummaries');
+        expect(teamCalendarFeedSource).not.toContain('collection(`teams/${teamId}/players`)');
+        expect(teamCalendarFeedSource).not.toContain('collection(`teams/${teamId}/games/${gameId}/rsvps`)');
+        expect(teamCalendarFeedSource).not.toContain('.collection(\'rsvps\')');
         expect(teamCalendarFeedSource).not.toContain('game.rsvps');
-        expect(summaryHelperSource).toContain('firestore.collection(`teams/${teamId}/players`).get()');
-        expect(summaryHelperSource).toContain('firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`).get()');
-        expect(summaryHelperSource).toContain('responsesByPlayerId');
-        expect(summaryHelperSource).not.toContain('displayName');
+        expect(functionsSource).not.toContain('async function loadTeamCalendarRsvpSummaries');
     });
 });

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -144,19 +144,25 @@ describe('team calendar subscription feed', () => {
         expect(functionsSource).toContain('buildTeamCalendarIcs({ teamId, team, events })');
     });
 
-    it('builds private feeds from game documents without per-game RSVP fan-out', () => {
+    it('hydrates missing private feed summaries from RSVP rows without exposing attendee rows', () => {
         const feedStart = functionsSource.indexOf('exports.teamCalendarFeed = functions.https.onRequest');
         const feedEnd = functionsSource.indexOf('exports.resolveFamilyShareTokenChildren', feedStart);
         const teamCalendarFeedSource = functionsSource.slice(feedStart, feedEnd);
+        const summaryHelperStart = functionsSource.indexOf('async function loadMissingTeamCalendarRsvpSummaries');
+        const summaryHelperEnd = functionsSource.indexOf('function calendarTokenHasTeamAccess', summaryHelperStart);
+        const summaryHelperSource = functionsSource.slice(summaryHelperStart, summaryHelperEnd);
 
         expect(teamCalendarFeedSource).toContain("firestore.collection(`teams/${teamId}/games`).orderBy('date').get()");
-        expect(teamCalendarFeedSource).toContain('const game = { id: docSnap.id, ...(docSnap.data() || {}) }');
+        expect(teamCalendarFeedSource).toContain('const rawEvents = eventsSnap.docs.map');
+        expect(teamCalendarFeedSource).toContain("filter((game) => !game.rsvpSummary || typeof game.rsvpSummary !== 'object')");
+        expect(teamCalendarFeedSource).toContain('loadMissingTeamCalendarRsvpSummaries(teamId, missingSummaryGameIds)');
+        expect(teamCalendarFeedSource).toContain('game.rsvpSummary = liveRsvpSummary');
         expect(teamCalendarFeedSource).toContain('buildTeamCalendarIcs({ teamId, team, events })');
-        expect(teamCalendarFeedSource).not.toContain('loadTeamCalendarRsvpSummaries');
-        expect(teamCalendarFeedSource).not.toContain('collection(`teams/${teamId}/players`)');
-        expect(teamCalendarFeedSource).not.toContain('collection(`teams/${teamId}/games/${gameId}/rsvps`)');
-        expect(teamCalendarFeedSource).not.toContain('.collection(\'rsvps\')');
         expect(teamCalendarFeedSource).not.toContain('game.rsvps');
-        expect(functionsSource).not.toContain('async function loadTeamCalendarRsvpSummaries');
+        expect(summaryHelperSource).toContain('if (!uniqueGameIds.length) return new Map()');
+        expect(summaryHelperSource).toContain('firestore.collection(`teams/${teamId}/players`).get()');
+        expect(summaryHelperSource).toContain('firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`).get()');
+        expect(summaryHelperSource).toContain('responsesByPlayerId');
+        expect(summaryHelperSource).not.toContain('displayName');
     });
 });


### PR DESCRIPTION
Closes #3597

## What changed
- Removed request-time RSVP summary hydration from `teamCalendarFeed`.
- Private calendar feeds now build ICS from team and game documents only, preserving `game.rsvpSummary` when present.
- Replaced the old source-contract test that expected live RSVP subcollection hydration with a guard that fails if per-game RSVP reads are reintroduced in the feed path.

## Root Cause
`teamCalendarFeed` recomputed RSVP aggregates on every feed request by reading `teams/{teamId}/players` and then each `teams/{teamId}/games/{gameId}/rsvps` subcollection, creating one RSVP read fan-out per event. The adjacent unit test locked in that unbounded behavior instead of guarding the denormalized game-document path.

## Prevention / Learning
Calendar and feed request paths must use bounded source documents and denormalized fields already persisted for the workflow. Source-contract tests for feed assembly should fail on per-event subcollection reads, not require them.

## Regression Tests
- `npx vitest run tests/unit/team-calendar-feed.test.js --reporter=verbose`
- Existing ICS coverage verifies stable UID, dates, location, notes, arrival time, cancellation status, officiating text, and rendering from `rsvpSummary` while ignoring attendee RSVP arrays.
- Updated source-contract coverage verifies `teamCalendarFeed` reads games and does not call `loadTeamCalendarRsvpSummaries`, read players for aggregation, or read per-game RSVP subcollections.

## Recurrence Risk
Low. The fan-out helper was removed and the focused test now fails if the private feed path reintroduces per-game RSVP reads.