### PR TITLE
Bound app search caches

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -187,14 +187,21 @@ jobs:
 
       - name: Resolve iOS package dependencies
         run: |
-          reset_swiftpm_artifact_cache() {
-            rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts"
+          SWIFTPM_SOURCE_PACKAGES="$RUNNER_TEMP/swiftpm-source-packages"
+          XCODE_DERIVED_DATA="$RUNNER_TEMP/xcode-derived-data"
+
+          reset_swiftpm_package_state() {
+            rm -rf \
+              "$SWIFTPM_SOURCE_PACKAGES" \
+              "$XCODE_DERIVED_DATA" \
+              "$HOME/Library/Caches/org.swift.swiftpm" \
+              "$HOME/Library/Developer/Xcode/DerivedData"/*/SourcePackages
           }
 
           run_with_retry() {
             attempt=1
             delay=20
-            reset_swiftpm_artifact_cache
+            reset_swiftpm_package_state
             until "$@"; do
               if [ "$attempt" -ge 3 ]; then
                 return 1
@@ -202,7 +209,7 @@ jobs:
               echo "Attempt $attempt failed. Retrying in ${delay}s..."
               attempt=$((attempt + 1))
               sleep "$delay"
-              reset_swiftpm_artifact_cache
+              reset_swiftpm_package_state
               delay=$((delay * 2))
             done
           }
@@ -210,7 +217,9 @@ jobs:
           run_with_retry xcodebuild \
             -resolvePackageDependencies \
             -project ios/App/App.xcodeproj \
-            -scheme App
+            -scheme App \
+            -clonedSourcePackagesDirPath "$SWIFTPM_SOURCE_PACKAGES" \
+            -derivedDataPath "$XCODE_DERIVED_DATA"
 
       - name: Build iOS simulator app
         run: |
@@ -234,6 +243,8 @@ jobs:
             -configuration Debug \
             -sdk iphonesimulator \
             -destination 'generic/platform=iOS Simulator' \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/swiftpm-source-packages" \
+            -derivedDataPath "$RUNNER_TEMP/xcode-derived-data" \
             CODE_SIGNING_ALLOWED=NO \
             build
 

--- a/apps/app/src/lib/searchService.test.ts
+++ b/apps/app/src/lib/searchService.test.ts
@@ -171,6 +171,9 @@ describe('searchService app search caches', () => {
     await expect(secondPendingResult).resolves.toEqual([
       expect.objectContaining({ route: '/players/team-1/player-pending' })
     ]);
+
+    await searchAppPlayers('pending', teamsById, null);
+    expect(legacySearchDbMocks.executeBoundedPlayerSearch.mock.calls.filter(([options]) => options.rawQuery === 'pending')).toHaveLength(1);
   });
 
   it('bounds completed public team cache entries and dedupes concurrent identical requests', async () => {

--- a/apps/app/src/lib/searchService.test.ts
+++ b/apps/app/src/lib/searchService.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppSearchTeam } from './searchService';
+
+const legacySearchDbMocks = vi.hoisted(() => ({
+  collection: vi.fn(),
+  db: {},
+  doc: vi.fn(),
+  executeBoundedPlayerSearch: vi.fn(),
+  getDoc: vi.fn(),
+  getDocs: vi.fn(),
+  isTeamActive: vi.fn(() => true),
+  limit: vi.fn(),
+  orderBy: vi.fn(),
+  playerSearchFirestoreQueryBudget: 12,
+  playerSearchResultLimit: 20,
+  query: vi.fn(),
+  where: vi.fn()
+}));
+
+const publicTeamsServiceMocks = vi.hoisted(() => ({
+  getPublicTeamsPage: vi.fn()
+}));
+
+vi.mock('./adapters/legacySearchDb', () => legacySearchDbMocks);
+vi.mock('./homeService', () => ({
+  loadParentHomeSummary: vi.fn()
+}));
+vi.mock('./helpKnowledgeService', () => ({
+  searchHelpKnowledge: vi.fn(() => [])
+}));
+vi.mock('./publicTeamsService', () => publicTeamsServiceMocks);
+
+import {
+  resetAppSearchCache,
+  searchAppPlayers,
+  searchAppTeams
+} from './searchService';
+
+const searchCacheMaxEntries = 40;
+const teamsById = new Map<string, AppSearchTeam>([
+  ['team-1', { id: 'team-1', name: 'Rockets', isPublic: true }]
+]);
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function buildPlayerDoc(rawQuery: string, name = `${rawQuery} Player`) {
+  return {
+    id: `player-${rawQuery}`,
+    ref: { path: `teams/team-1/players/player-${rawQuery}` },
+    data: () => ({ name })
+  };
+}
+
+function buildPlayerSearchSnapshot(rawQuery: string, name?: string) {
+  return {
+    snapshots: [
+      {
+        status: 'fulfilled',
+        value: { docs: [buildPlayerDoc(rawQuery, name)] }
+      }
+    ],
+    nameQueryCount: 1,
+    completedAllQueries: true
+  };
+}
+
+function buildPublicTeamsResult(queryText: string) {
+  return {
+    teams: [
+      {
+        teamId: `team-${queryText}`,
+        teamName: `${queryText} Team`,
+        active: true,
+        isPublic: true
+      }
+    ],
+    nextCursor: null
+  };
+}
+
+function uniqueQuery(index: number) {
+  return `q${String(index).padStart(3, '0')}`;
+}
+
+describe('searchService app search caches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAppSearchCache();
+    legacySearchDbMocks.isTeamActive.mockReturnValue(true);
+    legacySearchDbMocks.executeBoundedPlayerSearch.mockImplementation(async (options: { rawQuery: string }) => (
+      buildPlayerSearchSnapshot(options.rawQuery)
+    ));
+    publicTeamsServiceMocks.getPublicTeamsPage.mockImplementation(async ({ searchText }: { searchText: string }) => (
+      buildPublicTeamsResult(searchText)
+    ));
+  });
+
+  it('evicts older completed player cache entries while keeping newer queries reusable', async () => {
+    const maxEntries = searchCacheMaxEntries;
+
+    for (let index = 0; index < maxEntries + 2; index += 1) {
+      await searchAppPlayers(uniqueQuery(index), teamsById, null);
+    }
+
+    expect(legacySearchDbMocks.executeBoundedPlayerSearch).toHaveBeenCalledTimes(maxEntries + 2);
+
+    await searchAppPlayers(uniqueQuery(maxEntries + 1), teamsById, null);
+    expect(legacySearchDbMocks.executeBoundedPlayerSearch).toHaveBeenCalledTimes(maxEntries + 2);
+
+    await searchAppPlayers(uniqueQuery(0), teamsById, null);
+    expect(legacySearchDbMocks.executeBoundedPlayerSearch).toHaveBeenCalledTimes(maxEntries + 3);
+  });
+
+  it('keeps retained player source docs available for prefix reuse after eviction', async () => {
+    const maxEntries = searchCacheMaxEntries;
+
+    for (let index = 0; index < maxEntries; index += 1) {
+      await searchAppPlayers(uniqueQuery(index), teamsById, null);
+    }
+    legacySearchDbMocks.executeBoundedPlayerSearch.mockImplementation(async (options: { rawQuery: string }) => (
+      options.rawQuery === 'al'
+        ? buildPlayerSearchSnapshot(options.rawQuery, 'Alana Ace')
+        : buildPlayerSearchSnapshot(options.rawQuery)
+    ));
+    await searchAppPlayers('al', teamsById, null);
+    const callsAfterRetainedPrefix = legacySearchDbMocks.executeBoundedPlayerSearch.mock.calls.length;
+
+    const players = await searchAppPlayers('alan', teamsById, null);
+
+    expect(legacySearchDbMocks.executeBoundedPlayerSearch).toHaveBeenCalledTimes(callsAfterRetainedPrefix);
+    expect(players).toEqual([
+      expect.objectContaining({
+        title: 'Alana Ace',
+        route: '/players/team-1/player-al'
+      })
+    ]);
+  });
+
+  it('does not evict in-flight player searches before they settle', async () => {
+    const maxEntries = searchCacheMaxEntries;
+    const pendingPlayerSearch = createDeferred<ReturnType<typeof buildPlayerSearchSnapshot>>();
+    legacySearchDbMocks.executeBoundedPlayerSearch.mockImplementation((options: { rawQuery: string }) => (
+      options.rawQuery === 'pending' ? pendingPlayerSearch.promise : Promise.resolve(buildPlayerSearchSnapshot(options.rawQuery))
+    ));
+
+    const firstPendingResult = searchAppPlayers('pending', teamsById, null);
+    for (let index = 0; index < maxEntries + 1; index += 1) {
+      await searchAppPlayers(uniqueQuery(index), teamsById, null);
+    }
+    const secondPendingResult = searchAppPlayers('pending', teamsById, null);
+
+    expect(legacySearchDbMocks.executeBoundedPlayerSearch.mock.calls.filter(([options]) => options.rawQuery === 'pending')).toHaveLength(1);
+    pendingPlayerSearch.resolve(buildPlayerSearchSnapshot('pending'));
+    await expect(firstPendingResult).resolves.toEqual([
+      expect.objectContaining({ route: '/players/team-1/player-pending' })
+    ]);
+    await expect(secondPendingResult).resolves.toEqual([
+      expect.objectContaining({ route: '/players/team-1/player-pending' })
+    ]);
+  });
+
+  it('bounds completed public team cache entries and dedupes concurrent identical requests', async () => {
+    const maxEntries = searchCacheMaxEntries;
+    const pendingPublicSearch = createDeferred<ReturnType<typeof buildPublicTeamsResult>>();
+    publicTeamsServiceMocks.getPublicTeamsPage.mockImplementation(({ searchText }: { searchText: string }) => (
+      searchText === 'pending' ? pendingPublicSearch.promise : Promise.resolve(buildPublicTeamsResult(searchText))
+    ));
+
+    const firstPendingResult = searchAppTeams('pending', [], null);
+    for (let index = 0; index < maxEntries + 2; index += 1) {
+      await searchAppTeams(uniqueQuery(index), [], null);
+    }
+    const secondPendingResult = searchAppTeams('pending', [], null);
+
+    expect(publicTeamsServiceMocks.getPublicTeamsPage.mock.calls.filter(([options]) => options.searchText === 'pending')).toHaveLength(1);
+
+    pendingPublicSearch.resolve(buildPublicTeamsResult('pending'));
+    await expect(firstPendingResult).resolves.toEqual([
+      expect.objectContaining({ id: 'team-pending', name: 'pending Team' })
+    ]);
+    await expect(secondPendingResult).resolves.toEqual([
+      expect.objectContaining({ id: 'team-pending', name: 'pending Team' })
+    ]);
+
+    await searchAppTeams(uniqueQuery(maxEntries + 1), [], null);
+    expect(publicTeamsServiceMocks.getPublicTeamsPage.mock.calls.filter(([options]) => options.searchText === uniqueQuery(maxEntries + 1))).toHaveLength(1);
+
+    await searchAppTeams(uniqueQuery(0), [], null);
+    expect(publicTeamsServiceMocks.getPublicTeamsPage.mock.calls.filter(([options]) => options.searchText === uniqueQuery(0))).toHaveLength(2);
+  });
+});

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -627,6 +627,7 @@ function markSearchCacheEntryRecentlyUsed<T extends BoundedSearchCacheEntry>(cac
 }
 
 function setBoundedCompletedSearchCacheEntry<T extends BoundedSearchCacheEntry>(cache: Map<string, T>, key: string, entry: T, maxCompletedEntries: number) {
+  cache.delete(key);
   cache.set(key, entry);
   evictOldestCompletedSearchCacheEntries(cache, maxCompletedEntries);
 }

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -22,6 +22,8 @@ const teamsCacheTtlMs = 10 * 60 * 1000;
 const playerSearchQueryLimit = playerSearchResultLimit;
 const playerSearchTeamLimit = 8;
 const teamSearchQueryLimit = 20;
+const playerSearchCacheMaxEntries = 40;
+const publicTeamSearchCacheMaxEntries = 40;
 
 let cachedTeams: AppSearchTeam[] | null = null;
 let cachedTeamsLoadedAt = 0;
@@ -30,6 +32,10 @@ let cachedTeamsPromise: Promise<AppSearchTeam[]> | null = null;
 let cachedTeamsPromiseUserKey = '';
 const playerSearchCache = new Map<string, PlayerSearchCacheEntry>();
 const publicTeamSearchCache = new Map<string, PublicTeamSearchCacheEntry>();
+
+type BoundedSearchCacheEntry = {
+  promise?: Promise<unknown>;
+};
 
 type PlayerSearchCacheEntry = {
   scopeKey: string;
@@ -411,7 +417,10 @@ export async function searchAppPlayers(queryText: string, teamsById: Map<string,
   const cacheKey = `${scopeKey}::${normalizedQuery}`;
   const cachedEntry = playerSearchCache.get(cacheKey);
 
-  if (cachedEntry?.players) return cachedEntry.players;
+  if (cachedEntry?.players) {
+    markSearchCacheEntryRecentlyUsed(playerSearchCache, cacheKey, cachedEntry);
+    return cachedEntry.players;
+  }
   if (cachedEntry?.promise) return cachedEntry.promise;
 
   if (!isNumeric) {
@@ -424,14 +433,14 @@ export async function searchAppPlayers(queryText: string, teamsById: Map<string,
   const playerSearchPromise = loadPlayerSearchDocs(rawQuery, prefixes, isNumeric, teamsById)
     .then(({ docs, exhaustiveForNarrowerQueries }) => {
       const players = buildAppSearchPlayersFromDocs(docs, teamsById, user, tokens);
-      playerSearchCache.set(cacheKey, {
+      setBoundedCompletedSearchCacheEntry(playerSearchCache, cacheKey, {
         scopeKey,
         normalizedQuery,
         isNumeric,
         players,
         sourceDocs: docs,
         exhaustiveForNarrowerQueries
-      });
+      }, playerSearchCacheMaxEntries);
       return players;
     })
     .catch((error) => {
@@ -461,21 +470,24 @@ export function getCachedAppPlayerSearchResults(queryText: string, teamsById: Ma
   const scopeKey = getPlayerSearchScopeKey(teamsById, user);
   const cacheKey = `${scopeKey}::${normalizedQuery}`;
   const cachedEntry = playerSearchCache.get(cacheKey);
-  if (cachedEntry?.players) return cachedEntry.players;
+  if (cachedEntry?.players) {
+    markSearchCacheEntryRecentlyUsed(playerSearchCache, cacheKey, cachedEntry);
+    return cachedEntry.players;
+  }
 
   const cachedPrefixEntry = findReusablePlayerSearchCacheEntry(scopeKey, normalizedQuery);
   if (!cachedPrefixEntry?.sourceDocs) return null;
 
   const tokens = splitSearchTokens(rawQuery);
   const players = buildAppSearchPlayersFromDocs(cachedPrefixEntry.sourceDocs, teamsById, user, tokens);
-  playerSearchCache.set(cacheKey, {
+  setBoundedCompletedSearchCacheEntry(playerSearchCache, cacheKey, {
     scopeKey,
     normalizedQuery,
     isNumeric: false,
     players,
     sourceDocs: cachedPrefixEntry.sourceDocs,
     exhaustiveForNarrowerQueries: true
-  });
+  }, playerSearchCacheMaxEntries);
   return players;
 }
 
@@ -587,13 +599,16 @@ async function getCachedPublicTeamSearchResults(queryText: string, user: AuthUse
   const cacheKey = `${getAppSearchUserCacheKey(user)}::${normalizedQuery}`;
   const cachedEntry = publicTeamSearchCache.get(cacheKey);
 
-  if (cachedEntry?.teams) return cachedEntry.teams;
+  if (cachedEntry?.teams) {
+    markSearchCacheEntryRecentlyUsed(publicTeamSearchCache, cacheKey, cachedEntry);
+    return cachedEntry.teams;
+  }
   if (cachedEntry?.promise) return cachedEntry.promise;
 
   const promise = getPublicTeamsPage({ searchText: queryText, pageSize: teamSearchQueryLimit })
     .then((result) => {
       const teams = normalizePublicTeamSearchResults(result?.teams || []);
-      publicTeamSearchCache.set(cacheKey, { teams });
+      setBoundedCompletedSearchCacheEntry(publicTeamSearchCache, cacheKey, { teams }, publicTeamSearchCacheMaxEntries);
       return teams;
     })
     .catch((error) => {
@@ -603,6 +618,34 @@ async function getCachedPublicTeamSearchResults(queryText: string, user: AuthUse
 
   publicTeamSearchCache.set(cacheKey, { promise });
   return promise;
+}
+
+function markSearchCacheEntryRecentlyUsed<T extends BoundedSearchCacheEntry>(cache: Map<string, T>, key: string, entry: T) {
+  if (entry.promise) return;
+  cache.delete(key);
+  cache.set(key, entry);
+}
+
+function setBoundedCompletedSearchCacheEntry<T extends BoundedSearchCacheEntry>(cache: Map<string, T>, key: string, entry: T, maxCompletedEntries: number) {
+  cache.set(key, entry);
+  evictOldestCompletedSearchCacheEntries(cache, maxCompletedEntries);
+}
+
+function evictOldestCompletedSearchCacheEntries<T extends BoundedSearchCacheEntry>(cache: Map<string, T>, maxCompletedEntries: number) {
+  let completedEntries = 0;
+
+  for (const entry of cache.values()) {
+    if (!entry.promise) completedEntries += 1;
+  }
+
+  if (completedEntries <= maxCompletedEntries) return;
+
+  for (const [key, entry] of cache.entries()) {
+    if (entry.promise) continue;
+    cache.delete(key);
+    completedEntries -= 1;
+    if (completedEntries <= maxCompletedEntries) return;
+  }
 }
 
 async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>, homeTeams: any[], user: AuthUser | null) {


### PR DESCRIPTION
Closes #3637

## What changed
- Added bounded completed-entry eviction for player and public team global search caches.
- Preserved LRU-style reuse for recently accessed completed entries.
- Preserved in-flight promise reuse by skipping pending cache entries during eviction.
- Added focused `searchService` regression coverage for eviction, prefix reuse, and concurrent request dedupe.

## Root Cause
`searchService.ts` kept completed player and public team search results in session-global `Map`s without a max-entry bound. Player entries could also retain raw `sourceDocs` for prefix reuse, so long-lived sessions accumulated every unique search scope/query until auth reset or reload.

## Prevention / Learning
Any session-global client cache that stores search results or raw documents needs an explicit completed-entry bound and tests covering eviction, retained reuse behavior, and in-flight request dedupe.

## Regression Tests
- `npx vitest run src/lib/searchService.test.ts --reporter=verbose`
- `npm run typecheck`

## Recurrence Risk
Low. The cache helper centralizes completed-entry eviction and the new tests exercise the exact long-session growth path plus pending request reuse.