### PR TITLE
Make team email compose-first

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -1585,7 +1585,6 @@ export function ChatWindow({
             auth={auth}
             teamId={teamId}
             profile={profile}
-            isDesktopWeb={isDesktopWeb}
             selectedConversation={selectedConversation}
             selectedConversationId={effectiveConversationId}
             selectedRecipientTarget={selectedRecipientTarget}

--- a/apps/app/src/pages/messages/components/TeamEmailSheet.test.tsx
+++ b/apps/app/src/pages/messages/components/TeamEmailSheet.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthState } from '../../../lib/types';
+import TeamEmailSheet from './TeamEmailSheet';
+
+const chatServiceMocks = vi.hoisted(() => ({
+  loadSentTeamEmails: vi.fn(),
+  loadTeamEmailDrafts: vi.fn(),
+  loadTeamEmailTemplates: vi.fn(),
+  saveTeamEmailDraft: vi.fn(),
+  saveTeamEmailTemplate: vi.fn(),
+  sendTeamEmailMessage: vi.fn()
+}));
+
+vi.mock('../../../lib/chatService', () => chatServiceMocks);
+
+vi.mock('./ChatWindow', () => ({
+  Sheet: ({ title, children }: { title: string; children: ReactNode }) => <div role="dialog" aria-label={title}>{children}</div>,
+  StatusBanner: ({ status }: { status: { message: string } }) => <div role="status">{status.message}</div>
+}));
+
+vi.mock('lucide-react', () => {
+  const Icon = () => null;
+  return { Loader2: Icon, Mail: Icon, RefreshCw: Icon };
+});
+
+const auth: AuthState = {
+  user: {
+    uid: 'coach-1',
+    email: 'coach@example.com',
+    displayName: 'Coach One',
+    roles: ['coach']
+  },
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['coach'],
+  isParent: false,
+  isCoach: true,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function renderTeamEmailSheet(overrides: Record<string, unknown> = {}) {
+  const props = {
+    open: true,
+    auth,
+    teamId: 'team-1',
+    profile: {},
+    selectedConversation: null,
+    selectedConversationId: 'team',
+    selectedRecipientTarget: 'full_team' as const,
+    selectedRecipientIds: [] as string[],
+    recipientOptions: [{ id: 'user:parent-1', name: 'Parent One', email: 'parent@example.com' }],
+    recipientOptionsLoading: false,
+    recipientOptionsError: null,
+    ensureRecipientOptionsLoaded: vi.fn().mockResolvedValue([]),
+    setSelectedRecipientTarget: vi.fn(),
+    setSelectedRecipientIds: vi.fn(),
+    switchConversation: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides
+  };
+
+  return { ...render(<TeamEmailSheet {...props} />), props };
+}
+
+function expectBefore(first: Element, second: Element) {
+  expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+}
+
+describe('TeamEmailSheet compose-first workflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chatServiceMocks.loadTeamEmailDrafts.mockResolvedValue([{
+      id: 'draft-1',
+      subject: 'Practice reminder',
+      body: 'Bring shoes and water.',
+      recipientIds: ['user:parent-1'],
+      recipients: []
+    }]);
+    chatServiceMocks.loadTeamEmailTemplates.mockResolvedValue([{
+      id: 'template-1',
+      name: 'Weekly update',
+      subject: 'Week ahead',
+      body: 'Here is the plan.'
+    }]);
+    chatServiceMocks.loadSentTeamEmails.mockResolvedValue([]);
+  });
+
+  afterEach(() => cleanup());
+
+  it('renders compose and send before drafts/templates while preserving content restore actions', async () => {
+    const { props } = renderTeamEmailSheet();
+
+    const draftButton = await screen.findByRole('button', { name: /Practice reminder/ });
+    const subject = screen.getByLabelText('Subject');
+    const message = screen.getByLabelText('Message');
+    const send = screen.getByRole('button', { name: 'Send email' });
+    const savedDrafts = screen.getByText('Saved drafts');
+    const reusableTemplates = screen.getByText('Reusable templates');
+
+    expectBefore(subject, message);
+    expectBefore(message, send);
+    expectBefore(send, savedDrafts);
+    expectBefore(savedDrafts, reusableTemplates);
+
+    fireEvent.click(draftButton);
+    expect(subject).toHaveValue('Practice reminder');
+    expect(message).toHaveValue('Bring shoes and water.');
+    expect(props.setSelectedRecipientTarget).toHaveBeenCalledWith('individuals');
+    expect(props.setSelectedRecipientIds).toHaveBeenCalledWith(['user:parent-1']);
+
+    fireEvent.change(screen.getByLabelText('Saved template'), { target: { value: 'template-1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply template' }));
+    expect(subject).toHaveValue('Week ahead');
+    expect(message).toHaveValue('Here is the plan.');
+  });
+
+  it('keeps recipient errors and selected-member validation before disabled save/send actions', async () => {
+    renderTeamEmailSheet({
+      selectedRecipientTarget: 'individuals',
+      selectedRecipientIds: [],
+      recipientOptionsError: 'Could not load team recipients.'
+    });
+
+    await screen.findByText('Saved drafts');
+    fireEvent.change(screen.getByLabelText('Subject'), { target: { value: 'Rainout' } });
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'Practice is canceled.' } });
+
+    const recipientError = screen.getByText('Could not load team recipients.');
+    const selectedMemberValidation = screen.getByText('Choose at least one selected member before saving or sending email.');
+    const send = screen.getByRole('button', { name: 'Send email' });
+    expectBefore(recipientError, send);
+    expectBefore(selectedMemberValidation, send);
+    expect(send).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save draft' })).toBeDisabled();
+    fireEvent.submit(send.closest('form') as HTMLFormElement);
+    expect(chatServiceMocks.sendTeamEmailMessage).not.toHaveBeenCalled();
+    expect(screen.getByRole('status')).toHaveTextContent('Choose at least one selected member before sending.');
+  });
+});

--- a/apps/app/src/pages/messages/components/TeamEmailSheet.tsx
+++ b/apps/app/src/pages/messages/components/TeamEmailSheet.tsx
@@ -39,7 +39,6 @@ type TeamEmailSheetProps = {
   auth: AuthState;
   teamId: string;
   profile: Record<string, any>;
-  isDesktopWeb: boolean;
   selectedConversation: ChatConversation | null;
   selectedConversationId: string;
   selectedRecipientTarget: ChatTargetType;
@@ -59,7 +58,6 @@ export default function TeamEmailSheet({
   auth,
   teamId,
   profile,
-  isDesktopWeb,
   selectedConversation,
   selectedConversationId,
   selectedRecipientTarget,
@@ -97,6 +95,8 @@ export default function TeamEmailSheet({
     () => getAudienceSummaryText(emailAudienceMetadata, recipientOptions),
     [emailAudienceMetadata, recipientOptions]
   );
+  const selectedMemberAudience = emailAudienceMetadata.targetType === 'individuals'
+    || (isDefaultTeamConversation(selectedConversationId) && selectedRecipientTarget === 'individuals');
 
   const reloadSentEmailHistory = async ({ suppressErrorStatus = false } = {}) => {
     setEmailLoadingHistory(true);
@@ -242,7 +242,7 @@ export default function TeamEmailSheet({
       setEmailStatus({ tone: 'error', message: 'Subject and message are required.' });
       return;
     }
-    if (emailAudienceMetadata.targetType === 'individuals' && emailAudienceMetadata.recipientIds.length === 0) {
+    if (selectedMemberAudience && emailAudienceMetadata.recipientIds.length === 0) {
       setEmailStatus({ tone: 'error', message: 'Choose at least one selected member before sending.' });
       return;
     }
@@ -271,7 +271,6 @@ export default function TeamEmailSheet({
 
   return (
     <TeamEmailSheetView
-      isDesktopWeb={isDesktopWeb}
       subject={emailState.subject}
       body={emailState.body}
       drafts={emailState.drafts}
@@ -291,6 +290,7 @@ export default function TeamEmailSheet({
       sentEmails={sentEmails}
       audienceSummary={audienceSummary}
       audienceMetadata={emailAudienceMetadata}
+      selectedMemberAudience={selectedMemberAudience}
       onSubjectChange={(subject) => emailDispatch(emailComposerActions.updateSubject(subject))}
       onBodyChange={(body) => emailDispatch(emailComposerActions.updateBody(body))}
       onTemplateNameChange={(templateName) => emailDispatch(emailComposerActions.updateTemplateName(templateName))}
@@ -313,7 +313,6 @@ export default function TeamEmailSheet({
 }
 
 function TeamEmailSheetView({
-  isDesktopWeb,
   subject,
   body,
   drafts,
@@ -333,6 +332,7 @@ function TeamEmailSheetView({
   sentEmails,
   audienceSummary,
   audienceMetadata,
+  selectedMemberAudience,
   onSubjectChange,
   onBodyChange,
   onTemplateNameChange,
@@ -349,7 +349,6 @@ function TeamEmailSheetView({
   onHistoryStatusClose,
   onClose
 }: {
-  isDesktopWeb: boolean;
   subject: string;
   body: string;
   drafts: TeamEmailDraft[];
@@ -369,6 +368,7 @@ function TeamEmailSheetView({
   sentEmails: SentTeamEmail[];
   audienceSummary: string;
   audienceMetadata: ChatAudienceMetadata;
+  selectedMemberAudience: boolean;
   onSubjectChange: (value: string) => void;
   onBodyChange: (value: string) => void;
   onTemplateNameChange: (value: string) => void;
@@ -386,8 +386,8 @@ function TeamEmailSheetView({
   onClose: () => void;
 }) {
   const [selectedTemplateId, setSelectedTemplateId] = useState('');
-  const draftAudienceSupported = audienceMetadata.targetType === 'individuals';
-  const missingSelectedRecipients = audienceMetadata.targetType === 'individuals' && audienceMetadata.recipientIds.length === 0;
+  const draftAudienceSupported = selectedMemberAudience;
+  const missingSelectedRecipients = selectedMemberAudience && audienceMetadata.recipientIds.length === 0;
   const canSendEmail = Boolean(subject.trim() && body.trim()) && !missingSelectedRecipients && !sending;
   const canSaveDraft = draftAudienceSupported
     && !recipientOptionsLoading
@@ -454,10 +454,6 @@ function TeamEmailSheetView({
       {!draftAudienceSupported ? (
         <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-bold text-amber-800">
           Draft saving is available only for Selected members.
-        </div>
-      ) : missingSelectedRecipients ? (
-        <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
-          Choose at least one selected member before saving or sending email.
         </div>
       ) : null}
     </div>
@@ -540,8 +536,11 @@ function TeamEmailSheetView({
             </button>
           </div>
         ) : null}
-        {isDesktopWeb ? savedDraftsSection : null}
-        {isDesktopWeb ? reusableTemplatesSection : null}
+        {missingSelectedRecipients ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
+            Choose at least one selected member before saving or sending email.
+          </div>
+        ) : null}
         <label className="block">
           <span className="app-label">Subject</span>
           <input
@@ -569,8 +568,8 @@ function TeamEmailSheetView({
           Send email
         </button>
         {status ? <StatusBanner status={status} onClose={onStatusClose} /> : null}
-        {!isDesktopWeb ? savedDraftsSection : null}
-        {!isDesktopWeb ? reusableTemplatesSection : null}
+        {savedDraftsSection}
+        {reusableTemplatesSection}
       </form>
 
       <div className="mt-5 border-t border-gray-100 pt-4">


### PR DESCRIPTION
## Summary

- put Subject, Message, and Send email before saved drafts and reusable templates on every viewport
- keep recipient loading/errors and selected-member validation in the core pre-send area
- preserve draft/template restoration and close a zero-selected-recipient validation gap

## Investigation

Team Email has moved from `ChatWindow` into the lazy `TeamEmailSheet`, but its desktop branch still rendered drafts/templates before compose while mobile rendered them after. The reducer and service behaviors were already separated from presentation, so ordering could be unified without changing normal draft/template or delivery flows.

Focused testing also exposed that raw “Selected members” intent with zero IDs was normalized to full-team audience metadata before validation. The sheet now carries that intent into its save/send guards, so the existing no-recipient warning and block remain effective instead of silently falling through.

## Design and requirements

- remove viewport-specific advanced-section placement and obsolete layout prop plumbing
- keep delivery notice, audience, recipient load/error state, selected-member validation, Subject, Message, Send email, and send status first
- render Saved drafts and Reusable templates after that core flow on desktop and mobile
- keep Sent email history after the form
- use the existing reducer actions and service callbacks for draft restore, template apply, saving, and sending
- block save/send when a selected-member audience has no selected recipients

## Test plan and results

- `TeamEmailSheet.test.tsx`, `emailReducer.test.ts`, and `ChatWindow.test.tsx`: **19 passed**
  - DOM order proves compose/send precede drafts/templates
  - draft restore still populates subject/body and recipient callbacks
  - template apply still populates subject/body
  - recipient errors and no-selected-member validation precede Send
  - save/send remain blocked with zero selected recipients
- `ChatWindow.virtualization.test.tsx`: **22 passed**
- `app-messages.spec.js`: **8 passed** across mobile and desktop chat workflows
- `npm run app:build`: **passed**

Closes #3465
