### PR TITLE
Lazy-load Team Email sheet

### DIFF
--- a/apps/app/src/pages/Messages.test.ts
+++ b/apps/app/src/pages/Messages.test.ts
@@ -209,8 +209,8 @@ describe('direct thread mount telemetry', () => {
     expect(source).not.toContain('mergeInboxPreview');
   });
 
-  it('keeps Messages email composer dispatches on the shared action creators', () => {
-    const source = readFileSync(resolveAppSourcePath('src/pages/messages/components/ChatWindow.tsx'), 'utf8');
+  it('keeps Team Email composer dispatches on the shared action creators', () => {
+    const source = readFileSync(resolveAppSourcePath('src/pages/messages/components/TeamEmailSheet.tsx'), 'utf8');
 
     expect(source).toContain("import { emailComposerActions, emailReducer, initialEmailComposerState } from '../state/emailReducer';");
     expect(source).toContain("emailDispatch(emailComposerActions.setTemplates(await loadTeamEmailTemplates(teamId)));");

--- a/apps/app/src/pages/messages/components/ChatWindow.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.test.tsx
@@ -87,6 +87,21 @@ describe('Messages ALL PLAYS lazy loading', () => {
     expect(legacyChatServiceSource).not.toContain('firebase-ai');
   });
 
+  it('keeps Team Email reducer and service calls out of the eager ChatWindow imports', () => {
+    const sourcePath = resolveAppSourcePath('src/pages/messages/components/ChatWindow.tsx');
+    const source = readFileSync(sourcePath, 'utf8');
+    const chatServiceImport = source.match(/import \{[\s\S]*?\} from '..\/..\/..\/lib\/chatService';/)?.[0] || '';
+
+    expect(source).toContain("lazy(() => import('./TeamEmailSheet'))");
+    expect(source).not.toContain("from '../state/emailReducer'");
+    expect(chatServiceImport).not.toContain('loadTeamEmailDrafts');
+    expect(chatServiceImport).not.toContain('loadTeamEmailTemplates');
+    expect(chatServiceImport).not.toContain('loadSentTeamEmails');
+    expect(chatServiceImport).not.toContain('saveTeamEmailDraft');
+    expect(chatServiceImport).not.toContain('saveTeamEmailTemplate');
+    expect(chatServiceImport).not.toContain('sendTeamEmailMessage');
+  });
+
   it('loads and calls the AI module only through the lazy answer helper', async () => {
     const input = {
       teamId: 'team-1',

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, memo, useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { ChangeEvent, FormEvent, Suspense, lazy, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import {
   Archive,
@@ -30,23 +30,14 @@ import {
   editTeamChatMessage,
   ensureStaffChatConversation,
   loadChatRecipientOptions,
-  loadSentTeamEmails,
-  loadTeamEmailDrafts,
-  loadTeamEmailTemplates,
   markTeamChatRead,
   muteTeamChat,
   unmuteTeamChat,
-  saveTeamEmailDraft,
-  saveTeamEmailTemplate,
   sendTeamChatMessage,
-  sendTeamEmailMessage,
   toggleTeamChatReaction,
   type ChatAttachment,
   type ChatConversation,
   type ChatMessage,
-  type SentTeamEmail,
-  type TeamEmailDraft,
-  type TeamEmailTemplate,
   type ChatTeam
 } from '../../../lib/chatService';
 import { MessagesPageSkeleton } from '../../../components/PageSkeletons';
@@ -56,7 +47,6 @@ import {
   buildChatAudienceMetadata,
   buildChatMentionSuggestions,
   buildChatViewportSignature,
-  buildEmailAudienceMetadata,
   buildChatMediaShareDetails,
   chatReactions,
   collectThreadMedia,
@@ -98,8 +88,9 @@ import type { sendAllPlaysChatAnswer } from '../../../lib/chatAiService';
 import { useChatSheets } from '../hooks/useChatSheets';
 import { useChatTeam } from '../hooks/useChatTeam';
 import { useChatMessages } from '../hooks/useChatMessages';
-import { emailComposerActions, emailReducer, initialEmailComposerState } from '../state/emailReducer';
 import { Composer } from './ChatComposer';
+
+const LazyTeamEmailSheet = lazy(() => import('./TeamEmailSheet'));
 
 type StatusTone = 'neutral' | 'success' | 'error';
 
@@ -285,6 +276,7 @@ export function ChatWindow({
   const [aiThinking, setAiThinking] = useState(false);
   const [voiceListening, setVoiceListening] = useState(false);
   const [voiceSupported, setVoiceSupported] = useState(() => voiceRecognition.isNativeRuntime() || voiceRecognition.hasBrowserSupport());
+  const [teamEmailSheetRequested, setTeamEmailSheetRequested] = useState(false);
   const {
     showConversationSheet,
     showAudienceSheet,
@@ -305,16 +297,6 @@ export function ChatWindow({
     openEmailSheet: openTeamEmailSheet,
     closeEmailSheet: closeTeamEmailSheet
   } = useChatSheets();
-  const [emailState, emailDispatch] = useReducer(emailReducer, initialEmailComposerState);
-  const [emailSending, setEmailSending] = useState(false);
-  const [emailSavingTemplate, setEmailSavingTemplate] = useState(false);
-  const [emailSavingDraft, setEmailSavingDraft] = useState(false);
-  const [emailLoadingDrafts, setEmailLoadingDrafts] = useState(false);
-  const [emailLoadingHistory, setEmailLoadingHistory] = useState(false);
-  const [emailLoadingTemplates, setEmailLoadingTemplates] = useState(false);
-  const [emailStatus, setEmailStatus] = useState<ChatStatus | null>(null);
-  const [emailHistoryStatus, setEmailHistoryStatus] = useState<ChatStatus | null>(null);
-  const [sentEmails, setSentEmails] = useState<SentTeamEmail[]>([]);
   const [linkDraft, setLinkDraft] = useState('');
   const [reactionMessageId, setReactionMessageId] = useState('');
   const [actionMessageId, setActionMessageId] = useState('');
@@ -341,7 +323,6 @@ export function ChatWindow({
   const recipientOptionsPromiseRef = useRef<Promise<ChatRecipientOption[]> | null>(null);
   const recipientOptionsRequestIdRef = useRef(0);
   const currentTeamIdRef = useRef(teamId);
-  const emailSheetLoadedForTeamRef = useRef<string | null>(null);
   const programmaticScrollRef = useRef(false);
   const mountedRef = useRef(true);
   const scheduledViewportFrameRef = useRef<number | null>(null);
@@ -506,13 +487,6 @@ export function ChatWindow({
     selectedRecipientTarget,
     selectedRecipientIds
   }), [effectiveConversationId, selectedConversation, selectedRecipientIds, selectedRecipientTarget]);
-  const emailAudienceMetadata = useMemo(() => buildEmailAudienceMetadata({
-    selectedConversation,
-    selectedConversationId: effectiveConversationId,
-    selectedRecipientTarget,
-    selectedRecipientIds,
-    recipientOptions
-  }), [effectiveConversationId, recipientOptions, selectedConversation, selectedRecipientIds, selectedRecipientTarget]);
   const audienceSummary = useMemo(() => getAudienceSummaryText(audienceMetadata, recipientOptions), [audienceMetadata, recipientOptions]);
   const mentionSuggestions = useMemo(
     () => buildChatMentionSuggestions(recipientOptions, text, 5, composerCursorPosition),
@@ -736,9 +710,6 @@ export function ChatWindow({
   }, [clearScheduledScrollTimeouts, maybeScrollToLatest]);
 
   useEffect(() => {
-    if (currentTeamIdRef.current !== teamId) {
-      emailSheetLoadedForTeamRef.current = null;
-    }
     currentTeamIdRef.current = teamId;
   }, [teamId]);
 
@@ -1152,172 +1123,11 @@ export function ChatWindow({
     enqueueChatSend(request);
   };
 
-  const reloadSentEmailHistory = async ({ suppressErrorStatus = false } = {}) => {
-    if (!canModerate) return;
-    setEmailLoadingHistory(true);
-    try {
-      setSentEmails(await loadSentTeamEmails(teamId, { limit: 25 }));
-      setEmailHistoryStatus(null);
-    } catch (historyError: any) {
-      if (!suppressErrorStatus) {
-        setEmailHistoryStatus({ tone: 'error', message: historyError?.message || 'Could not load sent email history.' });
-      }
-    } finally {
-      setEmailLoadingHistory(false);
-    }
-  };
-
-  const reloadEmailTemplates = async ({ suppressErrorStatus = false } = {}) => {
-    if (!canModerate) return;
-    setEmailLoadingTemplates(true);
-    try {
-      emailDispatch(emailComposerActions.setTemplates(await loadTeamEmailTemplates(teamId)));
-      if (!suppressErrorStatus) {
-        setEmailStatus(null);
-      }
-    } catch (templateError: any) {
-      if (!suppressErrorStatus) {
-        setEmailStatus({ tone: 'error', message: templateError?.message || 'Could not load team email templates.' });
-      }
-    } finally {
-      setEmailLoadingTemplates(false);
-    }
-  };
-
-  const reloadEmailDrafts = async ({ suppressErrorStatus = false } = {}) => {
-    if (!canModerate) return;
-    setEmailLoadingDrafts(true);
-    try {
-      emailDispatch(emailComposerActions.setDrafts(await loadTeamEmailDrafts(teamId)));
-      if (!suppressErrorStatus) {
-        setEmailStatus(null);
-      }
-    } catch (draftError: any) {
-      if (!suppressErrorStatus) {
-        setEmailStatus({ tone: 'error', message: draftError?.message || 'Could not load saved drafts.' });
-      }
-    } finally {
-      setEmailLoadingDrafts(false);
-    }
-  };
-
   const openEmailSheet = () => {
     if (!canModerate) return;
+    setTeamEmailSheetRequested(true);
     openTeamEmailSheet();
-    emailDispatch(emailComposerActions.updateTemplateName(''));
-    setEmailStatus(null);
-    setEmailHistoryStatus(null);
-    emailDispatch(emailComposerActions.clearSelectedDraft());
     void ensureRecipientOptionsLoaded().catch(() => undefined);
-    if (emailSheetLoadedForTeamRef.current !== teamId) {
-      emailSheetLoadedForTeamRef.current = teamId;
-      void reloadEmailDrafts();
-      void reloadEmailTemplates();
-      void reloadSentEmailHistory();
-    }
-  };
-
-  const handleApplyEmailDraft = (draftId: string) => {
-    const draft = emailState.drafts.find((item) => item.id === draftId);
-    if (!draft) return;
-    if (!isDefaultTeamConversation(effectiveConversationId)) {
-      switchConversation(DEFAULT_TEAM_CONVERSATION_ID);
-    }
-    setSelectedRecipientTarget('individuals');
-    setSelectedRecipientIds(draft.recipientIds);
-    emailDispatch(emailComposerActions.selectDraft(draft.id));
-    setEmailStatus({ tone: 'success', message: `Restored draft “${draft.subject || 'Untitled draft'}”. This replaced the current email composer.` });
-  };
-
-  const handleApplyEmailTemplate = (templateId: string) => {
-    const template = emailState.templates.find((item) => item.id === templateId);
-    if (!template) return;
-    emailDispatch(emailComposerActions.applyTemplate(template.id));
-    setEmailStatus({ tone: 'success', message: `Applied template “${template.name}”.` });
-  };
-
-  const handleSaveEmailTemplate = async () => {
-    if (!canModerate || emailSavingTemplate) return;
-    setEmailSavingTemplate(true);
-    setEmailStatus({ tone: 'neutral', message: 'Saving team email template...' });
-    try {
-      const savedTemplate = await saveTeamEmailTemplate({
-        teamId,
-        name: emailState.templateName,
-        subject: emailState.subject,
-        body: emailState.body
-      });
-      emailDispatch(emailComposerActions.updateTemplateName(''));
-      emailDispatch(emailComposerActions.setTemplates([savedTemplate, ...emailState.templates.filter((item) => item.id !== savedTemplate.id)]));
-      setEmailStatus({ tone: 'success', message: `Saved template “${savedTemplate.name}”.` });
-      void reloadEmailTemplates({ suppressErrorStatus: true });
-    } catch (saveError: any) {
-      setEmailStatus({ tone: 'error', message: saveError?.message || 'Could not save team email template.' });
-    } finally {
-      setEmailSavingTemplate(false);
-    }
-  };
-
-  const handleSaveEmailDraft = async () => {
-    if (!canModerate || emailSavingDraft) return;
-    setEmailSavingDraft(true);
-    setEmailStatus({ tone: 'neutral', message: 'Saving team email draft...' });
-    try {
-      const savedDraft = await saveTeamEmailDraft({
-        teamId,
-        draftId: emailState.selectedDraftId || null,
-        subject: emailState.subject,
-        body: emailState.body,
-        recipientIds: emailAudienceMetadata.recipientIds,
-        recipientOptions,
-        authorId: auth.user?.uid || null,
-        authorEmail: auth.user?.email || null,
-        authorName: profile?.fullName || auth.user?.displayName || null
-      });
-      if (savedDraft?.id) {
-        emailDispatch(emailComposerActions.saveDraft(savedDraft));
-      }
-      setEmailStatus({ tone: 'success', message: `Saved draft “${savedDraft?.subject || emailState.subject || 'Untitled draft'}”. No email was sent.` });
-      void reloadEmailDrafts({ suppressErrorStatus: true });
-    } catch (saveError: any) {
-      setEmailStatus({ tone: 'error', message: saveError?.message || 'Could not save team email draft.' });
-    } finally {
-      setEmailSavingDraft(false);
-    }
-  };
-
-  const handleSendEmail = async (event?: FormEvent) => {
-    event?.preventDefault();
-    if (!canModerate || emailSending) return;
-    const subject = emailState.subject.trim();
-    const body = emailState.body.trim();
-    if (!subject || !body) {
-      setEmailStatus({ tone: 'error', message: 'Subject and message are required.' });
-      return;
-    }
-    if (emailAudienceMetadata.targetType === 'individuals' && emailAudienceMetadata.recipientIds.length === 0) {
-      setEmailStatus({ tone: 'error', message: 'Choose at least one selected member before sending.' });
-      return;
-    }
-
-    setEmailSending(true);
-    setEmailStatus({ tone: 'neutral', message: 'Creating backend mail jobs...' });
-    try {
-      const result = await sendTeamEmailMessage({
-        teamId,
-        subject,
-        body,
-        targetType: emailAudienceMetadata.targetType,
-        recipientIds: emailAudienceMetadata.recipientIds
-      });
-      emailDispatch(emailComposerActions.clearComposer());
-      setEmailStatus({ tone: 'success', message: `Queued ${Number(result?.recipientCount || 0)} recipient${Number(result?.recipientCount || 0) === 1 ? '' : 's'} for backend email delivery.` });
-      await reloadSentEmailHistory({ suppressErrorStatus: true });
-    } catch (sendError: any) {
-      setEmailStatus({ tone: 'error', message: sendError?.message || 'Email send failed. Nothing was silently dropped.' });
-    } finally {
-      setEmailSending(false);
-    }
   };
 
   const toggleVoiceCapture = async () => {
@@ -1767,46 +1577,29 @@ export function ChatWindow({
         />
       ) : null}
 
-      {showEmailSheet && canModerate ? (
-        <TeamEmailSheet
-          isDesktopWeb={isDesktopWeb}
-          subject={emailState.subject}
-          body={emailState.body}
-          drafts={emailState.drafts}
-          selectedDraftId={emailState.selectedDraftId}
-          templateName={emailState.templateName}
-          savingDraft={emailSavingDraft}
-          loadingDrafts={emailLoadingDrafts}
-          templates={emailState.templates}
-          sending={emailSending}
-          savingTemplate={emailSavingTemplate}
-          loadingHistory={emailLoadingHistory}
-          loadingTemplates={emailLoadingTemplates}
-          recipientOptionsLoading={recipientOptionsLoading}
-          recipientOptionsError={recipientOptionsError}
-          status={emailStatus}
-          historyStatus={emailHistoryStatus}
-          sentEmails={sentEmails}
-          audienceSummary={getAudienceSummaryText(emailAudienceMetadata, recipientOptions)}
-          audienceMetadata={emailAudienceMetadata}
-          onSubjectChange={(subject) => emailDispatch(emailComposerActions.updateSubject(subject))}
-          onBodyChange={(body) => emailDispatch(emailComposerActions.updateBody(body))}
-          onTemplateNameChange={(templateName) => emailDispatch(emailComposerActions.updateTemplateName(templateName))}
-          onApplyDraft={handleApplyEmailDraft}
-          onSaveDraft={handleSaveEmailDraft}
-          onApplyTemplate={handleApplyEmailTemplate}
-          onSaveTemplate={handleSaveEmailTemplate}
-          onSubmit={handleSendEmail}
-          onRefreshDrafts={reloadEmailDrafts}
-          onRefreshHistory={reloadSentEmailHistory}
-          onRefreshTemplates={reloadEmailTemplates}
-          onRetryRecipientOptions={() => {
-            void ensureRecipientOptionsLoaded().catch(() => undefined);
-          }}
-          onStatusClose={() => setEmailStatus(null)}
-          onHistoryStatusClose={() => setEmailHistoryStatus(null)}
-          onClose={closeTeamEmailSheet}
-        />
+      {teamEmailSheetRequested && canModerate ? (
+        <Suspense fallback={<Sheet title="Team Email" onClose={closeTeamEmailSheet}><div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">Loading Team Email...</div></Sheet>}>
+          <LazyTeamEmailSheet
+            key={teamId}
+            open={showEmailSheet}
+            auth={auth}
+            teamId={teamId}
+            profile={profile}
+            isDesktopWeb={isDesktopWeb}
+            selectedConversation={selectedConversation}
+            selectedConversationId={effectiveConversationId}
+            selectedRecipientTarget={selectedRecipientTarget}
+            selectedRecipientIds={selectedRecipientIds}
+            recipientOptions={recipientOptions}
+            recipientOptionsLoading={recipientOptionsLoading}
+            recipientOptionsError={recipientOptionsError}
+            ensureRecipientOptionsLoaded={ensureRecipientOptionsLoaded}
+            setSelectedRecipientTarget={setSelectedRecipientTarget}
+            setSelectedRecipientIds={setSelectedRecipientIds}
+            switchConversation={switchConversation}
+            onClose={closeTeamEmailSheet}
+          />
+        </Suspense>
       ) : null}
 
       {showMediaGallery ? (
@@ -2056,313 +1849,6 @@ export function StatusBanner({ status, onClose }: { status: ChatStatus; onClose:
       </button>
     </div>
   );
-}
-
-function TeamEmailSheet({
-  isDesktopWeb,
-  subject,
-  body,
-  drafts,
-  selectedDraftId,
-  templateName,
-  savingDraft,
-  loadingDrafts,
-  templates,
-  sending,
-  savingTemplate,
-  loadingHistory,
-  loadingTemplates,
-  recipientOptionsLoading,
-  recipientOptionsError,
-  status,
-  historyStatus,
-  sentEmails,
-  audienceSummary,
-  audienceMetadata,
-  onSubjectChange,
-  onBodyChange,
-  onTemplateNameChange,
-  onApplyDraft,
-  onSaveDraft,
-  onApplyTemplate,
-  onSaveTemplate,
-  onSubmit,
-  onRefreshDrafts,
-  onRefreshHistory,
-  onRefreshTemplates,
-  onRetryRecipientOptions,
-  onStatusClose,
-  onHistoryStatusClose,
-  onClose
-}: {
-  isDesktopWeb: boolean;
-  subject: string;
-  body: string;
-  drafts: TeamEmailDraft[];
-  selectedDraftId: string;
-  templateName: string;
-  savingDraft: boolean;
-  loadingDrafts: boolean;
-  templates: TeamEmailTemplate[];
-  sending: boolean;
-  savingTemplate: boolean;
-  loadingHistory: boolean;
-  loadingTemplates: boolean;
-  recipientOptionsLoading: boolean;
-  recipientOptionsError: string | null;
-  status: ChatStatus | null;
-  historyStatus: ChatStatus | null;
-  sentEmails: SentTeamEmail[];
-  audienceSummary: string;
-  audienceMetadata: ChatAudienceMetadata;
-  onSubjectChange: (value: string) => void;
-  onBodyChange: (value: string) => void;
-  onTemplateNameChange: (value: string) => void;
-  onApplyDraft: (draftId: string) => void;
-  onSaveDraft: () => void;
-  onApplyTemplate: (templateId: string) => void;
-  onSaveTemplate: () => void;
-  onSubmit: (event?: FormEvent) => void;
-  onRefreshDrafts: () => void;
-  onRefreshHistory: () => void;
-  onRefreshTemplates: () => void;
-  onRetryRecipientOptions: () => void;
-  onStatusClose: () => void;
-  onHistoryStatusClose: () => void;
-  onClose: () => void;
-}) {
-  const [selectedTemplateId, setSelectedTemplateId] = useState('');
-  const draftAudienceSupported = audienceMetadata.targetType === 'individuals';
-  const missingSelectedRecipients = audienceMetadata.targetType === 'individuals' && audienceMetadata.recipientIds.length === 0;
-  const canSendEmail = Boolean(subject.trim() && body.trim()) && !missingSelectedRecipients && !sending;
-  const canSaveDraft = draftAudienceSupported
-    && !recipientOptionsLoading
-    && !recipientOptionsError
-    && Boolean(subject.trim() && body.trim())
-    && !missingSelectedRecipients
-    && !savingDraft;
-  const canSaveTemplate = Boolean(templateName.trim() && subject.trim() && body.trim()) && !savingTemplate;
-
-  useEffect(() => {
-    if (!selectedTemplateId) return;
-    if (!templates.some((template) => template.id === selectedTemplateId)) {
-      setSelectedTemplateId('');
-    }
-  }, [selectedTemplateId, templates]);
-
-  const savedDraftsSection = (
-    <div className="space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-sm font-black text-gray-950">Saved drafts</div>
-          <div className="text-xs font-semibold leading-5 text-gray-500">Drafts keep selected recipients, subject, and body. Saving never sends email.</div>
-        </div>
-        <div className="flex gap-2">
-          <button type="button" className="ghost-button !h-9 !min-h-9 text-xs" onClick={onRefreshDrafts} disabled={loadingDrafts}>
-            {loadingDrafts ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
-            Refresh
-          </button>
-          <button type="button" className="secondary-button !h-9 !min-h-9 text-xs" disabled={!canSaveDraft} onClick={onSaveDraft}>
-            {savingDraft ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
-            Save draft
-          </button>
-        </div>
-      </div>
-      {loadingDrafts && drafts.length === 0 ? (
-        <div className="rounded-xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-500">Loading saved drafts...</div>
-      ) : drafts.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-gray-500">
-          No saved drafts yet.
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {drafts.map((draft) => {
-            const isSelected = draft.id === selectedDraftId;
-            return (
-              <button
-                key={draft.id}
-                type="button"
-                className={`w-full rounded-xl border px-3 py-2 text-left ${isSelected ? 'border-primary-200 bg-primary-50 text-primary-700' : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'}`}
-                onClick={() => onApplyDraft(draft.id)}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-black">{draft.subject || '(No subject)'}</div>
-                    <div className="mt-0.5 text-xs font-semibold text-gray-500">{Math.max(draft.recipientIds.length, draft.recipients.length)} recipient{Math.max(draft.recipientIds.length, draft.recipients.length) === 1 ? '' : 's'} · {formatEmailSentTime(draft.updatedAt)}</div>
-                  </div>
-                  {isSelected ? <span className="text-[11px] font-black uppercase">Current</span> : null}
-                </div>
-              </button>
-            );
-          })}
-        </div>
-      )}
-      {!draftAudienceSupported ? (
-        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-bold text-amber-800">
-          Draft saving is available only for Selected members.
-        </div>
-      ) : missingSelectedRecipients ? (
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
-          Choose at least one selected member before saving or sending email.
-        </div>
-      ) : null}
-    </div>
-  );
-
-  const reusableTemplatesSection = (
-    <div className="space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="text-sm font-black text-gray-950">Reusable templates</div>
-          <div className="text-xs font-semibold leading-5 text-gray-500">Apply a saved subject and body without changing recipients.</div>
-        </div>
-        <button type="button" className="ghost-button !h-9 !min-h-9 text-xs" onClick={onRefreshTemplates} disabled={loadingTemplates}>
-          {loadingTemplates ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
-          Refresh
-        </button>
-      </div>
-      <div className="flex flex-col gap-2 sm:flex-row">
-        <label className="min-w-0 flex-1">
-          <span className="app-label">Saved template</span>
-          <select
-            value={selectedTemplateId}
-            onChange={(event) => setSelectedTemplateId(event.target.value)}
-            className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
-          >
-            <option value="">Select a template</option>
-            {templates.map((template) => (
-              <option key={template.id} value={template.id}>{template.name}</option>
-            ))}
-          </select>
-        </label>
-        <button type="button" className="secondary-button sm:mt-6" disabled={!selectedTemplateId} onClick={() => onApplyTemplate(selectedTemplateId)}>
-          Apply template
-        </button>
-      </div>
-      {!loadingTemplates && templates.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-gray-500">
-          No saved team email templates yet.
-        </div>
-      ) : null}
-      <label className="block">
-        <span className="app-label">Save current email as template</span>
-        <div className="mt-1 flex flex-col gap-2 sm:flex-row">
-          <input
-            value={templateName}
-            onChange={(event) => onTemplateNameChange(event.target.value)}
-            className="min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
-            placeholder="Weekly reminder"
-            maxLength={120}
-            enterKeyHint="next"
-          />
-          <button type="button" className="secondary-button sm:min-w-[148px]" disabled={!canSaveTemplate} onClick={onSaveTemplate}>
-            {savingTemplate ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
-            Save template
-          </button>
-        </div>
-      </label>
-    </div>
-  );
-
-  return (
-    <Sheet title="Team Email" onClose={onClose}>
-      <form className="space-y-3" onSubmit={onSubmit}>
-        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-bold leading-5 text-amber-800">
-          Sends one backend roster email job. This is separate from chat posting, and delivery jobs are queued.
-        </div>
-        <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-bold text-gray-700">
-          Audience: {audienceSummary}
-        </div>
-        {recipientOptionsLoading ? (
-          <div className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-gray-500">
-            <Loader2 className="mr-2 inline h-4 w-4 animate-spin" aria-hidden="true" />
-            Loading recipient options...
-          </div>
-        ) : recipientOptionsError ? (
-          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
-            <div>{recipientOptionsError}</div>
-            <button type="button" className="ghost-button mt-2 !h-8 !min-h-8 !px-2 text-xs" onClick={onRetryRecipientOptions}>
-              Retry recipient load
-            </button>
-          </div>
-        ) : null}
-        {isDesktopWeb ? savedDraftsSection : null}
-        {isDesktopWeb ? reusableTemplatesSection : null}
-        <label className="block">
-          <span className="app-label">Subject</span>
-          <input
-            value={subject}
-            onChange={(event) => onSubjectChange(event.target.value)}
-            className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
-            placeholder="Team update"
-            maxLength={160}
-            enterKeyHint="next"
-          />
-        </label>
-        <label className="block">
-          <span className="app-label">Message</span>
-          <textarea
-            value={body}
-            onChange={(event) => onBodyChange(event.target.value)}
-            className="mt-1 min-h-36 w-full rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
-            placeholder="Write the email body..."
-            maxLength={5000}
-            enterKeyHint="send"
-          />
-        </label>
-        <button type="submit" className="primary-button w-full" disabled={!canSendEmail}>
-          {sending ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Mail className="h-4 w-4" aria-hidden="true" />}
-          Send email
-        </button>
-        {status ? <StatusBanner status={status} onClose={onStatusClose} /> : null}
-        {!isDesktopWeb ? savedDraftsSection : null}
-        {!isDesktopWeb ? reusableTemplatesSection : null}
-      </form>
-
-      <div className="mt-5 border-t border-gray-100 pt-4">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <div className="text-sm font-black text-gray-950">Sent email history</div>
-            <div className="text-xs font-semibold text-gray-500">Latest queued roster emails. Recipient email addresses are hidden.</div>
-          </div>
-          <button type="button" className="ghost-button !h-9 !min-h-9 text-xs" onClick={onRefreshHistory} disabled={loadingHistory}>
-            {loadingHistory ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
-            Refresh
-          </button>
-        </div>
-        {historyStatus ? <StatusBanner status={historyStatus} onClose={onHistoryStatusClose} /> : null}
-        <div className="mt-3 space-y-2">
-          {loadingHistory && sentEmails.length === 0 ? (
-            <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">Loading sent emails...</div>
-          ) : sentEmails.length === 0 ? (
-            <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">No sent team emails yet.</div>
-          ) : sentEmails.map((email) => {
-            const delivery = email.delivery || {};
-            const statusLabel = String(delivery.status || email.status || 'queued');
-            return (
-              <div key={email.id} className="rounded-xl border border-gray-200 bg-white px-3 py-2">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-black text-gray-950">{email.subject || '(No subject)'}</div>
-                    <div className="mt-0.5 text-xs font-semibold text-gray-500">From {email.senderName || 'Team admin'} · {formatEmailSentTime(email.sentAt)}</div>
-                  </div>
-                  <div className="flex-none text-right text-xs font-bold text-gray-500">
-                    {Number(email.recipientCount || 0)} recipients<br />{statusLabel}
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </Sheet>
-  );
-}
-
-function formatEmailSentTime(value: unknown) {
-  const day = formatChatDay(value);
-  const time = formatChatTime(value);
-  return [day, time].filter(Boolean).join(' ') || 'Queued';
 }
 
 type MessageListProps = {

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -20,6 +20,10 @@ import {
 const mockRouter = vi.hoisted(() => ({
   navigate: vi.fn()
 }));
+const teamEmailSheetMocks = vi.hoisted(() => ({
+  importModule: vi.fn(),
+  render: vi.fn()
+}));
 const normalizeChatReactionsSpy = vi.fn();
 const getMessageAttachmentsSpy = vi.fn();
 const mockShellLayoutState = { isDesktopWeb: false };
@@ -182,6 +186,17 @@ vi.mock('../../../lib/chatService', () => ({
   toggleTeamChatReaction: vi.fn()
 }));
 
+vi.mock('./TeamEmailSheet', async () => {
+  const React = await import('react');
+  teamEmailSheetMocks.importModule();
+  return {
+    default: (props: { open: boolean }) => {
+      teamEmailSheetMocks.render(props.open);
+      return props.open ? React.createElement('div', { role: 'dialog', 'aria-label': 'Team Email' }, 'Lazy Team Email Mock') : null;
+    }
+  };
+});
+
 vi.mock('../hooks/useChatSheets', async () => {
   const React = await import('react');
   const closeIfActive = (setActiveSheet: React.Dispatch<React.SetStateAction<MockActiveChatSheet>>, sheet: MockActiveChatSheet) => {
@@ -271,7 +286,14 @@ vi.mock('../hooks/useChatMessages', async () => {
 });
 
 vi.mock('./ChatComposer', () => ({
-  Composer: () => <div className="chat-composer">Composer</div>
+  Composer: ({ canSendTeamEmail, onTeamEmail }: { canSendTeamEmail: boolean; onTeamEmail: () => void }) => (
+    <div className="chat-composer">
+      Composer
+      {canSendTeamEmail ? (
+        <button type="button" onClick={onTeamEmail} aria-label="Open Team Email">Team Email</button>
+      ) : null}
+    </div>
+  )
 }));
 
 const auth: AuthState = {
@@ -326,10 +348,80 @@ beforeEach(() => {
   mockChatTeamState.switchConversation.mockReset();
   mockChatTeamState.switchConversation.mockReturnValue(true);
   vi.mocked(ensureStaffChatConversation).mockReset();
+  teamEmailSheetMocks.importModule.mockClear();
+  teamEmailSheetMocks.render.mockClear();
 });
 
 afterEach(() => {
   cleanup();
+});
+
+describe('ChatWindow lazy Team Email loading', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver as any);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 0));
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id));
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn()
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return this.classList.contains('chat-messages-scroll') ? 480 : 0;
+      }
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        if (this.classList.contains('chat-messages-scroll')) return scrollHeightValue;
+        if (this.classList.contains('chat-messages-content')) return contentScrollHeightValue;
+        return 0;
+      }
+    });
+    Object.defineProperty(window.HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      get() {
+        return 104;
+      }
+    });
+  });
+
+  it('does not render Team Email controls or import the lazy sheet for parents', () => {
+    mockChatTeamState.canModerate = false;
+    useStatefulChatSheets = true;
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Open Team Email' })).not.toBeInTheDocument();
+    expect(teamEmailSheetMocks.importModule).not.toHaveBeenCalled();
+    expect(teamEmailSheetMocks.render).not.toHaveBeenCalled();
+  });
+
+  it('imports and renders the lazy Team Email sheet only after a coach opens it', async () => {
+    mockChatTeamState.canModerate = true;
+    useStatefulChatSheets = true;
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: 'Open Team Email' })).toBeInTheDocument();
+    expect(teamEmailSheetMocks.importModule).not.toHaveBeenCalled();
+    expect(teamEmailSheetMocks.render).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Team Email' }));
+
+    await waitFor(() => expect(teamEmailSheetMocks.importModule).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Lazy Team Email Mock')).toBeInTheDocument();
+    expect(teamEmailSheetMocks.render).toHaveBeenCalledWith(true);
+  });
 });
 
 describe('ChatWindow virtualization', () => {

--- a/apps/app/src/pages/messages/components/TeamEmailSheet.tsx
+++ b/apps/app/src/pages/messages/components/TeamEmailSheet.tsx
@@ -84,6 +84,7 @@ export default function TeamEmailSheet({
   const [emailHistoryStatus, setEmailHistoryStatus] = useState<ChatStatus | null>(null);
   const [sentEmails, setSentEmails] = useState<SentTeamEmail[]>([]);
   const loadedForTeamRef = useRef<string | null>(null);
+  const openForTeamRef = useRef<string | null>(null);
 
   const emailAudienceMetadata = useMemo(() => buildEmailAudienceMetadata({
     selectedConversation,
@@ -144,11 +145,17 @@ export default function TeamEmailSheet({
   };
 
   useEffect(() => {
-    if (!open) return;
-    emailDispatch(emailComposerActions.updateTemplateName(''));
-    emailDispatch(emailComposerActions.clearSelectedDraft());
-    setEmailStatus(null);
-    setEmailHistoryStatus(null);
+    if (!open) {
+      openForTeamRef.current = null;
+      return;
+    }
+    if (openForTeamRef.current !== teamId) {
+      openForTeamRef.current = teamId;
+      emailDispatch(emailComposerActions.updateTemplateName(''));
+      emailDispatch(emailComposerActions.clearSelectedDraft());
+      setEmailStatus(null);
+      setEmailHistoryStatus(null);
+    }
     void ensureRecipientOptionsLoaded().catch(() => undefined);
     if (loadedForTeamRef.current === teamId) return;
     loadedForTeamRef.current = teamId;

--- a/apps/app/src/pages/messages/components/TeamEmailSheet.tsx
+++ b/apps/app/src/pages/messages/components/TeamEmailSheet.tsx
@@ -1,0 +1,613 @@
+import { FormEvent, useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { Loader2, Mail, RefreshCw } from 'lucide-react';
+import {
+  loadSentTeamEmails,
+  loadTeamEmailDrafts,
+  loadTeamEmailTemplates,
+  saveTeamEmailDraft,
+  saveTeamEmailTemplate,
+  sendTeamEmailMessage,
+  type ChatConversation,
+  type SentTeamEmail,
+  type TeamEmailDraft,
+  type TeamEmailTemplate
+} from '../../../lib/chatService';
+import {
+  DEFAULT_TEAM_CONVERSATION_ID,
+  buildEmailAudienceMetadata,
+  formatChatDay,
+  formatChatTime,
+  getAudienceSummaryText,
+  isDefaultTeamConversation,
+  type ChatAudienceMetadata,
+  type ChatRecipientOption,
+  type ChatTargetType
+} from '../../../lib/chatLogic';
+import type { AuthState } from '../../../lib/types';
+import { emailComposerActions, emailReducer, initialEmailComposerState } from '../state/emailReducer';
+import { Sheet, StatusBanner } from './ChatWindow';
+
+type StatusTone = 'neutral' | 'success' | 'error';
+
+type ChatStatus = {
+  tone: StatusTone;
+  message: string;
+};
+
+type TeamEmailSheetProps = {
+  open: boolean;
+  auth: AuthState;
+  teamId: string;
+  profile: Record<string, any>;
+  isDesktopWeb: boolean;
+  selectedConversation: ChatConversation | null;
+  selectedConversationId: string;
+  selectedRecipientTarget: ChatTargetType;
+  selectedRecipientIds: string[];
+  recipientOptions: ChatRecipientOption[];
+  recipientOptionsLoading: boolean;
+  recipientOptionsError: string | null;
+  ensureRecipientOptionsLoaded: () => Promise<ChatRecipientOption[]>;
+  setSelectedRecipientTarget: (target: ChatTargetType) => void;
+  setSelectedRecipientIds: (recipientIds: string[]) => void;
+  switchConversation: (conversationId: string) => void | boolean;
+  onClose: () => void;
+};
+
+export default function TeamEmailSheet({
+  open,
+  auth,
+  teamId,
+  profile,
+  isDesktopWeb,
+  selectedConversation,
+  selectedConversationId,
+  selectedRecipientTarget,
+  selectedRecipientIds,
+  recipientOptions,
+  recipientOptionsLoading,
+  recipientOptionsError,
+  ensureRecipientOptionsLoaded,
+  setSelectedRecipientTarget,
+  setSelectedRecipientIds,
+  switchConversation,
+  onClose
+}: TeamEmailSheetProps) {
+  const [emailState, emailDispatch] = useReducer(emailReducer, initialEmailComposerState);
+  const [emailSending, setEmailSending] = useState(false);
+  const [emailSavingTemplate, setEmailSavingTemplate] = useState(false);
+  const [emailSavingDraft, setEmailSavingDraft] = useState(false);
+  const [emailLoadingDrafts, setEmailLoadingDrafts] = useState(false);
+  const [emailLoadingHistory, setEmailLoadingHistory] = useState(false);
+  const [emailLoadingTemplates, setEmailLoadingTemplates] = useState(false);
+  const [emailStatus, setEmailStatus] = useState<ChatStatus | null>(null);
+  const [emailHistoryStatus, setEmailHistoryStatus] = useState<ChatStatus | null>(null);
+  const [sentEmails, setSentEmails] = useState<SentTeamEmail[]>([]);
+  const loadedForTeamRef = useRef<string | null>(null);
+
+  const emailAudienceMetadata = useMemo(() => buildEmailAudienceMetadata({
+    selectedConversation,
+    selectedConversationId,
+    selectedRecipientTarget,
+    selectedRecipientIds,
+    recipientOptions
+  }), [recipientOptions, selectedConversation, selectedConversationId, selectedRecipientIds, selectedRecipientTarget]);
+  const audienceSummary = useMemo(
+    () => getAudienceSummaryText(emailAudienceMetadata, recipientOptions),
+    [emailAudienceMetadata, recipientOptions]
+  );
+
+  const reloadSentEmailHistory = async ({ suppressErrorStatus = false } = {}) => {
+    setEmailLoadingHistory(true);
+    try {
+      setSentEmails(await loadSentTeamEmails(teamId, { limit: 25 }));
+      setEmailHistoryStatus(null);
+    } catch (historyError: any) {
+      if (!suppressErrorStatus) {
+        setEmailHistoryStatus({ tone: 'error', message: historyError?.message || 'Could not load sent email history.' });
+      }
+    } finally {
+      setEmailLoadingHistory(false);
+    }
+  };
+
+  const reloadEmailTemplates = async ({ suppressErrorStatus = false } = {}) => {
+    setEmailLoadingTemplates(true);
+    try {
+      emailDispatch(emailComposerActions.setTemplates(await loadTeamEmailTemplates(teamId)));
+      if (!suppressErrorStatus) {
+        setEmailStatus(null);
+      }
+    } catch (templateError: any) {
+      if (!suppressErrorStatus) {
+        setEmailStatus({ tone: 'error', message: templateError?.message || 'Could not load team email templates.' });
+      }
+    } finally {
+      setEmailLoadingTemplates(false);
+    }
+  };
+
+  const reloadEmailDrafts = async ({ suppressErrorStatus = false } = {}) => {
+    setEmailLoadingDrafts(true);
+    try {
+      emailDispatch(emailComposerActions.setDrafts(await loadTeamEmailDrafts(teamId)));
+      if (!suppressErrorStatus) {
+        setEmailStatus(null);
+      }
+    } catch (draftError: any) {
+      if (!suppressErrorStatus) {
+        setEmailStatus({ tone: 'error', message: draftError?.message || 'Could not load saved drafts.' });
+      }
+    } finally {
+      setEmailLoadingDrafts(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    emailDispatch(emailComposerActions.updateTemplateName(''));
+    emailDispatch(emailComposerActions.clearSelectedDraft());
+    setEmailStatus(null);
+    setEmailHistoryStatus(null);
+    void ensureRecipientOptionsLoaded().catch(() => undefined);
+    if (loadedForTeamRef.current === teamId) return;
+    loadedForTeamRef.current = teamId;
+    void reloadEmailDrafts();
+    void reloadEmailTemplates();
+    void reloadSentEmailHistory();
+  }, [ensureRecipientOptionsLoaded, open, teamId]);
+
+  const handleApplyEmailDraft = (draftId: string) => {
+    const draft = emailState.drafts.find((item) => item.id === draftId);
+    if (!draft) return;
+    if (!isDefaultTeamConversation(selectedConversationId)) {
+      switchConversation(DEFAULT_TEAM_CONVERSATION_ID);
+    }
+    setSelectedRecipientTarget('individuals');
+    setSelectedRecipientIds(draft.recipientIds);
+    emailDispatch(emailComposerActions.selectDraft(draft.id));
+    setEmailStatus({ tone: 'success', message: `Restored draft "${draft.subject || 'Untitled draft'}". This replaced the current email composer.` });
+  };
+
+  const handleApplyEmailTemplate = (templateId: string) => {
+    const template = emailState.templates.find((item) => item.id === templateId);
+    if (!template) return;
+    emailDispatch(emailComposerActions.applyTemplate(template.id));
+    setEmailStatus({ tone: 'success', message: `Applied template "${template.name}".` });
+  };
+
+  const handleSaveEmailTemplate = async () => {
+    if (emailSavingTemplate) return;
+    setEmailSavingTemplate(true);
+    setEmailStatus({ tone: 'neutral', message: 'Saving team email template...' });
+    try {
+      const savedTemplate = await saveTeamEmailTemplate({
+        teamId,
+        name: emailState.templateName,
+        subject: emailState.subject,
+        body: emailState.body
+      });
+      emailDispatch(emailComposerActions.updateTemplateName(''));
+      emailDispatch(emailComposerActions.setTemplates([savedTemplate, ...emailState.templates.filter((item) => item.id !== savedTemplate.id)]));
+      setEmailStatus({ tone: 'success', message: `Saved template "${savedTemplate.name}".` });
+      void reloadEmailTemplates({ suppressErrorStatus: true });
+    } catch (saveError: any) {
+      setEmailStatus({ tone: 'error', message: saveError?.message || 'Could not save team email template.' });
+    } finally {
+      setEmailSavingTemplate(false);
+    }
+  };
+
+  const handleSaveEmailDraft = async () => {
+    if (emailSavingDraft) return;
+    setEmailSavingDraft(true);
+    setEmailStatus({ tone: 'neutral', message: 'Saving team email draft...' });
+    try {
+      const savedDraft = await saveTeamEmailDraft({
+        teamId,
+        draftId: emailState.selectedDraftId || null,
+        subject: emailState.subject,
+        body: emailState.body,
+        recipientIds: emailAudienceMetadata.recipientIds,
+        recipientOptions,
+        authorId: auth.user?.uid || null,
+        authorEmail: auth.user?.email || null,
+        authorName: profile?.fullName || auth.user?.displayName || null
+      });
+      if (savedDraft?.id) {
+        emailDispatch(emailComposerActions.saveDraft(savedDraft));
+      }
+      setEmailStatus({ tone: 'success', message: `Saved draft "${savedDraft?.subject || emailState.subject || 'Untitled draft'}". No email was sent.` });
+      void reloadEmailDrafts({ suppressErrorStatus: true });
+    } catch (saveError: any) {
+      setEmailStatus({ tone: 'error', message: saveError?.message || 'Could not save team email draft.' });
+    } finally {
+      setEmailSavingDraft(false);
+    }
+  };
+
+  const handleSendEmail = async (event?: FormEvent) => {
+    event?.preventDefault();
+    if (emailSending) return;
+    const subject = emailState.subject.trim();
+    const body = emailState.body.trim();
+    if (!subject || !body) {
+      setEmailStatus({ tone: 'error', message: 'Subject and message are required.' });
+      return;
+    }
+    if (emailAudienceMetadata.targetType === 'individuals' && emailAudienceMetadata.recipientIds.length === 0) {
+      setEmailStatus({ tone: 'error', message: 'Choose at least one selected member before sending.' });
+      return;
+    }
+
+    setEmailSending(true);
+    setEmailStatus({ tone: 'neutral', message: 'Creating backend mail jobs...' });
+    try {
+      const result = await sendTeamEmailMessage({
+        teamId,
+        subject,
+        body,
+        targetType: emailAudienceMetadata.targetType,
+        recipientIds: emailAudienceMetadata.recipientIds
+      });
+      emailDispatch(emailComposerActions.clearComposer());
+      setEmailStatus({ tone: 'success', message: `Queued ${Number(result?.recipientCount || 0)} recipient${Number(result?.recipientCount || 0) === 1 ? '' : 's'} for backend email delivery.` });
+      await reloadSentEmailHistory({ suppressErrorStatus: true });
+    } catch (sendError: any) {
+      setEmailStatus({ tone: 'error', message: sendError?.message || 'Email send failed. Nothing was silently dropped.' });
+    } finally {
+      setEmailSending(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <TeamEmailSheetView
+      isDesktopWeb={isDesktopWeb}
+      subject={emailState.subject}
+      body={emailState.body}
+      drafts={emailState.drafts}
+      selectedDraftId={emailState.selectedDraftId}
+      templateName={emailState.templateName}
+      savingDraft={emailSavingDraft}
+      loadingDrafts={emailLoadingDrafts}
+      templates={emailState.templates}
+      sending={emailSending}
+      savingTemplate={emailSavingTemplate}
+      loadingHistory={emailLoadingHistory}
+      loadingTemplates={emailLoadingTemplates}
+      recipientOptionsLoading={recipientOptionsLoading}
+      recipientOptionsError={recipientOptionsError}
+      status={emailStatus}
+      historyStatus={emailHistoryStatus}
+      sentEmails={sentEmails}
+      audienceSummary={audienceSummary}
+      audienceMetadata={emailAudienceMetadata}
+      onSubjectChange={(subject) => emailDispatch(emailComposerActions.updateSubject(subject))}
+      onBodyChange={(body) => emailDispatch(emailComposerActions.updateBody(body))}
+      onTemplateNameChange={(templateName) => emailDispatch(emailComposerActions.updateTemplateName(templateName))}
+      onApplyDraft={handleApplyEmailDraft}
+      onSaveDraft={handleSaveEmailDraft}
+      onApplyTemplate={handleApplyEmailTemplate}
+      onSaveTemplate={handleSaveEmailTemplate}
+      onSubmit={handleSendEmail}
+      onRefreshDrafts={reloadEmailDrafts}
+      onRefreshHistory={reloadSentEmailHistory}
+      onRefreshTemplates={reloadEmailTemplates}
+      onRetryRecipientOptions={() => {
+        void ensureRecipientOptionsLoaded().catch(() => undefined);
+      }}
+      onStatusClose={() => setEmailStatus(null)}
+      onHistoryStatusClose={() => setEmailHistoryStatus(null)}
+      onClose={onClose}
+    />
+  );
+}
+
+function TeamEmailSheetView({
+  isDesktopWeb,
+  subject,
+  body,
+  drafts,
+  selectedDraftId,
+  templateName,
+  savingDraft,
+  loadingDrafts,
+  templates,
+  sending,
+  savingTemplate,
+  loadingHistory,
+  loadingTemplates,
+  recipientOptionsLoading,
+  recipientOptionsError,
+  status,
+  historyStatus,
+  sentEmails,
+  audienceSummary,
+  audienceMetadata,
+  onSubjectChange,
+  onBodyChange,
+  onTemplateNameChange,
+  onApplyDraft,
+  onSaveDraft,
+  onApplyTemplate,
+  onSaveTemplate,
+  onSubmit,
+  onRefreshDrafts,
+  onRefreshHistory,
+  onRefreshTemplates,
+  onRetryRecipientOptions,
+  onStatusClose,
+  onHistoryStatusClose,
+  onClose
+}: {
+  isDesktopWeb: boolean;
+  subject: string;
+  body: string;
+  drafts: TeamEmailDraft[];
+  selectedDraftId: string;
+  templateName: string;
+  savingDraft: boolean;
+  loadingDrafts: boolean;
+  templates: TeamEmailTemplate[];
+  sending: boolean;
+  savingTemplate: boolean;
+  loadingHistory: boolean;
+  loadingTemplates: boolean;
+  recipientOptionsLoading: boolean;
+  recipientOptionsError: string | null;
+  status: ChatStatus | null;
+  historyStatus: ChatStatus | null;
+  sentEmails: SentTeamEmail[];
+  audienceSummary: string;
+  audienceMetadata: ChatAudienceMetadata;
+  onSubjectChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+  onTemplateNameChange: (value: string) => void;
+  onApplyDraft: (draftId: string) => void;
+  onSaveDraft: () => void;
+  onApplyTemplate: (templateId: string) => void;
+  onSaveTemplate: () => void;
+  onSubmit: (event?: FormEvent) => void;
+  onRefreshDrafts: () => void;
+  onRefreshHistory: () => void;
+  onRefreshTemplates: () => void;
+  onRetryRecipientOptions: () => void;
+  onStatusClose: () => void;
+  onHistoryStatusClose: () => void;
+  onClose: () => void;
+}) {
+  const [selectedTemplateId, setSelectedTemplateId] = useState('');
+  const draftAudienceSupported = audienceMetadata.targetType === 'individuals';
+  const missingSelectedRecipients = audienceMetadata.targetType === 'individuals' && audienceMetadata.recipientIds.length === 0;
+  const canSendEmail = Boolean(subject.trim() && body.trim()) && !missingSelectedRecipients && !sending;
+  const canSaveDraft = draftAudienceSupported
+    && !recipientOptionsLoading
+    && !recipientOptionsError
+    && Boolean(subject.trim() && body.trim())
+    && !missingSelectedRecipients
+    && !savingDraft;
+  const canSaveTemplate = Boolean(templateName.trim() && subject.trim() && body.trim()) && !savingTemplate;
+
+  useEffect(() => {
+    if (!selectedTemplateId) return;
+    if (!templates.some((template) => template.id === selectedTemplateId)) {
+      setSelectedTemplateId('');
+    }
+  }, [selectedTemplateId, templates]);
+
+  const savedDraftsSection = (
+    <div className="space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Saved drafts</div>
+          <div className="text-xs font-semibold leading-5 text-gray-500">Drafts keep selected recipients, subject, and body. Saving never sends email.</div>
+        </div>
+        <div className="flex gap-2">
+          <button type="button" className="ghost-button !h-9 !min-h-9 text-xs" onClick={onRefreshDrafts} disabled={loadingDrafts}>
+            {loadingDrafts ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+            Refresh
+          </button>
+          <button type="button" className="secondary-button !h-9 !min-h-9 text-xs" disabled={!canSaveDraft} onClick={onSaveDraft}>
+            {savingDraft ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            Save draft
+          </button>
+        </div>
+      </div>
+      {loadingDrafts && drafts.length === 0 ? (
+        <div className="rounded-xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-500">Loading saved drafts...</div>
+      ) : drafts.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-gray-500">
+          No saved drafts yet.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {drafts.map((draft) => {
+            const isSelected = draft.id === selectedDraftId;
+            return (
+              <button
+                key={draft.id}
+                type="button"
+                className={`w-full rounded-xl border px-3 py-2 text-left ${isSelected ? 'border-primary-200 bg-primary-50 text-primary-700' : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'}`}
+                onClick={() => onApplyDraft(draft.id)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-black">{draft.subject || '(No subject)'}</div>
+                    <div className="mt-0.5 text-xs font-semibold text-gray-500">{Math.max(draft.recipientIds.length, draft.recipients.length)} recipient{Math.max(draft.recipientIds.length, draft.recipients.length) === 1 ? '' : 's'} · {formatEmailSentTime(draft.updatedAt)}</div>
+                  </div>
+                  {isSelected ? <span className="text-[11px] font-black uppercase">Current</span> : null}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {!draftAudienceSupported ? (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-bold text-amber-800">
+          Draft saving is available only for Selected members.
+        </div>
+      ) : missingSelectedRecipients ? (
+        <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
+          Choose at least one selected member before saving or sending email.
+        </div>
+      ) : null}
+    </div>
+  );
+
+  const reusableTemplatesSection = (
+    <div className="space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Reusable templates</div>
+          <div className="text-xs font-semibold leading-5 text-gray-500">Apply a saved subject and body without changing recipients.</div>
+        </div>
+        <button type="button" className="ghost-button !h-9 !min-h-9 text-xs" onClick={onRefreshTemplates} disabled={loadingTemplates}>
+          {loadingTemplates ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+          Refresh
+        </button>
+      </div>
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <label className="min-w-0 flex-1">
+          <span className="app-label">Saved template</span>
+          <select
+            value={selectedTemplateId}
+            onChange={(event) => setSelectedTemplateId(event.target.value)}
+            className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
+          >
+            <option value="">Select a template</option>
+            {templates.map((template) => (
+              <option key={template.id} value={template.id}>{template.name}</option>
+            ))}
+          </select>
+        </label>
+        <button type="button" className="secondary-button sm:mt-6" disabled={!selectedTemplateId} onClick={() => onApplyTemplate(selectedTemplateId)}>
+          Apply template
+        </button>
+      </div>
+      {!loadingTemplates && templates.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-200 bg-white px-3 py-2 text-xs font-semibold text-gray-500">
+          No saved team email templates yet.
+        </div>
+      ) : null}
+      <label className="block">
+        <span className="app-label">Save current email as template</span>
+        <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+          <input
+            value={templateName}
+            onChange={(event) => onTemplateNameChange(event.target.value)}
+            className="min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
+            placeholder="Weekly reminder"
+            maxLength={120}
+            enterKeyHint="next"
+          />
+          <button type="button" className="secondary-button sm:min-w-[148px]" disabled={!canSaveTemplate} onClick={onSaveTemplate}>
+            {savingTemplate ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            Save template
+          </button>
+        </div>
+      </label>
+    </div>
+  );
+
+  return (
+    <Sheet title="Team Email" onClose={onClose}>
+      <form className="space-y-3" onSubmit={onSubmit}>
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-bold leading-5 text-amber-800">
+          Sends one backend roster email job. This is separate from chat posting, and delivery jobs are queued.
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-bold text-gray-700">
+          Audience: {audienceSummary}
+        </div>
+        {recipientOptionsLoading ? (
+          <div className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-gray-500">
+            <Loader2 className="mr-2 inline h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading recipient options...
+          </div>
+        ) : recipientOptionsError ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
+            <div>{recipientOptionsError}</div>
+            <button type="button" className="ghost-button mt-2 !h-8 !min-h-8 !px-2 text-xs" onClick={onRetryRecipientOptions}>
+              Retry recipient load
+            </button>
+          </div>
+        ) : null}
+        {isDesktopWeb ? savedDraftsSection : null}
+        {isDesktopWeb ? reusableTemplatesSection : null}
+        <label className="block">
+          <span className="app-label">Subject</span>
+          <input
+            value={subject}
+            onChange={(event) => onSubjectChange(event.target.value)}
+            className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
+            placeholder="Team update"
+            maxLength={160}
+            enterKeyHint="next"
+          />
+        </label>
+        <label className="block">
+          <span className="app-label">Message</span>
+          <textarea
+            value={body}
+            onChange={(event) => onBodyChange(event.target.value)}
+            className="mt-1 min-h-36 w-full rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
+            placeholder="Write the email body..."
+            maxLength={5000}
+            enterKeyHint="send"
+          />
+        </label>
+        <button type="submit" className="primary-button w-full" disabled={!canSendEmail}>
+          {sending ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Mail className="h-4 w-4" aria-hidden="true" />}
+          Send email
+        </button>
+        {status ? <StatusBanner status={status} onClose={onStatusClose} /> : null}
+        {!isDesktopWeb ? savedDraftsSection : null}
+        {!isDesktopWeb ? reusableTemplatesSection : null}
+      </form>
+
+      <div className="mt-5 border-t border-gray-100 pt-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="text-sm font-black text-gray-950">Sent email history</div>
+            <div className="text-xs font-semibold text-gray-500">Latest queued roster emails. Recipient email addresses are hidden.</div>
+          </div>
+          <button type="button" className="ghost-button !h-9 !min-h-9 text-xs" onClick={onRefreshHistory} disabled={loadingHistory}>
+            {loadingHistory ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+            Refresh
+          </button>
+        </div>
+        {historyStatus ? <StatusBanner status={historyStatus} onClose={onHistoryStatusClose} /> : null}
+        <div className="mt-3 space-y-2">
+          {loadingHistory && sentEmails.length === 0 ? (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">Loading sent emails...</div>
+          ) : sentEmails.length === 0 ? (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">No sent team emails yet.</div>
+          ) : sentEmails.map((email) => {
+            const delivery = email.delivery || {};
+            const statusLabel = String(delivery.status || email.status || 'queued');
+            return (
+              <div key={email.id} className="rounded-xl border border-gray-200 bg-white px-3 py-2">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-black text-gray-950">{email.subject || '(No subject)'}</div>
+                    <div className="mt-0.5 text-xs font-semibold text-gray-500">From {email.senderName || 'Team admin'} · {formatEmailSentTime(email.sentAt)}</div>
+                  </div>
+                  <div className="flex-none text-right text-xs font-bold text-gray-500">
+                    {Number(email.recipientCount || 0)} recipients<br />{statusLabel}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Sheet>
+  );
+}
+
+function formatEmailSentTime(value: unknown) {
+  const day = formatChatDay(value);
+  const time = formatChatTime(value);
+  return [day, time].filter(Boolean).join(' ') || 'Queued';
+}

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -422,6 +422,7 @@
             "appSupportFiles": [
                 "apps/app/src/pages/messages/components/ChatComposer.tsx",
                 "apps/app/src/pages/messages/components/ChatWindow.tsx",
+                "apps/app/src/pages/messages/components/TeamEmailSheet.tsx",
                 "apps/app/src/pages/messages/hooks/useChatMessages.ts",
                 "apps/app/src/pages/messages/hooks/useChatSheets.ts",
                 "apps/app/src/pages/messages/hooks/useChatTeam.ts",

--- a/tests/unit/app-chat-email-templates-integration.test.tsx
+++ b/tests/unit/app-chat-email-templates-integration.test.tsx
@@ -215,6 +215,41 @@ describe('Messages team email templates', () => {
     expect(screen.getAllByText(/Audience: Blake Parent/).length).toBeGreaterThan(0);
   });
 
+  it('keeps the restored draft selected when recipient options finish loading', async () => {
+    let resolveRecipientOptions: (options: Array<{ id: string; name: string; detail: string; email: string }>) => void = () => undefined;
+    chatServiceMocks.loadChatRecipientOptions.mockReturnValueOnce(new Promise((resolve) => {
+      resolveRecipientOptions = resolve;
+    }));
+
+    renderMessages();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open Team Email' }));
+    expect(await screen.findByRole('dialog', { name: 'Team Email' })).toBeTruthy();
+    fireEvent.click(await screen.findByRole('button', { name: /Bus update/i }));
+
+    expect(screen.getByDisplayValue('Bus update')).toBeTruthy();
+    expect(screen.getByText(/Restored draft/)).toBeTruthy();
+
+    resolveRecipientOptions([
+      { id: 'email:avery.parent@example.com', name: 'Avery Parent', detail: 'Guardian for Avery Smith', email: 'avery.parent@example.com' },
+      { id: 'email:blake.parent@example.com', name: 'Blake Parent', detail: 'Guardian for Blake Jones', email: 'blake.parent@example.com' }
+    ]);
+
+    const saveDraftButton = screen.getByRole('button', { name: 'Save draft' });
+    await waitFor(() => {
+      expect((saveDraftButton as HTMLButtonElement).disabled).toBe(false);
+    });
+    fireEvent.click(saveDraftButton);
+
+    await waitFor(() => {
+      expect(chatServiceMocks.saveTeamEmailDraft).toHaveBeenCalledWith(expect.objectContaining({
+        teamId: 'team-1',
+        draftId: 'draft-1',
+        recipientIds: ['email:blake.parent@example.com']
+      }));
+    });
+  });
+
   it('saves a draft and updates the rendered draft list without touching sent history', async () => {
     chatServiceMocks.loadTeamEmailDrafts
       .mockResolvedValueOnce([])

--- a/tests/unit/app-chat-email-templates-integration.test.tsx
+++ b/tests/unit/app-chat-email-templates-integration.test.tsx
@@ -146,7 +146,9 @@ describe('Messages team email templates', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Open Team Email' }));
 
     expect(await screen.findByRole('dialog', { name: 'Team Email' })).toBeTruthy();
-    expect(chatServiceMocks.loadTeamEmailTemplates).toHaveBeenCalledWith('team-1');
+    await waitFor(() => {
+      expect(chatServiceMocks.loadTeamEmailTemplates).toHaveBeenCalledWith('team-1');
+    });
 
     fireEvent.change(screen.getByLabelText('Saved template'), { target: { value: 'template-1' } });
     fireEvent.click(screen.getByRole('button', { name: 'Apply template' }));

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1435,7 +1435,7 @@ describe('React app messages integration', () => {
         expect(scroller.scrollTop).toBe(0);
     });
 
-    it('renders the moderator thread before lazy recipient options finish loading', async () => {
+    it('renders the moderator thread before lazy Team Email resources finish loading', async () => {
         const deferredRecipients = createDeferred();
         chatMocks.loadChatRecipientOptions.mockImplementationOnce(() => deferredRecipients.promise);
 
@@ -1447,7 +1447,9 @@ describe('React app messages integration', () => {
         await click(container, 'Team Email');
 
         expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
-        expect(container.textContent).toContain('Loading recipient options...');
+        await flush();
+        await flush();
+        expect(container.textContent).toContain('Loading Team Email...');
         expect(container.textContent).toContain('Bring both jerseys.');
 
         await act(async () => {

--- a/tests/unit/app-messages-decomposition.test.js
+++ b/tests/unit/app-messages-decomposition.test.js
@@ -10,16 +10,18 @@ function readRepoFile(path) {
 
 describe('Messages page decomposition', () => {
     it('keeps chat data loading and email composer state in focused modules', () => {
-        const source = [
-            readRepoFile('apps/app/src/pages/Messages.tsx'),
-            readRepoFile('apps/app/src/pages/messages/components/ChatWindow.tsx')
-        ].join('\n');
+        const messagesSource = readRepoFile('apps/app/src/pages/Messages.tsx');
+        const chatWindowSource = readRepoFile('apps/app/src/pages/messages/components/ChatWindow.tsx');
+        const teamEmailSheetSource = readRepoFile('apps/app/src/pages/messages/components/TeamEmailSheet.tsx');
+        const source = [messagesSource, chatWindowSource, teamEmailSheetSource].join('\n');
 
         expect(source).toContain("from '../hooks/useChatSheets'");
         expect(source).toContain("from '../hooks/useChatTeam'");
         expect(source).toContain("from '../hooks/useChatMessages'");
-        expect(source).toContain("from '../state/emailReducer'");
-        expect(source).toContain('useReducer(emailReducer, initialEmailComposerState)');
+        expect(chatWindowSource).toContain("lazy(() => import('./TeamEmailSheet'))");
+        expect(chatWindowSource).not.toContain("from '../state/emailReducer'");
+        expect(teamEmailSheetSource).toContain("from '../state/emailReducer'");
+        expect(teamEmailSheetSource).toContain('useReducer(emailReducer, initialEmailComposerState)');
     });
 
     it('keeps split Messages modules covered by focused unit tests', () => {

--- a/tests/unit/messages-decomposition-contract.test.js
+++ b/tests/unit/messages-decomposition-contract.test.js
@@ -28,13 +28,16 @@ describe('Messages decomposition contract', () => {
     it('keeps email composer transitions in the reducer instead of separate page state', () => {
         const messages = readRepoFile('apps/app/src/pages/Messages.tsx');
         const chatWindow = readRepoFile('apps/app/src/pages/messages/components/ChatWindow.tsx');
+        const teamEmailSheet = readRepoFile('apps/app/src/pages/messages/components/TeamEmailSheet.tsx');
         const reducer = readRepoFile('apps/app/src/pages/messages/state/emailReducer.ts');
 
-        expect(chatWindow).toContain("from '../state/emailReducer';");
-        expect(chatWindow).toContain('emailComposerActions');
-        expect(chatWindow).toContain('emailReducer');
-        expect(chatWindow).toContain('initialEmailComposerState');
-        expect(chatWindow).toMatch(/const\s+\[emailState,\s*emailDispatch\]\s*=\s*useReducer\(emailReducer,\s*initialEmailComposerState\);/);
+        expect(chatWindow).toContain("const LazyTeamEmailSheet = lazy(() => import('./TeamEmailSheet'));");
+        expect(chatWindow).not.toContain("from '../state/emailReducer';");
+        expect(teamEmailSheet).toContain("from '../state/emailReducer';");
+        expect(teamEmailSheet).toContain('emailComposerActions');
+        expect(teamEmailSheet).toContain('emailReducer');
+        expect(teamEmailSheet).toContain('initialEmailComposerState');
+        expect(teamEmailSheet).toMatch(/const\s+\[emailState,\s*emailDispatch\]\s*=\s*useReducer\(emailReducer,\s*initialEmailComposerState\);/);
         expect(messages).not.toMatch(/const\s+\[emailSubject\b/);
         expect(messages).not.toMatch(/const\s+\[emailBody\b/);
         expect(messages).not.toMatch(/const\s+\[emailDrafts\b/);

--- a/tests/unit/messages-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/messages-decomposition-initiative-source-contract.test.js
@@ -7,6 +7,7 @@ function readSource(path) {
 
 const messagesSource = readSource('apps/app/src/pages/Messages.tsx');
 const chatWindowSource = readSource('apps/app/src/pages/messages/components/ChatWindow.tsx');
+const teamEmailSheetSource = readSource('apps/app/src/pages/messages/components/TeamEmailSheet.tsx');
 const chatMessagesHookSource = readSource('apps/app/src/pages/messages/hooks/useChatMessages.ts');
 const chatTeamHookSource = readSource('apps/app/src/pages/messages/hooks/useChatTeam.ts');
 const chatSheetsHookSource = readSource('apps/app/src/pages/messages/hooks/useChatSheets.ts');
@@ -70,11 +71,12 @@ describe('Messages decomposition initiative source contract', () => {
     });
 
     it('keeps team email composer transitions in the reducer with dedicated reducer tests', () => {
-        expect(chatWindowSource).toContain("from '../state/emailReducer';");
-        expect(chatWindowSource).toContain('emailComposerActions');
-        expect(chatWindowSource).toContain('emailReducer');
-        expect(chatWindowSource).toContain('initialEmailComposerState');
-        expect(chatWindowSource).toMatch(/useReducer\(emailReducer,\s*initialEmailComposerState\)/);
+        expect(chatWindowSource).toContain("const LazyTeamEmailSheet = lazy(() => import('./TeamEmailSheet'));");
+        expect(teamEmailSheetSource).toContain("from '../state/emailReducer';");
+        expect(teamEmailSheetSource).toContain('emailComposerActions');
+        expect(teamEmailSheetSource).toContain('emailReducer');
+        expect(teamEmailSheetSource).toContain('initialEmailComposerState');
+        expect(teamEmailSheetSource).toMatch(/useReducer\(emailReducer,\s*initialEmailComposerState\)/);
         expect(messagesSource).not.toMatch(/const\s+\[emailSubject\b/);
         expect(messagesSource).not.toMatch(/const\s+\[emailBody\b/);
         expect(messagesSource).not.toMatch(/const\s+\[selectedEmailDraftId\b/);
@@ -99,7 +101,7 @@ describe('Messages decomposition initiative source contract', () => {
         expect(useStateCount).toBeLessThan(10);
         expect(messagesSource.split('\n').length).toBeLessThan(1600);
         expect(chatWindowSource).toContain('const visibleMessages = useMemo(');
-        expect(chatWindowSource).toContain('const emailAudienceMetadata = useMemo(() => buildEmailAudienceMetadata({');
+        expect(teamEmailSheetSource).toContain('const emailAudienceMetadata = useMemo(() => buildEmailAudienceMetadata({');
         expect(chatWindowSource).toContain('const mediaEntries = useMemo(() => collectThreadMedia(visibleMessages), [visibleMessages]);');
     });
 });


### PR DESCRIPTION
Closes #3677

## What changed
- Extracted the Team Email sheet, reducer ownership, and Team Email service orchestration into `TeamEmailSheet.tsx`.
- Updated `ChatWindow.tsx` to keep only the moderator-only open/close boundary and lazy-load the Team Email module after Open Team Email is clicked.
- Kept the lazy sheet mounted after first open for the same team so close/reopen preserves loaded drafts, templates, sent history, and composer state.
- Added source and component regression coverage for the lazy import boundary.

## Root Cause
`ChatWindow.tsx` statically imported Team Email reducer and service functions and defined the full Team Email sheet inline, so every Messages thread paid the parse/render cost for a staff-only workflow before the workflow was opened.

## Prevention / Learning
Role-gated or hidden modal workflows should own their reducer/service orchestration inside a lazy-loaded component. Route-level modules should expose only the open/close boundary and context props, with source-level import guards for expensive/admin-only code.

## Regression Tests
- `npm --prefix apps/app run test -- src/pages/messages/components/ChatWindow.test.tsx src/pages/messages/components/ChatWindow.virtualization.test.tsx src/pages/messages/state/__tests__/emailReducer.test.ts`
- `npm --prefix apps/app run build`