### PR TITLE
Revoke accepted household access from Parent Dashboard

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -532,14 +532,6 @@ service cloud.firestore {
              data.status in ['pending', 'active', 'removed'];
     }
 
-    function isFamilyMembershipRemoval(data, userId) {
-      return data.keys().hasAll(['email', 'status', 'organizerUserId', 'accessStatus']) &&
-             data.organizerUserId == userId &&
-             data.email is string &&
-             data.status == 'removed' &&
-             data.accessStatus == 'revoked';
-    }
-
     function isAccountMergeRequestPayloadValid(data, userId) {
       return data.keys().hasOnly(['requestedBy', 'primaryEmail', 'secondaryEmail', 'status', 'createdAt', 'updatedAt']) &&
              data.keys().hasAll(['requestedBy', 'primaryEmail', 'secondaryEmail', 'status', 'createdAt', 'updatedAt']) &&
@@ -1978,10 +1970,7 @@ service cloud.firestore {
         allow read: if isOwner(userId) || isGlobalAdmin() ||
                        (isSignedIn() && resource.data.email is string && request.auth.token.email is string && resource.data.email == request.auth.token.email.lower());
         allow create: if isOwner(userId) && isFamilyMembershipPayloadValid(request.resource.data, userId);
-        allow update: if (isOwner(userId) &&
-                         isFamilyMembershipRemoval(request.resource.data, userId) &&
-                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'accessStatus', 'updatedAt', 'removedAt'])) ||
-                      isFamilyMembershipInviteMetadataUpdate(request.resource.data, userId) ||
+        allow update: if isFamilyMembershipInviteMetadataUpdate(request.resource.data, userId) ||
                       isFamilyMembershipAcceptance(request.resource.data);
         allow delete: if false;
       }

--- a/functions/household-access-core.cjs
+++ b/functions/household-access-core.cjs
@@ -74,16 +74,15 @@ function buildHouseholdAccessRevocationPlan({
     throw new Error('Household membership is not in a revocable state.');
   }
 
-  const teamId = compactString(membership.teamId);
-  const playerId = compactString(membership.playerId);
-  if (!teamId || !playerId) {
-    throw new Error('Household membership is missing its delegated player link.');
-  }
-
   const matchingCodes = (Array.isArray(accessCodes) ? accessCodes : [])
     .filter((code) => isMatchingHouseholdAccessCode(code, organizerId, memberId));
   const invitedUserId = compactString(membership.userId) ||
     compactString(matchingCodes.find((code) => compactString(code.usedBy))?.usedBy);
+  const teamId = compactString(membership.teamId);
+  const playerId = compactString(membership.playerId);
+  if ((!teamId || !playerId) && invitedUserId) {
+    throw new Error('Household membership is missing its delegated player link.');
+  }
   const auditTimestamp = timestamp || new Date().toISOString();
 
   const plan = {

--- a/functions/household-access-core.cjs
+++ b/functions/household-access-core.cjs
@@ -51,6 +51,14 @@ function isMatchingHouseholdAccessCode(code = {}, organizerUserId, membershipId)
     compactString(code.familyMembershipId) === membershipId;
 }
 
+function isAcceptedHouseholdAccessCode(code = {}) {
+  const status = compactString(code.status).toLowerCase();
+  return code.used === true &&
+    code.revoked !== true &&
+    compactString(code.usedBy) &&
+    !['removed', 'revoked'].includes(status);
+}
+
 function hasIndependentPlayerAccessReference({
   accessCodes = [],
   revokedCodeIds = [],
@@ -111,8 +119,12 @@ function buildHouseholdAccessRevocationPlan({
 
   const matchingCodes = (Array.isArray(accessCodes) ? accessCodes : [])
     .filter((code) => isMatchingHouseholdAccessCode(code, organizerId, memberId));
-  const invitedUserId = compactString(membership.userId) ||
-    compactString(matchingCodes.find((code) => compactString(code.usedBy))?.usedBy);
+  const membershipUserId = compactString(membership.userId);
+  const acceptedMatchingCode = matchingCodes.find((code) => {
+    const usedBy = compactString(code.usedBy);
+    return isAcceptedHouseholdAccessCode(code) && (!membershipUserId || usedBy === membershipUserId);
+  });
+  const invitedUserId = compactString(acceptedMatchingCode?.usedBy);
   const teamId = compactString(membership.teamId);
   const playerId = compactString(membership.playerId);
   if ((!teamId || !playerId) && invitedUserId) {
@@ -169,5 +181,6 @@ module.exports = {
   buildRevokedParentAccess,
   buildRevokedPrivatePlayerAccess,
   hasIndependentPlayerAccessReference,
+  isAcceptedHouseholdAccessCode,
   isMatchingHouseholdAccessCode
 };

--- a/functions/household-access-core.cjs
+++ b/functions/household-access-core.cjs
@@ -1,0 +1,126 @@
+function compactString(value) {
+  return value == null ? '' : String(value).trim();
+}
+
+function uniqueStrings(values = []) {
+  return [...new Set((Array.isArray(values) ? values : [])
+    .map(compactString)
+    .filter(Boolean))];
+}
+
+function isTargetParentLink(link = {}, teamId, playerId) {
+  return compactString(link.teamId) === teamId && compactString(link.playerId) === playerId;
+}
+
+function buildRevokedParentAccess(userData = {}, target = {}) {
+  const teamId = compactString(target.teamId);
+  const playerId = compactString(target.playerId);
+  if (!teamId || !playerId) {
+    throw new Error('Household access revocation requires a team and player.');
+  }
+
+  const parentOf = (Array.isArray(userData.parentOf) ? userData.parentOf : [])
+    .filter((link) => !isTargetParentLink(link, teamId, playerId));
+  const parentTeamIds = uniqueStrings(parentOf.map((link) => link?.teamId));
+  const parentPlayerKeys = uniqueStrings(parentOf.map((link) => (
+    link?.teamId && link?.playerId ? `${link.teamId}::${link.playerId}` : ''
+  )));
+  const roles = uniqueStrings(userData.roles)
+    .filter((role) => role !== 'parent' || parentOf.length > 0);
+
+  return {
+    parentOf,
+    parentTeamIds,
+    parentPlayerKeys,
+    roles
+  };
+}
+
+function buildRevokedPrivatePlayerAccess(privateProfile = {}, invitedUserId) {
+  const userId = compactString(invitedUserId);
+  if (!userId) return { parents: Array.isArray(privateProfile.parents) ? privateProfile.parents : [] };
+  return {
+    parents: (Array.isArray(privateProfile.parents) ? privateProfile.parents : [])
+      .filter((parent) => compactString(parent?.userId) !== userId)
+  };
+}
+
+function isMatchingHouseholdAccessCode(code = {}, organizerUserId, membershipId) {
+  return compactString(code.type) === 'household_invite' &&
+    compactString(code.organizerUserId) === organizerUserId &&
+    compactString(code.familyMembershipId) === membershipId;
+}
+
+function buildHouseholdAccessRevocationPlan({
+  organizerUserId,
+  membershipId,
+  membership = {},
+  accessCodes = [],
+  userData = {},
+  privateProfile = {},
+  timestamp
+} = {}) {
+  const organizerId = compactString(organizerUserId);
+  const memberId = compactString(membershipId);
+  if (!organizerId || !memberId) {
+    throw new Error('Household access revocation requires an organizer and membership.');
+  }
+  if (compactString(membership.organizerUserId) !== organizerId) {
+    throw new Error('Only the household organizer can revoke this membership.');
+  }
+
+  const membershipStatus = compactString(membership.status).toLowerCase();
+  if (!['pending', 'active', 'removed'].includes(membershipStatus)) {
+    throw new Error('Household membership is not in a revocable state.');
+  }
+
+  const teamId = compactString(membership.teamId);
+  const playerId = compactString(membership.playerId);
+  if (!teamId || !playerId) {
+    throw new Error('Household membership is missing its delegated player link.');
+  }
+
+  const matchingCodes = (Array.isArray(accessCodes) ? accessCodes : [])
+    .filter((code) => isMatchingHouseholdAccessCode(code, organizerId, memberId));
+  const invitedUserId = compactString(membership.userId) ||
+    compactString(matchingCodes.find((code) => compactString(code.usedBy))?.usedBy);
+  const auditTimestamp = timestamp || new Date().toISOString();
+
+  const plan = {
+    teamId,
+    playerId,
+    invitedUserId,
+    membershipUpdate: {
+      status: 'removed',
+      accessStatus: 'revoked',
+      removedAt: auditTimestamp,
+      revokedAt: auditTimestamp,
+      revokedBy: organizerId,
+      updatedAt: auditTimestamp
+    },
+    accessCodeUpdates: matchingCodes.map((code) => ({
+      id: compactString(code.id),
+      update: {
+        revoked: true,
+        status: 'revoked',
+        revokedAt: auditTimestamp,
+        revokedBy: organizerId,
+        updatedAt: auditTimestamp
+      }
+    })).filter((entry) => entry.id)
+  };
+
+  if (invitedUserId) {
+    plan.userUpdate = buildRevokedParentAccess(userData, { teamId, playerId });
+    plan.privateProfileUpdate = buildRevokedPrivatePlayerAccess(privateProfile, invitedUserId);
+  }
+
+  return plan;
+}
+
+module.exports = {
+  buildHouseholdAccessRevocationPlan,
+  buildRevokedParentAccess,
+  buildRevokedPrivatePlayerAccess,
+  isMatchingHouseholdAccessCode
+};

--- a/functions/household-access-core.cjs
+++ b/functions/household-access-core.cjs
@@ -51,12 +51,47 @@ function isMatchingHouseholdAccessCode(code = {}, organizerUserId, membershipId)
     compactString(code.familyMembershipId) === membershipId;
 }
 
+function hasIndependentPlayerAccessReference({
+  accessCodes = [],
+  revokedCodeIds = [],
+  invitedUserId,
+  teamId,
+  playerId,
+  player = {}
+} = {}) {
+  const userId = compactString(invitedUserId);
+  const targetTeamId = compactString(teamId);
+  const targetPlayerId = compactString(playerId);
+  if (!userId || !targetTeamId || !targetPlayerId) return false;
+
+  const revokedIds = new Set((Array.isArray(revokedCodeIds) ? revokedCodeIds : []).map(compactString));
+  const parentGrantTypes = new Set(['parent_invite', 'household_invite', 'coparent_invite']);
+  const hasAnotherAcceptedCode = (Array.isArray(accessCodes) ? accessCodes : []).some((code) => {
+    const status = compactString(code?.status).toLowerCase();
+    return !revokedIds.has(compactString(code?.id)) &&
+      parentGrantTypes.has(compactString(code?.type)) &&
+      code?.used === true &&
+      code?.revoked !== true &&
+      !['removed', 'revoked'].includes(status) &&
+      compactString(code?.usedBy) === userId &&
+      compactString(code?.teamId) === targetTeamId &&
+      compactString(code?.playerId) === targetPlayerId;
+  });
+  if (hasAnotherAcceptedCode) return true;
+
+  return (Array.isArray(player?.parents) ? player.parents : []).some((parent) => {
+    const status = compactString(parent?.status).toLowerCase();
+    return compactString(parent?.userId) === userId && !['removed', 'revoked'].includes(status);
+  });
+}
+
 function buildHouseholdAccessRevocationPlan({
   organizerUserId,
   membershipId,
   membership = {},
   accessCodes = [],
   userData = {},
+  player = {},
   privateProfile = {},
   timestamp
 } = {}) {
@@ -83,12 +118,24 @@ function buildHouseholdAccessRevocationPlan({
   if ((!teamId || !playerId) && invitedUserId) {
     throw new Error('Household membership is missing its delegated player link.');
   }
+  const matchingCodeIds = matchingCodes.map((code) => compactString(code.id)).filter(Boolean);
+  const preservedPlayerAccess = invitedUserId
+    ? hasIndependentPlayerAccessReference({
+        accessCodes,
+        revokedCodeIds: matchingCodeIds,
+        invitedUserId,
+        teamId,
+        playerId,
+        player
+      })
+    : false;
   const auditTimestamp = timestamp || new Date().toISOString();
 
   const plan = {
     teamId,
     playerId,
     invitedUserId,
+    preservedPlayerAccess,
     membershipUpdate: {
       status: 'removed',
       accessStatus: 'revoked',
@@ -109,7 +156,7 @@ function buildHouseholdAccessRevocationPlan({
     })).filter((entry) => entry.id)
   };
 
-  if (invitedUserId) {
+  if (invitedUserId && !preservedPlayerAccess) {
     plan.userUpdate = buildRevokedParentAccess(userData, { teamId, playerId });
     plan.privateProfileUpdate = buildRevokedPrivatePlayerAccess(privateProfile, invitedUserId);
   }
@@ -121,5 +168,6 @@ module.exports = {
   buildHouseholdAccessRevocationPlan,
   buildRevokedParentAccess,
   buildRevokedPrivatePlayerAccess,
+  hasIndependentPlayerAccessReference,
   isMatchingHouseholdAccessCode
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -2647,16 +2647,35 @@ exports.revokeHouseholdMemberAccess = functions.https.onCall(async (data, contex
       ? normalizeFirestoreId(invitedUserIdValue, 'invitedUserId')
       : '';
     const userRef = invitedUserId ? firestore.doc(`users/${invitedUserId}`) : null;
+    const playerRef = invitedUserId && teamId && playerId
+      ? firestore.doc(`teams/${teamId}/players/${playerId}`)
+      : null;
     const privateProfileRef = invitedUserId && teamId && playerId
       ? firestore.doc(`teams/${teamId}/players/${playerId}/private/profile`)
       : null;
+    const acceptedGrantQuery = invitedUserId
+      ? firestore.collection('accessCodes')
+        .where('usedBy', '==', invitedUserId)
+        .where('teamId', '==', teamId)
+        .where('playerId', '==', playerId)
+      : null;
 
-    const [userSnap, privateProfileSnap] = await Promise.all([
+    const [userSnap, playerSnap, privateProfileSnap, acceptedGrantSnap] = await Promise.all([
       userRef ? transaction.get(userRef) : Promise.resolve(null),
-      privateProfileRef ? transaction.get(privateProfileRef) : Promise.resolve(null)
+      playerRef ? transaction.get(playerRef) : Promise.resolve(null),
+      privateProfileRef ? transaction.get(privateProfileRef) : Promise.resolve(null),
+      acceptedGrantQuery ? transaction.get(acceptedGrantQuery) : Promise.resolve(null)
     ]);
     const userData = userSnap?.exists ? userSnap.data() || {} : {};
+    const player = playerSnap?.exists ? playerSnap.data() || {} : {};
     const privateProfile = privateProfileSnap?.exists ? privateProfileSnap.data() || {} : {};
+    const acceptedGrantCodes = acceptedGrantSnap?.docs?.map((codeSnap) => ({
+      id: codeSnap.id,
+      ...(codeSnap.data() || {})
+    })) || [];
+    const allAccessCodes = [...new Map(
+      [...accessCodes, ...acceptedGrantCodes].map((codeData) => [codeData.id, codeData])
+    ).values()];
     const now = admin.firestore.Timestamp.now();
     let plan;
     try {
@@ -2664,8 +2683,9 @@ exports.revokeHouseholdMemberAccess = functions.https.onCall(async (data, contex
         organizerUserId,
         membershipId,
         membership,
-        accessCodes,
+        accessCodes: allAccessCodes,
         userData,
+        player,
         privateProfile,
         timestamp: now
       });
@@ -2705,7 +2725,8 @@ exports.revokeHouseholdMemberAccess = functions.https.onCall(async (data, contex
       membershipId,
       teamId: plan.teamId,
       playerId: plan.playerId,
-      revokedUserId: plan.invitedUserId || null
+      revokedUserId: plan.invitedUserId || null,
+      preservedPlayerAccess: plan.preservedPlayerAccess
     };
   });
 
@@ -2714,7 +2735,8 @@ exports.revokeHouseholdMemberAccess = functions.https.onCall(async (data, contex
     membershipId,
     teamId: responsePayload?.teamId,
     playerId: responsePayload?.playerId,
-    revokedUserId: responsePayload?.revokedUserId
+    revokedUserId: responsePayload?.revokedUserId,
+    preservedPlayerAccess: responsePayload?.preservedPlayerAccess
   });
   return responsePayload;
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -2638,20 +2638,16 @@ exports.revokeHouseholdMemberAccess = functions.https.onCall(async (data, contex
       String(codeData.organizerUserId || '').trim() === organizerUserId &&
       String(codeData.familyMembershipId || '').trim() === membershipId
     ));
-    let teamId;
-    let playerId;
-    try {
-      teamId = normalizeFirestoreId(membership.teamId, 'teamId');
-      playerId = normalizeFirestoreId(membership.playerId, 'playerId');
-    } catch (_error) {
-      throw new functions.https.HttpsError('failed-precondition', 'Household membership is missing its delegated player link.');
-    }
+    const membershipTeamId = String(membership.teamId || '').trim();
+    const membershipPlayerId = String(membership.playerId || '').trim();
+    const teamId = membershipTeamId ? normalizeFirestoreId(membershipTeamId, 'teamId') : '';
+    const playerId = membershipPlayerId ? normalizeFirestoreId(membershipPlayerId, 'playerId') : '';
     const invitedUserIdValue = membership.userId || matchingCode?.usedBy || '';
     const invitedUserId = invitedUserIdValue
       ? normalizeFirestoreId(invitedUserIdValue, 'invitedUserId')
       : '';
     const userRef = invitedUserId ? firestore.doc(`users/${invitedUserId}`) : null;
-    const privateProfileRef = invitedUserId
+    const privateProfileRef = invitedUserId && teamId && playerId
       ? firestore.doc(`teams/${teamId}/players/${playerId}/private/profile`)
       : null;
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -40,7 +40,8 @@ const {
   resolveFamilyShareChildrenFromOwnerProfile
 } = require('./family-share-core.cjs');
 const {
-  buildHouseholdAccessRevocationPlan
+  buildHouseholdAccessRevocationPlan,
+  isAcceptedHouseholdAccessCode
 } = require('./household-access-core.cjs');
 const {
   hashRsvpToken,
@@ -2633,16 +2634,19 @@ exports.revokeHouseholdMemberAccess = functions.https.onCall(async (data, contex
       id: codeSnap.id,
       ...(codeSnap.data() || {})
     }));
-    const matchingCode = accessCodes.find((codeData) => (
+    const membershipUserId = String(membership.userId || '').trim();
+    const acceptedMatchingCode = accessCodes.find((codeData) => (
       codeData.type === 'household_invite' &&
       String(codeData.organizerUserId || '').trim() === organizerUserId &&
-      String(codeData.familyMembershipId || '').trim() === membershipId
+      String(codeData.familyMembershipId || '').trim() === membershipId &&
+      isAcceptedHouseholdAccessCode(codeData) &&
+      (!membershipUserId || String(codeData.usedBy || '').trim() === membershipUserId)
     ));
     const membershipTeamId = String(membership.teamId || '').trim();
     const membershipPlayerId = String(membership.playerId || '').trim();
     const teamId = membershipTeamId ? normalizeFirestoreId(membershipTeamId, 'teamId') : '';
     const playerId = membershipPlayerId ? normalizeFirestoreId(membershipPlayerId, 'playerId') : '';
-    const invitedUserIdValue = membership.userId || matchingCode?.usedBy || '';
+    const invitedUserIdValue = acceptedMatchingCode?.usedBy || '';
     const invitedUserId = invitedUserIdValue
       ? normalizeFirestoreId(invitedUserIdValue, 'invitedUserId')
       : '';

--- a/functions/index.js
+++ b/functions/index.js
@@ -40,6 +40,9 @@ const {
   resolveFamilyShareChildrenFromOwnerProfile
 } = require('./family-share-core.cjs');
 const {
+  buildHouseholdAccessRevocationPlan
+} = require('./household-access-core.cjs');
+const {
   hashRsvpToken,
   createRawRsvpToken,
   normalizeRsvpTokenCreateInput,
@@ -2593,6 +2596,130 @@ exports.redeemHouseholdInvite = functions.https.onCall(async (data, context) => 
     };
   });
 
+  return responsePayload;
+});
+
+exports.revokeHouseholdMemberAccess = functions.https.onCall(async (data, context) => {
+  if (!context.auth?.uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in before revoking household access.');
+  }
+
+  let membershipId;
+  try {
+    membershipId = normalizeFirestoreId(data?.membershipId, 'membershipId');
+  } catch (_error) {
+    throw new functions.https.HttpsError('invalid-argument', 'Household membership is required.');
+  }
+
+  const organizerUserId = context.auth.uid;
+  const membershipRef = firestore.doc(`users/${organizerUserId}/familyMemberships/${membershipId}`);
+  const codeQuery = firestore.collection('accessCodes')
+    .where('familyMembershipId', '==', membershipId);
+  let responsePayload = null;
+
+  await firestore.runTransaction(async (transaction) => {
+    const membershipSnap = await transaction.get(membershipRef);
+    if (!membershipSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Household membership could not be found.');
+    }
+
+    const membership = membershipSnap.data() || {};
+    if (String(membership.organizerUserId || '').trim() !== organizerUserId) {
+      throw new functions.https.HttpsError('permission-denied', 'Only the household organizer can revoke this access.');
+    }
+
+    const codeQuerySnap = await transaction.get(codeQuery);
+    const accessCodes = codeQuerySnap.docs.map((codeSnap) => ({
+      id: codeSnap.id,
+      ...(codeSnap.data() || {})
+    }));
+    const matchingCode = accessCodes.find((codeData) => (
+      codeData.type === 'household_invite' &&
+      String(codeData.organizerUserId || '').trim() === organizerUserId &&
+      String(codeData.familyMembershipId || '').trim() === membershipId
+    ));
+    let teamId;
+    let playerId;
+    try {
+      teamId = normalizeFirestoreId(membership.teamId, 'teamId');
+      playerId = normalizeFirestoreId(membership.playerId, 'playerId');
+    } catch (_error) {
+      throw new functions.https.HttpsError('failed-precondition', 'Household membership is missing its delegated player link.');
+    }
+    const invitedUserIdValue = membership.userId || matchingCode?.usedBy || '';
+    const invitedUserId = invitedUserIdValue
+      ? normalizeFirestoreId(invitedUserIdValue, 'invitedUserId')
+      : '';
+    const userRef = invitedUserId ? firestore.doc(`users/${invitedUserId}`) : null;
+    const privateProfileRef = invitedUserId
+      ? firestore.doc(`teams/${teamId}/players/${playerId}/private/profile`)
+      : null;
+
+    const [userSnap, privateProfileSnap] = await Promise.all([
+      userRef ? transaction.get(userRef) : Promise.resolve(null),
+      privateProfileRef ? transaction.get(privateProfileRef) : Promise.resolve(null)
+    ]);
+    const userData = userSnap?.exists ? userSnap.data() || {} : {};
+    const privateProfile = privateProfileSnap?.exists ? privateProfileSnap.data() || {} : {};
+    const now = admin.firestore.Timestamp.now();
+    let plan;
+    try {
+      plan = buildHouseholdAccessRevocationPlan({
+        organizerUserId,
+        membershipId,
+        membership,
+        accessCodes,
+        userData,
+        privateProfile,
+        timestamp: now
+      });
+    } catch (error) {
+      throw new functions.https.HttpsError('failed-precondition', error?.message || 'Household membership cannot be revoked.');
+    }
+
+    transaction.set(membershipRef, plan.membershipUpdate, { merge: true });
+    plan.accessCodeUpdates.forEach(({ id, update }) => {
+      transaction.set(firestore.doc(`accessCodes/${id}`), update, { merge: true });
+    });
+
+    if (plan.invitedUserId && userRef && userSnap?.exists && plan.userUpdate) {
+      const nextUserData = { ...userData, ...plan.userUpdate };
+      transaction.set(userRef, {
+        ...plan.userUpdate,
+        updatedAt: now
+      }, { merge: true });
+      transaction.set(
+        firestore.doc(`publicUserProfiles/${plan.invitedUserId}`),
+        buildTrustedPublicUserProfileProjectionPayload(nextUserData, {
+          trustedEmail: userData.email || null
+        }),
+        { merge: true }
+      );
+    }
+
+    if (plan.invitedUserId && privateProfileRef && privateProfileSnap?.exists && plan.privateProfileUpdate) {
+      transaction.set(privateProfileRef, {
+        ...plan.privateProfileUpdate,
+        updatedAt: now
+      }, { merge: true });
+    }
+
+    responsePayload = {
+      success: true,
+      membershipId,
+      teamId: plan.teamId,
+      playerId: plan.playerId,
+      revokedUserId: plan.invitedUserId || null
+    };
+  });
+
+  functions.logger.info('Revoked household member access', {
+    organizerUserId,
+    membershipId,
+    teamId: responsePayload?.teamId,
+    playerId: responsePayload?.playerId,
+    revokedUserId: responsePayload?.revokedUserId
+  });
   return responsePayload;
 });
 

--- a/functions/test/household-access-core.test.cjs
+++ b/functions/test/household-access-core.test.cjs
@@ -86,6 +86,134 @@ test('revoking the last parent link removes only the parent role', () => {
   });
 });
 
+test('revocation preserves same-player access backed by another accepted access code', () => {
+  const plan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: {
+      organizerUserId: 'organizer-1',
+      status: 'active',
+      userId: 'contact-1',
+      teamId: 'team-1',
+      playerId: 'player-1'
+    },
+    accessCodes: [
+      {
+        id: 'household-code',
+        type: 'household_invite',
+        organizerUserId: 'organizer-1',
+        familyMembershipId: 'membership-1',
+        teamId: 'team-1',
+        playerId: 'player-1',
+        used: true,
+        usedBy: 'contact-1',
+        status: 'accepted'
+      },
+      {
+        id: 'independent-parent-code',
+        type: 'parent_invite',
+        teamId: 'team-1',
+        playerId: 'player-1',
+        used: true,
+        usedBy: 'contact-1',
+        status: 'accepted'
+      }
+    ],
+    userData: {
+      roles: ['parent'],
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    },
+    privateProfile: { parents: [{ userId: 'contact-1' }] },
+    timestamp: 'now'
+  });
+
+  assert.equal(plan.preservedPlayerAccess, true);
+  assert.equal(plan.userUpdate, undefined);
+  assert.equal(plan.privateProfileUpdate, undefined);
+  assert.deepEqual(plan.accessCodeUpdates.map((entry) => entry.id), ['household-code']);
+});
+
+test('revocation preserves same-player access backed by the canonical player parent list', () => {
+  const plan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: {
+      organizerUserId: 'organizer-1',
+      status: 'active',
+      userId: 'contact-1',
+      teamId: 'team-1',
+      playerId: 'player-1'
+    },
+    accessCodes: [{
+      id: 'household-code',
+      type: 'household_invite',
+      organizerUserId: 'organizer-1',
+      familyMembershipId: 'membership-1',
+      teamId: 'team-1',
+      playerId: 'player-1',
+      used: true,
+      usedBy: 'contact-1'
+    }],
+    player: { parents: [{ userId: 'contact-1', status: 'active' }] },
+    userData: {
+      roles: ['parent'],
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    },
+    privateProfile: { parents: [{ userId: 'contact-1' }] },
+    timestamp: 'now'
+  });
+
+  assert.equal(plan.preservedPlayerAccess, true);
+  assert.equal(plan.userUpdate, undefined);
+  assert.equal(plan.privateProfileUpdate, undefined);
+});
+
+test('revoked same-player references do not prevent household access cleanup', () => {
+  const plan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: {
+      organizerUserId: 'organizer-1',
+      status: 'active',
+      userId: 'contact-1',
+      teamId: 'team-1',
+      playerId: 'player-1'
+    },
+    accessCodes: [
+      {
+        id: 'household-code',
+        type: 'household_invite',
+        organizerUserId: 'organizer-1',
+        familyMembershipId: 'membership-1',
+        teamId: 'team-1',
+        playerId: 'player-1',
+        used: true,
+        usedBy: 'contact-1'
+      },
+      {
+        id: 'revoked-code',
+        type: 'parent_invite',
+        teamId: 'team-1',
+        playerId: 'player-1',
+        used: true,
+        usedBy: 'contact-1',
+        revoked: true
+      }
+    ],
+    player: { parents: [{ userId: 'contact-1', status: 'revoked' }] },
+    userData: {
+      roles: ['parent'],
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    },
+    privateProfile: { parents: [{ userId: 'contact-1' }] },
+    timestamp: 'now'
+  });
+
+  assert.equal(plan.preservedPlayerAccess, false);
+  assert.deepEqual(plan.userUpdate.parentOf, []);
+  assert.deepEqual(plan.privateProfileUpdate.parents, []);
+});
+
 test('pending and previously shell-revoked memberships remain safely cleanable', () => {
   const pendingPlan = buildHouseholdAccessRevocationPlan({
     organizerUserId: 'organizer-1',

--- a/functions/test/household-access-core.test.cjs
+++ b/functions/test/household-access-core.test.cjs
@@ -19,7 +19,7 @@ test('accepted household revocation removes only the delegated player and preser
       playerId: 'player-1'
     },
     accessCodes: [
-      { id: 'code-1', type: 'household_invite', organizerUserId: 'organizer-1', familyMembershipId: 'membership-1', usedBy: 'contact-1' },
+      { id: 'code-1', type: 'household_invite', organizerUserId: 'organizer-1', familyMembershipId: 'membership-1', used: true, usedBy: 'contact-1', status: 'accepted' },
       { id: 'other-code', type: 'household_invite', organizerUserId: 'organizer-1', familyMembershipId: 'other-membership', usedBy: 'contact-1' }
     ],
     userData: {
@@ -152,7 +152,8 @@ test('revocation preserves same-player access backed by the canonical player par
       teamId: 'team-1',
       playerId: 'player-1',
       used: true,
-      usedBy: 'contact-1'
+      usedBy: 'contact-1',
+      status: 'accepted'
     }],
     player: { parents: [{ userId: 'contact-1', status: 'active' }] },
     userData: {
@@ -188,7 +189,8 @@ test('revoked same-player references do not prevent household access cleanup', (
         teamId: 'team-1',
         playerId: 'player-1',
         used: true,
-        usedBy: 'contact-1'
+        usedBy: 'contact-1',
+        status: 'accepted'
       },
       {
         id: 'revoked-code',
@@ -226,7 +228,7 @@ test('pending and previously shell-revoked memberships remain safely cleanable',
   assert.equal(pendingPlan.userUpdate, undefined);
   assert.equal(pendingPlan.accessCodeUpdates[0].update.revoked, true);
 
-  const legacyRemovedPlan = buildHouseholdAccessRevocationPlan({
+  const forgedRemovedPlan = buildHouseholdAccessRevocationPlan({
     organizerUserId: 'organizer-1',
     membershipId: 'membership-1',
     membership: { organizerUserId: 'organizer-1', status: 'removed', userId: 'contact-1', teamId: 'team-1', playerId: 'player-1' },
@@ -234,8 +236,46 @@ test('pending and previously shell-revoked memberships remain safely cleanable',
     privateProfile: { parents: [{ userId: 'contact-1' }] },
     timestamp: 'now'
   });
-  assert.deepEqual(legacyRemovedPlan.userUpdate.parentOf, []);
-  assert.deepEqual(legacyRemovedPlan.privateProfileUpdate.parents, []);
+  assert.equal(forgedRemovedPlan.invitedUserId, '');
+  assert.equal(forgedRemovedPlan.userUpdate, undefined);
+  assert.equal(forgedRemovedPlan.privateProfileUpdate, undefined);
+});
+
+test('forged membership shells cannot trigger victim parent grant cleanup without an accepted household code', () => {
+  const plan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'attacker',
+    membershipId: 'forged-membership',
+    membership: {
+      organizerUserId: 'attacker',
+      status: 'active',
+      userId: 'victim-user',
+      teamId: 'team-1',
+      playerId: 'player-1'
+    },
+    accessCodes: [{
+      id: 'unaccepted-code',
+      type: 'household_invite',
+      organizerUserId: 'attacker',
+      familyMembershipId: 'forged-membership',
+      teamId: 'team-1',
+      playerId: 'player-1',
+      usedBy: 'victim-user'
+    }],
+    userData: {
+      roles: ['parent'],
+      parentOf: [{ teamId: 'team-1', playerId: 'player-1' }],
+      parentTeamIds: ['team-1'],
+      parentPlayerKeys: ['team-1::player-1']
+    },
+    privateProfile: { parents: [{ userId: 'victim-user' }] },
+    timestamp: 'now'
+  });
+
+  assert.equal(plan.invitedUserId, '');
+  assert.equal(plan.preservedPlayerAccess, false);
+  assert.equal(plan.userUpdate, undefined);
+  assert.equal(plan.privateProfileUpdate, undefined);
+  assert.deepEqual(plan.accessCodeUpdates.map((entry) => entry.id), ['unaccepted-code']);
 });
 
 test('shell-only pending household memberships can be revoked without delegated player cleanup', () => {
@@ -275,7 +315,16 @@ test('accepted household memberships still require a delegated player link for c
       organizerUserId: 'organizer-1',
       status: 'active',
       userId: 'contact-1'
-    }
+    },
+    accessCodes: [{
+      id: 'code-1',
+      type: 'household_invite',
+      organizerUserId: 'organizer-1',
+      familyMembershipId: 'membership-1',
+      used: true,
+      usedBy: 'contact-1',
+      status: 'accepted'
+    }]
   }), /missing its delegated player link/);
 });
 

--- a/functions/test/household-access-core.test.cjs
+++ b/functions/test/household-access-core.test.cjs
@@ -1,0 +1,119 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildHouseholdAccessRevocationPlan,
+  buildRevokedParentAccess
+} = require('../household-access-core.cjs');
+
+test('accepted household revocation removes only the delegated player and preserves other access', () => {
+  const timestamp = { serverTimestamp: true };
+  const plan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: {
+      organizerUserId: 'organizer-1',
+      status: 'active',
+      userId: 'contact-1',
+      teamId: 'team-1',
+      playerId: 'player-1'
+    },
+    accessCodes: [
+      { id: 'code-1', type: 'household_invite', organizerUserId: 'organizer-1', familyMembershipId: 'membership-1', usedBy: 'contact-1' },
+      { id: 'other-code', type: 'household_invite', organizerUserId: 'organizer-1', familyMembershipId: 'other-membership', usedBy: 'contact-1' }
+    ],
+    userData: {
+      roles: ['parent', 'coach'],
+      parentOf: [
+        { teamId: 'team-1', playerId: 'player-1', playerName: 'Removed Player' },
+        { teamId: 'team-1', playerId: 'player-2', playerName: 'Sibling' },
+        { teamId: 'team-2', playerId: 'player-9', playerName: 'Other Team' }
+      ],
+      parentTeamIds: ['team-1', 'team-2'],
+      parentPlayerKeys: ['team-1::player-1', 'team-1::player-2', 'team-2::player-9']
+    },
+    privateProfile: {
+      parents: [
+        { userId: 'contact-1', email: 'contact@example.com' },
+        { userId: 'other-parent', email: 'other@example.com' }
+      ]
+    },
+    timestamp
+  });
+
+  assert.equal(plan.invitedUserId, 'contact-1');
+  assert.deepEqual(plan.userUpdate.parentOf, [
+    { teamId: 'team-1', playerId: 'player-2', playerName: 'Sibling' },
+    { teamId: 'team-2', playerId: 'player-9', playerName: 'Other Team' }
+  ]);
+  assert.deepEqual(plan.userUpdate.parentTeamIds, ['team-1', 'team-2']);
+  assert.deepEqual(plan.userUpdate.parentPlayerKeys, ['team-1::player-2', 'team-2::player-9']);
+  assert.deepEqual(plan.userUpdate.roles, ['parent', 'coach']);
+  assert.deepEqual(plan.privateProfileUpdate.parents, [
+    { userId: 'other-parent', email: 'other@example.com' }
+  ]);
+  assert.deepEqual(plan.accessCodeUpdates, [{
+    id: 'code-1',
+    update: {
+      revoked: true,
+      status: 'revoked',
+      revokedAt: timestamp,
+      revokedBy: 'organizer-1',
+      updatedAt: timestamp
+    }
+  }]);
+  assert.deepEqual(plan.membershipUpdate, {
+    status: 'removed',
+    accessStatus: 'revoked',
+    removedAt: timestamp,
+    revokedAt: timestamp,
+    revokedBy: 'organizer-1',
+    updatedAt: timestamp
+  });
+});
+
+test('revoking the last parent link removes only the parent role', () => {
+  assert.deepEqual(buildRevokedParentAccess({
+    roles: ['member', 'parent', 'coach'],
+    parentOf: [{ teamId: 'team-1', playerId: 'player-1' }],
+    parentTeamIds: ['team-1'],
+    parentPlayerKeys: ['team-1::player-1']
+  }, { teamId: 'team-1', playerId: 'player-1' }), {
+    parentOf: [],
+    parentTeamIds: [],
+    parentPlayerKeys: [],
+    roles: ['member', 'coach']
+  });
+});
+
+test('pending and previously shell-revoked memberships remain safely cleanable', () => {
+  const pendingPlan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: { organizerUserId: 'organizer-1', status: 'pending', teamId: 'team-1', playerId: 'player-1' },
+    accessCodes: [{ id: 'code-1', type: 'household_invite', organizerUserId: 'organizer-1', familyMembershipId: 'membership-1' }],
+    timestamp: 'now'
+  });
+  assert.equal(pendingPlan.invitedUserId, '');
+  assert.equal(pendingPlan.userUpdate, undefined);
+  assert.equal(pendingPlan.accessCodeUpdates[0].update.revoked, true);
+
+  const legacyRemovedPlan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: { organizerUserId: 'organizer-1', status: 'removed', userId: 'contact-1', teamId: 'team-1', playerId: 'player-1' },
+    userData: { roles: ['parent'], parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] },
+    privateProfile: { parents: [{ userId: 'contact-1' }] },
+    timestamp: 'now'
+  });
+  assert.deepEqual(legacyRemovedPlan.userUpdate.parentOf, []);
+  assert.deepEqual(legacyRemovedPlan.privateProfileUpdate.parents, []);
+});
+
+test('revocation refuses a membership owned by another organizer', () => {
+  assert.throws(() => buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: { organizerUserId: 'organizer-2', status: 'active', teamId: 'team-1', playerId: 'player-1' }
+  }), /Only the household organizer/);
+});

--- a/functions/test/household-access-core.test.cjs
+++ b/functions/test/household-access-core.test.cjs
@@ -110,6 +110,47 @@ test('pending and previously shell-revoked memberships remain safely cleanable',
   assert.deepEqual(legacyRemovedPlan.privateProfileUpdate.parents, []);
 });
 
+test('shell-only pending household memberships can be revoked without delegated player cleanup', () => {
+  const pendingPlan = buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: {
+      organizerUserId: 'organizer-1',
+      email: 'pending@example.com',
+      status: 'pending'
+    },
+    accessCodes: [{ id: 'code-1', type: 'household_invite', organizerUserId: 'organizer-1', familyMembershipId: 'membership-1' }],
+    timestamp: 'now'
+  });
+
+  assert.equal(pendingPlan.teamId, '');
+  assert.equal(pendingPlan.playerId, '');
+  assert.equal(pendingPlan.invitedUserId, '');
+  assert.equal(pendingPlan.userUpdate, undefined);
+  assert.equal(pendingPlan.privateProfileUpdate, undefined);
+  assert.deepEqual(pendingPlan.membershipUpdate, {
+    status: 'removed',
+    accessStatus: 'revoked',
+    removedAt: 'now',
+    revokedAt: 'now',
+    revokedBy: 'organizer-1',
+    updatedAt: 'now'
+  });
+  assert.equal(pendingPlan.accessCodeUpdates[0].update.revoked, true);
+});
+
+test('accepted household memberships still require a delegated player link for cleanup', () => {
+  assert.throws(() => buildHouseholdAccessRevocationPlan({
+    organizerUserId: 'organizer-1',
+    membershipId: 'membership-1',
+    membership: {
+      organizerUserId: 'organizer-1',
+      status: 'active',
+      userId: 'contact-1'
+    }
+  }), /missing its delegated player link/);
+});
+
 test('revocation refuses a membership owned by another organizer', () => {
   assert.throws(() => buildHouseholdAccessRevocationPlan({
     organizerUserId: 'organizer-1',

--- a/js/family-plan.js
+++ b/js/family-plan.js
@@ -141,7 +141,7 @@ export function buildFamilyPlanMarkup({ members = [], entitlementState = 'locked
                 : '';
             const removeButton = member.status === 'removed'
                 ? ''
-                : `<button type="button" data-family-plan-remove="${escapeHtml(member.id)}" class="text-xs font-semibold text-red-600 hover:text-red-700">Remove</button>`;
+                : `<button type="button" data-family-plan-remove="${escapeHtml(member.id)}" aria-label="Revoke household access for ${escapeHtml(label)}" class="text-xs font-semibold text-red-600 hover:text-red-700">Revoke access</button>`;
             return `
                 <div class="flex items-start justify-between gap-3 rounded-xl border border-gray-200 bg-white p-3">
                     <div>
@@ -436,20 +436,17 @@ async function revokeAccessCode(firebase, member, timestamp) {
 
 export async function removeFamilyMember(userId, memberId, { deps = {} } = {}) {
     if (!userId || !memberId) throw new Error('Missing family member to remove.');
-    const firebase = await loadFirebase(deps);
-    const { db, doc, getDoc, updateDoc, serverTimestamp } = firebase;
-    const timestamp = typeof serverTimestamp === 'function' ? serverTimestamp() : new Date().toISOString();
-    const memberRef = doc(db, 'users', userId, 'familyMemberships', memberId);
-    const memberSnap = getDoc ? await getDoc(memberRef) : null;
-    const member = normalizeFamilyMembers([{ id: memberId, ...dataFromSnapshot(memberSnap) }])[0] || { id: memberId };
-
-    await revokeAccessCode(firebase, member, timestamp);
-    await updateDoc(memberRef, {
-        status: 'removed',
-        accessStatus: 'revoked',
-        updatedAt: timestamp,
-        removedAt: timestamp,
-    });
+    const { functions, httpsCallable } = await loadFirebase(deps);
+    if (!functions || typeof httpsCallable !== 'function') {
+        throw new Error('Household access revocation is unavailable.');
+    }
+    const revokeAccess = httpsCallable(functions, 'revokeHouseholdMemberAccess');
+    const result = await revokeAccess({ membershipId: memberId });
+    const payload = result?.data || result || {};
+    if (payload.success !== true) {
+        throw new Error('Unable to revoke household access.');
+    }
+    return payload;
 }
 
 export async function revokeHouseholdInvite(userId, inviteId, { deps = {} } = {}) {
@@ -506,17 +503,17 @@ export async function renderFamilyPlanSection(container, user, options = {}) {
         container.querySelectorAll('[data-family-plan-remove]').forEach((button) => {
             button.addEventListener('click', async () => {
                 const memberId = button.getAttribute('data-family-plan-remove');
-                button.textContent = 'Removing...';
+                button.textContent = 'Revoking...';
                 button.disabled = true;
                 try {
                     await removeFamilyMember(user.uid, memberId, { deps });
                     await renderFamilyPlanSection(container, user, options);
                 } catch (error) {
                     if (validationEl) {
-                        validationEl.textContent = error.message || 'Unable to remove family member.';
+                        validationEl.textContent = error.message || 'Unable to revoke household access.';
                         validationEl.className = 'text-xs rounded-lg px-3 py-2 bg-red-50 text-red-700 border border-red-200';
                     }
-                    button.textContent = 'Remove';
+                    button.textContent = 'Revoke access';
                     button.disabled = false;
                 }
             });

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -424,7 +424,7 @@
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
         import { handleParentTeamFeeCheckoutClick, renderParentTeamFees } from './js/parent-dashboard-fees.js?v=6';
         import { initiateTeamFeeCheckout } from './js/stripe-service.js?v=1';
-        import { renderFamilyPlanSection } from './js/family-plan.js?v=2';
+        import { renderFamilyPlanSection } from './js/family-plan.js?v=3';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -607,16 +607,20 @@
                 "notifyRideClaimUpdated",
                 "notifyRideOfferCancelled",
                 "notifyRideOfferCreated",
+                "revokeHouseholdMemberAccess",
                 "resolveFamilyShareTokenChildren",
                 "sendPracticePacketDueTomorrowReminders"
             ],
             "unitTests": [
                 "functions/test/family-share-core.test.cjs",
+                "functions/test/household-access-core.test.cjs",
                 "tests/unit/app-parent-tools-household-service.test.js",
                 "tests/unit/app-parent-tools-service.test.js",
                 "tests/unit/app-parent-tools-single-event-ics.test.ts",
                 "tests/unit/family-calendar-failures.test.js",
                 "tests/unit/family-plan.test.js",
+                "tests/unit/household-access-revocation-rules.test.js",
+                "tests/unit/household-access-revocation.test.js",
                 "tests/unit/family-share-legacy-token.test.js",
                 "tests/unit/family-share-token-rules.test.js"
             ],

--- a/tests/unit/family-plan.test.js
+++ b/tests/unit/family-plan.test.js
@@ -239,65 +239,45 @@ describe('family plan helpers', () => {
 
         expect(markup).toContain('Family Plan');
         expect(markup).toContain('Household player access');
+        expect(markup).toContain('data-family-plan-remove="pending@example.com"');
+        expect(markup).toContain('aria-label="Revoke household access for pending@example.com"');
+        expect(markup).toContain('Revoke access');
     });
 
-    it('marks a family member as removed instead of deleting the record', async () => {
-        const updateDoc = vi.fn().mockResolvedValue();
+    it('routes family member revocation through the authoritative callable', async () => {
+        const callable = vi.fn().mockResolvedValue({ data: {
+            success: true,
+            membershipId: 'member-1',
+            revokedUserId: 'contact-1'
+        } });
         const firebase = {
-            db: {},
-            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
-            updateDoc,
-            serverTimestamp: () => 'server-now'
+            functions: {},
+            httpsCallable: vi.fn(() => callable)
         };
 
-        await removeFamilyMember('user-1', 'member-1', { deps: { firebase } });
+        await expect(removeFamilyMember('organizer', 'member-1', { deps: { firebase } })).resolves.toMatchObject({
+            success: true,
+            membershipId: 'member-1',
+            revokedUserId: 'contact-1'
+        });
 
-        expect(firebase.doc).toHaveBeenCalledWith({}, 'users', 'user-1', 'familyMemberships', 'member-1');
-        expect(updateDoc).toHaveBeenCalledWith({ path: 'users/user-1/familyMemberships/member-1' }, expect.objectContaining({
-            status: 'removed',
-            accessStatus: 'revoked',
-            removedAt: 'server-now'
-        }));
+        expect(firebase.httpsCallable).toHaveBeenCalledWith(firebase.functions, 'revokeHouseholdMemberAccess');
+        expect(callable).toHaveBeenCalledWith({ membershipId: 'member-1' });
     });
 
-    it('revokes invite tokens before marking a member removed without unprivileged profile or player writes', async () => {
-        const updateDoc = vi.fn().mockResolvedValue();
-        const docs = new Map([
-            ['users/organizer/familyMemberships/member-1', {
-                email: 'household@example.com',
-                userId: 'contact-1',
-                accessCodeId: 'code-1',
-                status: 'active',
-                organizerUserId: 'organizer',
-                playerAccess: [{ teamId: 'team-1', playerId: 'player-1', teamName: 'Team', playerName: 'Player' }]
-            }]
-        ]);
+    it('surfaces callable revocation failures without mutating Firestore in the browser', async () => {
+        const callable = vi.fn().mockRejectedValue(new Error('permission denied'));
         const firebase = {
-            db: {},
-            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
-            getDoc: vi.fn(async (ref) => ({
-                exists: () => docs.has(ref.path),
-                data: () => docs.get(ref.path) || {}
-            })),
-            updateDoc,
-            serverTimestamp: () => 'server-now'
+            functions: {},
+            httpsCallable: vi.fn(() => callable),
+            updateDoc: vi.fn(),
+            setDoc: vi.fn()
         };
 
-        await removeFamilyMember('organizer', 'member-1', { deps: { firebase } });
+        await expect(removeFamilyMember('organizer', 'member-1', { deps: { firebase } })).rejects.toThrow('permission denied');
 
-        expect(updateDoc).toHaveBeenNthCalledWith(1, { path: 'accessCodes/code-1' }, expect.objectContaining({
-            revoked: true,
-            used: true,
-            revokedAt: 'server-now'
-        }));
-        expect(updateDoc).toHaveBeenNthCalledWith(2, { path: 'users/organizer/familyMemberships/member-1' }, expect.objectContaining({
-            status: 'removed',
-            accessStatus: 'revoked',
-            removedAt: 'server-now'
-        }));
-        const updatedPaths = updateDoc.mock.calls.map(([ref]) => ref.path);
-        expect(updatedPaths).not.toContain('users/contact-1');
-        expect(updatedPaths).not.toContain('teams/team-1/players/player-1');
+        expect(firebase.updateDoc).not.toHaveBeenCalled();
+        expect(firebase.setDoc).not.toHaveBeenCalled();
     });
 
     it('marks a pending household invite revoked and invalidates its access code', async () => {
@@ -390,16 +370,15 @@ describe('family plan helpers', () => {
         });
     });
 
-    it('grants parents read/create/update access to their family membership shell records', () => {
+    it('requires family membership revocation to use the backend while preserving invite setup and acceptance writes', () => {
         const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
         expect(rules).toContain('match /familyMemberships/{memberId}');
         expect(rules).toContain('allow read: if isOwner(userId) || isGlobalAdmin();');
         expect(rules).toContain('allow create: if isOwner(userId) && isFamilyMembershipPayloadValid');
-        expect(rules).toContain('allow update: if isOwner(userId) &&');
-        expect(rules).toContain("affectedKeys().hasOnly(['status', 'accessStatus', 'updatedAt', 'removedAt'])");
-        expect(rules).toContain("data.accessStatus == 'revoked'");
         expect(rules).toContain('isFamilyMembershipInviteMetadataUpdate');
         expect(rules).toContain('isFamilyMembershipAcceptance');
+        expect(rules).not.toContain('function isFamilyMembershipRemoval');
+        expect(rules).not.toContain("affectedKeys().hasOnly(['status', 'accessStatus', 'updatedAt', 'removedAt'])");
         expect(rules).toContain('allow delete: if false;');
     });
 

--- a/tests/unit/household-access-revocation-rules.test.js
+++ b/tests/unit/household-access-revocation-rules.test.js
@@ -1,0 +1,72 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment
+} from '@firebase/rules-unit-testing';
+import { doc, setDoc, updateDoc } from 'firebase/firestore';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('household access revocation rules', () => {
+    let testEnv;
+
+    beforeAll(async () => {
+        testEnv = await initializeTestEnvironment({
+            projectId: `allplays-household-revocation-${Date.now()}`,
+            firestore: { rules }
+        });
+    }, 30000);
+
+    beforeEach(async () => {
+        await testEnv.clearFirestore();
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), 'users/organizer-1/familyMemberships/member-1'), {
+                email: 'contact@example.com',
+                organizerUserId: 'organizer-1',
+                status: 'pending',
+                teamId: 'team-1',
+                playerId: 'player-1'
+            });
+        });
+    });
+
+    afterAll(async () => {
+        await testEnv?.cleanup();
+    });
+
+    it('blocks organizer shell-only revocation while preserving setup and invited-user acceptance writes', async () => {
+        const organizerDb = testEnv.authenticatedContext('organizer-1', { email: 'organizer@example.com' }).firestore();
+        const invitedDb = testEnv.authenticatedContext('contact-1', { email: 'contact@example.com' }).firestore();
+        const membershipPath = 'users/organizer-1/familyMemberships/member-1';
+
+        await assertSucceeds(updateDoc(doc(organizerDb, membershipPath), {
+            accessCodeId: 'code-1',
+            accessCode: 'HOME1234',
+            inviteUrl: 'accept-invite.html?code=HOME1234',
+            updatedAt: 'now'
+        }));
+        await assertFails(updateDoc(doc(organizerDb, membershipPath), {
+            status: 'removed',
+            accessStatus: 'revoked',
+            removedAt: 'now',
+            updatedAt: 'now'
+        }));
+        await assertSucceeds(updateDoc(doc(invitedDb, membershipPath), {
+            status: 'active',
+            userId: 'contact-1',
+            acceptedAt: 'now',
+            updatedAt: 'now'
+        }));
+    });
+
+    it('keeps unauthenticated and unrelated users from mutating the membership', async () => {
+        const unrelatedDb = testEnv.authenticatedContext('other-user', { email: 'other@example.com' }).firestore();
+        const publicDb = testEnv.unauthenticatedContext().firestore();
+        const membershipPath = 'users/organizer-1/familyMemberships/member-1';
+
+        await assertFails(updateDoc(doc(unrelatedDb, membershipPath), { status: 'removed' }));
+        await assertFails(updateDoc(doc(publicDb, membershipPath), { status: 'removed' }));
+    });
+});

--- a/tests/unit/household-access-revocation.test.js
+++ b/tests/unit/household-access-revocation.test.js
@@ -23,6 +23,12 @@ describe('authoritative household access revocation', () => {
         expect(handler).toContain("const teamId = membershipTeamId ? normalizeFirestoreId(membershipTeamId, 'teamId') : '';");
         expect(handler).toContain("const membershipPlayerId = String(membership.playerId || '').trim();");
         expect(handler).toContain("const playerId = membershipPlayerId ? normalizeFirestoreId(membershipPlayerId, 'playerId') : '';");
+        expect(handler).toContain(".where('usedBy', '==', invitedUserId)");
+        expect(handler).toContain(".where('teamId', '==', teamId)");
+        expect(handler).toContain(".where('playerId', '==', playerId)");
+        expect(handler).toContain('playerRef ? transaction.get(playerRef)');
+        expect(handler).toContain('accessCodes: allAccessCodes');
+        expect(handler).toContain('player,');
         expect(handler).toContain('const privateProfileRef = invitedUserId && teamId && playerId');
         expect(handler).not.toContain("throw new functions.https.HttpsError('failed-precondition', 'Household membership is missing its delegated player link.');");
         expect(handler).toContain('transaction.set(membershipRef, plan.membershipUpdate, { merge: true });');

--- a/tests/unit/household-access-revocation.test.js
+++ b/tests/unit/household-access-revocation.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function extractHandler(source, exportName) {
+    const start = source.indexOf(`exports.${exportName} = functions.https.onCall`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const nextExport = source.indexOf('\nexports.', start + 1);
+    return source.slice(start, nextExport === -1 ? source.length : nextExport);
+}
+
+describe('authoritative household access revocation', () => {
+    it('performs membership, token, invited-user, public projection, and private-player cleanup in one transaction', () => {
+        const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+        const handler = extractHandler(source, 'revokeHouseholdMemberAccess');
+
+        expect(handler).toContain("if (!context.auth?.uid)");
+        expect(handler).toContain('const organizerUserId = context.auth.uid;');
+        expect(handler).toContain('firestore.runTransaction(async (transaction) =>');
+        expect(handler).toContain('transaction.get(membershipRef)');
+        expect(handler).toContain(".where('familyMembershipId', '==', membershipId)");
+        expect(handler).toContain('buildHouseholdAccessRevocationPlan');
+        expect(handler).toContain('transaction.set(membershipRef, plan.membershipUpdate, { merge: true });');
+        expect(handler).toContain('transaction.set(userRef, {');
+        expect(handler).toContain('buildTrustedPublicUserProfileProjectionPayload(nextUserData');
+        expect(handler).toContain('transaction.set(privateProfileRef, {');
+        expect(handler).toContain('revokedUserId: plan.invitedUserId || null');
+    });
+
+    it('routes Parent Dashboard removal through the callable and exposes revoke copy', () => {
+        const source = readFileSync(new URL('../../js/family-plan.js', import.meta.url), 'utf8');
+
+        expect(source).toContain("httpsCallable(functions, 'revokeHouseholdMemberAccess')");
+        expect(source).toContain('await revokeAccess({ membershipId: memberId })');
+        expect(source).toContain('>Revoke access</button>');
+        expect(source).not.toContain("updateDoc(memberRef, {\n        status: 'removed'");
+    });
+
+    it('blocks organizer-side shell revocation writes so cleanup cannot be bypassed', () => {
+        const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+        const familyMembershipBlock = rules.slice(
+            rules.indexOf('match /familyMemberships/{memberId}'),
+            rules.indexOf('match /householdInvites/{inviteId}')
+        );
+
+        expect(familyMembershipBlock).toContain('isFamilyMembershipInviteMetadataUpdate');
+        expect(familyMembershipBlock).toContain('isFamilyMembershipAcceptance');
+        expect(familyMembershipBlock).not.toContain('isFamilyMembershipRemoval');
+        expect(rules).not.toContain('function isFamilyMembershipRemoval');
+    });
+});

--- a/tests/unit/household-access-revocation.test.js
+++ b/tests/unit/household-access-revocation.test.js
@@ -18,6 +18,10 @@ describe('authoritative household access revocation', () => {
         expect(handler).toContain('firestore.runTransaction(async (transaction) =>');
         expect(handler).toContain('transaction.get(membershipRef)');
         expect(handler).toContain(".where('familyMembershipId', '==', membershipId)");
+        expect(handler).toContain('const acceptedMatchingCode = accessCodes.find');
+        expect(handler).toContain('isAcceptedHouseholdAccessCode(codeData)');
+        expect(handler).toContain("const invitedUserIdValue = acceptedMatchingCode?.usedBy || '';");
+        expect(handler).not.toContain('const invitedUserIdValue = membership.userId');
         expect(handler).toContain('buildHouseholdAccessRevocationPlan');
         expect(handler).toContain("const membershipTeamId = String(membership.teamId || '').trim();");
         expect(handler).toContain("const teamId = membershipTeamId ? normalizeFirestoreId(membershipTeamId, 'teamId') : '';");

--- a/tests/unit/household-access-revocation.test.js
+++ b/tests/unit/household-access-revocation.test.js
@@ -19,6 +19,12 @@ describe('authoritative household access revocation', () => {
         expect(handler).toContain('transaction.get(membershipRef)');
         expect(handler).toContain(".where('familyMembershipId', '==', membershipId)");
         expect(handler).toContain('buildHouseholdAccessRevocationPlan');
+        expect(handler).toContain("const membershipTeamId = String(membership.teamId || '').trim();");
+        expect(handler).toContain("const teamId = membershipTeamId ? normalizeFirestoreId(membershipTeamId, 'teamId') : '';");
+        expect(handler).toContain("const membershipPlayerId = String(membership.playerId || '').trim();");
+        expect(handler).toContain("const playerId = membershipPlayerId ? normalizeFirestoreId(membershipPlayerId, 'playerId') : '';");
+        expect(handler).toContain('const privateProfileRef = invitedUserId && teamId && playerId');
+        expect(handler).not.toContain("throw new functions.https.HttpsError('failed-precondition', 'Household membership is missing its delegated player link.');");
         expect(handler).toContain('transaction.set(membershipRef, plan.membershipUpdate, { merge: true });');
         expect(handler).toContain('transaction.set(userRef, {');
         expect(handler).toContain('buildTrustedPublicUserProfileProjectionPayload(nextUserData');

--- a/tests/unit/parent-dashboard-ics-export.test.js
+++ b/tests/unit/parent-dashboard-ics-export.test.js
@@ -34,7 +34,7 @@ const Blob = deps.Blob;
         .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
         .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/parent-dashboard-fees\.js\?v=\d+';/, 'const { handleParentTeamFeeCheckoutClick, renderParentTeamFees } = deps.parentDashboardFees;')
         .replace(/import\s*\{\s*initiateTeamFeeCheckout\s*\}\s*from '\.\/js\/stripe-service\.js\?v=\d+';/, 'const { initiateTeamFeeCheckout } = deps.stripeService;')
-        .replace("import { renderFamilyPlanSection } from './js/family-plan.js?v=2';", 'const { renderFamilyPlanSection } = deps.familyPlan;')
+        .replace("import { renderFamilyPlanSection } from './js/family-plan.js?v=3';", 'const { renderFamilyPlanSection } = deps.familyPlan;')
         .replace("import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';", 'const { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } = deps.availabilityPreferences;')
         .replace(/\binit\(\);\s*$/, `
 window.__parentDashboardIcsTestHooks = {


### PR DESCRIPTION
## Summary

- add an organizer-authenticated Cloud Function that revokes a family membership and related household invite tokens in one Firestore transaction
- remove the accepted contact's exact parent/player link, recompute derived team/player access keys, refresh the public profile projection, and remove the matching private player parent entry while preserving unrelated links
- route Parent Dashboard's visible **Revoke access** action through the authoritative callable and block browser-only membership-shell revocation in Firestore rules
- add pure server regression tests, client/callable wiring tests, coverage-map registration, and Firestore rules-engine coverage

## Root cause

Parent Dashboard previously marked only the organizer's `familyMemberships` shell as removed and revoked the invite token. Accepted household redemption had already written durable access to the invited user's `parentOf`, `parentTeamIds`, and `parentPlayerKeys` plus the player's private parent list, so those grants survived the client-side removal.

## Validation

- targeted Vitest: 35 passed
- Functions test suite: 50 passed
- household revocation core: 4 passed
- Firestore emulator rules tests: 2 passed
- `npm run app:build`: passed
- JavaScript syntax checks and `git diff --check`: passed
- full root unit suite was attempted after all locked dependencies were installed; it progressed through 1,962 passing tests before the host ran out of disk space (`ENOSPC`), causing remaining suite-load failures unrelated to this diff

Fixes #3380