### PR TITLE
Reject unsupported Team Media video links

### DIFF
--- a/apps/app/src/lib/adapters/legacyParentTools.ts
+++ b/apps/app/src/lib/adapters/legacyParentTools.ts
@@ -7,7 +7,7 @@ import { formatParentFeeAmount as legacy_formatParentFeeAmount, formatParentFeeD
 import * as legacyStripeService from '@legacy/stripe-service.js';
 import { buildPendingRegistrationRecord as legacy_buildPendingRegistrationRecord, calculateRegistrationFeeSnapshot as legacy_calculateRegistrationFeeSnapshot, decideRegistrationPlacement as legacy_decideRegistrationPlacement, getActiveRegistrationOptions as legacy_getActiveRegistrationOptions, getPaymentPlanChoices as legacy_getPaymentPlanChoices, getRegistrationPaymentNotice as legacy_getRegistrationPaymentNotice, hasOnlineRegistrationCheckout as legacy_hasOnlineRegistrationCheckout, normalizeRegistrationForm as legacy_normalizeRegistrationForm, requiresRegistrationOption as legacy_requiresRegistrationOption } from '@legacy/registration-flow.js';
 import { getRegistrationGuardianDrafts as legacy_getRegistrationGuardianDrafts, getRegistrationPlayerDraft as legacy_getRegistrationPlayerDraft, getRegistrationSubmittedData as legacy_getRegistrationSubmittedData, normalizeRegistrationStatus as legacy_normalizeRegistrationStatus } from '@legacy/registration-review.js';
-import { canContributeTeamMedia as legacy_canContributeTeamMedia, canManageTeamMedia as legacy_canManageTeamMedia, canReadTeamMediaAlbum as legacy_canReadTeamMediaAlbum, getTeamMediaItemUrl as legacy_getTeamMediaItemUrl, isSafeTeamMediaUrl as legacy_isSafeTeamMediaUrl, sortByMediaOrder as legacy_sortByMediaOrder } from '@legacy/team-media-utils.js';
+import { canContributeTeamMedia as legacy_canContributeTeamMedia, canManageTeamMedia as legacy_canManageTeamMedia, canReadTeamMediaAlbum as legacy_canReadTeamMediaAlbum, getTeamMediaItemUrl as legacy_getTeamMediaItemUrl, isSafeTeamMediaUrl as legacy_isSafeTeamMediaUrl, normalizeTeamMediaVideoDraft as legacy_normalizeTeamMediaVideoDraft, sortByMediaOrder as legacy_sortByMediaOrder } from '@legacy/team-media-utils.js';
 
 function callLegacyDb(name: string, args: any[]) {
   const fn = (legacyDb as Record<string, any>)[name];
@@ -64,6 +64,7 @@ export const uploadTeamMediaFile = (...args: any[]) => callLegacyDb('uploadTeamM
 export const uploadTeamMediaPhoto = (...args: any[]) => callLegacyDb('uploadTeamMediaPhoto', args);
 export const deleteTeamMediaItem = (...args: any[]) => callLegacyDb('deleteTeamMediaItem', args);
 export const updateTeamMediaItem = (...args: any[]) => callLegacyDb('updateTeamMediaItem', args);
+export const normalizeTeamMediaVideoDraft = legacy_normalizeTeamMediaVideoDraft as (...args: any[]) => any;
 export const moveTeamMediaItems = (...args: any[]) => callLegacyDb('moveTeamMediaItems', args);
 export const setTeamMediaAlbumCover = (...args: any[]) => callLegacyDb('setTeamMediaAlbumCover', args);
 export const addPendingFamilyMember = legacy_addPendingFamilyMember as (...args: any[]) => any;

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -47,6 +47,7 @@ import {
   listTeamRegistrationReviews,
   listTeamRegistrationReviewsPage,
   moveTeamMediaItems,
+  normalizeTeamMediaVideoDraft,
   normalizeParentFeeRecord,
   normalizeRegistrationForm,
   normalizeRegistrationStatus,
@@ -905,7 +906,11 @@ export async function createTeamMediaAlbumForApp(teamId: string, draft: { name: 
 }
 
 export async function addParentTeamMediaLink(teamId: string, folderId: string, title: string, url: string) {
-  return createTeamMediaLink(teamId, folderId, { title, url });
+  const normalized = normalizeTeamMediaVideoDraft({ title, url });
+  return createTeamMediaLink(teamId, folderId, {
+    title: normalized.title,
+    url: normalized.url
+  });
 }
 
 function normalizeAccessTeams(teams: any[]): ParentAccessTeam[] {

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -691,7 +691,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="text-sm font-black text-gray-950">Add to {activeFolder.name || 'album'}</div>
-              <div className="mt-0.5 text-xs font-semibold text-gray-500">Photos upload directly. Video and website links can be added by URL.</div>
+              <div className="mt-0.5 text-xs font-semibold text-gray-500">Photos upload directly. Video links require a public YouTube or Vimeo URL.</div>
             </div>
             {uploading ? <Loader2 className="h-5 w-5 animate-spin text-primary-600" aria-hidden="true" /> : <Upload className="h-5 w-5 text-primary-600" aria-hidden="true" />}
           </div>
@@ -729,7 +729,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             </div>
           ) : null}
           <form className="mt-3 grid gap-2 sm:grid-cols-[1fr_1fr_auto]" onSubmit={addLink}>
-            <input className="auth-input" value={linkTitle} onChange={(event) => setLinkTitle(event.target.value)} placeholder="Video or link title" />
+            <input className="auth-input" value={linkTitle} onChange={(event) => setLinkTitle(event.target.value)} placeholder="Video title" />
             <input className="auth-input" value={linkUrl} onChange={(event) => setLinkUrl(event.target.value)} placeholder="https://..." inputMode="url" />
             <button type="submit" className="primary-button justify-center" disabled={Boolean(uploading) || creatingAlbum || !linkTitle.trim() || !linkUrl.trim()}>
               {uploading === 'link' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Plus className="h-4 w-4" aria-hidden="true" />}

--- a/js/db.js
+++ b/js/db.js
@@ -202,7 +202,7 @@ import {
     loadVolunteerScreeningTargetRegistrations
 } from './volunteer-screening-access.js?v=2';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
-import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
+import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeTeamMediaVideoDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
 import { getApp } from './vendor/firebase-app.js';
 import {
     computeOfficiatingCoverageStatus,
@@ -1305,16 +1305,13 @@ export async function deleteTeamMediaFolder(teamId, folderId) {
 
 export async function createTeamMediaLink(teamId, folderId, media = {}) {
     const cleanFolderId = String(folderId || '').trim();
-    const title = String(media.title || '').trim();
-    const url = String(media.url || '').trim();
     if (!teamId || !cleanFolderId) throw new Error('Choose a folder for this media link.');
-    if (!title || !url) throw new Error('Media title and URL are required.');
-    if (!isSafeTeamMediaUrl(url)) throw new Error('Use a valid http or https media link.');
+    const normalized = normalizeTeamMediaVideoDraft(media);
     const order = await reserveNextTeamMediaOrder(teamId, cleanFolderId);
     const docRef = await addDoc(getTeamMediaItemsRef(teamId), {
         folderId: cleanFolderId,
-        title,
-        url,
+        title: normalized.title,
+        url: normalized.url,
         type: 'video-link',
         order,
         deleted: false,

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem
-} from './db.js?v=84';
+} from './db.js?v=85';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,
@@ -29,6 +29,7 @@ import {
     isSupportedTeamMediaDocument,
     isSupportedTeamMediaImage,
     isTeamMediaDocument,
+    normalizeTeamMediaVideoDraft,
     sortByMediaOrder
 } from './team-media-utils.js?v=4';
 
@@ -701,9 +702,13 @@ els.folderForm.addEventListener('submit', (event) => {
 els.linkForm.addEventListener('submit', (event) => {
     event.preventDefault();
     persistAndReload(async () => {
-        await createTeamMediaLink(state.teamId, els.linkFolder.value, {
+        const normalized = normalizeTeamMediaVideoDraft({
             title: els.linkTitle.value,
             url: els.linkUrl.value
+        });
+        await createTeamMediaLink(state.teamId, els.linkFolder.value, {
+            title: normalized.title,
+            url: normalized.url
         });
         state.selectedFolderId = els.linkFolder.value;
         els.linkTitle.value = '';

--- a/team-media.html
+++ b/team-media.html
@@ -66,7 +66,7 @@
                 <form id="link-form" class="space-y-3">
                     <div>
                         <h2 class="font-semibold text-gray-900">Video links</h2>
-                        <p id="link-form-help" class="text-xs text-gray-500">Choose a folder, then save the video link.</p>
+                        <p id="link-form-help" class="text-xs text-gray-500">Use a public YouTube or Vimeo URL.</p>
                     </div>
                     <label for="link-folder" class="sr-only">Folder</label>
                     <select id="link-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=11"></script>
+    <script type="module" src="js/team-media.js?v=12"></script>
 </body>
 </html>

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -485,6 +485,11 @@ async function mockParentToolsModules(page) {
                     return 'file-1';
                 }
                 export async function addParentTeamMediaLink(teamId, folderId, title, url) {
+                    const parsed = new URL(String(url || '').trim());
+                    const host = parsed.hostname.toLowerCase();
+                    if (!['youtube.com', 'youtu.be', 'vimeo.com'].some((allowed) => host === allowed || host.endsWith('.' + allowed))) {
+                        throw new Error('Enter a valid YouTube or Vimeo URL.');
+                    }
                     window.__mediaLinks.push({ teamId, folderId, title, url });
                     return 'link-1';
                 }
@@ -834,10 +839,17 @@ test('team media route supports photo upload, file upload, link add, and media o
     });
     await expect.poll(() => page.evaluate(() => window.__mediaUploads.at(-1))).toEqual({ type: 'file', teamId: 'team-1', folderId: 'folder-1', name: 'packet.pdf' });
 
-    await page.getByPlaceholder('Video or link title').fill('Replay');
-    await page.getByPlaceholder('https://...').fill('https://video.example.test/replay');
+    await page.getByPlaceholder('Video title').fill('Replay');
+    await page.getByPlaceholder('https://...').fill('https://example.com/not-a-video');
     await page.getByRole('button', { name: /Add link/ }).click();
-    await expect.poll(() => page.evaluate(() => window.__mediaLinks.at(-1))).toEqual({ teamId: 'team-1', folderId: 'folder-1', title: 'Replay', url: 'https://video.example.test/replay' });
+    await expect(page.getByText('Enter a valid YouTube or Vimeo URL.')).toBeVisible();
+    await expect(page.getByPlaceholder('Video title')).toHaveValue('Replay');
+    await expect(page.getByPlaceholder('https://...')).toHaveValue('https://example.com/not-a-video');
+    expect(await page.evaluate(() => window.__mediaLinks)).toEqual([]);
+
+    await page.getByPlaceholder('https://...').fill('https://youtu.be/replay123');
+    await page.getByRole('button', { name: /Add link/ }).click();
+    await expect.poll(() => page.evaluate(() => window.__mediaLinks.at(-1))).toEqual({ teamId: 'team-1', folderId: 'folder-1', title: 'Replay', url: 'https://youtu.be/replay123' });
 
     await page.getByRole('button', { name: 'Open Tipoff' }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://img.example.test/tipoff.jpg');

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -514,6 +514,21 @@ export function isTeamMediaDocument() {
 export function isSafeTeamMediaUrl() {
     return true;
 }
+export function normalizeTeamMediaVideoDraft(draft = {}) {
+    const title = String(draft.title || '').trim();
+    if (!title) throw new Error('Video title is required.');
+    let url;
+    try {
+        url = new URL(String(draft.url || '').trim());
+    } catch {
+        throw new Error('Enter a valid YouTube or Vimeo URL.');
+    }
+    const host = url.hostname.toLowerCase();
+    if (!['youtube.com', 'youtu.be', 'vimeo.com'].some((allowed) => host === allowed || host.endsWith('.' + allowed))) {
+        throw new Error('Enter a valid YouTube or Vimeo URL.');
+    }
+    return { title, url: url.toString(), type: 'video_link' };
+}
 export function isSupportedTeamMediaImage() {
     return true;
 }
@@ -552,6 +567,21 @@ export function isTeamMediaDocument() {
 }
 export function isSafeTeamMediaUrl() {
     return true;
+}
+export function normalizeTeamMediaVideoDraft(draft = {}) {
+    const title = String(draft.title || '').trim();
+    if (!title) throw new Error('Video title is required.');
+    let url;
+    try {
+        url = new URL(String(draft.url || '').trim());
+    } catch {
+        throw new Error('Enter a valid YouTube or Vimeo URL.');
+    }
+    const host = url.hostname.toLowerCase();
+    if (!['youtube.com', 'youtu.be', 'vimeo.com'].some((allowed) => host === allowed || host.endsWith('.' + allowed))) {
+        throw new Error('Enter a valid YouTube or Vimeo URL.');
+    }
+    return { title, url: url.toString(), type: 'video_link' };
 }
 export function isSupportedTeamMediaImage() {
     return true;
@@ -1076,14 +1106,24 @@ test('team media staff uploads photos and files and saves video links to the sel
 
     await page.locator('#link-folder').selectOption('folder-1');
     await page.locator('#link-title').fill('Replay');
-    await page.locator('#link-url').fill('https://example.test/replay');
+    await page.locator('#link-url').fill('https://example.com/not-a-video');
+    await page.locator('#link-submit').click();
+    await expect(page.locator('#team-media-alert')).toContainText('Enter a valid YouTube or Vimeo URL.');
+    await expect(page.locator('#link-title')).toHaveValue('Replay');
+    await expect(page.locator('#link-url')).toHaveValue('https://example.com/not-a-video');
+    await expect.poll(() => page.evaluate(() => window.__TEAM_MEDIA_CALLS__)).toEqual([
+        { type: 'photo', teamId: 'team-1', folderId: 'folder-1', fileName: 'photo.jpg' },
+        { type: 'file', teamId: 'team-1', folderId: 'folder-1', fileName: 'packet.pdf' }
+    ]);
+
+    await page.locator('#link-url').fill('https://youtu.be/replay123');
     await page.locator('#link-submit').click();
     await expect(page.locator('#team-media-alert')).toContainText('Video link saved.');
 
     await expect.poll(() => page.evaluate(() => window.__TEAM_MEDIA_CALLS__)).toEqual([
         { type: 'photo', teamId: 'team-1', folderId: 'folder-1', fileName: 'photo.jpg' },
         { type: 'file', teamId: 'team-1', folderId: 'folder-1', fileName: 'packet.pdf' },
-        { type: 'link', teamId: 'team-1', folderId: 'folder-1', title: 'Replay', url: 'https://example.test/replay' }
+        { type: 'link', teamId: 'team-1', folderId: 'folder-1', title: 'Replay', url: 'https://youtu.be/replay123' }
     ]);
     expect(pageErrors).toEqual([]);
 });

--- a/tests/unit/app-parent-tools-household-service.test.js
+++ b/tests/unit/app-parent-tools-household-service.test.js
@@ -68,6 +68,7 @@ vi.mock('../../js/team-media-utils.js', () => ({
     canReadTeamMediaAlbum: vi.fn(() => true),
     getTeamMediaItemUrl: vi.fn(() => ''),
     isSafeTeamMediaUrl: vi.fn(() => true),
+    normalizeTeamMediaVideoDraft: vi.fn((draft) => draft),
     sortByMediaOrder: vi.fn((items) => items)
 }));
 vi.mock('../../apps/app/src/lib/authService.ts', () => ({

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -1003,9 +1003,9 @@ describe('React app parent tools integration', () => {
 
         const inputs = Array.from(container.querySelectorAll('input.auth-input'));
         await changeValue(inputs.find((input) => input.placeholder.includes('title')), 'Replay');
-        await changeValue(inputs.find((input) => input.placeholder.includes('https://')), 'https://video.example.test/replay');
+        await changeValue(inputs.find((input) => input.placeholder.includes('https://')), 'https://youtu.be/replay123');
         await submitForm(container, 'Add link');
-        expect(serviceMocks.addParentTeamMediaLink).toHaveBeenCalledWith('team-1', 'folder-1', 'Replay', 'https://video.example.test/replay');
+        expect(serviceMocks.addParentTeamMediaLink).toHaveBeenCalledWith('team-1', 'folder-1', 'Replay', 'https://youtu.be/replay123');
 
         expect(container.textContent).toContain('Tipoff');
         expect(container.textContent).toContain('Open');

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -144,6 +144,21 @@ const mediaMocks = vi.hoisted(() => ({
     canReadTeamMediaAlbum: vi.fn((folder) => folder.visibility !== 'private'),
     getTeamMediaItemUrl: vi.fn((item) => item.url || item.downloadUrl || ''),
     isSafeTeamMediaUrl: vi.fn((url) => String(url).startsWith('https://')),
+    normalizeTeamMediaVideoDraft: vi.fn((draft = {}) => {
+        const title = String(draft.title || '').trim();
+        if (!title) throw new Error('Video title is required.');
+        let url;
+        try {
+            url = new URL(String(draft.url || '').trim());
+        } catch {
+            throw new Error('Enter a valid YouTube or Vimeo URL.');
+        }
+        const host = url.hostname.toLowerCase();
+        if (!['youtube.com', 'youtu.be', 'vimeo.com'].some((allowed) => host === allowed || host.endsWith(`.${allowed}`))) {
+            throw new Error('Enter a valid YouTube or Vimeo URL.');
+        }
+        return { title, url: url.toString(), type: 'video_link' };
+    }),
     sortByMediaOrder: vi.fn((items) => [...items].sort((a, b) => Number(a.order || 0) - Number(b.order || 0)))
 }));
 
@@ -1021,12 +1036,23 @@ describe('React app parent tools service', () => {
         await expect(createTeamMediaAlbumForApp('team-1', { name: '  Spring photos  ', visibility: 'private' })).resolves.toBe('folder-new');
         await uploadParentTeamMediaPhoto('team-1', 'folder-1', photoFile);
         await uploadParentTeamMediaFile('team-1', 'folder-1', docFile);
-        await addParentTeamMediaLink('team-1', 'folder-1', 'Replay', 'https://video.example.test/replay');
+        await addParentTeamMediaLink('team-1', 'folder-1', '  Replay  ', ' https://youtu.be/replay123 ');
         expect(dbMocks.canAccessTeamChat).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-1' }), { id: 'team-1', name: 'Bears' });
         expect(dbMocks.createTeamMediaFolder).toHaveBeenCalledWith('team-1', { name: 'Spring photos', visibility: 'private' });
         expect(dbMocks.uploadTeamMediaPhoto).toHaveBeenCalledWith('team-1', 'folder-1', photoFile, { returnItem: true });
         expect(dbMocks.uploadTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', docFile, { returnItem: true });
-        expect(dbMocks.createTeamMediaLink).toHaveBeenCalledWith('team-1', 'folder-1', { title: 'Replay', url: 'https://video.example.test/replay' });
+        expect(dbMocks.createTeamMediaLink).toHaveBeenCalledWith('team-1', 'folder-1', { title: 'Replay', url: 'https://youtu.be/replay123' });
+    });
+
+    it('rejects unsupported team media link hosts before calling the database helper', async () => {
+        await expect(addParentTeamMediaLink(
+            'team-1',
+            'folder-1',
+            'Not a video',
+            'https://example.com/not-a-video'
+        )).rejects.toThrow('Enter a valid YouTube or Vimeo URL.');
+
+        expect(dbMocks.createTeamMediaLink).not.toHaveBeenCalled();
     });
 
     it('returns normalized team media upload items so the app can merge them without rereading the album', async () => {

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -44,6 +44,21 @@ const teamMediaUtilsMocks = vi.hoisted(() => ({
         name: String(draft.name || '').trim(),
         visibility: String(draft.visibility || 'team').trim() || 'team'
     })),
+    normalizeTeamMediaVideoDraft: vi.fn((draft = {}) => {
+        const title = String(draft.title || '').trim();
+        if (!title) throw new Error('Video title is required.');
+        let url;
+        try {
+            url = new URL(String(draft.url || '').trim());
+        } catch {
+            throw new Error('Enter a valid YouTube or Vimeo URL.');
+        }
+        const host = url.hostname.toLowerCase();
+        if (!['youtube.com', 'youtu.be', 'vimeo.com'].some((allowed) => host === allowed || host.endsWith(`.${allowed}`))) {
+            throw new Error('Enter a valid YouTube or Vimeo URL.');
+        }
+        return { title, url: url.toString(), type: 'video_link' };
+    }),
     normalizeAlbumVisibility: vi.fn((value) => value),
     sortByMediaOrder: vi.fn((items) => items)
 }));
@@ -170,7 +185,7 @@ describe('team media db ordering', () => {
 
         const linkId = await createTeamMediaLink('team-1', 'folder-1', {
             title: 'Replay',
-            url: 'https://video.example.test/replay'
+            url: 'https://youtu.be/replay123'
         });
         const filePromise = uploadTeamMediaFile('team-1', 'folder-1', file);
         uploadTaskQueue.splice(0).forEach((complete) => complete());
@@ -191,6 +206,18 @@ describe('team media db ordering', () => {
         }));
         expect(firebaseMocks.addDoc.mock.calls[1][1]).not.toHaveProperty('downloadUrl');
         expect(firebaseMocks.getDownloadURL).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsupported video-link hosts before reserving order or writing an item', async () => {
+        const { createTeamMediaLink } = await import('../../js/db.js');
+
+        await expect(createTeamMediaLink('team-1', 'folder-1', {
+            title: 'Not a video',
+            url: 'https://example.com/not-a-video'
+        })).rejects.toThrow('Enter a valid YouTube or Vimeo URL.');
+
+        expect(firebaseMocks.runTransaction).not.toHaveBeenCalled();
+        expect(firebaseMocks.addDoc).not.toHaveBeenCalled();
     });
 
     it('returns the created media item for app callers that opt into the richer upload payload', async () => {

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => {
+vi.mock('../../js/db.js?v=85', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-legacy-upload-forms.test.js
+++ b/tests/unit/team-media-legacy-upload-forms.test.js
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => ({
+vi.mock('../../js/db.js?v=85', () => ({
     getTeam: mocks.getTeam,
     getTeamMediaFolders: mocks.getTeamMediaFolders,
     getTeamMediaItemsPage: mocks.getTeamMediaItemsPage,

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -24,7 +24,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=11"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=12"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
@@ -36,7 +36,8 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toContain("from './db.js?v=84'");
+        expect(pageJs).toContain("from './db.js?v=85'");
+        expect(pageJs).toContain('normalizeTeamMediaVideoDraft');
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -94,6 +94,14 @@ describe('team media video albums', () => {
             url: 'https://youtu.be/abc123',
             type: 'video_link'
         });
+        expect(() => normalizeTeamMediaVideoDraft({
+            title: 'Unsupported',
+            url: 'https://example.com/not-a-video'
+        })).toThrow('Enter a valid YouTube or Vimeo URL.');
+        expect(() => normalizeTeamMediaVideoDraft({
+            title: '   ',
+            url: 'https://youtu.be/abc123'
+        })).toThrow('Video title is required.');
     });
 
     it('hides private albums from parents', () => {

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -28,11 +28,12 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=11"');
+        expect(page).toContain('src="js/team-media.js?v=12"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=84'");
+        expect(source).toContain("from './db.js?v=85'");
+        expect(source).toContain('normalizeTeamMediaVideoDraft');
         expect(source).toContain("import { checkAuth } from './auth.js?v=42';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
@@ -50,7 +51,7 @@ describe('team media page wiring', () => {
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
         const dbImportVersion = source.match(/from '\.\/db\.js\?v=(\d+)'/)?.[1];
 
-        expect(dbImportVersion).toBe('84');
+        expect(dbImportVersion).toBe('85');
 
         for (const testFile of [
             'tests/unit/team-media-item-rename.test.js',


### PR DESCRIPTION
## Summary

- validate Team Media video-link drafts with the existing YouTube/Vimeo normalizer in both legacy and React entry points
- enforce the same validation again at the Firestore persistence boundary before reserving order or writing a document
- preserve invalid drafts and show the existing exact error: `Enter a valid YouTube or Vimeo URL.`
- clarify the UI copy and add regression coverage for unsupported hosts plus supported YouTube links

## Root cause

The legacy submit path and `createTeamMediaLink` passed raw HTTP(S) URLs through generic safe-URL validation. That allowed hosts the product cannot render as video items. The stricter shared validator already existed but was not connected to either UI flow or the database boundary.

## Impact

New video items can only be created from YouTube or Vimeo URLs. Existing saved records remain readable and unchanged. Rejected submissions do not reserve an item order or perform a Firestore write.

## Validation

- `npm test -- --reporter=dot` — 593 files passed; 3,890 tests passed; 9 skipped
- focused Team Media unit suite — 8 files and 115 tests passed
- `npm --prefix apps/app run build` — passed
- legacy Team Media smoke suite — 10 tests passed
- React Team Media smoke scenario — 1 test passed
- focused ESLint — 0 errors (existing warnings remain)
- `git diff --check` — passed

Closes #3432