### PR TITLE
Simplify registration form setup

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -385,10 +385,6 @@
                             <label for="registration-title" class="block text-sm font-medium text-gray-700">Title</label>
                             <input id="registration-title" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Spring Soccer Registration">
                         </div>
-                        <div>
-                            <label for="registration-description" class="block text-sm font-medium text-gray-700">Description</label>
-                            <textarea id="registration-description" rows="2" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Who this registration is for and what parents should expect"></textarea>
-                        </div>
                         <div class="grid gap-4 sm:grid-cols-3">
                             <div>
                                 <label for="registration-program-type" class="block text-sm font-medium text-gray-700">Program</label>
@@ -407,86 +403,96 @@
                                 <input id="registration-fee" type="number" min="0" step="0.01" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="125.00">
                             </div>
                         </div>
-                        <div class="rounded border border-indigo-100 bg-indigo-50 p-3">
-                            <h4 class="text-sm font-semibold text-gray-900">Checkout and payment settings</h4>
-                            <p class="mt-1 text-xs text-gray-600">Choose what this form should support. Online checkout is saved as intent only until backend processing lands.</p>
-                            <div class="mt-3 grid gap-3 text-sm text-gray-700 sm:grid-cols-2">
-                                <label class="flex items-start gap-2 rounded border border-indigo-100 bg-white p-3">
-                                    <input id="registration-offline-payment" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-                                    <span><span class="font-medium text-gray-900">Accept offline payment</span><span class="block text-xs text-gray-500">Parents submit registration and the organizer follows up with payment instructions.</span></span>
-                                </label>
-                                <label class="flex items-start gap-2 rounded border border-indigo-100 bg-white p-3">
-                                    <input id="registration-online-checkout" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-                                    <span><span class="font-medium text-gray-900">Plan for online checkout</span><span class="block text-xs text-gray-500">Saved for future checkout. Online payment processing is not available yet.</span></span>
-                                </label>
-                            </div>
-                        </div>
-                        <div>
-                            <label for="registration-participant-fields" class="block text-sm font-medium text-gray-700">Participant fields</label>
-                            <textarea id="registration-participant-fields" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Participant name&#10;Birthdate"></textarea>
-                            <p class="mt-1 text-xs text-gray-500">One field per line or comma. Fields are required on the public form.</p>
-                        </div>
-                        <div>
-                            <label for="registration-guardian-fields" class="block text-sm font-medium text-gray-700">Guardian fields</label>
-                            <textarea id="registration-guardian-fields" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Guardian name&#10;Guardian email&#10;Guardian phone"></textarea>
-                        </div>
-                        <div class="rounded border border-gray-200 p-3">
-                            <div class="mb-3 flex items-start justify-between gap-3">
+                        <details id="registration-advanced-settings" class="rounded border border-gray-200 bg-gray-50">
+                            <summary class="cursor-pointer px-3 py-3 text-sm font-semibold text-gray-900 hover:bg-gray-100">Advanced registration settings</summary>
+                            <div class="space-y-4 border-t border-gray-200 p-3">
+                                <p class="text-xs text-gray-600">Optional settings for descriptions, payments, capacity, discounts, screening, and custom fields. New forms use Participant name and Birthdate plus Guardian name, email, and phone by default.</p>
                                 <div>
-                                    <h4 class="text-sm font-semibold text-gray-900">Registration options</h4>
-                                    <p class="text-xs text-gray-500">Define capacity and waitlist setup for options.</p>
+                                    <label for="registration-description" class="block text-sm font-medium text-gray-700">Description</label>
+                                    <textarea id="registration-description" rows="2" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Who this registration is for and what parents should expect"></textarea>
                                 </div>
-                                <button type="button" onclick="window.addRegistrationOptionAdmin()" class="rounded bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200">Add option</button>
+                                <div class="rounded border border-indigo-100 bg-indigo-50 p-3">
+                                    <h4 class="text-sm font-semibold text-gray-900">Checkout and payment settings</h4>
+                                    <p class="mt-1 text-xs text-gray-600">Choose what this form should support. Online checkout is saved as intent only until backend processing lands.</p>
+                                    <div class="mt-3 grid gap-3 text-sm text-gray-700 sm:grid-cols-2">
+                                        <label class="flex items-start gap-2 rounded border border-indigo-100 bg-white p-3">
+                                            <input id="registration-offline-payment" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                            <span><span class="font-medium text-gray-900">Accept offline payment</span><span class="block text-xs text-gray-500">Parents submit registration and the organizer follows up with payment instructions.</span></span>
+                                        </label>
+                                        <label class="flex items-start gap-2 rounded border border-indigo-100 bg-white p-3">
+                                            <input id="registration-online-checkout" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                            <span><span class="font-medium text-gray-900">Plan for online checkout</span><span class="block text-xs text-gray-500">Saved for future checkout. Online payment processing is not available yet.</span></span>
+                                        </label>
+                                    </div>
+                                </div>
+                                <div>
+                                    <label for="registration-participant-fields" class="block text-sm font-medium text-gray-700">Participant fields</label>
+                                    <textarea id="registration-participant-fields" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Participant name&#10;Birthdate"></textarea>
+                                    <p class="mt-1 text-xs text-gray-500">One field per line or comma. Fields are required on the public form.</p>
+                                </div>
+                                <div>
+                                    <label for="registration-guardian-fields" class="block text-sm font-medium text-gray-700">Guardian fields</label>
+                                    <textarea id="registration-guardian-fields" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Guardian name&#10;Guardian email&#10;Guardian phone"></textarea>
+                                </div>
+                                <div class="rounded border border-gray-200 p-3">
+                                    <div class="mb-3 flex items-start justify-between gap-3">
+                                        <div>
+                                            <h4 class="text-sm font-semibold text-gray-900">Registration options</h4>
+                                            <p class="text-xs text-gray-500">Define capacity and waitlist setup for options.</p>
+                                        </div>
+                                        <button type="button" onclick="window.addRegistrationOptionAdmin()" class="rounded bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200">Add option</button>
+                                    </div>
+                                    <div id="registration-options-list" class="space-y-3"></div>
+                                </div>
+                                <div class="rounded border border-gray-200 p-3">
+                                    <label class="inline-flex items-center gap-2 text-sm font-semibold text-gray-900">
+                                        <input id="registration-installments-enabled" type="checkbox" class="rounded border-gray-300">
+                                        Offer installment plan
+                                    </label>
+                                    <div class="mt-3 grid gap-3 sm:grid-cols-3">
+                                        <label for="registration-installment-count" class="text-sm font-medium text-gray-700">Installments
+                                            <input id="registration-installment-count" type="number" min="2" max="12" step="1" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="3">
+                                        </label>
+                                        <label for="registration-installment-first-date" class="text-sm font-medium text-gray-700">First due date
+                                            <input id="registration-installment-first-date" type="date" class="mt-1 w-full rounded border border-gray-300 p-2">
+                                        </label>
+                                        <label for="registration-installment-interval" class="text-sm font-medium text-gray-700">Days between
+                                            <input id="registration-installment-interval" type="number" min="1" step="1" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="30">
+                                        </label>
+                                    </div>
+                                    <p class="mt-2 text-xs text-gray-500">Parents can choose pay-in-full or this simple equal installment schedule. No payments are charged yet.</p>
+                                </div>
+                                <div>
+                                    <label for="registration-discount-rules" class="block text-sm font-medium text-gray-700">Discount rules</label>
+                                    <textarea id="registration-discount-rules" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Early bird before 2026-03-01: $25\nSibling/cart discount 2+: 10%"></textarea>
+                                    <p class="mt-1 text-xs text-gray-500">Optional. Supports early-bird deadlines and quantity discounts for public fee previews.</p>
+                                </div>
+                                <div class="rounded border border-amber-200 bg-amber-50 p-3">
+                                    <label class="inline-flex items-start gap-2 text-sm font-semibold text-gray-900">
+                                        <input id="registration-background-check-required" type="checkbox" class="mt-1 rounded border-gray-300 text-amber-600 focus:ring-amber-500">
+                                        <span>Require volunteer background check</span>
+                                    </label>
+                                    <label for="registration-background-check-instructions" class="mt-3 block text-sm font-medium text-gray-700">Volunteer instructions</label>
+                                    <textarea id="registration-background-check-instructions" rows="3" class="mt-1 w-full rounded border border-amber-200 p-2" placeholder="Explain who must complete screening, timing, and where to find next steps."></textarea>
+                                    <label class="mt-3 inline-flex items-start gap-2 text-sm text-gray-700">
+                                        <input id="registration-background-check-enabled" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                        <span><span class="font-medium text-gray-900">Track manual screening status</span><span class="block text-xs text-gray-500">New registrations receive an admin-only screening status for volunteer background check tracking.</span></span>
+                                    </label>
+                                    <div class="mt-3 grid gap-3 md:grid-cols-2">
+                                        <label for="registration-screening-initial-status" class="text-sm font-medium text-gray-700">Initial status
+                                            <select id="registration-screening-initial-status" class="mt-1 w-full rounded border border-gray-300 p-2">
+                                                <option value="pending">Pending</option>
+                                                <option value="submitted">Submitted</option>
+                                            </select>
+                                        </label>
+                                        <label for="registration-screening-provider" class="text-sm font-medium text-gray-700">Provider name/reference
+                                            <input id="registration-screening-provider" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Optional provider name">
+                                        </label>
+                                    </div>
+                                    <p class="mt-1 text-xs text-gray-600">Optional policy metadata only. This does not create screening submissions, charge fees, or change access.</p>
+                                </div>
                             </div>
-                            <div id="registration-options-list" class="space-y-3"></div>
-                        </div>
-                        <div class="rounded border border-gray-200 p-3">
-                            <label class="inline-flex items-center gap-2 text-sm font-semibold text-gray-900">
-                                <input id="registration-installments-enabled" type="checkbox" class="rounded border-gray-300">
-                                Offer installment plan
-                            </label>
-                            <div class="mt-3 grid gap-3 sm:grid-cols-3">
-                                <label for="registration-installment-count" class="text-sm font-medium text-gray-700">Installments
-                                    <input id="registration-installment-count" type="number" min="2" max="12" step="1" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="3">
-                                </label>
-                                <label for="registration-installment-first-date" class="text-sm font-medium text-gray-700">First due date
-                                    <input id="registration-installment-first-date" type="date" class="mt-1 w-full rounded border border-gray-300 p-2">
-                                </label>
-                                <label for="registration-installment-interval" class="text-sm font-medium text-gray-700">Days between
-                                    <input id="registration-installment-interval" type="number" min="1" step="1" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="30">
-                                </label>
-                            </div>
-                            <p class="mt-2 text-xs text-gray-500">Parents can choose pay-in-full or this simple equal installment schedule. No payments are charged yet.</p>
-                        </div>
-                        <div>
-                            <label for="registration-discount-rules" class="block text-sm font-medium text-gray-700">Discount rules</label>
-                            <textarea id="registration-discount-rules" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Early bird before 2026-03-01: $25\nSibling/cart discount 2+: 10%"></textarea>
-                            <p class="mt-1 text-xs text-gray-500">Optional. Supports early-bird deadlines and quantity discounts for public fee previews.</p>
-                        </div>
-                        <div class="rounded border border-amber-200 bg-amber-50 p-3">
-                            <label class="inline-flex items-start gap-2 text-sm font-semibold text-gray-900">
-                                <input id="registration-background-check-required" type="checkbox" class="mt-1 rounded border-gray-300 text-amber-600 focus:ring-amber-500">
-                                <span>Require volunteer background check</span>
-                            </label>
-                            <label for="registration-background-check-instructions" class="mt-3 block text-sm font-medium text-gray-700">Volunteer instructions</label>
-                            <textarea id="registration-background-check-instructions" rows="3" class="mt-1 w-full rounded border border-amber-200 p-2" placeholder="Explain who must complete screening, timing, and where to find next steps."></textarea>
-                            <label class="mt-3 inline-flex items-start gap-2 text-sm text-gray-700">
-                                <input id="registration-background-check-enabled" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-                                <span><span class="font-medium text-gray-900">Track manual screening status</span><span class="block text-xs text-gray-500">New registrations receive an admin-only screening status for volunteer background check tracking.</span></span>
-                            </label>
-                            <div class="mt-3 grid gap-3 md:grid-cols-2">
-                                <label for="registration-screening-initial-status" class="text-sm font-medium text-gray-700">Initial status
-                                    <select id="registration-screening-initial-status" class="mt-1 w-full rounded border border-gray-300 p-2">
-                                        <option value="pending">Pending</option>
-                                        <option value="submitted">Submitted</option>
-                                    </select>
-                                </label>
-                                <label for="registration-screening-provider" class="text-sm font-medium text-gray-700">Provider name/reference
-                                    <input id="registration-screening-provider" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Optional provider name">
-                                </label>
-                            </div>
-                            <p class="mt-1 text-xs text-gray-600">Optional policy metadata only. This does not create screening submissions, charge fees, or change access.</p>
-                        </div>
+                        </details>
                         <div>
                             <label for="registration-waiver" class="block text-sm font-medium text-gray-700">Waiver text</label>
                             <textarea id="registration-waiver" rows="4" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Waiver and acknowledgement text parents must accept"></textarea>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1437,6 +1437,27 @@ window.closeRegistrationFormsAdmin = function () {
     document.getElementById('registration-forms-modal').classList.add('hidden');
 };
 
+function hasAdvancedRegistrationSettings(form = {}) {
+    const participantFields = formatFieldLabels(form.participantFields, adminRegistrationDefaults.participantLabels);
+    const guardianFields = formatFieldLabels(form.guardianFields, adminRegistrationDefaults.guardianLabels);
+    const defaultParticipantFields = adminRegistrationDefaults.participantLabels.join('\n');
+    const defaultGuardianFields = adminRegistrationDefaults.guardianLabels.join('\n');
+    return Boolean(
+        form.description
+        || participantFields !== defaultParticipantFields
+        || guardianFields !== defaultGuardianFields
+        || form.paymentSettings?.offlinePaymentEnabled
+        || form.paymentSettings?.onlineCheckoutEnabled
+        || form.installmentPlan?.enabled
+        || form.registrationOptions?.length
+        || form.discountRules?.length
+        || form.backgroundCheck?.required
+        || form.backgroundCheck?.enabled
+        || form.backgroundCheck?.instructions
+        || form.backgroundCheck?.providerName
+    );
+}
+
 window.startRegistrationFormAdmin = function (formId = '') {
     const form = activeRegistrationForms.find(item => item.id === formId) || {};
     const editor = document.getElementById('registration-form-editor');
@@ -1466,6 +1487,7 @@ window.startRegistrationFormAdmin = function (formId = '') {
     document.getElementById('registration-waiver').value = form.waiverText || '';
     document.getElementById('registration-status').value = getRegistrationAdminStatus(form);
     document.getElementById('registration-form-message').textContent = '';
+    document.getElementById('registration-advanced-settings').open = Boolean(form.id && hasAdvancedRegistrationSettings(form));
     editor.classList.remove('hidden');
 };
 

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -25,6 +25,21 @@ import {
 } from '../../js/registration-flow.js';
 
 describe('admin registration form setup', () => {
+    it('builds a valid minimal form with the default participant and guardian fields', () => {
+        const payload = buildAdminRegistrationFormPayload({
+            title: 'Spring Soccer',
+            waiverText: 'I accept the waiver.',
+            status: 'draft'
+        }, { teamId: 'team-1' });
+
+        expect(payload.participantFields.map((field) => field.label)).toEqual(['Participant name', 'Birthdate']);
+        expect(payload.guardianFields.map((field) => field.label)).toEqual(['Guardian name', 'Guardian email', 'Guardian phone']);
+        expect(payload.paymentSettings).toEqual({ offlinePaymentEnabled: false, onlineCheckoutEnabled: false });
+        expect(payload.registrationOptions).toEqual([]);
+        expect(payload.installmentPlan).toBeNull();
+        expect(validateAdminRegistrationFormPayload(payload)).toEqual([]);
+    });
+
     it('builds draft and published form payloads with metadata, fields, waiver, and fee', () => {
         const payload = buildAdminRegistrationFormPayload({
             title: 'Spring Soccer',
@@ -299,6 +314,8 @@ describe('admin registration form setup', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
 
         expect(adminPage).toContain('registration-forms-modal');
+        expect(adminPage).toContain('registration-advanced-settings');
+        expect(adminPage).toContain('Advanced registration settings');
         expect(adminPage).toContain('registration-participant-fields');
         expect(adminPage).toContain('registration-guardian-fields');
         expect(adminPage).toContain('registration-options-list');
@@ -337,5 +354,26 @@ describe('admin registration form setup', () => {
         expect(adminJs).toContain('try {');
         expect(adminJs).toContain('inlineJsString');
         expect(adminJs).toContain('copyRegistrationLinkAdmin');
+    });
+
+    it('keeps first-run basics outside the advanced registration disclosure', () => {
+        const adminPage = fs.readFileSync('admin.html', 'utf8');
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+        const advancedStart = adminPage.indexOf('id="registration-advanced-settings"');
+        const advancedEnd = adminPage.indexOf('</details>', advancedStart);
+        const advancedTagStart = adminPage.lastIndexOf('<details', advancedStart);
+        const advancedTagEnd = adminPage.indexOf('>', advancedStart);
+
+        expect(adminPage.slice(advancedTagStart, advancedTagEnd)).not.toMatch(/\sopen(?:\s|=|>)/);
+        expect(advancedStart).toBeGreaterThan(adminPage.indexOf('id="registration-title"'));
+        expect(advancedStart).toBeGreaterThan(adminPage.indexOf('id="registration-fee"'));
+        expect(adminPage.indexOf('id="registration-description"')).toBeGreaterThan(advancedStart);
+        expect(adminPage.indexOf('id="registration-participant-fields"')).toBeGreaterThan(advancedStart);
+        expect(adminPage.indexOf('id="registration-participant-fields"')).toBeLessThan(advancedEnd);
+        expect(adminPage.indexOf('id="registration-background-check-instructions"')).toBeLessThan(advancedEnd);
+        expect(adminPage.indexOf('id="registration-waiver"')).toBeGreaterThan(advancedEnd);
+        expect(adminPage.indexOf('id="registration-status"')).toBeGreaterThan(advancedEnd);
+        expect(adminPage.slice(advancedStart, advancedEnd)).toContain('Participant name and Birthdate');
+        expect(adminJs).toContain("document.getElementById('registration-advanced-settings').open = Boolean(form.id && hasAdvancedRegistrationSettings(form));");
     });
 });


### PR DESCRIPTION
## Summary
- reduce the first-run registration editor to title, program/season, fee, waiver, status, and save
- move description, payment intent, custom fields, options/capacity, installments, discounts, and screening behind an accessible native disclosure
- explain the automatic participant/guardian field defaults in the disclosure summary content
- keep the disclosure closed for new forms and reopen it when editing a form with saved advanced settings
- preserve the existing payload builder and save path
- add minimal-payload and source-structure regression coverage

## Investigation and design
The editor rendered every optional control at the same level even though the payload builder already supplies safe participant and guardian field defaults for blank inputs. A native `details`/`summary` disclosure provides keyboard and screen-reader behavior without another custom state implementation.

New forms reset the disclosure closed. Existing forms open it automatically only when they contain a description, customized field labels, payment intent, installments, registration options, discounts, or screening metadata, so saved configuration is not hidden during editing. Waiver and publication status remain outside the disclosure.

## Requirements covered
- New form initially exposes only core setup, waiver, status, and save
- required waiver and status remain visible
- default participant and guardian fields are still populated and saved
- all existing advanced controls and DOM IDs remain available
- existing payment/options/installment/discount/background-check payload shape is unchanged
- advanced forms reopen their disclosure when edited

## Test plan and results
- all admin unit suites — 18 files, 70 tests passed
- minimal payload test verifies default participant/guardian fields and successful validation
- source structure test verifies all advanced controls are inside the closed disclosure while waiver/status remain outside
- existing comprehensive payload test verifies optional data shapes remain unchanged
- `node --check js/admin.js` — passed
- `git diff --check` — passed

Closes #3603.