### PR TITLE
Block CGNAT calendar SSRF targets

### DIFF
--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -23,6 +23,12 @@ test('isPrivateIpAddress correctly identifies private IPs', () => {
   assert.strictEqual(isPrivateIpAddress('127.0.0.1'), true, '127.0.0.1 should be private');
   assert.strictEqual(isPrivateIpAddress('0.0.0.0'), true, '0.0.0.0 should be private');
   assert.strictEqual(isPrivateIpAddress('169.254.1.1'), true, '169.254.1.1 should be private');
+  assert.strictEqual(isPrivateIpAddress('100.63.255.255'), false, 'address below RFC 6598 shared space should be public');
+  assert.strictEqual(isPrivateIpAddress('100.64.0.0'), true, 'RFC 6598 lower boundary should be blocked');
+  assert.strictEqual(isPrivateIpAddress('100.64.0.1'), true, 'RFC 6598 shared address should be blocked');
+  assert.strictEqual(isPrivateIpAddress('100.127.255.254'), true, 'RFC 6598 shared address should be blocked');
+  assert.strictEqual(isPrivateIpAddress('100.127.255.255'), true, 'RFC 6598 upper boundary should be blocked');
+  assert.strictEqual(isPrivateIpAddress('100.128.0.1'), false, 'address above RFC 6598 shared space should be public');
   assert.strictEqual(isPrivateIpAddress('8.8.8.8'), false, '8.8.8.8 should be public');
   assert.strictEqual(isPrivateIpAddress('203.0.113.1'), false, '203.0.113.1 should be public');
 
@@ -41,6 +47,9 @@ test('isPrivateIpAddress correctly identifies private IPs', () => {
   assert.strictEqual(isPrivateIpAddress('::ffff:10.0.0.1'), true, 'IPv4-mapped IPv6 RFC1918 should be private');
   assert.strictEqual(isPrivateIpAddress('::ffff:192.168.1.1'), true, 'IPv4-mapped IPv6 RFC1918 should be private');
   assert.strictEqual(isPrivateIpAddress('::ffff:169.254.169.254'), true, 'IPv4-mapped IPv6 link-local should be private');
+  assert.strictEqual(isPrivateIpAddress('::ffff:100.64.0.1'), true, 'IPv4-mapped RFC 6598 address should be blocked');
+  assert.strictEqual(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:6440:0001'), true, 'zero-padded IPv4-mapped RFC 6598 address should be blocked');
+  assert.strictEqual(isPrivateIpAddress('::ffff:100.128.0.1'), false, 'IPv4-mapped address above RFC 6598 shared space should be public');
   assert.strictEqual(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:7f00:0001'), true, 'zero-padded IPv4-mapped IPv6 loopback should be private');
   assert.strictEqual(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:0a00:0001'), true, 'zero-padded IPv4-mapped IPv6 RFC1918 should be private');
   assert.strictEqual(isPrivateIpAddress('::ffff:8.8.8.8'), false, 'IPv4-mapped IPv6 public address should be public');
@@ -51,6 +60,7 @@ test('assertPublicHost prevents blocked hosts and private IPs', async () => {
   await assert.rejects(assertPublicHost('localhost'), { message: 'Blocked host' }, 'localhost should be blocked');
   await assert.rejects(assertPublicHost('127.0.0.1'), { message: 'Blocked host' }, '127.0.0.1 should be blocked');
   await assert.rejects(assertPublicHost('192.168.1.1'), { message: 'Blocked host address' }, 'private IP should be blocked');
+  await assert.rejects(assertPublicHost('100.64.0.1'), { message: 'Blocked host address' }, 'RFC 6598 shared IP should be blocked');
   await assert.rejects(assertPublicHost('evil.local'), { message: 'Blocked host' }, '.local should be blocked');
 
   await assert.rejects(assertPublicHost('::ffff:127.0.0.1'), { message: 'Blocked host address' }, 'IPv4-mapped IPv6 loopback should be blocked');
@@ -61,6 +71,28 @@ test('assertPublicHost prevents blocked hosts and private IPs', async () => {
 
   const publicIp = await assertPublicHost('8.8.8.8');
   assert.deepStrictEqual(publicIp, ['8.8.8.8'], 'public IP should be allowed');
+  const publicBoundaryIp = await assertPublicHost('100.128.0.1');
+  assert.deepStrictEqual(publicBoundaryIp, ['100.128.0.1'], 'address above RFC 6598 shared space should be allowed');
+});
+
+test('normalizeTargetUrl rejects calendar hosts resolving to RFC 6598 shared space', async () => {
+  const originalDnsLookup = dns.lookup;
+  try {
+    dns.lookup = async (hostname, options) => {
+      if (hostname === 'calendar.attacker.test') {
+        return [{ address: '100.64.0.1', family: 4 }];
+      }
+      return originalDnsLookup(hostname, options);
+    };
+
+    await assert.rejects(
+      normalizeTargetUrl('https://calendar.attacker.test/team.ics'),
+      { message: 'Blocked host address' },
+      'calendar proxy normalization must reject DNS answers in RFC 6598 shared space'
+    );
+  } finally {
+    dns.lookup = originalDnsLookup;
+  }
 });
 
 test('fetchWithTimeout uses validated IPs and falls back across failures', async () => {

--- a/functions/utils/ip-address-validation.js
+++ b/functions/utils/ip-address-validation.js
@@ -58,6 +58,7 @@ function isPrivateIpAddress(ip) {
       return true;
     }
     if (parts[0] === 10 || parts[0] === 127 || parts[0] === 0) return true;
+    if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true; // RFC 6598 shared address space
     if (parts[0] === 169 && parts[1] === 254) return true;
     if (parts[0] === 192 && parts[1] === 168) return true;
     if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;

--- a/functions/utils/security-utils.js
+++ b/functions/utils/security-utils.js
@@ -69,6 +69,7 @@ function isPrivateIpAddress(ip) {
       return true;
     }
     if (parts[0] === 10 || parts[0] === 127 || parts[0] === 0) return true;
+    if (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) return true; // RFC 6598 shared address space
     if (parts[0] === 169 && parts[1] === 254) return true;
     if (parts[0] === 192 && parts[1] === 168) return true;
     if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;

--- a/tests/unit/is-private-ip-address.test.js
+++ b/tests/unit/is-private-ip-address.test.js
@@ -37,6 +37,15 @@ describe('isPrivateIpAddress', () => {
     expect(isPrivateIpAddress('169.254.1.1')).toBe(true);
   });
 
+  it('should block RFC 6598 shared address space (100.64.0.0/10) without crossing its boundaries', () => {
+    expect(isPrivateIpAddress('100.63.255.255')).toBe(false);
+    expect(isPrivateIpAddress('100.64.0.0')).toBe(true);
+    expect(isPrivateIpAddress('100.64.0.1')).toBe(true);
+    expect(isPrivateIpAddress('100.127.255.254')).toBe(true);
+    expect(isPrivateIpAddress('100.127.255.255')).toBe(true);
+    expect(isPrivateIpAddress('100.128.0.1')).toBe(false);
+  });
+
   // Public IPv6 addresses
   it('should return false for public IPv6 addresses', () => {
     expect(isPrivateIpAddress('2001:0db8::1')).toBe(false);
@@ -76,6 +85,9 @@ describe('isPrivateIpAddress', () => {
     expect(isPrivateIpAddress('::ffff:10.0.0.1')).toBe(true);
     expect(isPrivateIpAddress('::ffff:192.168.1.1')).toBe(true);
     expect(isPrivateIpAddress('::ffff:169.254.169.254')).toBe(true);
+    expect(isPrivateIpAddress('::ffff:100.64.0.1')).toBe(true);
+    expect(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:6440:0001')).toBe(true);
+    expect(isPrivateIpAddress('::ffff:100.128.0.1')).toBe(false);
     expect(isPrivateIpAddress('::ffff:7f00:1')).toBe(true);
     expect(isPrivateIpAddress('0:0:0:0:0:ffff:7f00:1')).toBe(true);
     expect(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:7f00:0001')).toBe(true);


### PR DESCRIPTION
## Summary

- classify RFC 6598 shared address space (`100.64.0.0/10`) as blocked in both active IP validators
- block direct, DNS-resolved, and IPv4-mapped IPv6 representations before calendar fetch
- preserve the exact lower/upper boundaries so `100.128.0.1` remains allowed

## Investigation

Both `security-utils.js` and `ip-address-validation.js` independently checked the same limited IPv4 ranges and omitted carrier-grade NAT shared space. `assertPublicHost` trusts that result for literal and DNS-resolved addresses, and `normalizeTargetUrl` returns accepted answers as connection targets for `fetchWithTimeout`. Consequently, a hostname resolving to `100.64.0.1` reached the outbound connection path.

IPv4-mapped IPv6 addresses recurse through the same IPv4 validator, so correcting the shared `/10` check also closes mapped forms when implemented consistently in both helpers.

## Design and requirements

- reject IPv4 addresses whose first octet is `100` and second octet is `64` through `127` inclusive
- apply the identical RFC 6598 rule in the calendar SSRF utility and shared IP-validation helper
- retain addresses below (`100.63.255.255`) and above (`100.128.0.1`) the `/10` boundary
- verify dotted and zero-padded IPv4-mapped IPv6 forms recurse to the blocked result
- verify `assertPublicHost` and DNS-backed `normalizeTargetUrl` fail before `fetchWithTimeout`
- leave all existing URL protocol, hostname, DNS pinning, redirect, timeout, and fetch behavior unchanged

## Test plan and results

- focused SSRF/shared-validator tests: **20 passed**
  - lower/upper boundaries, interior addresses, allowed adjacent boundaries
  - dotted and hexadecimal IPv4-mapped IPv6 forms
  - direct `assertPublicHost` rejection
  - original hostname-to-`100.64.0.1` DNS reproduction rejected by `normalizeTargetUrl`
- complete Cloud Functions suite: **47 passed**
- full repository `npm test`: **3,503 passed, 154 failed, 9 skipped**
  - current untouched-master baseline has the same **31 failing files / 154 failures**, with 3,502 passed and 9 skipped
  - this branch adds one passing boundary test and no new failure; baseline failures are unrelated native public-actions and React integration tests

Closes #3437
