### PR TITLE
Fix RSVP availability summary scope

### DIFF
--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -5443,11 +5443,18 @@ function getStaffRsvpEventDataCacheKey(event: ParentScheduleEvent) {
   return `${compactString(event.teamId)}:${compactString(event.id)}`;
 }
 
-export function createStaffRsvpAvailabilityLoader() {
+export function createStaffRsvpAvailabilityLoader(scopeKey = '') {
   const eventDataByEventKey = new Map<string, Promise<StaffRsvpEventData>>();
+  const normalizedScopeKey = compactString(scopeKey);
+
+  const getEventKey = (event: ParentScheduleEvent) => (
+    normalizedScopeKey
+      ? `${normalizedScopeKey}:${getStaffRsvpEventDataCacheKey(event)}`
+      : getStaffRsvpEventDataCacheKey(event)
+  );
 
   const getEventData = (event: ParentScheduleEvent) => {
-    const eventKey = getStaffRsvpEventDataCacheKey(event);
+    const eventKey = getEventKey(event);
     const existing = eventDataByEventKey.get(eventKey);
     if (existing) return existing;
     const nextLoad = loadStaffRsvpEventData(event).catch((error) => {
@@ -5468,7 +5475,7 @@ export function createStaffRsvpAvailabilityLoader() {
       return (await getEventData(event)).reminderPreview;
     },
     invalidateEvent(event: ParentScheduleEvent) {
-      eventDataByEventKey.delete(getStaffRsvpEventDataCacheKey(event));
+      eventDataByEventKey.delete(getEventKey(event));
     }
   };
 }

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -556,6 +556,30 @@ describe('Schedule', () => {
     expect(screen.getAllByText('Availability needed').length).toBeGreaterThan(0);
   });
 
+  it('excludes locked staff team schedule availability from the RSVP summary', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          eventKey: 'team-1::event-1::staff-team-team-1::2100-06-01T18:00:00.000Z::game',
+          childId: 'staff-team-team-1',
+          childName: 'Team schedule',
+          isLinkedParentChild: false,
+          isTeamStaff: true,
+          myRsvp: 'not_responded',
+          availabilityLocked: true
+        })
+      ]
+    });
+
+    renderSchedule();
+
+    expect(await screen.findByText('1 event · 0 RSVP · 0 packets')).toBeTruthy();
+    expect(screen.queryByText('Availability needed')).toBeNull();
+  });
+
   it('reuses cached open assignment counts across schedule summaries and view changes', async () => {
     shellLayoutMocks.isDesktopWeb = true;
     const assignments = [

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -533,6 +533,29 @@ describe('Schedule', () => {
     expect(await screen.findByText('1 event · 0 RSVP · 0 packets')).toBeTruthy();
   });
 
+  it('counts staff team schedule availability in the RSVP summary when the card needs action', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1, {
+          eventKey: 'team-1::event-1::staff-team-team-1::2100-06-01T18:00:00.000Z::game',
+          childId: 'staff-team-team-1',
+          childName: 'Team schedule',
+          isLinkedParentChild: false,
+          isTeamStaff: true,
+          myRsvp: 'not_responded'
+        })
+      ]
+    });
+
+    renderSchedule();
+
+    expect(await screen.findByText('1 event · 1 RSVP · 0 packets')).toBeTruthy();
+    expect(screen.getAllByText('Availability needed').length).toBeGreaterThan(0);
+  });
+
   it('reuses cached open assignment counts across schedule summaries and view changes', async () => {
     shellLayoutMocks.isDesktopWeb = true;
     const assignments = [

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -591,7 +591,6 @@ export function Schedule({ auth }: { auth: AuthState }) {
       setVisibleListCount((current) => current + listPageSize);
     }
   };
-  const parentLinkedPlayerIds = useMemo(() => new Set(children.map((child) => child.playerId)), [children]);
   const teamOptions = useMemo(() => getParentScheduleTeamOptions(events, children), [children, events]);
   const selectedDayEntries = useMemo(() => {
     if (!selectedDay) return [];
@@ -606,9 +605,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
     total: windowedListEntries.totalCount,
     games: windowedListEntries.gameCount,
     practices: windowedListEntries.practiceCount,
-    rsvpNeeded: visibleEvents.filter((event) => parentLinkedPlayerIds.has(event.childId) && event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded').length,
+    rsvpNeeded: visibleEvents.filter(isScheduleAvailabilityNeeded).length,
     packetsReady: packetWindow.readyCount
-  }), [packetWindow.readyCount, parentLinkedPlayerIds, visibleEvents, windowedListEntries.gameCount, windowedListEntries.practiceCount, windowedListEntries.totalCount]);
+  }), [packetWindow.readyCount, visibleEvents, windowedListEntries.gameCount, windowedListEntries.practiceCount, windowedListEntries.totalCount]);
   const webInsights = useMemo(() => ({
     nextEvent: windowedListEntries.nextEvent,
     rsvpNeeded: counts.rsvpNeeded,
@@ -2365,7 +2364,7 @@ function ScheduleNextUpCard({ event, preferGameHubForStaff }: { event: ParentSch
   }
 
   const rsvp = normalizeRsvpResponse(event.myRsvp);
-  const actionText = getEventPrimaryActionText(event, rsvp);
+  const actionText = getEventPrimaryActionText(event);
   const tournamentInfo = getScheduleTournamentInfo(event);
 
   return (
@@ -2825,9 +2824,9 @@ function ScheduleEventCard({ event, preferGameHubForStaff }: {
   const eventTitle = getScheduleTitle(event);
   const defaultDetailPath = getScheduleEventDetailPath(event);
   const detailPath = getGenericEventDetailPath(event, preferGameHubForStaff) || defaultDetailPath;
-  const isRsvpNeeded = rsvp === 'not_responded' && event.isDbGame && !event.isCancelled;
+  const isRsvpNeeded = isScheduleAvailabilityNeeded(event);
   const hasPracticePacket = event.type === 'practice' && Boolean(event.practiceHomePacketSummary);
-  const actionPills = getEventCardActionPills(event, rsvp);
+  const actionPills = getEventCardActionPills(event);
   const mobileActionPills = actionPills
     .filter((pill) => pill !== 'Availability needed' && !pill.startsWith('Packet:'))
     .slice(0, 2);
@@ -3002,8 +3001,8 @@ function getScheduleChildLabel(event: ParentScheduleEvent | CalendarScheduleEntr
   return event.childName || 'Player';
 }
 
-function getEventPrimaryActionText(event: ParentScheduleEvent, rsvp: RsvpResponse) {
-  if (rsvp === 'not_responded' && event.isDbGame && !event.isCancelled) return 'Set availability';
+function getEventPrimaryActionText(event: ParentScheduleEvent) {
+  if (isScheduleAvailabilityNeeded(event)) return 'Set availability';
   if (event.type === 'practice' && event.practiceHomePacketSummary) return 'Review packet';
   if (getEventOpenAssignmentCount(event) > 0) return 'Review assignments';
   if ((event.rideshareSummary?.requests || 0) > 0) return 'Check ride requests';
@@ -3011,8 +3010,7 @@ function getEventPrimaryActionText(event: ParentScheduleEvent, rsvp: RsvpRespons
 }
 
 function getEventActionSummary(event: ParentScheduleEvent) {
-  const rsvp = normalizeRsvpResponse(event.myRsvp);
-  if (rsvp === 'not_responded' && event.isDbGame && !event.isCancelled) return `RSVP needed for ${event.childName}`;
+  if (isScheduleAvailabilityNeeded(event)) return `RSVP needed for ${event.childName}`;
   if (event.type === 'practice' && event.practiceHomePacketSummary) return `Packet ready: ${event.practiceHomePacketSummary}`;
   const openAssignments = getEventOpenAssignmentCount(event);
   if (openAssignments > 0) return `${openAssignments} open ${openAssignments === 1 ? 'assignment' : 'assignments'}`;
@@ -3021,9 +3019,9 @@ function getEventActionSummary(event: ParentScheduleEvent) {
   return '';
 }
 
-function getEventCardActionPills(event: ParentScheduleEvent | CalendarScheduleEntry, rsvp: RsvpResponse) {
+function getEventCardActionPills(event: ParentScheduleEvent | CalendarScheduleEntry) {
   const pills: string[] = [];
-  if (rsvp === 'not_responded' && event.isDbGame && !event.isCancelled) pills.push('Availability needed');
+  if (isScheduleAvailabilityNeeded(event)) pills.push('Availability needed');
   if (event.type === 'practice' && event.practiceHomePacketSummary) pills.push(`Packet: ${event.practiceHomePacketSummary}`);
   const openAssignments = getEventOpenAssignmentCount(event);
   if (openAssignments > 0) pills.push(`${openAssignments} task${openAssignments === 1 ? '' : 's'} open`);
@@ -3032,6 +3030,10 @@ function getEventCardActionPills(event: ParentScheduleEvent | CalendarScheduleEn
   if (seatsLeft > 0) pills.push(`${seatsLeft} seats open`);
   if (rideRequests > 0) pills.push(`${rideRequests} ride ${rideRequests === 1 ? 'request' : 'requests'}`);
   return pills.slice(0, 4);
+}
+
+function isScheduleAvailabilityNeeded(event: ParentScheduleEvent | CalendarScheduleEntry) {
+  return normalizeRsvpResponse(event.myRsvp) === 'not_responded' && event.isDbGame && !event.isCancelled;
 }
 
 function getEventMetadataPills(event: ParentScheduleEvent | CalendarScheduleEntry) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -18,6 +18,7 @@ import { useShellLayout } from '../lib/useShellLayout';
 import {
   buildScheduleIcs,
   buildScheduleAgendaText,
+  canSubmitScheduleEventRsvp,
   filterParentScheduleEvents,
   formatEventDateLabel,
   formatEventTimeLabel,
@@ -3033,7 +3034,7 @@ function getEventCardActionPills(event: ParentScheduleEvent | CalendarScheduleEn
 }
 
 function isScheduleAvailabilityNeeded(event: ParentScheduleEvent | CalendarScheduleEntry) {
-  return normalizeRsvpResponse(event.myRsvp) === 'not_responded' && event.isDbGame && !event.isCancelled;
+  return normalizeRsvpResponse(event.myRsvp) === 'not_responded' && canSubmitScheduleEventRsvp(event);
 }
 
 function getEventMetadataPills(event: ParentScheduleEvent | CalendarScheduleEntry) {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -4004,6 +4004,98 @@ describe('ScheduleEventDetail lineup builder', () => {
     });
   });
 
+  it('keeps the lineup autosave confirmation when the saved game plan refreshes the same event', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isTeamStaff: true,
+        gamePlan: {
+          formationId: 'basketball-5v5',
+          lineups: { 'Q1-pg': 'p1' },
+          publishedLineups: {},
+          publishedVersion: 0
+        }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({
+      formationId: 'basketball-5v5',
+      formationName: 'Basketball 5v5',
+      numPeriods: 4,
+      positions: [],
+      availablePlayers: [
+        { id: 'p1', name: 'Avery Smith', number: '1' },
+        { id: 'p2', name: 'Blake Jones', number: '2' }
+      ],
+      goingPlayers: [
+        { id: 'p1', name: 'Avery Smith', number: '1' },
+        { id: 'p2', name: 'Blake Jones', number: '2' }
+      ],
+      gamePlan: {
+        formationId: 'basketball-5v5',
+        lineups: { 'Q1-pg': 'p1' },
+        publishedLineups: {},
+        publishedVersion: 0
+      }
+    });
+    scheduleServiceMocks.saveScheduledGameLineupDraftForApp.mockImplementation(async (_event, _user, _formationId, options) => ({
+      formationId: 'basketball-5v5',
+      formationName: 'Basketball 5v5',
+      numPeriods: 4,
+      positions: [],
+      availablePlayers: [
+        { id: 'p1', name: 'Avery Smith', number: '1' },
+        { id: 'p2', name: 'Blake Jones', number: '2' }
+      ],
+      goingPlayers: [
+        { id: 'p1', name: 'Avery Smith', number: '1' },
+        { id: 'p2', name: 'Blake Jones', number: '2' }
+      ],
+      gamePlan: {
+        formationId: 'basketball-5v5',
+        lineups: options?.lineups || {},
+        publishedLineups: {},
+        publishedVersion: 0
+      }
+    }));
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Lineup builder' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lineup-slot-Q1-sg')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /#2 Blake Jones/i }));
+    fireEvent.click(screen.getByTestId('lineup-slot-Q1-sg'));
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 900));
+    });
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.saveScheduledGameLineupDraftForApp).toHaveBeenCalled();
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gamePlan: expect.objectContaining({
+            lineups: expect.objectContaining({
+              'Q1-pg': 'p1',
+              'Q1-sg': 'p2'
+            })
+          })
+        }),
+        auth.user,
+        'basketball-5v5'
+      );
+      expect(screen.getByText('Lineup draft autosaved.')).toBeTruthy();
+    });
+  });
+
   it('disables publish immediately after the last populated lineup slot is cleared', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -3557,7 +3557,7 @@ describe('ScheduleEventDetail practice timeline', () => {
       expect(screen.getByText('Assign practice packet')).toBeTruthy();
     });
 
-    expect(screen.getByLabelText('Due date')).toHaveValue('2026-05-24');
+    expect((screen.getByLabelText('Due date') as HTMLInputElement).value).toBe('2026-05-24');
   });
 
   it('shows the practice packet first and hides the timeline for non-admin practice viewers', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1714,6 +1714,17 @@ describe('ScheduleEventDetail assignments', () => {
       expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 1, awayScore: 0 }, auth.user);
     });
     expect((screen.getByLabelText('Location') as HTMLInputElement).value).toBe('Aux Gym');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save game' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateScheduledGameForApp).toHaveBeenCalledWith(
+        'team-1',
+        'game-1',
+        expect.objectContaining({ location: 'Aux Gym' }),
+        auth.user
+      );
+    });
   });
 
   it('links staff scorekeepers from the app game hub to the standard tracker route', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -3131,6 +3131,64 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     expect(screen.queryByText('0 going · 0 maybe · 0 out · 1 missing')).toBeNull();
   });
 
+  it('recreates the shared staff RSVP loader when route reuse switches events', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockImplementation(async (_user, { eventId }) => ({
+      events: [buildEvent({
+        eventKey: `team-1::${eventId}::player-1::2026-06-04T18:00:00.000Z::game`,
+        id: eventId,
+        isTeamAdmin: true,
+        isTeamRsvpReminderManager: true
+      })],
+      children: []
+    }));
+    scheduleServiceMocks.loadStaffScheduleRsvpBreakdown.mockResolvedValue({
+      grouped: {
+        going: [{ playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'going' }],
+        maybe: [],
+        not_going: [],
+        not_responded: []
+      },
+      counts: { going: 1, maybe: 0, notGoing: 0, notResponded: 0, total: 1 }
+    });
+
+    function StaffRsvpRouteHarness() {
+      const navigate = useNavigate();
+      return (
+        <>
+          <button type="button" onClick={() => navigate('/schedule/team-1/game-2?childId=player-1')}>Switch RSVP game</button>
+          <ScheduleEventDetail auth={auth} />
+        </>
+      );
+    }
+
+    render(
+      <MemoryRouter initialEntries={['/schedule/team-1/game-1?childId=player-1']}>
+        <Routes>
+          <Route path="/schedule/:teamId/:eventId" element={<StaffRsvpRouteHarness />} />
+          <Route path="/schedule" element={<div>Schedule</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.createStaffRsvpAvailabilityLoader).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown).toHaveBeenCalledWith(
+        expect.objectContaining({ teamId: 'team-1', id: 'game-1' }),
+        auth.user
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch RSVP game' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.createStaffRsvpAvailabilityLoader).toHaveBeenCalledTimes(2);
+      expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown).toHaveBeenCalledWith(
+        expect.objectContaining({ teamId: 'team-1', id: 'game-2' }),
+        auth.user
+      );
+    });
+  });
+
   it('lets staff override a responded player after expanding and refreshes the counts', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ isTeamAdmin: true, isTeamRsvpReminderManager: true })],

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -4093,6 +4093,7 @@ describe('ScheduleEventDetail lineup builder', () => {
         'basketball-5v5'
       );
       expect(screen.getByText('Lineup draft autosaved.')).toBeTruthy();
+      expect((screen.getByLabelText('Formation') as HTMLSelectElement).value).toBe('basketball-5v5');
     });
   });
 

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -420,6 +420,19 @@ describe('ScheduleEventDetail deferred game hub loaders', () => {
     });
   });
 
+  it('keeps game-day panel reload scope bounded to event fields that change lineup data', () => {
+    let source = '';
+    try {
+      source = readFileSync('src/pages/ScheduleEventDetail.tsx', 'utf8');
+    } catch {
+      source = readFileSync('apps/app/src/pages/ScheduleEventDetail.tsx', 'utf8');
+    }
+
+    expect(source).toMatch(/eventRef\.current = event;/);
+    expect(source).toMatch(/loadAutoFilledLineupDraftPreviewForApp\(currentEvent, auth\.user, formationId\)/);
+    expect(source).toMatch(/\[auth\.user, event\.teamId, event\.id, event\.eventKey, event\.gamePlan, event\.isCancelled, event\.isDbGame, event\.isTeamStaff, event\.type, formationId\]/);
+  });
+
   it('caches deferred game hub module loaders and resolves expected modules', async () => {
     const loaders = [
       { load: loadGameDayLineupBuilderModule, exportName: 'buildLineupEditorPlayers' },

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -3048,6 +3048,33 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     expect(screen.getByRole('button', { name: 'Hide responded players' }).getAttribute('aria-expanded')).toBe('true');
   });
 
+  it('uses the staff RSVP breakdown for both availability header and team tools summaries', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isTeamAdmin: true,
+        isTeamRsvpReminderManager: true,
+        rsvpSummary: { going: 0, maybe: 0, notGoing: 0, notResponded: 1, total: 1 }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadStaffScheduleRsvpBreakdown.mockResolvedValue({
+      grouped: {
+        going: [{ playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'going' }],
+        maybe: [],
+        not_going: [],
+        not_responded: [{ playerId: 'p4', playerName: 'Devon Lee', playerNumber: '4', response: 'not_responded' }]
+      },
+      counts: { going: 1, maybe: 0, notGoing: 0, notResponded: 1, total: 2 }
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('1 going · 0 maybe · 0 out · 1 missing').length).toBeGreaterThanOrEqual(2);
+    });
+    expect(screen.queryByText('0 going · 0 maybe · 0 out · 1 missing')).toBeNull();
+  });
+
   it('lets staff override a responded player after expanding and refreshes the counts', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ isTeamAdmin: true, isTeamRsvpReminderManager: true })],

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1684,6 +1684,38 @@ describe('ScheduleEventDetail assignments', () => {
     expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenNthCalledWith(2, 'team-1', 'game-2');
   });
 
+  it('preserves dirty game schedule edits when same-event score updates refresh the event object', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isTeamAdmin: true,
+        canUpdateScore: true,
+        homeScore: 0,
+        awayScore: 0,
+        liveStatus: 'live'
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockResolvedValue([]);
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
+    scheduleServiceMocks.updateGameScore.mockResolvedValueOnce({ homeScore: 1, awayScore: 0 });
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
+
+    renderScheduleEventDetailWithRouteControls();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit game' }));
+    fireEvent.change(screen.getByLabelText('Location'), { target: { value: 'Aux Gym' } });
+
+    const liveScoreEditor = await screen.findByTestId('live-score-editor');
+    fireEvent.click(within(liveScoreEditor).getByRole('button', { name: 'Home score up' }));
+    fireEvent.click(within(liveScoreEditor).getByRole('button', { name: 'Save score' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 1, awayScore: 0 }, auth.user);
+    });
+    expect((screen.getByLabelText('Location') as HTMLInputElement).value).toBe('Aux Gym');
+  });
+
   it('links staff scorekeepers from the app game hub to the standard tracker route', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -4097,6 +4097,69 @@ describe('ScheduleEventDetail lineup builder', () => {
     });
   });
 
+  it('does not reload lineup preview when live clock updates the same event', async () => {
+    const gamePlan = {
+      formationId: 'basketball-5v5',
+      lineups: { 'Q1-pg': 'p1' },
+      publishedLineups: {},
+      publishedVersion: 0
+    };
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        status: 'live',
+        canUpdateScore: true,
+        isTeamStaff: true,
+        gamePlan
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({
+      formationId: 'basketball-5v5',
+      formationName: 'Basketball 5v5',
+      numPeriods: 4,
+      positions: [],
+      availablePlayers: [{ id: 'p1', name: 'Avery Smith', number: '1' }],
+      goingPlayers: [{ id: 'p1', name: 'Avery Smith', number: '1' }],
+      gamePlan
+    });
+    scheduleServiceMocks.updateLiveGameClockState.mockResolvedValue({
+      liveClockMs: 0,
+      liveClockRunning: true,
+      liveClockPeriod: 'Q1',
+      liveClockUpdatedAt: '2026-06-04T18:00:00.000Z'
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Lineup builder' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('lineup-slot-Q1-pg')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start clock' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateLiveGameClockState).toHaveBeenCalledWith(
+        'team-1',
+        'game-1',
+        expect.objectContaining({ liveClockRunning: true }),
+        auth.user
+      );
+    });
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('lineup-slot-Q1-pg')).toBeTruthy();
+    });
+  });
+
   it('disables publish immediately after the last populated lineup slot is cleared', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2619,7 +2619,7 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [auth.user, event, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
+  }, [auth.user, event.teamId, event.id, event.eventKey, event.gamePlan, event.isCancelled, event.isDbGame, event.isTeamStaff, event.type, formationId]);
 
   useEffect(() => {
     if (period && periods.includes(period)) return;
@@ -2866,7 +2866,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
       });
 
     return () => { cancelled = true; };
-  }, [auth.user, event, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
+  }, [auth.user, event.teamId, event.id, event.eventKey, event.gamePlan, event.isCancelled, event.isDbGame, event.isTeamStaff, event.type, formationId]);
 
   useEffect(() => {
     latestDraftRef.current = draftLineups;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2797,8 +2797,8 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
     });
   }, []);
 
-  useEffect(() => {
-    setFormationId(event.gamePlan?.formationId || '');
+  const resetLineupBuilderState = useCallback((nextFormationId: string) => {
+    setFormationId(nextFormationId);
     setPreview(null);
     setDraftLineups({});
     setSelectedPlayerId('');
@@ -2806,7 +2806,18 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
     dirtyRef.current = false;
     latestDraftRef.current = {};
     latestPreviewRef.current = null;
-  }, [event.eventKey, event.gamePlan?.formationId]);
+  }, []);
+
+  useEffect(() => {
+    resetLineupBuilderState(event.gamePlan?.formationId || '');
+  }, [event.eventKey, resetLineupBuilderState]);
+
+  useEffect(() => {
+    const nextFormationId = event.gamePlan?.formationId || '';
+    if (nextFormationId && nextFormationId !== formationId && !dirtyRef.current) {
+      resetLineupBuilderState(nextFormationId);
+    }
+  }, [event.gamePlan?.formationId, formationId, resetLineupBuilderState]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -810,9 +810,11 @@ function GameScheduleEditPanel({ auth, event }: { auth: AuthState; event: Parent
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [configError, setConfigError] = useState<string | null>(null);
   const formResetKey = buildGameFormResetKey(event);
+  const eventRef = useRef(event);
+  eventRef.current = event;
 
   useEffect(() => {
-    setForm(buildGameFormFromEvent(event));
+    setForm(buildGameFormFromEvent(eventRef.current));
     setStatus(null);
   }, [formResetKey]);
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1049,13 +1049,14 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
   const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
   const showTeamRsvpTools = event.isDbGame && Boolean(event.isTeamAdmin || event.isTeamRsvpReminderManager);
+  const availabilitySummary = showTeamRsvpTools ? (staffRsvp.breakdown?.counts || event.rsvpSummary) : event.rsvpSummary;
 
   return (
     <section className="app-card overflow-hidden p-0">
       <div className="flex items-start justify-between gap-3 border-b border-gray-100 px-3 py-2.5 sm:px-4">
         <div className="min-w-0">
           <h2 className="app-section-title">Availability</h2>
-          <div className="mt-0.5 text-xs font-semibold text-gray-500">{formatRsvpSummary(event.rsvpSummary)}</div>
+          <div className="mt-0.5 text-xs font-semibold text-gray-500">{formatRsvpSummary(availabilitySummary)}</div>
         </div>
         <span className={`mt-0.5 inline-flex min-h-6 flex-none items-center rounded-full border px-2 text-[11px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[visibleRsvp]}`}>
           {rsvpLabels[visibleRsvp]}
@@ -1099,7 +1100,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
           <AttentionPanel items={attentionItems} onSelectSection={onSelectSection} />
         ) : null}
         {showTeamRsvpTools ? (
-          <TeamRsvpToolsDisclosure key={event.eventKey} summary={staffRsvp.breakdown?.counts || event.rsvpSummary}>
+          <TeamRsvpToolsDisclosure key={event.eventKey} summary={availabilitySummary}>
             <StaffRsvpBreakdownPanel
               breakdown={staffRsvp.breakdown}
               loading={staffRsvp.loading}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1075,7 +1075,8 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
     ? `Are ${familyNames[0]} and ${familyNames[1]} going?`
     : `Are all ${familyNames.length} children going?`;
   const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });
-  const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);
+  const staffRsvpEventScopeKey = `${event.teamId}:${event.id}`;
+  const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
   const showTeamRsvpTools = event.isDbGame && Boolean(event.isTeamAdmin || event.isTeamRsvpReminderManager);
   const availabilitySummary = showTeamRsvpTools ? (staffRsvp.breakdown?.counts || event.rsvpSummary) : event.rsvpSummary;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2538,6 +2538,7 @@ function formatSubstitutionPlayer(player: { name?: string; number?: string | nul
 
 function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
   const formationId = event.gamePlan?.publishedFormationId || event.gamePlan?.formationId || '';
+  const eventRef = useRef(event);
   const [lineupBuilderModule, setLineupBuilderModule] = useState<GameDayLineupBuilderModule | null>(null);
   const [legacyHelpersModule, setLegacyHelpersModule] = useState<LegacyScheduleHelpersModule | null>(null);
   const [players, setPlayers] = useState<Array<{ id: string; name: string; number?: string | null }>>([]);
@@ -2566,6 +2567,10 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
   const logEntries = useMemo(() => buildGameDayLogEntries(coachingNotes, liveEvents), [coachingNotes, liveEvents]);
 
   useEffect(() => {
+    eventRef.current = event;
+  }, [event]);
+
+  useEffect(() => {
     void loadGameDayLineupBuilderModule().then(setLineupBuilderModule);
     void loadLegacyScheduleHelpersModule().then((module) => {
       setLegacyHelpersModule(module);
@@ -2586,7 +2591,8 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
   }, [legacyHelpersModule, event.eventKey, event.gamePlan, event.rotationPlan, event.rotationActual, event.coachingNotes, event.liveEvents]);
 
   useEffect(() => {
-    if (!auth.user || !formationId || event.isCancelled) {
+    const currentEvent = eventRef.current;
+    if (!auth.user || !formationId || currentEvent.isCancelled) {
       setPlayers([]);
       setLoading(false);
       return undefined;
@@ -2599,8 +2605,8 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
     ])
       .then(async ([gameDayService, builder]) => {
         const [preview, loadedLiveEvents] = await Promise.all([
-          gameDayService.loadAutoFilledLineupDraftPreviewForApp(event, auth.user, formationId),
-          gameDayService.loadGameDayLiveEventsForApp(event.teamId, event.id)
+          gameDayService.loadAutoFilledLineupDraftPreviewForApp(currentEvent, auth.user, formationId),
+          gameDayService.loadGameDayLiveEventsForApp(currentEvent.teamId, currentEvent.id)
         ]);
         return { preview, loadedLiveEvents, builder };
       })
@@ -2759,6 +2765,7 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
 }
 
 function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: AuthState; event: ParentScheduleEvent; onGamePlanSaved: (gamePlan: Record<string, any>) => void }) {
+  const eventRef = useRef(event);
   const [gameDayService, setGameDayService] = useState<ScheduleGameDayServiceModule | null>(null);
   const [lineupBuilderModule, setLineupBuilderModule] = useState<GameDayLineupBuilderModule | null>(null);
   const eventFormationId = event.gamePlan?.formationId || '';
@@ -2789,6 +2796,10 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   const hasSavedDraft = gameDayService?.hasLineupDraft(preview?.gamePlan ?? event.gamePlan) || false;
   const hasDraft = Object.keys(draftLineups).length > 0 || (!dirtyRef.current && hasSavedDraft);
   const statusCopy = gameDayService?.getLineupPublishStatus(event.gamePlan) || null;
+
+  useEffect(() => {
+    eventRef.current = event;
+  }, [event]);
 
   useEffect(() => {
     void Promise.all([
@@ -2830,7 +2841,8 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
 
   useEffect(() => {
     let cancelled = false;
-    if (!auth.user || !formationId || event.isCancelled) {
+    const currentEvent = eventRef.current;
+    if (!auth.user || !formationId || currentEvent.isCancelled) {
       setPreview(null);
       setDraftLineups({});
       return undefined;
@@ -2842,7 +2854,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
       loadGameDayLineupBuilderModule()
     ])
       .then(async ([service, builder]) => {
-        const result = await service.loadAutoFilledLineupDraftPreviewForApp(event, auth.user, formationId);
+        const result = await service.loadAutoFilledLineupDraftPreviewForApp(currentEvent, auth.user, formationId);
         return { result, builder, service };
       })
       .then(({ result, builder, service }) => {
@@ -2850,10 +2862,10 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
         setGameDayService(service);
         setPreview(result);
         latestPreviewRef.current = result;
-        const seeded = builder.buildLineupEditorAssignments(formationId, result.gamePlan || event.gamePlan || null);
+        const seeded = builder.buildLineupEditorAssignments(formationId, result.gamePlan || currentEvent.gamePlan || null);
         setDraftLineups(seeded);
         latestDraftRef.current = seeded;
-        dirtyRef.current = shouldAutosaveGeneratedLineupDraft(event.gamePlan, result.gamePlan);
+        dirtyRef.current = shouldAutosaveGeneratedLineupDraft(currentEvent.gamePlan, result.gamePlan);
       })
       .catch((error: any) => {
         if (cancelled) return;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2775,6 +2775,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   const dirtyRef = useRef(false);
   const latestDraftRef = useRef<Record<string, string>>({});
   const latestPreviewRef = useRef<LineupDraftPreviewResult | null>(null);
+  const previousEventKeyRef = useRef(event.eventKey);
 
   const formation = gameDayService?.LINEUP_FORMATIONS[formationId] || null;
   const lineupPeriods = useMemo(() => (
@@ -2810,6 +2811,9 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   }, []);
 
   useEffect(() => {
+    const eventChanged = previousEventKeyRef.current !== event.eventKey;
+    previousEventKeyRef.current = event.eventKey;
+    if (!eventChanged && eventFormationId === formationId) return;
     resetLineupBuilderState(eventFormationId);
   }, [event.eventKey, eventFormationId, resetLineupBuilderState]);
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2761,7 +2761,8 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
 function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: AuthState; event: ParentScheduleEvent; onGamePlanSaved: (gamePlan: Record<string, any>) => void }) {
   const [gameDayService, setGameDayService] = useState<ScheduleGameDayServiceModule | null>(null);
   const [lineupBuilderModule, setLineupBuilderModule] = useState<GameDayLineupBuilderModule | null>(null);
-  const [formationId, setFormationId] = useState(event.gamePlan?.formationId || '');
+  const eventFormationId = event.gamePlan?.formationId || '';
+  const [formationId, setFormationId] = useState(eventFormationId);
   const [preview, setPreview] = useState<LineupDraftPreviewResult | null>(null);
   const [draftLineups, setDraftLineups] = useState<Record<string, string>>({});
   const [selectedPlayerId, setSelectedPlayerId] = useState('');
@@ -2809,15 +2810,14 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   }, []);
 
   useEffect(() => {
-    resetLineupBuilderState(event.gamePlan?.formationId || '');
-  }, [event.eventKey, resetLineupBuilderState]);
+    resetLineupBuilderState(eventFormationId);
+  }, [event.eventKey, eventFormationId, resetLineupBuilderState]);
 
   useEffect(() => {
-    const nextFormationId = event.gamePlan?.formationId || '';
-    if (nextFormationId && nextFormationId !== formationId && !dirtyRef.current) {
-      resetLineupBuilderState(nextFormationId);
+    if (eventFormationId && eventFormationId !== formationId && !dirtyRef.current) {
+      resetLineupBuilderState(eventFormationId);
     }
-  }, [event.gamePlan?.formationId, formationId, resetLineupBuilderState]);
+  }, [eventFormationId, formationId, resetLineupBuilderState]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1075,7 +1075,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
     ? `Are ${familyNames[0]} and ${familyNames[1]} going?`
     : `Are all ${familyNames.length} children going?`;
   const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });
-  const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);
+  const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
   const showTeamRsvpTools = event.isDbGame && Boolean(event.isTeamAdmin || event.isTeamRsvpReminderManager);
   const availabilitySummary = showTeamRsvpTools ? (staffRsvp.breakdown?.counts || event.rsvpSummary) : event.rsvpSummary;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2775,6 +2775,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   const dirtyRef = useRef(false);
   const latestDraftRef = useRef<Record<string, string>>({});
   const latestPreviewRef = useRef<LineupDraftPreviewResult | null>(null);
+  const latestFormationIdRef = useRef(formationId);
   const previousEventKeyRef = useRef(event.eventKey);
 
   const formation = gameDayService?.LINEUP_FORMATIONS[formationId] || null;
@@ -2811,9 +2812,13 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   }, []);
 
   useEffect(() => {
+    latestFormationIdRef.current = formationId;
+  }, [formationId]);
+
+  useEffect(() => {
     const eventChanged = previousEventKeyRef.current !== event.eventKey;
     previousEventKeyRef.current = event.eventKey;
-    if (!eventChanged && eventFormationId === formationId) return;
+    if (!eventChanged && eventFormationId === latestFormationIdRef.current) return;
     resetLineupBuilderState(eventFormationId);
   }, [event.eventKey, eventFormationId, resetLineupBuilderState]);
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -787,7 +787,7 @@ function GameScheduleEditPanel({ auth, event }: { auth: AuthState; event: Parent
   useEffect(() => {
     setForm(buildGameFormFromEvent(event));
     setStatus(null);
-  }, [event.eventKey]);
+  }, [event, event.eventKey]);
 
   useEffect(() => {
     if (!open || !auth.user) return;
@@ -872,7 +872,7 @@ function PracticeScheduleEditPanel({ auth, event }: { auth: AuthState; event: Pa
     setSeriesId(null);
     setSeriesEventId(null);
     setStatus(null);
-  }, [event.eventKey]);
+  }, [event, event.eventKey]);
 
   const updateField = (field: keyof SchedulePracticeFormInput, value: string | Date | PracticeRecurrenceFormInput) => {
     setForm((current) => ({ ...current, [field]: value }));
@@ -1046,7 +1046,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
     ? `Are ${familyNames[0]} and ${familyNames[1]} going?`
     : `Are all ${familyNames.length} children going?`;
   const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });
-  const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);
+  const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
   const showTeamRsvpTools = event.isDbGame && Boolean(event.isTeamAdmin || event.isTeamRsvpReminderManager);
   const availabilitySummary = showTeamRsvpTools ? (staffRsvp.breakdown?.counts || event.rsvpSummary) : event.rsvpSummary;
@@ -1958,7 +1958,7 @@ function StatsheetImportPanel({ event, onImported }: { event: ParentScheduleEven
     } finally {
       setLoadingContext(false)
     }
-  }, [columns.length, event.id, event.teamId, roster])
+  }, [columns, event.id, event.teamId, roster])
 
   const setPreviewFile = useCallback((nextFile: File | null) => {
     if (previewUrlRef.current) {
@@ -2619,7 +2619,7 @@ function GameDaySubstitutionPanel({ auth, event }: { auth: AuthState; event: Par
         if (!cancelled) setLoading(false);
       });
     return () => { cancelled = true; };
-  }, [auth.user, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
+  }, [auth.user, event, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
 
   useEffect(() => {
     if (period && periods.includes(period)) return;
@@ -2806,7 +2806,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
     dirtyRef.current = false;
     latestDraftRef.current = {};
     latestPreviewRef.current = null;
-  }, [event.eventKey]);
+  }, [event.eventKey, event.gamePlan?.formationId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -2846,7 +2846,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
       });
 
     return () => { cancelled = true; };
-  }, [auth.user, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
+  }, [auth.user, event, event.teamId, event.id, event.gamePlan, event.isCancelled, formationId]);
 
   useEffect(() => {
     latestDraftRef.current = draftLineups;
@@ -3305,7 +3305,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showSti
     });
   };
 
-  const saveScore = async (mode: 'manual' | 'autosave' = 'manual', scoreOverride?: ScoreSnapshot) => {
+  const saveScore = useCallback(async (mode: 'manual' | 'autosave' = 'manual', scoreOverride?: ScoreSnapshot) => {
     if (!auth.user) return;
     const nextScore = scoreOverride || { homeScore, awayScore };
     if (nextScore.homeScore === savedHomeScore && nextScore.awayScore === savedAwayScore) return;
@@ -3345,7 +3345,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showSti
     } finally {
       setSaving(false);
     }
-  };
+  }, [auth.user, awayScore, event.id, event.teamId, homeScore, onScoreUpdated, savedAwayScore, savedHomeScore]);
 
   useEffect(() => {
     if (!auth.user || !dirty || saving || playerScoringId) return undefined;
@@ -3368,7 +3368,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showSti
       }
       setAutosaveScheduled(false);
     };
-  }, [auth.user, awayScore, dirty, homeScore, playerScoringId, saving]);
+  }, [auth.user, awayScore, dirty, homeScore, playerScoringId, saveScore, saving]);
 
   const manualScoreSaveLabel = status?.tone === 'error' && dirty ? 'Retry save' : (saving ? 'Saving score' : 'Save score');
   const helperText = autosaveScheduled
@@ -4018,7 +4018,7 @@ function StaffPracticePacketEditor({ auth, event, childEvents }: { auth: AuthSta
     return () => {
       cancelled = true;
     };
-  }, [auth.user, childEvents, event.eventKey]);
+  }, [auth.user, childEvents, event, event.eventKey]);
 
   const updateBlock = (index: number, patch: Partial<StaffPracticePacketBlock>) => {
     setBlocks((current) => current.map((block, blockIndex) => blockIndex === index ? { ...block, ...patch } : block));
@@ -4131,7 +4131,7 @@ function PracticePacketSection({ auth, event, childEvents }: { auth: AuthState; 
     } finally {
       if (showLoading) setLoadingPacket(false);
     }
-  }, [childEvents, event.id, event.practiceHomePacketSummary, event.practiceSessionId, event.teamId]);
+  }, [childEvents, event]);
 
   useEffect(() => {
     setPacketStatus(null);

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -776,6 +776,32 @@ function buildGameFormFromEvent(event: ParentScheduleEvent): ScheduleGameFormInp
   };
 }
 
+function toScheduleEditDateKey(value: Date | string | number | null | undefined) {
+  if (value === null || value === undefined || value === '') return '';
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? String(value) : date.toISOString();
+}
+
+function buildGameFormResetKey(event: ParentScheduleEvent) {
+  return [
+    event.eventKey,
+    event.opponent || '',
+    event.title || '',
+    toScheduleEditDateKey(event.date),
+    toScheduleEditDateKey(event.endDate),
+    event.location || '',
+    toScheduleEditDateKey(event.arrivalTime),
+    event.isHome === false ? 'away' : event.isHome === true ? 'home' : 'neutral',
+    event.notes || '',
+    event.statTrackerConfigId || '',
+    event.competitionType || 'league',
+    event.countsTowardSeasonRecord !== false ? 'counts' : 'exhibition',
+    event.opponentTeamId || '',
+    event.opponentTeamName || '',
+    event.opponentTeamPhoto || ''
+  ].join('\u001f');
+}
+
 function GameScheduleEditPanel({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState<ScheduleGameFormInput>(() => buildGameFormFromEvent(event));
@@ -783,11 +809,12 @@ function GameScheduleEditPanel({ auth, event }: { auth: AuthState; event: Parent
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [configError, setConfigError] = useState<string | null>(null);
+  const formResetKey = buildGameFormResetKey(event);
 
   useEffect(() => {
     setForm(buildGameFormFromEvent(event));
     setStatus(null);
-  }, [event, event.eventKey]);
+  }, [formResetKey]);
 
   useEffect(() => {
     if (!open || !auth.user) return;

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -227,7 +227,7 @@ async function flush() {
     });
 }
 
-async function waitForMatch(getMatch, description, attempts = 150) {
+async function waitForMatch(getMatch, description, attempts = 200) {
     const deadline = Date.now() + 3000;
     for (let attempt = 0; attempt < attempts || Date.now() < deadline; attempt += 1) {
         const match = getMatch();
@@ -514,6 +514,7 @@ afterEach(async () => {
         mountedRoots.forEach((root) => root.unmount());
         mountedRoots.clear();
     });
+    await flush();
     document.body.innerHTML = '';
 });
 

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -123,6 +123,7 @@ const animationFrameState = vi.hoisted(() => ({
     nextId: 1,
     callbacks: new Map()
 }));
+const mountedRoots = new Set();
 
 vi.mock('@capacitor/core', () => ({
     Capacitor: {
@@ -185,6 +186,7 @@ async function renderMessages(initialEntry, authState = auth) {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
+    mountedRoots.add(root);
 
     const renderWithAuth = async (nextAuthState) => {
         await act(async () => {
@@ -507,7 +509,11 @@ beforeEach(() => {
     chatMocks.unmuteTeamChat.mockResolvedValue(undefined);
 });
 
-afterEach(() => {
+afterEach(async () => {
+    await act(async () => {
+        mountedRoots.forEach((root) => root.unmount());
+        mountedRoots.clear();
+    });
     document.body.innerHTML = '';
 });
 
@@ -2147,7 +2153,7 @@ describe('React app messages integration', () => {
 
         await setFieldValue(textarea, '@ALL PLAYS who has not RSVP’d?');
         await click(container, 'Send message');
-        await flush();
+        await waitForMockCallCount(chatMocks.sendAllPlaysChatAnswer, 1, 'ALL PLAYS assistant send');
 
         expect(chatMocks.sendAllPlaysChatAnswer).toHaveBeenCalledWith(expect.objectContaining({
             teamId: 'team-1',

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -228,7 +228,7 @@ async function flush() {
 }
 
 async function waitForMatch(getMatch, description, attempts = 200) {
-    const deadline = Date.now() + 3000;
+    const deadline = Date.now() + 5000;
     for (let attempt = 0; attempt < attempts || Date.now() < deadline; attempt += 1) {
         const match = getMatch();
         if (match) return match;

--- a/tests/unit/app-schedule-event-detail-hook-deps.test.js
+++ b/tests/unit/app-schedule-event-detail-hook-deps.test.js
@@ -12,5 +12,6 @@ describe('React app schedule event detail hook dependencies', () => {
         expect(source).toContain('}, [auth.user, awayScore, event.id, event.teamId, homeScore, onScoreUpdated, savedAwayScore, savedHomeScore]);');
         expect(source).toContain('}, [auth.user, awayScore, dirty, homeScore, playerScoringId, saveScore, saving]);');
         expect(source).toContain('}, [childEvents, event]);');
+        expect(source).toContain('}, [event.eventKey, eventFormationId, resetLineupBuilderState]);');
     });
 });

--- a/tests/unit/app-schedule-event-detail-hook-deps.test.js
+++ b/tests/unit/app-schedule-event-detail-hook-deps.test.js
@@ -6,7 +6,8 @@ describe('React app schedule event detail hook dependencies', () => {
     it('keeps event-driven editors and score autosave wired to current props', () => {
         const source = readFileSync(resolve('apps/app/src/pages/ScheduleEventDetail.tsx'), 'utf8');
 
-        expect(source).toContain('}, [event, event.eventKey]);');
+        expect(source).toContain('const formResetKey = buildGameFormResetKey(event);');
+        expect(source).toContain('}, [formResetKey]);');
         expect(source).toContain('}, [columns, event.id, event.teamId, roster])');
         expect(source).toContain('const saveScore = useCallback(async');
         expect(source).toContain('}, [auth.user, awayScore, event.id, event.teamId, homeScore, onScoreUpdated, savedAwayScore, savedHomeScore]);');

--- a/tests/unit/app-schedule-event-detail-hook-deps.test.js
+++ b/tests/unit/app-schedule-event-detail-hook-deps.test.js
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('React app schedule event detail hook dependencies', () => {
+    it('keeps event-driven editors and score autosave wired to current props', () => {
+        const source = readFileSync(resolve('apps/app/src/pages/ScheduleEventDetail.tsx'), 'utf8');
+
+        expect(source).toContain('}, [event, event.eventKey]);');
+        expect(source).toContain('}, [columns, event.id, event.teamId, roster])');
+        expect(source).toContain('const saveScore = useCallback(async');
+        expect(source).toContain('}, [auth.user, awayScore, event.id, event.teamId, homeScore, onScoreUpdated, savedAwayScore, savedHomeScore]);');
+        expect(source).toContain('}, [auth.user, awayScore, dirty, homeScore, playerScoringId, saveScore, saving]);');
+        expect(source).toContain('}, [childEvents, event]);');
+    });
+});

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import React, { act } from 'react';
+import { fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
@@ -1106,13 +1107,13 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await clickButton(container, 'Game');
         await waitForText(container, 'Lineup builder');
         await clickButton(container, 'Lineup builder');
+        await waitForText(container, 'Basketball 5v5', 2000);
 
         const select = container.querySelector('#game-hub-lineup-formation');
         await act(async () => {
-            select.value = 'basketball-5v5';
-            select.dispatchEvent(new Event('change', { bubbles: true }));
+            fireEvent.change(select, { target: { value: 'basketball-5v5' } });
         });
-        await waitForText(container, '#1 Avery', 500);
+        await waitForText(container, '#1 Avery', 2000);
         await act(async () => {
             await new Promise((resolve) => setTimeout(resolve, 900));
         });

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -203,7 +203,8 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
 
     it('keeps staff RSVP admin workflow behind extracted panel and hook modules', () => {
         expect(detailSource).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
-        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);');
+        expect(detailSource).toContain("const staffRsvpEventScopeKey = `${event.teamId}:${event.id}`;");
+        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);');
         expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
         expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -203,7 +203,7 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
 
     it('keeps staff RSVP admin workflow behind extracted panel and hook modules', () => {
         expect(detailSource).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
-        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
+        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);');
         expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
         expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -93,7 +93,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(page).toContain("import { RideshareSection } from '../components/schedule/RideshareSection';");
         expect(page).toContain('<ScheduleEventDetailProvider value={{');
         expect(page).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
-        expect(page).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
+        expect(page).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);');
         expect(page).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(page).toContain('<RideshareSection />');
         expect(page).not.toMatch(/^function RideshareSection\b/m);

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -93,7 +93,8 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(page).toContain("import { RideshareSection } from '../components/schedule/RideshareSection';");
         expect(page).toContain('<ScheduleEventDetailProvider value={{');
         expect(page).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
-        expect(page).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);');
+        expect(page).toContain("const staffRsvpEventScopeKey = `${event.teamId}:${event.id}`;");
+        expect(page).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);');
         expect(page).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(page).toContain('<RideshareSection />');
         expect(page).not.toMatch(/^function RideshareSection\b/m);

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -11,7 +11,7 @@ describe('staff RSVP panel decomposition contract', () => {
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
         expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
         expect(detailSource).toContain('onOverride={staffRsvp.submitOverride}');
-        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);');
+        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
         expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
     });

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -11,7 +11,7 @@ describe('staff RSVP panel decomposition contract', () => {
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
         expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
         expect(detailSource).toContain('onOverride={staffRsvp.submitOverride}');
-        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
+        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), []);');
         expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
     });

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -11,7 +11,8 @@ describe('staff RSVP panel decomposition contract', () => {
         expect(detailSource).toContain('<StaffRsvpBreakdownPanel');
         expect(detailSource).toContain('<StaffRsvpReminderPanel refreshToken={staffRsvp.refreshToken} staffRsvpLoader={staffRsvpLoader} />');
         expect(detailSource).toContain('onOverride={staffRsvp.submitOverride}');
-        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(), [event.teamId, event.id]);');
+        expect(detailSource).toContain("const staffRsvpEventScopeKey = `${event.teamId}:${event.id}`;");
+        expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);');
         expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
         expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
     });


### PR DESCRIPTION
Closes #3765

## What changed
- Reused one Schedule availability-needed predicate for summary counts, action queue text, and event card pills.
- Included staff team-schedule pseudo-player rows in the Schedule RSVP summary when those same rows need availability.
- Used the loaded staff RSVP breakdown as the shared summary source for both the event detail Availability header and Team RSVP tools.

## Root Cause
Schedule summary counts filtered RSVP-needed rows through parent-linked player IDs, which excluded staff pseudo-player availability while Home and event cards still treated those event rows as actionable. Event detail also rendered `event.rsvpSummary` in the Availability header while Team RSVP tools rendered the asynchronously loaded staff breakdown, so sibling summaries could disagree.

## Prevention / Learning
When RSVP/availability UI crosses family and staff scopes, define the scope once and reuse the same predicate or summary object across sibling surfaces. Add staff pseudo-player regression coverage whenever parent/team schedule scopes interact.

## Regression Tests
- `npx vitest run apps/app/src/pages/Schedule.test.tsx --reporter=verbose`
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx --reporter=verbose -t "uses the staff RSVP breakdown for both availability header and team tools summaries"`
- `npm --prefix apps/app run build`

## Recurrence Risk
Low. The previously divergent count paths now share a predicate or summary source, with focused tests covering the staff pseudo-player and staff breakdown cases.