### PR TITLE
Prove single-game tournament persistence delegation

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -182,19 +182,14 @@ describe('legacyScheduleDb game persistence', () => {
         const tournamentDocument = buildSingleLegacyTournamentGameDocument([
             buildValidLegacyGamePayload()
         ], validTournamentMetadata);
-        const expectedDocument = {
-            ...tournamentDocument,
-            tournament: {
-                ...validTournamentMetadata
-            }
-        };
+        const documentBeforeCall = structuredClone(tournamentDocument);
         vi.mocked(legacyAddGame).mockResolvedValueOnce('tournament-game-1');
 
         await expect(addGame('team-1', tournamentDocument)).resolves.toBe('tournament-game-1');
 
         expect(legacyAddGame).toHaveBeenCalledTimes(1);
-        expect(legacyAddGame).toHaveBeenCalledWith('team-1', expectedDocument);
-        expect(tournamentDocument).toStrictEqual(expectedDocument);
+        expect(legacyAddGame).toHaveBeenCalledWith('team-1', documentBeforeCall);
+        expect(tournamentDocument).toStrictEqual(documentBeforeCall);
     });
 
     it('keeps non-tournament game persistence on the same single legacy delegation', async () => {

--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@legacy/db.js', () => ({
     addGame: vi.fn(),
@@ -61,7 +61,8 @@ vi.mock('@legacy/firebase.js', () => ({
     where: vi.fn()
 }));
 
-import { buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, buildSingleLegacyTournamentGameDocument, LegacyTournamentGameAdapterValidationError } from './legacyScheduleDb';
+import { addGame as legacyAddGame } from '@legacy/db.js';
+import { addGame, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, buildSingleLegacyTournamentGameDocument, LegacyTournamentGameAdapterValidationError } from './legacyScheduleDb';
 
 const buildValidLegacyGamePayload = (overrides: Record<string, unknown> = {}) => ({
     type: 'game',
@@ -88,6 +89,10 @@ const validTournamentMetadata = {
     roundName: 'Semifinal',
     poolName: 'Pool A'
 };
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
 
 describe('legacyScheduleDb tournament mapping', () => {
     it('maps the supported single-game tournament adapter entry point to one legacy-compatible game document', () => {
@@ -169,5 +174,38 @@ describe('legacyScheduleDb tournament mapping', () => {
             buildValidLegacyGamePayload({ opponent: 'Tigers' }),
             null
         ], validTournamentMetadata)).toThrow('Tournament adapter requires complete tournament game payloads.');
+    });
+});
+
+describe('legacyScheduleDb game persistence', () => {
+    it('delegates one valid tournament document to the legacy save adapter exactly once', async () => {
+        const tournamentDocument = buildSingleLegacyTournamentGameDocument([
+            buildValidLegacyGamePayload()
+        ], validTournamentMetadata);
+        const expectedDocument = {
+            ...tournamentDocument,
+            tournament: {
+                ...validTournamentMetadata
+            }
+        };
+        vi.mocked(legacyAddGame).mockResolvedValueOnce('tournament-game-1');
+
+        await expect(addGame('team-1', tournamentDocument)).resolves.toBe('tournament-game-1');
+
+        expect(legacyAddGame).toHaveBeenCalledTimes(1);
+        expect(legacyAddGame).toHaveBeenCalledWith('team-1', expectedDocument);
+        expect(tournamentDocument).toStrictEqual(expectedDocument);
+    });
+
+    it('keeps non-tournament game persistence on the same single legacy delegation', async () => {
+        const leagueDocument = buildValidLegacyGamePayload({
+            competitionType: 'league'
+        });
+        vi.mocked(legacyAddGame).mockResolvedValueOnce('league-game-1');
+
+        await expect(addGame('team-1', leagueDocument)).resolves.toBe('league-game-1');
+
+        expect(legacyAddGame).toHaveBeenCalledTimes(1);
+        expect(legacyAddGame).toHaveBeenCalledWith('team-1', leagueDocument);
     });
 });


### PR DESCRIPTION
## Summary

- add direct coverage at the real legacy schedule adapter boundary
- prove one valid tournament document invokes the legacy `addGame` persistence function exactly once
- verify the adapter returns the one created id and does not mutate the tournament document
- prove ordinary non-tournament games keep the same single-delegation behavior

## Investigation

Production behavior for #3222 already exists on `master`:

- #3244 was closed as a duplicate of the mapping work in #3197 / PR #3201
- #3245 was closed as a duplicate of the save-service work tracked by #3198
- #3246 was completed by merged PR #3329, adding the duplicate-prevention guard
- merged PR #3344 later made the invariant structural: the tournament workflow accepts exactly one row, constructs one document, and calls `createScheduledGameForApp` once
- existing service tests verify one mapped document and one mocked `addGame` call

The missing proof was below the service mock: no test verified that the exported adapter `addGame` wrapper delegates one received tournament document to the actual legacy persistence dependency exactly once. This PR closes that test gap without duplicating runtime behavior.

## Impact

No runtime behavior changes. The regression fails if the adapter drops, mutates, or duplicates a tournament save, or if non-tournament delegation changes.

## Validation

- focused adapter/service suites: **2 files, 99 tests passed**
- full app suite: **115 files, 1,025 tests passed**
- React production build: **passed**
- focused ESLint: **0 errors**
- `git diff --check`: **passed**

Closes #3222