### PR TITLE
Improve mobile search clearing

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -140,6 +140,34 @@ describe('AppSearchDialog', () => {
     preloadSearchRouteMock.mockImplementation(async () => true);
   });
 
+  it('uses mobile search hints and clears the query without closing or losing focus', async () => {
+    const onClose = vi.fn();
+    searchAppPlayersMock.mockRejectedValueOnce(new Error('Player search unavailable for this account.'));
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByLabelText('Search teams, players, actions, help');
+    expect(input).toHaveAttribute('type', 'search');
+    expect(input).toHaveAttribute('enterkeyhint', 'search');
+    expect(input).toHaveAttribute('autocomplete', 'off');
+
+    fireEvent.change(input, { target: { value: 'error' } });
+    expect(await screen.findByText('Player search unavailable for this account.')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search query' }));
+
+    await waitFor(() => expect(input).toHaveValue(''));
+    expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy();
+    expect(screen.getByText('Type at least 2 characters to search players')).toBeTruthy();
+    expect(screen.queryByText('Player search unavailable for this account.')).toBeNull();
+    expect(input).toHaveFocus();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('shows player guidance while keeping player results hidden until search has a real query', async () => {
     const onClose = vi.fn();
 

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -168,6 +168,31 @@ describe('AppSearchDialog', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('lets Enter on the clear button stay scoped to clearing instead of opening the highlighted result', async () => {
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByLabelText('Search teams, players, actions, help');
+    fireEvent.change(input, { target: { value: 'ro' } });
+
+    const clearButton = screen.getByRole('button', { name: 'Clear search query' });
+    clearButton.focus();
+    fireEvent.keyDown(clearButton, { key: 'Enter' });
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(clearButton);
+
+    await waitFor(() => expect(input).toHaveValue(''));
+    expect(input).toHaveFocus();
+  });
+
   it('shows player guidance while keeping player results hidden until search has a real query', async () => {
     const onClose = vi.fn();
 

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -393,6 +393,11 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
                     type="button"
                     className="absolute right-1.5 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-lg text-gray-500 transition hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary-200"
                     onClick={clearQuery}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter') {
+                        event.stopPropagation();
+                      }
+                    }}
                     aria-label="Clear search query"
                   >
                     <X className="h-4 w-4" aria-hidden="true" />

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -41,6 +41,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [keyboardInset, setKeyboardInset] = useState(0);
   const searchRequestId = useRef(0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const openedAtRef = useRef(Date.now());
   const preloadedRoutesRef = useRef(new Set<string>());
   const baseTeamsRef = useRef<AppSearchTeam[]>([]);
@@ -298,6 +299,12 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     });
   };
 
+  const clearQuery = () => {
+    searchRequestId.current += 1;
+    setQuery('');
+    searchInputRef.current?.focus();
+  };
+
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Escape') {
       event.preventDefault();
@@ -368,14 +375,30 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               <Search className="h-5 w-5" aria-hidden="true" />
             </span>
             <div className="min-w-0 flex-1">
-              <input
-                autoFocus
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                className="min-h-11 w-full rounded-xl border border-gray-200 px-3 text-base font-semibold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
-                placeholder="Search teams, players, actions, help..."
-                aria-label="Search teams, players, actions, help"
-              />
+              <div className="relative">
+                <input
+                  ref={searchInputRef}
+                  autoFocus
+                  type="search"
+                  enterKeyHint="search"
+                  autoComplete="off"
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  className="min-h-11 w-full rounded-xl border border-gray-200 px-3 pr-11 text-base font-semibold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+                  placeholder="Search teams, players, actions, help..."
+                  aria-label="Search teams, players, actions, help"
+                />
+                {query ? (
+                  <button
+                    type="button"
+                    className="absolute right-1.5 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-lg text-gray-500 transition hover:bg-gray-100 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                    onClick={clearQuery}
+                    aria-label="Clear search query"
+                  >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                ) : null}
+              </div>
               <div className="mt-2 hidden text-xs font-semibold text-gray-500 sm:block">
                 Use arrow keys to move, Enter to open, Esc to close.
               </div>

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -434,6 +434,13 @@ test.describe('app global search', () => {
         await expect(page.getByRole('button', { name: /Bears Basketball/ })).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__teamSearchQueries)).toEqual(['bea']);
 
+        await page.getByRole('button', { name: 'Clear search query' }).click();
+        await expect(page.getByLabel('Search teams, players, actions, help')).toHaveValue('');
+        await expect(page.getByLabel('Search teams, players, actions, help')).toBeFocused();
+        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+        await expect(page.getByText('Type at least 2 characters to search players')).toBeVisible();
+        await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
+
         await page.getByLabel('Search teams, players, actions, help').fill('pat');
         await expect(page.getByText('#9 Pat Star')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual(['bea', 'pat']);
@@ -456,6 +463,10 @@ test.describe('app global search', () => {
         await expect(page.getByText('No matching players')).toBeVisible();
         await expect(page.getByText('No results')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual(['zzzz']);
+
+        await page.getByRole('button', { name: 'Clear search query' }).click();
+        await expect(page.getByLabel('Search teams, players, actions, help')).toHaveValue('');
+        await expect(page.getByText('No results')).toBeHidden();
 
         await page.getByLabel('Search teams, players, actions, help').fill('error');
         await expect(page.getByText('Player search unavailable for this account.')).toBeVisible();


### PR DESCRIPTION
## Summary
- make the global search input expose mobile search keyboard hints
- add an accessible inline clear-query action that keeps the dialog open and restores focus
- invalidate in-flight player searches when clearing so stale results cannot repopulate the reset view
- extend component and 390px mobile smoke coverage for clearing from result, no-result, and error states

## Investigation and design
The dialog used a generic controlled input and only exposed a separate action that closed the entire dialog. The clear action now follows the existing controlled-query path, increments the request generation to ignore an outstanding async search, and focuses the input ref after resetting.

## Requirements covered
- clear action is visible only for a non-empty query
- clearing returns the initial guidance state without calling `onClose`
- input remains focused and the dialog remains open
- `type="search"`, `enterKeyHint="search"`, and `autoComplete="off"` are exposed
- the existing close action stays separate
- the 390px layout does not overflow

## Test plan and results
- `npm --prefix apps/app run test:ci -- src/components/AppSearchDialog.test.tsx` — 17 passed
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5176 npx playwright test tests/smoke/app-search.spec.js --config=playwright.smoke.config.js --reporter=line -g 'mobile search' --workers=1 --timeout=90000` — 2 passed
- `npm run app:build` — passed
- focused ESLint — 0 errors (existing warnings only)

Closes #3590.