### PR TITLE
Add native tournament standings parity

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -84,7 +84,11 @@ export async function getGame(teamId: string, gameId: string) {
     return await Promise.resolve(legacyGetGame(teamId, gameId));
 }
 
-export type GamesQueryOptions = { startDate?: Date | null; endDate?: Date | null };
+export type GamesQueryOptions = {
+    startDate?: Date | null;
+    endDate?: Date | null;
+    tournamentGroup?: { poolName: string; divisionName: string } | null;
+};
 
 export async function getGames(teamId: string, options: GamesQueryOptions = {}) {
     return await Promise.resolve(legacyGetGames(teamId, options));

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -88,6 +88,7 @@ export type GamesQueryOptions = {
     startDate?: Date | null;
     endDate?: Date | null;
     tournamentGroup?: { poolName: string; divisionName: string } | null;
+    tournamentGroups?: Array<{ poolName: string; divisionName: string }> | null;
 };
 
 export async function getGames(teamId: string, options: GamesQueryOptions = {}) {

--- a/apps/app/src/lib/adapters/legacySharedGames.ts
+++ b/apps/app/src/lib/adapters/legacySharedGames.ts
@@ -1,0 +1,7 @@
+/* Typed app boundary for shared-game schedule projection. */
+import { projectSharedGameForTeam as legacyProjectSharedGameForTeam } from '@legacy/shared-games.js';
+
+export const projectSharedGameForTeam = legacyProjectSharedGameForTeam as (
+  sharedGame: Record<string, unknown>,
+  teamId: string
+) => Record<string, unknown> | null;

--- a/apps/app/src/lib/adapters/legacyTournamentStandings.ts
+++ b/apps/app/src/lib/adapters/legacyTournamentStandings.ts
@@ -1,6 +1,7 @@
 /* Typed app boundary for the pure legacy tournament standings contract. */
 import {
   buildTournamentPoolStandings as legacy_buildTournamentPoolStandings,
+  getTournamentStandingsGroupKey as legacy_getTournamentStandingsGroupKey,
   getTournamentStandingsGroupName as legacy_getTournamentStandingsGroupName
 } from '@legacy/tournament-standings.js';
 
@@ -11,6 +12,9 @@ export type LegacyTournamentStandingRow = Record<string, unknown> & {
 };
 
 export type LegacyTournamentPoolStanding = {
+  groupKey: string;
+  groupName: string;
+  divisionName: string;
   poolName: string;
   gameCount: number;
   computedRows: LegacyTournamentStandingRow[];
@@ -29,5 +33,9 @@ export const buildTournamentPoolStandings = legacy_buildTournamentPoolStandings 
 ) => Record<string, LegacyTournamentPoolStanding>;
 
 export const getTournamentStandingsGroupName = legacy_getTournamentStandingsGroupName as (
+  game: Record<string, unknown>
+) => string | null;
+
+export const getTournamentStandingsGroupKey = legacy_getTournamentStandingsGroupKey as (
   game: Record<string, unknown>
 ) => string | null;

--- a/apps/app/src/lib/adapters/legacyTournamentStandings.ts
+++ b/apps/app/src/lib/adapters/legacyTournamentStandings.ts
@@ -1,0 +1,26 @@
+/* Typed app boundary for the pure legacy tournament standings contract. */
+import { buildTournamentPoolStandings as legacy_buildTournamentPoolStandings } from '@legacy/tournament-standings.js';
+
+export type LegacyTournamentStandingRow = Record<string, unknown> & {
+  rank?: number | string;
+  team?: string;
+  teamName?: string;
+};
+
+export type LegacyTournamentPoolStanding = {
+  poolName: string;
+  gameCount: number;
+  computedRows: LegacyTournamentStandingRow[];
+  rows: LegacyTournamentStandingRow[];
+  isOverridden: boolean;
+  override: Record<string, unknown> | null;
+};
+
+export const buildTournamentPoolStandings = legacy_buildTournamentPoolStandings as (
+  games: Array<Record<string, unknown>>,
+  options?: {
+    currentTeamName?: string | null;
+    standingsConfig?: Record<string, unknown>;
+    poolOverrides?: Record<string, unknown>;
+  }
+) => Record<string, LegacyTournamentPoolStanding>;

--- a/apps/app/src/lib/adapters/legacyTournamentStandings.ts
+++ b/apps/app/src/lib/adapters/legacyTournamentStandings.ts
@@ -1,5 +1,8 @@
 /* Typed app boundary for the pure legacy tournament standings contract. */
-import { buildTournamentPoolStandings as legacy_buildTournamentPoolStandings } from '@legacy/tournament-standings.js';
+import {
+  buildTournamentPoolStandings as legacy_buildTournamentPoolStandings,
+  getTournamentStandingsGroupName as legacy_getTournamentStandingsGroupName
+} from '@legacy/tournament-standings.js';
 
 export type LegacyTournamentStandingRow = Record<string, unknown> & {
   rank?: number | string;
@@ -24,3 +27,7 @@ export const buildTournamentPoolStandings = legacy_buildTournamentPoolStandings 
     poolOverrides?: Record<string, unknown>;
   }
 ) => Record<string, LegacyTournamentPoolStanding>;
+
+export const getTournamentStandingsGroupName = legacy_getTournamentStandingsGroupName as (
+  game: Record<string, unknown>
+) => string | null;

--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -610,7 +610,8 @@ function getScheduleTournamentStandingInfo(event: Record<string, any>, tournamen
     tournament.standingsRows,
     event.tournamentStandings,
     event.poolStandings,
-    event.standings
+    event.standings,
+    tournament.computedStandings
   ];
 
   for (const source of sources) {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -1,5 +1,10 @@
 import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const readAppSource = (relativePath: string) => readFileSync(resolve(testDir, '..', relativePath), 'utf8');
 
 const mocks = vi.hoisted(() => {
   const transactionSet = vi.fn();
@@ -198,8 +203,8 @@ function playerSnapshot(id: string, data: Record<string, unknown> | null) {
 }
 
 it('keeps schedule workflows behind typed legacy adapters', () => {
-  const scheduleServiceSource = readFileSync('src/lib/scheduleService.ts', 'utf8');
-  const scheduleEventDetailSource = readFileSync('src/pages/ScheduleEventDetail.tsx', 'utf8');
+  const scheduleServiceSource = readAppSource('lib/scheduleService.ts');
+  const scheduleEventDetailSource = readAppSource('pages/ScheduleEventDetail.tsx');
 
   expect(scheduleServiceSource).not.toContain("../../../../js/");
   expect(scheduleServiceSource).toContain("./adapters/legacyScheduleDb");
@@ -476,7 +481,7 @@ describe('scheduled tournament writes', () => {
   });
 
   it('routes a single-game tournament block through the scheduled game save flow with one legacy document', async () => {
-    const scheduleServiceSource = readFileSync('src/lib/scheduleService.ts', 'utf8');
+    const scheduleServiceSource = readAppSource('lib/scheduleService.ts');
     vi.mocked(addGame).mockResolvedValueOnce('game-1' as any);
 
     const createdIds = await createScheduledTournamentBlockForApp('team-1', {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2959,6 +2959,9 @@ describe('web-created tournament standings hydration (#1967)', () => {
       const body = JSON.parse(String(init?.body));
       const from = body.structuredQuery.from[0];
       const fieldPath = body.structuredQuery.where.fieldFilter.field.fieldPath;
+      if (from.collectionId === 'sharedGames' && fieldPath === 'teamIds') {
+        throw new Error('teamIds membership query is not authorized');
+      }
       const sharedGameDocument = {
         name: 'projects/allplays-test/databases/(default)/documents/tournaments/t-1/sharedGames/shared-1',
         fields: {
@@ -3002,7 +3005,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
       expandStaffPlayers: false
     });
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3);
     const gameQueryCall = vi.mocked(globalThis.fetch).mock.calls.find(([, init]) => {
       const body = JSON.parse(String(init?.body));
       return body.structuredQuery.from[0].collectionId === 'games';
@@ -3024,9 +3027,9 @@ describe('web-created tournament standings hydration (#1967)', () => {
     const sharedQueryBodies = vi.mocked(globalThis.fetch).mock.calls
       .map(([, init]) => JSON.parse(String(init?.body)))
       .filter((body) => body.structuredQuery.from[0].collectionId === 'sharedGames');
-    expect(sharedQueryBodies).toHaveLength(3);
+    expect(sharedQueryBodies).toHaveLength(2);
     expect(sharedQueryBodies.map((body) => body.structuredQuery.where.fieldFilter.field.fieldPath).sort()).toEqual([
-      'awayTeamId', 'homeTeamId', 'teamIds'
+      'awayTeamId', 'homeTeamId'
     ]);
     expect(sharedQueryBodies.every((body) => body.structuredQuery.from[0].allDescendants === true)).toBe(true);
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2840,12 +2840,11 @@ describe('web-created tournament standings hydration (#1967)', () => {
     vi.mocked(getDoc).mockResolvedValue(playerSnapshot('p1', { id: 'p1', name: 'Kid One', active: true }) as any);
   });
 
-  it('computes from the complete game set and exposes the result on schedule rows', async () => {
+  it('computes standings from the bounded schedule game load without a full-history reread', async () => {
     const result = await loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false });
 
-    expect(getGames).toHaveBeenCalledTimes(2);
+    expect(getGames).toHaveBeenCalledTimes(1);
     expect(vi.mocked(getGames).mock.calls[0][1]).toMatchObject({ startDate: expect.any(Date) });
-    expect(vi.mocked(getGames).mock.calls[1][1]).toEqual({});
     expect(getScheduleTournamentInfo(result.events[0] as any).standings).toMatchObject({
       groupName: 'Pool A',
       rows: [
@@ -2856,7 +2855,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
     });
   });
 
-  it('hydrates a direct tournament detail route from the same complete game set', async () => {
+  it('hydrates a direct tournament detail route without a full-history standings reread', async () => {
     vi.mocked(getGame).mockResolvedValue(tournamentGames[0] as any);
 
     const result = await loadParentScheduleEventDetail(parentUser, {
@@ -2867,11 +2866,10 @@ describe('web-created tournament standings hydration (#1967)', () => {
     });
 
     expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
-    expect(getGames).toHaveBeenCalledWith('team-1', {});
+    expect(getGames).not.toHaveBeenCalled();
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
-      { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
-      { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
-      { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
+      { rank: '1', teamName: 'Tigers', record: '1-0', points: 3 },
+      { rank: '2', teamName: 'Lions', record: '0-1', points: 0 }
     ]);
   });
 });

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2882,6 +2882,28 @@ describe('web-created tournament standings hydration (#1967)', () => {
       { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
     ]);
   });
+
+  it('does not load a standings pool for direct tournament details without standings config', async () => {
+    vi.mocked(getTeam).mockResolvedValue({
+      id: 'team-1',
+      name: 'Tigers'
+    } as any);
+    vi.mocked(getGame).mockResolvedValue(tournamentGames[0] as any);
+
+    const result = await loadParentScheduleEventDetail(parentUser, {
+      teamId: 'team-1',
+      eventId: 'pool-a-1',
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    });
+
+    expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
+    expect(getGames).not.toHaveBeenCalled();
+    expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
+      { rank: '1', teamName: 'Tigers', record: '1-0', points: 3 },
+      { rank: '2', teamName: 'Lions', record: '0-1', points: 0 }
+    ]);
+  });
 });
 
 describe('team schedule game windowing (#2034)', () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2843,7 +2843,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
     } as any);
     vi.mocked(getTeams).mockResolvedValue([] as any);
     vi.mocked(getGames).mockImplementation(async (_teamId, options: any = {}) => (
-      options.tournamentGroup ? tournamentGames : [tournamentGames[0]]
+      options.tournamentGroups?.length ? tournamentGames : [tournamentGames[0]]
     ) as any);
     vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
     vi.mocked(getDoc).mockResolvedValue(playerSnapshot('p1', { id: 'p1', name: 'Kid One', active: true }) as any);
@@ -2855,7 +2855,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
     expect(getGames).toHaveBeenCalledTimes(2);
     expect(vi.mocked(getGames).mock.calls[0][1]).toMatchObject({ startDate: expect.any(Date) });
     expect(vi.mocked(getGames).mock.calls[1][1]).toEqual({
-      tournamentGroup: { poolName: 'Pool A', divisionName: '' }
+      tournamentGroups: [{ poolName: 'Pool A', divisionName: '' }]
     });
     expect(result.events).toHaveLength(1);
     expect(getScheduleTournamentInfo(result.events[0] as any).standings).toMatchObject({
@@ -2881,7 +2881,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
     expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
     expect(getGames).toHaveBeenCalledTimes(1);
     expect(vi.mocked(getGames).mock.calls[0][1]).toEqual({
-      tournamentGroup: { poolName: 'Pool A', divisionName: '' }
+      tournamentGroups: [{ poolName: 'Pool A', divisionName: '' }]
     });
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
       { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
@@ -2890,24 +2890,124 @@ describe('web-created tournament standings hydration (#1967)', () => {
     ]);
   });
 
-  it('uses a pool-equality native fallback instead of listing full game history', async () => {
-    (globalThis as any).window = { location: { protocol: 'capacitor:' }, setTimeout, clearTimeout } as any;
-    vi.mocked(getGame).mockResolvedValue(tournamentGames[0] as any);
-    vi.mocked(getGames).mockRejectedValueOnce(new Error('legacy SDK unavailable'));
-    vi.mocked(globalThis.fetch).mockResolvedValue({
-      ok: true,
-      json: async () => []
-    } as any);
+  it('omits derived list standings when the complete group read fails', async () => {
+    vi.mocked(getGames)
+      .mockResolvedValueOnce([tournamentGames[0]] as any)
+      .mockRejectedValueOnce(new Error('pool query unavailable'));
 
-    await loadParentScheduleEventDetail(parentUser, {
+    const result = await loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(getGames).toHaveBeenCalledTimes(2);
+    expect(getScheduleTournamentInfo(result.events[0] as any).standings).toBeNull();
+    expect((result.events[0].tournament as Record<string, unknown>)?.computedStandings).toBeUndefined();
+  });
+
+  it('preserves inline detail standings when the complete group read fails', async () => {
+    const inlineStandings = {
+      poolName: 'Published Pool A',
+      rows: [{ rank: 1, teamName: 'Published Tigers', wins: 4, losses: 0, points: 12 }],
+      isOverridden: true
+    };
+    vi.mocked(getGame).mockResolvedValue({
+      ...tournamentGames[0],
+      tournament: { ...tournamentGames[0].tournament, standings: inlineStandings }
+    } as any);
+    vi.mocked(getGames).mockRejectedValueOnce(new Error('pool query unavailable'));
+
+    const result = await loadParentScheduleEventDetail(parentUser, {
       teamId: 'team-1',
       eventId: 'pool-a-1',
       hydrateDetails: false,
       expandStaffPlayers: false
     });
 
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    const [requestUrl, requestInit] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(getGames).toHaveBeenCalledTimes(1);
+    expect((result.events[0].tournament as Record<string, unknown>)?.computedStandings).toBeUndefined();
+    expect(getScheduleTournamentInfo(result.events[0] as any).standings).toMatchObject({
+      groupName: 'Published Pool A',
+      rows: [{ rank: '1', teamName: 'Published Tigers', record: '4-0', points: 12 }]
+    });
+  });
+
+  it('loads every visible tournament group through one de-duplicated standings call', async () => {
+    const poolBGame = {
+      ...tournamentGames[0],
+      id: 'pool-b-1',
+      tournament: { ...tournamentGames[0].tournament, poolName: 'Pool B' }
+    };
+    vi.mocked(getGames).mockImplementation(async (_teamId, options: any = {}) => (
+      options.tournamentGroups?.length ? [tournamentGames[0], poolBGame] : [tournamentGames[0], poolBGame]
+    ) as any);
+
+    await loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(getGames).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(getGames).mock.calls[1][1]).toEqual({
+      tournamentGroups: [
+        { poolName: 'Pool A', divisionName: '' },
+        { poolName: 'Pool B', divisionName: '' }
+      ]
+    });
+  });
+
+  it('uses bounded native queries and includes shared tournament games in standings', async () => {
+    (globalThis as any).window = { location: { protocol: 'capacitor:' }, setTimeout, clearTimeout } as any;
+    vi.mocked(getGame).mockResolvedValue(tournamentGames[0] as any);
+    vi.mocked(getGames).mockRejectedValueOnce(new Error('legacy SDK unavailable'));
+    vi.mocked(getNativeAuthIdToken).mockResolvedValue('native-token' as any);
+    vi.mocked(globalThis.fetch).mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      const from = body.structuredQuery.from[0];
+      const fieldPath = body.structuredQuery.where.fieldFilter.field.fieldPath;
+      const sharedGameDocument = {
+        name: 'projects/allplays-test/databases/(default)/documents/tournaments/t-1/sharedGames/shared-1',
+        fields: {
+          type: { stringValue: 'game' },
+          date: { timestampValue: '2026-07-21T18:00:00.000Z' },
+          competitionType: { stringValue: 'tournament' },
+          status: { stringValue: 'completed' },
+          homeScore: { integerValue: '2' },
+          awayScore: { integerValue: '0' },
+          homeTeamId: { stringValue: 'team-1' },
+          awayTeamId: { stringValue: 'team-2' },
+          tournament: {
+            mapValue: {
+              fields: {
+                poolName: { stringValue: 'Pool A' },
+                slotAssignments: {
+                  mapValue: {
+                    fields: {
+                      home: { mapValue: { fields: { sourceType: { stringValue: 'team' }, teamName: { stringValue: 'Bears' } } } },
+                      away: { mapValue: { fields: { sourceType: { stringValue: 'team' }, teamName: { stringValue: 'Tigers' } } } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      };
+      return {
+        ok: true,
+        json: async () => from.collectionId === 'sharedGames' && fieldPath === 'homeTeamId'
+          ? [{ document: sharedGameDocument }]
+          : []
+      } as any;
+    });
+
+    const result = await loadParentScheduleEventDetail(parentUser, {
+      teamId: 'team-1',
+      eventId: 'pool-a-1',
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+    const gameQueryCall = vi.mocked(globalThis.fetch).mock.calls.find(([, init]) => {
+      const body = JSON.parse(String(init?.body));
+      return body.structuredQuery.from[0].collectionId === 'games';
+    }) as [string, RequestInit];
+    const [requestUrl, requestInit] = gameQueryCall;
     expect(requestUrl).toContain('/documents/teams/team-1:runQuery');
     expect(requestUrl).not.toContain('/documents/teams/team-1/games');
     const body = JSON.parse(String(requestInit.body));
@@ -2921,6 +3021,19 @@ describe('web-created tournament standings hydration (#1967)', () => {
         }
       }
     });
+    const sharedQueryBodies = vi.mocked(globalThis.fetch).mock.calls
+      .map(([, init]) => JSON.parse(String(init?.body)))
+      .filter((body) => body.structuredQuery.from[0].collectionId === 'sharedGames');
+    expect(sharedQueryBodies).toHaveLength(3);
+    expect(sharedQueryBodies.map((body) => body.structuredQuery.where.fieldFilter.field.fieldPath).sort()).toEqual([
+      'awayTeamId', 'homeTeamId', 'teamIds'
+    ]);
+    expect(sharedQueryBodies.every((body) => body.structuredQuery.from[0].allDescendants === true)).toBe(true);
+    expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
+      { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
+      { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
+      { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
+    ]);
   });
 
   it('loads the complete pool with default standings rules when the team has no custom config', async () => {
@@ -2940,7 +3053,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
     expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
     expect(getGames).toHaveBeenCalledTimes(1);
     expect(vi.mocked(getGames).mock.calls[0][1]).toEqual({
-      tournamentGroup: { poolName: 'Pool A', divisionName: '' }
+      tournamentGroups: [{ poolName: 'Pool A', divisionName: '' }]
     });
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
       { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
@@ -2969,7 +3082,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
     });
 
     expect(vi.mocked(getGames).mock.calls[0][1]).toEqual({
-      tournamentGroup: { poolName: '', divisionName: '10U Gold' }
+      tournamentGroups: [{ poolName: '', divisionName: '10U Gold' }]
     });
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
       { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2855,7 +2855,7 @@ describe('web-created tournament standings hydration (#1967)', () => {
     });
   });
 
-  it('hydrates a direct tournament detail route without a full-history standings reread', async () => {
+  it('hydrates a direct tournament detail route from the bounded tournament pool', async () => {
     vi.mocked(getGame).mockResolvedValue(tournamentGames[0] as any);
 
     const result = await loadParentScheduleEventDetail(parentUser, {
@@ -2866,10 +2866,15 @@ describe('web-created tournament standings hydration (#1967)', () => {
     });
 
     expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
-    expect(getGames).not.toHaveBeenCalled();
+    expect(getGames).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getGames).mock.calls[0][1]).toMatchObject({
+      startDate: expect.any(Date),
+      endDate: expect.any(Date)
+    });
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
-      { rank: '1', teamName: 'Tigers', record: '1-0', points: 3 },
-      { rank: '2', teamName: 'Lions', record: '0-1', points: 0 }
+      { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
+      { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
+      { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
     ]);
   });
 });

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -186,6 +186,7 @@ import { expandRecurrence, fetchAndParseCalendar, isTeamActive, mergeAssignments
 import { getCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
+import { getScheduleTournamentInfo } from './scheduleLogic';
 import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
@@ -2781,6 +2782,98 @@ describe('partial parent schedule team failures (#3021)', () => {
     });
   });
 
+});
+
+describe('web-created tournament standings hydration (#1967)', () => {
+  const parentUser = {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    parentOf: [{ teamId: 'team-1', playerId: 'p1', playerName: 'Kid One' }]
+  } as any;
+  const tournamentGames = [
+    {
+      id: 'pool-a-1',
+      type: 'game',
+      date: new Date('2026-06-20T18:00:00.000Z'),
+      competitionType: 'tournament',
+      status: 'completed',
+      homeScore: 3,
+      awayScore: 1,
+      tournament: {
+        poolName: 'Pool A',
+        slotAssignments: {
+          home: { sourceType: 'team', teamName: 'Tigers' },
+          away: { sourceType: 'team', teamName: 'Lions' }
+        }
+      }
+    },
+    {
+      id: 'pool-a-2',
+      type: 'game',
+      date: new Date('2026-06-21T18:00:00.000Z'),
+      competitionType: 'tournament',
+      status: 'completed',
+      homeScore: 2,
+      awayScore: 0,
+      tournament: {
+        poolName: 'Pool A',
+        slotAssignments: {
+          home: { sourceType: 'team', teamName: 'Bears' },
+          away: { sourceType: 'team', teamName: 'Tigers' }
+        }
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).window = { location: { protocol: 'https:' }, setTimeout, clearTimeout } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: parentUser.parentOf } as any);
+    vi.mocked(getTeam).mockResolvedValue({
+      id: 'team-1',
+      name: 'Tigers',
+      standingsConfig: { rankingMode: 'points', points: { win: 3, tie: 1, loss: 0 } }
+    } as any);
+    vi.mocked(getTeams).mockResolvedValue([] as any);
+    vi.mocked(getGames).mockResolvedValue(tournamentGames as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+    vi.mocked(getDoc).mockResolvedValue(playerSnapshot('p1', { id: 'p1', name: 'Kid One', active: true }) as any);
+  });
+
+  it('computes from the complete game set and exposes the result on schedule rows', async () => {
+    const result = await loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(getGames).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(getGames).mock.calls[0][1]).toMatchObject({ startDate: expect.any(Date) });
+    expect(vi.mocked(getGames).mock.calls[1][1]).toEqual({});
+    expect(getScheduleTournamentInfo(result.events[0] as any).standings).toMatchObject({
+      groupName: 'Pool A',
+      rows: [
+        { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
+        { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
+        { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
+      ]
+    });
+  });
+
+  it('hydrates a direct tournament detail route from the same complete game set', async () => {
+    vi.mocked(getGame).mockResolvedValue(tournamentGames[0] as any);
+
+    const result = await loadParentScheduleEventDetail(parentUser, {
+      teamId: 'team-1',
+      eventId: 'pool-a-1',
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    });
+
+    expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
+    expect(getGames).toHaveBeenCalledWith('team-1', {});
+    expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
+      { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
+      { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
+      { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
+    ]);
+  });
 });
 
 describe('team schedule game windowing (#2034)', () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2842,16 +2842,22 @@ describe('web-created tournament standings hydration (#1967)', () => {
       standingsConfig: { rankingMode: 'points', points: { win: 3, tie: 1, loss: 0 } }
     } as any);
     vi.mocked(getTeams).mockResolvedValue([] as any);
-    vi.mocked(getGames).mockResolvedValue(tournamentGames as any);
+    vi.mocked(getGames).mockImplementation(async (_teamId, options: any = {}) => (
+      options.tournamentGroup ? tournamentGames : [tournamentGames[0]]
+    ) as any);
     vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
     vi.mocked(getDoc).mockResolvedValue(playerSnapshot('p1', { id: 'p1', name: 'Kid One', active: true }) as any);
   });
 
-  it('computes standings from the bounded schedule game load without a full-history reread', async () => {
+  it('computes windowed schedule standings from the complete bounded tournament pool', async () => {
     const result = await loadParentSchedule(parentUser, { hydrateDetails: false, expandStaffPlayers: false });
 
-    expect(getGames).toHaveBeenCalledTimes(1);
+    expect(getGames).toHaveBeenCalledTimes(2);
     expect(vi.mocked(getGames).mock.calls[0][1]).toMatchObject({ startDate: expect.any(Date) });
+    expect(vi.mocked(getGames).mock.calls[1][1]).toEqual({
+      tournamentGroup: { poolName: 'Pool A', divisionName: '' }
+    });
+    expect(result.events).toHaveLength(1);
     expect(getScheduleTournamentInfo(result.events[0] as any).standings).toMatchObject({
       groupName: 'Pool A',
       rows: [

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2815,7 +2815,9 @@ describe('web-created tournament standings hydration (#1967)', () => {
     {
       id: 'pool-a-2',
       type: 'game',
-      date: new Date('2026-06-21T18:00:00.000Z'),
+      // Keep this game outside the old +/-14-day detail window. Pool identity,
+      // rather than an arbitrary date cutoff, must define the standings input.
+      date: new Date('2026-07-21T18:00:00.000Z'),
       competitionType: 'tournament',
       status: 'completed',
       homeScore: 2,
@@ -2872,9 +2874,8 @@ describe('web-created tournament standings hydration (#1967)', () => {
 
     expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
     expect(getGames).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(getGames).mock.calls[0][1]).toMatchObject({
-      startDate: expect.any(Date),
-      endDate: expect.any(Date)
+    expect(vi.mocked(getGames).mock.calls[0][1]).toEqual({
+      tournamentGroup: { poolName: 'Pool A', divisionName: '' }
     });
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
       { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
@@ -2883,7 +2884,40 @@ describe('web-created tournament standings hydration (#1967)', () => {
     ]);
   });
 
-  it('does not load a standings pool for direct tournament details without standings config', async () => {
+  it('uses a pool-equality native fallback instead of listing full game history', async () => {
+    (globalThis as any).window = { location: { protocol: 'capacitor:' }, setTimeout, clearTimeout } as any;
+    vi.mocked(getGame).mockResolvedValue(tournamentGames[0] as any);
+    vi.mocked(getGames).mockRejectedValueOnce(new Error('legacy SDK unavailable'));
+    vi.mocked(globalThis.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => []
+    } as any);
+
+    await loadParentScheduleEventDetail(parentUser, {
+      teamId: 'team-1',
+      eventId: 'pool-a-1',
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [requestUrl, requestInit] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain('/documents/teams/team-1:runQuery');
+    expect(requestUrl).not.toContain('/documents/teams/team-1/games');
+    const body = JSON.parse(String(requestInit.body));
+    expect(body.structuredQuery).toEqual({
+      from: [{ collectionId: 'games' }],
+      where: {
+        fieldFilter: {
+          field: { fieldPath: 'tournament.poolName' },
+          op: 'EQUAL',
+          value: { stringValue: 'Pool A' }
+        }
+      }
+    });
+  });
+
+  it('loads the complete pool with default standings rules when the team has no custom config', async () => {
     vi.mocked(getTeam).mockResolvedValue({
       id: 'team-1',
       name: 'Tigers'
@@ -2898,10 +2932,43 @@ describe('web-created tournament standings hydration (#1967)', () => {
     });
 
     expect(getGame).toHaveBeenCalledWith('team-1', 'pool-a-1');
-    expect(getGames).not.toHaveBeenCalled();
+    expect(getGames).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getGames).mock.calls[0][1]).toEqual({
+      tournamentGroup: { poolName: 'Pool A', divisionName: '' }
+    });
     expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
-      { rank: '1', teamName: 'Tigers', record: '1-0', points: 3 },
-      { rank: '2', teamName: 'Lions', record: '0-1', points: 0 }
+      { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
+      { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
+      { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
+    ]);
+  });
+
+  it('loads complete legacy division-only standings groups', async () => {
+    const divisionGames = tournamentGames.map((game) => ({
+      ...game,
+      tournament: {
+        division: '10U Gold',
+        slotAssignments: game.tournament.slotAssignments
+      }
+    }));
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', name: 'Tigers' } as any);
+    vi.mocked(getGame).mockResolvedValue(divisionGames[0] as any);
+    vi.mocked(getGames).mockResolvedValue(divisionGames as any);
+
+    const result = await loadParentScheduleEventDetail(parentUser, {
+      teamId: 'team-1',
+      eventId: 'pool-a-1',
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    });
+
+    expect(vi.mocked(getGames).mock.calls[0][1]).toEqual({
+      tournamentGroup: { poolName: '', divisionName: '10U Gold' }
+    });
+    expect(getScheduleTournamentInfo(result.events[0] as any).standings?.rows).toEqual([
+      { rank: '1', teamName: 'Bears', record: '1-0', points: 3 },
+      { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
+      { rank: '3', teamName: 'Lions', record: '0-1', points: 0 }
     ]);
   });
 });

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -81,6 +81,7 @@ import {
   isTeamActive
 } from './adapters/legacyScheduleHelpers';
 import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './adapters/legacyAvailability';
+import { projectSharedGameForTeam } from './adapters/legacySharedGames';
 import { buildTrackerEventDocument } from './statTrackingEvent';
 import {
   enrichTournamentScheduleStandings,
@@ -929,27 +930,26 @@ async function nativeQueryScheduleEventDocuments(teamId: string, range: Schedule
     : [];
 }
 
-async function nativeQueryTournamentScheduleGroupDocuments(
+async function nativeQuerySharedTournamentScheduleDocuments(
   teamId: string,
-  group: TournamentScheduleGroupQuery
+  groups: TournamentScheduleGroupQuery[]
 ): Promise<ScheduleEventFirestoreRecord[]> {
-  const fieldQueries = group.poolName
-    ? [{ fieldPath: 'tournament.poolName', value: group.poolName }]
-    : [
-        { fieldPath: 'tournament.divisionName', value: group.divisionName },
-        { fieldPath: 'tournament.division', value: group.divisionName }
-      ];
-  const payloads = await Promise.all(fieldQueries.map(({ fieldPath, value }) => (
-    nativeFirestoreRequest(`/teams/${encodeURIComponent(teamId)}:runQuery`, {
+  const membershipQueries = [
+    { fieldPath: 'homeTeamId', op: 'EQUAL' },
+    { fieldPath: 'awayTeamId', op: 'EQUAL' },
+    { fieldPath: 'teamIds', op: 'ARRAY_CONTAINS' }
+  ] as const;
+  const payloads = await Promise.all(membershipQueries.map(({ fieldPath, op }) => (
+    nativeFirestoreRequest(':runQuery', {
       method: 'POST',
       body: JSON.stringify({
         structuredQuery: {
-          from: [{ collectionId: 'games' }],
+          from: [{ collectionId: 'sharedGames', allDescendants: true }],
           where: {
             fieldFilter: {
               field: { fieldPath },
-              op: 'EQUAL',
-              value: encodeFirestoreValue(value)
+              op,
+              value: encodeFirestoreValue(teamId)
             }
           }
         }
@@ -959,15 +959,69 @@ async function nativeQueryTournamentScheduleGroupDocuments(
 
   const gamesById = new Map<string, ScheduleEventFirestoreRecord>();
   payloads.forEach((payload) => {
-    const games = Array.isArray(payload)
-      ? mapScheduleEventDocuments(payload.map((entry) => entry?.document).filter(Boolean) as NativeFirestoreDocument[])
-      : [];
-    games.forEach((game) => {
+    (Array.isArray(payload) ? payload : []).forEach((entry) => {
+      const document = entry?.document as NativeFirestoreDocument | undefined;
+      const decoded = mapFirestoreDocument(document);
+      const documentPath = compactString(document?.name).split('/documents/')[1] || '';
+      const projected = decoded
+        ? projectSharedGameForTeam({ ...decoded, _sharedGamePath: documentPath }, teamId)
+        : null;
+      const game = projected ? mapScheduleEventRecord(projected, compactString(projected.id)) : null;
+      if (!game || !groups.some((group) => matchesTournamentScheduleGroup(game, group))) return;
       const gameId = compactString(game.id || game.gameId);
       if (gameId && !gamesById.has(gameId)) gamesById.set(gameId, game);
     });
   });
-  return Array.from(gamesById.values()).filter((game) => matchesTournamentScheduleGroup(game, group));
+  return Array.from(gamesById.values());
+}
+
+async function nativeQueryTournamentScheduleGroupDocuments(
+  teamId: string,
+  groups: TournamentScheduleGroupQuery[]
+): Promise<ScheduleEventFirestoreRecord[]> {
+  const fieldQueries = groups.flatMap((group) => group.poolName
+    ? [{ fieldPath: 'tournament.poolName', value: group.poolName }]
+    : [
+        { fieldPath: 'tournament.divisionName', value: group.divisionName },
+        { fieldPath: 'tournament.division', value: group.divisionName }
+      ]);
+  const [teamPayloads, sharedGames] = await Promise.all([
+    Promise.all(fieldQueries.map(({ fieldPath, value }) => (
+      nativeFirestoreRequest(`/teams/${encodeURIComponent(teamId)}:runQuery`, {
+        method: 'POST',
+        body: JSON.stringify({
+          structuredQuery: {
+            from: [{ collectionId: 'games' }],
+            where: {
+              fieldFilter: {
+                field: { fieldPath },
+                op: 'EQUAL',
+                value: encodeFirestoreValue(value)
+              }
+            }
+          }
+        })
+      })
+    ))),
+    nativeQuerySharedTournamentScheduleDocuments(teamId, groups)
+  ]);
+
+  const gamesById = new Map<string, ScheduleEventFirestoreRecord>();
+  teamPayloads.forEach((payload) => {
+    const games = Array.isArray(payload)
+      ? mapScheduleEventDocuments(payload.map((entry) => entry?.document).filter(Boolean) as NativeFirestoreDocument[])
+      : [];
+    games.forEach((game) => {
+      if (!groups.some((group) => matchesTournamentScheduleGroup(game, group))) return;
+      const gameId = compactString(game.id || game.gameId);
+      if (gameId && !gamesById.has(gameId)) gamesById.set(gameId, game);
+    });
+  });
+  sharedGames.forEach((game) => {
+    const gameId = compactString(game.id || game.gameId);
+    if (gameId && !gamesById.has(gameId)) gamesById.set(gameId, game);
+  });
+  return Array.from(gamesById.values());
 }
 
 const nativeDeleteFieldSentinel = { __deleteField: true };
@@ -2576,10 +2630,8 @@ async function loadTournamentScheduleStandingsGames(
   });
   if (!groups.size) return scheduleGames;
 
-  const standingsGroups = await Promise.all(
-    [...groups.values()].map((tournamentGroup) => loadGames(teamId, { tournamentGroup }).catch(() => []))
-  );
-  return mergeScheduleStandingsGames(scheduleGames, standingsGroups);
+  const standingsGames = await loadGames(teamId, { tournamentGroups: [...groups.values()] });
+  return mergeScheduleStandingsGames(scheduleGames, [standingsGames]);
 }
 
 async function loadRawTeam(teamId: string) {
@@ -2596,7 +2648,10 @@ async function loadTeam(teamId: string) {
 }
 
 type ScheduleDateRange = { startDate?: Date | null; endDate?: Date | null };
-type ScheduleGamesQuery = ScheduleDateRange & { tournamentGroup?: TournamentScheduleGroupQuery | null };
+type ScheduleGamesQuery = ScheduleDateRange & {
+  tournamentGroup?: TournamentScheduleGroupQuery | null;
+  tournamentGroups?: TournamentScheduleGroupQuery[] | null;
+};
 type ScheduleDateRangeByTeam = Record<string, ScheduleDateRange | undefined>;
 
 function isEventWithinRange(game: any, range: ScheduleDateRange) {
@@ -2613,13 +2668,16 @@ async function loadGames(teamId: string, range: ScheduleGamesQuery = {}): Promis
     `games ${teamId}`,
     async () => mapScheduleEventRecords(await getGames(teamId, range)),
     async () => {
-      const docs = range.tournamentGroup
-        ? await nativeQueryTournamentScheduleGroupDocuments(teamId, range.tournamentGroup)
+      const tournamentGroups = range.tournamentGroups?.length
+        ? range.tournamentGroups
+        : range.tournamentGroup ? [range.tournamentGroup] : [];
+      const docs = tournamentGroups.length
+        ? await nativeQueryTournamentScheduleGroupDocuments(teamId, tournamentGroups)
         : (range.startDate || range.endDate)
           ? await nativeQueryScheduleEventDocuments(teamId, range)
           : await nativeListScheduleEventDocuments(`teams/${encodeURIComponent(teamId)}/games`);
-      const windowed = range.tournamentGroup
-        ? docs.filter((doc) => matchesTournamentScheduleGroup(doc, range.tournamentGroup!))
+      const windowed = tournamentGroups.length
+        ? docs.filter((doc) => tournamentGroups.some((group) => matchesTournamentScheduleGroup(doc, group)))
         : (range.startDate || range.endDate)
           ? docs.filter((doc) => isEventWithinRange(doc, range))
           : docs;
@@ -3014,10 +3072,17 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
   ]);
   if (!team) return events;
   const loadedScheduleGames = dbGames || [];
-  const standingsGames = (gamesRange.startDate || gamesRange.endDate) && hasTournamentScheduleGames(loadedScheduleGames)
-    ? await loadTournamentScheduleStandingsGames(teamId, loadedScheduleGames)
-    : loadedScheduleGames;
-  const scheduleGames = enrichTournamentScheduleStandings(loadedScheduleGames, team, standingsGames);
+  let scheduleGames = loadedScheduleGames;
+  if ((gamesRange.startDate || gamesRange.endDate) && hasTournamentScheduleGames(loadedScheduleGames)) {
+    try {
+      const standingsGames = await loadTournamentScheduleStandingsGames(teamId, loadedScheduleGames);
+      scheduleGames = enrichTournamentScheduleStandings(loadedScheduleGames, team, standingsGames);
+    } catch (error) {
+      logScheduleWarning('Unable to load complete tournament standings.', 'tournament-standings-load', error, { teamId });
+    }
+  } else {
+    scheduleGames = enrichTournamentScheduleStandings(loadedScheduleGames, team, loadedScheduleGames);
+  }
   const trackedUids = getTrackedCalendarEventUidsFromLoadedGames(scheduleGames);
 
   const teamName = compactString(team.name) || teamId;
@@ -3271,10 +3336,18 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
   const tournamentGroup = hasTournamentScheduleGames([loadedGame])
     ? getTournamentScheduleGroupQuery(loadedGame)
     : null;
-  const standingsGames = tournamentGroup
-    ? mergeLoadedGameWithStandingsPool(loadedGame, await loadGames(teamId, { tournamentGroup }).catch(() => []))
-    : [loadedGame];
-  const game = enrichTournamentScheduleStandings([loadedGame], team, standingsGames)[0];
+  let game = loadedGame;
+  if (tournamentGroup) {
+    try {
+      const standingsGames = mergeLoadedGameWithStandingsPool(
+        loadedGame,
+        await loadGames(teamId, { tournamentGroups: [tournamentGroup] })
+      );
+      game = enrichTournamentScheduleStandings([loadedGame], team, standingsGames)[0];
+    } catch (error) {
+      logScheduleWarning('Unable to load complete tournament standings.', 'tournament-standings-load', error, { teamId });
+    }
+  }
 
   const teamName = compactString(team.name) || teamId;
   const teamWithId = { ...team, id: team.id || teamId };

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -82,7 +82,7 @@ import {
 } from './adapters/legacyScheduleHelpers';
 import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './adapters/legacyAvailability';
 import { buildTrackerEventDocument } from './statTrackingEvent';
-import { enrichTournamentScheduleStandings } from './tournamentScheduleStandings';
+import { enrichTournamentScheduleStandings, hasTournamentScheduleGames } from './tournamentScheduleStandings';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { startUxTimer } from './uxTiming';
@@ -144,6 +144,7 @@ const parentHomeHydrationLookBehindMs = 12 * 60 * 60 * 1000;
 // previous season so the "Past Events" filter still shows recent history before
 // an explicit full-history load. Tune here if season length assumptions change.
 const defaultScheduleHistoryWindowMs = 400 * 24 * 60 * 60 * 1000;
+const tournamentDetailStandingsWindowMs = 14 * 24 * 60 * 60 * 1000;
 const logger = createLogger('schedule-service');
 type GameDayLineupPublishModule = typeof import('./gameDayLineupPublish');
 
@@ -2491,6 +2492,28 @@ function getTrackedCalendarEventUidsFromLoadedGames(games: any[] = []) {
     .filter(Boolean);
 }
 
+function getTournamentDetailStandingsRange(game: any): ScheduleDateRange {
+  const date = normalizeScheduleDate(game?.date);
+  if (!date) {
+    return { startDate: new Date(Date.now() - defaultScheduleHistoryWindowMs) };
+  }
+  return {
+    startDate: new Date(date.getTime() - tournamentDetailStandingsWindowMs),
+    endDate: new Date(date.getTime() + tournamentDetailStandingsWindowMs)
+  };
+}
+
+function mergeLoadedGameWithStandingsPool(loadedGame: ScheduleEventFirestoreRecord, standingsGames: ScheduleEventFirestoreRecord[]) {
+  const loadedGameId = compactString(loadedGame.id || loadedGame.gameId);
+  return [
+    loadedGame,
+    ...(Array.isArray(standingsGames) ? standingsGames : []).filter((game) => {
+      const gameId = compactString(game?.id || game?.gameId);
+      return !loadedGameId || gameId !== loadedGameId;
+    })
+  ];
+}
+
 async function loadRawTeam(teamId: string) {
   return readWithNativeFallback(
     `team ${teamId}`,
@@ -3168,7 +3191,10 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
     : null);
   if (!loadedGame) return [];
 
-  const game = enrichTournamentScheduleStandings([loadedGame], team)[0];
+  const standingsGames = hasTournamentScheduleGames([loadedGame])
+    ? mergeLoadedGameWithStandingsPool(loadedGame, await loadGames(teamId, getTournamentDetailStandingsRange(loadedGame)).catch(() => []))
+    : [loadedGame];
+  const game = enrichTournamentScheduleStandings([loadedGame], team, standingsGames)[0];
 
   const teamName = compactString(team.name) || teamId;
   const teamWithId = { ...team, id: team.id || teamId };

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -82,6 +82,7 @@ import {
 } from './adapters/legacyScheduleHelpers';
 import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './adapters/legacyAvailability';
 import { buildTrackerEventDocument } from './statTrackingEvent';
+import { enrichTournamentScheduleStandings, hasTournamentScheduleGames } from './tournamentScheduleStandings';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { startUxTimer } from './uxTiming';
@@ -2531,6 +2532,20 @@ async function loadGames(teamId: string, range: ScheduleDateRange = {}): Promise
   );
 }
 
+async function loadTournamentStandingsSourceGames(
+  teamId: string,
+  loadedGames: ScheduleEventFirestoreRecord[],
+  needsFullHistory: boolean
+) {
+  if (!needsFullHistory || !hasTournamentScheduleGames(loadedGames)) return loadedGames;
+  try {
+    return await loadGames(teamId);
+  } catch (error) {
+    logScheduleWarning('Unable to load full tournament standings history; using loaded schedule games.', 'tournament-standings-history-load', error, { teamId });
+    return loadedGames;
+  }
+}
+
 async function loadGameById(teamId: string, gameId: string): Promise<ScheduleEventFirestoreRecord | null> {
   return readWithNativeFallback(
     `game ${teamId}/${gameId}`,
@@ -2916,7 +2931,13 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
     loadPracticeSessions(teamId, gamesRange)
   ]);
   if (!team) return events;
-  const trackedUids = getTrackedCalendarEventUidsFromLoadedGames(dbGames || []);
+  const standingsSourceGames = await loadTournamentStandingsSourceGames(
+    teamId,
+    dbGames || [],
+    Boolean(gamesRange.startDate || gamesRange.endDate)
+  );
+  const scheduleGames = enrichTournamentScheduleStandings(dbGames || [], team, standingsSourceGames);
+  const trackedUids = getTrackedCalendarEventUidsFromLoadedGames(scheduleGames);
 
   const teamName = compactString(team.name) || teamId;
   const teamWithId = { ...team, id: team.id || teamId };
@@ -2927,7 +2948,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
     child.teamName = child.teamName || teamName;
   });
   const availabilityPreferences = normalizeAvailabilityPreferences(team.availabilityPreferences);
-  const visibleSessions = filterVisiblePracticeSessions(practiceSessions || [], dbGames || []);
+  const visibleSessions = filterVisiblePracticeSessions(practiceSessions || [], scheduleGames);
   const sessionsByEventId = new Map<string, any>();
   const sessions: any[] = [];
   const matchedSessionIds = new Set<string>();
@@ -2937,7 +2958,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
     sessions.push({ ...session, _parsedDate: normalizeScheduleDate(session.date) });
   });
 
-  for (const game of Array.isArray(dbGames) ? dbGames : []) {
+  for (const game of scheduleGames) {
     const isPractice = game.type === 'practice';
     const type = isPractice ? 'practice' : 'game';
     const isCancelled = game.status === 'cancelled';
@@ -3078,7 +3099,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
       if (isTrackedCalendarEvent(calendarEvent, trackedUids)) return;
       const date = normalizeScheduleDate(calendarEvent.dtstart);
       if (!date) return;
-      const hasConflict = (dbGames || []).some((dbGame: any) => Math.abs(toEventDate(dbGame.date).getTime() - date.getTime()) < 60000);
+      const hasConflict = scheduleGames.some((dbGame: any) => Math.abs(toEventDate(dbGame.date).getTime() - date.getTime()) < 60000);
       if (hasConflict) return;
       const isPractice = isPracticeEvent(calendarEvent.summary);
       const type = isPractice ? 'practice' : 'game';
@@ -3161,10 +3182,13 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
   ]);
   if (!team) return [];
 
-  const game = initialGame || (occurrenceMatch?.[1]
+  const loadedGame = initialGame || (occurrenceMatch?.[1]
     ? await loadGameById(teamId, occurrenceMatch[1]).catch(() => null)
     : null);
-  if (!game) return [];
+  if (!loadedGame) return [];
+
+  const standingsSourceGames = await loadTournamentStandingsSourceGames(teamId, [loadedGame], true);
+  const game = enrichTournamentScheduleStandings([loadedGame], team, standingsSourceGames)[0];
 
   const teamName = compactString(team.name) || teamId;
   const teamWithId = { ...team, id: team.id || teamId };

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2572,7 +2572,7 @@ async function loadTournamentScheduleStandingsGames(
   scheduleGames.forEach((game) => {
     const group = getTournamentScheduleGroupQuery(game);
     if (!group || compactString(game.competitionType).toLowerCase() !== 'tournament') return;
-    groups.set(`${group.divisionName}\u0000${group.poolName}`, group);
+    groups.set(JSON.stringify([group.divisionName, group.poolName]), group);
   });
   if (!groups.size) return scheduleGames;
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -82,7 +82,13 @@ import {
 } from './adapters/legacyScheduleHelpers';
 import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './adapters/legacyAvailability';
 import { buildTrackerEventDocument } from './statTrackingEvent';
-import { enrichTournamentScheduleStandings, hasTournamentScheduleGames } from './tournamentScheduleStandings';
+import {
+  enrichTournamentScheduleStandings,
+  getTournamentScheduleGroupQuery,
+  hasTournamentScheduleGames,
+  matchesTournamentScheduleGroup,
+  type TournamentScheduleGroupQuery
+} from './tournamentScheduleStandings';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { startUxTimer } from './uxTiming';
@@ -144,7 +150,6 @@ const parentHomeHydrationLookBehindMs = 12 * 60 * 60 * 1000;
 // previous season so the "Past Events" filter still shows recent history before
 // an explicit full-history load. Tune here if season length assumptions change.
 const defaultScheduleHistoryWindowMs = 400 * 24 * 60 * 60 * 1000;
-const tournamentDetailStandingsWindowMs = 14 * 24 * 60 * 60 * 1000;
 const logger = createLogger('schedule-service');
 type GameDayLineupPublishModule = typeof import('./gameDayLineupPublish');
 
@@ -922,6 +927,47 @@ async function nativeQueryScheduleEventDocuments(teamId: string, range: Schedule
   return Array.isArray(payload)
     ? mapScheduleEventDocuments(payload.map((entry) => entry?.document).filter(Boolean) as NativeFirestoreDocument[])
     : [];
+}
+
+async function nativeQueryTournamentScheduleGroupDocuments(
+  teamId: string,
+  group: TournamentScheduleGroupQuery
+): Promise<ScheduleEventFirestoreRecord[]> {
+  const fieldQueries = group.poolName
+    ? [{ fieldPath: 'tournament.poolName', value: group.poolName }]
+    : [
+        { fieldPath: 'tournament.divisionName', value: group.divisionName },
+        { fieldPath: 'tournament.division', value: group.divisionName }
+      ];
+  const payloads = await Promise.all(fieldQueries.map(({ fieldPath, value }) => (
+    nativeFirestoreRequest(`/teams/${encodeURIComponent(teamId)}:runQuery`, {
+      method: 'POST',
+      body: JSON.stringify({
+        structuredQuery: {
+          from: [{ collectionId: 'games' }],
+          where: {
+            fieldFilter: {
+              field: { fieldPath },
+              op: 'EQUAL',
+              value: encodeFirestoreValue(value)
+            }
+          }
+        }
+      })
+    })
+  )));
+
+  const gamesById = new Map<string, ScheduleEventFirestoreRecord>();
+  payloads.forEach((payload) => {
+    const games = Array.isArray(payload)
+      ? mapScheduleEventDocuments(payload.map((entry) => entry?.document).filter(Boolean) as NativeFirestoreDocument[])
+      : [];
+    games.forEach((game) => {
+      const gameId = compactString(game.id || game.gameId);
+      if (gameId && !gamesById.has(gameId)) gamesById.set(gameId, game);
+    });
+  });
+  return Array.from(gamesById.values()).filter((game) => matchesTournamentScheduleGroup(game, group));
 }
 
 const nativeDeleteFieldSentinel = { __deleteField: true };
@@ -2492,17 +2538,6 @@ function getTrackedCalendarEventUidsFromLoadedGames(games: any[] = []) {
     .filter(Boolean);
 }
 
-function getTournamentDetailStandingsRange(game: any): ScheduleDateRange {
-  const date = normalizeScheduleDate(game?.date);
-  if (!date) {
-    return { startDate: new Date(Date.now() - defaultScheduleHistoryWindowMs) };
-  }
-  return {
-    startDate: new Date(date.getTime() - tournamentDetailStandingsWindowMs),
-    endDate: new Date(date.getTime() + tournamentDetailStandingsWindowMs)
-  };
-}
-
 function mergeLoadedGameWithStandingsPool(loadedGame: ScheduleEventFirestoreRecord, standingsGames: ScheduleEventFirestoreRecord[]) {
   const loadedGameId = compactString(loadedGame.id || loadedGame.gameId);
   return [
@@ -2512,15 +2547,6 @@ function mergeLoadedGameWithStandingsPool(loadedGame: ScheduleEventFirestoreReco
       return !loadedGameId || gameId !== loadedGameId;
     })
   ];
-}
-
-function hasTournamentTeamStandingsConfig(team: any) {
-  const config = team?.standingsConfig && typeof team.standingsConfig === 'object' ? team.standingsConfig : null;
-  const overrides = team?.tournamentPoolOverrides && typeof team.tournamentPoolOverrides === 'object' ? team.tournamentPoolOverrides : null;
-  return Boolean(
-    (config && config.enabled !== false && Object.keys(config).some((key) => key !== 'enabled')) ||
-    (overrides && Object.keys(overrides).length)
-  );
 }
 
 async function loadRawTeam(teamId: string) {
@@ -2537,6 +2563,7 @@ async function loadTeam(teamId: string) {
 }
 
 type ScheduleDateRange = { startDate?: Date | null; endDate?: Date | null };
+type ScheduleGamesQuery = ScheduleDateRange & { tournamentGroup?: TournamentScheduleGroupQuery | null };
 type ScheduleDateRangeByTeam = Record<string, ScheduleDateRange | undefined>;
 
 function isEventWithinRange(game: any, range: ScheduleDateRange) {
@@ -2548,17 +2575,21 @@ function isEventWithinRange(game: any, range: ScheduleDateRange) {
   return true;
 }
 
-async function loadGames(teamId: string, range: ScheduleDateRange = {}): Promise<ScheduleEventFirestoreRecord[]> {
+async function loadGames(teamId: string, range: ScheduleGamesQuery = {}): Promise<ScheduleEventFirestoreRecord[]> {
   return readWithNativeFallback(
     `games ${teamId}`,
     async () => mapScheduleEventRecords(await getGames(teamId, range)),
     async () => {
-      const docs = (range.startDate || range.endDate)
-        ? await nativeQueryScheduleEventDocuments(teamId, range)
-        : await nativeListScheduleEventDocuments(`teams/${encodeURIComponent(teamId)}/games`);
-      const windowed = (range.startDate || range.endDate)
-        ? docs.filter((doc) => isEventWithinRange(doc, range))
-        : docs;
+      const docs = range.tournamentGroup
+        ? await nativeQueryTournamentScheduleGroupDocuments(teamId, range.tournamentGroup)
+        : (range.startDate || range.endDate)
+          ? await nativeQueryScheduleEventDocuments(teamId, range)
+          : await nativeListScheduleEventDocuments(`teams/${encodeURIComponent(teamId)}/games`);
+      const windowed = range.tournamentGroup
+        ? docs.filter((doc) => matchesTournamentScheduleGroup(doc, range.tournamentGroup!))
+        : (range.startDate || range.endDate)
+          ? docs.filter((doc) => isEventWithinRange(doc, range))
+          : docs;
       return windowed.sort((a, b) => toEventDate(a.date).getTime() - toEventDate(b.date).getTime());
     }
   );
@@ -3200,8 +3231,11 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
     : null);
   if (!loadedGame) return [];
 
-  const standingsGames = hasTournamentTeamStandingsConfig(team) && hasTournamentScheduleGames([loadedGame])
-    ? mergeLoadedGameWithStandingsPool(loadedGame, await loadGames(teamId, getTournamentDetailStandingsRange(loadedGame)).catch(() => []))
+  const tournamentGroup = hasTournamentScheduleGames([loadedGame])
+    ? getTournamentScheduleGroupQuery(loadedGame)
+    : null;
+  const standingsGames = tournamentGroup
+    ? mergeLoadedGameWithStandingsPool(loadedGame, await loadGames(teamId, { tournamentGroup }).catch(() => []))
     : [loadedGame];
   const game = enrichTournamentScheduleStandings([loadedGame], team, standingsGames)[0];
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -936,8 +936,7 @@ async function nativeQuerySharedTournamentScheduleDocuments(
 ): Promise<ScheduleEventFirestoreRecord[]> {
   const membershipQueries = [
     { fieldPath: 'homeTeamId', op: 'EQUAL' },
-    { fieldPath: 'awayTeamId', op: 'EQUAL' },
-    { fieldPath: 'teamIds', op: 'ARRAY_CONTAINS' }
+    { fieldPath: 'awayTeamId', op: 'EQUAL' }
   ] as const;
   const payloads = await Promise.all(membershipQueries.map(({ fieldPath, op }) => (
     nativeFirestoreRequest(':runQuery', {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2549,6 +2549,39 @@ function mergeLoadedGameWithStandingsPool(loadedGame: ScheduleEventFirestoreReco
   ];
 }
 
+function mergeScheduleStandingsGames(
+  scheduleGames: ScheduleEventFirestoreRecord[],
+  standingsGroups: ScheduleEventFirestoreRecord[][]
+) {
+  const merged = [...scheduleGames];
+  const seenIds = new Set(scheduleGames.map((game) => compactString(game.id || game.gameId)).filter(Boolean));
+  standingsGroups.flat().forEach((game) => {
+    const gameId = compactString(game?.id || game?.gameId);
+    if (gameId && seenIds.has(gameId)) return;
+    if (gameId) seenIds.add(gameId);
+    merged.push(game);
+  });
+  return merged;
+}
+
+async function loadTournamentScheduleStandingsGames(
+  teamId: string,
+  scheduleGames: ScheduleEventFirestoreRecord[]
+) {
+  const groups = new Map<string, TournamentScheduleGroupQuery>();
+  scheduleGames.forEach((game) => {
+    const group = getTournamentScheduleGroupQuery(game);
+    if (!group || compactString(game.competitionType).toLowerCase() !== 'tournament') return;
+    groups.set(`${group.divisionName}\u0000${group.poolName}`, group);
+  });
+  if (!groups.size) return scheduleGames;
+
+  const standingsGroups = await Promise.all(
+    [...groups.values()].map((tournamentGroup) => loadGames(teamId, { tournamentGroup }).catch(() => []))
+  );
+  return mergeScheduleStandingsGames(scheduleGames, standingsGroups);
+}
+
 async function loadRawTeam(teamId: string) {
   return readWithNativeFallback(
     `team ${teamId}`,
@@ -2980,7 +3013,11 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
     loadPracticeSessions(teamId, gamesRange)
   ]);
   if (!team) return events;
-  const scheduleGames = enrichTournamentScheduleStandings(dbGames || [], team);
+  const loadedScheduleGames = dbGames || [];
+  const standingsGames = (gamesRange.startDate || gamesRange.endDate) && hasTournamentScheduleGames(loadedScheduleGames)
+    ? await loadTournamentScheduleStandingsGames(teamId, loadedScheduleGames)
+    : loadedScheduleGames;
+  const scheduleGames = enrichTournamentScheduleStandings(loadedScheduleGames, team, standingsGames);
   const trackedUids = getTrackedCalendarEventUidsFromLoadedGames(scheduleGames);
 
   const teamName = compactString(team.name) || teamId;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -82,7 +82,7 @@ import {
 } from './adapters/legacyScheduleHelpers';
 import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './adapters/legacyAvailability';
 import { buildTrackerEventDocument } from './statTrackingEvent';
-import { enrichTournamentScheduleStandings, hasTournamentScheduleGames } from './tournamentScheduleStandings';
+import { enrichTournamentScheduleStandings } from './tournamentScheduleStandings';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import { startUxTimer } from './uxTiming';
@@ -2532,20 +2532,6 @@ async function loadGames(teamId: string, range: ScheduleDateRange = {}): Promise
   );
 }
 
-async function loadTournamentStandingsSourceGames(
-  teamId: string,
-  loadedGames: ScheduleEventFirestoreRecord[],
-  needsFullHistory: boolean
-) {
-  if (!needsFullHistory || !hasTournamentScheduleGames(loadedGames)) return loadedGames;
-  try {
-    return await loadGames(teamId);
-  } catch (error) {
-    logScheduleWarning('Unable to load full tournament standings history; using loaded schedule games.', 'tournament-standings-history-load', error, { teamId });
-    return loadedGames;
-  }
-}
-
 async function loadGameById(teamId: string, gameId: string): Promise<ScheduleEventFirestoreRecord | null> {
   return readWithNativeFallback(
     `game ${teamId}/${gameId}`,
@@ -2931,12 +2917,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
     loadPracticeSessions(teamId, gamesRange)
   ]);
   if (!team) return events;
-  const standingsSourceGames = await loadTournamentStandingsSourceGames(
-    teamId,
-    dbGames || [],
-    Boolean(gamesRange.startDate || gamesRange.endDate)
-  );
-  const scheduleGames = enrichTournamentScheduleStandings(dbGames || [], team, standingsSourceGames);
+  const scheduleGames = enrichTournamentScheduleStandings(dbGames || [], team);
   const trackedUids = getTrackedCalendarEventUidsFromLoadedGames(scheduleGames);
 
   const teamName = compactString(team.name) || teamId;
@@ -3187,8 +3168,7 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
     : null);
   if (!loadedGame) return [];
 
-  const standingsSourceGames = await loadTournamentStandingsSourceGames(teamId, [loadedGame], true);
-  const game = enrichTournamentScheduleStandings([loadedGame], team, standingsSourceGames)[0];
+  const game = enrichTournamentScheduleStandings([loadedGame], team)[0];
 
   const teamName = compactString(team.name) || teamId;
   const teamWithId = { ...team, id: team.id || teamId };

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2514,6 +2514,15 @@ function mergeLoadedGameWithStandingsPool(loadedGame: ScheduleEventFirestoreReco
   ];
 }
 
+function hasTournamentTeamStandingsConfig(team: any) {
+  const config = team?.standingsConfig && typeof team.standingsConfig === 'object' ? team.standingsConfig : null;
+  const overrides = team?.tournamentPoolOverrides && typeof team.tournamentPoolOverrides === 'object' ? team.tournamentPoolOverrides : null;
+  return Boolean(
+    (config && config.enabled !== false && Object.keys(config).some((key) => key !== 'enabled')) ||
+    (overrides && Object.keys(overrides).length)
+  );
+}
+
 async function loadRawTeam(teamId: string) {
   return readWithNativeFallback(
     `team ${teamId}`,
@@ -3191,7 +3200,7 @@ async function buildTargetedTeamScheduleEvent(teamId: string, eventId: string, t
     : null);
   if (!loadedGame) return [];
 
-  const standingsGames = hasTournamentScheduleGames([loadedGame])
+  const standingsGames = hasTournamentTeamStandingsConfig(team) && hasTournamentScheduleGames([loadedGame])
     ? mergeLoadedGameWithStandingsPool(loadedGame, await loadGames(teamId, getTournamentDetailStandingsRange(loadedGame)).catch(() => []))
     : [loadedGame];
   const game = enrichTournamentScheduleStandings([loadedGame], team, standingsGames)[0];

--- a/apps/app/src/lib/tournamentScheduleStandings.test.ts
+++ b/apps/app/src/lib/tournamentScheduleStandings.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { buildTournamentPoolOverrideKey } from '../../../../js/tournament-standings.js';
+import { getScheduleTournamentInfo } from './scheduleLogic';
+import { enrichTournamentScheduleStandings } from './tournamentScheduleStandings';
+
+function buildWebTournamentGames() {
+  return [
+    {
+      id: 'pool-a-1',
+      competitionType: 'tournament',
+      status: 'completed',
+      homeScore: 3,
+      awayScore: 1,
+      tournament: {
+        divisionName: '10U Gold',
+        poolName: 'Pool A',
+        slotAssignments: {
+          home: { sourceType: 'team', teamName: 'Tigers' },
+          away: { sourceType: 'team', teamName: 'Lions' }
+        }
+      }
+    },
+    {
+      id: 'pool-a-2',
+      competitionType: 'tournament',
+      status: 'completed',
+      homeScore: 2,
+      awayScore: 0,
+      tournament: {
+        divisionName: '10U Gold',
+        poolName: 'Pool A',
+        slotAssignments: {
+          home: { sourceType: 'team', teamName: 'Bears' },
+          away: { sourceType: 'team', teamName: 'Tigers' }
+        }
+      }
+    },
+    {
+      id: 'pool-a-3',
+      competitionType: 'tournament',
+      status: 'completed',
+      homeScore: 4,
+      awayScore: 1,
+      tournament: {
+        divisionName: '10U Gold',
+        poolName: 'Pool A',
+        slotAssignments: {
+          home: { sourceType: 'team', teamName: 'Lions' },
+          away: { sourceType: 'team', teamName: 'Bears' }
+        }
+      }
+    }
+  ];
+}
+
+describe('tournament schedule standings enrichment', () => {
+  it('derives legacy standings for ordinary web-created game docs with no inline rows', () => {
+    const webGames = buildWebTournamentGames();
+    const enriched = enrichTournamentScheduleStandings(webGames, {
+      name: 'Tigers',
+      standingsConfig: {
+        rankingMode: 'points',
+        points: { win: 3, tie: 1, loss: 0 }
+      }
+    });
+
+    expect(webGames[0].tournament).not.toHaveProperty('computedStandings');
+    expect(enriched[0]).not.toBe(webGames[0]);
+    expect(getScheduleTournamentInfo(enriched[0] as any).standings).toEqual({
+      groupName: '10U Gold • Pool A',
+      isOverridden: false,
+      note: '',
+      rows: [
+        { rank: '1', teamName: 'Lions', record: '1-1', points: 3 },
+        { rank: '2', teamName: 'Tigers', record: '1-1', points: 3 },
+        { rank: '3', teamName: 'Bears', record: '1-1', points: 3 }
+      ]
+    });
+  });
+
+  it('applies team tournamentPoolOverrides through the same legacy ranking contract', () => {
+    const groupName = '10U Gold • Pool A';
+    const enriched = enrichTournamentScheduleStandings(buildWebTournamentGames(), {
+      name: 'Tigers',
+      standingsConfig: {
+        rankingMode: 'points',
+        points: { win: 3, tie: 1, loss: 0 }
+      },
+      tournamentPoolOverrides: {
+        [buildTournamentPoolOverrideKey(groupName)]: {
+          poolName: groupName,
+          teamOrder: ['Bears', 'Tigers', 'Lions']
+        }
+      }
+    });
+
+    expect(getScheduleTournamentInfo(enriched[1] as any).standings).toMatchObject({
+      groupName,
+      isOverridden: true,
+      note: 'Final ranking',
+      rows: [
+        { rank: '1', teamName: 'Bears' },
+        { rank: '2', teamName: 'Tigers' },
+        { rank: '3', teamName: 'Lions' }
+      ]
+    });
+  });
+
+  it('keeps an existing inline standings payload ahead of derived standings', () => {
+    const webGames = buildWebTournamentGames();
+    const inlineStandings = {
+      poolName: 'Published Pool A',
+      rows: [{ rank: 7, teamName: 'Published Tigers', wins: 9, losses: 0, points: 27 }],
+      isOverridden: true
+    };
+    webGames[0].tournament = {
+      ...webGames[0].tournament,
+      standings: inlineStandings
+    } as typeof webGames[0]['tournament'];
+
+    const enriched = enrichTournamentScheduleStandings(webGames, { name: 'Tigers' });
+
+    expect((enriched[0].tournament as Record<string, unknown>)?.standings).toBe(inlineStandings);
+    expect(getScheduleTournamentInfo(enriched[0] as any).standings).toEqual({
+      groupName: 'Published Pool A',
+      isOverridden: true,
+      note: 'Final ranking',
+      rows: [{ rank: '7', teamName: 'Published Tigers', record: '9-0', points: 27 }]
+    });
+  });
+});

--- a/apps/app/src/lib/tournamentScheduleStandings.test.ts
+++ b/apps/app/src/lib/tournamentScheduleStandings.test.ts
@@ -84,6 +84,29 @@ describe('tournament schedule standings enrichment', () => {
     expect(matchesTournamentScheduleGroup(game, group!)).toBe(true);
   });
 
+  it('keeps colliding display labels isolated through enrichment lookup', () => {
+    const divisionPoolGame = buildWebTournamentGames()[0];
+    const displayCollisionGame = {
+      ...buildWebTournamentGames()[1],
+      id: 'display-collision',
+      tournament: {
+        poolName: '10U Gold • Pool A',
+        slotAssignments: {
+          home: { sourceType: 'team', teamName: 'Bears' },
+          away: { sourceType: 'team', teamName: 'Hawks' }
+        }
+      }
+    };
+
+    const enriched = enrichTournamentScheduleStandings(
+      [divisionPoolGame, displayCollisionGame],
+      { name: 'Tigers' }
+    );
+
+    expect(getScheduleTournamentInfo(enriched[0] as any).standings?.rows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
+    expect(getScheduleTournamentInfo(enriched[1] as any).standings?.rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
+  });
+
   it('derives legacy standings for ordinary web-created game docs with no inline rows', () => {
     const webGames = buildWebTournamentGames();
     const enriched = enrichTournamentScheduleStandings(webGames, {

--- a/apps/app/src/lib/tournamentScheduleStandings.test.ts
+++ b/apps/app/src/lib/tournamentScheduleStandings.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { buildTournamentPoolOverrideKey } from '../../../../js/tournament-standings.js';
 import { getScheduleTournamentInfo } from './scheduleLogic';
-import { enrichTournamentScheduleStandings } from './tournamentScheduleStandings';
+import {
+  enrichTournamentScheduleStandings,
+  getTournamentScheduleGroupQuery,
+  matchesTournamentScheduleGroup
+} from './tournamentScheduleStandings';
 
 function buildWebTournamentGames() {
   return [
@@ -54,6 +58,32 @@ function buildWebTournamentGames() {
 }
 
 describe('tournament schedule standings enrichment', () => {
+  it('builds an exact pool query and rejects same-named pools from another division', () => {
+    const [game] = buildWebTournamentGames();
+    const group = getTournamentScheduleGroupQuery(game);
+
+    expect(group).toEqual({ poolName: 'Pool A', divisionName: '10U Gold' });
+    expect(matchesTournamentScheduleGroup(game, group!)).toBe(true);
+    expect(matchesTournamentScheduleGroup({
+      ...game,
+      tournament: { ...game.tournament, divisionName: '12U Gold' }
+    }, group!)).toBe(false);
+  });
+
+  it('preserves legacy division-only standings groups', () => {
+    const game = {
+      ...buildWebTournamentGames()[0],
+      tournament: {
+        division: '10U Gold',
+        slotAssignments: buildWebTournamentGames()[0].tournament.slotAssignments
+      }
+    };
+    const group = getTournamentScheduleGroupQuery(game);
+
+    expect(group).toEqual({ poolName: '', divisionName: '10U Gold' });
+    expect(matchesTournamentScheduleGroup(game, group!)).toBe(true);
+  });
+
   it('derives legacy standings for ordinary web-created game docs with no inline rows', () => {
     const webGames = buildWebTournamentGames();
     const enriched = enrichTournamentScheduleStandings(webGames, {

--- a/apps/app/src/lib/tournamentScheduleStandings.ts
+++ b/apps/app/src/lib/tournamentScheduleStandings.ts
@@ -1,0 +1,71 @@
+import { buildTournamentPoolStandings } from './adapters/legacyTournamentStandings';
+
+export type ScheduleTournamentGameLike = {
+  competitionType?: unknown;
+  tournament?: Record<string, unknown> | null;
+  [key: string]: unknown;
+};
+
+export type ScheduleTournamentTeamLike = {
+  name?: unknown;
+  standingsConfig?: Record<string, unknown> | null;
+  tournamentPoolOverrides?: Record<string, unknown> | null;
+};
+
+function compactString(value: unknown) {
+  return String(value || '').trim();
+}
+
+function getTournamentStandingsGroupName(game: ScheduleTournamentGameLike) {
+  const tournament = game?.tournament && typeof game.tournament === 'object' ? game.tournament : {};
+  const divisionName = compactString(tournament.divisionName || tournament.division);
+  const poolName = compactString(tournament.poolName);
+  if (divisionName && poolName) return `${divisionName} • ${poolName}`;
+  return poolName || divisionName;
+}
+
+export function hasTournamentScheduleGames(gamesInput: readonly ScheduleTournamentGameLike[]) {
+  return (Array.isArray(gamesInput) ? gamesInput : []).some((game) => (
+    compactString(game?.competitionType).toLowerCase() === 'tournament'
+  ));
+}
+
+/**
+ * Add the legacy-computed pool result to tournament game read models without
+ * changing the stored document or replacing any inline standings payload.
+ */
+export function enrichTournamentScheduleStandings<T extends ScheduleTournamentGameLike>(
+  gamesInput: readonly T[],
+  team: ScheduleTournamentTeamLike | null | undefined,
+  standingsGamesInput: readonly ScheduleTournamentGameLike[] = gamesInput
+): T[] {
+  const games = Array.isArray(gamesInput) ? gamesInput : [];
+  if (!games.length || !hasTournamentScheduleGames(standingsGamesInput)) return [...games];
+
+  const standingsByGroup = buildTournamentPoolStandings(
+    [...standingsGamesInput] as Array<Record<string, unknown>>,
+    {
+      currentTeamName: compactString(team?.name) || null,
+      standingsConfig: team?.standingsConfig || {},
+      poolOverrides: team?.tournamentPoolOverrides || {}
+    }
+  );
+
+  if (!Object.keys(standingsByGroup).length) return [...games];
+
+  return games.map((game) => {
+    if (compactString(game?.competitionType).toLowerCase() !== 'tournament') return game;
+    const groupName = getTournamentStandingsGroupName(game);
+    const computedStandings = standingsByGroup[groupName];
+    const tournament = game?.tournament && typeof game.tournament === 'object' ? game.tournament : null;
+    if (!computedStandings || !tournament) return game;
+
+    return {
+      ...game,
+      tournament: {
+        ...tournament,
+        computedStandings: tournament.computedStandings || computedStandings
+      }
+    };
+  });
+}

--- a/apps/app/src/lib/tournamentScheduleStandings.ts
+++ b/apps/app/src/lib/tournamentScheduleStandings.ts
@@ -1,4 +1,4 @@
-import { buildTournamentPoolStandings } from './adapters/legacyTournamentStandings';
+import { buildTournamentPoolStandings, getTournamentStandingsGroupName } from './adapters/legacyTournamentStandings';
 
 export type ScheduleTournamentGameLike = {
   competitionType?: unknown;
@@ -12,16 +12,28 @@ export type ScheduleTournamentTeamLike = {
   tournamentPoolOverrides?: Record<string, unknown> | null;
 };
 
+export type TournamentScheduleGroupQuery = {
+  poolName: string;
+  divisionName: string;
+};
+
 function compactString(value: unknown) {
   return String(value || '').trim();
 }
 
-function getTournamentStandingsGroupName(game: ScheduleTournamentGameLike) {
+export function getTournamentScheduleGroupQuery(game: ScheduleTournamentGameLike): TournamentScheduleGroupQuery | null {
   const tournament = game?.tournament && typeof game.tournament === 'object' ? game.tournament : {};
   const divisionName = compactString(tournament.divisionName || tournament.division);
   const poolName = compactString(tournament.poolName);
-  if (divisionName && poolName) return `${divisionName} • ${poolName}`;
-  return poolName || divisionName;
+  return poolName || divisionName ? { poolName, divisionName } : null;
+}
+
+export function matchesTournamentScheduleGroup(game: ScheduleTournamentGameLike, group: TournamentScheduleGroupQuery) {
+  const expectedGroupName = group.divisionName && group.poolName
+    ? `${group.divisionName} • ${group.poolName}`
+    : group.poolName || group.divisionName;
+  return compactString(game?.competitionType).toLowerCase() === 'tournament' &&
+    getTournamentStandingsGroupName(game as Record<string, unknown>) === expectedGroupName;
 }
 
 export function hasTournamentScheduleGames(gamesInput: readonly ScheduleTournamentGameLike[]) {
@@ -56,7 +68,7 @@ export function enrichTournamentScheduleStandings<T extends ScheduleTournamentGa
   return games.map((game) => {
     if (compactString(game?.competitionType).toLowerCase() !== 'tournament') return game;
     const groupName = getTournamentStandingsGroupName(game);
-    const computedStandings = standingsByGroup[groupName];
+    const computedStandings = groupName ? standingsByGroup[groupName] : null;
     const tournament = game?.tournament && typeof game.tournament === 'object' ? game.tournament : null;
     if (!computedStandings || !tournament) return game;
 

--- a/apps/app/src/lib/tournamentScheduleStandings.ts
+++ b/apps/app/src/lib/tournamentScheduleStandings.ts
@@ -1,4 +1,7 @@
-import { buildTournamentPoolStandings, getTournamentStandingsGroupName } from './adapters/legacyTournamentStandings';
+import {
+  buildTournamentPoolStandings,
+  getTournamentStandingsGroupKey
+} from './adapters/legacyTournamentStandings';
 
 export type ScheduleTournamentGameLike = {
   competitionType?: unknown;
@@ -29,11 +32,10 @@ export function getTournamentScheduleGroupQuery(game: ScheduleTournamentGameLike
 }
 
 export function matchesTournamentScheduleGroup(game: ScheduleTournamentGameLike, group: TournamentScheduleGroupQuery) {
-  const expectedGroupName = group.divisionName && group.poolName
-    ? `${group.divisionName} • ${group.poolName}`
-    : group.poolName || group.divisionName;
+  const actualGroup = getTournamentScheduleGroupQuery(game);
   return compactString(game?.competitionType).toLowerCase() === 'tournament' &&
-    getTournamentStandingsGroupName(game as Record<string, unknown>) === expectedGroupName;
+    actualGroup?.divisionName === compactString(group.divisionName) &&
+    actualGroup.poolName === compactString(group.poolName);
 }
 
 export function hasTournamentScheduleGames(gamesInput: readonly ScheduleTournamentGameLike[]) {
@@ -67,8 +69,8 @@ export function enrichTournamentScheduleStandings<T extends ScheduleTournamentGa
 
   return games.map((game) => {
     if (compactString(game?.competitionType).toLowerCase() !== 'tournament') return game;
-    const groupName = getTournamentStandingsGroupName(game);
-    const computedStandings = groupName ? standingsByGroup[groupName] : null;
+    const groupKey = getTournamentStandingsGroupKey(game as Record<string, unknown>);
+    const computedStandings = groupKey ? standingsByGroup[groupKey] : null;
     const tournament = game?.tournament && typeof game.tournament === 'object' ? game.tournament : null;
     if (!computedStandings || !tournament) return game;
 

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -948,7 +948,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, getPlayers, getRsvps, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=84';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, getPlayers, getRsvps, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=85';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, getCalendarEventStatus, getCalendarEventTrackingId, isTrackedCalendarEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=14';
         import { mergeCalendarImportEvents, validateCalendarImportUrl } from './js/edit-schedule-calendar-import.js?v=2';
         import { checkAuth } from './js/auth.js?v=42';
@@ -968,7 +968,7 @@
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=2';
         import { normalizeScheduleNotificationSettings, describeScheduleReminderWindow, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage, sendPublicRsvpReminderEmails, buildAvailabilityReminderRecipients, buildAvailabilityReminderEmailPreview } from './js/schedule-notifications.js?v=5';
-        import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=3';
+        import { buildTournamentGroupOverrideKey, buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=4';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=4';
 
@@ -1251,7 +1251,7 @@
         }
 
         function getTournamentPoolStandingByKey(poolKey) {
-            return Object.values(currentTournamentPoolStandings || {}).find((pool) => buildTournamentPoolOverrideKey(pool?.poolName) === poolKey) || null;
+            return Object.values(currentTournamentPoolStandings || {}).find((pool) => pool?.groupKey === poolKey) || null;
         }
 
         function toDateValue(value) {
@@ -1389,8 +1389,8 @@
             tournamentStandingsDraft = [];
         }
 
-        function updateCurrentTeamPoolOverride(poolName, override) {
-            const key = buildTournamentPoolOverrideKey(poolName);
+        function updateCurrentTeamPoolOverride(pool, override) {
+            const key = buildTournamentGroupOverrideKey(pool?.groupKey) || buildTournamentPoolOverrideKey(pool?.poolName);
             currentTeam = {
                 ...currentTeam,
                 tournamentPoolOverrides: {
@@ -1400,8 +1400,8 @@
             };
         }
 
-        function removeCurrentTeamPoolOverride(poolName) {
-            const key = buildTournamentPoolOverrideKey(poolName);
+        function removeCurrentTeamPoolOverride(pool) {
+            const key = buildTournamentGroupOverrideKey(pool?.groupKey) || buildTournamentPoolOverrideKey(pool?.poolName);
             const nextOverrides = { ...(currentTeam?.tournamentPoolOverrides || {}) };
             delete nextOverrides[key];
             currentTeam = {
@@ -1480,6 +1480,7 @@
 
             const override = {
                 poolName: pool.poolName,
+                groupKey: pool.groupKey,
                 teamOrder: tournamentStandingsDraft,
                 finalizedAt: Timestamp.now(),
                 finalizedBy: {
@@ -1490,7 +1491,7 @@
             };
 
             await saveTournamentPoolOverride(currentTeamId, override);
-            updateCurrentTeamPoolOverride(pool.poolName, override);
+            updateCurrentTeamPoolOverride(pool, override);
             closeTournamentStandingsModal();
             await loadSchedule();
         }
@@ -1500,8 +1501,8 @@
             if (!pool || !pool.override) return;
             if (!confirm(`Clear the final ranking override for ${pool.poolName}?`)) return;
 
-            await clearTournamentPoolOverride(currentTeamId, pool.poolName);
-            removeCurrentTeamPoolOverride(pool.poolName);
+            await clearTournamentPoolOverride(currentTeamId, pool.poolName, pool.groupKey);
+            removeCurrentTeamPoolOverride(pool);
             closeTournamentStandingsModal();
             await loadSchedule();
         }
@@ -1554,7 +1555,7 @@
                     </div>
                     <div class="grid gap-4 lg:grid-cols-2">
                         ${pools.map((pool) => {
-                            const poolKey = buildTournamentPoolOverrideKey(pool.poolName);
+                            const poolKey = pool.groupKey;
                             const advancementPlan = buildFinalizedTournamentAdvancementPlan(pool);
                             return `
                                 <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">

--- a/js/db.js
+++ b/js/db.js
@@ -309,8 +309,7 @@ async function getSharedGamesForTeam(teamId, { requireComplete = false } = {}) {
     const sharedGamesRef = collectionGroup(db, 'sharedGames');
     const queries = [
         query(sharedGamesRef, where('homeTeamId', '==', teamId)),
-        query(sharedGamesRef, where('awayTeamId', '==', teamId)),
-        query(sharedGamesRef, where('teamIds', 'array-contains', teamId))
+        query(sharedGamesRef, where('awayTeamId', '==', teamId))
     ];
 
     const snapshots = await Promise.allSettled(queries.map((q) => getDocs(q)));

--- a/js/db.js
+++ b/js/db.js
@@ -2331,9 +2331,11 @@ function collectTournamentPoolOverrideKeys(poolOverrides = {}, poolName, groupKe
     const structuredKey = buildTournamentGroupOverrideKey(groupKey);
     const keys = new Set(structuredKey ? [structuredKey] : [buildTournamentPoolOverrideKey(normalizedPoolName)]);
     Object.entries(poolOverrides || {}).forEach(([key, override]) => {
+        const matchesLegacyPool = !override?.groupKey
+            && normalizeTournamentPoolOverrideName(override?.poolName) === normalizedPoolName;
         const matchesGroup = groupKey
-            ? normalizeTournamentPoolOverrideName(override?.groupKey) === groupKey
-            : !override?.groupKey && normalizeTournamentPoolOverrideName(override?.poolName) === normalizedPoolName;
+            ? normalizeTournamentPoolOverrideName(override?.groupKey) === groupKey || matchesLegacyPool
+            : matchesLegacyPool;
         if (matchesGroup) {
             keys.add(key);
         }

--- a/js/db.js
+++ b/js/db.js
@@ -201,7 +201,7 @@ import {
     assertVolunteerScreeningCleared,
     loadVolunteerScreeningTargetRegistrations
 } from './volunteer-screening-access.js?v=2';
-import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
+import { buildTournamentPoolOverrideKey, getTournamentStandingsGroupName } from './tournament-standings.js?v=2';
 import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeTeamMediaVideoDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
 import { getApp } from './vendor/firebase-app.js';
 import {
@@ -3397,22 +3397,50 @@ async function getRecurringPracticeMastersForDateRange(gamesRef, startDate, endD
         .filter(game => recurringPracticeMasterMayOverlapDateRange(game, startDate, endDate));
 }
 
-// Pass { startDate, endDate } (Date objects) to window the query and avoid loading
-// a team's entire multi-season history when only a recent range is needed (#2034).
-// Called with no options it preserves the original full-collection behavior.
+// Pass { startDate, endDate } (Date objects) to window ordinary schedule reads.
+// Direct tournament details pass { tournamentGroup } so standings load every
+// matching pool/division game through equality queries without scanning a
+// team's entire multi-season history (#2034).
+// Called with no options this preserves the original full-collection behavior.
 export async function getGames(teamId, options = {}) {
     const startDate = options?.startDate ?? null;
     const endDate = options?.endDate ?? null;
+    const tournamentGroup = options?.tournamentGroup && typeof options.tournamentGroup === 'object'
+        ? {
+            poolName: String(options.tournamentGroup.poolName || '').trim(),
+            divisionName: String(options.tournamentGroup.divisionName || '').trim()
+        }
+        : null;
+    const hasTournamentGroup = Boolean(tournamentGroup?.poolName || tournamentGroup?.divisionName);
+    const tournamentGroupName = tournamentGroup?.divisionName && tournamentGroup?.poolName
+        ? `${tournamentGroup.divisionName} • ${tournamentGroup.poolName}`
+        : tournamentGroup?.poolName || tournamentGroup?.divisionName || '';
     const gamesRef = getTeamGameCollectionRef(teamId);
     let teamGames = [];
     const rangeConstraints = [];
     if (startDate instanceof Date) rangeConstraints.push(where("date", ">=", Timestamp.fromDate(startDate)));
     if (endDate instanceof Date) rangeConstraints.push(where("date", "<=", Timestamp.fromDate(endDate)));
     try {
-        const q = query(gamesRef, ...rangeConstraints, orderBy("date"));
-        const snapshot = await getDocs(q);
-        teamGames = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        if (tournamentGroup?.poolName) {
+            const snapshot = await getDocs(query(gamesRef, where("tournament.poolName", "==", tournamentGroup.poolName)));
+            teamGames = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        } else if (tournamentGroup?.divisionName) {
+            const snapshots = await Promise.all([
+                getDocs(query(gamesRef, where("tournament.divisionName", "==", tournamentGroup.divisionName))),
+                getDocs(query(gamesRef, where("tournament.division", "==", tournamentGroup.divisionName)))
+            ]);
+            teamGames = mergeGamesById(
+                snapshots[0].docs.map(doc => ({ id: doc.id, ...doc.data() })),
+                snapshots[1].docs.map(doc => ({ id: doc.id, ...doc.data() }))
+            );
+        } else {
+            const snapshot = await getDocs(query(gamesRef, ...rangeConstraints, orderBy("date")));
+            teamGames = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        }
     } catch (error) {
+        // Tournament group equality queries use single fields and need no
+        // composite index. Never replace them with an unbounded history read.
+        if (hasTournamentGroup) throw error;
         // Fallback when indexes are still building or unavailable: read the
         // collection and apply the range client-side so results stay correct.
         const snapshot = await getDocs(gamesRef);
@@ -3420,7 +3448,7 @@ export async function getGames(teamId, options = {}) {
             .map(doc => ({ id: doc.id, ...doc.data() }))
             .filter(game => isGameWithinDateRange(game, startDate, endDate));
     }
-    if (startDate || endDate) {
+    if (!hasTournamentGroup && (startDate || endDate)) {
         try {
             const recurringMasters = await getRecurringPracticeMastersForDateRange(gamesRef, startDate, endDate);
             teamGames = mergeGamesById(teamGames, recurringMasters);
@@ -3437,6 +3465,10 @@ export async function getGames(teamId, options = {}) {
     }
 
     const merged = mergeGamesForTeam(teamGames, sharedGames, teamId);
+    if (hasTournamentGroup) {
+        return merged.filter(game => String(game?.competitionType || '').toLowerCase() === 'tournament' &&
+            getTournamentStandingsGroupName(game) === tournamentGroupName);
+    }
     return (startDate || endDate)
         ? merged.filter(game => isGameWithinDateRange(game, startDate, endDate))
         : merged;

--- a/js/db.js
+++ b/js/db.js
@@ -201,7 +201,7 @@ import {
     assertVolunteerScreeningCleared,
     loadVolunteerScreeningTargetRegistrations
 } from './volunteer-screening-access.js?v=2';
-import { buildTournamentPoolOverrideKey, getTournamentStandingsGroupName } from './tournament-standings.js?v=2';
+import { buildTournamentGroupOverrideKey, buildTournamentPoolOverrideKey, matchesTournamentStandingsGroup } from './tournament-standings.js?v=4';
 import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeTeamMediaVideoDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=4';
 import { getApp } from './vendor/firebase-app.js';
 import {
@@ -305,7 +305,7 @@ function normalizeSharedGameSnapshot(docSnap) {
     };
 }
 
-async function getSharedGamesForTeam(teamId) {
+async function getSharedGamesForTeam(teamId, { requireComplete = false } = {}) {
     const sharedGamesRef = collectionGroup(db, 'sharedGames');
     const queries = [
         query(sharedGamesRef, where('homeTeamId', '==', teamId)),
@@ -314,6 +314,10 @@ async function getSharedGamesForTeam(teamId) {
     ];
 
     const snapshots = await Promise.allSettled(queries.map((q) => getDocs(q)));
+    if (requireComplete) {
+        const failedQuery = snapshots.find((result) => result.status === 'rejected');
+        if (failedQuery) throw failedQuery.reason;
+    }
     const sharedGamesByPath = new Map();
 
     snapshots.forEach((result) => {
@@ -2321,13 +2325,17 @@ function normalizeTournamentPoolOverrideName(poolName) {
     return String(poolName || '').trim();
 }
 
-function collectTournamentPoolOverrideKeys(poolOverrides = {}, poolName) {
+function collectTournamentPoolOverrideKeys(poolOverrides = {}, poolName, groupKey = null) {
     const normalizedPoolName = normalizeTournamentPoolOverrideName(poolName);
     if (!normalizedPoolName) return [];
 
-    const keys = new Set([buildTournamentPoolOverrideKey(normalizedPoolName)]);
+    const structuredKey = buildTournamentGroupOverrideKey(groupKey);
+    const keys = new Set(structuredKey ? [structuredKey] : [buildTournamentPoolOverrideKey(normalizedPoolName)]);
     Object.entries(poolOverrides || {}).forEach(([key, override]) => {
-        if (normalizeTournamentPoolOverrideName(override?.poolName) === normalizedPoolName) {
+        const matchesGroup = groupKey
+            ? normalizeTournamentPoolOverrideName(override?.groupKey) === groupKey
+            : !override?.groupKey && normalizeTournamentPoolOverrideName(override?.poolName) === normalizedPoolName;
+        if (matchesGroup) {
             keys.add(key);
         }
     });
@@ -2336,6 +2344,7 @@ function collectTournamentPoolOverrideKeys(poolOverrides = {}, poolName) {
 
 export async function saveTournamentPoolOverride(teamId, override = {}) {
     const poolName = normalizeTournamentPoolOverrideName(override?.poolName);
+    const groupKey = normalizeTournamentPoolOverrideName(override?.groupKey);
     if (!teamId || !poolName) {
         throw new Error('Missing teamId or poolName for tournament pool override');
     }
@@ -2347,10 +2356,11 @@ export async function saveTournamentPoolOverride(teamId, override = {}) {
     const teamRef = doc(db, "teams", teamId);
     const teamSnapshot = await getDoc(teamRef);
     const existingOverrides = teamSnapshot.exists() ? (teamSnapshot.data()?.tournamentPoolOverrides || {}) : {};
-    const key = buildTournamentPoolOverrideKey(poolName);
+    const key = buildTournamentGroupOverrideKey(groupKey) || buildTournamentPoolOverrideKey(poolName);
     const updatePayload = {
         [`tournamentPoolOverrides.${key}`]: {
             poolName,
+            ...(groupKey ? { groupKey } : {}),
             teamOrder,
             finalizedAt: override?.finalizedAt || Timestamp.now(),
             finalizedBy: {
@@ -2361,7 +2371,7 @@ export async function saveTournamentPoolOverride(teamId, override = {}) {
         }
     };
 
-    collectTournamentPoolOverrideKeys(existingOverrides, poolName)
+    collectTournamentPoolOverrideKeys(existingOverrides, poolName, groupKey)
         .filter((existingKey) => existingKey !== key)
         .forEach((existingKey) => {
             updatePayload[`tournamentPoolOverrides.${existingKey}`] = deleteField();
@@ -2370,8 +2380,9 @@ export async function saveTournamentPoolOverride(teamId, override = {}) {
     await updateTeam(teamId, updatePayload);
 }
 
-export async function clearTournamentPoolOverride(teamId, poolName) {
+export async function clearTournamentPoolOverride(teamId, poolName, groupKey = null) {
     const normalizedPoolName = normalizeTournamentPoolOverrideName(poolName);
+    const normalizedGroupKey = normalizeTournamentPoolOverrideName(groupKey);
     if (!teamId || !normalizedPoolName) {
         throw new Error('Missing teamId or poolName for tournament pool override clear');
     }
@@ -2379,7 +2390,7 @@ export async function clearTournamentPoolOverride(teamId, poolName) {
     const teamRef = doc(db, "teams", teamId);
     const teamSnapshot = await getDoc(teamRef);
     const existingOverrides = teamSnapshot.exists() ? (teamSnapshot.data()?.tournamentPoolOverrides || {}) : {};
-    const keysToDelete = collectTournamentPoolOverrideKeys(existingOverrides, normalizedPoolName);
+    const keysToDelete = collectTournamentPoolOverrideKeys(existingOverrides, normalizedPoolName, normalizedGroupKey);
     if (!keysToDelete.length) return;
 
     const updatePayload = {};
@@ -3405,34 +3416,43 @@ async function getRecurringPracticeMastersForDateRange(gamesRef, startDate, endD
 export async function getGames(teamId, options = {}) {
     const startDate = options?.startDate ?? null;
     const endDate = options?.endDate ?? null;
-    const tournamentGroup = options?.tournamentGroup && typeof options.tournamentGroup === 'object'
-        ? {
-            poolName: String(options.tournamentGroup.poolName || '').trim(),
-            divisionName: String(options.tournamentGroup.divisionName || '').trim()
-        }
-        : null;
-    const hasTournamentGroup = Boolean(tournamentGroup?.poolName || tournamentGroup?.divisionName);
-    const tournamentGroupName = tournamentGroup?.divisionName && tournamentGroup?.poolName
-        ? `${tournamentGroup.divisionName} • ${tournamentGroup.poolName}`
-        : tournamentGroup?.poolName || tournamentGroup?.divisionName || '';
+    const rawTournamentGroups = Array.isArray(options?.tournamentGroups)
+        ? options.tournamentGroups
+        : options?.tournamentGroup ? [options.tournamentGroup] : [];
+    const tournamentGroupsByKey = new Map();
+    rawTournamentGroups.forEach((group) => {
+        if (!group || typeof group !== 'object') return;
+        const normalized = {
+            poolName: String(group.poolName || '').trim(),
+            divisionName: String(group.divisionName || group.division || '').trim()
+        };
+        if (!normalized.poolName && !normalized.divisionName) return;
+        tournamentGroupsByKey.set(JSON.stringify([normalized.divisionName, normalized.poolName]), normalized);
+    });
+    const tournamentGroups = Array.from(tournamentGroupsByKey.values());
+    const hasTournamentGroup = tournamentGroups.length > 0;
     const gamesRef = getTeamGameCollectionRef(teamId);
     let teamGames = [];
     const rangeConstraints = [];
     if (startDate instanceof Date) rangeConstraints.push(where("date", ">=", Timestamp.fromDate(startDate)));
     if (endDate instanceof Date) rangeConstraints.push(where("date", "<=", Timestamp.fromDate(endDate)));
     try {
-        if (tournamentGroup?.poolName) {
-            const snapshot = await getDocs(query(gamesRef, where("tournament.poolName", "==", tournamentGroup.poolName)));
-            teamGames = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-        } else if (tournamentGroup?.divisionName) {
-            const snapshots = await Promise.all([
-                getDocs(query(gamesRef, where("tournament.divisionName", "==", tournamentGroup.divisionName))),
-                getDocs(query(gamesRef, where("tournament.division", "==", tournamentGroup.divisionName)))
-            ]);
-            teamGames = mergeGamesById(
-                snapshots[0].docs.map(doc => ({ id: doc.id, ...doc.data() })),
-                snapshots[1].docs.map(doc => ({ id: doc.id, ...doc.data() }))
-            );
+        if (hasTournamentGroup) {
+            const groupGames = await Promise.all(tournamentGroups.map(async (tournamentGroup) => {
+                if (tournamentGroup.poolName) {
+                    const snapshot = await getDocs(query(gamesRef, where("tournament.poolName", "==", tournamentGroup.poolName)));
+                    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                }
+                const snapshots = await Promise.all([
+                    getDocs(query(gamesRef, where("tournament.divisionName", "==", tournamentGroup.divisionName))),
+                    getDocs(query(gamesRef, where("tournament.division", "==", tournamentGroup.divisionName)))
+                ]);
+                return mergeGamesById(
+                    snapshots[0].docs.map(doc => ({ id: doc.id, ...doc.data() })),
+                    snapshots[1].docs.map(doc => ({ id: doc.id, ...doc.data() }))
+                );
+            }));
+            teamGames = groupGames.reduce((merged, games) => mergeGamesById(merged, games), []);
         } else {
             const snapshot = await getDocs(query(gamesRef, ...rangeConstraints, orderBy("date")));
             teamGames = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
@@ -3459,15 +3479,15 @@ export async function getGames(teamId, options = {}) {
 
     let sharedGames = [];
     try {
-        sharedGames = await getSharedGamesForTeam(teamId);
+        sharedGames = await getSharedGamesForTeam(teamId, { requireComplete: hasTournamentGroup });
     } catch (error) {
+        if (hasTournamentGroup) throw error;
         console.warn('[getGames] Failed to load shared games for team', teamId, error);
     }
 
     const merged = mergeGamesForTeam(teamGames, sharedGames, teamId);
     if (hasTournamentGroup) {
-        return merged.filter(game => String(game?.competitionType || '').toLowerCase() === 'tournament' &&
-            getTournamentStandingsGroupName(game) === tournamentGroupName);
+        return merged.filter(game => tournamentGroups.some((group) => matchesTournamentStandingsGroup(game, group)));
     }
     return (startDate || endDate)
         ? merged.filter(game => isGameWithinDateRange(game, startDate, endDate))

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -30,6 +30,14 @@ export function buildTournamentPoolOverrideKey(poolName) {
     return `${buildLegacyTournamentPoolOverrideKey(normalized)}-${hashTournamentPoolName(normalized)}`;
 }
 
+export function buildTournamentGroupOverrideKey(groupKey) {
+    const normalized = normalizeString(groupKey);
+    if (!normalized) return null;
+    return `group-${Array.from(normalized)
+        .map((character) => character.codePointAt(0).toString(16))
+        .join('-')}`;
+}
+
 function getSlotTeamName(slot = {}) {
     if (String(slot?.sourceType || '').toLowerCase() !== 'team') return null;
     return normalizeString(slot?.teamName);
@@ -60,11 +68,34 @@ function getTournamentDivisionName(game = {}) {
         || normalizeString(game?.tournament?.division);
 }
 
+export function getTournamentStandingsGroupIdentity(game = {}) {
+    return {
+        divisionName: getTournamentDivisionName(game) || '',
+        poolName: getTournamentPoolName(game) || ''
+    };
+}
+
+export function getTournamentStandingsGroupKey(game = {}) {
+    const group = getTournamentStandingsGroupIdentity(game);
+    return group.divisionName || group.poolName
+        ? JSON.stringify([group.divisionName, group.poolName])
+        : null;
+}
+
 export function getTournamentStandingsGroupName(game = {}) {
-    const divisionName = getTournamentDivisionName(game);
-    const poolName = getTournamentPoolName(game);
+    const { divisionName, poolName } = getTournamentStandingsGroupIdentity(game);
     if (divisionName && poolName) return `${divisionName} • ${poolName}`;
-    return poolName || divisionName;
+    return poolName || divisionName || null;
+}
+
+export function matchesTournamentStandingsGroup(game = {}, group = {}) {
+    if (!isTournamentGame(game)) return false;
+    const actual = getTournamentStandingsGroupIdentity(game);
+    const expected = {
+        divisionName: normalizeString(group?.divisionName || group?.division) || '',
+        poolName: normalizeString(group?.poolName) || ''
+    };
+    return actual.divisionName === expected.divisionName && actual.poolName === expected.poolName;
 }
 
 function normalizeTournamentGroupOption(value) {
@@ -182,10 +213,17 @@ export function applyTournamentStandingsOverride(rowsInput = [], override = null
     };
 }
 
-function getPoolOverride(poolOverrides = {}, poolName) {
+function getPoolOverride(poolOverrides = {}, poolName, groupKey = null, allowLegacyLookup = true) {
     if (!poolOverrides || typeof poolOverrides !== 'object') return null;
     const normalizedPoolName = normalizeString(poolName);
     if (!normalizedPoolName) return null;
+
+    const structuredKey = buildTournamentGroupOverrideKey(groupKey);
+    const structuredOverride = structuredKey ? poolOverrides[structuredKey] : null;
+    if (structuredOverride && normalizeString(structuredOverride?.groupKey) === groupKey) {
+        return structuredOverride;
+    }
+    if (!allowLegacyLookup) return null;
 
     const directOverride = poolOverrides[buildTournamentPoolOverrideKey(normalizedPoolName)] || null;
     if (directOverride) return directOverride;
@@ -207,9 +245,11 @@ export function buildTournamentPoolStandings(gamesInput = [], options = {}) {
 
     games.forEach((game) => {
         if (!isCompletedTournamentPoolGame(game)) return;
-        const poolName = getTournamentStandingsGroupName(game);
+        const groupKey = getTournamentStandingsGroupKey(game);
+        const groupName = getTournamentStandingsGroupName(game);
+        const groupIdentity = getTournamentStandingsGroupIdentity(game);
         const { homeTeam, awayTeam, homeScore, awayScore } = getTournamentGameTeams(game, currentTeamName);
-        if (!poolName || !homeTeam || !awayTeam) return;
+        if (!groupKey || !groupName || !homeTeam || !awayTeam) return;
         if (homeTeam === awayTeam) return;
 
         const normalizedGame = {
@@ -219,22 +259,44 @@ export function buildTournamentPoolStandings(gamesInput = [], options = {}) {
             awayScore: Number(awayScore ?? game.awayScore),
             status: 'completed'
         };
-        const existing = poolGames.get(poolName) || [];
-        existing.push(normalizedGame);
-        poolGames.set(poolName, existing);
+        const existing = poolGames.get(groupKey) || {
+            groupKey,
+            groupName,
+            divisionName: groupIdentity.divisionName,
+            poolName: groupIdentity.poolName,
+            games: []
+        };
+        existing.games.push(normalizedGame);
+        poolGames.set(groupKey, existing);
     });
 
+    const groupNameCounts = Array.from(poolGames.values()).reduce((counts, group) => {
+        counts.set(group.groupName, (counts.get(group.groupName) || 0) + 1);
+        return counts;
+    }, new Map());
+
     return Array.from(poolGames.entries())
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .reduce((acc, [poolName, poolGameList]) => {
+        .sort((a, b) => a[1].groupName.localeCompare(b[1].groupName) || a[0].localeCompare(b[0]))
+        .reduce((acc, [groupKey, group]) => {
+            const poolGameList = group.games;
             const computedRows = computeNativeStandings(poolGameList, standingsConfig).map((row) => ({
                 ...row,
                 teamName: row.team
             }));
-            const override = getPoolOverride(poolOverrides, poolName);
+            // Legacy overrides are display-label keyed. Do not apply an
+            // ambiguous override to multiple distinct structured groups.
+            const override = getPoolOverride(
+                poolOverrides,
+                group.groupName,
+                groupKey,
+                groupNameCounts.get(group.groupName) === 1
+            );
             const applied = applyTournamentStandingsOverride(computedRows, override);
-            acc[poolName] = {
-                poolName,
+            acc[groupKey] = {
+                groupKey,
+                groupName: group.groupName,
+                divisionName: group.divisionName,
+                poolName: group.groupName,
                 gameCount: poolGameList.length,
                 computedRows,
                 rows: applied.rows,
@@ -251,25 +313,31 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
     if (!currentTeamName) return [];
 
     const groupGames = new Map();
-    const ensureGroup = (groupName) => {
+    const ensureGroup = (groupKey, groupName) => {
+        const normalizedGroupKey = normalizeString(groupKey);
         const normalizedGroupName = normalizeString(groupName);
-        if (!normalizedGroupName) return null;
-        if (!groupGames.has(normalizedGroupName)) {
-            groupGames.set(normalizedGroupName, {
+        if (!normalizedGroupKey || !normalizedGroupName) return null;
+        if (!groupGames.has(normalizedGroupKey)) {
+            groupGames.set(normalizedGroupKey, {
+                groupKey: normalizedGroupKey,
+                groupName: normalizedGroupName,
                 games: [],
                 scheduledGameCount: 0,
                 noScoreGameCount: 0
             });
         }
-        return groupGames.get(normalizedGroupName);
+        return groupGames.get(normalizedGroupKey);
     };
 
-    getConfiguredTournamentGroupNames(options).forEach(ensureGroup);
+    getConfiguredTournamentGroupNames(options).forEach((groupName) => {
+        ensureGroup(JSON.stringify(['', groupName]), groupName);
+    });
 
     games.forEach((game) => {
         if (!isTournamentGame(game)) return;
-        const poolName = getTournamentStandingsGroupName(game);
-        const group = ensureGroup(poolName);
+        const groupKey = getTournamentStandingsGroupKey(game);
+        const groupName = getTournamentStandingsGroupName(game);
+        const group = ensureGroup(groupKey, groupName);
         if (!group) return;
 
         group.scheduledGameCount += 1;
@@ -280,7 +348,7 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
         }
 
         const { homeTeam, awayTeam, homeScore, awayScore } = getTournamentGameTeams(game, currentTeamName);
-        if (!poolName || !homeTeam || !awayTeam) return;
+        if (!groupName || !homeTeam || !awayTeam) return;
         if (homeTeam === awayTeam) return;
 
         const normalizedGame = {
@@ -294,8 +362,9 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
     });
 
     return Array.from(groupGames.entries())
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([poolName, pool]) => {
+        .sort((a, b) => a[1].groupName.localeCompare(b[1].groupName) || a[0].localeCompare(b[0]))
+        .map(([groupKey, pool]) => {
+            const poolName = pool.groupName;
             const poolGameList = pool.games;
             const rows = computeNativeStandingsDetailed(poolGameList, options?.standingsConfig || {}).map((row) => ({
                 ...row,
@@ -304,6 +373,7 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
             const override = getPoolOverride(options?.poolOverrides || {}, poolName);
             const applied = applyTournamentStandingsOverride(rows, override);
             return {
+                groupKey,
                 poolName,
                 groupName: poolName,
                 gameCount: poolGameList.length,

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -361,6 +361,11 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
         group.games.push(normalizedGame);
     });
 
+    const groupNameCounts = Array.from(groupGames.values()).reduce((counts, group) => {
+        counts.set(group.groupName, (counts.get(group.groupName) || 0) + 1);
+        return counts;
+    }, new Map());
+
     return Array.from(groupGames.entries())
         .sort((a, b) => a[1].groupName.localeCompare(b[1].groupName) || a[0].localeCompare(b[0]))
         .map(([groupKey, pool]) => {
@@ -370,7 +375,12 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
                 ...row,
                 teamName: row.team
             }));
-            const override = getPoolOverride(options?.poolOverrides || {}, poolName);
+            const override = getPoolOverride(
+                options?.poolOverrides || {},
+                poolName,
+                groupKey,
+                groupNameCounts.get(poolName) === 1
+            );
             const applied = applyTournamentStandingsOverride(rows, override);
             return {
                 groupKey,

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -98,31 +98,57 @@ export function matchesTournamentStandingsGroup(game = {}, group = {}) {
     return actual.divisionName === expected.divisionName && actual.poolName === expected.poolName;
 }
 
-function normalizeTournamentGroupOption(value) {
-    if (typeof value === 'string') return normalizeString(value);
+function getTournamentGroupDisplayName(divisionName, poolName) {
+    if (divisionName && poolName) return `${divisionName} • ${poolName}`;
+    return poolName || divisionName || null;
+}
+
+function normalizeConfiguredTournamentGroup(value, sourceType = 'display') {
+    if (typeof value === 'string') {
+        const name = normalizeString(value);
+        if (!name) return null;
+        if (sourceType === 'division') {
+            return { groupKey: JSON.stringify([name, '']), groupName: name, displayOnly: false };
+        }
+        if (sourceType === 'pool') {
+            return { groupKey: JSON.stringify(['', name]), groupName: name, displayOnly: false };
+        }
+        return { groupKey: null, groupName: name, displayOnly: true };
+    }
     if (!value || typeof value !== 'object') return null;
     const divisionName = normalizeString(value.divisionName) || normalizeString(value.division);
     const poolName = normalizeString(value.poolName);
-    if (divisionName && poolName) return `${divisionName} • ${poolName}`;
-    return normalizeString(value.name)
-        || normalizeString(value.label)
-        || poolName
-        || divisionName;
+    if (divisionName || poolName) {
+        return {
+            groupKey: JSON.stringify([divisionName || '', poolName || '']),
+            groupName: getTournamentGroupDisplayName(divisionName, poolName),
+            displayOnly: false
+        };
+    }
+    const groupName = normalizeString(value.name) || normalizeString(value.label);
+    if (!groupName) return null;
+    if (sourceType === 'division') {
+        return { groupKey: JSON.stringify([groupName, '']), groupName, displayOnly: false };
+    }
+    if (sourceType === 'pool') {
+        return { groupKey: JSON.stringify(['', groupName]), groupName, displayOnly: false };
+    }
+    return { groupKey: null, groupName, displayOnly: true };
 }
 
-function getConfiguredTournamentGroupNames(options = {}) {
+function getConfiguredTournamentGroups(options = {}) {
     const sources = [
-        options.groupNames,
-        options.poolNames,
-        options.divisionNames,
-        options.tournamentGroups,
-        options.tournamentPools,
-        options.tournamentDivisions
+        { values: options.groupNames, sourceType: 'display' },
+        { values: options.poolNames, sourceType: 'pool' },
+        { values: options.divisionNames, sourceType: 'division' },
+        { values: options.tournamentGroups, sourceType: 'display' },
+        { values: options.tournamentPools, sourceType: 'pool' },
+        { values: options.tournamentDivisions, sourceType: 'division' }
     ];
 
     return sources
-        .flatMap((source) => Array.isArray(source) ? source : [])
-        .map(normalizeTournamentGroupOption)
+        .flatMap(({ values, sourceType }) => (Array.isArray(values) ? values : [])
+            .map((value) => normalizeConfiguredTournamentGroup(value, sourceType)))
         .filter(Boolean);
 }
 
@@ -329,9 +355,10 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
         return groupGames.get(normalizedGroupKey);
     };
 
-    getConfiguredTournamentGroupNames(options).forEach((groupName) => {
-        ensureGroup(JSON.stringify(['', groupName]), groupName);
-    });
+    const configuredGroups = getConfiguredTournamentGroups(options);
+    configuredGroups
+        .filter((group) => !group.displayOnly)
+        .forEach((group) => ensureGroup(group.groupKey, group.groupName));
 
     games.forEach((game) => {
         if (!isTournamentGame(game)) return;
@@ -360,6 +387,15 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
         };
         group.games.push(normalizedGame);
     });
+
+    configuredGroups
+        .filter((group) => group.displayOnly)
+        .forEach((group) => {
+            const matchingGroups = Array.from(groupGames.values())
+                .filter((candidate) => candidate.groupName === group.groupName);
+            if (matchingGroups.length === 1) return;
+            ensureGroup(JSON.stringify(['', group.groupName]), group.groupName);
+        });
 
     const groupNameCounts = Array.from(groupGames.values()).reduce((counts, group) => {
         counts.set(group.groupName, (counts.get(group.groupName) || 0) + 1);

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -116,8 +116,11 @@ function normalizeConfiguredTournamentGroup(value, sourceType = 'display') {
         return { groupKey: null, groupName: name, displayOnly: true };
     }
     if (!value || typeof value !== 'object') return null;
-    const divisionName = normalizeString(value.divisionName) || normalizeString(value.division);
-    const poolName = normalizeString(value.poolName);
+    const configuredName = normalizeString(value.name) || normalizeString(value.label);
+    let divisionName = normalizeString(value.divisionName) || normalizeString(value.division);
+    let poolName = normalizeString(value.poolName);
+    if (sourceType === 'division' && !divisionName) divisionName = configuredName;
+    if (sourceType === 'pool' && !poolName) poolName = configuredName;
     if (divisionName || poolName) {
         return {
             groupKey: JSON.stringify([divisionName || '', poolName || '']),
@@ -125,7 +128,7 @@ function normalizeConfiguredTournamentGroup(value, sourceType = 'display') {
             displayOnly: false
         };
     }
-    const groupName = normalizeString(value.name) || normalizeString(value.label);
+    const groupName = configuredName;
     if (!groupName) return null;
     if (sourceType === 'division') {
         return { groupKey: JSON.stringify([groupName, '']), groupName, displayOnly: false };
@@ -393,7 +396,7 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
         .forEach((group) => {
             const matchingGroups = Array.from(groupGames.values())
                 .filter((candidate) => candidate.groupName === group.groupName);
-            if (matchingGroups.length === 1) return;
+            if (matchingGroups.length > 0) return;
             ensureGroup(JSON.stringify(['', group.groupName]), group.groupName);
         });
 

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -60,7 +60,7 @@ function getTournamentDivisionName(game = {}) {
         || normalizeString(game?.tournament?.division);
 }
 
-function getTournamentStandingsGroupName(game = {}) {
+export function getTournamentStandingsGroupName(game = {}) {
     const divisionName = getTournamentDivisionName(game);
     const poolName = getTournamentPoolName(game);
     if (divisionName && poolName) return `${divisionName} • ${poolName}`;

--- a/team.html
+++ b/team.html
@@ -329,7 +329,7 @@
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, expandRecurrence, escapeHtml, shareOrCopy } from './js/utils.js?v=14';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
-        import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=3';
+        import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=4';
         import { aggregateSeasonStatsByPlayerId, buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=3';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=42';

--- a/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
@@ -255,6 +255,11 @@ export function buildTournamentPoolStandings() {
 export function buildTournamentPoolOverrideKey(poolName = '') {
     return String(poolName || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'pool';
 }
+
+export function buildTournamentGroupOverrideKey(groupKey = '') {
+    const normalized = String(groupKey || '').trim();
+    return normalized ? 'group-' + normalized : null;
+}
 `;
 
 const SCHEDULE_NOTIFICATIONS_STUB = `

--- a/tests/smoke/edit-schedule-calendar-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-import.spec.js
@@ -285,6 +285,11 @@ export function buildTournamentPoolStandings() {
 export function buildTournamentPoolOverrideKey(poolName = '') {
     return String(poolName || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '-') || 'pool';
 }
+
+export function buildTournamentGroupOverrideKey(groupKey = '') {
+    const normalized = String(groupKey || '').trim();
+    return normalized ? 'group-' + normalized : null;
+}
 `,
     '/js/schedule-notifications.js': `
 export function normalizeScheduleNotificationSettings() {

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -436,7 +436,7 @@ async function mockTeamPageModules(page, scenario) {
         contentType: 'application/javascript',
         body: TEAM_ADMIN_BANNER_STUB
     }));
-    await page.route('**/js/tournament-standings.js?v=3', (route) => route.fulfill({
+    await page.route('**/js/tournament-standings.js?v=4', (route) => route.fulfill({
         status: 200,
         contentType: 'application/javascript',
         body: TOURNAMENT_STANDINGS_STUB

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -649,7 +649,13 @@ describe('React app schedule service contract integration', () => {
 
         expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1');
         expect(dbMocks.getGame).toHaveBeenCalledWith('team-1', 'game-1');
-        expect(dbMocks.getGames).not.toHaveBeenCalled();
+        expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {
+            tournamentGroup: {
+                divisionName: '10U Gold',
+                poolName: 'Pool A'
+            }
+        });
         expect(dbMocks.getPracticeSessions).not.toHaveBeenCalled();
         expect(utilsMocks.fetchAndParseCalendar).not.toHaveBeenCalled();
         expect(dbMocks.getPracticeSessionByEvent).not.toHaveBeenCalled();

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -465,7 +465,7 @@ describe('React app schedule service contract integration', () => {
         });
         expect(dbMocks.getGames).toHaveBeenCalledTimes(2);
         expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {
-            tournamentGroup: { poolName: 'Pool A', divisionName: '10U Gold' }
+            tournamentGroups: [{ poolName: 'Pool A', divisionName: '10U Gold' }]
         });
         expect(dbMocks.getTrackedCalendarEventUids).not.toHaveBeenCalled();
         expect(dbMocks.getPracticeSessions).toHaveBeenCalledWith('team-1', {
@@ -654,10 +654,10 @@ describe('React app schedule service contract integration', () => {
         expect(dbMocks.getGame).toHaveBeenCalledWith('team-1', 'game-1');
         expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
         expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {
-            tournamentGroup: {
+            tournamentGroups: [{
                 divisionName: '10U Gold',
                 poolName: 'Pool A'
-            }
+            }]
         });
         expect(dbMocks.getPracticeSessions).not.toHaveBeenCalled();
         expect(utilsMocks.fetchAndParseCalendar).not.toHaveBeenCalled();

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -463,7 +463,10 @@ describe('React app schedule service contract integration', () => {
         expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {
             startDate: expect.any(Date)
         });
-        expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getGames).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1', {
+            tournamentGroup: { poolName: 'Pool A', divisionName: '10U Gold' }
+        });
         expect(dbMocks.getTrackedCalendarEventUids).not.toHaveBeenCalled();
         expect(dbMocks.getPracticeSessions).toHaveBeenCalledWith('team-1', {
             startDate: expect.any(Date)

--- a/tests/unit/db-tournament-overrides.test.js
+++ b/tests/unit/db-tournament-overrides.test.js
@@ -1,20 +1,115 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+import {
+  buildTournamentGroupOverrideKey,
+  buildTournamentPoolOverrideKey,
+  computeTournamentPoolStandings
+} from '../../js/tournament-standings.js';
 
 function readDbSource() {
   return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
 }
 
-describe('db tournament pool override persistence', () => {
-  it('cleans up matching structured group overrides when saving or clearing', () => {
-    const source = readDbSource();
+function buildTournamentOverridePersistenceHarness(initialOverrides = {}) {
+  const source = readDbSource();
+  const start = source.indexOf('function normalizeTournamentPoolOverrideName');
+  const end = source.indexOf('\nexport async function addTeamAdminEmail', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
 
-    expect(source).toContain('function collectTournamentPoolOverrideKeys');
-    expect(source).toContain('Object.entries(poolOverrides || {})');
-    expect(source).toContain('buildTournamentGroupOverrideKey(groupKey)');
-    expect(source).toContain('normalizeTournamentPoolOverrideName(override?.groupKey) === groupKey');
-    expect(source).toContain('collectTournamentPoolOverrideKeys(existingOverrides, poolName, groupKey)');
-    expect(source).toContain('collectTournamentPoolOverrideKeys(existingOverrides, normalizedPoolName, normalizedGroupKey)');
-    expect(source).toContain('deleteField()');
+  const persistenceSource = source
+    .slice(start, end)
+    .replace('export async function saveTournamentPoolOverride', 'async function saveTournamentPoolOverride')
+    .replace('export async function clearTournamentPoolOverride', 'async function clearTournamentPoolOverride');
+  const deleted = Symbol('deleted');
+  let poolOverrides = { ...initialOverrides };
+  const getDoc = vi.fn(async () => ({
+    exists: () => true,
+    data: () => ({ tournamentPoolOverrides: poolOverrides })
+  }));
+  const updateTeam = vi.fn(async (_teamId, updatePayload) => {
+    Object.entries(updatePayload).forEach(([path, value]) => {
+      const key = path.replace('tournamentPoolOverrides.', '');
+      if (value === deleted) {
+        delete poolOverrides[key];
+      } else {
+        poolOverrides[key] = value;
+      }
+    });
+  });
+  const persistence = new Function(
+    'db',
+    'doc',
+    'getDoc',
+    'Timestamp',
+    'updateTeam',
+    'deleteField',
+    'buildTournamentGroupOverrideKey',
+    'buildTournamentPoolOverrideKey',
+    `${persistenceSource}\nreturn { saveTournamentPoolOverride, clearTournamentPoolOverride };`
+  )(
+    {},
+    vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
+    getDoc,
+    { now: vi.fn(() => 'now') },
+    updateTeam,
+    vi.fn(() => deleted),
+    buildTournamentGroupOverrideKey,
+    buildTournamentPoolOverrideKey
+  );
+
+  return {
+    ...persistence,
+    getPoolOverrides: () => ({ ...poolOverrides }),
+    updateTeam
+  };
+}
+
+describe('db tournament pool override persistence', () => {
+  it('retires a legacy override through a structured save and clear round trip', async () => {
+    const poolName = 'Pool A';
+    const groupKey = JSON.stringify(['', poolName]);
+    const legacyKey = buildTournamentPoolOverrideKey(poolName);
+    const structuredKey = buildTournamentGroupOverrideKey(groupKey);
+    const harness = buildTournamentOverridePersistenceHarness({
+      [legacyKey]: {
+        poolName,
+        teamOrder: ['Lions', 'Tigers']
+      }
+    });
+
+    await harness.saveTournamentPoolOverride('team-1', {
+      poolName,
+      groupKey,
+      teamOrder: ['Tigers', 'Lions'],
+      finalizedAt: 'saved-at'
+    });
+
+    expect(harness.getPoolOverrides()).toEqual({
+      [structuredKey]: expect.objectContaining({
+        poolName,
+        groupKey,
+        teamOrder: ['Tigers', 'Lions']
+      })
+    });
+
+    await harness.clearTournamentPoolOverride('team-1', poolName, groupKey);
+
+    expect(harness.getPoolOverrides()).toEqual({});
+    const [pool] = computeTournamentPoolStandings([{
+      competitionType: 'tournament',
+      status: 'completed',
+      opponent: 'Lions',
+      isHome: true,
+      homeScore: 2,
+      awayScore: 1,
+      tournament: { poolName }
+    }], {
+      teamName: 'Tigers',
+      poolOverrides: harness.getPoolOverrides()
+    });
+    expect(pool.isOverridden).toBe(false);
+    expect(pool.rows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
+    expect(harness.updateTeam).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/db-tournament-overrides.test.js
+++ b/tests/unit/db-tournament-overrides.test.js
@@ -6,14 +6,15 @@ function readDbSource() {
 }
 
 describe('db tournament pool override persistence', () => {
-  it('cleans up matching override entries by exact pool name when saving or clearing', () => {
+  it('cleans up matching structured group overrides when saving or clearing', () => {
     const source = readDbSource();
 
     expect(source).toContain('function collectTournamentPoolOverrideKeys');
     expect(source).toContain('Object.entries(poolOverrides || {})');
-    expect(source).toContain("normalizeTournamentPoolOverrideName(override?.poolName) === normalizedPoolName");
-    expect(source).toContain('collectTournamentPoolOverrideKeys(existingOverrides, poolName)');
-    expect(source).toContain('collectTournamentPoolOverrideKeys(existingOverrides, normalizedPoolName)');
+    expect(source).toContain('buildTournamentGroupOverrideKey(groupKey)');
+    expect(source).toContain('normalizeTournamentPoolOverrideName(override?.groupKey) === groupKey');
+    expect(source).toContain('collectTournamentPoolOverrideKeys(existingOverrides, poolName, groupKey)');
+    expect(source).toContain('collectTournamentPoolOverrideKeys(existingOverrides, normalizedPoolName, normalizedGroupKey)');
     expect(source).toContain('deleteField()');
   });
 });

--- a/tests/unit/issue-1967-schedule-tournament-tools-source.test.js
+++ b/tests/unit/issue-1967-schedule-tournament-tools-source.test.js
@@ -23,7 +23,7 @@ describe('issue 1967 schedule tournament tools source contract', () => {
         expect(dbSource).toContain('export async function saveTournamentPoolOverride');
         expect(dbSource).toContain('export async function clearTournamentPoolOverride');
         expect(tournamentStandingsTestSource).toContain('builds division-scoped admin standings and applies final ranking overrides');
-        expect(dbTournamentOverridesTestSource).toContain('cleans up matching structured group overrides when saving or clearing');
+        expect(dbTournamentOverridesTestSource).toContain('retires a legacy override through a structured save and clear round trip');
     });
 
     it('keeps bracket source resolution and pool advancement helpers wired for schedule games', () => {

--- a/tests/unit/issue-1967-schedule-tournament-tools-source.test.js
+++ b/tests/unit/issue-1967-schedule-tournament-tools-source.test.js
@@ -23,7 +23,7 @@ describe('issue 1967 schedule tournament tools source contract', () => {
         expect(dbSource).toContain('export async function saveTournamentPoolOverride');
         expect(dbSource).toContain('export async function clearTournamentPoolOverride');
         expect(tournamentStandingsTestSource).toContain('builds division-scoped admin standings and applies final ranking overrides');
-        expect(dbTournamentOverridesTestSource).toContain('cleans up matching override entries by exact pool name when saving or clearing');
+        expect(dbTournamentOverridesTestSource).toContain('cleans up matching structured group overrides when saving or clearing');
     });
 
     it('keeps bracket source resolution and pool advancement helpers wired for schedule games', () => {

--- a/tests/unit/schedule-date-range-source.test.js
+++ b/tests/unit/schedule-date-range-source.test.js
@@ -33,8 +33,19 @@ describe('schedule date range source contracts', () => {
         expect(getGamesSource).toContain('where("tournament.division", "==", tournamentGroup.divisionName)');
         expect(getGamesSource).toContain('if (hasTournamentGroup) throw error;');
         expect(targetedSource).toContain('getTournamentScheduleGroupQuery(loadedGame)');
-        expect(targetedSource).toContain('loadGames(teamId, { tournamentGroup })');
+        expect(targetedSource).toContain('loadGames(teamId, { tournamentGroups: [tournamentGroup] })');
         expect(targetedSource).not.toContain('getTournamentDetailStandingsRange');
         expect(targetedSource).not.toContain('hasTournamentTeamStandingsConfig');
+    });
+
+    it('loads all visible tournament groups together and fetches shared history once', () => {
+        const getGamesSource = extractSource(dbSource, 'export async function getGames', 'export async function getAggregatedStatsForGames');
+        const groupedLoadSource = extractSource(appSource, 'async function loadTournamentScheduleStandingsGames', 'async function loadRawTeam');
+
+        expect(groupedLoadSource).toContain('loadGames(teamId, { tournamentGroups: [...groups.values()] })');
+        expect(groupedLoadSource).not.toContain('.map((tournamentGroup) => loadGames');
+        expect((getGamesSource.match(/getSharedGamesForTeam\(teamId/g) || [])).toHaveLength(1);
+        expect(getGamesSource).toContain('getSharedGamesForTeam(teamId, { requireComplete: hasTournamentGroup })');
+        expect(getGamesSource).toContain('if (hasTournamentGroup) throw error;');
     });
 });

--- a/tests/unit/schedule-date-range-source.test.js
+++ b/tests/unit/schedule-date-range-source.test.js
@@ -23,4 +23,18 @@ describe('schedule date range source contracts', () => {
         expect(appLoadGamesSource).toContain('mapScheduleEventRecords(await getGames(teamId, range))');
         expect(appLoadGamesSource).not.toContain('loadRecurringPracticeMasters');
     });
+
+    it('keeps direct tournament standings reads bounded by pool identity rather than dates', () => {
+        const getGamesSource = extractSource(dbSource, 'export async function getGames', 'export async function getAggregatedStatsForGames');
+        const targetedSource = extractSource(appSource, 'async function buildTargetedTeamScheduleEvent', 'function resolveMyRsvpNotesByChildForGame');
+
+        expect(getGamesSource).toContain('where("tournament.poolName", "==", tournamentGroup.poolName)');
+        expect(getGamesSource).toContain('where("tournament.divisionName", "==", tournamentGroup.divisionName)');
+        expect(getGamesSource).toContain('where("tournament.division", "==", tournamentGroup.divisionName)');
+        expect(getGamesSource).toContain('if (hasTournamentGroup) throw error;');
+        expect(targetedSource).toContain('getTournamentScheduleGroupQuery(loadedGame)');
+        expect(targetedSource).toContain('loadGames(teamId, { tournamentGroup })');
+        expect(targetedSource).not.toContain('getTournamentDetailStandingsRange');
+        expect(targetedSource).not.toContain('hasTournamentTeamStandingsConfig');
+    });
 });

--- a/tests/unit/schedule-date-range-source.test.js
+++ b/tests/unit/schedule-date-range-source.test.js
@@ -40,10 +40,14 @@ describe('schedule date range source contracts', () => {
 
     it('loads all visible tournament groups together and fetches shared history once', () => {
         const getGamesSource = extractSource(dbSource, 'export async function getGames', 'export async function getAggregatedStatsForGames');
+        const sharedGamesSource = extractSource(dbSource, 'async function getSharedGamesForTeam', 'async function hasSharedGameUsingConfig');
         const groupedLoadSource = extractSource(appSource, 'async function loadTournamentScheduleStandingsGames', 'async function loadRawTeam');
 
         expect(groupedLoadSource).toContain('loadGames(teamId, { tournamentGroups: [...groups.values()] })');
         expect(groupedLoadSource).not.toContain('.map((tournamentGroup) => loadGames');
+        expect(sharedGamesSource).toContain("where('homeTeamId', '==', teamId)");
+        expect(sharedGamesSource).toContain("where('awayTeamId', '==', teamId)");
+        expect(sharedGamesSource).not.toContain("where('teamIds', 'array-contains', teamId)");
         expect((getGamesSource.match(/getSharedGamesForTeam\(teamId/g) || [])).toHaveLength(1);
         expect(getGamesSource).toContain('getSharedGamesForTeam(teamId, { requireComplete: hasTournamentGroup })');
         expect(getGamesSource).toContain('if (hasTournamentGroup) throw error;');

--- a/tests/unit/team-tournament-standings.test.js
+++ b/tests/unit/team-tournament-standings.test.js
@@ -8,7 +8,7 @@ describe('team tournament standings wiring', () => {
   it('imports the tournament standings helper and renders the public standings section', () => {
     const source = fs.readFileSync(TEAM_HTML_PATH, 'utf8');
 
-    expect(source).toContain("import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=3';");
+    expect(source).toContain("import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=4';");
     expect(source).toContain('id="tournament-standings-section"');
     expect(source).toContain('Results &amp; Standings');
     expect(source).toContain('No completed tournament games with scores yet.');

--- a/tests/unit/tournament-standings.test.js
+++ b/tests/unit/tournament-standings.test.js
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyTournamentStandingsOverride,
+  buildTournamentGroupOverrideKey,
   buildTournamentPoolOverrideKey,
   buildTournamentPoolStandings,
-  computeTournamentPoolStandings
+  computeTournamentPoolStandings,
+  getTournamentStandingsGroupKey
 } from '../../js/tournament-standings.js';
+
+function standingsKey(divisionName = '', poolName = '') {
+  return getTournamentStandingsGroupKey({ tournament: { divisionName, poolName } });
+}
 
 describe('tournament standings helpers', () => {
   it('builds unique override keys for distinct pool names that share the same slug', () => {
@@ -55,10 +61,11 @@ describe('tournament standings helpers', () => {
       }
     ]);
 
-    expect(standings['Pool A'].computedRows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers', 'Bears']);
-    expect(standings['Pool A'].rows.map((row) => row.rank)).toEqual([1, 2, 3]);
-    expect(standings['Pool A'].gameCount).toBe(3);
-    expect(standings['Pool A'].isOverridden).toBe(false);
+    const pool = standings[standingsKey('', 'Pool A')];
+    expect(pool.computedRows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers', 'Bears']);
+    expect(pool.rows.map((row) => row.rank)).toEqual([1, 2, 3]);
+    expect(pool.gameCount).toBe(3);
+    expect(pool.isOverridden).toBe(false);
   });
 
   it('applies a saved final ranking override with audit metadata', () => {
@@ -115,11 +122,12 @@ describe('tournament standings helpers', () => {
       }
     });
 
-    expect(standings['Pool A'].computedRows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers', 'Bears']);
-    expect(standings['Pool A'].rows.map((row) => row.teamName)).toEqual(['Lions', 'Bears', 'Tigers']);
-    expect(standings['Pool A'].rows.map((row) => row.rank)).toEqual([1, 2, 3]);
-    expect(standings['Pool A'].isOverridden).toBe(true);
-    expect(standings['Pool A'].override).toEqual(override);
+    const pool = standings[standingsKey('', 'Pool A')];
+    expect(pool.computedRows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers', 'Bears']);
+    expect(pool.rows.map((row) => row.teamName)).toEqual(['Lions', 'Bears', 'Tigers']);
+    expect(pool.rows.map((row) => row.rank)).toEqual([1, 2, 3]);
+    expect(pool.isOverridden).toBe(true);
+    expect(pool.override).toEqual(override);
   });
 
   it('keeps overrides isolated for pools whose names normalize to the same legacy slug', () => {
@@ -166,8 +174,8 @@ describe('tournament standings helpers', () => {
       }
     });
 
-    expect(standings['Pool A'].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
-    expect(standings['Pool-A'].rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
+    expect(standings[standingsKey('', 'Pool A')].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+    expect(standings[standingsKey('', 'Pool-A')].rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
   });
 
   it('keeps admin standings scoped by division and pool names', () => {
@@ -202,9 +210,58 @@ describe('tournament standings helpers', () => {
       }
     ]);
 
-    expect(Object.keys(standings)).toEqual(['10U Gold • Pool A', '12U Silver • Pool A']);
-    expect(standings['10U Gold • Pool A'].rows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
-    expect(standings['12U Silver • Pool A'].rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
+    expect(Object.keys(standings)).toEqual([
+      standingsKey('10U Gold', 'Pool A'),
+      standingsKey('12U Silver', 'Pool A')
+    ]);
+    expect(standings[standingsKey('10U Gold', 'Pool A')].rows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
+    expect(standings[standingsKey('12U Silver', 'Pool A')].rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
+  });
+
+  it('keeps groups distinct when their display labels collide', () => {
+    const standings = buildTournamentPoolStandings([
+      {
+        competitionType: 'tournament', status: 'completed', homeScore: 2, awayScore: 1,
+        tournament: {
+          divisionName: '10U Gold', poolName: 'Pool A',
+          slotAssignments: {
+            home: { sourceType: 'team', teamName: 'Tigers' },
+            away: { sourceType: 'team', teamName: 'Lions' }
+          }
+        }
+      },
+      {
+        competitionType: 'tournament', status: 'completed', homeScore: 3, awayScore: 0,
+        tournament: {
+          poolName: '10U Gold • Pool A',
+          slotAssignments: {
+            home: { sourceType: 'team', teamName: 'Bears' },
+            away: { sourceType: 'team', teamName: 'Hawks' }
+          }
+        }
+      }
+    ], {
+      poolOverrides: {
+        [buildTournamentPoolOverrideKey('10U Gold • Pool A')]: {
+          poolName: '10U Gold • Pool A',
+          teamOrder: ['Hawks', 'Lions']
+        },
+        [buildTournamentGroupOverrideKey(standingsKey('10U Gold', 'Pool A'))]: {
+          groupKey: standingsKey('10U Gold', 'Pool A'),
+          poolName: '10U Gold • Pool A',
+          teamOrder: ['Lions', 'Tigers']
+        }
+      }
+    });
+
+    expect(Object.keys(standings)).toEqual([
+      standingsKey('', '10U Gold • Pool A'),
+      standingsKey('10U Gold', 'Pool A')
+    ]);
+    expect(standings[standingsKey('10U Gold', 'Pool A')].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+    expect(standings[standingsKey('', '10U Gold • Pool A')].rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
+    expect(standings[standingsKey('10U Gold', 'Pool A')].isOverridden).toBe(true);
+    expect(standings[standingsKey('', '10U Gold • Pool A')].isOverridden).toBe(false);
   });
 
   it('falls back to exact pool-name matches when reading legacy override entries', () => {
@@ -233,8 +290,8 @@ describe('tournament standings helpers', () => {
       }
     });
 
-    expect(standings['Pool A'].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
-    expect(standings['Pool A'].override).toEqual(legacyOverride);
+    expect(standings[standingsKey('', 'Pool A')].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+    expect(standings[standingsKey('', 'Pool A')].override).toEqual(legacyOverride);
   });
 
   it('builds division-scoped admin standings and applies final ranking overrides', () => {
@@ -263,10 +320,10 @@ describe('tournament standings helpers', () => {
       }
     });
 
-    expect(Object.keys(standings)).toEqual(['10U Gold']);
-    expect(standings['10U Gold'].computedRows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
-    expect(standings['10U Gold'].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
-    expect(standings['10U Gold'].isOverridden).toBe(true);
+    expect(Object.keys(standings)).toEqual([standingsKey('10U Gold', '')]);
+    expect(standings[standingsKey('10U Gold', '')].computedRows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
+    expect(standings[standingsKey('10U Gold', '')].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+    expect(standings[standingsKey('10U Gold', '')].isOverridden).toBe(true);
   });
 
   it('falls back to computed ranks when an override is cleared', () => {

--- a/tests/unit/tournament-standings.test.js
+++ b/tests/unit/tournament-standings.test.js
@@ -596,6 +596,71 @@ describe('tournament standings helpers', () => {
     });
   });
 
+  it('does not synthesize a phantom group when a display-only label is structurally ambiguous', () => {
+    const groupName = 'A • B • C';
+    const firstGroupKey = standingsKey('A • B', 'C');
+    const secondGroupKey = standingsKey('A', 'B • C');
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Lions',
+        isHome: true,
+        homeScore: 2,
+        awayScore: 1,
+        tournament: { divisionName: 'A • B', poolName: 'C' }
+      },
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Hawks',
+        isHome: true,
+        homeScore: 3,
+        awayScore: 1,
+        tournament: { divisionName: 'A', poolName: 'B • C' }
+      }
+    ], {
+      teamName: 'Tigers',
+      groupNames: [groupName]
+    });
+
+    expect(pools).toHaveLength(2);
+    expect(pools.map((pool) => pool.groupKey)).toEqual([firstGroupKey, secondGroupKey]);
+    expect(pools.every((pool) => pool.groupName === groupName && pool.gameCount === 1)).toBe(true);
+    expect(pools.find((pool) => pool.groupKey === standingsKey('', groupName))).toBeUndefined();
+  });
+
+  it('uses name and label aliases as source-aware structured descriptor components', () => {
+    const groupKey = standingsKey('10U Gold', 'Pool A');
+    const pools = computeTournamentPoolStandings([{
+      competitionType: 'tournament',
+      status: 'completed',
+      opponent: 'Lions',
+      isHome: true,
+      homeScore: 2,
+      awayScore: 1,
+      tournament: { divisionName: '10U Gold', poolName: 'Pool A' }
+    }], {
+      teamName: 'Tigers',
+      tournamentPools: [
+        { divisionName: '10U Gold', name: 'Pool A' },
+        { divisionName: '10U Gold', poolName: 'Pool A', name: 'Ignored pool alias' }
+      ],
+      tournamentDivisions: [
+        { poolName: 'Pool A', label: '10U Gold' },
+        { divisionName: '10U Gold', poolName: 'Pool A', label: 'Ignored division alias' }
+      ]
+    });
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toMatchObject({
+      groupKey,
+      groupName: '10U Gold • Pool A',
+      scheduledGameCount: 1,
+      gameCount: 1
+    });
+  });
+
   it('computes division-scoped standings when tournament games use division names', () => {
     const pools = computeTournamentPoolStandings([
       {

--- a/tests/unit/tournament-standings.test.js
+++ b/tests/unit/tournament-standings.test.js
@@ -470,6 +470,132 @@ describe('tournament standings helpers', () => {
     });
   });
 
+  it('merges configured division names into the matching division-only game group', () => {
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Lions',
+        isHome: true,
+        homeScore: 2,
+        awayScore: 1,
+        tournament: { divisionName: '10U Gold' }
+      }
+    ], {
+      teamName: 'Tigers',
+      tournamentDivisions: ['10U Gold'],
+      poolOverrides: {
+        [buildTournamentPoolOverrideKey('10U Gold')]: {
+          poolName: '10U Gold',
+          teamOrder: ['Lions', 'Tigers']
+        }
+      }
+    });
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toMatchObject({
+      groupKey: standingsKey('10U Gold', ''),
+      groupName: '10U Gold',
+      scheduledGameCount: 1,
+      gameCount: 1,
+      isOverridden: true
+    });
+    expect(pools[0].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+  });
+
+  it('merges configured pool names into the matching pool-only game group', () => {
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Lions',
+        isHome: true,
+        homeScore: 2,
+        awayScore: 1,
+        tournament: { poolName: 'Pool A' }
+      }
+    ], {
+      teamName: 'Tigers',
+      poolNames: ['Pool A'],
+      poolOverrides: {
+        [buildTournamentPoolOverrideKey('Pool A')]: {
+          poolName: 'Pool A',
+          teamOrder: ['Lions', 'Tigers']
+        }
+      }
+    });
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toMatchObject({
+      groupKey: standingsKey('', 'Pool A'),
+      groupName: 'Pool A',
+      scheduledGameCount: 1,
+      gameCount: 1,
+      isOverridden: true
+    });
+    expect(pools[0].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+  });
+
+  it('merges configured division-pool objects and applies their legacy override once', () => {
+    const groupName = '10U Gold • Pool A';
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Lions',
+        isHome: true,
+        homeScore: 2,
+        awayScore: 1,
+        tournament: { divisionName: '10U Gold', poolName: 'Pool A' }
+      }
+    ], {
+      teamName: 'Tigers',
+      tournamentPools: [{ divisionName: '10U Gold', poolName: 'Pool A' }],
+      poolOverrides: {
+        [buildTournamentPoolOverrideKey(groupName)]: {
+          poolName: groupName,
+          teamOrder: ['Lions', 'Tigers']
+        }
+      }
+    });
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toMatchObject({
+      groupKey: standingsKey('10U Gold', 'Pool A'),
+      groupName,
+      scheduledGameCount: 1,
+      gameCount: 1,
+      isOverridden: true
+    });
+    expect(pools[0].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+  });
+
+  it('reconciles a display-only configured group when its matching game group is unambiguous', () => {
+    const groupName = '10U Gold • Pool A';
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Lions',
+        isHome: true,
+        homeScore: 2,
+        awayScore: 1,
+        tournament: { divisionName: '10U Gold', poolName: 'Pool A' }
+      }
+    ], {
+      teamName: 'Tigers',
+      groupNames: [groupName]
+    });
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toMatchObject({
+      groupKey: standingsKey('10U Gold', 'Pool A'),
+      groupName,
+      scheduledGameCount: 1,
+      gameCount: 1
+    });
+  });
+
   it('computes division-scoped standings when tournament games use division names', () => {
     const pools = computeTournamentPoolStandings([
       {

--- a/tests/unit/tournament-standings.test.js
+++ b/tests/unit/tournament-standings.test.js
@@ -421,6 +421,55 @@ describe('tournament standings helpers', () => {
     });
   });
 
+  it('keeps structured team-page overrides from leaking across colliding display labels', () => {
+    const targetedGroupKey = standingsKey('10U Gold', 'Pool A');
+    const collidingGroupKey = standingsKey('', '10U Gold • Pool A');
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Tigers',
+        isHome: true,
+        homeScore: 1,
+        awayScore: 2,
+        tournament: { divisionName: '10U Gold', poolName: 'Pool A' }
+      },
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Hawks',
+        isHome: true,
+        homeScore: 0,
+        awayScore: 3,
+        tournament: { poolName: '10U Gold • Pool A' }
+      }
+    ], {
+      teamName: 'Bears',
+      poolOverrides: {
+        [buildTournamentGroupOverrideKey(targetedGroupKey)]: {
+          groupKey: targetedGroupKey,
+          poolName: '10U Gold • Pool A',
+          teamOrder: ['Bears', 'Tigers']
+        }
+      }
+    });
+
+    expect(pools.find((pool) => pool.groupKey === targetedGroupKey)).toMatchObject({
+      isOverridden: true,
+      rows: [
+        expect.objectContaining({ teamName: 'Bears' }),
+        expect.objectContaining({ teamName: 'Tigers' })
+      ]
+    });
+    expect(pools.find((pool) => pool.groupKey === collidingGroupKey)).toMatchObject({
+      isOverridden: false,
+      rows: [
+        expect.objectContaining({ teamName: 'Hawks' }),
+        expect.objectContaining({ teamName: 'Bears' })
+      ]
+    });
+  });
+
   it('computes division-scoped standings when tournament games use division names', () => {
     const pools = computeTournamentPoolStandings([
       {


### PR DESCRIPTION
## What changed

- share the legacy `buildTournamentPoolStandings` contract with the React/Capacitor app through a typed adapter
- derive read-only standings from ordinary web-created tournament game documents, even when they do not contain synthetic inline standings
- apply `team.tournamentPoolOverrides` with the same ordering and final-ranking behavior as the legacy schedule
- hydrate both windowed schedule rows and direct event-detail routes from the complete tournament game set
- retain existing inline standings as the highest-priority display source
- leave non-tournament schedule reads and every persisted game/team document unchanged

## Root cause

The app renderer could normalize standings only when a game document already embedded rows under fields such as `tournament.standings` or `poolStandings`. The legacy web schedule instead computes rows client-side from all tournament games plus the team standings configuration and `tournamentPoolOverrides`. Normal web-created game documents therefore rendered bracket context in the app but no standings.

## User impact

Parents and staff now see the same computed pool ordering, records, points, and finalized override order in native schedule list/detail views that the legacy web schedule derives from the same stored games.

## Validation

- app focused schedule/standings suites: 100/100 passed
- full app suite: 116 files, 1,028/1,028 tests passed
- legacy/tournament focused suites: 3 files, 22/22 tests passed
- TypeScript typecheck: passed
- production app build: passed
- ESLint on changed files: no errors
- `git diff --check`: passed

## Parent issue status

This PR resolves the previously unowned computed-standings requirement only. It intentionally does not close the parent: draft PR #3760 still needs to land for multi-game native creation, the active proof PRs (#3752, #3756, and #3758) still need reconciliation/merge, and the parent web/app RSVP-tracking-report plus manual round-trip matrix remains outstanding.

Refs #1967
