### PR TITLE
Escape basketball tracker event logs

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1095,8 +1095,8 @@ function renderLog() {
   els.log.innerHTML = state.log.slice(0, 40).map((ev, idx) => `
     <div class="flex justify-between items-center border rounded-lg p-2 ${ev.undoData?.isOpponent ? 'border-red-200 bg-red-50/40' : 'border-slate/10 bg-white'}">
       <div class="flex-1">
-        <p class="text-xs font-semibold ${ev.undoData?.isOpponent ? 'text-red-700' : 'text-slate-800'}">${ev.text}</p>
-        <p class="text-[10px] text-slate-500">${ev.period} · ${ev.clock}</p>
+        <p class="text-xs font-semibold ${ev.undoData?.isOpponent ? 'text-red-700' : 'text-slate-800'}">${escapeHtml(ev.text)}</p>
+        <p class="text-[10px] text-slate-500">${escapeHtml(ev.period)} · ${escapeHtml(ev.clock)}</p>
       </div>
       <div class="flex items-center gap-2">
         <span class="text-[10px] text-slate-400">${new Date(ev.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -419,8 +419,8 @@ function renderLog() {
   els.log.innerHTML = state.log.slice(0, 40).map((ev, idx) => `
     <div class="flex justify-between items-center border border-slate/10 rounded-lg p-2 bg-white">
       <div class="flex-1">
-        <p class="text-xs font-semibold">${ev.text}</p>
-        <p class="text-[10px] text-slate-500">${ev.period} · ${ev.clock}</p>
+        <p class="text-xs font-semibold">${escapeHtml(ev.text)}</p>
+        <p class="text-[10px] text-slate-500">${escapeHtml(ev.period)} · ${escapeHtml(ev.clock)}</p>
       </div>
       <div class="flex items-center gap-2">
         <span class="text-[10px] text-slate-400">${new Date(ev.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>

--- a/live-tracker.html
+++ b/live-tracker.html
@@ -355,6 +355,6 @@
     </div>
   </div>
 
-  <script type="module" src="js/live-tracker.js"></script>
+  <script type="module" src="js/live-tracker.js?v=1"></script>
 </body>
 </html>

--- a/tests/unit/tracker-log-xss.test.js
+++ b/tests/unit/tracker-log-xss.test.js
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+
+import { escapeHtml } from '../../js/utils.js';
+
+function buildRenderLog(sourcePath, nextFunctionName) {
+    const source = readFileSync(new URL(sourcePath, import.meta.url), 'utf8');
+    const match = source.match(new RegExp(
+        `function renderLog\\(\\) \\{([\\s\\S]*?)\\n\\}\\n\\nfunction ${nextFunctionName}\\(`
+    ));
+    expect(match, `renderLog should exist in ${sourcePath}`).toBeTruthy();
+
+    return new Function('deps', `
+        const { state, els, escapeHtml } = deps;
+        const removeLogEntry = () => {};
+        const safeDecrement = () => 0;
+        const isPointsColumn = () => false;
+        const renderAll = () => {};
+        const scheduleScoreSync = () => {};
+        const scheduleOpponentStatsSync = () => {};
+        const schedulePlayerStatsSync = () => {};
+        const scheduleLiveHasData = () => {};
+        const liveState = { isLive: false };
+        const broadcastEvent = () => {};
+        const baseLiveEvent = value => value;
+        const buildStatEvent = value => value;
+        return function renderLog() {
+${match[1]}
+        };
+    `);
+}
+
+function renderMaliciousLog(sourcePath, nextFunctionName) {
+    const dom = new JSDOM('<div id="log"></div>');
+    const log = dom.window.document.getElementById('log');
+    const state = {
+        log: [{
+            text: 'Opp <img src=x onerror="globalThis.__trackerXss = true"> PTS +2',
+            period: '<svg onload="globalThis.__periodXss = true">',
+            clock: '<script>globalThis.__clockXss = true</script>',
+            ts: 0,
+            undoData: { isOpponent: true }
+        }]
+    };
+    const renderLog = buildRenderLog(sourcePath, nextFunctionName)({ state, els: { log }, escapeHtml });
+
+    renderLog();
+
+    return { dom, log };
+}
+
+describe('basketball tracker event log HTML safety', () => {
+    it.each([
+        ['Beta basketball tracker', '../../js/track-basketball.js', 'saveHistory'],
+        ['Live Broadcast tracker', '../../js/live-tracker.js', 'saveHistory']
+    ])('%s renders opponent event payloads as text', (_label, sourcePath, nextFunctionName) => {
+        const { dom, log } = renderMaliciousLog(sourcePath, nextFunctionName);
+
+        try {
+            expect(log.querySelector('img')).toBeNull();
+            expect(log.querySelector('svg')).toBeNull();
+            expect(log.querySelector('script')).toBeNull();
+            expect(log.textContent).toContain('Opp <img src=x onerror="globalThis.__trackerXss = true"> PTS +2');
+            expect(log.textContent).toContain('<svg onload="globalThis.__periodXss = true">');
+            expect(log.textContent).toContain('<script>globalThis.__clockXss = true</script>');
+            expect(log.innerHTML).toContain('&lt;img');
+            expect(log.innerHTML).toContain('&lt;svg');
+            expect(log.innerHTML).toContain('&lt;script&gt;');
+        } finally {
+            dom.window.close();
+        }
+    });
+
+    it('cache-busts both fixed tracker entry modules', () => {
+        const betaPage = readFileSync(new URL('../../track-basketball.html', import.meta.url), 'utf8');
+        const livePage = readFileSync(new URL('../../live-tracker.html', import.meta.url), 'utf8');
+
+        expect(betaPage).toContain('src="js/track-basketball.js?v=1"');
+        expect(livePage).toContain('src="js/live-tracker.js?v=1"');
+    });
+});

--- a/track-basketball.html
+++ b/track-basketball.html
@@ -271,6 +271,6 @@
     </div>
   </div>
 
-  <script type="module" src="js/track-basketball.js"></script>
+  <script type="module" src="js/track-basketball.js?v=1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- escape event text, period, and clock values before rendering tracker log HTML
- apply the fix to both Beta basketball and Live Broadcast tracker variants
- keep persisted event data as plain text to avoid double encoding; existing report/app consumers escape or use React text rendering
- cache-bust both fixed tracker entry modules
- add executable JSDOM regression coverage for hostile opponent names and log metadata

## Validation
- XSS regression suite — 3 passed
- focused basketball/opponent suites — 17 passed
- syntax checks for both tracker modules
- critical cache-bust guard
- `git diff --check`

Closes #3431