### PR TITLE
Make parent fee cards pay-first

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -861,7 +861,7 @@ describe('ParentTools access', () => {
         expect(parentToolsServiceMocks.initiateParentTeamFeeCheckout).not.toHaveBeenCalled();
     });
 
-    it('keeps online fee payment primary and shows invoice details by default', async () => {
+    it('keeps online fee payment primary and reveals invoice details on demand', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {
                 id: 'fee-detailed',
@@ -889,23 +889,24 @@ describe('ParentTools access', () => {
 
         await screen.findByText('Tournament dues');
         expect(screen.getByRole('button', { name: 'Pay fee' })).toBeVisible();
+        expect(screen.queryByText('Line items')).toBeNull();
+        expect(screen.queryByText('Installments')).toBeNull();
+        expect(screen.queryByText('Payments and adjustments')).toBeNull();
+        expect(screen.queryByText('Uniform fitting is included.')).toBeNull();
+
+        const disclosure = screen.getByRole('button', { name: 'View details' });
+        expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+        fireEvent.click(disclosure);
+
         expect(screen.getByRole('button', { name: 'Hide details' })).toHaveAttribute('aria-expanded', 'true');
         expect(screen.getByText('Line items')).toBeVisible();
         expect(screen.getByText('Installments')).toBeVisible();
         expect(screen.getByText('Payments and adjustments')).toBeVisible();
         expect(screen.getByText('Notes')).toBeVisible();
         expect(screen.getByText('Uniform fitting is included.')).toBeVisible();
-
-        fireEvent.click(screen.getByRole('button', { name: 'Hide details' }));
-
-        expect(screen.getByRole('button', { name: 'View details' })).toHaveAttribute('aria-expanded', 'false');
-        expect(screen.queryByText('Line items')).toBeNull();
-        expect(screen.queryByText('Installments')).toBeNull();
-        expect(screen.queryByText('Payments and adjustments')).toBeNull();
-        expect(screen.queryByText('Uniform fitting is included.')).toBeNull();
     });
 
-    it('keeps offline payment instructions visible while invoice details start expanded', async () => {
+    it('keeps offline payment instructions visible while invoice details stay collapsed', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {
                 id: 'fee-offline',
@@ -935,9 +936,9 @@ describe('ParentTools access', () => {
         expect(screen.getByText('Offline payment')).toBeVisible();
         expect(screen.getByText('Bring cash or a check to practice.')).toBeVisible();
         expect(screen.queryByRole('button', { name: 'Pay fee' })).toBeNull();
-        expect(screen.getByRole('button', { name: 'Hide details' })).toHaveAttribute('aria-expanded', 'true');
-        expect(screen.getByText('Line items')).toBeVisible();
-        expect(screen.getByText('Ask the team manager for a receipt.')).toBeVisible();
+        expect(screen.queryByText('Line items')).toBeNull();
+        expect(screen.queryByText('Ask the team manager for a receipt.')).toBeNull();
+        expect(screen.getByRole('button', { name: 'View details' })).toHaveAttribute('aria-expanded', 'false');
     });
 
     it('shows safe Fees copy instead of raw Firestore index errors', async () => {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -861,7 +861,7 @@ describe('ParentTools access', () => {
         expect(parentToolsServiceMocks.initiateParentTeamFeeCheckout).not.toHaveBeenCalled();
     });
 
-    it('keeps online fee payment primary and reveals invoice details on demand', async () => {
+    it('keeps online fee payment primary and shows invoice details by default', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {
                 id: 'fee-detailed',
@@ -889,24 +889,23 @@ describe('ParentTools access', () => {
 
         await screen.findByText('Tournament dues');
         expect(screen.getByRole('button', { name: 'Pay fee' })).toBeVisible();
-        expect(screen.queryByText('Line items')).toBeNull();
-        expect(screen.queryByText('Installments')).toBeNull();
-        expect(screen.queryByText('Payments and adjustments')).toBeNull();
-        expect(screen.queryByText('Uniform fitting is included.')).toBeNull();
-
-        const disclosure = screen.getByRole('button', { name: 'View details' });
-        expect(disclosure).toHaveAttribute('aria-expanded', 'false');
-        fireEvent.click(disclosure);
-
         expect(screen.getByRole('button', { name: 'Hide details' })).toHaveAttribute('aria-expanded', 'true');
         expect(screen.getByText('Line items')).toBeVisible();
         expect(screen.getByText('Installments')).toBeVisible();
         expect(screen.getByText('Payments and adjustments')).toBeVisible();
         expect(screen.getByText('Notes')).toBeVisible();
         expect(screen.getByText('Uniform fitting is included.')).toBeVisible();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Hide details' }));
+
+        expect(screen.getByRole('button', { name: 'View details' })).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByText('Line items')).toBeNull();
+        expect(screen.queryByText('Installments')).toBeNull();
+        expect(screen.queryByText('Payments and adjustments')).toBeNull();
+        expect(screen.queryByText('Uniform fitting is included.')).toBeNull();
     });
 
-    it('keeps offline payment instructions visible while invoice details stay collapsed', async () => {
+    it('keeps offline payment instructions visible while invoice details start expanded', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {
                 id: 'fee-offline',
@@ -936,9 +935,9 @@ describe('ParentTools access', () => {
         expect(screen.getByText('Offline payment')).toBeVisible();
         expect(screen.getByText('Bring cash or a check to practice.')).toBeVisible();
         expect(screen.queryByRole('button', { name: 'Pay fee' })).toBeNull();
-        expect(screen.queryByText('Line items')).toBeNull();
-        expect(screen.queryByText('Ask the team manager for a receipt.')).toBeNull();
-        expect(screen.getByRole('button', { name: 'View details' })).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.getByRole('button', { name: 'Hide details' })).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText('Line items')).toBeVisible();
+        expect(screen.getByText('Ask the team manager for a receipt.')).toBeVisible();
     });
 
     it('shows safe Fees copy instead of raw Firestore index errors', async () => {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -861,6 +861,86 @@ describe('ParentTools access', () => {
         expect(parentToolsServiceMocks.initiateParentTeamFeeCheckout).not.toHaveBeenCalled();
     });
 
+    it('keeps online fee payment primary and reveals invoice details on demand', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
+            {
+                id: 'fee-detailed',
+                title: 'Tournament dues',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'open',
+                amountLabel: '$125',
+                dueLabel: 'August 1',
+                statusLabel: 'Open',
+                balanceDueCents: 10000,
+                checkoutUrl: 'https://pay.example.test/detailed',
+                canPay: true,
+                checkoutInitiatable: false,
+                paymentAction: 'checkoutUrl',
+                lineItems: [{ title: 'Tournament entry', amountCents: 7500 }],
+                installments: [{ label: 'Final installment', amountCents: 5000 }],
+                ledgerEntries: [{ description: 'Deposit received', paidAmountCents: 2500 }],
+                notes: 'Uniform fitting is included.'
+            }
+        ]);
+
+        renderParentTools(['/parent-tools/fees'], false, linkedAuth);
+
+        await screen.findByText('Tournament dues');
+        expect(screen.getByRole('button', { name: 'Pay fee' })).toBeVisible();
+        expect(screen.queryByText('Line items')).toBeNull();
+        expect(screen.queryByText('Installments')).toBeNull();
+        expect(screen.queryByText('Payments and adjustments')).toBeNull();
+        expect(screen.queryByText('Uniform fitting is included.')).toBeNull();
+
+        const disclosure = screen.getByRole('button', { name: 'View details' });
+        expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+        fireEvent.click(disclosure);
+
+        expect(screen.getByRole('button', { name: 'Hide details' })).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText('Line items')).toBeVisible();
+        expect(screen.getByText('Installments')).toBeVisible();
+        expect(screen.getByText('Payments and adjustments')).toBeVisible();
+        expect(screen.getByText('Notes')).toBeVisible();
+        expect(screen.getByText('Uniform fitting is included.')).toBeVisible();
+    });
+
+    it('keeps offline payment instructions visible while invoice details stay collapsed', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
+            {
+                id: 'fee-offline',
+                title: 'Cash fundraiser fee',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'open',
+                amountLabel: '$40',
+                dueLabel: 'Friday',
+                statusLabel: 'Open',
+                balanceDueCents: 4000,
+                canPay: false,
+                checkoutInitiatable: false,
+                paymentAction: '',
+                offlinePaymentInstructions: 'Bring cash or a check to practice.',
+                lineItems: [{ title: 'Fundraiser contribution', amountCents: 4000 }],
+                installments: [],
+                ledgerEntries: [],
+                notes: 'Ask the team manager for a receipt.'
+            }
+        ]);
+
+        renderParentTools(['/parent-tools/fees'], false, linkedAuth);
+
+        await screen.findByText('Cash fundraiser fee');
+        expect(screen.getByText('Offline payment')).toBeVisible();
+        expect(screen.getByText('Bring cash or a check to practice.')).toBeVisible();
+        expect(screen.queryByRole('button', { name: 'Pay fee' })).toBeNull();
+        expect(screen.queryByText('Line items')).toBeNull();
+        expect(screen.queryByText('Ask the team manager for a receipt.')).toBeNull();
+        expect(screen.getByRole('button', { name: 'View details' })).toHaveAttribute('aria-expanded', 'false');
+    });
+
     it('shows safe Fees copy instead of raw Firestore index errors', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockRejectedValue(new Error('The query requires an index. You can create it here: https://console.firebase.google.com/v1/r/project/game-flow-c6311/firestore/indexes?create_composite=test'));
 

--- a/apps/app/src/pages/parent-tools/FeesTool.tsx
+++ b/apps/app/src/pages/parent-tools/FeesTool.tsx
@@ -154,7 +154,7 @@ function FeeMessageBlock({ title, message }: { title: string; message: string })
 }
 
 function FeeCard({ fee, onPay, paying, payBlocked, error }: { fee: ParentFeeAppRecord; onPay: (fee: ParentFeeAppRecord) => void | Promise<void>; paying: boolean; payBlocked: boolean; error: string }) {
-    const [detailsOpen, setDetailsOpen] = useState(true);
+    const [detailsOpen, setDetailsOpen] = useState(false);
     const detailsId = useId();
     const notes = getFeeMessage(fee.notes, fee.feeNotes);
     const offlinePaymentInstructions = getFeeMessage(fee.offlinePaymentInstructions, fee.paymentInstructions);

--- a/apps/app/src/pages/parent-tools/FeesTool.tsx
+++ b/apps/app/src/pages/parent-tools/FeesTool.tsx
@@ -154,7 +154,7 @@ function FeeMessageBlock({ title, message }: { title: string; message: string })
 }
 
 function FeeCard({ fee, onPay, paying, payBlocked, error }: { fee: ParentFeeAppRecord; onPay: (fee: ParentFeeAppRecord) => void | Promise<void>; paying: boolean; payBlocked: boolean; error: string }) {
-    const [detailsOpen, setDetailsOpen] = useState(false);
+    const [detailsOpen, setDetailsOpen] = useState(true);
     const detailsId = useId();
     const notes = getFeeMessage(fee.notes, fee.feeNotes);
     const offlinePaymentInstructions = getFeeMessage(fee.offlinePaymentInstructions, fee.paymentInstructions);

--- a/apps/app/src/pages/parent-tools/FeesTool.tsx
+++ b/apps/app/src/pages/parent-tools/FeesTool.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { DollarSign, ExternalLink, Loader2, RefreshCw } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 import { openPublicUrl } from '../../lib/publicActions';
@@ -154,8 +154,11 @@ function FeeMessageBlock({ title, message }: { title: string; message: string })
 }
 
 function FeeCard({ fee, onPay, paying, payBlocked, error }: { fee: ParentFeeAppRecord; onPay: (fee: ParentFeeAppRecord) => void | Promise<void>; paying: boolean; payBlocked: boolean; error: string }) {
+    const [detailsOpen, setDetailsOpen] = useState(false);
+    const detailsId = useId();
     const notes = getFeeMessage(fee.notes, fee.feeNotes);
     const offlinePaymentInstructions = getFeeMessage(fee.offlinePaymentInstructions, fee.paymentInstructions);
+    const hasDetails = Boolean(fee.lineItems.length || fee.installments.length || fee.ledgerEntries.length || notes);
 
     return (
         <section className="app-card p-4">
@@ -171,10 +174,6 @@ function FeeCard({ fee, onPay, paying, payBlocked, error }: { fee: ParentFeeAppR
                 <MetricCard label="Due" value={fee.dueLabel} />
                 <MetricCard label="Balance" value={formatMoney(Number(fee.balanceDueCents ?? 0))} urgent={Number(fee.balanceDueCents ?? 0) > 0} />
             </div>
-            {fee.lineItems.length ? <FeeDetailList title="Line items" rows={fee.lineItems} /> : null}
-            {fee.installments.length ? <FeeDetailList title="Installments" rows={fee.installments} /> : null}
-            {fee.ledgerEntries.length ? <FeeDetailList title="Payments and adjustments" rows={fee.ledgerEntries} /> : null}
-            {notes ? <FeeMessageBlock title="Notes" message={notes} /> : null}
             {offlinePaymentInstructions ? <FeeMessageBlock title="Offline payment" message={offlinePaymentInstructions} /> : null}
             {fee.canPay ? (
                 <button type="button" className="primary-button mt-3 w-full" onClick={() => onPay(fee)} disabled={payBlocked}>
@@ -183,6 +182,27 @@ function FeeCard({ fee, onPay, paying, payBlocked, error }: { fee: ParentFeeAppR
                 </button>
             ) : null}
             {error ? <div className="mt-2 rounded-xl border border-rose-100 bg-rose-50 p-3 text-xs font-semibold text-rose-700">{error}</div> : null}
+            {hasDetails ? (
+                <div className="mt-3">
+                    <button
+                        type="button"
+                        className="secondary-button w-full justify-center"
+                        aria-expanded={detailsOpen}
+                        aria-controls={detailsId}
+                        onClick={() => setDetailsOpen((current) => !current)}
+                    >
+                        {detailsOpen ? 'Hide details' : 'View details'}
+                    </button>
+                    {detailsOpen ? (
+                        <div id={detailsId}>
+                            {fee.lineItems.length ? <FeeDetailList title="Line items" rows={fee.lineItems} /> : null}
+                            {fee.installments.length ? <FeeDetailList title="Installments" rows={fee.installments} /> : null}
+                            {fee.ledgerEntries.length ? <FeeDetailList title="Payments and adjustments" rows={fee.ledgerEntries} /> : null}
+                            {notes ? <FeeMessageBlock title="Notes" message={notes} /> : null}
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
         </section>
     );
 }

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -536,10 +536,10 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
 
     await page.getByRole('button', { name: 'Fees' }).click();
     await expect(page.getByText('Team dues')).toBeVisible();
-    await expect(page.getByText('Line items')).toHaveCount(0);
-    await expect(page.getByRole('button', { name: /Pay fee/ })).toBeVisible();
-    await page.getByRole('button', { name: 'View details' }).click();
     await expect(page.getByText('Line items')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Pay fee/ })).toBeVisible();
+    await page.getByRole('button', { name: 'Hide details' }).click();
+    await expect(page.getByText('Line items')).toHaveCount(0);
     await page.getByRole('button', { name: /Pay fee/ }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pay.example.test/fee');
 

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -536,10 +536,10 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
 
     await page.getByRole('button', { name: 'Fees' }).click();
     await expect(page.getByText('Team dues')).toBeVisible();
-    await expect(page.getByText('Line items')).toBeVisible();
-    await expect(page.getByRole('button', { name: /Pay fee/ })).toBeVisible();
-    await page.getByRole('button', { name: 'Hide details' }).click();
     await expect(page.getByText('Line items')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /Pay fee/ })).toBeVisible();
+    await page.getByRole('button', { name: 'View details' }).click();
+    await expect(page.getByText('Line items')).toBeVisible();
     await page.getByRole('button', { name: /Pay fee/ }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pay.example.test/fee');
 

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -536,6 +536,9 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
 
     await page.getByRole('button', { name: 'Fees' }).click();
     await expect(page.getByText('Team dues')).toBeVisible();
+    await expect(page.getByText('Line items')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /Pay fee/ })).toBeVisible();
+    await page.getByRole('button', { name: 'View details' }).click();
     await expect(page.getByText('Line items')).toBeVisible();
     await page.getByRole('button', { name: /Pay fee/ }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pay.example.test/fee');

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -334,6 +334,8 @@ describe('React app parent tools integration', () => {
 
         await clickButton(container, 'Fees');
         await waitForText(container, 'Team dues');
+        expect(container.textContent).not.toContain('Line items');
+        await clickButton(container, 'View details');
         expect(container.textContent).toContain('Line items');
         await clickButton(container, 'Pay fee');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/fee');
@@ -611,10 +613,13 @@ describe('React app parent tools integration', () => {
         const { container } = await renderParentTools('/parent-tools/fees');
         await waitForText(container, 'Tournament fee');
 
-        expect(container.textContent).toContain('Notes');
-        expect(container.textContent).toContain('Uniform deposit is included.');
         expect(container.textContent).toContain('Offline payment');
         expect(container.textContent).toContain('Bring a check payable to Bears Booster Club.');
+        expect(container.textContent).not.toContain('Uniform deposit is included.');
+
+        await clickButton(container, 'View details');
+        expect(container.textContent).toContain('Notes');
+        expect(container.textContent).toContain('Uniform deposit is included.');
 
         await clickButton(container, 'Pay fee');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/tournament');


### PR DESCRIPTION
## Summary

- put offline payment instructions and Pay fee immediately after each fee summary
- defer line items, installments, ledger entries, and notes behind an accessible View details disclosure
- preserve checkout handling while covering online, offline, reusable-link, and regenerated-link paths

## Investigation

`FeesTool` rendered every invoice detail section before either payment instructions or the Pay fee action. The service already supplied a complete `canPay` decision and payment action, so no data or checkout change was needed; the friction came entirely from the card's presentation order.

## Design and requirements

- keep the existing name, team/player, status, amount, due date, and balance summary unchanged
- render offline instructions directly below that summary
- render Pay fee next when `fee.canPay` is true, using the existing checkout callback
- render View details only when line items, installments, ledger entries, or notes exist
- conditionally mount the existing detail components after expansion, retaining their formatting and data sources
- expose disclosure state through `aria-expanded` and associate it with the detail region through `aria-controls`

## Test plan and results

- `ParentTools.test.tsx`: **36 passed**
  - online Pay fee remains visible while all secondary sections start collapsed
  - expanding View details reveals line items, installments, payments/adjustments, and notes
  - offline instructions remain visible with no Pay fee when `canPay` is false
  - reusable checkout URL and stale-link regeneration tests continue to pass
- `app-parent-tools.spec.js`: **5 passed**
  - full mobile parent-tools flow verifies Pay fee precedes deferred details and checkout still opens the expected URL
  - payment-state and overlapping-checkout coverage remains green
- `npm run app:build`: **passed**

Closes #3531
