### PR TITLE
Add homepage discovery regression coverage

### DIFF
--- a/tests/smoke/homepage-discovery.spec.js
+++ b/tests/smoke/homepage-discovery.spec.js
@@ -1,0 +1,126 @@
+import { expect, test } from '@playwright/test';
+import { assertPageBootsWithoutFatalErrors } from './helpers/boot-path.js';
+
+async function installHomepageModuleMocks(page) {
+    await page.route('**/*', async (route) => {
+        const url = new URL(route.request().url());
+        if (url.pathname.endsWith('/js/auth.js')) {
+            await route.fulfill({
+                contentType: 'application/javascript',
+                body: `
+                    export function checkAuth(callback) { callback(null); }
+                    export function getRedirectUrl() { return 'dashboard.html'; }
+                `
+            });
+            return;
+        }
+
+        if (url.pathname.endsWith('/js/utils.js')) {
+            await route.fulfill({
+                contentType: 'application/javascript',
+                body: `
+                    function toDate(value) { return value?.toDate ? value.toDate() : new Date(value); }
+                    export function renderHeader(container) { if (container) container.textContent = 'guest'; }
+                    export function formatDate(value) { return toDate(value).toLocaleDateString('en-US', { timeZone: 'UTC' }); }
+                    export function formatTime(value) { return toDate(value).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' }); }
+                `
+            });
+            return;
+        }
+
+        if (url.pathname.endsWith('/js/db.js')) {
+            await route.fulfill({
+                contentType: 'application/javascript',
+                body: `
+                    function timestamp(isoValue) {
+                        return { toDate() { return new Date(isoValue); } };
+                    }
+                    export async function getLiveGamesNow() {
+                        return [{
+                            id: 'smoke-live-1',
+                            teamId: 'smoke-team-live',
+                            opponent: 'Falcons',
+                            date: timestamp('2026-04-10T23:00:00.000Z'),
+                            homeScore: 21,
+                            awayScore: 17,
+                            liveViewerCount: 3,
+                            liveStatus: 'live',
+                            team: { id: 'smoke-team-live', name: 'Smoke Tigers', photoUrl: '' }
+                        }];
+                    }
+                    export async function getUpcomingLiveGames() {
+                        return [{
+                            id: 'smoke-upcoming-1',
+                            teamId: 'smoke-team-upcoming',
+                            opponent: 'Owls',
+                            date: timestamp('2026-04-11T20:30:00.000Z'),
+                            status: 'scheduled',
+                            liveStatus: 'scheduled',
+                            team: { id: 'smoke-team-upcoming', name: 'Smoke Panthers', photoUrl: '' }
+                        }];
+                    }
+                    export async function getRecentLiveTrackedGames() {
+                        return [{
+                            id: 'smoke-replay-1',
+                            teamId: 'smoke-team-replay',
+                            opponent: 'Bears',
+                            date: timestamp('2026-04-09T01:15:00.000Z'),
+                            homeScore: 44,
+                            awayScore: 41,
+                            liveStatus: 'completed',
+                            team: { id: 'smoke-team-replay', name: 'Smoke Wolves', photoUrl: '' }
+                        }];
+                    }
+                `
+            });
+            return;
+        }
+
+        await route.continue();
+    });
+}
+
+async function assertResolvedDiscoverySection(page, selector, { emptyText, linkPattern, ctaPattern }) {
+    const section = page.locator(selector);
+    await expect(section).not.toContainText(/Loading (games|replays)\.\.\./, { timeout: 15000 });
+    await expect(section).not.toContainText(/Unable to load/i);
+
+    const cards = section.locator('a[href^="live-game.html?teamId="]');
+    if (await cards.count()) {
+        const firstCard = cards.first();
+        await expect(firstCard).toHaveAttribute('href', linkPattern);
+        await expect(firstCard).toContainText(ctaPattern);
+        return;
+    }
+
+    await expect(section).toHaveText(emptyText);
+}
+
+test('homepage resolves live/upcoming and replay discovery cards', async ({ page, baseURL }) => {
+    await installHomepageModuleMocks(page);
+
+    await assertPageBootsWithoutFatalErrors(page, {
+        baseURL,
+        path: '/',
+        titlePatterns: [/ALL PLAYS/i],
+        readySelectors: ['#live-games-list', '#past-games-list']
+    });
+
+    await assertResolvedDiscoverySection(page, '#live-games-list', {
+        emptyText: 'No upcoming live games scheduled',
+        linkPattern: /^live-game\.html\?teamId=[^&]+&gameId=[^&]+$/,
+        ctaPattern: /Watch Now|View Details/
+    });
+    await expect(page.locator('#live-games-list')).toContainText('Smoke Tigers');
+    await expect(page.locator('#live-games-list')).toContainText('Smoke Panthers');
+    await expect(page.locator('#live-games-list a[href="live-game.html?teamId=smoke-team-live&gameId=smoke-live-1"]')).toHaveCount(1);
+    await expect(page.locator('#live-games-list a[href="live-game.html?teamId=smoke-team-upcoming&gameId=smoke-upcoming-1"]')).toHaveCount(1);
+
+    await assertResolvedDiscoverySection(page, '#past-games-list', {
+        emptyText: 'No recent replays available',
+        linkPattern: /^live-game\.html\?teamId=[^&]+&gameId=[^&]+&replay=true$/,
+        ctaPattern: /Watch Replay/
+    });
+    await expect(page.locator('#past-games-list')).toContainText('Smoke Wolves');
+    await expect(page.locator('#past-games-list a[href="live-game.html?teamId=smoke-team-replay&gameId=smoke-replay-1&replay=true"]')).toHaveCount(1);
+});

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -73,7 +73,9 @@ async function runHomepage({
     liveError = null,
     upcomingError = null,
     replayError = null,
-    getRedirectUrl = () => 'dashboard.html'
+    getRedirectUrl = () => 'dashboard.html',
+    formatDate = (value) => `DATE:${value}`,
+    formatTime = (value) => `TIME:${value}`
 } = {}) {
     const { document, elements } = createEnvironment();
     const renderHeader = vi.fn((container, currentUser) => {
@@ -105,12 +107,8 @@ async function runHomepage({
             }
             return replayGames;
         },
-        formatDate(value) {
-            return `DATE:${value}`;
-        },
-        formatTime(value) {
-            return `TIME:${value}`;
-        },
+        formatDate,
+        formatTime,
         logger: {
             warn: vi.fn(),
             error: vi.fn()
@@ -175,6 +173,94 @@ describe('homepage index workflow', () => {
         expect(replayMarkup).toContain('DATE:2026-03-29T19:30:00.000Z');
         expect(replayMarkup).toContain('Watch Replay');
         expect(replayMarkup).toContain('href="live-game.html?teamId=team-9&gameId=game-2&replay=true"');
+    });
+
+    it('renders db-shaped live, upcoming, and replay games with Timestamp-like dates and parent team metadata', async () => {
+        function timestampLike(isoValue) {
+            return {
+                toDate() {
+                    return new Date(isoValue);
+                }
+            };
+        }
+
+        const liveGame = {
+            id: 'live-game-1',
+            teamId: 'team-live-1',
+            opponent: 'Roadrunners',
+            date: timestampLike('2026-04-10T23:00:00.000Z'),
+            homeScore: 18,
+            awayScore: 14,
+            liveViewerCount: 9,
+            liveStatus: 'live',
+            team: {
+                id: 'team-live-1',
+                name: 'Live Tigers',
+                parentName: 'North Club',
+                photoUrl: ''
+            }
+        };
+        const upcomingGame = {
+            id: 'upcoming-game-1',
+            teamId: 'team-upcoming-1',
+            opponent: 'Rockets',
+            date: timestampLike('2026-04-11T20:30:00.000Z'),
+            status: 'scheduled',
+            liveStatus: 'scheduled',
+            team: {
+                id: 'team-upcoming-1',
+                name: 'Future Panthers',
+                parentName: 'East Club',
+                photoUrl: ''
+            }
+        };
+        const replayGame = {
+            id: 'replay-game-1',
+            teamId: 'team-replay-1',
+            opponent: 'Bears',
+            date: timestampLike('2026-04-09T01:15:00.000Z'),
+            homeScore: 44,
+            awayScore: 41,
+            liveStatus: 'completed',
+            team: {
+                id: 'team-replay-1',
+                name: 'Replay Wolves',
+                parentName: 'West Club',
+                photoUrl: ''
+            }
+        };
+
+        const { elements } = await runHomepage({
+            liveGames: [liveGame],
+            upcomingGames: [upcomingGame],
+            replayGames: [replayGame],
+            formatDate(value) {
+                return `DATE:${value.toDate().toISOString()}`;
+            },
+            formatTime(value) {
+                return `TIME:${value.toDate().toISOString()}`;
+            }
+        });
+
+        const liveMarkup = elements.get('live-games-list').innerHTML;
+        expect(liveMarkup).not.toContain('Loading games...');
+        expect(liveMarkup).toContain('Live Tigers');
+        expect(liveMarkup).toContain('Live Now');
+        expect(liveMarkup).toContain('9 watching');
+        expect(liveMarkup).toContain('href="live-game.html?teamId=team-live-1&gameId=live-game-1"');
+        expect(liveMarkup).toContain('Future Panthers');
+        expect(liveMarkup).toContain('vs Rockets');
+        expect(liveMarkup).toContain('DATE:2026-04-11T20:30:00.000Z');
+        expect(liveMarkup).toContain('TIME:2026-04-11T20:30:00.000Z');
+        expect(liveMarkup).toContain('href="live-game.html?teamId=team-upcoming-1&gameId=upcoming-game-1"');
+
+        const replayMarkup = elements.get('past-games-list').innerHTML;
+        expect(replayMarkup).not.toContain('Loading replays...');
+        expect(replayMarkup).toContain('Replay Wolves');
+        expect(replayMarkup).toContain('vs Bears');
+        expect(replayMarkup).toContain('44 - 41');
+        expect(replayMarkup).toContain('DATE:2026-04-09T01:15:00.000Z');
+        expect(replayMarkup).toContain('href="live-game.html?teamId=team-replay-1&gameId=replay-game-1&replay=true"');
     });
 
     it('routes parent users to the parent dashboard CTA', async () => {


### PR DESCRIPTION
Closes #3643

## What changed
- Added a Playwright homepage discovery smoke test that loads `/` through `index.html`, mocks the imported auth/utils/db modules, waits for live/replay loading placeholders to clear, and verifies rendered live/upcoming/replay cards.
- Added focused unit coverage for `initHomepage` using db-helper-shaped live, upcoming, and replay games with Timestamp-like dates and parent team metadata.

## Root Cause
The public homepage smoke path only waited for `body`, and the existing unit tests used already-normalized arrays. That left async section completion, Firestore-shaped date handling, and live-game link generation unverified for the public discovery workflow.

## Prevention / Learning
Public discovery surfaces need browser-level section assertions that wait past loading placeholders plus focused unit coverage using helper-shaped data, especially for Timestamp-like dates and generated navigation URLs.

## Regression Tests
- `npx vitest run tests/unit/homepage-index.test.js tests/unit/db-homepage-shared-games.test.js --reporter=dot`
- `npx playwright test tests/smoke/homepage-discovery.spec.js --config=playwright.smoke.config.js --reporter=line`