### PR TITLE
Verify the generated bundle visualizer artifact

### DIFF
--- a/apps/app/build/fixBundleVisualizerTooltip.js
+++ b/apps/app/build/fixBundleVisualizerTooltip.js
@@ -68,6 +68,23 @@ export function fixBundleVisualizerTooltip(html) {
     return patchedHtml;
 }
 
+export function assertBundleVisualizerTooltipPatched(html) {
+    const missingGuards = [];
+    if (!html.includes(FIXED_TOOLTIP_HANDLER)) {
+        missingGuards.push('guarded tooltip hover handler');
+    }
+    if (!html.includes(FIXED_FILTER_THROTTLE)) {
+        missingGuards.push('trailing filter throttle callback');
+    }
+
+    if (missingGuards.length > 0) {
+        throw new Error(
+            `Bundle visualizer output is missing the ${missingGuards.join(' and ')}. ` +
+            'The rollup-plugin-visualizer template may have changed; update the patch before shipping this artifact.'
+        );
+    }
+}
+
 export function patchBundleVisualizerTooltipFile(filePath) {
     const html = readFileSync(filePath, 'utf8');
     const patchedHtml = fixBundleVisualizerTooltip(html);
@@ -75,6 +92,8 @@ export function patchBundleVisualizerTooltipFile(filePath) {
     if (patchedHtml !== html) {
         writeFileSync(filePath, patchedHtml);
     }
+
+    assertBundleVisualizerTooltipPatched(patchedHtml);
 
     return patchedHtml !== html;
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "app:check-bundle-size": "node scripts/check-app-bundle-size.mjs",
     "serve:firebase": "firebase emulators:start --only hosting --project demo-allplays",
     "app:dev": "npm --prefix apps/app run dev",
-    "app:build": "npm --prefix apps/app run build",
+    "app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs",
     "app:preview": "npm --prefix apps/app run preview",
     "mobile:serve": "npm run app:dev",
     "mobile:sync": "npm run app:build && npx cap sync",

--- a/scripts/verify-app-bundle-visualizer.mjs
+++ b/scripts/verify-app-bundle-visualizer.mjs
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { JSDOM, VirtualConsole } from 'jsdom';
+
+import { assertBundleVisualizerTooltipPatched } from '../apps/app/build/fixBundleVisualizerTooltip.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const artifactPath = path.join(repoRoot, 'apps/app/bundle-visualizer.html');
+const artifactHtml = readFileSync(artifactPath, 'utf8');
+
+assertBundleVisualizerTooltipPatched(artifactHtml);
+
+const runtimeErrors = [];
+const virtualConsole = new VirtualConsole();
+virtualConsole.on('error', (...args) => runtimeErrors.push(new Error(args.map(String).join(' '))));
+virtualConsole.on('jsdomError', (error) => runtimeErrors.push(error));
+
+const dom = new JSDOM(artifactHtml, {
+    pretendToBeVisual: true,
+    runScripts: 'dangerously',
+    url: 'http://localhost/',
+    virtualConsole
+});
+
+function wait(milliseconds) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function waitFor(predicate, message, timeoutMs = 2000) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        if (predicate()) return;
+        await wait(20);
+    }
+    throw new Error(message);
+}
+
+try {
+    const { document, Event, MouseEvent } = dom.window;
+    await waitFor(
+        () => document.querySelector('.node') && document.querySelector('.tooltip') && document.querySelector('#module-filter-include'),
+        'Generated bundle visualizer did not render its node, tooltip, and include-filter controls.'
+    );
+
+    const firstNode = document.querySelector('.node');
+    const tooltip = document.querySelector('.tooltip');
+    const includeInput = document.querySelector('#module-filter-include');
+    const initialNodeCount = document.querySelectorAll('.node').length;
+
+    firstNode.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    await wait(0);
+    if (tooltip.classList.contains('tooltip-hidden')) {
+        throw new Error('Generated bundle visualizer did not show its tooltip when a module node was hovered.');
+    }
+
+    tooltip.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    await wait(0);
+    if (tooltip.classList.contains('tooltip-hidden')) {
+        throw new Error('Generated bundle visualizer hid its tooltip while the tooltip itself was hovered.');
+    }
+
+    includeInput.value = '**/react/**';
+    includeInput.dispatchEvent(new Event('input', { bubbles: true }));
+    includeInput.value = '**/react-dom/**';
+    includeInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    await waitFor(
+        () => document.querySelector('svg')?.textContent.includes('react-dom') &&
+            document.querySelectorAll('.node').length < initialNodeCount,
+        'Generated bundle visualizer did not apply the final rapidly typed include-filter value.'
+    );
+
+    if (runtimeErrors.length > 0) {
+        throw runtimeErrors[0];
+    }
+
+    console.log(`Bundle visualizer artifact verified (${initialNodeCount} rendered nodes).`);
+} finally {
+    dom.window.close();
+}

--- a/tests/unit/app-bundle-visualizer-tooltip.test.js
+++ b/tests/unit/app-bundle-visualizer-tooltip.test.js
@@ -4,7 +4,11 @@ import path from 'node:path';
 import { JSDOM } from 'jsdom';
 import { describe, expect, it, vi } from 'vitest';
 
-import { fixBundleVisualizerTooltip, patchBundleVisualizerTooltipFile } from '../../apps/app/build/fixBundleVisualizerTooltip.js';
+import {
+    assertBundleVisualizerTooltipPatched,
+    fixBundleVisualizerTooltip,
+    patchBundleVisualizerTooltipFile
+} from '../../apps/app/build/fixBundleVisualizerTooltip.js';
 
 const brokenTooltipHandler = `          const handleMouseOut = () => {
               setShowTooltip(false);
@@ -182,5 +186,26 @@ ${brokenTooltipHandler}
         const artifactFixtureHtml = readArtifactFixtureHtml();
 
         expect(fixBundleVisualizerTooltip(artifactFixtureHtml)).toBe(artifactFixtureHtml);
+    });
+
+    it('fails loudly when upstream visualizer output no longer contains the expected patch anchors', () => {
+        expect(() => assertBundleVisualizerTooltipPatched('<html><body>new template</body></html>'))
+            .toThrow(/rollup-plugin-visualizer template may have changed/);
+    });
+
+    it('runs the real generated-artifact interaction verifier after every app build', () => {
+        const packageSource = readFileSync(new URL('../../package.json', import.meta.url), 'utf8');
+        const verifierSource = readFileSync(
+            new URL('../../scripts/verify-app-bundle-visualizer.mjs', import.meta.url),
+            'utf8'
+        );
+
+        expect(packageSource).toContain('npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs');
+        expect(verifierSource).toContain("path.join(repoRoot, 'apps/app/bundle-visualizer.html')");
+        expect(verifierSource).toContain("document.querySelector('.node')");
+        expect(verifierSource).toContain("document.querySelector('.tooltip')");
+        expect(verifierSource).toContain("document.querySelector('#module-filter-include')");
+        expect(verifierSource).toContain("includeInput.value = '**/react-dom/**';");
+        expect(verifierSource).toContain("document.querySelector('svg')?.textContent.includes('react-dom')");
     });
 });

--- a/tests/unit/app-performance-measurement-initiative-source-contract.test.js
+++ b/tests/unit/app-performance-measurement-initiative-source-contract.test.js
@@ -41,7 +41,7 @@ describe('app performance measurement initiative source contract', () => {
     });
 
     it('keeps app preview and bundle budget commands available for baseline captures', () => {
-        expect(packageSource).toContain('"app:build": "npm --prefix apps/app run build"');
+        expect(packageSource).toContain('"app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs"');
         expect(packageSource).toContain('"app:preview": "npm --prefix apps/app run preview"');
         expect(packageSource).toContain('"app:check-bundle-size": "node scripts/check-app-bundle-size.mjs"');
         expect(appPackageSource).toContain('"preview": "vite preview --host 0.0.0.0"');


### PR DESCRIPTION
## Summary
- make the visualizer patch fail loudly when upstream generated HTML no longer contains the expected fixed tooltip and throttle handlers
- run a real generated-artifact interaction verifier after every root app build
- exercise node hover, tooltip hover, and rapidly typed include-filter behavior against the current Vite visualizer output
- add source-contract and drift regression coverage

## Validation
- `npm run app:build` — production build passed; real report verified with 632 rendered nodes
- focused visualizer/Vite/build-contract tests — 17 passed
- direct verifier run — passed against the generated report
- `git diff --check`

Closes #3436