### PR TITLE
Fix app co-parent invite redemption

### DIFF
--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -1302,6 +1302,7 @@ export async function redeemInviteForUser(userId: string, code: string, authEmai
     validateAccessCode: dbModule.validateAccessCode,
     redeemParentInvite: dbModule.redeemParentInvite,
     redeemHouseholdInvite: dbModule.redeemHouseholdInvite,
+    redeemCoParentInvite: dbModule.redeemCoParentInvite,
     redeemAdminInviteAtomically,
     updateUserProfile: dbModule.updateUserProfile,
     updateTeam: dbModule.updateTeam,

--- a/tests/unit/app-email-signup-invite-redemption.test.ts
+++ b/tests/unit/app-email-signup-invite-redemption.test.ts
@@ -21,4 +21,17 @@ describe('React app email signup invite redemption dependencies', () => {
     expect(adapterSource).toContain('redeemCoParentInvite: (...args: any[]) => Promise<unknown>;');
     expect(adapterSource).toContain('redeemAdminInviteAtomically: (...args: any[]) => Promise<unknown>;');
   });
+
+  it('passes the co-parent invite redeemer into signed-in app invite redemption', () => {
+    const authServiceSource = readFileSync(resolve(process.cwd(), 'apps/app/src/lib/authService.ts'), 'utf8');
+
+    const redeemStart = authServiceSource.indexOf('export async function redeemInviteForUser');
+    const redeemEnd = authServiceSource.indexOf('export function rememberPendingInvite', redeemStart);
+    const redeemSource = authServiceSource.slice(redeemStart, redeemEnd);
+
+    expect(redeemSource).toContain('redeemParentInvite: dbModule.redeemParentInvite');
+    expect(redeemSource).toContain('redeemHouseholdInvite: dbModule.redeemHouseholdInvite');
+    expect(redeemSource).toContain('redeemCoParentInvite: dbModule.redeemCoParentInvite');
+    expect(redeemSource).toContain('redeemAdminInviteAtomically');
+  });
 });


### PR DESCRIPTION
Closes #3621

## What changed
- Passed `dbModule.redeemCoParentInvite` into the signed-in app invite redemption processor.
- Added a focused regression assertion that `redeemInviteForUser` wires the co-parent redeemer alongside parent, household, and admin handlers.

## Root Cause
The signed-in app invite redemption adapter built `createInviteProcessor` dependencies without `redeemCoParentInvite`, so `coparent_invite` codes reached the shared co-parent branch with no handler and threw `Missing co-parent invite redemption handler` before linking the invited caregiver.

## Prevention / Learning
When app routes reuse shared legacy processors, parity tests must cover each invite type across every adapter wiring path, not only signup or the shared processor itself.

## Regression Tests
- `npx vitest run tests/unit/app-email-signup-invite-redemption.test.ts --reporter=verbose`

## Recurrence Risk
Low. The exact signed-in app wiring path now has a focused regression assertion for the co-parent handler dependency.