### PR TITLE
Decouple public team search primitives

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs';
 import type { ComponentProps } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
@@ -87,6 +88,13 @@ describe('PublicTeamSearch', () => {
         expect(screen.queryByRole('button', { name: 'Clear public team search' })).toBeNull();
         expect(screen.queryByText('Atlanta United')).toBeNull();
         expect(getPublicTeamsPage).not.toHaveBeenCalled();
+    });
+
+    it('keeps the public browse route decoupled from the private Teams page module', () => {
+        const source = readFileSync('src/components/PublicTeamSearch.tsx', 'utf8');
+
+        expect(source).not.toContain('../pages/Teams');
+        expect(source).toContain('./TeamSummaryPrimitives');
     });
 
     it('does not browse all teams when the search button is clicked with an empty or whitespace-only query', async () => {

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Search, XCircle, Loader2, Users } from 'lucide-react';
 import { type ParentHomeTeam } from '../lib/homeLogic';
-import { TeamAvatar, TeamLauncherChip, Status } from '../pages/Teams';
+import { TeamAvatar, TeamLauncherChip, Status } from './TeamSummaryPrimitives';
 import { getPublicTeamsPage } from '../lib/publicTeamsService';
 import { openPublicUrl } from '../lib/publicActions';
 import { getTeamWebsiteHashHref } from '../lib/teamNavigation';
@@ -293,5 +293,3 @@ function PublicTeamCard({ team, onOpenTeam }: { team: ParentHomeTeam; onOpenTeam
     </article>
   );
 }
-
-// Remove duplicated Status component as it's now imported from './Teams'

--- a/apps/app/src/components/TeamSummaryPrimitives.tsx
+++ b/apps/app/src/components/TeamSummaryPrimitives.tsx
@@ -1,0 +1,40 @@
+import { Shield } from 'lucide-react';
+
+export function getInitials(name: string) {
+  return name.split(/\s+/).filter(Boolean).slice(0, 2).map((part) => part[0]?.toUpperCase()).join('') || 'T';
+}
+
+export function TeamAvatar({ name, photoUrl, large = false }: { name: string; photoUrl?: string | null; large?: boolean }) {
+  if (photoUrl) {
+    return (
+      <span className={`flex flex-none overflow-hidden rounded-2xl bg-gray-100 shadow-sm ${large ? 'h-12 w-12' : 'h-11 w-11'}`}>
+        <img src={photoUrl} alt="" className="h-full w-full object-cover" loading="lazy" />
+      </span>
+    );
+  }
+  return (
+    <span className={`flex flex-none items-center justify-center rounded-2xl bg-gray-950 font-black text-white shadow-sm ${large ? 'h-12 w-12 text-sm' : 'h-11 w-11 text-xs'}`}>
+      {getInitials(name)}
+    </span>
+  );
+}
+
+export function TeamLauncherChip({ label, tone = 'gray' }: { label: string; tone?: 'gray' | 'primary' | 'amber' }) {
+  const toneClass = tone === 'primary'
+    ? 'bg-primary-50 text-primary-700'
+    : tone === 'amber'
+      ? 'bg-amber-50 text-amber-700'
+      : 'bg-gray-100 text-gray-600';
+
+  return <span className={`rounded-full px-2 py-0.5 text-[10px] font-black ${toneClass}`}>{label}</span>;
+}
+
+export function Status({ tone, message }: { tone: 'error' | 'success'; message: string }) {
+  const isError = tone === 'error';
+  return (
+    <div className={`flex items-start gap-2 rounded-xl border px-3 py-2 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
+      <Shield className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
+      {message}
+    </div>
+  );
+}

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -25,6 +25,7 @@ import {
   WalletCards
 } from 'lucide-react';
 import { RoleBadge } from '../components/Badges';
+import { TeamAvatar, TeamLauncherChip, Status, getInitials } from '../components/TeamSummaryPrimitives';
 import { toAppServiceError, type AppServiceError } from '../lib/appErrors';
 import { getEventDetailPath, getPlayerDetailPath, type ParentHomeModel, type ParentHomeTeam } from '../lib/homeLogic';
 import { loadParentHomeSummary, loadParentTeamsSummaryBootstrap } from '../lib/homeService';
@@ -433,16 +434,6 @@ function TeamHubQuickLink({ team }: { team: ParentHomeTeam }) {
   );
 }
 
-export function TeamLauncherChip({ label, tone = 'gray' }: { label: string; tone?: 'gray' | 'primary' | 'amber' }) {
-  const toneClass = tone === 'primary'
-    ? 'bg-primary-50 text-primary-700'
-    : tone === 'amber'
-      ? 'bg-amber-50 text-amber-700'
-      : 'bg-gray-100 text-gray-600';
-
-  return <span className={`rounded-full px-2 py-0.5 text-[10px] font-black ${toneClass}`}>{label}</span>;
-}
-
 function SelectedTeamPanel({ team, variant = 'mobile' }: { team: ParentHomeTeam; variant?: 'mobile' | 'web' }) {
   const [showAllTools, setShowAllTools] = useState(false);
   const navigationSections = useMemo(() => buildTeamNavigation(team), [team]);
@@ -704,35 +695,6 @@ function TeamsLoadErrorState({ error, onRetry, retrying }: { error: AppServiceEr
         Retry
       </button>
     </section>
-  );
-}
-
-export function Status({ tone, message }: { tone: 'error' | 'success'; message: string }) {
-  const isError = tone === 'error';
-  return (
-    <div className={`flex items-start gap-2 rounded-xl border px-3 py-2 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
-      <Shield className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
-      {message}
-    </div>
-  );
-}
-
-function getInitials(name: string) {
-  return name.split(/\s+/).filter(Boolean).slice(0, 2).map((part) => part[0]?.toUpperCase()).join('') || 'T';
-}
-
-export function TeamAvatar({ name, photoUrl, large = false }: { name: string; photoUrl?: string | null; large?: boolean }) {
-  if (photoUrl) {
-    return (
-      <span className={`flex flex-none overflow-hidden rounded-2xl bg-gray-100 shadow-sm ${large ? 'h-12 w-12' : 'h-11 w-11'}`}>
-        <img src={photoUrl} alt="" className="h-full w-full object-cover" loading="lazy" />
-      </span>
-    );
-  }
-  return (
-    <span className={`flex flex-none items-center justify-center rounded-2xl bg-gray-950 font-black text-white shadow-sm ${large ? 'h-12 w-12 text-sm' : 'h-11 w-11 text-xs'}`}>
-      {getInitials(name)}
-    </span>
   );
 }
 


### PR DESCRIPTION
Closes #3676

## What changed
- Moved `TeamAvatar`, `TeamLauncherChip`, `Status`, and `getInitials` into `apps/app/src/components/TeamSummaryPrimitives.tsx`.
- Updated `PublicTeamSearch` and `Teams` to import the shared primitives from the lightweight component module.
- Added an import-boundary regression test so `PublicTeamSearch.tsx` cannot reintroduce a `../pages/Teams` dependency.

## Root Cause
`PublicTeamSearch` imported small presentational helpers from the full `Teams.tsx` route module. Because `/teams/browse` lazy-loads `PublicTeamsBrowse`, that static import pulled private Teams page code and its data-loading dependencies into the public browse route path.

## Prevention / Learning
Shared UI primitives used by multiple lazy routes should live in lightweight component modules, not route page modules. Add boundary tests for route-level performance fixes so the coupling cannot quietly regress.

## Regression Tests
- `npm --prefix apps/app run test:ci -- PublicTeamSearch Teams`
- `npm run app:build`
- Verified the built `PublicTeamsBrowse` chunk has no Teams page/homeService markers.