### PR TITLE
Lock parent RSVP writes to linked players

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2362,13 +2362,31 @@ service cloud.firestore {
                  playerId.size() > 0 &&
                  rsvpId == request.auth.uid + "__" + playerId;
         }
+        function hasRsvpPlayerScope(data) {
+          return (data.get('playerId', '') is string && data.get('playerId', '').size() > 0) ||
+                 (data.get('childId', '') is string && data.get('childId', '').size() > 0) ||
+                 ('playerIds' in data && data.playerIds is list && data.playerIds.size() > 0);
+        }
         match /rsvps/{rsvpId} {
           // Supports two doc ID patterns for writes by the authenticated user:
           // 1) request.auth.uid (standard parent RSVP)
           // 2) request.auth.uid__{playerId} (coach/player-specific override RSVP)
+          function isOwnBaseRsvpDoc() {
+            return rsvpId == request.auth.uid;
+          }
+          function isOwnLinkedPlayerRsvpDoc() {
+            return rsvpId.matches('^' + request.auth.uid + '__[A-Za-z0-9_-]+$');
+          }
           function isOwnRsvpDoc() {
-            return rsvpId == request.auth.uid ||
-                   rsvpId.matches('^' + request.auth.uid + '__[A-Za-z0-9_-]+$');
+            return isOwnBaseRsvpDoc() || isOwnLinkedPlayerRsvpDoc();
+          }
+          function canWriteOwnParentRsvp(data) {
+            return (isOwnBaseRsvpDoc() &&
+                    isParentForTeam(teamId) &&
+                    (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))) ||
+                   (isOwnLinkedPlayerRsvpDoc() &&
+                    canUseLinkedPlayerRsvp(teamId, data) &&
+                    isOwnLinkedPlayerRsvpId(rsvpId, data));
           }
           function isRsvpStatusPayloadSafe(data) {
             return !data.keys().hasAny([
@@ -2389,16 +2407,12 @@ service cloud.firestore {
                           canUseLinkedPlayerRsvp(teamId, resource.data) &&
                           isOwnLinkedPlayerRsvpId(rsvpId, resource.data));
           allow create, update: if (isTeamOwnerOrAdmin(teamId) ||
-                                    isParentForTeam(teamId) ||
-                                    (canUseLinkedPlayerRsvp(teamId, request.resource.data) &&
-                                     isOwnLinkedPlayerRsvpId(rsvpId, request.resource.data))) &&
+                                    canWriteOwnParentRsvp(request.resource.data)) &&
                                    isSignedIn() && isOwnRsvpDoc() &&
                                    request.resource.data.userId == request.auth.uid &&
                                    isRsvpStatusPayloadSafe(request.resource.data);
           allow delete: if (isTeamOwnerOrAdmin(teamId) ||
-                            isParentForTeam(teamId) ||
-                            (canUseLinkedPlayerRsvp(teamId, resource.data) &&
-                             isOwnLinkedPlayerRsvpId(rsvpId, resource.data))) &&
+                            canWriteOwnParentRsvp(resource.data)) &&
                            isSignedIn() && isOwnRsvpDoc();
         }
 
@@ -2409,9 +2423,33 @@ service cloud.firestore {
                    (rsvpId == request.auth.uid ||
                     rsvpId.matches('^' + request.auth.uid + '__[A-Za-z0-9_-]+$'));
           }
+          function isOwnBaseRsvpNoteId() {
+            return isSignedIn() && rsvpId == request.auth.uid;
+          }
+          function isOwnLinkedPlayerRsvpNoteId() {
+            return isSignedIn() &&
+                   rsvpId.matches('^' + request.auth.uid + '__[A-Za-z0-9_-]+$');
+          }
           function isOwnRsvpNoteDoc(data) {
             return isSignedIn() &&
                    (data.userId == request.auth.uid || isOwnRsvpNoteId());
+          }
+          function canWriteOwnParentRsvpNote(teamId, rsvpId, data) {
+            return ((isOwnBaseRsvpNoteId() &&
+                     isParentForTeam(teamId) &&
+                     (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))) ||
+                    (isOwnLinkedPlayerRsvpNoteId() &&
+                     canUseLinkedPlayerRsvp(teamId, data) &&
+                     isOwnLinkedPlayerRsvpId(rsvpId, data))) &&
+                   data.userId == request.auth.uid &&
+                   isOwnRsvpNoteId();
+          }
+          function canDeleteOwnParentRsvpNote(teamId, rsvpId, data) {
+            return isOwnRsvpNoteDoc(data) &&
+                   (rsvpId == request.auth.uid ||
+                    (isOwnLinkedPlayerRsvpNoteId() &&
+                     canUseLinkedPlayerRsvp(teamId, data) &&
+                     isOwnLinkedPlayerRsvpId(rsvpId, data)));
           }
           function teamAllowsTeamVisibleRsvpNotes(teamId) {
             return get(/databases/$(database)/documents/teams/$(teamId)).data
@@ -2459,15 +2497,11 @@ service cloud.firestore {
           function canWriteRsvpNote(teamId, rsvpId, data) {
             return isRsvpNotePayloadValid(teamId, data) &&
                    (isTeamOwnerOrAdmin(teamId) ||
-                    ((isParentForTeam(teamId) ||
-                      (canUseLinkedPlayerRsvp(teamId, data) &&
-                       isOwnLinkedPlayerRsvpId(rsvpId, data))) &&
-                     data.userId == request.auth.uid &&
-                     isOwnRsvpNoteId()));
+                    canWriteOwnParentRsvpNote(teamId, rsvpId, data));
           }
           allow read: if canReadRsvpNote(teamId, resource.data);
           allow create, update: if isSignedIn() && canWriteRsvpNote(teamId, rsvpId, request.resource.data);
-          allow delete: if isTeamOwnerOrAdmin(teamId) || isOwnRsvpNoteDoc(resource.data);
+          allow delete: if isTeamOwnerOrAdmin(teamId) || canDeleteOwnParentRsvpNote(teamId, rsvpId, resource.data);
         }
 
         // Rideshare offers for games/practices.

--- a/firestore.rules
+++ b/firestore.rules
@@ -2362,6 +2362,33 @@ service cloud.firestore {
                  playerId.size() > 0 &&
                  rsvpId == request.auth.uid + "__" + playerId;
         }
+        function rsvpPayloadHasNoDirectPlayerId(data) {
+          return (!('playerId' in data) || data.playerId == null || data.playerId == '') &&
+                 (!('childId' in data) || data.childId == null || data.childId == '');
+        }
+        function isParentForRsvpPlayerAt(teamId, playerIds, index) {
+          return playerIds.size() <= index ||
+                 (playerIds[index] is string &&
+                  playerIds[index].size() > 0 &&
+                  isParentForPlayer(teamId, playerIds[index]));
+        }
+        function canUseGroupedLinkedPlayerRsvp(teamId, data) {
+          let playerIds = data.get('playerIds', []);
+          return playerIds is list &&
+                 playerIds.size() > 0 &&
+                 playerIds.size() <= 10 &&
+                 rsvpPayloadHasNoDirectPlayerId(data) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 0) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 1) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 2) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 3) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 4) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 5) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 6) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 7) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 8) &&
+                 isParentForRsvpPlayerAt(teamId, playerIds, 9);
+        }
         function hasRsvpPlayerScope(data) {
           return (data.get('playerId', '') is string && data.get('playerId', '').size() > 0) ||
                  (data.get('childId', '') is string && data.get('childId', '').size() > 0) ||
@@ -2383,7 +2410,9 @@ service cloud.firestore {
           function canWriteOwnParentRsvp(data) {
             return (isOwnBaseRsvpDoc() &&
                     isParentForTeam(teamId) &&
-                    (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))) ||
+                    (!hasRsvpPlayerScope(data) ||
+                     canUseLinkedPlayerRsvp(teamId, data) ||
+                     canUseGroupedLinkedPlayerRsvp(teamId, data))) ||
                    (isOwnLinkedPlayerRsvpDoc() &&
                     canUseLinkedPlayerRsvp(teamId, data) &&
                     isOwnLinkedPlayerRsvpId(rsvpId, data));
@@ -2437,7 +2466,9 @@ service cloud.firestore {
           function canWriteOwnParentRsvpNote(teamId, rsvpId, data) {
             return ((isOwnBaseRsvpNoteId() &&
                      isParentForTeam(teamId) &&
-                     (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))) ||
+                     (!hasRsvpPlayerScope(data) ||
+                      canUseLinkedPlayerRsvp(teamId, data) ||
+                      canUseGroupedLinkedPlayerRsvp(teamId, data))) ||
                     (isOwnLinkedPlayerRsvpNoteId() &&
                      canUseLinkedPlayerRsvp(teamId, data) &&
                      isOwnLinkedPlayerRsvpId(rsvpId, data))) &&

--- a/tests/unit/rsvp-note-privacy-rules.test.js
+++ b/tests/unit/rsvp-note-privacy-rules.test.js
@@ -44,13 +44,15 @@ describe('RSVP note privacy Firestore rules', () => {
     expect(gamesBlock).toContain('function getRsvpPayloadPlayerId(data)');
     expect(gamesBlock).toContain('function rsvpPayloadMatchesSinglePlayer(data, playerId)');
     expect(gamesBlock).toContain('function canUseLinkedPlayerRsvp(teamId, data)');
+    expect(gamesBlock).toContain('function canUseGroupedLinkedPlayerRsvp(teamId, data)');
     expect(gamesBlock).toContain('function isOwnLinkedPlayerRsvpId(rsvpId, data)');
     expect(gamesBlock).toContain('function hasRsvpPlayerScope(data)');
     expect(gamesBlock).toContain('isParentForPlayer(teamId, playerId)');
+    expect(gamesBlock).toContain('isParentForRsvpPlayerAt(teamId, playerIds, 9)');
     expect(gamesBlock).toContain('rsvpId == request.auth.uid + "__" + playerId');
     expect(rsvpBlock).toContain('canUseLinkedPlayerRsvp(teamId, resource.data)');
     expect(rsvpBlock).toContain('isOwnLinkedPlayerRsvpId(rsvpId, resource.data)');
-    expect(parentWriteFunction).toContain('isOwnBaseRsvpDoc() &&\n                    isParentForTeam(teamId) &&\n                    (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))');
+    expect(parentWriteFunction).toContain('isOwnBaseRsvpDoc() &&\n                    isParentForTeam(teamId) &&\n                    (!hasRsvpPlayerScope(data) ||\n                     canUseLinkedPlayerRsvp(teamId, data) ||\n                     canUseGroupedLinkedPlayerRsvp(teamId, data))');
     expect(parentWriteFunction).toContain('isOwnLinkedPlayerRsvpDoc() &&\n                    canUseLinkedPlayerRsvp(teamId, data) &&\n                    isOwnLinkedPlayerRsvpId(rsvpId, data)');
     expect(rsvpBlock).not.toContain('isParentForTeam(teamId) ||\n                                    (canUseLinkedPlayerRsvp');
     expect(rsvpBlock).not.toContain('isParentForTeam(teamId) ||\n                            (canUseLinkedPlayerRsvp');
@@ -93,8 +95,9 @@ describe('RSVP note privacy Firestore rules', () => {
     expect(noteBlock).toContain("data.visibility in ['admins', 'team']");
     expect(noteBlock).toContain("(data.visibility == 'admins' || teamAllowsTeamVisibleRsvpNotes(teamId))");
     expect(noteBlock).toContain('canUseLinkedPlayerRsvp(teamId, data)');
+    expect(noteBlock).toContain('canUseGroupedLinkedPlayerRsvp(teamId, data)');
     expect(noteBlock).toContain('isOwnLinkedPlayerRsvpId(rsvpId, data)');
-    expect(parentNoteWriteFunction).toContain('isOwnBaseRsvpNoteId() &&\n                     isParentForTeam(teamId) &&\n                     (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))');
+    expect(parentNoteWriteFunction).toContain('isOwnBaseRsvpNoteId() &&\n                     isParentForTeam(teamId) &&\n                     (!hasRsvpPlayerScope(data) ||\n                      canUseLinkedPlayerRsvp(teamId, data) ||\n                      canUseGroupedLinkedPlayerRsvp(teamId, data))');
     expect(parentNoteWriteFunction).toContain('isOwnLinkedPlayerRsvpNoteId() &&\n                     canUseLinkedPlayerRsvp(teamId, data) &&\n                     isOwnLinkedPlayerRsvpId(rsvpId, data)');
     expect(parentNoteWriteFunction).toContain('data.userId == request.auth.uid &&\n                   isOwnRsvpNoteId()');
     expect(noteBlock).not.toContain('data.userId == request.auth.uid &&\n                     isOwnRsvpNoteDoc(data)');
@@ -148,7 +151,7 @@ describe('RSVP note privacy Firestore rules', () => {
           email: 'parent@example.com',
           isAdmin: false,
           parentTeamIds: ['team-1'],
-          parentPlayerKeys: ['team-1::player-a']
+          parentPlayerKeys: ['team-1::player-a', 'team-1::player-c']
         });
         await setDoc(doc(firestore, 'users/owner-1'), {
           email: 'owner@example.com',
@@ -193,6 +196,18 @@ describe('RSVP note privacy Firestore rules', () => {
       };
     }
 
+    function groupedRsvpPayload(playerIds, uid = 'parent-1') {
+      return {
+        userId: uid,
+        displayName: 'Parent One',
+        playerIds,
+        playerId: null,
+        childId: null,
+        response: 'going',
+        respondedAt: now
+      };
+    }
+
     function notePayload(playerId, uid = 'parent-1') {
       return {
         userId: uid,
@@ -200,6 +215,21 @@ describe('RSVP note privacy Firestore rules', () => {
         playerIds: [playerId],
         playerId,
         childId: playerId,
+        response: 'going',
+        note: 'Available',
+        visibility: 'admins',
+        updatedAt: now,
+        respondedAt: now
+      };
+    }
+
+    function groupedNotePayload(playerIds, uid = 'parent-1') {
+      return {
+        userId: uid,
+        displayName: 'Parent One',
+        playerIds,
+        playerId: null,
+        childId: null,
         response: 'going',
         note: 'Available',
         visibility: 'admins',
@@ -234,6 +264,17 @@ describe('RSVP note privacy Firestore rules', () => {
       await assertSucceeds(updateDoc(playerARef, { response: 'maybe' }));
       await assertSucceeds(deleteDoc(playerARef));
       await assertSucceeds(setDoc(baseRsvpRef(parentDb), rsvpPayload('player-a')));
+    });
+
+    it('allows grouped base RSVP and note writes only when every player is linked to the parent', async () => {
+      const parentDb = authedFirestore('parent-1', 'parent@example.com');
+      const linkedPlayers = ['player-a', 'player-c'];
+      const mixedPlayers = ['player-a', 'player-b'];
+
+      await assertSucceeds(setDoc(baseRsvpRef(parentDb), groupedRsvpPayload(linkedPlayers)));
+      await assertSucceeds(setDoc(baseNoteRef(parentDb), groupedNotePayload(linkedPlayers)));
+      await assertFails(setDoc(baseRsvpRef(parentDb), groupedRsvpPayload(mixedPlayers)));
+      await assertFails(setDoc(baseNoteRef(parentDb), groupedNotePayload(mixedPlayers)));
     });
 
     it('denies same-team different-player parent RSVP note create, update, and delete', async () => {

--- a/tests/unit/rsvp-note-privacy-rules.test.js
+++ b/tests/unit/rsvp-note-privacy-rules.test.js
@@ -1,5 +1,11 @@
 import { readFileSync } from 'node:fs';
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment
+} from '@firebase/rules-unit-testing';
+import { deleteDoc, doc, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
 import { extractMatchBlock } from '../../scripts/validate-firebase-rules-ci.mjs';
 
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
@@ -33,17 +39,36 @@ describe('RSVP note privacy Firestore rules', () => {
 
   it('allows linked-player parent RSVP writes only for the matching player-scoped document', () => {
     const rsvpBlock = extractNestedBlock(gamesBlock, 'match /rsvps/{rsvpId} {');
+    const parentWriteFunction = extractNestedBlock(rsvpBlock, 'function canWriteOwnParentRsvp(data) {');
 
     expect(gamesBlock).toContain('function getRsvpPayloadPlayerId(data)');
     expect(gamesBlock).toContain('function rsvpPayloadMatchesSinglePlayer(data, playerId)');
     expect(gamesBlock).toContain('function canUseLinkedPlayerRsvp(teamId, data)');
     expect(gamesBlock).toContain('function isOwnLinkedPlayerRsvpId(rsvpId, data)');
+    expect(gamesBlock).toContain('function hasRsvpPlayerScope(data)');
     expect(gamesBlock).toContain('isParentForPlayer(teamId, playerId)');
     expect(gamesBlock).toContain('rsvpId == request.auth.uid + "__" + playerId');
-    expect(rsvpBlock).toContain('canUseLinkedPlayerRsvp(teamId, request.resource.data)');
-    expect(rsvpBlock).toContain('isOwnLinkedPlayerRsvpId(rsvpId, request.resource.data)');
     expect(rsvpBlock).toContain('canUseLinkedPlayerRsvp(teamId, resource.data)');
     expect(rsvpBlock).toContain('isOwnLinkedPlayerRsvpId(rsvpId, resource.data)');
+    expect(parentWriteFunction).toContain('isOwnBaseRsvpDoc() &&\n                    isParentForTeam(teamId) &&\n                    (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))');
+    expect(parentWriteFunction).toContain('isOwnLinkedPlayerRsvpDoc() &&\n                    canUseLinkedPlayerRsvp(teamId, data) &&\n                    isOwnLinkedPlayerRsvpId(rsvpId, data)');
+    expect(rsvpBlock).not.toContain('isParentForTeam(teamId) ||\n                                    (canUseLinkedPlayerRsvp');
+    expect(rsvpBlock).not.toContain('isParentForTeam(teamId) ||\n                            (canUseLinkedPlayerRsvp');
+  });
+
+  it('denies same-team parents from writing or deleting another player-scoped RSVP doc', () => {
+    const rsvpBlock = extractNestedBlock(gamesBlock, 'match /rsvps/{rsvpId} {');
+    const parentWriteFunction = extractNestedBlock(rsvpBlock, 'function canWriteOwnParentRsvp(data) {');
+    const createUpdateRule = rsvpBlock.match(/allow create, update: if [\s\S]*?;/)?.[0] || '';
+    const deleteRule = rsvpBlock.match(/allow delete: if [\s\S]*?;/)?.[0] || '';
+
+    expect(parentWriteFunction).toContain('isOwnLinkedPlayerRsvpDoc() &&');
+    expect(parentWriteFunction).toContain('canUseLinkedPlayerRsvp(teamId, data)');
+    expect(parentWriteFunction).toContain('isOwnLinkedPlayerRsvpId(rsvpId, data)');
+    expect(createUpdateRule).toContain('canWriteOwnParentRsvp(request.resource.data)');
+    expect(deleteRule).toContain('canWriteOwnParentRsvp(resource.data)');
+    expect(createUpdateRule).not.toContain('isParentForTeam(teamId) ||');
+    expect(deleteRule).not.toContain('isParentForTeam(teamId) ||');
   });
 
   it('restricts note docs to admins, the note owner, or explicit team-visible notes', () => {
@@ -59,16 +84,177 @@ describe('RSVP note privacy Firestore rules', () => {
 
   it('requires an explicit safe RSVP note document shape and writer-owned ID for writes', () => {
     const noteBlock = extractNestedBlock(gamesBlock, 'match /rsvpNotes/{rsvpId} {');
+    const parentNoteWriteFunction = extractNestedBlock(noteBlock, 'function canWriteOwnParentRsvpNote(teamId, rsvpId, data) {');
 
     expect(noteBlock).toContain('function isRsvpNotePayloadValid(teamId, data)');
     expect(noteBlock).toContain('function isOwnRsvpNoteId()');
+    expect(noteBlock).toContain('function canWriteOwnParentRsvpNote(teamId, rsvpId, data)');
     expect(noteBlock).toContain("data.keys().hasAll(['userId', 'note', 'visibility', 'updatedAt'])");
     expect(noteBlock).toContain("data.visibility in ['admins', 'team']");
     expect(noteBlock).toContain("(data.visibility == 'admins' || teamAllowsTeamVisibleRsvpNotes(teamId))");
     expect(noteBlock).toContain('canUseLinkedPlayerRsvp(teamId, data)');
     expect(noteBlock).toContain('isOwnLinkedPlayerRsvpId(rsvpId, data)');
-    expect(noteBlock).toContain('data.userId == request.auth.uid &&\n                     isOwnRsvpNoteId()');
+    expect(parentNoteWriteFunction).toContain('isOwnBaseRsvpNoteId() &&\n                     isParentForTeam(teamId) &&\n                     (!hasRsvpPlayerScope(data) || canUseLinkedPlayerRsvp(teamId, data))');
+    expect(parentNoteWriteFunction).toContain('isOwnLinkedPlayerRsvpNoteId() &&\n                     canUseLinkedPlayerRsvp(teamId, data) &&\n                     isOwnLinkedPlayerRsvpId(rsvpId, data)');
+    expect(parentNoteWriteFunction).toContain('data.userId == request.auth.uid &&\n                   isOwnRsvpNoteId()');
     expect(noteBlock).not.toContain('data.userId == request.auth.uid &&\n                     isOwnRsvpNoteDoc(data)');
     expect(noteBlock).toContain('allow create, update: if isSignedIn() && canWriteRsvpNote(teamId, rsvpId, request.resource.data);');
+  });
+
+  it('requires linked-player ownership for same-team parent RSVP note writes and deletes', () => {
+    const noteBlock = extractNestedBlock(gamesBlock, 'match /rsvpNotes/{rsvpId} {');
+    const parentNoteWriteFunction = extractNestedBlock(noteBlock, 'function canWriteOwnParentRsvpNote(teamId, rsvpId, data) {');
+    const parentNoteDeleteFunction = extractNestedBlock(noteBlock, 'function canDeleteOwnParentRsvpNote(teamId, rsvpId, data) {');
+    const writeFunction = extractNestedBlock(noteBlock, 'function canWriteRsvpNote(teamId, rsvpId, data) {');
+
+    expect(parentNoteWriteFunction).toContain('isOwnLinkedPlayerRsvpNoteId() &&');
+    expect(parentNoteWriteFunction).toContain('canUseLinkedPlayerRsvp(teamId, data)');
+    expect(parentNoteWriteFunction).toContain('isOwnLinkedPlayerRsvpId(rsvpId, data)');
+    expect(parentNoteDeleteFunction).toContain('isOwnLinkedPlayerRsvpNoteId() &&');
+    expect(parentNoteDeleteFunction).toContain('canUseLinkedPlayerRsvp(teamId, data)');
+    expect(parentNoteDeleteFunction).toContain('isOwnLinkedPlayerRsvpId(rsvpId, data)');
+    expect(writeFunction).toContain('canWriteOwnParentRsvpNote(teamId, rsvpId, data)');
+    expect(writeFunction).not.toContain('isParentForTeam(teamId) ||');
+    expect(noteBlock).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || canDeleteOwnParentRsvpNote(teamId, rsvpId, resource.data);');
+  });
+
+  describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('RSVP linked-player rules engine coverage', () => {
+    let testEnv;
+    const now = Timestamp.fromMillis(1710000000000);
+
+    beforeAll(async () => {
+      testEnv = await initializeTestEnvironment({
+        projectId: `allplays-rsvp-linked-player-${Date.now()}`,
+        firestore: {
+          rules
+        }
+      });
+    }, 30000);
+
+    beforeEach(async () => {
+      await testEnv.clearFirestore();
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        const firestore = context.firestore();
+        await setDoc(doc(firestore, 'teams/team-1'), {
+          ownerId: 'owner-1',
+          adminEmails: ['admin@example.com']
+        });
+        await setDoc(doc(firestore, 'teams/team-1/games/game-1'), {
+          teamId: 'team-1',
+          type: 'game',
+          date: '2026-07-09'
+        });
+        await setDoc(doc(firestore, 'users/parent-1'), {
+          email: 'parent@example.com',
+          isAdmin: false,
+          parentTeamIds: ['team-1'],
+          parentPlayerKeys: ['team-1::player-a']
+        });
+        await setDoc(doc(firestore, 'users/owner-1'), {
+          email: 'owner@example.com',
+          isAdmin: false
+        });
+      });
+    });
+
+    afterAll(async () => {
+      await testEnv?.cleanup();
+    });
+
+    function authedFirestore(uid, email = `${uid}@example.com`) {
+      return testEnv.authenticatedContext(uid, { email }).firestore();
+    }
+
+    function rsvpRef(firestore, playerId, uid = 'parent-1') {
+      return doc(firestore, `teams/team-1/games/game-1/rsvps/${uid}__${playerId}`);
+    }
+
+    function baseRsvpRef(firestore, uid = 'parent-1') {
+      return doc(firestore, `teams/team-1/games/game-1/rsvps/${uid}`);
+    }
+
+    function noteRef(firestore, playerId, uid = 'parent-1') {
+      return doc(firestore, `teams/team-1/games/game-1/rsvpNotes/${uid}__${playerId}`);
+    }
+
+    function baseNoteRef(firestore, uid = 'parent-1') {
+      return doc(firestore, `teams/team-1/games/game-1/rsvpNotes/${uid}`);
+    }
+
+    function rsvpPayload(playerId, uid = 'parent-1') {
+      return {
+        userId: uid,
+        displayName: 'Parent One',
+        playerIds: [playerId],
+        playerId,
+        childId: playerId,
+        response: 'going',
+        respondedAt: now
+      };
+    }
+
+    function notePayload(playerId, uid = 'parent-1') {
+      return {
+        userId: uid,
+        displayName: 'Parent One',
+        playerIds: [playerId],
+        playerId,
+        childId: playerId,
+        response: 'going',
+        note: 'Available',
+        visibility: 'admins',
+        updatedAt: now,
+        respondedAt: now
+      };
+    }
+
+    async function seedRsvpDoc(path, data) {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        await setDoc(doc(context.firestore(), path), data);
+      });
+    }
+
+    it('denies same-team different-player parent RSVP create, update, and delete', async () => {
+      const parentDb = authedFirestore('parent-1', 'parent@example.com');
+      const playerBRef = rsvpRef(parentDb, 'player-b');
+
+      await assertFails(setDoc(playerBRef, rsvpPayload('player-b')));
+      await assertFails(setDoc(baseRsvpRef(parentDb), rsvpPayload('player-b')));
+
+      await seedRsvpDoc('teams/team-1/games/game-1/rsvps/parent-1__player-b', rsvpPayload('player-b'));
+      await assertFails(updateDoc(playerBRef, { response: 'not_going' }));
+      await assertFails(deleteDoc(playerBRef));
+    });
+
+    it('allows a parent to create, update, and delete their linked player RSVP', async () => {
+      const parentDb = authedFirestore('parent-1', 'parent@example.com');
+      const playerARef = rsvpRef(parentDb, 'player-a');
+
+      await assertSucceeds(setDoc(playerARef, rsvpPayload('player-a')));
+      await assertSucceeds(updateDoc(playerARef, { response: 'maybe' }));
+      await assertSucceeds(deleteDoc(playerARef));
+      await assertSucceeds(setDoc(baseRsvpRef(parentDb), rsvpPayload('player-a')));
+    });
+
+    it('denies same-team different-player parent RSVP note create, update, and delete', async () => {
+      const parentDb = authedFirestore('parent-1', 'parent@example.com');
+      const playerBNoteRef = noteRef(parentDb, 'player-b');
+
+      await assertFails(setDoc(playerBNoteRef, notePayload('player-b')));
+      await assertFails(setDoc(baseNoteRef(parentDb), notePayload('player-b')));
+
+      await seedRsvpDoc('teams/team-1/games/game-1/rsvpNotes/parent-1__player-b', notePayload('player-b'));
+      await assertFails(updateDoc(playerBNoteRef, { note: 'Still available', updatedAt: now }));
+      await assertFails(deleteDoc(playerBNoteRef));
+    });
+
+    it('keeps team owner writes available for player-scoped RSVP docs and notes', async () => {
+      const ownerDb = authedFirestore('owner-1', 'owner@example.com');
+      const ownerRsvpRef = rsvpRef(ownerDb, 'player-b', 'owner-1');
+      const ownerNoteRef = noteRef(ownerDb, 'player-b', 'owner-1');
+
+      await assertSucceeds(setDoc(ownerRsvpRef, rsvpPayload('player-b', 'owner-1')));
+      await assertSucceeds(setDoc(ownerNoteRef, notePayload('player-b', 'owner-1')));
+    });
   });
 });


### PR DESCRIPTION
Closes #3670

## What changed
- Tightened Firestore RSVP parent write/delete rules so player-scoped RSVP docs require the authenticated parent to be linked to the referenced player.
- Applied the same linked-player boundary to RSVP note create/update/delete paths.
- Preserved base RSVP docs for team parents only when the payload has no player scope or references a linked player.
- Added source guards and Firestore emulator regression coverage for same-team different-player denial, linked-player allow, and owner write allow cases.

## Root Cause
The RSVP and RSVP note rules allowed `isParentForTeam(teamId)` as a standalone authorization branch for writes that carried `playerId`, `childId`, or `playerIds`, so any parent on the team could write or delete documents for another player before the linked-player checks were evaluated.

## Prevention / Learning
Parent/team membership is not sufficient for player-scoped writes. Any rule path that accepts player identifiers must bind the document ID and payload back to `parentPlayerKeys` or an equivalent player-level authorization check.

## Regression Tests
- `npx vitest run tests/unit/rsvp-note-privacy-rules.test.js --reporter=verbose`
- `npm run ci:firebase-rules`
- `npx firebase emulators:exec --only firestore "npx vitest run tests/unit/rsvp-note-privacy-rules.test.js --reporter=verbose"`

## Recurrence Risk
Low. The risky branches now use linked-player helpers, and the regression tests cover denied same-team different-player writes plus allowed linked-player and owner flows.