### PR TITLE
Paginate parent access team search

### DIFF
--- a/apps/app/src/lib/parentToolsAccessService.test.ts
+++ b/apps/app/src/lib/parentToolsAccessService.test.ts
@@ -3,13 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const legacyMocks = vi.hoisted(() => ({
     createParentMembershipRequest: vi.fn(),
     discoverPublicTeams: vi.fn(),
+    getTeam: vi.fn(),
     getPlayers: vi.fn(),
     listMyParentMembershipRequests: vi.fn()
 }));
 
 vi.mock('./adapters/legacyParentTools', () => legacyMocks);
 
-import { discoverParentAccessTeams } from './parentToolsAccessService';
+import { discoverParentAccessTeams, loadParentAccessTeam } from './parentToolsAccessService';
 
 describe('parentToolsAccessService', () => {
     beforeEach(() => {
@@ -41,5 +42,35 @@ describe('parentToolsAccessService', () => {
             cursor: { id: 'previous' },
             pageSize: 12
         });
+    });
+
+    it('loads one public active team by id for deep-linked access requests', async () => {
+        legacyMocks.getTeam.mockResolvedValue({
+            id: 'team-late',
+            name: 'Late Team',
+            sport: 'Soccer',
+            isPublic: true
+        });
+
+        await expect(loadParentAccessTeam('team-late')).resolves.toEqual({
+            id: 'team-late',
+            name: 'Late Team',
+            sport: 'Soccer',
+            city: '',
+            state: '',
+            zip: ''
+        });
+
+        expect(legacyMocks.getTeam).toHaveBeenCalledWith('team-late');
+    });
+
+    it('does not expose a private deep-linked team', async () => {
+        legacyMocks.getTeam.mockResolvedValue({
+            id: 'team-private',
+            name: 'Private Team',
+            isPublic: false
+        });
+
+        await expect(loadParentAccessTeam('team-private')).resolves.toBeNull();
     });
 });

--- a/apps/app/src/lib/parentToolsAccessService.test.ts
+++ b/apps/app/src/lib/parentToolsAccessService.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const legacyMocks = vi.hoisted(() => ({
+    createParentMembershipRequest: vi.fn(),
+    discoverPublicTeams: vi.fn(),
+    getPlayers: vi.fn(),
+    listMyParentMembershipRequests: vi.fn()
+}));
+
+vi.mock('./adapters/legacyParentTools', () => legacyMocks);
+
+import { discoverParentAccessTeams } from './parentToolsAccessService';
+
+describe('parentToolsAccessService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('searches public teams with bounded cursor pagination and preserves nextCursor', async () => {
+        legacyMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                { id: 'private-team', name: 'Private Wolves', isPublic: false },
+                { id: 'team-1', name: 'Austin Bats', sport: 'Soccer', city: 'Austin', state: 'TX', zip: '73301', isPublic: true }
+            ],
+            nextCursor: { id: 'team-1' }
+        });
+
+        await expect(discoverParentAccessTeams({
+            searchText: '  Austin  ',
+            cursor: { id: 'previous' },
+            pageSize: 12
+        })).resolves.toEqual({
+            teams: [
+                { id: 'team-1', name: 'Austin Bats', sport: 'Soccer', city: 'Austin', state: 'TX', zip: '73301' }
+            ],
+            nextCursor: { id: 'team-1' }
+        });
+
+        expect(legacyMocks.discoverPublicTeams).toHaveBeenCalledWith({
+            searchText: 'Austin',
+            cursor: { id: 'previous' },
+            pageSize: 12
+        });
+    });
+});

--- a/apps/app/src/lib/parentToolsAccessService.ts
+++ b/apps/app/src/lib/parentToolsAccessService.ts
@@ -1,4 +1,4 @@
-import { createParentMembershipRequest, discoverPublicTeams, getPlayers, listMyParentMembershipRequests } from './adapters/legacyParentTools';
+import { createParentMembershipRequest, discoverPublicTeams, getPlayers, getTeam, listMyParentMembershipRequests } from './adapters/legacyParentTools';
 import type { AuthUser } from './types';
 
 export type ParentAccessTeam = {
@@ -72,6 +72,12 @@ export async function loadParentAccessPlayers(teamId: string): Promise<ParentAcc
         }))
         .filter((player: ParentAccessPlayer) => player.id)
         .sort((a: ParentAccessPlayer, b: ParentAccessPlayer) => a.name.localeCompare(b.name));
+}
+
+export async function loadParentAccessTeam(teamId: string): Promise<ParentAccessTeam | null> {
+    if (!teamId) return null;
+    const team = await Promise.resolve(getTeam(teamId));
+    return normalizeAccessTeams(team ? [team] : [])[0] || null;
 }
 
 export async function submitParentAccessRequest(teamId: string, playerId: string, relation: string) {

--- a/apps/app/src/lib/parentToolsAccessService.ts
+++ b/apps/app/src/lib/parentToolsAccessService.ts
@@ -5,7 +5,14 @@ export type ParentAccessTeam = {
     id: string;
     name: string;
     sport?: string;
+    city?: string;
+    state?: string;
     zip?: string;
+};
+
+export type ParentAccessTeamsPage = {
+    teams: ParentAccessTeam[];
+    nextCursor: unknown | null;
 };
 
 export type ParentAccessPlayer = {
@@ -36,9 +43,20 @@ export async function loadParentAccessModel(user: AuthUser | null) {
     };
 }
 
-export async function loadParentAccessTeams(): Promise<ParentAccessTeam[]> {
-    const result = await Promise.resolve(discoverPublicTeams({ pageSize: 100 }));
-    return normalizeAccessTeams(result?.teams);
+export async function discoverParentAccessTeams({
+    searchText = '',
+    cursor = null,
+    pageSize = 20
+}: { searchText?: string; cursor?: unknown | null; pageSize?: number } = {}): Promise<ParentAccessTeamsPage> {
+    const result = await Promise.resolve(discoverPublicTeams({
+        searchText: String(searchText || '').trim(),
+        cursor,
+        pageSize
+    }));
+    return {
+        teams: normalizeAccessTeams(result?.teams),
+        nextCursor: result?.nextCursor || null
+    };
 }
 
 export async function loadParentAccessPlayers(teamId: string): Promise<ParentAccessPlayer[]> {
@@ -67,6 +85,8 @@ function normalizeAccessTeams(teams: any[]): ParentAccessTeam[] {
             id: compactString(team.id || team.teamId),
             name: compactString(team.name || team.teamName) || 'Team',
             sport: compactString(team.sport),
+            city: compactString(team.city),
+            state: compactString(team.state),
             zip: compactString(team.zip)
         }))
         .filter((team) => team.id)

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -75,7 +75,14 @@ export type ParentAccessTeam = {
   id: string;
   name: string;
   sport?: string;
+  city?: string;
+  state?: string;
   zip?: string;
+};
+
+export type ParentAccessTeamsPage = {
+  teams: ParentAccessTeam[];
+  nextCursor: unknown | null;
 };
 
 export type ParentAccessPlayer = {
@@ -361,9 +368,20 @@ export async function loadParentAccessModel(user: AuthUser | null) {
   };
 }
 
-export async function loadParentAccessTeams(): Promise<ParentAccessTeam[]> {
-  const result = await Promise.resolve(discoverPublicTeams({ pageSize: 100 }));
-  return normalizeAccessTeams(result?.teams);
+export async function discoverParentAccessTeams({
+  searchText = '',
+  cursor = null,
+  pageSize = 20
+}: { searchText?: string; cursor?: unknown | null; pageSize?: number } = {}): Promise<ParentAccessTeamsPage> {
+  const result = await Promise.resolve(discoverPublicTeams({
+    searchText: String(searchText || '').trim(),
+    cursor,
+    pageSize
+  }));
+  return {
+    teams: normalizeAccessTeams(result?.teams),
+    nextCursor: result?.nextCursor || null
+  };
 }
 
 export async function loadParentAccessPlayers(teamId: string): Promise<ParentAccessPlayer[]> {
@@ -920,6 +938,8 @@ function normalizeAccessTeams(teams: any[]): ParentAccessTeam[] {
       id: compactString(team.id || team.teamId),
       name: compactString(team.name || team.teamName) || 'Team',
       sport: compactString(team.sport),
+      city: compactString(team.city),
+      state: compactString(team.state),
       zip: compactString(team.zip)
     }))
     .filter((team) => team.id)

--- a/apps/app/src/lib/useAsyncOperation.test.tsx
+++ b/apps/app/src/lib/useAsyncOperation.test.tsx
@@ -83,6 +83,42 @@ function StaleOperationHarness({
     );
 }
 
+function InvalidatableOperationHarness({
+    operation,
+    onSuccess,
+    onError,
+    onFinally
+}: {
+    operation: () => Promise<string>;
+    onSuccess: (value: string) => void;
+    onError: (error: unknown) => void;
+    onFinally: () => void;
+}) {
+    const { loading, error, invalidate, run } = useAsyncOperation();
+
+    return (
+        <div>
+            <div data-testid="loading">{String(loading)}</div>
+            <div data-testid="error">{error || ''}</div>
+            <button
+                type="button"
+                onClick={() => {
+                    void run(operation, {
+                        ignoreStale: true,
+                        rethrow: false,
+                        onSuccess,
+                        onError,
+                        onFinally
+                    });
+                }}
+            >
+                Run invalidatable
+            </button>
+            <button type="button" onClick={invalidate}>Invalidate</button>
+        </div>
+    );
+}
+
 function GuardedErrorHarness({
     operation,
     shouldHandleError,
@@ -191,6 +227,39 @@ describe('useAsyncOperation', () => {
             expect(screen.getByTestId('value').textContent).toBe('latest value');
         });
         expect(screen.getByTestId('error').textContent).toBe('');
+    });
+
+    it('can invalidate an in-flight run when its caller intent is removed', async () => {
+        const deferred = createDeferred<string>();
+        const onSuccess = vi.fn();
+        const onError = vi.fn();
+        const onFinally = vi.fn();
+
+        render(
+            <InvalidatableOperationHarness
+                operation={() => deferred.promise}
+                onSuccess={onSuccess}
+                onError={onError}
+                onFinally={onFinally}
+            />
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Run invalidatable' }));
+        await waitFor(() => {
+            expect(screen.getByTestId('loading').textContent).toBe('true');
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Invalidate' }));
+        expect(screen.getByTestId('loading').textContent).toBe('false');
+
+        deferred.reject(new Error('obsolete request failed'));
+        await waitFor(() => {
+            expect(screen.getByTestId('loading').textContent).toBe('false');
+        });
+        expect(screen.getByTestId('error').textContent).toBe('');
+        expect(onSuccess).not.toHaveBeenCalled();
+        expect(onError).not.toHaveBeenCalled();
+        expect(onFinally).not.toHaveBeenCalled();
     });
 
     it('can skip handling current-run errors when a caller guard rejects them', async () => {

--- a/apps/app/src/lib/useAsyncOperation.ts
+++ b/apps/app/src/lib/useAsyncOperation.ts
@@ -34,6 +34,11 @@ export function useAsyncOperation() {
         setError(null);
     }, []);
 
+    const invalidate = useCallback(() => {
+        latestRunIdRef.current += 1;
+        setLoading(false);
+    }, []);
+
     const run = useCallback(async function runAsyncOperation<T>(
         operation: () => Promise<T>,
         {
@@ -84,6 +89,7 @@ export function useAsyncOperation() {
         loading,
         error,
         clearError,
+        invalidate,
         setError,
         run
     };

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -29,7 +29,7 @@ const parentToolsServiceMocks = vi.hoisted(() => ({
 
 const parentToolsAccessServiceMocks = vi.hoisted(() => ({
     loadParentAccessModel: vi.fn(),
-    loadParentAccessTeams: vi.fn(),
+    discoverParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     submitParentAccessRequest: vi.fn()
 }));
@@ -88,6 +88,7 @@ vi.mock('lucide-react', () => {
         KeyRound: Icon,
         Loader2: Icon,
         RefreshCw: Icon,
+        Search: Icon,
         Share2: Icon,
         Shield: Icon,
         Ticket: Icon,
@@ -189,9 +190,10 @@ describe('ParentTools access', () => {
         parentToolsAccessServiceMocks.loadParentAccessModel.mockResolvedValue({
             requests: []
         });
-        parentToolsAccessServiceMocks.loadParentAccessTeams.mockResolvedValue([
-            { id: 'team-1', name: 'Bears', sport: 'Soccer' }
-        ]);
+        parentToolsAccessServiceMocks.discoverParentAccessTeams.mockResolvedValue({
+            teams: [{ id: 'team-1', name: 'Bears', sport: 'Soccer' }],
+            nextCursor: null
+        });
         parentToolsAccessServiceMocks.loadParentAccessPlayers.mockResolvedValue([
             { id: 'player-1', name: 'Sam Player', number: '12' }
         ]);
@@ -308,13 +310,13 @@ describe('ParentTools access', () => {
         expect(inviteRedemptionMocks.redeemSignedInInvite).not.toHaveBeenCalled();
     });
 
-    it('opens the manual request form immediately while public teams finish loading', async () => {
+    it('opens the manual request form without loading public teams until search starts', async () => {
         type PublicTeamRow = { id: string; name: string; sport: string };
-        const deferredTeams: { resolve: ((value: PublicTeamRow[]) => void) | null } = { resolve: null };
+        const deferredTeams: { resolve: ((value: { teams: PublicTeamRow[]; nextCursor: null }) => void) | null } = { resolve: null };
         let loadStartedAfterFormRendered = false;
-        parentToolsAccessServiceMocks.loadParentAccessTeams.mockImplementation(() => {
+        parentToolsAccessServiceMocks.discoverParentAccessTeams.mockImplementation(() => {
             loadStartedAfterFormRendered = Boolean(screen.queryByRole('combobox', { name: 'Team' }));
-            return new Promise<PublicTeamRow[]>((resolve) => {
+            return new Promise<{ teams: PublicTeamRow[]; nextCursor: null }>((resolve) => {
                 deferredTeams.resolve = resolve;
             });
         });
@@ -329,14 +331,21 @@ describe('ParentTools access', () => {
         expect(playerSelect).toBeTruthy();
         expect(teamSelect.disabled).toBe(true);
         expect(playerSelect.disabled).toBe(true);
-        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).not.toHaveBeenCalled();
+        expect(screen.getByRole('option', { name: 'Search or browse teams' })).toBeTruthy();
+
+        fireEvent.change(screen.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Bears' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledWith({ searchText: 'Bears', cursor: null, pageSize: 20 });
         expect(loadStartedAfterFormRendered).toBe(true);
         expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
         expect(screen.getByRole('option', { name: 'Loading public teams...' })).toBeTruthy();
 
         await waitFor(() => expect(deferredTeams.resolve).toBeTruthy());
         if (!deferredTeams.resolve) throw new Error('Expected public teams loader to be pending.');
-        deferredTeams.resolve([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
+        deferredTeams.resolve({ teams: [{ id: 'team-1', name: 'Bears', sport: 'Soccer' }], nextCursor: null });
 
         expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
         expect((screen.getByLabelText('Team') as HTMLSelectElement).disabled).toBe(false);
@@ -355,7 +364,7 @@ describe('ParentTools access', () => {
         renderParentTools(['/parent-tools/access?teamId=team-1']);
 
         await screen.findByText('Request player access');
-        await waitFor(() => expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1));
 
         const teamSelect = await screen.findByRole('combobox', { name: 'Team' }) as HTMLSelectElement;
         expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
@@ -383,20 +392,21 @@ describe('ParentTools access', () => {
         const teamSelect = await screen.findByRole('combobox', { name: 'Team' }) as HTMLSelectElement;
         expect(teamSelect.value).toBe('');
         expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
-        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1);
         expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
         expect(screen.getByRole('button', { name: 'Redeem code' })).toBeTruthy();
         expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
     });
 
     it('allows retry when public team loading fails after opening manual requests', async () => {
-        parentToolsAccessServiceMocks.loadParentAccessTeams
+        parentToolsAccessServiceMocks.discoverParentAccessTeams
             .mockRejectedValueOnce(new Error('Network hiccup.'))
-            .mockResolvedValueOnce([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
+            .mockResolvedValueOnce({ teams: [{ id: 'team-1', name: 'Bears', sport: 'Soccer' }], nextCursor: null });
         renderParentTools();
 
         await screen.findByText('Request player access');
         fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Browse' }));
 
         expect(await screen.findByText('Network hiccup.')).toBeTruthy();
         const retryButton = screen.getByRole('button', { name: 'Retry' });
@@ -404,7 +414,7 @@ describe('ParentTools access', () => {
         fireEvent.click(retryButton);
 
         expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
-        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(2);
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(2);
     });
 
     it('still submits request access after the redeem panel is added', async () => {
@@ -412,6 +422,7 @@ describe('ParentTools access', () => {
 
         await screen.findByText('Request player access');
         fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Browse' }));
         await screen.findByRole('option', { name: 'Bears - Soccer' });
         fireEvent.change(screen.getByLabelText('Team'), { target: { value: 'team-1' } });
         await screen.findByRole('option', { name: '#12 Sam Player' });
@@ -546,14 +557,14 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Fees' }));
         await screen.findByText('Team dues');
         expect(parentToolsAccessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).not.toHaveBeenCalled();
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).not.toHaveBeenCalled();
         expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
         expect(parentToolsServiceMocks.loadParentFeesForApp).toHaveBeenCalledTimes(1);
 
         fireEvent.click(screen.getByRole('button', { name: 'Access' }));
         await screen.findByText('Request player access');
         expect(parentToolsAccessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).not.toHaveBeenCalled();
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).not.toHaveBeenCalled();
         expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
 
         fireEvent.click(screen.getByRole('button', { name: 'Register' }));
@@ -1467,13 +1478,15 @@ describe('ParentTools access', () => {
 
         await screen.findByText('Request player access');
         expect(parentToolsAccessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).not.toHaveBeenCalled();
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).not.toHaveBeenCalled();
         expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
         expect(screen.getByRole('button', { name: 'Request access without a code' })).toBeTruthy();
 
         fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).not.toHaveBeenCalled();
+        fireEvent.click(screen.getByRole('button', { name: 'Browse' }));
         await screen.findByRole('option', { name: 'Bears - Soccer' });
-        expect(parentToolsAccessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(parentToolsAccessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1);
         expect(parentToolsAccessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
 
         fireEvent.change(screen.getByLabelText('Team'), { target: { value: 'team-1' } });

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -29,6 +29,7 @@ const parentToolsServiceMocks = vi.hoisted(() => ({
 
 const parentToolsAccessServiceMocks = vi.hoisted(() => ({
     loadParentAccessModel: vi.fn(),
+    loadParentAccessTeam: vi.fn(),
     discoverParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     submitParentAccessRequest: vi.fn()
@@ -194,6 +195,9 @@ describe('ParentTools access', () => {
             teams: [{ id: 'team-1', name: 'Bears', sport: 'Soccer' }],
             nextCursor: null
         });
+        parentToolsAccessServiceMocks.loadParentAccessTeam.mockImplementation(async (teamId: string) => (
+            teamId === 'team-1' ? { id: 'team-1', name: 'Bears', sport: 'Soccer' } : null
+        ));
         parentToolsAccessServiceMocks.loadParentAccessPlayers.mockResolvedValue([
             { id: 'player-1', name: 'Sam Player', number: '12' }
         ]);

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -93,6 +93,40 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
         });
     });
 
+    it('does not repeat initial discovery when a deep link returns an empty team page', async () => {
+        accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({ teams: [], nextCursor: null });
+        accessServiceMocks.loadParentAccessTeam.mockResolvedValue(null);
+
+        renderTool('team-z');
+
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessTeam).toHaveBeenCalledWith('team-z'));
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(accessServiceMocks.loadParentAccessTeam).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not repeat initial discovery when a deep-link browse rejects', async () => {
+        accessServiceMocks.discoverParentAccessTeams.mockRejectedValue(new Error('Discovery unavailable'));
+        accessServiceMocks.loadParentAccessTeam.mockResolvedValue(null);
+
+        renderTool('team-z');
+
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessTeam).toHaveBeenCalledWith('team-z'));
+        await act(async () => {
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(accessServiceMocks.loadParentAccessTeam).toHaveBeenCalledTimes(1);
+    });
+
     it('switches to a newly deep-linked team while already mounted', async () => {
         renderTool('team-a');
         await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-a'));
@@ -121,6 +155,46 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
             expect(select?.value).toBe('');
         });
         expect(accessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalledWith('team-z');
+    });
+
+    it('clears the prior team and player when an unmatched deep-link lookup rejects', async () => {
+        let rejectTargetLookup: (reason?: unknown) => void = () => {};
+        accessServiceMocks.loadParentAccessPlayers.mockResolvedValue([
+            { id: 'player-a', name: 'Player A', number: '7' }
+        ]);
+        accessServiceMocks.loadParentAccessTeam.mockImplementation((teamId: string) => {
+            if (teamId !== 'team-z') return Promise.resolve(null);
+            return new Promise((_resolve, reject) => {
+                rejectTargetLookup = reject;
+            });
+        });
+        const view = renderTool('team-a');
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-a'));
+        expect(await view.findByRole('option', { name: '#7 Player A' })).toBeTruthy();
+        expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-a');
+        expect((view.getByLabelText('Player') as HTMLSelectElement).value).toBe('player-a');
+        expect(view.getByRole('button', { name: 'Send request' })).not.toBeDisabled();
+
+        await act(async () => {
+            navigate('/parent-tools/access?teamId=team-z');
+        });
+
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessTeam).toHaveBeenCalledWith('team-z'));
+        await waitFor(() => {
+            expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('');
+            expect((view.getByLabelText('Player') as HTMLSelectElement).value).toBe('');
+            expect(view.getByRole('button', { name: 'Send request' })).toBeDisabled();
+        });
+
+        await act(async () => {
+            rejectTargetLookup(new Error('Target lookup failed'));
+        });
+
+        expect(await view.findByText('Target lookup failed')).toBeTruthy();
+        expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('');
+        expect((view.getByLabelText('Player') as HTMLSelectElement).value).toBe('');
+        expect(view.getByRole('button', { name: 'Send request' })).toBeDisabled();
+        expect(accessServiceMocks.submitParentAccessRequest).not.toHaveBeenCalled();
     });
 
     it('resolves a deep-linked team that is beyond the first discovery page', async () => {

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -139,6 +139,29 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
         await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-b'));
     });
 
+    it('does not invalidate discovery started for a newly added deep-link intent', async () => {
+        let resolveDiscovery: (value: unknown) => void = () => {};
+        accessServiceMocks.discoverParentAccessTeams.mockReturnValue(new Promise((resolve) => {
+            resolveDiscovery = resolve;
+        }));
+
+        const view = renderTool('');
+        await act(async () => {
+            navigate('/parent-tools/access?teamId=team-b');
+        });
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1));
+
+        await act(async () => {
+            resolveDiscovery({ teams: [{ id: 'team-b', name: 'Team B' }], nextCursor: null });
+        });
+
+        await waitFor(() => {
+            expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-b');
+        });
+        expect(accessServiceMocks.loadParentAccessTeam).not.toHaveBeenCalledWith('team-b');
+        expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-b');
+    });
+
     it('clears the stale selection when the new deep-linked team is inaccessible', async () => {
         const view = renderTool('team-a');
         await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-a'));

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -367,6 +367,50 @@ describe('AccessTool manual public team discovery', () => {
         expect(view.getByRole('option', { name: 'Lions' })).toBeTruthy();
     });
 
+    it('ignores a pending search rejection after the query intent changes', async () => {
+        let rejectSearch: (reason?: unknown) => void = () => {};
+        accessServiceMocks.discoverParentAccessTeams.mockReturnValue(new Promise((_resolve, reject) => {
+            rejectSearch = reject;
+        }));
+
+        const view = renderTool('');
+
+        fireEvent.click(await view.findByRole('button', { name: 'Request access without a code' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Bears' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1));
+
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Lions' } });
+        await act(async () => {
+            rejectSearch(new Error('Stale Bears failure'));
+        });
+
+        expect(view.queryByText('Stale Bears failure')).toBeNull();
+        expect(view.getByRole('option', { name: 'Search or browse teams' })).toBeTruthy();
+    });
+
+    it('ignores a direct deep-link lookup after that navigation intent is removed', async () => {
+        let resolveLookup: (value: unknown) => void = () => {};
+        accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({ teams: [], nextCursor: null });
+        accessServiceMocks.loadParentAccessTeam.mockReturnValue(new Promise((resolve) => {
+            resolveLookup = resolve;
+        }));
+
+        const view = renderTool('team-z');
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessTeam).toHaveBeenCalledWith('team-z'));
+
+        await act(async () => {
+            navigate('/parent-tools/access');
+        });
+        await act(async () => {
+            resolveLookup({ id: 'team-z', name: 'Team Z' });
+        });
+
+        expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('');
+        expect(view.queryByRole('option', { name: 'Team Z' })).toBeNull();
+        expect(accessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalledWith('team-z');
+    });
+
     it('ignores a retried player load after the user switches to another team', async () => {
         let resolveTeamARetry: (value: unknown) => void = () => {};
         accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -8,7 +8,7 @@ import type { AuthState } from '../../lib/types';
 
 const accessServiceMocks = vi.hoisted(() => ({
     loadParentAccessModel: vi.fn(),
-    loadParentAccessTeams: vi.fn(),
+    discoverParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     submitParentAccessRequest: vi.fn()
 }));
@@ -17,7 +17,7 @@ vi.mock('../../lib/parentToolsAccessService', () => accessServiceMocks);
 vi.mock('../../lib/inviteRedemption', () => ({ redeemSignedInInvite: vi.fn() }));
 vi.mock('lucide-react', () => {
     const Icon = () => null;
-    return { AlertCircle: Icon, CheckCircle2: Icon, KeyRound: Icon, Loader2: Icon, RefreshCw: Icon, Shield: Icon, Users: Icon };
+    return { AlertCircle: Icon, CheckCircle2: Icon, KeyRound: Icon, Loader2: Icon, RefreshCw: Icon, Search: Icon, Shield: Icon, Users: Icon };
 });
 
 const auth = {
@@ -54,10 +54,13 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         accessServiceMocks.loadParentAccessModel.mockResolvedValue({ requests: [] });
-        accessServiceMocks.loadParentAccessTeams.mockResolvedValue([
-            { id: 'team-a', name: 'Team A' },
-            { id: 'team-b', name: 'Team B' }
-        ]);
+        accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({
+            teams: [
+                { id: 'team-a', name: 'Team A' },
+                { id: 'team-b', name: 'Team B' }
+            ],
+            nextCursor: null
+        });
         accessServiceMocks.loadParentAccessPlayers.mockResolvedValue([]);
     });
 
@@ -65,13 +68,13 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
 
     it('opens the manual request form while deep-linked teams are still loading', async () => {
         let resolveTeams: (teams: Array<{ id: string; name: string }>) => void = () => {};
-        accessServiceMocks.loadParentAccessTeams.mockReturnValue(new Promise((resolve) => {
+        accessServiceMocks.discoverParentAccessTeams.mockReturnValue(new Promise((resolve) => {
             resolveTeams = resolve;
         }));
 
         const view = renderTool('team-a');
 
-        await waitFor(() => expect(accessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1));
         await waitFor(() => {
             const select = view.container.querySelector('#parent-access-team') as HTMLSelectElement | null;
             expect(select).not.toBeNull();
@@ -80,7 +83,7 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
         });
 
         await act(async () => {
-            resolveTeams([{ id: 'team-a', name: 'Team A' }]);
+            resolveTeams({ teams: [{ id: 'team-a', name: 'Team A' }], nextCursor: null } as any);
         });
     });
 
@@ -135,5 +138,105 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
         });
 
         await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-a'));
+    });
+});
+
+describe('AccessTool manual public team discovery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        accessServiceMocks.loadParentAccessModel.mockResolvedValue({ requests: [] });
+        accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({
+            teams: [{ id: 'team-a', name: 'Team A', sport: 'Soccer' }],
+            nextCursor: null
+        });
+        accessServiceMocks.loadParentAccessPlayers.mockResolvedValue([
+            { id: 'player-a', name: 'Player A', number: '7' }
+        ]);
+    });
+
+    afterEach(() => cleanup());
+
+    it('waits for search or browse before loading public teams, then pages later results', async () => {
+        accessServiceMocks.discoverParentAccessTeams
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-a', name: 'Austin Bats', sport: 'Soccer', city: 'Austin', state: 'TX' }],
+                nextCursor: 'cursor-2'
+            })
+            .mockResolvedValueOnce({
+                teams: [{ id: 'team-b', name: 'Austin Comets', zip: '73301' }],
+                nextCursor: null
+            });
+
+        const view = renderTool('');
+
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1));
+        fireEvent.click(view.getByRole('button', { name: 'Request access without a code' }));
+        expect(accessServiceMocks.discoverParentAccessTeams).not.toHaveBeenCalled();
+        expect(view.getByRole('option', { name: 'Search or browse teams' })).toBeTruthy();
+
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Austin' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledWith({ searchText: 'Austin', cursor: null, pageSize: 20 }));
+        expect(await view.findByRole('option', { name: 'Austin Bats - Soccer - Austin, TX' })).toBeTruthy();
+        expect(accessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
+
+        fireEvent.click(view.getByRole('button', { name: 'Load more teams' }));
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenLastCalledWith({ searchText: 'Austin', cursor: 'cursor-2', pageSize: 20 }));
+        expect(await view.findByRole('option', { name: 'Austin Comets - 73301' })).toBeTruthy();
+
+        fireEvent.change(view.getByLabelText('Team'), { target: { value: 'team-b' } });
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-b'));
+    });
+
+    it('clears team and player selection when the search text changes', async () => {
+        const view = renderTool('');
+
+        fireEvent.click(await view.findByRole('button', { name: 'Request access without a code' }));
+        fireEvent.click(view.getByRole('button', { name: 'Browse' }));
+        expect(await view.findByRole('option', { name: 'Team A - Soccer' })).toBeTruthy();
+
+        fireEvent.change(view.getByLabelText('Team'), { target: { value: 'team-a' } });
+        expect(await view.findByRole('option', { name: '#7 Player A' })).toBeTruthy();
+        expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-a');
+        expect((view.getByLabelText('Player') as HTMLSelectElement).value).toBe('player-a');
+
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Chicago' } });
+
+        expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('');
+        expect((view.getByLabelText('Player') as HTMLSelectElement).value).toBe('');
+        expect(view.getByRole('option', { name: 'Search or browse teams' })).toBeTruthy();
+    });
+
+    it('ignores stale team search results that resolve after a newer search', async () => {
+        let resolveFirst: (value: unknown) => void = () => {};
+        let resolveSecond: (value: unknown) => void = () => {};
+        accessServiceMocks.discoverParentAccessTeams
+            .mockReturnValueOnce(new Promise((resolve) => {
+                resolveFirst = resolve;
+            }))
+            .mockReturnValueOnce(new Promise((resolve) => {
+                resolveSecond = resolve;
+            }));
+
+        const view = renderTool('');
+
+        fireEvent.click(await view.findByRole('button', { name: 'Request access without a code' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Bears' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Lions' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+
+        await act(async () => {
+            resolveSecond({ teams: [{ id: 'team-lions', name: 'Lions' }], nextCursor: null });
+        });
+        expect(await view.findByRole('option', { name: 'Lions' })).toBeTruthy();
+
+        await act(async () => {
+            resolveFirst({ teams: [{ id: 'team-bears', name: 'Bears' }], nextCursor: null });
+        });
+
+        expect(view.queryByRole('option', { name: 'Bears' })).toBeNull();
+        expect(view.getByRole('option', { name: 'Lions' })).toBeTruthy();
     });
 });

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -8,6 +8,7 @@ import type { AuthState } from '../../lib/types';
 
 const accessServiceMocks = vi.hoisted(() => ({
     loadParentAccessModel: vi.fn(),
+    loadParentAccessTeam: vi.fn(),
     discoverParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     submitParentAccessRequest: vi.fn()
@@ -60,6 +61,11 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
                 { id: 'team-b', name: 'Team B' }
             ],
             nextCursor: null
+        });
+        accessServiceMocks.loadParentAccessTeam.mockImplementation(async (teamId: string) => {
+            if (teamId === 'team-a') return { id: 'team-a', name: 'Team A' };
+            if (teamId === 'team-b') return { id: 'team-b', name: 'Team B' };
+            return null;
         });
         accessServiceMocks.loadParentAccessPlayers.mockResolvedValue([]);
     });
@@ -117,6 +123,20 @@ describe('AccessTool deep-link reconciliation (#3088)', () => {
         expect(accessServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalledWith('team-z');
     });
 
+    it('resolves a deep-linked team that is beyond the first discovery page', async () => {
+        accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({
+            teams: [{ id: 'team-a', name: 'Team A' }],
+            nextCursor: 'cursor-2'
+        });
+        accessServiceMocks.loadParentAccessTeam.mockResolvedValue({ id: 'team-z', name: 'Team Z' });
+
+        renderTool('team-z');
+
+        await waitFor(() => expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessTeam).toHaveBeenCalledWith('team-z'));
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-z'));
+    });
+
     it('reapplies the same deep link after the param is cleared', async () => {
         const view = renderTool('team-a');
         await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-a'));
@@ -149,6 +169,7 @@ describe('AccessTool manual public team discovery', () => {
             teams: [{ id: 'team-a', name: 'Team A', sport: 'Soccer' }],
             nextCursor: null
         });
+        accessServiceMocks.loadParentAccessTeam.mockResolvedValue(null);
         accessServiceMocks.loadParentAccessPlayers.mockResolvedValue([
             { id: 'player-a', name: 'Player A', number: '7' }
         ]);
@@ -238,5 +259,26 @@ describe('AccessTool manual public team discovery', () => {
 
         expect(view.queryByRole('option', { name: 'Bears' })).toBeNull();
         expect(view.getByRole('option', { name: 'Lions' })).toBeTruthy();
+    });
+
+    it('ignores a pending team search when the query text changes before it resolves', async () => {
+        let resolveSearch: (value: unknown) => void = () => {};
+        accessServiceMocks.discoverParentAccessTeams.mockReturnValue(new Promise((resolve) => {
+            resolveSearch = resolve;
+        }));
+
+        const view = renderTool('');
+
+        fireEvent.click(await view.findByRole('button', { name: 'Request access without a code' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Bears' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Lions' } });
+
+        await act(async () => {
+            resolveSearch({ teams: [{ id: 'team-bears', name: 'Bears' }], nextCursor: null });
+        });
+
+        expect(view.queryByRole('option', { name: 'Bears' })).toBeNull();
+        expect(view.getByRole('option', { name: 'Search or browse teams' })).toBeTruthy();
     });
 });

--- a/apps/app/src/pages/parent-tools/AccessTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.test.tsx
@@ -335,6 +335,76 @@ describe('AccessTool manual public team discovery', () => {
         expect(view.getByRole('option', { name: 'Lions' })).toBeTruthy();
     });
 
+    it('ignores a stale team search rejection after a newer search succeeds', async () => {
+        let rejectFirst: (reason?: unknown) => void = () => {};
+        let resolveSecond: (value: unknown) => void = () => {};
+        accessServiceMocks.discoverParentAccessTeams
+            .mockReturnValueOnce(new Promise((_resolve, reject) => {
+                rejectFirst = reject;
+            }))
+            .mockReturnValueOnce(new Promise((resolve) => {
+                resolveSecond = resolve;
+            }));
+
+        const view = renderTool('');
+
+        fireEvent.click(await view.findByRole('button', { name: 'Request access without a code' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Bears' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+        fireEvent.change(view.getByPlaceholderText('Team name, city, state, or zip'), { target: { value: 'Lions' } });
+        fireEvent.click(view.getByRole('button', { name: 'Search' }));
+
+        await act(async () => {
+            resolveSecond({ teams: [{ id: 'team-lions', name: 'Lions' }], nextCursor: null });
+        });
+        expect(await view.findByRole('option', { name: 'Lions' })).toBeTruthy();
+
+        await act(async () => {
+            rejectFirst(new Error('Stale Bears failure'));
+        });
+
+        expect(view.queryByText('Stale Bears failure')).toBeNull();
+        expect(view.getByRole('option', { name: 'Lions' })).toBeTruthy();
+    });
+
+    it('ignores a retried player load after the user switches to another team', async () => {
+        let resolveTeamARetry: (value: unknown) => void = () => {};
+        accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({
+            teams: [
+                { id: 'team-a', name: 'Team A' },
+                { id: 'team-b', name: 'Team B' }
+            ],
+            nextCursor: null
+        });
+        accessServiceMocks.loadParentAccessPlayers
+            .mockRejectedValueOnce(new Error('Team A players unavailable'))
+            .mockReturnValueOnce(new Promise((resolve) => {
+                resolveTeamARetry = resolve;
+            }))
+            .mockResolvedValueOnce([{ id: 'player-b', name: 'Player B', number: '8' }]);
+
+        const view = renderTool('');
+
+        fireEvent.click(await view.findByRole('button', { name: 'Request access without a code' }));
+        fireEvent.click(view.getByRole('button', { name: 'Browse' }));
+        expect(await view.findByRole('option', { name: 'Team A' })).toBeTruthy();
+        fireEvent.change(view.getByLabelText('Team'), { target: { value: 'team-a' } });
+        expect(await view.findByText('Team A players unavailable')).toBeTruthy();
+
+        fireEvent.click(view.getByRole('button', { name: 'Retry' }));
+        await waitFor(() => expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(2));
+        fireEvent.change(view.getByLabelText('Team'), { target: { value: 'team-b' } });
+        expect(await view.findByRole('option', { name: '#8 Player B' })).toBeTruthy();
+
+        await act(async () => {
+            resolveTeamARetry([{ id: 'player-a', name: 'Player A', number: '7' }]);
+        });
+
+        expect((view.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-b');
+        expect((view.getByLabelText('Player') as HTMLSelectElement).value).toBe('player-b');
+        expect(view.queryByRole('option', { name: '#7 Player A' })).toBeNull();
+    });
+
     it('ignores a pending team search when the query text changes before it resolves', async () => {
         let resolveSearch: (value: unknown) => void = () => {};
         accessServiceMocks.discoverParentAccessTeams.mockReturnValue(new Promise((resolve) => {

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -33,7 +33,11 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     // teamId opened while already mounted) is applied, while team-list refreshes
     // for the same deep link don't clobber a later manual selection.
     const appliedDeepLinkRef = useRef('');
+    const initialDeepLinkDiscoveryAttemptRef = useRef('');
+    const initialDeepLinkDiscoveryCompleteRef = useRef('');
+    const deepLinkLookupAttemptRef = useRef('');
     const teamSearchRequestRef = useRef(0);
+    const [deepLinkReconcileVersion, setDeepLinkReconcileVersion] = useState(0);
     const [redeemCode, setRedeemCode] = useState('');
     const [message, setMessage] = useState('');
     const accessLoadOperation = useParentToolAsyncOperation();
@@ -181,6 +185,10 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [auth.user?.uid, refresh]);
 
     useEffect(() => {
+        appliedDeepLinkRef.current = '';
+        initialDeepLinkDiscoveryAttemptRef.current = '';
+        initialDeepLinkDiscoveryCompleteRef.current = '';
+        deepLinkLookupAttemptRef.current = '';
         setManualRequestOpen(false);
         setTeams([]);
         setTeamSearchText('');
@@ -199,19 +207,28 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
 
     useEffect(() => {
         if (!deepLinkedTeamId || teams.length || loadingTeams) return;
-        void loadTeams({ searchText: '', cursor: null, append: false });
-    }, [deepLinkedTeamId, loadTeams, loadingTeams, teams.length]);
+        if (initialDeepLinkDiscoveryAttemptRef.current === deepLinkedTeamId) return;
+        initialDeepLinkDiscoveryAttemptRef.current = deepLinkedTeamId;
+        void loadTeams({ searchText: '', cursor: null, append: false }).finally(() => {
+            if (initialDeepLinkDiscoveryAttemptRef.current !== deepLinkedTeamId) return;
+            initialDeepLinkDiscoveryCompleteRef.current = deepLinkedTeamId;
+            setDeepLinkReconcileVersion((current) => current + 1);
+        });
+    }, [deepLinkedTeamId, deepLinkReconcileVersion, loadTeams, loadingTeams, teams.length]);
 
     useEffect(() => {
         if (deepLinkedTeamId) return;
         appliedDeepLinkRef.current = '';
+        initialDeepLinkDiscoveryAttemptRef.current = '';
+        initialDeepLinkDiscoveryCompleteRef.current = '';
+        deepLinkLookupAttemptRef.current = '';
     }, [deepLinkedTeamId]);
 
     useEffect(() => {
         // Wait until teams have loaded so we can tell whether the deep-linked team
         // is accessible before reconciling the selection.
         if (!deepLinkedTeamId || appliedDeepLinkRef.current === deepLinkedTeamId) return;
-        if (loadingTeams || !teams.length) return;
+        if (loadingTeams) return;
         setManualRequestOpen(true);
         if (teams.some((team) => team.id === deepLinkedTeamId)) {
             // A new deep link is an explicit navigation intent: switch to it even
@@ -219,9 +236,18 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             appliedDeepLinkRef.current = deepLinkedTeamId;
             setSelectedTeamId(deepLinkedTeamId);
         } else {
+            if (!teams.length && initialDeepLinkDiscoveryCompleteRef.current !== deepLinkedTeamId) return;
+            if (deepLinkLookupAttemptRef.current === deepLinkedTeamId) return;
+            deepLinkLookupAttemptRef.current = deepLinkedTeamId;
+            // A new deep link replaces the prior selection intent. Clear the old
+            // roster before looking up the target so a failed lookup cannot leave
+            // submission enabled for the previous team.
+            setSelectedTeamId('');
+            setSelectedPlayerId('');
+            setPlayers([]);
             void loadDeepLinkedTeam(deepLinkedTeamId);
         }
-    }, [deepLinkedTeamId, teams, loadingTeams, loadDeepLinkedTeam]);
+    }, [deepLinkedTeamId, deepLinkReconcileVersion, teams, loadingTeams, loadDeepLinkedTeam]);
 
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
         const rows = await runPlayerLoad(
@@ -235,6 +261,22 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             }
         );
     }, [runPlayerLoad]);
+
+    const retryManualLookup = useCallback(() => {
+        if (playerLoadError && selectedTeamId) {
+            void loadPlayersForTeam(selectedTeamId);
+            return;
+        }
+        if (deepLinkedTeamId) {
+            appliedDeepLinkRef.current = '';
+            initialDeepLinkDiscoveryAttemptRef.current = '';
+            initialDeepLinkDiscoveryCompleteRef.current = '';
+            deepLinkLookupAttemptRef.current = '';
+            setDeepLinkReconcileVersion((current) => current + 1);
+            return;
+        }
+        void loadTeams({ searchText: teamSearchText, cursor: null, append: false });
+    }, [deepLinkedTeamId, loadPlayersForTeam, loadTeams, playerLoadError, selectedTeamId, teamSearchText]);
 
     useEffect(() => {
         let cancelled = false;
@@ -352,7 +394,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                         </form>
                         {manualRequestOpen ? (
                             <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
-                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={playerLoadError && selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : () => { void loadTeams({ searchText: teamSearchText, cursor: null, append: false }); }} retrying={loadingTeams || loadingPlayers} /></div> : null}
+                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={retryManualLookup} retrying={loadingTeams || loadingPlayers} /></div> : null}
                                 <div className="min-w-0 lg:col-span-3">
                                     <label className="app-label" htmlFor="parent-access-team-search">Search public teams</label>
                                     <div className="mt-1 flex flex-col gap-2 sm:flex-row">

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -5,6 +5,7 @@ import { redeemSignedInInvite } from '../../lib/inviteRedemption';
 import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
 import {
     loadParentAccessModel,
+    loadParentAccessTeam,
     loadParentAccessPlayers,
     discoverParentAccessTeams,
     submitParentAccessRequest,
@@ -102,6 +103,36 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         );
     }, [clearPlayerLoadError, clearRedeemError, clearSubmitError, clearTeamLoadError, runTeamLoad, teamSearchText]);
 
+    const loadDeepLinkedTeam = useCallback(async (teamId: string) => {
+        const requestId = teamSearchRequestRef.current + 1;
+        teamSearchRequestRef.current = requestId;
+        clearTeamLoadError();
+        clearPlayerLoadError();
+        clearSubmitError();
+        clearRedeemError();
+        setTeamDiscoveryStarted(true);
+        return runTeamLoad(
+            () => loadParentAccessTeam(teamId),
+            'Unable to load public teams.',
+            {
+                onSuccess: (team) => {
+                    if (requestId !== teamSearchRequestRef.current) return;
+                    appliedDeepLinkRef.current = teamId;
+                    setManualRequestOpen(true);
+                    if (!team) {
+                        setSelectedTeamId('');
+                        return;
+                    }
+                    setTeams((currentRows) => {
+                        if (currentRows.some((row) => row.id === team.id)) return currentRows;
+                        return [...currentRows, team];
+                    });
+                    setSelectedTeamId(teamId);
+                }
+            }
+        );
+    }, [clearPlayerLoadError, clearRedeemError, clearSubmitError, clearTeamLoadError, runTeamLoad]);
+
     const openManualRequest = useCallback(() => {
         setManualRequestOpen(true);
     }, []);
@@ -181,18 +212,16 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         // is accessible before reconciling the selection.
         if (!deepLinkedTeamId || appliedDeepLinkRef.current === deepLinkedTeamId) return;
         if (loadingTeams || !teams.length) return;
-        appliedDeepLinkRef.current = deepLinkedTeamId;
         setManualRequestOpen(true);
         if (teams.some((team) => team.id === deepLinkedTeamId)) {
             // A new deep link is an explicit navigation intent: switch to it even
             // if a previous team was already selected.
+            appliedDeepLinkRef.current = deepLinkedTeamId;
             setSelectedTeamId(deepLinkedTeamId);
         } else {
-            // The newly deep-linked team isn't accessible — clear the stale
-            // selection so the form can't submit against the previous roster.
-            setSelectedTeamId('');
+            void loadDeepLinkedTeam(deepLinkedTeamId);
         }
-    }, [deepLinkedTeamId, teams, loadingTeams]);
+    }, [deepLinkedTeamId, teams, loadingTeams, loadDeepLinkedTeam]);
 
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
         const rows = await runPlayerLoad(
@@ -332,6 +361,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                                             className="auth-input min-w-0 flex-1"
                                             value={teamSearchText}
                                             onChange={(event) => {
+                                                teamSearchRequestRef.current += 1;
                                                 setTeamSearchText(event.target.value);
                                                 setSelectedTeamId('');
                                                 setSelectedPlayerId('');

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -37,6 +37,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const initialDeepLinkDiscoveryCompleteRef = useRef('');
     const deepLinkLookupAttemptRef = useRef('');
     const teamSearchRequestRef = useRef(0);
+    const playerLoadRequestRef = useRef(0);
     const [deepLinkReconcileVersion, setDeepLinkReconcileVersion] = useState(0);
     const [redeemCode, setRedeemCode] = useState('');
     const [message, setMessage] = useState('');
@@ -86,6 +87,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             () => discoverParentAccessTeams({ searchText: normalizedSearchText, cursor, pageSize: 20 }),
             'Unable to load public teams.',
             {
+                ignoreStale: true,
                 onSuccess: (page) => {
                     if (requestId !== teamSearchRequestRef.current) return;
                     setTeamNextCursor(page.nextCursor);
@@ -119,6 +121,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             () => loadParentAccessTeam(teamId),
             'Unable to load public teams.',
             {
+                ignoreStale: true,
                 onSuccess: (team) => {
                     if (requestId !== teamSearchRequestRef.current) return;
                     appliedDeepLinkRef.current = teamId;
@@ -250,17 +253,27 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [deepLinkedTeamId, deepLinkReconcileVersion, teams, loadingTeams, loadDeepLinkedTeam]);
 
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
-        const rows = await runPlayerLoad(
+        const requestId = playerLoadRequestRef.current + 1;
+        playerLoadRequestRef.current = requestId;
+        setPlayers([]);
+        setSelectedPlayerId('');
+        if (!teamId) {
+            clearPlayerLoadError();
+            return;
+        }
+        await runPlayerLoad(
             () => loadParentAccessPlayers(teamId),
             'Unable to load players for this team.',
             {
+                ignoreStale: true,
                 onSuccess: (result) => {
+                    if (requestId !== playerLoadRequestRef.current) return;
                     setPlayers(result);
                     setSelectedPlayerId(result[0]?.id || '');
                 }
             }
         );
-    }, [runPlayerLoad]);
+    }, [clearPlayerLoadError, runPlayerLoad]);
 
     const retryManualLookup = useCallback(() => {
         if (playerLoadError && selectedTeamId) {
@@ -279,32 +292,11 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [deepLinkedTeamId, loadPlayersForTeam, loadTeams, playerLoadError, selectedTeamId, teamSearchText]);
 
     useEffect(() => {
-        let cancelled = false;
-        async function loadPlayers() {
-            setPlayers([]);
-            setSelectedPlayerId('');
-            if (!selectedTeamId) {
-                clearPlayerLoadError();
-                return;
-            }
-            const rows = await runPlayerLoad(
-                () => loadParentAccessPlayers(selectedTeamId),
-                'Unable to load players for this team.',
-                {
-                    onSuccess: (result) => {
-                        if (cancelled) return;
-                        setPlayers(result);
-                        setSelectedPlayerId(result[0]?.id || '');
-                    }
-                }
-            );
-            if (cancelled || !rows) return;
-        }
-        void loadPlayers();
+        void loadPlayersForTeam(selectedTeamId);
         return () => {
-            cancelled = true;
+            playerLoadRequestRef.current += 1;
         };
-    }, [clearPlayerLoadError, runPlayerLoad, selectedTeamId]);
+    }, [loadPlayersForTeam, selectedTeamId]);
 
     const redeem = async (event: FormEvent) => {
         event.preventDefault();

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -36,6 +36,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const initialDeepLinkDiscoveryAttemptRef = useRef('');
     const initialDeepLinkDiscoveryCompleteRef = useRef('');
     const deepLinkLookupAttemptRef = useRef('');
+    const deepLinkIntentRef = useRef(deepLinkedTeamId);
     const teamSearchRequestRef = useRef(0);
     const playerLoadRequestRef = useRef(0);
     const [deepLinkReconcileVersion, setDeepLinkReconcileVersion] = useState(0);
@@ -54,6 +55,8 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const clearAccessLoadError = accessLoadOperation.clearError;
     const clearTeamLoadError = teamLoadOperation.clearError;
     const clearPlayerLoadError = playerLoadOperation.clearError;
+    const invalidateTeamLoad = teamLoadOperation.invalidate;
+    const invalidatePlayerLoad = playerLoadOperation.invalidate;
     const clearSubmitError = submitOperation.clearError;
     const clearRedeemError = redeemOperation.clearError;
     const setSubmitError = submitOperation.setError;
@@ -188,6 +191,10 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [auth.user?.uid, refresh]);
 
     useEffect(() => {
+        teamSearchRequestRef.current += 1;
+        playerLoadRequestRef.current += 1;
+        invalidateTeamLoad();
+        invalidatePlayerLoad();
         appliedDeepLinkRef.current = '';
         initialDeepLinkDiscoveryAttemptRef.current = '';
         initialDeepLinkDiscoveryCompleteRef.current = '';
@@ -200,7 +207,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         setPlayers([]);
         setSelectedTeamId('');
         setSelectedPlayerId('');
-    }, [auth.user?.uid]);
+    }, [auth.user?.uid, invalidatePlayerLoad, invalidateTeamLoad]);
 
     useEffect(() => {
         if (!deepLinkedTeamId) return;
@@ -220,12 +227,17 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [deepLinkedTeamId, deepLinkReconcileVersion, loadTeams, loadingTeams, teams.length]);
 
     useEffect(() => {
+        if (deepLinkIntentRef.current !== deepLinkedTeamId) {
+            deepLinkIntentRef.current = deepLinkedTeamId;
+            teamSearchRequestRef.current += 1;
+            invalidateTeamLoad();
+        }
         if (deepLinkedTeamId) return;
         appliedDeepLinkRef.current = '';
         initialDeepLinkDiscoveryAttemptRef.current = '';
         initialDeepLinkDiscoveryCompleteRef.current = '';
         deepLinkLookupAttemptRef.current = '';
-    }, [deepLinkedTeamId]);
+    }, [deepLinkedTeamId, invalidateTeamLoad]);
 
     useEffect(() => {
         // Wait until teams have loaded so we can tell whether the deep-linked team
@@ -255,6 +267,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
         const requestId = playerLoadRequestRef.current + 1;
         playerLoadRequestRef.current = requestId;
+        invalidatePlayerLoad();
         setPlayers([]);
         setSelectedPlayerId('');
         if (!teamId) {
@@ -273,7 +286,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                 }
             }
         );
-    }, [clearPlayerLoadError, runPlayerLoad]);
+    }, [clearPlayerLoadError, invalidatePlayerLoad, runPlayerLoad]);
 
     const retryManualLookup = () => {
         if (playerLoadError && selectedTeamId) {
@@ -396,6 +409,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                                             value={teamSearchText}
                                             onChange={(event) => {
                                                 teamSearchRequestRef.current += 1;
+                                                invalidateTeamLoad();
                                                 setTeamSearchText(event.target.value);
                                                 setSelectedTeamId('');
                                                 setSelectedPlayerId('');

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { AlertCircle, CheckCircle2, KeyRound, Loader2, RefreshCw, Shield, Users } from 'lucide-react';
+import { AlertCircle, CheckCircle2, KeyRound, Loader2, RefreshCw, Search, Shield, Users } from 'lucide-react';
 import { redeemSignedInInvite } from '../../lib/inviteRedemption';
 import { toAppServiceError, type AppServiceError } from '../../lib/appErrors';
 import {
     loadParentAccessModel,
     loadParentAccessPlayers,
-    loadParentAccessTeams,
+    discoverParentAccessTeams,
     submitParentAccessRequest,
     type ParentAccessPlayer,
     type ParentAccessRequest,
@@ -19,10 +19,12 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const [searchParams] = useSearchParams();
     const deepLinkedTeamId = searchParams.get('teamId')?.trim() || '';
     const [teams, setTeams] = useState<ParentAccessTeam[]>([]);
+    const [teamSearchText, setTeamSearchText] = useState('');
+    const [teamNextCursor, setTeamNextCursor] = useState<unknown | null>(null);
+    const [teamDiscoveryStarted, setTeamDiscoveryStarted] = useState(false);
     const [requests, setRequests] = useState<ParentAccessRequest[]>([]);
     const [players, setPlayers] = useState<ParentAccessPlayer[]>([]);
     const [manualRequestOpen, setManualRequestOpen] = useState(false);
-    const [manualTeamsRequested, setManualTeamsRequested] = useState(false);
     const [selectedTeamId, setSelectedTeamId] = useState('');
     const [selectedPlayerId, setSelectedPlayerId] = useState('');
     const [relation, setRelation] = useState('Parent');
@@ -30,6 +32,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     // teamId opened while already mounted) is applied, while team-list refreshes
     // for the same deep link don't clobber a later manual selection.
     const appliedDeepLinkRef = useRef('');
+    const teamSearchRequestRef = useRef(0);
     const [redeemCode, setRedeemCode] = useState('');
     const [message, setMessage] = useState('');
     const accessLoadOperation = useParentToolAsyncOperation();
@@ -65,27 +68,64 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const normalizedRedeemCode = redeemCode.trim().toUpperCase();
     const redeemCodeReady = normalizedRedeemCode.length === 8;
 
-    const loadTeams = useCallback(async () => {
+    const loadTeams = useCallback(async ({ cursor = null, append = false, searchText = teamSearchText }: { cursor?: unknown | null; append?: boolean; searchText?: string } = {}) => {
+        const requestId = teamSearchRequestRef.current + 1;
+        teamSearchRequestRef.current = requestId;
+        const normalizedSearchText = String(searchText || '').trim();
         clearTeamLoadError();
         clearPlayerLoadError();
         clearSubmitError();
         clearRedeemError();
+        setTeamDiscoveryStarted(true);
         return runTeamLoad(
-            () => loadParentAccessTeams(),
+            () => discoverParentAccessTeams({ searchText: normalizedSearchText, cursor, pageSize: 20 }),
             'Unable to load public teams.',
             {
-                onSuccess: (rows) => {
-                    setTeams(rows);
-                    setSelectedTeamId((current) => rows.some((team) => team.id === current) ? current : '');
+                onSuccess: (page) => {
+                    if (requestId !== teamSearchRequestRef.current) return;
+                    setTeamNextCursor(page.nextCursor);
+                    setTeams((currentRows) => {
+                        const nextRows = append ? [...currentRows, ...page.teams] : page.teams;
+                        const seen = new Set<string>();
+                        return nextRows.filter((team) => {
+                            if (seen.has(team.id)) return false;
+                            seen.add(team.id);
+                            return true;
+                        });
+                    });
+                    setSelectedTeamId((current) => {
+                        if (append) return current;
+                        return page.teams.some((team) => team.id === current) ? current : '';
+                    });
                 }
             }
         );
-    }, [clearPlayerLoadError, clearRedeemError, clearSubmitError, clearTeamLoadError, runTeamLoad]);
+    }, [clearPlayerLoadError, clearRedeemError, clearSubmitError, clearTeamLoadError, runTeamLoad, teamSearchText]);
 
     const openManualRequest = useCallback(() => {
         setManualRequestOpen(true);
-        setManualTeamsRequested(false);
     }, []);
+
+    const searchTeams = useCallback(async (event?: FormEvent) => {
+        event?.preventDefault();
+        setSelectedTeamId('');
+        setSelectedPlayerId('');
+        setPlayers([]);
+        await loadTeams({ searchText: teamSearchText, cursor: null, append: false });
+    }, [loadTeams, teamSearchText]);
+
+    const browseTeams = useCallback(async () => {
+        setTeamSearchText('');
+        setSelectedTeamId('');
+        setSelectedPlayerId('');
+        setPlayers([]);
+        await loadTeams({ searchText: '', cursor: null, append: false });
+    }, [loadTeams]);
+
+    const loadMoreTeams = useCallback(async () => {
+        if (!teamNextCursor) return;
+        await loadTeams({ searchText: teamSearchText, cursor: teamNextCursor, append: true });
+    }, [loadTeams, teamNextCursor, teamSearchText]);
 
     const refresh = useCallback(async () => {
         clearAccessLoadError();
@@ -111,8 +151,10 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
 
     useEffect(() => {
         setManualRequestOpen(false);
-        setManualTeamsRequested(false);
         setTeams([]);
+        setTeamSearchText('');
+        setTeamNextCursor(null);
+        setTeamDiscoveryStarted(false);
         setPlayers([]);
         setSelectedTeamId('');
         setSelectedPlayerId('');
@@ -121,12 +163,12 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     useEffect(() => {
         if (!deepLinkedTeamId) return;
         setManualRequestOpen(true);
-        setManualTeamsRequested(true);
+        setTeamDiscoveryStarted(true);
     }, [deepLinkedTeamId]);
 
     useEffect(() => {
         if (!deepLinkedTeamId || teams.length || loadingTeams) return;
-        void loadTeams();
+        void loadTeams({ searchText: '', cursor: null, append: false });
     }, [deepLinkedTeamId, loadTeams, loadingTeams, teams.length]);
 
     useEffect(() => {
@@ -151,12 +193,6 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             setSelectedTeamId('');
         }
     }, [deepLinkedTeamId, teams, loadingTeams]);
-
-    useEffect(() => {
-        if (!manualRequestOpen || manualTeamsRequested || teams.length || loadingTeams) return;
-        setManualTeamsRequested(true);
-        void loadTeams();
-    }, [loadTeams, loadingTeams, manualRequestOpen, manualTeamsRequested, teams.length]);
 
     const loadPlayersForTeam = useCallback(async (teamId: string) => {
         const rows = await runPlayerLoad(
@@ -287,18 +323,51 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                         </form>
                         {manualRequestOpen ? (
                             <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
-                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={playerLoadError && selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : loadTeams} retrying={loadingTeams || loadingPlayers} /></div> : null}
+                                {manualLookupError ? <div className="lg:col-span-3"><RetryableStatus error={manualLookupError} fallbackMessage="Unable to load public teams." onRetry={playerLoadError && selectedTeamId ? () => { void loadPlayersForTeam(selectedTeamId); } : () => { void loadTeams({ searchText: teamSearchText, cursor: null, append: false }); }} retrying={loadingTeams || loadingPlayers} /></div> : null}
+                                <div className="min-w-0 lg:col-span-3">
+                                    <label className="app-label" htmlFor="parent-access-team-search">Search public teams</label>
+                                    <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                                        <input
+                                            id="parent-access-team-search"
+                                            className="auth-input min-w-0 flex-1"
+                                            value={teamSearchText}
+                                            onChange={(event) => {
+                                                setTeamSearchText(event.target.value);
+                                                setSelectedTeamId('');
+                                                setSelectedPlayerId('');
+                                                setPlayers([]);
+                                                setTeams([]);
+                                                setTeamNextCursor(null);
+                                                setTeamDiscoveryStarted(false);
+                                            }}
+                                            onKeyDown={(event) => {
+                                                if (event.key !== 'Enter') return;
+                                                event.preventDefault();
+                                                void searchTeams();
+                                            }}
+                                            placeholder="Team name, city, state, or zip"
+                                            disabled={saving || redeeming}
+                                        />
+                                        <button type="button" className="secondary-button sm:min-w-[8rem]" onClick={() => { void searchTeams(); }} disabled={saving || redeeming}>
+                                            {loadingTeams ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Search className="h-4 w-4" aria-hidden="true" />}
+                                            Search
+                                        </button>
+                                        <button type="button" className="ghost-button !min-h-10 text-xs sm:min-w-[7rem]" onClick={browseTeams} disabled={saving || redeeming}>
+                                            Browse
+                                        </button>
+                                    </div>
+                                </div>
                                 <div className="min-w-0">
                                     <label className="app-label" htmlFor="parent-access-team">Team</label>
                                     <select id="parent-access-team" aria-label="Team" className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>
-                                        <option value="">{loadingTeams ? 'Loading public teams...' : teams.length ? 'Choose a team' : 'No public teams'}</option>
+                                        <option value="">{loadingTeams ? 'Loading public teams...' : teams.length ? 'Choose a team' : teamDiscoveryStarted ? 'No public teams found' : 'Search or browse teams'}</option>
                                         {teams.map((team) => (
-                                            <option key={team.id} value={team.id}>{team.name}{team.sport ? ` - ${team.sport}` : ''}</option>
+                                            <option key={team.id} value={team.id}>{formatTeamOption(team)}</option>
                                         ))}
                                     </select>
-                                    {!loadingTeams && !teams.length ? (
-                                        <button type="button" className="ghost-button mt-2 !min-h-9 text-xs" onClick={loadTeams} disabled={redeeming || saving}>
-                                            Retry loading public teams
+                                    {teamNextCursor ? (
+                                        <button type="button" className="ghost-button mt-2 !min-h-9 text-xs" onClick={loadMoreTeams} disabled={loadingTeams || redeeming || saving}>
+                                            {loadingTeams ? 'Loading...' : 'Load more teams'}
                                         </button>
                                     ) : null}
                                 </div>
@@ -349,6 +418,11 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             </section>
         </div>
     );
+}
+
+function formatTeamOption(team: ParentAccessTeam) {
+    const details = [team.sport, [team.city, team.state].filter(Boolean).join(', '), team.zip].filter(Boolean);
+    return details.length ? `${team.name} - ${details.join(' - ')}` : team.name;
 }
 
 function AccessRequestCard({ request }: { request: ParentAccessRequest }) {

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -216,17 +216,6 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     }, [deepLinkedTeamId]);
 
     useEffect(() => {
-        if (!deepLinkedTeamId || teams.length || loadingTeams) return;
-        if (initialDeepLinkDiscoveryAttemptRef.current === deepLinkedTeamId) return;
-        initialDeepLinkDiscoveryAttemptRef.current = deepLinkedTeamId;
-        void loadTeams({ searchText: '', cursor: null, append: false }).finally(() => {
-            if (initialDeepLinkDiscoveryAttemptRef.current !== deepLinkedTeamId) return;
-            initialDeepLinkDiscoveryCompleteRef.current = deepLinkedTeamId;
-            setDeepLinkReconcileVersion((current) => current + 1);
-        });
-    }, [deepLinkedTeamId, deepLinkReconcileVersion, loadTeams, loadingTeams, teams.length]);
-
-    useEffect(() => {
         if (deepLinkIntentRef.current !== deepLinkedTeamId) {
             deepLinkIntentRef.current = deepLinkedTeamId;
             teamSearchRequestRef.current += 1;
@@ -238,6 +227,17 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         initialDeepLinkDiscoveryCompleteRef.current = '';
         deepLinkLookupAttemptRef.current = '';
     }, [deepLinkedTeamId, invalidateTeamLoad]);
+
+    useEffect(() => {
+        if (!deepLinkedTeamId || teams.length || loadingTeams) return;
+        if (initialDeepLinkDiscoveryAttemptRef.current === deepLinkedTeamId) return;
+        initialDeepLinkDiscoveryAttemptRef.current = deepLinkedTeamId;
+        void loadTeams({ searchText: '', cursor: null, append: false }).finally(() => {
+            if (initialDeepLinkDiscoveryAttemptRef.current !== deepLinkedTeamId) return;
+            initialDeepLinkDiscoveryCompleteRef.current = deepLinkedTeamId;
+            setDeepLinkReconcileVersion((current) => current + 1);
+        });
+    }, [deepLinkedTeamId, deepLinkReconcileVersion, loadTeams, loadingTeams, teams.length]);
 
     useEffect(() => {
         // Wait until teams have loaded so we can tell whether the deep-linked team

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -275,7 +275,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         );
     }, [clearPlayerLoadError, runPlayerLoad]);
 
-    const retryManualLookup = useCallback(() => {
+    const retryManualLookup = () => {
         if (playerLoadError && selectedTeamId) {
             void loadPlayersForTeam(selectedTeamId);
             return;
@@ -289,7 +289,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
             return;
         }
         void loadTeams({ searchText: teamSearchText, cursor: null, append: false });
-    }, [deepLinkedTeamId, loadPlayersForTeam, loadTeams, playerLoadError, selectedTeamId, teamSearchText]);
+    };
 
     useEffect(() => {
         void loadPlayersForTeam(selectedTeamId);

--- a/apps/app/src/pages/parent-tools/shared.tsx
+++ b/apps/app/src/pages/parent-tools/shared.tsx
@@ -9,6 +9,7 @@ type ParentToolAsyncOptions<T> = {
     onError?: (error: AppServiceError) => void | Promise<void>;
     onFinally?: () => void | Promise<void>;
     clearError?: boolean;
+    ignoreStale?: boolean;
 };
 
 export function useParentToolAsyncOperation() {
@@ -32,6 +33,7 @@ export function useParentToolAsyncOperation() {
 
         return runOperation(task, {
             rethrow: false,
+            ignoreStale: options.ignoreStale,
             getErrorMessage: (taskError) => getParentToolErrorMessage(toAppServiceError(taskError, fallbackMessage), fallbackMessage),
             onSuccess: async (value) => {
                 setError(null);

--- a/apps/app/src/pages/parent-tools/shared.tsx
+++ b/apps/app/src/pages/parent-tools/shared.tsx
@@ -13,13 +13,19 @@ type ParentToolAsyncOptions<T> = {
 };
 
 export function useParentToolAsyncOperation() {
-    const { loading, clearError: clearOperationError, run: runOperation } = useAsyncOperation();
+    const { loading, clearError: clearOperationError, invalidate: invalidateOperation, run: runOperation } = useAsyncOperation();
     const [error, setError] = useState<AppServiceError | null>(null);
 
     const clearError = useCallback(() => {
         setError(null);
         clearOperationError();
     }, [clearOperationError]);
+
+    const invalidate = useCallback(() => {
+        setError(null);
+        clearOperationError();
+        invalidateOperation();
+    }, [clearOperationError, invalidateOperation]);
 
     const run = useCallback(async function runParentToolAsyncOperation<T>(
         task: () => Promise<T>,
@@ -55,6 +61,7 @@ export function useParentToolAsyncOperation() {
         error,
         setError,
         clearError,
+        invalidate,
         run
     };
 }

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -771,8 +771,8 @@ async function mockHomePlayerModules(page) {
                     };
                 }
 
-                export async function loadParentAccessTeams() {
-                    return [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+                export async function discoverParentAccessTeams() {
+                    return { teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }], nextCursor: null };
                 }
 
                 export async function loadParentAccessPlayers() {

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -289,12 +289,18 @@ async function mockParentToolsModules(page) {
                         requests: [{ id: 'request-1', teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', relation: 'Parent', status: 'pending' }]
                     };
                 }
-                export async function loadParentAccessTeams() {
+                export async function discoverParentAccessTeams(options = {}) {
                     window.__publicTeamLoads += 1;
-                    return [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+                    if (options.cursor === 'cursor-2') {
+                        return { teams: [{ id: 'team-2', name: 'Comets', sport: 'Soccer', city: 'Austin', state: 'TX' }], nextCursor: null };
+                    }
+                    return { teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }], nextCursor: 'cursor-2' };
                 }
                 export async function loadParentAccessPlayers(teamId) {
                     window.__playerLoads.push(String(teamId));
+                    if (String(teamId) === 'team-2') {
+                        return [{ id: 'player-2', name: 'Cam Comet', number: '22', photoUrl: null }];
+                    }
                     return [{ id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null }];
                 }
                 export async function submitParentAccessRequest(teamId, playerId, relation) {
@@ -363,12 +369,18 @@ async function mockParentToolsModules(page) {
                         requests: [{ id: 'request-1', teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', relation: 'Parent', status: 'pending' }]
                     };
                 }
-                export async function loadParentAccessTeams() {
+                export async function discoverParentAccessTeams(options = {}) {
                     window.__publicTeamLoads += 1;
-                    return [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+                    if (options.cursor === 'cursor-2') {
+                        return { teams: [{ id: 'team-2', name: 'Comets', sport: 'Soccer', city: 'Austin', state: 'TX' }], nextCursor: null };
+                    }
+                    return { teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }], nextCursor: 'cursor-2' };
                 }
                 export async function loadParentAccessPlayers(teamId) {
                     window.__playerLoads.push(String(teamId));
+                    if (String(teamId) === 'team-2') {
+                        return [{ id: 'player-2', name: 'Cam Comet', number: '22', photoUrl: null }];
+                    }
                     return [{ id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null }];
                 }
                 export async function submitParentAccessRequest(teamId, playerId, relation) {
@@ -526,13 +538,17 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await expect.poll(() => page.evaluate(() => window.__playerLoads.length)).toBe(0);
     await expect(page.getByText('Pat Star')).toBeVisible();
     await page.getByRole('button', { name: 'Request access without a code' }).click();
+    await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(0);
+    await page.getByRole('button', { name: 'Browse' }).click();
     await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(1);
     await expect(page.getByLabel('Team')).toBeVisible();
-    await page.getByLabel('Team').selectOption('team-1');
-    await expect.poll(() => page.evaluate(() => window.__playerLoads)).toEqual(['team-1']);
-    await page.getByLabel('Player').selectOption('player-1');
+    await page.getByRole('button', { name: 'Load more teams' }).click();
+    await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(2);
+    await page.getByLabel('Team').selectOption('team-2');
+    await expect.poll(() => page.evaluate(() => window.__playerLoads)).toEqual(['team-2']);
+    await page.getByLabel('Player').selectOption('player-2');
     await page.getByRole('button', { name: /Send request/ }).click();
-    await expect.poll(() => page.evaluate(() => window.__accessRequests.at(-1))).toEqual({ teamId: 'team-1', playerId: 'player-1', relation: 'Parent' });
+    await expect.poll(() => page.evaluate(() => window.__accessRequests.at(-1))).toEqual({ teamId: 'team-2', playerId: 'player-2', relation: 'Parent' });
 
     await page.getByRole('button', { name: 'Fees' }).click();
     await expect(page.getByText('Team dues')).toBeVisible();

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -541,10 +541,10 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(0);
     await page.getByRole('button', { name: 'Browse' }).click();
     await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(1);
-    await expect(page.getByLabel('Team')).toBeVisible();
+    await expect(page.getByLabel('Team', { exact: true })).toBeVisible();
     await page.getByRole('button', { name: 'Load more teams' }).click();
     await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(2);
-    await page.getByLabel('Team').selectOption('team-2');
+    await page.getByLabel('Team', { exact: true }).selectOption('team-2');
     await expect.poll(() => page.evaluate(() => window.__playerLoads)).toEqual(['team-2']);
     await page.getByLabel('Player').selectOption('player-2');
     await page.getByRole('button', { name: /Send request/ }).click();

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -296,6 +296,9 @@ async function mockParentToolsModules(page) {
                     }
                     return { teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }], nextCursor: 'cursor-2' };
                 }
+                export async function loadParentAccessTeam(teamId) {
+                    return { id: String(teamId), name: 'Bears', sport: 'Basketball', zip: '66210' };
+                }
                 export async function loadParentAccessPlayers(teamId) {
                     window.__playerLoads.push(String(teamId));
                     if (String(teamId) === 'team-2') {
@@ -375,6 +378,9 @@ async function mockParentToolsModules(page) {
                         return { teams: [{ id: 'team-2', name: 'Comets', sport: 'Soccer', city: 'Austin', state: 'TX' }], nextCursor: null };
                     }
                     return { teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }], nextCursor: 'cursor-2' };
+                }
+                export async function loadParentAccessTeam(teamId) {
+                    return { id: String(teamId), name: 'Bears', sport: 'Basketball', zip: '66210' };
                 }
                 export async function loadParentAccessPlayers(teamId) {
                     window.__playerLoads.push(String(teamId));

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -37,7 +37,7 @@ const publicActionMocks = vi.hoisted(() => ({
 
 const accessServiceMocks = vi.hoisted(() => ({
     loadParentAccessModel: vi.fn(),
-    loadParentAccessTeams: vi.fn(),
+    discoverParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     submitParentAccessRequest: vi.fn()
 }));
@@ -193,6 +193,7 @@ async function changeSelectValue(element, value) {
 
 async function openManualAccessRequest(container) {
     await clickButton(container, 'Request access without a code');
+    await clickButton(container, 'Browse');
     await waitForText(container, 'Choose a team');
     const teamSelect = Array.from(container.querySelectorAll('select')).find((candidate) => candidate.previousElementSibling?.textContent === 'Team');
     await changeSelectValue(teamSelect, 'team-1');
@@ -219,7 +220,10 @@ beforeEach(() => {
     accessServiceMocks.loadParentAccessModel.mockResolvedValue({
         requests: [{ id: 'request-1', teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', relation: 'Parent', status: 'pending' }]
     });
-    accessServiceMocks.loadParentAccessTeams.mockResolvedValue([{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }]);
+    accessServiceMocks.discoverParentAccessTeams.mockResolvedValue({
+        teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }],
+        nextCursor: null
+    });
     accessServiceMocks.loadParentAccessPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null }]);
     accessServiceMocks.submitParentAccessRequest.mockResolvedValue({ success: true });
     inviteRedemptionMocks.redeemSignedInInvite.mockResolvedValue({
@@ -388,7 +392,7 @@ describe('React app parent tools integration', () => {
         const { container } = await renderParentTools('/parent-tools/access');
         await waitForText(container, 'Request player access');
         expect(accessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(accessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(0);
+        expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(0);
         expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
 
         await clickButton(container, 'Fees');
@@ -398,7 +402,7 @@ describe('React app parent tools integration', () => {
         await clickButton(container, 'Access');
         await waitForText(container, 'Request player access');
         expect(accessServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(accessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(0);
+        expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(0);
         expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
 
         await clickButton(container, 'Register');
@@ -505,12 +509,14 @@ describe('React app parent tools integration', () => {
         await waitForText(container, 'Request player access');
         expect(container.textContent).toContain('Access requests');
         expect(container.textContent).toContain('Pat Star');
-        expect(accessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(0);
+        expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(0);
         expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
 
         await clickButton(container, 'Request access without a code');
+        await waitForText(container, 'Search or browse teams');
+        await clickButton(container, 'Browse');
         await waitForText(container, 'Choose a team');
-        expect(accessServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(accessServiceMocks.discoverParentAccessTeams).toHaveBeenCalledTimes(1);
         expect(accessServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
 
         const teamSelect = Array.from(container.querySelectorAll('select')).find((candidate) => candidate.previousElementSibling?.textContent === 'Team');

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -37,6 +37,7 @@ const publicActionMocks = vi.hoisted(() => ({
 
 const accessServiceMocks = vi.hoisted(() => ({
     loadParentAccessModel: vi.fn(),
+    loadParentAccessTeam: vi.fn(),
     discoverParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     submitParentAccessRequest: vi.fn()
@@ -224,6 +225,9 @@ beforeEach(() => {
         teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }],
         nextCursor: null
     });
+    accessServiceMocks.loadParentAccessTeam.mockImplementation(async (teamId) => (
+        teamId === 'team-1' ? { id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' } : null
+    ));
     accessServiceMocks.loadParentAccessPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null }]);
     accessServiceMocks.submitParentAccessRequest.mockResolvedValue({ success: true });
     inviteRedemptionMocks.redeemSignedInInvite.mockResolvedValue({

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -222,7 +222,7 @@ import {
     loadTeamRegistrationQueuePage,
     loadFamilyShareModel,
     loadParentAccessModel,
-    loadParentAccessTeams,
+    discoverParentAccessTeams,
     loadParentAccessPlayers,
     loadParentCalendarTools,
     loadParentCertificates,
@@ -297,11 +297,11 @@ describe('React app parent tools service', () => {
         expect(getGoogleCalendarFeedUrl(privateFeedUrl)).toBe(`https://calendar.google.com/calendar/render?cid=${encodeURIComponent(privateFeedUrl)}`);
     });
 
-    it('loads access requests first, then lazy-loads public teams and players', async () => {
+    it('loads access requests first, then searches paginated public teams and players', async () => {
         dbMocks.discoverPublicTeams.mockResolvedValue({
             teams: [
                 { id: 'team-b', name: 'Wolves', isPublic: false },
-                { id: 'team-a', name: 'Bears', sport: 'Basketball', zip: '66210', isPublic: true }
+                { id: 'team-a', name: 'Bears', sport: 'Basketball', city: 'Overland Park', state: 'KS', zip: '66210', isPublic: true }
             ],
             nextCursor: 'cursor-1'
         });
@@ -319,15 +319,18 @@ describe('React app parent tools service', () => {
             teams: [],
             requests: [{ id: 'request-1', playerName: 'Pat Star', status: 'pending' }]
         });
-        await expect(loadParentAccessTeams()).resolves.toEqual([
-            { id: 'team-a', name: 'Bears', sport: 'Basketball', zip: '66210' }
-        ]);
+        await expect(discoverParentAccessTeams({ searchText: '  Bears  ', cursor: 'cursor-0', pageSize: 12 })).resolves.toEqual({
+            teams: [
+                { id: 'team-a', name: 'Bears', sport: 'Basketball', city: 'Overland Park', state: 'KS', zip: '66210' }
+            ],
+            nextCursor: 'cursor-1'
+        });
         await expect(loadParentAccessPlayers('team-a')).resolves.toEqual([
             { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null },
             { id: 'player-2', name: 'Sam Wing', number: '12', photoUrl: 'https://img.example.test/sam.png' }
         ]);
         expect(dbMocks.listMyParentMembershipRequests).toHaveBeenCalledWith('user-1');
-        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ pageSize: 100 });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'Bears', cursor: 'cursor-0', pageSize: 12 });
         await submitParentAccessRequest('team-a', 'player-1', 'Guardian');
         expect(dbMocks.createParentMembershipRequest).toHaveBeenCalledWith('team-a', 'player-1', 'Guardian');
     });


### PR DESCRIPTION
Closes #3642

## What changed
- Replaced the Parent Tools manual access bulk team loader with `discoverParentAccessTeams`, a bounded search/page API that passes `searchText`, `cursor`, and `pageSize` through to `discoverPublicTeams` and preserves `nextCursor`.
- Updated the manual access picker to wait for explicit Search or Browse, support Load more, clear stale team/player selection on search changes, and defer player loading until a team is selected.
- Updated component, service, integration, and smoke mocks to cover two-page public team discovery and later-page team selection.

## Root Cause
The manual access flow used `loadParentAccessTeams()` to call `discoverPublicTeams({ pageSize: 100 })` with no search text or cursor, discarded `nextCursor`, and auto-loaded that capped first page into a static select when the manual form opened.

## Prevention / Learning
Optional team discovery flows must use explicit, cursor-aware search APIs and should not preload broad public collections for hidden or optional pickers. Add regression coverage for pagination, deferred dependent loads, and stale async search responses.

## Regression Tests
- `apps/app/src/lib/parentToolsAccessService.test.ts`
- `apps/app/src/pages/parent-tools/AccessTool.test.tsx`
- `tests/unit/app-parent-tools-service.test.js`
- `apps/app/src/pages/ParentTools.test.tsx`
- `tests/unit/app-parent-tools-integration.test.jsx`
- Updated `tests/smoke/app-parent-tools.spec.js` mock flow for two-page browse and later-page selection.

Validated with:
- `npx vitest run apps/app/src/lib/parentToolsAccessService.test.ts apps/app/src/pages/parent-tools/AccessTool.test.tsx tests/unit/app-parent-tools-service.test.js --reporter=verbose`
- `npx vitest run apps/app/src/pages/ParentTools.test.tsx -t "ParentTools access" --reporter=verbose`
- `npx vitest run tests/unit/app-parent-tools-integration.test.jsx -t "manual discovery|access changes|parent tools hub" --reporter=verbose`
- `npm run app:build`

## Recurrence Risk
Low. The service contract is now bounded and cursor-aware, and the UI tests assert no eager team load, pagination, deferred player loading, and stale result handling.