### PR TITLE
Gate invite code redemption

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -248,6 +248,37 @@ describe('ParentTools access', () => {
         expect(screen.getByRole('button', { name: 'Redeem code' })).toBeTruthy();
     });
 
+    it('keeps invite redemption disabled until the normalized code has 8 characters', async () => {
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        const input = screen.getByPlaceholderText('XXXXXXXX') as HTMLInputElement;
+        const button = screen.getByRole('button', { name: 'Redeem code' }) as HTMLButtonElement;
+        const form = input.closest('form');
+
+        expect(button.disabled).toBe(true);
+
+        fireEvent.change(input, { target: { value: '   ' } });
+        expect(button.disabled).toBe(true);
+
+        fireEvent.change(input, { target: { value: 'abc1234' } });
+        expect(button.disabled).toBe(true);
+        expect(form).not.toBeNull();
+        fireEvent.submit(form as HTMLFormElement);
+        expect(inviteRedemptionMocks.redeemSignedInInvite).not.toHaveBeenCalled();
+
+        fireEvent.change(input, { target: { value: 'ab12cd34' } });
+        expect(button.disabled).toBe(false);
+        fireEvent.click(button);
+
+        await waitFor(() => expect(inviteRedemptionMocks.redeemSignedInInvite).toHaveBeenCalledWith({
+            userId: 'parent-1',
+            code: 'AB12CD34',
+            email: 'parent@example.com',
+            refresh: auth.refresh
+        }));
+    });
+
     it('shows inline redeem errors without breaking the request form', async () => {
         inviteRedemptionMocks.redeemSignedInInvite.mockRejectedValue(new Error('Invite code expired.'));
         renderParentTools();

--- a/apps/app/src/pages/parent-tools/AccessTool.tsx
+++ b/apps/app/src/pages/parent-tools/AccessTool.tsx
@@ -62,6 +62,8 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
     const { error: redeemError } = redeemOperation;
     const manualLookupError = teamLoadError ?? playerLoadError;
     const actionError = submitError ?? redeemError;
+    const normalizedRedeemCode = redeemCode.trim().toUpperCase();
+    const redeemCodeReady = normalizedRedeemCode.length === 8;
 
     const loadTeams = useCallback(async () => {
         clearTeamLoadError();
@@ -199,6 +201,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
 
     const redeem = async (event: FormEvent) => {
         event.preventDefault();
+        if (!redeemCodeReady) return;
         const currentUser = auth.user;
         if (!currentUser?.uid) {
             setRedeemError(toAppServiceError(new Error('Sign in to redeem an invite code.'), 'Sign in to redeem an invite code.'));
@@ -211,7 +214,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
         await runRedeem(
             () => redeemSignedInInvite({
                 userId: currentUser.uid,
-                code: redeemCode,
+                code: normalizedRedeemCode,
                 email: currentUser.email,
                 refresh: auth.refresh
             }),
@@ -275,7 +278,7 @@ export function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAcces
                                         disabled={redeeming || saving}
                                     />
                                 </label>
-                                <button type="submit" className="primary-button sm:min-w-[10rem]" disabled={redeeming || saving}>
+                                <button type="submit" className="primary-button sm:min-w-[10rem]" disabled={redeeming || saving || !redeemCodeReady}>
                                     {redeeming ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <KeyRound className="h-4 w-4" aria-hidden="true" />}
                                     {redeeming ? 'Redeeming...' : 'Redeem code'}
                                 </button>


### PR DESCRIPTION
## Summary
- disable inline invite redemption until the trimmed code is exactly eight characters
- normalize the submitted value to uppercase
- guard the submit handler so programmatic or Enter-key submissions cannot call the service early
- add regression coverage for empty, whitespace-only, seven-character, and ready codes

## Investigation and design
The input already capped visible entry at eight characters, while the submit button only reflected loading state. Validation therefore happened downstream after an avoidable request. The component now derives a single normalized code and readiness flag, uses that flag for both UI state and a defensive submit guard, and sends the same normalized value to the redemption service.

## Requirements covered
- initial, whitespace-only, and fewer-than-eight-character values keep Redeem code disabled
- incomplete programmatic form submission does not call `redeemSignedInInvite`
- an eight-character value enables the action
- redemption receives the uppercase normalized code
- existing success, error, signed-out, and manual-access paths remain intact

## Test plan and results
- `npm --prefix apps/app run test:ci -- src/pages/ParentTools.test.tsx src/pages/parent-tools/AccessTool.test.tsx` — 39 passed
- `npm run app:build` — passed
- focused ESLint — 0 errors (four pre-existing warnings)
- `git diff --check` — passed

Closes #3564.