### PR TITLE
Prevent empty selected-member chats from widening audience

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -6576,9 +6576,10 @@ export async function postChatMessage(teamId, {
             .map((id) => String(id || '').trim())
             .filter(Boolean)))
         : [];
-    const effectiveTargetType = normalizedTargetType === 'individuals' && normalizedRecipientIds.length === 0
-        ? 'full_team'
-        : normalizedTargetType;
+    if (normalizedTargetType === 'individuals' && normalizedRecipientIds.length === 0) {
+        throw new Error('Selected-member chat messages require at least one recipient.');
+    }
+    const effectiveTargetType = normalizedTargetType;
     if (isDefaultTeamConversation(conversationId) && effectiveTargetType !== 'full_team') {
         throw new Error('Targeted team chat messages must use a non-default conversation.');
     }

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,7 +344,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=42';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=88';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=89';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=2';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/team-chat.html
+++ b/team-chat.html
@@ -1625,6 +1625,16 @@
         function buildRecipientTargetMetadata() {
             const activeConversation = getSelectedConversation();
             if (activeConversation && !isDefaultTeamConversation(selectedConversationId)) {
+                const participantRoles = Array.isArray(activeConversation.participantRoles)
+                    ? activeConversation.participantRoles.map((role) => String(role || '').trim().toLowerCase())
+                    : [];
+                if (participantRoles.includes('staff')) {
+                    return {
+                        targetType: 'staff',
+                        recipientIds: [],
+                        targetRole: 'staff'
+                    };
+                }
                 return {
                     targetType: activeConversation.type === 'direct' ? 'individuals' : 'individuals',
                     recipientIds: Array.isArray(activeConversation.participantIds) ? activeConversation.participantIds : [],

--- a/team-chat.html
+++ b/team-chat.html
@@ -1638,7 +1638,7 @@
                     targetRole: 'staff'
                 };
             }
-            if (selectedRecipientTarget === 'individuals' && selectedRecipientIds.size > 0) {
+            if (selectedRecipientTarget === 'individuals') {
                 const selectedOptionsById = new Map(recipientOptions.map((option) => [option.id, option]));
                 const recipientIds = Array.from(new Set(Array.from(selectedRecipientIds).flatMap((id) => {
                     const option = selectedOptionsById.get(id);
@@ -1705,7 +1705,7 @@
             if (target.targetType === 'individuals') {
                 const selected = recipientOptions.filter((option) => selectedRecipientIds.has(option.id));
                 if (selected.length === 0) {
-                    return 'Audience: Full team (no selected members yet)';
+                    return 'Audience: Select at least one member';
                 }
                 if (selected.length <= 3) {
                     return `Audience: ${selected.map(getRecipientOptionLabel).join(', ')}`;
@@ -1869,6 +1869,21 @@
             const input = document.getElementById('message-input');
             const sendBtn = document.getElementById('send-btn');
             sendBtn.disabled = !input.value.trim() && pendingImageFiles.length === 0;
+        }
+
+        function isMissingSelectedChatRecipients() {
+            return isDefaultTeamConversation(selectedConversationId) &&
+                selectedRecipientTarget === 'individuals' &&
+                selectedRecipientIds.size === 0;
+        }
+
+        function validateChatAudienceSelection() {
+            if (!isMissingSelectedChatRecipients()) return true;
+            const targetSelect = document.getElementById('recipient-target');
+            targetSelect?.setAttribute('aria-invalid', 'true');
+            targetSelect?.focus();
+            showError('Select at least one recipient before sending.');
+            return false;
         }
 
         function setVoiceButtonState(isListening) {
@@ -2749,6 +2764,8 @@
                 if (selectedRecipientTarget !== 'individuals') {
                     selectedRecipientIds = new Set();
                 }
+                event.target.removeAttribute('aria-invalid');
+                document.getElementById('send-error').classList.add('hidden');
                 renderRecipientPicker();
             });
             document.getElementById('recipient-list').addEventListener('change', (event) => {
@@ -2759,6 +2776,8 @@
                 } else {
                     selectedRecipientIds.delete(recipientId);
                 }
+                document.getElementById('recipient-target').removeAttribute('aria-invalid');
+                document.getElementById('send-error').classList.add('hidden');
                 renderRecipientPicker();
             });
 
@@ -2883,6 +2902,8 @@
         function triggerSend() {
             const input = document.getElementById('message-input');
             const text = input.value.trim();
+            if (!text && pendingImageFiles.length === 0) return;
+            if (!validateChatAudienceSelection()) return;
             if (/@all\s*plays/i.test(text)) {
                 aiUiPending = true;
                 renderMessages();
@@ -2903,6 +2924,7 @@
             const originalConversationId = selectedConversationId;
 
             if (!text && imageFiles.length === 0) return;
+            if (!validateChatAudienceSelection()) return;
 
             sendBtn.disabled = true;
             sendBtn.textContent = imageFiles.length > 0 ? 'Uploading...' : 'Sending...';

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -389,6 +389,18 @@ const CHAT_DB_CONVERSATION_SWITCH_STUB = CHAT_DB_STUB
 }`
     );
 
+const CHAT_DB_TARGETING_STUB = CHAT_DB_STUB
+    .replace('export async function postChatMessage() {}', `
+export async function postChatMessage() {
+    window.__chatPostCalls = (window.__chatPostCalls || 0) + 1;
+}
+`)
+    .replace(`export function canModerateChat() {
+    return false;
+}`, `export function canModerateChat() {
+    return true;
+}`);
+
 const MEDIA_DB_STUB = `
 ${PERMISSION_ERROR}
 export async function getTeam(teamId) {
@@ -939,6 +951,31 @@ test('team chat scopes subscription, last-read, send, and reaction operations to
         userId: 'user-1',
         conversationId: 'staff-conversation'
     });
+    expect(pageErrors).toEqual([]);
+});
+
+test('team chat keeps selected-member drafts unsent when no recipient is selected', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await page.addInitScript(() => {
+        window.__chatPostCalls = 0;
+    });
+    await routeCommonPageStubs(page);
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: CHAT_DB_TARGETING_STUB }));
+
+    await page.goto(`${baseURL}/team-chat.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#recipient-picker')).toBeVisible();
+    await page.locator('#recipient-target').selectOption('individuals');
+    await expect(page.locator('#recipient-summary')).toHaveText('Audience: Select at least one member');
+    await page.locator('#message-input').fill('Private player follow-up');
+    await page.locator('#send-btn').click();
+
+    await expect(page.locator('#send-error')).toHaveText('Select at least one recipient before sending.');
+    await expect(page.locator('#send-error')).toBeVisible();
+    await expect(page.locator('#recipient-target')).toHaveAttribute('aria-invalid', 'true');
+    await expect(page.locator('#recipient-target')).toBeFocused();
+    await expect(page.locator('#message-input')).toHaveValue('Private player follow-up');
+    expect(await page.evaluate(() => window.__chatPostCalls)).toBe(0);
     expect(pageErrors).toEqual([]);
 });
 

--- a/tests/unit/team-chat-recipient-targets.test.js
+++ b/tests/unit/team-chat-recipient-targets.test.js
@@ -68,6 +68,22 @@ describe('team chat recipient targets', () => {
         expect(sendMessage).toContain('if (!validateChatAudienceSelection()) return;');
     });
 
+    it('keeps follow-up messages in staff-only conversations targeted to staff', () => {
+        const html = readRepoFile('team-chat.html');
+        const buildTargetMetadata = html.slice(
+            html.indexOf('function buildRecipientTargetMetadata()'),
+            html.indexOf('function getConversationEmailRecipientIds')
+        );
+
+        expect(buildTargetMetadata).toContain('activeConversation.participantRoles');
+        expect(buildTargetMetadata).toContain("participantRoles.includes('staff')");
+        expect(buildTargetMetadata).toContain("targetType: 'staff'");
+        expect(buildTargetMetadata).toContain('recipientIds: []');
+        expect(buildTargetMetadata).toContain("targetRole: 'staff'");
+        expect(buildTargetMetadata.indexOf("participantRoles.includes('staff')"))
+            .toBeLessThan(buildTargetMetadata.indexOf("targetType: activeConversation.type === 'direct' ? 'individuals' : 'individuals'"));
+    });
+
     it('persists normalized target metadata from postChatMessage', () => {
         const db = readRepoFile('js/db.js');
 

--- a/tests/unit/team-chat-recipient-targets.test.js
+++ b/tests/unit/team-chat-recipient-targets.test.js
@@ -44,6 +44,30 @@ describe('team chat recipient targets', () => {
         expect(html).not.toContain("name: targetMetadata.targetType === 'staff' ? 'Staff only' : null");
     });
 
+    it('blocks selected-member sends until a recipient is selected', () => {
+        const html = readRepoFile('team-chat.html');
+
+        expect(html).toContain('function isMissingSelectedChatRecipients()');
+        expect(html).toContain("selectedRecipientTarget === 'individuals' &&\n                selectedRecipientIds.size === 0");
+        expect(html).toContain('function validateChatAudienceSelection()');
+        expect(html).toContain("showError('Select at least one recipient before sending.');");
+        expect(html).toContain("return 'Audience: Select at least one member';");
+        expect(html).not.toContain('Audience: Full team (no selected members yet)');
+
+        const triggerSend = html.slice(
+            html.indexOf('function triggerSend()'),
+            html.indexOf('async function sendMessage()')
+        );
+        expect(triggerSend.indexOf('if (!validateChatAudienceSelection()) return;'))
+            .toBeLessThan(triggerSend.indexOf('aiUiPending = true;'));
+
+        const sendMessage = html.slice(
+            html.indexOf('async function sendMessage()'),
+            html.indexOf('window.removeSelectedMedia = function')
+        );
+        expect(sendMessage).toContain('if (!validateChatAudienceSelection()) return;');
+    });
+
     it('persists normalized target metadata from postChatMessage', () => {
         const db = readRepoFile('js/db.js');
 
@@ -51,7 +75,9 @@ describe('team chat recipient targets', () => {
         expect(db).toContain('recipientIds = []');
         expect(db).toContain('targetRole = null');
         expect(db).toContain("const allowedTargetTypes = new Set(['full_team', 'staff', 'individuals']);");
-        expect(db).toContain("const effectiveTargetType = normalizedTargetType === 'individuals' && normalizedRecipientIds.length === 0");
+        expect(db).toContain("if (normalizedTargetType === 'individuals' && normalizedRecipientIds.length === 0)");
+        expect(db).toContain("throw new Error('Selected-member chat messages require at least one recipient.');");
+        expect(db).toContain('const effectiveTargetType = normalizedTargetType;');
         expect(db).toContain('targetType: effectiveTargetType');
         expect(db).toContain('recipientIds: normalizedRecipientIds');
         expect(db).toContain("targetRole: effectiveTargetType === 'staff' ? (targetRole || 'staff') : null");

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=88';");
+        expect(html).toContain("from './js/db.js?v=89';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {


### PR DESCRIPTION
## What changed

- Preserve the `individuals` audience intent when no members are selected instead of converting it to `full_team`.
- Block send attempts before AI state, uploads, conversation creation, or message persistence and keep the draft intact.
- Show a specific recipient-selection error, focus/mark the audience control invalid, and correct the audience summary.
- Reject empty selected-member recipient lists in `postChatMessage` as a persistence-layer defense.
- Add unit contract coverage and an end-to-end regression proving no post is attempted.

## Why

The legacy team chat recipient builder only emitted `individuals` metadata when the selected-recipient set was nonempty. With no selection it fell through to `full_team`, silently widening the audience of potentially sensitive messages.

## Impact

Selected-member messages can no longer become full-team messages because of an empty selection. Valid full-team, staff, direct, and selected-member flows retain their existing behavior.

## Checks

- `vitest run tests/unit/team-chat-recipient-targets.test.js --reporter=verbose` — 4 passed
- `playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --reporter=line` — 11 passed
- `git diff --check` — passed

Closes #3454