### PR TITLE
Add player game-context smoke coverage

### DIFF
--- a/player.html
+++ b/player.html
@@ -706,7 +706,7 @@
                 }
 
                 const gameStatsForDisplay = [...perGameStats];
-                if (selectedGame && selectedGameId && !gameStatsForDisplay.some((entry) => entry.gameId === selectedGameId)) {
+                if (requestedGame && selectedGame && selectedGameId && !gameStatsForDisplay.some((entry) => entry.gameId === selectedGameId)) {
                     const selectedStatsByPlayerId = gameLoadResults.find((entry) => entry.gameId === selectedGameId)?.statsByPlayerId || {};
                     gameStatsForDisplay.push({
                         gameId: selectedGameId,

--- a/player.html
+++ b/player.html
@@ -705,6 +705,18 @@
                     renderPlayerGameInsights(null, []);
                 }
 
+                const gameStatsForDisplay = [...perGameStats];
+                if (selectedGame && selectedGameId && !gameStatsForDisplay.some((entry) => entry.gameId === selectedGameId)) {
+                    const selectedStatsByPlayerId = gameLoadResults.find((entry) => entry.gameId === selectedGameId)?.statsByPlayerId || {};
+                    gameStatsForDisplay.push({
+                        gameId: selectedGameId,
+                        date: selectedGame.date?.toDate ? selectedGame.date.toDate() : new Date(selectedGame.date),
+                        opponent: selectedGame.opponent || 'Opponent',
+                        stats: selectedStatsByPlayerId[playerId] || {},
+                        timeMs: 0
+                    });
+                }
+
                 const analyticsConfig = selectAnalyticsConfig(configs, team?.sport || team?.baseType || '');
                 const leaderboardSnapshot = analyticsConfig
                     ? buildPlayerLeaderboardSnapshot({
@@ -945,8 +957,8 @@
 
                 // Render per-game stats
                 const gameStatsDiv = document.getElementById('game-stats');
-                if (perGameStats.length > 0) {
-                    const sortedGames = perGameStats.sort((a, b) => b.date - a.date);
+                if (gameStatsForDisplay.length > 0) {
+                    const sortedGames = gameStatsForDisplay.sort((a, b) => b.date - a.date);
                     gameStatsDiv.innerHTML = sortedGames.map(g => `
                         <div class="group bg-gradient-to-br from-gray-50 to-white rounded-xl p-6 border border-gray-200 hover:border-primary-300 hover:shadow-md transition">
                             <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 gap-2">

--- a/tests/smoke/player-game-context.spec.js
+++ b/tests/smoke/player-game-context.spec.js
@@ -2,7 +2,40 @@ import { test, expect } from '@playwright/test';
 
 const STORE_KEY = '__playerGameContextStore';
 
-function createScenario({ requestedGameHasStats = true } = {}) {
+function createScenario({ requestedGameHasStats = true, playerHasParticipatedGames = true } = {}) {
+    const olderPlayerStats = playerHasParticipatedGames && requestedGameHasStats
+        ? {
+            playerName: 'Ava Cole',
+            playerNumber: '3',
+            stats: { pts: 12, reb: 4, ast: 3 },
+            timeMs: 720000,
+            participated: true
+        }
+        : {
+            playerName: 'Ava Cole',
+            playerNumber: '3',
+            stats: { pts: 0, reb: 0, ast: 0 },
+            timeMs: 0,
+            didNotPlay: true,
+            participated: false
+        };
+    const newerPlayerStats = playerHasParticipatedGames
+        ? {
+            playerName: 'Ava Cole',
+            playerNumber: '3',
+            stats: { pts: 24, reb: 6, ast: 5 },
+            timeMs: 900000,
+            participated: true
+        }
+        : {
+            playerName: 'Ava Cole',
+            playerNumber: '3',
+            stats: { pts: 0, reb: 0, ast: 0 },
+            timeMs: 0,
+            didNotPlay: true,
+            participated: false
+        };
+
     return {
         team: {
             id: 'team-1',
@@ -47,22 +80,7 @@ function createScenario({ requestedGameHasStats = true } = {}) {
         ],
         aggregatedStatsByGame: {
             'older-game': {
-                p1: requestedGameHasStats
-                    ? {
-                        playerName: 'Ava Cole',
-                        playerNumber: '3',
-                        stats: { pts: 12, reb: 4, ast: 3 },
-                        timeMs: 720000,
-                        participated: true
-                    }
-                    : {
-                        playerName: 'Ava Cole',
-                        playerNumber: '3',
-                        stats: { pts: 0, reb: 0, ast: 0 },
-                        timeMs: 0,
-                        didNotPlay: true,
-                        participated: false
-                    },
+                p1: olderPlayerStats,
                 p2: {
                     playerName: 'Mia Diaz',
                     playerNumber: '5',
@@ -72,13 +90,7 @@ function createScenario({ requestedGameHasStats = true } = {}) {
                 }
             },
             'newer-game': {
-                p1: {
-                    playerName: 'Ava Cole',
-                    playerNumber: '3',
-                    stats: { pts: 24, reb: 6, ast: 5 },
-                    timeMs: 900000,
-                    participated: true
-                },
+                p1: newerPlayerStats,
                 p2: {
                     playerName: 'Mia Diaz',
                     playerNumber: '5',
@@ -89,7 +101,7 @@ function createScenario({ requestedGameHasStats = true } = {}) {
             }
         },
         eventsByGame: {
-            'older-game': requestedGameHasStats
+            'older-game': playerHasParticipatedGames && requestedGameHasStats
                 ? [
                     {
                         playerId: 'p1',
@@ -103,7 +115,7 @@ function createScenario({ requestedGameHasStats = true } = {}) {
                     }
                 ]
                 : [],
-            'newer-game': [
+            'newer-game': playerHasParticipatedGames ? [
                 {
                     playerId: 'p1',
                     statKey: 'pts',
@@ -114,7 +126,7 @@ function createScenario({ requestedGameHasStats = true } = {}) {
                     text: 'Ava Cole made 3-pointer',
                     timestamp: { seconds: 1773000001 }
                 }
-            ]
+            ] : []
         }
     };
 }
@@ -374,4 +386,15 @@ test('game-context player page honors requested DNP game over newer stats', asyn
     const newerGameCard = page.locator('#game-stats .group', { hasText: 'vs. Rockets' });
     await expect(requestedGameCard).toContainText('Current');
     await expect(newerGameCard).not.toContainText('Current');
+});
+
+test('normal player page does not synthesize a current game card without participated games', async ({ page, baseURL }) => {
+    await installMocks(page, createScenario({ playerHasParticipatedGames: false }));
+    await page.goto(`${baseURL}/player.html#teamId=team-1&playerId=p1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#player-header')).toContainText('Ava Cole');
+    await expect(page.locator('#player-game-insights-section')).toBeHidden();
+    await expect(page.locator('#game-stats')).toContainText('No statistics available');
+    await expect(page.locator('#game-stats')).not.toContainText('vs. Owls');
+    await expect(page.locator('#game-stats')).not.toContainText('Current');
 });

--- a/tests/smoke/player-game-context.spec.js
+++ b/tests/smoke/player-game-context.spec.js
@@ -1,0 +1,377 @@
+import { test, expect } from '@playwright/test';
+
+const STORE_KEY = '__playerGameContextStore';
+
+function createScenario({ requestedGameHasStats = true } = {}) {
+    return {
+        team: {
+            id: 'team-1',
+            name: 'Comets',
+            sport: 'Basketball',
+            ownerId: 'coach-1',
+            adminEmails: ['coach@example.com']
+        },
+        players: [
+            { id: 'p1', name: 'Ava Cole', number: '3', position: 'Guard' },
+            { id: 'p2', name: 'Mia Diaz', number: '5', position: 'Forward' }
+        ],
+        games: [
+            {
+                id: 'older-game',
+                opponent: 'Owls',
+                date: '2026-03-01',
+                status: 'completed',
+                liveStatus: 'completed',
+                statTrackerConfigId: 'cfg-1'
+            },
+            {
+                id: 'newer-game',
+                opponent: 'Rockets',
+                date: '2026-03-08',
+                status: 'completed',
+                liveStatus: 'completed',
+                statTrackerConfigId: 'cfg-1'
+            }
+        ],
+        configs: [
+            {
+                id: 'cfg-1',
+                baseType: 'Basketball',
+                columns: ['pts', 'reb', 'ast'],
+                statDefinitions: [
+                    { id: 'pts', label: 'PTS', scope: 'player', visibility: 'public', type: 'base', topStat: true },
+                    { id: 'reb', label: 'REB', scope: 'player', visibility: 'public', type: 'base' },
+                    { id: 'ast', label: 'AST', scope: 'player', visibility: 'public', type: 'base' }
+                ]
+            }
+        ],
+        aggregatedStatsByGame: {
+            'older-game': {
+                p1: requestedGameHasStats
+                    ? {
+                        playerName: 'Ava Cole',
+                        playerNumber: '3',
+                        stats: { pts: 12, reb: 4, ast: 3 },
+                        timeMs: 720000,
+                        participated: true
+                    }
+                    : {
+                        playerName: 'Ava Cole',
+                        playerNumber: '3',
+                        stats: { pts: 0, reb: 0, ast: 0 },
+                        timeMs: 0,
+                        didNotPlay: true,
+                        participated: false
+                    },
+                p2: {
+                    playerName: 'Mia Diaz',
+                    playerNumber: '5',
+                    stats: requestedGameHasStats ? { pts: 8, reb: 7, ast: 1 } : { pts: 9, reb: 5, ast: 2 },
+                    timeMs: 600000,
+                    participated: true
+                }
+            },
+            'newer-game': {
+                p1: {
+                    playerName: 'Ava Cole',
+                    playerNumber: '3',
+                    stats: { pts: 24, reb: 6, ast: 5 },
+                    timeMs: 900000,
+                    participated: true
+                },
+                p2: {
+                    playerName: 'Mia Diaz',
+                    playerNumber: '5',
+                    stats: { pts: 6, reb: 3, ast: 2 },
+                    timeMs: 500000,
+                    participated: true
+                }
+            }
+        },
+        eventsByGame: {
+            'older-game': requestedGameHasStats
+                ? [
+                    {
+                        playerId: 'p1',
+                        statKey: 'pts',
+                        value: 2,
+                        period: 'Q4',
+                        clock: '2:18',
+                        gameTime: '2:18',
+                        text: 'Ava Cole made jumper',
+                        timestamp: { seconds: 1772400001 }
+                    }
+                ]
+                : [],
+            'newer-game': [
+                {
+                    playerId: 'p1',
+                    statKey: 'pts',
+                    value: 3,
+                    period: 'Q4',
+                    clock: '1:14',
+                    gameTime: '1:14',
+                    text: 'Ava Cole made 3-pointer',
+                    timestamp: { seconds: 1773000001 }
+                }
+            ]
+        }
+    };
+}
+
+async function installMocks(page, scenario) {
+    await page.addInitScript(({ storeKey, value }) => {
+        localStorage.setItem(storeKey, JSON.stringify(value));
+    }, { storeKey: STORE_KEY, value: scenario });
+
+    await page.route('https://www.googletagmanager.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: ''
+    }));
+
+    const dbModule = `
+        const STORE_KEY = ${JSON.stringify(STORE_KEY)};
+
+        function loadStore() {
+            return JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+        }
+
+        function clone(value) {
+            return JSON.parse(JSON.stringify(value));
+        }
+
+        export async function getTeam() {
+            return clone(loadStore().team);
+        }
+
+        export async function getPlayers() {
+            return clone(loadStore().players || []);
+        }
+
+        export async function getGames() {
+            return clone(loadStore().games || []);
+        }
+
+        export async function getConfigs() {
+            return clone(loadStore().configs || []);
+        }
+
+        export async function getRosterFieldDefinitions() {
+            return [];
+        }
+
+        export async function getUnreadChatCounts() {
+            return {};
+        }
+
+        export async function getUserProfile() {
+            return { coachOf: ['team-1'], isAdmin: false };
+        }
+
+        export async function getGame(teamId, gameId) {
+            return clone((loadStore().games || []).find((game) => game.id === gameId) || null);
+        }
+
+        export async function getPlayerPrivateProfile() {
+            return null;
+        }
+
+        export async function updatePlayerProfile() {
+            return {};
+        }
+
+        export async function updatePlayerPrivateProfile() {
+            return {};
+        }
+
+        export async function uploadPlayerPhoto() {
+            return '';
+        }
+    `;
+
+    const firebaseModule = `
+        const STORE_KEY = ${JSON.stringify(STORE_KEY)};
+
+        function loadStore() {
+            return JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+        }
+
+        function clone(value) {
+            return JSON.parse(JSON.stringify(value));
+        }
+
+        function createSnapshot(entries) {
+            const docs = entries.map(([id, data, path]) => ({
+                id,
+                ref: { path },
+                data() {
+                    return clone(data);
+                }
+            }));
+            return {
+                docs,
+                size: docs.length,
+                forEach(callback) {
+                    docs.forEach((doc) => callback(doc));
+                }
+            };
+        }
+
+        function extractGameId(path) {
+            return String(path || '').match(/\\/games\\/([^/]+)\\//)?.[1] || '';
+        }
+
+        function buildSnapshot(path) {
+            const store = loadStore();
+            const gameId = extractGameId(path);
+
+            if (path.endsWith('/aggregatedStats')) {
+                return createSnapshot(Object.entries(store.aggregatedStatsByGame?.[gameId] || {}).map(([id, data]) => [
+                    id,
+                    data,
+                    'teams/team-1/games/' + gameId + '/aggregatedStats/' + id
+                ]));
+            }
+
+            if (path.endsWith('/events')) {
+                return createSnapshot((store.eventsByGame?.[gameId] || []).map((event, index) => [
+                    'event-' + index,
+                    event,
+                    'teams/team-1/games/' + gameId + '/events/event-' + index
+                ]));
+            }
+
+            return createSnapshot([]);
+        }
+
+        export const db = {};
+
+        export function collection(_db, path) {
+            return { path };
+        }
+
+        export function doc(_db, ...segments) {
+            return { path: segments.join('/') };
+        }
+
+        export async function getDoc() {
+            return { exists: () => false, data: () => null };
+        }
+
+        export function query(ref) {
+            return ref;
+        }
+
+        export function orderBy() {
+            return null;
+        }
+
+        export async function getDocs(ref) {
+            return buildSnapshot(ref.path);
+        }
+    `;
+
+    const utilsModule = `
+        export function renderHeader(container) {
+            if (container) container.innerHTML = '<div data-testid="header"></div>';
+        }
+
+        export function renderFooter(container) {
+            if (container) container.innerHTML = '<div data-testid="footer"></div>';
+        }
+
+        export function getUrlParams() {
+            const raw = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.search.slice(1);
+            return Object.fromEntries(new URLSearchParams(raw));
+        }
+
+        export function escapeHtml(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+    `;
+
+    const authModule = `
+        export function checkAuth(callback) {
+            callback({ uid: 'coach-1', email: 'coach@example.com' });
+        }
+    `;
+
+    const bannerModule = `
+        export function renderTeamAdminBanner(container) {
+            if (container) container.innerHTML = '<div data-testid="team-banner"></div>';
+        }
+
+        export function getTeamAccessInfo() {
+            return { hasAccess: true, accessLevel: 'full', exitUrl: 'team.html#teamId=team-1' };
+        }
+    `;
+
+    const teamAccessModule = `
+        export function hasFullTeamAccess() {
+            return true;
+        }
+    `;
+
+    const premiumModule = `
+        export async function readAccountPremiumEntitlement() {
+            return { state: 'locked', reason: 'test' };
+        }
+
+        export function renderPremiumGateState(container) {
+            if (container) container.innerHTML = '<div data-testid="premium-gate"></div>';
+            return true;
+        }
+    `;
+
+    await page.route(/\/js\/db\.js\?v=\d+$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: dbModule }));
+    await page.route(/\/js\/firebase\.js\?v=\d+$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: firebaseModule }));
+    await page.route(/\/js\/utils\.js\?v=\d+$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: utilsModule }));
+    await page.route(/\/js\/auth\.js\?v=\d+$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: authModule }));
+    await page.route(/\/js\/team-admin-banner\.js$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: bannerModule }));
+    await page.route(/\/js\/team-access\.js$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: teamAccessModule }));
+    await page.route(/\/js\/premium-entitlements\.js\?v=\d+$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: premiumModule }));
+}
+
+async function openRequestedPlayerGame(page, baseURL, scenario) {
+    await installMocks(page, scenario);
+    await page.goto(`${baseURL}/player.html#teamId=team-1&gameId=older-game&playerId=p1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#player-header')).toContainText('Ava Cole');
+    await expect(page.locator('body')).not.toContainText(/Player not found|Error loading player details/i);
+}
+
+test('game-context player page renders insights for the requested older game', async ({ page, baseURL }) => {
+    await openRequestedPlayerGame(page, baseURL, createScenario({ requestedGameHasStats: true }));
+
+    const insightsSection = page.locator('#player-game-insights-section');
+    await expect(insightsSection).toBeVisible();
+    await expect(insightsSection).toContainText('Selected game: Owls');
+    await expect(insightsSection).toContainText(/Scoring load|All-around impact|Workload|Closing presence/);
+    await expect(page.locator('#game-stats')).toContainText('vs. Owls');
+    await expect(page.locator('#game-stats')).toContainText('vs. Rockets');
+
+    const olderGameCard = page.locator('#game-stats .group', { hasText: 'vs. Owls' });
+    const newerGameCard = page.locator('#game-stats .group', { hasText: 'vs. Rockets' });
+    await expect(olderGameCard).toContainText('Current');
+    await expect(newerGameCard).not.toContainText('Current');
+});
+
+test('game-context player page honors requested DNP game over newer stats', async ({ page, baseURL }) => {
+    await openRequestedPlayerGame(page, baseURL, createScenario({ requestedGameHasStats: false }));
+
+    await expect(page.locator('#player-game-insights-section')).toBeVisible();
+    await expect(page.locator('#player-game-insights-section')).toContainText('No player-specific insights are available for this game yet.');
+    await expect(page.locator('#game-stats')).toContainText('vs. Owls');
+    await expect(page.locator('#game-stats')).toContainText('vs. Rockets');
+
+    const requestedGameCard = page.locator('#game-stats .group', { hasText: 'vs. Owls' });
+    const newerGameCard = page.locator('#game-stats .group', { hasText: 'vs. Rockets' });
+    await expect(requestedGameCard).toContainText('Current');
+    await expect(newerGameCard).not.toContainText('Current');
+});


### PR DESCRIPTION
Closes #3687

## What changed
- Added focused Playwright smoke coverage for player profile URLs opened with `teamId`, `gameId`, and `playerId`.
- Covered both requested older-game insights and requested DNP/zero-stat game context when a newer game has stats.
- Updated `player.html` so a requested game that is filtered out of season stats still appears as a display-only game card and keeps the `Current` label.

## Root Cause
The player profile used participation-filtered `perGameStats` for visible game cards. That meant a requested game-context URL could preserve `selectedGame` for insights while hiding a DNP or zero-stat requested game from the game list, causing the `Current` label to fall off when another newer game had stats.

## Prevention / Learning
Game-context smoke tests must assert the routed game owns visible page context, not just that the target page boots or that newer stats render.

## Regression Tests
- `npx playwright test tests/smoke/player-game-context.spec.js --config=playwright.smoke.config.js --reporter=line`

## Recurrence Risk
Low. Focused browser smoke now covers both older-stat and requested DNP/zero-stat game-context routing.