### PR TITLE
Preserve early-bird price on checkout retry

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -573,8 +573,9 @@ function calculatePublicRegistrationFeeSnapshot(form = {}, options = {}) {
   const subtotalAmountCents = originalFeeAmountCents * quantity;
   let finalAmountDueCents = subtotalAmountCents;
   const appliedDiscounts = [];
+  const discountRules = normalizePublicRegistrationDiscountRules(form.discountRules || []);
 
-  normalizePublicRegistrationDiscountRules(form.discountRules || []).forEach((rule) => {
+  discountRules.forEach((rule) => {
     if (!rule.active || !isPublicRegistrationDiscountEligible(rule, { quantity, now: submittedAt })) return;
     const discountAmountCents = rule.amountType === 'percent'
       ? Math.round(finalAmountDueCents * (rule.amountValue / 100))
@@ -588,6 +589,8 @@ function calculatePublicRegistrationFeeSnapshot(form = {}, options = {}) {
       label: rule.label,
       amountType: rule.amountType,
       amountValue: rule.amountValue,
+      earlyBirdDeadline: rule.earlyBirdDeadline,
+      minimumQuantity: rule.minimumQuantity,
       amountCents: appliedAmountCents
     });
   });
@@ -597,6 +600,7 @@ function calculatePublicRegistrationFeeSnapshot(form = {}, options = {}) {
     quantity,
     originalFeeAmountCents,
     subtotalAmountCents,
+    discountRules,
     appliedDiscounts,
     finalAmountDueCents
   };
@@ -891,7 +895,8 @@ function computeRegistrationFeeAmountCentsFromForm(form, now = new Date(), optio
   const originalFeeAmountCents = Math.max(0, Math.round(Number(form.feeAmountCents || 0)));
   const quantity = Math.max(1, Math.floor(Number(options.quantity || 1)));
   let remainingAmountCents = originalFeeAmountCents * quantity;
-  normalizeServerRegistrationDiscountRules(form.discountRules || []).forEach((rule) => {
+  const discountRulesSource = Array.isArray(options.discountRules) ? options.discountRules : form.discountRules || [];
+  normalizeServerRegistrationDiscountRules(discountRulesSource).forEach((rule) => {
     if (!rule.active || !isServerDiscountRuleEligible(rule, { quantity, now })) return;
     let discountAmountCents;
     if (rule.amountType === 'percent') {
@@ -950,6 +955,26 @@ function getRegistrationSubmittedAtDate(registration = {}, fallback = new Date()
   return resolved instanceof Date && Number.isFinite(resolved.getTime()) ? resolved : fallback;
 }
 
+function getRegistrationCapturedDiscountRules(registration = {}) {
+  if (Array.isArray(registration.feeSnapshot?.discountRules)) {
+    return registration.feeSnapshot.discountRules;
+  }
+  if (Array.isArray(registration.feeSnapshot?.appliedDiscounts)) {
+    const submittedAt = getRegistrationSubmittedAtDate(registration);
+    const submittedAtDeadline = submittedAt.toISOString().slice(0, 10);
+    return registration.feeSnapshot.appliedDiscounts.map((discount, index) => ({
+      id: discount?.id || `captured_discount_${index + 1}`,
+      type: discount?.type,
+      amountType: discount?.amountType || 'fixed',
+      amountValue: discount?.amountValue ?? discount?.amountCents,
+      earlyBirdDeadline: discount?.earlyBirdDeadline || submittedAtDeadline,
+      minimumQuantity: discount?.minimumQuantity || 1,
+      active: discount?.active !== false
+    }));
+  }
+  return registration.feeSnapshot ? [] : null;
+}
+
 function buildRegistrationInstallmentPaymentState(registration = {}, form = null, nextPaidInstallmentCount = getRegistrationPaymentPlanPaidInstallmentCount(registration)) {
   const storedSchedule = getStoredRegistrationInstallmentSchedule(registration);
   const authoritativeTotalBalanceDueCents = storedSchedule.length
@@ -998,11 +1023,12 @@ function getRegistrationCheckoutAmountCents(registration = {}, form = null) {
   }
   if (form) {
     // Recompute from the authoritative form pricing rules using the quantity
-    // and submission time captured by the server-created registration. Using
-    // submittedAt preserves time-sensitive discounts on later checkout retries
-    // without trusting a client-provided feeSnapshot amount.
+    // plus the discount rules and submission time captured by the
+    // server-created registration. Using the captured rule scope preserves
+    // retry discounts without granting rules added after submission.
     return computeRegistrationFeeAmountCentsFromForm(form, getRegistrationSubmittedAtDate(registration), {
-      quantity: registration.feeSnapshot?.quantity || 1
+      quantity: registration.feeSnapshot?.quantity || 1,
+      discountRules: getRegistrationCapturedDiscountRules(registration)
     });
   }
   if (registration.paymentPlan?.id === 'installments') {

--- a/functions/index.js
+++ b/functions/index.js
@@ -959,20 +959,7 @@ function getRegistrationCapturedDiscountRules(registration = {}) {
   if (Array.isArray(registration.feeSnapshot?.discountRules)) {
     return registration.feeSnapshot.discountRules;
   }
-  if (Array.isArray(registration.feeSnapshot?.appliedDiscounts)) {
-    const submittedAt = getRegistrationSubmittedAtDate(registration);
-    const submittedAtDeadline = submittedAt.toISOString().slice(0, 10);
-    return registration.feeSnapshot.appliedDiscounts.map((discount, index) => ({
-      id: discount?.id || `captured_discount_${index + 1}`,
-      type: discount?.type,
-      amountType: discount?.amountType || 'fixed',
-      amountValue: discount?.amountValue ?? discount?.amountCents,
-      earlyBirdDeadline: discount?.earlyBirdDeadline || submittedAtDeadline,
-      minimumQuantity: discount?.minimumQuantity || 1,
-      active: discount?.active !== false
-    }));
-  }
-  return registration.feeSnapshot ? [] : null;
+  return null;
 }
 
 function buildRegistrationInstallmentPaymentState(registration = {}, form = null, nextPaidInstallmentCount = getRegistrationPaymentPlanPaidInstallmentCount(registration)) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -959,6 +959,9 @@ function getRegistrationCapturedDiscountRules(registration = {}) {
   if (Array.isArray(registration.feeSnapshot?.discountRules)) {
     return registration.feeSnapshot.discountRules;
   }
+  // Legacy snapshots did not capture the authoritative rule scope. Keep that
+  // state distinct from a captured empty list so callers can fail closed
+  // instead of applying rules that may have been added after submission.
   return null;
 }
 
@@ -1009,13 +1012,16 @@ function getRegistrationCheckoutAmountCents(registration = {}, form = null) {
     return Math.max(0, Math.round(Number(installmentState.currentInstallment?.amountCents || 0) || 0));
   }
   if (form) {
+    const capturedDiscountRules = getRegistrationCapturedDiscountRules(registration);
     // Recompute from the authoritative form pricing rules using the quantity
     // plus the discount rules and submission time captured by the
     // server-created registration. Using the captured rule scope preserves
-    // retry discounts without granting rules added after submission.
+    // retry discounts without granting rules added after submission. Legacy
+    // snapshots without a captured rule scope receive no retry discount;
+    // stored appliedDiscounts remain non-authoritative for billing.
     return computeRegistrationFeeAmountCentsFromForm(form, getRegistrationSubmittedAtDate(registration), {
       quantity: registration.feeSnapshot?.quantity || 1,
-      discountRules: getRegistrationCapturedDiscountRules(registration)
+      discountRules: capturedDiscountRules === null ? [] : capturedDiscountRules
     });
   }
   if (registration.paymentPlan?.id === 'installments') {

--- a/functions/index.js
+++ b/functions/index.js
@@ -935,6 +935,21 @@ function shouldKeepRegistrationCapacityReserved(registration = {}) {
   return registration.paymentPlan?.id === 'installments' && getRegistrationPaymentPlanPaidInstallmentCount(registration) > 0;
 }
 
+function getRegistrationSubmittedAtDate(registration = {}, fallback = new Date()) {
+  const submittedAt = registration.submittedAt;
+  let resolved = null;
+  if (submittedAt instanceof Date) {
+    resolved = submittedAt;
+  } else if (submittedAt && typeof submittedAt.toDate === 'function') {
+    resolved = submittedAt.toDate();
+  } else if (submittedAt && typeof submittedAt.toMillis === 'function') {
+    resolved = new Date(submittedAt.toMillis());
+  } else if (submittedAt !== null && submittedAt !== undefined && submittedAt !== '') {
+    resolved = new Date(submittedAt);
+  }
+  return resolved instanceof Date && Number.isFinite(resolved.getTime()) ? resolved : fallback;
+}
+
 function buildRegistrationInstallmentPaymentState(registration = {}, form = null, nextPaidInstallmentCount = getRegistrationPaymentPlanPaidInstallmentCount(registration)) {
   const storedSchedule = getStoredRegistrationInstallmentSchedule(registration);
   const authoritativeTotalBalanceDueCents = storedSchedule.length
@@ -983,8 +998,10 @@ function getRegistrationCheckoutAmountCents(registration = {}, form = null) {
   }
   if (form) {
     // Recompute from the authoritative form pricing rules using the quantity
-    // captured on the server-created registration snapshot for this submission.
-    return computeRegistrationFeeAmountCentsFromForm(form, new Date(), {
+    // and submission time captured by the server-created registration. Using
+    // submittedAt preserves time-sensitive discounts on later checkout retries
+    // without trusting a client-provided feeSnapshot amount.
+    return computeRegistrationFeeAmountCentsFromForm(form, getRegistrationSubmittedAtDate(registration), {
       quantity: registration.feeSnapshot?.quantity || 1
     });
   }
@@ -3528,8 +3545,9 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
     throw new functions.https.HttpsError('failed-precondition', 'This registration has already been paid.');
   }
 
-  // Always recompute the expected amount from the authoritative form document.
-  // This prevents a tampered feeSnapshot on the stored registration from lowering the charge.
+  // Recompute from the authoritative form at the server-captured submission
+  // time. This prevents a tampered feeSnapshot from lowering the charge while
+  // preserving time-sensitive discounts when checkout is retried later.
   const expectedAmountCents = getRegistrationCheckoutAmountCents(registration, form);
   const amountCents = expectedAmountCents;
   if (!Number.isFinite(amountCents) || amountCents <= 0) {

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -390,10 +390,10 @@ test('retry checkout does not grant an early-bird discount added after submissio
     assert.equal(registration.checkoutAmountCents, 10000);
 });
 
-test('legacy retry checkout ignores stored applied discount amounts without captured rules', async () => {
+test('legacy retry checkout ignores stored and current discounts without a captured rule scope', async () => {
     const seed = buildSeedState({
         registrationCapacityReleased: false,
-        submittedAt: 'not-a-valid-date',
+        submittedAt: '2000-01-01T12:00:00.000Z',
         feeAmountCents: 10000,
         feeSnapshot: {
             currency: 'USD',
@@ -409,7 +409,7 @@ test('legacy retry checkout ignores stored applied discount amounts without capt
     Object.assign(seed['teams/team-1/registrationForms/form-1'], {
         feeAmountCents: 10000,
         discountRules: [
-            { id: 'expired', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+            { id: 'inflated', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
         ]
     });
     let stripeCreateArgs = null;

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -316,6 +316,9 @@ test('retry checkout preserves an early-bird discount captured at submission tim
             quantity: 1,
             originalFeeAmountCents: 10000,
             subtotalAmountCents: 10000,
+            discountRules: [
+                { id: 'early', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+            ],
             appliedDiscounts: [{ id: 'early', type: 'early_bird', amountCents: 2500 }],
             finalAmountDueCents: 7500
         }
@@ -344,6 +347,47 @@ test('retry checkout preserves an early-bird discount captured at submission tim
     assert.equal(stripeCreateArgs.line_items[0].price_data.unit_amount, 7500);
     const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
     assert.equal(registration.checkoutAmountCents, 7500);
+});
+
+test('retry checkout does not grant an early-bird discount added after submission', async () => {
+    const seed = buildSeedState({
+        registrationCapacityReleased: false,
+        submittedAt: '2000-01-01T12:00:00.000Z',
+        feeAmountCents: 10000,
+        feeSnapshot: {
+            currency: 'USD',
+            quantity: 1,
+            originalFeeAmountCents: 10000,
+            subtotalAmountCents: 10000,
+            discountRules: [],
+            appliedDiscounts: [],
+            finalAmountDueCents: 10000
+        }
+    });
+    Object.assign(seed['teams/team-1/registrationForms/form-1'], {
+        feeAmountCents: 10000,
+        discountRules: [
+            { id: 'later-early', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+        ]
+    });
+    let stripeCreateArgs = null;
+    const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
+        seed,
+        stripeCreateImpl: async (args) => {
+            stripeCreateArgs = args;
+            return {
+                id: 'cs_later_early_bird_retry',
+                url: 'https://checkout.stripe.com/c/later_early_bird_retry',
+                payment_status: 'unpaid'
+            };
+        }
+    });
+
+    await createStripeRegistrationCheckout(checkoutInput);
+
+    assert.equal(stripeCreateArgs.line_items[0].price_data.unit_amount, 10000);
+    const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
+    assert.equal(registration.checkoutAmountCents, 10000);
 });
 
 test('rolls back reserved capacity when Stripe checkout creation fails', async () => {

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -306,6 +306,46 @@ afterEach(() => {
     StripeStub = null;
 });
 
+test('retry checkout preserves an early-bird discount captured at submission time', async () => {
+    const seed = buildSeedState({
+        registrationCapacityReleased: false,
+        submittedAt: '2000-01-01T12:00:00.000Z',
+        feeAmountCents: 10000,
+        feeSnapshot: {
+            currency: 'USD',
+            quantity: 1,
+            originalFeeAmountCents: 10000,
+            subtotalAmountCents: 10000,
+            appliedDiscounts: [{ id: 'early', type: 'early_bird', amountCents: 2500 }],
+            finalAmountDueCents: 7500
+        }
+    });
+    Object.assign(seed['teams/team-1/registrationForms/form-1'], {
+        feeAmountCents: 10000,
+        discountRules: [
+            { id: 'early', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+        ]
+    });
+    let stripeCreateArgs = null;
+    const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
+        seed,
+        stripeCreateImpl: async (args) => {
+            stripeCreateArgs = args;
+            return {
+                id: 'cs_early_bird_retry',
+                url: 'https://checkout.stripe.com/c/early_bird_retry',
+                payment_status: 'unpaid'
+            };
+        }
+    });
+
+    await createStripeRegistrationCheckout(checkoutInput);
+
+    assert.equal(stripeCreateArgs.line_items[0].price_data.unit_amount, 7500);
+    const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
+    assert.equal(registration.checkoutAmountCents, 7500);
+});
+
 test('rolls back reserved capacity when Stripe checkout creation fails', async () => {
     const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
         seed: buildSeedState(),

--- a/functions/test/registration-checkout-retry-capacity.test.js
+++ b/functions/test/registration-checkout-retry-capacity.test.js
@@ -390,6 +390,48 @@ test('retry checkout does not grant an early-bird discount added after submissio
     assert.equal(registration.checkoutAmountCents, 10000);
 });
 
+test('legacy retry checkout ignores stored applied discount amounts without captured rules', async () => {
+    const seed = buildSeedState({
+        registrationCapacityReleased: false,
+        submittedAt: 'not-a-valid-date',
+        feeAmountCents: 10000,
+        feeSnapshot: {
+            currency: 'USD',
+            quantity: 1,
+            originalFeeAmountCents: 10000,
+            subtotalAmountCents: 10000,
+            appliedDiscounts: [
+                { id: 'inflated', type: 'early_bird', amountType: 'fixed', amountCents: 9000 }
+            ],
+            finalAmountDueCents: 1000
+        }
+    });
+    Object.assign(seed['teams/team-1/registrationForms/form-1'], {
+        feeAmountCents: 10000,
+        discountRules: [
+            { id: 'expired', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+        ]
+    });
+    let stripeCreateArgs = null;
+    const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
+        seed,
+        stripeCreateImpl: async (args) => {
+            stripeCreateArgs = args;
+            return {
+                id: 'cs_legacy_applied_discount_retry',
+                url: 'https://checkout.stripe.com/c/legacy_applied_discount_retry',
+                payment_status: 'unpaid'
+            };
+        }
+    });
+
+    await createStripeRegistrationCheckout(checkoutInput);
+
+    assert.equal(stripeCreateArgs.line_items[0].price_data.unit_amount, 10000);
+    const registration = firestore.snapshot('teams/team-1/registrationForms/form-1/registrations/reg-1');
+    assert.equal(registration.checkoutAmountCents, 10000);
+});
+
 test('rolls back reserved capacity when Stripe checkout creation fails', async () => {
     const { firestore, createStripeRegistrationCheckout } = loadCheckoutHandler({
         seed: buildSeedState(),

--- a/tests/unit/stripe-registration-fee-recompute.test.js
+++ b/tests/unit/stripe-registration-fee-recompute.test.js
@@ -44,7 +44,17 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
         expect(source).toContain('function getRegistrationCheckoutAmountCents(registration = {}, form = null)');
         expect(source).toContain('return computeRegistrationFeeAmountCentsFromForm(form, getRegistrationSubmittedAtDate(registration), {');
         expect(source).toContain('quantity: registration.feeSnapshot?.quantity || 1');
-        expect(source).toContain('discountRules: getRegistrationCapturedDiscountRules(registration)');
+        expect(source).toContain('discountRules: capturedDiscountRules === null ? [] : capturedDiscountRules');
+    });
+
+    it('distinguishes legacy snapshots from captured empty and populated rule lists', () => {
+        const { getRegistrationCapturedDiscountRules } = loadServerFeeHelpers();
+        const capturedRule = { id: 'early', type: 'early_bird' };
+
+        expect(getRegistrationCapturedDiscountRules({ feeSnapshot: {} })).toBeNull();
+        expect(getRegistrationCapturedDiscountRules({ feeSnapshot: { discountRules: { id: 'invalid' } } })).toBeNull();
+        expect(getRegistrationCapturedDiscountRules({ feeSnapshot: { discountRules: [] } })).toEqual([]);
+        expect(getRegistrationCapturedDiscountRules({ feeSnapshot: { discountRules: [capturedRule] } })).toEqual([capturedRule]);
     });
 
     it('recomputes early-bird eligibility at the server-captured submission time on retry', () => {
@@ -77,6 +87,28 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
                 quantity: 1,
                 finalAmountDueCents: 10000,
                 discountRules: []
+            }
+        };
+        const form = {
+            feeAmountCents: 10000,
+            discountRules: [
+                { id: 'later-early', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+            ]
+        };
+
+        expect(getRegistrationCheckoutAmountCents(registration, form)).toBe(10000);
+    });
+
+    it('does not grant current form rules to a legacy snapshot with a valid historical submittedAt', () => {
+        const { getRegistrationCheckoutAmountCents } = loadServerFeeHelpers();
+        const registration = {
+            submittedAt: { toDate: () => new Date('2000-01-01T12:00:00Z') },
+            feeSnapshot: {
+                quantity: 1,
+                finalAmountDueCents: 1000,
+                appliedDiscounts: [
+                    { id: 'later-early', type: 'early_bird', amountType: 'fixed', amountCents: 9000 }
+                ]
             }
         };
         const form = {

--- a/tests/unit/stripe-registration-fee-recompute.test.js
+++ b/tests/unit/stripe-registration-fee-recompute.test.js
@@ -25,8 +25,9 @@ function loadServerFeeHelpers() {
         ${extractFunction('normalizeServerRegistrationDiscountRules')}
         ${extractFunction('computeRegistrationFeeAmountCentsFromForm')}
         ${extractFunction('getRegistrationSubmittedAtDate')}
+        ${extractFunction('getRegistrationCapturedDiscountRules')}
         ${extractFunction('getRegistrationCheckoutAmountCents')}
-        return { computeRegistrationFeeAmountCentsFromForm, getRegistrationSubmittedAtDate, getRegistrationCheckoutAmountCents };
+        return { computeRegistrationFeeAmountCentsFromForm, getRegistrationSubmittedAtDate, getRegistrationCapturedDiscountRules, getRegistrationCheckoutAmountCents };
     `)();
 }
 
@@ -43,13 +44,20 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
         expect(source).toContain('function getRegistrationCheckoutAmountCents(registration = {}, form = null)');
         expect(source).toContain('return computeRegistrationFeeAmountCentsFromForm(form, getRegistrationSubmittedAtDate(registration), {');
         expect(source).toContain('quantity: registration.feeSnapshot?.quantity || 1');
+        expect(source).toContain('discountRules: getRegistrationCapturedDiscountRules(registration)');
     });
 
     it('recomputes early-bird eligibility at the server-captured submission time on retry', () => {
         const { getRegistrationCheckoutAmountCents } = loadServerFeeHelpers();
         const registration = {
             submittedAt: { toDate: () => new Date('2000-01-01T12:00:00Z') },
-            feeSnapshot: { quantity: 1, finalAmountDueCents: 7500 }
+            feeSnapshot: {
+                quantity: 1,
+                finalAmountDueCents: 7500,
+                discountRules: [
+                    { id: 'early', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+                ]
+            }
         };
         const form = {
             feeAmountCents: 10000,
@@ -59,6 +67,26 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
         };
 
         expect(getRegistrationCheckoutAmountCents(registration, form)).toBe(7500);
+    });
+
+    it('does not grant early-bird rules added to the form after registration submission', () => {
+        const { getRegistrationCheckoutAmountCents } = loadServerFeeHelpers();
+        const registration = {
+            submittedAt: { toDate: () => new Date('2000-01-01T12:00:00Z') },
+            feeSnapshot: {
+                quantity: 1,
+                finalAmountDueCents: 10000,
+                discountRules: []
+            }
+        };
+        const form = {
+            feeAmountCents: 10000,
+            discountRules: [
+                { id: 'later-early', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+            ]
+        };
+
+        expect(getRegistrationCheckoutAmountCents(registration, form)).toBe(10000);
     });
 
     it('falls back to checkout time for legacy registrations without a valid submittedAt', () => {
@@ -72,7 +100,7 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
                 { id: 'expired', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
             ]
         };
-        expect(getRegistrationCheckoutAmountCents({ feeSnapshot: { quantity: 1 } }, form)).toBe(10000);
+        expect(getRegistrationCheckoutAmountCents({ feeSnapshot: { quantity: 1, discountRules: [] } }, form)).toBe(10000);
     });
 
     it('createStripeRegistrationCheckout passes form to getRegistrationCheckoutAmountCents', () => {
@@ -169,8 +197,8 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
         // feeSnapshot.finalAmountDueCents = 1 (tampered), the checkout function ignores it
         // because it calls getRegistrationCheckoutAmountCents(registration, form) which uses
         // computeRegistrationFeeAmountCentsFromForm(form, now, { quantity }) — derived from the
-        // authoritative form plus the server-captured registration quantity and submittedAt,
-        // not the stored amount.
+        // authoritative form plus the server-captured registration quantity, discount rule
+        // scope, and submittedAt, not the stored amount.
         // We assert this via the source check above and via the algorithm test below.
         const tamperedRegistration = {
             feeSnapshot: { finalAmountDueCents: 1 },

--- a/tests/unit/stripe-registration-fee-recompute.test.js
+++ b/tests/unit/stripe-registration-fee-recompute.test.js
@@ -24,7 +24,9 @@ function loadServerFeeHelpers() {
         ${extractFunction('isServerDiscountRuleEligible')}
         ${extractFunction('normalizeServerRegistrationDiscountRules')}
         ${extractFunction('computeRegistrationFeeAmountCentsFromForm')}
-        return { computeRegistrationFeeAmountCentsFromForm };
+        ${extractFunction('getRegistrationSubmittedAtDate')}
+        ${extractFunction('getRegistrationCheckoutAmountCents')}
+        return { computeRegistrationFeeAmountCentsFromForm, getRegistrationSubmittedAtDate, getRegistrationCheckoutAmountCents };
     `)();
 }
 
@@ -39,8 +41,38 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
 
     it('getRegistrationCheckoutAmountCents accepts a form argument and calls computeRegistrationFeeAmountCentsFromForm', () => {
         expect(source).toContain('function getRegistrationCheckoutAmountCents(registration = {}, form = null)');
-        expect(source).toContain('return computeRegistrationFeeAmountCentsFromForm(form, new Date(), {');
+        expect(source).toContain('return computeRegistrationFeeAmountCentsFromForm(form, getRegistrationSubmittedAtDate(registration), {');
         expect(source).toContain('quantity: registration.feeSnapshot?.quantity || 1');
+    });
+
+    it('recomputes early-bird eligibility at the server-captured submission time on retry', () => {
+        const { getRegistrationCheckoutAmountCents } = loadServerFeeHelpers();
+        const registration = {
+            submittedAt: { toDate: () => new Date('2000-01-01T12:00:00Z') },
+            feeSnapshot: { quantity: 1, finalAmountDueCents: 7500 }
+        };
+        const form = {
+            feeAmountCents: 10000,
+            discountRules: [
+                { id: 'early', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+            ]
+        };
+
+        expect(getRegistrationCheckoutAmountCents(registration, form)).toBe(7500);
+    });
+
+    it('falls back to checkout time for legacy registrations without a valid submittedAt', () => {
+        const { getRegistrationSubmittedAtDate, getRegistrationCheckoutAmountCents } = loadServerFeeHelpers();
+        const fallback = new Date('2026-07-09T12:00:00Z');
+        expect(getRegistrationSubmittedAtDate({ submittedAt: 'not-a-date' }, fallback)).toBe(fallback);
+
+        const form = {
+            feeAmountCents: 10000,
+            discountRules: [
+                { id: 'expired', type: 'early_bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2000-01-02', active: true }
+            ]
+        };
+        expect(getRegistrationCheckoutAmountCents({ feeSnapshot: { quantity: 1 } }, form)).toBe(10000);
     });
 
     it('createStripeRegistrationCheckout passes form to getRegistrationCheckoutAmountCents', () => {
@@ -137,7 +169,8 @@ describe('server-side registration fee recomputation (issue #2243)', () => {
         // feeSnapshot.finalAmountDueCents = 1 (tampered), the checkout function ignores it
         // because it calls getRegistrationCheckoutAmountCents(registration, form) which uses
         // computeRegistrationFeeAmountCentsFromForm(form, now, { quantity }) — derived from the
-        // authoritative form plus the server-captured registration quantity, not the stored amount.
+        // authoritative form plus the server-captured registration quantity and submittedAt,
+        // not the stored amount.
         // We assert this via the source check above and via the algorithm test below.
         const tamperedRegistration = {
             feeSnapshot: { finalAmountDueCents: 1 },


### PR DESCRIPTION
## Summary
- evaluate time-sensitive registration discounts at the server-captured submission timestamp during checkout and retry
- preserve the existing authoritative-form recomputation so stored/client fee snapshots cannot lower the Stripe charge
- support Firestore Timestamp, Date, millisecond timestamp, and serialized date forms with a safe legacy fallback
- add end-to-end Stripe retry and helper regression coverage

## Investigation and design
Checkout deliberately recomputed pricing from the authoritative form to prevent a tampered stored fee snapshot from reducing the charge. The bug was that this otherwise-correct recomputation used checkout time, so an early-bird rule valid at submission expired before a retry.

The registration is created by the callable in a Firestore transaction with a server-owned `submittedAt`. Checkout now uses that timestamp only as the eligibility clock while continuing to take the base price, discount rules, currency, and quantity from authoritative/server-captured sources. Registrations without a valid timestamp retain the prior checkout-time behavior.

## Requirements covered
- retry after an early-bird deadline preserves the discount that was eligible at submission
- Stripe receives the recomputed submission-time amount
- a tampered `feeSnapshot.finalAmountDueCents` remains ignored
- quantity discounts still use the server-captured quantity
- installment registrations continue to use their stored schedule
- legacy records without `submittedAt` safely fall back to current checkout time

## Test plan and results
- full Functions suite — 47 passed
- registration-flow + server fee suites — 35 passed
- end-to-end retry fixture submits before a year-2000 deadline, retries long after it, and verifies Stripe plus stored checkout amount remain 7,500 cents
- helper tests cover Firestore Timestamp conversion, invalid legacy timestamps, expired fallback, discount ordering/quantity, and tampered snapshot protection
- `node --check functions/index.js` — passed
- `git diff --check` — passed

Closes #3467.