### PR TITLE
Lock the single-game tournament mapping contract

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -95,17 +95,35 @@ beforeEach(() => {
 });
 
 describe('legacyScheduleDb tournament mapping', () => {
-    it('maps the supported single-game tournament adapter entry point to one legacy-compatible game document', () => {
-        const basePayload = buildValidLegacyGamePayload();
-        const tournament = validTournamentMetadata;
-
-        const document = buildSingleLegacyTournamentGameDocument([basePayload], tournament);
-
-        expect(document).toEqual(expect.objectContaining({
+    it('deterministically maps one validated completed row to the exact legacy document without save side effects', () => {
+        const basePayload = buildValidLegacyGamePayload({
+            title: null,
+            opponentTeamId: null,
+            opponentTeamName: null,
+            opponentTeamPhoto: null
+        });
+        const tournament = { ...validTournamentMetadata };
+        const expectedDocument = {
             ...basePayload,
             competitionType: 'tournament',
-            tournament
+            tournament: { ...tournament }
+        };
+
+        const firstDocument = buildSingleLegacyTournamentGameDocument([basePayload], tournament);
+        const secondDocument = buildSingleLegacyTournamentGameDocument([basePayload], tournament);
+
+        expect(firstDocument).toStrictEqual(expectedDocument);
+        expect(secondDocument).toStrictEqual(expectedDocument);
+        expect(secondDocument).not.toBe(firstDocument);
+        expect(secondDocument.tournament).not.toBe(firstDocument.tournament);
+        expect(basePayload).toStrictEqual(buildValidLegacyGamePayload({
+            title: null,
+            opponentTeamId: null,
+            opponentTeamName: null,
+            opponentTeamPhoto: null
         }));
+        expect(tournament).toStrictEqual(validTournamentMetadata);
+        expect(legacyAddGame).not.toHaveBeenCalled();
     });
 
     it('rejects unsupported tournament row counts at the adapter entry point', () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -404,12 +404,15 @@ describe('scheduled tournament writes', () => {
   });
 
   it('adapts one completed tournament row into a normalized legacy game payload', () => {
+    const startDate = new Date('2026-06-24T18:30:00.000Z');
+    const endDate = new Date('2026-06-24T20:00:00.000Z');
+    const arrivalTime = new Date('2026-06-24T18:00:00.000Z');
     const payload = buildSingleGameTournamentLegacySchedulePayload({
       opponent: '  Tigers  ',
-      startDate: new Date('2026-06-24T18:30:00.000Z'),
-      endDate: new Date('2026-06-24T20:00:00.000Z'),
+      startDate,
+      endDate,
       location: '  Main Gym  ',
-      arrivalTime: new Date('2026-06-24T18:00:00.000Z'),
+      arrivalTime,
       isHome: true,
       notes: '  Bring dark jerseys  ',
       competitionType: 'league'
@@ -420,30 +423,41 @@ describe('scheduled tournament writes', () => {
       poolName: '  Pool A  '
     }, coachUser);
 
-    expect(buildSingleLegacyTournamentGameDocument).toHaveBeenCalledWith([expect.objectContaining({
+    const expectedBasePayload = {
       type: 'game',
+      date: startDate,
+      end: endDate,
       opponent: 'Tigers',
+      title: null,
       location: 'Main Gym',
+      isHome: true,
+      arrivalTime,
       notes: 'Bring dark jerseys',
+      assignments: [],
+      status: 'scheduled',
+      homeScore: 0,
+      awayScore: 0,
       competitionType: 'tournament',
+      countsTowardSeasonRecord: true,
+      statTrackerConfigId: null,
+      opponentTeamId: null,
+      opponentTeamName: null,
+      opponentTeamPhoto: null,
       createdBy: 'coach-1'
-    })], {
+    };
+    const expectedTournament = {
       divisionName: '10U Gold',
       bracketName: 'Gold Bracket',
       roundName: 'Semifinal',
       poolName: 'Pool A'
-    });
-    expect(payload).toEqual(expect.objectContaining({
-      type: 'game',
-      opponent: 'Tigers',
+    };
+
+    expect(buildSingleLegacyTournamentGameDocument).toHaveBeenCalledWith([expectedBasePayload], expectedTournament);
+    expect(payload).toStrictEqual({
+      ...expectedBasePayload,
       competitionType: 'tournament',
-      tournament: {
-        divisionName: '10U Gold',
-        bracketName: 'Gold Bracket',
-        roundName: 'Semifinal',
-        poolName: 'Pool A'
-      }
-    }));
+      tournament: expectedTournament
+    });
     expect(addGame).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- replace permissive partial assertions with an exact legacy tournament document contract
- verify a validated single-game row maps identically on repeated adapter calls
- prove the mapper returns fresh output, preserves its inputs, and performs no legacy save
- lock every normalized field produced by the form-to-legacy service mapping

## Investigation

The production implementation is already present on `master`:

- PR #3201 introduced the legacy tournament document mapper
- PR #3341 added explicit adapter validation
- PR #3344 isolated the single-game adapter entry point and single-row guard

Those merged changes fully implement issue #3338, but the remaining tests used `objectContaining`, allowing unexpected fields or omissions outside the partial match to escape. This PR adds the missing exact regression proof instead of duplicating production code.

## Impact

There is no runtime behavior change. The tests now fail if the mapping adds, removes, or changes any legacy field; mutates its inputs; depends on a save; or becomes nondeterministic.

## Validation

- focused adapter/service suites: **2 files, 97 tests passed**
- full app suite: **115 files, 1,023 tests passed**
- React production build: **passed**
- focused ESLint: **0 errors** (pre-existing warnings remain)
- `git diff --check`: **passed**

Closes #3338