### PR TITLE
Defer Team Fees recipient editors

### DIFF
--- a/apps/app/src/pages/TeamFees.test.tsx
+++ b/apps/app/src/pages/TeamFees.test.tsx
@@ -72,6 +72,36 @@ function renderTeamFees(initialEntry = '/teams/team-1/fees/batch-1') {
   );
 }
 
+function getRecipientCard(name: string) {
+  const card = screen.getByText(name).closest('section');
+  if (!card) throw new Error(`Recipient card not found for ${name}`);
+  return card;
+}
+
+function openRecipientDetails(name: string) {
+  const card = getRecipientCard(name);
+  fireEvent.click(within(card).getByRole('button', { name: 'Open details' }));
+  return card;
+}
+
+function buildRecipient(index: number, overrides: Record<string, any> = {}) {
+  return {
+    id: `recipient-${index}`,
+    playerName: `Player ${index}`,
+    parentName: `Parent ${index}`,
+    parentEmail: `parent${index}@example.com`,
+    status: 'unpaid',
+    collectionMode: 'online_stripe',
+    checkoutUrl: '',
+    checkoutStatus: '',
+    amountDueCents: 10000,
+    amountPaidCents: 0,
+    remainingBalanceCents: 10000,
+    paymentLedger: [],
+    ...overrides
+  };
+}
+
 describe('TeamFees recipient queue', () => {
   afterEach(() => {
     cleanup();
@@ -149,21 +179,64 @@ describe('TeamFees recipient queue', () => {
     });
   });
 
-  it('shows only unpaid and partial recipients in the default payment queue', async () => {
+  it('shows compact unpaid and partial recipient rows without mounting editors by default', async () => {
     renderTeamFees();
 
-    const queue = await screen.findByLabelText('Actionable recipients');
+    await screen.findByText('Unpaid Player');
+    const queue = screen.getByLabelText('Actionable recipient list');
     expect(within(queue).getByText('Unpaid Player')).toBeTruthy();
     expect(within(queue).getByText('Partial Player')).toBeTruthy();
     expect(within(queue).queryByText('Paid Player')).toBeNull();
-    expect(within(queue).getAllByRole('button', { name: 'Record payment' })).toHaveLength(2);
-    expect(within(queue).getAllByRole('button', { name: 'Save adjustment' })).toHaveLength(2);
-    expect(within(queue).getByRole('button', { name: 'Record refund' })).toBeTruthy();
-    expect(screen.getByDisplayValue('100.00')).toBeTruthy();
-    expect(screen.getByDisplayValue('75.00')).toBeTruthy();
-    expect(screen.getAllByText('Positive credits reduce what is owed. Negative charges increase it.')).toHaveLength(3);
-    expect(within(queue).getByRole('button', { name: 'Generate & share link' })).toBeTruthy();
-    expect(within(queue).getByText('This fee is marked for offline collection only, so no Stripe checkout link can be generated from the app.')).toBeTruthy();
+    expect(within(queue).getAllByRole('button', { name: 'Open details' })).toHaveLength(2);
+    expect(within(queue).queryByRole('button', { name: 'Record payment' })).toBeNull();
+    expect(within(queue).queryByRole('button', { name: 'Save adjustment' })).toBeNull();
+    expect(within(queue).queryByRole('button', { name: 'Record refund' })).toBeNull();
+    expect(screen.queryByDisplayValue('100.00')).toBeNull();
+    expect(screen.queryByDisplayValue('75.00')).toBeNull();
+
+    const unpaidCard = openRecipientDetails('Unpaid Player');
+    expect(within(unpaidCard).getByRole('button', { name: 'Record payment' })).toBeTruthy();
+    expect(within(unpaidCard).getByRole('button', { name: 'Save adjustment' })).toBeTruthy();
+    expect(within(unpaidCard).getByRole('button', { name: 'Generate & share link' })).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Record payment' })).toHaveLength(1);
+  });
+
+  it('renders a large batch as summary rows without mounting every editor', async () => {
+    teamFeesServiceMocks.loadTeamFeeManagementModel.mockResolvedValue({
+      team: { id: 'team-1', name: 'Bears' },
+      batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
+      selectedBatch: { id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' },
+      canManageFees: true,
+      rosterPlayers: [],
+      recipients: Array.from({ length: 50 }, (_, index) => buildRecipient(index + 1))
+    });
+
+    renderTeamFees();
+
+    expect(await screen.findByText('Player 1')).toBeTruthy();
+    expect(screen.getByText('Player 50')).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Open details' })).toHaveLength(50);
+    expect(screen.queryByRole('button', { name: 'Record payment' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Save adjustment' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Generate & share link' })).toBeNull();
+  });
+
+  it('unmounts inactive recipient editors while preserving typed drafts', async () => {
+    renderTeamFees();
+
+    await screen.findByText('Unpaid Player');
+    const unpaidCard = openRecipientDetails('Unpaid Player');
+    fireEvent.change(within(unpaidCard).getByDisplayValue('100.00'), { target: { value: '42.25' } });
+    fireEvent.change(within(unpaidCard).getByPlaceholderText('25.00 or -10.00'), { target: { value: '5.00' } });
+
+    const partialCard = openRecipientDetails('Partial Player');
+    expect(within(partialCard).getByRole('button', { name: 'Record payment' })).toBeTruthy();
+    expect(within(unpaidCard).queryByRole('button', { name: 'Record payment' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: 'Record payment' })).toHaveLength(1);
+
+    fireEvent.click(within(unpaidCard).getByRole('button', { name: 'Open details' }));
+    expect(within(unpaidCard).getByDisplayValue('42.25')).toBeTruthy();
+    expect(within(unpaidCard).getByDisplayValue('5.00')).toBeTruthy();
   });
 
   it('generates and shares a staff checkout link with the public URL only', async () => {
@@ -213,7 +286,9 @@ describe('TeamFees recipient queue', () => {
 
     renderTeamFees();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Generate & share link' }));
+    await screen.findByText('Pat Star');
+    const recipientCard = openRecipientDetails('Pat Star');
+    fireEvent.click(within(recipientCard).getByRole('button', { name: 'Generate & share link' }));
 
     expect(await screen.findByText('Shared checkout link for Pat Star.')).toBeTruthy();
     expect(teamFeesServiceMocks.initiateStaffTeamFeeCheckout).toHaveBeenCalledWith({
@@ -306,7 +381,7 @@ describe('TeamFees recipient queue', () => {
     }));
   });
 
-  it('renders paid recipients in a secondary review area with adjustment-only controls', async () => {
+  it('keeps paid recipient controls unmounted until the paid section and recipient are opened', async () => {
     renderTeamFees();
 
     const paidSection = await screen.findByText('Paid recipients (1)');
@@ -314,7 +389,16 @@ describe('TeamFees recipient queue', () => {
     expect(reviewCard).not.toBeNull();
     if (!reviewCard) throw new Error('Paid recipients details not found');
 
+    expect(within(reviewCard).queryByText('Paid Player')).toBeNull();
+    expect(within(reviewCard).queryByRole('button', { name: 'Save adjustment' })).toBeNull();
+    expect(within(reviewCard).queryByRole('button', { name: 'Record refund' })).toBeNull();
+
+    fireEvent.click(paidSection);
     expect(within(reviewCard).getByText('Paid Player')).toBeTruthy();
+    expect(within(reviewCard).queryByRole('button', { name: 'Save adjustment' })).toBeNull();
+    expect(within(reviewCard).queryByRole('button', { name: 'Record refund' })).toBeNull();
+
+    fireEvent.click(within(reviewCard).getByRole('button', { name: 'Open details' }));
     expect(within(reviewCard).queryByRole('button', { name: 'Record payment' })).toBeNull();
     expect(within(reviewCard).queryByText('Record offline payment')).toBeNull();
     expect(within(reviewCard).getByRole('button', { name: 'Save adjustment' })).toBeTruthy();
@@ -361,8 +445,10 @@ describe('TeamFees recipient queue', () => {
 
     renderTeamFees();
 
-    const refundTrigger = await screen.findByRole('button', { name: 'Record refund' });
-    fireEvent.click(refundTrigger);
+    await screen.findByText('Paid recipients (1)');
+    fireEvent.click(screen.getByText('Paid recipients (1)'));
+    const recipientCard = openRecipientDetails('Pat Star');
+    fireEvent.click(within(recipientCard).getByRole('button', { name: 'Record refund' }));
     fireEvent.change(screen.getByDisplayValue('Full refund'), { target: { value: 'partial' } });
     fireEvent.change(screen.getByPlaceholderText('100.00'), { target: { value: '25.00' } });
     fireEvent.change(screen.getByDisplayValue('Select method'), { target: { value: 'cash' } });
@@ -386,8 +472,8 @@ describe('TeamFees recipient queue', () => {
 
     renderTeamFees();
 
-    const recipientCard = (await screen.findByText('Partial Player')).closest('section');
-    if (!recipientCard) throw new Error('Recipient card not found');
+    await screen.findByText('Partial Player');
+    const recipientCard = openRecipientDetails('Partial Player');
 
     fireEvent.click(within(recipientCard).getByRole('button', { name: 'Record refund' }));
     fireEvent.change(within(recipientCard).getByPlaceholderText('Why this was refunded and how it was handled'), { target: { value: 'Need to fix overcollection' } });
@@ -436,8 +522,8 @@ describe('TeamFees recipient queue', () => {
 
     renderTeamFees();
 
-    const recipientCard = (await screen.findByText('Pat Star')).closest('section');
-    if (!recipientCard) throw new Error('Recipient card not found');
+    await screen.findByText('Pat Star');
+    const recipientCard = openRecipientDetails('Pat Star');
     fireEvent.change(within(recipientCard).getByPlaceholderText('25.00 or -10.00'), { target: { value: '25.00' } });
     fireEvent.change(within(recipientCard).getByPlaceholderText('Scholarship credit, late fee, correction...'), { target: { value: 'Scholarship credit' } });
     fireEvent.click(within(recipientCard).getByRole('button', { name: 'Save adjustment' }));
@@ -462,8 +548,8 @@ describe('TeamFees recipient queue', () => {
 
     renderTeamFees();
 
-    const recipientCard = (await screen.findByText('Unpaid Player')).closest('section');
-    if (!recipientCard) throw new Error('Recipient card not found');
+    await screen.findByText('Unpaid Player');
+    const recipientCard = openRecipientDetails('Unpaid Player');
 
     fireEvent.click(within(recipientCard).getByRole('button', { name: 'Record payment' }));
 

--- a/apps/app/src/pages/TeamFees.tsx
+++ b/apps/app/src/pages/TeamFees.tsx
@@ -64,6 +64,8 @@ export function TeamFees({ auth }: { auth: AuthState }) {
   const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>([]);
   const [createError, setCreateError] = useState('');
   const [formByRecipient, setFormByRecipient] = useState<Record<string, RecipientFormState>>({});
+  const [activeRecipientId, setActiveRecipientId] = useState('');
+  const [paidRecipientsOpen, setPaidRecipientsOpen] = useState(false);
   const { error: loadError, clearError: clearLoadError, run: runLoadOperation } = useAppAsyncOperation();
   const { run: runMutationOperation } = useAppAsyncOperation();
 
@@ -78,7 +80,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
         fallbackMessage: 'Unable to load team fees.',
         onSuccess: (nextModel) => {
           setModel(nextModel);
-          setFormByRecipient((current) => seedRecipientForms(current, nextModel.recipients));
+          setFormByRecipient((current) => pruneRecipientForms(current, nextModel.recipients));
           if (nextModel.selectedBatch?.id && nextModel.selectedBatch.id !== batchId) {
             navigate(`/teams/${encodeURIComponent(teamId)}/fees/${encodeURIComponent(nextModel.selectedBatch.id)}`, { replace: true });
           }
@@ -152,10 +154,11 @@ export function TeamFees({ auth }: { auth: AuthState }) {
   if (!teamId) return <Navigate to="/teams" replace />;
 
   const updateForm = (recipientId: string, patch: Partial<RecipientFormState>) => {
+    const recipient = recipients.find((nextRecipient) => nextRecipient.id === recipientId);
     setFormByRecipient((current) => ({
       ...current,
       [recipientId]: {
-        ...(current[recipientId] || buildRecipientFormState()),
+        ...(current[recipientId] || buildRecipientFormState(recipient)),
         ...patch
       }
     }));
@@ -170,6 +173,10 @@ export function TeamFees({ auth }: { auth: AuthState }) {
   const updateCreateDueDate = (nextDueDate: string) => {
     setCreateDueDate(nextDueDate);
     setCreateInstallmentFirstDueDate((current) => current && current !== createDueDate ? current : nextDueDate);
+  };
+
+  const toggleActiveRecipient = (recipientId: string) => {
+    setActiveRecipientId((current) => current === recipientId ? '' : recipientId);
   };
 
   const submitCreateBatch = async (event: FormEvent<HTMLFormElement>) => {
@@ -535,75 +542,28 @@ export function TeamFees({ auth }: { auth: AuthState }) {
           <h2 id="actionable-recipients-heading" className="text-sm font-black uppercase tracking-[0.06em] text-gray-500">Actionable recipients</h2>
           <p className="mt-1 text-xs font-semibold text-gray-500">Only recipients with an outstanding balance appear in the payment queue.</p>
         </div>
-        <div className="grid gap-3 lg:grid-cols-2">
+        <div className="grid gap-3 lg:grid-cols-2" aria-label="Actionable recipient list">
           {actionableRecipients.length ? actionableRecipients.map((recipient) => {
             const form = formByRecipient[recipient.id] || buildRecipientFormState(recipient);
             const recipientSubmitting = isRecipientSubmitting(recipient.id);
+            const expanded = activeRecipientId === recipient.id;
             return (
               <section key={recipient.id} className="app-card p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <h3 className="text-lg font-black text-gray-950">{recipient.playerName}</h3>
-                    <p className="mt-1 text-xs font-semibold text-gray-500">{[recipient.parentName, recipient.parentEmail].filter(Boolean).join(' · ') || 'Fee recipient'}</p>
-                  </div>
-                  <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-black uppercase text-gray-700">{recipient.status}</span>
-                </div>
-
-                <div className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
-                  <Metric label="Status" value={recipient.status} />
-                  <Metric label="Amount due" value={formatMoney(recipient.amountDueCents)} />
-                  <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
-                  <Metric label="Outstanding" value={formatMoney(recipient.remainingBalanceCents)} urgent={recipient.remainingBalanceCents > 0} />
-                </div>
-
-                <CheckoutLinkSection
-                  recipient={recipient}
-                  form={form}
-                  recipientSubmitting={recipientSubmitting}
-                  onShare={() => shareCheckoutLink(recipient)}
-                  onCopy={() => copyCheckoutLink(recipient)}
-                />
-
-                <form className="mt-4 space-y-3" onSubmit={(event) => submitPayment(event, recipient)}>
-                  <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Record offline payment</div>
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment amount
-                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.paymentAmount} onChange={(event) => updateForm(recipient.id, { paymentAmount: event.target.value })} disabled={recipientSubmitting} />
-                    </label>
-                    <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment date
-                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.paymentDate} onChange={(event) => updateForm(recipient.id, { paymentDate: event.target.value })} disabled={recipientSubmitting} />
-                    </label>
-                  </div>
-                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment note
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.paymentNote} onChange={(event) => updateForm(recipient.id, { paymentNote: event.target.value })} disabled={recipientSubmitting} />
-                  </label>
-                  {form.paymentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.paymentError}</div> : null}
-                  <button type="submit" className="primary-button w-full" disabled={recipientSubmitting}>{submittingId === `payment:${recipient.id}` ? 'Recording...' : 'Record payment'}</button>
-                </form>
-
-                <form className="mt-4 space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3" onSubmit={(event) => submitAdjustment(event, recipient)}>
-                  <div>
-                    <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Adjust balance</div>
-                    <p className="mt-1 text-xs font-semibold text-gray-500">Positive credits reduce what is owed. Negative charges increase it.</p>
-                  </div>
-                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Signed amount
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} disabled={recipientSubmitting} />
-                  </label>
-                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Reason
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} disabled={recipientSubmitting} />
-                  </label>
-                  {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
-                  <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
-                </form>
-
-                <RefundSection
-                  recipient={recipient}
-                  form={form}
-                  submittingId={submittingId}
-                  recipientSubmitting={recipientSubmitting}
-                  updateForm={updateForm}
-                  submitRefund={submitRefund}
-                />
+                <RecipientSummary recipient={recipient} expanded={expanded} onToggle={() => toggleActiveRecipient(recipient.id)} />
+                {expanded ? (
+                  <RecipientEditor
+                    recipient={recipient}
+                    form={form}
+                    submittingId={submittingId}
+                    recipientSubmitting={recipientSubmitting}
+                    updateForm={updateForm}
+                    submitPayment={submitPayment}
+                    submitAdjustment={submitAdjustment}
+                    submitRefund={submitRefund}
+                    shareCheckoutLink={shareCheckoutLink}
+                    copyCheckoutLink={copyCheckoutLink}
+                  />
+                ) : null}
               </section>
             );
           }) : recipients.length ? (
@@ -618,59 +578,39 @@ export function TeamFees({ auth }: { auth: AuthState }) {
 
       {paidRecipients.length ? (
         <details className="app-card p-4">
-          <summary className="cursor-pointer list-none text-sm font-black text-gray-950">
+          <summary className="cursor-pointer list-none text-sm font-black text-gray-950" onClick={() => setPaidRecipientsOpen((current) => !current)}>
             Paid recipients ({paidRecipients.length})
           </summary>
           <p className="mt-2 text-xs font-semibold text-gray-500">Fully paid recipients stay available for review without editable payment controls.</p>
-          <div className="mt-4 grid gap-3 lg:grid-cols-2">
-            {paidRecipients.map((recipient) => {
+          {paidRecipientsOpen ? (
+            <div className="mt-4 grid gap-3 lg:grid-cols-2">
+              {paidRecipients.map((recipient) => {
               const form = formByRecipient[recipient.id] || buildRecipientFormState(recipient);
               const recipientSubmitting = isRecipientSubmitting(recipient.id);
+              const expanded = activeRecipientId === recipient.id;
               return (
               <section key={recipient.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <h3 className="text-lg font-black text-gray-950">{recipient.playerName}</h3>
-                    <p className="mt-1 text-xs font-semibold text-gray-500">{[recipient.parentName, recipient.parentEmail].filter(Boolean).join(' · ') || 'Fee recipient'}</p>
-                  </div>
-                  <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-black uppercase text-emerald-700">{recipient.status}</span>
-                </div>
-
-                <div className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
-                  <Metric label="Status" value={recipient.status} />
-                  <Metric label="Amount due" value={formatMoney(recipient.amountDueCents)} />
-                  <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
-                  <Metric label="Outstanding" value={formatMoney(recipient.remainingBalanceCents)} />
-                </div>
-
-                <form className="mt-4 space-y-3 rounded-2xl border border-gray-200 bg-white p-3" onSubmit={(event) => submitAdjustment(event, recipient)}>
-                  <div>
-                    <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Adjust balance</div>
-                    <p className="mt-1 text-xs font-semibold text-gray-500">Positive credits reduce what is owed. Negative charges increase it.</p>
-                  </div>
-                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Signed amount
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} disabled={recipientSubmitting} />
-                  </label>
-                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Reason
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} disabled={recipientSubmitting} />
-                  </label>
-                  {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
-                  <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
-                </form>
-
-                <RefundSection
-                  recipient={recipient}
-                  form={form}
-                  submittingId={submittingId}
-                  recipientSubmitting={recipientSubmitting}
-                  updateForm={updateForm}
-                  submitRefund={submitRefund}
-                  className="mt-4"
-                />
+                <RecipientSummary recipient={recipient} expanded={expanded} onToggle={() => toggleActiveRecipient(recipient.id)} />
+                {expanded ? (
+                  <RecipientEditor
+                    recipient={recipient}
+                    form={form}
+                    submittingId={submittingId}
+                    recipientSubmitting={recipientSubmitting}
+                    updateForm={updateForm}
+                    submitPayment={submitPayment}
+                    submitAdjustment={submitAdjustment}
+                    submitRefund={submitRefund}
+                    shareCheckoutLink={shareCheckoutLink}
+                    copyCheckoutLink={copyCheckoutLink}
+                    hidePayment
+                  />
+                ) : null}
               </section>
               );
-            })}
-          </div>
+              })}
+            </div>
+          ) : null}
         </details>
       ) : null}
 
@@ -704,9 +644,10 @@ function buildRecipientFormState(recipient?: TeamFeeRecipientSummary): Recipient
   };
 }
 
-function seedRecipientForms(current: Record<string, RecipientFormState>, recipients: TeamFeeRecipientSummary[]) {
+function pruneRecipientForms(current: Record<string, RecipientFormState>, recipients: TeamFeeRecipientSummary[]) {
+  const recipientIds = new Set(recipients.map((recipient) => recipient.id));
   return recipients.reduce<Record<string, RecipientFormState>>((next, recipient) => {
-    next[recipient.id] = current[recipient.id] || buildRecipientFormState(recipient);
+    if (recipientIds.has(recipient.id) && current[recipient.id]) next[recipient.id] = current[recipient.id];
     return next;
   }, {});
 }
@@ -762,6 +703,124 @@ function StatusCard({ title, message, backTo, onRetry }: { title: string; messag
         </div>
       </div>
     </section>
+  );
+}
+
+function RecipientSummary({
+  recipient,
+  expanded,
+  onToggle
+}: {
+  recipient: TeamFeeRecipientSummary;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const paid = recipient.remainingBalanceCents <= 0;
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-black text-gray-950">{recipient.playerName}</h3>
+          <p className="mt-1 text-xs font-semibold text-gray-500">{[recipient.parentName, recipient.parentEmail].filter(Boolean).join(' · ') || 'Fee recipient'}</p>
+        </div>
+        <span className={`rounded-full px-2.5 py-1 text-xs font-black uppercase ${paid ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-100 text-gray-700'}`}>{recipient.status}</span>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
+        <Metric label="Status" value={recipient.status} />
+        <Metric label="Amount due" value={formatMoney(recipient.amountDueCents)} />
+        <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
+        <Metric label="Outstanding" value={formatMoney(recipient.remainingBalanceCents)} urgent={recipient.remainingBalanceCents > 0} />
+      </div>
+
+      <button type="button" className="secondary-button mt-3 w-full justify-center" aria-expanded={expanded} onClick={onToggle}>
+        {expanded ? 'Close details' : 'Open details'}
+      </button>
+    </>
+  );
+}
+
+function RecipientEditor({
+  recipient,
+  form,
+  submittingId,
+  recipientSubmitting,
+  updateForm,
+  submitPayment,
+  submitAdjustment,
+  submitRefund,
+  shareCheckoutLink,
+  copyCheckoutLink,
+  hidePayment = false
+}: {
+  recipient: TeamFeeRecipientSummary;
+  form: RecipientFormState;
+  submittingId: string;
+  recipientSubmitting: boolean;
+  updateForm: (recipientId: string, patch: Partial<RecipientFormState>) => void;
+  submitPayment: (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => Promise<void>;
+  submitAdjustment: (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => Promise<void>;
+  submitRefund: (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => Promise<void>;
+  shareCheckoutLink: (recipient: TeamFeeRecipientSummary) => Promise<void>;
+  copyCheckoutLink: (recipient: TeamFeeRecipientSummary) => Promise<void>;
+  hidePayment?: boolean;
+}) {
+  return (
+    <>
+      {!hidePayment ? (
+        <>
+          <CheckoutLinkSection
+            recipient={recipient}
+            form={form}
+            recipientSubmitting={recipientSubmitting}
+            onShare={() => shareCheckoutLink(recipient)}
+            onCopy={() => copyCheckoutLink(recipient)}
+          />
+
+          <form className="mt-4 space-y-3" onSubmit={(event) => submitPayment(event, recipient)}>
+            <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Record offline payment</div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment amount
+                <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.paymentAmount} onChange={(event) => updateForm(recipient.id, { paymentAmount: event.target.value })} disabled={recipientSubmitting} />
+              </label>
+              <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment date
+                <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.paymentDate} onChange={(event) => updateForm(recipient.id, { paymentDate: event.target.value })} disabled={recipientSubmitting} />
+              </label>
+            </div>
+            <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment note
+              <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.paymentNote} onChange={(event) => updateForm(recipient.id, { paymentNote: event.target.value })} disabled={recipientSubmitting} />
+            </label>
+            {form.paymentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.paymentError}</div> : null}
+            <button type="submit" className="primary-button w-full" disabled={recipientSubmitting}>{submittingId === `payment:${recipient.id}` ? 'Recording...' : 'Record payment'}</button>
+          </form>
+        </>
+      ) : null}
+
+      <form className="mt-4 space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3" onSubmit={(event) => submitAdjustment(event, recipient)}>
+        <div>
+          <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Adjust balance</div>
+          <p className="mt-1 text-xs font-semibold text-gray-500">Positive credits reduce what is owed. Negative charges increase it.</p>
+        </div>
+        <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Signed amount
+          <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} disabled={recipientSubmitting} />
+        </label>
+        <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Reason
+          <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} disabled={recipientSubmitting} />
+        </label>
+        {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
+        <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
+      </form>
+
+      <RefundSection
+        recipient={recipient}
+        form={form}
+        submittingId={submittingId}
+        recipientSubmitting={recipientSubmitting}
+        updateForm={updateForm}
+        submitRefund={submitRefund}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
Closes #3683

## What changed
- Render Team Fees recipients as compact summary rows on initial load.
- Mount payment, adjustment, checkout, and refund controls only for the active recipient.
- Keep paid recipients unmounted until the paid section is opened, then defer controls until a paid recipient is opened.
- Preserve per-recipient draft form values while switching between recipients.

## Root Cause
TeamFees treated every recipient row as an always-expanded editor and seeded form state for every recipient during refresh, so large batches mounted payment, adjustment, checkout, and refund controls before an admin selected anyone to edit.

## Prevention / Learning
Large roster or recipient-management screens should render summaries first, lazy-mount only the active editor, and keep draft state keyed independently from mounted editor DOM.

## Regression Tests
- `npm --prefix apps/app test -- TeamFees.test.tsx`
- `npm --prefix apps/app run build`
- Added 50-recipient coverage proving initial render mounts summary rows without eager payment/adjustment/checkout editors.
- Added draft-preservation coverage for switching recipients.
- Updated paid-recipient coverage to require closed paid sections and unopened paid rows to keep controls out of the DOM.

## Recurrence Risk
Low. Focused component tests now cover large-batch initial render, editor switching, paid-recipient lazy mounting, and existing mutation call shapes.