### PR TITLE
Show notification recency in the mobile inbox sheet

### DIFF
--- a/apps/app/src/components/NotificationInboxSheet.test.tsx
+++ b/apps/app/src/components/NotificationInboxSheet.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationInboxSheet } from './NotificationInboxSheet';
+import type { NotificationInboxItem } from '../lib/notificationInboxService';
+import { formatNotificationRecency, normalizeNotificationTimestamp } from '../lib/notificationRecency';
+
+function notification(overrides: Partial<NotificationInboxItem>): NotificationInboxItem {
+    return {
+        id: 'notification-1',
+        category: 'schedule_update',
+        type: 'schedule_update',
+        title: '',
+        body: '',
+        text: 'Practice moved to 6 PM',
+        appRoute: '/schedule',
+        conversationId: '',
+        createdAt: null,
+        readAt: null,
+        ...overrides
+    };
+}
+
+function LocationDisplay() {
+    const location = useLocation();
+    return <div data-testid="current-route">{location.pathname}</div>;
+}
+
+describe('notification recency', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-07-11T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.useRealTimers();
+    });
+
+    it('normalizes supported timestamp values and rejects missing or invalid values', () => {
+        const expected = '2026-07-11T11:48:00.000Z';
+
+        expect(normalizeNotificationTimestamp(new Date(expected))?.toISOString()).toBe(expected);
+        expect(normalizeNotificationTimestamp({ toDate: () => new Date(expected) })?.toISOString()).toBe(expected);
+        expect(normalizeNotificationTimestamp(expected)?.toISOString()).toBe(expected);
+        expect(normalizeNotificationTimestamp({ seconds: 1_783_770_480 })?.toISOString()).toBe(expected);
+        expect(normalizeNotificationTimestamp(1_783_770_480)?.toISOString()).toBe(expected);
+        expect(normalizeNotificationTimestamp(null)).toBeNull();
+        expect(normalizeNotificationTimestamp('not-a-date')).toBeNull();
+    });
+
+    it('formats compact relative labels and short dates', () => {
+        expect(formatNotificationRecency('2026-07-11T11:59:30.000Z')).toBe('Just now');
+        expect(formatNotificationRecency('2026-07-11T11:48:00.000Z')).toBe('12m');
+        expect(formatNotificationRecency('2026-07-11T09:00:00.000Z')).toBe('3h');
+        expect(formatNotificationRecency('2026-07-08T12:00:00.000Z')).toBe('Jul 8');
+        expect(formatNotificationRecency('invalid')).toBe('');
+    });
+
+    it('renders recency beside notification metadata and preserves unread navigation behavior', () => {
+        const onClose = vi.fn();
+        const onMarkRead = vi.fn(() => Promise.resolve());
+        const items = [
+            notification({ id: 'recent', createdAt: { seconds: 1_783_770_480 } }),
+            notification({
+                id: 'older',
+                text: 'Registration fee is due',
+                type: 'fee_alert',
+                createdAt: new Date('2026-07-08T12:00:00.000Z'),
+                readAt: new Date('2026-07-09T12:00:00.000Z')
+            })
+        ];
+
+        render(
+            <MemoryRouter initialEntries={['/home']}>
+                <Routes>
+                    <Route path="*" element={(
+                        <>
+                            <LocationDisplay />
+                            <NotificationInboxSheet
+                                items={items}
+                                inboxState="ready"
+                                uid="user-123"
+                                onClose={onClose}
+                                onMarkRead={onMarkRead}
+                            />
+                        </>
+                    )} />
+                </Routes>
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('12m').tagName).toBe('TIME');
+        expect(screen.getByText('Jul 8').tagName).toBe('TIME');
+        expect(screen.getByText('schedule update')).toBeTruthy();
+        expect(screen.getByText('fee alert')).toBeTruthy();
+
+        fireEvent.click(screen.getByTestId('notification-item-recent'));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(onMarkRead).toHaveBeenCalledWith('user-123', 'recent');
+        expect(screen.getByTestId('current-route').textContent).toBe('/schedule');
+    });
+
+    it('renders invalid timestamps without a broken recency label', () => {
+        render(
+            <MemoryRouter>
+                <NotificationInboxSheet
+                    items={[notification({ createdAt: 'not-a-date' })]}
+                    inboxState="ready"
+                    uid="user-123"
+                    onClose={vi.fn()}
+                    onMarkRead={vi.fn(() => Promise.resolve())}
+                />
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('Practice moved to 6 PM')).toBeTruthy();
+        expect(document.querySelector('time')).toBeNull();
+    });
+});

--- a/apps/app/src/components/NotificationInboxSheet.tsx
+++ b/apps/app/src/components/NotificationInboxSheet.tsx
@@ -1,6 +1,7 @@
 import { AlertCircle, Bell, CheckCheck, Loader2, RotateCcw, X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import type { NotificationInboxItem } from '../lib/notificationInboxService';
+import { formatNotificationRecency, normalizeNotificationTimestamp } from '../lib/notificationRecency';
 
 interface NotificationInboxSheetProps {
     items: NotificationInboxItem[];
@@ -108,6 +109,8 @@ export function NotificationInboxSheet({ items, inboxState, uid, onClose, onRetr
                 <ul role="list" className="divide-y divide-gray-100">
                     {items.map((item) => {
                         const isUnread = !item.readAt;
+                        const createdAt = normalizeNotificationTimestamp(item.createdAt);
+                        const recencyLabel = formatNotificationRecency(createdAt);
                         return (
                             <li key={item.id}>
                                 <button
@@ -124,9 +127,22 @@ export function NotificationInboxSheet({ items, inboxState, uid, onClose, onRetr
                                         <span className={`block text-sm leading-snug ${isUnread ? 'font-bold text-gray-950' : 'font-semibold text-gray-700'}`}>
                                             {item.text}
                                         </span>
-                                        {item.type ? (
-                                            <span className="mt-0.5 block text-xs font-medium text-gray-400 capitalize">
-                                                {item.type.replace(/_/g, ' ')}
+                                        {item.type || recencyLabel ? (
+                                            <span className="mt-0.5 flex min-w-0 items-center gap-2 text-xs font-medium text-gray-400">
+                                                {item.type ? (
+                                                    <span className="min-w-0 flex-1 truncate capitalize">
+                                                        {item.type.replace(/_/g, ' ')}
+                                                    </span>
+                                                ) : null}
+                                                {recencyLabel && createdAt ? (
+                                                    <time
+                                                        className="flex-none"
+                                                        dateTime={createdAt.toISOString()}
+                                                        title={createdAt.toLocaleString()}
+                                                    >
+                                                        {recencyLabel}
+                                                    </time>
+                                                ) : null}
                                             </span>
                                         ) : null}
                                     </span>

--- a/apps/app/src/lib/notificationRecency.ts
+++ b/apps/app/src/lib/notificationRecency.ts
@@ -1,0 +1,65 @@
+import { formatDateTime } from './datetime';
+
+type TimestampLike = {
+    seconds?: unknown;
+    toDate?: () => unknown;
+    toMillis?: () => unknown;
+};
+
+export function normalizeNotificationTimestamp(value: unknown): Date | null {
+    if (value instanceof Date) {
+        return Number.isNaN(value.getTime()) ? null : value;
+    }
+
+    if (value === null || value === undefined || value === '') return null;
+
+    const timestamp = value as TimestampLike;
+    if (typeof timestamp.toDate === 'function') {
+        try {
+            return normalizeNotificationTimestamp(timestamp.toDate());
+        } catch {
+            return null;
+        }
+    }
+
+    if (typeof timestamp.toMillis === 'function') {
+        try {
+            return normalizeNotificationTimestamp(timestamp.toMillis());
+        } catch {
+            return null;
+        }
+    }
+
+    if (typeof timestamp.seconds === 'number') {
+        return normalizeNotificationTimestamp(timestamp.seconds * 1000);
+    }
+
+    if (typeof value === 'number') {
+        const milliseconds = Math.abs(value) < 100_000_000_000 ? value * 1000 : value;
+        const date = new Date(milliseconds);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+
+    if (typeof value !== 'string') return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function formatNotificationRecency(value: unknown, now = new Date()): string {
+    const date = normalizeNotificationTimestamp(value);
+    if (!date || Number.isNaN(now.getTime())) return '';
+
+    const ageMilliseconds = Math.max(0, now.getTime() - date.getTime());
+    const ageMinutes = Math.floor(ageMilliseconds / 60_000);
+    if (ageMinutes < 1) return 'Just now';
+    if (ageMinutes < 60) return `${ageMinutes}m`;
+
+    const ageHours = Math.floor(ageMinutes / 60);
+    if (ageHours < 24) return `${ageHours}h`;
+
+    return formatDateTime(date, {
+        month: 'short',
+        day: 'numeric',
+        ...(date.getFullYear() === now.getFullYear() ? {} : { year: 'numeric' })
+    });
+}


### PR DESCRIPTION
## Need / root cause

The notification inbox service already preserves and sorts by each item's `createdAt`, but `NotificationInboxSheet` only rendered the notification text and category. Mobile users therefore could not judge whether an alert was fresh or stale before opening it.

## Changes

- Normalize Date, Firestore Timestamp-like, ISO string, millisecond, and epoch-seconds values safely.
- Render compact `Just now`, minute, hour, or short-date recency labels in each row without truncating notification text.
- Omit the label for missing or invalid timestamps while preserving category, unread, navigation, close, and mark-read behavior.
- Add focused helper and component regression coverage.

## Impact

Mobile notification rows now expose recency at a glance. Notification delivery, routing, and backend payloads are unchanged.

## Validation

- `npm test -- --run src/components/NotificationInboxSheet.test.tsx` (4 tests passed)
- `npm run typecheck`
- `npm run build`
- `npx eslint src/components/NotificationInboxSheet.tsx src/components/NotificationInboxSheet.test.tsx src/lib/notificationRecency.ts` (0 errors; 2 pre-existing `console.error` warnings)

Closes #3774
