### PR TITLE
Keep live score controls within reach

### DIFF
--- a/apps/app/src/components/schedule/ScoreStepper.tsx
+++ b/apps/app/src/components/schedule/ScoreStepper.tsx
@@ -4,16 +4,19 @@ interface ScoreStepperProps {
   onDecrease: () => void;
   onIncrease: () => void;
   disabled: boolean;
+  compact?: boolean;
+  controlLabel?: string;
 }
 
-export function ScoreStepper({ label, value, onDecrease, onIncrease, disabled }: ScoreStepperProps) {
+export function ScoreStepper({ label, value, onDecrease, onIncrease, disabled, compact = false, controlLabel }: ScoreStepperProps) {
+  const accessibleLabel = controlLabel || label;
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-2">
-      <div className="mb-2 text-center text-xs font-black uppercase tracking-[0.04em] text-gray-500">{label}</div>
-      <div className="flex items-center justify-center gap-3">
-        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onDecrease} disabled={disabled || value <= 0} aria-label={`${label} score down`}>−</button>
-        <div className="min-w-12 text-center text-3xl font-black tabular-nums text-gray-950">{value}</div>
-        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onIncrease} disabled={disabled} aria-label={`${label} score up`}>+</button>
+    <div className={`rounded-xl border border-gray-200 bg-white ${compact ? 'p-1.5' : 'p-2'}`}>
+      <div className={`${compact ? 'mb-1' : 'mb-2'} text-center text-xs font-black uppercase tracking-[0.04em] text-gray-500`}>{label}</div>
+      <div className={`flex items-center justify-center ${compact ? 'gap-1' : 'gap-3'}`}>
+        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onDecrease} disabled={disabled || value <= 0} aria-label={`${accessibleLabel} score down`}>−</button>
+        <div className={`${compact ? 'min-w-8 text-2xl' : 'min-w-12 text-3xl'} text-center font-black tabular-nums text-gray-950`}>{value}</div>
+        <button type="button" className="min-h-11 min-w-11 rounded-full border border-gray-200 text-xl font-black text-gray-700 disabled:opacity-40" onClick={onIncrease} disabled={disabled} aria-label={`${accessibleLabel} score up`}>+</button>
       </div>
     </div>
   );

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -241,6 +241,7 @@ import {
   setScheduleGameDayServiceImporterForTest,
   shouldAutosaveGeneratedLineupDraft,
   shouldAutosaveLineupDraft,
+  shouldShowLiveScoreControls,
   shouldPersistLineupDraft
 } from './ScheduleEventDetail';
 import type { PracticeTimelineBlock } from '../lib/practiceTimelineService';
@@ -1117,6 +1118,19 @@ describe('ScheduleEventDetail nav visibility', () => {
   });
 });
 
+describe('ScheduleEventDetail live score control visibility', () => {
+  it('only enables score controls for authenticated non-cancelled DB games with score permission', () => {
+    const scoreCapableGame = buildEvent({ canUpdateScore: true });
+
+    expect(shouldShowLiveScoreControls(scoreCapableGame, auth.user)).toBe(true);
+    expect(shouldShowLiveScoreControls({ ...scoreCapableGame, canUpdateScore: false }, auth.user)).toBe(false);
+    expect(shouldShowLiveScoreControls({ ...scoreCapableGame, isDbGame: false }, auth.user)).toBe(false);
+    expect(shouldShowLiveScoreControls({ ...scoreCapableGame, isCancelled: true }, auth.user)).toBe(false);
+    expect(shouldShowLiveScoreControls({ ...scoreCapableGame, type: 'practice' }, auth.user)).toBe(false);
+    expect(shouldShowLiveScoreControls(scoreCapableGame, null)).toBe(false);
+  });
+});
+
 describe('ScheduleEventDetail rideshare permissions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1240,6 +1254,62 @@ describe('ScheduleEventDetail assignments', () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it('keeps mobile sticky score controls synchronized with the existing autosave path', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ liveStatus: 'live', status: 'live', canUpdateScore: true, homeScore: 41, awayScore: 38 })],
+      children: []
+    });
+    scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 42, awayScore: 38 });
+    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockResolvedValue({});
+
+    renderScheduleEventDetailWithRouteControls();
+
+    const tray = await screen.findByRole('region', { name: 'Mobile live score controls' });
+    expect(tray.className).toContain('mobile-live-score-tray');
+    expect(tray.querySelector('.mobile-live-score-tray__surface')).toBeTruthy();
+    expect(within(tray).getByText('41-38')).toBeTruthy();
+
+    fireEvent.click(within(tray).getByRole('button', { name: 'Sticky home score up' }));
+
+    expect(within(tray).getByText('42-38')).toBeTruthy();
+    expect(within(tray).getByText('Autosaving manual score change…')).toBeTruthy();
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 42, awayScore: 38 }, auth.user);
+    }, { timeout: 2000 });
+    expect(scheduleServiceMocks.publishLiveScoreUpdateEvent).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 42, awayScore: 38 }, auth.user, { homeScore: 41, awayScore: 38 });
+    await waitFor(() => {
+      expect(within(tray).getByText('Score autosaved and posted to live play-by-play.')).toBeTruthy();
+    });
+  });
+
+  it('surfaces sticky autosave failures and retries through the existing manual save path', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ liveStatus: 'live', status: 'live', canUpdateScore: true, homeScore: 12, awayScore: 9 })],
+      children: []
+    });
+    scheduleServiceMocks.updateGameScore
+      .mockRejectedValueOnce(new Error('Score service unavailable'))
+      .mockResolvedValueOnce({ homeScore: 12, awayScore: 10 });
+    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockResolvedValue({});
+
+    renderScheduleEventDetailWithRouteControls();
+
+    const tray = await screen.findByRole('region', { name: 'Mobile live score controls' });
+    fireEvent.click(within(tray).getByRole('button', { name: 'Sticky away score up' }));
+
+    await waitFor(() => {
+      expect(within(tray).getByText('Score service unavailable')).toBeTruthy();
+    }, { timeout: 2000 });
+    const retryButton = within(tray).getByRole('button', { name: 'Retry save from sticky controls' });
+    expect(retryButton).toHaveProperty('disabled', false);
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledTimes(2);
+      expect(within(tray).getByText('Score saved and posted to live play-by-play.')).toBeTruthy();
+    });
   });
 
   it('streams and sends live game reactions from the game hub', async () => {
@@ -2178,7 +2248,7 @@ describe('ScheduleEventDetail assignments', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Home score up' }));
-    expect(screen.getByText('Autosaving manual score change…')).toBeTruthy();
+    expect(within(screen.getByTestId('live-score-editor')).getByText('Autosaving manual score change…')).toBeTruthy();
     expect(scheduleServiceMocks.updateGameScore).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: '#1 Avery Smith plus 2 points' })).toHaveProperty('disabled', true);
 
@@ -2194,7 +2264,7 @@ describe('ScheduleEventDetail assignments', () => {
     });
     expect(chatServiceMocks.sendTeamChatMessage).not.toHaveBeenCalled();
     expect(screen.queryByText('Loading lineup builder…')).toBeNull();
-    expect(screen.getByText('Score autosaved and posted to live play-by-play.')).toBeTruthy();
+    expect(within(screen.getByTestId('live-score-editor')).getByText('Score autosaved and posted to live play-by-play.')).toBeTruthy();
   });
 
   it('keeps report sections mounted during live score updates', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -43,6 +43,7 @@ import {
 } from '../lib/scheduleHub';
 import { type AppServiceError, toAppServiceError } from '../lib/appErrors';
 import { useAsyncOperation } from '../lib/useAsyncOperation';
+import { useShellLayout } from '../lib/useShellLayout';
 import { EventDetailPageSkeleton } from '../components/PageSkeletons';
 import { AssignmentsSection } from '../components/schedule/AssignmentsSection';
 import { CompactMeta } from '../components/schedule/CompactMeta';
@@ -1490,6 +1491,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
   onPracticeOccurrenceCancelled: () => void;
   onGamePlanPublished: (gamePlan: Record<string, any>) => void;
 }) {
+  const { isDesktopWeb } = useShellLayout();
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
@@ -1646,7 +1648,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
   };
 
   return (
-    <section className={`space-y-3 ${canUpdateScore ? 'mobile-live-score-tray-offset' : ''}`}>
+    <section className={`space-y-3 ${canUpdateScore && !isDesktopWeb ? 'mobile-live-score-tray-offset' : ''}`}>
       {showNonAdminPracticePacketFirst ? <PracticePacketSection auth={auth} event={event} childEvents={childEvents} /> : null}
       {showAdminPracticeTimeline ? <PracticeTimelineSection auth={auth} event={event} /> : null}
       {!isPractice && event.isTeamAdmin && event.isDbGame && !event.isCancelled ? <GameScheduleEditPanel auth={auth} event={event} /> : null}
@@ -1716,6 +1718,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
               event={event}
               homePlayers={homeScoringPlayers}
               loadingHomePlayers={loadingHomeScoringPlayers}
+              showStickyControls={!isDesktopWeb}
               onHomePlayersUpdated={updateHomeScoringPlayers}
               onScoreUpdated={onScoreUpdated}
             />
@@ -3196,7 +3199,7 @@ function getBonusState(teamFouls: number) {
   };
 }
 
-function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, onHomePlayersUpdated, onScoreUpdated }: { auth: AuthState; event: ParentScheduleEvent; homePlayers: ScheduleHomeScoringPlayer[]; loadingHomePlayers: boolean; onHomePlayersUpdated: (updater: HomeScoringPlayersUpdater) => void; onScoreUpdated: (homeScore: number, awayScore: number) => void }) {
+function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showStickyControls, onHomePlayersUpdated, onScoreUpdated }: { auth: AuthState; event: ParentScheduleEvent; homePlayers: ScheduleHomeScoringPlayer[]; loadingHomePlayers: boolean; showStickyControls: boolean; onHomePlayersUpdated: (updater: HomeScoringPlayersUpdater) => void; onScoreUpdated: (homeScore: number, awayScore: number) => void }) {
   const autosaveDelayMs = 700;
   const savedHomeScore = Math.max(0, Number(event.homeScore ?? 0));
   const savedAwayScore = Math.max(0, Number(event.awayScore ?? 0));
@@ -3441,7 +3444,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, onHomeP
           {status ? <span className={`text-xs font-bold ${status.tone === 'error' ? 'text-rose-700' : 'text-emerald-700'}`}>{status.message}</span> : null}
         </div>
       </div>
-      <div className="mobile-live-score-tray" data-testid="mobile-live-score-tray" role="region" aria-label="Mobile live score controls">
+      {showStickyControls ? <div className="mobile-live-score-tray" data-testid="mobile-live-score-tray" role="region" aria-label="Mobile live score controls">
         <div className={`mobile-live-score-tray__surface rounded-2xl border p-2 shadow-xl ${dirty ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
           <div className="flex items-center justify-between gap-2 px-1 pb-1.5">
             <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-600">Live score</div>
@@ -3466,7 +3469,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, onHomeP
             </button>
           </div>
         </div>
-      </div>
+      </div> : null}
     </>
   );
 }

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -242,6 +242,10 @@ function isActiveTrackedScheduleEvent(event?: ParentScheduleEvent | null) {
   return Boolean(event?.isDbGame && !event?.isCancelled);
 }
 
+export function shouldShowLiveScoreControls(event?: ParentScheduleEvent | null, user?: AuthState['user'] | null) {
+  return Boolean(event && event.type !== 'practice' && event.isDbGame && !event.isCancelled && event.canUpdateScore && user);
+}
+
 function getDefaultEventDetailSection(event?: ParentScheduleEvent | null) {
   if (isActiveTrackedScheduleEvent(event) && event?.canUpdateScore) {
     return 'game';
@@ -1497,7 +1501,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
   const isPractice = event.type === 'practice';
   const showAdminPracticeTimeline = Boolean(isPractice && event.isTeamAdmin);
   const showNonAdminPracticePacketFirst = Boolean(isPractice && !event.isTeamAdmin);
-  const canUpdateScore = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
+  const canUpdateScore = shouldShowLiveScoreControls(event, auth.user);
   const canWrapup = canUpdateScore;
   const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
   const isRecurringPracticeOccurrence = Boolean(isPractice && event.id.includes('__'));
@@ -1642,7 +1646,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
   };
 
   return (
-    <section className="space-y-3">
+    <section className={`space-y-3 ${canUpdateScore ? 'mobile-live-score-tray-offset' : ''}`}>
       {showNonAdminPracticePacketFirst ? <PracticePacketSection auth={auth} event={event} childEvents={childEvents} /> : null}
       {showAdminPracticeTimeline ? <PracticeTimelineSection auth={auth} event={event} /> : null}
       {!isPractice && event.isTeamAdmin && event.isDbGame && !event.isCancelled ? <GameScheduleEditPanel auth={auth} event={event} /> : null}
@@ -3329,6 +3333,14 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, onHomeP
     : (saving && activeSaveModeRef.current === 'autosave')
       ? 'Saving manual score change…'
       : 'Save or undo manual score changes before recording player stats.';
+  const stickyStatusMessage = status?.message
+    || (autosaveScheduled
+      ? 'Autosaving manual score change…'
+      : saving
+        ? (activeSaveModeRef.current === 'autosave' ? 'Saving manual score change…' : 'Saving score…')
+        : dirty
+          ? 'Unsaved score changes.'
+          : 'Score saved.');
 
   const recordPlayerTwo = async (player: ScheduleHomeScoringPlayer) => {
     if (!auth.user || saving || playerScoringId || dirty) return;
@@ -3360,7 +3372,8 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, onHomeP
   };
 
   return (
-    <div data-testid="live-score-editor" className={`mt-3 rounded-2xl border p-3 ${dirty ? 'border-amber-200 bg-amber-50' : 'border-gray-100 bg-gray-50'}`}>
+    <>
+      <div data-testid="live-score-editor" className={`mt-3 rounded-2xl border p-3 ${dirty ? 'border-amber-200 bg-amber-50' : 'border-gray-100 bg-gray-50'}`}>
       <div className="flex items-center justify-between gap-3">
         <div>
           <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Live score</div>
@@ -3403,31 +3416,58 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, onHomeP
         ) : !loadingHomePlayers ? <div className="mt-2 text-xs font-semibold text-gray-500">No active team roster players found.</div> : null}
         {dirty ? <div className="mt-2 text-xs font-semibold text-amber-700">{helperText}</div> : null}
       </div>
-      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <button
-            type="button"
-            className="primary-button min-h-11 px-4 text-sm"
-            onClick={() => void saveScore('manual')}
-            disabled={saving || Boolean(playerScoringId) || !dirty}
-          >
-            {manualScoreSaveLabel}
-          </button>
-          {previousScoreSnapshots.length ? (
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <button
               type="button"
-              className="ghost-button min-h-11 px-4 text-sm"
-              onClick={undoLastScoreChange}
-              disabled={saving || Boolean(playerScoringId) || !previousScoreSnapshots.length}
-              aria-label="Undo last score change"
+              className="primary-button min-h-11 px-4 text-sm"
+              onClick={() => void saveScore('manual')}
+              disabled={saving || Boolean(playerScoringId) || !dirty}
             >
-              Undo last score change
+              {manualScoreSaveLabel}
             </button>
-          ) : null}
+            {previousScoreSnapshots.length ? (
+              <button
+                type="button"
+                className="ghost-button min-h-11 px-4 text-sm"
+                onClick={undoLastScoreChange}
+                disabled={saving || Boolean(playerScoringId) || !previousScoreSnapshots.length}
+                aria-label="Undo last score change"
+              >
+                Undo last score change
+              </button>
+            ) : null}
+          </div>
+          {status ? <span className={`text-xs font-bold ${status.tone === 'error' ? 'text-rose-700' : 'text-emerald-700'}`}>{status.message}</span> : null}
         </div>
-        {status ? <span className={`text-xs font-bold ${status.tone === 'error' ? 'text-rose-700' : 'text-emerald-700'}`}>{status.message}</span> : null}
       </div>
-    </div>
+      <div className="mobile-live-score-tray" data-testid="mobile-live-score-tray" role="region" aria-label="Mobile live score controls">
+        <div className={`mobile-live-score-tray__surface rounded-2xl border p-2 shadow-xl ${dirty ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
+          <div className="flex items-center justify-between gap-2 px-1 pb-1.5">
+            <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-600">Live score</div>
+            <div className="rounded-full bg-gray-950 px-2.5 py-1 text-sm font-black tabular-nums text-white">{homeScore}-{awayScore}</div>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <ScoreStepper compact label="Home" controlLabel="Sticky home" value={homeScore} onDecrease={() => adjust('home', -1)} onIncrease={() => adjust('home', 1)} disabled={saving || Boolean(playerScoringId)} />
+            <ScoreStepper compact label="Away" controlLabel="Sticky away" value={awayScore} onDecrease={() => adjust('away', -1)} onIncrease={() => adjust('away', 1)} disabled={saving || Boolean(playerScoringId)} />
+          </div>
+          <div className="mt-2 flex min-h-11 items-center justify-between gap-2 px-1">
+            <span className={`min-w-0 text-xs font-bold ${status?.tone === 'error' ? 'text-rose-700' : dirty ? 'text-amber-700' : 'text-emerald-700'}`} aria-live="polite">
+              {stickyStatusMessage}
+            </span>
+            <button
+              type="button"
+              className="primary-button min-h-11 flex-none px-3 text-xs"
+              onClick={() => void saveScore('manual')}
+              disabled={saving || Boolean(playerScoringId) || !dirty}
+              aria-label={`${manualScoreSaveLabel} from sticky controls`}
+            >
+              {manualScoreSaveLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
   );
 }
 

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -83,31 +83,24 @@
 }
 
 .mobile-live-score-tray {
-  display: none;
+  position: fixed;
+  z-index: 39;
+  right: 0;
+  bottom: calc(var(--app-bottom-nav-height) + 8px);
+  left: 0;
+  padding-right: max(12px, env(safe-area-inset-right));
+  padding-left: max(12px, env(safe-area-inset-left));
+  pointer-events: none;
 }
 
-@media (max-width: 639px) {
-  .mobile-live-score-tray {
-    position: fixed;
-    z-index: 39;
-    right: 0;
-    bottom: calc(var(--app-bottom-nav-height) + 8px);
-    left: 0;
-    display: block;
-    padding-right: max(12px, env(safe-area-inset-right));
-    padding-left: max(12px, env(safe-area-inset-left));
-    pointer-events: none;
-  }
+.mobile-live-score-tray__surface {
+  max-width: 40rem;
+  margin: 0 auto;
+  pointer-events: auto;
+}
 
-  .mobile-live-score-tray__surface {
-    max-width: 40rem;
-    margin: 0 auto;
-    pointer-events: auto;
-  }
-
-  .mobile-live-score-tray-offset {
-    padding-bottom: 200px;
-  }
+.mobile-live-score-tray-offset {
+  padding-bottom: 200px;
 }
 
 .app-page-ai {

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -82,6 +82,34 @@
   padding-bottom: calc(88px + env(safe-area-inset-bottom));
 }
 
+.mobile-live-score-tray {
+  display: none;
+}
+
+@media (max-width: 639px) {
+  .mobile-live-score-tray {
+    position: fixed;
+    z-index: 39;
+    right: 0;
+    bottom: calc(var(--app-bottom-nav-height) + 8px);
+    left: 0;
+    display: block;
+    padding-right: max(12px, env(safe-area-inset-right));
+    padding-left: max(12px, env(safe-area-inset-left));
+    pointer-events: none;
+  }
+
+  .mobile-live-score-tray__surface {
+    max-width: 40rem;
+    margin: 0 auto;
+    pointer-events: auto;
+  }
+
+  .mobile-live-score-tray-offset {
+    padding-bottom: 200px;
+  }
+}
+
 .app-page-ai {
   height: 100dvh;
   min-height: 0;

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1367,6 +1367,32 @@ test('mobile game-day score tray stays above the bottom nav while deeper panels 
     expect(await page.evaluate(() => window.__scheduleCalls.liveScoreEvents)).toHaveLength(1);
 });
 
+test('landscape mobile shell keeps the game-day score tray fixed above navigation', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 844, height: 390 });
+    await mockScheduleModules(page, {
+        isCoach: true,
+        staffManageable: true,
+        gameStatus: 'live',
+        gameLiveStatus: 'live',
+        gameHomeScore: 4,
+        gameAwayScore: 2
+    });
+    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1&section=game'), { waitUntil: 'domcontentloaded' });
+
+    const tray = page.getByRole('region', { name: 'Mobile live score controls' });
+    await waitForScheduleRoute(page, tray);
+    await expect(tray).toBeVisible();
+
+    const bottomNav = page.locator('nav[aria-label="Primary navigation"]').last();
+    const [trayBox, navBox] = await Promise.all([tray.boundingBox(), bottomNav.boundingBox()]);
+    expect(trayBox?.bottom || 0).toBeLessThanOrEqual((navBox?.y || 0) + 1);
+    expect(await tray.evaluate((node) => window.getComputedStyle(node).position)).toBe('fixed');
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
+
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await expect(tray).toHaveCount(0);
+});
+
 test('iOS-sized staff schedule keeps tools collapsed below the event list', async ({ page, baseURL }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await mockScheduleModules(page, { isCoach: true, staffManageable: true });

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1327,6 +1327,46 @@ test('iOS-sized Game hub deep link opens and positions Live chat without an acco
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 });
 
+test('mobile game-day score tray stays above the bottom nav while deeper panels scroll', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockScheduleModules(page, {
+        isCoach: true,
+        staffManageable: true,
+        gameStatus: 'live',
+        gameLiveStatus: 'live',
+        gameHomeScore: 4,
+        gameAwayScore: 2
+    });
+    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1&section=game'), { waitUntil: 'domcontentloaded' });
+
+    const tray = page.getByRole('region', { name: 'Mobile live score controls' });
+    await waitForScheduleRoute(page, tray);
+    await expect(tray).toBeVisible();
+    await expect(tray.getByText('4-2')).toBeVisible();
+
+    const bottomNav = page.locator('nav[aria-label="Primary navigation"]').last();
+    const [trayBox, navBox] = await Promise.all([tray.boundingBox(), bottomNav.boundingBox()]);
+    expect(trayBox?.bottom || 0).toBeLessThanOrEqual((navBox?.y || 0) + 1);
+    expect(await tray.evaluate((node) => window.getComputedStyle(node).position)).toBe('fixed');
+
+    await page.getByRole('button', { name: 'Report sections', exact: true }).click();
+    await page.getByRole('button', { name: 'Live chat', exact: true }).scrollIntoViewIfNeeded();
+    await expect(tray).toBeVisible();
+
+    const homeIncrease = tray.getByRole('button', { name: 'Sticky home score up' });
+    const homeIncreaseBox = await homeIncrease.boundingBox();
+    expect(homeIncreaseBox?.height || 0).toBeGreaterThanOrEqual(44);
+    await homeIncrease.click();
+
+    await expect(tray.getByText('5-2')).toBeVisible();
+    await expect(tray.getByText('Autosaving manual score change…')).toBeVisible();
+    await expect(tray.getByText('Score autosaved and posted to live play-by-play.')).toBeVisible({ timeout: 3000 });
+    expect(await page.evaluate(() => window.__scheduleCalls.scoreUpdates)).toEqual([
+        { teamId: 'team-1', gameId: 'game-1', payload: { homeScore: 5, awayScore: 2, scoreUpdatedBy: 'user-1' } }
+    ]);
+    expect(await page.evaluate(() => window.__scheduleCalls.liveScoreEvents)).toHaveLength(1);
+});
+
 test('iOS-sized staff schedule keeps tools collapsed below the event list', async ({ page, baseURL }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await mockScheduleModules(page, { isCoach: true, staffManageable: true });

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -154,7 +154,9 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
         expect(practiceAttendancePanelSource).toContain('export function PracticeAttendancePanel');
         expect(practiceAttendancePanelSource).toContain('data-testid={`practice-attendance-row-${player.playerId}`}');
         expect(scoreStepperSource).toContain('export function ScoreStepper');
-        expect(scoreStepperSource).toContain('aria-label={`${label} score down`}');
+        expect(scoreStepperSource).toContain('controlLabel?: string;');
+        expect(scoreStepperSource).toContain('const accessibleLabel = controlLabel || label;');
+        expect(scoreStepperSource).toContain('aria-label={`${accessibleLabel} score down`}');
         expect(scheduleStatusSource).toContain('export function Status');
         expect(availabilityPanelsSource).toContain('export function QuickAvailabilityPanel');
         expect(availabilityPanelsSource).toContain("export { AvailabilityNotesList");

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -71,7 +71,9 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(scheduleEventHeader).toContain("import { EventBrief } from './EventBrief';");
         expect(scheduleEventHeader).toContain('export function ScheduleEventHeader');
         expect(scoreStepper).toContain('export function ScoreStepper');
-        expect(scoreStepper).toContain('aria-label={`${label} score up`}');
+        expect(scoreStepper).toContain('controlLabel?: string;');
+        expect(scoreStepper).toContain('const accessibleLabel = controlLabel || label;');
+        expect(scoreStepper).toContain('aria-label={`${accessibleLabel} score up`}');
         expect(scheduleStatus).toContain('export function Status');
         expect(focusedTests).toContain("describe('ScheduleEventDetail presentational components'");
     });


### PR DESCRIPTION
## Summary

- Add a compact mobile-only live-score tray that stays fixed above the AppShell bottom navigation and safe-area inset.
- Reuse the existing `LiveScoreEditor` state, autosave/manual-save path, retry state, and live play-by-play publisher rather than introducing a second score model.
- Extend `ScoreStepper` with a compact presentation and distinct accessible control labels while retaining 44px touch targets.
- Centralize the score-control permission predicate for authenticated, non-cancelled database games.
- Add bottom content clearance so deep Game Hub panels can scroll above the fixed tray.

## Why

The only Home/Away score controls lived in the inline Live Score editor. On a phone they scrolled away while scorekeepers used fouls, chat, reactions, lineup, and report panels. The new tray keeps the same controls and status within thumb reach without changing score permissions or persistence semantics.

## User impact

Mobile scorekeepers can adjust either score, observe autosave/manual-save/error state, and retry failures while remaining anywhere in the Game Hub. Parents/fans without score permission, cancelled games, non-database events, and practices do not render the tray. Desktop keeps the existing inline editor only.

## Validation

- `npm --prefix apps/app test -- --run src/pages/ScheduleEventDetail.test.tsx` — 99 passed
- `npm --prefix apps/app test -- --run --reporter=dot --silent=passed-only` — 115 files / 1,026 tests passed
- Focused 390×844 Playwright smokes after rebasing onto the latest Game Hub changes — 2 passed
- `npm run app:build` — passed
- Focused app ESLint — 0 errors
- `git diff --check` — passed

Closes #3530