### PR TITLE
Deep-link mobile Game hub tools from schedule events

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -237,6 +237,7 @@ import {
   loadPracticeTimelineServiceModule,
   loadScheduleGameDayService,
   loadStatsheetImportServiceModule,
+  parseGameHubPanel,
   setScheduleGameDayServiceImporterForTest,
   shouldAutosaveGeneratedLineupDraft,
   shouldAutosaveLineupDraft,
@@ -704,6 +705,10 @@ describe('ScheduleEventDetail route state', () => {
       value: vi.fn(),
       writable: true
     });
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn()
+    });
     scheduleServiceMocks.loadParentScheduleRideOffers.mockResolvedValue([]);
     scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue([]);
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
@@ -754,6 +759,104 @@ describe('ScheduleEventDetail route state', () => {
     expect(within(switcher).getByRole('button', { name: 'Sam Lee' }).getAttribute('aria-pressed')).toBe('true');
     expect(screen.getAllByRole('button', { name: 'Assignments' })[0].className).toContain('bg-primary-600');
     expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-2&section=assignments');
+  });
+
+  it.each([
+    ['chat', 'chat'],
+    [' ReAcTiOnS ', 'reactions'],
+    ['wrapup', 'wrapup'],
+    ['statsheet', 'statsheet'],
+    ['lineup', 'lineup'],
+    ['substitutions', 'substitutions'],
+    ['report', 'report'],
+    ['unknown', null],
+    ['', null],
+    [null, null]
+  ])('guards the Game hub panel route value %s', (input, expected) => {
+    expect(parseGameHubPanel(input)).toBe(expected);
+  });
+
+  it('opens and subscribes to route-requested Live chat without an accordion tap', async () => {
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=game&panel=chat');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('live-game-chat-panel')).toBeTruthy();
+      expect(liveGameChatServiceMocks.subscribeToLiveGameChat).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByRole('button', { name: 'Live chat' }).getAttribute('aria-expanded')).toBe('true');
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=game&panel=chat');
+  });
+
+  it('keeps child context while focusing tools and removes panel state outside Game', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [
+        buildEvent({ childId: 'player-1', childName: 'Avery Smith', canUpdateScore: true, isTeamStaff: true }),
+        buildEvent({
+          eventKey: 'team-1::game-1::player-2::2026-06-04T18:00:00.000Z::game',
+          childId: 'player-2',
+          childName: 'Sam Lee',
+          canUpdateScore: true,
+          isTeamStaff: true
+        })
+      ],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
+    statsheetImportServiceMocks.loadTrackStatsheetContextForApp.mockResolvedValue({ roster: [], config: { columns: [] } });
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=game');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('game-hub-mobile-tools')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Open Live substitutions tool' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=game&panel=substitutions');
+      expect(screen.getByTestId('game-day-substitution-panel')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Statsheet import tool' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=game&panel=statsheet');
+      expect(screen.getByTestId('statsheet-import-panel')).toBeTruthy();
+    });
+
+    fireEvent.click(within(screen.getByTestId('event-player-switcher')).getByRole('button', { name: 'Sam Lee' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-2&section=game&panel=statsheet');
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Availability' })[0]);
+    await waitFor(() => {
+      expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-2&section=availability');
+    });
+  });
+
+  it.each([
+    ['invalid', { isTeamStaff: true }],
+    ['lineup', { isTeamStaff: false }]
+  ])('ignores invalid or unavailable panel value %s', async (panel, eventOverrides) => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent(eventOverrides)],
+      children: []
+    });
+
+    renderScheduleEventDetailWithLocation(`/schedule/team-1/game-1?childId=player-1&section=game&panel=${panel}`);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Game hub' })).toBeTruthy();
+    });
+    if (panel === 'lineup') {
+      expect(screen.queryByRole('button', { name: 'Lineup builder' })).toBeNull();
+    } else {
+      expect(screen.queryByTestId('live-game-chat-panel')).toBeNull();
+      expect(screen.queryByTestId('live-game-reactions-panel')).toBeNull();
+      expect(screen.queryByTestId('statsheet-import-panel')).toBeNull();
+    }
+    expect(liveGameChatServiceMocks.subscribeToLiveGameChat).not.toHaveBeenCalled();
   });
 
 });

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -190,9 +190,21 @@ import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';
 export { getAvailabilityNoteSaveState } from '../components/schedule/AvailabilityPanels';
 
 type EventDetailSectionId = ScheduleEventDetailSectionId;
+export type GameHubPanelId = 'chat' | 'reactions' | 'wrapup' | 'statsheet' | 'lineup' | 'substitutions' | 'report';
 type HomeScoringPlayersUpdater = (players: ScheduleHomeScoringPlayer[]) => ScheduleHomeScoringPlayer[];
 
 const eventDetailSectionIds = new Set<EventDetailSectionId>(['availability', 'rideshare', 'assignments', 'game']);
+const gameHubPanelIds = new Set<GameHubPanelId>(['chat', 'reactions', 'wrapup', 'statsheet', 'lineup', 'substitutions', 'report']);
+
+const gameHubPanelDetails: Record<GameHubPanelId, { label: string; elementId: string }> = {
+  chat: { label: 'Live chat', elementId: 'game-hub-chat-panel' },
+  reactions: { label: 'Live reactions', elementId: 'game-hub-reactions-panel' },
+  wrapup: { label: 'Post-game wrap-up', elementId: 'game-hub-wrapup-panel' },
+  statsheet: { label: 'Statsheet import', elementId: 'game-hub-statsheet-panel' },
+  lineup: { label: 'Lineup builder', elementId: 'game-hub-lineup-panel' },
+  substitutions: { label: 'Live substitutions', elementId: 'game-hub-substitutions-panel' },
+  report: { label: 'Report sections', elementId: 'game-hub-report-panel' }
+};
 
 function parseRequestedEventDetailSection(section: string | null | undefined): EventDetailSectionId | null {
   const normalized = String(section || '').trim().toLowerCase();
@@ -204,6 +216,14 @@ function parseRequestedEventDetailSection(section: string | null | undefined): E
 
 export function parseEventDetailSection(section: string | null | undefined): EventDetailSectionId {
   return parseRequestedEventDetailSection(section) || 'availability';
+}
+
+export function parseGameHubPanel(panel: string | null | undefined): GameHubPanelId | null {
+  const normalized = String(panel || '').trim().toLowerCase();
+  if (normalized && gameHubPanelIds.has(normalized as GameHubPanelId)) {
+    return normalized as GameHubPanelId;
+  }
+  return null;
 }
 
 const hubIconComponents: Record<ScheduleHubIcon, LucideIcon> = {
@@ -307,15 +327,25 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const decodedTeamId = decodeURIComponent(teamId);
   const decodedEventId = decodeURIComponent(eventId);
 
-  const replaceEventRouteParams = (updates: { section?: EventDetailSectionId; childId?: string }) => {
+  const replaceEventRouteParams = (updates: { section?: EventDetailSectionId; childId?: string; panel?: GameHubPanelId | null }) => {
     const nextParams = new URLSearchParams(searchParams);
-    if (updates.section) nextParams.set('section', updates.section);
+    if (updates.section) {
+      nextParams.set('section', updates.section);
+      if (updates.section !== 'game') nextParams.delete('panel');
+    }
     if (Object.prototype.hasOwnProperty.call(updates, 'childId')) {
       const nextChildId = String(updates.childId || '').trim();
       if (nextChildId) {
         nextParams.set('childId', nextChildId);
       } else {
         nextParams.delete('childId');
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, 'panel')) {
+      if (updates.panel) {
+        nextParams.set('panel', updates.panel);
+      } else {
+        nextParams.delete('panel');
       }
     }
     setSearchParams(nextParams, { replace: true });
@@ -332,6 +362,11 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const selectChild = (childId: string) => {
     setSelectedChildId(childId);
     replaceEventRouteParams({ childId });
+  };
+
+  const selectGameHubPanel = (panel: GameHubPanelId | null) => {
+    setActiveSection('game');
+    replaceEventRouteParams({ section: 'game', panel });
   };
 
   const loadEvent = useCallback(async () => {
@@ -540,6 +575,9 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     : sectionIds.has(defaultSection)
       ? defaultSection
       : sections[0]?.id || 'availability';
+  const requestedGameHubPanel = resolvedActiveSection === 'game'
+    ? parseGameHubPanel(searchParams.get('panel'))
+    : null;
 
   const addEventToCalendar = async () => {
     const icsTitle = `${title} | ${selectedEvent.teamName}`;
@@ -656,7 +694,23 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
         ) : null}
         {resolvedActiveSection === 'rideshare' ? <RideshareSection /> : null}
         {resolvedActiveSection === 'assignments' ? <AssignmentsSection /> : null}
-        {resolvedActiveSection === 'game' ? <GameHubSection key={selectedEvent.eventKey} auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onLiveClockUpdated={handleLiveClockUpdated} onWrapupCompleted={handleWrapupCompleted} onStatsheetImported={handleStatsheetImported} onGameCancelled={handleGameCancelled} onPracticeOccurrenceCancelled={handlePracticeOccurrenceCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
+        {resolvedActiveSection === 'game' ? (
+          <GameHubSection
+            key={selectedEvent.eventKey}
+            auth={auth}
+            event={selectedEvent}
+            childEvents={events}
+            requestedPanel={requestedGameHubPanel}
+            onPanelChange={selectGameHubPanel}
+            onScoreUpdated={handleScoreUpdated}
+            onLiveClockUpdated={handleLiveClockUpdated}
+            onWrapupCompleted={handleWrapupCompleted}
+            onStatsheetImported={handleStatsheetImported}
+            onGameCancelled={handleGameCancelled}
+            onPracticeOccurrenceCancelled={handlePracticeOccurrenceCancelled}
+            onGamePlanPublished={handleGamePlanPublished}
+          />
+        ) : null}
       </div>
       </div>
     </ScheduleEventDetailProvider>
@@ -1365,7 +1419,7 @@ function LazyGameHubPanel({
         </div>
         <ChevronDown className={`h-4 w-4 flex-none text-gray-500 transition ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
       </button>
-      {open ? <div id={panelId}>{children}</div> : null}
+      {open ? <div id={panelId} className="scroll-mt-40">{children}</div> : null}
     </div>
   );
 }
@@ -1402,7 +1456,20 @@ function GameHubLiveClockBadge({ event }: { event: ParentScheduleEvent }) {
   );
 }
 
-function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockUpdated, onWrapupCompleted, onStatsheetImported, onGameCancelled, onPracticeOccurrenceCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onLiveClockUpdated: (payload: Partial<ParentScheduleEvent> & { period?: string | null }) => void; onWrapupCompleted: (payload: { homeScore: number; awayScore: number; postGameNotes: string; summary: string; practiceFeedItems: PracticeFeedItem[] }) => void; onStatsheetImported: (payload: { homeScore: number; awayScore: number; statSheetPhotoUrl?: string | null }) => void; onGameCancelled: () => void; onPracticeOccurrenceCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
+function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChange, onScoreUpdated, onLiveClockUpdated, onWrapupCompleted, onStatsheetImported, onGameCancelled, onPracticeOccurrenceCancelled, onGamePlanPublished }: {
+  auth: AuthState;
+  event: ParentScheduleEvent;
+  childEvents: ParentScheduleEvent[];
+  requestedPanel: GameHubPanelId | null;
+  onPanelChange: (panel: GameHubPanelId | null) => void;
+  onScoreUpdated: (homeScore: number, awayScore: number) => void;
+  onLiveClockUpdated: (payload: Partial<ParentScheduleEvent> & { period?: string | null }) => void;
+  onWrapupCompleted: (payload: { homeScore: number; awayScore: number; postGameNotes: string; summary: string; practiceFeedItems: PracticeFeedItem[] }) => void;
+  onStatsheetImported: (payload: { homeScore: number; awayScore: number; statSheetPhotoUrl?: string | null }) => void;
+  onGameCancelled: () => void;
+  onPracticeOccurrenceCancelled: () => void;
+  onGamePlanPublished: (gamePlan: Record<string, any>) => void;
+}) {
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
@@ -1423,10 +1490,42 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
   const notifiesCounterpartTeam = Boolean(event.opponentTeamId || event.sharedScheduleOpponentTeamId);
   const hubDestinations = isPractice ? buildPracticeHubDestinations(event) : buildGameHubDestinations(event);
   const standardTrackerHref = `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}/track`;
+  const availablePanelIds = useMemo(() => {
+    const panels: GameHubPanelId[] = [];
+    if (!isPractice) panels.push('reactions', 'chat');
+    if (canWrapup) panels.push('wrapup', 'statsheet');
+    if (canPublishLineup) panels.push('lineup', 'substitutions');
+    if (!isPractice) panels.push('report');
+    return panels;
+  }, [canPublishLineup, canWrapup, isPractice]);
+  const requestedPanelAvailable = requestedPanel && availablePanelIds.includes(requestedPanel)
+    ? requestedPanel
+    : null;
+  const requestedPanelOpen = requestedPanelAvailable
+    ? Boolean(openPanels[requestedPanelAvailable])
+    : false;
 
   useEffect(() => {
     setOpenPanels({});
   }, [event.eventKey]);
+
+  useEffect(() => {
+    if (!requestedPanelAvailable) return undefined;
+
+    setOpenPanels((current) => current[requestedPanelAvailable]
+      ? current
+      : { ...current, [requestedPanelAvailable]: true });
+
+    return undefined;
+  }, [requestedPanelAvailable]);
+
+  useLayoutEffect(() => {
+    if (!requestedPanelAvailable || !requestedPanelOpen) return;
+    const panel = document.getElementById(gameHubPanelDetails[requestedPanelAvailable].elementId);
+    if (panel && typeof panel.scrollIntoView === 'function') {
+      panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [requestedPanelAvailable, requestedPanelOpen]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1457,12 +1556,16 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
     setHomeScoringPlayers(updater);
   }, []);
 
-  const togglePanel = useCallback((panelId: string) => {
-    setOpenPanels((current) => ({
-      ...current,
-      [panelId]: !current[panelId]
-    }));
-  }, []);
+  const openPanel = useCallback((panelId: GameHubPanelId) => {
+    setOpenPanels((current) => current[panelId] ? current : { ...current, [panelId]: true });
+    onPanelChange(panelId);
+  }, [onPanelChange]);
+
+  const togglePanel = useCallback((panelId: GameHubPanelId) => {
+    const nextOpen = !openPanels[panelId];
+    setOpenPanels((current) => ({ ...current, [panelId]: nextOpen }));
+    onPanelChange(nextOpen ? panelId : requestedPanel === panelId ? null : requestedPanel);
+  }, [onPanelChange, openPanels, requestedPanel]);
 
   const cancelGame = async () => {
     if (!auth.user) return;
@@ -1541,6 +1644,26 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
               {statusLabel}
             </span>
           </div>
+          {!isPractice && availablePanelIds.length ? (
+            <div
+              className="-mx-1 mt-3 flex gap-2 overflow-x-auto px-1 pb-1 sm:hidden"
+              aria-label="Game hub tools"
+              data-testid="game-hub-mobile-tools"
+            >
+              {availablePanelIds.map((panelId) => (
+                <button
+                  key={panelId}
+                  type="button"
+                  className={`min-h-9 flex-none rounded-full border px-3 text-xs font-black transition ${requestedPanelAvailable === panelId ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 bg-white text-gray-700 hover:border-primary-200 hover:text-primary-700'}`}
+                  onClick={() => openPanel(panelId)}
+                  aria-label={`Open ${gameHubPanelDetails[panelId].label} tool`}
+                  aria-pressed={requestedPanelAvailable === panelId}
+                >
+                  {gameHubPanelDetails[panelId].label}
+                </button>
+              ))}
+            </div>
+          ) : null}
         </div>
 
         <div className="px-3 py-3 sm:px-4">

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -85,7 +85,8 @@ async function mockScheduleModules(page, options = {}) {
             rsvps: [],
             rideshare: [],
             assignments: [],
-            packets: []
+            packets: [],
+            chatSubscriptions: []
         };
         window.__trackerCalls = {
             recordEvents: [],
@@ -1088,6 +1089,32 @@ async function mockScheduleModules(page, options = {}) {
             `
         });
     });
+
+    await page.route(/\/src\/lib\/liveGameChatService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export function canUseLiveGameChat() {
+                    return true;
+                }
+
+                export function getLiveGameChatNotice() {
+                    return null;
+                }
+
+                export function subscribeToLiveGameChat(teamId, gameId, onMessages) {
+                    window.__scheduleCalls.chatSubscriptions.push({ teamId, gameId });
+                    queueMicrotask(() => onMessages([]));
+                    return () => {};
+                }
+
+                export async function sendLiveGameChatMessage() {
+                    return { id: 'smoke-chat-message' };
+                }
+            `
+        });
+    });
 }
 
 test('app schedule loads agenda filters, player select, calendar, export, and game detail link', async ({ page, baseURL }) => {
@@ -1277,6 +1304,29 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 });
 
+test('iOS-sized Game hub deep link opens and positions Live chat without an accordion tap', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockScheduleModules(page);
+    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1&section=game&panel=chat'), { waitUntil: 'domcontentloaded' });
+
+    const chatPanel = page.getByTestId('live-game-chat-panel');
+    await waitForScheduleRoute(page, chatPanel);
+    await expect(page.getByRole('button', { name: 'Live chat', exact: true })).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByRole('button', { name: 'Open Live chat tool' })).toHaveAttribute('aria-pressed', 'true');
+    await expect.poll(() => page.evaluate(() => window.__scheduleCalls.chatSubscriptions)).toEqual([
+        { teamId: 'team-1', gameId: 'game-1' }
+    ]);
+    await expect(page).toHaveURL(/#\/schedule\/team-1\/game-1\?childId=player-1&section=game&panel=chat$/);
+
+    await expect.poll(async () => {
+        const navBox = await page.locator('.event-nav-mobile').boundingBox();
+        const panelBox = await page.locator('#game-hub-chat-panel').boundingBox();
+        if (!navBox || !panelBox) return false;
+        return panelBox.y >= navBox.y + navBox.height - 1 && panelBox.y < 844 - 80;
+    }).toBe(true);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
+});
+
 test('iOS-sized staff schedule keeps tools collapsed below the event list', async ({ page, baseURL }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await mockScheduleModules(page, { isCoach: true, staffManageable: true });
@@ -1391,10 +1441,11 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
 
     await page.getByRole('button', { name: 'Game', exact: true }).click();
     await expect(page.getByRole('heading', { name: 'Game hub' })).toBeVisible();
-    await expect(page.getByText('Report sections')).toBeVisible();
-    await page.getByRole('button', { name: 'Report sections' }).click();
+    const reportPanelToggle = page.getByRole('button', { name: 'Report sections', exact: true });
+    await expect(reportPanelToggle).toBeVisible();
+    await reportPanelToggle.click();
     await expect(page.getByText('Pat helped set the tone early and the team finished strong.')).toBeVisible();
-    const reportSections = page.locator('.app-card').filter({ has: page.getByText('Report sections') });
+    const reportSections = page.locator('#game-hub-report-panel');
     await expect(reportSections.locator('strong').filter({ hasText: 'Strong start' })).toBeVisible();
     await expect(reportSections.getByText('**Strong start**')).toHaveCount(0);
     await expect(reportSections.locator('li').filter({ hasText: 'Shared the ball well' })).toBeVisible();
@@ -1404,7 +1455,7 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
     await page.getByRole('button', { name: 'Share replay' }).click();
     expect(await page.evaluate(() => window.__sharedPayloads[0]?.url)).toBe('https://allplays.ai/live-game.html?teamId=team-1&gameId=game-1&replay=true');
     expect(await page.evaluate(() => window.__sharedPayloads[0]?.text)).toContain('https://allplays.ai/live-game.html?teamId=team-1&gameId=game-1&replay=true');
-    await expect(page.getByRole('button', { name: 'Open report' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open report', exact: true })).toBeVisible();
     await page.getByRole('button', { name: 'Share match report' }).click();
     expect(await page.evaluate(() => window.__sharedPayloads[1]?.url)).toBe('https://allplays.ai/game.html#teamId=team-1&gameId=game-1');
     expect(await page.evaluate(() => window.__sharedPayloads[1]?.text)).toContain('https://allplays.ai/game.html#teamId=team-1&gameId=game-1');


### PR DESCRIPTION
## What changed

- add a guarded `panel=chat|reactions|wrapup|statsheet|lineup|substitutions|report` query contract to schedule event Game routes
- auto-open and scroll valid, available panels below the sticky mobile event navigation while preserving lazy loading
- keep `childId` and `section=game` when focusing tools, and remove `panel` when leaving the Game section
- add a compact, permission-aware mobile Game hub tool strip backed by the same panel ids
- cover parser guards, deep-link chat subscription, route preservation, unavailable tools, and mobile positioning

## Why

Mobile users previously landed only on the coarse Game tab and had to hunt through accordions. The Game hub's private local state also prevented schedule, push, or search links from opening a specific game-day tool.

## Validation

- `npm --prefix apps/app test -- --run src/pages/ScheduleEventDetail.test.tsx --reporter=verbose` (96 passed)
- `npm --prefix apps/app test -- --run src/pages/ScheduleEventDetail.test.tsx --reporter=dot -t "ScheduleEventDetail route state"` (16 passed)
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5175 npx playwright test --config=playwright.smoke.config.js tests/smoke/app-schedule.spec.js` (16 passed)
- `npm run app:build`

Closes #3672
