### PR TITLE
Fix team permission member loading

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -573,7 +573,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=84';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=84';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
@@ -1438,19 +1438,33 @@
             try {
                 const players = await getPlayers(teamId);
                 const membersById = new Map();
-                (players || []).forEach((player) => {
-                    (Array.isArray(player.parents) ? player.parents : []).forEach((parent) => {
-                        const id = String(parent?.userId || parent?.uid || '').trim();
-                        if (!id || membersById.has(id)) return;
-                        const email = String(parent?.email || '').trim();
-                        const name = String(parent?.name || parent?.fullName || parent?.displayName || email || 'Member').trim();
-                        membersById.set(id, {
-                            id,
-                            name: name || 'Member',
-                            email: email || 'No email on file'
-                        });
+                const addParentMember = (parent) => {
+                    const id = String(parent?.userId || parent?.uid || '').trim();
+                    if (!id || membersById.has(id)) return;
+                    const email = String(parent?.email || '').trim();
+                    const name = String(parent?.name || parent?.fullName || parent?.displayName || email || 'Member').trim();
+                    membersById.set(id, {
+                        id,
+                        name: name || 'Member',
+                        email: email || 'No email on file'
                     });
-                });
+                };
+
+                await Promise.all((players || []).map(async (player) => {
+                    const rosterParents = Array.isArray(player.parents) ? player.parents : [];
+                    const privateProfileParents = Array.isArray(player.privateProfileParents) ? player.privateProfileParents : [];
+                    rosterParents.forEach(addParentMember);
+                    privateProfileParents.forEach(addParentMember);
+                    if (rosterParents.length > 0 || privateProfileParents.length > 0 || !player?.id) return;
+                    try {
+                        const privateProfile = await getPlayerPrivateProfile(teamId, player.id);
+                        (Array.isArray(privateProfile?.parents) ? privateProfile.parents : []).forEach(addParentMember);
+                    } catch (error) {
+                        if (error?.code !== 'permission-denied') {
+                            throw error;
+                        }
+                    }
+                }));
                 confirmedTeamMembers = Array.from(membersById.values())
                     .sort((a, b) => a.name.localeCompare(b.name));
             } catch (error) {

--- a/edit-team.html
+++ b/edit-team.html
@@ -573,7 +573,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=84';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=84';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
@@ -1436,15 +1436,22 @@
             }
 
             try {
-                const users = await getAllUsers();
-                confirmedTeamMembers = (users || [])
-                    .filter((user) => (user.parentOf || []).some((link) => link.teamId === teamId))
-                    .map((user) => ({
-                        id: user.id,
-                        name: user.fullName || user.displayName || user.email || 'Member',
-                        email: user.email || 'No email on file'
-                    }))
-                    .filter((member) => member.id)
+                const players = await getPlayers(teamId);
+                const membersById = new Map();
+                (players || []).forEach((player) => {
+                    (Array.isArray(player.parents) ? player.parents : []).forEach((parent) => {
+                        const id = String(parent?.userId || parent?.uid || '').trim();
+                        if (!id || membersById.has(id)) return;
+                        const email = String(parent?.email || '').trim();
+                        const name = String(parent?.name || parent?.fullName || parent?.displayName || email || 'Member').trim();
+                        membersById.set(id, {
+                            id,
+                            name: name || 'Member',
+                            email: email || 'No email on file'
+                        });
+                    });
+                });
+                confirmedTeamMembers = Array.from(membersById.values())
                     .sort((a, b) => a.name.localeCompare(b.name));
             } catch (error) {
                 console.warn('Failed to load confirmed team members for permissions:', error);

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -38,6 +38,10 @@ export async function getPlayers() {
     return [];
 }
 
+export async function getPlayerPrivateProfile() {
+    return {};
+}
+
 export async function copySelectedPlayersForTeamRollover() {
     return { copiedCount: 0 };
 }

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -357,7 +357,7 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getAllUsers,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?(?:,\s*getRegistrationSources)?(?:,\s*syncRegistrationProvider)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
+            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?(?:,\s*getRegistrationSources)?(?:,\s*syncRegistrationProvider)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
             'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } = deps.db;'
         )
         .replace(
@@ -757,6 +757,68 @@ describe('edit team admin access persistence', () => {
                 streaming: { mode: 'all_confirmed', memberIds: [] },
                 videography: { mode: 'selected', memberIds: [] }
             });
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('loads confirmed permission members from team roster parents without reading all users', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Legacy Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: '',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: [],
+                teamPermissions: {
+                    scorekeeping: { mode: 'selected', memberIds: ['parent-1'] },
+                    streaming: { mode: 'selected', memberIds: [] },
+                    videography: { mode: 'selected', memberIds: [] }
+                }
+            },
+            players: [
+                {
+                    id: 'player-1',
+                    name: 'Avery',
+                    parents: [
+                        { userId: 'parent-1', name: 'Jordan Parent', email: 'jordan@example.com' },
+                        { userId: 'parent-2', fullName: 'Casey Guardian', email: 'casey@example.com' }
+                    ]
+                },
+                {
+                    id: 'player-2',
+                    name: 'Blake',
+                    parents: [
+                        { userId: 'parent-1', name: 'Jordan Parent', email: 'jordan@example.com' }
+                    ]
+                }
+            ],
+            updateCalls: []
+        };
+        const getAllUsersCalls = [];
+        const env = await bootEditTeam(initialState, undefined, {
+            db: {
+                async getAllUsers() {
+                    getAllUsersCalls.push(true);
+                    throw new Error('Edit Team should not scan the global users collection for team permission members');
+                }
+            }
+        });
+        try {
+            expect(getAllUsersCalls).toHaveLength(0);
+            expect(env.elements.get('team-permissions-empty').classList.contains('hidden')).toBe(true);
+            expect(env.elements.get('scorekeeping-member-list').textContent).toContain('Jordan Parent');
+            expect(env.elements.get('scorekeeping-member-list').textContent).toContain('jordan@example.com');
+            expect(env.elements.get('scorekeeping-member-list').textContent).toContain('Casey Guardian');
+            expect(env.elements.get('scorekeeping-member-list').innerHTML.match(/value="parent-1"/g)).toHaveLength(1);
+            expect(env.elements.get('scorekeeping-member-list').innerHTML).toContain('value="parent-1" checked');
         } finally {
             env.cleanup();
         }

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -357,8 +357,8 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?(?:,\s*getRegistrationSources)?(?:,\s*syncRegistrationProvider)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
-            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } = deps.db;'
+            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*getPlayerPrivateProfile,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?(?:,\s*getRegistrationSources)?(?:,\s*syncRegistrationProvider)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=\d+';/,
+            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } = deps.db;'
         )
         .replace(
             "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';",
@@ -452,6 +452,9 @@ async function bootEditTeam(initialState, overrides = {}, dependencyOverrides = 
             },
             async getPlayers() {
                 return deepClone(env.state.players || []);
+            },
+            async getPlayerPrivateProfile(teamId, playerId) {
+                return deepClone(env.state.privateProfiles?.[`${teamId}/${playerId}`] || env.state.privateProfiles?.[playerId] || null);
             },
             async copySelectedPlayersForTeamRollover() {
                 return { copiedCount: 0 };
@@ -819,6 +822,71 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('scorekeeping-member-list').textContent).toContain('Casey Guardian');
             expect(env.elements.get('scorekeeping-member-list').innerHTML.match(/value="parent-1"/g)).toHaveLength(1);
             expect(env.elements.get('scorekeeping-member-list').innerHTML).toContain('value="parent-1" checked');
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('loads selected permission members from private-profile parent links when public roster parents are redacted', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Legacy Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: '',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: [],
+                teamPermissions: {
+                    scorekeeping: { mode: 'selected', memberIds: ['parent-private'] },
+                    streaming: { mode: 'selected', memberIds: [] },
+                    videography: { mode: 'selected', memberIds: [] }
+                }
+            },
+            players: [
+                {
+                    id: 'player-private',
+                    name: 'Avery',
+                    parents: []
+                },
+                {
+                    id: 'player-public',
+                    name: 'Blake',
+                    parents: [
+                        { userId: 'parent-public', name: 'Public Parent', email: 'public@example.com' }
+                    ]
+                }
+            ],
+            privateProfiles: {
+                'team-1/player-private': {
+                    parents: [
+                        { userId: 'parent-private', name: 'Private Parent', email: 'private@example.com' }
+                    ]
+                }
+            },
+            updateCalls: []
+        };
+        const privateProfileCalls = [];
+        const env = await bootEditTeam(initialState, undefined, {
+            db: {
+                async getPlayerPrivateProfile(teamId, playerId) {
+                    privateProfileCalls.push({ teamId, playerId });
+                    return deepClone(initialState.privateProfiles[`${teamId}/${playerId}`] || null);
+                }
+            }
+        });
+        try {
+            expect(privateProfileCalls).toEqual([{ teamId: 'team-1', playerId: 'player-private' }]);
+            expect(env.elements.get('team-permissions-empty').classList.contains('hidden')).toBe(true);
+            expect(env.elements.get('scorekeeping-member-list').textContent).toContain('Private Parent');
+            expect(env.elements.get('scorekeeping-member-list').textContent).toContain('private@example.com');
+            expect(env.elements.get('scorekeeping-member-list').textContent).toContain('Public Parent');
+            expect(env.elements.get('scorekeeping-member-list').innerHTML).toContain('value="parent-private" checked');
         } finally {
             env.cleanup();
         }


### PR DESCRIPTION
Closes #3619

## What changed
- Replaced the Edit Team permission member lookup with a team-scoped roster parent read from `getPlayers(teamId)`.
- Deduplicates confirmed parent/member candidates by user id before rendering scorekeeping, streaming, and videography selections.
- Added regression coverage proving Edit Team does not call `getAllUsers()` for confirmed permission members.

## Root Cause
Edit Team populated Team Permissions by calling `getAllUsers()` and filtering `user.parentOf` client-side. Firestore rules only allow global admins or a user reading their own `/users/{uid}` document, so non-global team admins hit `permission-denied`; the catch block then reset `confirmedTeamMembers` to an empty array.

## Prevention / Learning
Team-scoped admin workflows must use rules-compatible team-scoped sources, such as `teams/{teamId}/players`, instead of top-level collection scans for membership data.

## Regression Tests
- `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js --reporter=verbose`

## Recurrence Risk
Low. The focused Edit Team harness now fails if confirmed permission members require the global users collection again.