### PR TITLE
Defer first-run Private AI conversation controls

### DIFF
--- a/apps/app/src/pages/PrivateAiChat.test.tsx
+++ b/apps/app/src/pages/PrivateAiChat.test.tsx
@@ -96,27 +96,39 @@ describe('PrivateAiChat', () => {
         cleanup();
     });
 
-    it('shows one default first-run action and defers advanced prompts behind expansion', async () => {
-        renderChat();
+    it('centers the first-run prompt and defers desktop conversation management until a chat exists', async () => {
+        const { container } = renderChat();
 
-        expect(await screen.findByText('What do you need from ALL PLAYS?')).toBeTruthy();
-
-        const railCard = screen.getByText('Ask about').closest('section');
-        expect(railCard).toBeTruthy();
-        if (!railCard) {
-            throw new Error('Ask about card not found');
+        const welcomeHeading = await screen.findByText('What do you need from ALL PLAYS?');
+        const welcome = welcomeHeading.closest<HTMLElement>('.private-ai-welcome');
+        expect(welcome).toBeTruthy();
+        if (!welcome) {
+            throw new Error('Private AI welcome not found');
         }
 
-        expect(within(railCard).getByRole('button', { name: 'What do I need to handle today?' })).toBeTruthy();
-        expect(within(railCard).queryByRole('button', { name: 'Who still needs an RSVP?' })).toBeNull();
+        await waitFor(() => {
+            expect(privateAiServiceMocks.loadPrivateAiConversations).toHaveBeenCalledWith(auth.user);
+            expect(privateAiServiceMocks.loadPrivateAiMessages).toHaveBeenCalledWith(auth.user, undefined, 'default');
+        });
+        expect(container.querySelector('.private-ai-first-run')).toBeTruthy();
+        expect(container.querySelector('.private-ai-rail')).toBeNull();
+        expect(screen.queryByLabelText('AI conversations')).toBeNull();
+        expect(screen.queryByText('Chats')).toBeNull();
+        expect(screen.queryByText('Messages')).toBeNull();
+        expect(screen.queryByText('Lookups')).toBeNull();
+        expect(screen.queryByRole('button', { name: 'New' })).toBeNull();
+        expect(screen.queryByText('No saved chats')).toBeNull();
+        expect(screen.queryByText('Start a private chat and it will stay here for later.')).toBeNull();
+
+        expect(within(welcome).getByRole('button', { name: 'What do I need to handle today?' })).toBeTruthy();
+        expect(within(welcome).queryByRole('button', { name: 'Who still needs an RSVP?' })).toBeNull();
         expect(screen.queryByRole('button', { name: 'What is my next game?' })).toBeNull();
 
-        const expandButtons = screen.getAllByRole('button', { name: 'More ways to ask' });
-        fireEvent.click(expandButtons[0]!);
+        fireEvent.click(within(welcome).getByRole('button', { name: 'More ways to ask' }));
 
-        expect(await within(railCard).findByRole('button', { name: 'Who still needs an RSVP?' })).toBeTruthy();
-        expect(within(railCard).getByRole('button', { name: 'What is my next game?' })).toBeTruthy();
-        expect(within(railCard).getByRole('button', { name: 'Show unread team messages' })).toBeTruthy();
+        expect(await within(welcome).findByRole('button', { name: 'Who still needs an RSVP?' })).toBeTruthy();
+        expect(within(welcome).getByRole('button', { name: 'What is my next game?' })).toBeTruthy();
+        expect(within(welcome).getByRole('button', { name: 'Show unread team messages' })).toBeTruthy();
     });
 
     it('sends the primary first-run action through the existing send flow and preserves optimistic chat behavior', async () => {
@@ -193,7 +205,14 @@ describe('PrivateAiChat', () => {
 
         expect(await screen.findByText('Here is your summary.')).toBeTruthy();
         await waitFor(() => {
-            expect(privateAiServiceMocks.loadPrivateAiMessages).toHaveBeenCalledWith(auth.user, undefined, 'conversation-1');
+            expect(privateAiServiceMocks.loadPrivateAiConversations).toHaveBeenCalledTimes(2);
         });
+        const conversationList = screen.getByLabelText('AI conversations');
+        const savedConversation = within(conversationList).getByRole('button', { name: /What do I need to handle today\?/ });
+        expect(savedConversation.getAttribute('aria-pressed')).toBe('true');
+        fireEvent.click(savedConversation);
+
+        expect(screen.getByText('Here is your summary.')).toBeTruthy();
+        expect(privateAiServiceMocks.loadPrivateAiMessages).not.toHaveBeenCalledWith(auth.user, undefined, 'conversation-1');
     });
 });

--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -92,6 +92,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
   const bottomRef = useRef<HTMLDivElement | null>(null);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const stopNativeDictationRef = useRef<(() => Promise<void>) | null>(null);
+  const preserveMessagesForConversationRef = useRef<string | null>(null);
 
   const refreshConversations = async (showLoading = true, currentConversationId = activeConversationId) => {
     if (!auth.user) {
@@ -148,13 +149,18 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
   };
 
   useEffect(() => {
+    preserveMessagesForConversationRef.current = null;
     setActiveConversationId(DEFAULT_PRIVATE_AI_CONVERSATION_ID);
     void refreshConversations();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid]);
 
   useEffect(() => {
-    refreshMessages();
+    if (preserveMessagesForConversationRef.current === activeConversationId) {
+      preserveMessagesForConversationRef.current = null;
+      return;
+    }
+    void refreshMessages();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, activeConversationId]);
 
@@ -298,6 +304,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
         result.assistantMessage
       ]);
       if (nextConversationId !== activeConversationId) {
+        preserveMessagesForConversationRef.current = nextConversationId;
         setActiveConversationId(nextConversationId);
       }
       await refreshConversations(false, nextConversationId);
@@ -340,6 +347,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
     lookups: messages.reduce((total, message) => total + (message.toolNames?.length || 0), 0),
     conversations: conversations.length || (messages.length ? 1 : 0)
   }), [conversations.length, messages]);
+  const showDesktopConversationManagement = conversations.length > 0 || isDraftConversationId(activeConversationId);
 
   const refreshAiView = () => {
     void (async () => {
@@ -368,70 +376,78 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
     return (
       <div className="messages-page messages-page-web private-ai-page">
         <PrivateAiHeader loading={loading || conversationLoading} onRefresh={refreshAiView} />
-        <section className="messages-two-pane private-ai-two-pane mt-4">
-          <aside className="messages-list-pane private-ai-rail">
-            <section className="app-card p-3">
-              <div className="flex items-center gap-3">
-                <div className="private-ai-desktop-mark flex h-10 w-10 flex-none items-center justify-center rounded-xl text-primary-700">
-                  <img src="./logo_small.png" alt="" aria-hidden="true" />
-                  <Sparkles className="private-ai-mark-spark" aria-hidden="true" />
-                </div>
-                <div className="min-w-0">
-                  <div className="text-sm font-black text-gray-950">Private AI</div>
-                  <div className="truncate text-xs font-bold text-gray-500">{auth.user?.email || 'Signed in'}</div>
-                </div>
-              </div>
-              <div className="mt-3 grid grid-cols-3 gap-2">
-                <StatPill label="Chats" value={String(stats.conversations)} />
-                <StatPill label="Messages" value={String(stats.messages)} />
-                <StatPill label="Lookups" value={String(stats.lookups)} />
-              </div>
-            </section>
-
-            <PrivateAiConversationList
-              conversations={conversations}
-              activeConversationId={activeConversationId}
-              loading={conversationLoading}
-              onSelect={selectConversation}
-              onNewConversation={startNewConversation}
-            />
-
-            <section className="app-card p-3">
-              {!messages.length ? (
-                <PromptSection
-                  title="Ask about"
-                  primaryPrompt={primaryStarterPrompt}
-                  secondaryPrompts={secondarySuggestedPrompts}
-                  onPrompt={sendSuggestion}
-                  disabled={sending}
-                />
-              ) : (
-                <>
-                  <div className="app-label">Ask about</div>
-                  <div className="mt-2 space-y-2">
-                    {suggestedPrompts.map((prompt) => (
-                      <button
-                        key={prompt}
-                        type="button"
-                        className="private-ai-prompt-button"
-                        onClick={() => sendSuggestion(prompt)}
-                        disabled={sending}
-                      >
-                        <span>{prompt}</span>
-                        <ChevronRight className="h-4 w-4 flex-none" aria-hidden="true" />
-                      </button>
-                    ))}
+        {showDesktopConversationManagement ? (
+          <section className="messages-two-pane private-ai-two-pane mt-4">
+            <aside className="messages-list-pane private-ai-rail">
+              <section className="app-card p-3">
+                <div className="flex items-center gap-3">
+                  <div className="private-ai-desktop-mark flex h-10 w-10 flex-none items-center justify-center rounded-xl text-primary-700">
+                    <img src="./logo_small.png" alt="" aria-hidden="true" />
+                    <Sparkles className="private-ai-mark-spark" aria-hidden="true" />
                   </div>
-                </>
-              )}
-            </section>
-          </aside>
-          <div className="messages-chat-pane min-w-0">
+                  <div className="min-w-0">
+                    <div className="text-sm font-black text-gray-950">Private AI</div>
+                    <div className="truncate text-xs font-bold text-gray-500">{auth.user?.email || 'Signed in'}</div>
+                  </div>
+                </div>
+                <div className="mt-3 grid grid-cols-3 gap-2">
+                  <StatPill label="Chats" value={String(stats.conversations)} />
+                  <StatPill label="Messages" value={String(stats.messages)} />
+                  <StatPill label="Lookups" value={String(stats.lookups)} />
+                </div>
+              </section>
+
+              <PrivateAiConversationList
+                conversations={conversations}
+                activeConversationId={activeConversationId}
+                loading={conversationLoading}
+                onSelect={selectConversation}
+                onNewConversation={startNewConversation}
+              />
+
+              <section className="app-card p-3">
+                {!messages.length ? (
+                  <PromptSection
+                    title="Ask about"
+                    primaryPrompt={primaryStarterPrompt}
+                    secondaryPrompts={secondarySuggestedPrompts}
+                    onPrompt={sendSuggestion}
+                    disabled={sending}
+                  />
+                ) : (
+                  <>
+                    <div className="app-label">Ask about</div>
+                    <div className="mt-2 space-y-2">
+                      {suggestedPrompts.map((prompt) => (
+                        <button
+                          key={prompt}
+                          type="button"
+                          className="private-ai-prompt-button"
+                          onClick={() => sendSuggestion(prompt)}
+                          disabled={sending}
+                        >
+                          <span>{prompt}</span>
+                          <ChevronRight className="h-4 w-4 flex-none" aria-hidden="true" />
+                        </button>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </section>
+            </aside>
+            <div className="messages-chat-pane min-w-0">
+              <div className="chat-window chat-window-embedded private-ai-window">
+                {thread}
+              </div>
+            </div>
+          </section>
+        ) : (
+          <section className="private-ai-first-run mt-4">
             <div className="chat-window chat-window-embedded private-ai-window">
               {thread}
             </div>
-          </div>
-        </section>
+          </section>
+        )}
       </div>
     );
   }

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -974,6 +974,18 @@
   grid-template-columns: minmax(260px, 312px) minmax(0, 1fr);
 }
 
+.private-ai-first-run {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  justify-content: center;
+}
+
+.private-ai-first-run .private-ai-window {
+  width: min(100%, 900px);
+  height: 100%;
+}
+
 .private-ai-rail {
   gap: 10px;
 }

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -23,7 +23,7 @@ async function openPrivateAi(page) {
     }).toPass({ timeout: 30000 });
 }
 
-async function mockPrivateAiModules(page) {
+async function mockPrivateAiModules(page, { firstRun = false } = {}) {
     await page.addInitScript(() => {
         window.__privateAiCalls = [];
     });
@@ -108,7 +108,7 @@ async function mockPrivateAiModules(page) {
                 export const DEFAULT_PRIVATE_AI_CONVERSATION_ID = 'default';
                 export const DRAFT_PRIVATE_AI_CONVERSATION_ID = '__draft__';
  
-                let conversations = [
+                let conversations = ${firstRun ? '[]' : `[
                     {
                         id: 'default',
                         title: 'Recent chat',
@@ -116,9 +116,9 @@ async function mockPrivateAiModules(page) {
                         updatedAt: new Date('2026-05-21T12:00:00Z'),
                         lastMessagePreview: 'I can look up your ALL PLAYS schedule and messages.'
                     }
-                ];
+                ]`};
 
-                let messages = [
+                let messages = ${firstRun ? '[]' : `[
                     {
                         id: 'msg-1',
                         role: 'assistant',
@@ -127,7 +127,7 @@ async function mockPrivateAiModules(page) {
                         createdAt: new Date('2026-05-21T12:00:00Z'),
                         toolNames: []
                     }
-                ];
+                ]`};
 
                 export async function loadPrivateAiConversations() {
                     return conversations;
@@ -151,25 +151,35 @@ async function mockPrivateAiModules(page) {
 
                 export async function sendPrivateAiMessage(user, text, conversationId = 'default') {
                     window.__privateAiCalls.push({ uid: user.uid, text, conversationId });
+                    const savedConversationId = conversationId === 'default' && !conversations.some((conversation) => conversation.id === conversationId)
+                        ? 'conversation-2'
+                        : conversationId;
                     const userMessage = {
                         id: 'msg-2',
                         role: 'user',
                         text,
-                        conversationId,
+                        conversationId: savedConversationId,
                         createdAt: new Date('2026-05-21T12:01:00Z')
                     };
                     const assistantMessage = {
                         id: 'msg-3',
                         role: 'assistant',
                         text: '**Bears** play Monday at 6:00 PM.',
-                        conversationId,
+                        conversationId: savedConversationId,
                         createdAt: new Date('2026-05-21T12:01:02Z'),
                         toolNames: ['get_schedule']
                     };
                     messages = [...messages, userMessage, assistantMessage];
-                    conversations = conversations.map((conversation) => conversation.id === conversationId
-                        ? { ...conversation, title: text, lastMessagePreview: assistantMessage.text, updatedAt: new Date('2026-05-21T12:01:02Z') }
-                        : conversation);
+                    const savedConversation = {
+                        id: savedConversationId,
+                        title: text,
+                        createdAt: new Date('2026-05-21T12:01:00Z'),
+                        updatedAt: new Date('2026-05-21T12:01:02Z'),
+                        lastMessagePreview: assistantMessage.text
+                    };
+                    conversations = conversations.some((conversation) => conversation.id === savedConversationId)
+                        ? conversations.map((conversation) => conversation.id === savedConversationId ? { ...conversation, ...savedConversation } : conversation)
+                        : [savedConversation, ...conversations];
                     return {
                         userMessage,
                         assistantMessage,
@@ -182,6 +192,31 @@ async function mockPrivateAiModules(page) {
 }
 
 test.describe('private AI chat', () => {
+    test('desktop first run defers history controls until the first saved conversation', async ({ page, baseURL }) => {
+        await mockPrivateAiModules(page, { firstRun: true });
+        await page.setViewportSize({ width: 1440, height: 900 });
+        await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
+
+        await page.getByTitle('Private AI').first().click();
+        await expect(page).toHaveURL(/#\/ai$/);
+        await expect(page.getByText('What do you need from ALL PLAYS?')).toBeVisible();
+        await expect(page.locator('.private-ai-first-run')).toBeVisible();
+        await expect(page.locator('.private-ai-rail')).toHaveCount(0);
+        await expect(page.getByLabel('AI conversations')).toHaveCount(0);
+        await expect(page.getByRole('button', { name: 'New', exact: true })).toHaveCount(0);
+        await expect(page.getByText('No saved chats', { exact: true })).toHaveCount(0);
+
+        await page.getByPlaceholder('Ask ALL PLAYS...').fill('What is next?');
+        await page.getByRole('button', { name: 'Send AI message' }).click();
+
+        await expect(page.getByText('Bears play Monday at 6:00 PM.')).toBeVisible();
+        await expect(page.locator('.private-ai-rail')).toBeVisible();
+        const conversationList = page.getByLabel('AI conversations');
+        await expect(conversationList).toBeVisible();
+        await expect(conversationList.getByRole('button', { name: /What is next\?/ })).toHaveAttribute('aria-pressed', 'true');
+        await expect(page.getByText('Bears play Monday at 6:00 PM.')).toBeVisible();
+    });
+
     test('desktop top nav opens private AI and sends a message', async ({ page, baseURL }) => {
         await mockPrivateAiModules(page);
         await page.setViewportSize({ width: 1440, height: 900 });


### PR DESCRIPTION
## Summary

- replace the empty desktop Private AI two-pane workspace with a centered first-run thread
- defer conversation history, stats, New chat, and empty history messaging until a saved conversation exists
- reveal the normal desktop conversation workspace after the first prompt creates and refreshes the saved conversation
- preserve the returned user and assistant messages when the first send changes from the default ID to the generated conversation ID
- add component and browser coverage for the complete first-run-to-saved-chat transition

## Root cause

The desktop page always mounted the stats/history rail regardless of whether conversation or message data existed. The first successful send also changed the active conversation ID, which triggered the normal conversation-selection message reload and could overwrite the response already returned by the send operation.

## User impact

New coaches and parents now land directly on the welcome prompt and composer. Conversation-management controls appear only once they are useful, and the first assistant response remains visible while the newly saved conversation becomes selectable.

## Validation

- `npx vitest run tests/unit/app-private-ai-integration.test.jsx apps/app/src/pages/PrivateAiChat.test.tsx --reporter=dot` — 11 passed
- `npm run app:build` — TypeScript and production Vite build passed
- `tests/smoke/app-private-ai.spec.js` — 4 passed
- targeted ESLint — no errors

Closes #3488