### PR TITLE
Fix parent registration search preloads

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -420,6 +420,38 @@ describe('AppSearchDialog', () => {
     expect(navigateMock).toHaveBeenCalledWith('/teams/team-2');
   });
 
+  it('preloads a parent registration detail search result before navigation', async () => {
+    const onClose = vi.fn();
+    searchAppPlayersMock.mockResolvedValueOnce([{
+      id: 'registration:team-1:form-1',
+      kind: 'player',
+      title: 'Spring registration',
+      subtitle: 'Rockets',
+      route: '/parent-tools/registrations/team-1/form-1',
+      teamId: 'team-1',
+      playerId: 'form-1',
+    }]);
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="*" element={<AppSearchDialog auth={auth} open={true} onClose={onClose} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'spring' } });
+    const registrationResult = await screen.findByRole('button', { name: /Spring registration/i });
+    fireEvent.click(registrationResult);
+
+    await waitFor(() => {
+      expect(preloadSearchRouteMock).toHaveBeenCalledWith('/parent-tools/registrations/team-1/form-1');
+    });
+    expect(preloadSearchRouteMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/parent-tools/registrations/team-1/form-1');
+    expect(preloadSearchRouteMock.mock.invocationCallOrder[0]).toBeLessThan(navigateMock.mock.invocationCallOrder[0]);
+  });
+
   it('starts loading accessible teams on open and reuses that warm load for the first query', async () => {
     const onClose = vi.fn();
 

--- a/apps/app/src/lib/searchRoutePreload.test.ts
+++ b/apps/app/src/lib/searchRoutePreload.test.ts
@@ -21,6 +21,21 @@ describe('searchRoutePreload', () => {
     expect(resolveSearchRoutePreloader('/help/parent-fees')).toBeTypeOf('function');
   });
 
+  it('preloads protected parent registration details with the registration detail loader', async () => {
+    const registrationDetailPreloader = resolveSearchRoutePreloader('/registration');
+    const parentToolsPreloader = resolveSearchRoutePreloader('/parent-tools');
+
+    expect(resolveSearchRoutePreloader('/parent-tools/registrations/team-1/form-1')).toBe(registrationDetailPreloader);
+    expect(resolveSearchRoutePreloader('/parent-tools/registrations/team-1/form-1')).not.toBe(parentToolsPreloader);
+    await expect(preloadSearchRoute('/parent-tools/registrations/team-1/form-1?source=search')).resolves.toBe(true);
+  });
+
+  it('keeps parent registrations tab routes on the parent tools preloader', () => {
+    const parentToolsPreloader = resolveSearchRoutePreloader('/parent-tools');
+
+    expect(resolveSearchRoutePreloader('/parent-tools/registrations')).toBe(parentToolsPreloader);
+  });
+
   it('does not match unknown routes after normalization', async () => {
     expect(resolveSearchRoutePreloader('/unknown?section=feed')).toBeNull();
     await expect(preloadSearchRoute('/unknown?section=feed')).resolves.toBe(false);

--- a/apps/app/src/lib/searchRoutePreload.test.ts
+++ b/apps/app/src/lib/searchRoutePreload.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   preloadSearchRoute,
   resolveSearchRoutePreloader
 } from './searchRoutePreload';
+
+vi.mock('../pages/Home', () => ({}));
+vi.mock('../pages/RegistrationDetail', () => ({}));
 
 describe('searchRoutePreload', () => {
   it('matches query-string search routes by pathname while preserving navigation routes', async () => {

--- a/apps/app/src/lib/searchRoutePreload.ts
+++ b/apps/app/src/lib/searchRoutePreload.ts
@@ -1,3 +1,6 @@
+const parentToolsPreloader = () => import('../pages/ParentTools');
+const registrationDetailPreloader = () => import('../pages/RegistrationDetail');
+
 const routePreloaders: Array<{ pattern: RegExp; load: () => Promise<unknown> }> = [
   { pattern: /^\/home$/, load: () => import('../pages/Home') },
   { pattern: /^\/schedule$/, load: () => import('../pages/Schedule') },
@@ -9,7 +12,8 @@ const routePreloaders: Array<{ pattern: RegExp; load: () => Promise<unknown> }> 
   { pattern: /^\/teams\/[^/]+\/edit$/, load: () => import('../pages/TeamSettings') },
   { pattern: /^\/teams\/[^/]+\/fees(?:\/[^/]+)?$/, load: () => import('../pages/TeamFees') },
   { pattern: /^\/teams\/[^/]+\/media$/, load: () => import('../pages/TeamMedia') },
-  { pattern: /^\/parent-tools(?:\/[^/]+(?:\/[^/]+\/[^/]+)?)?$/, load: () => import('../pages/ParentTools') },
+  { pattern: /^\/parent-tools\/registrations\/[^/]+\/[^/]+$/, load: registrationDetailPreloader },
+  { pattern: /^\/parent-tools(?:\/[^/]+)?$/, load: parentToolsPreloader },
   { pattern: /^\/players(?:\/[^/]+){1,2}$/, load: () => import('../pages/PlayerDetail') },
   { pattern: /^\/games\/[^/]+$/, load: () => import('../pages/GameDetail') },
   { pattern: /^\/help(?:\/[^/]+)?$/, load: async () => {
@@ -18,7 +22,7 @@ const routePreloaders: Array<{ pattern: RegExp; load: () => Promise<unknown> }> 
   { pattern: /^\/profile$/, load: () => import('../pages/Profile') },
   { pattern: /^\/ai$/, load: () => import('../pages/PrivateAiChat') },
   { pattern: /^\/capabilities\/[^/]+$/, load: () => import('../pages/CapabilityPage') },
-  { pattern: /^\/registration$/, load: () => import('../pages/RegistrationDetail') },
+  { pattern: /^\/registration$/, load: registrationDetailPreloader },
   { pattern: /^\/accept-invite$/, load: () => import('../pages/AcceptInvite') },
   { pattern: /^\/verify-pending$/, load: () => import('../pages/VerifyPending') },
   { pattern: /^\/reset-password$/, load: () => import('../pages/ResetPassword') },


### PR DESCRIPTION
Closes #3640

## What changed
- Added an explicit `/parent-tools/registrations/:teamId/:formId` search-route preloader that uses the existing RegistrationDetail loader.
- Narrowed the generic ParentTools preload matcher to hub and one-segment tab routes only.
- Added regression coverage for loader identity, query-string normalization, tab-route preservation, and AppSearchDialog preload-before-navigation behavior.

## Root Cause
The generic ParentTools preload regex accepted deeper `/parent-tools/...` paths and was ordered before any protected registration-detail route mapping, so `/parent-tools/registrations/:teamId/:formId` warmed the ParentTools hub chunk instead of the RegistrationDetail chunk React renders.

## Prevention / Learning
Route preloader tables need specific deep-route mappings before generic parent mappings, and generic regexes should only match the route shapes rendered by that module.

## Regression Tests
- `npx vitest run src/lib/searchRoutePreload.test.ts src/components/AppSearchDialog.test.tsx --reporter=verbose`
- `apps/app/src/lib/searchRoutePreload.test.ts` verifies protected parent registration detail routes share the `/registration` loader, differ from ParentTools, and still resolve with query strings.
- `apps/app/src/lib/searchRoutePreload.test.ts` verifies `/parent-tools/registrations` remains a ParentTools tab preload.
- `apps/app/src/components/AppSearchDialog.test.tsx` verifies a parent registration detail result calls `preloadSearchRoute` once before navigation.

## Recurrence Risk
Low. The route table now has focused tests for the exact competing route shapes and query normalization path.