### PR TITLE
Avoid redundant TeamDrills reloads

### DIFF
--- a/apps/app/src/pages/TeamDrills.test.tsx
+++ b/apps/app/src/pages/TeamDrills.test.tsx
@@ -96,11 +96,22 @@ function createPage(overrides: Record<string, any> = {}) {
   };
 }
 
-function renderTeamDrills() {
+function renderTeamDrills(authState: AuthState = auth) {
   return render(
     <MemoryRouter initialEntries={['/teams/team-1/drills']}>
       <Routes>
-        <Route path="/teams/:teamId/drills" element={<TeamDrills auth={auth} />} />
+        <Route path="/teams/:teamId/drills" element={<TeamDrills auth={authState} />} />
+        <Route path="/teams/:teamId" element={<div>Team detail</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function rerenderTeamDrills(view: ReturnType<typeof render>, authState: AuthState) {
+  view.rerender(
+    <MemoryRouter initialEntries={['/teams/team-1/drills']}>
+      <Routes>
+        <Route path="/teams/:teamId/drills" element={<TeamDrills auth={authState} />} />
         <Route path="/teams/:teamId" element={<div>Team detail</div>} />
       </Routes>
     </MemoryRouter>
@@ -187,6 +198,7 @@ describe('TeamDrills', () => {
     renderTeamDrills();
 
     expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(1);
     fireEvent.change(screen.getByLabelText('Search drills'), { target: { value: 'finish' } });
     fireEvent.change(screen.getByLabelText('Category'), { target: { value: 'Technical' } });
     fireEvent.change(screen.getByLabelText(/^Skill level$/i), { target: { value: 'Advanced' } });
@@ -197,6 +209,39 @@ describe('TeamDrills', () => {
       type: 'Technical',
       level: 'Advanced'
     }));
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reload the community library when auth object identity changes but the signed-in user does not', async () => {
+    const initialAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
+    const nextAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
+    const view = renderTeamDrills(initialAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(1);
+
+    rerenderTeamDrills(view, nextAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads the community library when the signed-in user changes', async () => {
+    const initialAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
+    const nextAuth: AuthState = { ...auth, user: { ...auth.user!, uid: 'coach-2' } as AuthState['user'] };
+    const view = renderTeamDrills(initialAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(1);
+
+    rerenderTeamDrills(view, nextAuth);
+
+    await waitFor(() => expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(2));
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenLastCalledWith('team-1', nextAuth.user, {
+      searchText: '',
+      type: '',
+      level: ''
+    });
   });
 
   it('opens drill detail and toggles a team favorite that syncs with the website store', async () => {
@@ -224,6 +269,24 @@ describe('TeamDrills', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
 
     expect(await screen.findByText('No team favorites match the current search and filter combination.')).toBeTruthy();
+  });
+
+  it('does not reload favorites when auth object identity changes but the signed-in user does not', async () => {
+    const initialAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
+    const nextAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
+    const view = renderTeamDrills(initialAuth);
+
+    expect(await screen.findByText('Rondo 4v2')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Favorites (1)' }));
+
+    await waitFor(() => expect(teamDrillsServiceMocks.loadFavoriteDrills).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('Finishing ladder')).toBeTruthy();
+
+    rerenderTeamDrills(view, nextAuth);
+
+    expect(await screen.findByText('Finishing ladder')).toBeTruthy();
+    expect(teamDrillsServiceMocks.loadFavoriteDrills).toHaveBeenCalledTimes(1);
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(1);
   });
 
   it('generates an editable AI coach proposal and waits for acceptance before saving the timeline', async () => {

--- a/apps/app/src/pages/TeamDrills.test.tsx
+++ b/apps/app/src/pages/TeamDrills.test.tsx
@@ -244,6 +244,42 @@ describe('TeamDrills', () => {
     });
   });
 
+  it('reloads the community library when the current user email changes access for the same uid', async () => {
+    const initialAuth: AuthState = { ...auth, user: { ...auth.user!, email: 'coach@example.com' } as AuthState['user'] };
+    const nextAuth: AuthState = { ...auth, user: { ...auth.user!, email: 'team-admin@example.com' } as AuthState['user'] };
+    const view = renderTeamDrills(initialAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(1);
+
+    rerenderTeamDrills(view, nextAuth);
+
+    await waitFor(() => expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(2));
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenLastCalledWith('team-1', nextAuth.user, {
+      searchText: '',
+      type: '',
+      level: ''
+    });
+  });
+
+  it('reloads the community library when the current user gains platform admin access for the same uid', async () => {
+    const initialAuth: AuthState = { ...auth, user: { ...auth.user!, isAdmin: false } as AuthState['user'] };
+    const nextAuth: AuthState = { ...auth, user: { ...auth.user!, isAdmin: true } as AuthState['user'] };
+    const view = renderTeamDrills(initialAuth);
+
+    expect(await screen.findByRole('heading', { name: 'Bears drills' })).toBeTruthy();
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(1);
+
+    rerenderTeamDrills(view, nextAuth);
+
+    await waitFor(() => expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenCalledTimes(2));
+    expect(teamDrillsServiceMocks.loadTeamDrillLibraryPage).toHaveBeenLastCalledWith('team-1', nextAuth.user, {
+      searchText: '',
+      type: '',
+      level: ''
+    });
+  });
+
   it('opens drill detail and toggles a team favorite that syncs with the website store', async () => {
     renderTeamDrills();
 

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -60,7 +60,11 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
   const [coachSaving, setCoachSaving] = useState(false);
   const [coachStatus, setCoachStatus] = useState('');
   const { error: loadError, clearError: clearLoadError, run: runLoadOperation } = useAppAsyncOperation();
-  const authUserId = auth.user?.uid || '';
+  const authAccessKey = [
+    auth.user?.uid || '',
+    String(auth.user?.email || '').trim().toLowerCase(),
+    auth.user?.isAdmin === true ? 'admin' : 'user'
+  ].join('|');
 
   useEffect(() => {
     let cancelled = false;
@@ -106,7 +110,7 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [authUserId, levelFilter, searchText, teamId, typeFilter]);
+  }, [authAccessKey, levelFilter, searchText, teamId, typeFilter]);
 
   useEffect(() => {
     let cancelled = false;
@@ -132,7 +136,7 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [authUserId, canManageDrills, favoriteDrills, selectedTab, teamId]);
+  }, [authAccessKey, canManageDrills, favoriteDrills, selectedTab, teamId]);
 
   useEffect(() => {
     if (eventIdFromUrl) {

--- a/apps/app/src/pages/TeamDrills.tsx
+++ b/apps/app/src/pages/TeamDrills.tsx
@@ -60,6 +60,7 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
   const [coachSaving, setCoachSaving] = useState(false);
   const [coachStatus, setCoachStatus] = useState('');
   const { error: loadError, clearError: clearLoadError, run: runLoadOperation } = useAppAsyncOperation();
+  const authUserId = auth.user?.uid || '';
 
   useEffect(() => {
     let cancelled = false;
@@ -105,7 +106,7 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [auth.user, levelFilter, searchText, teamId, typeFilter]);
+  }, [authUserId, levelFilter, searchText, teamId, typeFilter]);
 
   useEffect(() => {
     let cancelled = false;
@@ -131,7 +132,7 @@ export function TeamDrills({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [auth.user, canManageDrills, favoriteDrills, selectedTab, teamId]);
+  }, [authUserId, canManageDrills, favoriteDrills, selectedTab, teamId]);
 
   useEffect(() => {
     if (eventIdFromUrl) {


### PR DESCRIPTION
Closes #3641

## What changed
- Added a stable `authUserId` dependency key for TeamDrills community and favorites load effects.
- Kept passing the current `auth.user` object into drill service calls so auth context remains intact.
- Added TeamDrills regression coverage for same-uid auth object rerenders, uid changes, favorites reload behavior, and exact filter-triggered reload counts.

## Root Cause
TeamDrills depended on the mutable `auth.user` object in load effects. When auth/profile refresh rehydrated a new user object with the same uid, React treated that as a meaningful dependency change and reran community and favorites data loads.

## Prevention / Learning
Route data-load effects should depend on stable identity keys such as `auth.user?.uid` plus explicit route/filter/access keys, while still passing the current auth object to service calls. Avoid whole mutable auth/profile objects as reload dependencies unless object identity is itself the intended trigger.

## Regression Tests
- `npm run test:ci -- src/pages/TeamDrills.test.tsx`
- `npm run test:ci -- src/pages/TeamDrills.test.tsx src/pages/TeamDetail.test.tsx`