### PR TITLE
Show registration description before form fields

### DIFF
--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -151,6 +151,57 @@ function renderParentRegistrationWithRouteSwap() {
   );
 }
 
+describe('RegistrationDetail registration description', () => {
+  beforeEach(() => {
+    Object.values(parentRegistrationsServiceMocks).forEach((mock) => mock.mockReset());
+    openPublicUrlMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a trimmed public registration description before participant fields', async () => {
+    parentRegistrationsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      form: {
+        description: '  Open to players ages 9–12.\nBring a water bottle.  ',
+        participantFields: [{ id: 'name', label: 'Player name', type: 'text', required: true }]
+      }
+    }));
+
+    renderPublicRegistration();
+
+    const description = await screen.findByLabelText('Registration description');
+    const participantHeading = screen.getByRole('heading', { name: 'Participant information' });
+
+    expect(description).toHaveTextContent('Open to players ages 9–12. Bring a water bottle.');
+    expect(description.compareDocumentPosition(participantHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('omits whitespace-only descriptions and preserves the parent submit flow', async () => {
+    parentRegistrationsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail({
+      form: {
+        description: '  \n\t ',
+        participantFields: [{ id: 'name', label: 'Player name', type: 'text', required: false }]
+      }
+    }));
+    parentRegistrationsServiceMocks.submitOfflineRegistration.mockResolvedValue({
+      status: 'pending',
+      registrationId: 'registration-1'
+    });
+
+    renderParentRegistration();
+
+    const submitButton = await screen.findByRole('button', { name: 'Submit registration' });
+    expect(screen.queryByLabelText('Registration description')).toBeNull();
+    expect(screen.getByRole('heading', { name: 'Participant information' })).toBeTruthy();
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(parentRegistrationsServiceMocks.submitOfflineRegistration).toHaveBeenCalledTimes(1));
+  });
+});
+
 describe('RegistrationDetail payment notice', () => {
   beforeEach(() => {
     Object.values(parentRegistrationsServiceMocks).forEach((mock) => mock.mockReset());

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -285,6 +285,7 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
 
   if (loading) return <LoadingBlock label="Loading registration" />;
   if (!form) return <EmptyState icon={Ticket} title="Registration unavailable" detail={error || 'This registration form could not be loaded.'} actionLabel={error ? 'Retry' : ''} onAction={error ? () => setReloadKey((current) => current + 1) : undefined} />;
+  const registrationDescription = String(form.description || '').trim();
 
   return (
     <div className="space-y-3">
@@ -307,6 +308,11 @@ function RegistrationDetailPage({ auth, publicAccess = false }: { auth: AuthStat
             </button>
           ) : null}
         </div>
+        {registrationDescription ? (
+          <div className="border-t border-gray-100 bg-gray-50 px-3 py-3 sm:px-4" aria-label="Registration description">
+            <p className="whitespace-pre-line text-sm font-semibold leading-6 text-gray-700">{registrationDescription}</p>
+          </div>
+        ) : null}
       </section>
 
       {message ? <Status tone="success" message={message} /> : null}

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -133,7 +133,7 @@ const parentRegistrationsServiceMock = `
                 description: 'Skills week',
                 season: 'Summer',
                 currency: 'USD',
-                participantFields: [],
+                participantFields: [{ id: 'name', label: 'Player name', type: 'text', required: false }],
                 guardianFields: [],
                 waiverText: '',
                 registrationOptionCounts: {}
@@ -563,6 +563,14 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await page.getByRole('button', { name: /Legacy form/ }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://allplays.ai/registration.html?teamId=team-1&formId=form-1');
     await page.getByRole('link', { name: /Review/ }).click();
+    const registrationDescription = page.getByLabel('Registration description');
+    await expect(registrationDescription).toHaveText('Skills week');
+    await expect(page.getByRole('heading', { name: 'Participant information' })).toBeVisible();
+    expect(await page.evaluate(() => {
+        const description = document.querySelector('[aria-label="Registration description"]');
+        const participantHeading = Array.from(document.querySelectorAll('h2')).find((heading) => heading.textContent?.trim() === 'Participant information');
+        return Boolean(description && participantHeading && (description.compareDocumentPosition(participantHeading) & Node.DOCUMENT_POSITION_FOLLOWING));
+    })).toBe(true);
     await expect(page.getByRole('button', { name: 'Pay registration with Stripe' })).toBeVisible();
     await page.getByRole('button', { name: 'Pay registration with Stripe' }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pay.example.test/registration-checkout');


### PR DESCRIPTION
## Summary
- render a trimmed, non-empty registration description directly beneath the registration header
- preserve line breaks while keeping participant, guardian, options, quantity, payment, waiver, and submit controls in the existing form flow
- add component and 390×844 Playwright coverage for populated and whitespace-only descriptions and DOM ordering

## Why
Parents need the admin-authored eligibility and program context before entering participant and guardian information.

## Root cause
`RegistrationDetail` mapped `detail.form.description` into its card model but never rendered that field before starting the parent form.

## Validation
- `npm --prefix apps/app test -- --run src/pages/RegistrationDetail.test.tsx` (14 passed)
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5183 npx playwright test tests/smoke/app-parent-tools.spec.js --config=playwright.smoke.config.js --grep 'parent tools hub completes' --reporter=line` (1 passed)
- `npm --prefix apps/app run lint` (passes with 0 errors; repository has 2,285 existing warnings)
- `npm run app:build`

Closes #3633