### PR TITLE
Defer optional availability note in quick RSVP

### DIFF
--- a/apps/app/src/components/schedule/AvailabilityPanels.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { type ParentScheduleEvent, type RsvpResponse } from '../../lib/scheduleLogic';
 import { rsvpBadgeClasses, rsvpLabels } from './AvailabilityNotesList';
 import { PlayerInitials } from './PlayerInitials';
@@ -35,7 +36,14 @@ export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting,
 }) {
   const needsResponse = rsvp === 'not_responded';
   const noteSaveState = getAvailabilityNoteSaveState(rsvp, availabilityNote, event.myRsvpNote || '');
+  const hasSavedNote = Boolean(String(event.myRsvpNote || '').trim());
+  const [isNoteEditorOpen, setIsNoteEditorOpen] = useState(() => hasSavedNote || noteSaveState.isDirty);
   const showDirtyState = rsvp !== 'not_responded' && noteSaveState.isDirty;
+
+  useEffect(() => {
+    setIsNoteEditorOpen(hasSavedNote || noteSaveState.isDirty);
+  }, [event.childId, event.eventKey, hasSavedNote, noteSaveState.isDirty]);
+
   return (
     <div className={`border-b px-3 py-2.5 sm:px-4 sm:py-3 ${needsResponse ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
       <div className="flex items-center gap-2.5 sm:items-start sm:gap-3">
@@ -60,22 +68,36 @@ export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting,
               </button>
             ))}
           </div>
-          <label className="mt-2 block">
-            <span className="sr-only">Availability note</span>
-            <textarea
-              aria-label="Availability note"
-              className="auth-input min-h-16 resize-none !px-3 !py-2 text-xs font-semibold"
-              value={availabilityNote}
-              onChange={(changeEvent) => onAvailabilityNoteChange(changeEvent.target.value)}
-              disabled={!canSubmitRsvp}
-              placeholder="Optional note for coaches, rides, or arrival details"
-              rows={2}
-              maxLength={280}
-            />
-          </label>
-          <div className="mt-1 text-[11px] font-semibold text-gray-500">
-            {event.availabilityNotesVisible ? 'Team note sharing is on for this team.' : 'Notes are visible to team staff unless sharing is enabled.'}
-          </div>
+          <button
+            type="button"
+            className="mt-2 min-h-8 rounded-full border border-gray-200 bg-white px-3 text-xs font-black text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700 disabled:cursor-not-allowed disabled:opacity-60"
+            aria-expanded={isNoteEditorOpen}
+            aria-controls={`availability-note-${event.eventKey}-${event.childId}`}
+            disabled={!canSubmitRsvp || (isNoteEditorOpen && noteSaveState.isDirty)}
+            onClick={() => setIsNoteEditorOpen((current) => !current)}
+          >
+            {isNoteEditorOpen ? 'Hide note' : hasSavedNote ? 'Edit note' : 'Add note'}
+          </button>
+          {isNoteEditorOpen ? (
+            <div id={`availability-note-${event.eventKey}-${event.childId}`}>
+              <label className="mt-2 block">
+                <span className="sr-only">Availability note</span>
+                <textarea
+                  aria-label="Availability note"
+                  className="auth-input min-h-16 resize-none !px-3 !py-2 text-xs font-semibold"
+                  value={availabilityNote}
+                  onChange={(changeEvent) => onAvailabilityNoteChange(changeEvent.target.value)}
+                  disabled={!canSubmitRsvp}
+                  placeholder="Optional note for coaches, rides, or arrival details"
+                  rows={2}
+                  maxLength={280}
+                />
+              </label>
+              <div className="mt-1 text-[11px] font-semibold text-gray-500">
+                {event.availabilityNotesVisible ? 'Team note sharing is on for this team.' : 'Notes are visible to team staff unless sharing is enabled.'}
+              </div>
+            </div>
+          ) : null}
           {noteSaveState.canSaveNote ? (
             <div className="mt-2 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2">
               <div className="text-xs font-black text-amber-900">Note edited but not saved yet.</div>

--- a/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
+++ b/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
@@ -5,6 +5,7 @@ import { Users } from 'lucide-react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { StaffPracticeAttendance } from '../../lib/scheduleService';
 import type { ParentScheduleEvent } from '../../lib/scheduleLogic';
+import { QuickAvailabilityPanel } from './AvailabilityPanels';
 import { AttentionPanel } from './AttentionPanel';
 import { AvailabilityNotesList } from './AvailabilityNotesList';
 import { CompactMeta } from './CompactMeta';
@@ -39,7 +40,83 @@ function buildAvailabilityNotesEvent(overrides: Partial<ParentScheduleEvent>): P
   } as unknown as ParentScheduleEvent;
 }
 
+function buildQuickAvailabilityEvent(overrides: Partial<ParentScheduleEvent> = {}): ParentScheduleEvent {
+  return {
+    eventKey: 'team-1:event-1:player-1',
+    childId: 'player-1',
+    childName: 'Avery Smith',
+    availabilityNotesVisible: false,
+    myRsvpNote: '',
+    ...overrides
+  } as unknown as ParentScheduleEvent;
+}
+
 describe('ScheduleEventDetail presentational components', () => {
+  it('defers the optional availability note until a parent opens it', () => {
+    const onAvailabilityNoteChange = vi.fn();
+    const onSubmit = vi.fn(() => Promise.resolve());
+
+    render(
+      <QuickAvailabilityPanel
+        event={buildQuickAvailabilityEvent()}
+        rsvp="not_responded"
+        canSubmitRsvp
+        submitting={null}
+        availabilityNote=""
+        onAvailabilityNoteChange={onAvailabilityNoteChange}
+        onSubmit={onSubmit}
+      />
+    );
+
+    expect(screen.queryByRole('textbox', { name: 'Availability note' })).toBeNull();
+    expect(screen.queryByText('Notes are visible to team staff unless sharing is enabled.')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }));
+
+    expect(screen.getByRole('textbox', { name: 'Availability note' })).toBeTruthy();
+    expect(screen.getByText('Notes are visible to team staff unless sharing is enabled.')).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('opens the availability note editor for saved or unsaved note content', () => {
+    const event = buildQuickAvailabilityEvent({ myRsvpNote: 'Arriving late' });
+    const commonProps = {
+      rsvp: 'going' as const,
+      canSubmitRsvp: true,
+      submitting: null,
+      onAvailabilityNoteChange: vi.fn(),
+      onSubmit: vi.fn(() => Promise.resolve())
+    };
+    const { rerender } = render(
+      <QuickAvailabilityPanel
+        {...commonProps}
+        event={event}
+        availabilityNote="Arriving late"
+      />
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Availability note' })).toHaveProperty('value', 'Arriving late');
+
+    rerender(
+      <QuickAvailabilityPanel
+        {...commonProps}
+        event={buildQuickAvailabilityEvent({ eventKey: 'team-1:event-2:player-1' })}
+        availabilityNote=""
+      />
+    );
+    expect(screen.queryByRole('textbox', { name: 'Availability note' })).toBeNull();
+
+    rerender(
+      <QuickAvailabilityPanel
+        {...commonProps}
+        event={buildQuickAvailabilityEvent({ eventKey: 'team-1:event-2:player-1' })}
+        availabilityNote="Draft note"
+      />
+    );
+    expect(screen.getByRole('textbox', { name: 'Availability note' })).toHaveProperty('value', 'Draft note');
+    expect(screen.getByText('Note edited but not saved yet.')).toBeTruthy();
+  });
+
   it('renders compact metadata with the supplied icon and value', () => {
     render(<CompactMeta icon={Users} value="Avery Smith · Tigers" />);
 

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1521,6 +1521,7 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
     const availabilitySection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Availability' }) });
     await expect(availabilitySection.getByRole('heading', { name: 'Availability' })).toBeVisible();
     await expect(availabilitySection.getByText('Dana Parent')).toBeVisible();
+    await availabilitySection.getByRole('button', { name: 'Add note' }).click();
     await availabilitySection.getByLabel('Availability note').fill('Arriving after school pickup.');
     await availabilitySection.getByRole('button', { name: 'Going' }).click();
     expect(await page.evaluate(() => window.__scheduleCalls.rsvps)).toEqual([


### PR DESCRIPTION
Closes #3665

## What changed
- defer the optional availability note behind an Add note / Edit note disclosure
- automatically open the note editor when a saved note or unsaved draft exists
- keep one-tap RSVP submission unchanged when no note is entered
- add component regression coverage for first-run, saved-note, event-switch, and dirty-draft states

## Why
The optional textarea and note visibility copy competed with the primary Going / Maybe / Can't go action in the quick RSVP flow.

## Validation
- `npm --prefix apps/app run test:ci -- src/components/schedule/ScheduleEventDetailPresentational.test.tsx src/hooks/schedule/useScheduleEventRsvp.test.tsx` (15 passed)
- `npx eslint src/components/schedule/AvailabilityPanels.tsx src/components/schedule/ScheduleEventDetailPresentational.test.tsx`
- `npm run app:build`
