### PR TITLE
Require current access for storage deletes

### DIFF
--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -121,6 +121,7 @@ export function validateFirebaseRulesCi() {
     assertIncludes(storageRules, 'function canDeleteOwnTeamMediaObject(teamId, folderId, userId)', 'Team media scoped Storage delete helper');
     assertIncludes(storageRules, 'function canDeleteOwnChatAttachment(teamId, conversationId, userId)', 'Chat fallback scoped Storage delete helper');
     assertIncludes(storageRules, 'function canDeleteOwnTeamScopedUpload(teamId, userId)', 'Team scoped Storage delete helper');
+    assertIncludes(storageRules, '(hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId))', 'Team media current upload grant delete scope');
     assertIncludes(teamMediaRules, 'allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);', 'Team media scoped Storage delete rules');
     assertIncludes(chatFallbackRules, 'allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnChatAttachment(teamId, conversationId, userId);', 'Chat fallback scoped Storage delete rules');
     for (const [label, block] of [

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -17,6 +17,18 @@ function assertMatches(text, pattern, label) {
     }
 }
 
+function assertEquals(actual, expected, label) {
+    if (actual !== expected) {
+        throw new Error(`${label} expected ${expected} but got ${actual}`);
+    }
+}
+
+function canDeleteOwnScopedStorageUpload({ authUid, pathUserId, isTeamAdmin = false, hasCurrentScopeAccess = false }) {
+    return authUid !== null &&
+        (isTeamAdmin ||
+            (authUid === pathUserId && hasCurrentScopeAccess));
+}
+
 export function extractMatchBlock(text, startMarker) {
     const start = text.indexOf(startMarker);
     if (start === -1) {
@@ -32,7 +44,12 @@ export function validateFirebaseRulesCi() {
     const firebaseJson = JSON.parse(readText('firebase.json'));
     const firestoreRules = readText('firestore.rules');
     const storageRules = readText('storage.rules');
+    const teamMediaRules = extractMatchBlock(storageRules, 'match /team-media/{teamId}/{folderId}/{userId}/{fileName}');
     const chatFallbackRules = extractMatchBlock(storageRules, 'match /stat-sheets/team-chat/{teamId}/{conversationId}/{userId}/{fileName}');
+    const legacyChatFallbackRules = extractMatchBlock(storageRules, 'match /stat-sheets/team-chat/{teamId}/{userId}/{fileName}');
+    const statSheetFallbackRules = extractMatchBlock(storageRules, 'match /stat-sheets/team-games/{teamId}/{userId}/{fileName}');
+    const drillFallbackRules = extractMatchBlock(storageRules, 'match /stat-sheets/drills/{teamId}/{drillId}/{userId}/{fileName}');
+    const clipFallbackRules = extractMatchBlock(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}');
     const legacyGameClipRules = extractMatchBlock(storageRules, 'match /game-clips/{fileName} {');
     const collectionGroupGamesHelper = (firestoreRules.match(/function canReadCollectionGroupGameDocument\(teamPath, data\) \{[\s\S]*?\n\s*}/) || [''])[0];
     const gameEventsRules = (firestoreRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/) || [''])[0];
@@ -101,6 +118,51 @@ export function validateFirebaseRulesCi() {
     assertIncludes(storageRules, 'allow create: if canAccessTeamMedia(teamId) &&', 'Scoped Storage game clip create rules');
     assertIncludes(storageRules, 'request.auth.uid == userId', 'Scoped Storage uploader match rules');
     assertIncludes(storageRules, 'request.resource.contentType.matches(\'video/.*\')', 'Scoped Storage video content-type rules');
+    assertIncludes(storageRules, 'function canDeleteOwnTeamMediaObject(teamId, folderId, userId)', 'Team media scoped Storage delete helper');
+    assertIncludes(storageRules, 'function canDeleteOwnChatAttachment(teamId, conversationId, userId)', 'Chat fallback scoped Storage delete helper');
+    assertIncludes(storageRules, 'function canDeleteOwnTeamScopedUpload(teamId, userId)', 'Team scoped Storage delete helper');
+    assertIncludes(teamMediaRules, 'allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);', 'Team media scoped Storage delete rules');
+    assertIncludes(chatFallbackRules, 'allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnChatAttachment(teamId, conversationId, userId);', 'Chat fallback scoped Storage delete rules');
+    for (const [label, block] of [
+        ['Legacy chat fallback scoped Storage delete rules', legacyChatFallbackRules],
+        ['Stat sheet scoped Storage delete rules', statSheetFallbackRules],
+        ['Drill scoped Storage delete rules', drillFallbackRules],
+        ['Game clip scoped Storage delete rules', clipFallbackRules]
+    ]) {
+        assertIncludes(block, 'allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamScopedUpload(teamId, userId);', label);
+    }
+    for (const [label, block] of [
+        ['Team media Storage delete rule', teamMediaRules],
+        ['Chat fallback Storage delete rule', chatFallbackRules],
+        ['Legacy chat fallback Storage delete rule', legacyChatFallbackRules],
+        ['Stat sheet Storage delete rule', statSheetFallbackRules],
+        ['Drill Storage delete rule', drillFallbackRules],
+        ['Game clip Storage delete rule', clipFallbackRules]
+    ]) {
+        if (block.includes('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;')) {
+            throw new Error(`${label} must not use bare uploader UID deletes without current scope access.`);
+        }
+    }
+    assertEquals(canDeleteOwnScopedStorageUpload({
+        authUid: 'uploader-1',
+        pathUserId: 'uploader-1',
+        hasCurrentScopeAccess: true
+    }), true, 'Current uploader Storage delete case');
+    assertEquals(canDeleteOwnScopedStorageUpload({
+        authUid: 'uploader-1',
+        pathUserId: 'uploader-1',
+        hasCurrentScopeAccess: false
+    }), false, 'Revoked uploader Storage delete case');
+    assertEquals(canDeleteOwnScopedStorageUpload({
+        authUid: 'outsider-1',
+        pathUserId: 'uploader-1',
+        hasCurrentScopeAccess: true
+    }), false, 'Outsider Storage delete case');
+    assertEquals(canDeleteOwnScopedStorageUpload({
+        authUid: 'coach-1',
+        pathUserId: 'uploader-1',
+        isTeamAdmin: true
+    }), true, 'Team admin Storage delete case');
     assertIncludes(storageRules, 'match /game-clips/{fileName} {', 'Legacy Storage game clip rules');
     assertIncludes(legacyGameClipRules, 'allow get, create, delete: if false;', 'Legacy Storage deny-all rule');
     assertIncludes(storageRules, 'function isAllowedChatAttachmentUpload(contentType, size)', 'Chat fallback attachment upload helper');

--- a/storage.rules
+++ b/storage.rules
@@ -86,7 +86,8 @@ service firebase.storage {
     function canDeleteOwnTeamMediaObject(teamId, folderId, userId) {
       return isSignedIn() &&
         request.auth.uid == userId &&
-        canReadTeamMediaObject(teamId, folderId);
+        (canReadTeamMediaObject(teamId, folderId) ||
+         (hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId)));
     }
 
     function canDeleteOwnChatAttachment(teamId, conversationId, userId) {

--- a/storage.rules
+++ b/storage.rules
@@ -83,6 +83,24 @@ service firebase.storage {
          firestore.get(folderPath).data.get('visibility', 'team') == 'team');
     }
 
+    function canDeleteOwnTeamMediaObject(teamId, folderId, userId) {
+      return isSignedIn() &&
+        request.auth.uid == userId &&
+        canReadTeamMediaObject(teamId, folderId);
+    }
+
+    function canDeleteOwnChatAttachment(teamId, conversationId, userId) {
+      return isSignedIn() &&
+        request.auth.uid == userId &&
+        canAccessChatAttachment(teamId, conversationId);
+    }
+
+    function canDeleteOwnTeamScopedUpload(teamId, userId) {
+      return isSignedIn() &&
+        request.auth.uid == userId &&
+        canAccessTeamMedia(teamId);
+    }
+
     function isAllowedTeamMediaUploadType(contentType) {
       return contentType.matches('image/.*') ||
         contentType in [
@@ -125,7 +143,8 @@ service firebase.storage {
         request.resource.size > 0 &&
         request.resource.size <= 10 * 1024 * 1024 &&
         isAllowedTeamMediaUploadType(request.resource.contentType);
-      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow delete: if isTeamOwnerOrAdmin(teamId) ||
+        canDeleteOwnTeamMediaObject(teamId, folderId, userId);
       allow update: if false;
     }
 
@@ -146,7 +165,8 @@ service firebase.storage {
       allow create: if canAccessChatAttachment(teamId, conversationId) &&
         request.auth.uid == userId &&
         isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);
-      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow delete: if isTeamOwnerOrAdmin(teamId) ||
+        canDeleteOwnChatAttachment(teamId, conversationId, userId);
       allow update: if false;
     }
 
@@ -154,7 +174,8 @@ service firebase.storage {
       allow get: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
       allow list: if false;
       allow create: if false;
-      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow delete: if isTeamOwnerOrAdmin(teamId) ||
+        canDeleteOwnTeamScopedUpload(teamId, userId);
       allow update: if false;
     }
 
@@ -165,7 +186,8 @@ service firebase.storage {
         request.auth.uid == userId &&
         request.resource.size > 0 &&
         request.resource.size <= 20 * 1024 * 1024;
-      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow delete: if isTeamOwnerOrAdmin(teamId) ||
+        canDeleteOwnTeamScopedUpload(teamId, userId);
       allow update: if false;
     }
 
@@ -177,7 +199,8 @@ service firebase.storage {
         request.auth.uid == userId &&
         request.resource.size > 0 &&
         request.resource.size <= 20 * 1024 * 1024;
-      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow delete: if isTeamOwnerOrAdmin(teamId) ||
+        canDeleteOwnTeamScopedUpload(teamId, userId);
       allow update: if false;
     }
 
@@ -195,7 +218,8 @@ service firebase.storage {
         request.resource.size > 0 &&
         request.resource.size <= 100 * 1024 * 1024 &&
         request.resource.contentType.matches('video/.*');
-      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow delete: if isTeamOwnerOrAdmin(teamId) ||
+        canDeleteOwnTeamScopedUpload(teamId, userId);
       allow update: if false;
     }
 

--- a/tests/unit/fallback-media-storage.test.js
+++ b/tests/unit/fallback-media-storage.test.js
@@ -45,8 +45,17 @@ function canCreateScopedFallback({ authUid, pathUserId, conversationId = 'team',
     return canAccessChatAttachment({ authUid, conversationId, isTeamAdmin, isTeamParent, isParticipant }) && authUid === pathUserId;
 }
 
-function canDeleteScopedFallback({ authUid, pathUserId, isTeamAdmin = false }) {
-    return authUid !== null && (isTeamAdmin || authUid === pathUserId);
+function canDeleteChatFallback({ authUid, pathUserId, conversationId = 'team', isTeamAdmin = false, isTeamParent = false, isParticipant = false }) {
+    return authUid !== null &&
+        (isTeamAdmin ||
+            (authUid === pathUserId &&
+                canAccessChatAttachment({ authUid, conversationId, isTeamParent, isParticipant })));
+}
+
+function canDeleteTeamScopedFallback({ authUid, pathUserId, isTeamAdmin = false, isTeamParent = false }) {
+    return authUid !== null &&
+        (isTeamAdmin ||
+            (authUid === pathUserId && canAccessTeamMedia({ authUid, isTeamParent })));
 }
 
 function canAccessLegacyGameClipFallback({ authUid }) {
@@ -71,15 +80,18 @@ describe('fallback media paths and Storage rules', () => {
         expect(dbSource).toContain('buildGameClipFallbackPath(teamId, gameId, userId, file.name, ts)');
     });
 
-    it('limits fallback chat media access to the same team audience and uploader/admin delete rights', () => {
+    it('limits fallback chat media access to the same team audience and current uploader/admin delete rights', () => {
         expect(chatFallbackRules).toContain('allow get: if canAccessChatAttachment(teamId, conversationId);');
         expect(rules).toContain("('user:' + request.auth.uid) in participantIds");
         expect(rules).toContain("('email:' + request.auth.token.email.lower()) in participantIds");
         expect(chatFallbackRules).toContain('request.auth.uid == userId');
         expect(chatFallbackRules).toContain('isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);');
-        expect(chatFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(rules).toContain('function canDeleteOwnChatAttachment(teamId, conversationId, userId)');
+        expect(chatFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnChatAttachment(teamId, conversationId, userId);');
+        expect(chatFallbackRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
         expect(legacyChatFallbackRules).toContain('allow get: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
         expect(legacyChatFallbackRules).toContain('allow create: if false;');
+        expect(legacyChatFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamScopedUpload(teamId, userId);');
 
         expect(canAccessTeamMedia({ authUid: 'coach-1', isTeamAdmin: true })).toBe(true);
         expect(canAccessTeamMedia({ authUid: 'parent-1', isTeamParent: true })).toBe(true);
@@ -91,8 +103,12 @@ describe('fallback media paths and Storage rules', () => {
         expect(canCreateScopedFallback({ authUid: 'parent-1', pathUserId: 'parent-1', conversationId: 'direct-1', isTeamParent: true, isParticipant: true })).toBe(true);
         expect(canCreateScopedFallback({ authUid: 'parent-1', pathUserId: 'parent-1', conversationId: 'direct-1', isTeamParent: true })).toBe(false);
         expect(canCreateScopedFallback({ authUid: 'parent-2', pathUserId: 'parent-1', isTeamParent: true })).toBe(false);
-        expect(canDeleteScopedFallback({ authUid: 'coach-1', pathUserId: 'parent-1', isTeamAdmin: true })).toBe(true);
-        expect(canDeleteScopedFallback({ authUid: 'parent-2', pathUserId: 'parent-1' })).toBe(false);
+        expect(canDeleteChatFallback({ authUid: 'coach-1', pathUserId: 'parent-1', isTeamAdmin: true })).toBe(true);
+        expect(canDeleteChatFallback({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: true })).toBe(true);
+        expect(canDeleteChatFallback({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: false })).toBe(false);
+        expect(canDeleteChatFallback({ authUid: 'parent-1', pathUserId: 'parent-1', conversationId: 'direct-1', isTeamParent: true })).toBe(false);
+        expect(canDeleteChatFallback({ authUid: 'parent-1', pathUserId: 'parent-1', conversationId: 'direct-1', isTeamParent: true, isParticipant: true })).toBe(true);
+        expect(canDeleteChatFallback({ authUid: 'parent-2', pathUserId: 'parent-1', isTeamParent: true })).toBe(false);
     });
 
     it('restricts fallback chat creates to image/video uploads no larger than 5 MB', () => {
@@ -140,28 +156,36 @@ describe('fallback media paths and Storage rules', () => {
     it('denies unrelated signed-in users from scoped game clip reads and deletes', () => {
         expect(clipFallbackRules).toContain('allow get: if canAccessTeamMedia(teamId);');
         expect(clipFallbackRules).toContain("request.resource.contentType.matches('video/.*')");
-        expect(clipFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(clipFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamScopedUpload(teamId, userId);');
+        expect(clipFallbackRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
 
         expect(canAccessTeamMedia({ authUid: 'coach-1', isTeamAdmin: true })).toBe(true);
         expect(canAccessTeamMedia({ authUid: 'outsider-1' })).toBe(false);
-        expect(canDeleteScopedFallback({ authUid: 'uploader-1', pathUserId: 'uploader-1' })).toBe(true);
-        expect(canDeleteScopedFallback({ authUid: 'outsider-1', pathUserId: 'uploader-1' })).toBe(false);
+        expect(canDeleteTeamScopedFallback({ authUid: 'uploader-1', pathUserId: 'uploader-1', isTeamParent: true })).toBe(true);
+        expect(canDeleteTeamScopedFallback({ authUid: 'uploader-1', pathUserId: 'uploader-1', isTeamParent: false })).toBe(false);
+        expect(canDeleteTeamScopedFallback({ authUid: 'outsider-1', pathUserId: 'uploader-1', isTeamParent: true })).toBe(false);
     });
 
-    it('limits stat sheet and drill fallback access to team-scoped readers and uploader/admin writes', () => {
+    it('limits stat sheet and drill fallback access to team-scoped readers and current uploader/admin writes', () => {
         expect(statSheetFallbackRules).toContain('allow get: if canAccessTeamMedia(teamId);');
         expect(statSheetFallbackRules).toContain('request.auth.uid == userId');
-        expect(statSheetFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(rules).toContain('function canDeleteOwnTeamScopedUpload(teamId, userId)');
+        expect(statSheetFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamScopedUpload(teamId, userId);');
+        expect(statSheetFallbackRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
 
         expect(drillFallbackRules).toContain('allow get: if canAccessTeamMedia(teamId);');
         expect(drillFallbackRules).toContain('drillId.size() > 0');
         expect(drillFallbackRules).toContain('request.auth.uid == userId');
-        expect(drillFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(drillFallbackRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamScopedUpload(teamId, userId);');
+        expect(drillFallbackRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
 
         expect(canAccessTeamMedia({ authUid: 'coach-1', isTeamAdmin: true })).toBe(true);
         expect(canAccessTeamMedia({ authUid: 'outsider-1' })).toBe(false);
         expect(canCreateScopedFallback({ authUid: 'scorekeeper-1', pathUserId: 'scorekeeper-1', isTeamParent: true })).toBe(true);
         expect(canCreateScopedFallback({ authUid: 'outsider-1', pathUserId: 'scorekeeper-1' })).toBe(false);
+        expect(canDeleteTeamScopedFallback({ authUid: 'scorekeeper-1', pathUserId: 'scorekeeper-1', isTeamParent: true })).toBe(true);
+        expect(canDeleteTeamScopedFallback({ authUid: 'scorekeeper-1', pathUserId: 'scorekeeper-1', isTeamParent: false })).toBe(false);
+        expect(canDeleteTeamScopedFallback({ authUid: 'coach-1', pathUserId: 'scorekeeper-1', isTeamAdmin: true })).toBe(true);
     });
 
     it('hard-denies legacy flat stat sheet and game clip access', () => {

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -10,11 +10,12 @@ function canReadTeamMediaObject({ authUid, isTeamAdmin = false, isTeamParent = f
     return isTeamParent && folderExists && folderVisibility === 'team';
 }
 
-function canDeleteTeamMediaObject({ authUid, pathUserId, isTeamAdmin = false, isTeamParent = false, folderExists = true, folderVisibility = 'team' }) {
+function canDeleteTeamMediaObject({ authUid, pathUserId, isTeamAdmin = false, isTeamParent = false, hasUploadGrant = false, folderExists = true, folderVisibility = 'team' }) {
     return authUid !== null &&
         (isTeamAdmin ||
             (authUid === pathUserId &&
-                canReadTeamMediaObject({ authUid, isTeamParent, folderExists, folderVisibility })));
+                (canReadTeamMediaObject({ authUid, isTeamParent, folderExists, folderVisibility }) ||
+                    (hasUploadGrant && folderExists && folderVisibility === 'team'))));
 }
 
 describe('team media page wiring', () => {
@@ -94,6 +95,7 @@ describe('team media page wiring', () => {
         expect(storageRules).toContain('isAllowedTeamMediaUploadType(request.resource.contentType)');
         expect(storageRules).toContain('application/pdf');
         expect(storageRules).toContain('function canDeleteOwnTeamMediaObject(teamId, folderId, userId)');
+        expect(storageRules).toContain('(hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId))');
         expect(storageRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);');
         expect(storageRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
     });
@@ -105,7 +107,10 @@ describe('team media page wiring', () => {
         expect(canReadTeamMediaObject({ authUid: 'admin-1', isTeamAdmin: true, folderVisibility: 'private' })).toBe(true);
         expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: true })).toBe(true);
         expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: false })).toBe(false);
+        expect(canDeleteTeamMediaObject({ authUid: 'contributor-1', pathUserId: 'contributor-1', hasUploadGrant: true })).toBe(true);
+        expect(canDeleteTeamMediaObject({ authUid: 'contributor-1', pathUserId: 'contributor-1', hasUploadGrant: false })).toBe(false);
         expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: true, folderVisibility: 'private' })).toBe(false);
+        expect(canDeleteTeamMediaObject({ authUid: 'contributor-1', pathUserId: 'contributor-1', hasUploadGrant: true, folderVisibility: 'private' })).toBe(false);
         expect(canDeleteTeamMediaObject({ authUid: 'admin-1', pathUserId: 'parent-1', isTeamAdmin: true, folderVisibility: 'private' })).toBe(true);
     });
 

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -10,6 +10,13 @@ function canReadTeamMediaObject({ authUid, isTeamAdmin = false, isTeamParent = f
     return isTeamParent && folderExists && folderVisibility === 'team';
 }
 
+function canDeleteTeamMediaObject({ authUid, pathUserId, isTeamAdmin = false, isTeamParent = false, folderExists = true, folderVisibility = 'team' }) {
+    return authUid !== null &&
+        (isTeamAdmin ||
+            (authUid === pathUserId &&
+                canReadTeamMediaObject({ authUid, isTeamParent, folderExists, folderVisibility })));
+}
+
 describe('team media page wiring', () => {
     it('links the dashboard to the team media library', () => {
         const dashboard = fs.readFileSync(path.join(repoRoot, 'dashboard.html'), 'utf8');
@@ -86,14 +93,20 @@ describe('team media page wiring', () => {
         expect(storageRules).toContain('canUploadTeamMediaFolder(teamId, folderId)');
         expect(storageRules).toContain('isAllowedTeamMediaUploadType(request.resource.contentType)');
         expect(storageRules).toContain('application/pdf');
-        expect(storageRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+        expect(storageRules).toContain('function canDeleteOwnTeamMediaObject(teamId, folderId, userId)');
+        expect(storageRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);');
+        expect(storageRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
     });
 
-    it('denies parent reads for private team-media objects while preserving admin access', () => {
+    it('denies revoked or private-folder uploader deletes while preserving current uploader and admin cleanup', () => {
         expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderVisibility: 'team' })).toBe(true);
         expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderVisibility: 'private' })).toBe(false);
         expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderExists: false })).toBe(false);
         expect(canReadTeamMediaObject({ authUid: 'admin-1', isTeamAdmin: true, folderVisibility: 'private' })).toBe(true);
+        expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: true })).toBe(true);
+        expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: false })).toBe(false);
+        expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: true, folderVisibility: 'private' })).toBe(false);
+        expect(canDeleteTeamMediaObject({ authUid: 'admin-1', pathUserId: 'parent-1', isTeamAdmin: true, folderVisibility: 'private' })).toBe(true);
     });
 
     it('models moved media as inaccessible to parents once the old team-visible object is gone', () => {


### PR DESCRIPTION
Closes #3664

## What changed
- Added scoped Storage delete helpers for team media, chat fallback attachments, stat sheets, drills, and game clips.
- Uploader-owned deletes now require both path ownership and current access to the owning team/conversation/media scope.
- Team owner/admin deletion remains allowed for moderation and cleanup.
- Added unit and Firebase rules validation coverage for current uploader allowed, revoked uploader denied, outsider denied, and admin allowed.

## Root Cause
Storage delete rules trusted the historical uploader UID embedded in team-scoped object paths without rechecking current team, conversation, folder, or media scope access. That let revoked uploaders delete files still referenced by team-visible metadata.

## Prevention / Learning
For team-scoped Storage objects, uploader self-delete must require both path ownership and current access to the owning team scope. Regression tests should include revoked uploader denial, not only outsider denial.

## Regression Tests
- `npx vitest run tests/unit/team-media-wiring.test.js tests/unit/fallback-media-storage.test.js --reporter=verbose`
- `node scripts/validate-firebase-rules-ci.mjs`

## Recurrence Risk
Low. The affected delete paths now route through explicit scoped helpers and source-level assertions guard against reintroducing bare uploader UID deletes.