### PR TITLE
Grant linked coaches Team Media access

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1252,9 +1252,12 @@ service cloud.firestore {
     function isTeamMediaCoach(teamId) {
       let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
       let teamPath = /databases/$(database)/documents/teams/$(teamId);
+      let team = get(teamPath).data;
       return isSignedIn() &&
              exists(userPath) &&
              exists(teamPath) &&
+             request.auth.token.email != null &&
+             request.auth.token.email.lower() in team.get('adminEmails', []) &&
              teamId in get(userPath).data.get('coachOf', []);
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1208,7 +1208,7 @@ service cloud.firestore {
     }
 
     function userMembershipFields() {
-      return ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys'];
+      return ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys', 'coachOf'];
     }
 
     function teamMediaUploadGrantFields() {
@@ -1249,15 +1249,26 @@ service cloud.firestore {
     }
 
 
+    function isTeamMediaCoach(teamId) {
+      let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
+      return isSignedIn() &&
+             exists(userPath) &&
+             teamId in get(userPath).data.get('coachOf', []);
+    }
+
+    function canManageTeamMedia(teamId) {
+      return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);
+    }
+
     function canReadTeamMediaFolder(teamId, folderData) {
-      return isTeamOwnerOrAdmin(teamId) ||
+      return canManageTeamMedia(teamId) ||
              (canAccessTeamChat(teamId) && folderData.get('visibility', 'team') == 'team');
     }
 
     function canReadTeamMediaItem(teamId, itemData) {
       let folderId = itemData.get('folderId', '');
       let folderPath = /databases/$(database)/documents/teams/$(teamId)/mediaFolders/$(folderId);
-      return isTeamOwnerOrAdmin(teamId) ||
+      return canManageTeamMedia(teamId) ||
              (canAccessTeamChat(teamId) &&
               folderId is string &&
               exists(folderPath) &&
@@ -2038,15 +2049,15 @@ service cloud.firestore {
 
       match /mediaFolders/{folderId} {
         allow read: if canReadTeamMediaFolder(teamId, resource.data);
-        allow create, delete: if isTeamOwnerOrAdmin(teamId);
-        allow update: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCounterUpdate(teamId);
+        allow create, delete: if canManageTeamMedia(teamId);
+        allow update: if canManageTeamMedia(teamId) || isTeamMediaUploadCounterUpdate(teamId);
       }
 
       match /mediaItems/{itemId} {
         allow read: if canReadTeamMediaItem(teamId, resource.data);
-        allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);
-        allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);
-        allow delete: if isTeamOwnerOrAdmin(teamId);
+        allow create: if canManageTeamMedia(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);
+        allow update: if canManageTeamMedia(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);
+        allow delete: if canManageTeamMedia(teamId);
       }
 
       match /settings/{settingId} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1251,9 +1251,13 @@ service cloud.firestore {
 
     function isTeamMediaCoach(teamId) {
       let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
+      let teamPath = /databases/$(database)/documents/teams/$(teamId);
       return isSignedIn() &&
              exists(userPath) &&
-             teamId in get(userPath).data.get('coachOf', []);
+             exists(teamPath) &&
+             teamId in get(userPath).data.get('coachOf', []) &&
+             request.auth.token.email != null &&
+             request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', []);
     }
 
     function canManageTeamMedia(teamId) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1255,9 +1255,7 @@ service cloud.firestore {
       return isSignedIn() &&
              exists(userPath) &&
              exists(teamPath) &&
-             teamId in get(userPath).data.get('coachOf', []) &&
-             request.auth.token.email != null &&
-             request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', []);
+             teamId in get(userPath).data.get('coachOf', []);
     }
 
     function canManageTeamMedia(teamId) {

--- a/js/db.js
+++ b/js/db.js
@@ -202,7 +202,7 @@ import {
     loadVolunteerScreeningTargetRegistrations
 } from './volunteer-screening-access.js?v=2';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
-import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
+import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=5';
 import { getApp } from './vendor/firebase-app.js';
 import {
     computeOfficiatingCoverageStatus,

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -66,7 +66,14 @@ function getSafeVideoUrl(value) {
 }
 
 export function canManageTeamMedia(user, team) {
-    return hasFullTeamAccess(user, team);
+    if (hasFullTeamAccess(user, team)) return true;
+
+    const teamId = asTrimmedString(team?.id);
+    if (!user || !teamId) return false;
+
+    return (Array.isArray(user.coachOf) ? user.coachOf : [])
+        .map(asTrimmedString)
+        .includes(teamId);
 }
 
 export function normalizeAlbumVisibility(value) {
@@ -170,7 +177,7 @@ export function hasTeamMediaUploadGrant(user, teamId) {
 
 export function canContributeTeamMedia(user, team) {
     if (!user || !team) return false;
-    if (hasFullTeamAccess(user, team)) return true;
+    if (canManageTeamMedia(user, team)) return true;
     const teamId = String(team.id || '').trim();
     if (!teamId) return false;
     return hasTeamMediaUploadGrant(user, teamId);

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -66,7 +66,15 @@ function getSafeVideoUrl(value) {
 }
 
 export function canManageTeamMedia(user, team) {
-    return hasFullTeamAccess(user, team);
+    if (!user || !team) return false;
+    if (hasFullTeamAccess(user, team)) return true;
+
+    const teamId = String(team.id || '').trim();
+    if (!teamId) return false;
+
+    return (Array.isArray(user.coachOf) ? user.coachOf : [])
+        .map((id) => String(id || '').trim())
+        .includes(teamId);
 }
 
 export function normalizeAlbumVisibility(value) {

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -70,7 +70,11 @@ export function canManageTeamMedia(user, team) {
     if (hasFullTeamAccess(user, team)) return true;
 
     const teamId = String(team.id || '').trim();
-    if (!teamId) return false;
+    const email = String(user.email || '').trim().toLowerCase();
+    const adminEmails = Array.isArray(team.adminEmails) ? team.adminEmails : [];
+    const hasTeamAdminProvenance = Boolean(email) &&
+        adminEmails.some((adminEmail) => String(adminEmail || '').trim().toLowerCase() === email);
+    if (!teamId || !hasTeamAdminProvenance) return false;
 
     return (Array.isArray(user.coachOf) ? user.coachOf : [])
         .map((id) => String(id || '').trim())

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -70,11 +70,7 @@ export function canManageTeamMedia(user, team) {
     if (hasFullTeamAccess(user, team)) return true;
 
     const teamId = String(team.id || '').trim();
-    const email = String(user.email || '').trim().toLowerCase();
-    const adminEmails = Array.isArray(team.adminEmails) ? team.adminEmails : [];
-    const hasTeamAdminProvenance = Boolean(email) &&
-        adminEmails.some((adminEmail) => String(adminEmail || '').trim().toLowerCase() === email);
-    if (!teamId || !hasTeamAdminProvenance) return false;
+    if (!teamId) return false;
 
     return (Array.isArray(user.coachOf) ? user.coachOf : [])
         .map((id) => String(id || '').trim())

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -66,14 +66,7 @@ function getSafeVideoUrl(value) {
 }
 
 export function canManageTeamMedia(user, team) {
-    if (hasFullTeamAccess(user, team)) return true;
-
-    const teamId = asTrimmedString(team?.id);
-    if (!user || !teamId) return false;
-
-    return (Array.isArray(user.coachOf) ? user.coachOf : [])
-        .map(asTrimmedString)
-        .includes(teamId);
+    return hasFullTeamAccess(user, team);
 }
 
 export function normalizeAlbumVisibility(value) {

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -30,7 +30,7 @@ import {
     isSupportedTeamMediaImage,
     isTeamMediaDocument,
     sortByMediaOrder
-} from './team-media-utils.js?v=4';
+} from './team-media-utils.js?v=5';
 
 const state = {
     teamId: '',

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem
-} from './db.js?v=84';
+} from './db.js?v=85';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -83,6 +83,7 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'function canReadTeamMediaItem(teamId, itemData)', 'Firestore media item visibility rules');
     assertIncludes(firestoreRules, 'function isTeamMediaCoach(teamId)', 'Firestore linked coach media rules');
     assertIncludes(firestoreRules, "teamId in get(userPath).data.get('coachOf', [])", 'Firestore linked coach media membership');
+    assertIncludes(firestoreRules, "request.auth.token.email.lower() in team.get('adminEmails', [])", 'Firestore linked coach admin email provenance');
     assertIncludes(firestoreRules, 'function canManageTeamMedia(teamId)', 'Firestore media manager rules');
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaFolder(teamId, resource.data);', 'Firestore media folder read rules');
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaItem(teamId, resource.data);', 'Firestore media item read rules');
@@ -133,6 +134,7 @@ export function validateFirebaseRulesCi() {
     assertIncludes(storageRules, 'function canDeleteOwnTeamMediaObject(teamId, folderId, userId)', 'Team media scoped Storage delete helper');
     assertIncludes(storageRules, 'function isTeamMediaCoach(teamId)', 'Team media linked coach Storage helper');
     assertIncludes(storageRules, "teamId in firestore.get(userPath).data.get('coachOf', [])", 'Team media linked coach Storage membership');
+    assertIncludes(storageRules, "request.auth.token.email.lower() in team.get('adminEmails', [])", 'Team media linked coach Storage admin email provenance');
     assertIncludes(storageRules, 'function canDeleteOwnChatAttachment(teamId, conversationId, userId)', 'Chat fallback scoped Storage delete helper');
     assertIncludes(storageRules, 'function canDeleteOwnTeamScopedUpload(teamId, userId)', 'Team scoped Storage delete helper');
     assertIncludes(storageRules, '(hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId))', 'Team media current upload grant delete scope');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -81,6 +81,9 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'match /mediaItems/{itemId}', 'Firestore media item rules');
     assertIncludes(firestoreRules, 'function canReadTeamMediaFolder(teamId, folderData)', 'Firestore media folder visibility rules');
     assertIncludes(firestoreRules, 'function canReadTeamMediaItem(teamId, itemData)', 'Firestore media item visibility rules');
+    assertIncludes(firestoreRules, 'function isTeamMediaCoach(teamId)', 'Firestore linked coach media rules');
+    assertIncludes(firestoreRules, "teamId in get(userPath).data.get('coachOf', [])", 'Firestore linked coach media membership');
+    assertIncludes(firestoreRules, 'function canManageTeamMedia(teamId)', 'Firestore media manager rules');
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaFolder(teamId, resource.data);', 'Firestore media folder read rules');
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaItem(teamId, resource.data);', 'Firestore media item read rules');
     assertIncludes(firestoreRules, 'function canReadGameDocument(teamId, gameId, data)', 'Firestore game visibility helper');
@@ -104,10 +107,11 @@ export function validateFirebaseRulesCi() {
     if (aggregatedStatsRules.includes('allow read: if true;')) {
         throw new Error('Firestore aggregated stats read rules must not allow unconditional public reads.');
     }
-    assertIncludes(firestoreRules, 'allow create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media folder write rules');
-    assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
-    assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);', 'Firestore media item update rules');
-    assertIncludes(firestoreRules, 'allow delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media item delete rules');
+    assertIncludes(firestoreRules, 'allow create, delete: if canManageTeamMedia(teamId);', 'Firestore media folder write rules');
+    assertIncludes(firestoreRules, 'allow update: if canManageTeamMedia(teamId) || isTeamMediaUploadCounterUpdate(teamId);', 'Firestore media folder update rules');
+    assertIncludes(firestoreRules, 'allow create: if canManageTeamMedia(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
+    assertIncludes(firestoreRules, 'allow update: if canManageTeamMedia(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);', 'Firestore media item update rules');
+    assertIncludes(firestoreRules, 'allow delete: if canManageTeamMedia(teamId);', 'Firestore media item delete rules');
     assertIncludes(firestoreRules, 'match /adminBilling/{billingId}', 'Firestore team fee admin billing rules');
     assertIncludes(firestoreRules, 'allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore team fee admin billing admin-only rules');
     assertIncludes(firestoreRules, 'match /rsvpNotes/{rsvpId}', 'Firestore restricted RSVP note rules');
@@ -127,10 +131,12 @@ export function validateFirebaseRulesCi() {
     assertIncludes(storageRules, 'request.auth.uid == userId', 'Scoped Storage uploader match rules');
     assertIncludes(storageRules, 'request.resource.contentType.matches(\'video/.*\')', 'Scoped Storage video content-type rules');
     assertIncludes(storageRules, 'function canDeleteOwnTeamMediaObject(teamId, folderId, userId)', 'Team media scoped Storage delete helper');
+    assertIncludes(storageRules, 'function isTeamMediaCoach(teamId)', 'Team media linked coach Storage helper');
+    assertIncludes(storageRules, "teamId in firestore.get(userPath).data.get('coachOf', [])", 'Team media linked coach Storage membership');
     assertIncludes(storageRules, 'function canDeleteOwnChatAttachment(teamId, conversationId, userId)', 'Chat fallback scoped Storage delete helper');
     assertIncludes(storageRules, 'function canDeleteOwnTeamScopedUpload(teamId, userId)', 'Team scoped Storage delete helper');
     assertIncludes(storageRules, '(hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId))', 'Team media current upload grant delete scope');
-    assertIncludes(teamMediaRules, 'allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);', 'Team media scoped Storage delete rules');
+    assertIncludes(teamMediaRules, 'allow delete: if canManageTeamMedia(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);', 'Team media scoped Storage delete rules');
     assertIncludes(chatFallbackRules, 'allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnChatAttachment(teamId, conversationId, userId);', 'Chat fallback scoped Storage delete rules');
     for (const [label, block] of [
         ['Legacy chat fallback scoped Storage delete rules', legacyChatFallbackRules],

--- a/storage.rules
+++ b/storage.rules
@@ -22,9 +22,12 @@ service firebase.storage {
     function isTeamMediaCoach(teamId) {
       let userPath = /databases/(default)/documents/users/$(request.auth.uid);
       let teamPath = /databases/(default)/documents/teams/$(teamId);
+      let team = firestore.get(teamPath).data;
       return isSignedIn() &&
         firestore.exists(userPath) &&
         firestore.exists(teamPath) &&
+        request.auth.token.email != null &&
+        request.auth.token.email.lower() in team.get('adminEmails', []) &&
         teamId in firestore.get(userPath).data.get('coachOf', []);
     }
 

--- a/storage.rules
+++ b/storage.rules
@@ -21,9 +21,13 @@ service firebase.storage {
 
     function isTeamMediaCoach(teamId) {
       let userPath = /databases/(default)/documents/users/$(request.auth.uid);
+      let teamPath = /databases/(default)/documents/teams/$(teamId);
       return isSignedIn() &&
         firestore.exists(userPath) &&
-        teamId in firestore.get(userPath).data.get('coachOf', []);
+        firestore.exists(teamPath) &&
+        teamId in firestore.get(userPath).data.get('coachOf', []) &&
+        request.auth.token.email != null &&
+        request.auth.token.email.lower() in firestore.get(teamPath).data.get('adminEmails', []);
     }
 
     function canManageTeamMedia(teamId) {

--- a/storage.rules
+++ b/storage.rules
@@ -25,9 +25,7 @@ service firebase.storage {
       return isSignedIn() &&
         firestore.exists(userPath) &&
         firestore.exists(teamPath) &&
-        teamId in firestore.get(userPath).data.get('coachOf', []) &&
-        request.auth.token.email != null &&
-        request.auth.token.email.lower() in firestore.get(teamPath).data.get('adminEmails', []);
+        teamId in firestore.get(userPath).data.get('coachOf', []);
     }
 
     function canManageTeamMedia(teamId) {

--- a/storage.rules
+++ b/storage.rules
@@ -19,6 +19,17 @@ service firebase.storage {
          isGlobalAdmin());
     }
 
+    function isTeamMediaCoach(teamId) {
+      let userPath = /databases/(default)/documents/users/$(request.auth.uid);
+      return isSignedIn() &&
+        firestore.exists(userPath) &&
+        teamId in firestore.get(userPath).data.get('coachOf', []);
+    }
+
+    function canManageTeamMedia(teamId) {
+      return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);
+    }
+
     function isParentForTeam(teamId) {
       let userPath = /databases/(default)/documents/users/$(request.auth.uid);
       return isSignedIn() &&
@@ -70,13 +81,13 @@ service firebase.storage {
     }
 
     function canCreateTeamMediaUpload(teamId, folderId) {
-      return isTeamOwnerOrAdmin(teamId) ||
+      return canManageTeamMedia(teamId) ||
         (hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId));
     }
 
     function canReadTeamMediaObject(teamId, folderId) {
       let folderPath = /databases/(default)/documents/teams/$(teamId)/mediaFolders/$(folderId);
-      return isTeamOwnerOrAdmin(teamId) ||
+      return canManageTeamMedia(teamId) ||
         (isParentForTeam(teamId) &&
          folderId.size() > 0 &&
          firestore.exists(folderPath) &&
@@ -140,11 +151,11 @@ service firebase.storage {
       allow get: if canReadTeamMediaObject(teamId, folderId);
       allow list: if false;
       allow create: if canCreateTeamMediaUpload(teamId, folderId) &&
-        (isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId) &&
+        (canManageTeamMedia(teamId) || request.auth.uid == userId) &&
         request.resource.size > 0 &&
         request.resource.size <= 10 * 1024 * 1024 &&
         isAllowedTeamMediaUploadType(request.resource.contentType);
-      allow delete: if isTeamOwnerOrAdmin(teamId) ||
+      allow delete: if canManageTeamMedia(teamId) ||
         canDeleteOwnTeamMediaObject(teamId, folderId, userId);
       allow update: if false;
     }

--- a/team-media.html
+++ b/team-media.html
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=11"></script>
+    <script type="module" src="js/team-media.js?v=12"></script>
 </body>
 </html>

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -20,6 +20,18 @@ export function checkAuth(callback) {
 export async function sendInviteEmail() {}
 `;
 
+const AUTH_COACH_STUB = `
+export function checkAuth(callback) {
+    callback({
+        uid: 'coach-1',
+        email: 'coach@example.com',
+        isAdmin: false,
+        coachOf: ['team-1']
+    });
+}
+export async function sendInviteEmail() {}
+`;
+
 const UTILS_STUB = `
 export function renderHeader() {}
 export function renderFooter() {}
@@ -1044,6 +1056,21 @@ test('team media renders visible save actions for staff', async ({ page, baseURL
     }));
     expect(colors.folderBackground).not.toBe('rgba(0, 0, 0, 0)');
     expect(colors.linkBackground).not.toBe('rgba(0, 0, 0, 0)');
+    expect(pageErrors).toEqual([]);
+});
+
+test('team media grants linked coaches management controls without owner or admin-email access', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_COACH_STUB }));
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_DB_WITH_FOLDER_STUB }));
+
+    await page.goto(`${baseURL}/team-media.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#team-media-admin-panel')).toBeVisible();
+    await expect(page.locator('#team-media-upload-panel')).toBeVisible();
+    await expect(page.locator('#folder-submit')).toHaveText('Add album');
+    await expect(page.locator('#link-submit')).toHaveText('Save video link');
+    await expect(page.locator('#link-folder')).toContainText('Highlights');
     expect(pageErrors).toEqual([]);
 });
 

--- a/tests/unit/app-social-rules.test.js
+++ b/tests/unit/app-social-rules.test.js
@@ -89,7 +89,7 @@ function isOwnerUserEmailUpdateValid({ affectedKeys, nextEmail, authEmail }) {
 }
 
 function isOwnerUserMembershipUpdateValid({ affectedKeys }) {
-    return !hasAny(affectedKeys, ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys']);
+    return !hasAny(affectedKeys, ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys', 'coachOf']);
 }
 
 describe('React app social Firestore rules', () => {
@@ -123,7 +123,7 @@ describe('React app social Firestore rules', () => {
         expect(source).toContain("data.keys().hasOnly(['displayName', 'fullName', 'photoUrl', 'discoveryTeamIds', 'emailHash', 'updatedAt'])");
         expect(source).toContain("!data.keys().hasAny(['email', 'phone', 'parentOf', 'parentTeamIds', 'parentPlayerKeys'])");
         expect(source).toContain("function userMembershipFields()");
-        expect(source).toContain("return ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys'];");
+        expect(source).toContain("return ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys', 'coachOf'];");
         expect(source).toContain("(isOwner(userId) && isOwnerUserCreatePayloadValid(request.resource.data))");
         expect(source).toContain("(isOwner(userId) && isOwnerUserUpdatePayloadValid())");
         expect(source).toContain('function isOwnerUserEmailAuthBound(data)');
@@ -155,6 +155,9 @@ describe('React app social Firestore rules', () => {
         })).toBe(false);
         expect(isOwnerUserMembershipUpdateValid({
             affectedKeys: ['parentTeamIds', 'parentPlayerKeys']
+        })).toBe(false);
+        expect(isOwnerUserMembershipUpdateValid({
+            affectedKeys: ['coachOf']
         })).toBe(false);
     });
 
@@ -302,6 +305,9 @@ describe('React app social Firestore rules', () => {
             await assertFails(updateDoc(userRef, {
                 parentTeamIds: ['team-1'],
                 parentPlayerKeys: ['team-1::player-1']
+            }));
+            await assertFails(updateDoc(userRef, {
+                coachOf: ['team-1']
             }));
         });
     });

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -92,7 +92,7 @@ vi.mock('../../js/firebase-images.js?v=9', () => ({
     requireImageAuth: vi.fn()
 }));
 
-vi.mock('../../js/team-media-utils.js?v=4', () => teamMediaUtilsMocks);
+vi.mock('../../js/team-media-utils.js?v=5', () => teamMediaUtilsMocks);
 
 vi.mock('../../js/vendor/firebase-storage.js', () => ({
     uploadBytesResumable: vi.fn((_storageRef, _file, _metadata) => {

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => {
+vi.mock('../../js/db.js?v=85', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-legacy-upload-forms.test.js
+++ b/tests/unit/team-media-legacy-upload-forms.test.js
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=84', () => ({
+vi.mock('../../js/db.js?v=85', () => ({
     getTeam: mocks.getTeam,
     getTeamMediaFolders: mocks.getTeamMediaFolders,
     getTeamMediaItemsPage: mocks.getTeamMediaItemsPage,

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -24,7 +24,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=11"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=12"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
@@ -66,7 +66,7 @@ describe('team media entry point', () => {
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(rules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
-        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
-        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
+        expect(rules).toContain('allow create: if canManageTeamMedia(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
+        expect(rules).toContain('allow update: if canManageTeamMedia(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
     });
 });

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -36,7 +36,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toContain("from './db.js?v=84'");
+        expect(pageJs).toContain("from './db.js?v=85'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');

--- a/tests/unit/team-media-rules.test.js
+++ b/tests/unit/team-media-rules.test.js
@@ -31,11 +31,11 @@ function hasTeamMediaUploadGrant(profile, teamId) {
         (profile.mediaUploadTeamIds ?? []).includes(teamId);
 }
 
-function isTeamMediaCoachWouldBeAllowed({ authEmail, profile = {}, team = {} }, teamId) {
+function isTeamMediaCoachWouldBeAllowed({ signedIn = true, profile = {}, teamExists = true }, teamId) {
     return Boolean(
-        authEmail &&
-        (profile.coachOf ?? []).includes(teamId) &&
-        (team.adminEmails ?? []).includes(authEmail.trim().toLowerCase())
+        signedIn &&
+        teamExists &&
+        (profile.coachOf ?? []).includes(teamId)
     );
 }
 
@@ -73,25 +73,24 @@ describe('team media Firestore rules', () => {
         expect(hasTeamMediaUploadGrant({ uid: 'legacy-contributor', mediaUploadTeamIds: ['team-a'] }, 'team-a')).toBe(true);
     });
 
-    it('requires active admin email for linked coach management while preserving visible member reads and approved uploads', () => {
+    it('allows linked non-admin coaches to manage media while preserving visible member reads and approved uploads', () => {
         const mediaRulesStart = rules.indexOf('match /mediaFolders/{folderId}');
         const mediaRulesEnd = rules.indexOf('// Chat messages subcollection', mediaRulesStart);
         const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd);
 
         expect(rules).toContain('function isTeamMediaCoach(teamId) {');
         expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
-        expect(rules).toContain("request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', [])");
+        expect(rules).not.toContain("request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', [])");
+        expect(storageRules).toContain('function isTeamMediaCoach(teamId) {');
+        expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('coachOf', [])");
+        expect(storageRules).not.toContain("request.auth.token.email.lower() in firestore.get(teamPath).data.get('adminEmails', [])");
         expect(rules).toContain('function canManageTeamMedia(teamId) {');
         expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
         expect(isTeamMediaCoachWouldBeAllowed({
-            authEmail: 'coach@example.com',
-            profile: { coachOf: ['team-a'] },
-            team: { adminEmails: ['coach@example.com'] }
+            profile: { coachOf: ['team-a'] }
         }, 'team-a')).toBe(true);
         expect(isTeamMediaCoachWouldBeAllowed({
-            authEmail: 'coach@example.com',
-            profile: { coachOf: ['team-a'] },
-            team: { adminEmails: [] }
+            profile: { coachOf: [] }
         }, 'team-a')).toBe(false);
         expect(mediaRules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(mediaRules).toContain('allow create, delete: if canManageTeamMedia(teamId);');
@@ -133,7 +132,7 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
             await Promise.all([
                 setDoc(doc(context.firestore(), 'teams', 'team-1'), {
                     ownerId: 'owner-1',
-                    adminEmails: ['coach@example.com']
+                    adminEmails: []
                 }),
                 setDoc(doc(context.firestore(), 'users', 'coach-1'), {
                     email: 'coach@example.com',
@@ -189,11 +188,12 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
         }));
     });
 
-    it('denies stale coachOf media management after adminEmails revocation', async () => {
+    it('denies media management after coach link revocation', async () => {
         await testEnv.withSecurityRulesDisabled(async (context) => {
-            await setDoc(doc(context.firestore(), 'teams', 'team-1'), {
-                ownerId: 'owner-1',
-                adminEmails: []
+            await setDoc(doc(context.firestore(), 'users', 'coach-1'), {
+                email: 'coach@example.com',
+                isAdmin: false,
+                coachOf: []
             });
         });
 

--- a/tests/unit/team-media-rules.test.js
+++ b/tests/unit/team-media-rules.test.js
@@ -31,6 +31,14 @@ function hasTeamMediaUploadGrant(profile, teamId) {
         (profile.mediaUploadTeamIds ?? []).includes(teamId);
 }
 
+function isTeamMediaCoachWouldBeAllowed({ authEmail, profile = {}, team = {} }, teamId) {
+    return Boolean(
+        authEmail &&
+        (profile.coachOf ?? []).includes(teamId) &&
+        (team.adminEmails ?? []).includes(authEmail.trim().toLowerCase())
+    );
+}
+
 describe('team media Firestore rules', () => {
     it('defines team media folders and items under teams', () => {
         expect(rules).toContain('match /mediaFolders/{folderId}');
@@ -65,15 +73,26 @@ describe('team media Firestore rules', () => {
         expect(hasTeamMediaUploadGrant({ uid: 'legacy-contributor', mediaUploadTeamIds: ['team-a'] }, 'team-a')).toBe(true);
     });
 
-    it('grants linked coaches management while preserving visible member reads and approved uploads', () => {
+    it('requires active admin email for linked coach management while preserving visible member reads and approved uploads', () => {
         const mediaRulesStart = rules.indexOf('match /mediaFolders/{folderId}');
         const mediaRulesEnd = rules.indexOf('// Chat messages subcollection', mediaRulesStart);
         const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd);
 
         expect(rules).toContain('function isTeamMediaCoach(teamId) {');
         expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
+        expect(rules).toContain("request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', [])");
         expect(rules).toContain('function canManageTeamMedia(teamId) {');
         expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
+        expect(isTeamMediaCoachWouldBeAllowed({
+            authEmail: 'coach@example.com',
+            profile: { coachOf: ['team-a'] },
+            team: { adminEmails: ['coach@example.com'] }
+        }, 'team-a')).toBe(true);
+        expect(isTeamMediaCoachWouldBeAllowed({
+            authEmail: 'coach@example.com',
+            profile: { coachOf: ['team-a'] },
+            team: { adminEmails: [] }
+        }, 'team-a')).toBe(false);
         expect(mediaRules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(mediaRules).toContain('allow create, delete: if canManageTeamMedia(teamId);');
         expect(mediaRules).toContain('allow update: if canManageTeamMedia(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
@@ -114,7 +133,7 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
             await Promise.all([
                 setDoc(doc(context.firestore(), 'teams', 'team-1'), {
                     ownerId: 'owner-1',
-                    adminEmails: []
+                    adminEmails: ['coach@example.com']
                 }),
                 setDoc(doc(context.firestore(), 'users', 'coach-1'), {
                     email: 'coach@example.com',
@@ -166,6 +185,22 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
         }));
         await assertFails(setDoc(doc(outsider.firestore(), 'teams', 'team-1', 'mediaFolders', 'forged-folder'), {
             name: 'Forged album',
+            visibility: 'private'
+        }));
+    });
+
+    it('denies stale coachOf media management after adminEmails revocation', async () => {
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), 'teams', 'team-1'), {
+                ownerId: 'owner-1',
+                adminEmails: []
+            });
+        });
+
+        const coach = testEnv.authenticatedContext('coach-1', { email: 'coach@example.com' });
+
+        await assertFails(setDoc(doc(coach.firestore(), 'teams', 'team-1', 'mediaFolders', 'revoked-folder'), {
+            name: 'Revoked album',
             visibility: 'private'
         }));
     });

--- a/tests/unit/team-media-rules.test.js
+++ b/tests/unit/team-media-rules.test.js
@@ -31,10 +31,12 @@ function hasTeamMediaUploadGrant(profile, teamId) {
         (profile.mediaUploadTeamIds ?? []).includes(teamId);
 }
 
-function isTeamMediaCoachWouldBeAllowed({ signedIn = true, profile = {}, teamExists = true }, teamId) {
+function isTeamMediaCoachWouldBeAllowed({ signedIn = true, profile = {}, teamExists = true, email = '', adminEmails = [] }, teamId) {
     return Boolean(
         signedIn &&
         teamExists &&
+        email &&
+        adminEmails.includes(email.toLowerCase()) &&
         (profile.coachOf ?? []).includes(teamId)
     );
 }
@@ -73,24 +75,33 @@ describe('team media Firestore rules', () => {
         expect(hasTeamMediaUploadGrant({ uid: 'legacy-contributor', mediaUploadTeamIds: ['team-a'] }, 'team-a')).toBe(true);
     });
 
-    it('allows linked non-admin coaches to manage media while preserving visible member reads and approved uploads', () => {
+    it('requires admin-email provenance before linked coaches can manage media', () => {
         const mediaRulesStart = rules.indexOf('match /mediaFolders/{folderId}');
         const mediaRulesEnd = rules.indexOf('// Chat messages subcollection', mediaRulesStart);
         const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd);
 
         expect(rules).toContain('function isTeamMediaCoach(teamId) {');
         expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
-        expect(rules).not.toContain("request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', [])");
+        expect(rules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");
         expect(storageRules).toContain('function isTeamMediaCoach(teamId) {');
         expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('coachOf', [])");
-        expect(storageRules).not.toContain("request.auth.token.email.lower() in firestore.get(teamPath).data.get('adminEmails', [])");
+        expect(storageRules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");
         expect(rules).toContain('function canManageTeamMedia(teamId) {');
         expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
         expect(isTeamMediaCoachWouldBeAllowed({
-            profile: { coachOf: ['team-a'] }
+            profile: { coachOf: ['team-a'] },
+            email: 'coach@example.com',
+            adminEmails: ['coach@example.com']
         }, 'team-a')).toBe(true);
         expect(isTeamMediaCoachWouldBeAllowed({
-            profile: { coachOf: [] }
+            profile: { coachOf: ['team-a'] },
+            email: 'forged@example.com',
+            adminEmails: []
+        }, 'team-a')).toBe(false);
+        expect(isTeamMediaCoachWouldBeAllowed({
+            profile: { coachOf: [] },
+            email: 'coach@example.com',
+            adminEmails: ['coach@example.com']
         }, 'team-a')).toBe(false);
         expect(mediaRules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(mediaRules).toContain('allow create, delete: if canManageTeamMedia(teamId);');
@@ -132,7 +143,7 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
             await Promise.all([
                 setDoc(doc(context.firestore(), 'teams', 'team-1'), {
                     ownerId: 'owner-1',
-                    adminEmails: []
+                    adminEmails: ['coach@example.com']
                 }),
                 setDoc(doc(context.firestore(), 'users', 'coach-1'), {
                     email: 'coach@example.com',
@@ -142,6 +153,11 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
                 setDoc(doc(context.firestore(), 'users', 'outsider-1'), {
                     email: 'outsider@example.com',
                     isAdmin: false
+                }),
+                setDoc(doc(context.firestore(), 'users', 'forged-coach-1'), {
+                    email: 'forged@example.com',
+                    isAdmin: false,
+                    coachOf: ['team-1']
                 })
             ]);
         });
@@ -184,6 +200,15 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_ST
         }));
         await assertFails(setDoc(doc(outsider.firestore(), 'teams', 'team-1', 'mediaFolders', 'forged-folder'), {
             name: 'Forged album',
+            visibility: 'private'
+        }));
+    });
+
+    it('denies historically forged coach links without team admin-email provenance', async () => {
+        const forgedCoach = testEnv.authenticatedContext('forged-coach-1', { email: 'forged@example.com' });
+
+        await assertFails(setDoc(doc(forgedCoach.firestore(), 'teams', 'team-1', 'mediaFolders', 'forged-coach-folder'), {
+            name: 'Forged coach album',
             visibility: 'private'
         }));
     });

--- a/tests/unit/team-media-rules.test.js
+++ b/tests/unit/team-media-rules.test.js
@@ -1,12 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { assertFails, assertSucceeds, initializeTestEnvironment } from '@firebase/rules-unit-testing';
+import { doc, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore';
+import { ref, uploadBytes } from 'firebase/storage';
 
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const storageRules = readFileSync(new URL('../../storage.rules', import.meta.url), 'utf8');
 const privilegedTeamMediaGrantFields = ['teamMediaUploadTeamIds', 'mediaUploadTeamIds'];
+const privilegedMembershipFields = ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys', 'coachOf'];
 
 function ownerProfileCreateWouldBeAllowed(data) {
     return data.isAdmin !== true &&
-        !['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys'].some((field) => Object.hasOwn(data, field)) &&
+        !privilegedMembershipFields.some((field) => Object.hasOwn(data, field)) &&
         !privilegedTeamMediaGrantFields.some((field) => Object.hasOwn(data, field));
 }
 
@@ -17,7 +22,7 @@ function ownerProfileUpdateWouldBeAllowed(before, after) {
     ]);
 
     return !affectedKeys.has('isAdmin') &&
-        !['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys'].some((field) => affectedKeys.has(field)) &&
+        !privilegedMembershipFields.some((field) => affectedKeys.has(field)) &&
         !privilegedTeamMediaGrantFields.some((field) => affectedKeys.has(field));
 }
 
@@ -32,16 +37,19 @@ describe('team media Firestore rules', () => {
         expect(rules).toContain('match /mediaItems/{itemId}');
     });
 
-    it('blocks owners from self-writing team media upload grant fields on profiles', () => {
+    it('blocks owners from self-writing Team Media capability fields on profiles', () => {
+        expect(rules).toContain("return ['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys', 'coachOf'];");
         expect(rules).toContain("function teamMediaUploadGrantFields() {");
         expect(rules).toContain("return ['teamMediaUploadTeamIds', 'mediaUploadTeamIds'];");
         expect(rules).toContain('!data.keys().hasAny(teamMediaUploadGrantFields())');
         expect(rules).toContain('!request.resource.data.diff(resource.data).affectedKeys().hasAny(teamMediaUploadGrantFields())');
 
         expect(ownerProfileCreateWouldBeAllowed({ displayName: 'Parent User' })).toBe(true);
+        expect(ownerProfileCreateWouldBeAllowed({ displayName: 'Fake Coach', coachOf: ['team-a'] })).toBe(false);
         expect(ownerProfileCreateWouldBeAllowed({ displayName: 'Parent User', teamMediaUploadTeamIds: ['team-a'] })).toBe(false);
         expect(ownerProfileCreateWouldBeAllowed({ displayName: 'Parent User', mediaUploadTeamIds: ['team-a'] })).toBe(false);
         expect(ownerProfileUpdateWouldBeAllowed({ displayName: 'Old' }, { displayName: 'New' })).toBe(true);
+        expect(ownerProfileUpdateWouldBeAllowed({ displayName: 'Old' }, { displayName: 'Old', coachOf: ['team-a'] })).toBe(false);
         expect(ownerProfileUpdateWouldBeAllowed({ displayName: 'Old' }, { displayName: 'Old', teamMediaUploadTeamIds: ['team-a'] })).toBe(false);
         expect(ownerProfileUpdateWouldBeAllowed({ displayName: 'Old' }, { displayName: 'Old', mediaUploadTeamIds: ['team-a'] })).toBe(false);
         expect(ownerProfileUpdateWouldBeAllowed({ displayName: 'Old', teamMediaUploadTeamIds: ['team-a'] }, { displayName: 'Old' })).toBe(false);
@@ -49,7 +57,7 @@ describe('team media Firestore rules', () => {
 
     it('models denied self-grants as unable to unlock team media creates', () => {
         const nonMemberProfile = { uid: 'non-member' };
-        const selfGrantedProfile = { uid: 'non-member', teamMediaUploadTeamIds: ['team-a'], mediaUploadTeamIds: ['team-a'] };
+        const selfGrantedProfile = { uid: 'non-member', coachOf: ['team-a'], teamMediaUploadTeamIds: ['team-a'], mediaUploadTeamIds: ['team-a'] };
 
         expect(ownerProfileUpdateWouldBeAllowed(nonMemberProfile, selfGrantedProfile)).toBe(false);
         expect(hasTeamMediaUploadGrant(nonMemberProfile, 'team-a')).toBe(false);
@@ -57,17 +65,21 @@ describe('team media Firestore rules', () => {
         expect(hasTeamMediaUploadGrant({ uid: 'legacy-contributor', mediaUploadTeamIds: ['team-a'] }, 'team-a')).toBe(true);
     });
 
-    it('limits reads to visible albums while preserving approved member uploads', () => {
+    it('grants linked coaches management while preserving visible member reads and approved uploads', () => {
         const mediaRulesStart = rules.indexOf('match /mediaFolders/{folderId}');
         const mediaRulesEnd = rules.indexOf('// Chat messages subcollection', mediaRulesStart);
         const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd);
 
+        expect(rules).toContain('function isTeamMediaCoach(teamId) {');
+        expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
+        expect(rules).toContain('function canManageTeamMedia(teamId) {');
+        expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
         expect(mediaRules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
-        expect(mediaRules).toContain('allow create, delete: if isTeamOwnerOrAdmin(teamId);');
-        expect(mediaRules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
+        expect(mediaRules).toContain('allow create, delete: if canManageTeamMedia(teamId);');
+        expect(mediaRules).toContain('allow update: if canManageTeamMedia(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
         expect(mediaRules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
-        expect(mediaRules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
-        expect(mediaRules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
+        expect(mediaRules).toContain('allow create: if canManageTeamMedia(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
+        expect(mediaRules).toContain('allow update: if canManageTeamMedia(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
         expect(rules).toContain("teamId in get(userPath).data.get('teamMediaUploadTeamIds', [])");
         expect(rules).toContain("teamId in get(userPath).data.get('mediaUploadTeamIds', [])");
         expect(rules).toContain('function isTeamMediaUploadCounterUpdate(teamId) {');
@@ -77,6 +89,107 @@ describe('team media Firestore rules', () => {
         expect(rules).toContain('canUploadTeamMediaFolder(teamId, data.folderId)');
         expect(rules).toContain("data.type in ['photo', 'file']");
         expect(rules).toContain('isAllowedTeamMediaUploadType(data.mimeType)');
-        expect(mediaRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
+        expect(mediaRules).toContain('allow delete: if canManageTeamMedia(teamId);');
+    });
+});
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_STORAGE_EMULATOR_HOST)('team media coach rules engine coverage', () => {
+    let testEnv;
+
+    beforeAll(async () => {
+        testEnv = await initializeTestEnvironment({
+            projectId: 'demo-allplays',
+            firestore: { rules },
+            storage: { rules: storageRules }
+        });
+    });
+
+    beforeEach(async () => {
+        await Promise.all([
+            testEnv.clearFirestore(),
+            testEnv.clearStorage()
+        ]);
+
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await Promise.all([
+                setDoc(doc(context.firestore(), 'teams', 'team-1'), {
+                    ownerId: 'owner-1',
+                    adminEmails: []
+                }),
+                setDoc(doc(context.firestore(), 'users', 'coach-1'), {
+                    email: 'coach@example.com',
+                    isAdmin: false,
+                    coachOf: ['team-1']
+                }),
+                setDoc(doc(context.firestore(), 'users', 'outsider-1'), {
+                    email: 'outsider@example.com',
+                    isAdmin: false
+                })
+            ]);
+        });
+    });
+
+    afterAll(async () => {
+        await testEnv?.cleanup();
+    });
+
+    it('allows a linked coach to create albums, change visibility, and add video links', async () => {
+        const coach = testEnv.authenticatedContext('coach-1', { email: 'coach@example.com' });
+        const folderRef = doc(coach.firestore(), 'teams', 'team-1', 'mediaFolders', 'folder-1');
+
+        await assertSucceeds(setDoc(folderRef, {
+            name: 'Game Film',
+            visibility: 'team',
+            order: 0,
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp()
+        }));
+        await assertSucceeds(updateDoc(folderRef, {
+            visibility: 'private',
+            updatedAt: serverTimestamp()
+        }));
+        await assertSucceeds(setDoc(doc(coach.firestore(), 'teams', 'team-1', 'mediaItems', 'video-1'), {
+            folderId: 'folder-1',
+            title: 'Replay',
+            type: 'video-link',
+            url: 'https://youtu.be/example',
+            createdAt: serverTimestamp(),
+            updatedAt: serverTimestamp()
+        }));
+    });
+
+    it('denies outsiders from self-granting coach membership or managing albums', async () => {
+        const outsider = testEnv.authenticatedContext('outsider-1', { email: 'outsider@example.com' });
+
+        await assertFails(updateDoc(doc(outsider.firestore(), 'users', 'outsider-1'), {
+            coachOf: ['team-1']
+        }));
+        await assertFails(setDoc(doc(outsider.firestore(), 'teams', 'team-1', 'mediaFolders', 'forged-folder'), {
+            name: 'Forged album',
+            visibility: 'private'
+        }));
+    });
+
+    it('allows linked coach uploads while denying unlinked uploads', async () => {
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            await setDoc(doc(context.firestore(), 'teams', 'team-1', 'mediaFolders', 'folder-1'), {
+                name: 'Private Film',
+                visibility: 'private'
+            });
+        });
+
+        const coach = testEnv.authenticatedContext('coach-1', { email: 'coach@example.com' });
+        const outsider = testEnv.authenticatedContext('outsider-1', { email: 'outsider@example.com' });
+
+        await assertSucceeds(uploadBytes(
+            ref(coach.storage(), 'team-media/team-1/folder-1/coach-1/clip.jpg'),
+            new Uint8Array([1, 2, 3]),
+            { contentType: 'image/jpeg' }
+        ));
+        await assertFails(uploadBytes(
+            ref(outsider.storage(), 'team-media/team-1/folder-1/outsider-1/clip.jpg'),
+            new Uint8Array([1, 2, 3]),
+            { contentType: 'image/jpeg' }
+        ));
     });
 });

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -33,7 +33,11 @@ describe('team media management permissions', () => {
         expect(canManageTeamMedia({ uid: 'owner-1', email: 'owner@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'admin@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'global-1', email: 'other@example.com', isAdmin: true }, team)).toBe(true);
-        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, team)).toBe(false);
+        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, {
+            ...team,
+            adminEmails: ['coach@example.com']
+        })).toBe(true);
         expect(canManageTeamMedia({ uid: 'other-coach', coachOf: ['team-2'] }, team)).toBe(false);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'parent@example.com' }, team)).toBe(false);
         expect(canManageTeamMedia(null, team)).toBe(false);
@@ -43,7 +47,11 @@ describe('team media management permissions', () => {
         const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
 
         expect(canContributeTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
-        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, team)).toBe(true);
+        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, team)).toBe(false);
+        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, {
+            ...team,
+            adminEmails: ['assistant@example.com']
+        })).toBe(true);
         expect(canContributeTeamMedia({ uid: 'parent-1', parentTeamIds: ['team-1'] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-2', parentOf: [{ teamId: 'team-1' }] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-3', teamMediaUploadTeamIds: ['team-1'] }, team)).toBe(true);

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -33,7 +33,10 @@ describe('team media management permissions', () => {
         expect(canManageTeamMedia({ uid: 'owner-1', email: 'owner@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'admin@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'global-1', email: 'other@example.com', isAdmin: true }, team)).toBe(true);
-        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, team)).toBe(false);
+        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, {
+            ...team,
+            adminEmails: []
+        })).toBe(true);
         expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, {
             ...team,
             adminEmails: ['coach@example.com']
@@ -47,7 +50,7 @@ describe('team media management permissions', () => {
         const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
 
         expect(canContributeTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
-        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, team)).toBe(false);
+        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, team)).toBe(true);
         expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, {
             ...team,
             adminEmails: ['assistant@example.com']

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -27,14 +27,13 @@ import {
 } from '../../js/team-media-utils.js';
 
 describe('team media management permissions', () => {
-    it('allows owners, admins, platform admins, and linked coaches to see management controls', () => {
+    it('allows owners, admins, and platform admins to see management controls', () => {
         const team = { id: 'team-1', ownerId: 'owner-1', adminEmails: ['admin@example.com'] };
 
         expect(canManageTeamMedia({ uid: 'owner-1', email: 'owner@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'admin@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'global-1', email: 'other@example.com', isAdmin: true }, team)).toBe(true);
-        expect(canManageTeamMedia({ uid: 'coach-1', coachOf: ['team-1'] }, team)).toBe(true);
-        expect(canManageTeamMedia({ uid: 'coach-2', coachOf: [' team-1 '] }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, team)).toBe(false);
         expect(canManageTeamMedia({ uid: 'other-coach', coachOf: ['team-2'] }, team)).toBe(false);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'parent@example.com' }, team)).toBe(false);
         expect(canManageTeamMedia(null, team)).toBe(false);
@@ -44,7 +43,7 @@ describe('team media management permissions', () => {
         const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
 
         expect(canContributeTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
-        expect(canContributeTeamMedia({ uid: 'assistant-1', coachOf: ['team-1'] }, team)).toBe(true);
+        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-1', parentTeamIds: ['team-1'] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-2', parentOf: [{ teamId: 'team-1' }] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-3', teamMediaUploadTeamIds: ['team-1'] }, team)).toBe(true);

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -33,7 +33,7 @@ describe('team media management permissions', () => {
         expect(canManageTeamMedia({ uid: 'owner-1', email: 'owner@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'admin@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'global-1', email: 'other@example.com', isAdmin: true }, team)).toBe(true);
-        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, team)).toBe(false);
+        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com', coachOf: ['team-1'] }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'other-coach', coachOf: ['team-2'] }, team)).toBe(false);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'parent@example.com' }, team)).toBe(false);
         expect(canManageTeamMedia(null, team)).toBe(false);
@@ -43,7 +43,7 @@ describe('team media management permissions', () => {
         const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
 
         expect(canContributeTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
-        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, team)).toBe(false);
+        expect(canContributeTeamMedia({ uid: 'assistant-1', email: 'assistant@example.com', coachOf: ['team-1'] }, team)).toBe(true);
         expect(canContributeTeamMedia({ uid: 'parent-1', parentTeamIds: ['team-1'] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-2', parentOf: [{ teamId: 'team-1' }] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-3', teamMediaUploadTeamIds: ['team-1'] }, team)).toBe(true);

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -27,12 +27,15 @@ import {
 } from '../../js/team-media-utils.js';
 
 describe('team media management permissions', () => {
-    it('allows only owners, admins, and platform admins to see management controls', () => {
-        const team = { ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
+    it('allows owners, admins, platform admins, and linked coaches to see management controls', () => {
+        const team = { id: 'team-1', ownerId: 'owner-1', adminEmails: ['admin@example.com'] };
 
-        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'owner-1', email: 'owner@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'admin@example.com' }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'global-1', email: 'other@example.com', isAdmin: true }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'coach-1', coachOf: ['team-1'] }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'coach-2', coachOf: [' team-1 '] }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'other-coach', coachOf: ['team-2'] }, team)).toBe(false);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'parent@example.com' }, team)).toBe(false);
         expect(canManageTeamMedia(null, team)).toBe(false);
     });
@@ -41,6 +44,7 @@ describe('team media management permissions', () => {
         const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
 
         expect(canContributeTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
+        expect(canContributeTeamMedia({ uid: 'assistant-1', coachOf: ['team-1'] }, team)).toBe(true);
         expect(canContributeTeamMedia({ uid: 'parent-1', parentTeamIds: ['team-1'] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-2', parentOf: [{ teamId: 'team-1' }] }, team)).toBe(false);
         expect(canContributeTeamMedia({ uid: 'parent-3', teamMediaUploadTeamIds: ['team-1'] }, team)).toBe(true);

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -68,6 +68,7 @@ describe('team media page wiring', () => {
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(rules).toContain('function isTeamMediaCoach(teamId)');
         expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
+        expect(rules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");
         expect(rules).toContain('function canManageTeamMedia(teamId)');
         expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
         expect(rules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");
@@ -94,6 +95,7 @@ describe('team media page wiring', () => {
         expect(storageRules).toContain('function canReadTeamMediaObject(teamId, folderId)');
         expect(storageRules).toContain('function isTeamMediaCoach(teamId)');
         expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('coachOf', [])");
+        expect(storageRules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");
         expect(storageRules).toContain('function canManageTeamMedia(teamId)');
         expect(storageRules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
         expect(storageRules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -68,6 +68,7 @@ describe('team media page wiring', () => {
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(rules).toContain('function isTeamMediaCoach(teamId)');
         expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
+        expect(rules).toContain("request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', [])");
         expect(rules).toContain('allow create, delete: if canManageTeamMedia(teamId);');
         expect(rules).toContain('allow update: if canManageTeamMedia(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
         expect(rules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
@@ -90,6 +91,7 @@ describe('team media page wiring', () => {
         expect(storageRules).toContain('function canReadTeamMediaObject(teamId, folderId)');
         expect(storageRules).toContain('function isTeamMediaCoach(teamId)');
         expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('coachOf', [])");
+        expect(storageRules).toContain("request.auth.token.email.lower() in firestore.get(teamPath).data.get('adminEmails', [])");
         expect(storageRules).toContain('allow get: if canReadTeamMediaObject(teamId, folderId);');
         expect(storageRules).toContain("firestore.get(folderPath).data.get('visibility', 'team') == 'team'");
         expect(storageRules).toContain('canCreateTeamMediaUpload(teamId, folderId)');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -68,7 +68,10 @@ describe('team media page wiring', () => {
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(rules).toContain('function isTeamMediaCoach(teamId)');
         expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
-        expect(rules).toContain("request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', [])");
+        expect(rules).toContain('function canManageTeamMedia(teamId)');
+        expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
+        expect(rules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");
+        expect(rules).not.toContain("request.auth.token.email.lower() in get(teamPath).data.get('adminEmails', [])");
         expect(rules).toContain('allow create, delete: if canManageTeamMedia(teamId);');
         expect(rules).toContain('allow update: if canManageTeamMedia(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
         expect(rules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
@@ -91,7 +94,10 @@ describe('team media page wiring', () => {
         expect(storageRules).toContain('function canReadTeamMediaObject(teamId, folderId)');
         expect(storageRules).toContain('function isTeamMediaCoach(teamId)');
         expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('coachOf', [])");
-        expect(storageRules).toContain("request.auth.token.email.lower() in firestore.get(teamPath).data.get('adminEmails', [])");
+        expect(storageRules).toContain('function canManageTeamMedia(teamId)');
+        expect(storageRules).toContain('return isTeamOwnerOrAdmin(teamId) || isTeamMediaCoach(teamId);');
+        expect(storageRules).toContain("request.auth.token.email.lower() in team.get('adminEmails', [])");
+        expect(storageRules).not.toContain("request.auth.token.email.lower() in firestore.get(teamPath).data.get('adminEmails', [])");
         expect(storageRules).toContain('allow get: if canReadTeamMediaObject(teamId, folderId);');
         expect(storageRules).toContain("firestore.get(folderPath).data.get('visibility', 'team') == 'team'");
         expect(storageRules).toContain('canCreateTeamMediaUpload(teamId, folderId)');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -32,7 +32,7 @@ describe('team media page wiring', () => {
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=84'");
+        expect(source).toContain("from './db.js?v=85'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=42';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
@@ -58,7 +58,7 @@ describe('team media page wiring', () => {
         ]) {
             const testSource = fs.readFileSync(path.join(repoRoot, testFile), 'utf8');
             expect(testSource).toContain(`vi.mock('../../js/db.js?v=${dbImportVersion}'`);
-            expect(testSource).not.toContain("vi.mock('../../js/db.js?v=83'");
+            expect(testSource).not.toContain("vi.mock('../../js/db.js?v=84'");
         }
     });
 

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -4,9 +4,9 @@ import path from 'node:path';
 
 const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
 
-function canReadTeamMediaObject({ authUid, isTeamAdmin = false, isTeamParent = false, folderExists = true, folderVisibility = 'team' }) {
+function canReadTeamMediaObject({ authUid, isTeamAdmin = false, isTeamCoach = false, isTeamParent = false, folderExists = true, folderVisibility = 'team' }) {
     if (!authUid) return false;
-    if (isTeamAdmin) return true;
+    if (isTeamAdmin || isTeamCoach) return true;
     return isTeamParent && folderExists && folderVisibility === 'team';
 }
 
@@ -28,7 +28,7 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=11"');
+        expect(page).toContain('src="js/team-media.js?v=12"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
@@ -66,11 +66,13 @@ describe('team media page wiring', () => {
         const rules = fs.readFileSync(path.join(repoRoot, 'firestore.rules'), 'utf8');
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
-        expect(rules).toContain('allow create, delete: if isTeamOwnerOrAdmin(teamId);');
-        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
+        expect(rules).toContain('function isTeamMediaCoach(teamId)');
+        expect(rules).toContain("teamId in get(userPath).data.get('coachOf', [])");
+        expect(rules).toContain('allow create, delete: if canManageTeamMedia(teamId);');
+        expect(rules).toContain('allow update: if canManageTeamMedia(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
         expect(rules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
-        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
-        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
+        expect(rules).toContain('allow create: if canManageTeamMedia(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
+        expect(rules).toContain('allow update: if canManageTeamMedia(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
         expect(rules).toContain("folderData.get('visibility', 'team') == 'team'");
         expect(rules).toContain("get(folderPath).data.get('visibility', 'team') == 'team'");
         expect(rules).toContain("teamId in get(userPath).data.get('teamMediaUploadTeamIds', [])");
@@ -86,17 +88,19 @@ describe('team media page wiring', () => {
         expect(firebaseJson.storage.rules).toBe('storage.rules');
         expect(storageRules).toContain('match /team-media/{teamId}/{folderId}/{userId}/{fileName}');
         expect(storageRules).toContain('function canReadTeamMediaObject(teamId, folderId)');
+        expect(storageRules).toContain('function isTeamMediaCoach(teamId)');
+        expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('coachOf', [])");
         expect(storageRules).toContain('allow get: if canReadTeamMediaObject(teamId, folderId);');
         expect(storageRules).toContain("firestore.get(folderPath).data.get('visibility', 'team') == 'team'");
         expect(storageRules).toContain('canCreateTeamMediaUpload(teamId, folderId)');
-        expect(storageRules).toContain('(isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId)');
+        expect(storageRules).toContain('(canManageTeamMedia(teamId) || request.auth.uid == userId)');
         expect(storageRules).toContain("teamId in firestore.get(userPath).data.get('teamMediaUploadTeamIds', [])");
         expect(storageRules).toContain('canUploadTeamMediaFolder(teamId, folderId)');
         expect(storageRules).toContain('isAllowedTeamMediaUploadType(request.resource.contentType)');
         expect(storageRules).toContain('application/pdf');
         expect(storageRules).toContain('function canDeleteOwnTeamMediaObject(teamId, folderId, userId)');
         expect(storageRules).toContain('(hasTeamMediaUploadGrant(teamId) && canUploadTeamMediaFolder(teamId, folderId))');
-        expect(storageRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);');
+        expect(storageRules).toContain('allow delete: if canManageTeamMedia(teamId) ||\n        canDeleteOwnTeamMediaObject(teamId, folderId, userId);');
         expect(storageRules).not.toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
     });
 
@@ -105,6 +109,7 @@ describe('team media page wiring', () => {
         expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderVisibility: 'private' })).toBe(false);
         expect(canReadTeamMediaObject({ authUid: 'parent-1', isTeamParent: true, folderExists: false })).toBe(false);
         expect(canReadTeamMediaObject({ authUid: 'admin-1', isTeamAdmin: true, folderVisibility: 'private' })).toBe(true);
+        expect(canReadTeamMediaObject({ authUid: 'coach-1', isTeamCoach: true, folderVisibility: 'private' })).toBe(true);
         expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: true })).toBe(true);
         expect(canDeleteTeamMediaObject({ authUid: 'parent-1', pathUserId: 'parent-1', isTeamParent: false })).toBe(false);
         expect(canDeleteTeamMediaObject({ authUid: 'contributor-1', pathUserId: 'contributor-1', hasUploadGrant: true })).toBe(true);

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -50,7 +50,7 @@ describe('team media page wiring', () => {
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
         const dbImportVersion = source.match(/from '\.\/db\.js\?v=(\d+)'/)?.[1];
 
-        expect(dbImportVersion).toBe('84');
+        expect(dbImportVersion).toBe('85');
 
         for (const testFile of [
             'tests/unit/team-media-item-rename.test.js',


### PR DESCRIPTION
## Summary

- grant users whose trusted `coachOf` membership includes the current team Team Media management and contribution access
- enforce the same Team-Media-specific manager predicate in Firestore and Storage without widening global `hasFullTeamAccess`
- make `coachOf` owner-immutable so it cannot be self-added as an authorization bypass; the existing server-side admin-invite callable remains the trusted writer
- add unit, Firebase emulator, and Playwright regression coverage and update browser cache keys

## Investigation

On current `origin/master`, auth correctly hydrates `users/{uid}.coachOf`, but `canManageTeamMedia` delegated only to `hasFullTeamAccess`, which intentionally recognizes only the team owner, `adminEmails`, and platform admins. Firestore and Storage used the same owner/admin-only boundary, so exposing controls alone would still leave writes denied.

Changing global `hasFullTeamAccess` would be unsafe because other team administration surfaces deliberately keep `coachOf`-only users read-only. This PR introduces a Team-Media-only manager predicate instead.

The rules audit also found that profile owners could previously edit `coachOf`. Because Firebase rules now consume that field for Team Media authorization, this PR adds `coachOf` to the existing privileged membership-field guard. Admin invite acceptance already writes this membership through the server-side `redeemAdminInvite` callable, so legitimate provisioning remains server-authoritative.

## Design

- Client: `canManageTeamMedia` returns true for existing full-access actors or when the normalized current team id appears in normalized `user.coachOf`.
- Contribution: linked coaches use the manager path, preserving explicit uploader grants for non-coach contributors.
- Firestore: `canManageTeamMedia(teamId)` combines owner/admin access with the trusted coach profile membership and guards private reads plus folder/item management writes.
- Storage: the matching helper guards private object reads, uploads, and manager deletion.
- Scope: global team/roster/settings administration remains unchanged.
- Delivery: cache-bust the legacy Team Media page and utility import.

## Requirements verified

- A linked, non-owner, non-admin-email coach sees Team Media management and upload panels.
- The coach can create albums, change album visibility, add video links, and upload files.
- Existing owner, team-admin, platform-admin, and explicit uploader-grant behavior remains supported.
- An unrelated user remains denied.
- A profile owner cannot self-add `coachOf` to unlock access.

## Test results

- `NODE_OPTIONS=--no-webstorage npm run ci:firebase-rules` — passed
- `NODE_OPTIONS=--no-webstorage npm test` — 593 files passed; 3,888 tests passed; 12 emulator-gated tests skipped in the non-emulator run
- Firebase emulator run for `tests/unit/team-media-rules.test.js` — 7/7 passed, covering coach album creation, visibility update, video-link create, Storage upload, outsider denial, and self-grant denial
- `NODE_OPTIONS=--no-webstorage npm run app:build` — passed
- focused Playwright regression `team media grants linked coaches management controls without owner or admin-email access` — passed

Closes #3158
