### PR TITLE
Add browse-all recovery to public team search

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -280,7 +280,28 @@ describe('PublicTeamSearch', () => {
             const message = screen.getByText(/No public teams found/i);
             expect(message.textContent).toContain('for "boston"');
         });
+        expect(screen.getByRole('button', { name: /Browse all public teams/i })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Clear search' })).toBeTruthy();
         expect(screen.queryByText('Atlanta United')).toBeNull();
+    });
+
+    it('recovers from an empty filtered search by browsing all public teams', async () => {
+        (getPublicTeamsPage as import('vitest').Mock)
+            .mockResolvedValueOnce({ teams: [], nextCursor: null })
+            .mockResolvedValueOnce({ teams: mockTeams, nextCursor: null });
+        renderSearch();
+
+        const searchInput = screen.getByPlaceholderText('Search by team, city, state, or zip') as HTMLInputElement;
+        fireEvent.change(searchInput, { target: { value: 'not-a-team' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Search public teams' }));
+
+        await waitFor(() => expect(screen.getByText(/No public teams found/i)).toBeTruthy());
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(getPublicTeamsPage).toHaveBeenNthCalledWith(2, { searchText: undefined, cursor: null }));
+        expect(screen.getByText('Atlanta United')).toBeTruthy();
+        expect(screen.getByText('New York Knicks')).toBeTruthy();
+        expect(screen.queryByText(/No public teams found/i)).toBeNull();
     });
 
     it('groups teams into separate location sections after browsing all', async () => {

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -29,9 +29,15 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
   const [nextCursor, setNextCursor] = useState<unknown | null>(null);
   const autoBrowseTriggeredRef = useRef(false);
   const latestRequestIdRef = useRef(0);
+  const pendingRequestKeyRef = useRef<string | null>(null);
 
   const fetchPublicTeams = useCallback(async ({ searchText, cursor = null, append = false }: { searchText?: string; cursor?: unknown | null; append?: boolean } = {}) => {
     const submittedSearchText = searchText?.trim() || undefined;
+    const requestKey = publicTeamRequestKey(submittedSearchText);
+    if (!append && pendingRequestKeyRef.current === requestKey) {
+      return;
+    }
+
     const requestId = latestRequestIdRef.current + 1;
     latestRequestIdRef.current = requestId;
 
@@ -40,7 +46,8 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
       setError('');
       setPendingSearchQuery(submittedSearchText || null);
       setPendingMode(submittedSearchText ? 'search' : 'browse');
-      setPendingRequestKey(publicTeamRequestKey(submittedSearchText));
+      pendingRequestKeyRef.current = requestKey;
+      setPendingRequestKey(requestKey);
     }
     setHasSearched(true);
     try {
@@ -65,6 +72,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
         setLoading(false);
         setPendingSearchQuery(null);
         setPendingMode(null);
+        pendingRequestKeyRef.current = null;
         setPendingRequestKey(null);
       }
     }
@@ -99,6 +107,7 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
     setActiveSearchQuery(null);
     setPendingSearchQuery(null);
     setPendingMode(null);
+    pendingRequestKeyRef.current = null;
     setPendingRequestKey(null);
     setHasSearched(false);
     setLoading(false);
@@ -250,8 +259,27 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
           ) : null}
         </div>
       ) : (
-        <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500 text-center">
-          No public teams found {activeSearchQuery ? `for "${activeSearchQuery}"` : ''}. Try a different search or browse all public teams.
+        <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-center">
+          <div className="text-sm font-semibold text-gray-500">
+            No public teams found {activeSearchQuery ? `for "${activeSearchQuery}"` : ''}. Try a different search or browse all public teams.
+          </div>
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-center">
+            <button
+              type="button"
+              className="primary-button w-full justify-center !min-h-10 !px-4 text-sm sm:w-auto"
+              onClick={handleBrowseAll}
+              disabled={loading && pendingRequestKey === publicTeamRequestKey(undefined)}
+            >
+              Browse all public teams
+            </button>
+            <button
+              type="button"
+              className="ghost-button w-full justify-center !min-h-10 !px-4 text-sm sm:w-auto"
+              onClick={handleClear}
+            >
+              Clear search
+            </button>
+          </div>
         </div>
       )}
     </section>


### PR DESCRIPTION
Closes #3668

## What changed
- Added Browse all public teams and Clear search actions to the zero-results public team search panel.
- Reused the existing unfiltered browse handler so users can recover directly from an empty filtered search.
- Added a synchronous pending request key guard to avoid duplicate identical in-flight browse/search requests.

## Root Cause
PublicTeamSearch rendered the empty-results branch as static instructional copy while the existing handleBrowseAll action was only exposed in the initial search-first state.

## Prevention / Learning
When empty-state copy names a recovery action, render the actual action in that same state and cover the full empty-to-recovered flow in component tests.

## Regression Tests
- `npm --prefix apps/app test -- PublicTeamSearch.test.tsx --run`
- Added coverage that zero-result searches render Browse all public teams and Clear search.
- Added coverage for search -> no results -> browse all -> team cards render and the no-results message disappears.

## Recurrence Risk
Low: the exact empty-state recovery path is now covered by focused component tests.