### PR TITLE
Avoid dead Availability workflows

### DIFF
--- a/apps/app/src/components/schedule/AvailabilityPanels.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.tsx
@@ -25,6 +25,52 @@ export function formatRsvpSummary(summary?: { going?: number; maybe?: number; no
   return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} out · ${summary.notResponded || 0} missing`;
 }
 
+function getReadOnlyAvailabilityMessage(event: ParentScheduleEvent) {
+  if (event.isCancelled) {
+    return 'This event was cancelled, so availability can no longer be changed.';
+  }
+  if (!event.isDbGame) {
+    return 'This event is not tracked in the team schedule, so availability is unavailable.';
+  }
+  if (event.availabilityLocked) {
+    const cutoffLabel = String(event.availabilityCutoffLabel || '').trim().toLowerCase();
+    return cutoffLabel
+      ? `The team availability cutoff (${cutoffLabel}) has passed, so responses can no longer be changed.`
+      : 'The team availability cutoff has passed, so responses can no longer be changed.';
+  }
+  return 'Availability is closed for this event.';
+}
+
+export function ReadOnlyAvailabilityPanel({ event, rsvp }: {
+  event: ParentScheduleEvent;
+  rsvp: RsvpResponse;
+}) {
+  const savedNote = String(event.myRsvpNote || '').trim();
+  const responseLabel = rsvp === 'not_responded' ? 'No response recorded' : rsvpLabels[rsvp];
+
+  return (
+    <div className="border-b border-gray-200 bg-gray-50 px-3 py-3 sm:px-4">
+      <div className="flex items-start gap-2.5 sm:gap-3">
+        <PlayerInitials name={event.childName} />
+        <div className="min-w-0 flex-1">
+          <div className="text-[11px] font-black uppercase tracking-[0.06em] text-gray-500">Availability unavailable</div>
+          <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{getReadOnlyAvailabilityMessage(event)}</div>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2">
+            <span className="text-xs font-bold text-gray-600">Current response for {event.childName}</span>
+            <span className={`rounded-full border px-2.5 py-1 text-[11px] font-extrabold ${rsvpBadgeClasses[rsvp]}`}>{responseLabel}</span>
+          </div>
+          {savedNote ? (
+            <div className="mt-2 rounded-xl border border-gray-200 bg-white px-3 py-2">
+              <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Saved note</div>
+              <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{savedNote}</div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit }: {
   event: ParentScheduleEvent;
   rsvp: RsvpResponse;

--- a/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
+++ b/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { toAppServiceError } from '../../lib/appErrors';
 import { submitParentScheduleRsvp } from '../../lib/scheduleService';
 import { useAsyncOperation } from '../../lib/useAsyncOperation';
-import { normalizeRsvpResponse, type ParentScheduleEvent, type RsvpResponse } from '../../lib/scheduleLogic';
+import { canSubmitScheduleEventRsvp, normalizeRsvpResponse, type ParentScheduleEvent, type RsvpResponse } from '../../lib/scheduleLogic';
 import { UX_TIMING, startInteractionTimer } from '../../lib/uxTiming';
 import { useScheduleEventDetailContext } from '../../pages/schedule/ScheduleEventDetailContext';
 
@@ -53,7 +53,7 @@ export function useScheduleEventRsvp({ availabilityNote }: { availabilityNote: s
   const [message, setMessage] = useState<string | null>(null);
   const { error, run } = useAsyncOperation();
 
-  const canSubmit = Boolean(event.isDbGame && !event.isCancelled && !event.availabilityLocked);
+  const canSubmit = canSubmitScheduleEventRsvp(event);
 
   const submit = async (response: Exclude<RsvpResponse, 'not_responded'>) => {
     const currentUser = auth.user;

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -393,6 +393,10 @@ export function normalizeRsvpResponse(response: unknown): RsvpResponse {
   return 'not_responded';
 }
 
+export function canSubmitScheduleEventRsvp(event: Pick<ParentScheduleEvent, 'isDbGame' | 'isCancelled' | 'availabilityLocked'>) {
+  return Boolean(event.isDbGame && !event.isCancelled && !event.availabilityLocked);
+}
+
 function compactString(value: unknown) {
   return String(value || '').trim();
 }
@@ -800,8 +804,8 @@ export function getEventOpenAssignmentCount(event: Pick<ParentScheduleEvent, 'op
     : countOpenScheduleAssignments(event.assignments);
 }
 
-export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'openAssignmentCount' | 'rideshareSummary' | 'isDbGame' | 'isCancelled' | 'myRsvp'>): ScheduleEventDetailSection | '' {
-  if (event.type === 'game' && event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded') return 'availability';
+export function getScheduleTaskDetailSection(event: Pick<ParentScheduleEvent, 'type' | 'practiceHomePacketSummary' | 'assignments' | 'openAssignmentCount' | 'rideshareSummary' | 'isDbGame' | 'isCancelled' | 'availabilityLocked' | 'myRsvp'>): ScheduleEventDetailSection | '' {
+  if (event.type === 'game' && canSubmitScheduleEventRsvp(event) && normalizeRsvpResponse(event.myRsvp) === 'not_responded') return 'availability';
   // Practice packets render in the shared game/report tab inside ScheduleEventDetail.
   if (event.type === 'practice' && event.practiceHomePacketSummary) return PRACTICE_PACKET_DETAIL_SECTION;
   if (getEventOpenAssignmentCount(event) > 0) return 'assignments';

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -942,11 +942,11 @@ describe('ScheduleEventDetail nav visibility', () => {
     cleanup();
   });
 
-  it('hides rideshare and assignments tabs for inactive events with no related data', async () => {
+  it('defaults inactive events to the Game hub and hides empty rideshare and assignments tabs', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({
         isDbGame: false,
-        isCancelled: true,
+        isCancelled: false,
         rideshareSummary: { offerCount: 0, seatsLeft: 0, requests: 0, pending: 0, confirmed: 0, isFull: false },
         assignments: []
       })],
@@ -956,16 +956,17 @@ describe('ScheduleEventDetail nav visibility', () => {
     renderScheduleEventDetailWithLocation();
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Game hub' })).toBeTruthy();
     });
 
+    expect(screen.queryByRole('heading', { name: 'Availability' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Rideshare' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Assignments' })).toBeNull();
     expect(screen.getAllByRole('button', { name: 'Availability' }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
   });
 
-  it('keeps rideshare and assignments tabs when inactive events still have related data', async () => {
+  it('keeps related tabs but still defaults inactive events to the read-only Game hub', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({
         isDbGame: false,
@@ -979,11 +980,53 @@ describe('ScheduleEventDetail nav visibility', () => {
     renderScheduleEventDetail();
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Game hub' })).toBeTruthy();
     });
 
     expect(screen.getAllByRole('button', { name: 'Rideshare' }).length).toBeGreaterThan(0);
     expect(screen.getAllByRole('button', { name: 'Assignments' }).length).toBeGreaterThan(0);
+  });
+
+  it('renders an explicitly requested closed Availability section as read-only saved context', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isCancelled: true,
+        myRsvp: 'maybe',
+        myRsvpNote: 'Arriving after halftime'
+      })],
+      children: []
+    });
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=availability');
+
+    await waitFor(() => {
+      expect(screen.getByText('Availability unavailable')).toBeTruthy();
+    });
+
+    expect(screen.getByText('This event was cancelled, so availability can no longer be changed.')).toBeTruthy();
+    expect(screen.getByText('Current response for Avery Smith')).toBeTruthy();
+    expect(screen.getByText('Arriving after halftime')).toBeTruthy();
+    expect(screen.queryByText('Is Avery Smith going?')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Going' })).toBeNull();
+    expect(screen.queryByLabelText('Availability note')).toBeNull();
+    expect(screen.getByTestId('event-route').textContent).toBe('/schedule/team-1/game-1?childId=player-1&section=availability');
+  });
+
+  it.each([
+    ['cancelled', { isCancelled: true }],
+    ['availability-locked', { availabilityLocked: true, availabilityCutoffLabel: '2 hours before the event' }]
+  ])('defaults %s events away from Availability', async (_state, eventOverrides) => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent(eventOverrides)],
+      children: []
+    });
+
+    renderScheduleEventDetailWithLocation();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Game hub' })).toBeTruthy();
+    });
+    expect(screen.queryByRole('heading', { name: 'Availability' })).toBeNull();
   });
 
   it('defaults score-capable tracked games to the Game tab when the route omits section', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -61,6 +61,7 @@ import { AttentionPanel, type AttentionItem, type ScheduleEventDetailSectionId }
 import { AvailabilityNotesList } from '../components/schedule/AvailabilityNotesList';
 import {
   QuickAvailabilityPanel,
+  ReadOnlyAvailabilityPanel,
   formatRsvpSummary,
   getAvailabilityNoteSaveState,
   rsvpBadgeClasses,
@@ -71,6 +72,7 @@ import {
   formatEventTimeLabel,
   getScheduleMapHref,
   getScheduleForecastHref,
+  canSubmitScheduleEventRsvp,
   isScheduleAssignmentOpen,
   getScheduleTitle,
   getLiveClockViewModel,
@@ -243,7 +245,10 @@ function getDefaultEventDetailSection(event?: ParentScheduleEvent | null) {
   if (isActiveTrackedScheduleEvent(event) && event?.canUpdateScore) {
     return 'game';
   }
-  return 'availability';
+  if (event && canSubmitScheduleEventRsvp(event)) {
+    return 'availability';
+  }
+  return 'game';
 }
 
 function hasRideshareActivity(event?: ParentScheduleEvent | null) {
@@ -1015,6 +1020,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
   const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote });
   const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
+  const responseLabel = !rsvpWorkflow.canSubmit && rsvp === 'not_responded' ? 'No response' : rsvpLabels[rsvp];
 
   return (
     <section className="app-card overflow-hidden p-0">
@@ -1024,18 +1030,22 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
           <div className="mt-0.5 text-xs font-semibold text-gray-500">{formatRsvpSummary(event.rsvpSummary)}</div>
         </div>
         <span className={`mt-0.5 inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[rsvp]}`}>
-          {rsvpLabels[rsvp]}
+          {responseLabel}
         </span>
       </div>
-      <QuickAvailabilityPanel
-        event={event}
-        rsvp={rsvp}
-        canSubmitRsvp={rsvpWorkflow.canSubmit}
-        submitting={rsvpWorkflow.submitting}
-        availabilityNote={availabilityNote}
-        onAvailabilityNoteChange={onAvailabilityNoteChange}
-        onSubmit={rsvpWorkflow.submit}
-      />
+      {rsvpWorkflow.canSubmit ? (
+        <QuickAvailabilityPanel
+          event={event}
+          rsvp={rsvp}
+          canSubmitRsvp
+          submitting={rsvpWorkflow.submitting}
+          availabilityNote={availabilityNote}
+          onAvailabilityNoteChange={onAvailabilityNoteChange}
+          onSubmit={rsvpWorkflow.submit}
+        />
+      ) : (
+        <ReadOnlyAvailabilityPanel event={event} rsvp={rsvp} />
+      )}
       <div className="px-3 pb-3 sm:px-4">
         {rsvpWorkflow.message ? <Status tone="success" message={rsvpWorkflow.message} /> : null}
         {rsvpWorkflow.error ? <div className="mt-2"><Status tone="error" message={rsvpWorkflow.error} /></div> : null}
@@ -1052,8 +1062,6 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
         />
         <StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />
         <AvailabilityNotesList event={event} />
-        {!event.isDbGame ? <div className="mt-2 text-xs font-semibold text-gray-500">Availability opens after this event is tracked in the schedule.</div> : null}
-        {event.availabilityLocked ? <div className="mt-2 text-xs font-semibold text-amber-700">Availability locked {String(event.availabilityCutoffLabel || '').toLowerCase()}.</div> : null}
       </div>
     </section>
   );
@@ -4308,7 +4316,7 @@ function formatAssignment(assignment?: { role?: string; value?: string; claim?: 
 function getAttentionItems(event: ParentScheduleEvent, rsvp: RsvpResponse): AttentionItem[] {
   const items: AttentionItem[] = [];
 
-  if (event.isDbGame && !event.isCancelled && !event.availabilityLocked && rsvp === 'not_responded') {
+  if (canSubmitScheduleEventRsvp(event) && rsvp === 'not_responded') {
     items.push({
       title: 'Set availability',
       detail: `${event.childName} still needs an RSVP for this ${event.type}.`,

--- a/tests/unit/app-schedule-availability-panels.test.tsx
+++ b/tests/unit/app-schedule-availability-panels.test.tsx
@@ -8,6 +8,7 @@ import {
   AttentionPanel,
   AvailabilityNotesList,
   QuickAvailabilityPanel,
+  ReadOnlyAvailabilityPanel,
   getAvailabilityNoteSaveState,
   type AttentionItem
 } from '../../apps/app/src/components/schedule/AvailabilityPanels';
@@ -37,6 +38,47 @@ function buildEvent(overrides: Partial<ParentScheduleEvent> = {}): ParentSchedul
 }
 
 describe('availability schedule panels', () => {
+  it.each([
+    [
+      'cancelled',
+      { isDbGame: true, isCancelled: true },
+      'This event was cancelled, so availability can no longer be changed.'
+    ],
+    [
+      'untracked',
+      { isDbGame: false, isCancelled: false },
+      'This event is not tracked in the team schedule, so availability is unavailable.'
+    ],
+    [
+      'locked',
+      { isDbGame: true, availabilityLocked: true, availabilityCutoffLabel: '2 hours before the event' },
+      'The team availability cutoff (2 hours before the event) has passed, so responses can no longer be changed.'
+    ]
+  ])('renders %s availability as saved read-only context without form controls', (_state, overrides, explanation) => {
+    render(
+      <ReadOnlyAvailabilityPanel
+        event={buildEvent({ ...overrides, myRsvpNote: 'Arriving after halftime' })}
+        rsvp="maybe"
+      />
+    );
+
+    expect(screen.getByText('Availability unavailable')).toBeTruthy();
+    expect(screen.getByText(explanation)).toBeTruthy();
+    expect(screen.getByText('Current response for Avery Smith')).toBeTruthy();
+    expect(screen.getByText('Maybe')).toBeTruthy();
+    expect(screen.getByText('Saved note')).toBeTruthy();
+    expect(screen.getByText('Arriving after halftime')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('labels a closed event with no saved RSVP as no response instead of requesting action', () => {
+    render(<ReadOnlyAvailabilityPanel event={buildEvent()} rsvp="not_responded" />);
+
+    expect(screen.getByText('No response recorded')).toBeTruthy();
+    expect(screen.queryByText('RSVP needed')).toBeNull();
+  });
+
   it('tracks trimmed availability note save state', () => {
     expect(getAvailabilityNoteSaveState('going', '  carpool after practice  ', 'carpool after practice')).toEqual({
       isDirty: false,

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     buildScheduleIcs,
     buildScheduleAgendaText,
+    canSubmitScheduleEventRsvp,
     canRequestScheduleRide,
     findScheduleRideRequestForChild,
     filterParentScheduleEvents,
@@ -48,6 +49,13 @@ function event(overrides = {}) {
 
 describe('React app parent schedule logic', () => {
 
+    it('treats only active tracked events before the cutoff as RSVP-actionable', () => {
+        expect(canSubmitScheduleEventRsvp(event())).toBe(true);
+        expect(canSubmitScheduleEventRsvp(event({ isDbGame: false }))).toBe(false);
+        expect(canSubmitScheduleEventRsvp(event({ isCancelled: true }))).toBe(false);
+        expect(canSubmitScheduleEventRsvp(event({ availabilityLocked: true }))).toBe(false);
+    });
+
     it('validates external calendar .ics URLs like legacy schedule import', () => {
         expect(validateExternalCalendarUrl('')).toMatchObject({ valid: false, error: 'Enter a calendar .ics URL.' });
         expect(validateExternalCalendarUrl('https://example.com/calendar')).toMatchObject({ valid: false, error: 'Calendar URL must be an .ics link.' });
@@ -85,6 +93,11 @@ describe('React app parent schedule logic', () => {
             myRsvp: 'going',
             rideshareSummary: { offerCount: 1, seatsLeft: 1, requests: 0, pending: 0, confirmed: 0, isFull: false }
         });
+        const lockedRsvp = event({
+            id: 'game-locked',
+            myRsvp: 'not_responded',
+            availabilityLocked: true
+        });
 
         expect(getScheduleTaskDetailSection(generic)).toBe('');
         expect(getScheduleEventDetailPath(generic, getScheduleTaskDetailSection(generic))).toBe('/schedule/team%2Fwith%20slash/game%201?childId=player+1');
@@ -95,6 +108,8 @@ describe('React app parent schedule logic', () => {
         expect(getScheduleEventDetailPath(packet, getScheduleTaskDetailSection(packet))).toBe('/schedule/team-1/practice-1?childId=player-1&section=game');
         expect(getScheduleEventDetailPath(assignment, getScheduleTaskDetailSection(assignment))).toBe('/schedule/team-1/game-1?childId=player-1&section=assignments');
         expect(getScheduleEventDetailPath(ride, getScheduleTaskDetailSection(ride))).toBe('/schedule/team-1/game-1?childId=player-1&section=rideshare');
+        expect(getScheduleTaskDetailSection(lockedRsvp)).toBe('');
+        expect(getScheduleEventDetailPath(lockedRsvp, getScheduleTaskDetailSection(lockedRsvp))).toBe('/schedule/team-1/game-locked?childId=player-1');
     });
 
     it('matches parent-dashboard upcoming and past filter behavior with a three-hour cutoff', () => {


### PR DESCRIPTION
## What changed

- Added one shared RSVP-actionability predicate for tracked, active, pre-cutoff events and reused it in routing, attention items, task links, and the RSVP hook.
- Defaulted cancelled, untracked, and availability-locked events to the Game/More context hub instead of the interactive Availability section.
- Added a compact read-only Availability panel with reason-specific copy, current response, and saved note context.
- Kept explicit Availability navigation valid, but omitted RSVP buttons and the note textarea whenever submissions are unavailable.
- Preserved the existing Quick Availability panel for active tracked events with open availability.
- Prevented task-targeted links from sending cutoff-locked events back to Availability.

## Why

The event-detail default only distinguished score-capable events from everyone else. As a result, cancelled, imported/untracked, and cutoff-locked events opened a disabled RSVP form even though the RSVP hook could never submit. The UI presented false choices and duplicated the unavailable explanation below the disabled controls.

The shared predicate now keeps every entry path aligned with the actual write guard. Game/More is the non-actionable default because inactive Rideshare is also an action workflow, while the event hub remains useful read-only context.

## Validation

- `npx vitest run tests/unit/app-schedule-availability-panels.test.tsx tests/unit/app-schedule-logic.test.js --reporter=dot` — 25/25 passed.
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx --reporter=dot` from `apps/app` — 99/99 passed.
- `npm run app:build` — TypeScript check and Vite production build passed.
- Broad root unit suite — 3,892 passed, 9 skipped, with one unrelated Messages lazy-loading timing assertion failing under full concurrency. Its complete test file passed immediately in isolation, 70/70.
- `git diff --check` — passed.

Closes #3408
