### PR TITLE
Select teams from launcher rows

### DIFF
--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { StrictMode } from 'react';
-import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Teams } from './Teams';
 import type { ParentHomeModel } from '../lib/homeLogic';
@@ -105,11 +105,16 @@ function TeamHubRoute() {
   return <div data-testid="team-hub">Team hub: {teamId}</div>;
 }
 
+function TeamsLocation() {
+  const location = useLocation();
+  return <div data-testid="teams-location">{location.pathname}{location.search}</div>;
+}
+
 function renderTeamsWithNav(initialEntry = '/teams') {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
-        <Route path="/teams" element={<Teams auth={auth} />} />
+        <Route path="/teams" element={<><Teams auth={auth} /><TeamsLocation /></>} />
         <Route path="/teams/:teamId" element={<TeamHubRoute />} />
         <Route path="/teams/:teamId/fees" element={<div data-testid="team-fees-route">Team fees route</div>} />
       </Routes>
@@ -204,7 +209,7 @@ describe('Teams empty state', () => {
     expect(await screen.findByRole('heading', { name: '1 team ready' })).toBeInTheDocument();
     expect(screen.getByText('Choose a team')).toBeInTheDocument();
     expect(screen.getByText('Unable to refresh teams. Showing the last loaded teams. Try again.')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Open Fast Falcons' })).toHaveAttribute('href', '/teams/team-fast');
+    expect(screen.getByRole('link', { name: 'Select Fast Falcons' })).toHaveAttribute('href', '/teams?selectedTeamId=team-fast');
     expect(screen.queryByText('Teams could not load')).toBeNull();
     expect(screen.queryByText('No teams available')).toBeNull();
   });
@@ -327,13 +332,42 @@ describe('Teams launcher navigation', () => {
     cleanup();
   });
 
-  it('opens the team hub when a launcher team is clicked', async () => {
+  it('defaults to the first team when no selectedTeamId is present', async () => {
     renderTeamsWithNav();
 
-    const fastFalcons = await screen.findByRole('link', { name: 'Open Fast Falcons' });
-    expect(fastFalcons).toHaveAttribute('href', '/teams/team-fast');
+    const fastFalcons = await screen.findByRole('link', { name: 'Select Fast Falcons' });
+    expect(fastFalcons).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('heading', { name: 'Fast Falcons' })).toBeInTheDocument();
+    expect(screen.getByTestId('teams-location')).toHaveTextContent('/teams');
+    expect(screen.queryByTestId('team-hub')).toBeNull();
+  });
+
+  it('selects a launcher team in place and updates the selected team panel', async () => {
+    renderTeamsWithNav('/teams?selectedTeamId=team-slow');
+
+    expect(await screen.findByRole('heading', { name: 'Slow Sharks' })).toBeInTheDocument();
+    const fastFalcons = screen.getByRole('link', { name: 'Select Fast Falcons' });
+    expect(fastFalcons).toHaveAttribute('href', '/teams?selectedTeamId=team-fast');
 
     fireEvent.click(fastFalcons);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('teams-location')).toHaveTextContent('/teams?selectedTeamId=team-fast');
+      expect(screen.getByRole('heading', { name: 'Fast Falcons' })).toBeInTheDocument();
+    });
+    expect(fastFalcons).toHaveAttribute('aria-current', 'page');
+    expect(screen.queryByTestId('team-hub')).toBeNull();
+  });
+
+  it('keeps the explicit hub, messages, and schedule quick links on their existing routes', async () => {
+    renderTeamsWithNav('/teams?selectedTeamId=team-fast');
+
+    const teamHub = await screen.findByRole('link', { name: 'Fast Falcons team hub' });
+    expect(teamHub).toHaveAttribute('href', '/teams/team-fast');
+    expect(screen.getByRole('link', { name: 'Fast Falcons messages' })).toHaveAttribute('href', '/messages/team-fast');
+    expect(screen.getByRole('link', { name: 'Fast Falcons schedule' })).toHaveAttribute('href', '/schedule?teamId=team-fast');
+
+    fireEvent.click(teamHub);
 
     expect(await screen.findByTestId('team-hub')).toHaveTextContent('Team hub: team-fast');
   });

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -354,7 +354,7 @@ function TeamLauncher({ teams, selectedTeamId, variant = 'grid' }: {
       <div className="flex items-center justify-between gap-3 px-1">
         <div className="min-w-0">
           <div className="text-sm font-black text-gray-950">{isRail ? 'Teams' : 'Choose a team'}</div>
-          <div className="mt-0.5 text-xs font-semibold text-gray-500">{isRail ? 'Select a team, or jump straight to chat and schedule.' : 'Open the team hub, or jump straight to chat, schedule, or the full team page.'}</div>
+          <div className="mt-0.5 text-xs font-semibold text-gray-500">{isRail ? 'Select a team, or jump straight to chat and schedule.' : 'Select a team, or use the quick links for chat, schedule, and the full team hub.'}</div>
         </div>
         <span className="inline-flex h-7 flex-none items-center rounded-full bg-gray-100 px-2.5 text-[11px] font-black text-gray-700">
           {teams.length} team{teams.length === 1 ? '' : 's'}
@@ -386,7 +386,7 @@ function TeamLauncherRow({ team, selected, compact = false }: { team: ParentHome
 
   return (
     <article className={`team-launcher-row flex min-w-0 items-center gap-2 rounded-2xl border bg-white p-2 shadow-sm transition ${compact ? 'team-launcher-row-compact' : ''} ${selected ? 'border-primary-300 bg-primary-50/50 ring-2 ring-primary-100' : 'border-gray-200 hover:border-primary-200 hover:bg-primary-50/25'}`}>
-      <Link to={`/teams/${encodeURIComponent(team.teamId)}`} className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" aria-current={selected ? 'page' : undefined} aria-label={`Open ${team.teamName}`}>
+      <Link to={`/teams?selectedTeamId=${encodeURIComponent(team.teamId)}`} className="flex min-w-0 flex-1 items-center gap-3 rounded-xl p-1 text-left" aria-current={selected ? 'page' : undefined} aria-label={`Select ${team.teamName}`}>
         <TeamAvatar name={team.teamName} photoUrl={team.photoUrl} />
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center gap-2">

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -1788,7 +1788,7 @@ test('my teams opens from Home data with selected team, player, and chat routes'
     await expect(page.getByRole('link', { name: /Media/ })).toHaveAttribute('href', '#/teams/team-1/media');
     await expect(page.locator('a[href="#/players/team-1/player-1"]').first()).toBeVisible();
     await expect(page.locator('a[href="#/players/team-1/player-1"]').filter({ hasText: 'Pat Star' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Open Bears' }).first()).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByRole('link', { name: 'Select Bears' }).first()).toHaveAttribute('aria-current', 'page');
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 
     await page.locator('a[href="#/teams/team-1"]').first().click();

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -554,13 +554,13 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Choose a team')).toBeVisible();
         await expect(page.getByPlaceholder('Search teams or players')).toBeVisible();
         await page.getByPlaceholder('Search teams or players').fill('Riley');
-        await expect(page.getByRole('link', { name: 'Open Rockets' }).first()).toBeVisible();
-        await expect(page.getByRole('link', { name: 'Open Staff Wolves' })).toHaveCount(0);
-        await expect(page.getByRole('link', { name: 'Open Bears' })).toHaveCount(0);
+        await expect(page.getByRole('link', { name: 'Select Rockets' }).first()).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Select Staff Wolves' })).toHaveCount(0);
+        await expect(page.getByRole('link', { name: 'Select Bears' })).toHaveCount(0);
         await page.getByPlaceholder('Search teams or players').fill('zzz');
         await expect(page.getByText('No teams match that search.')).toBeVisible();
         await page.getByPlaceholder('Search teams or players').fill('Staff Wolves');
-        await expect(page.getByRole('link', { name: 'Open Staff Wolves' }).first()).toHaveAttribute('aria-current', 'page');
+        await expect(page.getByRole('link', { name: 'Select Staff Wolves' }).first()).toHaveAttribute('aria-current', 'page');
         await expect(page.locator('a[aria-label="Staff Wolves messages"]')).toBeVisible();
         await expect(page.locator('a[aria-label="Staff Wolves schedule"]')).toHaveCount(0);
         await expect(page.getByText('No player is linked to this account for the team, but team chat is available.')).toBeVisible();
@@ -575,10 +575,13 @@ test.describe('mobile My Teams', () => {
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://allplays.ai/team.html#teamId=team-staff');
         await expect(page).toHaveURL(/#\/teams/);
 
-        await page.goto(appUrl(baseURL, '/teams?selectedTeamId=team-1&from=home'), { waitUntil: 'domcontentloaded' });
-        await waitForTeamsRoute(page, teamsReadyHeading);
         await page.getByPlaceholder('Search teams or players').fill('');
-        await expect(page.getByRole('link', { name: 'Open Bears' }).first()).toHaveAttribute('aria-current', 'page');
+        const bearsSelector = page.getByRole('link', { name: 'Select Bears' }).first();
+        await expect(bearsSelector).toHaveAttribute('href', '#/teams?selectedTeamId=team-1');
+        await bearsSelector.click();
+        await expect(page).toHaveURL(/#\/teams\?selectedTeamId=team-1$/);
+        await expect(page.getByRole('heading', { name: 'Bears' })).toBeVisible();
+        await expect(bearsSelector).toHaveAttribute('aria-current', 'page');
         await expect(page.getByText('Pat Star, Sam Wing')).toBeVisible();
         await expect(page.getByText('Coach/admin tools')).toHaveCount(0);
         await expect(page.getByRole('link', { name: /Team drills/ })).toHaveCount(0);
@@ -588,7 +591,7 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByRole('link', { name: /Players/ })).toHaveAttribute('href', 'https://allplays.ai/team.html#teamId=team-1');
         await expect(page.locator('a[href="#/players/team-1/player-1"]')).toBeVisible();
         await expect(page.locator('a[href="#/players/team-1/player-2"]')).toBeVisible();
-        await page.getByRole('link', { name: 'Open Bears' }).first().click();
+        await page.getByRole('link', { name: 'Bears team hub' }).click();
         await waitForTeamDetailRoute(page, 'Bears');
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
     });
@@ -743,7 +746,7 @@ test.describe('mobile My Teams', () => {
 
         const teamsReadyHeading = page.getByRole('heading', { name: '3 teams ready' });
         await waitForTeamsRoute(page, teamsReadyHeading);
-        await page.getByRole('link', { name: 'Open Bears' }).first().click();
+        await page.getByRole('link', { name: 'Bears team hub' }).click();
 
         await waitForTeamDetailRoute(page, 'Bears');
         await page.getByRole('button', { name: /Roster/ }).click();
@@ -805,8 +808,8 @@ test.describe('desktop My Teams', () => {
             return Math.round((panel?.x || 0) - (rail?.x || 0));
         }).toBeGreaterThan(360);
         await page.getByPlaceholder('Search teams or players').fill('Rockets');
-        await expect(page.getByRole('link', { name: 'Open Rockets' })).toBeVisible();
-        await expect(page.getByRole('link', { name: 'Open Bears' })).toHaveCount(0);
+        await expect(page.getByRole('link', { name: 'Select Rockets' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Select Bears' })).toHaveCount(0);
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
     });
 

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -233,7 +233,7 @@ describe('React app Teams page', () => {
         expect(hrefs).toContain('/teams/team-staff/fees');
         expect(hrefs).not.toContain('https://allplays.ai/team-fees.html#teamId=team-staff');
         expect(container.textContent).not.toContain('Team drills');
-        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
+        expect(linkByAriaLabel(container, 'Select Staff Wolves').getAttribute('aria-current')).toBe('page');
 
         await clickLink(container, 'Website team page');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/team.html#teamId=team-staff');
@@ -243,8 +243,8 @@ describe('React app Teams page', () => {
         hrefs = getHrefs(container);
         expect(hrefs).toContain('/teams/team-staff/drills');
         expect(hrefs).toContain('https://allplays.ai/game-day.html?teamId=team-staff');
-        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
-        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('href')).toBe('/teams/team-staff');
+        expect(linkByAriaLabel(container, 'Select Bears').getAttribute('href')).toBe('/teams?selectedTeamId=team-1');
+        expect(linkByAriaLabel(container, 'Select Staff Wolves').getAttribute('href')).toBe('/teams?selectedTeamId=team-staff');
     });
 
     it('filters the mobile launcher by team and player text before opening a result', async () => {
@@ -255,19 +255,19 @@ describe('React app Teams page', () => {
         expect(filterInput).toBeTruthy();
 
         await typeIntoInput(container, 'Search teams or players', 'Pat');
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(true);
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(false);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Select Bears')).toBe(true);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Select Staff Wolves')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'Wolves');
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Staff Wolves')).toBe(true);
-        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Open Bears')).toBe(false);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Select Staff Wolves')).toBe(true);
+        expect(Array.from(container.querySelectorAll('a')).some((link) => link.getAttribute('aria-label') === 'Select Bears')).toBe(false);
 
         await typeIntoInput(container, 'Search teams or players', 'zzz');
         expect(container.textContent).toContain('No teams match that search.');
 
         await typeIntoInput(container, 'Search teams or players', 'Bears');
 
-        expect(linkByAriaLabel(container, 'Open Bears').getAttribute('href')).toBe('/teams/team-1');
+        expect(linkByAriaLabel(container, 'Select Bears').getAttribute('href')).toBe('/teams?selectedTeamId=team-1');
         expect(container.textContent.indexOf('Choose a team')).toBeLessThan(container.textContent.indexOf('Team navigation'));
         const hrefs = getHrefs(container);
         expect(hrefs).toContain('/messages/team-1');
@@ -550,6 +550,6 @@ describe('React app Teams page', () => {
         await waitForText(container, '2 teams ready');
         expect(container.textContent).toContain('Choose a team');
         expect(container.querySelector('[data-testid="team-hub"]')).toBeNull();
-        expect(linkByAriaLabel(container, 'Open Staff Wolves').getAttribute('aria-current')).toBe('page');
+        expect(linkByAriaLabel(container, 'Select Staff Wolves').getAttribute('aria-current')).toBe('page');
     });
 });


### PR DESCRIPTION
## Summary

- make each main team launcher row select that team on `/teams` via `selectedTeamId`
- update the selected-team workbench in place and expose accurate “Select team” accessible names
- preserve the dedicated team hub, messages, and schedule quick-link destinations
- cover default selection, multi-team switching, unchanged quick links, and the existing single-team behavior

## Why

The launcher’s main row and team-hub chevron both opened the full hub, so the selected-team panel could not be switched from the launcher even though it is already driven by the `selectedTeamId` query parameter.

## User impact

People with multiple teams can switch the selected team without leaving My Teams. The explicit team-hub quick link remains available when they want the full hub.

## Validation

- `npm --prefix apps/app test -- --run src/pages/Teams.test.tsx` — 11 passed
- `npm --prefix apps/app test -- --run --reporter=dot --silent=passed-only` — 115 files / 1,025 tests passed
- targeted Playwright smoke coverage for mobile/desktop My Teams and Home-to-team navigation — 4 passed
- `npm run app:build` — passed
- `./node_modules/.bin/eslint src/pages/Teams.tsx src/pages/Teams.test.tsx` — passed
- `git diff --cached --check` — passed before commit

Closes #3449