### PR TITLE
Keep team detail tabs reachable on mobile

### DIFF
--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -538,19 +538,25 @@ describe('TeamDetail', () => {
     expect(tabControls.getByRole('button', { name: /roster/i }).getAttribute('aria-pressed')).toBe('true');
     expect(screen.getAllByText('Add player').length).toBeGreaterThan(0);
     expect(router.state.location.search).toBe('?tab=roster');
+    vi.mocked(window.scrollTo).mockClear();
 
     fireEvent.click(tabControls.getByRole('button', { name: /schedule/i }));
     await waitFor(() => expect(router.state.location.search).toBe('?tab=schedule'));
     expect(tabControls.getByRole('button', { name: /schedule/i }).getAttribute('aria-pressed')).toBe('true');
+    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' }));
+    vi.mocked(window.scrollTo).mockClear();
 
     fireEvent.click(tabControls.getByRole('button', { name: /more/i }));
     await waitFor(() => expect(router.state.location.search).toBe('?tab=more'));
     expect(tabControls.getByRole('button', { name: /more/i }).getAttribute('aria-pressed')).toBe('true');
     expect(await screen.findByText('Stat tracker configs')).toBeTruthy();
+    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' }));
+    vi.mocked(window.scrollTo).mockClear();
 
     fireEvent.click(tabControls.getByRole('button', { name: /overview/i }));
     await waitFor(() => expect(router.state.location.search).toBe(''));
     expect(tabControls.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
+    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' }));
   });
 
   it('steps back to team overview before leaving the team hub', async () => {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TeamDetail } from './TeamDetail';
@@ -514,6 +514,8 @@ describe('TeamDetail', () => {
   });
 
   it('drives team tabs from the route search state', async () => {
+    const managedModel = { ...model, canManageTeam: true };
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(managedModel);
     const router = createMemoryRouter(
       [
         {
@@ -527,16 +529,28 @@ describe('TeamDetail', () => {
     render(<RouterProvider router={router} />);
 
     expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
-    expect(screen.getByRole('button', { name: /roster/i }).getAttribute('aria-pressed')).toBe('true');
+    const tabNav = screen.getByTestId('team-detail-tab-nav');
+    expect(tabNav.classList.contains('team-detail-tab-nav')).toBe(true);
+    expect(tabNav.classList.contains('sticky')).toBe(true);
+    expect(tabNav.classList.contains('top-24')).toBe(true);
+    expect(tabNav.querySelectorAll('button')).toHaveLength(5);
+    const tabControls = within(tabNav);
+    expect(tabControls.getByRole('button', { name: /roster/i }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getAllByText('Add player').length).toBeGreaterThan(0);
     expect(router.state.location.search).toBe('?tab=roster');
 
-    fireEvent.click(screen.getByRole('button', { name: /more/i }));
-    await waitFor(() => expect(router.state.location.search).toBe('?tab=more'));
-    expect(screen.getByRole('button', { name: /more/i }).getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(tabControls.getByRole('button', { name: /schedule/i }));
+    await waitFor(() => expect(router.state.location.search).toBe('?tab=schedule'));
+    expect(tabControls.getByRole('button', { name: /schedule/i }).getAttribute('aria-pressed')).toBe('true');
 
-    fireEvent.click(screen.getByRole('button', { name: /overview/i }));
+    fireEvent.click(tabControls.getByRole('button', { name: /more/i }));
+    await waitFor(() => expect(router.state.location.search).toBe('?tab=more'));
+    expect(tabControls.getByRole('button', { name: /more/i }).getAttribute('aria-pressed')).toBe('true');
+    expect(await screen.findByText('Stat tracker configs')).toBeTruthy();
+
+    fireEvent.click(tabControls.getByRole('button', { name: /overview/i }));
     await waitFor(() => expect(router.state.location.search).toBe(''));
-    expect(screen.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
+    expect(tabControls.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
   });
 
   it('steps back to team overview before leaving the team hub', async () => {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -364,7 +364,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     } else {
       scroll();
     }
-  }, [teamId]);
+  }, [teamId, activeTab]);
 
   async function refreshTeamDetail() {
     if (!teamId) return;

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -499,8 +499,12 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     <div className="team-detail-page space-y-4">
       <TeamHero model={model} />
 
-      <section className="app-card p-2">
-        <div className="grid grid-cols-5 gap-1">
+      <nav
+        className="team-detail-tab-nav sticky top-24 z-30 -mx-1 bg-gray-50/95 py-2 backdrop-blur"
+        aria-label="Team detail sections"
+        data-testid="team-detail-tab-nav"
+      >
+        <div className="app-card grid grid-cols-5 gap-1 p-2">
           {tabs.map((tab) => {
             const Icon = tab.icon;
             const selected = activeTab === tab.id;
@@ -522,7 +526,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
             );
           })}
         </div>
-      </section>
+      </nav>
 
       {activeTab === 'overview' ? <OverviewTab model={model} /> : null}
       {activeTab === 'schedule' ? (

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -113,6 +113,10 @@
   box-shadow: 0 10px 24px rgba(16, 24, 40, 0.07);
 }
 
+.team-detail-tab-nav {
+  top: calc(52px + max(12px, env(safe-area-inset-top)));
+}
+
 .add-workflow-panel {
   max-height: calc(100dvh - max(16px, env(safe-area-inset-top)) - max(16px, env(safe-area-inset-bottom)) - 24px);
   overflow: hidden;
@@ -1659,6 +1663,17 @@
 
 .desktop-app-page .teams-grid {
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.desktop-app-page .team-detail-tab-nav {
+  position: static;
+  top: auto;
+  z-index: auto;
+  margin-right: 0;
+  margin-left: 0;
+  background: transparent;
+  padding: 0;
+  backdrop-filter: none;
 }
 
 .desktop-app-page .teams-page-web {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -36,12 +36,13 @@ async function waitForTeamDetailRoute(page, teamName) {
     }).toPass({ timeout: 45000 });
 }
 
-async function mockTeamsModules(page, { scenario = '' } = {}) {
-    await page.addInitScript(({ scenarioName }) => {
+async function mockTeamsModules(page, { scenario = '', managedTeam = false } = {}) {
+    await page.addInitScript(({ scenarioName, shouldManageTeam }) => {
         window.__openedPublicUrls = [];
         window.__homeLoads = 0;
         window.__teamsScenario = scenarioName;
-    }, { scenarioName: scenario });
+        window.__managedTeam = shouldManageTeam;
+    }, { scenarioName: scenario, shouldManageTeam: managedTeam });
 
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {
         await route.fulfill({
@@ -445,8 +446,8 @@ async function mockTeamsModules(page, { scenario = '' } = {}) {
                         ] }],
                         sponsors: [{ id: 'sponsor-1', name: 'Pizza Place', description: 'After the game', imageUrl: 'https://img.example.test/pizza.png', websiteUrl: 'https://pizza.example.test' }],
                         statTrackerConfigs: [],
-                        canManageTeam: false,
-                        canManageAdmins: false,
+                        canManageTeam: window.__managedTeam,
+                        canManageAdmins: window.__managedTeam,
                         staffPermissions: null,
                         counts: { games: 8, practices: 3, completedGames: 6 }
                     };
@@ -648,6 +649,46 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('No teams available')).toHaveCount(0);
     });
 
+    test('keeps team detail tabs reachable while managing a long mobile roster', async ({ page, baseURL }) => {
+        await mockTeamsModules(page, { managedTeam: true });
+        await page.goto(appUrl(baseURL, '/teams/team-1?tab=roster'), { waitUntil: 'domcontentloaded' });
+
+        await waitForTeamDetailRoute(page, 'Bears');
+        const tabNav = page.getByTestId('team-detail-tab-nav');
+        await expect(tabNav).toBeVisible();
+        await expect(page.getByText('Add player').first()).toBeVisible();
+        await expect(tabNav.getByRole('button', { name: /Roster/ })).toHaveAttribute('aria-pressed', 'true');
+        expect(await tabNav.evaluate((node) => window.getComputedStyle(node).position)).toBe('sticky');
+
+        await page.evaluate(() => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'instant' }));
+        await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(200);
+        await expect(tabNav).toBeVisible();
+
+        const shellHeader = page.locator('.app-page > header');
+        const bottomNav = page.getByRole('navigation', { name: 'Primary navigation' });
+        await expect.poll(async () => {
+            const headerBox = await shellHeader.boundingBox();
+            const tabsBox = await tabNav.boundingBox();
+            const bottomBox = await bottomNav.boundingBox();
+            if (!headerBox || !tabsBox || !bottomBox) return false;
+            return tabsBox.y >= headerBox.y + headerBox.height - 1
+                && tabsBox.y + tabsBox.height <= bottomBox.y + 1;
+        }).toBe(true);
+
+        await tabNav.getByRole('button', { name: /More/ }).click();
+        await expect(page).toHaveURL(/#\/teams\/team-1\?tab=more$/);
+        const statConfigs = page.getByText('Stat tracker configs', { exact: true });
+        await expect(statConfigs).toBeAttached();
+        await statConfigs.evaluate((node) => node.scrollIntoView({ block: 'center' }));
+        await expect(statConfigs).toBeVisible();
+        await expect(tabNav).toBeVisible();
+
+        await tabNav.getByRole('button', { name: /Overview/ }).click();
+        await expect(page).toHaveURL(/#\/teams\/team-1$/);
+        await expect(tabNav.getByRole('button', { name: /Overview/ })).toHaveAttribute('aria-pressed', 'true');
+        await expect(page.getByText('Parent actions')).toBeAttached();
+    });
+
     test('team detail tabs expose parent-facing team page features', async ({ page, baseURL }) => {
         await mockTeamsModules(page);
         await page.goto(appUrl(baseURL, '/teams/team-1'), { waitUntil: 'domcontentloaded' });
@@ -767,5 +808,17 @@ test.describe('desktop My Teams', () => {
         await expect(page.getByRole('link', { name: 'Open Rockets' })).toBeVisible();
         await expect(page.getByRole('link', { name: 'Open Bears' })).toHaveCount(0);
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
+    });
+
+    test('keeps the team detail tab navigation static on desktop', async ({ page, baseURL }) => {
+        await mockTeamsModules(page, { managedTeam: true });
+        await page.goto(appUrl(baseURL, '/teams/team-1?tab=roster'), { waitUntil: 'domcontentloaded' });
+
+        await waitForTeamDetailRoute(page, 'Bears');
+        const tabNav = page.getByTestId('team-detail-tab-nav');
+        await expect(tabNav).toBeVisible();
+        await expect(tabNav).toHaveCount(1);
+        expect(await tabNav.evaluate((node) => window.getComputedStyle(node).position)).toBe('static');
+        await expect(tabNav.getByRole('button', { name: /Roster/ })).toHaveAttribute('aria-pressed', 'true');
     });
 });


### PR DESCRIPTION
## What changed

- keep the existing Overview, Schedule, Roster, Insights, and More controls in one semantic TeamDetail navigation bar
- make that bar sticky in the mobile shell with a safe-area-aware offset below the app header
- keep the sticky bar layered above long roster/settings content and below the fixed bottom navigation
- explicitly restore static positioning and the existing card presentation on desktop web
- add stable selectors plus managed-roster route, mobile positioning, and desktop regression coverage

## Why

The TeamDetail tab card previously scrolled out of reach during long roster and team-management workflows. Users had to return to the top before switching tabs because TeamDetail did not use the sticky mobile detail-navigation pattern already present elsewhere in the app.

## Validation

- `npm --prefix apps/app test -- --run src/pages/TeamDetail.test.tsx --reporter=dot` (26 passed)
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5175 npx playwright test --config=playwright.smoke.config.js tests/smoke/app-teams.spec.js` (10 passed)
- focused mobile and desktop sticky-nav smoke checks (2 passed after the safe-area offset refinement)
- `npm run app:build`

Closes #3632
