### PR TITLE
Fix app CSS cascade layers, default route, and team row overflow

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -289,7 +289,8 @@ describe('App protected route loading', () => {
     expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
   });
 
-  it('routes signed-in coach users from the root route to Teams', async () => {
+  it('routes signed-in coach users from the root route to Home', async () => {
+    homeRenderMode = 'render';
     authMock.state = {
       ...authMock.signedInAuth,
       user: { ...authMock.signedInAuth.user!, email: 'coach@example.com', roles: ['coach'] },
@@ -304,11 +305,12 @@ describe('App protected route loading', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('Teams page')).toBeTruthy();
+    expect(await screen.findByText('Home page')).toBeTruthy();
     expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
   });
 
-  it('routes signed-in coach users from unknown routes to Teams', async () => {
+  it('routes signed-in coach users from unknown routes to Home', async () => {
+    homeRenderMode = 'render';
     authMock.state = {
       ...authMock.signedInAuth,
       user: { ...authMock.signedInAuth.user!, email: 'coach@example.com', roles: ['coach'] },
@@ -323,7 +325,7 @@ describe('App protected route loading', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('Teams page')).toBeTruthy();
+    expect(await screen.findByText('Home page')).toBeTruthy();
     expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
   });
 

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -80,7 +80,7 @@ vi.mock('./logger', () => ({
   })
 }));
 
-import { hydrateFirebaseUser, observeFirebaseUser, signInWithEmail, signOut } from './authService';
+import { getRouteForUser, hydrateFirebaseUser, observeFirebaseUser, signInWithEmail, signOut } from './authService';
 
 describe('hydrateFirebaseUser', () => {
   beforeEach(() => {
@@ -235,6 +235,19 @@ describe('observeFirebaseUser', () => {
     emit({ uid: 'user-a' });
     emit({ uid: 'user-a' });
     expect(appDataCacheMocks.clearAppDataCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRouteForUser', () => {
+  it('routes signed-out users to auth', () => {
+    expect(getRouteForUser(null)).toBe('/auth');
+  });
+
+  it('routes every signed-in user to home, including coaches and admins', () => {
+    const baseUser = { uid: 'user-1', email: 'user@example.com', displayName: 'User', emailVerified: true };
+    expect(getRouteForUser({ ...baseUser, isAdmin: false, roles: [] } as never)).toBe('/home');
+    expect(getRouteForUser({ ...baseUser, isAdmin: false, roles: ['coach'] } as never)).toBe('/home');
+    expect(getRouteForUser({ ...baseUser, isAdmin: true, roles: ['admin', 'platformAdmin'] } as never)).toBe('/home');
   });
 });
 

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -1340,10 +1340,6 @@ export function getRouteForUser(user: AuthUser | null) {
     return '/auth';
   }
 
-  if (user.isAdmin || user.roles.includes('coach') || user.roles.includes('admin') || user.roles.includes('platformAdmin')) {
-    return '/teams';
-  }
-
   return '/home';
 }
 

--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -12,9 +12,6 @@ const authServiceMocks = vi.hoisted(() => ({
     if (!user) {
       return '/auth';
     }
-    if (user.isAdmin || user.roles.includes('coach') || user.roles.includes('admin') || user.roles.includes('platformAdmin')) {
-      return '/teams';
-    }
     return '/home';
   }),
   hydrateFirebaseUser: vi.fn(),
@@ -74,7 +71,7 @@ describe('AuthPage native post-login routing', () => {
     cleanup();
   });
 
-  it('reloads native email sign-in to the coach/admin teams dashboard', async () => {
+  it('reloads native email sign-in to the home page', async () => {
     authServiceMocks.signInWithEmail.mockResolvedValue({
       user: { uid: 'coach-1', email: 'coach@example.com' },
       nativeRest: true
@@ -91,11 +88,11 @@ describe('AuthPage native post-login routing', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Sign in' })[1]);
 
     await waitFor(() => expect(authServiceMocks.signInWithEmail).toHaveBeenCalledWith('coach@example.com', 'password123'));
-    await waitFor(() => expect(window.location.hash).toBe('#/teams'));
+    await waitFor(() => expect(window.location.hash).toBe('#/home'));
     expect(window.location.reload).toHaveBeenCalledTimes(1);
   });
 
-  it('reloads native Google sign-in to the coach/admin teams dashboard', async () => {
+  it('reloads native Google sign-in to the home page', async () => {
     authServiceMocks.signInWithGoogleAccount.mockResolvedValue({
       user: { uid: 'admin-1', email: 'admin@example.com' },
       nativeRest: true
@@ -110,7 +107,7 @@ describe('AuthPage native post-login routing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Continue with Google' }));
 
     await waitFor(() => expect(authServiceMocks.signInWithGoogleAccount).toHaveBeenCalledWith(null));
-    await waitFor(() => expect(window.location.hash).toBe('#/teams'));
+    await waitFor(() => expect(window.location.hash).toBe('#/home'));
     expect(window.location.reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -517,7 +517,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
                   <Icon className="h-5 w-5" aria-hidden="true" />
                   {badge > 0 ? <span className={`absolute -right-2 -top-1 min-w-4 rounded-full px-1 text-center text-[9px] leading-4 ${selected ? 'bg-white text-primary-700' : 'bg-primary-600 text-white'}`}>{badge > 9 ? '9+' : badge}</span> : null}
                 </span>
-                <span className="truncate">{tab.label}</span>
+                <span className="max-w-full truncate">{tab.label}</span>
               </button>
             );
           })}

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -413,7 +413,7 @@ function TeamLauncherRow({ team, selected, compact = false }: { team: ParentHome
 
 function TeamQuickLink({ to, label, icon: Icon, badge = 0 }: { to: string; label: string; icon: typeof Users; badge?: number }) {
   return (
-    <Link to={to} className="relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-gray-200 bg-gray-50 text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700" aria-label={label} title={label}>
+    <Link to={to} className="team-quick-link relative inline-flex h-10 w-10 items-center justify-center rounded-xl border border-gray-200 bg-gray-50 text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700" aria-label={label} title={label}>
       <Icon className="h-4 w-4" aria-hidden="true" />
       {badge > 0 ? <span className="absolute -right-1 -top-1 min-w-4 rounded-full bg-primary-600 px-1 text-center text-[9px] font-black leading-4 text-white">{badge > 9 ? '9+' : badge}</span> : null}
     </Link>
@@ -424,7 +424,7 @@ function TeamHubQuickLink({ team }: { team: ParentHomeTeam }) {
   return (
     <Link
       to={`/teams/${encodeURIComponent(team.teamId)}`}
-      className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-gray-200 bg-gray-50 text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700"
+      className="team-quick-link inline-flex h-10 w-10 items-center justify-center rounded-xl border border-gray-200 bg-gray-50 text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700"
       aria-label={`${team.teamName} team hub`}
       title={`${team.teamName} team hub`}
     >

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -34,17 +34,19 @@
     background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
   }
 
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+@layer utilities {
   @media (max-width: 767px) {
     input,
     select,
     textarea {
       font-size: 16px;
     }
-  }
-
-  a {
-    color: inherit;
-    text-decoration: none;
   }
 }
 

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -1,52 +1,51 @@
 @import "tailwindcss";
 @config "../../tailwind.config.js";
 
-:root {
-  color: #101828;
-  background: #f6f8fb;
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  --app-bottom-nav-height: calc(64px + max(12px, env(safe-area-inset-bottom)));
-}
-
-* {
-  box-sizing: border-box;
-}
-
-html,
-body,
-#root {
-  min-height: 100%;
-}
-
-body {
-  margin: 0;
-  min-width: 320px;
-  min-height: 100vh;
-  background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
-}
-
-button,
-input,
-select,
-textarea {
-  font: inherit;
-}
-
-@media (max-width: 767px) {
-  input,
-  select,
-  textarea {
-    font-size: 16px;
+/* Element-level resets must live in @layer base: with Tailwind v4 utilities in
+   @layer utilities, any unlayered rule here would override them regardless of
+   specificity (e.g. an unlayered `button { font: inherit }` disables every
+   text-size/weight utility on buttons). */
+@layer base {
+  :root {
+    color: #101828;
+    background: #f6f8fb;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    --app-bottom-nav-height: calc(64px + max(12px, env(safe-area-inset-bottom)));
   }
-}
 
-a {
-  color: inherit;
-  text-decoration: none;
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body,
+  #root {
+    min-height: 100%;
+  }
+
+  body {
+    margin: 0;
+    min-width: 320px;
+    min-height: 100vh;
+    background: linear-gradient(135deg, #f9fafb 0%, #f3f4f6 100%);
+  }
+
+  @media (max-width: 767px) {
+    input,
+    select,
+    textarea {
+      font-size: 16px;
+    }
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 .safe-top {
@@ -1679,7 +1678,9 @@ a {
   gap: 4px;
 }
 
-.desktop-app-page .team-launcher-row-compact a[aria-label] {
+/* Scope to the icon quick-links only — the row's main content link also
+   carries an aria-label and must not be forced to 36px. */
+.desktop-app-page .team-launcher-row-compact .team-quick-link {
   width: 36px;
   height: 36px;
   border-radius: 12px;

--- a/tests/unit/app-css-layer-regression.test.js
+++ b/tests/unit/app-css-layer-regression.test.js
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const indexCss = readFileSync(
+    path.join(process.cwd(), 'apps/app/src/styles/index.css'),
+    'utf8'
+);
+
+// Tailwind v4 emits utilities inside a real `@layer utilities`. Any unlayered
+// element-level rule in app CSS outranks every utility regardless of
+// specificity — an unlayered `button { font: inherit }` silently disabled all
+// text-size/weight utilities on buttons (oversized team tab labels on iOS).
+describe('app CSS cascade layers', () => {
+    it('keeps element-level resets inside @layer base', () => {
+        expect(indexCss).toContain('@layer base');
+
+        const cssWithoutComments = indexCss.replace(/\/\*[\s\S]*?\*\//g, '');
+        const unlayeredTopLevelElementRules = [];
+        let depth = 0;
+        let buffer = '';
+        for (const char of cssWithoutComments) {
+            if (char === '{') {
+                if (depth === 0) {
+                    const selector = buffer.trim().split('\n').pop().trim();
+                    if (/^([a-z][a-z0-9]*|\*|:root)([\s,].*)?$/i.test(selector) && !selector.startsWith('@')) {
+                        unlayeredTopLevelElementRules.push(selector);
+                    }
+                }
+                depth += 1;
+                buffer = '';
+            } else if (char === '}') {
+                depth -= 1;
+                buffer = '';
+            } else {
+                buffer += char;
+            }
+        }
+
+        expect(unlayeredTopLevelElementRules).toEqual([]);
+    });
+
+    it('scopes compact team-row icon sizing to the quick-link class', () => {
+        // A bare `a[aria-label]` selector also matches the row's main content
+        // link, squashing it to 36px and spilling the chips out of the card.
+        expect(indexCss).not.toContain('.team-launcher-row-compact a[aria-label]');
+        expect(indexCss).toContain('.team-launcher-row-compact .team-quick-link');
+
+        const teamsPage = readFileSync(
+            path.join(process.cwd(), 'apps/app/src/pages/Teams.tsx'),
+            'utf8'
+        );
+        expect(teamsPage.match(/team-quick-link/g)?.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does not duplicate the preflight form-control font reset', () => {
+        // Tailwind v4 preflight already applies `font: inherit` to buttons and
+        // inputs inside @layer base; a local copy is redundant and, if ever
+        // unlayered again, breaks font utilities on those elements.
+        expect(indexCss).not.toMatch(/button\s*,\s*\n?\s*input\s*,\s*\n?\s*select\s*,\s*\n?\s*textarea\s*\{\s*font:\s*inherit/);
+    });
+});

--- a/tests/unit/app-css-layer-regression.test.js
+++ b/tests/unit/app-css-layer-regression.test.js
@@ -7,6 +7,8 @@ const indexCss = readFileSync(
     'utf8'
 );
 
+const cssWithoutComments = indexCss.replace(/\/\*[\s\S]*?\*\//g, '');
+
 // Tailwind v4 emits utilities inside a real `@layer utilities`. Any unlayered
 // element-level rule in app CSS outranks every utility regardless of
 // specificity — an unlayered `button { font: inherit }` silently disabled all
@@ -15,7 +17,6 @@ describe('app CSS cascade layers', () => {
     it('keeps element-level resets inside @layer base', () => {
         expect(indexCss).toContain('@layer base');
 
-        const cssWithoutComments = indexCss.replace(/\/\*[\s\S]*?\*\//g, '');
         const unlayeredTopLevelElementRules = [];
         let depth = 0;
         let buffer = '';
@@ -38,6 +39,22 @@ describe('app CSS cascade layers', () => {
         }
 
         expect(unlayeredTopLevelElementRules).toEqual([]);
+    });
+
+    it('keeps the mobile form-control anti-zoom rule above base-layer resets', () => {
+        const baseLayerIndex = cssWithoutComments.indexOf('@layer base');
+        const utilitiesLayerIndex = cssWithoutComments.indexOf('@layer utilities');
+        if (baseLayerIndex === -1 || utilitiesLayerIndex === -1) {
+            throw new Error('Expected app CSS to define base and utilities layers.');
+        }
+
+        expect(utilitiesLayerIndex).toBeGreaterThan(baseLayerIndex);
+
+        const baseLayerCss = cssWithoutComments.slice(baseLayerIndex, utilitiesLayerIndex);
+        const utilitiesLayerCss = cssWithoutComments.slice(utilitiesLayerIndex);
+        const mobileFormControlRule = /@media\s*\(max-width:\s*767px\)\s*\{\s*input\s*,\s*select\s*,\s*textarea\s*\{\s*font-size:\s*16px\s*;/;
+        expect(baseLayerCss).not.toMatch(mobileFormControlRule);
+        expect(utilitiesLayerCss).toMatch(mobileFormControlRule);
     });
 
     it('scopes compact team-row icon sizing to the quick-link class', () => {


### PR DESCRIPTION
## Summary
- **Restore Tailwind utility precedence on buttons (all platforms).** The Tailwind v4 migration put utilities in a real `@layer utilities`, but `apps/app/src/styles/index.css` kept unlayered element resets. Unlayered CSS beats layered CSS regardless of specificity, so the unlayered `button { font: inherit }` silently disabled every font-size/weight utility on every button — team hub tab labels rendered 16px/normal instead of 11px/black (worst on iOS where SF Pro is wider). Element resets now live in `@layer base`, and the reset that Tailwind v4 preflight already provides is removed.
- **Team hub tab labels truncate instead of overflowing** (`max-w-full` on the label span so `truncate` can engage inside the flex column).
- **Default signed-in users to `/home`.** `getRouteForUser` previously routed coach/admin roles to `/teams`, so those users always landed on My Teams instead of Home.
- **Fix team row content overflow on desktop Teams page.** `.team-launcher-row-compact a[aria-label]` (meant for the 36px icon quick-links) also matched the row's main content link, squashing it to 36px and spilling the player/event chips out of the card. Sizing is now scoped to a `team-quick-link` class.

## Tests
- New `tests/unit/app-css-layer-regression.test.js`: element resets must stay inside `@layer base`, no duplicate preflight font reset, quick-link sizing must not use the bare `a[aria-label]` selector.
- New `getRouteForUser` regression tests in `apps/app/src/lib/authService.test.ts` (coach/admin now land on `/home`).
- Updated `AuthPage.test.tsx` native post-login routing tests for the new default.
- Full unit suite passes: 3,864 passed / 4 skipped. `tsc --noEmit` clean.

## Manual test steps
1. `npm run app:dev`, sign in as a coach/admin user → app lands on **Home**, not My Teams.
2. Open a team hub on a phone-sized viewport (or iOS simulator) → Overview/Schedule/Roster/Insights/More labels render small (11px, black weight) inside their pills with no overflow.
3. On a desktop-width window, open My Teams → team rows no longer clip; player/event chips stay inside the card.
4. Verified on-device: iOS simulator (iPhone 16e) and Android emulator (API 36) both boot to Home; Android team hub tab label measured 11px/900 via WebView DevTools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)