### PR TITLE
Document app startup timing spans

### DIFF
--- a/docs/app-performance-baseline.md
+++ b/docs/app-performance-baseline.md
@@ -14,8 +14,8 @@ rather than assumed.
 
 | Metric | What it measures | How to capture |
 | --- | --- | --- |
-| Cold-start TTI (Home) | App launch → Home schedule cards interactive | `first meaningful render` span (web + device), Lighthouse TTI for web |
-| Warm resume time | Foreground after backgrounding → fresh data on screen | Manual stopwatch + `app startup` span on resume |
+| Cold-start TTI (Home) | App launch → Home schedule cards interactive | `app start to home first meaningful render` span (web + device), Lighthouse TTI for web |
+| Warm resume time | Foreground after backgrounding → fresh data on screen | `warm resume to interactive` span + manual stopwatch |
 | Firestore reads / Home mount | Read/REST count on a Home cold mount | Dev read-count instrumentation (see below) |
 | Firestore reads / Schedule mount | Read/REST count to render the schedule | Dev read-count instrumentation |
 | Firestore reads / Messages mount | Read/REST count to render the inbox | Dev read-count instrumentation |
@@ -31,9 +31,16 @@ The app records these spans through `recordUxTiming` /
 `apps/app/src/lib/uxTiming.ts` (`UX_TIMING`):
 
 - `app startup` — emitted in `main.tsx` at initial React render.
+- `app start to home first meaningful render` — emitted once when Home's
+  initial primary and secondary loads settle. Its start point is navigation
+  start, so use this label for the cold-start Home TTI row above.
 - `first meaningful render` — `recordFirstMeaningfulRender(route)`, fired once
   per page load when Home/Schedule leave their loading state. Baseline is
   navigation start, so this is the true cold-start cost.
+- `warm resume to interactive` — emitted by `useRefreshOnResume` after the
+  stale foreground refresh settles on web (`visibilitychange`) or native
+  (`appStateChange`). Use this label for warm-resume measurements; `app startup`
+  is only the initial render and is not a resume span.
 - `rsvp tap latency` — `startInteractionTimer(UX_TIMING.rsvpTap)` around the
   parent RSVP submit in `scheduleService.ts`. RSVP timing validation uses the
   lab action "open a Schedule event and tap Going" and the `app_ux_timing`

--- a/tests/unit/app-performance-baseline-doc.test.js
+++ b/tests/unit/app-performance-baseline-doc.test.js
@@ -48,13 +48,21 @@ describe('app performance baseline documentation', () => {
     it('ties baseline capture to stable uxTiming spans and repeatable commands', () => {
         [
             '`app startup`',
+            '`app start to home first meaningful render`',
             '`first meaningful render`',
+            '`warm resume to interactive`',
             '`rsvp tap latency`',
             '`chat send latency`',
             '`npm run app:build && npm run app:preview`'
         ].forEach((needle) => {
             expect(doc).toContain(needle);
         });
+    });
+
+    it('maps cold start and warm resume to their dedicated stable spans', () => {
+        expect(doc).toContain('| Cold-start TTI (Home) | App launch → Home schedule cards interactive | `app start to home first meaningful render` span');
+        expect(doc).toContain('| Warm resume time | Foreground after backgrounding → fresh data on screen | `warm resume to interactive` span');
+        expect(doc).toContain('`app startup`\n  is only the initial render and is not a resume span');
     });
 
     it('documents the stable RSVP telemetry event name and label for baseline validation', () => {


### PR DESCRIPTION
## What changed

- Correct the performance baseline guide to use the dedicated `app start to home first meaningful render` span for cold Home startup.
- Correct warm-resume capture to use `warm resume to interactive`, not the initial-render `app startup` span.
- Document the exact emission boundaries for the Home and web/native resume paths.
- Add a regression contract for the stable documented event names and metric mappings.

## Why

The runtime instrumentation and its focused tests already satisfied the startup and warm-resume behavior, but the operator guide omitted the dedicated Home span and incorrectly mapped warm resume to `app startup`. That made repeatable measurements ambiguous even though the correct telemetry was available.

Closes #3189

## Validation

- `npx vitest run tests/unit/app-performance-baseline-doc.test.js apps/app/src/lib/uxTiming.test.ts tests/unit/app-refresh-on-resume.test.tsx apps/app/src/pages/Home.test.tsx apps/app/src/main.test.tsx --reporter=dot` — 43 passed
- `npm run app:build` — passed