### PR TITLE
Keep definitions-only configs in post-game editing

### DIFF
--- a/game.html
+++ b/game.html
@@ -395,7 +395,7 @@
         import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=20";
         import { db } from './js/firebase.js?v=20';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
-        import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
+        import { resolveLiveStatConfig } from './js/live-game-state.js?v=4';
         import { splitPlayerStatsByVisibility } from './js/stat-leaderboards.js?v=2';
         import { formatGameReportEventTimestamp, resolveReportStatColumns, resolveOpponentReportStatColumns } from './js/game-report-stats.js?v=2';
         import { normalizeStatKey, resolvePostGameStatFields, resolvePostGameTeamStatFields, resolvePostGameEditorDidNotPlay, buildCompletedGamePlayerStatsPayload, buildCompletedGameTeamStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=4';

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -82,7 +82,7 @@ export function resolveLiveStatColumns({ columns = [], configs = [], game = null
   if (Array.isArray(columns) && columns.length) return directColumns;
 
   const config = resolveLiveStatConfig({ configs, game, team });
-  if (config) {
+  if (Array.isArray(config?.columns) && config.columns.length) {
     return normalizeLiveStatColumns(config.columns);
   }
 

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -45,9 +45,7 @@ export function resolveLiveStatConfig({ configs = [], game = null, team = null }
 
   if (configId) {
     const configMatch = safeConfigs.find((config) => String(config?.id || '').trim() === configId);
-    if (Array.isArray(configMatch?.columns) && configMatch.columns.length) {
-      return configMatch;
-    }
+    if (configMatch) return configMatch;
   }
 
   if (desiredSport) {

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -48,6 +48,23 @@ describe('live game state helpers', () => {
     })).toEqual(['GOALS']);
   });
 
+  it('uses goal columns for assigned definitions-only goal sport configs', () => {
+    expect(resolveLiveStatColumns({
+      configs: [
+        {
+          id: 'cfg-manager-only',
+          baseType: 'Soccer',
+          columns: [],
+          statDefinitions: [
+            { id: 'deflections', scope: 'team', visibility: 'private', type: 'base' }
+          ]
+        }
+      ],
+      game: { statTrackerConfigId: 'cfg-manager-only', sport: 'Soccer' },
+      team: { sport: 'Soccer' }
+    })).toEqual(['GOALS']);
+  });
+
   it('keeps basketball stat fallback for unsupported sports without a custom config', () => {
     expect(resolveLiveStatColumns({
       configs: [],

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -65,6 +65,26 @@ describe('live game state helpers', () => {
     })?.id).toBe('cfg-soccer');
   });
 
+  it('returns an explicitly assigned config even when it has definitions but no public columns', () => {
+    const assignedConfig = {
+      id: 'cfg-manager-only',
+      baseType: 'Basketball',
+      columns: [],
+      statDefinitions: [
+        { id: 'deflections', scope: 'team', visibility: 'private', type: 'base' }
+      ]
+    };
+
+    expect(resolveLiveStatConfig({
+      configs: [
+        { id: 'cfg-public', baseType: 'Basketball', columns: ['PTS'] },
+        assignedConfig
+      ],
+      game: { statTrackerConfigId: 'cfg-manager-only', sport: 'Basketball' },
+      team: { sport: 'Basketball' }
+    })).toBe(assignedConfig);
+  });
+
   it('returns the preferred config id for schedule defaults', () => {
     expect(resolvePreferredStatConfigId({
       configs: [

--- a/tests/unit/post-game-stat-editor.test.js
+++ b/tests/unit/post-game-stat-editor.test.js
@@ -9,6 +9,7 @@ import {
     resolvePostGameStatFields,
     resolvePostGameTeamStatFields
 } from '../../js/post-game-stat-editor.js';
+import { resolveLiveStatConfig } from '../../js/live-game-state.js';
 import { hasPlayerProfileParticipation } from '../../js/player-profile-stats.js';
 
 describe('post-game stat editor helpers', () => {
@@ -67,6 +68,32 @@ describe('post-game stat editor helpers', () => {
             { fieldName: 'effort', label: 'Coach Effort' },
             { fieldName: 'fouls', label: 'FOULS' }
         ]);
+    });
+
+    it('keeps manager-only team and player definitions from an assigned columns-free config', () => {
+        const gameHtml = readFileSync(new URL('../../game.html', import.meta.url), 'utf8');
+        const resolvedConfig = resolveLiveStatConfig({
+            configs: [{
+                id: 'cfg-manager-only',
+                baseType: 'Basketball',
+                columns: [],
+                statDefinitions: [
+                    { id: 'deflections', label: 'Deflections', visibility: 'private', scope: 'team', type: 'base' },
+                    { id: 'coachEffort', label: 'Coach Effort', visibility: 'private', scope: 'player', type: 'base' }
+                ]
+            }],
+            game: { statTrackerConfigId: 'cfg-manager-only' },
+            team: { sport: 'Basketball' }
+        });
+
+        expect(resolvePostGameTeamStatFields({ resolvedConfig, teamStats: {} })).toEqual([
+            { fieldName: 'deflections', label: 'Deflections' }
+        ]);
+        expect(resolvePostGameStatFields({ resolvedConfig, statsMap: {} })).toEqual(expect.arrayContaining([
+            { fieldName: 'coacheffort', label: 'Coach Effort' },
+            { fieldName: 'fouls', label: 'FOULS' }
+        ]));
+        expect(gameHtml).toContain("import { resolveLiveStatConfig } from './js/live-game-state.js?v=4';");
     });
 
     it('builds an absolute stat payload and zeroes the row when a player did not play', () => {


### PR DESCRIPTION
## Summary
- return an explicitly assigned stat config by ID even when it has no public columns
- retain existing public-column requirements for sport and single-config heuristic fallbacks
- restore manager-only team and private player definitions in completed-game editing
- cache-bust the game report's stat-config resolver import
- add direct resolver and post-game integration regression coverage

## Validation
- focused live-state/post-game suites — 41 passed
- full unit suite — 593 files, 3,890 passed, 9 skipped
- live-game-state syntax check
- critical cache-bust guard
- `git diff --check`

Closes #3429