### PR TITLE
Cover tournament save refresh and error outcomes

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -935,10 +935,45 @@ describe('Schedule', () => {
         ]
       }), auth.user);
     });
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+    });
+    expect((await screen.findAllByText('10U Gold / Gold Bracket / Semifinal')).length).toBeGreaterThan(0);
     expect(await screen.findByText('Tournament created and schedule refreshed.')).toBeTruthy();
     expect((await screen.findAllByText('vs. Tigers')).length).toBeGreaterThan(0);
     expect((await screen.findAllByText('vs. Lions')).length).toBeGreaterThan(0);
     expect(screen.queryByRole('heading', { name: 'Add tournament for Bears' })).toBeNull();
+  });
+
+  it('shows tournament save errors without refreshing or clearing the attempted block', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
+    scheduleServiceMocks.createScheduledTournamentBlockForApp.mockRejectedValueOnce(new Error('Tournament save denied.'));
+
+    renderSchedule();
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'New tournament block' }));
+    expect(await screen.findByRole('heading', { name: 'Add tournament for Bears' })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Tournament division'), { target: { value: '10U Gold' } });
+    fireEvent.change(screen.getByLabelText('Tournament bracket'), { target: { value: 'Gold Bracket' } });
+    fireEvent.change(screen.getByLabelText('Tournament round'), { target: { value: 'Semifinal' } });
+    fireEvent.change(screen.getByLabelText('Tournament pool'), { target: { value: 'Pool A' } });
+    fireEvent.change(screen.getByLabelText('Game 1 opponent'), { target: { value: 'Tigers' } });
+    fireEvent.change(screen.getByLabelText('Game 1 location'), { target: { value: 'Main Gym' } });
+    fireEvent.change(screen.getByLabelText('Game 1 starts'), { target: { value: '2026-06-24T18:30' } });
+    fireEvent.click(screen.getByRole('button', { name: /^create tournament$/i }));
+
+    expect(await screen.findByText('Tournament save denied.')).toBeTruthy();
+    expect(screen.getByDisplayValue('10U Gold')).toBeTruthy();
+    expect(screen.getByDisplayValue('Gold Bracket')).toBeTruthy();
+    expect(screen.getByDisplayValue('Semifinal')).toBeTruthy();
+    expect(screen.getByDisplayValue('Pool A')).toBeTruthy();
+    expect(screen.getByDisplayValue('Tigers')).toBeTruthy();
+    expect(screen.getByDisplayValue('Main Gym')).toBeTruthy();
+    expect(scheduleServiceMocks.createScheduledTournamentBlockForApp).toHaveBeenCalledTimes(1);
+    expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(1);
   });
 
   it('hides Manage schedule from non-staff schedule users', async () => {


### PR DESCRIPTION
## Summary

- strengthen the tournament submission test so the forced second schedule load returns the newly saved tournament
- verify the refreshed tournament metadata is rendered and the success status is shown
- add a rejected-save regression proving the error is visible, all entered values remain, and no refresh runs

## Investigation

The runtime workflow already satisfies #3179:

- the form maps through the legacy tournament adapter and existing save flow
- one game is persisted for the supported single-row case
- `handleCreateTournament` awaits `refreshSchedule(true)` after success
- rejected saves populate `tournamentFormError`

The remaining gap was regression coverage. Existing UI tests stopped after asserting the service call; they did not prove the reload returned and rendered the saved tournament, or that failure skipped reload while preserving the attempted draft. This PR adds only that parent-level proof and does not duplicate the reconciled adapter/persistence issues.

## Impact

No runtime behavior changes. The tests now fail if a successful tournament save stops refreshing/rendering the new item, or if a failed save clears the draft, hides the error, or triggers a refresh.

## Validation

- focused success/failure page regressions: **2 passed**
- full app suite: **115 files, 1,024 tests passed**
- React production build: **passed**
- focused ESLint: **0 errors** (existing warnings remain)
- `git diff --check`: **passed**

Closes #3179