### PR TITLE
Prepare Firebase Hosting cutover and retire GitHub Pages references

### DIFF
--- a/FIREBASE-HOSTING-MIGRATION.md
+++ b/FIREBASE-HOSTING-MIGRATION.md
@@ -1,0 +1,29 @@
+# GitHub Pages → Firebase Hosting cutover runbook
+
+Goal: serve `allplays.ai` from Firebase Hosting so the GitHub repo can be made private without taking the site down.
+
+## Current state
+
+- `deploy-prod.yml` already deploys the full site (legacy root + `/app/` + Functions + Firestore rules/indexes) to Firebase Hosting on `game-flow-c6311` on every push to `master`. The Firebase copy at <https://game-flow-c6311.web.app> stays current automatically.
+- `allplays.ai` DNS still points at GitHub Pages (A records `185.199.108-111.153`, `www` CNAME to `pauljsnider.github.io`).
+- GitHub Pages deploys are gated by the repo Actions variable `APP_GITHUB_PAGES_DEPLOY_ENABLED` (in `app-github-pages.yml`).
+- A `firebase=game-flow-c6311` TXT record already exists on the domain for Firebase domain verification.
+
+## Cutover steps (manual, in order)
+
+1. **Firebase console**: Hosting → Add custom domain for `allplays.ai` and `www.allplays.ai` on the `game-flow-c6311` site. Domain verification should pass via the existing TXT record.
+2. **DNS registrar**: replace the four GitHub Pages A records on `allplays.ai` with the A record(s) Firebase provides, and repoint the `www` CNAME to the Firebase target.
+3. **Wait for SSL**: Firebase provisions the certificate (minutes up to ~1 hour). Verify with:
+   ```bash
+   curl -sI https://allplays.ai/ | grep -i server   # should no longer say GitHub.com
+   ```
+4. **Verify the site**: `https://allplays.ai/`, `https://allplays.ai/app/`, sign-in, and a public RSVP page.
+5. **Disable Pages deploys**: set the repo Actions variable `APP_GITHUB_PAGES_DEPLOY_ENABLED` to `false`, then disable Pages in repo Settings → Pages.
+6. **Post-cutover repo cleanup** (separate PR): delete `CNAME`, remove the `deploy` job from `.github/workflows/app-github-pages.yml` (keep the bundle build/size-check job or fold it into `ci.yml`).
+7. **Firebase Auth cleanup**: remove `pauljsnider.github.io` from Authentication → Settings → Authorized domains.
+
+## Making the repo private (after cutover)
+
+- **Actions billing**: private repos on the Free plan include 2,000 minutes/month; beyond that Linux is $0.008/min and macOS is 10× ($0.08/min). Current CI cadence (~100 runs/day, `scheduled-prod-smoke` every 15 min, `ios-simulator` on `macos-15`) would far exceed the free tier. Mitigations: relax the smoke schedule, gate the macOS job harder, or use a self-hosted runner.
+- **Access**: re-grant any GitHub Apps/bots (PR reviewers) and collaborators access to the private repo.
+- **Side effects**: the repo's public forks are detached, README badges stop rendering publicly, and issue links become owner-only.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A static HTML + JavaScript sports team management and stat tracking application,
 
 - **Frontend**: Pure HTML, JavaScript (ES Modules), Tailwind CSS (CDN).
 - **Backend**: Firebase (Auth, Firestore, Storage).
-- **Hosting**: GitHub Pages (or any static host).
+- **Hosting**: Firebase Hosting (or any static host).
 
 ## Setup & Deployment
 
@@ -40,7 +40,7 @@ A static HTML + JavaScript sports team management and stat tracking application,
    - On Firebase Hosting, primary config can also come from `/__/firebase/init.json`.
 
 Notes:
-- Auth domains must include your GitHub Pages host and local dev (e.g., `localhost`, `127.0.0.1`, `pauljsnider.github.io`, custom domain).
+- Auth domains must include your hosting domains and local dev (e.g., `localhost`, `127.0.0.1`, `allplays.ai`, `game-flow-c6311.web.app`).
 - Email summaries are mailto-only; there is no backend email send.
 - AI match summary in `track.html` requires Firebase AI enabled/billing; hide it if disabled.
 
@@ -68,12 +68,20 @@ Stripe should send checkout events to:
 
 Only verified `checkout.session.completed` events with paid status create or update team entitlements at `teams/{teamId}/entitlements/{seasonId}_team-pass`.
 
-### 2. GitHub Pages Deployment
+### 2. Deployment
 
-1. Push this repository to GitHub.
-2. Go to **Settings > Pages**.
-3. Select the **Source** as `main` branch (or `gh-pages`) and folder `/` (root).
-4. Save. Your site will be live at `https://<username>.github.io/<repo-name>/`.
+Production deploys run automatically from `.github/workflows/deploy-prod.yml` on every push to `master`: the workflow stages the site bundle (legacy root plus the React app under `/app/`) and deploys Firebase Hosting, Firestore rules/indexes, and Functions to the `game-flow-c6311` project.
+
+To deploy manually:
+
+```bash
+npm run app:build
+node scripts/stage-pages-bundle.mjs /tmp/allplays-site
+node scripts/write-firebase-hosting-config.mjs /tmp/allplays-site /tmp/firebase-prod.json
+npx firebase-tools deploy --only hosting --project game-flow-c6311 --config /tmp/firebase-prod.json
+```
+
+See `FIREBASE-HOSTING-MIGRATION.md` for the GitHub Pages → Firebase Hosting cutover runbook.
 
 ### 3. Local Development
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -10234,6 +10234,7 @@ exports.notifyPracticePacketAssigned = functions.firestore
 function writePublicRsvpCors(req, res) {
   const allowedOrigins = new Set([
     'https://allplays.ai',
+    'https://www.allplays.ai',
     'https://game-flow-c6311.web.app',
     'https://game-flow-c6311.firebaseapp.com',
     'http://localhost:8000',

--- a/functions/index.js
+++ b/functions/index.js
@@ -10234,7 +10234,8 @@ exports.notifyPracticePacketAssigned = functions.firestore
 function writePublicRsvpCors(req, res) {
   const allowedOrigins = new Set([
     'https://allplays.ai',
-    'https://pauljsnider.github.io',
+    'https://game-flow-c6311.web.app',
+    'https://game-flow-c6311.firebaseapp.com',
     'http://localhost:8000',
     'http://127.0.0.1:8000',
     'http://localhost:8004',

--- a/password-reset.md
+++ b/password-reset.md
@@ -52,7 +52,7 @@ Added `actionCodeSettings` to configure the reset flow:
 export function resetPassword(email) {
     const actionCodeSettings = {
         // URL to redirect back to after password reset
-        url: 'https://pauljsnider.github.io/allplays/reset-password.html',
+        url: 'https://allplays.ai/reset-password.html',
         handleCodeInApp: true
     };
 
@@ -129,7 +129,7 @@ These manual steps must be completed in Firebase Console:
    - **From name**: "ALL PLAYS"
    - **Reply-to email**: Your support email
    - **Subject**: "Reset Your ALL PLAYS Password"
-   - **Action URL**: `https://pauljsnider.github.io/allplays/__/auth/action`
+   - **Action URL**: `https://allplays.ai/__/auth/action`
 4. Save changes
 
 ### B. Add Authorized Domains
@@ -138,8 +138,8 @@ These manual steps must be completed in Firebase Console:
 2. Ensure these are added:
    - `localhost` (for development)
    - `127.0.0.1` (for development)
-   - `pauljsnider.github.io` (production)
-   - Any custom domain you use
+   - `allplays.ai` (production)
+   - `game-flow-c6311.web.app` / `game-flow-c6311.firebaseapp.com` (Firebase Hosting defaults)
 
 ### C. Verify Authentication Provider
 

--- a/tests/unit/public-rsvp-cors-origins.test.js
+++ b/tests/unit/public-rsvp-cors-origins.test.js
@@ -9,8 +9,9 @@ function extractAllowedOrigins(functionsSource) {
     expect(start, 'Expected writePublicRsvpCors to exist in functions/index.js').toBeGreaterThanOrEqual(0);
 
     const setStart = functionsSource.indexOf('new Set([', start);
-    const setEnd = functionsSource.indexOf('])', setStart);
     expect(setStart, 'Expected an allowedOrigins Set literal in writePublicRsvpCors').toBeGreaterThan(start);
+    const setEnd = functionsSource.indexOf('])', setStart);
+    expect(setEnd, 'Expected closing ]) for the allowedOrigins Set literal').toBeGreaterThan(setStart);
 
     const literal = functionsSource.slice(setStart + 'new Set(['.length, setEnd);
     return literal
@@ -24,6 +25,7 @@ describe('public RSVP CORS origins', () => {
 
     it('allows the production domain and Firebase Hosting default domains', () => {
         expect(origins).toContain('https://allplays.ai');
+        expect(origins).toContain('https://www.allplays.ai');
         expect(origins).toContain('https://game-flow-c6311.web.app');
         expect(origins).toContain('https://game-flow-c6311.firebaseapp.com');
     });

--- a/tests/unit/public-rsvp-cors-origins.test.js
+++ b/tests/unit/public-rsvp-cors-origins.test.js
@@ -23,7 +23,7 @@ function extractAllowedOrigins(functionsSource) {
 describe('public RSVP CORS origins', () => {
     const origins = extractAllowedOrigins(source);
 
-    it('allows the production domain and Firebase Hosting default domains', () => {
+    it('allows the production domains and Firebase Hosting default domains', () => {
         expect(origins).toContain('https://allplays.ai');
         expect(origins).toContain('https://www.allplays.ai');
         expect(origins).toContain('https://game-flow-c6311.web.app');

--- a/tests/unit/public-rsvp-cors-origins.test.js
+++ b/tests/unit/public-rsvp-cors-origins.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const source = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
+
+function extractAllowedOrigins(functionsSource) {
+    const start = functionsSource.indexOf('function writePublicRsvpCors(');
+    expect(start, 'Expected writePublicRsvpCors to exist in functions/index.js').toBeGreaterThanOrEqual(0);
+
+    const setStart = functionsSource.indexOf('new Set([', start);
+    const setEnd = functionsSource.indexOf('])', setStart);
+    expect(setStart, 'Expected an allowedOrigins Set literal in writePublicRsvpCors').toBeGreaterThan(start);
+
+    const literal = functionsSource.slice(setStart + 'new Set(['.length, setEnd);
+    return literal
+        .split(',')
+        .map((entry) => entry.trim().replace(/^['"]|['"]$/g, ''))
+        .filter(Boolean);
+}
+
+describe('public RSVP CORS origins', () => {
+    const origins = extractAllowedOrigins(source);
+
+    it('allows the production domain and Firebase Hosting default domains', () => {
+        expect(origins).toContain('https://allplays.ai');
+        expect(origins).toContain('https://game-flow-c6311.web.app');
+        expect(origins).toContain('https://game-flow-c6311.firebaseapp.com');
+    });
+
+    it('no longer allows the retired GitHub Pages origin', () => {
+        expect(origins).not.toContain('https://pauljsnider.github.io');
+        expect(source).not.toContain('pauljsnider.github.io');
+    });
+});


### PR DESCRIPTION
## Summary
- Remove the retired `pauljsnider.github.io` origin from the public RSVP CORS allowlist and add the Firebase Hosting default domains (`game-flow-c6311.web.app` / `.firebaseapp.com`)
- Add `FIREBASE-HOSTING-MIGRATION.md`, a runbook for the GitHub Pages → Firebase Hosting DNS cutover and the follow-on steps for making the repo private
- Update `README.md` and `password-reset.md` to reflect Firebase Hosting deployment and `allplays.ai` URLs instead of GitHub Pages
- Add a regression unit test asserting the CORS allowlist contains the production/Firebase domains and no longer references the GitHub Pages origin

Deliberately **not** in this PR (site is still served by GitHub Pages until the DNS cutover): the `CNAME` file and the `app-github-pages.yml` deploy job stay untouched. Post-cutover cleanup is listed in the runbook.

## Test plan
- [x] `npx vitest run tests/unit/public-rsvp-cors-origins.test.js tests/unit/public-rsvp-email-contacts.test.js tests/unit/pages-bundle-staging.test.js` passes
- [x] Full `npm run test:unit:ci` passes locally (3853 passed, 4 skipped)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)