### PR TITLE
Collapse team RSVP staff tools

### DIFF
--- a/apps/app/src/components/schedule/AvailabilityPanels.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState, type ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { type ParentScheduleEvent, type RsvpResponse } from '../../lib/scheduleLogic';
 import { rsvpBadgeClasses, rsvpLabels } from './AvailabilityNotesList';
 import { PlayerInitials } from './PlayerInitials';
@@ -67,6 +68,34 @@ export function ReadOnlyAvailabilityPanel({ event, rsvp }: {
           ) : null}
         </div>
       </div>
+    </div>
+  );
+}
+
+export function TeamRsvpToolsDisclosure({ summary, children }: {
+  summary?: ParentScheduleEvent['rsvpSummary'];
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const contentId = useId();
+  const summaryLabel = formatRsvpSummary(summary);
+
+  return (
+    <div className="mt-3">
+      <button
+        type="button"
+        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-left transition hover:border-primary-200 hover:bg-primary-50"
+        aria-expanded={open}
+        aria-controls={contentId}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="min-w-0">
+          <span className="block text-sm font-black text-gray-950">Team RSVP tools</span>
+          <span className="mt-0.5 block text-xs font-semibold text-gray-600">{summaryLabel}</span>
+        </span>
+        <ChevronDown className={`h-4 w-4 flex-none text-gray-500 transition ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
+      </button>
+      {open ? <div id={contentId}>{children}</div> : null}
     </div>
   );
 }

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -2836,9 +2836,14 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     cleanup();
   });
 
-  it('shows only missing-player overrides by default and expands responded sections on demand', async () => {
+  it('hides admin tools by default, then shows missing-player overrides and expands responded sections on demand', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
-      events: [buildEvent({ isTeamAdmin: true, isTeamRsvpReminderManager: true })],
+      events: [buildEvent({
+        isTeamAdmin: true,
+        isTeamRsvpReminderManager: true,
+        availabilityNotesVisible: true,
+        availabilityNotes: [{ displayName: 'Sam Lee', response: 'maybe', note: 'Arriving after warmups' }]
+      })],
       children: []
     });
     scheduleServiceMocks.loadStaffScheduleRsvpBreakdown.mockResolvedValue({
@@ -2859,8 +2864,21 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     renderScheduleEventDetail();
 
     await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Team RSVP tools.*1 going.*1 missing/ })).toBeTruthy();
+    });
+    expect(screen.queryByText('Staff RSVP overrides')).toBeNull();
+    expect(screen.queryByText('Staff RSVP reminder')).toBeNull();
+    expect(screen.queryByText('Arriving after warmups')).toBeNull();
+    expect(screen.queryByTestId('staff-rsvp-row-p4')).toBeNull();
+
+    const teamToolsDisclosure = screen.getByRole('button', { name: /Team RSVP tools.*1 going.*1 missing/ });
+    expect(teamToolsDisclosure.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(teamToolsDisclosure);
+
+    await waitFor(() => {
       expect(screen.getByText('Staff RSVP overrides')).toBeTruthy();
     });
+    expect(screen.getByText('Arriving after warmups')).toBeTruthy();
     expect(screen.getByTestId('staff-rsvp-row-p4')).toBeTruthy();
     expect(screen.queryByTestId('staff-rsvp-row-p1')).toBeNull();
     expect(screen.queryByTestId('staff-rsvp-row-p2')).toBeNull();
@@ -2922,6 +2940,11 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     renderScheduleEventDetail();
 
     await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Team RSVP tools.*1 going.*1 missing/ })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Team RSVP tools.*1 going.*1 missing/ }));
+
+    await waitFor(() => {
       expect(screen.getByText('Staff RSVP overrides')).toBeTruthy();
     });
 
@@ -2959,7 +2982,57 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     });
 
     expect(screen.queryByText('Staff RSVP overrides')).toBeNull();
+    expect(screen.queryByRole('button', { name: /Team RSVP tools/ })).toBeNull();
     expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown).not.toHaveBeenCalled();
+  });
+
+  it('defers reminder-manager tools and reminder loading until the disclosure opens', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamAdmin: false, isTeamRsvpReminderManager: true })],
+      children: []
+    });
+    scheduleServiceMocks.loadStaffRsvpReminderPreview.mockResolvedValue({
+      missingPlayerCount: 1,
+      eligibleEmailCount: 1,
+      players: [{ playerId: 'p4', playerName: 'Devon Lee', parentEmails: ['devon@example.com'] }]
+    });
+
+    renderScheduleEventDetail();
+
+    const disclosure = await screen.findByRole('button', { name: /Team RSVP tools.*1 going.*1 missing/ });
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Staff RSVP reminder')).toBeNull();
+    expect(scheduleServiceMocks.loadStaffRsvpReminderPreview).not.toHaveBeenCalled();
+
+    fireEvent.click(disclosure);
+
+    await waitFor(() => {
+      expect(screen.getByText('Staff RSVP reminder')).toBeTruthy();
+    });
+    expect(scheduleServiceMocks.loadStaffRsvpReminderPreview).toHaveBeenCalledTimes(1);
+    expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown).not.toHaveBeenCalled();
+  });
+
+  it('keeps the quick RSVP and shared notes unchanged for a normal parent without staff tools', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isTeamStaff: false,
+        availabilityNotesVisible: true,
+        availabilityNotes: [{ displayName: 'Sam Lee', response: 'maybe', note: 'Arriving late' }]
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Is Avery Smith going?')).toBeTruthy();
+    });
+
+    expect(screen.getByText('Arriving late')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Team RSVP tools/ })).toBeNull();
+    expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown).not.toHaveBeenCalled();
+    expect(scheduleServiceMocks.loadStaffRsvpReminderPreview).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -62,6 +62,7 @@ import { AvailabilityNotesList } from '../components/schedule/AvailabilityNotesL
 import {
   QuickAvailabilityPanel,
   ReadOnlyAvailabilityPanel,
+  TeamRsvpToolsDisclosure,
   formatRsvpSummary,
   getAvailabilityNoteSaveState,
   rsvpBadgeClasses,
@@ -1021,6 +1022,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
   const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
   const responseLabel = !rsvpWorkflow.canSubmit && rsvp === 'not_responded' ? 'No response' : rsvpLabels[rsvp];
+  const showTeamRsvpTools = event.isDbGame && Boolean(event.isTeamAdmin || event.isTeamRsvpReminderManager);
 
   return (
     <section className="app-card overflow-hidden p-0">
@@ -1052,16 +1054,22 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
         {attentionItems.length > 0 || rsvp !== 'not_responded' ? (
           <AttentionPanel items={attentionItems} onSelectSection={onSelectSection} />
         ) : null}
-        <StaffRsvpBreakdownPanel
-          breakdown={staffRsvp.breakdown}
-          loading={staffRsvp.loading}
-          error={staffRsvp.error}
-          submittingPlayerId={staffRsvp.submittingPlayerId}
-          status={staffRsvp.status}
-          onOverride={staffRsvp.submitOverride}
-        />
-        <StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />
-        <AvailabilityNotesList event={event} />
+        {showTeamRsvpTools ? (
+          <TeamRsvpToolsDisclosure key={event.eventKey} summary={staffRsvp.breakdown?.counts || event.rsvpSummary}>
+            <StaffRsvpBreakdownPanel
+              breakdown={staffRsvp.breakdown}
+              loading={staffRsvp.loading}
+              error={staffRsvp.error}
+              submittingPlayerId={staffRsvp.submittingPlayerId}
+              status={staffRsvp.status}
+              onOverride={staffRsvp.submitOverride}
+            />
+            <StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />
+            <AvailabilityNotesList event={event} />
+          </TeamRsvpToolsDisclosure>
+        ) : (
+          <AvailabilityNotesList event={event} />
+        )}
       </div>
     </section>
   );

--- a/tests/unit/app-schedule-availability-panels.test.tsx
+++ b/tests/unit/app-schedule-availability-panels.test.tsx
@@ -9,6 +9,7 @@ import {
   AvailabilityNotesList,
   QuickAvailabilityPanel,
   ReadOnlyAvailabilityPanel,
+  TeamRsvpToolsDisclosure,
   getAvailabilityNoteSaveState,
   type AttentionItem
 } from '../../apps/app/src/components/schedule/AvailabilityPanels';
@@ -77,6 +78,23 @@ describe('availability schedule panels', () => {
 
     expect(screen.getByText('No response recorded')).toBeTruthy();
     expect(screen.queryByText('RSVP needed')).toBeNull();
+  });
+
+  it('keeps team RSVP tools collapsed until staff opens the disclosure', () => {
+    render(
+      <TeamRsvpToolsDisclosure summary={{ going: 3, maybe: 1, notGoing: 0, notResponded: 2, total: 6 }}>
+        <div>Staff-only RSVP action</div>
+      </TeamRsvpToolsDisclosure>
+    );
+
+    const disclosure = screen.getByRole('button', { name: /Team RSVP tools.*3 going.*2 missing/ });
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('Staff-only RSVP action')).toBeNull();
+
+    fireEvent.click(disclosure);
+
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByText('Staff-only RSVP action')).toBeTruthy();
   });
 
   it('tracks trimmed availability note save state', () => {


### PR DESCRIPTION
## What changed

- Added an accessible, default-collapsed `Team RSVP tools` disclosure with a compact going/maybe/out/missing summary.
- Kept the personal RSVP buttons and optional note in the immediate Availability path.
- Deferred staff override rows, reminder preview/actions, and shared availability notes for team admins and RSVP reminder managers until the disclosure opens.
- Preserved the existing top-level shared notes behavior for ordinary parents and coach-only users without either management capability.
- Added regression coverage for admin, reminder-manager, and normal-parent paths, including proof that reminder preview loading is deferred.

## Why

The Availability section mounted operational team controls directly after the common parent RSVP task. Staff users therefore encountered override, reminder, and shared-note workflows in the first-level path even when they only needed to answer for their own player. The new disclosure keeps those workflows available while making the common RSVP path simpler and preventing reminder effects from mounting until requested.

## Validation

- `npx vitest run tests/unit/app-schedule-availability-panels.test.tsx --reporter=dot` — 7/7 passed.
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx src/components/schedule/StaffRsvpReminderPanel.test.tsx --reporter=dot` from `apps/app` — 101/101 passed.
- `npm test -- --run tests/unit/app-schedule-availability-panels.test.tsx --reporter=verbose` — root unit suite 593 files, 3,889 passed, 9 skipped.
- `npm run app:build` — TypeScript check and Vite production build passed.
- Full app test run: 1,023 passed and 2 unrelated tests failed under full concurrency (`ParentTools` lazy Fees panel timing and `TeamMedia` bulk-delete timing); both affected suites passed together on immediate focused rerun, 47/47.
- `git diff --check` — passed.

Closes #3433
