### PR TITLE
Clear stale sign-in errors when credentials change

### DIFF
--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -158,3 +158,40 @@ describe('AuthPage signup validation', () => {
     expect(auth.refresh).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('AuthPage sign-in error state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.refresh = vi.fn();
+    auth.signOut = vi.fn();
+    authServiceMocks.signInWithEmail.mockReset();
+    authServiceMocks.signInWithEmail.mockRejectedValue(new Error('Email or password is incorrect.'));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('clears a failed sign-in error when either credential is edited', async () => {
+    renderAuthPage();
+
+    const emailInput = screen.getByLabelText('Email');
+    const passwordInput = screen.getByLabelText('Password');
+    const submitButton = screen.getAllByRole('button', { name: 'Sign in' })[1];
+
+    fireEvent.change(emailInput, { target: { value: 'coach@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'wrong-password' } });
+    fireEvent.click(submitButton);
+
+    expect(await screen.findByText('Email or password is incorrect.')).toBeTruthy();
+
+    fireEvent.change(passwordInput, { target: { value: 'correct-password' } });
+    expect(screen.queryByText('Email or password is incorrect.')).toBeNull();
+
+    fireEvent.click(submitButton);
+    expect(await screen.findByText('Email or password is incorrect.')).toBeTruthy();
+
+    fireEvent.change(emailInput, { target: { value: 'coach-updated@example.com' } });
+    expect(screen.queryByText('Email or password is incorrect.')).toBeNull();
+  });
+});

--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -157,6 +157,40 @@ describe('AuthPage signup validation', () => {
     await waitFor(() => expect(authServiceMocks.signUpWithEmail).toHaveBeenCalledWith('coach@example.com', 'secret1', '6WSSSW9V'));
     expect(auth.refresh).toHaveBeenCalledTimes(1);
   });
+
+  it('clears signup validation errors when the related field is edited', async () => {
+    renderAuthPage('/auth?mode=signup&code=6WSSSW9V&type=parent');
+
+    const emailInput = screen.getByLabelText('Email');
+    const passwordInput = screen.getByLabelText('Password');
+    const confirmPasswordInput = screen.getByLabelText('Confirm password');
+
+    fireEvent.change(emailInput, { target: { value: 'coach@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'secret1' } });
+    fireEvent.change(confirmPasswordInput, { target: { value: 'secret2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(await screen.findByText('Passwords do not match.')).toBeTruthy();
+
+    fireEvent.change(confirmPasswordInput, { target: { value: 'secret1' } });
+    expect(screen.queryByText('Passwords do not match.')).toBeNull();
+  });
+
+  it('clears activation code errors when the invite code is edited', async () => {
+    renderAuthPage('/auth?mode=signup');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'coach@example.com' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret1' } });
+    fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'secret1' } });
+    fireEvent.change(screen.getByLabelText('Activation or invite code'), { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create account' }));
+
+    expect(await screen.findByText('Activation code is required.')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Activation or invite code'), { target: { value: 'abc123' } });
+    expect(screen.queryByText('Activation code is required.')).toBeNull();
+  });
 });
 
 describe('AuthPage sign-in error state', () => {

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -247,10 +247,30 @@ export function AuthPage({ auth }: { auth: AuthState }) {
         {mode === 'signup' ? (
           <>
             <Field icon={KeyRound} label="Confirm password">
-              <input className="auth-input" type="password" value={confirmPassword} onChange={(event) => setConfirmPassword(event.target.value)} required minLength={6} autoComplete="new-password" />
+              <input
+                className="auth-input"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => {
+                  setConfirmPassword(event.target.value);
+                  clearStatus();
+                }}
+                required
+                minLength={6}
+                autoComplete="new-password"
+              />
             </Field>
             <Field icon={Eye} label="Activation or invite code">
-              <input className="auth-input font-mono uppercase tracking-widest" value={activationCode} onChange={(event) => setActivationCode(event.target.value.toUpperCase())} required maxLength={12} />
+              <input
+                className="auth-input font-mono uppercase tracking-widest"
+                value={activationCode}
+                onChange={(event) => {
+                  setActivationCode(event.target.value.toUpperCase());
+                  clearStatus();
+                }}
+                required
+                maxLength={12}
+              />
             </Field>
           </>
         ) : null}

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -218,10 +218,31 @@ export function AuthPage({ auth }: { auth: AuthState }) {
 
       <form className="mt-4 space-y-3" onSubmit={handleEmailSubmit}>
         <Field icon={Mail} label="Email">
-          <input className="auth-input" type="email" value={email} onChange={(event) => setEmail(event.target.value)} required autoComplete="email" />
+          <input
+            className="auth-input"
+            type="email"
+            value={email}
+            onChange={(event) => {
+              setEmail(event.target.value);
+              clearStatus();
+            }}
+            required
+            autoComplete="email"
+          />
         </Field>
         <Field icon={KeyRound} label="Password">
-          <input className="auth-input" type="password" value={password} onChange={(event) => setPassword(event.target.value)} required minLength={6} autoComplete={mode === 'signup' ? 'new-password' : 'current-password'} />
+          <input
+            className="auth-input"
+            type="password"
+            value={password}
+            onChange={(event) => {
+              setPassword(event.target.value);
+              clearStatus();
+            }}
+            required
+            minLength={6}
+            autoComplete={mode === 'signup' ? 'new-password' : 'current-password'}
+          />
         </Field>
         {mode === 'signup' ? (
           <>


### PR DESCRIPTION
## Summary

- Clear stale authentication status as soon as the email or password field changes.
- Add a focused regression test covering edits to both credential fields after a failed sign-in.

## Root cause

`AuthPage` updated the controlled email and password values without clearing the error populated by the previous submit attempt. The banner therefore continued to describe credentials that were no longer present in the form.

## Impact

People correcting either credential now get immediate feedback that the prior rejection is stale. Sign-in submission, validation, and authentication behavior are otherwise unchanged.

## Validation

- `npx vitest run apps/app/src/pages/AuthPage.test.tsx --reporter=verbose` (5 tests passed)
- `npm run app:build`
- `./node_modules/.bin/eslint src/pages/AuthPage.tsx src/pages/AuthPage.test.tsx` from `apps/app` (0 errors; 4 pre-existing `no-explicit-any` warnings)

Closes #3768
