### PR TITLE
Clarify RSVP reminder email coverage

### DIFF
--- a/apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpReminderPanel.test.tsx
@@ -32,8 +32,8 @@ const preview = {
     missingPlayerCount: 2,
     eligibleEmailCount: 3,
     players: [
-        { playerId: 'player-1', playerName: 'Avery Smith', parentEmails: ['one@example.com'] },
-        { playerId: 'player-2', playerName: 'Blake Jones', parentEmails: ['two@example.com'] }
+        { playerId: 'player-1', playerName: 'Avery Smith', parentEmails: ['one@example.com'], hasEligibleParentEmail: true },
+        { playerId: 'player-2', playerName: 'Blake Jones', parentEmails: ['two@example.com'], hasEligibleParentEmail: true }
     ]
 } as any;
 
@@ -101,6 +101,7 @@ describe('StaffRsvpReminderPanel', () => {
         });
         expect(staffRsvpLoader.loadReminderPreview).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user);
         expect(screen.getByText('2 no-response players · 3 eligible parent/guardian emails.')).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Review players without email' })).toBeNull();
 
         fireEvent.click(screen.getByRole('button', { name: 'Send reminder' }));
 
@@ -111,6 +112,65 @@ describe('StaffRsvpReminderPanel', () => {
         expect(screen.getByText('Sent')).toBeTruthy();
         expect(screen.queryByRole('button', { name: 'Send reminder' })).toBeNull();
         expect(screen.getByRole('button', { name: 'Send again' })).toBeTruthy();
+    });
+
+    it('warns about partial email coverage and reveals uncovered players without blocking send', async () => {
+        const partialPreview = {
+            ...preview,
+            eligibleEmailCount: 1,
+            players: [
+                { playerId: 'player-1', playerName: 'Avery Smith', parentEmails: ['one@example.com'], hasEligibleParentEmail: true },
+                { playerId: 'player-2', playerName: 'Blake Jones', parentEmails: [], hasEligibleParentEmail: false }
+            ]
+        };
+        const staffRsvpLoader = createStaffRsvpLoader();
+        staffRsvpLoader.loadReminderPreview.mockResolvedValue(partialPreview);
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+        renderPanel({}, staffRsvpLoader);
+
+        expect(await screen.findByText('1 no-response player has no eligible parent/guardian email. Reminder still posts to team chat; emails only reach eligible guardians.')).toBeVisible();
+        expect(screen.queryByText('Blake Jones')).toBeNull();
+        const disclosure = screen.getByRole('button', { name: 'Review players without email' });
+        expect(disclosure).toHaveAttribute('aria-expanded', 'false');
+        fireEvent.click(disclosure);
+        expect(screen.getByText('Blake Jones')).toBeVisible();
+        expect(screen.queryByText('Avery Smith')).toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Send reminder' }));
+
+        expect(confirmSpy).toHaveBeenCalledWith('Send an RSVP reminder to 2 no-response players? 1 eligible parent/guardian email will be targeted. 1 no-response player has no eligible parent/guardian email. The reminder will also post to team chat.');
+        expect(sendStaffRsvpReminder).not.toHaveBeenCalled();
+    });
+
+    it('uses team-chat-only copy and the existing send path when no email is eligible', async () => {
+        const zeroEmailPreview = {
+            ...preview,
+            eligibleEmailCount: 0,
+            players: [
+                { playerId: 'player-1', playerName: 'Avery Smith', parentEmails: [], hasEligibleParentEmail: false },
+                { playerId: 'player-2', playerName: 'Blake Jones', parentEmails: [], hasEligibleParentEmail: false }
+            ]
+        };
+        const staffRsvpLoader = createStaffRsvpLoader();
+        staffRsvpLoader.loadReminderPreview.mockResolvedValue(zeroEmailPreview);
+        vi.mocked(sendStaffRsvpReminder).mockResolvedValue({
+            ...zeroEmailPreview,
+            emailSentCount: 0
+        });
+        const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+        renderPanel({}, staffRsvpLoader);
+
+        expect(await screen.findByText('No eligible parent/guardian emails for 2 no-response players. Reminder will post to team chat only.')).toBeVisible();
+        expect(screen.getByRole('button', { name: 'Send reminder' })).toBeVisible();
+        fireEvent.click(screen.getByRole('button', { name: 'Send reminder' }));
+
+        expect(confirmSpy).toHaveBeenCalledWith('Send an RSVP reminder to 2 no-response players? No parent/guardian emails will be sent. The reminder will post to team chat only.');
+        await waitFor(() => {
+            expect(sendStaffRsvpReminder).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user, auth.profile);
+        });
+        expect(screen.getByText('RSVP reminder sent to team chat. No parent/guardian emails were sent.')).toBeVisible();
     });
 
     it('keeps repeat reminders secondary and confirmed after a successful send', async () => {

--- a/apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx
+++ b/apps/app/src/components/schedule/StaffRsvpReminderPanel.tsx
@@ -15,6 +15,7 @@ export function StaffRsvpReminderPanel({ refreshToken = 0, staffRsvpLoader }: { 
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [hasSentReminder, setHasSentReminder] = useState(false);
+  const [showPlayersWithoutEmail, setShowPlayersWithoutEmail] = useState(false);
 
   const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);
 
@@ -35,6 +36,7 @@ export function StaffRsvpReminderPanel({ refreshToken = 0, staffRsvpLoader }: { 
   useEffect(() => {
     setStatus(null);
     setHasSentReminder(false);
+    setShowPlayersWithoutEmail(false);
     if (canLoad) {
       refreshPreview();
     } else {
@@ -49,9 +51,21 @@ export function StaffRsvpReminderPanel({ refreshToken = 0, staffRsvpLoader }: { 
   }
   if (!preview || preview.missingPlayerCount <= 0) return null;
 
+  const playersWithoutEmail = preview.players.filter((player) => (
+    player.hasEligibleParentEmail === false
+    || !Array.isArray(player.parentEmails)
+    || player.parentEmails.length === 0
+  ));
+  const uncoveredPlayerCount = playersWithoutEmail.length;
+  const deliveryConfirmation = preview.eligibleEmailCount === 0
+    ? 'No parent/guardian emails will be sent. The reminder will post to team chat only.'
+    : uncoveredPlayerCount > 0
+      ? `${preview.eligibleEmailCount} eligible parent/guardian ${preview.eligibleEmailCount === 1 ? 'email' : 'emails'} will be targeted. ${uncoveredPlayerCount} no-response ${uncoveredPlayerCount === 1 ? 'player has' : 'players have'} no eligible parent/guardian email. The reminder will also post to team chat.`
+      : `${preview.eligibleEmailCount} eligible parent/guardian ${preview.eligibleEmailCount === 1 ? 'email' : 'emails'} will be targeted.`;
+
   const sendReminder = async () => {
     if (!auth.user || sending) return;
-    const confirmed = window.confirm(`Send an RSVP reminder to ${preview.missingPlayerCount} no-response ${preview.missingPlayerCount === 1 ? 'player' : 'players'}? ${preview.eligibleEmailCount} eligible parent/guardian ${preview.eligibleEmailCount === 1 ? 'email' : 'emails'} will be targeted.`);
+    const confirmed = window.confirm(`Send an RSVP reminder to ${preview.missingPlayerCount} no-response ${preview.missingPlayerCount === 1 ? 'player' : 'players'}? ${deliveryConfirmation}`);
     if (!confirmed) return;
     setSending(true);
     setError(null);
@@ -60,7 +74,9 @@ export function StaffRsvpReminderPanel({ refreshToken = 0, staffRsvpLoader }: { 
       const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});
       setPreview(result);
       setHasSentReminder(true);
-      setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? 'email' : 'emails'}.`);
+      setStatus(result.emailSentCount > 0
+        ? `RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? 'email' : 'emails'}.`
+        : 'RSVP reminder sent to team chat. No parent/guardian emails were sent.');
     } catch (sendError: any) {
       setError(sendError?.message || 'Unable to send RSVP reminder.');
     } finally {
@@ -100,6 +116,28 @@ export function StaffRsvpReminderPanel({ refreshToken = 0, staffRsvpLoader }: { 
           </button>
         )}
       </div>
+      {uncoveredPlayerCount > 0 ? (
+        <div className="mt-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs font-semibold leading-5 text-amber-900">
+          <div>
+            {preview.eligibleEmailCount === 0
+              ? `No eligible parent/guardian emails for ${uncoveredPlayerCount} no-response ${uncoveredPlayerCount === 1 ? 'player' : 'players'}. Reminder will post to team chat only.`
+              : `${uncoveredPlayerCount} no-response ${uncoveredPlayerCount === 1 ? 'player has' : 'players have'} no eligible parent/guardian email. Reminder still posts to team chat; emails only reach eligible guardians.`}
+          </div>
+          <button
+            type="button"
+            className="mt-1 font-black text-amber-900 underline underline-offset-2"
+            aria-expanded={showPlayersWithoutEmail}
+            onClick={() => setShowPlayersWithoutEmail((current) => !current)}
+          >
+            {showPlayersWithoutEmail ? 'Hide players without email' : 'Review players without email'}
+          </button>
+          {showPlayersWithoutEmail ? (
+            <ul className="mt-1 list-disc pl-5" aria-label="Players without eligible parent or guardian email">
+              {playersWithoutEmail.map((player) => <li key={player.playerId}>{player.playerName}</li>)}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
       {status ? <div className="mt-2 text-xs font-bold text-emerald-700">{status}</div> : null}
       {error ? <div className="mt-2 text-xs font-bold text-rose-700">{error}</div> : null}
     </div>

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -34,6 +34,8 @@ describe('staff RSVP panel decomposition contract', () => {
         expect(reminderPanelSource).toContain('const canLoad = Boolean(auth.user && event.isTeamRsvpReminderManager && event.isDbGame && !event.isCancelled);');
         expect(reminderPanelSource).toContain('staffRsvpLoader.loadReminderPreview(event, auth.user)');
         expect(reminderPanelSource).toContain('const result: StaffRsvpReminderSendResult = await sendStaffRsvpReminder(event, auth.user, auth.profile || {});');
-        expect(reminderPanelSource).toContain('setStatus(`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? \'email\' : \'emails\'}.`);');
+        expect(reminderPanelSource).toContain('setStatus(result.emailSentCount > 0');
+        expect(reminderPanelSource).toContain('`RSVP reminder sent to team chat and ${result.emailSentCount} parent/guardian ${result.emailSentCount === 1 ? \'email\' : \'emails\'}.`');
+        expect(reminderPanelSource).toContain("'RSVP reminder sent to team chat. No parent/guardian emails were sent.'");
     });
 });


### PR DESCRIPTION
## Summary

- warn staff before sending when any no-response player lacks eligible guardian email coverage
- provide a compact disclosure listing uncovered players without adding targeting steps
- use explicit team-chat-only confirmation and success copy when no email is eligible

## Investigation

The reminder preview already includes `players[].parentEmails` and `players[].hasEligibleParentEmail`, and the send service already posts to full-team chat after email handling. The panel did not use that per-player coverage data: it displayed only aggregate counts and always said eligible emails would be targeted, including when the eligible count was zero.

## Design and requirements

- preserve the existing summary and single Send reminder action when every no-response player has coverage
- derive uncovered players from the existing preview without changing service logic or data loading
- show a concise partial-coverage warning before send and clarify that email reaches only eligible guardians while team chat still receives the reminder
- show unambiguous team-chat-only copy when `eligibleEmailCount` is zero
- keep uncovered names behind a Review players without email disclosure with `aria-expanded` state
- keep the existing send function and positive-email success text; use explicit no-email success text for zero delivery

## Test plan and results

- `StaffRsvpReminderPanel.test.tsx`: **5 passed**
  - fully covered previews retain the current summary/action and show no warning
  - partial coverage shows the warning, disclosure, uncovered name, and delivery-aware confirmation
  - zero coverage confirms team-chat-only delivery, uses the existing send path, and reports that no emails were sent
  - repeat-send and no-missing-player behavior remains green
- `ScheduleEventDetail.test.tsx`: **96 passed** after rebasing onto current master
- `npm run app:build`: **passed** after rebasing onto current master

Closes #3516
