### PR TITLE
Add full roster contact import workflow

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -128,7 +128,10 @@
                     <!-- CSV Import Tab Content -->
                     <div id="content-csv-import" class="p-6 hidden">
                         <div class="mb-3">
-                            <h2 class="text-xl font-bold">CSV Roster Import</h2>
+                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                <h2 class="text-xl font-bold">CSV Roster Import</h2>
+                                <button id="download-roster-template-btn" type="button" class="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100">Download full roster template</button>
+                            </div>
                             <p class="text-sm text-gray-600">Upload or paste a CSV with Name, Number, profile columns such as Position, DOB, Gender, or Address, roster field label/key columns, and parent/guardian/contact columns such as Parent Email or Guardian Phone. Unknown headers and invalid field values are rejected before anything is saved.</p>
                         </div>
 
@@ -144,8 +147,13 @@
                                     class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono"
                                     placeholder="Name,Number,Position,DOB,Parent Name,Parent Email,Grade&#10;Avery Lee,4,Forward,2014-02-03,Pat Lee,pat@example.com,6"></textarea>
                             </div>
+                            <label class="flex items-start gap-2 rounded-md border border-indigo-100 bg-indigo-50 p-3 text-sm text-indigo-900">
+                                <input id="roster-csv-send-invites" type="checkbox" class="mt-0.5 rounded border-indigo-300 text-indigo-600" checked>
+                                <span><span class="block font-semibold">Email invitations to imported family contacts</span><span class="block text-xs text-indigo-700">Contacts with email addresses receive an invite after their player row saves. Failures stay visible for retry and do not discard the roster/contact import.</span></span>
+                            </label>
+                            <div id="csv-import-preview" class="hidden space-y-2 rounded-md border border-gray-200 bg-gray-50 p-3 text-sm"></div>
                             <button id="import-csv-btn" type="button"
-                                class="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Import CSV</button>
+                                class="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Review CSV</button>
                             <div id="csv-import-status" class="hidden rounded-md border p-3 text-sm"></div>
                         </div>
                     </div>
@@ -546,8 +554,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, acceptTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=85';
-        import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=3';
+        import { getTeam, getPlayers, getPlayersWithPrivateRosterContacts, addPlayer, applyRosterCsvImportOperations, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, acceptTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=86';
+        import { buildFullRosterCsvTemplate, buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, summarizeRosterContactInviteResults, validateRosterProfileValues } from './js/roster-profile-fields.js?v=4';
         import { buildTrackingStatusPayload, mergeTrackingStatusRows, normalizeTrackingItemDraft, summarizeTrackingStatus } from './js/tracking-status-admin.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=42';
@@ -574,6 +582,8 @@
         let latestRegistrationReviews = [];
         let selectedRegistrationExportColumns = getDefaultRegistrationReviewCsvColumnKeys();
         let registrationRosterImportPlan = null;
+        let rosterCsvImportPlan = null;
+        let rosterCsvImportSource = '';
         let trackingItems = [];
         let selectedTrackingItemId = '';
         let latestRosterPlayers = [];
@@ -1504,7 +1514,7 @@
 
             let players = [];
             try {
-                players = await getPlayers(currentTeamId, { includeInactive: true });
+                players = await getPlayersWithPrivateRosterContacts(currentTeamId, { includeInactive: true });
             } catch (err) {
                 console.error('Error loading roster players:', err);
                 tbody.innerHTML = `<tr><td colspan="3" class="px-6 py-4 text-center text-red-600">Unable to load roster players: ${escapeHtml(err?.message || 'Please try again.')}</td></tr>`;
@@ -1577,6 +1587,13 @@
                     parent?.inviterUserId ||
                     parent?.status === 'removed'
                 ));
+                const importedFamilyContacts = [
+                    ...(Array.isArray(p.parents) ? p.parents : []),
+                    ...(Array.isArray(p.contacts) ? p.contacts : []),
+                    ...(Array.isArray(p.privateProfileParents) ? p.privateProfileParents : []),
+                    ...(Array.isArray(p.privateProfileContacts) ? p.privateProfileContacts : [])
+                ].filter((contact) => contact?.source === 'roster-csv' && contact?.email);
+                const linkedParentEmails = new Set(profileParents.map((parent) => normalizeEmail(parent.email)).filter(Boolean));
                 const pendingRequests = pendingRequestsByPlayerId.get(p.id) || [];
                 const importSourceType = getPlayerImportSourceType(p);
                 const playerName = escapeHtml(p.name || 'Unnamed player');
@@ -1611,6 +1628,33 @@
                                                 </div>
                                             </div>
                                         `).join('')}
+                                    </div>
+                                </div>
+                            ` : '';
+                const importedContactBlock = importedFamilyContacts.length > 0 ? `
+                                <div class="mt-2 rounded-lg border border-indigo-200 bg-indigo-50 p-2">
+                                    <div class="text-[11px] font-bold uppercase tracking-wide text-indigo-800">Imported family contacts</div>
+                                    <div class="mt-2 space-y-1">
+                                        ${importedFamilyContacts.map((contact) => {
+                                            const linked = linkedParentEmails.has(normalizeEmail(contact.email));
+                                            return `
+                                                <div class="flex flex-wrap items-center justify-between gap-2 rounded border border-indigo-100 bg-white px-2 py-1.5 text-xs text-gray-700">
+                                                    <div>
+                                                        <div class="font-semibold text-gray-900">${escapeHtml(contact.name || contact.email)}</div>
+                                                        <div class="text-[11px] text-gray-500">${escapeHtml(contact.email)} · ${escapeHtml(contact.relation || 'Parent')} · ${linked ? 'Linked account' : 'Invite needed'}</div>
+                                                    </div>
+                                                    ${linked ? '<span class="rounded-full bg-emerald-100 px-2 py-1 text-[10px] font-bold text-emerald-800">Accepted</span>' : `
+                                                        <button type="button"
+                                                            class="invite-imported-contact-btn rounded border border-indigo-200 bg-indigo-50 px-2 py-1 text-[11px] font-semibold text-indigo-700 hover:bg-indigo-100"
+                                                            data-player-id="${escapeHtml(p.id)}"
+                                                            data-email="${escapeHtml(contact.email)}"
+                                                            data-relation="${escapeHtml(contact.relation || 'Parent')}">
+                                                            Send / resend invite
+                                                        </button>
+                                                    `}
+                                                </div>
+                                            `;
+                                        }).join('')}
                                     </div>
                                 </div>
                             ` : '';
@@ -1661,6 +1705,7 @@
                                 ${importSourceType ? `<span class="inline-flex text-[10px] bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded-full font-semibold uppercase tracking-wide">Imported: ${escapeHtml(importSourceType)}</span>` : '<span class="inline-flex text-[10px] bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full font-semibold uppercase tracking-wide">Local-only</span>'}
                             </div>
                             ${parentChips}
+                            ${importedContactBlock}
                             ${householdContactBlock}
                             ${pendingRequestBlock}
                         </td>
@@ -1698,6 +1743,18 @@
 
             document.querySelectorAll('.invite-btn').forEach(btn => {
                 btn.addEventListener('click', (e) => startInviteParent(players.find(p => p.id === e.target.dataset.id)));
+            });
+
+            document.querySelectorAll('.invite-imported-contact-btn').forEach(btn => {
+                btn.addEventListener('click', (event) => {
+                    const buttonEl = event.currentTarget;
+                    const player = players.find((candidate) => candidate.id === buttonEl.dataset.playerId);
+                    if (!player) return;
+                    startInviteParent(player, {
+                        email: buttonEl.dataset.email || '',
+                        relation: buttonEl.dataset.relation || 'Parent'
+                    });
+                });
             });
 
             document.querySelectorAll('.edit-btn').forEach(btn => {
@@ -1803,14 +1860,14 @@
             document.getElementById(stateName).classList.remove('hidden');
         }
 
-        function startInviteParent(player) {
+        function startInviteParent(player, contact = {}) {
             currentInvitePlayer = player;
             document.getElementById('invite-player-name').textContent = player.name;
             document.getElementById('manual-player-name').textContent = player.name;
             document.getElementById('invite-modal').classList.remove('hidden');
             showInviteState('invite-form-state');
-            document.getElementById('invite-email').value = '';
-            document.getElementById('invite-relation').value = 'Parent';
+            document.getElementById('invite-email').value = contact.email || '';
+            document.getElementById('invite-relation').value = contact.relation || 'Parent';
         }
 
         function closeInviteModal() {
@@ -1994,48 +2051,141 @@
                 : escapeHtml(String(messages || ''));
         }
 
+        function resetRosterCsvReview() {
+            rosterCsvImportPlan = null;
+            rosterCsvImportSource = '';
+            const preview = document.getElementById('csv-import-preview');
+            const button = document.getElementById('import-csv-btn');
+            preview?.classList.add('hidden');
+            if (preview) preview.innerHTML = '';
+            if (button && !button.disabled) button.textContent = 'Review CSV';
+        }
+
+        function renderRosterCsvReview(plan) {
+            const preview = document.getElementById('csv-import-preview');
+            if (!preview) return;
+            const rows = plan.operations.map((operation, index) => {
+                const contacts = Array.isArray(operation.familyContacts) ? operation.familyContacts : [];
+                const inviteCount = Array.isArray(operation.inviteRequests) ? operation.inviteRequests.length : 0;
+                return `
+                    <div class="rounded-md border border-gray-200 bg-white p-3">
+                        <div class="font-semibold text-gray-900">${escapeHtml(operation.type === 'update' ? 'Update' : 'Add')}: ${escapeHtml(operation.payload?.name || `Row ${index + 1}`)}${operation.payload?.number ? ` #${escapeHtml(operation.payload.number)}` : ''}</div>
+                        <div class="mt-1 text-xs text-gray-600">${contacts.length} family contact${contacts.length === 1 ? '' : 's'} · ${inviteCount} email invite${inviteCount === 1 ? '' : 's'}</div>
+                        ${contacts.length ? `<div class="mt-1 text-xs text-indigo-700">${contacts.map((contact) => escapeHtml([contact.name, contact.relation, contact.email].filter(Boolean).join(' · '))).join('<br>')}</div>` : ''}
+                    </div>
+                `;
+            });
+            preview.innerHTML = `
+                <div class="font-semibold text-gray-900">Review ${plan.operations.length} planned player row${plan.operations.length === 1 ? '' : 's'} before saving.</div>
+                <div class="text-xs text-gray-600">All rows passed header, value, duplicate, and contact-conflict validation. No writes have happened yet.</div>
+                ${rows.join('')}
+            `;
+            preview.classList.remove('hidden');
+        }
+
+        async function sendImportedRosterContactInvite(playerId, playerNumber, request) {
+            try {
+                const result = await inviteParent(currentTeamId, playerId, playerNumber || '', request.email, request.relation || 'Parent');
+                let emailSent = false;
+                try {
+                    await sendInviteEmail(request.email, result.code, 'parent', {
+                        teamName: result.teamName,
+                        playerName: result.playerName
+                    });
+                    emailSent = true;
+                } catch (emailError) {
+                    console.warn('Could not email imported roster contact invite:', emailError);
+                }
+                if (result.autoLinked) return { ...request, status: 'linked' };
+                return { ...request, status: emailSent ? 'sent' : 'code-created', code: result.code || '' };
+            } catch (error) {
+                console.warn('Could not create imported roster contact invite:', error);
+                return { ...request, status: 'failed', error: error?.message || 'Invite failed.' };
+            }
+        }
+
+        function formatRosterContactInviteSummary(results) {
+            const summary = summarizeRosterContactInviteResults(results);
+            const parts = [];
+            if (summary.sent) parts.push(`${summary.sent} emailed`);
+            if (summary.linked) parts.push(`${summary.linked} linked`);
+            if (summary.codeCreated) parts.push(`${summary.codeCreated} code${summary.codeCreated === 1 ? '' : 's'} created for retry`);
+            if (summary.failed) parts.push(`${summary.failed} failed and can be retried from the imported contact row`);
+            return parts.length ? ` Family invites: ${parts.join(', ')}.` : '';
+        }
+
+        function downloadFullRosterTemplate() {
+            const csv = buildFullRosterCsvTemplate(rosterFieldDefinitions);
+            const blobUrl = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }));
+            const link = document.createElement('a');
+            link.href = blobUrl;
+            link.download = `${String(currentTeam?.name || 'team').trim().toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'team'}-full-roster-template.csv`;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            URL.revokeObjectURL(blobUrl);
+        }
+
         async function handleRosterCsvImport() {
             const csvText = document.getElementById('roster-csv-input').value;
             const button = document.getElementById('import-csv-btn');
-            const currentPlayers = await getPlayers(currentTeamId, { includeInactive: true });
-            const plan = planRosterCsvImport({
-                csvText,
-                fields: rosterFieldDefinitions,
-                existingPlayers: currentPlayers
-            });
 
-            if (plan.errors.length) {
-                renderCsvImportStatus(plan.errors, 'error');
+            if (!rosterCsvImportPlan || rosterCsvImportSource !== csvText) {
+                const currentPlayers = await getPlayersWithPrivateRosterContacts(currentTeamId, { includeInactive: true });
+                const plan = planRosterCsvImport({
+                    csvText,
+                    fields: rosterFieldDefinitions,
+                    existingPlayers: currentPlayers
+                });
+
+                if (plan.errors.length) {
+                    resetRosterCsvReview();
+                    renderCsvImportStatus(plan.errors, 'error');
+                    return;
+                }
+                if (plan.operations.length === 0) {
+                    resetRosterCsvReview();
+                    renderCsvImportStatus('No CSV rows to import.', 'info');
+                    return;
+                }
+
+                rosterCsvImportPlan = plan;
+                rosterCsvImportSource = csvText;
+                renderRosterCsvReview(plan);
+                renderCsvImportStatus('Review the planned players and family contacts below. Click Import Reviewed Rows when ready.', 'info');
+                button.textContent = 'Import Reviewed Rows';
                 return;
             }
-            if (plan.operations.length === 0) {
-                renderCsvImportStatus('No CSV rows to import.', 'info');
-                return;
-            }
-            if (!confirm(`Import ${plan.operations.length} player row${plan.operations.length === 1 ? '' : 's'}?`)) return;
 
+            const plan = rosterCsvImportPlan;
+            if (!confirm(`Import ${plan.operations.length} reviewed player row${plan.operations.length === 1 ? '' : 's'}?`)) return;
+
+            const inviteResults = [];
+            const sendInvites = document.getElementById('roster-csv-send-invites')?.checked === true;
             try {
                 button.disabled = true;
                 button.textContent = 'Importing...';
-                for (const operation of plan.operations) {
-                    let playerId = operation.playerId;
-                    if (operation.type === 'update') {
-                        await updatePlayer(currentTeamId, playerId, operation.payload);
-                    } else {
-                        playerId = await addPlayer(currentTeamId, operation.payload);
-                    }
-                    if (operation.privateRosterFields || operation.privateFamilyContacts) {
-                        await setPlayerPrivateRosterProfileFields(currentTeamId, playerId, operation.privateRosterFields || {}, operation.privateFamilyContacts || {});
+                const savedOperations = await applyRosterCsvImportOperations(currentTeamId, plan.operations);
+                for (const operation of savedOperations) {
+                    if (sendInvites) {
+                        for (const request of operation.inviteRequests || []) {
+                            inviteResults.push(await sendImportedRosterContactInvite(operation.playerId, operation.payload?.number, request));
+                        }
                     }
                 }
-                renderCsvImportStatus(`Imported ${plan.operations.length} player row${plan.operations.length === 1 ? '' : 's'}.`, 'success');
+                renderCsvImportStatus(`Imported ${plan.operations.length} player row${plan.operations.length === 1 ? '' : 's'}.${formatRosterContactInviteSummary(inviteResults)}`, inviteResults.some((result) => result.status === 'failed') ? 'info' : 'success');
+                rosterCsvImportPlan = null;
+                rosterCsvImportSource = '';
+                document.getElementById('csv-import-preview')?.classList.add('hidden');
                 await loadRoster();
             } catch (error) {
                 console.error('CSV roster import failed:', error);
-                renderCsvImportStatus(error?.message || 'CSV roster import failed.', 'error');
+                renderCsvImportStatus(`${error?.message || 'CSV roster import failed.'} Fix the failure, then review the current roster before retrying to avoid duplicate rows.`, 'error');
+                rosterCsvImportPlan = null;
+                rosterCsvImportSource = '';
             } finally {
                 button.disabled = false;
-                button.textContent = 'Import CSV';
+                button.textContent = 'Review CSV';
             }
         }
 
@@ -2203,7 +2353,10 @@
             const file = e.target.files[0];
             if (!file) return;
             document.getElementById('roster-csv-input').value = await file.text();
+            resetRosterCsvReview();
         });
+        document.getElementById('roster-csv-input').addEventListener('input', resetRosterCsvReview);
+        document.getElementById('download-roster-template-btn').addEventListener('click', downloadFullRosterTemplate);
         document.getElementById('import-csv-btn').addEventListener('click', () => handleRosterCsvImport());
 
         // Image preview handler

--- a/js/db.js
+++ b/js/db.js
@@ -2596,6 +2596,24 @@ export async function getPlayers(teamId, options = {}) {
     }
 }
 
+export async function getPlayersWithPrivateRosterContacts(teamId, options = {}) {
+    const players = await getPlayers(teamId, options);
+    return Promise.all(players.map(async (player) => {
+        if (!player?.id) return player;
+        try {
+            const privateProfile = await getPlayerPrivateProfile(teamId, player.id);
+            return {
+                ...player,
+                privateProfileParents: Array.isArray(privateProfile?.parents) ? privateProfile.parents : [],
+                privateProfileContacts: Array.isArray(privateProfile?.contacts) ? privateProfile.contacts : []
+            };
+        } catch (error) {
+            if (error?.code === 'permission-denied') return player;
+            throw error;
+        }
+    }));
+}
+
 function playerHasRosterContactFields(player = {}) {
     return Boolean(
         (Array.isArray(player?.parents) && player.parents.length > 0) ||
@@ -2683,6 +2701,66 @@ export async function setPlayerPrivateRosterProfileFields(teamId, playerId, rost
         privateProfileUpdate.contacts = extraData.contacts;
     }
     await setDoc(doc(db, `teams/${teamId}/players/${playerId}/private/profile`), privateProfileUpdate, { merge: true });
+}
+
+export async function applyRosterCsvImportOperations(teamId, operations = []) {
+    const normalizedTeamId = String(teamId || '').trim();
+    const plannedOperations = Array.isArray(operations) ? operations : [];
+    if (!normalizedTeamId) throw new Error('Team is required for roster import.');
+    if (plannedOperations.length === 0) return [];
+    // Each row uses at most two writes (player + private profile). Keep the
+    // entire reviewed import below Firestore's 500-write batch ceiling so a
+    // service failure cannot leave half of the roster applied.
+    if (plannedOperations.length > 200) {
+        throw new Error('Import at most 200 roster rows at a time.');
+    }
+
+    const batch = writeBatch(db);
+    const savedOperations = plannedOperations.map((operation) => {
+        const type = operation?.type;
+        if (type !== 'add' && type !== 'update') {
+            throw new Error('Roster import contains an unsupported operation.');
+        }
+        const payload = { ...(operation.payload || {}) };
+        assertNoSensitivePlayerFields(payload);
+        const existingPlayerId = String(operation.playerId || '').trim();
+        if (type === 'update' && !existingPlayerId) {
+            throw new Error('Roster import update is missing a player.');
+        }
+        const playerRef = type === 'update'
+            ? doc(db, `teams/${normalizedTeamId}/players`, existingPlayerId)
+            : doc(collection(db, `teams/${normalizedTeamId}/players`));
+        if (!playerRef.id) throw new Error('Roster import player is required.');
+
+        if (type === 'update') {
+            batch.update(playerRef, { ...payload, updatedAt: Timestamp.now() });
+        } else {
+            batch.set(playerRef, {
+                ...payload,
+                active: Object.prototype.hasOwnProperty.call(payload, 'active') ? payload.active : true,
+                createdAt: Timestamp.now()
+            });
+        }
+
+        if (operation.privateRosterFields || operation.privateFamilyContacts) {
+            const privateProfileUpdate = {
+                rosterFields: operation.privateRosterFields || {},
+                updatedAt: Timestamp.now()
+            };
+            if (Array.isArray(operation.privateFamilyContacts?.parents)) {
+                privateProfileUpdate.parents = operation.privateFamilyContacts.parents;
+            }
+            if (Array.isArray(operation.privateFamilyContacts?.contacts)) {
+                privateProfileUpdate.contacts = operation.privateFamilyContacts.contacts;
+            }
+            batch.set(doc(db, `teams/${normalizedTeamId}/players/${playerRef.id}/private/profile`), privateProfileUpdate, { merge: true });
+        }
+
+        return { ...operation, playerId: playerRef.id };
+    });
+
+    await batch.commit();
+    return savedOperations;
 }
 
 export async function deletePlayer(teamId, playerId) {

--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -560,6 +560,41 @@ function mergeProfileImportValues(existingProfile = {}, profileValues = {}, addr
     return nextProfile;
 }
 
+function escapeRosterCsvCell(value) {
+    const text = String(value ?? '');
+    return /[",\r\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+export function buildFullRosterCsvTemplate(fields = []) {
+    const customHeaders = normalizeRosterFieldDefinitions(fields)
+        .map((field) => field.label)
+        .filter(Boolean);
+    const headers = [
+        'Name', 'Number', 'Position', 'DOB', 'Gender', 'Address', 'City', 'State', 'Zip', 'Roster Status',
+        'Parent Name', 'Parent Relation', 'Parent Email', 'Parent Phone',
+        'Guardian 2 Name', 'Guardian 2 Relation', 'Guardian 2 Email', 'Guardian 2 Phone',
+        ...customHeaders
+    ];
+    const sample = [
+        'Avery Lee', '4', 'Forward', '2014-02-03', '', '123 Main St', 'Kansas City', 'MO', '64110', 'Player',
+        'Pat Lee', 'Parent', 'pat@example.com', '555-0101',
+        '', '', '', '',
+        ...customHeaders.map(() => '')
+    ];
+    return `${headers.map(escapeRosterCsvCell).join(',')}\n${sample.map(escapeRosterCsvCell).join(',')}\n`;
+}
+
+export function summarizeRosterContactInviteResults(results = []) {
+    const summary = { sent: 0, linked: 0, codeCreated: 0, failed: 0 };
+    (Array.isArray(results) ? results : []).forEach((result) => {
+        if (result?.status === 'linked') summary.linked += 1;
+        else if (result?.status === 'sent') summary.sent += 1;
+        else if (result?.status === 'code-created') summary.codeCreated += 1;
+        else if (result?.status === 'failed') summary.failed += 1;
+    });
+    return summary;
+}
+
 export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers = [] } = {}) {
     const errors = [];
     const normalizedFields = normalizeRosterFieldDefinitions(fields);
@@ -716,8 +751,8 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
         const payload = { name, profile };
         if (hasNumberColumn) payload.number = number;
         if (Object.prototype.hasOwnProperty.call(profileValues, 'position')) payload.position = profileValues.position;
-        const mergedGuardians = mergeImportedContacts(existing?.guardians || existing?.parents || existing?.familyContacts || [], contactPlan.guardians);
-        const mergedContacts = mergeImportedContacts(existing?.contacts || [], contactPlan.contacts);
+        const mergedGuardians = mergeImportedContacts(existing?.guardians || existing?.parents || existing?.privateProfileParents || existing?.familyContacts || [], contactPlan.guardians);
+        const mergedContacts = mergeImportedContacts(existing?.contacts || existing?.privateProfileContacts || [], contactPlan.contacts);
         const privateRosterFields = Object.keys(privateValues).length > 0 ? privateValues : null;
         const privateFamilyContacts = mergedGuardians.length > 0 || mergedContacts.length > 0
             ? {

--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -477,6 +477,12 @@ function mergeImportedContacts(existingContacts = [], importedContacts = []) {
     return merged;
 }
 
+function collectExistingRosterContacts(existing = {}, primaryKeys = [], fallbackKey = '') {
+    const contacts = primaryKeys.flatMap((key) => Array.isArray(existing?.[key]) ? existing[key] : []);
+    if (contacts.length > 0 || !fallbackKey || !Array.isArray(existing?.[fallbackKey])) return contacts;
+    return existing[fallbackKey];
+}
+
 function buildRosterCsvContactPlan(contactValues = new Map(), rowNumber = 0) {
     const guardians = [];
     const contacts = [];
@@ -566,13 +572,18 @@ function escapeRosterCsvCell(value) {
 }
 
 export function buildFullRosterCsvTemplate(fields = []) {
-    const customHeaders = normalizeRosterFieldDefinitions(fields)
-        .map((field) => field.label)
-        .filter(Boolean);
-    const headers = [
+    const builtInHeaders = [
         'Name', 'Number', 'Position', 'DOB', 'Gender', 'Address', 'City', 'State', 'Zip', 'Roster Status',
         'Parent Name', 'Parent Relation', 'Parent Email', 'Parent Phone',
-        'Guardian 2 Name', 'Guardian 2 Relation', 'Guardian 2 Email', 'Guardian 2 Phone',
+        'Guardian 2 Name', 'Guardian 2 Relation', 'Guardian 2 Email', 'Guardian 2 Phone'
+    ];
+    const builtInHeaderKeys = new Set(builtInHeaders.map(normalizeHeaderKey));
+    const customHeaders = normalizeRosterFieldDefinitions(fields)
+        .map((field) => field.label)
+        .filter((label) => !builtInHeaderKeys.has(normalizeHeaderKey(label)))
+        .filter(Boolean);
+    const headers = [
+        ...builtInHeaders,
         ...customHeaders
     ];
     const sample = [
@@ -751,8 +762,10 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
         const payload = { name, profile };
         if (hasNumberColumn) payload.number = number;
         if (Object.prototype.hasOwnProperty.call(profileValues, 'position')) payload.position = profileValues.position;
-        const mergedGuardians = mergeImportedContacts(existing?.guardians || existing?.parents || existing?.privateProfileParents || existing?.familyContacts || [], contactPlan.guardians);
-        const mergedContacts = mergeImportedContacts(existing?.contacts || existing?.privateProfileContacts || [], contactPlan.contacts);
+        const existingGuardianContacts = collectExistingRosterContacts(existing, ['guardians', 'parents', 'privateProfileParents'], 'familyContacts');
+        const existingFamilyContacts = collectExistingRosterContacts(existing, ['contacts', 'privateProfileContacts']);
+        const mergedGuardians = mergeImportedContacts(existingGuardianContacts, contactPlan.guardians);
+        const mergedContacts = mergeImportedContacts(existingFamilyContacts, contactPlan.contacts);
         const privateRosterFields = Object.keys(privateValues).length > 0 ? privateValues : null;
         const privateFamilyContacts = mergedGuardians.length > 0 || mergedContacts.length > 0
             ? {

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -7,7 +7,38 @@ export async function getTeam(teamId) {
 export async function getPlayers() {
     return [];
 }
-export async function addPlayer() {}
+export async function getPlayersWithPrivateRosterContacts() {
+    return globalThis.__rosterCsvSavedPlayers || [];
+}
+export async function addPlayer(_teamId, payload) {
+    globalThis.__rosterCsvAdds = globalThis.__rosterCsvAdds || [];
+    globalThis.__rosterCsvAdds.push(payload);
+    return 'player-imported-1';
+}
+export async function applyRosterCsvImportOperations(teamId, operations) {
+    globalThis.__rosterCsvAdds = globalThis.__rosterCsvAdds || [];
+    globalThis.__rosterCsvPrivateWrites = globalThis.__rosterCsvPrivateWrites || [];
+    globalThis.__rosterCsvSavedPlayers = globalThis.__rosterCsvSavedPlayers || [];
+    return operations.map((operation, index) => {
+        const playerId = operation.playerId || 'player-imported-' + (index + 1);
+        if (operation.type === 'add') globalThis.__rosterCsvAdds.push(operation.payload);
+        if (operation.privateRosterFields || operation.privateFamilyContacts) {
+            globalThis.__rosterCsvPrivateWrites.push({
+                teamId,
+                playerId,
+                fields: operation.privateRosterFields || {},
+                contacts: operation.privateFamilyContacts || {}
+            });
+        }
+        globalThis.__rosterCsvSavedPlayers.push({
+            id: playerId,
+            ...operation.payload,
+            privateProfileParents: operation.privateFamilyContacts?.parents || [],
+            privateProfileContacts: operation.privateFamilyContacts?.contacts || []
+        });
+        return { ...operation, playerId };
+    });
+}
 export async function deactivatePlayer() {}
 export async function reactivatePlayer() {}
 export async function getGames() {
@@ -17,9 +48,14 @@ export async function uploadPlayerPhoto() {
     return 'https://example.test/photo.png';
 }
 export async function updatePlayer() {}
-export async function setPlayerPrivateRosterProfileFields() {}
-export async function inviteParent() {
-    return {};
+export async function setPlayerPrivateRosterProfileFields(teamId, playerId, fields, contacts) {
+    globalThis.__rosterCsvPrivateWrites = globalThis.__rosterCsvPrivateWrites || [];
+    globalThis.__rosterCsvPrivateWrites.push({ teamId, playerId, fields, contacts });
+}
+export async function inviteParent(teamId, playerId, number, email, relation) {
+    globalThis.__rosterCsvInvites = globalThis.__rosterCsvInvites || [];
+    globalThis.__rosterCsvInvites.push({ teamId, playerId, number, email, relation });
+    return { code: 'INVITE123', teamName: 'Test Team', playerName: 'Avery Lee', existingUser: false, autoLinked: false };
 }
 export async function removeParentFromPlayer() {}
 export async function getAllUsers() {
@@ -77,7 +113,10 @@ const AUTH_STUB = `
 export function checkAuth(callback) {
     callback({ uid: 'user-1', email: 'coach@example.com', isAdmin: false });
 }
-export async function sendInviteEmail() {}
+export async function sendInviteEmail(email, code, type, context) {
+    globalThis.__rosterCsvEmails = globalThis.__rosterCsvEmails || [];
+    globalThis.__rosterCsvEmails.push({ email, code, type, context });
+}
 `;
 
 const TEAM_ACCESS_STUB = `
@@ -258,4 +297,44 @@ test('fresh run after cancel only uses newly entered input', async ({ page, base
     expect(aiCalls[1]).toHaveLength(1);
     expect(aiCalls[1][0].type).toBe('text');
     expect(aiCalls[1][0].value).toContain('#22 Jordan Reed');
+});
+
+test('CSV roster review saves family contacts and sends imported invitations', async ({ page, baseURL }) => {
+    page.on('dialog', async (dialog) => dialog.accept());
+    await openBulkAiTab(page, baseURL);
+    await page.click('#tab-csv-import');
+    await expect(page.locator('#content-csv-import')).toBeVisible();
+
+    await page.fill('#roster-csv-input', [
+        'Name,Number,Position,DOB,Parent Name,Parent Email,Parent Relation',
+        'Avery Lee,4,Forward,2014-02-03,Pat Lee,pat@example.com,Mother'
+    ].join('\n'));
+    await page.click('#import-csv-btn');
+
+    await expect(page.locator('#csv-import-preview')).toBeVisible();
+    await expect(page.locator('#csv-import-preview')).toContainText('Review 1 planned player row');
+    await expect(page.locator('#csv-import-preview')).toContainText('Pat Lee · Mother · pat@example.com');
+    expect(await page.evaluate(() => (globalThis.__rosterCsvAdds || []).length)).toBe(0);
+
+    await page.click('#import-csv-btn');
+    await expect(page.locator('#csv-import-status')).toContainText('Imported 1 player row. Family invites: 1 emailed.');
+    await expect(page.getByText('Imported family contacts', { exact: true })).toBeVisible();
+    await expect(page.getByText('pat@example.com · Mother · Invite needed')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Send / resend invite' })).toBeVisible();
+
+    expect(await page.evaluate(() => globalThis.__rosterCsvAdds || [])).toEqual([
+        expect.objectContaining({ name: 'Avery Lee', number: '4', position: 'Forward' })
+    ]);
+    expect(await page.evaluate(() => globalThis.__rosterCsvPrivateWrites || [])).toEqual([
+        expect.objectContaining({
+            playerId: 'player-imported-1',
+            contacts: { parents: [expect.objectContaining({ email: 'pat@example.com', relation: 'Mother' })] }
+        })
+    ]);
+    expect(await page.evaluate(() => globalThis.__rosterCsvInvites || [])).toEqual([
+        expect.objectContaining({ playerId: 'player-imported-1', email: 'pat@example.com', relation: 'Mother' })
+    ]);
+    expect(await page.evaluate(() => globalThis.__rosterCsvEmails || [])).toEqual([
+        expect.objectContaining({ email: 'pat@example.com', code: 'INVITE123', type: 'parent' })
+    ]);
 });

--- a/tests/smoke/edit-roster-xss-escaping.spec.js
+++ b/tests/smoke/edit-roster-xss-escaping.spec.js
@@ -31,7 +31,11 @@ export async function getTeam(teamId) {
     return { id: teamId, name: 'Test Team', ownerId: 'user-1', adminEmails: [] };
 }
 export async function getPlayers() { return []; }
+export async function getPlayersWithPrivateRosterContacts() { return []; }
 export async function addPlayer() {}
+export async function applyRosterCsvImportOperations(_teamId, operations) {
+    return operations.map((operation, index) => ({ ...operation, playerId: operation.playerId || 'player-' + (index + 1) }));
+}
 export async function deactivatePlayer() {}
 export async function reactivatePlayer() {}
 export async function getGames() { return []; }

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -113,6 +113,9 @@ export function getGenerativeModel() {
 `;
 
 const ROSTER_PROFILE_FIELDS_STUB = `
+export function buildFullRosterCsvTemplate() {
+    return 'Name,Number\\n';
+}
 export function buildRosterFieldDefinitionPayload(field = {}, index = 0) {
     return { key: field.key || 'field-' + index, label: field.label || 'Field' };
 }
@@ -130,6 +133,9 @@ export function planRosterCsvImport() {
 }
 export function renderRosterProfileFields(container) {
     if (container) container.innerHTML = '';
+}
+export function summarizeRosterContactInviteResults() {
+    return { sent: 0, linked: 0, codeCreated: 0, failed: 0 };
 }
 export function validateRosterProfileValues() {
     return [];
@@ -165,7 +171,13 @@ export async function getPlayers() {
         { id: 'player-2', name: 'Jordan Reed', number: '22', active: true }
     ];
 }
+export async function getPlayersWithPrivateRosterContacts() {
+    return getPlayers();
+}
 export async function addPlayer() {}
+export async function applyRosterCsvImportOperations(_teamId, operations) {
+    return operations.map((operation, index) => ({ ...operation, playerId: operation.playerId || 'player-' + (index + 1) }));
+}
 export async function deactivatePlayer() {}
 export async function reactivatePlayer() {}
 export async function getGames() {

--- a/tests/unit/edit-roster-tracking-status.test.js
+++ b/tests/unit/edit-roster-tracking-status.test.js
@@ -242,7 +242,7 @@ describe('edit roster tracking status matrix wiring', () => {
     it('uses rules-compatible tracking item names in the selector and summary', () => {
         const source = readEditRoster();
 
-        expect(source).toContain("from './js/db.js?v=85'");
+        expect(source).toContain("from './js/db.js?v=86'");
         expect(source).not.toContain("from './js/db.js?v=69'");
         expect(source).toContain("from './js/tracking-status-admin.js?v=2'");
         expect(source).toContain('item.title || item.name || item.id');

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { planRosterCsvImport, splitRosterProfileValuesByVisibility } from '../../js/roster-profile-fields.js';
+import { buildFullRosterCsvTemplate, planRosterCsvImport, splitRosterProfileValuesByVisibility, summarizeRosterContactInviteResults } from '../../js/roster-profile-fields.js';
 
 describe('roster CSV import planning', () => {
     const fields = [
@@ -382,6 +382,28 @@ describe('roster CSV import planning', () => {
         expect(plan.operations[0].payload).not.toHaveProperty('guardians');
     });
 
+    it('deduplicates new contacts against the private roster contact projection', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            existingPlayers: [{
+                id: 'p1',
+                name: 'Avery Lee',
+                privateProfileParents: [{ name: 'Pat Lee', email: 'pat@example.com', relation: 'Parent', source: 'roster-csv' }],
+                privateProfileContacts: [{ name: 'Aunt Kim', email: 'kim@example.com', relation: 'Contact', source: 'roster-csv' }]
+            }],
+            csvText: [
+                'Name,Parent Name,Parent Email,Contact Name,Contact Email',
+                'Avery Lee,Pat Lee,pat@example.com,Aunt Kim,kim@example.com'
+            ].join('\n')
+        });
+
+        expect(plan.errors).toEqual([]);
+        expect(plan.operations[0].privateFamilyContacts).toEqual({
+            parents: [{ name: 'Pat Lee', email: 'pat@example.com', phone: '', relation: 'Parent', source: 'roster-csv' }],
+            contacts: [{ name: 'Aunt Kim', email: 'kim@example.com', phone: '', relation: 'Contact', source: 'roster-csv' }]
+        });
+    });
+
     it('returns actionable row validation errors without producing operations', () => {
         const plan = planRosterCsvImport({
             fields,
@@ -406,9 +428,44 @@ describe('roster CSV import planning', () => {
 
     it('describes parent and guardian contact columns in the roster CSV import UI', () => {
         const page = readFileSync('edit-roster.html', 'utf8');
+        const dbSource = readFileSync('js/db.js', 'utf8');
 
         expect(page).toContain('profile columns such as Position, DOB, Gender, or Address');
         expect(page).toContain('parent/guardian/contact columns such as Parent Email or Guardian Phone');
         expect(page).toContain('Name,Number,Position,DOB,Parent Name,Parent Email,Grade');
+        expect(page).toContain('download-roster-template-btn');
+        expect(page).toContain('roster-csv-send-invites');
+        expect(page).toContain('csv-import-preview');
+        expect(page).toContain('renderRosterCsvReview(plan)');
+        expect(page).toContain('sendImportedRosterContactInvite');
+        expect(page).toContain('operation.inviteRequests || []');
+        expect(page).toContain('Send / resend invite');
+        expect(page).toContain('Linked account');
+        expect(page).toContain('applyRosterCsvImportOperations(currentTeamId, plan.operations)');
+        expect(dbSource).toContain('export async function applyRosterCsvImportOperations');
+        expect(dbSource).toContain('export async function getPlayersWithPrivateRosterContacts');
+        expect(page).toContain('getPlayersWithPrivateRosterContacts(currentTeamId, { includeInactive: true })');
+        expect(dbSource).toContain("if (plannedOperations.length > 200)");
+        expect(dbSource).toContain('await batch.commit();');
+    });
+
+    it('builds a full roster template with family contacts and configured fields', () => {
+        const template = buildFullRosterCsvTemplate(fields);
+
+        expect(template).toContain('Name,Number,Position,DOB,Gender,Address,City,State,Zip,Roster Status');
+        expect(template).toContain('Parent Name,Parent Relation,Parent Email,Parent Phone');
+        expect(template).toContain('Guardian 2 Name,Guardian 2 Relation,Guardian 2 Email,Guardian 2 Phone');
+        expect(template).toContain('Grade,Throws Right,Birth Date,Medical Note');
+        expect(template).toContain('Avery Lee,4,Forward,2014-02-03');
+    });
+
+    it('summarizes imported contact invitation outcomes for retry UX', () => {
+        expect(summarizeRosterContactInviteResults([
+            { status: 'sent' },
+            { status: 'sent' },
+            { status: 'linked' },
+            { status: 'code-created' },
+            { status: 'failed' }
+        ])).toEqual({ sent: 2, linked: 1, codeCreated: 1, failed: 1 });
     });
 });

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -404,6 +404,28 @@ describe('roster CSV import planning', () => {
         });
     });
 
+    it('preserves private parent contacts when public parents already exist', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            existingPlayers: [{
+                id: 'p1',
+                name: 'Avery Lee',
+                parents: [{ name: 'Pat Lee', email: 'pat@example.com', relation: 'Parent', source: 'roster-csv' }],
+                privateProfileParents: [{ name: 'Robin Lee', email: 'robin@example.com', relation: 'Guardian', source: 'roster-csv' }]
+            }],
+            csvText: 'Name,Number\nAvery Lee,8'
+        });
+
+        expect(plan.errors).toEqual([]);
+        expect(plan.operations).toHaveLength(1);
+        expect(plan.operations[0].privateFamilyContacts).toEqual({
+            parents: [
+                { name: 'Pat Lee', email: 'pat@example.com', phone: '', relation: 'Parent', source: 'roster-csv' },
+                { name: 'Robin Lee', email: 'robin@example.com', phone: '', relation: 'Guardian', source: 'roster-csv' }
+            ]
+        });
+    });
+
     it('returns actionable row validation errors without producing operations', () => {
         const plan = planRosterCsvImport({
             fields,
@@ -457,6 +479,19 @@ describe('roster CSV import planning', () => {
         expect(template).toContain('Guardian 2 Name,Guardian 2 Relation,Guardian 2 Email,Guardian 2 Phone');
         expect(template).toContain('Grade,Throws Right,Birth Date,Medical Note');
         expect(template).toContain('Avery Lee,4,Forward,2014-02-03');
+    });
+
+    it('omits configured roster field headers that collide with built-in template columns', () => {
+        const template = buildFullRosterCsvTemplate([
+            { key: 'position', label: 'Position', type: 'text', visibility: 'public', active: true },
+            { key: 'gender', label: 'Gender', type: 'text', visibility: 'public', active: true },
+            { key: 'grade', label: 'Grade', type: 'text', visibility: 'public', active: true }
+        ]);
+        const headers = template.trim().split('\n')[0].split(',');
+
+        expect(headers.filter((header) => header === 'Position')).toHaveLength(1);
+        expect(headers.filter((header) => header === 'Gender')).toHaveLength(1);
+        expect(headers).toContain('Grade');
     });
 
     it('summarizes imported contact invitation outcomes for retry UX', () => {


### PR DESCRIPTION
## What changed

- Add a downloadable full-roster CSV template covering player profile, roster status, two family contacts, and configured roster fields.
- Turn CSV import into a two-step review/import flow; no writes occur until the validated plan is reviewed.
- Keep profile/contact header aliases, value validation, duplicate detection, and contact-conflict checks at the shared planner boundary.
- Apply every reviewed player/private-contact write in one Firestore batch (up to 200 rows) so service failures do not leave a half-applied roster.
- Optionally create and email parent invites for every imported contact after the atomic roster save.
- Show imported contacts on roster rows with Accepted vs Invite needed state and a prefilled Send / resend invite action.
- Load private roster contacts for admin display and deduplicate later CSV updates against them.
- Cache-bust the updated roster and DB modules.

## Why

The parser and private contact model had already been implemented, but the UI discarded `inviteRequests`, imported without a staged review, and did not surface imported-contact status or resend actions. This completes the end-to-end onboarding workflow.

Closes #959

## Validation

- Focused roster/import suites: 47 passed across 4 files
- Complete root unit suite: 3,891 passed, 9 skipped across 593 files
- Playwright roster flow: 3 passed; the new test verifies review-before-write, atomic player/contact persistence, invite creation/email, status, and resend UI
- `npm run app:build` — passed
- `git diff --check` — passed
- Focused suites re-run after rebase — 47 passed