### PR TITLE
Bound platform-admin Firestore list reads

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -72,7 +72,7 @@
                 <div class="bg-gradient-to-br from-blue-500 to-blue-600 p-6 rounded-xl shadow-lg text-white">
                     <div class="flex items-center justify-between">
                         <div>
-                            <p class="text-blue-100 text-sm font-medium">Total Teams</p>
+                            <p class="text-blue-100 text-sm font-medium">Loaded Teams</p>
                             <p class="text-4xl font-bold mt-2" id="stat-total-teams">-</p>
                             <p class="text-blue-100 text-xs mt-1" id="stat-teams-growth">-</p>
                         </div>
@@ -88,7 +88,7 @@
                 <div class="bg-gradient-to-br from-green-500 to-green-600 p-6 rounded-xl shadow-lg text-white">
                     <div class="flex items-center justify-between">
                         <div>
-                            <p class="text-green-100 text-sm font-medium">Total Users</p>
+                            <p class="text-green-100 text-sm font-medium">Loaded Users</p>
                             <p class="text-4xl font-bold mt-2" id="stat-total-users">-</p>
                             <p class="text-green-100 text-xs mt-1" id="stat-users-growth">-</p>
                         </div>
@@ -104,7 +104,7 @@
                 <div class="bg-gradient-to-br from-purple-500 to-purple-600 p-6 rounded-xl shadow-lg text-white">
                     <div class="flex items-center justify-between">
                         <div>
-                            <p class="text-purple-100 text-sm font-medium">Total Games</p>
+                            <p class="text-purple-100 text-sm font-medium">Recent Games</p>
                             <p class="text-4xl font-bold mt-2" id="stat-total-games">-</p>
                             <p class="text-purple-100 text-xs mt-1" id="stat-games-breakdown">-</p>
                         </div>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -97,6 +97,30 @@
       ]
     },
     {
+      "collectionGroup": "sharedGames",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "homeTeamId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "sharedGames",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "awayTeamId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "sharedGames",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "teamIds", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "registrations",
       "queryScope": "COLLECTION_GROUP",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -280,8 +280,19 @@ service cloud.firestore {
               isGlobalAdmin());
     }
 
+    function canReadPublicTeamDocument(data) {
+      return data.isPublic is bool && data.isPublic == true;
+    }
+
+    function canListManagedTeamDocument(data) {
+      return isSignedIn() &&
+             (data.ownerId == request.auth.uid ||
+              (request.auth.token.email != null &&
+               request.auth.token.email.lower() in data.get('adminEmails', [])));
+    }
+
     function canReadTeamDocument(data) {
-      return (data.isPublic is bool && data.isPublic == true) ||
+      return canReadPublicTeamDocument(data) ||
              canReadManagedTeamDocument(data);
     }
 
@@ -2224,7 +2235,8 @@ service cloud.firestore {
     match /teams/{teamId} {
       allow get: if canReadTeamDocument(resource.data);
       allow list: if isBoundedGlobalAdminListQuery() ||
-                     (!isGlobalAdmin() && canReadTeamDocument(resource.data));
+                     canReadPublicTeamDocument(resource.data) ||
+                     canListManagedTeamDocument(resource.data);
       allow create: if isSignedIn() && request.resource.data.ownerId == request.auth.uid;
       allow update: if (isTeamOwnerOrGlobalAdmin(teamId) && keepsOwnerControlledTeamPrivilegeFieldsImmutable()) ||
                        (isTeamOwnerOrAdmin(teamId) && keepsTeamPrivilegeFieldsImmutable());

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,6 +20,13 @@ service cloud.firestore {
       return isSignedIn() && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
     }
 
+    function isBoundedGlobalAdminListQuery() {
+      return isGlobalAdmin() &&
+             request.query.limit != null &&
+             request.query.limit > 0 &&
+             request.query.limit <= 100;
+    }
+
     function isTeamOwnerOrAdmin(teamId) {
       return isSignedIn() &&
              (get(/databases/$(database)/documents/teams/$(teamId)).data.ownerId == request.auth.uid ||
@@ -1893,7 +1900,8 @@ service cloud.firestore {
     // modify, or remove isAdmin. Firestore rules, not dashboard client state,
     // remain the authority for broad private-team reads.
     match /users/{userId} {
-      allow read: if isGlobalAdmin() || isOwner(userId);
+      allow get: if isGlobalAdmin() || isOwner(userId);
+      allow list: if isBoundedGlobalAdminListQuery() || isOwner(userId);
       allow create: if isGlobalAdmin() ||
                     (isOwner(userId) && isOwnerUserCreatePayloadValid(request.resource.data));
       allow update: if isGlobalAdmin() ||
@@ -2214,7 +2222,9 @@ service cloud.firestore {
 
     // Teams - only public teams are readable by anonymous browse/listing paths.
     match /teams/{teamId} {
-      allow read: if canReadTeamDocument(resource.data);
+      allow get: if canReadTeamDocument(resource.data);
+      allow list: if isBoundedGlobalAdminListQuery() ||
+                     (!isGlobalAdmin() && canReadTeamDocument(resource.data));
       allow create: if isSignedIn() && request.resource.data.ownerId == request.auth.uid;
       allow update: if (isTeamOwnerOrGlobalAdmin(teamId) && keepsOwnerControlledTeamPrivilegeFieldsImmutable()) ||
                        (isTeamOwnerOrAdmin(teamId) && keepsTeamPrivilegeFieldsImmutable());

--- a/js/admin-bootstrap.js
+++ b/js/admin-bootstrap.js
@@ -6,6 +6,15 @@ export function normalizeAdminPageSize(rawPageSize) {
     return Math.min(Math.max(Math.floor(pageSize), 1), 100);
 }
 
+export function buildBoundedAdminDashboardScope({ teams = [], users = [] } = {}, options = {}) {
+    const teamLimit = normalizeAdminPageSize(options.teamLimit);
+    const userLimit = normalizeAdminPageSize(options.userLimit);
+    return {
+        teams: (Array.isArray(teams) ? teams : []).slice(0, teamLimit),
+        users: (Array.isArray(users) ? users : []).slice(0, userLimit)
+    };
+}
+
 export async function loadAdminCollectionPage({ fetchPage, cursor = null, pageSize = DEFAULT_ADMIN_PAGE_SIZE }) {
     if (typeof fetchPage !== 'function') {
         throw new Error('fetchPage is required');

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,8 +1,6 @@
 import {
     getAdminTeamsPage,
     getAdminUsersPage,
-    getTeams,
-    getAllUsers,
     getGames,
     getOfficials,
     getOfficialsForUsers,
@@ -17,10 +15,10 @@ import {
     getTelemetryEventDaily,
     getTelemetrySessions
 } from './db.js?v=91';
-import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp, getCountFromServer, query, where } from './firebase.js?v=20';
+import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp, query } from './firebase.js?v=20';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=15';
 import { checkAuth } from './auth.js?v=46';
-import { DEFAULT_ADMIN_PAGE_SIZE, loadAdminCollectionPage, loadInitialAdminBootstrap } from './admin-bootstrap.js?v=1';
+import { DEFAULT_ADMIN_PAGE_SIZE, buildBoundedAdminDashboardScope, loadAdminCollectionPage, loadInitialAdminBootstrap } from './admin-bootstrap.js?v=2';
 import {
     adminRegistrationDefaults,
     buildAdminRegistrationFormPayload,
@@ -152,9 +150,9 @@ function resetGlobalAdminSearchCollections() {
 async function ensureGlobalAdminTeamsForSearch() {
     if (globalSearchTeamsLoaded) return globalSearchTeams;
     if (!globalSearchTeamsPromise) {
-        globalSearchTeamsPromise = getTeams({ includeInactive: true })
-            .then((teams) => {
-                globalSearchTeams = Array.isArray(teams) ? teams : [];
+        globalSearchTeamsPromise = getAdminTeamsPage({ pageSize: 100 })
+            .then((page) => {
+                globalSearchTeams = Array.isArray(page?.teams) ? page.teams : [];
                 globalSearchTeamsLoaded = true;
                 return globalSearchTeams;
             })
@@ -168,9 +166,9 @@ async function ensureGlobalAdminTeamsForSearch() {
 async function ensureGlobalAdminUsersForSearch() {
     if (globalSearchUsersLoaded) return globalSearchUsers;
     if (!globalSearchUsersPromise) {
-        globalSearchUsersPromise = getAllUsers()
-            .then((users) => {
-                globalSearchUsers = Array.isArray(users) ? users : [];
+        globalSearchUsersPromise = getAdminUsersPage({ pageSize: 100 })
+            .then((page) => {
+                globalSearchUsers = Array.isArray(page?.users) ? page.users : [];
                 globalSearchUsersLoaded = true;
                 return globalSearchUsers;
             })
@@ -326,7 +324,6 @@ async function loadData() {
         loadedUsersOfficialsKey = '';
         allGames = [];
         dashboardGames = [];
-        dashboardGameStatsByTeamId = new Map();
         dashboardTeams = [];
         dashboardUsers = [];
         resetGlobalAdminSearchCollections();
@@ -342,10 +339,10 @@ async function loadData() {
         setTeamsPage(teamsPage.teams, teamsPage.nextCursor);
         setUsersPage(usersPage.users, usersPage.nextCursor);
 
-        await Promise.all([
-            ensureCurrentTeamGamesLoaded(),
-            loadDashboardData()
-        ]);
+        await loadDashboardData({
+            teams: teamsPage.teams,
+            users: usersPage.users
+        });
         telemetryPromise.then(() => {
             if (activeTab === 'telemetry') {
                 updateTelemetryDashboard();
@@ -364,10 +361,11 @@ async function loadData() {
 
 let allGames = [];
 let dashboardGames = [];
-let dashboardGameStatsByTeamId = new Map();
 
 const DASHBOARD_GAME_LOOKBACK_DAYS = 30;
 const DASHBOARD_GAME_LOOKAHEAD_DAYS = 30;
+const DASHBOARD_SUMMARY_TEAM_LIMIT = DEFAULT_ADMIN_PAGE_SIZE;
+const DASHBOARD_SUMMARY_USER_LIMIT = DEFAULT_ADMIN_PAGE_SIZE;
 
 function buildDashboardGameQueryWindow(referenceDate = new Date()) {
     const startDate = new Date(referenceDate.getTime() - DASHBOARD_GAME_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
@@ -428,29 +426,6 @@ async function loadVisibleOfficialUserLinks(users = allUsers) {
     loadedUsersOfficialsKey = usersKey;
 }
 
-async function loadDashboardAllTimeGameStats(teams = []) {
-    const statsEntries = await Promise.all(teams.map(async (team) => {
-        try {
-            const gamesRef = collection(db, 'teams', team.id, 'games');
-            const [totalSnapshot, completedSnapshot, scheduledSnapshot] = await Promise.all([
-                getCountFromServer(gamesRef),
-                getCountFromServer(query(gamesRef, where('status', '==', 'completed'))),
-                getCountFromServer(query(gamesRef, where('status', '==', 'scheduled')))
-            ]);
-            const total = totalSnapshot.data().count || 0;
-            return [team.id, {
-                total,
-                completed: completedSnapshot.data().count || 0,
-                scheduled: scheduledSnapshot.data().count || 0
-            }];
-        } catch (error) {
-            console.warn('Failed to load all-time game stats for admin dashboard:', team.id, error);
-            return [team.id, { total: 0, completed: 0, scheduled: 0 }];
-        }
-    }));
-    dashboardGameStatsByTeamId = new Map(statsEntries);
-}
-
 async function loadGameStatsForTeams(teams = allTeams, { scope = 'page' } = {}) {
     const teamsKey = getTeamsKey(teams);
     if (scope === 'page' && teamsKey && loadedGamesPageKey === teamsKey) {
@@ -478,7 +453,6 @@ async function loadGameStatsForTeams(teams = allTeams, { scope = 'page' } = {}) 
 
     if (scope === 'dashboard') {
         dashboardGames = nextGames;
-        await loadDashboardAllTimeGameStats(teams);
         loadedDashboardGamesKey = teamsKey;
         return;
     }
@@ -487,13 +461,13 @@ async function loadGameStatsForTeams(teams = allTeams, { scope = 'page' } = {}) 
     loadedGamesPageKey = teamsKey;
 }
 
-async function loadDashboardData() {
-    dashboardTeams = await getTeams({ includeInactive: true });
-    dashboardUsers = await getAllUsers();
-    globalSearchTeams = dashboardTeams;
-    globalSearchUsers = dashboardUsers;
-    globalSearchTeamsLoaded = true;
-    globalSearchUsersLoaded = true;
+async function loadDashboardData({ teams = getCurrentTeamPage(), users = getCurrentUsersPage() } = {}) {
+    const scope = buildBoundedAdminDashboardScope({ teams, users }, {
+        teamLimit: DASHBOARD_SUMMARY_TEAM_LIMIT,
+        userLimit: DASHBOARD_SUMMARY_USER_LIMIT
+    });
+    dashboardTeams = scope.teams;
+    dashboardUsers = scope.users;
     await loadGameStatsForTeams(dashboardTeams, { scope: 'dashboard' });
 }
 
@@ -576,14 +550,6 @@ function updateDashboard() {
     const visibleTeams = showInactiveTeams ? sourceTeams : sourceTeams.filter(isTeamActive);
     const visibleTeamIds = new Set(visibleTeams.map(team => team.id));
     const visibleRecentGames = dashboardGames.filter(game => visibleTeamIds.has(game.teamId));
-    const visibleAllTimeGameStats = visibleTeams.reduce((totals, team) => {
-        const stats = dashboardGameStatsByTeamId.get(team.id) || { total: 0, completed: 0, scheduled: 0 };
-        totals.total += stats.total;
-        totals.completed += stats.completed;
-        totals.scheduled += stats.scheduled;
-        if (stats.total > 0) totals.teamsWithGames += 1;
-        return totals;
-    }, { total: 0, completed: 0, scheduled: 0, teamsWithGames: 0 });
     const now = new Date();
     const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -591,18 +557,18 @@ function updateDashboard() {
     // Total teams with growth
     const newTeamsLast30 = visibleTeams.filter(t => t.createdAt && t.createdAt.toDate() > thirtyDaysAgo).length;
     document.getElementById('stat-total-teams').textContent = visibleTeams.length;
-    document.getElementById('stat-teams-growth').textContent = `+${newTeamsLast30} this month`;
+    document.getElementById('stat-teams-growth').textContent = `Loaded page · +${newTeamsLast30} this month`;
 
     // Total users with growth
     const newUsersLast30 = sourceUsers.filter(u => u.createdAt && u.createdAt.toDate() > thirtyDaysAgo).length;
     document.getElementById('stat-total-users').textContent = sourceUsers.length;
-    document.getElementById('stat-users-growth').textContent = `+${newUsersLast30} this month`;
+    document.getElementById('stat-users-growth').textContent = `Loaded page · +${newUsersLast30} this month`;
 
-    // Total games
-    const completedGames = visibleAllTimeGameStats.completed;
-    const scheduledGames = visibleAllTimeGameStats.scheduled;
-    document.getElementById('stat-total-games').textContent = visibleAllTimeGameStats.total;
-    document.getElementById('stat-games-breakdown').textContent = `${completedGames} played, ${scheduledGames} scheduled`;
+    // Recent games from the bounded dashboard window.
+    const completedGames = visibleRecentGames.filter(game => game.status === 'completed').length;
+    const scheduledGames = visibleRecentGames.filter(game => game.status === 'scheduled').length;
+    document.getElementById('stat-total-games').textContent = visibleRecentGames.length;
+    document.getElementById('stat-games-breakdown').textContent = `±30 days · ${completedGames} played, ${scheduledGames} scheduled`;
     renderRecentGameResults(visibleRecentGames);
 
     // Activity (teams with games in last 7 days)
@@ -631,7 +597,7 @@ function updateDashboard() {
     // Team details
     const publicTeams = visibleTeams.filter(t => t.isPublic !== false).length;
     const privateTeams = visibleTeams.length - publicTeams;
-    const teamsWithGames = visibleAllTimeGameStats.teamsWithGames;
+    const teamsWithGames = new Set(visibleRecentGames.map(game => game.teamId)).size;
     document.getElementById('stat-team-details').innerHTML = `
         <div class="flex justify-between items-center">
             <span class="text-gray-700">Public</span>
@@ -642,7 +608,7 @@ function updateDashboard() {
             <span class="font-semibold text-gray-900">${privateTeams}</span>
         </div>
         <div class="flex justify-between items-center">
-            <span class="text-gray-700">With Games</span>
+            <span class="text-gray-700">With Recent Games</span>
             <span class="font-semibold text-gray-900">${teamsWithGames}</span>
         </div>
     `;
@@ -1771,11 +1737,14 @@ async function loadNextTeamsPage() {
             return;
         }
         if (activeTab === 'dashboard') {
-            await ensureCurrentTeamGamesLoaded();
+            await loadDashboardData();
             updateDashboard();
         }
         if (activeTab === 'teams') {
-            await ensureCurrentTeamOfficialsLoaded();
+            await Promise.all([
+                ensureCurrentTeamGamesLoaded(),
+                ensureCurrentTeamOfficialsLoaded()
+            ]);
         }
         if (activeTab === 'users') {
             await ensureCurrentUsersOfficialsLoaded();
@@ -1798,11 +1767,14 @@ async function loadPreviousTeamsPage() {
         const previousIndex = teamPageState.currentIndex - 1;
         setTeamsPage(teamPageState.pages[previousIndex] || [], teamPageState.nextCursor, previousIndex);
         if (activeTab === 'dashboard') {
-            await ensureCurrentTeamGamesLoaded();
+            await loadDashboardData();
             updateDashboard();
         }
         if (activeTab === 'teams') {
-            await ensureCurrentTeamOfficialsLoaded();
+            await Promise.all([
+                ensureCurrentTeamGamesLoaded(),
+                ensureCurrentTeamOfficialsLoaded()
+            ]);
         }
         if (activeTab === 'users') {
             await ensureCurrentUsersOfficialsLoaded();
@@ -1836,6 +1808,7 @@ async function loadNextUsersPage() {
         await ensureCurrentUsersOfficialsLoaded();
         renderCurrentUsersView();
         if (activeTab === 'dashboard') {
+            await loadDashboardData();
             updateDashboard();
         }
     } finally {
@@ -1854,6 +1827,7 @@ async function loadPreviousUsersPage() {
         await ensureCurrentUsersOfficialsLoaded();
         renderCurrentUsersView();
         if (activeTab === 'dashboard') {
+            await loadDashboardData();
             updateDashboard();
         }
     } finally {
@@ -1865,12 +1839,15 @@ async function loadPreviousUsersPage() {
 async function handleTabChange(tab) {
     activeTab = tab;
     if (tab === 'dashboard') {
-        await ensureCurrentTeamGamesLoaded();
+        await loadDashboardData();
         updateDashboard();
         return;
     }
     if (tab === 'teams') {
-        await ensureCurrentTeamOfficialsLoaded();
+        await Promise.all([
+            ensureCurrentTeamGamesLoaded(),
+            ensureCurrentTeamOfficialsLoaded()
+        ]);
         renderCurrentTeamsView();
         return;
     }

--- a/js/db.js
+++ b/js/db.js
@@ -2021,7 +2021,7 @@ export async function getAllUsers() {
 }
 
 export async function getUserByEmail(email) {
-    const q = query(collection(db, "users"), where("email", "==", email));
+    const q = query(collection(db, "users"), where("email", "==", email), limitQuery(1));
     const snapshot = await getDocs(q);
     if (snapshot.empty) return null;
     return { id: snapshot.docs[0].id, ...snapshot.docs[0].data() };

--- a/js/db.js
+++ b/js/db.js
@@ -336,27 +336,6 @@ async function getSharedGamesForTeam(teamId, options = {}) {
         const failedQuery = snapshots.find((result) => result.status === 'rejected');
         if (failedQuery) throw failedQuery.reason;
     }
-    if (dateConstraints.length > 0 && snapshots.some((result) => result.status === 'rejected')) {
-        try {
-            // The date-only collection-group query uses the single-field index and
-            // keeps the fallback bounded while compound indexes finish deploying.
-            const fallbackSnapshots = await Promise.all([
-                getDocs(query(sharedGamesRef, ...orderedDateConstraints)),
-                getDocs(query(sharedGamesRef, where('date', '==', null)))
-            ]);
-            return fallbackSnapshots.flatMap((snapshot) => snapshot.docs)
-                .filter((docSnap) => {
-                    const game = docSnap.data();
-                    return game.homeTeamId === teamId
-                        || game.awayTeamId === teamId
-                        || (Array.isArray(game.teamIds) && game.teamIds.includes(teamId));
-                })
-                .map(normalizeSharedGameSnapshot)
-                .filter((game) => isGameWithinDateRange(game, startDate, endDate));
-        } catch (error) {
-            console.warn('[getSharedGamesForTeam] Date-bounded fallback failed for team', teamId, error);
-        }
-    }
     const sharedGamesByPath = new Map();
 
     snapshots.forEach((result) => {

--- a/js/db.js
+++ b/js/db.js
@@ -886,7 +886,7 @@ export async function getTeams(options = {}) {
     const teamsRef = collection(db, "teams");
     let teams = [];
     if (includePrivate) {
-        teams = (await getDocs(query(teamsRef, orderBy("name")))).docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        teams = (await getDocs(query(teamsRef, orderBy("name"), limitQuery(100)))).docs.map(doc => ({ id: doc.id, ...doc.data() }));
     } else if (publicOnly) {
         teams = (await getDocs(query(teamsRef, where("isPublic", "==", true)))).docs
             .map(doc => ({ id: doc.id, ...doc.data() }))
@@ -2015,7 +2015,7 @@ export async function getAdminUsersPage(options = {}) {
 }
 
 export async function getAllUsers() {
-    const q = query(collection(db, "users"), orderBy("email"));
+    const q = query(collection(db, "users"), orderBy("email"), limitQuery(100));
     const snapshot = await getDocs(q);
     return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 }

--- a/js/db.js
+++ b/js/db.js
@@ -306,17 +306,56 @@ function normalizeSharedGameSnapshot(docSnap) {
     };
 }
 
-async function getSharedGamesForTeam(teamId, { requireComplete = false } = {}) {
+async function getSharedGamesForTeam(teamId, options = {}) {
     const sharedGamesRef = collectionGroup(db, 'sharedGames');
-    const queries = [
-        query(sharedGamesRef, where('homeTeamId', '==', teamId)),
-        query(sharedGamesRef, where('awayTeamId', '==', teamId))
+    const startDate = options?.startDate ?? null;
+    const endDate = options?.endDate ?? null;
+    const requireComplete = options?.requireComplete === true;
+    const dateConstraints = [];
+    if (startDate instanceof Date) dateConstraints.push(where('date', '>=', Timestamp.fromDate(startDate)));
+    if (endDate instanceof Date) dateConstraints.push(where('date', '<=', Timestamp.fromDate(endDate)));
+    const orderedDateConstraints = dateConstraints.length > 0
+        ? [...dateConstraints, orderBy('date')]
+        : [];
+    const teamConstraints = [
+        where('homeTeamId', '==', teamId),
+        where('awayTeamId', '==', teamId),
+        where('teamIds', 'array-contains', teamId)
     ];
+    const queries = teamConstraints.flatMap((teamConstraint) => (
+        dateConstraints.length > 0
+            ? [
+                query(sharedGamesRef, teamConstraint, ...orderedDateConstraints),
+                query(sharedGamesRef, teamConstraint, where('date', '==', null))
+            ]
+            : [query(sharedGamesRef, teamConstraint)]
+    ));
 
     const snapshots = await Promise.allSettled(queries.map((q) => getDocs(q)));
     if (requireComplete) {
         const failedQuery = snapshots.find((result) => result.status === 'rejected');
         if (failedQuery) throw failedQuery.reason;
+    }
+    if (dateConstraints.length > 0 && snapshots.some((result) => result.status === 'rejected')) {
+        try {
+            // The date-only collection-group query uses the single-field index and
+            // keeps the fallback bounded while compound indexes finish deploying.
+            const fallbackSnapshots = await Promise.all([
+                getDocs(query(sharedGamesRef, ...orderedDateConstraints)),
+                getDocs(query(sharedGamesRef, where('date', '==', null)))
+            ]);
+            return fallbackSnapshots.flatMap((snapshot) => snapshot.docs)
+                .filter((docSnap) => {
+                    const game = docSnap.data();
+                    return game.homeTeamId === teamId
+                        || game.awayTeamId === teamId
+                        || (Array.isArray(game.teamIds) && game.teamIds.includes(teamId));
+                })
+                .map(normalizeSharedGameSnapshot)
+                .filter((game) => isGameWithinDateRange(game, startDate, endDate));
+        } catch (error) {
+            console.warn('[getSharedGamesForTeam] Date-bounded fallback failed for team', teamId, error);
+        }
     }
     const sharedGamesByPath = new Map();
 
@@ -327,7 +366,8 @@ async function getSharedGamesForTeam(teamId, { requireComplete = false } = {}) {
         });
     });
 
-    return Array.from(sharedGamesByPath.values());
+    return Array.from(sharedGamesByPath.values())
+        .filter((game) => isGameWithinDateRange(game, startDate, endDate));
 }
 
 async function hasSharedGameUsingConfig(teamId, configId) {
@@ -877,6 +917,31 @@ export async function discoverPublicTeams(options = {}) {
 }
 
 // Teams
+// Legacy callers still require complete authorized collections. Page internally
+// so every request satisfies the global-admin list rule without truncating data.
+const COMPLETE_COLLECTION_PAGE_SIZE = 100;
+
+async function getAllOrderedCollectionDocuments(collectionRef, fieldName) {
+    const documents = [];
+    let cursor = null;
+
+    do {
+        const constraints = [orderBy(fieldName)];
+        if (cursor) {
+            constraints.push(startAfterQuery(cursor));
+        }
+        constraints.push(limitQuery(COMPLETE_COLLECTION_PAGE_SIZE));
+
+        const snapshot = await getDocs(query(collectionRef, ...constraints));
+        documents.push(...snapshot.docs);
+        cursor = snapshot.docs.length === COMPLETE_COLLECTION_PAGE_SIZE
+            ? snapshot.docs[snapshot.docs.length - 1]
+            : null;
+    } while (cursor);
+
+    return documents;
+}
+
 export async function getTeams(options = {}) {
     const includeInactive = !!options.includeInactive;
     const publicOnly = options.publicOnly === true;
@@ -886,7 +951,8 @@ export async function getTeams(options = {}) {
     const teamsRef = collection(db, "teams");
     let teams = [];
     if (includePrivate) {
-        teams = (await getDocs(query(teamsRef, orderBy("name"), limitQuery(100)))).docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        teams = (await getAllOrderedCollectionDocuments(teamsRef, "name"))
+            .map(doc => ({ id: doc.id, ...doc.data() }));
     } else if (publicOnly) {
         teams = (await getDocs(query(teamsRef, where("isPublic", "==", true)))).docs
             .map(doc => ({ id: doc.id, ...doc.data() }))
@@ -2015,9 +2081,8 @@ export async function getAdminUsersPage(options = {}) {
 }
 
 export async function getAllUsers() {
-    const q = query(collection(db, "users"), orderBy("email"), limitQuery(100));
-    const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const userDocs = await getAllOrderedCollectionDocuments(collection(db, "users"), "email");
+    return userDocs.map(doc => ({ id: doc.id, ...doc.data() }));
 }
 
 export async function getUserByEmail(email) {
@@ -3483,7 +3548,7 @@ export async function getGames(teamId, options = {}) {
 
     let sharedGames = [];
     try {
-        sharedGames = await getSharedGamesForTeam(teamId, { requireComplete: hasTournamentGroup });
+        sharedGames = await getSharedGamesForTeam(teamId, { startDate, endDate, requireComplete: hasTournamentGroup });
     } catch (error) {
         if (hasTournamentGroup) throw error;
         console.warn('[getGames] Failed to load shared games for team', teamId, error);

--- a/tests/unit/admin-bootstrap.test.js
+++ b/tests/unit/admin-bootstrap.test.js
@@ -1,11 +1,24 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     DEFAULT_ADMIN_PAGE_SIZE,
+    buildBoundedAdminDashboardScope,
     loadAdminCollectionPage,
     loadInitialAdminBootstrap
 } from '../../js/admin-bootstrap.js';
 
 describe('admin bootstrap paging helpers', () => {
+    it('caps dashboard scope independently of the supplied platform collection sizes', () => {
+        const teams = Array.from({ length: 250 }, (_, index) => ({ id: `team-${index + 1}` }));
+        const users = Array.from({ length: 400 }, (_, index) => ({ id: `user-${index + 1}` }));
+
+        const scope = buildBoundedAdminDashboardScope({ teams, users });
+
+        expect(scope.teams).toHaveLength(DEFAULT_ADMIN_PAGE_SIZE);
+        expect(scope.users).toHaveLength(DEFAULT_ADMIN_PAGE_SIZE);
+        expect(scope.teams.at(-1)?.id).toBe(`team-${DEFAULT_ADMIN_PAGE_SIZE}`);
+        expect(scope.users.at(-1)?.id).toBe(`user-${DEFAULT_ADMIN_PAGE_SIZE}`);
+    });
+
     it('uses a fixed first-page size and reuses returned cursors for follow-up loads', async () => {
         const firstCursor = { id: 'cursor-1' };
         const fetchPage = vi.fn()

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -30,7 +30,7 @@ describe('admin dashboard statistics scope', () => {
         expect(adminJs).toContain('await Promise.all([');
         expect(adminJs).toContain('loadDashboardData()');
         expect(adminJs).toContain('ensureCurrentTeamGamesLoaded()');
-        expect(adminJs).toContain('await ensureCurrentTeamOfficialsLoaded();');
+        expect(adminJs).toContain('ensureCurrentTeamOfficialsLoaded()');
         expect(adminJs).toContain('await ensureCurrentUsersOfficialsLoaded();');
         expect(adminHtml).toContain('id="teams-pagination-status"');
         expect(adminHtml).toContain('id="users-pagination-status"');

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -2,23 +2,26 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 
 describe('admin dashboard statistics scope', () => {
-    it('calculates dashboard stats from the full admin datasets instead of the current page', () => {
+    it('builds the initial dashboard from bounded first pages instead of full collections', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+        const loadDataBody = adminJs.match(/async function loadData\(\)[\s\S]*?let allGames = \[\];/)?.[0] || '';
+        const loadDashboardBody = adminJs.match(/async function loadDashboardData[\s\S]*?async function ensureCurrentTeamGamesLoaded/)?.[0] || '';
 
-        expect(adminJs).toContain('const sourceTeams = getDashboardTeams();');
-        expect(adminJs).toContain('const sourceUsers = getDashboardUsers();');
-        expect(adminJs).toContain("const visibleTeams = showInactiveTeams ? sourceTeams : sourceTeams.filter(isTeamActive);");
-        expect(adminJs).toContain('const visibleTeamIds = new Set(visibleTeams.map(team => team.id));');
-        expect(adminJs).toContain('const visibleRecentGames = dashboardGames.filter(game => visibleTeamIds.has(game.teamId));');
-        expect(adminJs).toContain("document.getElementById('stat-total-users').textContent = sourceUsers.length;");
-        expect(adminJs).toContain('const visibleAllTimeGameStats = visibleTeams.reduce((totals, team) => {');
-        expect(adminJs).toContain("document.getElementById('stat-total-games').textContent = visibleAllTimeGameStats.total;");
-        expect(adminJs).toContain('const teamsWithGames = visibleAllTimeGameStats.teamsWithGames;');
+        expect(loadDataBody).toContain('getTeamsPage: getAdminTeamsPage');
+        expect(loadDataBody).toContain('getUsersPage: getAdminUsersPage');
+        expect(loadDataBody).toContain('teams: teamsPage.teams');
+        expect(loadDataBody).toContain('users: usersPage.users');
+        expect(loadDataBody).not.toContain('ensureCurrentTeamGamesLoaded()');
+        expect(loadDashboardBody).toContain('buildBoundedAdminDashboardScope({ teams, users }');
+        expect(loadDashboardBody).not.toContain('getTeams({ includeInactive: true })');
+        expect(loadDashboardBody).not.toContain('getAllUsers()');
     });
 
-    it('boots from paged teams and users before lazy team detail fan-out', () => {
-        const adminHtml = fs.readFileSync('admin.html', 'utf8');
+    it('uses bounded page loaders for explicit broader admin searches', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+        const dbJs = fs.readFileSync('js/db.js', 'utf8');
+
+        const adminHtml = fs.readFileSync('admin.html', 'utf8');
 
         expect(adminJs).toContain("import { checkAuth } from './auth.js?v=46';");
         expect(adminJs).not.toContain("import { checkAuth } from './auth.js?v=42';");
@@ -32,34 +35,50 @@ describe('admin dashboard statistics scope', () => {
         expect(adminJs).toContain('await ensureCurrentUsersOfficialsLoaded();');
         expect(adminHtml).toContain('id="teams-pagination-status"');
         expect(adminHtml).toContain('id="users-pagination-status"');
+        expect(adminJs).toContain('getAdminTeamsPage({ pageSize: 100 })');
+        expect(adminJs).toContain('getAdminUsersPage({ pageSize: 100 })');
+        expect(adminJs).not.toContain('globalSearchTeamsPromise = getTeams(');
+        expect(adminJs).not.toContain('globalSearchUsersPromise = getAllUsers(');
+        expect(dbJs).toContain('query(teamsRef, orderBy("name"), limitQuery(100))');
+        expect(dbJs).toContain('query(collection(db, "users"), orderBy("email"), limitQuery(100))');
     });
 
-    it('bounds dashboard game reads while preserving page-scope full-history reads', () => {
+    it('bounds dashboard game reads to the loaded team page and a recent time window', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
-        const loadGameStatsBody = adminJs.match(/async function loadGameStatsForTeams[\s\S]*?async function loadDashboardData\(\)/)?.[0] || '';
+        const loadGameStatsBody = adminJs.match(/async function loadGameStatsForTeams[\s\S]*?async function loadDashboardData/)?.[0] || '';
 
         expect(adminJs).toContain('const DASHBOARD_GAME_LOOKBACK_DAYS = 30;');
         expect(adminJs).toContain('const DASHBOARD_GAME_LOOKAHEAD_DAYS = 30;');
+        expect(adminJs).toContain('const DASHBOARD_SUMMARY_TEAM_LIMIT = DEFAULT_ADMIN_PAGE_SIZE;');
         expect(loadGameStatsBody).toContain("scope === 'dashboard'");
         expect(loadGameStatsBody).toContain('buildDashboardGameQueryWindow()');
         expect(loadGameStatsBody).toContain('await getGames(team.id, dashboardGameQueryWindow)');
-        expect(loadGameStatsBody).toContain('await getGames(team.id);');
-        expect(loadGameStatsBody).toContain('await loadDashboardAllTimeGameStats(teams);');
-        expect(loadGameStatsBody).toContain('loadedDashboardGamesKey = teamsKey;');
+        expect(loadGameStatsBody).not.toContain('getCountFromServer');
+        expect(adminJs).not.toContain('loadDashboardAllTimeGameStats');
     });
 
-    it('keeps all-time dashboard game totals separate from bounded recent-game reads', () => {
+    it('labels dashboard values as loaded-page and recent-window counts', () => {
+        const adminHtml = fs.readFileSync('admin.html', 'utf8');
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
 
-        expect(adminJs).toContain('let dashboardGameStatsByTeamId = new Map();');
-        expect(adminJs).toContain('async function loadDashboardAllTimeGameStats(teams = [])');
-        expect(adminJs).toContain('getCountFromServer(gamesRef)');
-        expect(adminJs).toContain("getCountFromServer(query(gamesRef, where('status', '==', 'completed')))");
-        expect(adminJs).toContain("getCountFromServer(query(gamesRef, where('status', '==', 'scheduled')))");
-        expect(adminJs).toContain('totals.total += stats.total;');
-        expect(adminJs).toContain('totals.completed += stats.completed;');
-        expect(adminJs).toContain('totals.scheduled += stats.scheduled;');
-        expect(adminJs).toContain('if (stats.total > 0) totals.teamsWithGames += 1;');
-        expect(adminJs).toContain('renderRecentGameResults(visibleRecentGames);');
+        expect(adminHtml).toContain('Loaded Teams');
+        expect(adminHtml).toContain('Loaded Users');
+        expect(adminHtml).toContain('Recent Games');
+        expect(adminJs).toContain('Loaded page · +${newTeamsLast30} this month');
+        expect(adminJs).toContain('Loaded page · +${newUsersLast30} this month');
+        expect(adminJs).toContain('±30 days · ${completedGames} played, ${scheduledGames} scheduled');
+        expect(adminJs).toContain('const teamsWithGames = new Set(visibleRecentGames.map(game => game.teamId)).size;');
+        expect(adminJs).toContain('With Recent Games');
+    });
+
+    it('defers full-history team game reads until the Teams tab or explicit pagination', () => {
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+        const handleTabBody = adminJs.match(/async function handleTabChange[\s\S]*?function setupTabs/)?.[0] || '';
+
+        expect(handleTabBody).toContain("if (tab === 'dashboard')");
+        expect(handleTabBody).toContain('await loadDashboardData();');
+        expect(handleTabBody).toContain("if (tab === 'teams')");
+        expect(handleTabBody).toContain('ensureCurrentTeamGamesLoaded()');
+        expect(handleTabBody).toContain('ensureCurrentTeamOfficialsLoaded()');
     });
 });

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -19,7 +19,6 @@ describe('admin dashboard statistics scope', () => {
 
     it('uses bounded page loaders for explicit broader admin searches', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
-        const dbJs = fs.readFileSync('js/db.js', 'utf8');
 
         const adminHtml = fs.readFileSync('admin.html', 'utf8');
 
@@ -39,8 +38,21 @@ describe('admin dashboard statistics scope', () => {
         expect(adminJs).toContain('getAdminUsersPage({ pageSize: 100 })');
         expect(adminJs).not.toContain('globalSearchTeamsPromise = getTeams(');
         expect(adminJs).not.toContain('globalSearchUsersPromise = getAllUsers(');
-        expect(dbJs).toContain('query(teamsRef, orderBy("name"), limitQuery(100))');
-        expect(dbJs).toContain('query(collection(db, "users"), orderBy("email"), limitQuery(100))');
+    });
+
+    it('preserves complete shared team and user helpers through bounded internal pages', () => {
+        const dbJs = fs.readFileSync('js/db.js', 'utf8');
+        const pagingHelper = dbJs.match(/async function getAllOrderedCollectionDocuments[\s\S]*?\n\}/)?.[0] || '';
+        const getTeamsBody = dbJs.match(/export async function getTeams\(options = \{\}\)[\s\S]*?\n\}/)?.[0] || '';
+        const getAllUsersBody = dbJs.match(/export async function getAllUsers\(\)[\s\S]*?\n\}/)?.[0] || '';
+
+        expect(pagingHelper).toContain('limitQuery(COMPLETE_COLLECTION_PAGE_SIZE)');
+        expect(pagingHelper).toContain('startAfterQuery(cursor)');
+        expect(pagingHelper).toContain('} while (cursor);');
+        expect(getTeamsBody).toContain('getAllOrderedCollectionDocuments(teamsRef, "name")');
+        expect(getAllUsersBody).toContain('getAllOrderedCollectionDocuments(collection(db, "users"), "email")');
+        expect(getTeamsBody).not.toContain('limitQuery(100)');
+        expect(getAllUsersBody).not.toContain('limitQuery(100)');
     });
 
     it('bounds dashboard game reads to the loaded team page and a recent time window', () => {

--- a/tests/unit/app-social-rules.test.js
+++ b/tests/unit/app-social-rules.test.js
@@ -129,7 +129,8 @@ describe('React app social Firestore rules', () => {
         expect(source).toContain('function isOwnerUserEmailAuthBound(data)');
         expect(source).toContain("data.email.lower() == request.auth.token.email.lower()");
         expect(source).toContain("(!request.resource.data.diff(resource.data).affectedKeys().hasAny(['email']) ||");
-        expect(source).toContain('allow read: if isGlobalAdmin() || isOwner(userId);');
+        expect(source).toContain('allow get: if isGlobalAdmin() || isOwner(userId);');
+        expect(source).toContain('allow list: if isBoundedGlobalAdminListQuery() || isOwner(userId);');
         expect(source).not.toContain('allow read: if true;  // Public profiles');
 
         expect(isOwnerUserEmailUpdateValid({

--- a/tests/unit/db-homepage-shared-games.test.js
+++ b/tests/unit/db-homepage-shared-games.test.js
@@ -60,6 +60,9 @@ describe('homepage shared game discovery queries', () => {
 
         expect(sharedGameIndexes).toContain('type:ASCENDING,date:ASCENDING');
         expect(sharedGameIndexes).toContain('liveStatus:ASCENDING,date:DESCENDING');
+        expect(sharedGameIndexes).toContain('homeTeamId:ASCENDING,date:ASCENDING');
+        expect(sharedGameIndexes).toContain('awayTeamId:ASCENDING,date:ASCENDING');
+        expect(sharedGameIndexes).toContain('teamIds:CONTAINS,date:ASCENDING');
         expect(dateFieldOverrides).toContainEqual({
             collectionGroup: 'games',
             indexes: ['ASCENDING:COLLECTION_GROUP', 'DESCENDING:COLLECTION_GROUP']

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -172,3 +172,47 @@ describe('discoverPublicTeams search pagination', () => {
         expect(firebaseMocks.startAfter).not.toHaveBeenCalled();
     });
 });
+
+describe('complete legacy collection helpers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns every authorized user while keeping each Firestore query bounded to 100', async () => {
+        const firstPage = Array.from({ length: 100 }, (_, index) => createTeamDoc(`user-${index + 1}`, {
+            email: `user-${String(index + 1).padStart(3, '0')}@example.com`
+        }));
+        const secondPage = [createTeamDoc('user-101', { email: 'user-101@example.com' })];
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: firstPage })
+            .mockResolvedValueOnce({ docs: secondPage });
+
+        const { getAllUsers } = await import('../../js/db.js?v=85');
+        const users = await getAllUsers();
+
+        expect(users).toHaveLength(101);
+        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(2);
+        expect(firebaseMocks.limit).toHaveBeenNthCalledWith(1, 100);
+        expect(firebaseMocks.limit).toHaveBeenNthCalledWith(2, 100);
+        expect(firebaseMocks.startAfter).toHaveBeenCalledWith(firstPage.at(-1));
+    });
+
+    it('returns every private team page instead of silently truncating at 100', async () => {
+        const firstPage = Array.from({ length: 100 }, (_, index) => createTeamDoc(`team-${index + 1}`, {
+            name: `Team ${String(index + 1).padStart(3, '0')}`
+        }));
+        const secondPage = [createTeamDoc('team-101', { name: 'Team 101' })];
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: firstPage })
+            .mockResolvedValueOnce({ docs: secondPage });
+
+        const { getTeams } = await import('../../js/db.js?v=85');
+        const teams = await getTeams({ includePrivate: true });
+
+        expect(teams).toHaveLength(101);
+        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(2);
+        expect(firebaseMocks.limit).toHaveBeenNthCalledWith(1, 100);
+        expect(firebaseMocks.limit).toHaveBeenNthCalledWith(2, 100);
+        expect(firebaseMocks.startAfter).toHaveBeenCalledWith(firstPage.at(-1));
+    });
+});

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -4,6 +4,28 @@ import { readFileSync } from 'node:fs';
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 
 describe('firestore.rules architecture fixes', () => {
+    it('requires platform-admin team and user list reads to carry a limit of at most 100', () => {
+        const helperStart = rules.indexOf('function isBoundedGlobalAdminListQuery()');
+        const helperEnd = rules.indexOf('\n    }', helperStart) + '\n    }'.length;
+        const helperRules = rules.slice(helperStart, helperEnd);
+        const usersStart = rules.indexOf('match /users/{userId}');
+        const usersEnd = rules.indexOf('\n    }', usersStart) + '\n    }'.length;
+        const userRules = rules.slice(usersStart, usersEnd);
+        const teamsStart = rules.indexOf('match /teams/{teamId}');
+        const teamsEnd = rules.indexOf('\n    }', teamsStart) + '\n    }'.length;
+        const teamRules = rules.slice(teamsStart, teamsEnd);
+
+        expect(helperRules).toContain('request.query.limit != null');
+        expect(helperRules).toContain('request.query.limit > 0');
+        expect(helperRules).toContain('request.query.limit <= 100');
+        expect(userRules).toContain('allow get: if isGlobalAdmin() || isOwner(userId);');
+        expect(userRules).toContain('allow list: if isBoundedGlobalAdminListQuery() || isOwner(userId);');
+        expect(teamRules).toContain('allow get: if canReadTeamDocument(resource.data);');
+        expect(teamRules).toContain('allow list: if isBoundedGlobalAdminListQuery() ||');
+        expect(userRules).not.toContain('allow read: if isGlobalAdmin()');
+        expect(teamRules).not.toContain('allow read: if canReadTeamDocument(resource.data);');
+    });
+
     // Duplicate-block regression coverage lives in tests/unit/team-fee-recipient-rules.test.js.
     it('keeps feeRecipients access scoped to the fee recipient or team owner/admin', () => {
         const start = rules.indexOf('match /{path=**}/feeRecipients/{recipientId}');

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -26,6 +26,26 @@ describe('firestore.rules architecture fixes', () => {
         expect(teamRules).not.toContain('allow read: if canReadTeamDocument(resource.data);');
     });
 
+    it('keeps exact user email lookups bounded under global-admin user list rules', () => {
+        const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+        const getUserByEmailBody = dbSource.match(/export async function getUserByEmail\(email\) \{[\s\S]*?\n\}/)?.[0] || '';
+
+        expect(getUserByEmailBody).toContain('where("email", "==", email), limitQuery(1)');
+    });
+
+    it('preserves unbounded public team list queries while keeping broad admin lists bounded', () => {
+        const teamsStart = rules.indexOf('match /teams/{teamId}');
+        const teamsEnd = rules.indexOf('\n    }', teamsStart) + '\n    }'.length;
+        const teamRules = rules.slice(teamsStart, teamsEnd);
+
+        expect(rules).toContain('function canReadPublicTeamDocument(data)');
+        expect(rules).toContain('function canListManagedTeamDocument(data)');
+        expect(teamRules).toContain('allow list: if isBoundedGlobalAdminListQuery() ||');
+        expect(teamRules).toContain('canReadPublicTeamDocument(resource.data) ||');
+        expect(teamRules).toContain('canListManagedTeamDocument(resource.data);');
+        expect(teamRules).not.toContain('(!isGlobalAdmin() && canReadTeamDocument(resource.data));');
+    });
+
     // Duplicate-block regression coverage lives in tests/unit/team-fee-recipient-rules.test.js.
     it('keeps feeRecipients access scoped to the fee recipient or team owner/admin', () => {
         const start = rules.indexOf('match /{path=**}/feeRecipients/{recipientId}');

--- a/tests/unit/firestore-rules-architecture-fixes.test.js
+++ b/tests/unit/firestore-rules-architecture-fixes.test.js
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment
+} from '@firebase/rules-unit-testing';
+import {
+    collection,
+    getDocs,
+    limit,
+    query,
+    setDoc,
+    where,
+    doc
+} from 'firebase/firestore';
 
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 
@@ -79,5 +93,79 @@ describe('firestore.rules architecture fixes', () => {
 
         expect(statTrackerConfigRules).toContain('allow read: if true;');
         expect(statTrackerConfigRules).toContain('allow write: if isTeamOwnerOrAdmin(teamId);');
+    });
+
+    describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('rules engine coverage for bounded admin lists and team discovery', () => {
+        let testEnv;
+
+        beforeAll(async () => {
+            testEnv = await initializeTestEnvironment({
+                projectId: `allplays-rules-architecture-${Date.now()}`,
+                firestore: {
+                    rules
+                }
+            });
+        }, 30000);
+
+        beforeEach(async () => {
+            await testEnv.clearFirestore();
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const adminDb = context.firestore();
+                await setDoc(doc(adminDb, 'users/admin-1'), {
+                    email: 'admin@example.com',
+                    isAdmin: true
+                });
+                await setDoc(doc(adminDb, 'users/parent-1'), {
+                    email: 'parent@example.com',
+                    isAdmin: false
+                });
+                await setDoc(doc(adminDb, 'teams/public-team'), {
+                    name: 'Public Team',
+                    ownerId: 'owner-1',
+                    adminEmails: [],
+                    isPublic: true
+                });
+                await setDoc(doc(adminDb, 'teams/private-team'), {
+                    name: 'Private Team',
+                    ownerId: 'owner-2',
+                    adminEmails: [],
+                    isPublic: false
+                });
+            });
+        });
+
+        afterAll(async () => {
+            await testEnv?.cleanup();
+        });
+
+        function adminFirestore() {
+            return testEnv.authenticatedContext('admin-1', { email: 'admin@example.com' }).firestore();
+        }
+
+        it('allows platform admins to list users and teams only with a positive limit of at most 100', async () => {
+            const adminDb = adminFirestore();
+
+            await assertSucceeds(getDocs(query(collection(adminDb, 'users'), limit(100))));
+            await assertSucceeds(getDocs(query(collection(adminDb, 'teams'), limit(100))));
+
+            await assertFails(getDocs(collection(adminDb, 'users')));
+            await assertFails(getDocs(query(collection(adminDb, 'users'), limit(101))));
+            await assertFails(getDocs(collection(adminDb, 'teams')));
+            await assertFails(getDocs(query(collection(adminDb, 'teams'), limit(101))));
+        });
+
+        it('allows public team browsing while denying private team list leakage', async () => {
+            const publicDb = testEnv.unauthenticatedContext().firestore();
+
+            await assertSucceeds(getDocs(query(
+                collection(publicDb, 'teams'),
+                where('isPublic', '==', true)
+            )));
+            await assertFails(getDocs(collection(publicDb, 'teams')));
+            await assertFails(getDocs(query(
+                collection(publicDb, 'teams'),
+                where('isPublic', '==', false)
+            )));
+        });
     });
 });

--- a/tests/unit/schedule-date-range-source.test.js
+++ b/tests/unit/schedule-date-range-source.test.js
@@ -47,9 +47,26 @@ describe('schedule date range source contracts', () => {
         expect(groupedLoadSource).not.toContain('.map((tournamentGroup) => loadGames');
         expect(sharedGamesSource).toContain("where('homeTeamId', '==', teamId)");
         expect(sharedGamesSource).toContain("where('awayTeamId', '==', teamId)");
-        expect(sharedGamesSource).not.toContain("where('teamIds', 'array-contains', teamId)");
+        expect(sharedGamesSource).toContain("where('teamIds', 'array-contains', teamId)");
         expect((getGamesSource.match(/getSharedGamesForTeam\(teamId/g) || [])).toHaveLength(1);
-        expect(getGamesSource).toContain('getSharedGamesForTeam(teamId, { requireComplete: hasTournamentGroup })');
+        expect(getGamesSource).toContain('getSharedGamesForTeam(teamId, { startDate, endDate, requireComplete: hasTournamentGroup })');
         expect(getGamesSource).toContain('if (hasTournamentGroup) throw error;');
+    });
+
+    it('applies the requested date window to shared-game queries and their fallback', () => {
+        const sharedGamesSource = extractSource(dbSource, 'async function getSharedGamesForTeam', 'async function hasSharedGameUsingConfig');
+        const getGamesSource = extractSource(dbSource, 'export async function getGames', 'export async function getAggregatedStatsForGames');
+
+        expect(sharedGamesSource).toContain("where('date', '>=', Timestamp.fromDate(startDate))");
+        expect(sharedGamesSource).toContain("where('date', '<=', Timestamp.fromDate(endDate))");
+        expect(sharedGamesSource).toContain("where('homeTeamId', '==', teamId)");
+        expect(sharedGamesSource).toContain("where('awayTeamId', '==', teamId)");
+        expect(sharedGamesSource).toContain("where('teamIds', 'array-contains', teamId)");
+        expect(sharedGamesSource).toContain('query(sharedGamesRef, teamConstraint, ...orderedDateConstraints)');
+        expect(sharedGamesSource).toContain("query(sharedGamesRef, teamConstraint, where('date', '==', null))");
+        expect(sharedGamesSource).toContain('getDocs(query(sharedGamesRef, ...orderedDateConstraints))');
+        expect(sharedGamesSource).toContain("getDocs(query(sharedGamesRef, where('date', '==', null)))");
+        expect(sharedGamesSource).toContain('.filter((game) => isGameWithinDateRange(game, startDate, endDate))');
+        expect(getGamesSource).toContain('getSharedGamesForTeam(teamId, { startDate, endDate, requireComplete: hasTournamentGroup })');
     });
 });

--- a/tests/unit/schedule-date-range-source.test.js
+++ b/tests/unit/schedule-date-range-source.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
@@ -10,6 +10,31 @@ function extractSource(source, startMarker, endMarker) {
     expect(start).toBeGreaterThanOrEqual(0);
     expect(end).toBeGreaterThan(start);
     return source.slice(start, end);
+}
+
+function buildGetSharedGamesForTeam(deps) {
+    const normalizeSource = extractSource(dbSource, 'function normalizeSharedGameSnapshot', 'async function getSharedGamesForTeam');
+    const sharedGamesSource = extractSource(dbSource, 'async function getSharedGamesForTeam', 'async function hasSharedGameUsingConfig');
+    return new Function(
+        'db',
+        'collectionGroup',
+        'query',
+        'where',
+        'orderBy',
+        'Timestamp',
+        'getDocs',
+        'isGameWithinDateRange',
+        `${normalizeSource}\n${sharedGamesSource}\nreturn getSharedGamesForTeam;`
+    )(
+        deps.db,
+        deps.collectionGroup,
+        deps.query,
+        deps.where,
+        deps.orderBy,
+        deps.Timestamp,
+        deps.getDocs,
+        deps.isGameWithinDateRange
+    );
 }
 
 describe('schedule date range source contracts', () => {
@@ -53,7 +78,7 @@ describe('schedule date range source contracts', () => {
         expect(getGamesSource).toContain('if (hasTournamentGroup) throw error;');
     });
 
-    it('applies the requested date window to shared-game queries and their fallback', () => {
+    it('applies the requested date window to scoped shared-game queries without unscoped fallback reads', () => {
         const sharedGamesSource = extractSource(dbSource, 'async function getSharedGamesForTeam', 'async function hasSharedGameUsingConfig');
         const getGamesSource = extractSource(dbSource, 'export async function getGames', 'export async function getAggregatedStatsForGames');
 
@@ -64,9 +89,48 @@ describe('schedule date range source contracts', () => {
         expect(sharedGamesSource).toContain("where('teamIds', 'array-contains', teamId)");
         expect(sharedGamesSource).toContain('query(sharedGamesRef, teamConstraint, ...orderedDateConstraints)');
         expect(sharedGamesSource).toContain("query(sharedGamesRef, teamConstraint, where('date', '==', null))");
-        expect(sharedGamesSource).toContain('getDocs(query(sharedGamesRef, ...orderedDateConstraints))');
-        expect(sharedGamesSource).toContain("getDocs(query(sharedGamesRef, where('date', '==', null)))");
+        expect(sharedGamesSource).not.toContain('getDocs(query(sharedGamesRef, ...orderedDateConstraints))');
+        expect(sharedGamesSource).not.toContain("getDocs(query(sharedGamesRef, where('date', '==', null)))");
         expect(sharedGamesSource).toContain('.filter((game) => isGameWithinDateRange(game, startDate, endDate))');
         expect(getGamesSource).toContain('getSharedGamesForTeam(teamId, { startDate, endDate, requireComplete: hasTournamentGroup })');
+    });
+
+    it('does not fall back to unscoped shared-game collection-group date scans when compound queries reject', async () => {
+        const calls = [];
+        const collectionGroup = vi.fn((_db, name) => ({ type: 'collectionGroup', name }));
+        const where = vi.fn((field, op, value) => ({ type: 'where', field, op, value }));
+        const orderBy = vi.fn((field) => ({ type: 'orderBy', field }));
+        const query = vi.fn((ref, ...constraints) => ({ ref, constraints }));
+        const getDocs = vi.fn(async (queryRef) => {
+            calls.push(queryRef);
+            throw new Error('missing compound index');
+        });
+        const getSharedGamesForTeam = buildGetSharedGamesForTeam({
+            db: {},
+            collectionGroup,
+            query,
+            where,
+            orderBy,
+            Timestamp: { fromDate: (date) => ({ date }) },
+            getDocs,
+            isGameWithinDateRange: () => true
+        });
+
+        const games = await getSharedGamesForTeam('team-123', {
+            startDate: new Date('2026-07-01T00:00:00Z'),
+            endDate: new Date('2026-07-31T23:59:59Z')
+        });
+
+        expect(games).toEqual([]);
+        expect(getDocs).toHaveBeenCalledTimes(6);
+        expect(calls.every((queryRef) => queryRef.constraints.some((constraint) => (
+            constraint.type === 'where'
+                && ['homeTeamId', 'awayTeamId', 'teamIds'].includes(constraint.field)
+                && constraint.value === 'team-123'
+        )))).toBe(true);
+        expect(calls.some((queryRef) => !queryRef.constraints.some((constraint) => (
+            constraint.type === 'where'
+                && ['homeTeamId', 'awayTeamId', 'teamIds'].includes(constraint.field)
+        )))).toBe(false);
     });
 });

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -78,10 +78,12 @@ describe('public teams visibility', () => {
         const rules = readRepoFile('firestore.rules');
 
         expect(rules).toContain('function canReadTeamDocument(data)');
-        expect(rules).toContain('return (data.isPublic is bool && data.isPublic == true) ||');
+        expect(rules).toContain('function canReadPublicTeamDocument(data)');
+        expect(rules).toContain('return canReadPublicTeamDocument(data) ||');
         expect(rules).toContain('allow get: if canReadTeamDocument(resource.data);');
         expect(rules).toContain('allow list: if isBoundedGlobalAdminListQuery() ||');
-        expect(rules).toContain('(!isGlobalAdmin() && canReadTeamDocument(resource.data));');
+        expect(rules).toContain('canReadPublicTeamDocument(resource.data) ||');
+        expect(rules).toContain('canListManagedTeamDocument(resource.data);');
         expect(rules).not.toContain('allow read: if true;  // Public teams for browsing');
     });
 });

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -79,7 +79,9 @@ describe('public teams visibility', () => {
 
         expect(rules).toContain('function canReadTeamDocument(data)');
         expect(rules).toContain('return (data.isPublic is bool && data.isPublic == true) ||');
-        expect(rules).toContain('allow read: if canReadTeamDocument(resource.data);');
+        expect(rules).toContain('allow get: if canReadTeamDocument(resource.data);');
+        expect(rules).toContain('allow list: if isBoundedGlobalAdminListQuery() ||');
+        expect(rules).toContain('(!isGlobalAdmin() && canReadTeamDocument(resource.data));');
         expect(rules).not.toContain('allow read: if true;  // Public teams for browsing');
     });
 });


### PR DESCRIPTION
## Summary
- boot the platform-admin dashboard from bounded 25-record team and user pages
- calculate dashboard game activity from a bounded ±30-day window and label summary values as loaded/recent
- cap fallback admin collection helpers at 100 records and enforce the same maximum for global-admin list queries in Firestore rules
- defer full-history team game reads until the Teams tab is explicitly opened
- bump the shared db module cache key so deployed pages use the bounded queries

## Validation
- `npx vitest run tests/unit/admin-dashboard-stats.test.js tests/unit/admin-bootstrap.test.js tests/unit/firestore-rules-architecture-fixes.test.js --reporter=verbose` — 12 passed
- `npm test` — 3,890 passed, 9 skipped; one pre-existing timing-sensitive Team Email lazy-load assertion failed in the full concurrent suite and passed in the isolated rerun (89 passed, 4 skipped)
- `node --check js/admin.js && node --check js/db.js && node --check js/admin-bootstrap.js`
- `node scripts/check-critical-cache-bust.mjs`
- `npm run ci:firebase-rules`
- `git diff --check`

Closes #3455