### PR TITLE
Prioritize viewing notification-opened awards

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -989,7 +989,9 @@ describe('ParentTools access', () => {
         expect(await screen.findByText('Hustle Award')).toBeTruthy();
         expect(screen.queryByText('Leadership Award')).toBeNull();
         expect(screen.getByText('Opened from a notification')).toBeTruthy();
-        expect(screen.getByRole('button', { name: 'Open' })).toBeTruthy();
+        const requestedAwardCard = screen.getByText('Hustle Award').closest('section') as HTMLElement;
+        expect(within(requestedAwardCard).getByRole('button', { name: 'View award' })).toBeTruthy();
+        expect(within(requestedAwardCard).getByRole('button', { name: 'Share' })).toBeTruthy();
     });
 
     it('redirects invalid tabs without triggering a hook order violation', async () => {

--- a/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.test.tsx
@@ -8,15 +8,16 @@ import type { AuthState } from '../../lib/types';
 const parentCertificatesServiceMocks = vi.hoisted(() => ({
     loadParentCertificates: vi.fn()
 }));
+const publicActionMocks = vi.hoisted(() => ({
+    openPublicUrl: vi.fn(),
+    sharePublicUrl: vi.fn()
+}));
 
 vi.mock('../../lib/parentCertificatesService', () => ({
     loadParentCertificates: parentCertificatesServiceMocks.loadParentCertificates
 }));
 
-vi.mock('../../lib/publicActions', () => ({
-    openPublicUrl: vi.fn(),
-    sharePublicUrl: vi.fn()
-}));
+vi.mock('../../lib/publicActions', () => publicActionMocks);
 
 vi.mock('lucide-react', () => {
     const Icon = () => null;
@@ -93,7 +94,13 @@ describe('CertificatesTool deep links', () => {
         expect(screen.queryByText('Leadership Award')).toBeNull();
         expect(screen.getByText('Opened from a notification')).toBeTruthy();
         expect(screen.getByRole('button', { name: 'Show all awards' })).toBeTruthy();
-        expect(screen.getByRole('button', { name: 'Open' })).toBeTruthy();
+        const requestedCard = screen.getByText('Hustle Award').closest('section') as HTMLElement;
+        const viewAward = within(requestedCard).getByRole('button', { name: 'View award' });
+        const requestedShare = within(requestedCard).getByRole('button', { name: 'Share' });
+        expect(viewAward.className).toContain('primary-button');
+        expect(requestedShare.className).toContain('secondary-button');
+        fireEvent.click(viewAward);
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1');
         expect(parentCertificatesServiceMocks.loadParentCertificates).toHaveBeenCalledWith(auth.user, {
             requestedTeamId: 'team-1',
             requestedCertificateId: 'cert-1'
@@ -102,6 +109,11 @@ describe('CertificatesTool deep links', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Show all awards' }));
 
         expect(await screen.findByText('Leadership Award')).toBeTruthy();
+        expect(within(requestedCard).getByRole('button', { name: 'View award' })).toBeTruthy();
+        expect(within(requestedCard).getByRole('button', { name: 'Share' })).toBeTruthy();
+        const leadershipCard = screen.getByText('Leadership Award').closest('section') as HTMLElement;
+        expect(within(leadershipCard).getByRole('button', { name: 'Open' })).toBeTruthy();
+        expect(within(leadershipCard).getByRole('button', { name: 'Share' })).toBeTruthy();
     });
 
     it('falls back to the full list with an inline explanation when the requested certificate is missing', async () => {
@@ -143,5 +155,7 @@ describe('CertificatesTool deep links', () => {
         expect(currentRender.getByText('Leadership Award')).toBeTruthy();
         expect(currentRender.getByText('Sam Player - Bears')).toBeTruthy();
         expect(currentRender.getByText('Jordan Star - Bears')).toBeTruthy();
+        expect(currentRender.getAllByRole('button', { name: 'Open' })).toHaveLength(2);
+        expect(currentRender.queryByRole('button', { name: 'View award' })).toBeNull();
     });
 });

--- a/apps/app/src/pages/parent-tools/CertificatesTool.tsx
+++ b/apps/app/src/pages/parent-tools/CertificatesTool.tsx
@@ -81,7 +81,13 @@ export function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; re
             </section>
             {!error && (loading ? <LoadingBlock label="Loading awards" /> : (
                 <div className="grid gap-3 lg:grid-cols-2">
-                    {visibleCards.length ? visibleCards.map((card) => <CertificateCard key={`${card.teamId}-${card.playerId}-${card.id}`} card={card} />) : (
+                    {visibleCards.length ? visibleCards.map((card) => (
+                        <CertificateCard
+                            key={`${card.teamId}-${card.playerId}-${card.id}`}
+                            card={card}
+                            isRequested={Boolean(requestedCard && card.teamId === requestedCard.teamId && card.id === requestedCard.id)}
+                        />
+                    )) : (
                         <EmptyState icon={Award} title="No published awards" detail="Awards appear after a coach publishes certificates." />
                     )}
                 </div>
@@ -90,7 +96,7 @@ export function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; re
     );
 }
 
-function CertificateCard({ card }: { card: ParentCertificateCard }) {
+function CertificateCard({ card, isRequested }: { card: ParentCertificateCard; isRequested: boolean }) {
     return (
         <section className="app-card p-4">
             <div className="flex items-start gap-3">
@@ -103,10 +109,10 @@ function CertificateCard({ card }: { card: ParentCertificateCard }) {
                     {card.narrative || card.description ? <div className="mt-2 line-clamp-2 text-sm font-semibold leading-5 text-gray-600">{card.narrative || card.description}</div> : null}
                 </div>
             </div>
-            <div className="mt-3 grid grid-cols-2 gap-2">
-                <button type="button" className="secondary-button justify-center text-xs" onClick={() => openPublicUrl(card.url)}>
+            <div className={`mt-3 grid gap-2 ${isRequested ? 'grid-cols-1' : 'grid-cols-2'}`}>
+                <button type="button" className={`${isRequested ? 'primary-button' : 'secondary-button'} justify-center text-xs`} onClick={() => openPublicUrl(card.url)}>
                     <ExternalLink className="h-4 w-4" aria-hidden="true" />
-                    Open
+                    {isRequested ? 'View award' : 'Open'}
                 </button>
                 <button type="button" className="secondary-button justify-center text-xs" onClick={() => sharePublicUrl({ title: card.title || 'ALL PLAYS award', text: `${card.playerName} award`, url: card.url })}>
                     <Share2 className="h-4 w-4" aria-hidden="true" />

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -786,13 +786,22 @@ test('awards deep links surface the requested certificate first on mobile', asyn
     await expect(page.getByText('Opened from a notification')).toBeVisible({ timeout: 15000 });
     await expect(page.getByText('Hustle Award', { exact: true })).toBeVisible();
     await expect(page.getByText('Leadership Award', { exact: true })).toHaveCount(0);
-    const openButton = page.getByRole('button', { name: 'Open' }).first();
-    await expect(openButton).toBeVisible();
-    const box = await openButton.boundingBox();
+    const requestedAwardCard = page.locator('section.app-card', { hasText: 'Hustle Award' });
+    const viewAwardButton = requestedAwardCard.getByRole('button', { name: 'View award' });
+    await expect(viewAwardButton).toBeVisible();
+    const box = await viewAwardButton.boundingBox();
     expect(box && box.y + box.height).toBeLessThanOrEqual(844);
+    await expect(requestedAwardCard.getByRole('button', { name: 'Share' })).toBeVisible();
+    await viewAwardButton.click();
+    await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1');
 
     await page.getByRole('button', { name: 'Show all awards' }).click();
     await expect(page.getByText('Leadership Award')).toBeVisible();
+    await expect(requestedAwardCard.getByRole('button', { name: 'View award' })).toBeVisible();
+    await expect(requestedAwardCard.getByRole('button', { name: 'Share' })).toBeVisible();
+    const leadershipAwardCard = page.locator('section.app-card', { hasText: 'Leadership Award' });
+    await expect(leadershipAwardCard.getByRole('button', { name: 'Open' })).toBeVisible();
+    await expect(leadershipAwardCard.getByRole('button', { name: 'Share' })).toBeVisible();
 });
 
 test('team media route supports photo upload, file upload, link add, and media open', async ({ page, baseURL }) => {


### PR DESCRIPTION
## Summary

- make the notification-requested certificate expose a primary View award action
- keep Share immediately after it as a visually secondary action
- preserve normal Open/Share list cards and the Show all awards expansion path

## Investigation

The deep-link flow already loads, identifies, and isolates the requested certificate and displays its notification context. The remaining friction was local to `CertificateCard`: every card rendered Open and Share as equal two-column secondary buttons, so the requested “see the award” action did not have a clear priority.

## Design and requirements

- pass requested-card context into the existing card component
- render the requested card's actions in one column with a primary View award button first and secondary Share second
- keep `openPublicUrl(card.url)` and `sharePublicUrl(...)` unchanged
- retain requested-card styling after Show all awards expands the list
- retain the existing two-column secondary Open/Share layout for every non-requested or non-deep-linked card

## Test plan and results

- `CertificatesTool.test.tsx` and `ParentTools.test.tsx`: **37 passed**
  - requested View award has the primary class and opens the exact certificate URL
  - Share remains secondary
  - Show all awards restores the full list with View/Share on the requested card and Open/Share on normal cards
  - non-deep-linked multi-card lists have only normal Open actions
- `app-parent-tools.spec.js`: **5 passed**
  - mobile deep link keeps View award above the fold, opens the requested URL, and preserves both cards' actions after expansion
- `npm run app:build`: **passed**

Closes #3469
