### PR TITLE
Require verified account merge previews

### DIFF
--- a/functions/account-merge-core.cjs
+++ b/functions/account-merge-core.cjs
@@ -37,6 +37,13 @@ function hashAccountMergeVerificationToken(token) {
     return crypto.createHash('sha256').update(rawToken).digest('hex');
 }
 
+function requireAccountMergeVerificationToken(input = {}) {
+    if (!String(input.verificationToken || '').trim()) {
+        throw new Error('Verify ownership of the source account before previewing an account merge.');
+    }
+    return input.verificationToken;
+}
+
 function toMillis(value) {
     if (!value) return 0;
     if (typeof value.toMillis === 'function') return value.toMillis();
@@ -49,7 +56,7 @@ function validateAccountMergeVerificationRecord({ record = {}, destinationUid, s
     if (record.status !== 'verified') {
         throw new Error('Account merge verification token is not verified.');
     }
-    if (record.destinationUid && record.destinationUid !== destinationUid) {
+    if (!record.destinationUid || record.destinationUid !== destinationUid) {
         throw new Error('Account merge verification token is for a different destination account.');
     }
     if (sourceUid && record.sourceUid && record.sourceUid !== sourceUid) {
@@ -280,6 +287,7 @@ module.exports = {
     mergePreferenceObjects,
     normalizeAccountMergePreviewInput,
     normalizeEmail,
+    requireAccountMergeVerificationToken,
     uniqueValues,
     validateAccountMergeVerificationRecord
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -56,6 +56,7 @@ const {
   normalizeEmail,
   normalizeAccountMergePreviewInput,
   hashAccountMergeVerificationToken,
+  requireAccountMergeVerificationToken,
   validateAccountMergeVerificationRecord,
   assertNotSelfMerge,
   buildAccountMergePreview,
@@ -2795,51 +2796,28 @@ async function writeAccountMergePreviewAudit(payload) {
   });
 }
 
-async function findAccountMergeSourceByEmail(sourceEmail) {
-  const [emailSnap, profileEmailSnap] = await Promise.all([
-    firestore.collection('users')
-      .where('email', '==', sourceEmail)
-      .limit(1)
-      .get(),
-    firestore.collection('users')
-      .where('profileEmail', '==', sourceEmail)
-      .limit(1)
-      .get()
-  ]);
-  return emailSnap.empty ? (profileEmailSnap.empty ? null : profileEmailSnap.docs[0]) : emailSnap.docs[0];
-}
-
 async function resolveAccountMergeSource(input, destinationUid) {
-  let sourceUid = input.sourceUid;
-  let verification = null;
-
-  if (input.verificationToken) {
-    const tokenHash = hashAccountMergeVerificationToken(input.verificationToken);
-    const tokenSnap = await firestore.doc(`accountMergeVerificationTokens/${tokenHash}`).get();
-    if (!tokenSnap.exists) {
-      throw new functions.https.HttpsError('failed-precondition', 'Account merge verification token is invalid.');
-    }
-    verification = {
-      ...(tokenSnap.data() || {}),
-      id: tokenSnap.id
-    };
-    try {
-      sourceUid = validateAccountMergeVerificationRecord({
-        record: verification,
-        destinationUid,
-        sourceUid: input.sourceUid
-      });
-    } catch (error) {
-      throw new functions.https.HttpsError('failed-precondition', error.message || 'Account merge verification token is invalid.');
-    }
+  const tokenHash = hashAccountMergeVerificationToken(input.verificationToken);
+  const tokenSnap = await firestore.doc(`accountMergeVerificationTokens/${tokenHash}`).get();
+  if (!tokenSnap.exists) {
+    throw new functions.https.HttpsError('failed-precondition', 'Account merge verification token is invalid.');
+  }
+  const verification = {
+    ...(tokenSnap.data() || {}),
+    id: tokenSnap.id
+  };
+  let sourceUid;
+  try {
+    sourceUid = validateAccountMergeVerificationRecord({
+      record: verification,
+      destinationUid,
+      sourceUid: input.sourceUid
+    });
+  } catch (error) {
+    throw new functions.https.HttpsError('failed-precondition', error.message || 'Account merge verification token is invalid.');
   }
 
-  if (sourceUid) {
-    const sourceSnap = await firestore.doc(`users/${sourceUid}`).get();
-    return { sourceSnap, verification };
-  }
-
-  const sourceSnap = await findAccountMergeSourceByEmail(input.sourceEmail);
+  const sourceSnap = await firestore.doc(`users/${sourceUid}`).get();
   return { sourceSnap, verification };
 }
 
@@ -2868,6 +2846,22 @@ exports.previewAccountMerge = functions.https.onCall(async (data, context) => {
       errorMessage: error.message || 'Invalid account merge preview request.'
     });
     throw new functions.https.HttpsError('invalid-argument', error.message || 'Invalid account merge preview request.');
+  }
+
+  try {
+    requireAccountMergeVerificationToken(input);
+  } catch (error) {
+    const message = error.message || 'Verify ownership of the source account before previewing an account merge.';
+    await writeAccountMergePreviewAudit({
+      destinationUid,
+      destinationEmail,
+      sourceUid: input.sourceUid || '',
+      sourceEmail: input.sourceEmail || '',
+      status: 'rejected',
+      errorCode: 'failed-precondition',
+      errorMessage: message
+    });
+    throw new functions.https.HttpsError('failed-precondition', message);
   }
 
   try {

--- a/tests/unit/account-merge-core.test.js
+++ b/tests/unit/account-merge-core.test.js
@@ -5,6 +5,7 @@ const require = createRequire(import.meta.url);
 const {
     normalizeAccountMergePreviewInput,
     hashAccountMergeVerificationToken,
+    requireAccountMergeVerificationToken,
     validateAccountMergeVerificationRecord,
     assertNotSelfMerge,
     buildAccountMergePreview
@@ -13,6 +14,19 @@ const {
 describe('account merge preview helpers', () => {
     it('rejects a preview request with no source account identifier or token', () => {
         expect(() => normalizeAccountMergePreviewInput({})).toThrow('source account identifier or verification token');
+    });
+
+    it('requires verified ownership before accepting raw source identifiers for preview', () => {
+        expect(() => requireAccountMergeVerificationToken(normalizeAccountMergePreviewInput({
+            sourceEmail: 'source@example.com'
+        }))).toThrow('Verify ownership');
+        expect(() => requireAccountMergeVerificationToken(normalizeAccountMergePreviewInput({
+            sourceUid: 'source-1'
+        }))).toThrow('Verify ownership');
+        expect(requireAccountMergeVerificationToken(normalizeAccountMergePreviewInput({
+            sourceEmail: 'source@example.com',
+            verificationToken: 'verified-token'
+        }))).toBe('verified-token');
     });
 
     it('rejects self-merge attempts by uid or email', () => {
@@ -55,6 +69,13 @@ describe('account merge preview helpers', () => {
                 status: 'verified',
                 sourceUid: 'source-1',
                 destinationUid: 'dest-1'
+            }
+        })).toThrow('different destination');
+        expect(() => validateAccountMergeVerificationRecord({
+            destinationUid: 'dest-1',
+            record: {
+                status: 'verified',
+                sourceUid: 'source-1'
             }
         })).toThrow('different destination');
     });

--- a/tests/unit/account-merge-functions-source.test.js
+++ b/tests/unit/account-merge-functions-source.test.js
@@ -21,10 +21,15 @@ describe('account merge preview callable source contract', () => {
         expect(functionsSource).toContain("HttpsError('not-found', 'Source account could not be found.')");
     });
 
-    it('looks up source accounts by email and profileEmail', () => {
-        expect(functionsSource).toContain('findAccountMergeSourceByEmail');
-        expect(functionsSource).toContain(".where('email', '==', sourceEmail)");
-        expect(functionsSource).toContain(".where('profileEmail', '==', sourceEmail)");
+    it('requires a verification token before resolving source account data', () => {
+        const callableStart = functionsSource.indexOf('exports.previewAccountMerge = functions.https.onCall');
+        const callableSource = functionsSource.slice(callableStart, functionsSource.indexOf('async function logRsvpTokenRedemptionAttempt', callableStart));
+
+        expect(callableSource).toContain('requireAccountMergeVerificationToken(input)');
+        expect(callableSource).toContain("errorCode: 'failed-precondition'");
+        expect(callableSource).not.toContain('findAccountMergeSourceByEmail');
+        expect(functionsSource).not.toContain(".where('email', '==', sourceEmail)");
+        expect(functionsSource).not.toContain(".where('profileEmail', '==', sourceEmail)");
     });
 
     it('persists the accepted verification token document id in audits', () => {


### PR DESCRIPTION
Closes #3635

## What changed
- require a non-empty verification token before account-merge preview source resolution
- remove direct source-account lookup by email/profileEmail
- validate that verified tokens are unexpired and explicitly bound to the signed-in destination UID
- continue writing bounded rejection audits without source snapshots
- preserve the existing preview shape for valid verified requests
- update helper and callable source-contract regression coverage

## Root cause
The callable treated authentication to any destination account as enough to discover a source account. Verification-token validation was optional, with raw UID and Admin SDK email-query fallbacks exposing source account links and roles.

## Validation
- `npx vitest run tests/unit/account-merge-core.test.js tests/unit/account-merge-functions-source.test.js --reporter=verbose` (10 passed)
- `npm test --prefix functions` (46 passed)
- `node --check functions/index.js`
- `node --check functions/account-merge-core.cjs`
