### PR TITLE
Fix signup access code redemption

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -155,8 +155,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=43';
-        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=84';
+        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=44';
+        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=85';
         import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';
         import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -15,7 +15,21 @@ const legacyAuthMocks = vi.hoisted(() => ({
   getUserProfile: vi.fn(),
   listMyParentMembershipRequests: vi.fn(),
   updateUserProfile: vi.fn(),
-  getUserTeams: vi.fn()
+  getUserTeams: vi.fn(),
+  validateAccessCode: vi.fn(),
+  redeemParentInvite: vi.fn(),
+  redeemHouseholdInvite: vi.fn(),
+  redeemCoParentInvite: vi.fn(),
+  markAccessCodeAsUsed: vi.fn(),
+  getTeam: vi.fn()
+}));
+
+const legacyAdminInviteMocks = vi.hoisted(() => ({
+  redeemAdminInviteAcceptance: vi.fn()
+}));
+
+const legacySignupFlowMocks = vi.hoisted(() => ({
+  executeEmailPasswordSignup: vi.fn()
 }));
 
 const parentMembershipMocks = vi.hoisted(() => ({
@@ -61,11 +75,11 @@ vi.mock('./firebaseAuthRuntime', () => ({
 }));
 
 vi.mock('./adapters/legacyAuth', () => ({
-  loadLegacyAdminInvite: vi.fn(),
+  loadLegacyAdminInvite: vi.fn(async () => legacyAdminInviteMocks),
   loadLegacyAuthDb: vi.fn(async () => legacyAuthMocks),
   loadLegacyInviteFlow: vi.fn(),
   loadLegacyParentMembershipUtils: vi.fn(async () => parentMembershipMocks),
-  loadLegacySignupFlow: vi.fn()
+  loadLegacySignupFlow: vi.fn(async () => legacySignupFlowMocks)
 }));
 
 vi.mock('./appDataCache', () => ({
@@ -80,7 +94,29 @@ vi.mock('./logger', () => ({
   })
 }));
 
-import { hydrateFirebaseUser, observeFirebaseUser, signInWithEmail, signOut } from './authService';
+import {
+  describeAuthError,
+  hydrateFirebaseUser,
+  isValidAuthEmail,
+  observeFirebaseUser,
+  signInWithEmail,
+  signOut,
+  signUpWithEmail
+} from './authService';
+
+describe('auth email validation', () => {
+  it('rejects Firebase-invalid emails before they reach the auth SDK', () => {
+    expect(isValidAuthEmail('p@paulsnider')).toBe(false);
+    expect(isValidAuthEmail('player@example.com')).toBe(true);
+  });
+
+  it('maps Firebase invalid-email errors to app copy', () => {
+    expect(describeAuthError({
+      code: 'auth/invalid-email',
+      message: 'Firebase: Error (auth/invalid-email).'
+    })).toBe('Enter a valid email address.');
+  });
+});
 
 describe('hydrateFirebaseUser', () => {
   beforeEach(() => {
@@ -124,6 +160,34 @@ describe('signOut', () => {
   it('clears persisted app-data cache so the next user cannot read cached data', async () => {
     await signOut();
     expect(appDataCacheMocks.clearAppDataCache).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('signUpWithEmail', () => {
+  beforeEach(() => {
+    legacySignupFlowMocks.executeEmailPasswordSignup.mockReset();
+    legacySignupFlowMocks.executeEmailPasswordSignup.mockResolvedValue({
+      user: { uid: 'new-user', email: 'player@example.com' }
+    });
+  });
+
+  it('normalizes signup input and delegates to the shared access-code redemption flow', async () => {
+    await signUpWithEmail(' Player@Example.COM ', 'secret1', ' 85nsbz7k ');
+
+    expect(legacySignupFlowMocks.executeEmailPasswordSignup).toHaveBeenCalledWith(expect.objectContaining({
+      email: 'player@example.com',
+      password: 'secret1',
+      activationCode: '85NSBZ7K',
+      dependencies: expect.objectContaining({
+        markAccessCodeAsUsed: legacyAuthMocks.markAccessCodeAsUsed,
+        validateAccessCode: legacyAuthMocks.validateAccessCode
+      })
+    }));
+  });
+
+  it('stops invalid signup emails before loading Firebase signup work', async () => {
+    await expect(signUpWithEmail('p@paulsnider', 'secret1', '85nsbz7k')).rejects.toThrow('Enter a valid email address.');
+    expect(legacySignupFlowMocks.executeEmailPasswordSignup).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const authState = vi.hoisted(() => ({
   currentUser: null,
@@ -95,11 +95,17 @@ vi.mock('./logger', () => ({
 }));
 
 import {
+  signInWithPopup,
+  signInWithRedirect
+} from './firebaseAuthRuntime';
+import { Capacitor } from '@capacitor/core';
+import {
   describeAuthError,
   hydrateFirebaseUser,
   isValidAuthEmail,
   observeFirebaseUser,
   signInWithEmail,
+  signInWithGoogleAccount,
   signOut,
   signUpWithEmail
 } from './authService';
@@ -188,6 +194,77 @@ describe('signUpWithEmail', () => {
   it('stops invalid signup emails before loading Firebase signup work', async () => {
     await expect(signUpWithEmail('p@paulsnider', 'secret1', '85nsbz7k')).rejects.toThrow('Enter a valid email address.');
     expect(legacySignupFlowMocks.executeEmailPasswordSignup).not.toHaveBeenCalled();
+  });
+});
+
+describe('signInWithGoogleAccount invite redemption', () => {
+  const signInWithPopupMock = vi.mocked(signInWithPopup);
+  const signInWithRedirectMock = vi.mocked(signInWithRedirect);
+  const isNativePlatformMock = vi.mocked(Capacitor.isNativePlatform);
+
+  beforeEach(() => {
+    isNativePlatformMock.mockReturnValue(false);
+    signInWithPopupMock.mockReset();
+    signInWithRedirectMock.mockReset();
+    legacyAuthMocks.validateAccessCode.mockReset();
+    legacyAuthMocks.redeemHouseholdInvite.mockReset();
+    legacyAuthMocks.redeemCoParentInvite.mockReset();
+    legacyAuthMocks.markAccessCodeAsUsed.mockReset();
+    legacyAuthMocks.updateUserProfile.mockReset();
+    legacyAuthMocks.updateUserProfile.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    isNativePlatformMock.mockReturnValue(true);
+    window.sessionStorage.clear();
+  });
+
+  function mockNewGoogleUser(email: string) {
+    signInWithPopupMock.mockResolvedValue({
+      user: {
+        uid: 'google-user',
+        email,
+        displayName: 'Google User',
+        photoURL: 'https://example.com/photo.png',
+        metadata: {
+          creationTime: '2026-03-01T11:00:00.000Z',
+          lastSignInTime: '2026-03-01T11:00:00.000Z'
+        },
+        delete: vi.fn()
+      }
+    } as any);
+  }
+
+  it('redeems household invites instead of claiming them as standard activation codes', async () => {
+    mockNewGoogleUser('household@example.com');
+    legacyAuthMocks.validateAccessCode.mockResolvedValue({
+      valid: true,
+      type: 'household_invite',
+      codeId: 'household-code-id',
+      data: { code: 'HOME1234' }
+    });
+    legacyAuthMocks.redeemHouseholdInvite.mockResolvedValue({ success: true });
+
+    await signInWithGoogleAccount('home1234');
+
+    expect(legacyAuthMocks.redeemHouseholdInvite).toHaveBeenCalledWith('google-user', 'HOME1234');
+    expect(legacyAuthMocks.markAccessCodeAsUsed).not.toHaveBeenCalled();
+  });
+
+  it('redeems co-parent invites with the Google account email', async () => {
+    mockNewGoogleUser('coparent@example.com');
+    legacyAuthMocks.validateAccessCode.mockResolvedValue({
+      valid: true,
+      type: 'coparent_invite',
+      codeId: 'coparent-code-id',
+      data: { code: 'COPO1234' }
+    });
+    legacyAuthMocks.redeemCoParentInvite.mockResolvedValue({ success: true });
+
+    await signInWithGoogleAccount('copo1234');
+
+    expect(legacyAuthMocks.redeemCoParentInvite).toHaveBeenCalledWith('google-user', 'COPO1234', 'coparent@example.com');
+    expect(legacyAuthMocks.markAccessCodeAsUsed).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -1115,6 +1115,10 @@ async function processGoogleResult(result: UserCredential | null, activationCode
   try {
     if (validation.type === 'parent_invite') {
       await dbModule.redeemParentInvite(result.user.uid, validation.data?.code || code, result.user.email);
+    } else if (validation.type === 'household_invite') {
+      await dbModule.redeemHouseholdInvite(result.user.uid, validation.data?.code || code);
+    } else if (validation.type === 'coparent_invite') {
+      await dbModule.redeemCoParentInvite(result.user.uid, validation.data?.code || code, result.user.email);
     } else if (validation.type === 'admin_invite') {
       const { redeemAdminInviteAcceptance } = await loadLegacyAdminInvite();
       await redeemAdminInviteAcceptance({
@@ -1124,10 +1128,6 @@ async function processGoogleResult(result: UserCredential | null, activationCode
         getTeam: dbModule.getTeam,
         getUserProfile: dbModule.getUserProfile
       });
-    } else if (validation.type === 'household_invite') {
-      await dbModule.redeemHouseholdInvite(result.user.uid, validation.data?.code || code);
-    } else if (validation.type === 'coparent_invite') {
-      await dbModule.redeemCoParentInvite(result.user.uid, validation.data?.code || code, result.user.email);
     } else {
       await dbModule.markAccessCodeAsUsed(validation.codeId, result.user.uid);
     }

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -142,8 +142,32 @@ type NativePluginSignInResult = {
   } | null;
 };
 
-function normalizeEmail(email: string) {
+export function normalizeAuthEmail(email: string | null | undefined) {
   return String(email || '').trim().toLowerCase();
+}
+
+export function isValidAuthEmail(email: string | null | undefined) {
+  const normalizedEmail = normalizeAuthEmail(email);
+  const parts = normalizedEmail.split('@');
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [localPart, domain] = parts;
+  return Boolean(
+    localPart &&
+    domain &&
+    domain.includes('.') &&
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)
+  );
+}
+
+function requireValidAuthEmail(email: string | null | undefined) {
+  const normalizedEmail = normalizeAuthEmail(email);
+  if (!isValidAuthEmail(normalizedEmail)) {
+    throw new Error('Enter a valid email address.');
+  }
+  return normalizedEmail;
 }
 
 function normalizeCode(code: string | null | undefined) {
@@ -197,6 +221,10 @@ export function describeAuthError(error: any) {
 
   if (code === 'auth/invalid-credential' || code === 'auth/wrong-password') {
     return 'Email or password is incorrect.';
+  }
+
+  if (code === 'auth/invalid-email' || message.includes('auth/invalid-email') || message.includes('INVALID_EMAIL')) {
+    return 'Enter a valid email address.';
   }
 
   if (code === 'auth/user-not-found') {
@@ -962,7 +990,7 @@ export function getCurrentFirebaseUser(): FirebaseUser | null {
 }
 
 export async function signInWithEmail(email: string, password: string) {
-  const normalizedEmail = normalizeEmail(email);
+  const normalizedEmail = requireValidAuthEmail(email);
   const { updateUserProfile } = await loadLegacyAuthDb();
 
   if (isNativeRuntime()) {
@@ -991,6 +1019,7 @@ export async function signInWithEmail(email: string, password: string) {
 }
 
 export async function signUpWithEmail(email: string, password: string, activationCode: string) {
+  const normalizedEmail = requireValidAuthEmail(email);
   const [
     dbModule,
     { redeemAdminInviteAcceptance },
@@ -1002,7 +1031,7 @@ export async function signUpWithEmail(email: string, password: string, activatio
   ]);
 
   return executeEmailPasswordSignup({
-    email: email.trim(),
+    email: normalizedEmail,
     password,
     activationCode: normalizeCode(activationCode),
     auth,
@@ -1159,7 +1188,7 @@ export async function completeGoogleRedirect() {
 }
 
 export async function sendResetEmail(email: string) {
-  await sendPasswordResetEmail(auth, email.trim(), {
+  await sendPasswordResetEmail(auth, requireValidAuthEmail(email), {
     url: 'https://allplays.ai/reset-password.html',
     handleCodeInApp: true
   });
@@ -1239,10 +1268,11 @@ export function isEmailLink(url: string) {
 }
 
 export async function completeEmailLink(email: string, url: string) {
-  const result = await signInWithEmailLink(auth, email.trim(), url) as UserCredential;
+  const normalizedEmail = requireValidAuthEmail(email);
+  const result = await signInWithEmailLink(auth, normalizedEmail, url) as UserCredential;
   const { updateUserProfile } = await loadLegacyAuthDb();
   await updateUserProfile(result.user.uid, {
-    email: email.trim(),
+    email: normalizedEmail,
     lastLogin: new Date(),
     signInMethod: 'emailLink'
   });

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -1124,6 +1124,10 @@ async function processGoogleResult(result: UserCredential | null, activationCode
         getTeam: dbModule.getTeam,
         getUserProfile: dbModule.getUserProfile
       });
+    } else if (validation.type === 'household_invite') {
+      await dbModule.redeemHouseholdInvite(result.user.uid, validation.data?.code || code);
+    } else if (validation.type === 'coparent_invite') {
+      await dbModule.redeemCoParentInvite(result.user.uid, validation.data?.code || code, result.user.email);
     } else {
       await dbModule.markAccessCodeAsUsed(validation.codeId, result.user.uid);
     }

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -399,6 +399,7 @@ async function nativeCreateAccessCode(userId: string, email: string, phone: stri
     body: JSON.stringify({
       fields: {
         code: encodeFirestoreValue(code),
+        type: encodeFirestoreValue('standard'),
         generatedBy: encodeFirestoreValue(userId),
         email: encodeFirestoreValue(email || null),
         phone: encodeFirestoreValue(phone || null),

--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -18,6 +18,12 @@ const authServiceMocks = vi.hoisted(() => ({
     return '/home';
   }),
   hydrateFirebaseUser: vi.fn(),
+  isValidAuthEmail: (value: string | null | undefined) => {
+    const normalized = String(value || '').trim().toLowerCase();
+    const parts = normalized.split('@');
+    return parts.length === 2 && Boolean(parts[0] && parts[1]?.includes('.') && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized));
+  },
+  normalizeAuthEmail: (value: string | null | undefined) => String(value || '').trim().toLowerCase(),
   rememberPendingInvite: vi.fn(),
   sendResetEmail: vi.fn(),
   signInWithEmail: vi.fn(),
@@ -112,5 +118,46 @@ describe('AuthPage native post-login routing', () => {
     await waitFor(() => expect(authServiceMocks.signInWithGoogleAccount).toHaveBeenCalledWith(null));
     await waitFor(() => expect(window.location.hash).toBe('#/teams'));
     expect(window.location.reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AuthPage signup validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.refresh = vi.fn();
+    auth.signOut = vi.fn();
+    authServiceMocks.signUpWithEmail.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('stops signup before Firebase when the email is invalid for Firebase Auth', async () => {
+    renderAuthPage('/auth?mode=signup&code=6WSSSW9V&type=parent');
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'p@paulsnider' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret1' } });
+    fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'secret1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(await screen.findByText('Enter a valid email address.')).toBeTruthy();
+    expect(authServiceMocks.signUpWithEmail).not.toHaveBeenCalled();
+  });
+
+  it('normalizes a valid signup email before calling the auth service', async () => {
+    authServiceMocks.signUpWithEmail.mockResolvedValue({
+      user: { uid: 'new-user', email: 'coach@example.com' }
+    });
+
+    renderAuthPage('/auth?mode=signup&code=6WSSSW9V&type=parent');
+
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: ' Coach@Example.COM ' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret1' } });
+    fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'secret1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    await waitFor(() => expect(authServiceMocks.signUpWithEmail).toHaveBeenCalledWith('coach@example.com', 'secret1', '6WSSSW9V'));
+    expect(auth.refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -8,6 +8,8 @@ import {
   describeAuthError,
   getRouteForUser,
   hydrateFirebaseUser,
+  isValidAuthEmail,
+  normalizeAuthEmail,
   rememberPendingInvite,
   sendResetEmail,
   signInWithEmail,
@@ -89,6 +91,11 @@ export function AuthPage({ auth }: { auth: AuthState }) {
     setBusy(true);
 
     try {
+      const normalizedEmail = normalizeAuthEmail(email);
+      if (!isValidAuthEmail(normalizedEmail)) {
+        throw new Error('Enter a valid email address.');
+      }
+
       if (mode === 'signup') {
         const code = activationCode.trim().toUpperCase();
         if (!code) {
@@ -98,13 +105,13 @@ export function AuthPage({ auth }: { auth: AuthState }) {
           throw new Error('Passwords do not match.');
         }
 
-        await signUpWithEmail(email, password, code);
+        await signUpWithEmail(normalizedEmail, password, code);
         await auth.refresh();
         navigate('/verify-pending', { replace: true });
         return;
       }
 
-      const credential = await signInWithEmail(email, password);
+      const credential = await signInWithEmail(normalizedEmail, password);
       if (inviteCode) {
         rememberPendingInvite(inviteCode, inviteType);
       }
@@ -168,7 +175,11 @@ export function AuthPage({ auth }: { auth: AuthState }) {
     setBusy(true);
 
     try {
-      await sendResetEmail(resetEmail || email);
+      const normalizedEmail = normalizeAuthEmail(resetEmail || email);
+      if (!isValidAuthEmail(normalizedEmail)) {
+        throw new Error('Enter a valid email address.');
+      }
+      await sendResetEmail(normalizedEmail);
       setMessage('Password reset email sent. Check your inbox and spam folder.');
       setShowReset(false);
     } catch (resetError: any) {

--- a/edit-team.html
+++ b/edit-team.html
@@ -577,7 +577,7 @@
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth, sendInviteEmail } from './js/auth.js?v=43';
+        import { checkAuth, sendInviteEmail } from './js/auth.js?v=44';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=3';

--- a/firestore.rules
+++ b/firestore.rules
@@ -57,12 +57,12 @@ service cloud.firestore {
 
     function isStandardAccessCodePayloadValid(data) {
       return data.keys().hasOnly([
-               'code', 'generatedBy', 'email', 'phone', 'createdAt', 'used', 'usedBy', 'usedAt'
+               'code', 'type', 'generatedBy', 'email', 'phone', 'createdAt', 'used', 'usedBy', 'usedAt'
              ]) &&
              data.keys().hasAll([
                'code', 'generatedBy', 'createdAt', 'used', 'usedBy', 'usedAt'
              ]) &&
-             !data.keys().hasAny(['type']) &&
+             (!data.keys().hasAny(['type']) || data.type == 'standard') &&
              data.code is string &&
              data.code.size() > 0 &&
              data.generatedBy == request.auth.uid &&
@@ -155,8 +155,13 @@ service cloud.firestore {
     }
 
     function isStandardAccessCodeRedemptionUpdate() {
-      let codeType = resource.data.get('type', 'standard');
-      return codeType == 'standard' &&
+      let codeType = resource.data.get('type', null);
+      let isLegacyStandardCode = codeType == null &&
+             !resource.data.keys().hasAny([
+               'teamId', 'playerId', 'familyMembershipId',
+               'teamName', 'playerName', 'playerNum', 'relation'
+             ]);
+      return (codeType == 'standard' || isLegacyStandardCode) &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
              resource.data.used == false &&
              resource.data.get('revoked', false) != true &&
@@ -1762,7 +1767,8 @@ service cloud.firestore {
       allow create: if isSignedIn() &&
                        request.resource.data.generatedBy == request.auth.uid &&
                        (
-                         (!request.resource.data.keys().hasAny(['type']) &&
+                         ((!request.resource.data.keys().hasAny(['type']) ||
+                           request.resource.data.type == 'standard') &&
                           isStandardAccessCodePayloadValid(request.resource.data) &&
                           request.resource.data.code == codeId) ||
                          (request.resource.data.get('type', null) == 'admin_invite' &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -154,6 +154,23 @@ service cloud.firestore {
              request.resource.data.usedAt is timestamp;
     }
 
+    function isStandardAccessCodeRedemptionUpdate() {
+      let codeType = resource.data.get('type', 'standard');
+      return (codeType == 'standard' || codeType == null) &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
+             resource.data.used == false &&
+             resource.data.get('revoked', false) != true &&
+             resource.data.get('active', true) != false &&
+             resource.data.get('status', 'active') != 'removed' &&
+             resource.data.get('status', 'active') != 'cancelled' &&
+             resource.data.get('status', 'active') != 'revoked' &&
+             (resource.data.get('expiresAt', null) == null ||
+              (resource.data.expiresAt is timestamp && resource.data.expiresAt > request.time)) &&
+             request.resource.data.used == true &&
+             request.resource.data.usedBy == request.auth.uid &&
+             request.resource.data.usedAt is timestamp;
+    }
+
     function isParentInviteRevocationUpdate() {
       return resource.data.get('type', null) == 'parent_invite' &&
              resource.data.generatedBy == request.auth.uid &&
@@ -1773,15 +1790,12 @@ service cloud.firestore {
                         isParentInviteRevocationUpdate() ||
                         isHouseholdInviteRedemptionUpdate() ||
                         isHouseholdInviteRevocationUpdate() ||
-                        // Allow marking as used only if setting these specific fields
+                        // Allow standard activation-code redemption without raw document reads.
+                        isStandardAccessCodeRedemptionUpdate() ||
                         (resource.data.get('type', null) != 'admin_invite' &&
                          resource.data.get('type', null) != 'parent_invite' &&
                          resource.data.get('type', null) != 'household_invite' &&
-                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
-                         request.resource.data.usedBy == request.auth.uid) ||
-                        (resource.data.get('type', null) != 'admin_invite' &&
-                         resource.data.get('type', null) != 'parent_invite' &&
-                         resource.data.get('type', null) != 'household_invite' &&
+                         resource.data.get('type', null) != 'coparent_invite' &&
                          resource.data.generatedBy == request.auth.uid &&
                          request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt'])));
 	      allow delete: if isSignedIn() && resource.data.generatedBy == request.auth.uid;

--- a/firestore.rules
+++ b/firestore.rules
@@ -156,7 +156,7 @@ service cloud.firestore {
 
     function isStandardAccessCodeRedemptionUpdate() {
       let codeType = resource.data.get('type', 'standard');
-      return (codeType == 'standard' || codeType == null) &&
+      return codeType == 'standard' &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
              resource.data.used == false &&
              resource.data.get('revoked', false) != true &&

--- a/js/admin.js
+++ b/js/admin.js
@@ -19,7 +19,7 @@ import {
 } from './db.js?v=84';
 import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp, getCountFromServer, query, where } from './firebase.js?v=20';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=43';
+import { checkAuth } from './auth.js?v=44';
 import { DEFAULT_ADMIN_PAGE_SIZE, loadAdminCollectionPage, loadInitialAdminBootstrap } from './admin-bootstrap.js?v=1';
 import {
     adminRegistrationDefaults,

--- a/js/auth.js
+++ b/js/auth.js
@@ -15,7 +15,7 @@ import {
     signInWithEmailLink,
     updatePassword
 } from './firebase.js?v=20';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=84';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests, normalizeParentScopeLinks } from './db.js?v=85';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=6';
 import { redeemAdminInviteAcceptance } from './admin-invite.js?v=6';
 import { mergeApprovedParentMembershipRequests } from './parent-membership-utils.js?v=2';

--- a/js/db.js
+++ b/js/db.js
@@ -4149,6 +4149,7 @@ async function createUniqueAccessCode(accessCodeData, preferredCode) {
 
 export async function createAccessCode(userId, email, phone, code) {
     const accessCodeData = {
+        type: 'standard',
         generatedBy: userId,
         email: email || null,
         phone: phone || null,

--- a/js/db.js
+++ b/js/db.js
@@ -4250,27 +4250,23 @@ async function getValidatedAccessCodeDoc(code) {
 
 export async function markAccessCodeAsUsed(codeId, userId) {
     const codeRef = doc(db, "accessCodes", codeId);
-    await runTransaction(db, async (transaction) => {
-        const codeSnapshot = await transaction.get(codeRef);
-        if (!codeSnapshot.exists()) {
-            throw new Error("Invalid access code");
-        }
-
-        const codeData = codeSnapshot.data() || {};
-        if (codeData.used) {
-            throw new Error("Code already used");
-        }
-
-        if (isAccessCodeExpired(codeData.expiresAt)) {
-            throw new Error("Code has expired");
-        }
-
-        transaction.update(codeRef, {
-            used: true,
-            usedBy: userId,
-            usedAt: Timestamp.now()
+    try {
+        await runTransaction(db, async (transaction) => {
+            transaction.update(codeRef, {
+                used: true,
+                usedBy: userId,
+                usedAt: serverTimestamp()
+            });
         });
-    });
+    } catch (error) {
+        const message = String(error?.message || '').toLowerCase();
+        if (error?.code === 'permission-denied' ||
+            error?.code === 'not-found' ||
+            message.includes('no document')) {
+            throw new Error('Activation code is invalid, expired, or already used.');
+        }
+        throw error;
+    }
 }
 
 export async function redeemAdminInviteAtomicPersistence({

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -20,7 +20,7 @@ import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, 
 import { hasFullTeamAccess } from './team-access.js?v=1';
 import { buildScoreLinkedClipRecord, isScoredPlayEvent, validateGameClipFile } from './game-clips.js?v=1';
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
-import { checkAuth } from './auth.js?v=43';
+import { checkAuth } from './auth.js?v=44';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { createPlayAnnouncer } from './live-game-announcer.js?v=1';
 import {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -2,7 +2,7 @@
 import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=84';
 import { db } from './firebase.js?v=20';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
-import { checkAuth } from './auth.js?v=43';
+import { checkAuth } from './auth.js?v=44';
 import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=20';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -2,7 +2,7 @@
 import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=84';
 import { db } from './firebase.js?v=20';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=43';
+import { checkAuth } from './auth.js?v=44';
 import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=20';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/utils.js
+++ b/js/utils.js
@@ -178,7 +178,7 @@ export function renderHeader(container, user) {
 
     // Keep shared-header logout on the same auth bundle as page consumers.
     navLogout.addEventListener('click', async () => {
-      const { logout } = await import('./auth.js?v=42');
+      const { logout } = await import('./auth.js?v=44');
       await logout();
       window.location.href = 'index.html';
     });

--- a/login.html
+++ b/login.html
@@ -97,8 +97,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=43';
-        import { getUserProfile } from './js/db.js?v=84';
+        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=44';
+        import { getUserProfile } from './js/db.js?v=85';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';
         import * as loginPageModule from './js/login-page.js?v=6';

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -123,6 +123,17 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     return error?.message || 'Authentication failed.';
                 }
 
+                export function normalizeAuthEmail(email) {
+                    return String(email || '').trim().toLowerCase();
+                }
+
+                export function isValidAuthEmail(email) {
+                    const normalizedEmail = normalizeAuthEmail(email);
+                    const parts = normalizedEmail.split('@');
+                    return parts.length === 2 &&
+                        Boolean(parts[0] && parts[1]?.includes('.') && /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/.test(normalizedEmail));
+                }
+
                 export function getRouteForUser(user) {
                     if (!user) return '/auth';
                     return user.roles?.includes('coach') || user.roles?.includes('admin') ? '/teams' : '/home';

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from '../../js/accept-invite-flow.js';
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=84';";
+const ACCEPT_INVITE_DB_IMPORT = "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=85';";
 const ACCEPT_INVITE_ADMIN_IMPORT = "import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';";
 
 class MockClassList {
@@ -105,7 +105,7 @@ const URLSearchParams = deps.URLSearchParams;
 const setTimeout = deps.setTimeout;
 ` + match[1]
         .replace(
-            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=43';",
+            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=44';",
             'const { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } = deps.auth;'
         )
         .replace(

--- a/tests/unit/access-code-atomic-redemption-guard.test.js
+++ b/tests/unit/access-code-atomic-redemption-guard.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 describe('access code atomic redemption guard', () => {
-    it('keeps generic access-code use inside a transaction', () => {
+    it('claims generic access codes without reading protected access-code documents', () => {
         const dbSourcePath = resolve(process.cwd(), 'js/db.js');
         const source = readFileSync(dbSourcePath, 'utf8');
 
@@ -11,8 +11,13 @@ describe('access code atomic redemption guard', () => {
         const fnIndex = source.indexOf(fnAnchor);
         expect(fnIndex).toBeGreaterThanOrEqual(0);
 
-        const afterFunction = source.slice(fnIndex, fnIndex + 1800);
+        const nextFunctionIndex = source.indexOf('\nexport async function', fnIndex + fnAnchor.length);
+        const afterFunction = source.slice(fnIndex, nextFunctionIndex);
         expect(afterFunction).toContain('runTransaction(db, async (transaction) =>');
+        expect(afterFunction).toContain('transaction.update(codeRef');
+        expect(afterFunction).toContain('usedAt: serverTimestamp()');
+        expect(afterFunction).not.toContain('transaction.get(codeRef)');
+        expect(afterFunction).not.toContain('codeSnapshot.data()');
     });
 
     it('routes parent invite membership grants through a callable instead of browser membership writes', () => {

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -7,6 +7,8 @@ const accessCodeMatch = rules.match(/match \/accessCodes\/\{codeId\} \{[\s\S]*?\
 const accessCodeRules = accessCodeMatch?.[0] || '';
 const parentInviteRedemptionMatch = rules.match(/function isParentInviteRedemptionUpdate\(\) \{[\s\S]*?\n    \}/);
 const parentInviteRedemptionRule = parentInviteRedemptionMatch?.[0] || '';
+const standardCodeRedemptionMatch = rules.match(/function isStandardAccessCodeRedemptionUpdate\(\) \{[\s\S]*?\n    \}/);
+const standardCodeRedemptionRule = standardCodeRedemptionMatch?.[0] || '';
 
 describe('access code Firestore rules', () => {
     it('removes the public accessCodes read loophole and scopes raw access to authorized users', () => {
@@ -79,13 +81,28 @@ describe('access code Firestore rules', () => {
     });
 
     it('excludes admin_invite documents from generic used-field redemption updates', () => {
-        const genericUsedUpdateIndex = accessCodeRules.indexOf("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
-        expect(genericUsedUpdateIndex).toBeGreaterThanOrEqual(0);
+        expect(accessCodeRules).toContain('isStandardAccessCodeRedemptionUpdate()');
+        expect(standardCodeRedemptionRule).toContain("let codeType = resource.data.get('type', 'standard');");
+        expect(standardCodeRedemptionRule).toContain("(codeType == 'standard' || codeType == null)");
+        expect(standardCodeRedemptionRule).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
+        expect(standardCodeRedemptionRule).toContain('resource.data.used == false');
+        expect(standardCodeRedemptionRule).toContain("resource.data.get('status', 'active') != 'revoked'");
+        expect(standardCodeRedemptionRule).toContain('request.resource.data.usedBy == request.auth.uid');
+        expect(standardCodeRedemptionRule).not.toContain('admin_invite');
+        expect(standardCodeRedemptionRule).not.toContain('parent_invite');
+        expect(standardCodeRedemptionRule).not.toContain('household_invite');
+        expect(standardCodeRedemptionRule).not.toContain('coparent_invite');
+    });
 
-        const genericUsedUpdateBranch = accessCodeRules.slice(genericUsedUpdateIndex - 280, genericUsedUpdateIndex + 220);
-        expect(genericUsedUpdateBranch).toContain("resource.data.get('type', null) != 'admin_invite'");
-        expect(genericUsedUpdateBranch).toContain("resource.data.get('type', null) != 'parent_invite'");
-        expect(genericUsedUpdateBranch).toContain("resource.data.get('type', null) != 'household_invite'");
+    it('keeps typed invite records out of owner-only generic revocation updates', () => {
+        const revocationIndex = accessCodeRules.indexOf("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['revoked', 'revokedAt', 'used', 'updatedAt'])");
+        expect(revocationIndex).toBeGreaterThanOrEqual(0);
+
+        const revocationBranch = accessCodeRules.slice(revocationIndex - 520, revocationIndex + 180);
+        expect(revocationBranch).toContain("resource.data.get('type', null) != 'admin_invite'");
+        expect(revocationBranch).toContain("resource.data.get('type', null) != 'parent_invite'");
+        expect(revocationBranch).toContain("resource.data.get('type', null) != 'household_invite'");
+        expect(revocationBranch).toContain("resource.data.get('type', null) != 'coparent_invite'");
     });
 
     it('requires parent_invite redemption to use an active invite owned by the signed-in email', () => {

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -83,7 +83,8 @@ describe('access code Firestore rules', () => {
     it('excludes admin_invite documents from generic used-field redemption updates', () => {
         expect(accessCodeRules).toContain('isStandardAccessCodeRedemptionUpdate()');
         expect(standardCodeRedemptionRule).toContain("let codeType = resource.data.get('type', 'standard');");
-        expect(standardCodeRedemptionRule).toContain("(codeType == 'standard' || codeType == null)");
+        expect(standardCodeRedemptionRule).toContain("return codeType == 'standard' &&");
+        expect(standardCodeRedemptionRule).not.toContain('codeType == null');
         expect(standardCodeRedemptionRule).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
         expect(standardCodeRedemptionRule).toContain('resource.data.used == false');
         expect(standardCodeRedemptionRule).toContain("resource.data.get('status', 'active') != 'revoked'");

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -34,9 +34,10 @@ describe('access code Firestore rules', () => {
 
     it('preserves standard profile access-code creation without reopening typed invite paths', () => {
         expect(rules).toContain('function isStandardAccessCodePayloadValid(data)');
-        expect(rules).toContain("'code', 'generatedBy', 'email', 'phone', 'createdAt', 'used', 'usedBy', 'usedAt'");
-        expect(rules).toContain("!data.keys().hasAny(['type'])");
-        expect(accessCodeRules).toContain("!request.resource.data.keys().hasAny(['type'])");
+        expect(rules).toContain("'code', 'type', 'generatedBy', 'email', 'phone', 'createdAt', 'used', 'usedBy', 'usedAt'");
+        expect(rules).toContain("(!data.keys().hasAny(['type']) || data.type == 'standard')");
+        expect(accessCodeRules).toContain("!request.resource.data.keys().hasAny(['type']) ||");
+        expect(accessCodeRules).toContain("request.resource.data.type == 'standard'");
         expect(accessCodeRules).toContain('isStandardAccessCodePayloadValid(request.resource.data)');
         expect(accessCodeRules).toContain('request.resource.data.code == codeId');
     });
@@ -82,9 +83,11 @@ describe('access code Firestore rules', () => {
 
     it('excludes admin_invite documents from generic used-field redemption updates', () => {
         expect(accessCodeRules).toContain('isStandardAccessCodeRedemptionUpdate()');
-        expect(standardCodeRedemptionRule).toContain("let codeType = resource.data.get('type', 'standard');");
-        expect(standardCodeRedemptionRule).toContain("return codeType == 'standard' &&");
-        expect(standardCodeRedemptionRule).not.toContain('codeType == null');
+        expect(standardCodeRedemptionRule).toContain("let codeType = resource.data.get('type', null);");
+        expect(standardCodeRedemptionRule).toContain('let isLegacyStandardCode = codeType == null');
+        expect(standardCodeRedemptionRule).toContain("!resource.data.keys().hasAny([");
+        expect(standardCodeRedemptionRule).toContain("'teamId', 'playerId', 'familyMembershipId'");
+        expect(standardCodeRedemptionRule).toContain("(codeType == 'standard' || isLegacyStandardCode)");
         expect(standardCodeRedemptionRule).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt'])");
         expect(standardCodeRedemptionRule).toContain('resource.data.used == false');
         expect(standardCodeRedemptionRule).toContain("resource.data.get('status', 'active') != 'revoked'");

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -20,7 +20,7 @@ describe('admin dashboard statistics scope', () => {
         const adminHtml = fs.readFileSync('admin.html', 'utf8');
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
 
-        expect(adminJs).toContain("import { checkAuth } from './auth.js?v=43';");
+        expect(adminJs).toContain("import { checkAuth } from './auth.js?v=44';");
         expect(adminJs).not.toContain("import { checkAuth } from './auth.js?v=42';");
         expect(adminJs).toContain('loadInitialAdminBootstrap({');
         expect(adminJs).toContain('getTeamsPage: getAdminTeamsPage');

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -32,14 +32,14 @@ describe('admin invite signup cache busting', () => {
 
         expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=6';");
         expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=6';");
-        expect(authSource).toContain("from './db.js?v=84';");
+        expect(authSource).toContain("from './db.js?v=85';");
     });
 
     it('pins fresh invite acceptance module versions for admin invite redemption', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=84';"
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=85';"
         );
         expect(acceptInviteSource).toContain(
             "import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';"
@@ -51,13 +51,13 @@ describe('admin invite signup cache busting', () => {
 
     it('bumps auth module consumers after signup flow changes', () => {
         const authConsumers = {
-            'login.html': 'auth.js?v=43',
-            'accept-invite.html': 'auth.js?v=43',
-            'edit-team.html': 'auth.js?v=43',
-            'js/admin.js': 'auth.js?v=43',
-            'js/live-game.js': 'auth.js?v=43',
-            'js/live-tracker.js': 'auth.js?v=43',
-            'js/track-basketball.js': 'auth.js?v=43'
+            'login.html': 'auth.js?v=44',
+            'accept-invite.html': 'auth.js?v=44',
+            'edit-team.html': 'auth.js?v=44',
+            'js/admin.js': 'auth.js?v=44',
+            'js/live-game.js': 'auth.js?v=44',
+            'js/live-tracker.js': 'auth.js?v=44',
+            'js/track-basketball.js': 'auth.js?v=44'
         };
 
         for (const [relativePath, expectedVersion] of Object.entries(authConsumers)) {
@@ -66,13 +66,13 @@ describe('admin invite signup cache busting', () => {
         }
 
         const editTeamSource = readFileSync(resolve(process.cwd(), 'edit-team.html'), 'utf8');
-        expect(editTeamSource).toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=43';");
+        expect(editTeamSource).toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=44';");
         expect(editTeamSource).not.toContain("import { checkAuth, sendInviteEmail } from './js/auth.js?v=40';");
     });
 
     it('bumps the shared header logout import with auth.js consumers', () => {
         const utilsSource = readFileSync(resolve(process.cwd(), 'js/utils.js'), 'utf8');
-        const logoutImportMatches = utilsSource.match(/const \{ logout \} = await import\('\.\/auth\.js\?v=42'\);/g) || [];
+        const logoutImportMatches = utilsSource.match(/const \{ logout \} = await import\('\.\/auth\.js\?v=44'\);/g) || [];
 
         expect(logoutImportMatches).toHaveLength(1);
         expect(utilsSource).not.toContain("const { logout } = await import('./auth.js?v=25');");

--- a/tests/unit/app-native-google-auth.test.js
+++ b/tests/unit/app-native-google-auth.test.js
@@ -57,6 +57,7 @@ const dbMocks = vi.hoisted(() => ({
     listMyParentMembershipRequests: vi.fn(),
     markAccessCodeAsUsed: vi.fn(),
     redeemAdminInviteAtomically: vi.fn(),
+    redeemCoParentInvite: vi.fn(),
     redeemHouseholdInvite: vi.fn(),
     redeemParentInvite: vi.fn(),
     updateTeam: vi.fn(),
@@ -318,5 +319,27 @@ describe('React app native Google auth', () => {
             nativeAuthToken: 'firebase-id-token'
         });
         expect(dbMocks.markAccessCodeAsUsed).toHaveBeenCalledWith('native-code', 'native-google-user');
+    });
+
+    it('redeems co-parent invites during React app Google signup instead of generic code consumption', async () => {
+        mockFirebaseAuthRest({ isNewUser: true });
+        dbMocks.validateAccessCode.mockResolvedValue({
+            valid: true,
+            codeId: 'coparent-code',
+            type: 'coparent_invite',
+            data: { code: 'COPO1234' }
+        });
+        dbMocks.redeemCoParentInvite.mockResolvedValue({ success: true });
+        dbMocks.updateUserProfile.mockResolvedValue(undefined);
+        const { signInWithGoogleAccount } = await loadAuthService();
+
+        await signInWithGoogleAccount('copo1234');
+
+        expect(dbMocks.redeemCoParentInvite).toHaveBeenCalledWith(
+            'native-google-user',
+            'COPO1234',
+            'parent@example.com'
+        );
+        expect(dbMocks.markAccessCodeAsUsed).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=20', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => ({
+vi.mock('../../js/db.js?v=85', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -29,7 +29,7 @@ vi.mock('../../js/firebase.js?v=20', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => ({
+vi.mock('../../js/db.js?v=85', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-google-popup-fallback.test.js
+++ b/tests/unit/auth-google-popup-fallback.test.js
@@ -21,7 +21,7 @@ vi.mock('../../js/firebase.js?v=20', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => ({
+vi.mock('../../js/db.js?v=85', () => ({
     validateAccessCode: vi.fn(),
     markAccessCodeAsUsed: vi.fn(),
     updateUserProfile: vi.fn(),

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -35,7 +35,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=20', () => firebaseMocks);
-vi.mock('../../js/db.js?v=84', () => dbMocks);
+vi.mock('../../js/db.js?v=85', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=6', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));

--- a/tests/unit/auth-send-invite-email-no-localstorage.test.js
+++ b/tests/unit/auth-send-invite-email-no-localstorage.test.js
@@ -21,7 +21,7 @@ vi.mock('../../js/firebase.js?v=20', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => ({
+vi.mock('../../js/db.js?v=85', () => ({
     validateAccessCode: vi.fn(),
     markAccessCodeAsUsed: vi.fn(),
     updateUserProfile: vi.fn(),

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -38,7 +38,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=20', () => firebaseMocks);
-vi.mock('../../js/db.js?v=84', () => dbMocks);
+vi.mock('../../js/db.js?v=85', () => dbMocks);
 vi.mock('../../js/admin-invite.js?v=6', () => ({
     redeemAdminInviteAcceptance: vi.fn()
 }));

--- a/tests/unit/co-parent-invite-workflow.test.js
+++ b/tests/unit/co-parent-invite-workflow.test.js
@@ -17,7 +17,7 @@ describe('co-parent invite workflow regression', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain('redeemCoParentInvite');
-        expect(acceptInviteSource).toContain("./js/db.js?v=84");
+        expect(acceptInviteSource).toContain("./js/db.js?v=85");
         expect(acceptInviteSource).toContain("./js/accept-invite-flow.js?v=8");
     });
 


### PR DESCRIPTION
## Summary
- Allow signed-in users to redeem standard activation codes without reading protected access code documents.
- Keep typed invite records protected while permitting narrow standard-code redemption writes.
- Add app email validation so Firebase invalid-email errors do not surface raw in signup/reset flows.
- Bump legacy auth/db cache versions for signup consumers.

## Tests
- npm --prefix apps/app exec vitest run src/pages/AuthPage.test.tsx src/lib/authService.test.ts --reporter=verbose
- npm run app:build
- npx vitest run tests/unit/access-code-rules.test.js tests/unit/access-code-atomic-redemption-guard.test.js tests/unit/signup-flow.test.js tests/unit/auth-signup-parent-invite.test.js tests/unit/auth-google-parent-invite-cleanup.test.js tests/unit/auth-google-admin-invite-cleanup.test.js tests/unit/auth-google-popup-fallback.test.js tests/unit/admin-invite-signup-cache-busting.test.js tests/unit/accept-invite-page.test.js tests/unit/co-parent-invite-workflow.test.js tests/unit/admin-dashboard-stats.test.js --reporter=verbose
- npm run ci:firebase-rules
- npm run test:unit:ci
- SMOKE_BASE_URL=http://127.0.0.1:4173 npm run test:smoke:team-fallback