### PR TITLE
Cap unread notification listener

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -256,6 +256,27 @@ describe('AppShell', () => {
     });
   });
 
+  it('renders 99+ and syncs the bounded native badge count when the unread cap is reached', async () => {
+    subscribeToUnreadNotificationCountMock.mockImplementation((_uid, onCount) => {
+      onCount(100);
+      return vi.fn();
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-unread-badge').textContent).toBe('99+');
+      expect(updateAppIconBadgeMock).toHaveBeenCalledWith(100);
+    });
+    expect(subscribeToNotificationInboxMock).not.toHaveBeenCalled();
+  });
+
   it('does not clear the native app badge while auth is still bootstrapping', async () => {
     render(
       <MemoryRouter initialEntries={['/home']}>

--- a/apps/app/src/lib/notificationInboxService.test.ts
+++ b/apps/app/src/lib/notificationInboxService.test.ts
@@ -39,7 +39,7 @@ describe('notificationInboxService', () => {
         vi.mocked(onSnapshot).mockReturnValue(vi.fn());
     });
 
-    it('subscribes to unread notifications without hydrating inbox items', () => {
+    it('subscribes to unread notifications with a hard count cap without hydrating inbox items', () => {
         const callback = vi.fn();
         vi.mocked(onSnapshot).mockImplementation((_query, onNext) => {
             onNext({ size: 3 } as never);
@@ -50,8 +50,22 @@ describe('notificationInboxService', () => {
 
         expect(collection).toHaveBeenCalledWith(db, 'users/user-123/notificationInbox');
         expect(where).toHaveBeenCalledWith('readAt', '==', null);
-        expect(query).toHaveBeenCalledWith({ kind: 'collection' }, { kind: 'where' });
+        expect(limit).toHaveBeenCalledWith(100);
+        expect(query).toHaveBeenCalledWith({ kind: 'collection' }, { kind: 'where' }, { kind: 'limit' });
         expect(callback).toHaveBeenCalledWith(3);
+    });
+
+    it('reports the capped unread snapshot size so the shell can render 99+', () => {
+        const callback = vi.fn();
+        vi.mocked(onSnapshot).mockImplementation((_query, onNext) => {
+            onNext({ size: 100 } as never);
+            return vi.fn();
+        });
+
+        subscribeToUnreadNotificationCount('user-123', callback);
+
+        expect(limit).toHaveBeenCalledWith(100);
+        expect(callback).toHaveBeenCalledWith(100);
     });
 
     it('does not attach a full inbox fallback when the unread query fails', () => {
@@ -70,12 +84,12 @@ describe('notificationInboxService', () => {
 
         const unsubscribe = subscribeToUnreadNotificationCount('user-123', callback, onError);
 
-        expect(query).toHaveBeenCalledWith(primaryCollection, { kind: 'where' });
+        expect(query).toHaveBeenCalledWith(primaryCollection, { kind: 'where' }, { kind: 'limit' });
         expect(onSnapshot).toHaveBeenCalledTimes(1);
         expect(onSnapshot).toHaveBeenNthCalledWith(1, primaryQuery, expect.any(Function), expect.any(Function));
         expect(collection).toHaveBeenCalledTimes(1);
         expect(orderBy).not.toHaveBeenCalled();
-        expect(limit).not.toHaveBeenCalled();
+        expect(limit).toHaveBeenCalledWith(100);
         expect(callback).not.toHaveBeenCalled();
         expect(onError).toHaveBeenCalledWith(unreadError);
 

--- a/apps/app/src/lib/notificationInboxService.ts
+++ b/apps/app/src/lib/notificationInboxService.ts
@@ -17,6 +17,7 @@ import { createLogger } from './logger';
 
 const logger = createLogger('notification-inbox-service');
 const notificationInboxLimit = 50;
+const unreadNotificationCountLimit = 100;
 
 export type NotificationInboxItem = {
     id: string;
@@ -74,7 +75,8 @@ export function subscribeToUnreadNotificationCount(
 ): () => void {
     const q = query(
         collection(db, `users/${uid}/notificationInbox`),
-        where('readAt', '==', null)
+        where('readAt', '==', null),
+        limit(unreadNotificationCountLimit)
     );
 
     const primaryUnsubscribe = onSnapshot(


### PR DESCRIPTION
Closes #3678

## What changed
- Added a hard `limit(100)` cap to the always-on unread notification count subscription.
- Preserved the existing 50-item limit for the full notification inbox sheet.
- Added regression coverage for the bounded unread query, capped `100` snapshot behavior, `99+` shell rendering, native badge sync, and lazy full-inbox subscription.

## Root Cause
The app shell subscribed to every unread notification document on startup with only `where('readAt', '==', null)`, then used `snapshot.size`, even though the UI and native badge only need zero, exact 1-99, or capped `99+` state.

## Prevention / Learning
Always-on badge/count listeners must be bounded to the highest user-visible threshold. Full-list subscriptions should remain lazy, separately limited, and tied to the surface that actually displays the list.

## Regression Tests
- `npm --prefix apps/app exec vitest run src/lib/notificationInboxService.test.ts src/components/AppShell.test.tsx --reporter=verbose`
- `apps/app/src/lib/notificationInboxService.test.ts` now asserts the unread count query passes `limit(100)` into Firestore `query` and reports a capped snapshot size of `100`.
- `apps/app/src/components/AppShell.test.tsx` now asserts capped unread count renders `99+`, syncs the native badge with the bounded count, and does not subscribe to the full inbox until opened.

## Recurrence Risk
Low. The query shape and app-shell capped-count behavior are now locked by focused tests.