### PR TITLE
Add mobile conversation quick-switch chips

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1439,6 +1439,35 @@ export function ChatWindow({
             })}
           </div>
         ) : null}
+
+        {!isDesktopWeb && conversationSheetConversations.length > 1 ? (
+          <div
+            className="chat-mobile-conversation-chips mt-3 flex w-full max-w-full gap-2 overflow-x-auto pb-1"
+            aria-label="Quick conversation switcher"
+            data-testid="mobile-conversation-chips"
+          >
+            {conversationSheetConversations.map((conversation) => {
+              const active = conversation.id === effectiveConversationId;
+              const label = getConversationDisplayName(conversation, team || {});
+              return (
+                <button
+                  key={conversation.id}
+                  type="button"
+                  className={`shrink-0 rounded-full border px-3 py-1.5 text-xs font-black transition ${
+                    active
+                      ? 'border-primary-600 bg-primary-600 text-white shadow-sm'
+                      : 'border-gray-200 bg-white text-gray-700 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700'
+                  }`}
+                  onClick={() => handleConversationSelect(conversation.id)}
+                  aria-label={`Switch to ${label}`}
+                  aria-pressed={active}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
       </section>
 
       {status ? <StatusBanner status={status} onClose={() => setStatus(null)} /> : null}

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import '@testing-library/jest-dom/vitest';
 import * as React from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureStaffChatConversation, type ChatConversation, type ChatMessage } from '../../../lib/chatService';
@@ -646,7 +646,7 @@ describe('ChatWindow virtualization', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /Team chat/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Team chat', exact: true }));
     expect(screen.getByRole('dialog', { name: 'Conversations' })).toBeVisible();
 
     fireEvent.click(screen.getByRole('button', { name: 'Open photos and videos' }));
@@ -765,6 +765,65 @@ describe('ChatWindow deferred conversation hydration', () => {
 });
 
 describe('ChatWindow conversation switching', () => {
+  it('quick-switches an existing mobile conversation without opening the selector sheet', () => {
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] },
+      { id: 'direct-parent', type: 'direct', name: 'Pat Parent', participantIds: ['parent-1'], participantRoles: ['parent'] },
+      { id: 'travel-group', type: 'group', name: 'Tournament travel', participantIds: ['coach-1', 'parent-1'], participantRoles: ['staff', 'parent'] }
+    ];
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    const quickSwitcher = screen.getByTestId('mobile-conversation-chips');
+    expect(quickSwitcher.classList.contains('overflow-x-auto')).toBe(true);
+    expect(within(quickSwitcher).getAllByRole('button')).toHaveLength(4);
+    expect(within(quickSwitcher).getByRole('button', { name: 'Switch to Team chat' })).toHaveAttribute('aria-pressed', 'true');
+    expect(within(quickSwitcher).getByRole('button', { name: 'Switch to Staff only' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByRole('dialog', { name: 'Conversations' })).toBeNull();
+
+    fireEvent.click(within(quickSwitcher).getByRole('button', { name: 'Switch to Staff only' }));
+
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
+    expect(ensureStaffChatConversation).not.toHaveBeenCalled();
+    expect(mockChatSheetsState.openConversationSheet).not.toHaveBeenCalled();
+  });
+
+  it('creates and switches to Staff only from the mobile quick-switcher', async () => {
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
+    ];
+    vi.mocked(ensureStaffChatConversation).mockResolvedValue({
+      id: 'staff-conversation',
+      type: 'group',
+      name: 'Staff only',
+      participantIds: [],
+      participantRoles: ['staff']
+    } as ChatConversation);
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    const quickSwitcher = screen.getByTestId('mobile-conversation-chips');
+    expect(screen.queryByRole('dialog', { name: 'Conversations' })).toBeNull();
+    fireEvent.click(within(quickSwitcher).getByRole('button', { name: 'Switch to Staff only' }));
+
+    await waitFor(() => {
+      expect(ensureStaffChatConversation).toHaveBeenCalledWith('team-1', auth.user, [
+        { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
+      ]);
+    });
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
+    expect(mockChatSheetsState.openConversationSheet).not.toHaveBeenCalled();
+  });
+
   it('keeps staff chat reachable from the conversation selector without audience-sheet staff routing', () => {
     mockChatSheetsState.showConversationSheet = true;
     mockChatTeamState.conversations = [

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -646,7 +646,7 @@ describe('ChatWindow virtualization', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Team chat', exact: true }));
+    fireEvent.click(screen.getByRole('button', { name: /^Team chat$/ }));
     expect(screen.getByRole('dialog', { name: 'Conversations' })).toBeVisible();
 
     fireEvent.click(screen.getByRole('button', { name: 'Open photos and videos' }));

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -1366,6 +1366,16 @@
   border-radius: 0 0 16px 16px;
 }
 
+.chat-mobile-conversation-chips {
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.chat-mobile-conversation-chips::-webkit-scrollbar {
+  display: none;
+}
+
 .desktop-app-page .chat-topbar {
   position: sticky;
   top: 84px;

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -486,6 +486,12 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await expect(page.getByRole('dialog', { name: 'Notifications' })).toBeHidden();
     await expect(page).toHaveURL(/#\/messages\/team-1$/);
     await expect(page.getByRole('button', { name: /Audience: Full team/ })).toBeVisible();
+    const quickSwitcher = page.getByTestId('mobile-conversation-chips');
+    await expect(quickSwitcher).toBeVisible();
+    await expect(quickSwitcher.getByRole('button', { name: /Switch to .*Team Chat/i })).toBeVisible();
+    await expect(quickSwitcher.getByRole('button', { name: 'Switch to Staff only' })).toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Conversations' })).toHaveCount(0);
+    await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 
     await page.getByRole('button', { name: 'Add attachment' }).click();
     await expect(page.getByRole('dialog', { name: 'Add to message' })).toBeVisible();
@@ -524,8 +530,9 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await page.getByPlaceholder('Message Bears').fill('');
 
     await page.getByRole('button', { name: /Audience: Full team/ }).click();
-    await expect(page.getByRole('button', { name: 'Staff only' })).toBeHidden();
-    await page.getByRole('button', { name: 'Close Message audience' }).click();
+    const audienceDialog = page.getByRole('dialog', { name: 'Message audience' });
+    await expect(audienceDialog.getByRole('button', { name: 'Staff only' })).toHaveCount(0);
+    await audienceDialog.getByRole('button', { name: 'Close Message audience' }).click();
 
     await page.getByPlaceholder('Message Bears').fill('See you at practice');
     await page.getByRole('button', { name: 'Send message' }).click();
@@ -538,10 +545,9 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     });
     await expect.poll(() => page.evaluate(() => window.__chatCalls.chatAiModuleRequests)).toEqual([]);
 
-    await page.getByRole('button', { name: 'Team chat' }).click();
-    const conversationsDialog = page.getByRole('dialog', { name: 'Conversations' });
-    await expect(conversationsDialog).toBeVisible();
-    await conversationsDialog.getByRole('button', { name: 'Staff only Group conversation' }).click();
+    await quickSwitcher.getByRole('button', { name: 'Switch to Staff only' }).click();
+    await expect(page.getByRole('dialog', { name: 'Conversations' })).toHaveCount(0);
+    await expect(quickSwitcher.getByRole('button', { name: 'Switch to Staff only' })).toHaveAttribute('aria-pressed', 'true');
 
     await page.getByPlaceholder('Message Bears').fill('@ALL PLAYS who needs RSVP help?');
     await page.getByRole('button', { name: 'Send message' }).click();


### PR DESCRIPTION
## Summary

- add a compact, horizontally scrollable conversation quick-switcher to the mobile chat header
- route every chip through the existing conversation-selection path, including lazy Staff-only creation
- retain the existing Conversations sheet as the fallback and preserve desktop behavior
- cover existing conversations, Staff-only creation, active state, overflow, and message targeting

## Investigation

`ChatWindow` already builds the complete `conversationSheetConversations` collection and centralizes selection in `handleConversationSelect`, but its inline chips were gated behind `isDesktopWeb`. Mobile users therefore had to open the Conversations sheet for every switch even though all required state and routing behavior were already available.

## Design and requirements

- render the quick-switcher only on non-desktop layouts when more than one destination is available
- derive chips from `conversationSheetConversations` so Team chat, Staff only, direct, and group conversations stay consistent with the sheet
- call `handleConversationSelect` so an existing conversation switches immediately and the Staff-only placeholder creates the real conversation before switching
- expose active state with `aria-pressed` and keep each chip at intrinsic width inside a horizontal scroll container
- contain horizontal overscroll and hide the strip scrollbar without introducing page-level overflow
- leave the Conversations sheet trigger and fallback behavior intact

## Test plan and results

- `ChatWindow.virtualization.test.tsx`: **24 passed**
  - existing mobile conversation switches without opening the sheet
  - Staff-only placeholder creates and switches through the shared handler
  - existing sheet behavior remains covered
- `tests/smoke/app-messages.spec.js`: **8 passed**
  - chips are visible in the mobile viewport
  - Staff-only switching does not open the sheet
  - active state and message delivery target are correct
  - the page does not develop horizontal overflow
- `npm run app:build`: **passed**

Closes #3593
