### PR TITLE
Add parent fees workflow smoke coverage

### DIFF
--- a/apps/app/src/pages/parent-tools/FeesTool.tsx
+++ b/apps/app/src/pages/parent-tools/FeesTool.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { DollarSign, ExternalLink, Loader2, RefreshCw } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { openPublicUrl } from '../../lib/publicActions';
@@ -11,6 +11,7 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
     const [fees, setFees] = useState<ParentFeeAppRecord[]>([]);
     const [filter, setFilter] = useState<'open' | 'all' | 'paid'>('open');
     const [payingFeeId, setPayingFeeId] = useState('');
+    const paymentInFlightRef = useRef(false);
     const [feeErrors, setFeeErrors] = useState<Record<string, string>>({});
     const { loading, error, run: runLoad } = useParentToolAsyncOperation();
     const payOperation = useParentToolAsyncOperation();
@@ -64,6 +65,9 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
     const openCount = fees.filter((fee) => !['paid', 'canceled', 'cancelled'].includes(String(fee.status || '').toLowerCase())).length;
     const balanceCents = visibleFees.reduce((sum, fee) => sum + Number(fee.balanceDueCents ?? fee.amountDueCents ?? 0), 0);
     const payFee = async (fee: ParentFeeAppRecord) => {
+        if (paymentInFlightRef.current) return;
+
+        paymentInFlightRef.current = true;
         const feeKey = getFeeCardKey(fee);
         const checkoutStatus = String(fee.checkoutStatus || '').toLowerCase();
         const reusableCheckoutUrl = Boolean(fee.checkoutUrl) && (!checkoutStatus || checkoutStatus === 'open');
@@ -92,6 +96,7 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
                     setFeeErrors((current) => ({ ...current, [feeKey]: String(payError.message || 'Unable to open checkout. Please try again.') }));
                 },
                 onFinally: () => {
+                    paymentInFlightRef.current = false;
                     setPayingFeeId('');
                 }
             }
@@ -121,7 +126,7 @@ export function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVer
                 <div className="grid gap-3 lg:grid-cols-2">
                     {visibleFees.length ? visibleFees.map((fee) => {
                         const feeKey = getFeeCardKey(fee);
-                        return <FeeCard key={feeKey} fee={fee} onPay={payFee} paying={payingFeeId === feeKey} error={feeErrors[feeKey] || ''} />;
+                        return <FeeCard key={feeKey} fee={fee} onPay={payFee} paying={payingFeeId === feeKey} payBlocked={Boolean(payingFeeId)} error={feeErrors[feeKey] || ''} />;
                     }) : (
                         <EmptyState icon={DollarSign} title="No fees in this view" detail="Paid and canceled items are available under All." />
                     )}
@@ -148,7 +153,7 @@ function FeeMessageBlock({ title, message }: { title: string; message: string })
     );
 }
 
-function FeeCard({ fee, onPay, paying, error }: { fee: ParentFeeAppRecord; onPay: (fee: ParentFeeAppRecord) => void | Promise<void>; paying: boolean; error: string }) {
+function FeeCard({ fee, onPay, paying, payBlocked, error }: { fee: ParentFeeAppRecord; onPay: (fee: ParentFeeAppRecord) => void | Promise<void>; paying: boolean; payBlocked: boolean; error: string }) {
     const notes = getFeeMessage(fee.notes, fee.feeNotes);
     const offlinePaymentInstructions = getFeeMessage(fee.offlinePaymentInstructions, fee.paymentInstructions);
 
@@ -172,7 +177,7 @@ function FeeCard({ fee, onPay, paying, error }: { fee: ParentFeeAppRecord; onPay
             {notes ? <FeeMessageBlock title="Notes" message={notes} /> : null}
             {offlinePaymentInstructions ? <FeeMessageBlock title="Offline payment" message={offlinePaymentInstructions} /> : null}
             {fee.canPay ? (
-                <button type="button" className="primary-button mt-3 w-full" onClick={() => onPay(fee)} disabled={paying}>
+                <button type="button" className="primary-button mt-3 w-full" onClick={() => onPay(fee)} disabled={payBlocked}>
                     {paying ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ExternalLink className="h-4 w-4" aria-hidden="true" />}
                     {paying ? 'Opening checkout' : 'Pay fee'}
                 </button>

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -394,13 +394,8 @@
                 "apps/app/src/pages/TeamFees.test.tsx"
             ],
             "workflowTests": [
+                "tests/smoke/app-parent-tools.spec.js",
                 "tests/smoke/team-fees-manage.spec.js"
-            ],
-            "knownGaps": [
-                {
-                    "tier": "workflow",
-                    "description": "Parent fee checkout states still need workflow coverage."
-                }
             ]
         },
         {

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -574,6 +574,162 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 });
 
+test('parent fees workflow renders payment states and blocks overlapping checkout', async ({ page, baseURL }) => {
+    await mockParentToolsModules(page);
+    await page.addInitScript(() => {
+        window.__teamFeeCheckoutCalls = [];
+        window.__resolveTeamFeeCheckout = null;
+    });
+    await page.unroute(/\/src\/lib\/parentFeesService\.ts(\?.*)?$/);
+    await page.route(/\/src\/lib\/parentFeesService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export async function loadParentFeesForApp() {
+                    window.__parentToolLoadCounts.fees += 1;
+                    return [{
+                        id: 'fee-online',
+                        title: 'Online registration',
+                        teamId: 'team-1',
+                        batchId: 'batch-online',
+                        recipientId: 'recipient-online',
+                        teamName: 'Bears',
+                        playerName: 'Pat Star',
+                        status: 'unpaid',
+                        amountLabel: '$125',
+                        dueLabel: 'Jul 1',
+                        statusLabel: 'Open',
+                        balanceDueCents: 12500,
+                        checkoutUrl: '',
+                        canPay: true,
+                        checkoutInitiatable: true,
+                        paymentAction: 'createCheckout',
+                        lineItems: [],
+                        installments: [],
+                        ledgerEntries: []
+                    }, {
+                        id: 'fee-second-online',
+                        title: 'Tournament fee',
+                        teamId: 'team-1',
+                        batchId: 'batch-second',
+                        recipientId: 'recipient-second',
+                        teamName: 'Bears',
+                        playerName: 'Pat Star',
+                        status: 'unpaid',
+                        amountLabel: '$80',
+                        dueLabel: 'Jul 8',
+                        statusLabel: 'Open',
+                        balanceDueCents: 8000,
+                        checkoutUrl: '',
+                        canPay: true,
+                        checkoutInitiatable: true,
+                        paymentAction: 'createCheckout',
+                        lineItems: [],
+                        installments: [],
+                        ledgerEntries: []
+                    }, {
+                        id: 'fee-offline',
+                        title: 'Cash registration',
+                        teamId: 'team-1',
+                        batchId: 'batch-offline',
+                        recipientId: 'recipient-offline',
+                        teamName: 'Bears',
+                        playerName: 'Pat Star',
+                        status: 'unpaid',
+                        amountLabel: '$65',
+                        dueLabel: 'Jul 15',
+                        statusLabel: 'Open',
+                        balanceDueCents: 6500,
+                        checkoutUrl: '',
+                        canPay: false,
+                        checkoutInitiatable: false,
+                        paymentAction: '',
+                        offlinePaymentInstructions: 'Bring cash or check to practice.',
+                        lineItems: [],
+                        installments: [],
+                        ledgerEntries: []
+                    }, {
+                        id: 'fee-paid',
+                        title: 'Paid registration',
+                        teamId: 'team-1',
+                        batchId: 'batch-paid',
+                        recipientId: 'recipient-paid',
+                        teamName: 'Bears',
+                        playerName: 'Pat Star',
+                        status: 'paid',
+                        amountLabel: '$125',
+                        dueLabel: 'Paid',
+                        statusLabel: 'Paid',
+                        balanceDueCents: 0,
+                        canPay: false,
+                        checkoutInitiatable: false,
+                        paymentAction: '',
+                        lineItems: [],
+                        installments: [],
+                        ledgerEntries: [{ label: 'Paid by card', amountCents: 12500 }]
+                    }, {
+                        id: 'fee-canceled',
+                        title: 'Canceled registration',
+                        teamId: 'team-1',
+                        batchId: 'batch-canceled',
+                        recipientId: 'recipient-canceled',
+                        teamName: 'Bears',
+                        playerName: 'Pat Star',
+                        status: 'canceled',
+                        amountLabel: '$65',
+                        dueLabel: 'Canceled',
+                        statusLabel: 'Canceled',
+                        balanceDueCents: 0,
+                        canPay: false,
+                        checkoutInitiatable: false,
+                        paymentAction: '',
+                        lineItems: [],
+                        installments: [],
+                        ledgerEntries: []
+                    }];
+                }
+                export async function initiateParentTeamFeeCheckout(teamId, batchId, recipientId) {
+                    window.__teamFeeCheckoutCalls.push({ teamId, batchId, recipientId });
+                    return new Promise((resolve) => {
+                        window.__resolveTeamFeeCheckout = () => resolve({ success: true, checkoutUrl: 'https://pay.example.test/online-registration' });
+                    });
+                }
+            `
+        });
+    });
+
+    await page.goto(appUrl(baseURL, '/parent-tools/fees'), { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText('Online registration')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Cash registration')).toBeVisible();
+    await expect(page.getByText('Bring cash or check to practice.')).toBeVisible();
+    await expect(page.getByText('Paid registration')).toBeHidden();
+    await expect(page.getByText('Canceled registration')).toBeHidden();
+
+    const onlineCard = page.locator('section.app-card', { hasText: 'Online registration' });
+    const secondOnlineCard = page.locator('section.app-card', { hasText: 'Tournament fee' });
+    const offlineCard = page.locator('section.app-card', { hasText: 'Cash registration' });
+    await expect(onlineCard.getByRole('button', { name: /Pay fee/ })).toBeVisible();
+    await expect(secondOnlineCard.getByRole('button', { name: /Pay fee/ })).toBeVisible();
+    await expect(offlineCard.getByRole('button', { name: /Pay fee/ })).toHaveCount(0);
+
+    await onlineCard.getByRole('button', { name: /Pay fee/ }).click();
+    await expect(onlineCard.getByRole('button', { name: /Opening checkout/ })).toBeVisible();
+    await expect(secondOnlineCard.getByRole('button', { name: /Pay fee/ })).toBeDisabled();
+    await expect.poll(() => page.evaluate(() => window.__teamFeeCheckoutCalls)).toEqual([{
+        teamId: 'team-1',
+        batchId: 'batch-online',
+        recipientId: 'recipient-online'
+    }]);
+
+    await page.evaluate(() => window.__resolveTeamFeeCheckout());
+    await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pay.example.test/online-registration');
+
+    await page.getByRole('button', { name: 'All' }).click();
+    await expect(page.getByText('Paid registration')).toBeVisible();
+    await expect(page.getByText('Canceled registration')).toBeVisible();
+});
+
 test('same-user parent auth rehydrate does not reload visited hidden panels', async ({ page, baseURL }) => {
     await mockParentToolsModules(page);
     await page.goto(appUrl(baseURL, '/parent-tools/access'), { waitUntil: 'domcontentloaded' });

--- a/tests/unit/test-coverage-map.test.js
+++ b/tests/unit/test-coverage-map.test.js
@@ -73,7 +73,7 @@ describe('feature coverage map', () => {
         ]);
         expect(formatted).toContain('Known follow-up gaps:');
         expect(formatted).toContain('registration.provider-sync-checkout [workflow]');
-        expect(formatted).toContain('fees.payments-team-pass [workflow]');
         expect(formatted).toContain('officials.org-tournaments-drills [workflow]');
+        expect(formatted).not.toContain('fees.payments-team-pass [workflow]');
     });
 });


### PR DESCRIPTION
Closes #3657

## What changed
- Added a parent fees Playwright workflow covering unpaid online fees, unpaid offline instructions, paid/canceled history visibility, selected-recipient checkout initiation, and redirect handoff.
- Blocked overlapping parent fee checkout attempts while any fee checkout is already in flight.
- Updated the coverage map to record the new parent fees workflow coverage and remove the known gap.

## Root Cause
Parent fees had unit coverage for mapping and checkout calls, but no rendered workflow test asserted online, offline, paid, canceled, and in-flight checkout states together. The rendered app also only disabled the selected fee button during checkout, leaving other fee buttons able to initiate overlapping sessions.

## Prevention / Learning
Payment workflows need browser-level coverage that renders mixed online, offline, paid, and canceled states together and asserts global in-flight checkout blocking, not only selected-item loading state.

## Regression Tests
- `npx vitest run apps/app/src/pages/ParentTools.test.tsx --reporter=verbose`
- `npx vitest run tests/unit/test-coverage-map.test.js --reporter=verbose`
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/smoke/app-parent-tools.spec.js --config=playwright.smoke.config.js --grep "parent fees workflow" --reporter=line`
- `npm run app:build`

## Recurrence Risk
Low. The focused smoke test now exercises the mixed rendered fee states and blocks the overlapping checkout path that made the gap risky.