### PR TITLE
Harden nested team chat message payload validation

### DIFF
--- a/apps/app/src/lib/chatAiService.ts
+++ b/apps/app/src/lib/chatAiService.ts
@@ -14,6 +14,7 @@ import {
 import type { ChatConversation } from './chatService';
 import {
   buildChatAudienceMetadata,
+  isDefaultTeamConversation,
   type ChatTargetType
 } from './chatLogic';
 import type { AuthUser } from './types';
@@ -232,18 +233,19 @@ export async function sendAllPlaysChatAnswer({
     selectedRecipientTarget,
     selectedRecipientIds
   });
+  const isTargetedConversation = !isDefaultTeamConversation(selectedConversationId);
   await postChatMessage(teamId, {
-    text: responseText,
+    text: isTargetedConversation ? `ALL PLAYS\n\n${responseText}` : responseText,
     senderId: user.uid,
-    senderName: null,
-    senderEmail: null,
-    senderPhotoUrl: null,
-    ai: true,
-    aiName: 'ALL PLAYS',
-    aiQuestion: question,
+    senderName: isTargetedConversation ? (user.displayName || user.email || null) : null,
+    senderEmail: isTargetedConversation ? (user.email || null) : null,
+    senderPhotoUrl: isTargetedConversation ? (user.photoUrl || null) : null,
+    ai: !isTargetedConversation,
+    aiName: isTargetedConversation ? null : 'ALL PLAYS',
+    aiQuestion: isTargetedConversation ? null : question,
     conversationId: selectedConversationId,
     ...targetMetadata,
-    aiMeta: {
+    aiMeta: isTargetedConversation ? null : {
       statsGameLimit: aiStatsGamesLimit,
       gamesContextLimit: aiGamesContextLimit,
       statsRequested: fetchStats,

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -375,6 +375,45 @@ async function nativeCreateDocument(path: string, data: Record<string, unknown>,
   }) as NativeFirestoreDocument);
 }
 
+function getNativeDocumentResourceName(path: string) {
+  const decodedPath = path
+    .split('/')
+    .map((segment) => decodeURIComponent(segment))
+    .join('/');
+  return `projects/${getProjectId()}/databases/(default)/documents/${decodedPath}`;
+}
+
+async function nativeCommitDocument(
+  path: string,
+  data: Record<string, unknown>,
+  { serverTimestampFields = [] }: { serverTimestampFields?: string[] } = {}
+) {
+  const transformFields = new Set(serverTimestampFields);
+  const storedFieldNames = Object.keys(data).filter((key) => !transformFields.has(key));
+  const fields = storedFieldNames.reduce<Record<string, Record<string, unknown>>>((acc, key) => {
+    acc[key] = encodeFirestoreValue(data[key]);
+    return acc;
+  }, {});
+  await nativeFirestoreRequest(':commit', {
+    method: 'POST',
+    body: JSON.stringify({
+      writes: [{
+        update: {
+          name: getNativeDocumentResourceName(path),
+          fields
+        },
+        updateMask: {
+          fieldPaths: storedFieldNames
+        },
+        updateTransforms: serverTimestampFields.map((fieldPath) => ({
+          fieldPath,
+          setToServerValue: 'REQUEST_TIME'
+        }))
+      }]
+    })
+  });
+}
+
 async function nativeRunQuery(structuredQuery: Record<string, unknown>) {
   const payload = await nativeFirestoreRequest(':runQuery', {
     method: 'POST',
@@ -1186,11 +1225,15 @@ async function nativeUploadChatMedia(teamId: string, file: File, conversationId 
     throw new Error('Image upload Firebase config is missing.');
   }
   const session = await getImageUploadSession(imageConfig.apiKey);
+  const userId = firebaseAuth.currentUser?.uid;
+  if (!userId) {
+    throw new Error('Sign in before uploading team chat media.');
+  }
   const safeName = String(file.name || 'media').replace(/[^\w.-]+/g, '_');
   const isVideo = String(file.type || '').toLowerCase().startsWith('video/');
   const mediaFolder = isVideo ? 'team-videos' : 'team-photos';
   const safeConversationId = String(conversationId || DEFAULT_TEAM_CONVERSATION_ID).replace(/[^\w.-]+/g, '_') || DEFAULT_TEAM_CONVERSATION_ID;
-  const path = `${mediaFolder}/${Date.now()}_chat_${teamId}_${safeConversationId}_${safeName}`;
+  const path = `${mediaFolder}/${Date.now()}_chat_${teamId}_${safeConversationId}_${userId}_${safeName}`;
   const response = await withTimeout(fetch(`https://firebasestorage.googleapis.com/v0/b/${encodeURIComponent(bucket)}/o?uploadType=media&name=${encodeURIComponent(path)}`, {
     method: 'POST',
     headers: {
@@ -1299,23 +1342,28 @@ async function nativePostChatMessage(teamId: string, input: {
   aiMeta?: Record<string, unknown> | null;
   conversationId?: string;
 } & ChatAudienceMetadata) {
-  const createdAt = new Date();
+  const attachmentUploadedAt = new Date();
   const attachments = input.attachments || [];
   const firstImage = attachments.find((attachment) => attachment.type === 'image') || null;
-  return nativeCreateDocument(getMessageCollectionPath(teamId, input.conversationId), {
+  const isLegacyTeamConversation = isDefaultTeamConversation(input.conversationId);
+  const documentId = input.clientMessageId || `native_${input.senderId}_${Date.now()}_${Math.random().toString(36).slice(2)}`
+    .replace(/[^A-Za-z0-9_-]/g, '_')
+    .slice(0, 120);
+  const collectionPath = getMessageCollectionPath(teamId, input.conversationId);
+  return nativeCommitDocument(`${collectionPath}/${encodeURIComponent(documentId)}`, {
     clientMessageId: input.clientMessageId || null,
     text: input.text || '',
     senderId: input.senderId,
     senderName: input.senderName || null,
     senderEmail: input.senderEmail || null,
     senderPhotoUrl: input.senderPhotoUrl || null,
-    attachments: attachments.map((attachment) => ({ ...attachment, uploadedAt: createdAt })),
-    imageUrl: firstImage?.url || null,
-    imagePath: firstImage?.path || null,
-    imageName: firstImage?.name || null,
-    imageType: firstImage?.mimeType || null,
-    imageSize: firstImage?.size ?? null,
-    createdAt,
+    attachments: attachments.map((attachment) => ({ ...attachment, uploadedAt: attachmentUploadedAt })),
+    imageUrl: isLegacyTeamConversation ? (firstImage?.url || null) : null,
+    imagePath: isLegacyTeamConversation ? (firstImage?.path || null) : null,
+    imageName: isLegacyTeamConversation ? (firstImage?.name || null) : null,
+    imageType: isLegacyTeamConversation ? (firstImage?.mimeType || null) : null,
+    imageSize: isLegacyTeamConversation ? (firstImage?.size ?? null) : null,
+    createdAt: null,
     editedAt: null,
     deleted: false,
     ai: input.ai === true,
@@ -1326,7 +1374,7 @@ async function nativePostChatMessage(teamId: string, input: {
     recipientIds: input.targetType === 'individuals' ? input.recipientIds : [],
     targetRole: input.targetType === 'staff' ? (input.targetRole || 'staff') : null,
     conversationId: isDefaultTeamConversation(input.conversationId) ? null : input.conversationId
-  }, { documentId: input.clientMessageId || null });
+  }, { serverTimestampFields: ['createdAt'] });
 }
 
 export async function sendTeamChatMessage({
@@ -1375,7 +1423,7 @@ export async function sendTeamChatMessage({
   }
   const uploadedAttachments: Array<ChatAttachment | undefined> = [];
   try {
-    const targetMetadata = buildChatAudienceMetadata({
+    let targetMetadata = buildChatAudienceMetadata({
       selectedConversation,
       selectedConversationId,
       selectedRecipientTarget,
@@ -1397,6 +1445,13 @@ export async function sendTeamChatMessage({
         name: targetMetadata.targetType === 'staff' ? 'Staff only' : null
       })), 'Chat conversation create') as ChatConversation;
       conversationId = createdConversation.id;
+      if (targetMetadata.targetType === 'individuals') {
+        targetMetadata = {
+          targetType: 'individuals',
+          recipientIds: Array.isArray(createdConversation.participantIds) ? createdConversation.participantIds : participantIds,
+          targetRole: null
+        };
+      }
     }
 
     const orderedUploadedAttachments = await uploadTeamChatAttachments({
@@ -1602,10 +1657,10 @@ export async function editTeamChatMessage(teamId: string, messageId: string, tex
   } catch (error) {
     if (!isNativeRuntime()) throw error;
     logger.warn('Falling back to REST chat message edit.', { error });
-    return nativePatchDocument(getMessageDocumentPath(teamId, messageId, conversationId), {
+    return nativeCommitDocument(getMessageDocumentPath(teamId, messageId, conversationId), {
       text,
-      editedAt: new Date()
-    });
+      editedAt: null
+    }, { serverTimestampFields: ['editedAt'] });
   }
 }
 

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1021,7 +1021,7 @@ export function ChatWindow({
               team: request.team,
               user: request.user,
               question,
-              selectedConversation: request.selectedConversation,
+              selectedConversation: result.createdConversation || request.selectedConversation,
               selectedConversationId: normalizeConversationId(result.conversationId),
               selectedRecipientTarget: request.selectedRecipientTarget,
               selectedRecipientIds: request.selectedRecipientIds

--- a/firestore.rules
+++ b/firestore.rules
@@ -1385,6 +1385,14 @@ service cloud.firestore {
              hasValidChatRecipientIds(teamId, data);
     }
 
+    function hasValidNestedChatRecipientIds(conversationData, data) {
+      return data.recipientIds is list &&
+             data.recipientIds.size() > 0 &&
+             data.recipientIds.size() <= 50 &&
+             conversationData.get('participantIds', []) is list &&
+             data.recipientIds == conversationData.get('participantIds', []);
+    }
+
     function isValidChatMessageTarget(teamId, data) {
       return isFullTeamChatMessage(data) ||
              isStaffChatMessage(data) ||
@@ -1626,7 +1634,8 @@ service cloud.firestore {
                  !isCanonicalStaffChatConversation(conversationId) &&
                  !isStaffRoleChatConversation(conversationData) &&
                  conversationData.get('type', '') in ['direct', 'group'] &&
-                 isIndividualChatMessage(teamId, data) &&
+                 data.get('targetType', 'full_team') == 'individuals' &&
+                 hasValidNestedChatRecipientIds(conversationData, data) &&
                  data.get('targetRole', null) == null &&
                  data.recipientIds == conversationData.get('participantIds', [])
                )

--- a/firestore.rules
+++ b/firestore.rules
@@ -1491,12 +1491,32 @@ service cloud.firestore {
               value.matches('https://storage[.]googleapis[.]com/.*'));
     }
 
+    function isSafeNestedChatRegexSegment(value) {
+      return value is string &&
+             value.size() > 0 &&
+             value.size() <= 256 &&
+             value.matches('[A-Za-z0-9_%:-]+');
+    }
+
+    function isScopedNestedChatFallbackMediaPath(teamId, conversationId, value) {
+      let pathSegments = value.split('/');
+      return pathSegments.size() == 6 &&
+             pathSegments[0] == 'stat-sheets' &&
+             pathSegments[1] == 'team-chat' &&
+             pathSegments[2] == teamId &&
+             pathSegments[3] == conversationId &&
+             pathSegments[4] == request.auth.uid &&
+             pathSegments[5].size() > 0;
+    }
+
     function isScopedNestedChatMediaPath(teamId, conversationId, value) {
       return value is string &&
              value.size() > 0 &&
              value.size() <= 1024 &&
-             (value.matches('team-(photos|videos)/[0-9]+_chat_' + teamId + '_[^/]+_' + request.auth.uid + '_[^/]+') ||
-              value.matches('stat-sheets/team-chat/' + teamId + '/' + conversationId + '/' + request.auth.uid + '/[^/]+'));
+             ((isSafeNestedChatRegexSegment(teamId) &&
+               isSafeNestedChatRegexSegment(request.auth.uid) &&
+               value.matches('team-(photos|videos)/[0-9]+_chat_' + teamId + '_[^/]+_' + request.auth.uid + '_[^/]+')) ||
+              isScopedNestedChatFallbackMediaPath(teamId, conversationId, value));
     }
 
     function isValidNestedChatAttachment(teamId, conversationId, attachment) {
@@ -1627,6 +1647,7 @@ service cloud.firestore {
              isNullableBoundedChatString(data.get('clientMessageId', null), 120) &&
              data.text is string &&
              data.text.size() <= 10000 &&
+             hasValidNestedChatAttachments(teamId, conversationId, data) &&
              (data.text.size() > 0 || data.attachments.size() > 0) &&
              data.senderId == request.auth.uid &&
              isNullableBoundedChatString(data.get('senderName', null), 120) &&
@@ -1637,7 +1658,6 @@ service cloud.firestore {
                data.senderEmail.lower() == request.auth.token.email.lower())) &&
              isNullableBoundedChatString(data.get('senderPhotoUrl', null), 2048) &&
              (data.get('senderPhotoUrl', null) == null || data.senderPhotoUrl.matches('https://.*')) &&
-             hasValidNestedChatAttachments(teamId, conversationId, data) &&
              data.get('imageUrl', null) == null &&
              data.get('imagePath', null) == null &&
              data.get('imageName', null) == null &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -1532,17 +1532,14 @@ service cloud.firestore {
       return value is string &&
              value.size() > 0 &&
              value.size() <= 1024 &&
-             ((isSafeNestedChatRegexSegment(teamId) &&
+             (isScopedNestedChatFallbackMediaPath(teamId, conversationId, value) ||
+              (isSafeNestedChatRegexSegment(teamId) &&
                isSafeNestedChatRegexSegment(request.auth.uid) &&
-               value.matches('team-(photos|videos)/[0-9]+_chat_' + teamId + '_[^/]+_' + request.auth.uid + '_[^/]+')) ||
-              isScopedNestedChatFallbackMediaPath(teamId, conversationId, value));
+               value.matches('team-(photos|videos)/[0-9]+_chat_' + teamId + '_[^/]+_' + request.auth.uid + '_[^/]+')));
     }
 
     function isValidNestedChatAttachment(teamId, conversationId, attachment) {
       return attachment is map &&
-             attachment.keys().hasAll([
-               'type', 'url', 'path', 'thumbnailUrl', 'name', 'mimeType', 'size', 'uploadedAt'
-             ]) &&
              attachment.keys().hasOnly([
                'type', 'url', 'path', 'thumbnailUrl', 'name', 'mimeType', 'size', 'uploadedAt'
              ]) &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -1393,6 +1393,17 @@ service cloud.firestore {
              data.recipientIds == conversationData.get('participantIds', []);
     }
 
+    function hasValidLegacyNestedChatRecipientIds(conversationData, data) {
+      let participantIds = conversationData.get('participantIds', []);
+      return data.recipientIds is list &&
+             data.recipientIds.size() > 0 &&
+             data.recipientIds.size() <= 50 &&
+             participantIds is list &&
+             data.recipientIds.hasOnly(participantIds) &&
+             data.senderId in participantIds &&
+             !(data.senderId in data.recipientIds);
+    }
+
     function isValidChatMessageTarget(teamId, data) {
       return isFullTeamChatMessage(data) ||
              isStaffChatMessage(data) ||
@@ -1639,6 +1650,19 @@ service cloud.firestore {
                  data.get('targetRole', null) == null &&
                  data.recipientIds == conversationData.get('participantIds', [])
                )
+             );
+    }
+
+    function isNestedChatMessageEditTargetValid(teamId, conversationId, conversationData, data) {
+      return isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data) ||
+             (
+               data.conversationId == conversationId &&
+               !isCanonicalStaffChatConversation(conversationId) &&
+               !isStaffRoleChatConversation(conversationData) &&
+               conversationData.get('type', '') in ['direct', 'group'] &&
+               data.get('targetType', 'full_team') == 'individuals' &&
+               hasValidLegacyNestedChatRecipientIds(conversationData, data) &&
+               data.get('targetRole', null) == null
              );
     }
 
@@ -3076,7 +3100,7 @@ service cloud.firestore {
                                .hasAll(['text', 'editedAt']) &&
                            request.resource.data.diff(resource.data).affectedKeys()
                                .hasOnly(['text', 'editedAt']) &&
-                           isNestedChatMessageTargetValid(
+                           isNestedChatMessageEditTargetValid(
                              teamId,
                              conversationId,
                              get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data,

--- a/firestore.rules
+++ b/firestore.rules
@@ -1478,6 +1478,188 @@ service cloud.firestore {
              data.get('mutedBy', []) is list;
     }
 
+    function isNullableBoundedChatString(value, maxSize) {
+      return value == null ||
+             (value is string && value.size() <= maxSize);
+    }
+
+    function isAllowedNestedChatMediaUrl(value) {
+      return value is string &&
+             value.size() > 0 &&
+             value.size() <= 2048 &&
+             (value.matches('https://firebasestorage[.]googleapis[.]com/.*') ||
+              value.matches('https://storage[.]googleapis[.]com/.*'));
+    }
+
+    function isScopedNestedChatMediaPath(teamId, conversationId, value) {
+      return value is string &&
+             value.size() > 0 &&
+             value.size() <= 1024 &&
+             (value.matches('team-(photos|videos)/[0-9]+_chat_' + teamId + '_[^/]+_' + request.auth.uid + '_[^/]+') ||
+              value.matches('stat-sheets/team-chat/' + teamId + '/' + conversationId + '/' + request.auth.uid + '/[^/]+'));
+    }
+
+    function isValidNestedChatAttachment(teamId, conversationId, attachment) {
+      return attachment is map &&
+             attachment.keys().hasAll([
+               'type', 'url', 'path', 'thumbnailUrl', 'name', 'mimeType', 'size', 'uploadedAt'
+             ]) &&
+             attachment.keys().hasOnly([
+               'type', 'url', 'path', 'thumbnailUrl', 'name', 'mimeType', 'size', 'uploadedAt'
+             ]) &&
+             attachment.type in ['image', 'video'] &&
+             isAllowedNestedChatMediaUrl(attachment.url) &&
+             isScopedNestedChatMediaPath(teamId, conversationId, attachment.path) &&
+             (attachment.thumbnailUrl == null || isAllowedNestedChatMediaUrl(attachment.thumbnailUrl)) &&
+             isNullableBoundedChatString(attachment.name, 255) &&
+             attachment.mimeType is string &&
+             attachment.mimeType.size() <= 120 &&
+             ((attachment.type == 'image' && attachment.mimeType.matches('image/.*')) ||
+              (attachment.type == 'video' && attachment.mimeType.matches('video/.*'))) &&
+             attachment.size is int &&
+             attachment.size > 0 &&
+             attachment.size <= 5 * 1024 * 1024 &&
+             attachment.uploadedAt is timestamp;
+    }
+
+    function hasValidNestedChatAttachments(teamId, conversationId, data) {
+      return data.attachments is list &&
+             data.attachments.size() <= 10 &&
+             (
+               data.attachments.size() == 0 ||
+               (data.attachments.size() == 1 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0])) ||
+               (data.attachments.size() == 2 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1])) ||
+               (data.attachments.size() == 3 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2])) ||
+               (data.attachments.size() == 4 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[3])) ||
+               (data.attachments.size() == 5 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[3]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[4])) ||
+               (data.attachments.size() == 6 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[3]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[4]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[5])) ||
+               (data.attachments.size() == 7 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[3]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[4]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[5]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[6])) ||
+               (data.attachments.size() == 8 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[3]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[4]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[5]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[6]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[7])) ||
+               (data.attachments.size() == 9 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[3]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[4]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[5]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[6]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[7]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[8])) ||
+               (data.attachments.size() == 10 &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[0]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[1]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[2]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[3]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[4]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[5]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[6]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[7]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[8]) &&
+                isValidNestedChatAttachment(teamId, conversationId, data.attachments[9]))
+             );
+    }
+
+    function isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data) {
+      return data.conversationId == conversationId &&
+             (
+               (
+                 isCanonicalStaffChatConversationPayload(conversationId, conversationData) &&
+                 isStaffChatMessage(data)
+               ) ||
+               (
+                 !isCanonicalStaffChatConversation(conversationId) &&
+                 !isStaffRoleChatConversation(conversationData) &&
+                 conversationData.get('type', '') in ['direct', 'group'] &&
+                 isIndividualChatMessage(teamId, data) &&
+                 data.get('targetRole', null) == null &&
+                 data.recipientIds == conversationData.get('participantIds', [])
+               )
+             );
+    }
+
+    function isNestedChatMessageCreateValid(teamId, conversationId, conversationData, data) {
+      return data.keys().hasAll([
+               'text', 'senderId', 'attachments', 'createdAt', 'targetType',
+               'recipientIds', 'conversationId'
+             ]) &&
+             data.keys().hasOnly([
+               'clientMessageId', 'text', 'senderId', 'senderName', 'senderEmail', 'senderPhotoUrl',
+               'attachments', 'imageUrl', 'imagePath', 'imageName', 'imageType', 'imageSize',
+               'createdAt', 'editedAt', 'deleted', 'ai', 'aiName', 'aiQuestion', 'aiMeta',
+               'targetType', 'recipientIds', 'targetRole', 'conversationId'
+             ]) &&
+             isNullableBoundedChatString(data.get('clientMessageId', null), 120) &&
+             data.text is string &&
+             data.text.size() <= 10000 &&
+             (data.text.size() > 0 || data.attachments.size() > 0) &&
+             data.senderId == request.auth.uid &&
+             isNullableBoundedChatString(data.get('senderName', null), 120) &&
+             (data.get('senderEmail', null) == null ||
+              (request.auth.token.email is string &&
+               data.senderEmail is string &&
+               data.senderEmail.size() <= 320 &&
+               data.senderEmail.lower() == request.auth.token.email.lower())) &&
+             isNullableBoundedChatString(data.get('senderPhotoUrl', null), 2048) &&
+             (data.get('senderPhotoUrl', null) == null || data.senderPhotoUrl.matches('https://.*')) &&
+             hasValidNestedChatAttachments(teamId, conversationId, data) &&
+             data.get('imageUrl', null) == null &&
+             data.get('imagePath', null) == null &&
+             data.get('imageName', null) == null &&
+             data.get('imageType', null) == null &&
+             data.get('imageSize', null) == null &&
+             data.createdAt == request.time &&
+             data.get('editedAt', null) == null &&
+             data.get('deleted', false) == false &&
+             data.get('ai', false) == false &&
+             data.get('aiName', null) == null &&
+             data.get('aiQuestion', null) == null &&
+             data.get('aiMeta', null) == null &&
+             isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data);
+    }
+
+    function isNestedChatMessageEditValid(data) {
+      return data.text is string &&
+             data.text.size() <= 10000 &&
+             (data.text.size() > 0 || data.attachments.size() > 0) &&
+             data.editedAt == request.time;
+    }
+
     function isChatConversationParticipantMetadataUpdate() {
       return request.resource.data.get('type', '') == resource.data.get('type', '') &&
              request.resource.data.get('name', null) == resource.data.get('name', null) &&
@@ -2853,11 +3035,25 @@ service cloud.firestore {
         match /chatMessages/{messageId} {
           allow read: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data);
           allow create: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
-                           request.resource.data.senderId == request.auth.uid;
+                           isNestedChatMessageCreateValid(
+                             teamId,
+                             conversationId,
+                             get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data,
+                             request.resource.data
+                           );
           allow update: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
                            resource.data.senderId == request.auth.uid &&
                            request.resource.data.diff(resource.data).affectedKeys()
-                               .hasOnly(['text', 'editedAt']);
+                               .hasAll(['text', 'editedAt']) &&
+                           request.resource.data.diff(resource.data).affectedKeys()
+                               .hasOnly(['text', 'editedAt']) &&
+                           isNestedChatMessageTargetValid(
+                             teamId,
+                             conversationId,
+                             get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data,
+                             request.resource.data
+                           ) &&
+                           isNestedChatMessageEditValid(request.resource.data);
           allow update: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
                            request.resource.data.diff(resource.data).affectedKeys()
                                .hasOnly(['deleted']) &&

--- a/js/db.js
+++ b/js/db.js
@@ -496,9 +496,11 @@ export async function uploadChatImage(teamId, file, { conversationId = DEFAULT_T
     const ts = Date.now();
     const userId = getRequiredSignedInUserId();
     const safeName = String(file.name || 'media').replace(/[^\w.\-]+/g, '_');
+    const safeConversationId = String(conversationId || DEFAULT_TEAM_CONVERSATION_ID)
+        .replace(/[^\w.\-]+/g, '_') || DEFAULT_TEAM_CONVERSATION_ID;
     const isVideo = String(file.type || '').toLowerCase().startsWith('video/');
     const mediaFolder = isVideo ? 'team-videos' : 'team-photos';
-    const imagePath = `${mediaFolder}/${ts}_chat_${teamId}_${safeName}`;
+    const imagePath = `${mediaFolder}/${ts}_chat_${teamId}_${safeConversationId}_${userId}_${safeName}`;
 
     try {
         const storageRef = ref(imageStorage, imagePath);
@@ -6659,7 +6661,8 @@ export async function postChatMessage(teamId, {
     conversationId = DEFAULT_TEAM_CONVERSATION_ID
 }) {
     const messagesRef = getTeamChatMessagesRef(teamId, conversationId);
-    const createdAt = Timestamp.now();
+    const attachmentUploadedAt = Timestamp.now();
+    const createdAt = serverTimestamp();
     const normalizedMedia = normalizeChatAttachments(
         attachments.length > 0
             ? attachments
@@ -6673,7 +6676,7 @@ export async function postChatMessage(teamId, {
     );
     const storedAttachments = normalizedMedia.attachments.map((attachment) => ({
         ...attachment,
-        uploadedAt: createdAt
+        uploadedAt: attachmentUploadedAt
     }));
     const allowedTargetTypes = new Set(['full_team', 'staff', 'individuals']);
     const normalizedTargetType = allowedTargetTypes.has(targetType) ? targetType : 'full_team';
@@ -6689,6 +6692,7 @@ export async function postChatMessage(teamId, {
     if (isDefaultTeamConversation(conversationId) && effectiveTargetType !== 'full_team') {
         throw new Error('Targeted team chat messages must use a non-default conversation.');
     }
+    const isLegacyTeamConversation = isDefaultTeamConversation(conversationId);
     const normalizedClientMessageId = normalizeChatClientMessageId(clientMessageId);
     const messageData = {
         clientMessageId: normalizedClientMessageId,
@@ -6698,13 +6702,15 @@ export async function postChatMessage(teamId, {
         senderEmail: senderEmail || null,
         senderPhotoUrl: senderPhotoUrl || null,
         attachments: storedAttachments,
-        imageUrl: normalizedMedia.legacyImage.imageUrl || imageUrl || null,
-        imagePath: normalizedMedia.legacyImage.imagePath || imagePath || null,
-        imageName: normalizedMedia.legacyImage.imageName || imageName || null,
-        imageType: normalizedMedia.legacyImage.imageType || imageType || null,
-        imageSize: Number.isFinite(normalizedMedia.legacyImage.imageSize)
-            ? normalizedMedia.legacyImage.imageSize
-            : (Number.isFinite(imageSize) ? imageSize : null),
+        imageUrl: isLegacyTeamConversation ? (normalizedMedia.legacyImage.imageUrl || imageUrl || null) : null,
+        imagePath: isLegacyTeamConversation ? (normalizedMedia.legacyImage.imagePath || imagePath || null) : null,
+        imageName: isLegacyTeamConversation ? (normalizedMedia.legacyImage.imageName || imageName || null) : null,
+        imageType: isLegacyTeamConversation ? (normalizedMedia.legacyImage.imageType || imageType || null) : null,
+        imageSize: isLegacyTeamConversation
+            ? (Number.isFinite(normalizedMedia.legacyImage.imageSize)
+                ? normalizedMedia.legacyImage.imageSize
+                : (Number.isFinite(imageSize) ? imageSize : null))
+            : null,
         createdAt,
         editedAt: null,
         deleted: false,
@@ -6745,7 +6751,7 @@ export async function editChatMessage(teamId, messageId, newText, { conversation
         : doc(db, 'teams', teamId, 'chatConversations', conversationId, 'chatMessages', messageId);
     return await updateDoc(messageRef, {
         text: newText,
-        editedAt: Timestamp.now()
+        editedAt: serverTimestamp()
     });
 }
 

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -114,6 +114,13 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'match /rsvpNotes/{rsvpId}', 'Firestore restricted RSVP note rules');
     assertIncludes(firestoreRules, 'function isRsvpStatusPayloadSafe(data)', 'Firestore RSVP status note exclusion helper');
     assertIncludes(firestoreRules, 'allow read: if canReadRsvpNote(teamId, resource.data);', 'Firestore restricted RSVP note read rules');
+    assertIncludes(firestoreRules, 'function isNestedChatMessageCreateValid(teamId, conversationId, conversationData, data)', 'Nested chat message payload validator');
+    assertIncludes(firestoreRules, 'function isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data)', 'Nested chat message target validator');
+    assertIncludes(firestoreRules, 'function hasValidNestedChatAttachments(teamId, conversationId, data)', 'Nested chat attachment validator');
+    assertIncludes(firestoreRules, 'data.createdAt == request.time', 'Nested chat server timestamp binding');
+    assertIncludes(firestoreRules, 'data.senderEmail.lower() == request.auth.token.email.lower()', 'Nested chat sender email binding');
+    assertIncludes(firestoreRules, "data.recipientIds == conversationData.get('participantIds', [])", 'Nested chat conversation participant binding');
+    assertIncludes(firestoreRules, 'isNestedChatMessageCreateValid(', 'Nested chat create rules');
 
     assertIncludes(deployProd, 'firestore:rules', 'Production deploy');
     assertIncludes(deployProd, 'firestore:indexes', 'Production deploy');

--- a/team-chat.html
+++ b/team-chat.html
@@ -2603,18 +2603,19 @@
             try {
                 const needs = await inferDataNeeds(question);
                 const responseText = await askAllPlays(question, needs);
+                const isTargetedConversation = !isDefaultTeamConversation(selectedConversationId);
                 await postChatMessage(teamId, {
-                    text: responseText,
+                    text: isTargetedConversation ? `ALL PLAYS\n\n${responseText}` : responseText,
                     senderId: currentUser.uid,
-                    senderName: null,
-                    senderEmail: null,
-                    senderPhotoUrl: null,
-                    ai: true,
-                    aiName: 'ALL PLAYS',
-                    aiQuestion: question,
+                    senderName: isTargetedConversation ? (currentUserProfile?.fullName || currentUser.displayName || currentUser.email || null) : null,
+                    senderEmail: isTargetedConversation ? (currentUser.email || null) : null,
+                    senderPhotoUrl: isTargetedConversation ? (currentUserProfile?.photoUrl || currentUser.photoURL || null) : null,
+                    ai: !isTargetedConversation,
+                    aiName: isTargetedConversation ? null : 'ALL PLAYS',
+                    aiQuestion: isTargetedConversation ? null : question,
                     conversationId: selectedConversationId,
                     ...buildRecipientTargetMetadata(),
-                    aiMeta: {
+                    aiMeta: isTargetedConversation ? null : {
                         statsGameLimit: AI_STATS_GAMES_LIMIT,
                         gamesContextLimit: AI_GAMES_CONTEXT_LIMIT,
                         statsRequested: needs.fetchStats,
@@ -2944,7 +2945,7 @@
 
             let mediaPayloads = [];
             try {
-                const targetMetadata = buildRecipientTargetMetadata();
+                let targetMetadata = buildRecipientTargetMetadata();
                 let conversationId = selectedConversationId;
                 if (isDefaultTeamConversation(conversationId) && targetMetadata.targetType !== 'full_team') {
                     const participantIds = targetMetadata.targetType === 'staff'
@@ -2959,6 +2960,13 @@
                         name: getTargetedConversationName(targetMetadata)
                     });
                     conversationId = conversation.id;
+                    if (targetMetadata.targetType === 'individuals') {
+                        targetMetadata = {
+                            targetType: 'individuals',
+                            recipientIds: Array.isArray(conversation.participantIds) ? conversation.participantIds : participantIds,
+                            targetRole: null
+                        };
+                    }
                     selectedConversationId = conversationId;
                     await loadConversations();
                 }

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,7 +344,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=15';
         import { checkAuth } from './js/auth.js?v=46';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=91';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=92';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=2';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -1093,7 +1093,7 @@ describe('React app chat recipient service', () => {
             attachments: [uploadedPhoto, uploadedVideo],
             conversationId: 'group-player-coach',
             targetType: 'individuals',
-            recipientIds: ['player:player-1', 'user:coach-1'],
+            recipientIds: ['user-1', 'email:guardian@example.com', 'user:coach-1', 'user:parent-2'],
             targetRole: null
         }));
         expect(result).toEqual({

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -9,22 +9,22 @@ describe('RSVP precedence cache delivery', () => {
     it('uses one fresh db module key and versions the indirect staff breakdown graph', () => {
         const dbSource = readRepoFile('js/db.js');
         const breakdownSource = readRepoFile('js/game-day-rsvp-breakdown.js');
-        const runtimeSources = [
-            'accept-invite.html',
-            'calendar.html',
-            'edit-schedule.html',
-            'game-day.html',
-            'login.html',
-            'parent-dashboard.html',
-            'team.html',
-            'team-chat.html',
-            'js/auth.js',
-            'js/team-media.js'
-        ].map(readRepoFile);
+        const runtimeSources = {
+            'accept-invite.html': 'db.js?v=91',
+            'calendar.html': 'db.js?v=91',
+            'edit-schedule.html': 'db.js?v=91',
+            'game-day.html': 'db.js?v=91',
+            'login.html': 'db.js?v=91',
+            'parent-dashboard.html': 'db.js?v=91',
+            'team.html': 'db.js?v=91',
+            'team-chat.html': 'db.js?v=92',
+            'js/auth.js': 'db.js?v=91',
+            'js/team-media.js': 'db.js?v=91'
+        };
 
-        runtimeSources.forEach((source) => {
-            expect(source).toContain('db.js?v=91');
-        });
+        for (const [path, expectedVersion] of Object.entries(runtimeSources)) {
+            expect(readRepoFile(path)).toContain(expectedVersion);
+        }
         expect(dbSource).toContain("from './rsvp-summary.js?v=2';");
         expect(dbSource).toContain("from './game-day-rsvp-breakdown.js?v=2';");
         expect(breakdownSource).toContain("from './rsvp-summary.js?v=2';");

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -26,9 +26,21 @@ describe('nested team chat message payload contracts', () => {
         expect(rules).toContain("data.get('ai', false) == false");
         expect(rules).toContain("data.get('aiMeta', null) == null");
         expect(rules).toContain('function hasValidNestedChatAttachments(teamId, conversationId, data)');
+        expect(rules).toContain('function isSafeNestedChatRegexSegment(value)');
+        expect(rules).toContain('function isScopedNestedChatFallbackMediaPath(teamId, conversationId, value)');
+        expect(rules).toContain("let pathSegments = value.split('/');");
+        expect(rules).toContain('pathSegments[3] == conversationId');
+        expect(rules).toContain("value.matches('[A-Za-z0-9_%:-]+')");
         expect(rules).toContain('data.attachments.size() <= 10');
         expect(rules).toContain('attachment.size <= 5 * 1024 * 1024');
         expect(rules).toContain("value.matches('https://firebasestorage[.]googleapis[.]com/.*')");
+        const createValidator = rules.slice(
+            rules.indexOf('function isNestedChatMessageCreateValid'),
+            rules.indexOf('function isNestedChatMessageEditValid')
+        );
+        expect(createValidator.indexOf('hasValidNestedChatAttachments(teamId, conversationId, data)')).toBeLessThan(
+            createValidator.indexOf('(data.text.size() > 0 || data.attachments.size() > 0)')
+        );
         expect(rules).toContain('function isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data)');
         expect(rules).toContain("conversationData.get('type', '') in ['direct', 'group']");
         expect(rules).toContain("data.recipientIds == conversationData.get('participantIds', [])");
@@ -200,6 +212,7 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
     it('denies spoofed, privileged, stale, extra-field, and mismatched creates', async () => {
         const parentDb = authedFirestore('parent-1', 'parent@example.com');
         const invalidPayloads = [
+            directPayload({ text: '', attachments: [] }),
             directPayload({ senderId: 'user-2' }),
             directPayload({ senderEmail: 'spoofed@example.com' }),
             directPayload({ createdAt: Timestamp.fromMillis(1700000000000) }),
@@ -238,6 +251,66 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
                 attachments: [attachment]
             })));
         }
+    });
+
+    it('denies attachment-only messages when the conversation id is not safe to interpolate into path regexes', async () => {
+        const unsafeConversationId = 'direct_parent-1__user-2.*';
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), `teams/team-1/chatConversations/${unsafeConversationId}`), {
+                type: 'direct',
+                participantIds: ['parent-1', 'user-2'],
+                participantRoles: [],
+                mutedBy: []
+            });
+        });
+
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const attachment = {
+            type: 'image',
+            url: 'https://firebasestorage.googleapis.com/v0/b/allplays-images/o/team-photo.jpg?alt=media',
+            path: 'stat-sheets/team-chat/team-1/direct_parent-1__user-2x/parent-1/photo.jpg',
+            thumbnailUrl: null,
+            name: 'photo.jpg',
+            mimeType: 'image/jpeg',
+            size: 1024,
+            uploadedAt: Timestamp.now()
+        };
+
+        await assertFails(setDoc(messageRef(parentDb, unsafeConversationId, 'unsafe-conversation-media'), directPayload({
+            text: '',
+            attachments: [attachment],
+            conversationId: unsafeConversationId
+        })));
+    });
+
+    it('allows exact-segment fallback paths for dotted email-derived conversation ids', async () => {
+        const emailConversationId = 'direct_email%3Aparent.name%40example.com__user-2';
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), `teams/team-1/chatConversations/${emailConversationId}`), {
+                type: 'direct',
+                participantIds: ['parent-1', 'user-2'],
+                participantRoles: [],
+                mutedBy: []
+            });
+        });
+
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const attachment = {
+            type: 'image',
+            url: 'https://firebasestorage.googleapis.com/v0/b/allplays-images/o/team-photo.jpg?alt=media',
+            path: `stat-sheets/team-chat/team-1/${emailConversationId}/parent-1/photo.jpg`,
+            thumbnailUrl: null,
+            name: 'photo.jpg',
+            mimeType: 'image/jpeg',
+            size: 1024,
+            uploadedAt: Timestamp.now()
+        };
+
+        await assertSucceeds(setDoc(messageRef(parentDb, emailConversationId, 'valid-dotted-conversation-media'), directPayload({
+            text: '',
+            attachments: [attachment],
+            conversationId: emailConversationId
+        })));
     });
 
     it('allows bounded server-timestamp edits and rejects forged or oversized edits', async () => {

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -31,6 +31,21 @@ describe('nested team chat message payload contracts', () => {
         expect(rules).toContain("let pathSegments = value.split('/');");
         expect(rules).toContain('pathSegments[3] == conversationId');
         expect(rules).toContain("value.matches('[A-Za-z0-9_%:-]+')");
+        const scopedMediaPathValidator = rules.slice(
+            rules.indexOf('function isScopedNestedChatMediaPath'),
+            rules.indexOf('function isValidNestedChatAttachment')
+        );
+        expect(scopedMediaPathValidator.indexOf('isScopedNestedChatFallbackMediaPath')).toBeLessThan(
+            scopedMediaPathValidator.indexOf("value.matches('team-(photos|videos)")
+        );
+        const attachmentValidator = rules.slice(
+            rules.indexOf('function isValidNestedChatAttachment'),
+            rules.indexOf('function hasValidNestedChatAttachments')
+        );
+        expect(attachmentValidator).toContain("attachment.keys().hasOnly([\n               'type', 'url', 'path', 'thumbnailUrl', 'name', 'mimeType', 'size', 'uploadedAt'");
+        for (const requiredField of ['type', 'url', 'path', 'thumbnailUrl', 'name', 'mimeType', 'size', 'uploadedAt']) {
+            expect(attachmentValidator).toContain(`attachment.${requiredField}`);
+        }
         expect(rules).toContain('data.attachments.size() <= 10');
         expect(rules).toContain('attachment.size <= 5 * 1024 * 1024');
         expect(rules).toContain("value.matches('https://firebasestorage[.]googleapis[.]com/.*')");
@@ -275,10 +290,14 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
             size: 1024,
             uploadedAt: Timestamp.now()
         };
+        const missingRequiredField = { ...baseAttachment };
+        delete missingRequiredField.uploadedAt;
         const invalidAttachments = [
             { ...baseAttachment, url: 'https://attacker.example/photo.jpg' },
             { ...baseAttachment, path: 'team-photos/unscoped-photo.jpg' },
-            { ...baseAttachment, size: 5 * 1024 * 1024 + 1 }
+            { ...baseAttachment, size: 5 * 1024 * 1024 + 1 },
+            missingRequiredField,
+            { ...baseAttachment, unexpectedField: true }
         ];
 
         for (const [index, attachment] of invalidAttachments.entries()) {

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -48,11 +48,37 @@ describe('nested team chat message payload contracts', () => {
         expect(rules).toContain('hasValidNestedChatRecipientIds(conversationData, data)');
         expect(rules).toContain("data.recipientIds == conversationData.get('participantIds', [])");
 
-        const nestedTargetValidator = rules.slice(
-            rules.indexOf('function isNestedChatMessageTargetValid'),
+        const editTargetValidator = rules.slice(
+            rules.indexOf('function isNestedChatMessageEditTargetValid'),
             rules.indexOf('function isNestedChatMessageCreateValid')
         );
+        expect(editTargetValidator).toContain('isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data)');
+        expect(editTargetValidator).toContain('hasValidLegacyNestedChatRecipientIds(conversationData, data)');
+        expect(editTargetValidator).toContain('data.conversationId == conversationId');
+        expect(rules).toContain('data.recipientIds.hasOnly(participantIds)');
+        expect(rules).toContain('data.senderId in participantIds');
+        expect(rules).toContain('!(data.senderId in data.recipientIds)');
+
+        const nestedTargetValidator = rules.slice(
+            rules.indexOf('function isNestedChatMessageTargetValid'),
+            rules.indexOf('function isNestedChatMessageEditTargetValid')
+        );
         expect(nestedTargetValidator).not.toContain('isIndividualChatMessage(teamId, data)');
+
+        const createTargetValidator = rules.slice(
+            rules.indexOf('function isNestedChatMessageCreateValid'),
+            rules.indexOf('function isNestedChatMessageEditValid')
+        );
+        expect(createTargetValidator).toContain('isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data)');
+        expect(createTargetValidator).not.toContain('isNestedChatMessageEditTargetValid');
+
+        const nestedMessageRules = rules.slice(
+            rules.indexOf('match /chatConversations/{conversationId} {'),
+            rules.indexOf('// Server-only dedup log')
+        );
+        expect(nestedMessageRules).toContain('request.resource.data.diff(resource.data).affectedKeys()\n                               .hasOnly([\'text\', \'editedAt\'])');
+        expect(nestedMessageRules).toContain('resource.data.senderId == request.auth.uid');
+        expect(nestedMessageRules).toContain('isNestedChatMessageEditTargetValid(');
     });
 
     it('keeps the legacy full-team message rules independent from the nested validator', () => {
@@ -228,6 +254,7 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
             directPayload({ ai: true, aiName: 'ALL PLAYS' }),
             directPayload({ reactions: { heart: ['parent-1'] } }),
             directPayload({ recipientIds: ['parent-1'] }),
+            directPayload({ recipientIds: ['user-2'] }),
             directPayload({ conversationId: 'another-conversation' })
         ];
 
@@ -336,6 +363,58 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
         }));
         await assertFails(updateDoc(ref, {
             text: 'x'.repeat(10001),
+            editedAt: serverTimestamp()
+        }));
+    });
+
+    it('allows text-only edits of legitimate legacy targets that omitted the sender', async () => {
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const legacyRef = messageRef(parentDb, directConversationId, 'legacy-editable');
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(messageRef(context.firestore(), directConversationId, 'legacy-editable'), directPayload({
+                recipientIds: ['user-2'],
+                createdAt: Timestamp.now()
+            }));
+        });
+
+        await assertSucceeds(updateDoc(legacyRef, {
+            text: 'Edited legacy update',
+            editedAt: serverTimestamp()
+        }));
+    });
+
+    it('keeps legacy edit compatibility scoped to the sender, conversation, and immutable target fields', async () => {
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const otherParticipantDb = authedFirestore('user-2', 'user2@example.com');
+        const legacyRef = messageRef(parentDb, directConversationId, 'legacy-protected');
+        const unsafeLegacyRef = messageRef(parentDb, directConversationId, 'legacy-unsafe-target');
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(messageRef(context.firestore(), directConversationId, 'legacy-protected'), directPayload({
+                recipientIds: ['user-2'],
+                createdAt: Timestamp.now()
+            }));
+            await setDoc(messageRef(context.firestore(), directConversationId, 'legacy-unsafe-target'), directPayload({
+                recipientIds: ['outsider-1'],
+                createdAt: Timestamp.now()
+            }));
+        });
+
+        await assertFails(updateDoc(messageRef(otherParticipantDb, directConversationId, 'legacy-protected'), {
+            text: 'Edited by another participant',
+            editedAt: serverTimestamp()
+        }));
+        await assertFails(updateDoc(legacyRef, {
+            text: 'Mutated recipients',
+            editedAt: serverTimestamp(),
+            recipientIds: ['parent-1', 'user-2']
+        }));
+        await assertFails(updateDoc(legacyRef, {
+            text: 'Mutated conversation',
+            editedAt: serverTimestamp(),
+            conversationId: 'another-conversation'
+        }));
+        await assertFails(updateDoc(unsafeLegacyRef, {
+            text: 'Unsafe legacy target',
             editedAt: serverTimestamp()
         }));
     });

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -1,0 +1,261 @@
+import { readFileSync } from 'node:fs';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment
+} from '@firebase/rules-unit-testing';
+import { doc, serverTimestamp, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+const appChatSource = readFileSync(new URL('../../apps/app/src/lib/chatService.ts', import.meta.url), 'utf8');
+const appAiSource = readFileSync(new URL('../../apps/app/src/lib/chatAiService.ts', import.meta.url), 'utf8');
+const chatPageSource = readFileSync(new URL('../../team-chat.html', import.meta.url), 'utf8');
+
+describe('nested team chat message payload contracts', () => {
+    it('validates the complete create shape, trusted sender fields, server time, targets, and media', () => {
+        expect(rules).toContain('function isNestedChatMessageCreateValid(teamId, conversationId, conversationData, data)');
+        expect(rules).toContain("data.keys().hasAll([\n               'text', 'senderId', 'attachments', 'createdAt', 'targetType'");
+        expect(rules).toContain("data.keys().hasOnly([\n               'clientMessageId', 'text', 'senderId'");
+        expect(rules).toContain('data.senderId == request.auth.uid');
+        expect(rules).toContain('data.senderEmail.lower() == request.auth.token.email.lower()');
+        expect(rules).toContain('data.createdAt == request.time');
+        expect(rules).toContain("data.get('editedAt', null) == null");
+        expect(rules).toContain("data.get('deleted', false) == false");
+        expect(rules).toContain("data.get('ai', false) == false");
+        expect(rules).toContain("data.get('aiMeta', null) == null");
+        expect(rules).toContain('function hasValidNestedChatAttachments(teamId, conversationId, data)');
+        expect(rules).toContain('data.attachments.size() <= 10');
+        expect(rules).toContain('attachment.size <= 5 * 1024 * 1024');
+        expect(rules).toContain("value.matches('https://firebasestorage[.]googleapis[.]com/.*')");
+        expect(rules).toContain('function isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data)');
+        expect(rules).toContain("conversationData.get('type', '') in ['direct', 'group']");
+        expect(rules).toContain("data.recipientIds == conversationData.get('participantIds', [])");
+    });
+
+    it('keeps the legacy full-team message rules independent from the nested validator', () => {
+        const legacyStart = rules.indexOf('match /chatMessages/{messageId} {');
+        const conversationStart = rules.indexOf('match /chatConversations/{conversationId} {');
+        const legacyBlock = rules.slice(legacyStart, conversationStart);
+
+        expect(legacyBlock).toContain('isFullTeamChatMessage(request.resource.data);');
+        expect(legacyBlock).not.toContain('isNestedChatMessageCreateValid');
+    });
+
+    it('writes server-authored timestamps and canonical conversation participants from every client path', () => {
+        expect(dbSource).toContain('const createdAt = serverTimestamp();');
+        expect(dbSource).toContain('editedAt: serverTimestamp()');
+        expect(dbSource).toContain('const isLegacyTeamConversation = isDefaultTeamConversation(conversationId);');
+        expect(dbSource).toContain('imageUrl: isLegacyTeamConversation ?');
+        expect(appChatSource).toContain("serverTimestampFields: ['createdAt']");
+        expect(appChatSource).toContain("serverTimestampFields: ['editedAt']");
+        expect(appChatSource).toContain("setToServerValue: 'REQUEST_TIME'");
+        expect(appChatSource).toContain('recipientIds: Array.isArray(createdConversation.participantIds) ? createdConversation.participantIds : participantIds');
+        expect(chatPageSource).toContain('recipientIds: Array.isArray(conversation.participantIds) ? conversation.participantIds : participantIds');
+    });
+
+    it('does not persist privileged AI identity fields from a targeted client conversation', () => {
+        expect(appAiSource).toContain('const isTargetedConversation = !isDefaultTeamConversation(selectedConversationId);');
+        expect(appAiSource).toContain('ai: !isTargetedConversation');
+        expect(appAiSource).toContain("aiName: isTargetedConversation ? null : 'ALL PLAYS'");
+        expect(appAiSource).toContain('aiMeta: isTargetedConversation ? null : {');
+        expect(chatPageSource).toContain('ai: !isTargetedConversation');
+        expect(chatPageSource).toContain("aiName: isTargetedConversation ? null : 'ALL PLAYS'");
+    });
+});
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message rules engine coverage', () => {
+    let testEnv;
+    const directConversationId = 'direct_parent-1__user-2';
+    const staffConversationId = 'group_role%3Astaff';
+
+    beforeAll(async () => {
+        testEnv = await initializeTestEnvironment({
+            projectId: `allplays-nested-chat-payload-${Date.now()}`,
+            firestore: { rules }
+        });
+    }, 30000);
+
+    beforeEach(async () => {
+        await testEnv.clearFirestore();
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const firestore = context.firestore();
+            await setDoc(doc(firestore, 'teams/team-1'), {
+                ownerId: 'coach-1',
+                adminEmails: ['coach@example.com'],
+                chatMemberIds: ['coach-1', 'parent-1', 'user-2']
+            });
+            await setDoc(doc(firestore, 'users/coach-1'), {
+                email: 'coach@example.com',
+                isAdmin: false,
+                parentTeamIds: []
+            });
+            await setDoc(doc(firestore, 'users/parent-1'), {
+                email: 'parent@example.com',
+                isAdmin: false,
+                parentTeamIds: ['team-1']
+            });
+            await setDoc(doc(firestore, `teams/team-1/chatConversations/${directConversationId}`), {
+                type: 'direct',
+                participantIds: ['parent-1', 'user-2'],
+                participantRoles: [],
+                mutedBy: []
+            });
+            await setDoc(doc(firestore, `teams/team-1/chatConversations/${staffConversationId}`), {
+                type: 'group',
+                participantIds: [],
+                participantRoles: ['staff'],
+                mutedBy: []
+            });
+        });
+    });
+
+    afterAll(async () => {
+        await testEnv?.cleanup();
+    });
+
+    function authedFirestore(uid, email) {
+        return testEnv.authenticatedContext(uid, { email }).firestore();
+    }
+
+    function messageRef(firestore, conversationId, messageId) {
+        return doc(firestore, `teams/team-1/chatConversations/${conversationId}/chatMessages/${messageId}`);
+    }
+
+    function directPayload(overrides = {}) {
+        return {
+            clientMessageId: null,
+            text: 'Private team update',
+            senderId: 'parent-1',
+            senderName: 'Pat Parent',
+            senderEmail: 'parent@example.com',
+            senderPhotoUrl: null,
+            attachments: [],
+            imageUrl: null,
+            imagePath: null,
+            imageName: null,
+            imageType: null,
+            imageSize: null,
+            createdAt: serverTimestamp(),
+            editedAt: null,
+            deleted: false,
+            ai: false,
+            aiName: null,
+            aiQuestion: null,
+            aiMeta: null,
+            targetType: 'individuals',
+            recipientIds: ['parent-1', 'user-2'],
+            targetRole: null,
+            conversationId: directConversationId,
+            ...overrides
+        };
+    }
+
+    function staffPayload(overrides = {}) {
+        return {
+            ...directPayload({
+                senderId: 'coach-1',
+                senderName: 'Coach One',
+                senderEmail: 'coach@example.com',
+                targetType: 'staff',
+                recipientIds: [],
+                targetRole: 'staff',
+                conversationId: staffConversationId
+            }),
+            ...overrides
+        };
+    }
+
+    it('allows canonical direct and staff payloads', async () => {
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const coachDb = authedFirestore('coach-1', 'coach@example.com');
+        const directWithoutStoredEmail = directPayload();
+        delete directWithoutStoredEmail.senderEmail;
+
+        await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct'), directPayload()));
+        await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct-no-email'), directWithoutStoredEmail));
+        await assertSucceeds(setDoc(messageRef(coachDb, staffConversationId, 'valid-staff'), staffPayload()));
+    });
+
+    it('allows bounded, scoped Firebase Storage attachment metadata', async () => {
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const attachment = {
+            type: 'image',
+            url: 'https://firebasestorage.googleapis.com/v0/b/allplays-images/o/team-photo.jpg?alt=media',
+            path: `team-photos/1700000000000_chat_team-1_${directConversationId}_parent-1_photo.jpg`,
+            thumbnailUrl: null,
+            name: 'photo.jpg',
+            mimeType: 'image/jpeg',
+            size: 1024,
+            uploadedAt: Timestamp.now()
+        };
+
+        await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-media'), directPayload({
+            text: '',
+            attachments: [attachment]
+        })));
+    });
+
+    it('denies spoofed, privileged, stale, extra-field, and mismatched creates', async () => {
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const invalidPayloads = [
+            directPayload({ senderId: 'user-2' }),
+            directPayload({ senderEmail: 'spoofed@example.com' }),
+            directPayload({ createdAt: Timestamp.fromMillis(1700000000000) }),
+            directPayload({ deleted: true }),
+            directPayload({ ai: true, aiName: 'ALL PLAYS' }),
+            directPayload({ reactions: { heart: ['parent-1'] } }),
+            directPayload({ recipientIds: ['parent-1'] }),
+            directPayload({ conversationId: 'another-conversation' })
+        ];
+
+        for (const [index, payload] of invalidPayloads.entries()) {
+            await assertFails(setDoc(messageRef(parentDb, directConversationId, `invalid-${index}`), payload));
+        }
+    });
+
+    it('denies arbitrary attachment origins, paths, and oversized attachment metadata', async () => {
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const baseAttachment = {
+            type: 'image',
+            url: 'https://firebasestorage.googleapis.com/v0/b/allplays-images/o/team-photo.jpg?alt=media',
+            path: `team-photos/1700000000000_chat_team-1_${directConversationId}_parent-1_photo.jpg`,
+            thumbnailUrl: null,
+            name: 'photo.jpg',
+            mimeType: 'image/jpeg',
+            size: 1024,
+            uploadedAt: Timestamp.now()
+        };
+        const invalidAttachments = [
+            { ...baseAttachment, url: 'https://attacker.example/photo.jpg' },
+            { ...baseAttachment, path: 'team-photos/unscoped-photo.jpg' },
+            { ...baseAttachment, size: 5 * 1024 * 1024 + 1 }
+        ];
+
+        for (const [index, attachment] of invalidAttachments.entries()) {
+            await assertFails(setDoc(messageRef(parentDb, directConversationId, `invalid-media-${index}`), directPayload({
+                attachments: [attachment]
+            })));
+        }
+    });
+
+    it('allows bounded server-timestamp edits and rejects forged or oversized edits', async () => {
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const ref = messageRef(parentDb, directConversationId, 'editable');
+        await assertSucceeds(setDoc(ref, directPayload()));
+
+        await assertSucceeds(updateDoc(ref, {
+            text: 'Edited update',
+            editedAt: serverTimestamp()
+        }));
+        await assertFails(updateDoc(ref, {
+            text: 'Forged timestamp',
+            editedAt: Timestamp.fromMillis(1700000000000)
+        }));
+        await assertFails(updateDoc(ref, {
+            text: 'x'.repeat(10001),
+            editedAt: serverTimestamp()
+        }));
+    });
+});

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -43,7 +43,16 @@ describe('nested team chat message payload contracts', () => {
         );
         expect(rules).toContain('function isNestedChatMessageTargetValid(teamId, conversationId, conversationData, data)');
         expect(rules).toContain("conversationData.get('type', '') in ['direct', 'group']");
+        expect(rules).toContain('function hasValidNestedChatRecipientIds(conversationData, data)');
+        expect(rules).toContain("conversationData.get('participantIds', []) is list");
+        expect(rules).toContain('hasValidNestedChatRecipientIds(conversationData, data)');
         expect(rules).toContain("data.recipientIds == conversationData.get('participantIds', [])");
+
+        const nestedTargetValidator = rules.slice(
+            rules.indexOf('function isNestedChatMessageTargetValid'),
+            rules.indexOf('function isNestedChatMessageCreateValid')
+        );
+        expect(nestedTargetValidator).not.toContain('isIndividualChatMessage(teamId, data)');
     });
 
     it('keeps the legacy full-team message rules independent from the nested validator', () => {
@@ -95,8 +104,7 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
             const firestore = context.firestore();
             await setDoc(doc(firestore, 'teams/team-1'), {
                 ownerId: 'coach-1',
-                adminEmails: ['coach@example.com'],
-                chatMemberIds: ['coach-1', 'parent-1', 'user-2']
+                adminEmails: ['coach@example.com']
             });
             await setDoc(doc(firestore, 'users/coach-1'), {
                 email: 'coach@example.com',

--- a/tests/unit/team-chat-targeted-rules.test.js
+++ b/tests/unit/team-chat-targeted-rules.test.js
@@ -159,7 +159,7 @@ describe('targeted team chat Firestore rules', () => {
         expect(rules).toContain('match /chatConversations/{conversationId} {');
         expect(rules).toContain('match /chatMessages/{messageId} {');
         expect(rules).toContain('allow create: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&');
-        expect(rules).toContain("request.resource.data.senderId == request.auth.uid;");
+        expect(rules).toContain('isNestedChatMessageCreateValid(');
     });
 
     it('restricts staff/group messages to sender and team staff/admin roles', () => {
@@ -189,7 +189,7 @@ describe('targeted team chat Firestore rules', () => {
     });
 
     it('rejects unauthorized senders by requiring senderId to match auth uid', () => {
-        expect(rules).toContain('request.resource.data.senderId == request.auth.uid &&');
+        expect(rules).toContain('data.senderId == request.auth.uid &&');
     });
 
     it('locks membership and naming changes to team staff while letting participants update benign metadata', () => {

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=91';");
+        expect(html).toContain("from './js/db.js?v=92';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {


### PR DESCRIPTION
## Summary

- add a strict allowed-key and value validator for nested conversation messages
- bind sender ID/email, create/edit timestamps, and message targets to authenticated and parent-conversation data
- reject pre-seeded deletion, reaction, AI, legacy-image, and arbitrary attachment metadata
- align web and native clients on server timestamps, canonical conversation participants, uploader-scoped media paths, and safe targeted AI persistence
- keep the legacy full-team chat rule path unchanged

## Root cause

Nested `teams/{teamId}/chatConversations/{conversationId}/chatMessages` creates previously checked only conversation access and `senderId == auth.uid`. Every other field remained caller-controlled, and newly created direct/group conversations could persist the pre-resolution recipient selection instead of their canonical participant list.

## Validation

- `npx vitest run tests/unit/team-chat-nested-message-payload-rules.test.js tests/unit/team-chat-targeted-rules.test.js tests/unit/app-chat-service-recipients.test.js apps/app/src/lib/chatService.test.ts --reporter=dot` — 64 passed, 5 emulator-only skipped
- Firestore emulator: `tests/unit/team-chat-nested-message-payload-rules.test.js` — 9 passed
- `npm run ci:firebase-rules`
- `npm run app:build`
- `tests/smoke/app-messages.spec.js` — 8 passed

Closes #3630