### PR TITLE
Bound chat conversation reads

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -166,6 +166,10 @@ export type ChatInboxLoadOptions = {
   onPreview?: (update: ChatInboxPreviewUpdate) => void;
 };
 
+export type ChatConversationLoadOptions = {
+  activeConversationId?: string | null;
+};
+
 export type ChatSubscribeResult = {
   unsubscribe: () => void;
 };
@@ -985,9 +989,19 @@ export async function loadChatTeamContext(teamId: string, user: AuthUser | null)
   };
 }
 
-export async function loadChatConversations(teamId: string, user: AuthUser, team: Record<string, any>, canModerate: boolean): Promise<ChatConversation[]> {
+export async function loadChatConversations(
+  teamId: string,
+  user: AuthUser,
+  team: Record<string, any>,
+  canModerate: boolean,
+  options: ChatConversationLoadOptions = {}
+): Promise<ChatConversation[]> {
   try {
-    const conversations = await withTimeout(Promise.resolve(getChatConversations(teamId, user, { team, canModerate })), 'Chat conversations load') as ChatConversation[];
+    const conversations = await withTimeout(Promise.resolve(getChatConversations(teamId, user, {
+      team,
+      canModerate,
+      includeConversationId: options.activeConversationId || undefined
+    })), 'Chat conversations load') as ChatConversation[];
     return mapChatConversationRecords(conversations);
   } catch (error) {
     logger.warn('Falling back to default chat conversation.', { error });

--- a/apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx
+++ b/apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx
@@ -60,7 +60,9 @@ describe('useChatTeam', () => {
         expect(screen.getByTestId('can-moderate').textContent).toBe('true');
         expect(screen.getByTestId('selected-conversation').textContent).toBe('staff');
         expect(screen.getByTestId('conversation-count').textContent).toBe('2');
-        expect(loadChatConversations).toHaveBeenCalledWith('team-1', user, { id: 'team-1', name: 'Bears' }, true);
+        expect(loadChatConversations).toHaveBeenCalledWith('team-1', user, { id: 'team-1', name: 'Bears' }, true, {
+            activeConversationId: 'staff'
+        });
     });
 
     it('reloads context when switching teams and falls back to the default conversation', async () => {

--- a/apps/app/src/pages/messages/hooks/useChatTeam.ts
+++ b/apps/app/src/pages/messages/hooks/useChatTeam.ts
@@ -49,7 +49,9 @@ export function useChatTeam({ teamId, user, inboxTeam, preferredConversationId =
         }
 
         try {
-          const loadedConversations = await loadChatConversations(teamId, user, context.team, context.canModerate);
+          const loadedConversations = await loadChatConversations(teamId, user, context.team, context.canModerate, {
+            activeConversationId: nextConversationId
+          });
           if (cancelled) return;
           setConversations(loadedConversations);
           setSelectedConversationId((current: string) => {
@@ -84,10 +86,12 @@ export function useChatTeam({ teamId, user, inboxTeam, preferredConversationId =
 
   const reloadConversations = useCallback(async () => {
     if (!user || !team) return undefined;
-    const loadedConversations = await loadChatConversations(teamId, user, team, canModerate);
+    const loadedConversations = await loadChatConversations(teamId, user, team, canModerate, {
+      activeConversationId: selectedConversationId
+    });
     setConversations(loadedConversations);
     return loadedConversations;
-  }, [canModerate, team, teamId, user]);
+  }, [canModerate, selectedConversationId, team, teamId, user]);
 
   const switchConversation = useCallback((conversationId: string) => {
     if (!conversationId || selectedConversationId === conversationId) return false;

--- a/js/db.js
+++ b/js/db.js
@@ -230,6 +230,7 @@ export { collection, getDocs, deleteDoc, query };
 const limitQuery = limit;
 const startAfterQuery = startAfter;
 const DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE = 24;
+export const DEFAULT_CHAT_CONVERSATION_PAGE_SIZE = 25;
 const CHAT_REACTIONS = [
     { key: 'thumbs_up', emoji: '👍' },
     { key: 'heart', emoji: '❤️' },
@@ -6187,18 +6188,41 @@ function getDefaultTeamChatMessageConstraints(conversationId = DEFAULT_TEAM_CONV
  * Get conversations for a team. The default team-wide channel is virtual and keeps
  * using teams/{teamId}/chatMessages for backwards compatibility.
  */
-export async function getChatConversations(teamId, user = null, { team = null, canModerate = false } = {}) {
+function normalizeChatConversationPageSize(pageSize = DEFAULT_CHAT_CONVERSATION_PAGE_SIZE) {
+    const numericPageSize = Number(pageSize);
+    if (!Number.isFinite(numericPageSize) || numericPageSize <= 0) {
+        return DEFAULT_CHAT_CONVERSATION_PAGE_SIZE;
+    }
+    return Math.min(Math.max(Math.floor(numericPageSize), 1), 100);
+}
+
+function normalizeRequestedChatConversationId(conversationId) {
+    const normalized = String(conversationId || '').trim();
+    if (!normalized || isDefaultTeamConversation(normalized) || normalized.includes('/')) {
+        return '';
+    }
+    return normalized;
+}
+
+export async function getChatConversations(teamId, user = null, {
+    team = null,
+    canModerate = false,
+    pageSize = DEFAULT_CHAT_CONVERSATION_PAGE_SIZE,
+    includeConversationId = '',
+    activeConversationId = ''
+} = {}) {
     const conversationsRef = collection(db, 'teams', teamId, 'chatConversations');
     const normalizedEmail = user?.email ? String(user.email).trim().toLowerCase() : '';
+    const conversationPageSize = normalizeChatConversationPageSize(pageSize);
     const participantQueries = canModerate
-        ? [query(conversationsRef, orderBy('updatedAt', 'desc'))]
+        ? [query(conversationsRef, orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))]
         : [
             ...(user?.uid ? [
-                query(conversationsRef, where('participantIds', 'array-contains', user.uid), orderBy('updatedAt', 'desc')),
-                query(conversationsRef, where('participantIds', 'array-contains', `user:${user.uid}`), orderBy('updatedAt', 'desc'))
+                query(conversationsRef, where('participantIds', 'array-contains', user.uid), orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize)),
+                query(conversationsRef, where('participantIds', 'array-contains', `user:${user.uid}`), orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))
             ] : []),
             ...(normalizedEmail ? [
-                query(conversationsRef, where('participantIds', 'array-contains', `email:${normalizedEmail}`), orderBy('updatedAt', 'desc'))
+                query(conversationsRef, where('participantIds', 'array-contains', `email:${normalizedEmail}`), orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))
             ] : [])
         ];
     const snapshots = participantQueries.length > 0
@@ -6218,7 +6242,19 @@ export async function getChatConversations(teamId, user = null, { team = null, c
         return bTime - aTime;
     });
 
-    return [buildDefaultTeamConversation(team), ...stored];
+    const boundedStored = stored.slice(0, conversationPageSize);
+    const requestedConversationId = normalizeRequestedChatConversationId(includeConversationId || activeConversationId);
+    if (requestedConversationId && !boundedStored.some((conversation) => conversation.id === requestedConversationId)) {
+        const requestedConversationSnap = await getDoc(doc(db, 'teams', teamId, 'chatConversations', requestedConversationId));
+        if (requestedConversationSnap.exists()) {
+            const requestedConversation = { id: requestedConversationSnap.id, ...requestedConversationSnap.data() };
+            if (!user || isUserInConversation(requestedConversation, user, { canModerate })) {
+                boundedStored.push(requestedConversation);
+            }
+        }
+    }
+
+    return [buildDefaultTeamConversation(team), ...boundedStored];
 }
 
 /**

--- a/js/db.js
+++ b/js/db.js
@@ -6245,12 +6245,16 @@ export async function getChatConversations(teamId, user = null, {
     const boundedStored = stored.slice(0, conversationPageSize);
     const requestedConversationId = normalizeRequestedChatConversationId(includeConversationId || activeConversationId);
     if (requestedConversationId && !boundedStored.some((conversation) => conversation.id === requestedConversationId)) {
-        const requestedConversationSnap = await getDoc(doc(db, 'teams', teamId, 'chatConversations', requestedConversationId));
-        if (requestedConversationSnap.exists()) {
-            const requestedConversation = { id: requestedConversationSnap.id, ...requestedConversationSnap.data() };
-            if (!user || isUserInConversation(requestedConversation, user, { canModerate })) {
-                boundedStored.push(requestedConversation);
+        try {
+            const requestedConversationSnap = await getDoc(doc(db, 'teams', teamId, 'chatConversations', requestedConversationId));
+            if (requestedConversationSnap.exists()) {
+                const requestedConversation = { id: requestedConversationSnap.id, ...requestedConversationSnap.data() };
+                if (!user || isUserInConversation(requestedConversation, user, { canModerate })) {
+                    boundedStored.push(requestedConversation);
+                }
             }
+        } catch (error) {
+            console.warn('Ignoring unavailable requested chat conversation.', { teamId, requestedConversationId, error });
         }
     }
 

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,7 +344,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=42';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=84';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=88';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=2';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -497,6 +497,54 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Bring both jerseys.');
     });
 
+    it('renders only the bounded conversation set while selecting an older deep-linked thread', async () => {
+        const recentConversations = Array.from({ length: 24 }, (_, index) => ({
+            id: `recent-${index + 1}`,
+            type: 'group',
+            name: `Recent ${index + 1}`,
+            participantIds: ['user-1'],
+            participantRoles: []
+        }));
+        chatMocks.loadChatConversations.mockResolvedValueOnce([
+            { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
+            ...recentConversations,
+            { id: 'older-deep-link', type: 'direct', name: 'Older direct', participantIds: ['user-1', 'coach-1'], participantRoles: [] }
+        ]);
+        chatMocks.subscribeToTeamChatMessages.mockImplementationOnce((teamId, conversationId, onMessages) => {
+            onMessages([
+                chatMessage({
+                    id: 'older-msg',
+                    text: 'Older thread loaded.',
+                    conversationId,
+                    senderId: 'coach-1',
+                    senderName: 'Coach Jamie'
+                })
+            ], { id: `cursor-${teamId}-${conversationId}` });
+            return { unsubscribe: vi.fn() };
+        });
+
+        const { container } = await renderMessages('/messages/team-1?conversationId=older-deep-link');
+
+        expect(chatMocks.loadChatConversations).toHaveBeenCalledWith(
+            'team-1',
+            auth.user,
+            { id: 'team-1', name: 'Bears', sport: 'Basketball' },
+            true,
+            { activeConversationId: 'older-deep-link' }
+        );
+        expect(chatMocks.subscribeToTeamChatMessages).toHaveBeenLastCalledWith(
+            'team-1',
+            'older-deep-link',
+            expect.any(Function),
+            expect.any(Function)
+        );
+        expect(container.textContent).toContain('Older direct');
+        expect(container.textContent).toContain('Older thread loaded.');
+        await click(container, 'Older direct');
+        expect(container.textContent).toContain('Recent 24');
+        expect(container.textContent).not.toContain('Recent 25');
+    });
+
     it('falls back to the default team conversation when the requested conversation is unavailable', async () => {
         chatMocks.loadChatConversations.mockResolvedValueOnce([
             { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] }

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -978,6 +978,42 @@ describe('React app chat recipient service', () => {
         ]);
     });
 
+    it('requests and returns an active deep-linked conversation when the recent page omits it', async () => {
+        dbMocks.getChatConversations.mockImplementation(async (_teamId, _user, options = {}) => {
+            const recentPage = [
+                { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
+                { id: 'recent-family', type: 'group', name: 'Recent family', participantIds: ['user-1'], updatedAt: new Date('2026-06-19T20:00:00.000Z') }
+            ];
+            if (options.includeConversationId === 'older-deep-link') {
+                return [
+                    ...recentPage,
+                    { id: 'older-deep-link', type: 'direct', name: 'Older direct', participantIds: ['user-1', 'coach-1'], updatedAt: new Date('2026-04-01T12:00:00.000Z') }
+                ];
+            }
+            return recentPage;
+        });
+
+        const { loadChatConversations } = await import('../../apps/app/src/lib/chatService.ts');
+        const conversations = await loadChatConversations(
+            'team-1',
+            { uid: 'user-1', email: 'parent@example.com', roles: [] },
+            { id: 'team-1', name: 'Bears' },
+            false,
+            { activeConversationId: 'older-deep-link' }
+        );
+
+        expect(dbMocks.getChatConversations).toHaveBeenCalledWith('team-1', expect.objectContaining({ uid: 'user-1' }), {
+            team: { id: 'team-1', name: 'Bears' },
+            canModerate: false,
+            includeConversationId: 'older-deep-link'
+        });
+        expect(conversations.map((conversation) => conversation.id)).toEqual([
+            'team',
+            'recent-family',
+            'older-deep-link'
+        ]);
+    });
+
     it('routes selected-member messages into a non-default conversation before posting', async () => {
         const photo = new File(['photo'], 'arrival.jpg', { type: 'image/jpeg' });
         const video = new File(['clip'], 'warmups.mp4', { type: 'video/mp4' });

--- a/tests/unit/messages-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/messages-decomposition-initiative-source-contract.test.js
@@ -40,7 +40,8 @@ describe('Messages decomposition initiative source contract', () => {
         expect(chatWindowSource).not.toMatch(/const\s+\[selectedConversationId\b/);
 
         expect(chatTeamHookSource).toContain('loadChatTeamContext(teamId, user)');
-        expect(chatTeamHookSource).toContain('loadChatConversations(teamId, user, context.team, context.canModerate)');
+        expect(chatTeamHookSource).toContain('loadChatConversations(teamId, user, context.team, context.canModerate, {');
+        expect(chatTeamHookSource).toContain('activeConversationId: nextConversationId');
         expect(chatTeamHookSource).toContain('let cancelled = false;');
         expect(chatTeamHookSource).toContain('return DEFAULT_TEAM_CONVERSATION_ID;');
         expect(chatTeamHookSource).toContain('const switchConversation = useCallback((conversationId: string) => {');

--- a/tests/unit/team-chat-targeted-rules.test.js
+++ b/tests/unit/team-chat-targeted-rules.test.js
@@ -102,6 +102,17 @@ describe('targeted team chat Firestore rules', () => {
         expect(dbSource).toContain('const unreadConstraints = getDefaultTeamChatMessageConstraints(conversationId);');
     });
 
+    it('bounds chat conversation discovery while preserving default and requested conversations', () => {
+        expect(dbSource).toContain('export const DEFAULT_CHAT_CONVERSATION_PAGE_SIZE = 25;');
+        expect(dbSource).toContain("query(conversationsRef, orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))");
+        expect(dbSource).toContain("query(conversationsRef, where('participantIds', 'array-contains', user.uid), orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))");
+        expect(dbSource).toContain("query(conversationsRef, where('participantIds', 'array-contains', `user:${user.uid}`), orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))");
+        expect(dbSource).toContain("query(conversationsRef, where('participantIds', 'array-contains', `email:${normalizedEmail}`), orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))");
+        expect(dbSource).toContain('const boundedStored = stored.slice(0, conversationPageSize);');
+        expect(dbSource).toContain("const requestedConversationSnap = await getDoc(doc(db, 'teams', teamId, 'chatConversations', requestedConversationId));");
+        expect(dbSource).toContain('return [buildDefaultTeamConversation(team), ...boundedStored];');
+    });
+
     it('includes a backfill for fieldless legacy full-team messages before constrained reads ship', () => {
         expect(legacyChatBackfillSource).toContain('function getLegacyFullTeamBackfill(data = {})');
         expect(legacyChatBackfillSource).toContain("String(data.targetType || 'full_team').trim() || 'full_team'");

--- a/tests/unit/team-chat-targeted-rules.test.js
+++ b/tests/unit/team-chat-targeted-rules.test.js
@@ -110,6 +110,8 @@ describe('targeted team chat Firestore rules', () => {
         expect(dbSource).toContain("query(conversationsRef, where('participantIds', 'array-contains', `email:${normalizedEmail}`), orderBy('updatedAt', 'desc'), limitQuery(conversationPageSize))");
         expect(dbSource).toContain('const boundedStored = stored.slice(0, conversationPageSize);');
         expect(dbSource).toContain("const requestedConversationSnap = await getDoc(doc(db, 'teams', teamId, 'chatConversations', requestedConversationId));");
+        expect(dbSource).toContain('} catch (error) {');
+        expect(dbSource).toContain("console.warn('Ignoring unavailable requested chat conversation.', { teamId, requestedConversationId, error });");
         expect(dbSource).toContain('return [buildDefaultTeamConversation(team), ...boundedStored];');
     });
 

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=84';");
+        expect(html).toContain("from './js/db.js?v=88';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {


### PR DESCRIPTION
Closes #3675

## What changed
- Added a deterministic `chatConversations` page size and applied Firestore limits to moderator and member conversation discovery queries.
- Preserved the virtual default team conversation and added explicit by-id inclusion for active/deep-linked conversations outside the recent page.
- Passed the requested conversation id through the app chat service and `useChatTeam` so deep links and newly selected threads remain open without full collection reads.
- Bumped the legacy team chat `db.js` cache-bust import.

## Root Cause
`getChatConversations` ordered `teams/{teamId}/chatConversations` by `updatedAt` but never applied a limit or a direct fetch path for an active conversation. Large teams therefore paid for every conversation read and render before Messages became usable, while deep links depended on the full collection containing the requested id.

## Prevention / Learning
Conversation-list and inbox-style queries must always define bounded cardinality and an explicit selected-record inclusion path. Recent-page reads should not be reused as the only mechanism for opening a known deep link.

## Regression Tests
- `tests/unit/team-chat-targeted-rules.test.js` verifies bounded conversation query construction and default/requested conversation preservation.
- `tests/unit/app-chat-service-recipients.test.js` verifies `loadChatConversations` requests and returns an active conversation omitted from the recent page.
- `tests/unit/app-chat-messages-integration.test.jsx` verifies a bounded conversation set renders while an older deep-linked thread remains selected.
- `apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx` verifies the hook passes the requested active conversation through to the service.

Validation:
- `npx vitest run tests/unit/team-chat-targeted-rules.test.js tests/unit/app-chat-service-recipients.test.js tests/unit/app-chat-messages-integration.test.jsx tests/unit/team-email-drafts.test.js apps/app/src/pages/messages/hooks/__tests__/useChatTeam.test.tsx --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`