### PR TITLE
Bound team calendar feed game reads

### DIFF
--- a/functions/calendar-feed-window-core.cjs
+++ b/functions/calendar-feed-window-core.cjs
@@ -1,0 +1,34 @@
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+const CALENDAR_FEED_LOOKBACK_DAYS = 90;
+const CALENDAR_FEED_LOOKAHEAD_DAYS = 365;
+
+function getCalendarFeedDateWindow(now = new Date()) {
+  const anchor = now instanceof Date ? new Date(now.getTime()) : new Date(now);
+  if (Number.isNaN(anchor.getTime())) {
+    throw new TypeError('Calendar feed window requires a valid date');
+  }
+
+  return {
+    start: new Date(anchor.getTime() - CALENDAR_FEED_LOOKBACK_DAYS * MILLIS_PER_DAY),
+    end: new Date(anchor.getTime() + CALENDAR_FEED_LOOKAHEAD_DAYS * MILLIS_PER_DAY)
+  };
+}
+
+function buildCalendarFeedGamesQuery(gamesCollection, { now = new Date() } = {}) {
+  if (!gamesCollection || typeof gamesCollection.where !== 'function') {
+    throw new TypeError('Calendar feed games collection must support bounded queries');
+  }
+
+  const { start, end } = getCalendarFeedDateWindow(now);
+  return gamesCollection
+    .where('date', '>=', start)
+    .where('date', '<=', end)
+    .orderBy('date');
+}
+
+module.exports = {
+  CALENDAR_FEED_LOOKAHEAD_DAYS,
+  CALENDAR_FEED_LOOKBACK_DAYS,
+  buildCalendarFeedGamesQuery,
+  getCalendarFeedDateWindow
+};

--- a/functions/index.js
+++ b/functions/index.js
@@ -31,6 +31,7 @@ const {
 } = require('./team-fees-core.cjs');
 const { createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
+const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
   buildTeamCalendarIcs,
   normalizeCalendarRequest
@@ -4540,6 +4541,10 @@ const calendarIcsCache = createCalendarIcsCache({
   ttlMs: process.env.CALENDAR_ICS_CACHE_TTL_MS
 });
 
+function getCalendarFeedGamesQuery(teamId) {
+  return buildCalendarFeedGamesQuery(firestore.collection(`teams/${teamId}/games`));
+}
+
 exports.publicTeamGamesIcs = functions
   .runWith(fetchCalendarRuntime)
   .https
@@ -4563,7 +4568,7 @@ exports.publicTeamGamesIcs = functions
       }
 
       const team = { id: teamId, ...(teamSnap.data() || {}) };
-      const gamesSnap = await firestore.collection(`teams/${teamId}/games`).get();
+      const gamesSnap = await getCalendarFeedGamesQuery(teamId).get();
       const games = [];
       gamesSnap.forEach((docSnap) => games.push({ id: docSnap.id, ...(docSnap.data() || {}) }));
       const publicGames = games.filter((game) => isPublicFanGame(team, game));
@@ -4656,7 +4661,7 @@ exports.teamCalendarFeed = functions.https.onRequest(async (req, res) => {
       return;
     }
 
-    const eventsSnap = await firestore.collection(`teams/${teamId}/games`).orderBy('date').get();
+    const eventsSnap = await getCalendarFeedGamesQuery(teamId).get();
     const events = eventsSnap.docs.map((docSnap) => {
       const game = { id: docSnap.id, ...(docSnap.data() || {}) };
       game.officiating = Array.isArray(game.officiating) ? game.officiating : (Array.isArray(game.officials) ? game.officials : []);

--- a/tests/unit/calendar-feed-window.test.js
+++ b/tests/unit/calendar-feed-window.test.js
@@ -1,0 +1,44 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+    CALENDAR_FEED_LOOKAHEAD_DAYS,
+    CALENDAR_FEED_LOOKBACK_DAYS,
+    buildCalendarFeedGamesQuery,
+    getCalendarFeedDateWindow
+} = require('../../functions/calendar-feed-window-core.cjs');
+
+describe('calendar feed game query window', () => {
+    it('keeps recent history and one future season in a bounded window', () => {
+        const { start, end } = getCalendarFeedDateWindow(new Date('2026-07-11T12:00:00.000Z'));
+
+        expect(CALENDAR_FEED_LOOKBACK_DAYS).toBe(90);
+        expect(CALENDAR_FEED_LOOKAHEAD_DAYS).toBe(365);
+        expect(start.toISOString()).toBe('2026-04-12T12:00:00.000Z');
+        expect(end.toISOString()).toBe('2027-07-11T12:00:00.000Z');
+    });
+
+    it('applies inclusive date bounds before ordering the games query', () => {
+        const query = {
+            where: vi.fn(),
+            orderBy: vi.fn()
+        };
+        query.where.mockReturnValue(query);
+        query.orderBy.mockReturnValue(query);
+
+        const result = buildCalendarFeedGamesQuery(query, {
+            now: new Date('2026-07-11T12:00:00.000Z')
+        });
+
+        expect(query.where).toHaveBeenNthCalledWith(1, 'date', '>=', new Date('2026-04-12T12:00:00.000Z'));
+        expect(query.where).toHaveBeenNthCalledWith(2, 'date', '<=', new Date('2027-07-11T12:00:00.000Z'));
+        expect(query.orderBy).toHaveBeenCalledWith('date');
+        expect(result).toBe(query);
+    });
+
+    it('rejects invalid anchors and unqueryable collections', () => {
+        expect(() => getCalendarFeedDateWindow('not-a-date')).toThrow('requires a valid date');
+        expect(() => buildCalendarFeedGamesQuery(null)).toThrow('must support bounded queries');
+    });
+});

--- a/tests/unit/public-calendar-core.test.js
+++ b/tests/unit/public-calendar-core.test.js
@@ -91,9 +91,16 @@ describe('public games calendar feed helpers', () => {
 
     it('runs the public feed function with the configured calendar runtime', () => {
         const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+        const feedStart = source.indexOf('exports.publicTeamGamesIcs = functions');
+        const feedEnd = source.indexOf('async function getCalendarTokenSnapshot', feedStart);
+        const publicFeedSource = source.slice(feedStart, feedEnd);
 
         expect(source).toContain('exports.publicTeamGamesIcs = functions\n  .runWith(fetchCalendarRuntime)');
-        expect(source).toContain('!canExposeEmptyPublicFeed(team)');
+        expect(publicFeedSource).toContain('getCalendarFeedGamesQuery(teamId).get()');
+        expect(publicFeedSource).toContain('games.filter((game) => isPublicFanGame(team, game))');
+        expect(publicFeedSource).toContain('buildPublicGamesIcs({ teamId, team, games: publicGames })');
+        expect(publicFeedSource).toContain('!canExposeEmptyPublicFeed(team)');
+        expect(publicFeedSource).not.toContain("firestore.collection(`teams/${teamId}/games`).get()");
     });
 
     it('uses stable public game UIDs', () => {

--- a/tests/unit/team-calendar-feed.test.js
+++ b/tests/unit/team-calendar-feed.test.js
@@ -149,7 +149,9 @@ describe('team calendar subscription feed', () => {
         const feedEnd = functionsSource.indexOf('exports.resolveFamilyShareTokenChildren', feedStart);
         const teamCalendarFeedSource = functionsSource.slice(feedStart, feedEnd);
 
-        expect(teamCalendarFeedSource).toContain("firestore.collection(`teams/${teamId}/games`).orderBy('date').get()");
+        expect(teamCalendarFeedSource).toContain('getCalendarFeedGamesQuery(teamId).get()');
+        expect(teamCalendarFeedSource).not.toContain("firestore.collection(`teams/${teamId}/games`).get()");
+        expect(teamCalendarFeedSource).not.toContain("firestore.collection(`teams/${teamId}/games`).orderBy('date').get()");
         expect(teamCalendarFeedSource).toContain('const game = { id: docSnap.id, ...(docSnap.data() || {}) }');
         expect(teamCalendarFeedSource).toContain('buildTeamCalendarIcs({ teamId, team, events })');
         expect(teamCalendarFeedSource).not.toContain('loadMissingTeamCalendarRsvpSummaries');


### PR DESCRIPTION
## Summary

- Add a shared calendar-feed games query with a 90-day lookback and 365-day lookahead.
- Use the bounded query for both `publicTeamGamesIcs` and `teamCalendarFeed`.
- Add helper-level boundary/query tests and endpoint source contracts that reject the prior unbounded reads.

## Root cause

Both calendar subscription endpoints read the full team games subcollection on every poll. Public feeds filtered visibility only after that full read, while private feeds ordered the full collection without applying any date bounds.

## Impact

Recurring Apple, Google, and public calendar polls now read only recent and upcoming schedule documents. Existing public visibility filtering, private token/access validation, RSVP-summary behavior, event mapping, and ICS formatting remain unchanged.

## Validation

- `npx vitest run tests/unit/calendar-feed-window.test.js tests/unit/team-calendar-feed.test.js tests/unit/public-calendar-core.test.js --environment node --reporter=verbose` (15 tests passed)
- `npm test --prefix functions` (60 tests passed)
- `node --check functions/calendar-feed-window-core.cjs`
- `node --check functions/index.js`

Closes #3782
