### PR TITLE
Cover statsheet summary completion paths

### DIFF
--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -637,6 +637,13 @@ async function analyzeStatsheet(page, baseURL) {
     await page.locator('#home-rows tr').nth(1).waitFor();
 }
 
+async function applyStatsheet(page, baseURL) {
+    await analyzeStatsheet(page, baseURL);
+    await page.locator('#apply-btn').click();
+    await expect(page.locator('#apply-status')).toHaveText('Stats saved! Now you can add a game summary.');
+    await expect(page.locator('#summary-section')).not.toHaveClass(/hidden/);
+}
+
 test.beforeEach(async ({ page }) => {
     await installModuleMocks(page);
 });
@@ -732,6 +739,34 @@ test('applies matched rows while unmatched home rows stay available for review',
         statsheet_2: { name: 'Kai North', number: '11', pts: 9, fouls: 2 }
     });
 
+});
+
+test('saves the post-apply game summary before opening the game report', async ({ page, baseURL }) => {
+    await seedScenario(page, baseURL, createScenario());
+    await applyStatsheet(page, baseURL);
+
+    const summary = 'Comets rallied in the fourth quarter behind disciplined defense.';
+    await page.locator('#summary-notes').fill(summary);
+    await page.locator('#save-continue-btn').click();
+
+    await expect(page.locator('#summary-status')).toHaveText('Summary saved!');
+    await expect.poll(async () => {
+        const store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+        return store.updateCalls || [];
+    }).toEqual([{ summary }]);
+    await expect(page).toHaveURL(/\/game\.html#teamId=team-1&gameId=game-1$/);
+});
+
+test('skips an empty post-apply summary without a second game update', async ({ page, baseURL }) => {
+    await seedScenario(page, baseURL, createScenario());
+    await applyStatsheet(page, baseURL);
+
+    await expect(page.locator('#summary-notes')).toHaveValue('');
+    await page.locator('#skip-summary-btn').click();
+
+    await expect(page).toHaveURL(/\/game\.html#teamId=team-1&gameId=game-1$/);
+    const store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(store.updateCalls || []).toEqual([]);
 });
 
 test('prevents apply when analysis finds no uniquely matched home rows', async ({ page, baseURL }) => {


### PR DESCRIPTION
## Summary

- add a reusable smoke helper that completes statsheet analysis/apply and waits for the summary step
- cover saving a typed game summary through the mocked dynamic `updateGame` import
- assert the success status, exact `{ summary }` patch, and final game-report redirect
- cover skipping an empty summary with no second game update and the same redirect

## Why

The Track Statsheet smoke stopped after the initial stats commit revealed the optional summary panel. It did not exercise either completion branch, so regressions could drop the summary, perform an unexpected second update, or leave a coach on the import page after stats were already saved.

## User impact

The browser regression now protects both valid coach choices after applying a statsheet: save a game summary or continue without one.

## Validation

- `SMOKE_BASE_URL=http://127.0.0.1:4177 npx playwright test tests/smoke/track-statsheet-apply.spec.js --config=playwright.smoke.config.js --reporter=line` — 7 passed
- `npx vitest run tests/unit/track-statsheet-apply.test.js tests/unit/track-statsheet-summary-save.test.js --reporter=verbose` — 10 passed
- full root unit run — 592/593 files and 3,887/3,888 tests passed; one unrelated team-email-template timing assertion failed
- isolated rerun of that unrelated file — 1 file / 6 tests passed
- `node --check tests/smoke/track-statsheet-apply.spec.js` — passed
- `git diff --cached --check` — passed before commit
- focused smoke rerun after rebasing onto current `master` — 7 passed

Closes #3430