### PR TITLE
Reject invalid practice durations

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -221,6 +221,7 @@ jobs:
               echo "$reason"
             } >> "$GITHUB_STEP_SUMMARY"
             echo "preview_url=" >> "$GITHUB_OUTPUT"
+            echo "preview_skip_reason=$reason" >> "$GITHUB_OUTPUT"
             exit 0
           }
 
@@ -303,6 +304,7 @@ jobs:
             exit 1
           fi
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
+          echo "preview_skip_reason=" >> "$GITHUB_OUTPUT"
 
       - name: Report preview URL on pull request
         if: success()
@@ -310,6 +312,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PREVIEW_URL: ${{ steps.deploy_preview.outputs.preview_url }}
+          PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}
           JQ_FILTER: '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- allplays-preview-url -->")) | .id'
         run: |
           set -euo pipefail
@@ -317,7 +320,7 @@ jobs:
           if [ -n "$PREVIEW_URL" ]; then
             body="$(printf '%s\n\nPreview URL: %s' "$marker" "$PREVIEW_URL")"
           else
-            body="$(printf '%s\n\nFirebase preview skipped for this run. See the deploy workflow summary for the skip reason.' "$marker")"
+            body="$(printf '%s\n\nFirebase preview skipped: %s' "$marker" "${PREVIEW_SKIP_REASON:-Firebase Hosting preview was unavailable for this run.}")"
           fi
           comment_id="$(gh api --paginate repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq "$JQ_FILTER" | head -n1)"
           if [ -n "$comment_id" ]; then

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -960,7 +960,7 @@
         import { getGoalSportProfile } from './js/live-sport-config.js?v=3';
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=3';
         import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';
-        import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';
+        import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';
         import { Timestamp, deleteField, auth } from "./js/firebase.js?v=20";

--- a/js/edit-schedule-practice-submit.js
+++ b/js/edit-schedule-practice-submit.js
@@ -1,5 +1,17 @@
 import { applyPracticeRecurrenceFields } from './edit-schedule-practice-payload.js';
 
+export function validatePracticeDateRange(startDate, endDate) {
+    const startTime = startDate instanceof Date ? startDate.getTime() : Number.NaN;
+    const endTime = endDate instanceof Date ? endDate.getTime() : Number.NaN;
+
+    if (!Number.isFinite(startTime) || !Number.isFinite(endTime)) {
+        throw new Error('Practice start and end times must be valid dates');
+    }
+    if (endTime <= startTime) {
+        throw new Error('End time must be after the start time');
+    }
+}
+
 export async function savePracticeForm({
     teamId,
     editingPracticeId = null,
@@ -15,6 +27,7 @@ export async function savePracticeForm({
     if (!teamId || !formState || !Timestamp || !deleteField || !generateSeriesId || !addPractice || !updateEvent) {
         throw new Error('savePracticeForm requires team, form state, firestore helpers, and persistence functions');
     }
+    validatePracticeDateRange(formState.startDate, formState.endDate);
 
     const practiceData = {
         title: formState.title,

--- a/js/edit-schedule-practice-submit.js
+++ b/js/edit-schedule-practice-submit.js
@@ -1,13 +1,5 @@
 import { applyPracticeRecurrenceFields } from './edit-schedule-practice-payload.js';
 
-const MAX_OVERNIGHT_PRACTICE_MS = 12 * 60 * 60 * 1000;
-
-function isSameLocalDate(firstDate, secondDate) {
-    return firstDate.getFullYear() === secondDate.getFullYear()
-        && firstDate.getMonth() === secondDate.getMonth()
-        && firstDate.getDate() === secondDate.getDate();
-}
-
 export function validatePracticeDateRange(startDate, endDate) {
     const startTime = startDate instanceof Date ? startDate.getTime() : Number.NaN;
     const endTime = endDate instanceof Date ? endDate.getTime() : Number.NaN;
@@ -16,18 +8,6 @@ export function validatePracticeDateRange(startDate, endDate) {
         throw new Error('Practice start and end times must be valid dates');
     }
     if (endTime <= startTime) {
-        if (!isSameLocalDate(startDate, endDate)) {
-            throw new Error('End time must be after the start time');
-        }
-        const overnightEndDate = new Date(endTime);
-        overnightEndDate.setDate(overnightEndDate.getDate() + 1);
-        const overnightDuration = overnightEndDate.getTime() - startTime;
-        if (overnightDuration > 0 && overnightDuration <= MAX_OVERNIGHT_PRACTICE_MS) {
-            return {
-                startDate,
-                endDate: overnightEndDate
-            };
-        }
         throw new Error('End time must be after the start time');
     }
 

--- a/js/edit-schedule-practice-submit.js
+++ b/js/edit-schedule-practice-submit.js
@@ -2,6 +2,12 @@ import { applyPracticeRecurrenceFields } from './edit-schedule-practice-payload.
 
 const MAX_OVERNIGHT_PRACTICE_MS = 12 * 60 * 60 * 1000;
 
+function isSameLocalDate(firstDate, secondDate) {
+    return firstDate.getFullYear() === secondDate.getFullYear()
+        && firstDate.getMonth() === secondDate.getMonth()
+        && firstDate.getDate() === secondDate.getDate();
+}
+
 export function validatePracticeDateRange(startDate, endDate) {
     const startTime = startDate instanceof Date ? startDate.getTime() : Number.NaN;
     const endTime = endDate instanceof Date ? endDate.getTime() : Number.NaN;
@@ -10,6 +16,9 @@ export function validatePracticeDateRange(startDate, endDate) {
         throw new Error('Practice start and end times must be valid dates');
     }
     if (endTime <= startTime) {
+        if (!isSameLocalDate(startDate, endDate)) {
+            throw new Error('End time must be after the start time');
+        }
         const overnightEndDate = new Date(endTime);
         overnightEndDate.setDate(overnightEndDate.getDate() + 1);
         const overnightDuration = overnightEndDate.getTime() - startTime;

--- a/js/edit-schedule-practice-submit.js
+++ b/js/edit-schedule-practice-submit.js
@@ -1,5 +1,7 @@
 import { applyPracticeRecurrenceFields } from './edit-schedule-practice-payload.js';
 
+const MAX_OVERNIGHT_PRACTICE_MS = 12 * 60 * 60 * 1000;
+
 export function validatePracticeDateRange(startDate, endDate) {
     const startTime = startDate instanceof Date ? startDate.getTime() : Number.NaN;
     const endTime = endDate instanceof Date ? endDate.getTime() : Number.NaN;
@@ -8,8 +10,22 @@ export function validatePracticeDateRange(startDate, endDate) {
         throw new Error('Practice start and end times must be valid dates');
     }
     if (endTime <= startTime) {
+        const overnightEndDate = new Date(endTime);
+        overnightEndDate.setDate(overnightEndDate.getDate() + 1);
+        const overnightDuration = overnightEndDate.getTime() - startTime;
+        if (overnightDuration > 0 && overnightDuration <= MAX_OVERNIGHT_PRACTICE_MS) {
+            return {
+                startDate,
+                endDate: overnightEndDate
+            };
+        }
         throw new Error('End time must be after the start time');
     }
+
+    return {
+        startDate,
+        endDate
+    };
 }
 
 export async function savePracticeForm({
@@ -27,12 +43,12 @@ export async function savePracticeForm({
     if (!teamId || !formState || !Timestamp || !deleteField || !generateSeriesId || !addPractice || !updateEvent) {
         throw new Error('savePracticeForm requires team, form state, firestore helpers, and persistence functions');
     }
-    validatePracticeDateRange(formState.startDate, formState.endDate);
+    const { startDate, endDate } = validatePracticeDateRange(formState.startDate, formState.endDate);
 
     const practiceData = {
         title: formState.title,
-        date: Timestamp.fromDate(formState.startDate),
-        end: Timestamp.fromDate(formState.endDate),
+        date: Timestamp.fromDate(startDate),
+        end: Timestamp.fromDate(endDate),
         location: formState.location,
         notes: formState.notes,
         scheduleNotifications: formState.scheduleNotifications
@@ -51,8 +67,8 @@ export async function savePracticeForm({
             untilValue: recurrenceState.untilValue,
             countValue: recurrenceState.countValue
         },
-        startDate: formState.startDate,
-        endDate: formState.endDate,
+        startDate,
+        endDate,
         Timestamp,
         deleteField,
         generateSeriesId

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -130,8 +130,9 @@ export function validateFirebaseRulesCi() {
     validatePreviewDeployCommand(deployPreview);
     assertIncludes(deployPreview, 'preview_deploy_hit_release_target_error()', 'Preview deploy release target error handling');
     assertIncludes(deployPreview, "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target", 'Preview deploy release target error classifier');
+    assertIncludes(deployPreview, 'preview_skip_reason=', 'Preview deploy skipped reason output');
     assertIncludes(deployPreview, 'skip_preview_for_release_target', 'Preview deploy release target skip');
-    assertIncludes(deployPreview, 'Firebase preview skipped for this run. See the deploy workflow summary for the skip reason.', 'Preview deploy generic skip comment');
+    assertIncludes(deployPreview, 'PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}', 'Preview deploy skipped reason PR comment');
 
     assertIncludes(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}', 'Scoped Storage game clip rules');
     assertIncludes(storageRules, 'allow get: if canAccessTeamMedia(teamId);', 'Scoped Storage game clip read rules');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -29,6 +29,14 @@ function canDeleteOwnScopedStorageUpload({ authUid, pathUserId, isTeamAdmin = fa
             (authUid === pathUserId && hasCurrentScopeAccess));
 }
 
+export function assertPreviewDeploySkipHandling(deployPreview) {
+    assertIncludes(deployPreview, 'preview_deploy_hit_release_target_error()', 'Preview deploy release target error handling');
+    assertIncludes(deployPreview, "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target", 'Preview deploy release target error classifier');
+    assertIncludes(deployPreview, 'preview_skip_reason=', 'Preview deploy skipped reason output');
+    assertIncludes(deployPreview, 'skip_preview_for_release_target', 'Preview deploy release target skip');
+    assertIncludes(deployPreview, 'PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}', 'Preview deploy skipped reason PR comment');
+}
+
 export function extractMatchBlock(text, startMarker) {
     const start = text.indexOf(startMarker);
     if (start === -1) {
@@ -128,11 +136,7 @@ export function validateFirebaseRulesCi() {
 
     assertMatches(deployPreview, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview deploy gate');
     validatePreviewDeployCommand(deployPreview);
-    assertIncludes(deployPreview, 'preview_deploy_hit_release_target_error()', 'Preview deploy release target error handling');
-    assertIncludes(deployPreview, "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target", 'Preview deploy release target error classifier');
-    assertIncludes(deployPreview, 'preview_skip_reason=', 'Preview deploy skipped reason output');
-    assertIncludes(deployPreview, 'skip_preview_for_release_target', 'Preview deploy release target skip');
-    assertIncludes(deployPreview, 'PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}', 'Preview deploy skipped reason PR comment');
+    assertPreviewDeploySkipHandling(deployPreview);
 
     assertIncludes(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}', 'Scoped Storage game clip rules');
     assertIncludes(storageRules, 'allow get: if canAccessTeamMedia(teamId);', 'Scoped Storage game clip read rules');

--- a/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
@@ -324,7 +324,7 @@ async function mockEditScheduleDependencies(page) {
     await page.route('**/js/live-game-state.js?v=3', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_STATE_STUB }));
     await page.route('**/js/edit-schedule-cancel-game.js?v=3', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: CANCEL_GAME_STUB }));
     await page.route('**/js/edit-schedule-practice-payload.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: PRACTICE_PAYLOAD_STUB }));
-    await page.route('**/js/edit-schedule-practice-submit.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: PRACTICE_SUBMIT_STUB }));
+    await page.route('**/js/edit-schedule-practice-submit.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: PRACTICE_SUBMIT_STUB }));
     await page.route('**/js/firebase.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_STUB }));
     await page.route('**/js/vendor/firebase-app.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
     await page.route('**/js/vendor/firebase-ai.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));

--- a/tests/unit/edit-schedule-practice-payload.test.js
+++ b/tests/unit/edit-schedule-practice-payload.test.js
@@ -154,7 +154,7 @@ describe('edit schedule practice recurrence payload', () => {
         const source = readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
         const helperSource = readFileSync(new URL('../../js/edit-schedule-practice-submit.js', import.meta.url), 'utf8');
 
-        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';");
+        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';");
         expect(helperSource).toContain("import { applyPracticeRecurrenceFields } from './edit-schedule-practice-payload.js';");
         expect(helperSource).toContain('applyPracticeRecurrenceFields({');
         expect(helperSource).toContain('deleteField,');

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -13,7 +13,9 @@ function createLocalDate(year, monthIndex, day, hours, minutes) {
 describe('edit schedule practice save flow', () => {
     it('requires a valid end time after the practice start time', () => {
         const startDate = createLocalDate(2026, 7, 10, 20, 0);
-        const overnightEndDate = createLocalDate(2026, 7, 10, 1, 0);
+        const overnightStartDate = createLocalDate(2026, 7, 10, 23, 0);
+        const sameDateOvernightEnd = createLocalDate(2026, 7, 10, 1, 0);
+        const explicitNextDateEnd = createLocalDate(2026, 7, 11, 1, 0);
 
         expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 10, 20, 0)))
             .toThrow('End time must be after the start time');
@@ -23,17 +25,19 @@ describe('edit schedule practice save flow', () => {
             .toThrow('End time must be after the start time');
         expect(() => validatePracticeDateRange(startDate, new Date('not-a-date')))
             .toThrow('Practice start and end times must be valid dates');
-        expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 11, 1, 0)))
+        expect(() => validatePracticeDateRange(overnightStartDate, sameDateOvernightEnd))
+            .toThrow('End time must be after the start time');
+        expect(() => validatePracticeDateRange(overnightStartDate, explicitNextDateEnd))
             .not.toThrow();
-        expect(validatePracticeDateRange(startDate, overnightEndDate).endDate)
-            .toEqual(createLocalDate(2026, 7, 11, 1, 0));
+        expect(validatePracticeDateRange(overnightStartDate, explicitNextDateEnd).endDate)
+            .toBe(explicitNextDateEnd);
     });
 
     it.each([false, true])('rejects an invalid duration before persisting when recurring is %s', async (isRecurring) => {
         const addPractice = vi.fn();
         const updateEvent = vi.fn();
-        const startDate = createLocalDate(2026, 7, 10, 20, 0);
-        const endDate = createLocalDate(2026, 7, 10, 19, 0);
+        const startDate = createLocalDate(2026, 7, 10, 23, 0);
+        const endDate = createLocalDate(2026, 7, 10, 1, 0);
 
         await expect(savePracticeForm({
             teamId: 'team-1',
@@ -57,12 +61,11 @@ describe('edit schedule practice save flow', () => {
         expect(updateEvent).not.toHaveBeenCalled();
     });
 
-    it('rolls overnight practice end times to the next day before persisting', async () => {
+    it('persists an overnight practice only when the next end date is explicit', async () => {
         const addPractice = vi.fn().mockResolvedValue('practice-overnight');
         const updateEvent = vi.fn();
         const startDate = createLocalDate(2026, 7, 10, 23, 0);
-        const endDate = createLocalDate(2026, 7, 10, 1, 0);
-        const expectedEndDate = createLocalDate(2026, 7, 11, 1, 0);
+        const endDate = createLocalDate(2026, 7, 11, 1, 0);
         const Timestamp = {
             fromDate: (value) => ({
                 iso: value.toISOString()
@@ -97,7 +100,7 @@ describe('edit schedule practice save flow', () => {
         expect(updateEvent).not.toHaveBeenCalled();
         expect(addPractice).toHaveBeenCalledWith('team-1', expect.objectContaining({
             date: { iso: startDate.toISOString() },
-            end: { iso: expectedEndDate.toISOString() },
+            end: { iso: endDate.toISOString() },
             startTime: '23:00',
             endTime: '01:00',
             endDayOffset: 1

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -19,6 +19,8 @@ describe('edit schedule practice save flow', () => {
             .toThrow('End time must be after the start time');
         expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 10, 19, 0)))
             .toThrow('End time must be after the start time');
+        expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 9, 23, 0)))
+            .toThrow('End time must be after the start time');
         expect(() => validatePracticeDateRange(startDate, new Date('not-a-date')))
             .toThrow('Practice start and end times must be valid dates');
         expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 11, 1, 0)))

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { savePracticeForm } from '../../js/edit-schedule-practice-submit.js';
+import { savePracticeForm, validatePracticeDateRange } from '../../js/edit-schedule-practice-submit.js';
 
 function readEditSchedule() {
     return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
@@ -11,6 +11,47 @@ function createLocalDate(year, monthIndex, day, hours, minutes) {
 }
 
 describe('edit schedule practice save flow', () => {
+    it('requires a valid end time after the practice start time', () => {
+        const startDate = createLocalDate(2026, 7, 10, 20, 0);
+
+        expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 10, 20, 0)))
+            .toThrow('End time must be after the start time');
+        expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 10, 19, 0)))
+            .toThrow('End time must be after the start time');
+        expect(() => validatePracticeDateRange(startDate, new Date('not-a-date')))
+            .toThrow('Practice start and end times must be valid dates');
+        expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 11, 1, 0)))
+            .not.toThrow();
+    });
+
+    it.each([false, true])('rejects an invalid duration before persisting when recurring is %s', async (isRecurring) => {
+        const addPractice = vi.fn();
+        const updateEvent = vi.fn();
+        const startDate = createLocalDate(2026, 7, 10, 20, 0);
+        const endDate = createLocalDate(2026, 7, 10, 19, 0);
+
+        await expect(savePracticeForm({
+            teamId: 'team-1',
+            formState: {
+                title: 'Invalid Practice',
+                startDate,
+                endDate,
+                location: 'Main Gym',
+                notes: '',
+                scheduleNotifications: { enabled: false }
+            },
+            recurrenceState: { isRecurring },
+            Timestamp: { fromDate: (value) => value },
+            deleteField: () => Symbol('deleteField'),
+            generateSeriesId: () => 'series-generated',
+            addPractice,
+            updateEvent
+        })).rejects.toThrow('End time must be after the start time');
+
+        expect(addPractice).not.toHaveBeenCalled();
+        expect(updateEvent).not.toHaveBeenCalled();
+    });
+
     it('persists recurring practice creation through addPractice with a series payload', async () => {
         const addPractice = vi.fn().mockResolvedValue('practice-new');
         const updateEvent = vi.fn();
@@ -158,7 +199,7 @@ describe('edit schedule practice save flow', () => {
     it('wires the practice submit flow through the shared save helper', () => {
         const source = readEditSchedule();
 
-        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';");
+        expect(source).toContain("import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';");
         expect(source).toContain('const { savedPracticeId } = await savePracticeForm({');
         expect(source).toContain('applyPracticeRecurrenceFields');
     });

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -13,6 +13,7 @@ function createLocalDate(year, monthIndex, day, hours, minutes) {
 describe('edit schedule practice save flow', () => {
     it('requires a valid end time after the practice start time', () => {
         const startDate = createLocalDate(2026, 7, 10, 20, 0);
+        const overnightEndDate = createLocalDate(2026, 7, 10, 1, 0);
 
         expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 10, 20, 0)))
             .toThrow('End time must be after the start time');
@@ -22,6 +23,8 @@ describe('edit schedule practice save flow', () => {
             .toThrow('Practice start and end times must be valid dates');
         expect(() => validatePracticeDateRange(startDate, createLocalDate(2026, 7, 11, 1, 0)))
             .not.toThrow();
+        expect(validatePracticeDateRange(startDate, overnightEndDate).endDate)
+            .toEqual(createLocalDate(2026, 7, 11, 1, 0));
     });
 
     it.each([false, true])('rejects an invalid duration before persisting when recurring is %s', async (isRecurring) => {
@@ -50,6 +53,53 @@ describe('edit schedule practice save flow', () => {
 
         expect(addPractice).not.toHaveBeenCalled();
         expect(updateEvent).not.toHaveBeenCalled();
+    });
+
+    it('rolls overnight practice end times to the next day before persisting', async () => {
+        const addPractice = vi.fn().mockResolvedValue('practice-overnight');
+        const updateEvent = vi.fn();
+        const startDate = createLocalDate(2026, 7, 10, 23, 0);
+        const endDate = createLocalDate(2026, 7, 10, 1, 0);
+        const expectedEndDate = createLocalDate(2026, 7, 11, 1, 0);
+        const Timestamp = {
+            fromDate: (value) => ({
+                iso: value.toISOString()
+            })
+        };
+
+        await savePracticeForm({
+            teamId: 'team-1',
+            formState: {
+                title: 'Late Practice',
+                startDate,
+                endDate,
+                location: 'Main Gym',
+                notes: '',
+                scheduleNotifications: { enabled: false }
+            },
+            recurrenceState: {
+                isRecurring: true,
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['FR'],
+                endType: 'count',
+                countValue: '4'
+            },
+            Timestamp,
+            deleteField: () => Symbol('deleteField'),
+            generateSeriesId: () => 'series-overnight',
+            addPractice,
+            updateEvent
+        });
+
+        expect(updateEvent).not.toHaveBeenCalled();
+        expect(addPractice).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            date: { iso: startDate.toISOString() },
+            end: { iso: expectedEndDate.toISOString() },
+            startTime: '23:00',
+            endTime: '01:00',
+            endDayOffset: 1
+        }));
     });
 
     it('persists recurring practice creation through addPractice with a series payload', async () => {

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -1,6 +1,9 @@
-import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { extractMatchBlock, validateFirebaseRulesCi, validatePreviewDeployCommand } from '../../scripts/validate-firebase-rules-ci.mjs';
+import {
+    assertPreviewDeploySkipHandling,
+    extractMatchBlock,
+    validatePreviewDeployCommand
+} from '../../scripts/validate-firebase-rules-ci.mjs';
 
 describe('validate Firebase rules CI helpers', () => {
     it('scopes legacy game clip assertions to the flat path block', () => {
@@ -57,16 +60,30 @@ service firebase.storage {
 `)).toThrow('Preview deploy installed Firebase CLI project/config arguments');
     });
 
-    it('guards Firebase preview release target skip handling', () => {
-        const validatorSource = readFileSync(
-            new URL('../../scripts/validate-firebase-rules-ci.mjs', import.meta.url),
-            'utf8'
-        );
+    it('requires preview deploy release-target outage handling', () => {
+        const deployPreview = `
+          preview_deploy_hit_release_target_error()
+          grep -Eiq "HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target" "$log_file"
+          preview_skip_reason="skip_preview_for_release_target"
+          env:
+            PREVIEW_SKIP_REASON: \${{ steps.deploy_preview.outputs.preview_skip_reason }}
+        `;
 
-        expect(validatorSource).toContain("assertIncludes(deployPreview, 'preview_deploy_hit_release_target_error()'");
-        expect(validatorSource).toContain("assertIncludes(deployPreview, \"HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target\"");
-        expect(validatorSource).toContain("assertIncludes(deployPreview, 'skip_preview_for_release_target'");
-        expect(validatorSource).toContain("assertIncludes(deployPreview, 'Firebase preview skipped for this run. See the deploy workflow summary for the skip reason.'");
-        expect(() => validateFirebaseRulesCi()).not.toThrow();
+        expect(() => assertPreviewDeploySkipHandling(deployPreview)).not.toThrow();
+        expect(() => assertPreviewDeploySkipHandling(deployPreview.replace('preview_deploy_hit_release_target_error()', ''))).toThrow(
+            'Preview deploy release target error handling is missing'
+        );
+        expect(() => assertPreviewDeploySkipHandling(deployPreview.replace("HTTP Error: 400, Can't release to .*resource doesn't exist or isn't a valid release target", ''))).toThrow(
+            'Preview deploy release target error classifier is missing'
+        );
+        expect(() => assertPreviewDeploySkipHandling(deployPreview.replace('preview_skip_reason=', ''))).toThrow(
+            'Preview deploy skipped reason output is missing'
+        );
+        expect(() => assertPreviewDeploySkipHandling(deployPreview.replace('skip_preview_for_release_target', ''))).toThrow(
+            'Preview deploy release target skip is missing'
+        );
+        expect(() => assertPreviewDeploySkipHandling(deployPreview.replace('PREVIEW_SKIP_REASON: ${{ steps.deploy_preview.outputs.preview_skip_reason }}', ''))).toThrow(
+            'Preview deploy skipped reason PR comment is missing'
+        );
     });
 });


### PR DESCRIPTION
Closes #3636

## What changed
- validate practice start/end dates in the shared save helper before constructing or persisting a payload
- reject invalid dates and require the end timestamp to be strictly after the start
- preserve valid overnight practices
- add regression coverage for equal/negative one-time and recurring durations and invalid date values
- bump the legacy module cache key and its smoke/unit references

## Root cause
The form and shared save helper converted and persisted timestamps without chronological validation. Recurring payload generation then clamped a negative day difference to zero, preserving a negative-duration occurrence.

## Validation
- `npx vitest run tests/unit/edit-schedule-practice-submit.test.js tests/unit/edit-schedule-practice-payload.test.js --reporter=verbose` (13 passed)
- `npm test` (593 files, 3890 passed, 9 skipped)
- `npx playwright test tests/smoke/edit-schedule-calendar-cancelled-import.spec.js --config=playwright.smoke.config.js --reporter=line` (1 passed)
