### PR TITLE
Restore reloaded goal undo metadata

### DIFF
--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -141,13 +141,21 @@ function isHydratableLogEventType(type) {
 function buildResumeUndoData(event) {
   const type = normalizeTrackLiveText(event?.type);
   if (type === 'stat' || type === 'goal') {
-    return {
+    const undoData = {
       type,
       playerId: event?.playerId || null,
       statKey: event?.statKey || null,
       value: Number(event?.value || 0),
       isOpponent: Boolean(event?.isOpponent)
     };
+
+    if (type === 'goal') {
+      undoData.teamSide = normalizeTrackLiveText(event?.teamSide) || null;
+      undoData.liveNoteId = normalizeTrackLiveText(event?.liveNoteId) || null;
+      undoData.liveNoteText = normalizeTrackLiveText(event?.liveNoteText) || null;
+    }
+
+    return undoData;
   }
 
   return null;

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -213,6 +213,8 @@ export function buildTrackLiveResumeState({
   orderedEvents.forEach(({ event, index, createdAtMs }) => {
     const type = normalizeTrackLiveText(event?.type);
     const timestamp = createdAtMs ?? now();
+    let restoredGoalNoteId = '';
+    let restoredGoalNoteText = '';
     const baseEntry = {
       period: normalizeTrackLiveText(event?.period),
       time: formatTrackGameTime(event?.gameClockMs),
@@ -254,9 +256,11 @@ export function buildTrackLiveResumeState({
     if (type === 'goal') {
       const goalNoteText = normalizeTrackLiveText(buildGoalNoteText(event));
       if (goalNoteText) {
+        restoredGoalNoteId = normalizeTrackLiveText(event?.liveNoteId) || `resume-goal-note-${index}`;
+        restoredGoalNoteText = goalNoteText;
         liveNotes.push({
           ...baseEntry,
-          id: normalizeTrackLiveText(event?.liveNoteId) || `resume-goal-note-${index}`,
+          id: restoredGoalNoteId,
           text: goalNoteText,
           type: 'goal'
         });
@@ -274,10 +278,16 @@ export function buildTrackLiveResumeState({
     const text = buildResumeLogText(event);
     if (!text) return;
 
+    const undoData = buildResumeUndoData(event);
+    if (type === 'goal' && undoData) {
+      undoData.liveNoteId = undoData.liveNoteId || restoredGoalNoteId || null;
+      undoData.liveNoteText = undoData.liveNoteText || restoredGoalNoteText || null;
+    }
+
     gameLog.push({
       ...baseEntry,
       text,
-      undoData: buildResumeUndoData(event)
+      undoData
     });
   });
 

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -308,6 +308,38 @@ describe('track live state helpers', () => {
     ]);
   });
 
+  it('uses the hydrated fallback note metadata for legacy goals', () => {
+    const resumed = buildTrackLiveResumeState({
+      liveEvents: [
+        {
+          type: 'goal',
+          description: 'Legacy away goal',
+          note: 'Legacy finish',
+          teamSide: 'away',
+          statKey: 'goals',
+          value: 1,
+          playerId: 'opp7',
+          isOpponent: true,
+          period: 'H1',
+          gameClockMs: 12000,
+          createdAt: { seconds: 21, nanoseconds: 0 }
+        }
+      ]
+    });
+
+    expect(resumed.gameLog[0].undoData).toMatchObject({
+      type: 'goal',
+      teamSide: 'away',
+      liveNoteId: 'resume-goal-note-0',
+      liveNoteText: 'Legacy finish'
+    });
+    expect(resumed.liveNotes[0]).toMatchObject({
+      id: 'resume-goal-note-0',
+      text: 'Legacy finish',
+      type: 'goal'
+    });
+  });
+
   it('applies reset and undo events when rebuilding resumed tracker state', () => {
     const resumed = buildTrackLiveResumeState({
       liveEvents: [

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -202,6 +202,7 @@ describe('track live state helpers', () => {
           description: 'Ava scored for the home team',
           note: 'Left-footed finish',
           liveNoteId: 'goal-note-1',
+          liveNoteText: 'Home goal: Left-footed finish',
           teamSide: 'home',
           statKey: 'goals',
           value: 1,
@@ -234,7 +235,10 @@ describe('track live state helpers', () => {
           playerId: 'p9',
           statKey: 'goals',
           value: 1,
-          isOpponent: false
+          isOpponent: false,
+          teamSide: 'home',
+          liveNoteId: 'goal-note-1',
+          liveNoteText: 'Home goal: Left-footed finish'
         }
       },
       { text: 'Note: Strong defensive stretch', period: 'Q1', time: '0:20', timestamp: 12000, undoData: null },
@@ -258,6 +262,50 @@ describe('track live state helpers', () => {
       { id: 'note-1', text: 'Strong defensive stretch', type: 'text', period: 'Q1', time: '0:20', timestamp: 12000 }
     ]);
     expect(resumed.summaryText).toBe('Strong defensive stretch\nHome goal: Left-footed finish');
+  });
+
+  it('restores away goal undo metadata after reload', () => {
+    const resumed = buildTrackLiveResumeState({
+      liveEvents: [
+        {
+          type: 'goal',
+          description: 'Away goal by #9 (H1) - Top corner',
+          note: 'Top corner',
+          liveNoteId: 'away-goal-note-1',
+          liveNoteText: 'Tigers goal: Top corner',
+          teamSide: 'away',
+          statKey: 'goals',
+          value: 1,
+          playerId: 'opp9',
+          isOpponent: true,
+          period: 'H1',
+          gameClockMs: 42000,
+          createdAt: { seconds: 20, nanoseconds: 0 }
+        }
+      ],
+      buildGoalNoteText: (event) => event.liveNoteText
+    });
+
+    expect(resumed.gameLog[0].undoData).toEqual({
+      type: 'goal',
+      playerId: 'opp9',
+      statKey: 'goals',
+      value: 1,
+      isOpponent: true,
+      teamSide: 'away',
+      liveNoteId: 'away-goal-note-1',
+      liveNoteText: 'Tigers goal: Top corner'
+    });
+    expect(resumed.liveNotes).toEqual([
+      {
+        id: 'away-goal-note-1',
+        text: 'Tigers goal: Top corner',
+        type: 'goal',
+        period: 'H1',
+        time: '0:42',
+        timestamp: 20000
+      }
+    ]);
   });
 
   it('applies reset and undo events when rebuilding resumed tracker state', () => {


### PR DESCRIPTION
Closes #3645

## What changed
- Preserve goal-specific undo metadata when rebuilding live tracker state from persisted `liveEvents`.
- Added a focused regression test for a reloaded away goal with scorer/note metadata.

## Root Cause
`buildResumeUndoData(event)` rebuilt persisted goal events using only the generic stat undo fields. That dropped `teamSide`, `liveNoteId`, and `liveNoteText`, so the post-reload undo path treated away goals as home goals and could not remove the restored goal note by id/text.

## Prevention / Learning
When hydrating persisted live-event undo data, preserve every field consumed by the matching live undo handler. Reload/resume helpers need regression coverage for side-specific score changes and related cleanup metadata, not just the generic stat payload.

## Regression Tests
- `npx vitest run tests/unit/track-live-state.test.js --reporter=verbose`