### PR TITLE
Make tracker chooser recommendation-first

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -808,37 +808,47 @@
     <div id="basketball-tracker-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
         <div class="bg-white rounded-lg p-6 max-w-sm w-full mx-4">
             <h3 class="text-xl font-bold mb-2">Choose Tracker</h3>
-            <p id="tracker-choice-description" class="text-sm text-gray-600 mb-4">Which tracker do you want?</p>
-            <div class="space-y-2">
-                <button id="basketball-tracker-standard"
-                    class="w-full px-4 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition font-semibold">
-                    Standard
-                </button>
-                <button id="basketball-tracker-beta"
-                    class="w-full px-4 py-3 bg-gray-100 text-gray-800 rounded-lg hover:bg-gray-200 transition font-semibold">
-                    Beta
-                </button>
-                <button id="basketball-tracker-live"
-                    class="w-full px-4 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition font-semibold flex items-center justify-center gap-2">
-                    <span class="inline-flex items-center gap-1 bg-white/20 text-white text-[10px] font-bold px-2 py-0.5 rounded-full">
-                        <span class="w-1.5 h-1.5 bg-white rounded-full animate-pulse"></span>
-                        LIVE
-                    </span>
-                    Live Broadcast Tracker
-                </button>
-                <button id="basketball-tracker-live-simple"
-                    class="hidden w-full px-4 py-3 bg-emerald-100 text-emerald-800 rounded-lg hover:bg-emerald-200 transition font-semibold flex items-center justify-center gap-2">
-                    <span class="inline-flex items-center gap-1 bg-emerald-600 text-white text-[10px] font-bold px-2 py-0.5 rounded-full">
-                        <span class="w-1.5 h-1.5 bg-white rounded-full animate-pulse"></span>
-                        LIVE
-                    </span>
-                    Live Broadcast Simple
-                </button>
-                <button id="basketball-tracker-photo"
-                    class="w-full px-4 py-3 bg-amber-100 text-amber-800 rounded-lg hover:bg-amber-200 transition font-semibold">
-                    Photo Score Sheet
-                </button>
+            <p id="tracker-choice-description" class="text-sm text-gray-600 mb-4">Start with the recommended tracker for this game.</p>
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-wide text-indigo-700 mb-2">Recommended</p>
+                <div id="tracker-recommended-action">
+                    <button id="basketball-tracker-standard" data-tracker-label="Standard Tracker"
+                        class="w-full px-4 py-3 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition font-semibold">
+                        <span data-tracker-label-text>Start Standard Tracker</span>
+                    </button>
+                </div>
             </div>
+            <details id="tracker-advanced-options" class="mt-4 border border-gray-200 rounded-lg">
+                <summary class="cursor-pointer px-4 py-3 text-sm font-semibold text-gray-700 hover:bg-gray-50 rounded-lg">
+                    More tracker options
+                </summary>
+                <div id="tracker-advanced-actions" class="px-3 pb-3 space-y-2">
+                    <button id="basketball-tracker-beta" data-tracker-label="Basketball Beta"
+                        class="w-full px-4 py-3 bg-gray-100 text-gray-800 rounded-lg hover:bg-gray-200 transition font-semibold">
+                        <span data-tracker-label-text>Basketball Beta</span>
+                    </button>
+                    <button id="basketball-tracker-live" data-tracker-label="Live Broadcast Tracker"
+                        class="w-full px-4 py-3 bg-gray-100 text-gray-800 rounded-lg hover:bg-gray-200 transition font-semibold flex items-center justify-center gap-2">
+                        <span class="inline-flex items-center gap-1 bg-red-600 text-white text-[10px] font-bold px-2 py-0.5 rounded-full">
+                            <span class="w-1.5 h-1.5 bg-white rounded-full animate-pulse"></span>
+                            LIVE
+                        </span>
+                        <span data-tracker-label-text>Live Broadcast Tracker</span>
+                    </button>
+                    <button id="basketball-tracker-live-simple" data-tracker-label="Simple Live Tracker"
+                        class="hidden w-full px-4 py-3 bg-gray-100 text-gray-800 rounded-lg hover:bg-gray-200 transition font-semibold flex items-center justify-center gap-2">
+                        <span class="inline-flex items-center gap-1 bg-emerald-600 text-white text-[10px] font-bold px-2 py-0.5 rounded-full">
+                            <span class="w-1.5 h-1.5 bg-white rounded-full animate-pulse"></span>
+                            LIVE
+                        </span>
+                        <span data-tracker-label-text>Simple Live Tracker</span>
+                    </button>
+                    <button id="basketball-tracker-photo" data-tracker-label="Photo Score Sheet"
+                        class="w-full px-4 py-3 bg-gray-100 text-gray-800 rounded-lg hover:bg-gray-200 transition font-semibold">
+                        <span data-tracker-label-text>Photo Score Sheet</span>
+                    </button>
+                </div>
+            </details>
             <div class="flex justify-end mt-4">
                 <button id="basketball-tracker-cancel" class="px-4 py-2 text-gray-600 hover:text-gray-800">Cancel</button>
             </div>
@@ -2677,21 +2687,50 @@
 
         function configureTrackerChoiceModal(isBasketball, supportsSimpleLive) {
             const description = document.getElementById('tracker-choice-description');
+            const recommendedAction = document.getElementById('tracker-recommended-action');
+            const advancedActions = document.getElementById('tracker-advanced-actions');
+            const advancedOptions = document.getElementById('tracker-advanced-options');
+            const standardBtn = document.getElementById('basketball-tracker-standard');
             const betaBtn = document.getElementById('basketball-tracker-beta');
+            const liveBtn = document.getElementById('basketball-tracker-live');
             const simpleBtn = document.getElementById('basketball-tracker-live-simple');
             const photoBtn = document.getElementById('basketball-tracker-photo');
             if (description) {
                 if (isBasketball) {
-                    description.textContent = 'This game uses a Basketball stat config. Which tracker do you want?';
+                    description.textContent = 'This game uses a Basketball stat config. Live tracking is recommended.';
                 } else if (supportsSimpleLive) {
-                    description.textContent = 'Choose full stat broadcasting or simple goal broadcasting for this game.';
+                    description.textContent = 'Simple live tracking is recommended for this goal sport.';
                 } else {
-                    description.textContent = 'Choose a tracker for this game.';
+                    description.textContent = 'Standard tracking is recommended for this game.';
                 }
             }
             if (betaBtn) betaBtn.classList.toggle('hidden', !isBasketball);
             if (simpleBtn) simpleBtn.classList.toggle('hidden', !supportsSimpleLive);
             if (photoBtn) photoBtn.classList.toggle('hidden', !isBasketball);
+
+            const trackerButtons = [standardBtn, betaBtn, liveBtn, simpleBtn, photoBtn].filter(Boolean);
+            const recommendedBtn = isBasketball ? liveBtn : supportsSimpleLive ? simpleBtn : standardBtn;
+            trackerButtons.forEach((button) => {
+                const label = button.dataset.trackerLabel || 'Tracker';
+                button.dataset.recommended = 'false';
+                button.classList.remove('bg-indigo-600', 'text-white', 'hover:bg-indigo-700');
+                button.classList.add('bg-gray-100', 'text-gray-800', 'hover:bg-gray-200');
+                button.querySelector('[data-tracker-label-text]')?.replaceChildren(label);
+                advancedActions?.appendChild(button);
+            });
+            if (recommendedBtn) {
+                const label = isBasketball
+                    ? 'Start Live Tracker'
+                    : supportsSimpleLive
+                        ? 'Start Simple Live Tracker'
+                        : 'Start Standard Tracker';
+                recommendedBtn.dataset.recommended = 'true';
+                recommendedBtn.classList.remove('bg-gray-100', 'text-gray-800', 'hover:bg-gray-200');
+                recommendedBtn.classList.add('bg-indigo-600', 'text-white', 'hover:bg-indigo-700');
+                recommendedBtn.querySelector('[data-tracker-label-text]')?.replaceChildren(label);
+                recommendedAction?.appendChild(recommendedBtn);
+            }
+            if (advancedOptions) advancedOptions.open = false;
         }
 
         function openTrackerChoiceModal(gameId, isBasketball, supportsSimpleLive = false) {

--- a/tests/unit/edit-schedule-basketball-routing.test.js
+++ b/tests/unit/edit-schedule-basketball-routing.test.js
@@ -56,11 +56,27 @@ function buildTrackChoiceDomHarness({ allConfigs, currentTeam, gamesCache, curre
     const dom = new JSDOM(`
         <div id="basketball-tracker-modal" class="hidden">
             <p id="tracker-choice-description"></p>
-            <button id="basketball-tracker-standard"></button>
-            <button id="basketball-tracker-beta"></button>
-            <button id="basketball-tracker-live"></button>
-            <button id="basketball-tracker-live-simple" class="hidden"></button>
-            <button id="basketball-tracker-photo"></button>
+            <div id="tracker-recommended-action">
+                <button id="basketball-tracker-standard" data-tracker-label="Standard Tracker">
+                    <span data-tracker-label-text>Standard Tracker</span>
+                </button>
+            </div>
+            <details id="tracker-advanced-options" open>
+                <div id="tracker-advanced-actions">
+                    <button id="basketball-tracker-beta" data-tracker-label="Basketball Beta">
+                        <span data-tracker-label-text>Basketball Beta</span>
+                    </button>
+                    <button id="basketball-tracker-live" data-tracker-label="Live Broadcast Tracker">
+                        <span data-tracker-label-text>Live Broadcast Tracker</span>
+                    </button>
+                    <button id="basketball-tracker-live-simple" data-tracker-label="Simple Live Tracker" class="hidden">
+                        <span data-tracker-label-text>Simple Live Tracker</span>
+                    </button>
+                    <button id="basketball-tracker-photo" data-tracker-label="Photo Score Sheet">
+                        <span data-tracker-label-text>Photo Score Sheet</span>
+                    </button>
+                </div>
+            </details>
             <button id="basketball-tracker-cancel"></button>
         </div>
     `);
@@ -76,6 +92,11 @@ function buildTrackChoiceDomHarness({ allConfigs, currentTeam, gamesCache, curre
             alert,
             getHref: () => window.location.href,
             getDescription: () => document.getElementById('tracker-choice-description').textContent,
+            getRecommendedId: () => document.querySelector('#tracker-recommended-action > button')?.id,
+            getTrackerLabel: (id) => document.querySelector('#' + id + ' [data-tracker-label-text]')?.textContent,
+            getTrackerParentId: (id) => document.getElementById(id)?.parentElement?.id,
+            getRecommendedCount: () => document.querySelectorAll('[data-recommended="true"]').length,
+            isAdvancedOpen: () => document.getElementById('tracker-advanced-options').open,
             isHidden: (id) => document.getElementById(id).classList.contains('hidden'),
             click: (id) => document.getElementById(id).click()
         };
@@ -132,8 +153,11 @@ describe('edit schedule basketball tracker routing', () => {
         const source = readEditSchedule();
 
         expect(source).toContain('id="basketball-tracker-live-simple"');
-        expect(source).toContain('Live Broadcast Simple');
+        expect(source).toContain('Simple Live Tracker');
         expect(source).toContain("import { getGoalSportProfile } from './js/live-sport-config.js?v=3';");
+        expect(source).toContain('id="tracker-recommended-action"');
+        expect(source).toContain('id="tracker-advanced-options"');
+        expect(source).toContain('More tracker options');
         expect(source).toContain("const simpleBtn = document.getElementById('basketball-tracker-live-simple');");
         expect(source).toContain("if (simpleBtn) simpleBtn.classList.toggle('hidden', !supportsSimpleLive);");
         expect(source).toContain('openTrackerChoiceModal(gameId, isBasketballForGame(game), isGoalSportForGame(game));');
@@ -162,6 +186,11 @@ describe('edit schedule basketball tracker routing', () => {
             expect(harness.isHidden('basketball-tracker-beta')).toBe(false);
             expect(harness.isHidden('basketball-tracker-photo')).toBe(false);
             expect(harness.getDescription()).toContain('Basketball stat config');
+            expect(harness.getRecommendedId()).toBe('basketball-tracker-live');
+            expect(harness.getTrackerLabel('basketball-tracker-live')).toBe('Start Live Tracker');
+            expect(harness.getRecommendedCount()).toBe(1);
+            expect(harness.isAdvancedOpen()).toBe(false);
+            expect(harness.getTrackerParentId('basketball-tracker-standard')).toBe('tracker-advanced-actions');
             harness.click(buttonId);
             expect(harness.getHref()).toBe(expectedHref);
         }
@@ -182,8 +211,34 @@ describe('edit schedule basketball tracker routing', () => {
         expect(harness.isHidden('basketball-tracker-beta')).toBe(true);
         expect(harness.isHidden('basketball-tracker-photo')).toBe(true);
         expect(harness.isHidden('basketball-tracker-live-simple')).toBe(false);
+        expect(harness.getRecommendedId()).toBe('basketball-tracker-live-simple');
+        expect(harness.getTrackerLabel('basketball-tracker-live-simple')).toBe('Start Simple Live Tracker');
+        expect(harness.getRecommendedCount()).toBe(1);
+        expect(harness.getTrackerParentId('basketball-tracker-live')).toBe('tracker-advanced-actions');
         harness.click('basketball-tracker-live');
         expect(harness.getHref()).toBe('track-live.html?v=2#teamId=team-123&gameId=game-789');
+    });
+
+    it('recommends the standard tracker for a generic sport while keeping live advanced', () => {
+        const harness = buildTrackChoiceDomHarness({
+            allConfigs: [{ id: 'baseball-config', baseType: 'Baseball' }],
+            currentTeam: { sport: 'Baseball' },
+            gamesCache: {
+                'game-generic': { id: 'game-generic', statTrackerConfigId: 'baseball-config' }
+            }
+        });
+
+        harness.handleTrackClick('game-generic');
+
+        expect(harness.getRecommendedId()).toBe('basketball-tracker-standard');
+        expect(harness.getTrackerLabel('basketball-tracker-standard')).toBe('Start Standard Tracker');
+        expect(harness.getRecommendedCount()).toBe(1);
+        expect(harness.isHidden('basketball-tracker-beta')).toBe(true);
+        expect(harness.isHidden('basketball-tracker-live-simple')).toBe(true);
+        expect(harness.isHidden('basketball-tracker-photo')).toBe(true);
+        expect(harness.getTrackerParentId('basketball-tracker-live')).toBe('tracker-advanced-actions');
+        harness.click('basketball-tracker-standard');
+        expect(harness.getHref()).toBe('track.html#teamId=team-123&gameId=game-generic');
     });
 
     it('renders completed schedule games with Report instead of Track', () => {


### PR DESCRIPTION
## Summary
- show exactly one recommended tracker action at the top of the Track chooser
- recommend live tracking for basketball, simple live for supported goal sports, and standard tracking otherwise
- move the other valid tracker routes into a collapsed More tracker options section
- preserve all existing tracker button IDs, sport visibility rules, and destinations
- extend routing tests across basketball, goal-sport, and generic-sport recommendations

## Validation
- `npx vitest run tests/unit/edit-schedule-basketball-routing.test.js --reporter=verbose` — 8 passed
- all edit-schedule unit files — 93 passed
- authenticated edit-schedule boot smoke — 1 passed
- duplicate tracker IDs check — each tracker button ID occurs once
- `git diff --check`

Closes #3439