### PR TITLE
Verify production auth screen CSS

### DIFF
--- a/tests/smoke/app-production-bootstrap.spec.js
+++ b/tests/smoke/app-production-bootstrap.spec.js
@@ -41,7 +41,10 @@ test('production React app boots from deployed /app bundle', async ({ page }) =>
 
     await expect(page).toHaveTitle(/ALL PLAYS APP/i);
     await expect(page.locator('#root')).not.toBeEmpty();
-    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+    const signInHeading = page.getByRole('heading', { name: 'Sign in' });
+    await expect(signInHeading).toBeVisible();
+    const authCard = page.locator('.app-card').filter({ has: signInHeading });
+    await expect(authCard).toBeVisible();
     const googleButton = page.getByRole('button', { name: 'Continue with Google' });
     await expect(googleButton).toBeVisible();
     await expect(page.locator('input[type="email"]')).toBeVisible();
@@ -68,6 +71,24 @@ test('production React app boots from deployed /app bundle', async ({ page }) =>
             width: style.width
         };
     });
+    const authCardStyles = await authCard.evaluate((element) => {
+        const style = window.getComputedStyle(element);
+        return {
+            backgroundColor: style.backgroundColor,
+            borderRadius: style.borderRadius,
+            borderStyle: style.borderStyle,
+            borderWidth: style.borderWidth,
+            boxShadow: style.boxShadow
+        };
+    });
+    const signInHeadingStyles = await signInHeading.evaluate((element) => {
+        const style = window.getComputedStyle(element);
+        return {
+            color: style.color,
+            fontSize: style.fontSize,
+            fontWeight: style.fontWeight
+        };
+    });
 
     expect(fatalErrors).toEqual([]);
     expect(failedAssets).toEqual([]);
@@ -84,5 +105,17 @@ test('production React app boots from deployed /app bundle', async ({ page }) =>
         backgroundColor: 'rgb(238, 242, 255)',
         height: '44px',
         width: '44px'
+    });
+    expect(authCardStyles).toMatchObject({
+        backgroundColor: 'rgb(255, 255, 255)',
+        borderRadius: '16px',
+        borderStyle: 'solid',
+        borderWidth: '1px',
+        boxShadow: 'rgba(16, 24, 40, 0.07) 0px 10px 24px 0px'
+    });
+    expect(signInHeadingStyles).toMatchObject({
+        color: 'oklch(0.13 0.028 261.692)',
+        fontSize: '24px',
+        fontWeight: '900'
     });
 });

--- a/tests/unit/app-production-css-pipeline.test.js
+++ b/tests/unit/app-production-css-pipeline.test.js
@@ -49,7 +49,12 @@ describe('app production CSS pipeline', () => {
         const css = buildAppCss();
 
         expect(css).toContain('.bg-primary-600');
+        expect(css).toContain('.bg-primary-50');
+        expect(css).toContain('.text-gray-950');
+        expect(css).toContain('.rounded-xl');
         expect(css).not.toContain('@tailwind');
+        expect(css).toContain('-webkit-backdrop-filter:none');
+        expect(css).toContain('backdrop-filter:none');
         expect(css).toContain('.safe-top');
         expect(css).toContain('env(safe-area-inset-top)');
         expect(css).toContain('.safe-bottom');


### PR DESCRIPTION
## Summary

- assert production browser-computed styles for the sign-in card and heading
- verify the auth screen’s exact Tailwind utility selectors are present in the emitted CSS
- verify an Autoprefixer-generated `-webkit-backdrop-filter` rule survives the production pipeline
- retain the existing deployed stylesheet response, button, and icon checks

## Why

Issue #3438 predates the broader CSS coverage merged for #3435 and #3576. Those changes prove that CSS is emitted and generally applied, but the original sign-in contract still lacked direct checks for the `.app-card` surface and heading typography/color, and the emitted-asset test did not cover the auth utilities or a generated vendor prefix.

This closes that remaining, sign-in-specific regression gap without changing production UI behavior.

## User impact

The production smoke now fails if the first auth screen loses its card treatment or Tailwind heading styles even when the React controls still render. The build test also catches removal of the auth utilities or Autoprefixer output.

## Validation

- `npx vitest run tests/unit/app-production-css-pipeline.test.js --reporter=verbose` — 2 passed
- production `/app/#/auth` Playwright smoke — 1 passed
- `npm test -- --reporter=dot` — 593 files / 3,888 tests passed, 9 skipped
- `npm run app:build` — passed
- `node --check` for both changed test files — passed
- `git diff --cached --check` — passed before commit

Closes #3438