### PR TITLE
Fix mirrored scoreboard scores

### DIFF
--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -83,8 +83,11 @@ describe('scoreboard widget embed', () => {
         expect(source).toContain('.filter((game) => game._date && (isLive(game) || game._date >= now || (isCompleted(game) && game._date >= recentCutoff)))');
         expect(source).not.toContain('|| !isCompleted(game) || isLive(game)');
         expect(source).toContain('function renderGame(game)');
-        expect(source).toContain('const teamScore = game.isHome === false ? awayScore : homeScore;');
-        expect(source).toContain('const opponentScore = game.isHome === false ? homeScore : awayScore;');
+        expect(source).toContain('function isSharedScheduleMirror(game)');
+        expect(source).toContain("return !!String(game?.sharedScheduleSourceTeamId || '').trim();");
+        expect(source).toContain('const useStoredScoreOrder = isSharedScheduleMirror(game) || game.isHome !== false;');
+        expect(source).toContain('const teamScore = useStoredScoreOrder ? homeScore : awayScore;');
+        expect(source).toContain('const opponentScore = useStoredScoreOrder ? awayScore : homeScore;');
         expect(source).toContain("const scoreLabel = typeof game.isHome === 'boolean' ? 'team - opponent' : 'home - away';");
         expect(source).toContain('${teamScore} - ${opponentScore}');
         expect(source).toContain('${scoreLabel}');
@@ -192,6 +195,41 @@ describe('scoreboard widget embed', () => {
         expect(articles[1].textContent).toContain('68 - 71');
         expect(articles[1].textContent).toContain('team - opponent');
         expect(articles[1].textContent).not.toContain('71 - 68');
+    });
+
+    it('preserves mirrored shared schedule scores as team-oriented results', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-07T12:00:00Z'));
+        createWidgetDom('https://example.test/widget-scoreboard.html?teamId=team-bravo');
+
+        const harness = extractWidgetHarness({
+            getTeam: vi.fn().mockResolvedValue({ name: 'Bravo FC' }),
+            getGames: vi.fn().mockResolvedValue([
+                {
+                    id: 'mirrored-final',
+                    opponent: 'Alpha FC',
+                    date: '2026-07-06T18:00:00Z',
+                    liveStatus: 'completed',
+                    isHome: false,
+                    homeScore: 5,
+                    awayScore: 10,
+                    sharedScheduleId: 'shared_team-alpha_game-123',
+                    sharedScheduleSourceTeamId: 'team-alpha',
+                    sharedScheduleOpponentTeamId: 'team-alpha',
+                    sharedScheduleOpponentGameId: 'game-123'
+                }
+            ]),
+            getUrlParams: () => ({ teamId: 'team-bravo' })
+        });
+
+        harness.init();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const article = document.querySelector('#widget-games article');
+        expect(article.textContent).toContain('5 - 10');
+        expect(article.textContent).toContain('team - opponent');
+        expect(article.textContent).not.toContain('10 - 5');
     });
 
     it('shows the empty state when no games qualify', async () => {

--- a/widget-scoreboard.html
+++ b/widget-scoreboard.html
@@ -106,14 +106,19 @@
             return 'Upcoming';
         }
 
+        function isSharedScheduleMirror(game) {
+            return !!String(game?.sharedScheduleSourceTeamId || '').trim();
+        }
+
         function renderGame(game) {
             const url = getGameUrl(game);
             const statusLabel = getStatusLabel(game);
             const liveClass = isLive(game) ? 'bg-red-100 text-red-700' : isCompleted(game) ? 'bg-gray-100 text-gray-700' : 'bg-emerald-100 text-emerald-700';
             const homeScore = Number.isFinite(Number(game.homeScore)) ? Number(game.homeScore) : 0;
             const awayScore = Number.isFinite(Number(game.awayScore)) ? Number(game.awayScore) : 0;
-            const teamScore = game.isHome === false ? awayScore : homeScore;
-            const opponentScore = game.isHome === false ? homeScore : awayScore;
+            const useStoredScoreOrder = isSharedScheduleMirror(game) || game.isHome !== false;
+            const teamScore = useStoredScoreOrder ? homeScore : awayScore;
+            const opponentScore = useStoredScoreOrder ? awayScore : homeScore;
             const scoreLabel = typeof game.isHome === 'boolean' ? 'team - opponent' : 'home - away';
             const showScore = isLive(game) || isCompleted(game);
             return `


### PR DESCRIPTION
Closes #3644

## What changed
- Updated the public scoreboard widget to detect shared schedule mirror records.
- Preserved stored score order for mirrored shared schedule games while keeping normal away-game score mapping intact.
- Added a regression test for the mirrored Team B scoreboard case.

## Root Cause
The scoreboard widget assumed every `isHome === false` game stored venue-oriented scores and remapped `awayScore` as the team score. Shared schedule mirror records already store scores in the mirrored team's display order, so the widget applied the home/away perspective transform a second time.

## Prevention / Learning
When one workflow writes perspective-normalized records, downstream display code must detect that metadata and avoid applying the same home/away transform again. Future shared-record display paths should test both the source record and mirrored counterpart record.

## Regression Tests
- `npx vitest run tests/unit/scoreboard-widget.test.js tests/unit/shared-schedule-sync.test.js --reporter=verbose`

## Recurrence Risk
Low. The focused widget regression now covers mirrored shared schedule score orientation alongside normal away-game orientation.