### PR TITLE
Clear stale Google invite codes

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -290,6 +290,7 @@ async function processGoogleAuthResult(result, activationCode = null) {
         clearPendingActivationCode();
         console.log('[Google Auth] New user setup complete');
     } else {
+        clearPendingActivationCode();
         console.log('[Google Auth] Existing user - no setup needed');
     }
 

--- a/login.html
+++ b/login.html
@@ -97,7 +97,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=44';
+        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=45';
         import { getUserProfile } from './js/db.js?v=85';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -51,7 +51,7 @@ describe('admin invite signup cache busting', () => {
 
     it('bumps auth module consumers after signup flow changes', () => {
         const authConsumers = {
-            'login.html': 'auth.js?v=44',
+            'login.html': 'auth.js?v=45',
             'accept-invite.html': 'auth.js?v=44',
             'edit-team.html': 'auth.js?v=44',
             'js/admin.js': 'auth.js?v=44',

--- a/tests/unit/auth-google-popup-fallback.test.js
+++ b/tests/unit/auth-google-popup-fallback.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const signInWithPopupMock = vi.fn();
 const signInWithRedirectMock = vi.fn();
+const getRedirectResultMock = vi.fn();
 
 vi.mock('../../js/firebase.js?v=20', () => ({
     auth: { currentUser: null },
@@ -12,7 +13,7 @@ vi.mock('../../js/firebase.js?v=20', () => ({
     GoogleAuthProvider: class MockGoogleAuthProvider {},
     signInWithPopup: signInWithPopupMock,
     signInWithRedirect: signInWithRedirectMock,
-    getRedirectResult: vi.fn(),
+    getRedirectResult: getRedirectResultMock,
     sendPasswordResetEmail: vi.fn(),
     sendEmailVerification: vi.fn(),
     sendSignInLinkToEmail: vi.fn(),
@@ -114,6 +115,50 @@ describe('loginWithGoogle popup fallback handling', () => {
         });
 
         expect(signInWithRedirectMock).not.toHaveBeenCalled();
+        expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
+    });
+
+    it('clears an invite code after successful popup sign-in for an existing user', async () => {
+        signInWithPopupMock.mockResolvedValue({
+            user: {
+                uid: 'existing-user',
+                email: 'existing@example.com',
+                metadata: {
+                    creationTime: '2026-01-01T00:00:00.000Z',
+                    lastSignInTime: '2026-07-09T20:00:00.000Z'
+                }
+            }
+        });
+
+        const { loginWithGoogle } = await import('../../js/auth.js');
+
+        await expect(loginWithGoogle('INVITE123')).resolves.toMatchObject({
+            user: { uid: 'existing-user' }
+        });
+
+        expect(sessionStorageMock.setItem).toHaveBeenCalledWith('pendingActivationCode', 'INVITE123');
+        expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
+    });
+
+    it('clears a stored invite code after successful redirect sign-in for an existing user', async () => {
+        sessionStorageMock.getItem.mockReturnValue('STALE123');
+        getRedirectResultMock.mockResolvedValue({
+            user: {
+                uid: 'existing-redirect-user',
+                email: 'redirect@example.com',
+                metadata: {
+                    creationTime: '2026-01-01T00:00:00.000Z',
+                    lastSignInTime: '2026-07-09T20:00:00.000Z'
+                }
+            }
+        });
+
+        const { handleGoogleRedirectResult } = await import('../../js/auth.js');
+
+        await expect(handleGoogleRedirectResult()).resolves.toMatchObject({
+            user: { uid: 'existing-redirect-user' }
+        });
+
         expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
     });
 });


### PR DESCRIPTION
## Summary
- clear pendingActivationCode after successful Google authentication for existing users
- preserve the code only for the blocked-popup redirect handoff where the immediate redirect result still needs it
- cover both popup and redirect existing-user completions
- cache-bust the login page's auth module
- retain all existing invite redemption, cancellation, and failure cleanup behavior

## Validation
- focused auth/invite unit suites — 50 passed
- login invite redirect smoke — 6 passed
- auth syntax check
- critical cache-bust guard
- `git diff --check`

Closes #3379