### PR TITLE
Fix public registration proxy rate limiting

### DIFF
--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -47,7 +47,7 @@ function getForwardedIp(req = {}) {
     return trustedHops.includes(normalizedCandidate);
   });
 
-  if (trustedHopIndex <= 0) {
+  if (trustedHopIndex <= 0 || trustedHopIndex !== forwardedCandidates.length - 1) {
     return '';
   }
 

--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -1,3 +1,4 @@
+const net = require('node:net');
 const { isPrivateIpAddress } = require('./utils/ip-address-validation.js');
 
 function parsePositiveInteger(value, fallback) {
@@ -16,19 +17,53 @@ function getHeaderValue(headers = {}, name = '') {
   return Array.isArray(value) ? value[0] : value;
 }
 
-function getForwardedIp(headers = {}) {
-  const forwardedFor = getHeaderValue(headers, 'x-forwarded-for');
+function normalizeIp(value) {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (normalized.startsWith('::ffff:')) {
+    const mappedIpv4 = normalized.slice('::ffff:'.length);
+    if (net.isIP(mappedIpv4) === 4) {
+      return mappedIpv4;
+    }
+  }
+  return normalized;
+}
+
+function getForwardedIp(req = {}) {
+  const forwardedFor = getHeaderValue(req.headers, 'x-forwarded-for');
   if (typeof forwardedFor !== 'string' || !forwardedFor.trim()) {
     return '';
   }
 
-  return forwardedFor.split(',')[0].trim();
+  const forwardedCandidates = forwardedFor.split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const trustedHops = [
+    req.ip,
+    req.socket?.remoteAddress,
+    req.connection?.remoteAddress
+  ].map(normalizeIp).filter(Boolean);
+  const trustedHopIndex = forwardedCandidates.findLastIndex((candidate) => {
+    const normalizedCandidate = normalizeIp(candidate);
+    return trustedHops.includes(normalizedCandidate);
+  });
+
+  if (trustedHopIndex <= 0) {
+    return '';
+  }
+
+  for (let index = trustedHopIndex - 1; index >= 0; index -= 1) {
+    if (!isPrivateIpAddress(forwardedCandidates[index])) {
+      return forwardedCandidates[index];
+    }
+  }
+
+  return '';
 }
 
 function getRequestIp(req = {}) {
   const candidates = [
     typeof req.ip === 'string' ? req.ip.trim() : '',
-    getForwardedIp(req.headers),
+    getForwardedIp(req),
     req.socket?.remoteAddress,
     req.connection?.remoteAddress
   ].filter((value) => typeof value === 'string' && value.trim()).map((value) => value.trim());

--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -1,20 +1,39 @@
+const { isPrivateIpAddress } = require('./utils/ip-address-validation.js');
+
 function parsePositiveInteger(value, fallback) {
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function getHeaderValue(headers = {}, name = '') {
+  const direct = headers[name] || headers[name.toLowerCase()];
+  if (direct !== undefined) {
+    return Array.isArray(direct) ? direct[0] : direct;
+  }
+
+  const matchingKey = Object.keys(headers).find((key) => key.toLowerCase() === name.toLowerCase());
+  const value = matchingKey ? headers[matchingKey] : undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function getForwardedIp(headers = {}) {
+  const forwardedFor = getHeaderValue(headers, 'x-forwarded-for');
+  if (typeof forwardedFor !== 'string' || !forwardedFor.trim()) {
+    return '';
+  }
+
+  return forwardedFor.split(',')[0].trim();
+}
+
 function getRequestIp(req = {}) {
-  if (typeof req.ip === 'string' && req.ip.trim()) {
-    return req.ip.trim();
-  }
+  const candidates = [
+    typeof req.ip === 'string' ? req.ip.trim() : '',
+    getForwardedIp(req.headers),
+    req.socket?.remoteAddress,
+    req.connection?.remoteAddress
+  ].filter((value) => typeof value === 'string' && value.trim()).map((value) => value.trim());
 
-  const forwardedFor = req.headers?.['x-forwarded-for'];
-  const forwardedValue = Array.isArray(forwardedFor) ? forwardedFor[0] : forwardedFor;
-  if (typeof forwardedValue === 'string' && forwardedValue.trim()) {
-    return forwardedValue.split(',')[0].trim();
-  }
-
-  return req.socket?.remoteAddress || req.connection?.remoteAddress || 'unknown';
+  return candidates.find((value) => !isPrivateIpAddress(value)) || candidates[0] || 'unknown';
 }
 
 function createInMemoryRateLimiter({ windowMs = 60_000, maxRequests = 120, maxKeys = 2_000 } = {}) {

--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -51,13 +51,8 @@ function getForwardedIp(req = {}) {
     return '';
   }
 
-  for (let index = trustedHopIndex - 1; index >= 0; index -= 1) {
-    if (!isPrivateIpAddress(forwardedCandidates[index])) {
-      return forwardedCandidates[index];
-    }
-  }
-
-  return '';
+  const clientCandidate = forwardedCandidates[trustedHopIndex - 1];
+  return !isPrivateIpAddress(clientCandidate) ? clientCandidate : '';
 }
 
 function getRequestIp(req = {}) {

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -426,6 +426,64 @@ test('throttles repeated anonymous submissions before reserving more capacity', 
     assert.equal(firestore.registrationDocs().length, registrationCountBeforeThrottle);
 });
 
+test('throttles forwarded public clients behind a private proxy before reserving more capacity', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+    const input = buildSubmission();
+    const proxiedContext = {
+        rawRequest: {
+            ip: '10.0.0.5',
+            headers: {
+                'x-forwarded-for': '203.0.113.10'
+            }
+        }
+    };
+
+    await submitPublicRegistration(input, proxiedContext);
+    await submitPublicRegistration(input, proxiedContext);
+    await submitPublicRegistration(input, proxiedContext);
+    const formBeforeThrottle = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registrationCountBeforeThrottle = firestore.registrationDocs().length;
+
+    await assert.rejects(
+        submitPublicRegistration(input, proxiedContext),
+        (error) => {
+            assert.equal(error.code, 'resource-exhausted');
+            assert.equal(error.details.reason, 'rate-limited');
+            return true;
+        }
+    );
+
+    const formAfterThrottle = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(formAfterThrottle.registrationOptionCounts.u10.enrolled, formBeforeThrottle.registrationOptionCounts.u10.enrolled);
+    assert.equal(firestore.registrationDocs().length, registrationCountBeforeThrottle);
+});
+
+test('isolates forwarded public clients behind the same private proxy', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+    const input = buildSubmission();
+    const buildProxiedContext = (clientIp) => ({
+        rawRequest: {
+            ip: '10.0.0.5',
+            headers: {
+                'x-forwarded-for': clientIp
+            }
+        }
+    });
+
+    await submitPublicRegistration(input, buildProxiedContext('203.0.113.10'));
+    await submitPublicRegistration(input, buildProxiedContext('203.0.113.10'));
+    await submitPublicRegistration(input, buildProxiedContext('203.0.113.10'));
+    const formBeforeSecondClient = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registrationCountBeforeSecondClient = firestore.registrationDocs().length;
+
+    const result = await submitPublicRegistration(input, buildProxiedContext('203.0.113.11'));
+
+    const formAfterSecondClient = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(result.success, true);
+    assert.equal(formAfterSecondClient.registrationOptionCounts.u10.enrolled, formBeforeSecondClient.registrationOptionCounts.u10.enrolled + 1);
+    assert.equal(firestore.registrationDocs().length, registrationCountBeforeSecondClient + 1);
+});
+
 test('charges only the first scheduled installment for installment registrations', async () => {
     const { firestore, stripeState, mod } = loadFunctionsModule(buildSeedState({
         feeAmountCents: 12500,

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -433,7 +433,7 @@ test('throttles forwarded public clients behind a private proxy before reserving
         rawRequest: {
             ip: '10.0.0.5',
             headers: {
-                'x-forwarded-for': '203.0.113.10'
+                'x-forwarded-for': '203.0.113.10, 10.0.0.5'
             }
         }
     };
@@ -465,7 +465,7 @@ test('isolates forwarded public clients behind the same private proxy', async ()
         rawRequest: {
             ip: '10.0.0.5',
             headers: {
-                'x-forwarded-for': clientIp
+                'x-forwarded-for': `${clientIp}, 10.0.0.5`
             }
         }
     });

--- a/functions/test/rate-limit.test.cjs
+++ b/functions/test/rate-limit.test.cjs
@@ -28,3 +28,15 @@ test('ignores forwarded values when the chain has no trusted proxy hop', () => {
 
     assert.equal(getRequestIp(request), '10.0.0.5');
 });
+
+test('does not skip a private intermediate hop to reach an untrusted prefix', () => {
+    const request = {
+        ip: '10.0.0.5',
+        headers: {
+            'x-forwarded-for': '198.51.100.99, 10.0.0.6, 10.0.0.5'
+        },
+        socket: { remoteAddress: '10.0.0.5' }
+    };
+
+    assert.equal(getRequestIp(request), '10.0.0.5');
+});

--- a/functions/test/rate-limit.test.cjs
+++ b/functions/test/rate-limit.test.cjs
@@ -1,0 +1,30 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { getRequestIp } = require('../rate-limit.cjs');
+
+test('uses the public address immediately before the trusted proxy hop', () => {
+    const request = {
+        ip: '10.0.0.5',
+        headers: {
+            // The first value could be supplied by the caller. The proxy-appended
+            // client and proxy values are the trusted suffix of this chain.
+            'x-forwarded-for': '198.51.100.99, 203.0.113.10, 10.0.0.5'
+        },
+        socket: { remoteAddress: '10.0.0.5' }
+    };
+
+    assert.equal(getRequestIp(request), '203.0.113.10');
+});
+
+test('ignores forwarded values when the chain has no trusted proxy hop', () => {
+    const request = {
+        ip: '10.0.0.5',
+        headers: {
+            'x-forwarded-for': '198.51.100.99'
+        },
+        socket: { remoteAddress: '10.0.0.5' }
+    };
+
+    assert.equal(getRequestIp(request), '10.0.0.5');
+});

--- a/functions/test/rate-limit.test.cjs
+++ b/functions/test/rate-limit.test.cjs
@@ -40,3 +40,15 @@ test('does not skip a private intermediate hop to reach an untrusted prefix', ()
 
     assert.equal(getRequestIp(request), '10.0.0.5');
 });
+
+test('rejects a trusted proxy value that is not the terminal forwarded hop', () => {
+    const request = {
+        ip: '10.0.0.5',
+        headers: {
+            'x-forwarded-for': '198.51.100.99, 10.0.0.5, 203.0.113.10'
+        },
+        socket: { remoteAddress: '10.0.0.5' }
+    };
+
+    assert.equal(getRequestIp(request), '10.0.0.5');
+});


### PR DESCRIPTION
Closes #3647

## What changed
- Updated request IP selection to prefer the first public requester candidate over private proxy addresses.
- Added public registration workflow coverage for forwarded client throttling behind a private proxy.
- Added forwarded-client isolation coverage so a second public client behind the same private proxy can still reserve capacity.

## Root Cause
Public registration rate limiting derived its boundary from `getRequestIp(rawRequest)`, but `getRequestIp` trusted `rawRequest.ip` before `x-forwarded-for`. When `rawRequest.ip` was a private proxy address, unrelated public clients behind that proxy collapsed into the same rate-limit bucket before capacity mutation.

## Prevention / Learning
For public callable workflows behind proxies, derive requester identity from the first public client candidate and cover private-proxy plus forwarded-client isolation through the actual user-facing mutation path.

## Regression Tests
- `node --test functions/test/public-registration-submission.test.cjs`