### PR TITLE
Fix Home onboarding for officials access

### DIFF
--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -426,17 +426,35 @@ describe('Home', () => {
     expect(screen.queryByText('Practice packets')).toBeNull();
   });
 
-  it('keeps officials access visible for first-run users with no linked players or teams', async () => {
+  it('defers the parent first-run card while secondary Home data is still pending', async () => {
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: emptyHome, schedule: [] });
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockImplementationOnce(() => new Promise(() => {}));
+
+    renderHome(signedInAuth);
+
+    await waitFor(() => {
+      expect(homeServiceMocks.loadParentHomeWithSecondaryData).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText('Loading Home')).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'Get linked to your player' })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Accept invite/i })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Request player access/i })).toBeNull();
+  });
+
+  it('makes officials access primary for first-run users with no linked players or teams', async () => {
     homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValueOnce({ home: emptyHome, schedule: [] });
     homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValueOnce(emptyHome);
     scheduleServiceMocks.loadOfficialAssignmentsAccess.mockResolvedValueOnce({ hasAccess: true, teamCount: 1 });
 
     renderHome(signedInAuth);
 
-    expect(await screen.findByRole('heading', { name: 'Get linked to your player' })).toBeTruthy();
     expect(await screen.findByRole('heading', { name: 'Manage assignments' })).toBeTruthy();
     expect(screen.getByRole('link', { name: /Officials Manage assignments/i }).getAttribute('href')).toBe('/officials');
     expect(screen.getByText('1 linked team')).toBeTruthy();
+    expect(screen.queryByRole('heading', { name: 'Get linked to your player' })).toBeNull();
+    expect(screen.getByText('Need to link a player?')).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Accept invite/i }).getAttribute('href')).toBe('/accept-invite');
+    expect(screen.getByRole('link', { name: /Request player access/i }).getAttribute('href')).toBe('/parent-tools/access');
   });
 
   it('keeps the normal Today dashboard when at least one player or team is linked', async () => {

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -365,6 +365,15 @@ describe('Home', () => {
     expect(homeServiceMocks.loadParentHomeSummaryBootstrap).not.toHaveBeenCalled();
   });
 
+  it('renders signed-out Today without waiting for parent or officials hydration', async () => {
+    renderHome(signedOutAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Get linked to your player' })).toBeTruthy();
+    expect(screen.queryByText('Loading Home')).toBeNull();
+    expect(homeServiceMocks.loadParentHomeSummaryBootstrap).not.toHaveBeenCalled();
+    expect(scheduleServiceMocks.loadOfficialAssignmentsAccess).not.toHaveBeenCalled();
+  });
+
   it('resets to Today when navigation removes the Home section query param', async () => {
     render(
       <MemoryRouter initialEntries={['/home?section=feed']}>

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -301,6 +301,16 @@ const signedOutAuth: AuthState = {
   isParent: false
 };
 
+const secondSignedInAuth: AuthState = {
+  ...signedInAuth,
+  user: {
+    ...signedInAuth.user!,
+    uid: 'parent-2',
+    email: 'second-parent@example.com',
+    displayName: 'Second Parent'
+  } as AuthState['user']
+};
+
 function renderHome(auth: AuthState, initialEntry = '/home') {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
@@ -464,6 +474,43 @@ describe('Home', () => {
     expect(screen.getByText('Need to link a player?')).toBeTruthy();
     expect(screen.getByRole('link', { name: /Accept invite/i }).getAttribute('href')).toBe('/accept-invite');
     expect(screen.getByRole('link', { name: /Request player access/i }).getAttribute('href')).toBe('/parent-tools/access');
+  });
+
+  it('clears officials access while a new signed-in user is being checked', async () => {
+    homeServiceMocks.loadParentHomeSummaryBootstrap.mockResolvedValue({ home: emptyHome, schedule: [] });
+    homeServiceMocks.loadParentHomeWithSecondaryData.mockResolvedValue(emptyHome);
+    scheduleServiceMocks.loadOfficialAssignmentsAccess
+      .mockResolvedValueOnce({ hasAccess: true, teamCount: 1 })
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    const { rerender } = render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<Home auth={signedInAuth} />} />
+          <Route path="/officials" element={<div>Officials route</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Manage assignments' })).toBeTruthy();
+
+    rerender(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<Home auth={secondSignedInAuth} />} />
+          <Route path="/officials" element={<div>Officials route</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadOfficialAssignmentsAccess).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Loading Home')).toBeTruthy();
+    });
+    expect(screen.queryByRole('heading', { name: 'Manage assignments' })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Officials Manage assignments/i })).toBeNull();
   });
 
   it('keeps the normal Today dashboard when at least one player or team is linked', async () => {

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -479,7 +479,16 @@ export function Home({ auth }: { auth: AuthState }) {
 
       {showBlockingErrorState ? <HomeLoadErrorState error={homeLoadError} onRetry={() => refreshHome({ force: true })} retrying={loading} /> : null}
 
-      {!loading && !showBlockingErrorState && activeSection === 'today' ? <TodaySection home={home} social={social} socialLoading={socialLoading} onOpenComposer={openComposer} officialsAccess={officialsAccess} /> : null}
+      {!loading && !showBlockingErrorState && activeSection === 'today' ? (
+        <TodaySection
+          home={home}
+          social={social}
+          socialLoading={socialLoading}
+          hasLoadedHomeDetails={hasLoadedHomeDetails}
+          onOpenComposer={openComposer}
+          officialsAccess={officialsAccess}
+        />
+      ) : null}
       {!loading && !showBlockingErrorState && activeSection === 'feed' ? (
         <FeedSection
           social={social}
@@ -529,12 +538,14 @@ function TodaySection({
   home,
   social,
   socialLoading,
+  hasLoadedHomeDetails,
   onOpenComposer,
   officialsAccess
 }: {
   home: ParentHomeModel;
   social: SocialHomeModel;
   socialLoading: boolean;
+  hasLoadedHomeDetails: boolean;
   onOpenComposer: (type?: SocialPostType) => void;
   officialsAccess: { hasAccess: boolean; teamCount: number } | null;
 }) {
@@ -551,7 +562,13 @@ function TodaySection({
   const isFirstRunParent = home.players.length === 0 && home.teams.length === 0;
 
   if (isFirstRunParent) {
-    return <FirstRunAccessSection officialsAccess={officialsAccess} />;
+    if (!hasLoadedHomeDetails || officialsAccess === null) {
+      return <HomePageSkeleton />;
+    }
+    if (officialsAccess.hasAccess) {
+      return <TeamOperationsFirstRunSection officialsAccess={officialsAccess} />;
+    }
+    return <FirstRunAccessSection />;
   }
 
   return (
@@ -820,15 +837,33 @@ function TeamsSection({ teams }: { teams: ParentHomeTeam[] }) {
   );
 }
 
-function FirstRunAccessSection({ officialsAccess }: { officialsAccess: { hasAccess: boolean; teamCount: number } | null }) {
+function FirstRunAccessSection() {
   return (
     <section className="home-section-content space-y-3">
-      <OfficialsAccessCard officialsAccess={officialsAccess} />
       <div className="app-card overflow-hidden border-primary-100">
         <div className="p-4">
           <div className="app-label text-primary-700">Do first</div>
           <h2 className="mt-1 text-xl font-black leading-tight text-gray-950">Get linked to your player</h2>
           <p className="mt-1 text-sm font-semibold leading-5 text-gray-600">Accept a coach invite or request player access so schedules, chats, packets, and fees can appear here.</p>
+        </div>
+        <div className="grid gap-3 border-t border-gray-100 bg-gray-50 p-3 sm:grid-cols-2">
+          <AccessCard to="/accept-invite" icon={Shield} title="Accept invite" detail="Redeem a coach invite code." tone="primary" />
+          <AccessCard to="/parent-tools/access" icon={Users} title="Request player access" detail="Choose team, player, and relationship." tone="emerald" />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TeamOperationsFirstRunSection({ officialsAccess }: { officialsAccess: { hasAccess: boolean; teamCount: number } }) {
+  return (
+    <section className="home-section-content space-y-3">
+      <OfficialsAccessCard officialsAccess={officialsAccess} />
+      <div className="app-card overflow-hidden border-gray-200">
+        <div className="p-4">
+          <div className="app-label text-gray-600">Need to link a player?</div>
+          <h2 className="mt-1 text-lg font-black leading-tight text-gray-950">Family access</h2>
+          <p className="mt-1 text-sm font-semibold leading-5 text-gray-600">Accept a coach invite or request player access when you need schedules, chats, packets, and fees for a player.</p>
         </div>
         <div className="grid gap-3 border-t border-gray-100 bg-gray-50 p-3 sm:grid-cols-2">
           <AccessCard to="/accept-invite" icon={Shield} title="Accept invite" detail="Redeem a coach invite code." tone="primary" />

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -298,7 +298,9 @@ export function Home({ auth }: { auth: AuthState }) {
       setOfficialsAccess(null);
       return;
     }
-    loadOfficialAssignmentsAccess(auth.user)
+    setOfficialsAccess(null);
+    const user = auth.user;
+    loadOfficialAssignmentsAccess(user)
       .then((result) => {
         if (!cancelled) {
           setOfficialsAccess({ hasAccess: result.hasAccess, teamCount: result.teamCount });

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -328,6 +328,8 @@ export function Home({ auth }: { auth: AuthState }) {
   const selectedComposerType = (searchParams.get('type') || 'manual_post') as SocialPostType;
   const homeSectionRoute = getHomeSectionRoute(activeSection);
   const homeSectionReady = isHomeSectionReady(activeSection, { loading, socialLoading, hasLoadedHomeDetails, showBlockingErrorState });
+  const canRenderFirstRunHome = !authUserId || hasLoadedHomeDetails;
+  const resolvedOfficialsAccess = authUserId ? officialsAccess : { hasAccess: false, teamCount: 0 };
 
   useViewLoadTimer({
     viewName: `home ${activeSection}`,
@@ -484,9 +486,9 @@ export function Home({ auth }: { auth: AuthState }) {
           home={home}
           social={social}
           socialLoading={socialLoading}
-          hasLoadedHomeDetails={hasLoadedHomeDetails}
+          hasLoadedHomeDetails={canRenderFirstRunHome}
           onOpenComposer={openComposer}
-          officialsAccess={officialsAccess}
+          officialsAccess={resolvedOfficialsAccess}
         />
       ) : null}
       {!loading && !showBlockingErrorState && activeSection === 'feed' ? (


### PR DESCRIPTION
Closes #3623

## What changed
- Deferred the parent first-run Today card until secondary Home details and officials access are known.
- Made officials/team-operation access the primary empty-state path for zero-player, zero-team users with confirmed officials access.
- Kept Accept invite and Request player access available as secondary family-access actions.

## Root Cause
Home treated the zero players / zero teams bootstrap snapshot as a final parent-only state. That bootstrap data can arrive before secondary Home hydration and officials access resolve, so coach/admin users could see parent-link onboarding as the primary Today action.

## Prevention / Learning
Do not promote empty-state onboarding from partial bootstrap data. Gate role-specific primary CTAs on the authoritative async slices that prove the user lacks other operational access.

## Regression Tests
- `npx vitest run apps/app/src/pages/Home.test.tsx --reporter=verbose`
- Added coverage that the parent first-run card is deferred while secondary Home data is pending.
- Updated coverage so officials access is primary and parent-link actions are secondary for mixed/operations users.
- Preserved the parent-only empty-state regression for Accept invite and Request player access.

## Recurrence Risk
Low. The exact pending-hydration, officials-access, and true parent-only branches are now covered by focused component tests.