### PR TITLE
Window schedule list derivation

### DIFF
--- a/apps/app/src/lib/scheduleLogic.test.ts
+++ b/apps/app/src/lib/scheduleLogic.test.ts
@@ -108,6 +108,40 @@ describe('windowed schedule derivation', () => {
     expect(result.entries[0]?.childIds).toEqual(['player-1', 'player-2']);
   });
 
+  it('counts only actionable practice packets across the full filtered source', () => {
+    const now = new Date('2100-06-10T12:00:00.000Z');
+    const result = getWindowedCalendarScheduleEntries([
+      buildParentScheduleEvent({
+        eventKey: 'team-1::completed::player-1::2100-06-11T18:00:00.000Z::practice',
+        id: 'completed',
+        type: 'practice',
+        date: new Date('2100-06-11T18:00:00.000Z'),
+        title: 'Completed packet',
+        practiceHomePacketSummary: '2 drills',
+        practicePacketCompletions: [{ childId: 'player-1', status: 'completed' }]
+      }),
+      buildParentScheduleEvent({
+        eventKey: 'team-1::past::player-1::2100-06-09T06:00:00.000Z::practice',
+        id: 'past',
+        type: 'practice',
+        date: new Date('2100-06-09T06:00:00.000Z'),
+        title: 'Past packet',
+        practiceHomePacketSummary: '1 drill'
+      }),
+      buildParentScheduleEvent({
+        eventKey: 'team-1::ready-hidden::player-1::2100-06-12T18:00:00.000Z::practice',
+        id: 'ready-hidden',
+        type: 'practice',
+        date: new Date('2100-06-12T18:00:00.000Z'),
+        title: 'Ready packet',
+        practiceHomePacketSummary: '3 drills'
+      })
+    ], 1, now);
+
+    expect(result.entries.map((event) => event.id)).toEqual(['past']);
+    expect(result.packetsReady).toBe(1);
+  });
+
   it('orders windowed practice packet rows and reports total, ready, and hasMore metadata', () => {
     const now = new Date('2100-06-10T12:00:00.000Z');
     const ready = buildParentScheduleEvent({

--- a/apps/app/src/lib/scheduleLogic.test.ts
+++ b/apps/app/src/lib/scheduleLogic.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { countOpenScheduleAssignments, getCalendarScheduleEntries, type ParentScheduleEvent } from './scheduleLogic';
+import {
+  countOpenScheduleAssignments,
+  getCalendarScheduleEntries,
+  getWindowedCalendarScheduleEntries,
+  getWindowedPracticePacketRows,
+  type ParentScheduleEvent
+} from './scheduleLogic';
 
 function buildParentScheduleEvent(overrides: Partial<ParentScheduleEvent> = {}): ParentScheduleEvent {
   const assignments = Array.isArray(overrides.assignments) ? overrides.assignments : [];
@@ -57,5 +63,85 @@ describe('schedule open assignment counts', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.openAssignmentCount).toBe(1);
     expect(entries[0]?.childIds).toEqual(['player-1', 'player-2']);
+  });
+});
+
+describe('windowed schedule derivation', () => {
+  it('returns the first grouped schedule entries with total count and hasMore metadata', () => {
+    const events = [
+      buildParentScheduleEvent({
+        eventKey: 'team-1::event-3::player-1::2100-06-03T18:00:00.000Z::game',
+        id: 'event-3',
+        date: new Date('2100-06-03T18:00:00.000Z'),
+        opponent: 'Third'
+      }),
+      buildParentScheduleEvent({
+        eventKey: 'team-1::event-1::player-1::2100-06-01T18:00:00.000Z::game',
+        id: 'event-1',
+        date: new Date('2100-06-01T18:00:00.000Z'),
+        opponent: 'First'
+      }),
+      buildParentScheduleEvent({
+        eventKey: 'team-1::event-1::player-2::2100-06-01T18:00:00.000Z::game',
+        id: 'event-1',
+        date: new Date('2100-06-01T18:00:00.000Z'),
+        childId: 'player-2',
+        childName: 'Sam',
+        opponent: 'First'
+      }),
+      buildParentScheduleEvent({
+        eventKey: 'team-1::practice-2::player-1::2100-06-02T18:00:00.000Z::practice',
+        id: 'practice-2',
+        type: 'practice',
+        date: new Date('2100-06-02T18:00:00.000Z'),
+        title: 'Practice'
+      })
+    ];
+
+    const result = getWindowedCalendarScheduleEntries(events, 2);
+
+    expect(result.totalCount).toBe(3);
+    expect(result.gameCount).toBe(2);
+    expect(result.practiceCount).toBe(1);
+    expect(result.hasMore).toBe(true);
+    expect(result.entries.map((event) => event.id)).toEqual(['event-1', 'practice-2']);
+    expect(result.entries[0]?.childIds).toEqual(['player-1', 'player-2']);
+  });
+
+  it('orders windowed practice packet rows and reports total, ready, and hasMore metadata', () => {
+    const now = new Date('2100-06-10T12:00:00.000Z');
+    const ready = buildParentScheduleEvent({
+      eventKey: 'team-1::ready::player-1::2100-06-11T18:00:00.000Z::practice',
+      id: 'ready',
+      type: 'practice',
+      date: new Date('2100-06-11T18:00:00.000Z'),
+      title: 'Ready packet',
+      practiceHomePacketSummary: '3 drills'
+    });
+    const completed = buildParentScheduleEvent({
+      eventKey: 'team-1::completed::player-1::2100-06-12T18:00:00.000Z::practice',
+      id: 'completed',
+      type: 'practice',
+      date: new Date('2100-06-12T18:00:00.000Z'),
+      title: 'Completed packet',
+      practiceHomePacketSummary: '2 drills',
+      practicePacketCompletions: [{ childId: 'player-1', status: 'completed' }]
+    });
+    const past = buildParentScheduleEvent({
+      eventKey: 'team-1::past::player-1::2100-06-09T06:00:00.000Z::practice',
+      id: 'past',
+      type: 'practice',
+      date: new Date('2100-06-09T06:00:00.000Z'),
+      title: 'Past packet',
+      practiceHomePacketSummary: '1 drill'
+    });
+
+    const result = getWindowedPracticePacketRows([past, completed, ready], 2, now);
+
+    expect(result.totalCount).toBe(3);
+    expect(result.readyCount).toBe(1);
+    expect(result.hasMore).toBe(true);
+    expect(result.rows.map((row) => row.event.id)).toEqual(['ready', 'completed']);
+    expect(result.rows.map((row) => row.status)).toEqual(['ready', 'completed']);
   });
 });

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -267,6 +267,25 @@ export type PracticePacketScheduleRow = {
   status: 'ready' | 'completed' | 'past';
 };
 
+export type WindowedCalendarScheduleEntries = {
+  entries: CalendarScheduleEntry[];
+  totalCount: number;
+  gameCount: number;
+  practiceCount: number;
+  hasMore: boolean;
+  nextEvent: CalendarScheduleEntry | null;
+  packetsReady: number;
+  openAssignments: number;
+  rideRequests: number;
+};
+
+export type WindowedPracticePacketRows = {
+  rows: PracticePacketScheduleRow[];
+  totalCount: number;
+  readyCount: number;
+  hasMore: boolean;
+};
+
 export type ParentScheduleFilterOptions = {
   filter: ParentScheduleFilter;
   playerId?: string;
@@ -1166,10 +1185,68 @@ export function getPracticePacketRows(events: ParentScheduleEvent[], now = new D
     });
 }
 
+function normalizeWindowLimit(limit: number) {
+  if (!Number.isFinite(limit)) return 0;
+  return Math.max(0, Math.floor(limit));
+}
+
+function getScheduleEventGroupingKey(event: ParentScheduleEvent) {
+  return `${event.teamId}::${event.id}::${event.date.toISOString()}::${event.type}`;
+}
+
+function buildPracticePacketRow(event: ParentScheduleEvent, cutoff: Date): PracticePacketScheduleRow {
+  const completedChildIds = (Array.isArray(event.practicePacketCompletions) ? event.practicePacketCompletions : [])
+    .filter((completion) => completion.status === 'completed')
+    .map((completion) => String(completion.childId || '').trim())
+    .filter(Boolean);
+  const isCompletedForChild = completedChildIds.includes(event.childId);
+  const status: PracticePacketScheduleRow['status'] = isCompletedForChild ? 'completed' : event.date < cutoff ? 'past' : 'ready';
+  return {
+    event,
+    completedChildIds,
+    isCompletedForChild,
+    needsAction: status === 'ready',
+    status
+  };
+}
+
+export function getWindowedPracticePacketRows(events: ParentScheduleEvent[], limit: number, now = new Date()): WindowedPracticePacketRows {
+  const normalizedLimit = normalizeWindowLimit(limit);
+  const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+  const packets = (Array.isArray(events) ? events : [])
+    .reduce<Array<{ event: ParentScheduleEvent; status: PracticePacketScheduleRow['status']; index: number }>>((packetList, event) => {
+      if (event.type !== 'practice' || !event.practiceHomePacketSummary) return packetList;
+      const completedChildIds = (Array.isArray(event.practicePacketCompletions) ? event.practicePacketCompletions : [])
+        .filter((completion) => completion.status === 'completed')
+        .map((completion) => String(completion.childId || '').trim())
+        .filter(Boolean);
+      const status: PracticePacketScheduleRow['status'] = completedChildIds.includes(event.childId) ? 'completed' : event.date < cutoff ? 'past' : 'ready';
+      packetList.push({ event, status, index: packetList.length });
+      return packetList;
+    }, [])
+    .sort((a, b) => {
+      const statusOrder: Record<PracticePacketScheduleRow['status'], number> = { ready: 0, completed: 1, past: 2 };
+      const statusDelta = statusOrder[a.status] - statusOrder[b.status];
+      if (statusDelta !== 0) return statusDelta;
+      const dateDelta = a.event.date.getTime() - b.event.date.getTime();
+      return dateDelta !== 0 ? dateDelta : a.index - b.index;
+    });
+
+  const totalCount = packets.length;
+  const readyCount = packets.reduce((count, packet) => count + (packet.status === 'ready' ? 1 : 0), 0);
+
+  return {
+    rows: packets.slice(0, normalizedLimit).map((packet) => buildPracticePacketRow(packet.event, cutoff)),
+    totalCount,
+    readyCount,
+    hasMore: totalCount > normalizedLimit
+  };
+}
+
 export function getCalendarScheduleEntries(events: ParentScheduleEvent[]): CalendarScheduleEntry[] {
   const byKey = new Map<string, CalendarScheduleEntry>();
   events.forEach((event) => {
-    const key = `${event.teamId}::${event.id}::${event.date.toISOString()}::${event.type}`;
+    const key = getScheduleEventGroupingKey(event);
     if (!byKey.has(key)) {
       byKey.set(key, {
         ...event,
@@ -1198,6 +1275,88 @@ export function getCalendarScheduleEntries(events: ParentScheduleEvent[]): Calen
   });
 
   return [...byKey.values()].sort((a, b) => a.date.getTime() - b.date.getTime());
+}
+
+export function getWindowedCalendarScheduleEntries(events: ParentScheduleEvent[], limit: number): WindowedCalendarScheduleEntries {
+  const normalizedLimit = normalizeWindowLimit(limit);
+  const sourceEvents = Array.isArray(events) ? events : [];
+  const byKey = new Map<string, { key: string; event: ParentScheduleEvent; index: number }>();
+
+  sourceEvents.forEach((event) => {
+    const key = getScheduleEventGroupingKey(event);
+    if (!byKey.has(key)) {
+      byKey.set(key, { key, event, index: byKey.size });
+    }
+  });
+
+  const sortedGroups = [...byKey.values()].sort((a, b) => {
+    const dateDelta = a.event.date.getTime() - b.event.date.getTime();
+    return dateDelta !== 0 ? dateDelta : a.index - b.index;
+  });
+  const totalCount = sortedGroups.length;
+  const windowKeys = new Set(sortedGroups.slice(0, normalizedLimit).map((group) => group.key));
+  const windowEntries = new Map<string, CalendarScheduleEntry>();
+  let nextEvent: CalendarScheduleEntry | null = null;
+  let gameCount = 0;
+  let practiceCount = 0;
+  let packetsReady = 0;
+  let openAssignments = 0;
+  let rideRequests = 0;
+
+  sortedGroups.forEach((group) => {
+    if (group.event.type === 'game') gameCount += 1;
+    if (group.event.type === 'practice') practiceCount += 1;
+    if (!nextEvent && !group.event.isCancelled) {
+      nextEvent = {
+        ...group.event,
+        childIds: [],
+        childNames: [],
+        childRsvps: []
+      };
+    }
+    if (group.event.type === 'practice' && group.event.practiceHomePacketSummary) packetsReady += 1;
+    openAssignments += getEventOpenAssignmentCount(group.event);
+    rideRequests += group.event.rideshareSummary?.requests || 0;
+    if (windowKeys.has(group.key)) {
+      windowEntries.set(group.key, {
+        ...group.event,
+        childIds: [],
+        childNames: [],
+        childRsvps: []
+      });
+    }
+  });
+
+  sourceEvents.forEach((event) => {
+    const entry = windowEntries.get(getScheduleEventGroupingKey(event));
+    if (!entry) return;
+    if (event.childId && !entry.childIds.includes(event.childId)) {
+      entry.childIds.push(event.childId);
+    }
+    if (event.childName && !entry.childNames.includes(event.childName)) {
+      entry.childNames.push(event.childName);
+    }
+    if (event.childId && !entry.childRsvps.some((child) => child.childId === event.childId)) {
+      entry.childRsvps.push({
+        childId: event.childId,
+        childName: event.childName,
+        myRsvp: normalizeRsvpResponse(event.myRsvp)
+      });
+    }
+    entry.openAssignmentCount = getEventOpenAssignmentCount(entry);
+  });
+
+  return {
+    entries: sortedGroups.slice(0, normalizedLimit).map((group) => windowEntries.get(group.key)).filter((entry): entry is CalendarScheduleEntry => Boolean(entry)),
+    totalCount,
+    gameCount,
+    practiceCount,
+    hasMore: totalCount > normalizedLimit,
+    nextEvent,
+    packetsReady,
+    openAssignments,
+    rideRequests
+  };
 }
 
 function formatIcsDate(date: Date) {

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -1277,9 +1277,10 @@ export function getCalendarScheduleEntries(events: ParentScheduleEvent[]): Calen
   return [...byKey.values()].sort((a, b) => a.date.getTime() - b.date.getTime());
 }
 
-export function getWindowedCalendarScheduleEntries(events: ParentScheduleEvent[], limit: number): WindowedCalendarScheduleEntries {
+export function getWindowedCalendarScheduleEntries(events: ParentScheduleEvent[], limit: number, now = new Date()): WindowedCalendarScheduleEntries {
   const normalizedLimit = normalizeWindowLimit(limit);
   const sourceEvents = Array.isArray(events) ? events : [];
+  const packetCutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
   const byKey = new Map<string, { key: string; event: ParentScheduleEvent; index: number }>();
 
   sourceEvents.forEach((event) => {
@@ -1299,7 +1300,11 @@ export function getWindowedCalendarScheduleEntries(events: ParentScheduleEvent[]
   let nextEvent: CalendarScheduleEntry | null = null;
   let gameCount = 0;
   let practiceCount = 0;
-  let packetsReady = 0;
+  const packetsReady = sourceEvents.reduce((count, event) => (
+    event.type === 'practice' && event.practiceHomePacketSummary && buildPracticePacketRow(event, packetCutoff).needsAction
+      ? count + 1
+      : count
+  ), 0);
   let openAssignments = 0;
   let rideRequests = 0;
 
@@ -1314,7 +1319,6 @@ export function getWindowedCalendarScheduleEntries(events: ParentScheduleEvent[]
         childRsvps: []
       };
     }
-    if (group.event.type === 'practice' && group.event.practiceHomePacketSummary) packetsReady += 1;
     openAssignments += getEventOpenAssignmentCount(group.event);
     rideRequests += group.event.rideshareSummary?.requests || 0;
     if (windowKeys.has(group.key)) {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -574,13 +574,22 @@ describe('Schedule', () => {
       children: [
         { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
       ],
-      events: Array.from({ length: 21 }, (_, index) => buildScheduleEvent(index + 1))
+      events: Array.from({ length: 21 }, (_, index) => buildScheduleEvent(index + 1, {
+        opponent: `Rivals ${index + 1}`
+      }))
     });
 
     renderSchedule();
 
     expect(await screen.findByText('Showing 20 of 21 events')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Show 1 more' })).toBeTruthy();
+    expect(screen.getAllByText('vs. Rivals 20').length).toBeGreaterThan(0);
+    expect(screen.queryAllByText('vs. Rivals 21')).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show 1 more' }));
+
+    expect((await screen.findAllByText('vs. Rivals 21')).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Show 1 more' })).toBeNull();
   });
 
   it('paginates practice packet rows while keeping the all-packet summary count', async () => {
@@ -1015,8 +1024,8 @@ describe('Schedule', () => {
   it('keeps list pagination props in sync with the parent schedule view', () => {
     const source = readFileSync(resolveAppSourcePath('src/pages/Schedule.tsx'), 'utf8');
 
-    expect(source).toContain('function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }');
-    expect(source).toContain('function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }');
+    expect(source).toContain('function ScheduleList({ events, totalCount, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }');
+    expect(source).toContain('function CompactScheduleList({ events, totalCount, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }');
     expect(source).toContain("{loadingMore ? 'Loading more…' : `Show ${Math.min(pageSize, remainingCount || pageSize)} more`}");
   });
 

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -498,6 +498,41 @@ describe('Schedule', () => {
     expect(queueLinks).toContain('/schedule/team-1/event-2?childId=player-1&section=rideshare');
   });
 
+  it('keeps the desktop parent queue backed by actions beyond the current list window', async () => {
+    shellLayoutMocks.isDesktopWeb = true;
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: Array.from({ length: 22 }, (_, index) => buildScheduleEvent(index + 1, {
+        myRsvp: 'going',
+        assignments: index === 21 ? [{ role: 'Snack bar', value: '', claimable: true }] : []
+      }))
+    });
+
+    renderSchedule();
+
+    expect(await screen.findByText('Showing 20 of 22 events')).toBeTruthy();
+    expect(screen.getByText('1 open assignment')).toBeTruthy();
+  });
+
+  it('counts only actionable packets in non-packet schedule summaries', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildPracticePacketEvent(1, {
+          practicePacketCompletions: [{ childId: 'player-1', status: 'completed' }]
+        })
+      ]
+    });
+
+    renderSchedule();
+
+    expect(await screen.findByText('1 event · 0 RSVP · 0 packets')).toBeTruthy();
+  });
+
   it('reuses cached open assignment counts across schedule summaries and view changes', async () => {
     shellLayoutMocks.isDesktopWeb = true;
     const assignments = [

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -26,7 +26,8 @@ import {
   getGenericEventDetailPath,
   getParentScheduleTeamOptions,
   getScheduleEventDetailPath,
-  getPracticePacketRows,
+  getWindowedCalendarScheduleEntries,
+  getWindowedPracticePacketRows,
   getScheduleTitle,
   getScheduleTournamentInfo,
   getScheduleMapHref,
@@ -537,15 +538,38 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setVisibleListCount(filter === 'past-all' ? pastListPageSize : upcomingListPageSize);
   }, [filter, selectedPlayerId, selectedTeamId, timeRange, view]);
 
-  const calendarEntries = useMemo(() => getCalendarScheduleEntries(visibleEvents), [visibleEvents]);
-  const listEntries = calendarEntries;
-  const packetRows = useMemo(() => getPracticePacketRows(visibleEvents), [visibleEvents]);
-  const canLoadMorePastHistory = filter === 'past-all' && (pastHistoryHasMore || visibleListCount < listEntries.length);
-  const canLoadMorePacketRows = (filter === 'past-all' && pastHistoryHasMore) || visibleListCount < packetRows.length;
+  const listWindowLimit = visibleListCount + 1;
+  const calendarEntries = useMemo(() => (
+    view === 'calendar' ? getCalendarScheduleEntries(visibleEvents) : []
+  ), [visibleEvents, view]);
+  const windowedListEntries = useMemo(() => (
+    view === 'calendar'
+      ? {
+          entries: calendarEntries,
+          totalCount: calendarEntries.length,
+          gameCount: calendarEntries.filter((event) => event.type === 'game').length,
+          practiceCount: calendarEntries.filter((event) => event.type === 'practice').length,
+          hasMore: false,
+          nextEvent: calendarEntries.find((event) => !event.isCancelled) || null,
+          packetsReady: calendarEntries.filter((event) => event.type === 'practice' && event.practiceHomePacketSummary).length,
+          openAssignments: calendarEntries.reduce((total, event) => total + getEventOpenAssignmentCount(event), 0),
+          rideRequests: calendarEntries.reduce((total, event) => total + (event.rideshareSummary?.requests || 0), 0)
+        }
+      : getWindowedCalendarScheduleEntries(visibleEvents, listWindowLimit)
+  ), [calendarEntries, listWindowLimit, visibleEvents, view]);
+  const listEntries = windowedListEntries.entries;
+  const packetWindow = useMemo(() => (
+    view === 'packets'
+      ? getWindowedPracticePacketRows(visibleEvents, listWindowLimit)
+      : { rows: [], totalCount: 0, readyCount: 0, hasMore: false }
+  ), [listWindowLimit, visibleEvents, view]);
+  const packetRows = packetWindow.rows;
+  const canLoadMorePastHistory = filter === 'past-all' && (pastHistoryHasMore || visibleListCount < windowedListEntries.totalCount);
+  const canLoadMorePacketRows = (filter === 'past-all' && pastHistoryHasMore) || visibleListCount < packetWindow.totalCount;
 
   const handleShowMore = async () => {
-    if (visibleListCount < listEntries.length) {
-      setVisibleListCount((current) => Math.min(current + listPageSize, listEntries.length));
+    if (visibleListCount < windowedListEntries.totalCount) {
+      setVisibleListCount((current) => Math.min(current + listPageSize, windowedListEntries.totalCount));
       return;
     }
     if (filter !== 'past-all' || !pastHistoryHasMore || loadingPastHistory) {
@@ -557,8 +581,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
   };
   const handleShowMorePackets = async () => {
-    if (visibleListCount < packetRows.length) {
-      setVisibleListCount((current) => Math.min(current + listPageSize, packetRows.length));
+    if (visibleListCount < packetWindow.totalCount) {
+      setVisibleListCount((current) => Math.min(current + listPageSize, packetWindow.totalCount));
       return;
     }
     if (filter !== 'past-all' || !pastHistoryHasMore || loadingPastHistory) {
@@ -581,13 +605,19 @@ export function Schedule({ auth }: { auth: AuthState }) {
   }, [calendarEntries, selectedDay]);
 
   const counts = useMemo(() => ({
-    total: listEntries.length,
-    games: listEntries.filter((event) => event.type === 'game').length,
-    practices: listEntries.filter((event) => event.type === 'practice').length,
+    total: windowedListEntries.totalCount,
+    games: windowedListEntries.gameCount,
+    practices: windowedListEntries.practiceCount,
     rsvpNeeded: visibleEvents.filter((event) => parentLinkedPlayerIds.has(event.childId) && event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded').length,
-    packetsReady: packetRows.filter((row) => row.needsAction).length
-  }), [listEntries, packetRows, parentLinkedPlayerIds, visibleEvents]);
-  const webInsights = useMemo(() => buildScheduleWebInsights(listEntries), [listEntries]);
+    packetsReady: view === 'packets' ? packetWindow.readyCount : windowedListEntries.packetsReady
+  }), [packetWindow.readyCount, parentLinkedPlayerIds, view, visibleEvents, windowedListEntries.gameCount, windowedListEntries.packetsReady, windowedListEntries.practiceCount, windowedListEntries.totalCount]);
+  const webInsights = useMemo(() => ({
+    nextEvent: windowedListEntries.nextEvent,
+    rsvpNeeded: counts.rsvpNeeded,
+    packetsReady: counts.packetsReady,
+    openAssignments: windowedListEntries.openAssignments,
+    rideRequests: windowedListEntries.rideRequests
+  }), [counts.packetsReady, counts.rsvpNeeded, windowedListEntries.nextEvent, windowedListEntries.openAssignments, windowedListEntries.rideRequests]);
   const manageableTeamOptions = useMemo(() => (
     teamOptions.filter((team) => events.some((event) => event.teamId === team.teamId && event.isTeamStaff === true))
   ), [events, teamOptions]);
@@ -1506,6 +1536,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
           ) : view === 'packets' ? (
             <PracticePacketsPanel
               rows={packetRows}
+              totalCount={packetWindow.totalCount}
+              readyCount={packetWindow.readyCount}
               visibleCount={visibleListCount}
               pageSize={listPageSize}
               canShowMore={canLoadMorePacketRows}
@@ -1515,9 +1547,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
           ) : view === 'compact' ? (
             <CompactScheduleList
               events={listEntries}
+              totalCount={windowedListEntries.totalCount}
               visibleCount={visibleListCount}
               pageSize={listPageSize}
-              canShowMore={canLoadMorePastHistory || visibleListCount < listEntries.length}
+              canShowMore={canLoadMorePastHistory || visibleListCount < windowedListEntries.totalCount}
               loadingMore={filter === 'past-all' && loadingPastHistory}
               preferGameHubForStaff={!isDesktopWeb}
               onShowMore={handleShowMore}
@@ -1525,9 +1558,10 @@ export function Schedule({ auth }: { auth: AuthState }) {
           ) : (
             <ScheduleList
               events={listEntries}
+              totalCount={windowedListEntries.totalCount}
               visibleCount={visibleListCount}
               pageSize={listPageSize}
-              canShowMore={canLoadMorePastHistory || visibleListCount < listEntries.length}
+              canShowMore={canLoadMorePastHistory || visibleListCount < windowedListEntries.totalCount}
               loadingMore={filter === 'past-all' && loadingPastHistory}
               preferGameHubForStaff={!isDesktopWeb}
               onShowMore={handleShowMore}
@@ -2304,23 +2338,6 @@ type ScheduleWebInsights = {
   rideRequests: number;
 };
 
-function buildScheduleWebInsights(events: Array<ParentScheduleEvent | CalendarScheduleEntry>): ScheduleWebInsights {
-  return events.reduce<ScheduleWebInsights>((insights, event) => {
-    if (!insights.nextEvent && !event.isCancelled) insights.nextEvent = event;
-    if (event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded') insights.rsvpNeeded += 1;
-    if (event.type === 'practice' && event.practiceHomePacketSummary) insights.packetsReady += 1;
-    insights.openAssignments += getEventOpenAssignmentCount(event);
-    insights.rideRequests += event.rideshareSummary?.requests || 0;
-    return insights;
-  }, {
-    nextEvent: null,
-    rsvpNeeded: 0,
-    packetsReady: 0,
-    openAssignments: 0,
-    rideRequests: 0
-  });
-}
-
 function ScheduleNextUpCard({ event, preferGameHubForStaff }: { event: ParentScheduleEvent | null; preferGameHubForStaff: boolean }) {
   if (!event) {
     return (
@@ -2603,8 +2620,9 @@ function LoadingSchedule() {
   return <SchedulePageSkeleton />;
 }
 
-function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }: {
+function ScheduleList({ events, totalCount, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }: {
   events: CalendarScheduleEntry[];
+  totalCount: number;
   visibleCount: number;
   pageSize: number;
   canShowMore: boolean;
@@ -2612,7 +2630,7 @@ function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore
   preferGameHubForStaff: boolean;
   onShowMore: () => void;
 }) {
-  if (!events.length) {
+  if (!totalCount) {
     return (
       <div className="app-card p-8 text-center">
         <CalendarDays className="mx-auto h-10 w-10 text-gray-300" aria-hidden="true" />
@@ -2623,7 +2641,7 @@ function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore
   }
 
   const renderedEvents = events.slice(0, visibleCount);
-  const remainingCount = Math.max(events.length - renderedEvents.length, 0);
+  const remainingCount = Math.max(totalCount - renderedEvents.length, 0);
 
   return (
     <div className="space-y-3">
@@ -2635,7 +2653,7 @@ function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore
       {canShowMore ? (
         <div className="rounded-xl border border-gray-200 bg-white p-3 text-center shadow-sm">
           <div className="text-xs font-bold text-gray-500">
-            Showing {renderedEvents.length} of {events.length} events
+            Showing {renderedEvents.length} of {totalCount} events
           </div>
           <button type="button" className="secondary-button mt-2 min-h-9 px-3 py-2 text-xs" onClick={onShowMore} disabled={loadingMore}>
             {loadingMore ? 'Loading more…' : `Show ${Math.min(pageSize, remainingCount || pageSize)} more`}
@@ -2646,8 +2664,9 @@ function ScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore
   );
 }
 
-function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }: {
+function CompactScheduleList({ events, totalCount, visibleCount, pageSize, canShowMore, loadingMore, preferGameHubForStaff, onShowMore }: {
   events: CalendarScheduleEntry[];
+  totalCount: number;
   visibleCount: number;
   pageSize: number;
   canShowMore: boolean;
@@ -2655,7 +2674,7 @@ function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, load
   preferGameHubForStaff: boolean;
   onShowMore: () => void;
 }) {
-  if (!events.length) {
+  if (!totalCount) {
     return (
       <div className="app-card p-8 text-center">
         <CalendarDays className="mx-auto h-10 w-10 text-gray-300" aria-hidden="true" />
@@ -2666,7 +2685,7 @@ function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, load
   }
 
   const renderedEvents = events.slice(0, visibleCount);
-  const remainingCount = Math.max(events.length - renderedEvents.length, 0);
+  const remainingCount = Math.max(totalCount - renderedEvents.length, 0);
 
   return (
     <section className="space-y-3">
@@ -2702,7 +2721,7 @@ function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, load
       {canShowMore ? (
         <div className="rounded-xl border border-gray-200 bg-white p-3 text-center shadow-sm">
           <div className="text-xs font-bold text-gray-500">
-            Showing {renderedEvents.length} of {events.length} events
+            Showing {renderedEvents.length} of {totalCount} events
           </div>
           <button type="button" className="secondary-button mt-2 min-h-9 px-3 py-2 text-xs" onClick={onShowMore} disabled={loadingMore}>
             {loadingMore ? 'Loading more…' : `Show ${Math.min(pageSize, remainingCount || pageSize)} more`}
@@ -2713,15 +2732,17 @@ function CompactScheduleList({ events, visibleCount, pageSize, canShowMore, load
   );
 }
 
-function PracticePacketsPanel({ rows, visibleCount, pageSize, canShowMore, loadingMore, onShowMore }: {
+function PracticePacketsPanel({ rows, totalCount, readyCount, visibleCount, pageSize, canShowMore, loadingMore, onShowMore }: {
   rows: PracticePacketScheduleRow[];
+  totalCount: number;
+  readyCount: number;
   visibleCount: number;
   pageSize: number;
   canShowMore: boolean;
   loadingMore: boolean;
   onShowMore: () => void;
 }) {
-  if (!rows.length) {
+  if (!totalCount) {
     return (
       <div className="app-card p-8 text-center">
         <ClipboardCheck className="mx-auto h-10 w-10 text-gray-300" aria-hidden="true" />
@@ -2731,9 +2752,8 @@ function PracticePacketsPanel({ rows, visibleCount, pageSize, canShowMore, loadi
     );
   }
 
-  const readyCount = rows.filter((row) => row.needsAction).length;
   const renderedRows = rows.slice(0, visibleCount);
-  const remainingCount = Math.max(rows.length - renderedRows.length, 0);
+  const remainingCount = Math.max(totalCount - renderedRows.length, 0);
 
   return (
     <section className="space-y-3">
@@ -2771,7 +2791,7 @@ function PracticePacketsPanel({ rows, visibleCount, pageSize, canShowMore, loadi
       {canShowMore ? (
         <div className="rounded-xl border border-gray-200 bg-white p-3 text-center shadow-sm">
           <div className="text-xs font-bold text-gray-500">
-            Showing {renderedRows.length} of {rows.length} packets
+            Showing {renderedRows.length} of {totalCount} packets
           </div>
           <button type="button" className="secondary-button mt-2 min-h-9 px-3 py-2 text-xs" onClick={onShowMore} disabled={loadingMore}>
             {loadingMore ? 'Loading more…' : `Show ${Math.min(pageSize, remainingCount || pageSize)} more`}

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -542,6 +542,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const calendarEntries = useMemo(() => (
     view === 'calendar' ? getCalendarScheduleEntries(visibleEvents) : []
   ), [visibleEvents, view]);
+  const packetWindow = useMemo(() => (
+    getWindowedPracticePacketRows(visibleEvents, view === 'packets' ? listWindowLimit : 0)
+  ), [listWindowLimit, visibleEvents, view]);
   const windowedListEntries = useMemo(() => (
     view === 'calendar'
       ? {
@@ -551,18 +554,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
           practiceCount: calendarEntries.filter((event) => event.type === 'practice').length,
           hasMore: false,
           nextEvent: calendarEntries.find((event) => !event.isCancelled) || null,
-          packetsReady: calendarEntries.filter((event) => event.type === 'practice' && event.practiceHomePacketSummary).length,
+          packetsReady: packetWindow.readyCount,
           openAssignments: calendarEntries.reduce((total, event) => total + getEventOpenAssignmentCount(event), 0),
           rideRequests: calendarEntries.reduce((total, event) => total + (event.rideshareSummary?.requests || 0), 0)
         }
       : getWindowedCalendarScheduleEntries(visibleEvents, listWindowLimit)
-  ), [calendarEntries, listWindowLimit, visibleEvents, view]);
+  ), [calendarEntries, listWindowLimit, packetWindow.readyCount, visibleEvents, view]);
   const listEntries = windowedListEntries.entries;
-  const packetWindow = useMemo(() => (
-    view === 'packets'
-      ? getWindowedPracticePacketRows(visibleEvents, listWindowLimit)
-      : { rows: [], totalCount: 0, readyCount: 0, hasMore: false }
-  ), [listWindowLimit, visibleEvents, view]);
   const packetRows = packetWindow.rows;
   const canLoadMorePastHistory = filter === 'past-all' && (pastHistoryHasMore || visibleListCount < windowedListEntries.totalCount);
   const canLoadMorePacketRows = (filter === 'past-all' && pastHistoryHasMore) || visibleListCount < packetWindow.totalCount;
@@ -609,8 +607,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
     games: windowedListEntries.gameCount,
     practices: windowedListEntries.practiceCount,
     rsvpNeeded: visibleEvents.filter((event) => parentLinkedPlayerIds.has(event.childId) && event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded').length,
-    packetsReady: view === 'packets' ? packetWindow.readyCount : windowedListEntries.packetsReady
-  }), [packetWindow.readyCount, parentLinkedPlayerIds, view, visibleEvents, windowedListEntries.gameCount, windowedListEntries.packetsReady, windowedListEntries.practiceCount, windowedListEntries.totalCount]);
+    packetsReady: packetWindow.readyCount
+  }), [packetWindow.readyCount, parentLinkedPlayerIds, visibleEvents, windowedListEntries.gameCount, windowedListEntries.practiceCount, windowedListEntries.totalCount]);
   const webInsights = useMemo(() => ({
     nextEvent: windowedListEntries.nextEvent,
     rsvpNeeded: counts.rsvpNeeded,
@@ -1500,7 +1498,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
                 setTimeRange('all');
               }}
             />
-            <ScheduleActionQueue events={listEntries} />
+            <ScheduleActionQueue events={visibleEvents} />
           </aside>
         ) : null}
 


### PR DESCRIPTION
Closes #3671

## What changed
- Added windowed schedule-entry and practice-packet derivation helpers that return visible rows plus total/count metadata.
- Wired non-calendar Schedule views to materialize only the current visible window plus a sentinel while preserving full calendar derivation for calendar view.
- Updated list, compact list, and packet panels to render correct totals from metadata instead of full row arrays.

## Root Cause
Schedule.tsx built full grouped calendar entries and full practice packet rows for every filtered event before deciding whether the active view only needed the first paged list window.

## Prevention / Learning
For high-cardinality app views, split lightweight totals/counts from rendered row object materialization and regression-test first-page window behavior plus hidden-row absence.

## Regression Tests
- `npx vitest run src/lib/scheduleLogic.test.ts src/pages/Schedule.test.tsx --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Low. The paged derivation contract is centralized in focused helpers and covered by helper plus component regression tests.