### PR TITLE
Fix iOS statsheet photo permission prompts

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -3768,6 +3768,42 @@ describe('ScheduleEventDetail statsheet import', () => {
     cleanup();
   });
 
+  it.each([
+    {
+      button: 'Take photo',
+      source: 'camera',
+      message: 'Camera permission was denied. Allow camera access to capture a statsheet.'
+    },
+    {
+      button: 'Choose from library',
+      source: 'photos',
+      message: 'Photo permission was denied. Allow photo library access to choose a statsheet.'
+    }
+  ])('keeps $button permission recovery copy specific to statsheet import', async ({ button, source, message }) => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamStaff: true, canUpdateScore: true })],
+      children: []
+    });
+    statsheetImportServiceMocks.acquireTrackStatsheetPhoto.mockRejectedValue({
+      code: 'permission-denied',
+      message: 'Permission denied'
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Statsheet import' }));
+    fireEvent.click(await screen.findByRole('button', { name: button }));
+
+    await waitFor(() => {
+      expect(statsheetImportServiceMocks.acquireTrackStatsheetPhoto).toHaveBeenCalledWith(source);
+    });
+    expect(await screen.findByText(message)).toBeTruthy();
+  });
+
   it('lets coaches correct home row fouls before applying a statsheet photo', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ isTeamStaff: true, canUpdateScore: true })],

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -36,13 +36,13 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>
-	<string>ALL PLAYS uses the camera when you choose to take a new profile photo.</string>
+	<string>ALL PLAYS uses the camera to capture profile photos and game-day stat sheet photos.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>ALL PLAYS uses the microphone when you choose to dictate a message.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>ALL PLAYS saves selected photos only when you ask it to.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>ALL PLAYS needs photo library access so you can choose a profile image.</string>
+	<string>ALL PLAYS uses photo library access to choose profile images and game-day stat sheet photos.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>ALL PLAYS uses speech recognition when you choose to dictate a message.</string>
 	<key>UILaunchStoryboardName</key>

--- a/tests/unit/app-capacitor-native-config.test.js
+++ b/tests/unit/app-capacitor-native-config.test.js
@@ -5,6 +5,11 @@ function readProjectFile(path) {
     return readFileSync(path, 'utf8');
 }
 
+function readPlistStringValue(plist, key) {
+    const pattern = new RegExp(`<key>${key}</key>\\s*<string>([^<]+)</string>`);
+    return plist.match(pattern)?.[1] || '';
+}
+
 describe('Capacitor native config', () => {
     it('declares splash screen and status bar plugins in app and native manifests', () => {
         const config = JSON.parse(readProjectFile('capacitor.config.json'));
@@ -119,5 +124,18 @@ describe('Capacitor native config', () => {
         expect(extractionRules).toContain('<exclude domain="root" />');
         expect(extractionRules).toContain('<exclude domain="database" />');
         expect(extractionRules).toContain('<exclude domain="sharedpref" />');
+    });
+
+    it('describes shared iOS camera and photo access for profile images and statsheet capture', () => {
+        const iosInfo = readProjectFile('ios/App/App/Info.plist');
+        const cameraDescription = readPlistStringValue(iosInfo, 'NSCameraUsageDescription').toLowerCase();
+        const photoDescription = readPlistStringValue(iosInfo, 'NSPhotoLibraryUsageDescription').toLowerCase();
+
+        expect(cameraDescription).toContain('profile');
+        expect(cameraDescription).toContain('stat sheet');
+        expect(cameraDescription).toContain('game-day');
+        expect(photoDescription).toContain('profile');
+        expect(photoDescription).toContain('stat sheet');
+        expect(photoDescription).toContain('game-day');
     });
 });


### PR DESCRIPTION
Closes #3634

## What changed
- Updated iOS camera and photo library usage descriptions to cover both profile photos/images and game-day stat sheet photos.
- Added static native config coverage so the shared iOS prompt text cannot regress back to profile-only copy.
- Extended statsheet import UI coverage for camera and photo-library permission-denied recovery copy.

## Root Cause
The statsheet import flow reused the shared Capacitor Camera acquisition path originally built for profile photos, but the iOS `Info.plist` usage descriptions were never expanded beyond the profile-photo workflow. That made native OS prompts misleading when scorekeepers captured or selected a game-day stat sheet.

## Prevention / Learning
When a native permission-backed helper is reused by another workflow, update the platform permission purpose strings at the same time and add a static validation test for every user-facing workflow named in the OS prompt.

## Regression Tests
- `npx vitest run tests/unit/app-capacitor-native-config.test.js --reporter=verbose`
- `cd apps/app && npx vitest run src/pages/ScheduleEventDetail.test.tsx --reporter=verbose`

## Recurrence Risk
Low. The shared native prompt text is now statically validated, and the statsheet-specific denial recovery copy is covered in the adjacent component test.