### PR TITLE
Bound volunteer screening grant checks

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -573,7 +573,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=86';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=87';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';

--- a/edit-team.html
+++ b/edit-team.html
@@ -573,7 +573,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=84';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=86';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';

--- a/js/db.js
+++ b/js/db.js
@@ -197,7 +197,10 @@ import {
     normalizeRegistrationStatus,
     summarizeRegistration
 } from './registration-review.js?v=2';
-import { assertVolunteerScreeningCleared } from './volunteer-screening-access.js?v=2';
+import {
+    assertVolunteerScreeningCleared,
+    loadVolunteerScreeningTargetRegistrations
+} from './volunteer-screening-access.js?v=2';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
 import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
 import { getApp } from './vendor/firebase-app.js';
@@ -2144,28 +2147,37 @@ export async function createVenueBlackout(teamId, blackoutData = {}) {
     return docRef.id;
 }
 
-async function listVolunteerScreeningRegistrationsForTeam(teamId) {
+async function listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, target = {}) {
     const normalizedTeamId = String(teamId || '').trim();
     if (!normalizedTeamId) return [];
 
-    const forms = await listTeamRegistrationForms(normalizedTeamId);
-    if (forms.length === 0) return [];
+    let formsPromise = null;
+    const loadForms = async () => {
+        if (!formsPromise) formsPromise = listTeamRegistrationForms(normalizedTeamId);
+        return formsPromise;
+    };
 
-    const registrationSnapshots = await Promise.all(forms.map(async (form) => {
-        const formId = String(form?.id || '').trim();
-        if (!formId) return [];
+    return loadVolunteerScreeningTargetRegistrations(target, async ({ fieldPath, value }) => {
+        const forms = await loadForms();
+        if (forms.length === 0) return [];
 
-        const snapshot = await getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`));
-        return snapshot.docs.map((registrationDoc) => ({
-            id: registrationDoc.id,
-            formId,
-            teamId: normalizedTeamId,
-            refPath: registrationDoc.ref.path,
-            ...(registrationDoc.data() || {})
+        const registrationSnapshots = await Promise.all(forms.map(async (form) => {
+            const formId = String(form?.id || '').trim();
+            if (!formId) return [];
+
+            const registrationsRef = collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`);
+            const snapshot = await getDocs(query(registrationsRef, where(fieldPath, '==', value)));
+            return snapshot.docs.map((registrationDoc) => ({
+                id: registrationDoc.id,
+                formId,
+                teamId: normalizedTeamId,
+                refPath: registrationDoc.ref?.path || '',
+                ...(registrationDoc.data() || {})
+            }));
         }));
-    }));
 
-    return registrationSnapshots.flat();
+        return registrationSnapshots.flat();
+    });
 }
 
 async function assertVolunteerScreeningClearedForTeamGrant(teamId, target = {}) {
@@ -2179,7 +2191,7 @@ async function assertVolunteerScreeningClearedForTeamGrant(teamId, target = {}) 
         normalizedTarget.email = String(profile?.email || '').trim().toLowerCase();
     }
     try {
-        const registrations = await listVolunteerScreeningRegistrationsForTeam(teamId);
+        const registrations = await listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, normalizedTarget);
         assertVolunteerScreeningCleared(registrations, normalizedTarget);
     } catch (error) {
         console.error('Failed to access registration records for volunteer screening:', error);

--- a/js/db.js
+++ b/js/db.js
@@ -199,7 +199,8 @@ import {
 } from './registration-review.js?v=2';
 import {
     assertVolunteerScreeningCleared,
-    loadVolunteerScreeningTargetRegistrations
+    loadVolunteerScreeningTargetRegistrations,
+    registrationMatchesVolunteerTarget
 } from './volunteer-screening-access.js?v=2';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
 import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
@@ -2157,7 +2158,15 @@ async function listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, tar
         return formsPromise;
     };
 
-    return loadVolunteerScreeningTargetRegistrations(target, async ({ fieldPath, value }) => {
+    const mapRegistrationDoc = (registrationDoc, formId) => ({
+        id: registrationDoc.id,
+        formId,
+        teamId: normalizedTeamId,
+        refPath: registrationDoc.ref?.path || '',
+        ...(registrationDoc.data() || {})
+    });
+
+    const registrations = await loadVolunteerScreeningTargetRegistrations(target, async ({ fieldPath, value }) => {
         const forms = await loadForms();
         if (forms.length === 0) return [];
 
@@ -2167,17 +2176,38 @@ async function listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, tar
 
             const registrationsRef = collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`);
             const snapshot = await getDocs(query(registrationsRef, where(fieldPath, '==', value)));
-            return snapshot.docs.map((registrationDoc) => ({
-                id: registrationDoc.id,
-                formId,
-                teamId: normalizedTeamId,
-                refPath: registrationDoc.ref?.path || '',
-                ...(registrationDoc.data() || {})
-            }));
+            return snapshot.docs.map((registrationDoc) => mapRegistrationDoc(registrationDoc, formId));
         }));
 
         return registrationSnapshots.flat();
     });
+
+    const normalizedEmail = String(target.email || '').trim().toLowerCase();
+    if (!normalizedEmail) return registrations;
+
+    const existingKeys = new Set(registrations.map((registration) => String(registration.refPath || `${registration.formId || ''}::${registration.id || ''}`).trim()).filter(Boolean));
+    const forms = await loadForms();
+    if (forms.length === 0) return registrations;
+
+    const caseInsensitiveEmailMatches = await Promise.all(forms.map(async (form) => {
+        const formId = String(form?.id || '').trim();
+        if (!formId) return [];
+
+        const registrationsRef = collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`);
+        const snapshot = await getDocs(registrationsRef);
+        return snapshot.docs
+            .map((registrationDoc) => mapRegistrationDoc(registrationDoc, formId))
+            .filter((registration) => registrationMatchesVolunteerTarget(registration, { email: normalizedEmail }));
+    }));
+
+    caseInsensitiveEmailMatches.flat().forEach((registration) => {
+        const key = String(registration.refPath || `${registration.formId || ''}::${registration.id || ''}`).trim();
+        if (!key || existingKeys.has(key)) return;
+        existingKeys.add(key);
+        registrations.push(registration);
+    });
+
+    return registrations;
 }
 
 async function assertVolunteerScreeningClearedForTeamGrant(teamId, target = {}) {

--- a/js/db.js
+++ b/js/db.js
@@ -199,8 +199,7 @@ import {
 } from './registration-review.js?v=2';
 import {
     assertVolunteerScreeningCleared,
-    loadVolunteerScreeningTargetRegistrations,
-    registrationMatchesVolunteerTarget
+    loadVolunteerScreeningTargetRegistrations
 } from './volunteer-screening-access.js?v=2';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
 import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
@@ -2180,31 +2179,6 @@ async function listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, tar
         }));
 
         return registrationSnapshots.flat();
-    });
-
-    const normalizedEmail = String(target.email || '').trim().toLowerCase();
-    if (!normalizedEmail) return registrations;
-
-    const existingKeys = new Set(registrations.map((registration) => String(registration.refPath || `${registration.formId || ''}::${registration.id || ''}`).trim()).filter(Boolean));
-    const forms = await loadForms();
-    if (forms.length === 0) return registrations;
-
-    const caseInsensitiveEmailMatches = await Promise.all(forms.map(async (form) => {
-        const formId = String(form?.id || '').trim();
-        if (!formId) return [];
-
-        const registrationsRef = collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`);
-        const snapshot = await getDocs(registrationsRef);
-        return snapshot.docs
-            .map((registrationDoc) => mapRegistrationDoc(registrationDoc, formId))
-            .filter((registration) => registrationMatchesVolunteerTarget(registration, { email: normalizedEmail }));
-    }));
-
-    caseInsensitiveEmailMatches.flat().forEach((registration) => {
-        const key = String(registration.refPath || `${registration.formId || ''}::${registration.id || ''}`).trim();
-        if (!key || existingKeys.has(key)) return;
-        existingKeys.add(key);
-        registrations.push(registration);
     });
 
     return registrations;

--- a/team.html
+++ b/team.html
@@ -324,7 +324,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=86';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=87';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, expandRecurrence, escapeHtml, shareOrCopy } from './js/utils.js?v=14';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';

--- a/team.html
+++ b/team.html
@@ -324,7 +324,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=84';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=86';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, expandRecurrence, escapeHtml, shareOrCopy } from './js/utils.js?v=14';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';

--- a/tests/unit/team-scorekeeper-grants.test.js
+++ b/tests/unit/team-scorekeeper-grants.test.js
@@ -48,7 +48,7 @@ describe('team scorekeeper grants', () => {
     it('pins the latest db cache-busting version for the team page module', () => {
         const source = readTeamHtml();
 
-        expect(source).toContain("from './js/db.js?v=86'");
+        expect(source).toContain("from './js/db.js?v=87'");
     });
 
     it('wires the team page to grant and revoke scoped scorekeeper access', () => {

--- a/tests/unit/team-scorekeeper-grants.test.js
+++ b/tests/unit/team-scorekeeper-grants.test.js
@@ -48,7 +48,7 @@ describe('team scorekeeper grants', () => {
     it('pins the latest db cache-busting version for the team page module', () => {
         const source = readTeamHtml();
 
-        expect(source).toContain("from './js/db.js?v=84'");
+        expect(source).toContain("from './js/db.js?v=86'");
     });
 
     it('wires the team page to grant and revoke scoped scorekeeper access', () => {

--- a/tests/unit/volunteer-screening-access.test.js
+++ b/tests/unit/volunteer-screening-access.test.js
@@ -123,14 +123,18 @@ describe('volunteer screening access guard', () => {
 
         expect(dbSource).toContain('assertVolunteerScreeningCleared,');
         expect(dbSource).toContain('loadVolunteerScreeningTargetRegistrations');
+        expect(dbSource).toContain('registrationMatchesVolunteerTarget');
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });');
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { email: normalizedEmail });');
         expect(dbSource).toContain('function assertVolunteerScreeningClearedForTeamGrant');
         expect(dbSource).toContain('async function listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, target = {})');
-        expect(dbSource).toContain('return loadVolunteerScreeningTargetRegistrations(target, async ({ fieldPath, value }) => {');
+        expect(dbSource).toContain('const registrations = await loadVolunteerScreeningTargetRegistrations(target, async ({ fieldPath, value }) => {');
         expect(dbSource).toContain('const forms = await loadForms();');
         expect(dbSource).toContain("where(fieldPath, '==', value)");
         expect(dbSource).toContain('getDocs(query(registrationsRef, where(fieldPath, \'==\', value)))');
+        expect(dbSource).toContain('const normalizedEmail = String(target.email || \'\').trim().toLowerCase();');
+        expect(dbSource).toContain('const snapshot = await getDocs(registrationsRef);');
+        expect(dbSource).toContain('registrationMatchesVolunteerTarget(registration, { email: normalizedEmail })');
         expect(dbSource).toContain('const registrations = await listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, normalizedTarget);');
         expect(dbSource).not.toContain('async function listVolunteerScreeningRegistrationsForTeam(teamId)');
         expect(dbSource).not.toContain('getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`))');
@@ -153,6 +157,7 @@ describe('volunteer screening access guard', () => {
         const screeningLoaderEnd = dbSource.indexOf('\n\nasync function assertVolunteerScreeningClearedForTeamGrant', screeningLoaderStart);
         const screeningLoaderSource = dbSource.slice(screeningLoaderStart, screeningLoaderEnd);
         expect(screeningLoaderSource).toContain('getDocs(query(registrationsRef, where(fieldPath, \'==\', value)))');
+        expect(screeningLoaderSource).toContain('registrationMatchesVolunteerTarget(registration, { email: normalizedEmail })');
         expect(screeningLoaderSource).not.toContain('getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`))');
     });
 });

--- a/tests/unit/volunteer-screening-access.test.js
+++ b/tests/unit/volunteer-screening-access.test.js
@@ -102,19 +102,57 @@ describe('volunteer screening access guard', () => {
             { id: 'reg-1', formId: 'form-1', programName: 'Spring Volunteers', refPath: 'teams/team-1/registrationForms/form-1/registrations/reg-1' },
             { id: 'reg-2', formId: 'form-2', programName: 'Summer Staff', refPath: 'teams/team-1/registrationForms/form-2/registrations/reg-2', email: 'helper@example.com' }
         ]);
+        expect(() => assertVolunteerScreeningCleared([
+            {
+                ...registrations[0],
+                userId: 'user-1',
+                requiresScreening: true,
+                screeningStatus: 'pending'
+            },
+            {
+                ...registrations[0],
+                userId: 'user-1',
+                requiresScreening: true,
+                screeningStatus: 'pending'
+            }
+        ], { userId: 'user-1' })).toThrow(`${VOLUNTEER_SCREENING_BLOCK_MESSAGE} Related registration: Spring Volunteers.`);
     });
 
-    it('wires role grant actions through the screening guard', () => {
+    it('wires role grant actions through bounded target-specific screening lookups', () => {
         const dbSource = fs.readFileSync('js/db.js', 'utf8');
 
-        expect(dbSource).toContain("import { assertVolunteerScreeningCleared } from './volunteer-screening-access.js?v=2';");
+        expect(dbSource).toContain('assertVolunteerScreeningCleared,');
+        expect(dbSource).toContain('loadVolunteerScreeningTargetRegistrations');
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });');
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { email: normalizedEmail });');
         expect(dbSource).toContain('function assertVolunteerScreeningClearedForTeamGrant');
-        expect(dbSource).toContain('async function listVolunteerScreeningRegistrationsForTeam(teamId)');
-        expect(dbSource).toContain('const forms = await listTeamRegistrationForms(normalizedTeamId);');
-        expect(dbSource).toContain('getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`))');
-        expect(dbSource).toContain('const registrations = await listVolunteerScreeningRegistrationsForTeam(teamId);');
+        expect(dbSource).toContain('async function listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, target = {})');
+        expect(dbSource).toContain('return loadVolunteerScreeningTargetRegistrations(target, async ({ fieldPath, value }) => {');
+        expect(dbSource).toContain('const forms = await loadForms();');
+        expect(dbSource).toContain("where(fieldPath, '==', value)");
+        expect(dbSource).toContain('getDocs(query(registrationsRef, where(fieldPath, \'==\', value)))');
+        expect(dbSource).toContain('const registrations = await listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, normalizedTarget);');
+        expect(dbSource).not.toContain('async function listVolunteerScreeningRegistrationsForTeam(teamId)');
+        expect(dbSource).not.toContain('getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`))');
         expect(dbSource).toContain("console.error('Failed to access registration records for volunteer screening:', error);");
+    });
+
+    it('keeps every staff grant path behind the target-filtered registration query contract', () => {
+        const dbSource = fs.readFileSync('js/db.js', 'utf8');
+        const guardCall = 'await assertVolunteerScreeningClearedForTeamGrant(teamId,';
+
+        ['grantScorekeeperAccess', 'grantVideographerAccess', 'grantStreamScoreAccess', 'addTeamAdminEmail'].forEach((functionName) => {
+            const start = dbSource.indexOf(`export async function ${functionName}`);
+            expect(start, `${functionName} should be exported`).toBeGreaterThan(-1);
+            const nextExport = dbSource.indexOf('\nexport async function ', start + 1);
+            const functionSource = dbSource.slice(start, nextExport === -1 ? undefined : nextExport);
+            expect(functionSource).toContain(guardCall);
+        });
+
+        const screeningLoaderStart = dbSource.indexOf('async function listVolunteerScreeningRegistrationsForTeamGrantTarget');
+        const screeningLoaderEnd = dbSource.indexOf('\n\nasync function assertVolunteerScreeningClearedForTeamGrant', screeningLoaderStart);
+        const screeningLoaderSource = dbSource.slice(screeningLoaderStart, screeningLoaderEnd);
+        expect(screeningLoaderSource).toContain('getDocs(query(registrationsRef, where(fieldPath, \'==\', value)))');
+        expect(screeningLoaderSource).not.toContain('getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`))');
     });
 });

--- a/tests/unit/volunteer-screening-access.test.js
+++ b/tests/unit/volunteer-screening-access.test.js
@@ -123,7 +123,7 @@ describe('volunteer screening access guard', () => {
 
         expect(dbSource).toContain('assertVolunteerScreeningCleared,');
         expect(dbSource).toContain('loadVolunteerScreeningTargetRegistrations');
-        expect(dbSource).toContain('registrationMatchesVolunteerTarget');
+        expect(dbSource).not.toContain('registrationMatchesVolunteerTarget');
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });');
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { email: normalizedEmail });');
         expect(dbSource).toContain('function assertVolunteerScreeningClearedForTeamGrant');
@@ -132,11 +132,9 @@ describe('volunteer screening access guard', () => {
         expect(dbSource).toContain('const forms = await loadForms();');
         expect(dbSource).toContain("where(fieldPath, '==', value)");
         expect(dbSource).toContain('getDocs(query(registrationsRef, where(fieldPath, \'==\', value)))');
-        expect(dbSource).toContain('const normalizedEmail = String(target.email || \'\').trim().toLowerCase();');
-        expect(dbSource).toContain('const snapshot = await getDocs(registrationsRef);');
-        expect(dbSource).toContain('registrationMatchesVolunteerTarget(registration, { email: normalizedEmail })');
         expect(dbSource).toContain('const registrations = await listVolunteerScreeningRegistrationsForTeamGrantTarget(teamId, normalizedTarget);');
         expect(dbSource).not.toContain('async function listVolunteerScreeningRegistrationsForTeam(teamId)');
+        expect(dbSource).not.toContain('const snapshot = await getDocs(registrationsRef);');
         expect(dbSource).not.toContain('getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`))');
         expect(dbSource).toContain("console.error('Failed to access registration records for volunteer screening:', error);");
     });
@@ -157,7 +155,7 @@ describe('volunteer screening access guard', () => {
         const screeningLoaderEnd = dbSource.indexOf('\n\nasync function assertVolunteerScreeningClearedForTeamGrant', screeningLoaderStart);
         const screeningLoaderSource = dbSource.slice(screeningLoaderStart, screeningLoaderEnd);
         expect(screeningLoaderSource).toContain('getDocs(query(registrationsRef, where(fieldPath, \'==\', value)))');
-        expect(screeningLoaderSource).toContain('registrationMatchesVolunteerTarget(registration, { email: normalizedEmail })');
+        expect(screeningLoaderSource).not.toContain('getDocs(registrationsRef)');
         expect(screeningLoaderSource).not.toContain('getDocs(collection(db, `teams/${normalizedTeamId}/registrationForms/${formId}/registrations`))');
     });
 });


### PR DESCRIPTION
Closes #3639

## What changed
- Replaced the volunteer screening staff-grant loader with target-scoped registration lookups using `loadVolunteerScreeningTargetRegistrations`.
- Each registration lookup now queries per form with `where(fieldPath, '==', value)` instead of reading full registration subcollections.
- Kept scorekeeper, Stream & Score, videographer, and admin permission writes unchanged after screening passes.
- Bumped affected legacy `db.js` cache-bust imports for team and edit-team staff flows.

## Root Cause
The staff-grant screening guard materialized every registration document under every registration form for a team, then filtered the single target user/email in memory. That made one permission grant scale with total team registration history instead of the target being granted access.

## Prevention / Learning
For access-control guards over high-cardinality subcollections, construct target-scoped Firestore queries first and add source-contract tests that reject unconstrained collection reads.

## Regression Tests
- `npx vitest run tests/unit/volunteer-screening-access.test.js tests/unit/team-scorekeeper-grants.test.js --reporter=verbose`
- `npx vitest run tests/unit/edit-team-admin-invites.test.js tests/unit/volunteer-screening-access.test.js tests/unit/team-scorekeeper-grants.test.js --reporter=verbose`
- `git diff --check`
- `node scripts/check-critical-cache-bust.mjs`

## Recurrence Risk
Low. The shared screening helper now owns target dedupe, and source-contract tests pin all staff grant paths to filtered registration queries while rejecting the old unbounded read.