### PR TITLE
Avoid full report reloads for live plays

### DIFF
--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -234,7 +234,7 @@ describe('GameReportSections', () => {
         { id: 'event-final', text: 'Final horn', period: 'Q4', clock: '0:00', timestamp: new Date(1717200120 * 1000) }
       ]));
     gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
-      game: { id: 'game-1', liveStatus: 'completed', status: 'completed', homeScore: 43, awayScore: 40 },
+      game: { id: 'game-1', liveStatus: 'live', status: 'completed', homeScore: 43, awayScore: 40 },
       plays: [
         { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
         { id: 'event-final', text: 'Final horn', period: 'Q4', clock: '0:00', timestamp: new Date(1717200120 * 1000) }

--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -138,10 +138,13 @@ describe('GameReportSections', () => {
     gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('First report.', {}, [
       { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) }
     ]));
-    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue([
-      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
-      { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
-    ]);
+    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
+      game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38 },
+      plays: [
+        { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
+        { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
+      ]
+    });
 
     render(<GameReportSections event={buildEvent()} />);
 
@@ -177,10 +180,13 @@ describe('GameReportSections', () => {
         { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
         { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
       ]));
-    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue([
-      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
-      { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
-    ]);
+    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
+      game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38 },
+      plays: [
+        { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
+        { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
+      ]
+    });
 
     const { rerender } = render(<GameReportSections event={buildEvent()} />);
 
@@ -209,6 +215,46 @@ describe('GameReportSections', () => {
 
     await waitFor(() => {
       expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      await Promise.resolve();
+    });
+
+    expect(gameReportServiceMocks.loadGameReportPlays).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes live status during lightweight play polling and stops polling after completion', async () => {
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('Live report.', {}, [
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) }
+    ]));
+    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
+      game: { id: 'game-1', liveStatus: 'completed', status: 'completed', homeScore: 43, awayScore: 40 },
+      plays: [
+        { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
+        { id: 'event-final', text: 'Final horn', period: 'Q4', clock: '0:00', timestamp: new Date(1717200120 * 1000) }
+      ]
+    });
+
+    render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Live report.')).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
+
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Final horn')).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+      await Promise.resolve();
     });
     await act(async () => {
       window.dispatchEvent(new Event('focus'));

--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GameReportSections } from './GameReportSections';
 
 const gameReportServiceMocks = vi.hoisted(() => ({
+  loadGameReportPlays: vi.fn(),
   loadGameReportSections: vi.fn()
 }));
 
@@ -12,6 +13,7 @@ vi.mock('../../lib/gameReportService', () => gameReportServiceMocks);
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 
@@ -27,10 +29,10 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
   } as any;
 }
 
-function buildReport(summary: string, gameOverrides: Record<string, unknown> = {}) {
+function buildReport(summary: string, gameOverrides: Record<string, unknown> = {}, plays: any[] = []) {
   return {
     game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38, ...gameOverrides },
-    plays: [],
+    plays,
     summary,
     opponentRows: [],
     opponentStatKeys: [],
@@ -130,5 +132,89 @@ describe('GameReportSections', () => {
       expect(screen.getByText('Second report.')).toBeTruthy();
     });
     expect(screen.getByRole('button', { name: 'Summary' }).className).toContain('bg-primary-600');
+  });
+
+  it('polls live plays with the lightweight loader and merges them into the current report', async () => {
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('First report.', {}, [
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) }
+    ]));
+    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue([
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
+      { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
+    ]);
+
+    render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('First report.')).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
+    expect(screen.getByText('Opening tip')).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+      await Promise.resolve();
+    });
+
+    expect(gameReportServiceMocks.loadGameReportPlays).toHaveBeenCalledTimes(1);
+    expect(gameReportServiceMocks.loadGameReportPlays).toHaveBeenCalledWith('team-1', 'game-1');
+    expect(screen.getByText('Late bucket')).toBeTruthy();
+    expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Summary' }));
+    expect(screen.getByText('First report.')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('uses lightweight focus refreshes only when the Plays tab is active and live', async () => {
+    gameReportServiceMocks.loadGameReportSections
+      .mockResolvedValueOnce(buildReport('First report.', {}, [
+        { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) }
+      ]))
+      .mockResolvedValueOnce(buildReport('Completed report.', { liveStatus: 'completed', status: 'completed' }, [
+        { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
+        { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
+      ]));
+    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue([
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
+      { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
+    ]);
+
+    const { rerender } = render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('First report.')).toBeTruthy();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      await Promise.resolve();
+    });
+    expect(gameReportServiceMocks.loadGameReportPlays).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportPlays).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Late bucket')).toBeTruthy();
+    });
+    expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+
+    rerender(<GameReportSections event={buildEvent({ liveStatus: 'completed', status: 'completed' })} />);
+
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+      await Promise.resolve();
+    });
+
+    expect(gameReportServiceMocks.loadGameReportPlays).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -140,6 +140,7 @@ describe('GameReportSections', () => {
     ]));
     gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
       game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38 },
+      playsFresh: true,
       plays: [
         { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
         { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
@@ -171,6 +172,34 @@ describe('GameReportSections', () => {
     expect(screen.getByText('2')).toBeTruthy();
   });
 
+  it('preserves the displayed plays when the optional event refresh is unavailable', async () => {
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('First report.', {}, [
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) }
+    ]));
+    gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
+      game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 42, awayScore: 40 },
+      plays: [],
+      playsFresh: false
+    });
+
+    render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('First report.')).toBeTruthy();
+    });
+
+    vi.useFakeTimers();
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+      await Promise.resolve();
+    });
+
+    expect(gameReportServiceMocks.loadGameReportPlays).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('Opening tip')).toBeTruthy();
+    expect(screen.queryByText('Unable to refresh play-by-play.')).toBeNull();
+  });
+
   it('uses lightweight focus refreshes only when the Plays tab is active and live', async () => {
     gameReportServiceMocks.loadGameReportSections
       .mockResolvedValueOnce(buildReport('First report.', {}, [
@@ -182,6 +211,7 @@ describe('GameReportSections', () => {
       ]));
     gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
       game: { id: 'game-1', liveStatus: 'live', status: 'live', homeScore: 41, awayScore: 38 },
+      playsFresh: true,
       plays: [
         { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
         { id: 'event-late', text: 'Late bucket', period: 'Q1', clock: '0:12', timestamp: new Date(1717200060 * 1000) }
@@ -235,6 +265,7 @@ describe('GameReportSections', () => {
       ]));
     gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
       game: { id: 'game-1', liveStatus: 'live', status: 'completed', homeScore: 43, awayScore: 40 },
+      playsFresh: true,
       plays: [
         { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
         { id: 'event-final', text: 'Final horn', period: 'Q4', clock: '0:00', timestamp: new Date(1717200120 * 1000) }

--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -225,9 +225,14 @@ describe('GameReportSections', () => {
   });
 
   it('refreshes live status during lightweight play polling and stops polling after completion', async () => {
-    gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('Live report.', {}, [
-      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) }
-    ]));
+    gameReportServiceMocks.loadGameReportSections
+      .mockResolvedValueOnce(buildReport('Live report.', {}, [
+        { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) }
+      ]))
+      .mockResolvedValueOnce(buildReport('Completed report.', { liveStatus: 'completed', status: 'completed', homeScore: 43, awayScore: 40 }, [
+        { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: new Date(1717200000 * 1000) },
+        { id: 'event-final', text: 'Final horn', period: 'Q4', clock: '0:00', timestamp: new Date(1717200120 * 1000) }
+      ]));
     gameReportServiceMocks.loadGameReportPlays.mockResolvedValue({
       game: { id: 'game-1', liveStatus: 'completed', status: 'completed', homeScore: 43, awayScore: 40 },
       plays: [
@@ -251,6 +256,10 @@ describe('GameReportSections', () => {
     });
 
     expect(screen.getByText('Final horn')).toBeTruthy();
+    expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+    fireEvent.click(screen.getByRole('button', { name: 'Summary' }));
+    expect(screen.getByText('Completed report.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
 
     await act(async () => {
       vi.advanceTimersByTime(15000);
@@ -262,5 +271,6 @@ describe('GameReportSections', () => {
     });
 
     expect(gameReportServiceMocks.loadGameReportPlays).toHaveBeenCalledTimes(1);
+    expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -52,7 +52,7 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
       setReport((currentReport) => currentReport ? {
         ...currentReport,
         game: { ...currentReport.game, ...refresh.game },
-        plays: refresh.plays
+        plays: refresh.playsFresh ? refresh.plays : currentReport.plays
       } : currentReport);
       const refreshedStatuses = [refresh.game?.liveStatus, refresh.game?.status]
         .map((status) => String(status || '').trim().toLowerCase());

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -23,9 +23,14 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   const [loadingReport, setLoadingReport] = useState(true);
   const [reportError, setReportError] = useState<string | null>(null);
   const visibleReportSections = useMemo(() => getVisibleGameReportSections(report), [report]);
-  const liveReportStatus = String(report?.game?.liveStatus || report?.game?.status || event.liveStatus || event.status || '').trim().toLowerCase();
+  const currentReportStatuses = (report
+    ? [report.game?.liveStatus, report.game?.status]
+    : [event.liveStatus, event.status]
+  ).map((status) => String(status || '').trim().toLowerCase());
   const eventReportLoadStatus = normalizeGameReportLoadStatus(event.liveStatus || event.status);
-  const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && liveReportStatuses.has(liveReportStatus);
+  const isLivePlaysRefreshEnabled = activeReportSection === 'plays'
+    && !currentReportStatuses.some((status) => completedReportStatuses.has(status))
+    && currentReportStatuses.some((status) => liveReportStatuses.has(status));
 
   const refreshReport = useCallback(async (showLoading = true) => {
     if (showLoading) setLoadingReport(true);
@@ -49,8 +54,9 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
         game: { ...currentReport.game, ...refresh.game },
         plays: refresh.plays
       } : currentReport);
-      const refreshedStatus = String(refresh.game?.liveStatus || refresh.game?.status || '').trim().toLowerCase();
-      if (completedReportStatuses.has(refreshedStatus)) {
+      const refreshedStatuses = [refresh.game?.liveStatus, refresh.game?.status]
+        .map((status) => String(status || '').trim().toLowerCase());
+      if (refreshedStatuses.some((status) => completedReportStatuses.has(status))) {
         await refreshReport(false);
       }
     } catch (error: any) {

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -52,7 +52,7 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
       setReport((currentReport) => currentReport ? {
         ...currentReport,
         game: { ...currentReport.game, ...refresh.game },
-        plays: refresh.playsFresh ? refresh.plays : currentReport.plays
+        plays: refresh.playsFresh !== false ? refresh.plays : currentReport.plays
       } : currentReport);
       const refreshedStatuses = [refresh.game?.liveStatus, refresh.game?.status]
         .map((status) => String(status || '').trim().toLowerCase());

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -43,8 +43,12 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   const refreshLivePlays = useCallback(async () => {
     setReportError(null);
     try {
-      const plays = await loadGameReportPlays(event.teamId, event.id);
-      setReport((currentReport) => currentReport ? { ...currentReport, plays } : currentReport);
+      const refresh = await loadGameReportPlays(event.teamId, event.id);
+      setReport((currentReport) => currentReport ? {
+        ...currentReport,
+        game: { ...currentReport.game, ...refresh.game },
+        plays: refresh.plays
+      } : currentReport);
     } catch (error: any) {
       setReportError(error?.message || 'Unable to refresh play-by-play.');
     }

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -49,10 +49,14 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
         game: { ...currentReport.game, ...refresh.game },
         plays: refresh.plays
       } : currentReport);
+      const refreshedStatus = String(refresh.game?.liveStatus || refresh.game?.status || '').trim().toLowerCase();
+      if (completedReportStatuses.has(refreshedStatus)) {
+        await refreshReport(false);
+      }
     } catch (error: any) {
       setReportError(error?.message || 'Unable to refresh play-by-play.');
     }
-  }, [event.id, event.teamId]);
+  }, [event.id, event.teamId, refreshReport]);
 
   useEffect(() => {
     setReport(null);

--- a/apps/app/src/components/schedule/GameReportSections.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AlertCircle, CheckCircle2, RefreshCw } from 'lucide-react';
-import { loadGameReportSections, type GameReportData } from '../../lib/gameReportService';
+import { loadGameReportPlays, loadGameReportSections, type GameReportData } from '../../lib/gameReportService';
 import type { ParentScheduleEvent } from '../../lib/scheduleLogic';
 import { GameReportSectionContent, getRecordedTeamStatKeys, type GameReportSectionId } from './GameReportSectionContent';
 
@@ -40,6 +40,16 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
     }
   }, [event.id, event.teamId]);
 
+  const refreshLivePlays = useCallback(async () => {
+    setReportError(null);
+    try {
+      const plays = await loadGameReportPlays(event.teamId, event.id);
+      setReport((currentReport) => currentReport ? { ...currentReport, plays } : currentReport);
+    } catch (error: any) {
+      setReportError(error?.message || 'Unable to refresh play-by-play.');
+    }
+  }, [event.id, event.teamId]);
+
   useEffect(() => {
     setReport(null);
     setActiveReportSection('summary');
@@ -49,19 +59,19 @@ export function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   useEffect(() => {
     if (!isLivePlaysRefreshEnabled) return undefined;
     const intervalId = window.setInterval(() => {
-      void refreshReport(false);
+      void refreshLivePlays();
     }, liveReportPollIntervalMs);
     return () => window.clearInterval(intervalId);
-  }, [isLivePlaysRefreshEnabled, refreshReport]);
+  }, [isLivePlaysRefreshEnabled, refreshLivePlays]);
 
   useEffect(() => {
     if (!isLivePlaysRefreshEnabled) return undefined;
     const handleFocus = () => {
-      void refreshReport(false);
+      void refreshLivePlays();
     };
     window.addEventListener('focus', handleFocus);
     return () => window.removeEventListener('focus', handleFocus);
-  }, [isLivePlaysRefreshEnabled, refreshReport]);
+  }, [isLivePlaysRefreshEnabled, refreshLivePlays]);
 
   useEffect(() => {
     if (visibleReportSections.some((section) => section.id === activeReportSection)) return;

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -170,7 +170,8 @@ describe('gameReportService', () => {
     ]);
   });
 
-  it('loads only bounded game events for play-by-play refreshes', async () => {
+  it('loads only bounded game events and game status for play-by-play refreshes', async () => {
+    dbMocks.getGame.mockResolvedValue({ id: 'game-1', status: 'completed', liveStatus: 'completed', homeScore: 43, awayScore: 40 });
     dbMocks.getGameEvents.mockResolvedValue([
       { id: 'event-late', message: 'Late bucket', period: '', gameTime: '0:12', timestamp: { seconds: 1717200060 } },
       { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: 1717200000000 },
@@ -181,27 +182,36 @@ describe('gameReportService', () => {
     const plays = await loadGameReportPlays('team-1', 'game-1');
 
     expect(dbMocks.getGameEvents).toHaveBeenCalledWith('team-1', 'game-1', { limit: 100 });
+    expect(dbMocks.getGame).toHaveBeenCalledWith('team-1', 'game-1');
     expect(dbMocks.getTeam).not.toHaveBeenCalled();
-    expect(dbMocks.getGame).not.toHaveBeenCalled();
     expect(dbMocks.getPlayers).not.toHaveBeenCalled();
     expect(dbMocks.getConfigs).not.toHaveBeenCalled();
     expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
     expect(dbMocks.getTeamStatsForGame).not.toHaveBeenCalled();
-    expect(plays).toEqual([
-      {
-        id: 'event-early',
-        text: 'Opening tip',
-        period: 'Q1',
-        clock: '8:00',
-        timestamp: new Date(1717200000 * 1000)
-      },
-      {
-        id: 'event-late',
-        text: 'Late bucket',
-        period: 'Q1',
-        clock: '0:12',
-        timestamp: new Date(1717200060 * 1000)
-      }
-    ]);
+    expect(plays).toEqual({
+      game: expect.objectContaining({
+        id: 'game-1',
+        status: 'completed',
+        liveStatus: 'completed',
+        homeScore: 43,
+        awayScore: 40
+      }),
+      plays: [
+        {
+          id: 'event-early',
+          text: 'Opening tip',
+          period: 'Q1',
+          clock: '8:00',
+          timestamp: new Date(1717200000 * 1000)
+        },
+        {
+          id: 'event-late',
+          text: 'Late bucket',
+          period: 'Q1',
+          clock: '0:12',
+          timestamp: new Date(1717200060 * 1000)
+        }
+      ]
+    });
   });
 });

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -214,4 +214,23 @@ describe('gameReportService', () => {
       ]
     });
   });
+
+  it('keeps game status refreshes available when the optional event read fails', async () => {
+    dbMocks.getGame.mockResolvedValue({ id: 'game-1', status: 'completed', liveStatus: 'live', homeScore: 43, awayScore: 40 });
+    dbMocks.getGameEvents.mockRejectedValue(new Error('temporary event read failure'));
+
+    const refresh = await loadGameReportPlays('team-1', 'game-1');
+
+    expect(dbMocks.getGameEvents).toHaveBeenCalledWith('team-1', 'game-1', { limit: 100 });
+    expect(refresh).toEqual({
+      game: expect.objectContaining({
+        id: 'game-1',
+        status: 'completed',
+        liveStatus: 'live',
+        homeScore: 43,
+        awayScore: 40
+      }),
+      plays: []
+    });
+  });
 });

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -211,7 +211,8 @@ describe('gameReportService', () => {
           clock: '0:12',
           timestamp: new Date(1717200060 * 1000)
         }
-      ]
+      ],
+      playsFresh: true
     });
   });
 
@@ -230,7 +231,8 @@ describe('gameReportService', () => {
         homeScore: 43,
         awayScore: 40
       }),
-      plays: []
+      plays: [],
+      playsFresh: false
     });
   });
 });

--- a/apps/app/src/lib/gameReportService.test.ts
+++ b/apps/app/src/lib/gameReportService.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../../../js/post-game-stat-editor.js', () => ({
   resolvePostGameTeamStatFields: vi.fn(() => [])
 }));
 
-import { loadGameReportSections } from './gameReportService';
+import { loadGameReportPlays, loadGameReportSections } from './gameReportService';
 
 describe('gameReportService', () => {
   beforeEach(() => {
@@ -153,6 +153,41 @@ describe('gameReportService', () => {
     }));
     expect(report.teamStats).toEqual({ turnovers: 7, assists: '11' });
     expect(report.plays).toEqual([
+      {
+        id: 'event-early',
+        text: 'Opening tip',
+        period: 'Q1',
+        clock: '8:00',
+        timestamp: new Date(1717200000 * 1000)
+      },
+      {
+        id: 'event-late',
+        text: 'Late bucket',
+        period: 'Q1',
+        clock: '0:12',
+        timestamp: new Date(1717200060 * 1000)
+      }
+    ]);
+  });
+
+  it('loads only bounded game events for play-by-play refreshes', async () => {
+    dbMocks.getGameEvents.mockResolvedValue([
+      { id: 'event-late', message: 'Late bucket', period: '', gameTime: '0:12', timestamp: { seconds: 1717200060 } },
+      { id: 'event-early', text: 'Opening tip', period: 'Q1', clock: '8:00', timestamp: 1717200000000 },
+      { id: '', text: 'Missing id' },
+      'bad-event'
+    ]);
+
+    const plays = await loadGameReportPlays('team-1', 'game-1');
+
+    expect(dbMocks.getGameEvents).toHaveBeenCalledWith('team-1', 'game-1', { limit: 100 });
+    expect(dbMocks.getTeam).not.toHaveBeenCalled();
+    expect(dbMocks.getGame).not.toHaveBeenCalled();
+    expect(dbMocks.getPlayers).not.toHaveBeenCalled();
+    expect(dbMocks.getConfigs).not.toHaveBeenCalled();
+    expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
+    expect(dbMocks.getTeamStatsForGame).not.toHaveBeenCalled();
+    expect(plays).toEqual([
       {
         id: 'event-early',
         text: 'Opening tip',

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -72,6 +72,7 @@ export type GameReportPlay = {
 export type GameReportPlaysRefresh = {
   game: GameReportGameFirestoreRecord;
   plays: GameReportPlay[];
+  playsFresh: boolean;
 };
 
 export type GameReportHighlightClip = {
@@ -182,15 +183,18 @@ export async function loadGameReportPlays(teamId: string, gameId: string): Promi
     throw new Error('Team and game are required.');
   }
 
-  const [rawGame, rawEvents] = await Promise.all([
+  const [rawGame, eventsRefresh] = await Promise.all([
     getGame(teamId, gameId),
-    getGameEvents(teamId, gameId, { limit: 100 }).catch(() => [])
+    getGameEvents(teamId, gameId, { limit: 100 })
+      .then((rawEvents) => ({ rawEvents, playsFresh: true }))
+      .catch(() => ({ rawEvents: [], playsFresh: false }))
   ]);
   return {
     game: mapGameReportGameRecord(rawGame, gameId),
-    plays: mapGameReportEventRecords(rawEvents)
+    plays: mapGameReportEventRecords(eventsRefresh.rawEvents)
       .sort((a, b) => (normalizeDate(a.timestamp)?.getTime() || 0) - (normalizeDate(b.timestamp)?.getTime() || 0))
-      .map(normalizePlay)
+      .map(normalizePlay),
+    playsFresh: eventsRefresh.playsFresh
   };
 }
 

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -172,6 +172,17 @@ function normalizePlay(entry: GameReportEventFirestoreRecord): GameReportPlay {
   };
 }
 
+export async function loadGameReportPlays(teamId: string, gameId: string): Promise<GameReportPlay[]> {
+  if (!teamId || !gameId) {
+    throw new Error('Team and game are required.');
+  }
+
+  const rawEvents = await getGameEvents(teamId, gameId, { limit: 100 });
+  return mapGameReportEventRecords(rawEvents)
+    .sort((a, b) => (normalizeDate(a.timestamp)?.getTime() || 0) - (normalizeDate(b.timestamp)?.getTime() || 0))
+    .map(normalizePlay);
+}
+
 function normalizeOpponentRows(opponentStats: GameReportGameFirestoreRecord['opponentStats'] = {}): GameReportOpponentRow[] {
   return Object.entries(opponentStats || {}).map(([id, rawStats]) => {
     const { name, number, notes, playerId, photoUrl, ...stats } = rawStats || {};

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -184,7 +184,7 @@ export async function loadGameReportPlays(teamId: string, gameId: string): Promi
 
   const [rawGame, rawEvents] = await Promise.all([
     getGame(teamId, gameId),
-    getGameEvents(teamId, gameId, { limit: 100 })
+    getGameEvents(teamId, gameId, { limit: 100 }).catch(() => [])
   ]);
   return {
     game: mapGameReportGameRecord(rawGame, gameId),

--- a/apps/app/src/lib/gameReportService.ts
+++ b/apps/app/src/lib/gameReportService.ts
@@ -69,6 +69,11 @@ export type GameReportPlay = {
   timestamp: Date | null;
 };
 
+export type GameReportPlaysRefresh = {
+  game: GameReportGameFirestoreRecord;
+  plays: GameReportPlay[];
+};
+
 export type GameReportHighlightClip = {
   title: string;
   description: string;
@@ -172,15 +177,21 @@ function normalizePlay(entry: GameReportEventFirestoreRecord): GameReportPlay {
   };
 }
 
-export async function loadGameReportPlays(teamId: string, gameId: string): Promise<GameReportPlay[]> {
+export async function loadGameReportPlays(teamId: string, gameId: string): Promise<GameReportPlaysRefresh> {
   if (!teamId || !gameId) {
     throw new Error('Team and game are required.');
   }
 
-  const rawEvents = await getGameEvents(teamId, gameId, { limit: 100 });
-  return mapGameReportEventRecords(rawEvents)
-    .sort((a, b) => (normalizeDate(a.timestamp)?.getTime() || 0) - (normalizeDate(b.timestamp)?.getTime() || 0))
-    .map(normalizePlay);
+  const [rawGame, rawEvents] = await Promise.all([
+    getGame(teamId, gameId),
+    getGameEvents(teamId, gameId, { limit: 100 })
+  ]);
+  return {
+    game: mapGameReportGameRecord(rawGame, gameId),
+    plays: mapGameReportEventRecords(rawEvents)
+      .sort((a, b) => (normalizeDate(a.timestamp)?.getTime() || 0) - (normalizeDate(b.timestamp)?.getTime() || 0))
+      .map(normalizePlay)
+  };
 }
 
 function normalizeOpponentRows(opponentStats: GameReportGameFirestoreRecord['opponentStats'] = {}): GameReportOpponentRow[] {

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1017,10 +1017,21 @@ async function mockScheduleModules(page, options = {}) {
     });
 
     await page.route(/\/src\/lib\/gameReportService\.ts(\?.*)?$/, async (route) => {
+        const mockReportPlays = `
+            [
+                { id: 'play-1', text: 'Pat scored in transition', period: 'Q1', clock: '8:12', timestamp: new Date('2026-05-21T18:05:00Z') },
+                { id: 'play-2', text: 'Sam grabbed a rebound', period: 'Q2', clock: '4:30', timestamp: new Date('2026-05-21T18:22:00Z') }
+            ]
+        `;
         await route.fulfill({
             status: 200,
             contentType: 'application/javascript',
             body: `
+                export async function loadGameReportPlays(teamId, gameId) {
+                    window.__scheduleCalls.gameReportPlays = { teamId, gameId };
+                    return ${mockReportPlays};
+                }
+
                 export async function loadGameReportSections(teamId, gameId) {
                     window.__scheduleCalls.gameReport = { teamId, gameId };
                     return {
@@ -1054,10 +1065,7 @@ async function mockScheduleModules(page, options = {}) {
                         highlightClips: [
                             { title: 'Fast break', description: 'Pat scores in transition', period: 'Q1', gameTime: '8:12', startMs: 1000, endMs: 5000, url: 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-1&replay=true&clipStart=1000&clipEnd=5000' }
                         ],
-                        plays: [
-                            { id: 'play-1', text: 'Pat scored in transition', period: 'Q1', clock: '8:12', timestamp: new Date('2026-05-21T18:05:00Z') },
-                            { id: 'play-2', text: 'Sam grabbed a rebound', period: 'Q2', clock: '4:30', timestamp: new Date('2026-05-21T18:22:00Z') }
-                        ],
+                        plays: ${mockReportPlays},
                         teamInsights: [
                             { title: 'Offensive catalyst', body: 'Pat led the scoring with 12 points.', tone: 'positive' }
                         ],

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1029,7 +1029,17 @@ async function mockScheduleModules(page, options = {}) {
             body: `
                 export async function loadGameReportPlays(teamId, gameId) {
                     window.__scheduleCalls.gameReportPlays = { teamId, gameId };
-                    return ${mockReportPlays};
+                    return {
+                        game: {
+                            id: gameId,
+                            opponent: 'Falcons',
+                            status: 'completed',
+                            liveStatus: 'completed',
+                            homeScore: 4,
+                            awayScore: 2
+                        },
+                        plays: ${mockReportPlays}
+                    };
                 }
 
                 export async function loadGameReportSections(teamId, gameId) {

--- a/tests/unit/app-schedule-event-detail-audio-announcer.test.js
+++ b/tests/unit/app-schedule-event-detail-audio-announcer.test.js
@@ -26,7 +26,7 @@ describe('React app schedule event detail audio announcer wiring', () => {
         expect(source).toContain("const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && liveReportStatuses.has(liveReportStatus);");
         expect(source).toContain('if (!isLivePlaysRefreshEnabled) return undefined;');
         expect(source).toContain('const intervalId = window.setInterval(() => {');
-        expect(source).toContain('void refreshReport(false);');
+        expect(source).toContain('void refreshLivePlays();');
         expect(source).toContain("window.addEventListener('focus', handleFocus);");
         expect(source).toContain('}, liveReportPollIntervalMs);');
     });

--- a/tests/unit/app-schedule-event-detail-audio-announcer.test.js
+++ b/tests/unit/app-schedule-event-detail-audio-announcer.test.js
@@ -22,8 +22,12 @@ describe('React app schedule event detail audio announcer wiring', () => {
         const source = readSource('apps/app/src/components/schedule/GameReportSections.tsx');
 
         expect(source).toContain('const liveReportPollIntervalMs = 15000;');
-        expect(source).toContain("const liveReportStatus = String(report?.game?.liveStatus || report?.game?.status || event.liveStatus || event.status || '').trim().toLowerCase();");
-        expect(source).toContain("const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && liveReportStatuses.has(liveReportStatus);");
+        expect(source).toContain('const currentReportStatuses = (report');
+        expect(source).toContain('!currentReportStatuses.some((status) => completedReportStatuses.has(status))');
+        expect(source).toContain('currentReportStatuses.some((status) => liveReportStatuses.has(status))');
+        expect(source).toContain('const refreshedStatuses = [refresh.game?.liveStatus, refresh.game?.status]');
+        expect(source).toContain('refreshedStatuses.some((status) => completedReportStatuses.has(status))');
+        expect(source).toContain('await refreshReport(false);');
         expect(source).toContain('if (!isLivePlaysRefreshEnabled) return undefined;');
         expect(source).toContain('const intervalId = window.setInterval(() => {');
         expect(source).toContain('void refreshLivePlays();');

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -121,6 +121,7 @@ const scheduleMocks = vi.hoisted(() => ({
 }));
 
 const reportMocks = vi.hoisted(() => ({
+    loadGameReportPlays: vi.fn(),
     loadGameReportSections: vi.fn()
 }));
 
@@ -786,13 +787,18 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
     });
 
-    it('refreshes live game reports on Plays focus and interval only', async () => {
+    it('refreshes live game report plays on Plays focus and interval only', async () => {
         scheduleMocks.loadParentSchedule.mockResolvedValue({
             events: [event({ liveStatus: 'live', homeScore: 4, awayScore: 2 })]
         });
         reportMocks.loadGameReportSections.mockResolvedValue(report({
-            game: { id: 'game-1', status: 'live', liveStatus: 'live', homeScore: 4, awayScore: 2 }
+            game: { id: 'game-1', status: 'live', liveStatus: 'live', homeScore: 4, awayScore: 2 },
+            plays: [{ id: 'play-1', period: 'Q1', clock: '05:12', text: 'Opening bucket' }]
         }));
+        reportMocks.loadGameReportPlays.mockResolvedValue([
+            { id: 'play-1', period: 'Q1', clock: '05:12', text: 'Opening bucket' },
+            { id: 'play-2', period: 'Q1', clock: '04:58', text: 'Second bucket' }
+        ]);
 
         const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
         await waitForText(container, 'vs. Falcons');
@@ -809,13 +815,17 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await act(async () => {
             await vi.advanceTimersByTimeAsync(15000);
         });
-        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+        expect(reportMocks.loadGameReportPlays).toHaveBeenCalledTimes(1);
+        expect(reportMocks.loadGameReportPlays).toHaveBeenCalledWith('team-1', 'game-1');
+        await waitForText(container, 'Second bucket');
 
         await act(async () => {
             window.dispatchEvent(new Event('focus'));
             await Promise.resolve();
         });
-        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(3);
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+        expect(reportMocks.loadGameReportPlays).toHaveBeenCalledTimes(2);
 
         await clickButton(container, 'Summary');
         await act(async () => {
@@ -823,7 +833,8 @@ describe('React app ScheduleEventDetail More tab integration', () => {
             window.dispatchEvent(new Event('focus'));
             await Promise.resolve();
         });
-        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(3);
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+        expect(reportMocks.loadGameReportPlays).toHaveBeenCalledTimes(2);
     });
 
     it('renders the live period and clock chip beside the score for live games', async () => {

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -795,10 +795,13 @@ describe('React app ScheduleEventDetail More tab integration', () => {
             game: { id: 'game-1', status: 'live', liveStatus: 'live', homeScore: 4, awayScore: 2 },
             plays: [{ id: 'play-1', period: 'Q1', clock: '05:12', text: 'Opening bucket' }]
         }));
-        reportMocks.loadGameReportPlays.mockResolvedValue([
-            { id: 'play-1', period: 'Q1', clock: '05:12', text: 'Opening bucket' },
-            { id: 'play-2', period: 'Q1', clock: '04:58', text: 'Second bucket' }
-        ]);
+        reportMocks.loadGameReportPlays.mockResolvedValue({
+            game: { id: 'game-1', status: 'live', liveStatus: 'live', homeScore: 4, awayScore: 2 },
+            plays: [
+                { id: 'play-1', period: 'Q1', clock: '05:12', text: 'Opening bucket' },
+                { id: 'play-2', period: 'Q1', clock: '04:58', text: 'Second bucket' }
+            ]
+        });
 
         const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
         await waitForText(container, 'vs. Falcons');


### PR DESCRIPTION
Closes #3631

## What changed
- Added `loadGameReportPlays(teamId, gameId)` to fetch and normalize only the latest 100 game events.
- Updated live Play-by-Play interval and focus refreshes to call the lightweight plays loader and merge `report.plays` into the existing report state.
- Preserved the initial full report load and existing section visibility behavior.

## Root Cause
Live Play-by-Play interval and focus refreshes reused `loadGameReportSections`, so every lightweight poll fetched team, game, players, configs, aggregated stats, events, and team stats, then recomputed full report sections even though the active surface only needed `report.plays`.

## Prevention / Learning
For live polling on a single tab or panel, use a bounded surface-specific loader and add regression coverage asserting polling does not call broad report/page loaders after the initial render.

## Regression Tests
- `npm run test:ci -- GameReportSections.test.tsx gameReportService.test.ts`
- `apps/app/src/lib/gameReportService.test.ts` covers bounded plays-only loading, sorting, malformed event tolerance, and no full-report dependency calls.
- `apps/app/src/components/schedule/GameReportSections.test.tsx` covers interval and focus refreshes using the lightweight loader only while Plays is active and live.