### PR TITLE
Bind athlete profile media to owned profiles

### DIFF
--- a/apps/app/src/lib/adapters/legacyPlayerDb.ts
+++ b/apps/app/src/lib/adapters/legacyPlayerDb.ts
@@ -11,6 +11,8 @@ import {
     inviteCoParentToAthlete as legacyInviteCoParentToAthlete,
     listAthleteProfilesForParent as legacyListAthleteProfilesForParent,
     listCertificatesForPlayer as legacyListCertificatesForPlayer,
+    releaseAthleteProfileMediaReservation as legacyReleaseAthleteProfileMediaReservation,
+    reserveAthleteProfileMediaOwnership as legacyReserveAthleteProfileMediaOwnership,
     saveAthleteProfile as legacySaveAthleteProfile,
     setPlayerPrivateRosterProfileFields as legacySetPlayerPrivateRosterProfileFields,
     updatePlayer as legacyUpdatePlayer,
@@ -125,6 +127,14 @@ export async function inviteCoParentToAthlete(userId: string, teamId: string, pl
 
 export async function saveAthleteProfile(userId: string, draft: Record<string, unknown>, options: { profileId: string }) {
     return await Promise.resolve(legacySaveAthleteProfile(userId, draft, options));
+}
+
+export async function reserveAthleteProfileMediaOwnership(userId: string, profileId: string) {
+    return await Promise.resolve(legacyReserveAthleteProfileMediaOwnership(userId, profileId));
+}
+
+export async function releaseAthleteProfileMediaReservation(userId: string, profileId: string) {
+    return await Promise.resolve(legacyReleaseAthleteProfileMediaReservation(userId, profileId));
 }
 
 export async function uploadAthleteProfileMedia(userId: string, profileId: string, file: File, options: { kind: 'profile-photo' | 'clip' }) {

--- a/apps/app/src/lib/playerService.test.ts
+++ b/apps/app/src/lib/playerService.test.ts
@@ -14,6 +14,8 @@ const legacyPlayerDbMocks = vi.hoisted(() => ({
   inviteCoParentToAthlete: vi.fn(),
   listAthleteProfilesForParent: vi.fn(),
   listCertificatesForPlayer: vi.fn(),
+  releaseAthleteProfileMediaReservation: vi.fn(),
+  reserveAthleteProfileMediaOwnership: vi.fn(),
   saveAthleteProfile: vi.fn(),
   setPlayerPrivateRosterProfileFields: vi.fn(),
   updatePlayer: vi.fn(),
@@ -94,6 +96,8 @@ describe('saveParentAthleteProfileDraft', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     legacyPlayerDbMocks.saveAthleteProfile.mockResolvedValue({ id: 'profile-1' });
+    legacyPlayerDbMocks.reserveAthleteProfileMediaOwnership.mockImplementation(async (_userId, profileId) => ({ id: profileId, created: false }));
+    legacyPlayerDbMocks.releaseAthleteProfileMediaReservation.mockResolvedValue(true);
   });
 
   it('passes caller-provided selectedSeasonKeys to saveAthleteProfile', async () => {

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -11,6 +11,8 @@ import {
   inviteCoParentToAthlete,
   listAthleteProfilesForParent,
   listCertificatesForPlayer,
+  releaseAthleteProfileMediaReservation,
+  reserveAthleteProfileMediaOwnership,
   saveAthleteProfile,
   setPlayerPrivateRosterProfileFields,
   updatePlayer,
@@ -607,10 +609,16 @@ export async function saveParentAthleteProfileDraft({
   const uploadRequests = buildHighlightClipUploadRequests(highlightClipUploads, highlightClipFile, highlightClipTitle);
   if (profilePhotoFile) validateImageFile(profilePhotoFile);
   uploadRequests.forEach((upload) => validateHighlightClipFile(upload.file));
-  if (profilePhotoFile) {
-    uploadedProfilePhoto = await uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' });
+  const hasPendingMedia = !!profilePhotoFile || uploadRequests.length > 0;
+  let createdMediaReservation = false;
+  if (hasPendingMedia) {
+    const reservation = await reserveAthleteProfileMediaOwnership(user!.uid, workingProfileId);
+    createdMediaReservation = reservation.created === true;
   }
   try {
+    if (profilePhotoFile) {
+      uploadedProfilePhoto = await uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' });
+    }
     for (const upload of uploadRequests) {
       const uploaded = await uploadAthleteProfileMedia(user!.uid, workingProfileId, upload.file, { kind: 'clip' });
       uploadedHighlightClips.push(buildUploadedHighlightClip(upload, uploaded));
@@ -620,6 +628,9 @@ export async function saveParentAthleteProfileDraft({
       uploadedProfilePhoto?.storagePath,
       ...uploadedHighlightClips.map((clip) => clip.storagePath)
     ]);
+    if (createdMediaReservation) {
+      await releaseAthleteProfileMediaReservation(user!.uid, workingProfileId).catch(() => undefined);
+    }
     throw error;
   }
   const profilePhoto = uploadedProfilePhoto || (resetProfilePhoto ? null : draft.profilePhoto);
@@ -638,6 +649,9 @@ export async function saveParentAthleteProfileDraft({
       uploadedProfilePhoto?.storagePath,
       ...uploadedHighlightClips.map((clip) => clip.storagePath)
     ]);
+    if (createdMediaReservation) {
+      await releaseAthleteProfileMediaReservation(user!.uid, workingProfileId).catch(() => undefined);
+    }
     throw error;
   }
   return {

--- a/athlete-profile-builder.html
+++ b/athlete-profile-builder.html
@@ -154,8 +154,10 @@
             saveAthleteProfile,
             listAthleteProfilesForParent,
             uploadAthleteProfileMedia,
-            deleteAthleteProfileMediaByPath
-        } from './js/db.js?v=84';
+            deleteAthleteProfileMediaByPath,
+            releaseAthleteProfileMediaReservation,
+            reserveAthleteProfileMediaOwnership
+        } from './js/db.js?v=85';
         import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=2';
 
         const params = getUrlParams();
@@ -714,7 +716,12 @@
             setStatus('Saving...');
 
             let newlyUploadedPaths = [];
+            let createdMediaReservation = false;
             try {
+                if (pendingProfilePhotoFile || pendingClipFiles.size > 0) {
+                    const reservation = await reserveAthleteProfileMediaOwnership(currentUser.uid, workingProfileId);
+                    createdMediaReservation = reservation.created === true;
+                }
                 const prepared = await uploadPendingMedia((path) => newlyUploadedPaths.push(path));
                 currentProfile = await saveAthleteProfile(currentUser.uid, prepared.draft, {
                     profileId: currentProfile?.id || params.profileId || workingProfileId
@@ -731,6 +738,9 @@
                 setStatus('Athlete profile saved.');
             } catch (error) {
                 await Promise.allSettled(newlyUploadedPaths.map((path) => deleteAthleteProfileMediaByPath(path)));
+                if (createdMediaReservation) {
+                    await releaseAthleteProfileMediaReservation(currentUser.uid, workingProfileId).catch(() => undefined);
+                }
                 console.error('Failed to save athlete profile', error);
                 setStatus(error?.message || 'Unable to save athlete profile.', true);
             }

--- a/js/db.js
+++ b/js/db.js
@@ -5691,6 +5691,55 @@ function sanitizeAthleteProfileMediaName(fileName) {
     return String(fileName || 'media').replace(/[^\w.\-]+/g, '_');
 }
 
+export async function reserveAthleteProfileMediaOwnership(userId, profileId) {
+    const normalizedUserId = String(userId || '').trim();
+    const normalizedProfileId = String(profileId || '').trim();
+    if (!normalizedUserId) {
+        throw new Error('A signed-in parent account is required to reserve athlete profile media.');
+    }
+    if (!normalizedProfileId) {
+        throw new Error('A profile id is required to reserve athlete profile media.');
+    }
+
+    const profileRef = doc(db, 'athleteProfiles', normalizedProfileId);
+    return runTransaction(db, async (transaction) => {
+        const profileSnap = await transaction.get(profileRef);
+        if (profileSnap.exists()) {
+            if (profileSnap.data()?.parentUserId !== normalizedUserId) {
+                throw new Error('You do not have permission to upload media for this athlete profile.');
+            }
+            return { id: normalizedProfileId, created: false };
+        }
+
+        transaction.set(profileRef, {
+            parentUserId: normalizedUserId,
+            privacy: 'private',
+            mediaUploadReservation: true,
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp()
+        });
+        return { id: normalizedProfileId, created: true };
+    });
+}
+
+export async function releaseAthleteProfileMediaReservation(userId, profileId) {
+    const normalizedUserId = String(userId || '').trim();
+    const normalizedProfileId = String(profileId || '').trim();
+    if (!normalizedUserId || !normalizedProfileId) return false;
+
+    const profileRef = doc(db, 'athleteProfiles', normalizedProfileId);
+    return runTransaction(db, async (transaction) => {
+        const profileSnap = await transaction.get(profileRef);
+        if (!profileSnap.exists()) return false;
+        const profile = profileSnap.data() || {};
+        if (profile.parentUserId !== normalizedUserId || profile.mediaUploadReservation !== true) {
+            return false;
+        }
+        transaction.delete(profileRef);
+        return true;
+    });
+}
+
 export async function uploadAthleteProfileMedia(userId, profileId, file, options = {}) {
     if (!userId) {
         throw new Error('A signed-in parent account is required to upload athlete profile media.');
@@ -5739,6 +5788,7 @@ export async function listAthleteProfilesForParent(userId) {
 
     return snapshot.docs
         .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
+        .filter((profile) => profile.mediaUploadReservation !== true)
         .sort((a, b) => {
             const aTime = a.updatedAt?.toMillis ? a.updatedAt.toMillis() : 0;
             const bTime = b.updatedAt?.toMillis ? b.updatedAt.toMillis() : 0;
@@ -5825,7 +5875,10 @@ export async function saveAthleteProfile(userId, draft, options = {}) {
         payload.createdAt = serverTimestamp();
     }
 
-    await setDoc(profileRef, payload, { merge: true });
+    await setDoc(profileRef, {
+        ...payload,
+        mediaUploadReservation: deleteField()
+    }, { merge: true });
 
     const cleanupResults = await Promise.allSettled(cleanupPaths.map((path) => deleteAthleteProfileMediaByPath(path)));
     cleanupResults.forEach((result) => {
@@ -5834,11 +5887,13 @@ export async function saveAthleteProfile(userId, draft, options = {}) {
         }
     });
 
-    return {
+    const savedProfile = {
         id: profileRef.id,
         ...(existingProfile || {}),
         ...payload
     };
+    delete savedProfile.mediaUploadReservation;
+    return savedProfile;
 }
 
 // ============================================

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -58,6 +58,7 @@ export function validateFirebaseRulesCi() {
     const drillFallbackRules = extractMatchBlock(storageRules, 'match /stat-sheets/drills/{teamId}/{drillId}/{userId}/{fileName}');
     const clipFallbackRules = extractMatchBlock(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}');
     const legacyGameClipRules = extractMatchBlock(storageRules, 'match /game-clips/{fileName} {');
+    const athleteProfileMediaRules = extractMatchBlock(storageRules, 'match /athlete-profile-media/{userId}/{profileId}/{fileName}');
     const collectionGroupGamesHelper = (firestoreRules.match(/function canReadCollectionGroupGameDocument\(teamPath, data\) \{[\s\S]*?\n\s*}/) || [''])[0];
     const gameEventsRules = (firestoreRules.match(/match \/events\/\{eventId} \{[\s\S]*?\n\s*}/) || [''])[0];
     const aggregatedStatsRules = (firestoreRules.match(/match \/aggregatedStats\/\{statId} \{[\s\S]*?\n\s*}/) || [''])[0];
@@ -183,6 +184,12 @@ export function validateFirebaseRulesCi() {
     assertIncludes(storageRules, 'contentType.matches(\'image/.*\')', 'Chat fallback image content-type rules');
     assertIncludes(storageRules, 'contentType.matches(\'video/.*\')', 'Chat fallback video content-type rules');
     assertIncludes(chatFallbackRules, 'isAllowedChatAttachmentUpload(request.resource.contentType, request.resource.size);', 'Chat fallback create upload guard');
+    assertIncludes(storageRules, 'function athleteProfileMatchesPathOwner(userId, profileId)', 'Athlete profile media owner helper');
+    assertIncludes(storageRules, 'firestore.get(profilePath).data.parentUserId == userId;', 'Athlete profile media path owner match');
+    assertIncludes(storageRules, 'return athleteProfileMatchesPathOwner(userId, profileId) &&', 'Athlete profile media public read path owner guard');
+    assertIncludes(athleteProfileMediaRules, 'allow get: if canReadAthleteProfileMedia(userId, profileId);', 'Athlete profile media read guard');
+    assertIncludes(athleteProfileMediaRules, 'request.auth.uid == userId &&\n        athleteProfileMatchesPathOwner(userId, profileId) &&', 'Athlete profile media create owner guard');
+    assertIncludes(athleteProfileMediaRules, 'allow delete: if isSignedIn() &&\n        request.auth.uid == userId &&\n        athleteProfileMatchesPathOwner(userId, profileId);', 'Athlete profile media delete owner guard');
 
     assertIncludes(regressionGuards, 'npm run ci:firebase-rules', 'Regression guard workflow');
     assertIncludes(regressionGuards, 'npm run test:smoke:team-fallback', 'Regression guard workflow');

--- a/storage.rules
+++ b/storage.rules
@@ -129,10 +129,17 @@ service firebase.storage {
          contentType.matches('video/.*'));
     }
 
+    function athleteProfileMatchesPathOwner(userId, profileId) {
+      let profilePath = /databases/(default)/documents/athleteProfiles/$(profileId);
+      return profileId.size() > 0 &&
+        firestore.exists(profilePath) &&
+        firestore.get(profilePath).data.parentUserId == userId;
+    }
+
     function canReadAthleteProfileMedia(userId, profileId) {
       let profilePath = /databases/(default)/documents/athleteProfiles/$(profileId);
-      return (isSignedIn() && request.auth.uid == userId) ||
-        (firestore.exists(profilePath) &&
+      return athleteProfileMatchesPathOwner(userId, profileId) &&
+        ((isSignedIn() && request.auth.uid == userId) ||
          firestore.get(profilePath).data.get('privacy', 'private') == 'public');
     }
 
@@ -234,10 +241,13 @@ service firebase.storage {
       allow list: if false;
       allow create: if isSignedIn() &&
         request.auth.uid == userId &&
+        athleteProfileMatchesPathOwner(userId, profileId) &&
         request.resource.size > 0 &&
         request.resource.size <= 100 * 1024 * 1024 &&
         isAllowedAthleteProfileMediaUploadType(request.resource.contentType);
-      allow delete: if isSignedIn() && request.auth.uid == userId;
+      allow delete: if isSignedIn() &&
+        request.auth.uid == userId &&
+        athleteProfileMatchesPathOwner(userId, profileId);
       allow update: if false;
     }
   }

--- a/tests/smoke/athlete-profile-builder-media-save.spec.js
+++ b/tests/smoke/athlete-profile-builder-media-save.spec.js
@@ -71,6 +71,9 @@ function getState() {
     state.uploads = state.uploads || [];
     state.saveCalls = state.saveCalls || [];
     state.deletes = state.deletes || [];
+    state.reservations = state.reservations || [];
+    state.releasedReservations = state.releasedReservations || [];
+    state.events = state.events || [];
     state.shared = state.shared || [];
     window.__athleteProfileSmoke = state;
     return state;
@@ -99,6 +102,20 @@ export async function listAthleteProfilesForParent() {
     return clone(state.savedProfiles || []);
 }
 
+export async function reserveAthleteProfileMediaOwnership(userId, profileId) {
+    const state = getState();
+    state.reservations.push({ userId, profileId });
+    state.events.push('reserve:' + profileId);
+    return { id: profileId, created: true };
+}
+
+export async function releaseAthleteProfileMediaReservation(userId, profileId) {
+    const state = getState();
+    state.releasedReservations.push({ userId, profileId });
+    state.events.push('release:' + profileId);
+    return true;
+}
+
 export async function uploadAthleteProfileMedia(userId, profileId, file, options = {}) {
     const state = getState();
     const uploadNumber = state.uploads.length + 1;
@@ -116,6 +133,7 @@ export async function uploadAthleteProfileMedia(userId, profileId, file, options
         uploadedAtMs: 1800000000000 + uploadNumber
     };
     state.uploads.push({ userId, profileId, kind: options.kind, name: file.name, type: file.type, size: file.size, storagePath });
+    state.events.push('upload:' + options.kind + ':' + profileId);
     return uploaded;
 }
 
@@ -145,6 +163,7 @@ export async function saveAthleteProfile(userId, draft, options = {}) {
     };
 
     state.saveCalls.push({ userId, draft: clone(draft), options: clone(options) });
+    state.events.push('save:' + options.profileId);
     state.savedProfiles = [saved];
     state.profiles = { ...(state.profiles || {}), [saved.id]: saved };
     return clone(saved);
@@ -153,6 +172,7 @@ export async function saveAthleteProfile(userId, draft, options = {}) {
 export async function deleteAthleteProfileMediaByPath(path) {
     const state = getState();
     state.deletes.push(path);
+    state.events.push('delete:' + path);
 }
 `;
 
@@ -162,6 +182,9 @@ async function mockBuilderModules(page, scenario = {}) {
             uploads: [],
             saveCalls: [],
             deletes: [],
+            reservations: [],
+            releasedReservations: [],
+            events: [],
             shared: [],
             ...value
         };
@@ -243,9 +266,18 @@ test('standalone athlete profile builder uploads media, saves public profile, an
     await expect(page.locator('#share-profile-btn')).toBeVisible();
 
     const smokeState = await page.evaluate(() => window.__athleteProfileSmoke);
+    expect(smokeState.reservations).toHaveLength(1);
+    expect(smokeState.reservations[0]).toEqual(expect.objectContaining({ userId: 'parent-1' }));
     expect(smokeState.uploads).toEqual([
         expect.objectContaining({ userId: 'parent-1', kind: 'profile-photo', name: 'headshot.png', type: 'image/png' }),
         expect.objectContaining({ userId: 'parent-1', kind: 'clip', name: 'highlight.mp4', type: 'video/mp4' })
+    ]);
+    expect(smokeState.uploads[0].profileId).toBe(smokeState.reservations[0].profileId);
+    expect(smokeState.events.slice(0, 4)).toEqual([
+        `reserve:${smokeState.reservations[0].profileId}`,
+        `upload:profile-photo:${smokeState.reservations[0].profileId}`,
+        `upload:clip:${smokeState.reservations[0].profileId}`,
+        `save:${smokeState.reservations[0].profileId}`
     ]);
     expect(smokeState.saveCalls).toHaveLength(1);
     expect(smokeState.saveCalls[0].draft).toMatchObject({
@@ -286,6 +318,9 @@ test('standalone athlete profile builder cleans uploaded media when a later uplo
     expect(smokeState.saveCalls).toEqual([]);
     expect(smokeState.deletes).toEqual([
         expect.stringMatching(/athleteProfiles\/.+\/profile-photo\/headshot\.png$/)
+    ]);
+    expect(smokeState.releasedReservations).toEqual([
+        expect.objectContaining({ userId: 'parent-1', profileId: smokeState.reservations[0].profileId })
     ]);
     await expect(page.locator('#share-profile-btn')).toBeHidden();
     await expect(page).toHaveURL(/athlete-profile-builder\.html\?teamId=team-1&playerId=player-1&cb=\d+$/);

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -13,6 +13,8 @@ const dbMocks = vi.hoisted(() => ({
     inviteCoParentToAthlete: vi.fn(),
     listAthleteProfilesForParent: vi.fn(),
     listCertificatesForPlayer: vi.fn(),
+    releaseAthleteProfileMediaReservation: vi.fn(),
+    reserveAthleteProfileMediaOwnership: vi.fn(),
     saveAthleteProfile: vi.fn(),
     setPlayerPrivateRosterProfileFields: vi.fn(),
     updatePlayer: vi.fn(),
@@ -169,6 +171,8 @@ beforeEach(() => {
     }]);
     dbMocks.inviteCoParentToAthlete.mockResolvedValue({ id: 'invite-1', code: 'ABC12345', teamName: 'Bears', playerName: 'Pat Star', existingUser: false });
     dbMocks.saveAthleteProfile.mockResolvedValue({ id: 'profile-1', athlete: { name: 'Pat Star' }, privacy: 'public' });
+    dbMocks.reserveAthleteProfileMediaOwnership.mockImplementation(async (_userId, profileId) => ({ id: profileId, created: false }));
+    dbMocks.releaseAthleteProfileMediaReservation.mockResolvedValue(true);
     dbMocks.deleteAthleteProfileMediaByPath.mockResolvedValue(undefined);
     dbMocks.updatePlayerProfile.mockResolvedValue(undefined);
     dbMocks.uploadAthleteProfileMedia.mockImplementation(async (userId, profileId, file, options = {}) => {
@@ -416,7 +420,7 @@ describe('React app parent player detail service', () => {
         expect(savedProfile.shareUrl).toBe('https://allplays.ai/athlete-profile.html?profileId=profile-1');
     });
 
-    it('uploads athlete profile headshots before saving and supports linked-photo reset', async () => {
+    it('verifies athlete profile ownership before uploading headshots and supports linked-photo reset', async () => {
         const file = new File(['headshot'], 'headshot.jpg', { type: 'image/jpeg' });
 
         await saveParentAthleteProfileDraft({
@@ -434,7 +438,10 @@ describe('React app parent player detail service', () => {
             }
         });
 
+        expect(dbMocks.reserveAthleteProfileMediaOwnership).toHaveBeenCalledWith('user-1', 'profile-1');
         expect(dbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('user-1', 'profile-1', file, { kind: 'profile-photo' });
+        expect(dbMocks.reserveAthleteProfileMediaOwnership.mock.invocationCallOrder[0])
+            .toBeLessThan(dbMocks.uploadAthleteProfileMedia.mock.invocationCallOrder[0]);
         expect(dbMocks.saveAthleteProfile).toHaveBeenLastCalledWith('user-1', expect.objectContaining({
             profilePhoto: expect.objectContaining({ url: 'https://example.test/headshot.jpg' }),
             selectedSeasonKeys: ['team-1::player-1']
@@ -459,6 +466,34 @@ describe('React app parent player detail service', () => {
             profilePhoto: null,
             selectedSeasonKeys: ['team-1::player-1']
         }), { profileId: 'profile-1' });
+    });
+
+    it('reserves a new owned athlete profile before its first media upload', async () => {
+        const file = new File(['headshot'], 'headshot.jpg', { type: 'image/jpeg' });
+        dbMocks.reserveAthleteProfileMediaOwnership.mockImplementation(async (_userId, profileId) => ({ id: profileId, created: true }));
+        dbMocks.saveAthleteProfile.mockImplementation(async (_userId, draft, options) => ({ id: options.profileId, ...draft }));
+
+        await saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profilePhotoFile: file,
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'public',
+                clips: []
+            }
+        });
+
+        const reservedProfileId = dbMocks.reserveAthleteProfileMediaOwnership.mock.calls[0][1];
+        expect(reservedProfileId).toMatch(/^profile_/);
+        expect(dbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('user-1', reservedProfileId, file, { kind: 'profile-photo' });
+        expect(dbMocks.reserveAthleteProfileMediaOwnership.mock.invocationCallOrder[0])
+            .toBeLessThan(dbMocks.uploadAthleteProfileMedia.mock.invocationCallOrder[0]);
+        expect(dbMocks.uploadAthleteProfileMedia.mock.invocationCallOrder[0])
+            .toBeLessThan(dbMocks.saveAthleteProfile.mock.invocationCallOrder[0]);
+        expect(dbMocks.releaseAthleteProfileMediaReservation).not.toHaveBeenCalled();
     });
 
     it('rejects invalid athlete profile headshots before upload', async () => {
@@ -502,6 +537,30 @@ describe('React app parent player detail service', () => {
 
         expect(dbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('user-1', 'profile-1', file, { kind: 'profile-photo' });
         expect(dbMocks.deleteAthleteProfileMediaByPath).toHaveBeenCalledWith('athlete-profile-media/user-1/profile-1/headshot.jpg');
+    });
+
+    it('cleans media before releasing a failed new-profile reservation', async () => {
+        const file = new File(['headshot'], 'headshot.jpg', { type: 'image/jpeg' });
+        dbMocks.reserveAthleteProfileMediaOwnership.mockImplementation(async (_userId, profileId) => ({ id: profileId, created: true }));
+        dbMocks.saveAthleteProfile.mockRejectedValueOnce(new Error('profile save failed'));
+
+        await expect(saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profilePhotoFile: file,
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'public',
+                clips: []
+            }
+        })).rejects.toThrow('profile save failed');
+
+        const reservedProfileId = dbMocks.reserveAthleteProfileMediaOwnership.mock.calls[0][1];
+        expect(dbMocks.releaseAthleteProfileMediaReservation).toHaveBeenCalledWith('user-1', reservedProfileId);
+        expect(dbMocks.deleteAthleteProfileMediaByPath.mock.invocationCallOrder[0])
+            .toBeLessThan(dbMocks.releaseAthleteProfileMediaReservation.mock.invocationCallOrder[0]);
     });
 
     it('uploads a manual athlete profile highlight clip and preserves existing clips', async () => {

--- a/tests/unit/athlete-profile-storage-rules.test.js
+++ b/tests/unit/athlete-profile-storage-rules.test.js
@@ -12,25 +12,32 @@ function extractAthleteProfileMediaRules() {
     return rules.slice(mediaRulesStart, mediaRulesEnd === -1 ? undefined : mediaRulesEnd);
 }
 
-function canCreateAthleteProfileMedia({ authUid, userId, size, contentType }) {
+function profileMatchesPathOwner({ userId, profileParentUserId = userId, profileExists = true }) {
+    return profileExists && profileParentUserId === userId;
+}
+
+function canCreateAthleteProfileMedia({ authUid, userId, profileParentUserId = userId, profileExists = true, size, contentType }) {
     const signedIn = authUid !== null;
     const requiresPathOwner = mediaRules.includes('request.auth.uid == userId');
     const pathOwnerAllowed = !requiresPathOwner || authUid === userId;
     const hasAllowedSize = size > 0 && size <= 100 * 1024 * 1024;
     const hasAllowedContentType = contentType.startsWith('image/') || contentType.startsWith('video/');
 
-    return signedIn && pathOwnerAllowed && hasAllowedSize && hasAllowedContentType;
+    return signedIn && pathOwnerAllowed &&
+        profileMatchesPathOwner({ userId, profileParentUserId, profileExists }) &&
+        hasAllowedSize && hasAllowedContentType;
 }
 
-function canGetAthleteProfileMedia({ authUid, userId, profilePrivacy = 'private', profileExists = true }) {
+function canGetAthleteProfileMedia({ authUid, userId, profileParentUserId = userId, profilePrivacy = 'private', profileExists = true }) {
     const signedIn = authUid !== null;
     const isOwner = authUid === userId;
     const isPublicProfile = profileExists && profilePrivacy === 'public';
 
-    return (signedIn && isOwner) || isPublicProfile;
+    return profileMatchesPathOwner({ userId, profileParentUserId, profileExists }) &&
+        ((signedIn && isOwner) || isPublicProfile);
 }
 
-function canDeleteAthleteProfileMedia({ authUid, userId }) {
+function canDeleteAthleteProfileMedia({ authUid, userId, profileParentUserId = userId, profileExists = true }) {
     const signedIn = authUid !== null;
     const deleteRuleStart = mediaRules.indexOf('allow delete:');
     const deleteRuleEnd = mediaRules.indexOf(';', deleteRuleStart);
@@ -38,20 +45,24 @@ function canDeleteAthleteProfileMedia({ authUid, userId }) {
     const requiresPathOwner = deleteRule.includes('request.auth.uid == userId');
     const pathOwnerAllowed = !requiresPathOwner || authUid === userId;
 
-    return signedIn && pathOwnerAllowed;
+    return signedIn && pathOwnerAllowed &&
+        profileMatchesPathOwner({ userId, profileParentUserId, profileExists });
 }
 
 describe('athlete profile Storage rules', () => {
     it('allows profile owners to read and upload image/video media within limits', () => {
         expect(rules).toContain('function canReadAthleteProfileMedia(userId, profileId)');
+        expect(rules).toContain('return athleteProfileMatchesPathOwner(userId, profileId) &&');
         expect(mediaRules).toContain('allow get: if canReadAthleteProfileMedia(userId, profileId);');
         expect(mediaRules).toContain('allow list: if false;');
         expect(mediaRules).toContain('allow create: if isSignedIn() &&');
         expect(mediaRules).toContain('request.auth.uid == userId');
+        expect(rules).toContain('function athleteProfileMatchesPathOwner(userId, profileId)');
+        expect(mediaRules).toContain('athleteProfileMatchesPathOwner(userId, profileId)');
         expect(mediaRules).toContain('request.resource.size > 0');
         expect(mediaRules).toContain('request.resource.size <= 100 * 1024 * 1024');
         expect(mediaRules).toContain('isAllowedAthleteProfileMediaUploadType(request.resource.contentType);');
-        expect(mediaRules).toContain('allow delete: if isSignedIn() && request.auth.uid == userId;');
+        expect(mediaRules).toContain('allow delete: if isSignedIn() &&');
         expect(mediaRules).toContain('allow update: if false;');
 
         expect(canGetAthleteProfileMedia({
@@ -116,6 +127,38 @@ describe('athlete profile Storage rules', () => {
             authUid: null,
             userId: 'parent-1',
             profilePrivacy: 'private'
+        })).toBe(false);
+    });
+
+    it('denies public-profile piggyback objects when the path user does not own the profile', () => {
+        const piggybackCase = {
+            authUid: 'attacker-1',
+            userId: 'attacker-1',
+            profileParentUserId: 'parent-1',
+            profilePrivacy: 'public'
+        };
+
+        expect(canCreateAthleteProfileMedia({
+            ...piggybackCase,
+            size: 1024,
+            contentType: 'image/png'
+        })).toBe(false);
+        expect(canGetAthleteProfileMedia(piggybackCase)).toBe(false);
+        expect(canDeleteAthleteProfileMedia(piggybackCase)).toBe(false);
+    });
+
+    it('requires the owned profile document to exist before create or delete', () => {
+        expect(canCreateAthleteProfileMedia({
+            authUid: 'parent-1',
+            userId: 'parent-1',
+            profileExists: false,
+            size: 1024,
+            contentType: 'video/mp4'
+        })).toBe(false);
+        expect(canDeleteAthleteProfileMedia({
+            authUid: 'parent-1',
+            userId: 'parent-1',
+            profileExists: false
         })).toBe(false);
     });
 

--- a/tests/unit/athlete-profile-wiring.test.js
+++ b/tests/unit/athlete-profile-wiring.test.js
@@ -69,6 +69,9 @@ describe('athlete profile wiring', () => {
         expect(source).toContain('getTeam(link.teamId, { includeInactive: true })');
         expect(source).toContain('uploadAthleteProfileMedia');
         expect(source).toContain('deleteAthleteProfileMediaByPath');
+        expect(source).toContain('reserveAthleteProfileMediaOwnership');
+        expect(source).toContain('mediaUploadReservation: true');
+        expect(source).toContain('mediaUploadReservation: deleteField()');
         expect(source).toContain('collectAthleteProfileMediaCleanupPaths');
     });
 });

--- a/tests/unit/issue-1998-athlete-profile-upload-source.test.js
+++ b/tests/unit/issue-1998-athlete-profile-upload-source.test.js
@@ -28,6 +28,7 @@ describe('issue 1998 athlete profile upload source contract', () => {
         expect(playerServiceSource).toContain('export async function saveParentAthleteProfileDraft');
         expect(playerServiceSource).toContain('if (profilePhotoFile) validateImageFile(profilePhotoFile);');
         expect(playerServiceSource).toContain('uploadRequests.forEach((upload) => validateHighlightClipFile(upload.file));');
+        expect(playerServiceSource).toContain('reserveAthleteProfileMediaOwnership(user!.uid, workingProfileId)');
         expect(playerServiceSource).toContain("uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' })");
         expect(playerServiceSource).toContain("uploadAthleteProfileMedia(user!.uid, workingProfileId, upload.file, { kind: 'clip' })");
         expect(playerServiceSource).toContain("source: 'upload'");
@@ -39,7 +40,8 @@ describe('issue 1998 athlete profile upload source contract', () => {
     });
 
     it('keeps upload regression, legacy wiring, and storage-rule coverage in place', () => {
-        expect(playerServiceTestSource).toContain('uploads athlete profile headshots before saving and supports linked-photo reset');
+        expect(playerServiceTestSource).toContain('verifies athlete profile ownership before uploading headshots and supports linked-photo reset');
+        expect(playerServiceTestSource).toContain('reserves a new owned athlete profile before its first media upload');
         expect(playerServiceTestSource).toContain('uploads a manual athlete profile highlight clip and preserves existing clips');
         expect(playerServiceTestSource).toContain('saves ordered athlete profile clip links and matched uploads in the legacy draft shape');
         expect(playerServiceTestSource).toContain('validates athlete profile external clip links before saving');


### PR DESCRIPTION
## What changed

- Require every athlete-profile Storage read, create, and delete to resolve an existing `athleteProfiles/{profileId}` document whose `parentUserId` matches the path `userId`.
- Add a transaction-backed, private media reservation for new profile IDs before the first upload.
- Reserve/verify ownership before uploads in both the React/Capacitor player service and the standalone legacy profile builder.
- Remove the transient reservation marker on successful profile save.
- On failed new-profile saves, delete uploaded objects while the ownership document still exists, then remove only the still-marked reservation.
- Hide incomplete reservation documents from saved-profile listings.
- Expand unit, rules-CI, service, and browser regression coverage.

## Why

The Storage path previously trusted only the caller-controlled `userId` segment. A signed-in user could therefore upload an object under their own UID while using another parent's public `profileId`; public read checks looked only at that profile's privacy and exposed the unrelated object. New-profile clients also uploaded before the profile ownership document existed, preventing stricter rules from being applied without changing save order.

## Impact

Athlete profile media is now bound to the owning parent at both the Firestore document and Storage path layers. Legitimate new profiles with headshots or highlight clips continue to work because clients establish a private ownership reservation before uploading. Existing owned-profile upload and cleanup flows remain supported.

## Checks

- `vitest run tests/unit/athlete-profile-storage-rules.test.js tests/unit/app-player-service.test.js tests/unit/athlete-profile-wiring.test.js tests/unit/issue-1998-athlete-profile-upload-source.test.js --reporter=dot` — **33 passed**
- `vitest run apps/app/src/lib/playerService.test.ts --reporter=verbose` — **24 passed**
- `node scripts/validate-firebase-rules-ci.mjs` — **passed**
- `npm --prefix apps/app run build` — **passed**
- Modified app files lint — **0 errors** (existing `no-explicit-any` warnings remain)
- `playwright test tests/smoke/athlete-profile-builder-media-save.spec.js --config=playwright.smoke.config.js --reporter=line` — **2 passed**
- `git diff --check` — **passed**
- Firebase emulator startup was attempted but unavailable because this host has no Java runtime; no emulator-backed rule execution is claimed.

Closes #3441