### PR TITLE
Simplify Add workflow menu

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { Link, MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
@@ -539,6 +539,40 @@ describe('AppShell', () => {
     await waitFor(() => expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeTruthy());
   });
 
+  it.each([
+    { isDesktopWeb: true, layout: 'desktop web' },
+    { isDesktopWeb: false, layout: 'mobile/native' },
+  ])('shows the same common-first Add workflow state on $layout', ({ isDesktopWeb }) => {
+    useShellLayoutMock.mockReturnValue({ isDesktopWeb });
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Add workflow' });
+    expect(dialog.querySelectorAll('.add-workflow-card')).toHaveLength(3);
+    expect(within(dialog).getByRole('button', { name: /^Join with code/ })).toBeTruthy();
+    expect(within(dialog).getByRole('button', { name: /^Find team/ })).toBeTruthy();
+    expect(within(dialog).getByRole('button', { name: /^Create team/ })).toBeTruthy();
+    expect(within(dialog).queryByRole('button', { name: /^Game or practice/ })).toBeNull();
+    expect(within(dialog).queryByRole('button', { name: /^Fees/ })).toBeNull();
+
+    const disclosure = within(dialog).getByRole('button', { name: /^More workflows/ });
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(disclosure);
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true');
+    expect(dialog.querySelectorAll('.add-workflow-card')).toHaveLength(16);
+    expect(within(dialog).getByRole('button', { name: /^Game or practice/ })).toBeTruthy();
+    expect(within(dialog).getByRole('button', { name: /^Fees/ })).toBeTruthy();
+  });
+
   it('routes Fees through the native team picker instead of the public website handoff', async () => {
     render(
       <MemoryRouter initialEntries={['/home']}>
@@ -550,6 +584,7 @@ describe('AppShell', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getByRole('button', { name: /^More workflows/ }));
     fireEvent.click(screen.getByRole('button', { name: /FeesSelect a team for fee setup, checkout, and balancesCoach\/Admin/i }));
 
     await waitFor(() => {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -5,6 +5,7 @@ import {
   Bell,
   CalendarDays,
   CalendarPlus,
+  ChevronDown,
   ClipboardList,
   CreditCard,
   Dumbbell,
@@ -59,6 +60,9 @@ type AddWorkflow = {
   badge?: string;
 };
 
+const addWorkflowSections: AddWorkflow['section'][] = ['Team', 'Player', 'Schedule', 'Social', 'Team Ops'];
+const commonAddWorkflowIds = ['join-code', 'request-access', 'create-team'];
+
 interface AppShellProps {
   auth: AuthState;
   children: ReactNode;
@@ -67,6 +71,7 @@ interface AppShellProps {
 export function AppShell({ auth, children }: AppShellProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [addTeamOpen, setAddTeamOpen] = useState(false);
+  const [moreAddWorkflowsOpen, setMoreAddWorkflowsOpen] = useState(false);
   const [inboxOpen, setInboxOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<NotificationInboxItem[]>([]);
   const [inboxState, setInboxState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
@@ -131,6 +136,7 @@ export function AppShell({ auth, children }: AppShellProps) {
       }
       if (addTeamOpen) {
         setAddTeamOpen(false);
+        setMoreAddWorkflowsOpen(false);
         event.preventDefault();
       }
       if (inboxOpen) {
@@ -246,14 +252,51 @@ export function AppShell({ auth, children }: AppShellProps) {
   };
 
   const addWorkflows = buildAddWorkflows();
+  const commonAddWorkflows = commonAddWorkflowIds
+    .map((id) => addWorkflows.find((workflow) => workflow.id === id))
+    .filter((workflow): workflow is AddWorkflow => workflow !== undefined);
+  const advancedAddWorkflows = addWorkflows.filter((workflow) => !commonAddWorkflowIds.includes(workflow.id));
+
+  const openAddWorkflowModal = () => {
+    setMoreAddWorkflowsOpen(false);
+    setAddTeamOpen(true);
+  };
+
+  const closeAddWorkflowModal = () => {
+    setAddTeamOpen(false);
+    setMoreAddWorkflowsOpen(false);
+  };
 
   const handleAddWorkflow = async (workflow: AddWorkflow) => {
-    setAddTeamOpen(false);
+    closeAddWorkflowModal();
     if (workflow.kind === 'website') {
       await openPublicUrl(workflow.href);
       return;
     }
     navigate(workflow.href);
+  };
+
+  const renderAddWorkflow = (workflow: AddWorkflow) => {
+    const Icon = workflow.icon;
+    return (
+      <button
+        key={workflow.id}
+        type="button"
+        className="add-workflow-card"
+        onClick={() => void handleAddWorkflow(workflow)}
+      >
+        <span className="add-workflow-icon">
+          <Icon className="h-4 w-4" aria-hidden="true" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="add-workflow-label">{workflow.label}</span>
+          <span className="add-workflow-detail">{workflow.detail}</span>
+        </span>
+        <span className={`add-workflow-badge ${workflow.kind === 'website' ? 'add-workflow-badge-website' : ''}`}>
+          {workflow.badge || (workflow.kind === 'website' ? 'Site' : 'App')}
+        </span>
+      </button>
+    );
   };
 
   const renderNotificationTrigger = (className: string, iconOnly = false) => (
@@ -328,7 +371,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                 <button
                   type="button"
                   className="primary-button !h-10 !min-h-10"
-                  onClick={() => setAddTeamOpen(true)}
+                  onClick={openAddWorkflowModal}
                 >
                   <Plus className="h-5 w-5" aria-hidden="true" />
                   Add
@@ -430,7 +473,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                 <button
                   type="button"
                   className="primary-button !h-10 !min-h-10 !w-10 !p-0 sm:!w-auto sm:!px-3"
-                  onClick={() => setAddTeamOpen(true)}
+                  onClick={openAddWorkflowModal}
                   aria-label="Add"
                   title="Add"
                 >
@@ -497,7 +540,7 @@ export function AppShell({ auth, children }: AppShellProps) {
       ) : null}
 
       {addTeamOpen ? (
-        <Modal overlayClassName="z-50 flex items-end bg-gray-950/40 p-3 backdrop-blur-sm sm:items-center sm:justify-center" ariaLabel="Add workflow" onClose={() => setAddTeamOpen(false)}>
+        <Modal overlayClassName="z-50 flex items-end bg-gray-950/40 p-3 backdrop-blur-sm sm:items-center sm:justify-center" ariaLabel="Add workflow" onClose={closeAddWorkflowModal}>
           <div className="add-workflow-panel w-full max-w-3xl rounded-2xl bg-white shadow-app-lg">
             <div className="flex items-center justify-between border-b border-gray-200 p-4">
               <div>
@@ -508,51 +551,57 @@ export function AppShell({ auth, children }: AppShellProps) {
               <button
                 type="button"
                 className="ghost-button !h-10 !min-h-10 !w-10 !p-0"
-                onClick={() => setAddTeamOpen(false)}
+                onClick={closeAddWorkflowModal}
                 aria-label="Close add workflow"
               >
                 <X className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
             <div className="add-workflow-content p-4">
-              <div className="add-workflow-feature rounded-xl border border-primary-100 bg-primary-50 p-3">
-                <div className="flex items-center gap-2 text-sm font-black text-primary-800">
-                  <Shield className="h-4 w-4" aria-hidden="true" />
-                  Uses existing app and website workflows
+              <section aria-labelledby="common-add-workflows-title">
+                <div id="common-add-workflows-title" className="add-workflow-section-title">Common actions</div>
+                <div className="add-workflow-grid">
+                  {commonAddWorkflows.map(renderAddWorkflow)}
                 </div>
-                <p className="mt-1 text-sm font-semibold leading-6 text-primary-900/80">
-                  Native routes open in the app. Full coach/admin workflows open the current ALL PLAYS website until those screens are migrated.
-                </p>
-              </div>
-              {(['Team', 'Player', 'Schedule', 'Social', 'Team Ops'] as AddWorkflow['section'][]).map((section) => (
-                <section key={section} className="add-workflow-section">
-                  <div className="add-workflow-section-title">{section}</div>
-                  <div className="add-workflow-grid">
-                    {addWorkflows.filter((workflow) => workflow.section === section).map((workflow) => {
-                      const Icon = workflow.icon;
-                      return (
-                        <button
-                          key={workflow.id}
-                          type="button"
-                          className="add-workflow-card"
-                          onClick={() => void handleAddWorkflow(workflow)}
-                        >
-                          <span className="add-workflow-icon">
-                            <Icon className="h-4 w-4" aria-hidden="true" />
-                          </span>
-                          <span className="min-w-0 flex-1">
-                            <span className="add-workflow-label">{workflow.label}</span>
-                            <span className="add-workflow-detail">{workflow.detail}</span>
-                          </span>
-                          <span className={`add-workflow-badge ${workflow.kind === 'website' ? 'add-workflow-badge-website' : ''}`}>
-                            {workflow.badge || (workflow.kind === 'website' ? 'Site' : 'App')}
-                          </span>
-                        </button>
-                      );
-                    })}
+              </section>
+              <button
+                type="button"
+                className="ghost-button mt-3 w-full justify-between !px-3"
+                aria-expanded={moreAddWorkflowsOpen}
+                aria-controls="advanced-add-workflows"
+                onClick={() => setMoreAddWorkflowsOpen((open) => !open)}
+              >
+                <span className="text-left">
+                  <span className="block text-sm font-black">More workflows</span>
+                  <span className="block text-xs font-semibold text-gray-500">Schedule, social, player, and team operations</span>
+                </span>
+                <ChevronDown className={`h-5 w-5 transition-transform ${moreAddWorkflowsOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
+              </button>
+              {moreAddWorkflowsOpen ? (
+                <div id="advanced-add-workflows">
+                  <div className="add-workflow-feature mt-3 rounded-xl border border-primary-100 bg-primary-50 p-3">
+                    <div className="flex items-center gap-2 text-sm font-black text-primary-800">
+                      <Shield className="h-4 w-4" aria-hidden="true" />
+                      Uses existing app and website workflows
+                    </div>
+                    <p className="mt-1 text-sm font-semibold leading-6 text-primary-900/80">
+                      Native routes open in the app. Full coach/admin workflows open the current ALL PLAYS website until those screens are migrated.
+                    </p>
                   </div>
-                </section>
-              ))}
+                  {addWorkflowSections.map((section) => {
+                    const sectionWorkflows = advancedAddWorkflows.filter((workflow) => workflow.section === section);
+                    if (!sectionWorkflows.length) return null;
+                    return (
+                      <section key={section} className="add-workflow-section">
+                        <div className="add-workflow-section-title">{section}</div>
+                        <div className="add-workflow-grid">
+                          {sectionWorkflows.map(renderAddWorkflow)}
+                        </div>
+                      </section>
+                    );
+                  })}
+                </div>
+              ) : null}
               <div className="mt-3 flex flex-wrap gap-2">
                 {auth.roles.map((role) => <RoleBadge key={role} role={role} />)}
               </div>

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -617,6 +617,8 @@ describe('React app shell search', () => {
 
         expect(container.textContent).toContain('Add to ALL PLAYS');
         expect(container.textContent).toContain('Create team');
+
+        await clickButton(container, 'More workflows');
         expect(container.textContent).toContain('Add player');
         expect(container.textContent).toContain('Game or practice');
         expect(container.textContent).toContain('Invite family');


### PR DESCRIPTION
## Summary

- Present **Join with code**, **Find team**, and **Create team** as the three common actions shown when the shell Add modal opens.
- Place the remaining player, schedule, social, and team-operations actions behind an accessible **More workflows** disclosure.
- Reuse the existing workflow definitions and click handler so all 16 actions keep their current labels, details, badges, native/site routing, and behavior.
- Reset the disclosure whenever the modal closes or reopens, including native-back dismissal.
- Cover the same common-first and expanded states on desktop web and mobile/native layouts.

## Why

The Add modal exposed all 16 workflows across five sections at once. That made the first-run paths compete visually with advanced coach/admin and team-operations actions. The modal now prioritizes the three common entry points without removing or changing any existing workflow.

## User impact

Parents, coaches, and admins see a short first choice set under time pressure. Power users can expand the same modal to reach every prior action.

## Validation

- `npm --prefix apps/app test -- --run src/components/AppShell.test.tsx` — 20 passed
- `npm --prefix apps/app test -- --run --reporter=dot` — 115 files / 1,011 tests passed
- `npm run app:build` — passed
- `eslint src/components/AppShell.tsx src/components/AppShell.test.tsx` — passed
- `git diff --check` — passed

Closes #3591