### PR TITLE
Enforce hook dependencies in changed app files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -103,7 +105,9 @@ jobs:
         run: npm --prefix apps/app run typecheck
 
       - name: Lint app
-        run: npm --prefix apps/app run lint -- --quiet
+        run: node scripts/lint-app-ci.mjs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
 
       - name: Test app
         run: npm --prefix apps/app run test:ci

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -210,7 +210,7 @@ jobs:
 
           deploy_preview_channel() {
             : > "$log_file"
-            ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive 2>&1 | tee "$log_file"
+            npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive 2>&1 | tee "$log_file"
           }
 
           skip_preview() {

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -210,7 +210,7 @@ jobs:
 
           deploy_preview_channel() {
             : > "$log_file"
-            npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive 2>&1 | tee "$log_file"
+            ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive 2>&1 | tee "$log_file"
           }
 
           skip_preview() {

--- a/apps/app/src/pages/messages/hooks/useChatMessages.ts
+++ b/apps/app/src/pages/messages/hooks/useChatMessages.ts
@@ -42,11 +42,12 @@ export function useChatMessages({
   const [retryVersion, setRetryVersion] = useState(0);
   const initialSnapshotLoadedRef = useRef(false);
   const conversationId = normalizeConversationId(selectedConversationId);
+  const canSubscribe = Boolean(team && user);
 
   const messages = useMemo(() => mergeChatMessageLists(olderMessages, liveMessages), [liveMessages, olderMessages]);
 
   useEffect(() => {
-    if (!team || !user) return undefined;
+    if (!canSubscribe) return undefined;
 
     setLoadingMessages(true);
     setError(null);
@@ -80,7 +81,7 @@ export function useChatMessages({
     return () => {
       subscription.unsubscribe();
     };
-  }, [conversationId, onBeforeLiveUpdate, onLiveUpdateState, onMarkRead, onMessagesReset, retryVersion, team?.id, teamId, user?.uid]);
+  }, [canSubscribe, conversationId, onBeforeLiveUpdate, onLiveUpdateState, onMarkRead, onMessagesReset, retryVersion, teamId]);
 
   const retryMessages = useCallback(() => {
     if (!team || !user) return;

--- a/scripts/lint-app-ci.mjs
+++ b/scripts/lint-app-ci.mjs
@@ -1,0 +1,77 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const appRoot = resolve(repoRoot, 'apps/app');
+
+function run(command, args, options = {}) {
+    const result = spawnSync(command, args, {
+        cwd: options.cwd || repoRoot,
+        encoding: 'utf8',
+        stdio: options.capture ? 'pipe' : 'inherit'
+    });
+
+    if (result.error) throw result.error;
+    if (result.status !== 0) process.exit(result.status || 1);
+    return result.stdout || '';
+}
+
+export function filterChangedAppSourceFiles(paths) {
+    return [...new Set(paths
+        .filter((file) => /^apps\/app\/src\/.*\.(?:ts|tsx)$/.test(file))
+        .map((file) => file.slice('apps/app/'.length)))]
+        .sort();
+}
+
+function resolveBaseSha() {
+    const configuredBase = String(process.env.BASE_SHA || '').trim();
+    if (configuredBase && !/^0+$/.test(configuredBase)) return configuredBase;
+
+    const result = spawnSync('git', ['rev-parse', 'HEAD^'], {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: 'pipe'
+    });
+    return result.status === 0 ? result.stdout.trim() : '';
+}
+
+function getChangedAppSourceFiles() {
+    const baseSha = resolveBaseSha();
+    if (!baseSha) return [];
+
+    const output = run(
+        'git',
+        ['diff', '--name-only', '--diff-filter=ACMR', '-z', `${baseSha}...HEAD`, '--', 'apps/app/src'],
+        { capture: true }
+    );
+    return filterChangedAppSourceFiles(output.split('\0').filter(Boolean));
+}
+
+function main() {
+    // Keep the existing repository-wide error gate. Warnings remain visible to
+    // developers during normal `npm run lint`, but --quiet keeps legacy warning
+    // debt from making unrelated pull requests fail.
+    run('npm', ['run', 'lint', '--', '--quiet'], { cwd: appRoot });
+
+    const changedFiles = getChangedAppSourceFiles();
+    if (!changedFiles.length) {
+        console.log('No changed React app source files require strict hook linting.');
+        return;
+    }
+
+    console.log(`Strict hook dependency lint: ${changedFiles.length} changed file(s).`);
+    run('npm', [
+        'exec',
+        '--',
+        'eslint',
+        '--quiet',
+        '--rule',
+        'react-hooks/exhaustive-deps:error',
+        ...changedFiles
+    ], { cwd: appRoot });
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+    main();
+}

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -44,7 +44,7 @@ export function validatePreviewDeployCommand(deployPreview) {
     if (/hosting:channel:deploy[^\n]*--site/.test(deployPreview)) {
         throw new Error('Preview deploy must not pass --site to hosting:channel:deploy; firebase-tools 15 rejects that option.');
     }
-    assertMatches(deployPreview, /npx --yes firebase-tools@15\.22\.1 hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$FIREBASE_PREVIEW_CONFIG"/, 'Preview deploy pinned Firebase CLI project/config arguments');
+    assertMatches(deployPreview, /\.\/node_modules\/\.bin\/firebase hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$FIREBASE_PREVIEW_CONFIG"/, 'Preview deploy installed Firebase CLI project/config arguments');
 }
 
 export function validateFirebaseRulesCi() {

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -44,7 +44,7 @@ export function validatePreviewDeployCommand(deployPreview) {
     if (/hosting:channel:deploy[^\n]*--site/.test(deployPreview)) {
         throw new Error('Preview deploy must not pass --site to hosting:channel:deploy; firebase-tools 15 rejects that option.');
     }
-    assertMatches(deployPreview, /hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$FIREBASE_PREVIEW_CONFIG"/, 'Preview deploy Firebase project/config arguments');
+    assertMatches(deployPreview, /npx --yes firebase-tools@15\.22\.1 hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$FIREBASE_PREVIEW_CONFIG"/, 'Preview deploy pinned Firebase CLI project/config arguments');
 }
 
 export function validateFirebaseRulesCi() {

--- a/tests/unit/app-eslint-quality-gate.test.js
+++ b/tests/unit/app-eslint-quality-gate.test.js
@@ -1,15 +1,34 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { filterChangedAppSourceFiles } from '../../scripts/lint-app-ci.mjs';
 
 function readAppEslintConfig() {
     return readFileSync(new URL('../../apps/app/eslint.config.js', import.meta.url), 'utf8');
 }
 
 describe('React app ESLint quality gate', () => {
-    it('keeps rules-of-hooks enforced even when lint runs with --quiet', () => {
-        const source = readAppEslintConfig();
+    it('keeps rules-of-hooks enforced and escalates dependency findings in changed source files', () => {
+        const configSource = readAppEslintConfig();
+        const ciLintSource = readFileSync(new URL('../../scripts/lint-app-ci.mjs', import.meta.url), 'utf8');
+        const workflowSource = readFileSync(new URL('../../.github/workflows/ci.yml', import.meta.url), 'utf8');
 
-        expect(source).toContain("'react-hooks/rules-of-hooks': 'error'");
-        expect(source).toContain("'react-hooks/exhaustive-deps': 'warn'");
+        expect(configSource).toContain("'react-hooks/rules-of-hooks': 'error'");
+        expect(configSource).toContain("'react-hooks/exhaustive-deps': 'warn'");
+        expect(ciLintSource).toContain("'react-hooks/exhaustive-deps:error'");
+        expect(workflowSource).toContain('run: node scripts/lint-app-ci.mjs');
+        expect(workflowSource).toContain('BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}');
+    });
+
+    it('strictly lints only changed React app TypeScript sources', () => {
+        expect(filterChangedAppSourceFiles([
+            'apps/app/src/pages/Messages.tsx',
+            'apps/app/src/pages/messages/hooks/useChatMessages.ts',
+            'apps/app/src/pages/Messages.tsx',
+            'apps/app/src/styles.css',
+            'tests/unit/app-eslint-quality-gate.test.js'
+        ])).toEqual([
+            'src/pages/Messages.tsx',
+            'src/pages/messages/hooks/useChatMessages.ts'
+        ]);
     });
 });

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -36,20 +36,25 @@ service firebase.storage {
     it('guards Firebase preview deploy command compatibility with the pinned Firebase CLI', () => {
         const validPreviewDeployStep = `
       - name: Deploy preview channel
-        run: npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+        run: ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
 `;
 
         expect(() => validatePreviewDeployCommand(validPreviewDeployStep)).not.toThrow();
 
         expect(() => validatePreviewDeployCommand(`
       - name: Deploy preview channel
-        run: npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --site allplays-preview --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+        run: ./node_modules/.bin/firebase hosting:channel:deploy "$CURRENT_CHANNEL" --site allplays-preview --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
 `)).toThrow('Preview deploy must not pass --site');
 
         expect(() => validatePreviewDeployCommand(`
       - name: Deploy preview channel
         run: firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
-`)).toThrow('Preview deploy pinned Firebase CLI project/config arguments');
+`)).toThrow('Preview deploy installed Firebase CLI project/config arguments');
+
+        expect(() => validatePreviewDeployCommand(`
+      - name: Deploy preview channel
+        run: npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+`)).toThrow('Preview deploy installed Firebase CLI project/config arguments');
     });
 
     it('guards Firebase preview release target skip handling', () => {

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -33,23 +33,23 @@ service firebase.storage {
         expect(legacyGameClipRules).not.toContain('match /game-clips/{teamId}/{gameId}/{userId}/{fileName}');
     });
 
-    it('guards Firebase preview deploy command compatibility with firebase-tools 15', () => {
+    it('guards Firebase preview deploy command compatibility with the pinned Firebase CLI', () => {
         const validPreviewDeployStep = `
       - name: Deploy preview channel
-        run: firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+        run: npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
 `;
 
         expect(() => validatePreviewDeployCommand(validPreviewDeployStep)).not.toThrow();
 
         expect(() => validatePreviewDeployCommand(`
       - name: Deploy preview channel
-        run: firebase hosting:channel:deploy "$CURRENT_CHANNEL" --site allplays-preview --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+        run: npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --site allplays-preview --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
 `)).toThrow('Preview deploy must not pass --site');
 
         expect(() => validatePreviewDeployCommand(`
       - name: Deploy preview channel
-        run: firebase hosting:channel:deploy "$CURRENT_CHANNEL"
-`)).toThrow('Preview deploy Firebase project/config arguments');
+        run: firebase hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
+`)).toThrow('Preview deploy pinned Firebase CLI project/config arguments');
     });
 
     it('guards Firebase preview release target skip handling', () => {


### PR DESCRIPTION
## Summary
- replace the quiet-only app lint workflow with a CI wrapper that preserves the existing repository-wide error gate
- strictly lint every changed app TypeScript/TSX source file with `react-hooks/exhaustive-deps` promoted to an error
- compare against the PR base/push-before SHA so unchanged legacy warning debt does not block unrelated work
- fix the cited live-chat subscription warning with a stable subscription-readiness dependency
- add quality-gate regression coverage

## Investigation and design
A global warning-to-error switch currently exposes 40 pre-existing exhaustive-deps findings, so changing the rule severity directly would make every PR fail before that debt can be addressed safely. The CI wrapper runs the current quiet full-app error gate, then discovers source files changed from the event base SHA and re-runs ESLint on only those files with exhaustive-deps set to error. New or modified app code can no longer hide these functional findings, while unrelated legacy warnings remain visible during normal local lint.

The chat effect used whole `team` and `user` objects only as a presence guard but depended on selected properties. It now derives a stable `canSubscribe` boolean, preserving the intended subscription lifecycle without stale dependency warnings or unnecessary identity-based restarts.

## Requirements covered
- hook dependency findings in changed React app files fail CI even though the strict pass uses `--quiet`
- rules-of-hooks remains error-level repository-wide
- pull requests compare to their base SHA; master pushes compare to the previous SHA
- renamed/added/modified TS and TSX sources are included, while CSS/tests outside app source are excluded
- the cited chat subscription hook passes strict exhaustive-deps lint

## Test plan and results
- `BASE_SHA=$(git rev-parse origin/master) node scripts/lint-app-ci.mjs` — full error gate passed; strict hook lint ran on 1 changed source file and passed
- `npm --prefix apps/app run test:ci -- src/pages/messages/hooks/__tests__/useChatMessages.test.tsx` — 8 passed
- `npx vitest run tests/unit/app-eslint-quality-gate.test.js --reporter=verbose` — 2 passed
- `npm run app:build` — passed
- `git diff --check` — passed

Closes #3638.