### PR TITLE
Support multi-game tournament blocks

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -186,7 +186,7 @@ import { expandRecurrence, fetchAndParseCalendar, isTeamActive, mergeAssignments
 import { getCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
-import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
+import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
   return {
@@ -441,7 +441,7 @@ describe('scheduled tournament writes', () => {
     expect(addGame).not.toHaveBeenCalled();
   });
 
-  it('rejects multi-row tournament blocks before building partial tournament documents', async () => {
+  it('prevalidates every tournament row before building or writing documents', async () => {
     await expect(createScheduledTournamentBlockForApp('team-1', {
       divisionName: '10U Gold',
       bracketName: 'Gold Bracket',
@@ -458,7 +458,7 @@ describe('scheduled tournament writes', () => {
           notes: 'Bring dark jerseys'
         },
         {
-          opponent: 'Lions',
+          opponent: '',
           startDate: new Date('2026-06-25T18:30:00.000Z'),
           endDate: new Date('2026-06-25T20:00:00.000Z'),
           location: 'Field 2',
@@ -467,7 +467,7 @@ describe('scheduled tournament writes', () => {
           notes: ''
         }
       ]
-    }, coachUser)).rejects.toThrow('Tournament blocks currently support exactly one completed game.');
+    }, coachUser)).rejects.toThrow('Games require an opponent.');
 
     expect(buildSingleLegacyTournamentGameDocument).not.toHaveBeenCalled();
     expect(buildLegacyTournamentGameDocuments).not.toHaveBeenCalled();
@@ -525,8 +525,12 @@ describe('scheduled tournament writes', () => {
     }));
   });
 
-  it('does not let unsupported tournament row counts reach the legacy tournament mapper', async () => {
-    await expect(createScheduledTournamentBlockForApp('team-1', {
+  it('builds and persists every row in a multi-game tournament block', async () => {
+    vi.mocked(addGame)
+      .mockResolvedValueOnce('game-1' as any)
+      .mockResolvedValueOnce('game-2' as any);
+
+    const createdIds = await createScheduledTournamentBlockForApp('team-1', {
       divisionName: '10U Gold',
       bracketName: 'Gold Bracket',
       roundName: 'Semifinal',
@@ -551,11 +555,65 @@ describe('scheduled tournament writes', () => {
           notes: ''
         }
       ]
-    }, coachUser)).rejects.toThrow('Tournament blocks currently support exactly one completed game.');
+    }, coachUser);
 
+    expect(createdIds).toEqual(['game-1', 'game-2']);
     expect(buildSingleLegacyTournamentGameDocument).not.toHaveBeenCalled();
-    expect(buildLegacyTournamentGameDocuments).not.toHaveBeenCalled();
-    expect(addGame).not.toHaveBeenCalled();
+    expect(buildLegacyTournamentGameDocuments).toHaveBeenCalledTimes(1);
+    expect(buildLegacyTournamentGameDocuments).toHaveBeenCalledWith([
+      expect.objectContaining({ opponent: 'Tigers', competitionType: 'tournament', createdBy: 'coach-1' }),
+      expect.objectContaining({ opponent: 'Lions', competitionType: 'tournament', createdBy: 'coach-1' })
+    ], {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A'
+    });
+    expect(addGame).toHaveBeenCalledTimes(2);
+    expect(addGame).toHaveBeenNthCalledWith(1, 'team-1', expect.objectContaining({
+      opponent: 'Tigers',
+      tournament: expect.objectContaining({ bracketName: 'Gold Bracket' })
+    }));
+    expect(addGame).toHaveBeenNthCalledWith(2, 'team-1', expect.objectContaining({
+      opponent: 'Lions',
+      tournament: expect.objectContaining({ bracketName: 'Gold Bracket' })
+    }));
+  });
+
+  it('reports created ids and a safe retry action when a multi-game save is partial', async () => {
+    const writeError = new Error('Firestore unavailable');
+    vi.mocked(addGame)
+      .mockResolvedValueOnce('game-1' as any)
+      .mockRejectedValueOnce(writeError);
+
+    const save = createScheduledTournamentBlockForApp('team-1', {
+      divisionName: '10U Gold',
+      bracketName: 'Gold Bracket',
+      roundName: 'Semifinal',
+      poolName: 'Pool A',
+      games: [
+        {
+          opponent: 'Tigers',
+          startDate: new Date('2026-06-24T18:30:00.000Z'),
+          endDate: new Date('2026-06-24T20:00:00.000Z')
+        },
+        {
+          opponent: 'Lions',
+          startDate: new Date('2026-06-25T18:30:00.000Z'),
+          endDate: new Date('2026-06-25T20:00:00.000Z')
+        }
+      ]
+    }, coachUser);
+
+    await expect(save).rejects.toMatchObject({
+      name: 'TournamentBlockPartialSaveError',
+      createdIds: ['game-1'],
+      totalGames: 2,
+      failedGameNumber: 2,
+      cause: writeError,
+      message: 'Tournament block was only partially created: 1 of 2 games were saved. Refresh Schedule before retrying to avoid duplicate games.'
+    } satisfies Partial<TournamentBlockPartialSaveError>);
+    expect(addGame).toHaveBeenCalledTimes(2);
   });
 
   it('throws an explicit error when a single-game tournament save returns no id', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -15,6 +15,7 @@ import {
   getTeams,
   addGame,
   addPractice,
+  buildLegacyTournamentGameDocuments,
   buildSingleLegacyTournamentGameDocument,
   createRideOffer,
   claimAssignmentSlot,
@@ -1427,6 +1428,22 @@ export type ScheduleTournamentCreateFormInput = {
 
 export type ScheduleTournamentMetadataInput = Pick<ScheduleTournamentCreateFormInput, 'divisionName' | 'bracketName' | 'roundName' | 'poolName'>;
 
+export class TournamentBlockPartialSaveError extends Error {
+  readonly createdIds: string[];
+  readonly totalGames: number;
+  readonly failedGameNumber: number;
+  readonly cause: unknown;
+
+  constructor(createdIds: string[], totalGames: number, failedGameNumber: number, cause: unknown) {
+    super(`Tournament block was only partially created: ${createdIds.length} of ${totalGames} games were saved. Refresh Schedule before retrying to avoid duplicate games.`);
+    this.name = 'TournamentBlockPartialSaveError';
+    this.createdIds = [...createdIds];
+    this.totalGames = totalGames;
+    this.failedGameNumber = failedGameNumber;
+    this.cause = cause;
+  }
+}
+
 export type ScheduleStatTrackerConfigOption = {
   id: string;
   name: string;
@@ -1747,7 +1764,29 @@ export async function createScheduledTournamentBlockForApp(teamId: string, input
     return [createdId];
   }
 
-  throw new Error('Tournament blocks currently support exactly one completed game.');
+  // Normalize and validate every row before the first write. This prevents a
+  // malformed later row from leaving a partially-created tournament block.
+  const legacyPayloads = buildLegacyTournamentGameDocuments(games.map((game) => buildScheduledGamePayload({
+    ...game,
+    competitionType: 'tournament'
+  }, user as AuthUser)), tournament);
+  const createdIds: string[] = [];
+
+  for (let index = 0; index < games.length; index += 1) {
+    try {
+      const createdId = await createScheduledGameForApp(normalizedTeamId, games[index], user, {
+        legacyPayload: legacyPayloads[index],
+        requireCreatedId: true,
+        timeoutLabel: `Scheduled tournament game ${index + 1} create`
+      });
+      createdIds.push(createdId);
+    } catch (error) {
+      if (!createdIds.length) throw error;
+      throw new TournamentBlockPartialSaveError(createdIds, games.length, index + 1, error);
+    }
+  }
+
+  return createdIds;
 }
 
 export async function updateScheduledGameForApp(teamId: string, gameId: string, input: ScheduleGameFormInput, user: AuthUser | null) {

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -793,7 +793,7 @@ describe('Schedule', () => {
     expect(screen.getByRole('button', { name: /create tournament/i })).toBeTruthy();
   });
 
-  it('keeps tournament creation to one game row and validates required fields before saving', async () => {
+  it('adds and removes tournament game rows while preserving the remaining row', async () => {
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
 
     renderSchedule();
@@ -804,8 +804,17 @@ describe('Schedule', () => {
 
     expect(screen.getByText('Game 1')).toBeTruthy();
     expect(screen.queryByText('Game 2')).toBeNull();
-    expect(screen.queryByRole('button', { name: /add another game/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /add another game/i })).toBeTruthy();
     expect(screen.queryByRole('button', { name: /remove/i })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /add another game/i }));
+    expect(screen.getByText('Game 2')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Game 2 opponent'), { target: { value: 'Lions' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Remove game 1' }));
+
+    expect(screen.queryByText('Game 2')).toBeNull();
+    expect((screen.getByLabelText('Game 1 opponent') as HTMLInputElement).value).toBe('Lions');
+    expect(screen.queryByRole('button', { name: /remove game/i })).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: /^create tournament$/i }));
 
@@ -863,11 +872,27 @@ describe('Schedule', () => {
     });
   });
 
-  it('submits tournament blocks with metadata and one child game from schedule tools', async () => {
+  it('validates, submits, and reloads every game in a multi-game tournament block', async () => {
     scheduleServiceMocks.loadParentSchedule
       .mockResolvedValueOnce(buildStaffScheduleResult())
-      .mockResolvedValueOnce(buildStaffScheduleResult());
-    scheduleServiceMocks.createScheduledTournamentBlockForApp.mockResolvedValueOnce(['game-1']);
+      .mockResolvedValueOnce({
+        children: buildStaffScheduleResult().children,
+        events: [
+          buildScheduleEvent(2, {
+            isTeamStaff: true,
+            opponent: 'Tigers',
+            competitionType: 'tournament',
+            tournament: { divisionName: '10U Gold', bracketName: 'Gold Bracket', roundName: 'Semifinal', poolName: 'Pool A' }
+          }),
+          buildScheduleEvent(3, {
+            isTeamStaff: true,
+            opponent: 'Lions',
+            competitionType: 'tournament',
+            tournament: { divisionName: '10U Gold', bracketName: 'Gold Bracket', roundName: 'Semifinal', poolName: 'Pool A' }
+          })
+        ]
+      });
+    scheduleServiceMocks.createScheduledTournamentBlockForApp.mockResolvedValueOnce(['game-1', 'game-2']);
 
     renderSchedule();
 
@@ -883,6 +908,17 @@ describe('Schedule', () => {
     fireEvent.change(screen.getByLabelText('Game 1 location'), { target: { value: 'Main Gym' } });
     fireEvent.change(screen.getByLabelText('Game 1 starts'), { target: { value: '2026-06-24T18:30' } });
     fireEvent.change(screen.getByLabelText('Game 1 ends'), { target: { value: '2026-06-24T20:00' } });
+    fireEvent.click(screen.getByRole('button', { name: /add another game/i }));
+
+    fireEvent.click(screen.getByRole('button', { name: /^create tournament$/i }));
+    expect((await screen.findAllByText('Game opponent is required.')).length).toBeGreaterThan(0);
+    expect(scheduleServiceMocks.createScheduledTournamentBlockForApp).not.toHaveBeenCalled();
+    expect((screen.getByLabelText('Game 1 opponent') as HTMLInputElement).value).toBe('Tigers');
+
+    fireEvent.change(screen.getByLabelText('Game 2 opponent'), { target: { value: 'Lions' } });
+    fireEvent.change(screen.getByLabelText('Game 2 location'), { target: { value: 'Field 2' } });
+    fireEvent.change(screen.getByLabelText('Game 2 starts'), { target: { value: '2026-06-25T18:30' } });
+    fireEvent.change(screen.getByLabelText('Game 2 ends'), { target: { value: '2026-06-25T20:00' } });
 
     fireEvent.click(screen.getByRole('button', { name: /^create tournament$/i }));
 
@@ -893,12 +929,16 @@ describe('Schedule', () => {
         bracketName: 'Gold Bracket',
         roundName: 'Semifinal',
         poolName: 'Pool A',
-        games: [expect.objectContaining({
-          opponent: 'Tigers',
-          location: 'Main Gym'
-        })]
+        games: [
+          expect.objectContaining({ opponent: 'Tigers', location: 'Main Gym' }),
+          expect.objectContaining({ opponent: 'Lions', location: 'Field 2' })
+        ]
       }), auth.user);
     });
+    expect(await screen.findByText('Tournament created and schedule refreshed.')).toBeTruthy();
+    expect((await screen.findAllByText('vs. Tigers')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('vs. Lions')).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('heading', { name: 'Add tournament for Bears' })).toBeNull();
   });
 
   it('hides Manage schedule from non-staff schedule users', async () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -106,10 +106,10 @@ type ScheduleCsvImportPreviewRow = {
   normalized: ScheduleCsvImportNormalizedRow;
   errors: string[];
 };
-type ScheduleTournamentCreateFieldErrors = Partial<Record<
-  'divisionName' | 'bracketName' | 'roundName' | 'games' | 'gameOpponent' | 'gameStartDate' | 'gameEndDate' | 'gameArrivalTime',
-  string
->>;
+type ScheduleTournamentGameFieldErrors = Partial<Record<'opponent' | 'startDate' | 'endDate' | 'arrivalTime', string>>;
+type ScheduleTournamentCreateFieldErrors = Partial<Record<'divisionName' | 'bracketName' | 'roundName' | 'games', string>> & {
+  gameRows?: ScheduleTournamentGameFieldErrors[];
+};
 
 const SCHEDULE_CSV_IMPORT_FIELDS: Array<{ key: ScheduleCsvImportFieldKey; label: string }> = [
   { key: 'startDateTime', label: 'Start Date & Time' },
@@ -1666,35 +1666,41 @@ function getScheduleTournamentCreateFormValidation(form: ScheduleTournamentCreat
   if (!form.bracketName.trim()) fieldErrors.bracketName = 'Tournament bracket is required.';
   if (!form.roundName.trim()) fieldErrors.roundName = 'Tournament round is required.';
   if (!Array.isArray(form.games) || form.games.length === 0) fieldErrors.games = 'Tournament blocks require at least one game.';
-  else if (form.games.length !== 1) fieldErrors.games = 'Tournament blocks support exactly one game in this flow.';
 
-  const game = Array.isArray(form.games) ? form.games[0] : null;
-  if (game) {
-    if (!game.opponent.trim()) fieldErrors.gameOpponent = 'Game opponent is required.';
-    if (!isValidScheduleDate(game.startDate)) fieldErrors.gameStartDate = 'Game start time is required.';
-    if (!isValidScheduleDate(game.endDate)) fieldErrors.gameEndDate = 'Game end time is required.';
-    if (!fieldErrors.gameStartDate && !fieldErrors.gameEndDate) {
+  const gameRows = Array.isArray(form.games) ? form.games.map((game) => {
+    const gameErrors: ScheduleTournamentGameFieldErrors = {};
+    if (!String(game.opponent || '').trim()) gameErrors.opponent = 'Game opponent is required.';
+    if (!isValidScheduleDate(game.startDate)) gameErrors.startDate = 'Game start time is required.';
+    if (!isValidScheduleDate(game.endDate)) gameErrors.endDate = 'Game end time is required.';
+    if (!gameErrors.startDate && !gameErrors.endDate) {
       const startDate = game.startDate instanceof Date ? game.startDate : new Date(game.startDate);
       const endDate = game.endDate instanceof Date ? game.endDate : new Date(game.endDate || '');
-      if (endDate.getTime() <= startDate.getTime()) fieldErrors.gameEndDate = 'Game end time must be after the start time.';
+      if (endDate.getTime() <= startDate.getTime()) gameErrors.endDate = 'Game end time must be after the start time.';
     }
-    if (game.arrivalTime && !isValidScheduleDate(game.arrivalTime)) fieldErrors.gameArrivalTime = 'Arrival time is invalid.';
-  }
+    if (game.arrivalTime && !isValidScheduleDate(game.arrivalTime)) gameErrors.arrivalTime = 'Arrival time is invalid.';
+    return gameErrors;
+  }) : [];
+  if (gameRows.some((gameErrors) => Object.values(gameErrors).some(Boolean))) fieldErrors.gameRows = gameRows;
+
+  const firstGameError = gameRows.flatMap((gameErrors) => Object.values(gameErrors)).find(Boolean) || null;
 
   const formError = fieldErrors.divisionName
     || fieldErrors.bracketName
     || fieldErrors.roundName
     || fieldErrors.games
-    || fieldErrors.gameOpponent
-    || fieldErrors.gameStartDate
-    || fieldErrors.gameEndDate
-    || fieldErrors.gameArrivalTime
+    || firstGameError
     || null;
   return { formError, fieldErrors };
 }
 
 function hasScheduleTournamentFieldErrors(fieldErrors: ScheduleTournamentCreateFieldErrors) {
-  return Object.values(fieldErrors).some(Boolean);
+  return Boolean(
+    fieldErrors.divisionName
+    || fieldErrors.bracketName
+    || fieldErrors.roundName
+    || fieldErrors.games
+    || fieldErrors.gameRows?.some((gameErrors) => Object.values(gameErrors).some(Boolean))
+  );
 }
 
 function ScheduleFieldError({ message }: { message?: string }) {
@@ -1704,14 +1710,6 @@ function ScheduleFieldError({ message }: { message?: string }) {
 
 function getScheduleInputClassName(hasError?: boolean) {
   return `auth-input mt-1${hasError ? ' border-rose-300 bg-rose-50 focus:border-rose-500 focus:ring-rose-200' : ''}`;
-}
-
-function getSingleScheduleTournamentGame(form: ScheduleTournamentCreateFormInput) {
-  return form.games[0] || getDefaultScheduleTournamentGameForm();
-}
-
-function getScheduleTournamentFormWithSingleGame(form: ScheduleTournamentCreateFormInput, game: ScheduleGameFormInput): ScheduleTournamentCreateFormInput {
-  return { ...form, games: [game] };
 }
 
 function ScheduleRequiredHint() {
@@ -1801,9 +1799,16 @@ function ScheduleTournamentCreateModal({ children, saving, onClose }: { children
 }
 
 function ScheduleTournamentCreatePanel({ teamName, form, configs, saving, error, fieldErrors, configError, onStartUsing, onChange, onCancel, onSubmit }: { teamName: string; form: ScheduleTournamentCreateFormInput; configs: ScheduleStatTrackerConfigOption[]; saving: boolean; error: string | null; fieldErrors: ScheduleTournamentCreateFieldErrors; configError: string | null; onStartUsing?: () => void; onChange: (form: ScheduleTournamentCreateFormInput) => void; onCancel: () => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {
-  const game = getSingleScheduleTournamentGame(form);
-  const updateField = (field: keyof Omit<ScheduleTournamentCreateFormInput, 'games'>, value: string) => onChange({ ...form, games: [game], [field]: value });
-  const updateGame = (field: keyof ScheduleGameFormInput, value: string | Date | boolean | null) => onChange(getScheduleTournamentFormWithSingleGame(form, { ...game, [field]: value }));
+  const updateField = (field: keyof Omit<ScheduleTournamentCreateFormInput, 'games'>, value: string) => onChange({ ...form, [field]: value });
+  const updateGame = (gameIndex: number, field: keyof ScheduleGameFormInput, value: string | Date | boolean | null) => onChange({
+    ...form,
+    games: form.games.map((game, index) => index === gameIndex ? { ...game, [field]: value } : game)
+  });
+  const addGame = () => onChange({ ...form, games: [...form.games, getDefaultScheduleTournamentGameForm()] });
+  const removeGame = (gameIndex: number) => {
+    if (form.games.length <= 1) return;
+    onChange({ ...form, games: form.games.filter((_, index) => index !== gameIndex) });
+  };
 
   return (
     <section className="app-card border-0 p-0 shadow-none sm:p-0" aria-label="Create tournament" onFocusCapture={onStartUsing}>
@@ -1820,19 +1825,31 @@ function ScheduleTournamentCreatePanel({ teamName, form, configs, saving, error,
 
         <div className="space-y-3">
           <ScheduleFieldError message={fieldErrors.games} />
-          <div className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
-            <div className="text-sm font-black text-gray-900">Game 1</div>
-            <div className="mt-3 grid gap-3 sm:grid-cols-2">
-              <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Opponent<ScheduleRequiredHint /><input aria-label="Game 1 opponent" className={getScheduleInputClassName(Boolean(fieldErrors.gameOpponent))} aria-invalid={Boolean(fieldErrors.gameOpponent)} required value={game.opponent} onChange={(event) => updateGame('opponent', event.target.value)} /><ScheduleFieldError message={fieldErrors.gameOpponent} /></label>
-              <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Location<input aria-label="Game 1 location" className="auth-input mt-1" value={game.location || ''} onChange={(event) => updateGame('location', event.target.value)} /></label>
-              <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Starts<ScheduleRequiredHint /><input aria-label="Game 1 starts" type="datetime-local" className={getScheduleInputClassName(Boolean(fieldErrors.gameStartDate))} aria-invalid={Boolean(fieldErrors.gameStartDate)} required value={toDatetimeLocalInputValue(game.startDate)} onChange={(event) => updateGame('startDate', new Date(event.target.value))} /><ScheduleFieldError message={fieldErrors.gameStartDate} /></label>
-              <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Ends<ScheduleRequiredHint /><input aria-label="Game 1 ends" type="datetime-local" className={getScheduleInputClassName(Boolean(fieldErrors.gameEndDate))} aria-invalid={Boolean(fieldErrors.gameEndDate)} required value={toDatetimeLocalInputValue(game.endDate)} onChange={(event) => updateGame('endDate', event.target.value ? new Date(event.target.value) : null)} /><ScheduleFieldError message={fieldErrors.gameEndDate} /></label>
-              <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Arrival<input aria-label="Game 1 arrival" type="datetime-local" className={getScheduleInputClassName(Boolean(fieldErrors.gameArrivalTime))} aria-invalid={Boolean(fieldErrors.gameArrivalTime)} value={toDatetimeLocalInputValue(game.arrivalTime)} onChange={(event) => updateGame('arrivalTime', event.target.value ? new Date(event.target.value) : null)} /><ScheduleFieldError message={fieldErrors.gameArrivalTime} /></label>
-              <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Home / away<select aria-label="Game 1 home away" className="auth-input mt-1" value={game.isHome === false ? 'away' : game.isHome === true ? 'home' : 'neutral'} onChange={(event) => updateGame('isHome', event.target.value === 'neutral' ? null : event.target.value === 'home')}><option value="home">Home</option><option value="away">Away</option><option value="neutral">Neutral</option></select></label>
-              <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tracker config<select aria-label="Game 1 tracker config" className="auth-input mt-1" value={game.statTrackerConfigId || ''} onChange={(event) => updateGame('statTrackerConfigId', event.target.value)}><option value="">No tracker config</option>{configs.map((config) => <option key={config.id} value={config.id}>{config.name}</option>)}</select></label>
-            </div>
-            <label className="mt-3 block text-xs font-bold uppercase tracking-wide text-gray-600">Notes<textarea aria-label="Game 1 notes" className="auth-input mt-1 min-h-20" value={game.notes || ''} onChange={(event) => updateGame('notes', event.target.value)} /></label>
-          </div>
+          {form.games.map((game, gameIndex) => {
+            const gameNumber = gameIndex + 1;
+            const gameErrors = fieldErrors.gameRows?.[gameIndex] || {};
+            return (
+              <div key={gameIndex} className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="text-sm font-black text-gray-900">Game {gameNumber}</div>
+                  {form.games.length > 1 ? (
+                    <button type="button" className="text-xs font-black text-rose-700 hover:text-rose-800 disabled:cursor-not-allowed disabled:opacity-60" aria-label={`Remove game ${gameNumber}`} disabled={saving} onClick={() => removeGame(gameIndex)}>Remove</button>
+                  ) : null}
+                </div>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Opponent<ScheduleRequiredHint /><input aria-label={`Game ${gameNumber} opponent`} className={getScheduleInputClassName(Boolean(gameErrors.opponent))} aria-invalid={Boolean(gameErrors.opponent)} required value={game.opponent} onChange={(event) => updateGame(gameIndex, 'opponent', event.target.value)} /><ScheduleFieldError message={gameErrors.opponent} /></label>
+                  <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Location<input aria-label={`Game ${gameNumber} location`} className="auth-input mt-1" value={game.location || ''} onChange={(event) => updateGame(gameIndex, 'location', event.target.value)} /></label>
+                  <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Starts<ScheduleRequiredHint /><input aria-label={`Game ${gameNumber} starts`} type="datetime-local" className={getScheduleInputClassName(Boolean(gameErrors.startDate))} aria-invalid={Boolean(gameErrors.startDate)} required value={toDatetimeLocalInputValue(game.startDate)} onChange={(event) => updateGame(gameIndex, 'startDate', new Date(event.target.value))} /><ScheduleFieldError message={gameErrors.startDate} /></label>
+                  <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Ends<ScheduleRequiredHint /><input aria-label={`Game ${gameNumber} ends`} type="datetime-local" className={getScheduleInputClassName(Boolean(gameErrors.endDate))} aria-invalid={Boolean(gameErrors.endDate)} required value={toDatetimeLocalInputValue(game.endDate)} onChange={(event) => updateGame(gameIndex, 'endDate', event.target.value ? new Date(event.target.value) : null)} /><ScheduleFieldError message={gameErrors.endDate} /></label>
+                  <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Arrival<input aria-label={`Game ${gameNumber} arrival`} type="datetime-local" className={getScheduleInputClassName(Boolean(gameErrors.arrivalTime))} aria-invalid={Boolean(gameErrors.arrivalTime)} value={toDatetimeLocalInputValue(game.arrivalTime)} onChange={(event) => updateGame(gameIndex, 'arrivalTime', event.target.value ? new Date(event.target.value) : null)} /><ScheduleFieldError message={gameErrors.arrivalTime} /></label>
+                  <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Home / away<select aria-label={`Game ${gameNumber} home away`} className="auth-input mt-1" value={game.isHome === false ? 'away' : game.isHome === true ? 'home' : 'neutral'} onChange={(event) => updateGame(gameIndex, 'isHome', event.target.value === 'neutral' ? null : event.target.value === 'home')}><option value="home">Home</option><option value="away">Away</option><option value="neutral">Neutral</option></select></label>
+                  <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tracker config<select aria-label={`Game ${gameNumber} tracker config`} className="auth-input mt-1" value={game.statTrackerConfigId || ''} onChange={(event) => updateGame(gameIndex, 'statTrackerConfigId', event.target.value)}><option value="">No tracker config</option>{configs.map((config) => <option key={config.id} value={config.id}>{config.name}</option>)}</select></label>
+                </div>
+                <label className="mt-3 block text-xs font-bold uppercase tracking-wide text-gray-600">Notes<textarea aria-label={`Game ${gameNumber} notes`} className="auth-input mt-1 min-h-20" value={game.notes || ''} onChange={(event) => updateGame(gameIndex, 'notes', event.target.value)} /></label>
+              </div>
+            );
+          })}
+          <button type="button" className="secondary-button" disabled={saving} onClick={addGame}>Add another game</button>
         </div>
         <div className="flex flex-wrap gap-2">
           <button type="submit" className="primary-button" disabled={saving}>{saving ? 'Creating tournament' : 'Create tournament'}</button>

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1346,6 +1346,46 @@ test('iOS-sized staff schedule keeps tools collapsed below the event list', asyn
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 });
 
+test('iOS-sized staff schedule submits every row in a multi-game tournament block', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockScheduleModules(page, { isCoach: true, staffManageable: true });
+    await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
+
+    await expect(mobileScheduleFilter(page)).toBeVisible({ timeout: 15000 });
+    await page.getByRole('button', { name: /Manage schedule/ }).click();
+    await page.getByRole('button', { name: 'New tournament block' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Add tournament for Bears' })).toBeVisible();
+    await page.getByLabel('Tournament division').fill('10U Gold');
+    await page.getByLabel('Tournament bracket').fill('Gold Bracket');
+    await page.getByLabel('Tournament round').fill('Semifinal');
+    await page.getByLabel('Tournament pool').fill('Pool A');
+    await page.getByLabel('Game 1 opponent').fill('Tigers');
+    await page.getByLabel('Game 1 location').fill('Main Gym');
+
+    await page.getByRole('button', { name: 'Add another game' }).click();
+    await expect(page.getByText('Game 2')).toBeVisible();
+    await page.getByLabel('Game 2 opponent').fill('Lions');
+    await page.getByLabel('Game 2 location').fill('Field 2');
+    await page.getByRole('button', { name: 'Create tournament', exact: true }).click();
+
+    await expect.poll(async () => page.evaluate(() => {
+        const call = window.__scheduleCalls?.tournamentCreates?.[0];
+        return call ? {
+            teamId: call.teamId,
+            opponents: call.form.games.map((game) => game.opponent),
+            locations: call.form.games.map((game) => game.location)
+        } : null;
+    })).toEqual({
+        teamId: 'team-1',
+        opponents: ['Tigers', 'Lions'],
+        locations: ['Main Gym', 'Field 2']
+    });
+    await expect(page.getByText('Tournament created and schedule refreshed.')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Add tournament for Bears' })).toHaveCount(0);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
+});
+
 test('Android-sized schedule smoke covers practice packet and More workflow without overflow', async ({ page, baseURL }) => {
     await page.setViewportSize({ width: 412, height: 915 });
     await mockScheduleModules(page);


### PR DESCRIPTION
## Summary

- let staff add and remove indexed game rows in the native tournament-block modal
- validate every row independently without losing entered values
- prevalidate the full batch, build legacy-compatible tournament documents, and persist every valid row
- expose a structured partial-save error with created IDs and a safe refresh-before-retry action
- verify successful saves refresh and render both tournament games at a 390×844 mobile viewport

## Investigation and root cause

The current UI and service intentionally enforced a single-game invariant even though `buildLegacyTournamentGameDocuments(...)` already supports a validated batch. The modal rendered only Game 1, form validation rejected `games.length !== 1`, and the service threw before the batch mapper could run. Existing tests locked in that rejection.

This PR keeps the delivered single-game path unchanged (including the contracts covered by #3752 and #3756) and adds the missing multi-game branch only.

## Design and impact

- Tournament metadata remains shared across all rows.
- Every child row is normalized and validated before the first write, so invalid later rows cannot cause partial data.
- Valid rows are saved sequentially through the existing scheduled-game persistence path, preserving web/native fallback and created-ID checks.
- If an infrastructure failure occurs after one or more saves, `TournamentBlockPartialSaveError` reports the created IDs, total count, failed row, original cause, and tells the user to refresh before retrying to avoid duplicates.
- After an all-success save, Schedule refreshes and the legacy tournament metadata round-trips through existing rendering.

## Validation

- focused Schedule/service suites: **2 files, 128 tests passed**
- legacy adapter suite: **1 file, 7 tests passed**
- full React app suite: **115 files, 1,024 tests passed**
- React production build: **passed**
- 390×844 Playwright multi-game tournament smoke: **1 passed**
- focused ESLint: **0 errors** (existing warning baseline remains)
- `git diff --check`: **passed**

Closes #3175
