### PR TITLE
Make public RSVP summary refresh non-blocking

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -33,6 +33,11 @@ const { createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
+  buildPublicRsvpSummaryDelta,
+  refreshPublicRsvpSummary,
+  schedulePublicRsvpSummaryRefresh
+} = require('./public-rsvp-summary-core.cjs');
+const {
   buildTeamCalendarIcs,
   normalizeCalendarRequest
 } = require('./team-calendar-feed-core.cjs');
@@ -10666,6 +10671,76 @@ async function buildPublicRsvpSummary(teamId, gameId) {
   return summary;
 }
 
+async function loadPreviousPublicRsvpPlayerResponse(teamId, gameId, playerId) {
+  const rsvpsRef = firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`);
+  try {
+    const snapshots = await Promise.all([
+      rsvpsRef.where('playerIds', 'array-contains', playerId).get(),
+      rsvpsRef.where('playerId', '==', playerId).get(),
+      rsvpsRef.where('childId', '==', playerId).get()
+    ]);
+    const documents = new Map();
+    snapshots.forEach((snapshot) => snapshot.forEach((docSnap) => {
+      documents.set(docSnap.ref?.path || docSnap.id, docSnap);
+    }));
+
+    let latest = null;
+    let ambiguous = false;
+    documents.forEach((docSnap) => {
+      const rsvp = docSnap.data() || {};
+      if (!getPublicRsvpPlayerIds(rsvp).includes(playerId)) return;
+      const response = normalizePublicRsvpResponse(rsvp.response);
+      if (!response) return;
+      const respondedAtMs = getPublicRsvpResponseSortMs(rsvp, docSnap);
+      if (!latest || respondedAtMs > latest.respondedAtMs) {
+        latest = { response, respondedAtMs };
+        ambiguous = false;
+      } else if (respondedAtMs === latest.respondedAtMs && response !== latest.response) {
+        ambiguous = true;
+      }
+    });
+    return { previousResponse: latest?.response || '', ambiguous };
+  } catch (error) {
+    console.warn('Unable to load bounded public RSVP player state; using full summary fallback:', error);
+    return { previousResponse: '', ambiguous: true };
+  }
+}
+
+async function tryApplyPublicRsvpSummaryDelta({ teamId, gameId, playerId, previousResponse, nextResponse, ambiguous }) {
+  if (ambiguous) return false;
+  const gameRef = firestore.doc(`teams/${teamId}/games/${gameId}`);
+  try {
+    return await firestore.runTransaction(async (transaction) => {
+      const gameSnap = await transaction.get(gameRef);
+      if (!gameSnap.exists) return false;
+      const summary = buildPublicRsvpSummaryDelta({
+        summary: gameSnap.data()?.rsvpSummary,
+        playerId,
+        previousResponse,
+        nextResponse
+      });
+      if (!summary) return false;
+      transaction.set(gameRef, { rsvpSummary: summary }, { merge: true });
+      return true;
+    });
+  } catch (error) {
+    console.warn('Unable to apply bounded public RSVP summary delta; using full summary fallback:', error);
+    return false;
+  }
+}
+
+function refreshPublicRsvpSummaryInBackground(input) {
+  const gameRef = firestore.doc(`teams/${input.teamId}/games/${input.gameId}`);
+  schedulePublicRsvpSummaryRefresh(
+    () => refreshPublicRsvpSummary({
+      tryApplyDelta: () => tryApplyPublicRsvpSummaryDelta(input),
+      recomputeSummary: () => buildPublicRsvpSummary(input.teamId, input.gameId),
+      persistSummary: (summary) => gameRef.set({ rsvpSummary: summary }, { merge: true })
+    }),
+    (error) => console.error('Failed to refresh public RSVP summary:', error)
+  );
+}
+
 async function getPublicRsvpTokenData(token) {
   const tokenHash = publicRsvpHashToken(token);
   const tokenRef = firestore.doc(`publicRsvpTokens/${tokenHash}`);
@@ -10965,6 +11040,11 @@ exports.submitPublicRsvp = functions.https.onRequest(async (req, res) => {
     }
     const { tokenHash, tokenData } = await getPublicRsvpTokenData(token);
     const records = await assertUsablePublicRsvpToken(tokenData);
+    const previousPlayerState = await loadPreviousPublicRsvpPlayerResponse(
+      tokenData.teamId,
+      tokenData.gameId,
+      tokenData.playerId
+    );
     const docId = `public_${tokenHash.slice(0, 24)}`;
     await firestore.doc(`teams/${tokenData.teamId}/games/${tokenData.gameId}/rsvps/${docId}`).set({
       userId: docId,
@@ -10976,12 +11056,24 @@ exports.submitPublicRsvp = functions.https.onRequest(async (req, res) => {
       parentEmail: tokenData.parentEmail || null,
       respondedAt: admin.firestore.FieldValue.serverTimestamp()
     }, { merge: true });
-    const summary = await buildPublicRsvpSummary(tokenData.teamId, tokenData.gameId);
-    await firestore.doc(`teams/${tokenData.teamId}/games/${tokenData.gameId}`).set({ rsvpSummary: summary }, { merge: true });
     await firestore.doc(`publicRsvpTokens/${tokenHash}`).set({
       lastSubmittedAt: admin.firestore.FieldValue.serverTimestamp(),
       lastResponse: response
     }, { merge: true });
+    const summary = previousPlayerState.ambiguous ? null : buildPublicRsvpSummaryDelta({
+      summary: records.event.rsvpSummary,
+      playerId: tokenData.playerId,
+      previousResponse: previousPlayerState.previousResponse,
+      nextResponse: response
+    });
+    refreshPublicRsvpSummaryInBackground({
+      teamId: tokenData.teamId,
+      gameId: tokenData.gameId,
+      playerId: tokenData.playerId,
+      previousResponse: previousPlayerState.previousResponse,
+      nextResponse: response,
+      ambiguous: previousPlayerState.ambiguous
+    });
     res.status(200).json({ ok: true, context: buildPublicRsvpContext(records), summary });
   } catch (error) {
     publicRsvpJsonError(res, 403, error?.message || 'Unable to submit RSVP.');

--- a/functions/index.js
+++ b/functions/index.js
@@ -33,6 +33,7 @@ const { createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
+  buildPublicRsvpSummaryProjection,
   buildPublicRsvpSummaryJobPlan,
   refreshPublicRsvpSummary
 } = require('./public-rsvp-summary-core.cjs');
@@ -10677,26 +10678,42 @@ function getPublicRsvpSummaryPlayerStateRef(teamId, gameId, playerId) {
   return firestore.doc(`teams/${teamId}/games/${gameId}/rsvpSummaryPlayers/${playerId}`);
 }
 
+function getPublicRsvpSummaryStateRef(teamId, gameId) {
+  return firestore.doc(`publicRsvpSummaryStates/${teamId}__${gameId}`);
+}
+
 async function tryApplyPublicRsvpSummaryDelta({ jobId, teamId, gameId, playerId, response }) {
   const gameRef = firestore.doc(`teams/${teamId}/games/${gameId}`);
   const playerStateRef = getPublicRsvpSummaryPlayerStateRef(teamId, gameId, playerId);
+  const summaryStateRef = getPublicRsvpSummaryStateRef(teamId, gameId);
   return firestore.runTransaction(async (transaction) => {
-    const [gameSnap, playerStateSnap] = await Promise.all([
+    const [gameSnap, playerStateSnap, summaryStateSnap] = await Promise.all([
       transaction.get(gameRef),
-      transaction.get(playerStateRef)
+      transaction.get(playerStateRef),
+      transaction.get(summaryStateRef)
     ]);
     const playerState = playerStateSnap.exists ? (playerStateSnap.data() || {}) : {};
+    const summaryState = summaryStateSnap.exists ? (summaryStateSnap.data() || {}) : {};
     const plan = buildPublicRsvpSummaryJobPlan({
       jobId,
       response,
       playerState,
-      summary: gameSnap.data()?.rsvpSummary,
+      summary: {
+        ...(gameSnap.data()?.rsvpSummary || {}),
+        notRespondedPlayerIds: summaryState.notRespondedPlayerIds
+      },
       playerId
     });
     if (plan.mode === 'obsolete' || plan.mode === 'already_applied') return true;
     if (!gameSnap.exists) return false;
     if (plan.mode !== 'delta') return false;
-    transaction.set(gameRef, { rsvpSummary: plan.summary }, { merge: true });
+    transaction.set(gameRef, {
+      rsvpSummary: buildPublicRsvpSummaryProjection(plan.summary)
+    }, { mergeFields: ['rsvpSummary'] });
+    transaction.set(summaryStateRef, {
+      notRespondedPlayerIds: plan.summary.notRespondedPlayerIds,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
     transaction.set(playerStateRef, {
       appliedJobId: jobId,
       appliedResponse: response,
@@ -10709,11 +10726,18 @@ async function tryApplyPublicRsvpSummaryDelta({ jobId, teamId, gameId, playerId,
 async function persistRecomputedPublicRsvpSummary(input, summary) {
   const gameRef = firestore.doc(`teams/${input.teamId}/games/${input.gameId}`);
   const playerStateRef = getPublicRsvpSummaryPlayerStateRef(input.teamId, input.gameId, input.playerId);
+  const summaryStateRef = getPublicRsvpSummaryStateRef(input.teamId, input.gameId);
   return firestore.runTransaction(async (transaction) => {
     const playerStateSnap = await transaction.get(playerStateRef);
     const playerState = playerStateSnap.exists ? (playerStateSnap.data() || {}) : {};
     if (playerState.latestJobId !== input.jobId) return false;
-    transaction.set(gameRef, { rsvpSummary: summary }, { merge: true });
+    transaction.set(gameRef, {
+      rsvpSummary: buildPublicRsvpSummaryProjection(summary)
+    }, { mergeFields: ['rsvpSummary'] });
+    transaction.set(summaryStateRef, {
+      notRespondedPlayerIds: summary.notRespondedPlayerIds,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
     transaction.set(playerStateRef, {
       appliedJobId: input.jobId,
       appliedResponse: input.response,

--- a/functions/index.js
+++ b/functions/index.js
@@ -35,6 +35,7 @@ const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs
 const {
   buildPublicRsvpSummaryProjection,
   buildPublicRsvpSummaryJobPlan,
+  shouldPersistRecomputedPublicRsvpSummary,
   refreshPublicRsvpSummary
 } = require('./public-rsvp-summary-core.cjs');
 const {
@@ -10682,6 +10683,12 @@ function getPublicRsvpSummaryStateRef(teamId, gameId) {
   return firestore.doc(`publicRsvpSummaryStates/${teamId}__${gameId}`);
 }
 
+function getPublicRsvpSnapshotUpdateMillis(docSnap) {
+  if (!docSnap?.exists) return null;
+  if (typeof docSnap.updateTime?.toMillis === 'function') return docSnap.updateTime.toMillis();
+  return null;
+}
+
 async function tryApplyPublicRsvpSummaryDelta({ jobId, teamId, gameId, playerId, response }) {
   const gameRef = firestore.doc(`teams/${teamId}/games/${gameId}`);
   const playerStateRef = getPublicRsvpSummaryPlayerStateRef(teamId, gameId, playerId);
@@ -10728,9 +10735,17 @@ async function persistRecomputedPublicRsvpSummary(input, summary) {
   const playerStateRef = getPublicRsvpSummaryPlayerStateRef(input.teamId, input.gameId, input.playerId);
   const summaryStateRef = getPublicRsvpSummaryStateRef(input.teamId, input.gameId);
   return firestore.runTransaction(async (transaction) => {
-    const playerStateSnap = await transaction.get(playerStateRef);
+    const [playerStateSnap, summaryStateSnap] = await Promise.all([
+      transaction.get(playerStateRef),
+      transaction.get(summaryStateRef)
+    ]);
     const playerState = playerStateSnap.exists ? (playerStateSnap.data() || {}) : {};
-    if (playerState.latestJobId !== input.jobId) return false;
+    if (!shouldPersistRecomputedPublicRsvpSummary({
+      jobId: input.jobId,
+      playerState,
+      baselineStateUpdateMillis: input.summaryStateUpdateMillis,
+      currentStateUpdateMillis: getPublicRsvpSnapshotUpdateMillis(summaryStateSnap)
+    })) return false;
     transaction.set(gameRef, {
       rsvpSummary: buildPublicRsvpSummaryProjection(summary)
     }, { mergeFields: ['rsvpSummary'] });
@@ -10748,10 +10763,20 @@ async function persistRecomputedPublicRsvpSummary(input, summary) {
 }
 
 async function processPublicRsvpSummaryRefresh(input) {
+  const summaryStateRef = getPublicRsvpSummaryStateRef(input.teamId, input.gameId);
   return refreshPublicRsvpSummary({
     tryApplyDelta: () => tryApplyPublicRsvpSummaryDelta(input),
-    recomputeSummary: () => buildPublicRsvpSummary(input.teamId, input.gameId),
-    persistSummary: (summary) => persistRecomputedPublicRsvpSummary(input, summary)
+    recomputeSummary: async () => {
+      const summaryStateSnap = await summaryStateRef.get();
+      return {
+        summaryStateUpdateMillis: getPublicRsvpSnapshotUpdateMillis(summaryStateSnap),
+        summary: await buildPublicRsvpSummary(input.teamId, input.gameId)
+      };
+    },
+    persistSummary: ({ summaryStateUpdateMillis, summary }) => persistRecomputedPublicRsvpSummary({
+      ...input,
+      summaryStateUpdateMillis
+    }, summary)
   });
 }
 
@@ -11078,6 +11103,7 @@ exports.submitPublicRsvp = functions.https.onRequest(async (req, res) => {
     const docId = `public_${tokenHash.slice(0, 24)}`;
     const jobRef = firestore.collection('publicRsvpSummaryRefreshJobs').doc();
     const playerStateRef = getPublicRsvpSummaryPlayerStateRef(tokenData.teamId, tokenData.gameId, tokenData.playerId);
+    const summaryStateRef = getPublicRsvpSummaryStateRef(tokenData.teamId, tokenData.gameId);
     const batch = firestore.batch();
     batch.set(firestore.doc(`teams/${tokenData.teamId}/games/${tokenData.gameId}/rsvps/${docId}`), {
       userId: docId,
@@ -11096,6 +11122,11 @@ exports.submitPublicRsvp = functions.https.onRequest(async (req, res) => {
     batch.set(playerStateRef, {
       latestJobId: jobRef.id,
       latestResponse: response,
+      queuedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    batch.set(summaryStateRef, {
+      latestQueuedJobId: jobRef.id,
+      latestQueuedPlayerId: tokenData.playerId,
       queuedAt: admin.firestore.FieldValue.serverTimestamp()
     }, { merge: true });
     batch.set(jobRef, {

--- a/functions/index.js
+++ b/functions/index.js
@@ -33,9 +33,8 @@ const { createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
-  buildPublicRsvpSummaryDelta,
-  refreshPublicRsvpSummary,
-  schedulePublicRsvpSummaryRefresh
+  buildPublicRsvpSummaryJobPlan,
+  refreshPublicRsvpSummary
 } = require('./public-rsvp-summary-core.cjs');
 const {
   buildTeamCalendarIcs,
@@ -10668,78 +10667,90 @@ async function buildPublicRsvpSummary(teamId, gameId) {
     if (response === 'not_going') summary.notGoing += 1;
   });
   summary.notResponded = Math.max(activePlayerIds.size - responsesByPlayerId.size, 0);
+  summary.total = activePlayerIds.size;
+  summary.notRespondedPlayerIds = Array.from(activePlayerIds)
+    .filter((playerId) => !responsesByPlayerId.has(playerId));
   return summary;
 }
 
-async function loadPreviousPublicRsvpPlayerResponse(teamId, gameId, playerId) {
-  const rsvpsRef = firestore.collection(`teams/${teamId}/games/${gameId}/rsvps`);
-  try {
-    const snapshots = await Promise.all([
-      rsvpsRef.where('playerIds', 'array-contains', playerId).get(),
-      rsvpsRef.where('playerId', '==', playerId).get(),
-      rsvpsRef.where('childId', '==', playerId).get()
-    ]);
-    const documents = new Map();
-    snapshots.forEach((snapshot) => snapshot.forEach((docSnap) => {
-      documents.set(docSnap.ref?.path || docSnap.id, docSnap);
-    }));
-
-    let latest = null;
-    let ambiguous = false;
-    documents.forEach((docSnap) => {
-      const rsvp = docSnap.data() || {};
-      if (!getPublicRsvpPlayerIds(rsvp).includes(playerId)) return;
-      const response = normalizePublicRsvpResponse(rsvp.response);
-      if (!response) return;
-      const respondedAtMs = getPublicRsvpResponseSortMs(rsvp, docSnap);
-      if (!latest || respondedAtMs > latest.respondedAtMs) {
-        latest = { response, respondedAtMs };
-        ambiguous = false;
-      } else if (respondedAtMs === latest.respondedAtMs && response !== latest.response) {
-        ambiguous = true;
-      }
-    });
-    return { previousResponse: latest?.response || '', ambiguous };
-  } catch (error) {
-    console.warn('Unable to load bounded public RSVP player state; using full summary fallback:', error);
-    return { previousResponse: '', ambiguous: true };
-  }
+function getPublicRsvpSummaryPlayerStateRef(teamId, gameId, playerId) {
+  return firestore.doc(`teams/${teamId}/games/${gameId}/rsvpSummaryPlayers/${playerId}`);
 }
 
-async function tryApplyPublicRsvpSummaryDelta({ teamId, gameId, playerId, previousResponse, nextResponse, ambiguous }) {
-  if (ambiguous) return false;
+async function tryApplyPublicRsvpSummaryDelta({ jobId, teamId, gameId, playerId, response }) {
   const gameRef = firestore.doc(`teams/${teamId}/games/${gameId}`);
-  try {
-    return await firestore.runTransaction(async (transaction) => {
-      const gameSnap = await transaction.get(gameRef);
-      if (!gameSnap.exists) return false;
-      const summary = buildPublicRsvpSummaryDelta({
-        summary: gameSnap.data()?.rsvpSummary,
-        playerId,
-        previousResponse,
-        nextResponse
-      });
-      if (!summary) return false;
-      transaction.set(gameRef, { rsvpSummary: summary }, { merge: true });
-      return true;
+  const playerStateRef = getPublicRsvpSummaryPlayerStateRef(teamId, gameId, playerId);
+  return firestore.runTransaction(async (transaction) => {
+    const [gameSnap, playerStateSnap] = await Promise.all([
+      transaction.get(gameRef),
+      transaction.get(playerStateRef)
+    ]);
+    const playerState = playerStateSnap.exists ? (playerStateSnap.data() || {}) : {};
+    const plan = buildPublicRsvpSummaryJobPlan({
+      jobId,
+      response,
+      playerState,
+      summary: gameSnap.data()?.rsvpSummary,
+      playerId
     });
-  } catch (error) {
-    console.warn('Unable to apply bounded public RSVP summary delta; using full summary fallback:', error);
-    return false;
-  }
+    if (plan.mode === 'obsolete' || plan.mode === 'already_applied') return true;
+    if (!gameSnap.exists) return false;
+    if (plan.mode !== 'delta') return false;
+    transaction.set(gameRef, { rsvpSummary: plan.summary }, { merge: true });
+    transaction.set(playerStateRef, {
+      appliedJobId: jobId,
+      appliedResponse: response,
+      appliedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    return true;
+  });
 }
 
-function refreshPublicRsvpSummaryInBackground(input) {
+async function persistRecomputedPublicRsvpSummary(input, summary) {
   const gameRef = firestore.doc(`teams/${input.teamId}/games/${input.gameId}`);
-  schedulePublicRsvpSummaryRefresh(
-    () => refreshPublicRsvpSummary({
-      tryApplyDelta: () => tryApplyPublicRsvpSummaryDelta(input),
-      recomputeSummary: () => buildPublicRsvpSummary(input.teamId, input.gameId),
-      persistSummary: (summary) => gameRef.set({ rsvpSummary: summary }, { merge: true })
-    }),
-    (error) => console.error('Failed to refresh public RSVP summary:', error)
-  );
+  const playerStateRef = getPublicRsvpSummaryPlayerStateRef(input.teamId, input.gameId, input.playerId);
+  return firestore.runTransaction(async (transaction) => {
+    const playerStateSnap = await transaction.get(playerStateRef);
+    const playerState = playerStateSnap.exists ? (playerStateSnap.data() || {}) : {};
+    if (playerState.latestJobId !== input.jobId) return false;
+    transaction.set(gameRef, { rsvpSummary: summary }, { merge: true });
+    transaction.set(playerStateRef, {
+      appliedJobId: input.jobId,
+      appliedResponse: input.response,
+      appliedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    return true;
+  });
 }
+
+async function processPublicRsvpSummaryRefresh(input) {
+  return refreshPublicRsvpSummary({
+    tryApplyDelta: () => tryApplyPublicRsvpSummaryDelta(input),
+    recomputeSummary: () => buildPublicRsvpSummary(input.teamId, input.gameId),
+    persistSummary: (summary) => persistRecomputedPublicRsvpSummary(input, summary)
+  });
+}
+
+exports.processPublicRsvpSummaryRefreshJob = functions.firestore
+  .document('publicRsvpSummaryRefreshJobs/{jobId}')
+  .onCreate(async (jobSnap, context) => {
+    const data = jobSnap.data() || {};
+    const input = {
+      jobId: context.params.jobId,
+      teamId: normalizePublicRsvpText(data.teamId),
+      gameId: normalizePublicRsvpText(data.gameId),
+      playerId: normalizePublicRsvpText(data.playerId),
+      response: normalizePublicRsvpResponse(data.response)
+    };
+    if (!input.teamId || !input.gameId || !input.playerId || !input.response) {
+      console.error('Discarding invalid public RSVP summary refresh job:', context.params.jobId);
+      await jobSnap.ref.delete();
+      return null;
+    }
+    await processPublicRsvpSummaryRefresh(input);
+    await jobSnap.ref.delete();
+    return null;
+  });
 
 async function getPublicRsvpTokenData(token) {
   const tokenHash = publicRsvpHashToken(token);
@@ -11040,13 +11051,11 @@ exports.submitPublicRsvp = functions.https.onRequest(async (req, res) => {
     }
     const { tokenHash, tokenData } = await getPublicRsvpTokenData(token);
     const records = await assertUsablePublicRsvpToken(tokenData);
-    const previousPlayerState = await loadPreviousPublicRsvpPlayerResponse(
-      tokenData.teamId,
-      tokenData.gameId,
-      tokenData.playerId
-    );
     const docId = `public_${tokenHash.slice(0, 24)}`;
-    await firestore.doc(`teams/${tokenData.teamId}/games/${tokenData.gameId}/rsvps/${docId}`).set({
+    const jobRef = firestore.collection('publicRsvpSummaryRefreshJobs').doc();
+    const playerStateRef = getPublicRsvpSummaryPlayerStateRef(tokenData.teamId, tokenData.gameId, tokenData.playerId);
+    const batch = firestore.batch();
+    batch.set(firestore.doc(`teams/${tokenData.teamId}/games/${tokenData.gameId}/rsvps/${docId}`), {
       userId: docId,
       displayName: tokenData.parentName || tokenData.parentEmail || 'Parent RSVP',
       playerIds: [tokenData.playerId],
@@ -11056,25 +11065,24 @@ exports.submitPublicRsvp = functions.https.onRequest(async (req, res) => {
       parentEmail: tokenData.parentEmail || null,
       respondedAt: admin.firestore.FieldValue.serverTimestamp()
     }, { merge: true });
-    await firestore.doc(`publicRsvpTokens/${tokenHash}`).set({
+    batch.set(firestore.doc(`publicRsvpTokens/${tokenHash}`), {
       lastSubmittedAt: admin.firestore.FieldValue.serverTimestamp(),
       lastResponse: response
     }, { merge: true });
-    const summary = previousPlayerState.ambiguous ? null : buildPublicRsvpSummaryDelta({
-      summary: records.event.rsvpSummary,
-      playerId: tokenData.playerId,
-      previousResponse: previousPlayerState.previousResponse,
-      nextResponse: response
-    });
-    refreshPublicRsvpSummaryInBackground({
+    batch.set(playerStateRef, {
+      latestJobId: jobRef.id,
+      latestResponse: response,
+      queuedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+    batch.set(jobRef, {
       teamId: tokenData.teamId,
       gameId: tokenData.gameId,
       playerId: tokenData.playerId,
-      previousResponse: previousPlayerState.previousResponse,
-      nextResponse: response,
-      ambiguous: previousPlayerState.ambiguous
+      response,
+      createdAt: admin.firestore.FieldValue.serverTimestamp()
     });
-    res.status(200).json({ ok: true, context: buildPublicRsvpContext(records), summary });
+    await batch.commit();
+    res.status(200).json({ ok: true, context: buildPublicRsvpContext(records), summary: null });
   } catch (error) {
     publicRsvpJsonError(res, 403, error?.message || 'Unable to submit RSVP.');
   }

--- a/functions/public-rsvp-summary-core.cjs
+++ b/functions/public-rsvp-summary-core.cjs
@@ -4,6 +4,13 @@ const RESPONSE_SUMMARY_KEYS = {
   not_going: 'notGoing'
 };
 const SUMMARY_COUNT_KEYS = ['going', 'maybe', 'notGoing', 'notResponded'];
+const PUBLIC_SUMMARY_KEYS = [...SUMMARY_COUNT_KEYS, 'total'];
+
+function buildPublicRsvpSummaryProjection(summary = {}) {
+  return Object.fromEntries(PUBLIC_SUMMARY_KEYS
+    .filter((key) => Number.isInteger(summary[key]) && summary[key] >= 0)
+    .map((key) => [key, summary[key]]));
+}
 
 function buildPublicRsvpSummaryDelta({ summary, playerId, previousResponse, previousResponseVerified = false, nextResponse } = {}) {
   const nextKey = RESPONSE_SUMMARY_KEYS[nextResponse];
@@ -67,6 +74,7 @@ async function refreshPublicRsvpSummary({ tryApplyDelta, recomputeSummary, persi
 }
 
 module.exports = {
+  buildPublicRsvpSummaryProjection,
   buildPublicRsvpSummaryDelta,
   buildPublicRsvpSummaryJobPlan,
   refreshPublicRsvpSummary

--- a/functions/public-rsvp-summary-core.cjs
+++ b/functions/public-rsvp-summary-core.cjs
@@ -5,7 +5,7 @@ const RESPONSE_SUMMARY_KEYS = {
 };
 const SUMMARY_COUNT_KEYS = ['going', 'maybe', 'notGoing', 'notResponded'];
 
-function buildPublicRsvpSummaryDelta({ summary, playerId, previousResponse, nextResponse } = {}) {
+function buildPublicRsvpSummaryDelta({ summary, playerId, previousResponse, previousResponseVerified = false, nextResponse } = {}) {
   const nextKey = RESPONSE_SUMMARY_KEYS[nextResponse];
   const previousKey = previousResponse ? RESPONSE_SUMMARY_KEYS[previousResponse] : 'notResponded';
   if (!summary || typeof summary !== 'object' || !nextKey || !previousKey) return null;
@@ -20,20 +20,43 @@ function buildPublicRsvpSummaryDelta({ summary, playerId, previousResponse, next
     return null;
   }
 
-  if (summary.notRespondedPlayerIds !== undefined) {
-    if (!playerId || !Array.isArray(summary.notRespondedPlayerIds)) return null;
-    const normalizedPlayerId = String(playerId);
-    const wasNotResponded = summary.notRespondedPlayerIds.map(String).includes(normalizedPlayerId);
-    if ((!previousResponse && !wasNotResponded) || (previousResponse && wasNotResponded)) return null;
-    nextSummary.notRespondedPlayerIds = summary.notRespondedPlayerIds
-      .filter((id) => String(id) !== normalizedPlayerId);
-  }
+  if (!playerId || !Array.isArray(summary.notRespondedPlayerIds)) return null;
+  const normalizedPlayerId = String(playerId);
+  const wasNotResponded = summary.notRespondedPlayerIds.map(String).includes(normalizedPlayerId);
+  if ((!previousResponse && !wasNotResponded) || (previousResponse && (!previousResponseVerified || wasNotResponded))) return null;
+  nextSummary.notRespondedPlayerIds = summary.notRespondedPlayerIds
+    .filter((id) => String(id) !== normalizedPlayerId);
 
   if (previousKey === nextKey) return nextSummary;
   if (nextSummary[previousKey] < 1) return null;
   nextSummary[previousKey] -= 1;
   nextSummary[nextKey] += 1;
   return nextSummary;
+}
+
+function buildPublicRsvpSummaryJobPlan({ jobId, playerId, response, playerState = {}, summary } = {}) {
+  if (!jobId || playerState.latestJobId !== jobId) {
+    return { mode: 'obsolete', summary: null };
+  }
+  if (playerState.appliedJobId === jobId && playerState.appliedResponse === response) {
+    return { mode: 'already_applied', summary: null };
+  }
+  if (playerState.appliedJobId) {
+    return { mode: 'recompute', summary: null };
+  }
+  const appliedResponse = RESPONSE_SUMMARY_KEYS[playerState.appliedResponse]
+    ? playerState.appliedResponse
+    : '';
+  const nextSummary = buildPublicRsvpSummaryDelta({
+    summary,
+    playerId,
+    previousResponse: appliedResponse,
+    previousResponseVerified: false,
+    nextResponse: response
+  });
+  return nextSummary
+    ? { mode: 'delta', summary: nextSummary }
+    : { mode: 'recompute', summary: null };
 }
 
 async function refreshPublicRsvpSummary({ tryApplyDelta, recomputeSummary, persistSummary }) {
@@ -43,14 +66,8 @@ async function refreshPublicRsvpSummary({ tryApplyDelta, recomputeSummary, persi
   return 'recompute';
 }
 
-function schedulePublicRsvpSummaryRefresh(refresh, onError = () => {}) {
-  Promise.resolve()
-    .then(refresh)
-    .catch(onError);
-}
-
 module.exports = {
   buildPublicRsvpSummaryDelta,
-  refreshPublicRsvpSummary,
-  schedulePublicRsvpSummaryRefresh
+  buildPublicRsvpSummaryJobPlan,
+  refreshPublicRsvpSummary
 };

--- a/functions/public-rsvp-summary-core.cjs
+++ b/functions/public-rsvp-summary-core.cjs
@@ -66,16 +66,22 @@ function buildPublicRsvpSummaryJobPlan({ jobId, playerId, response, playerState 
     : { mode: 'recompute', summary: null };
 }
 
+function shouldPersistRecomputedPublicRsvpSummary({ jobId, playerState = {}, baselineStateUpdateMillis = null, currentStateUpdateMillis = null } = {}) {
+  if (!jobId || playerState.latestJobId !== jobId) return false;
+  return baselineStateUpdateMillis === currentStateUpdateMillis;
+}
+
 async function refreshPublicRsvpSummary({ tryApplyDelta, recomputeSummary, persistSummary }) {
   if (await tryApplyDelta()) return 'delta';
   const summary = await recomputeSummary();
-  await persistSummary(summary);
-  return 'recompute';
+  const persisted = await persistSummary(summary);
+  return persisted === false ? 'stale_recompute' : 'recompute';
 }
 
 module.exports = {
   buildPublicRsvpSummaryProjection,
   buildPublicRsvpSummaryDelta,
   buildPublicRsvpSummaryJobPlan,
+  shouldPersistRecomputedPublicRsvpSummary,
   refreshPublicRsvpSummary
 };

--- a/functions/public-rsvp-summary-core.cjs
+++ b/functions/public-rsvp-summary-core.cjs
@@ -1,0 +1,56 @@
+const RESPONSE_SUMMARY_KEYS = {
+  going: 'going',
+  maybe: 'maybe',
+  not_going: 'notGoing'
+};
+const SUMMARY_COUNT_KEYS = ['going', 'maybe', 'notGoing', 'notResponded'];
+
+function buildPublicRsvpSummaryDelta({ summary, playerId, previousResponse, nextResponse } = {}) {
+  const nextKey = RESPONSE_SUMMARY_KEYS[nextResponse];
+  const previousKey = previousResponse ? RESPONSE_SUMMARY_KEYS[previousResponse] : 'notResponded';
+  if (!summary || typeof summary !== 'object' || !nextKey || !previousKey) return null;
+
+  const nextSummary = { ...summary };
+  for (const key of SUMMARY_COUNT_KEYS) {
+    if (!Number.isInteger(summary[key]) || summary[key] < 0) return null;
+  }
+
+  const total = SUMMARY_COUNT_KEYS.reduce((sum, key) => sum + summary[key], 0);
+  if (summary.total !== undefined && (!Number.isInteger(summary.total) || summary.total !== total)) {
+    return null;
+  }
+
+  if (summary.notRespondedPlayerIds !== undefined) {
+    if (!playerId || !Array.isArray(summary.notRespondedPlayerIds)) return null;
+    const normalizedPlayerId = String(playerId);
+    const wasNotResponded = summary.notRespondedPlayerIds.map(String).includes(normalizedPlayerId);
+    if ((!previousResponse && !wasNotResponded) || (previousResponse && wasNotResponded)) return null;
+    nextSummary.notRespondedPlayerIds = summary.notRespondedPlayerIds
+      .filter((id) => String(id) !== normalizedPlayerId);
+  }
+
+  if (previousKey === nextKey) return nextSummary;
+  if (nextSummary[previousKey] < 1) return null;
+  nextSummary[previousKey] -= 1;
+  nextSummary[nextKey] += 1;
+  return nextSummary;
+}
+
+async function refreshPublicRsvpSummary({ tryApplyDelta, recomputeSummary, persistSummary }) {
+  if (await tryApplyDelta()) return 'delta';
+  const summary = await recomputeSummary();
+  await persistSummary(summary);
+  return 'recompute';
+}
+
+function schedulePublicRsvpSummaryRefresh(refresh, onError = () => {}) {
+  Promise.resolve()
+    .then(refresh)
+    .catch(onError);
+}
+
+module.exports = {
+  buildPublicRsvpSummaryDelta,
+  refreshPublicRsvpSummary,
+  schedulePublicRsvpSummaryRefresh
+};

--- a/functions/test/public-rsvp-summary.test.cjs
+++ b/functions/test/public-rsvp-summary.test.cjs
@@ -1,8 +1,28 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
+  buildPublicRsvpSummaryProjection,
   refreshPublicRsvpSummary
 } = require('../public-rsvp-summary-core.cjs');
+
+test('public RSVP summary projection strips the private player ledger', () => {
+  const summary = {
+    going: 1,
+    maybe: 0,
+    notGoing: 1,
+    notResponded: 2,
+    total: 4,
+    notRespondedPlayerIds: ['player-private-1', 'player-private-2']
+  };
+
+  assert.deepEqual(buildPublicRsvpSummaryProjection(summary), {
+    going: 1,
+    maybe: 0,
+    notGoing: 1,
+    notResponded: 2,
+    total: 4
+  });
+});
 
 test('public RSVP summary refresh uses a bounded delta without recomputing', async () => {
   let recomputeCount = 0;

--- a/functions/test/public-rsvp-summary.test.cjs
+++ b/functions/test/public-rsvp-summary.test.cjs
@@ -1,8 +1,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const {
-  refreshPublicRsvpSummary,
-  schedulePublicRsvpSummaryRefresh
+  refreshPublicRsvpSummary
 } = require('../public-rsvp-summary-core.cjs');
 
 test('public RSVP summary refresh uses a bounded delta without recomputing', async () => {
@@ -41,22 +40,27 @@ test('public RSVP summary refresh falls back to recompute when the delta is unsa
   assert.equal(persistedSummary, summary);
 });
 
-test('public RSVP summary scheduling returns before background work settles', async () => {
+test('public RSVP summary refresh remains pending until durable fallback work settles', async () => {
   let release;
-  let settled = false;
+  let persisted = false;
   const blocked = new Promise((resolve) => {
     release = resolve;
   });
 
-  const result = schedulePublicRsvpSummaryRefresh(async () => {
-    await blocked;
-    settled = true;
+  const lifecycle = refreshPublicRsvpSummary({
+    tryApplyDelta: async () => false,
+    recomputeSummary: async () => {
+      await blocked;
+      return { going: 1 };
+    },
+    persistSummary: async () => {
+      persisted = true;
+    }
   });
 
-  assert.equal(result, undefined);
-  assert.equal(settled, false);
-  release();
-  await blocked;
   await new Promise((resolve) => setImmediate(resolve));
-  assert.equal(settled, true);
+  assert.equal(persisted, false);
+  release();
+  assert.equal(await lifecycle, 'recompute');
+  assert.equal(persisted, true);
 });

--- a/functions/test/public-rsvp-summary.test.cjs
+++ b/functions/test/public-rsvp-summary.test.cjs
@@ -1,0 +1,62 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {
+  refreshPublicRsvpSummary,
+  schedulePublicRsvpSummaryRefresh
+} = require('../public-rsvp-summary-core.cjs');
+
+test('public RSVP summary refresh uses a bounded delta without recomputing', async () => {
+  let recomputeCount = 0;
+  let persistCount = 0;
+
+  const mode = await refreshPublicRsvpSummary({
+    tryApplyDelta: async () => true,
+    recomputeSummary: async () => {
+      recomputeCount += 1;
+      return {};
+    },
+    persistSummary: async () => {
+      persistCount += 1;
+    }
+  });
+
+  assert.equal(mode, 'delta');
+  assert.equal(recomputeCount, 0);
+  assert.equal(persistCount, 0);
+});
+
+test('public RSVP summary refresh falls back to recompute when the delta is unsafe', async () => {
+  const summary = { going: 1, maybe: 0, notGoing: 0, notResponded: 2 };
+  let persistedSummary = null;
+
+  const mode = await refreshPublicRsvpSummary({
+    tryApplyDelta: async () => false,
+    recomputeSummary: async () => summary,
+    persistSummary: async (value) => {
+      persistedSummary = value;
+    }
+  });
+
+  assert.equal(mode, 'recompute');
+  assert.equal(persistedSummary, summary);
+});
+
+test('public RSVP summary scheduling returns before background work settles', async () => {
+  let release;
+  let settled = false;
+  const blocked = new Promise((resolve) => {
+    release = resolve;
+  });
+
+  const result = schedulePublicRsvpSummaryRefresh(async () => {
+    await blocked;
+    settled = true;
+  });
+
+  assert.equal(result, undefined);
+  assert.equal(settled, false);
+  release();
+  await blocked;
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, true);
+});

--- a/functions/test/public-rsvp-summary.test.cjs
+++ b/functions/test/public-rsvp-summary.test.cjs
@@ -60,6 +60,16 @@ test('public RSVP summary refresh falls back to recompute when the delta is unsa
   assert.equal(persistedSummary, summary);
 });
 
+test('public RSVP summary refresh skips stale recompute persistence', async () => {
+  const mode = await refreshPublicRsvpSummary({
+    tryApplyDelta: async () => false,
+    recomputeSummary: async () => ({ going: 1 }),
+    persistSummary: async () => false
+  });
+
+  assert.equal(mode, 'stale_recompute');
+});
+
 test('public RSVP summary refresh remains pending until durable fallback work settles', async () => {
   let release;
   let persisted = false;

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -273,6 +273,7 @@
                 "notifyGameUpdated",
                 "notifyScheduleImportBatchCompleted",
                 "postSharedGameCancellationNotification",
+                "processPublicRsvpSummaryRefreshJob",
                 "publicTeamGamesIcs",
                 "publishOrganizationScheduleDraft",
                 "redeemScopedRsvpToken",

--- a/tests/unit/public-rsvp-functions-source.test.js
+++ b/tests/unit/public-rsvp-functions-source.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 
 function getSourceSection(startMarker, endMarker) {
     const start = source.indexOf(startMarker);
@@ -60,6 +61,14 @@ describe('public RSVP function safeguards', () => {
         );
 
         expect(workerSource).toContain('buildPublicRsvpSummaryJobPlan({');
+        expect(workerSource).toContain('getPublicRsvpSummaryStateRef(teamId, gameId)');
+        expect(workerSource).toContain('notRespondedPlayerIds: summaryState.notRespondedPlayerIds');
+        expect(workerSource).toContain('rsvpSummary: buildPublicRsvpSummaryProjection(plan.summary)');
+        expect(workerSource).toContain('notRespondedPlayerIds: plan.summary.notRespondedPlayerIds');
+        expect(workerSource).toContain('rsvpSummary: buildPublicRsvpSummaryProjection(summary)');
+        expect(workerSource).toContain('notRespondedPlayerIds: summary.notRespondedPlayerIds');
+        expect(workerSource).toContain("{ mergeFields: ['rsvpSummary'] }");
+        expect(rules).not.toContain('match /publicRsvpSummaryStates');
         expect(workerSource).toContain("if (plan.mode === 'obsolete' || plan.mode === 'already_applied') return true;");
         expect(workerSource).toContain(".document('publicRsvpSummaryRefreshJobs/{jobId}')");
         expect(workerSource).toContain('await processPublicRsvpSummaryRefresh(input)');

--- a/tests/unit/public-rsvp-functions-source.test.js
+++ b/tests/unit/public-rsvp-functions-source.test.js
@@ -45,6 +45,8 @@ describe('public RSVP function safeguards', () => {
         expect(submitSource).toContain('await assertUsablePublicRsvpToken(tokenData)');
         expect(submitSource).toContain("firestore.collection('publicRsvpSummaryRefreshJobs').doc()");
         expect(submitSource).toContain('batch.set(playerStateRef, {');
+        expect(submitSource).toContain('batch.set(summaryStateRef, {');
+        expect(submitSource).toContain('latestQueuedJobId: jobRef.id');
         expect(submitSource).toContain('batch.set(jobRef, {');
         expect(submitSource).toContain('await batch.commit()');
         expect(submitSource).not.toContain('await buildPublicRsvpSummary');
@@ -63,6 +65,10 @@ describe('public RSVP function safeguards', () => {
         expect(workerSource).toContain('buildPublicRsvpSummaryJobPlan({');
         expect(workerSource).toContain('getPublicRsvpSummaryStateRef(teamId, gameId)');
         expect(workerSource).toContain('notRespondedPlayerIds: summaryState.notRespondedPlayerIds');
+        expect(workerSource).toContain('shouldPersistRecomputedPublicRsvpSummary({');
+        expect(workerSource).toContain('baselineStateUpdateMillis: input.summaryStateUpdateMillis');
+        expect(workerSource).toContain('currentStateUpdateMillis: getPublicRsvpSnapshotUpdateMillis(summaryStateSnap)');
+        expect(workerSource).toContain('const summaryStateSnap = await summaryStateRef.get();');
         expect(workerSource).toContain('rsvpSummary: buildPublicRsvpSummaryProjection(plan.summary)');
         expect(workerSource).toContain('notRespondedPlayerIds: plan.summary.notRespondedPlayerIds');
         expect(workerSource).toContain('rsvpSummary: buildPublicRsvpSummaryProjection(summary)');

--- a/tests/unit/public-rsvp-functions-source.test.js
+++ b/tests/unit/public-rsvp-functions-source.test.js
@@ -29,38 +29,42 @@ describe('public RSVP function safeguards', () => {
             .toBeLessThan(source.indexOf("const respondedAt = coercePublicRsvpDate(rsvp?.respondedAt || rsvp?.updatedAt || rsvp?.createdAt);"));
         expect(source).toContain('responsesByPlayerId.set(playerId, { response, respondedAtMs });');
         expect(source).toContain('summary.notResponded = Math.max(activePlayerIds.size - responsesByPlayerId.size, 0);');
+        expect(source).toContain('summary.notRespondedPlayerIds = Array.from(activePlayerIds)');
         expect(source).not.toContain('summary.going += increment');
         expect(source).not.toContain('summary.maybe += increment');
         expect(source).not.toContain('summary.notGoing += increment');
     });
 
-    it('submits public RSVPs without blocking on full summary scans', () => {
+    it('submits public RSVPs with an atomically enqueued durable summary refresh', () => {
         const submitSource = getSourceSection(
             'exports.submitPublicRsvp = functions.https.onRequest',
             'exports.collectTelemetry'
         );
 
         expect(submitSource).toContain('await assertUsablePublicRsvpToken(tokenData)');
-        expect(submitSource).toContain('await loadPreviousPublicRsvpPlayerResponse(');
-        expect(submitSource).toContain('refreshPublicRsvpSummaryInBackground({');
+        expect(submitSource).toContain("firestore.collection('publicRsvpSummaryRefreshJobs').doc()");
+        expect(submitSource).toContain('batch.set(playerStateRef, {');
+        expect(submitSource).toContain('batch.set(jobRef, {');
+        expect(submitSource).toContain('await batch.commit()');
         expect(submitSource).not.toContain('await buildPublicRsvpSummary');
         expect(submitSource).not.toContain("firestore.collection(`teams/${tokenData.teamId}/players`).get()");
         expect(submitSource).not.toContain("firestore.collection(`teams/${tokenData.teamId}/games/${tokenData.gameId}/rsvps`).get()");
-        expect(submitSource.indexOf('refreshPublicRsvpSummaryInBackground({'))
+        expect(submitSource.indexOf('await batch.commit()'))
             .toBeLessThan(submitSource.indexOf('res.status(200).json'));
     });
 
-    it('loads only the target player RSVP state for the request-path delta', () => {
-        const loaderSource = getSourceSection(
-            'async function loadPreviousPublicRsvpPlayerResponse',
-            'async function tryApplyPublicRsvpSummaryDelta'
+    it('awaits the durable worker lifecycle and verifies per-player job ordering', () => {
+        const workerSource = getSourceSection(
+            'async function tryApplyPublicRsvpSummaryDelta',
+            'async function getPublicRsvpTokenData'
         );
 
-        expect(loaderSource).toContain("where('playerIds', 'array-contains', playerId).get()");
-        expect(loaderSource).toContain("where('playerId', '==', playerId).get()");
-        expect(loaderSource).toContain("where('childId', '==', playerId).get()");
-        expect(loaderSource).not.toContain('players`).get()');
-        expect(loaderSource).not.toContain('rsvps`).get()');
+        expect(workerSource).toContain('buildPublicRsvpSummaryJobPlan({');
+        expect(workerSource).toContain("if (plan.mode === 'obsolete' || plan.mode === 'already_applied') return true;");
+        expect(workerSource).toContain(".document('publicRsvpSummaryRefreshJobs/{jobId}')");
+        expect(workerSource).toContain('await processPublicRsvpSummaryRefresh(input)');
+        expect(workerSource).toContain('await jobSnap.ref.delete()');
+        expect(workerSource).not.toContain('schedulePublicRsvpSummaryRefresh');
     });
 
     it('chunks public RSVP email writes before hitting the Firestore batch limit', () => {

--- a/tests/unit/public-rsvp-functions-source.test.js
+++ b/tests/unit/public-rsvp-functions-source.test.js
@@ -3,6 +3,14 @@ import { readFileSync } from 'node:fs';
 
 const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 
+function getSourceSection(startMarker, endMarker) {
+    const start = source.indexOf(startMarker);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const end = source.indexOf(endMarker, start);
+    expect(end).toBeGreaterThan(start);
+    return source.slice(start, end);
+}
+
 describe('public RSVP function safeguards', () => {
     it('does not ship hardcoded Twilio credentials', () => {
         expect(source).not.toMatch(/AC[0-9a-f]{32}/i);
@@ -24,6 +32,35 @@ describe('public RSVP function safeguards', () => {
         expect(source).not.toContain('summary.going += increment');
         expect(source).not.toContain('summary.maybe += increment');
         expect(source).not.toContain('summary.notGoing += increment');
+    });
+
+    it('submits public RSVPs without blocking on full summary scans', () => {
+        const submitSource = getSourceSection(
+            'exports.submitPublicRsvp = functions.https.onRequest',
+            'exports.collectTelemetry'
+        );
+
+        expect(submitSource).toContain('await assertUsablePublicRsvpToken(tokenData)');
+        expect(submitSource).toContain('await loadPreviousPublicRsvpPlayerResponse(');
+        expect(submitSource).toContain('refreshPublicRsvpSummaryInBackground({');
+        expect(submitSource).not.toContain('await buildPublicRsvpSummary');
+        expect(submitSource).not.toContain("firestore.collection(`teams/${tokenData.teamId}/players`).get()");
+        expect(submitSource).not.toContain("firestore.collection(`teams/${tokenData.teamId}/games/${tokenData.gameId}/rsvps`).get()");
+        expect(submitSource.indexOf('refreshPublicRsvpSummaryInBackground({'))
+            .toBeLessThan(submitSource.indexOf('res.status(200).json'));
+    });
+
+    it('loads only the target player RSVP state for the request-path delta', () => {
+        const loaderSource = getSourceSection(
+            'async function loadPreviousPublicRsvpPlayerResponse',
+            'async function tryApplyPublicRsvpSummaryDelta'
+        );
+
+        expect(loaderSource).toContain("where('playerIds', 'array-contains', playerId).get()");
+        expect(loaderSource).toContain("where('playerId', '==', playerId).get()");
+        expect(loaderSource).toContain("where('childId', '==', playerId).get()");
+        expect(loaderSource).not.toContain('players`).get()');
+        expect(loaderSource).not.toContain('rsvps`).get()');
     });
 
     it('chunks public RSVP email writes before hitting the Firestore batch limit', () => {

--- a/tests/unit/public-rsvp-summary-delta.test.js
+++ b/tests/unit/public-rsvp-summary-delta.test.js
@@ -2,18 +2,35 @@ import { createRequire } from 'node:module';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { buildPublicRsvpSummaryDelta } = require('../../functions/public-rsvp-summary-core.cjs');
+const {
+    buildPublicRsvpSummaryDelta,
+    buildPublicRsvpSummaryJobPlan
+} = require('../../functions/public-rsvp-summary-core.cjs');
 
 describe('public RSVP summary delta', () => {
-    const baseSummary = { going: 1, maybe: 1, notGoing: 0, notResponded: 2, total: 4 };
+    const baseSummary = {
+        going: 1,
+        maybe: 1,
+        notGoing: 0,
+        notResponded: 2,
+        total: 4,
+        notRespondedPlayerIds: ['player-3', 'player-4']
+    };
 
     it('moves a first response out of not responded', () => {
         expect(buildPublicRsvpSummaryDelta({
-            summary: baseSummary,
+            summary: { ...baseSummary, notRespondedPlayerIds: ['player-1', 'player-4'] },
             playerId: 'player-1',
             previousResponse: '',
             nextResponse: 'going'
-        })).toEqual({ going: 2, maybe: 1, notGoing: 0, notResponded: 1, total: 4 });
+        })).toEqual({
+            going: 2,
+            maybe: 1,
+            notGoing: 0,
+            notResponded: 1,
+            total: 4,
+            notRespondedPlayerIds: ['player-4']
+        });
     });
 
     it('moves a changed response between response buckets', () => {
@@ -21,8 +38,9 @@ describe('public RSVP summary delta', () => {
             summary: baseSummary,
             playerId: 'player-1',
             previousResponse: 'maybe',
+            previousResponseVerified: true,
             nextResponse: 'not_going'
-        })).toEqual({ going: 1, maybe: 0, notGoing: 1, notResponded: 2, total: 4 });
+        })).toEqual({ ...baseSummary, maybe: 0, notGoing: 1 });
     });
 
     it('leaves a repeated response unchanged', () => {
@@ -30,6 +48,7 @@ describe('public RSVP summary delta', () => {
             summary: baseSummary,
             playerId: 'player-1',
             previousResponse: 'going',
+            previousResponseVerified: true,
             nextResponse: 'going'
         })).toEqual(baseSummary);
     });
@@ -55,18 +74,90 @@ describe('public RSVP summary delta', () => {
     it('requires a full recompute for missing or ambiguous summary state', () => {
         expect(buildPublicRsvpSummaryDelta({
             summary: null,
+            playerId: 'player-1',
             previousResponse: '',
             nextResponse: 'going'
         })).toBeNull();
         expect(buildPublicRsvpSummaryDelta({
-            summary: { ...baseSummary, going: 0 },
+            summary: baseSummary,
+            playerId: 'player-1',
             previousResponse: 'going',
             nextResponse: 'maybe'
         })).toBeNull();
         expect(buildPublicRsvpSummaryDelta({
             summary: { ...baseSummary, total: 99 },
+            playerId: 'player-3',
             previousResponse: '',
             nextResponse: 'going'
         })).toBeNull();
+    });
+
+    it('rejects a concurrent stale first-response delta after membership already moved', () => {
+        const initial = { ...baseSummary, notRespondedPlayerIds: ['player-1', 'player-4'] };
+        const first = buildPublicRsvpSummaryDelta({
+            summary: initial,
+            playerId: 'player-1',
+            previousResponse: '',
+            nextResponse: 'going'
+        });
+
+        expect(first).not.toBeNull();
+        expect(buildPublicRsvpSummaryDelta({
+            summary: first,
+            playerId: 'player-1',
+            previousResponse: '',
+            nextResponse: 'maybe'
+        })).toBeNull();
+    });
+
+    it('orders concurrent token jobs through the per-player applied-response ledger', () => {
+        const initial = { ...baseSummary, notRespondedPlayerIds: ['player-1', 'player-4'] };
+
+        expect(buildPublicRsvpSummaryJobPlan({
+            jobId: 'job-a',
+            playerId: 'player-1',
+            response: 'going',
+            playerState: { latestJobId: 'job-b', latestResponse: 'maybe' },
+            summary: initial
+        })).toEqual({ mode: 'obsolete', summary: null });
+
+        const latestPlan = buildPublicRsvpSummaryJobPlan({
+            jobId: 'job-b',
+            playerId: 'player-1',
+            response: 'maybe',
+            playerState: { latestJobId: 'job-b', latestResponse: 'maybe' },
+            summary: initial
+        });
+        expect(latestPlan).toMatchObject({
+            mode: 'delta',
+            summary: { going: 1, maybe: 2, notGoing: 0, notResponded: 1, total: 4 }
+        });
+
+        const changedPlan = buildPublicRsvpSummaryJobPlan({
+            jobId: 'job-c',
+            playerId: 'player-1',
+            response: 'not_going',
+            playerState: {
+                latestJobId: 'job-c',
+                latestResponse: 'not_going',
+                appliedJobId: 'job-b',
+                appliedResponse: 'maybe'
+            },
+            summary: latestPlan.summary
+        });
+        expect(changedPlan).toEqual({ mode: 'recompute', summary: null });
+
+        expect(buildPublicRsvpSummaryJobPlan({
+            jobId: 'job-b',
+            playerId: 'player-1',
+            response: 'maybe',
+            playerState: {
+                latestJobId: 'job-b',
+                latestResponse: 'maybe',
+                appliedJobId: 'job-b',
+                appliedResponse: 'maybe'
+            },
+            summary: latestPlan.summary
+        })).toEqual({ mode: 'already_applied', summary: null });
     });
 });

--- a/tests/unit/public-rsvp-summary-delta.test.js
+++ b/tests/unit/public-rsvp-summary-delta.test.js
@@ -1,0 +1,72 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { buildPublicRsvpSummaryDelta } = require('../../functions/public-rsvp-summary-core.cjs');
+
+describe('public RSVP summary delta', () => {
+    const baseSummary = { going: 1, maybe: 1, notGoing: 0, notResponded: 2, total: 4 };
+
+    it('moves a first response out of not responded', () => {
+        expect(buildPublicRsvpSummaryDelta({
+            summary: baseSummary,
+            playerId: 'player-1',
+            previousResponse: '',
+            nextResponse: 'going'
+        })).toEqual({ going: 2, maybe: 1, notGoing: 0, notResponded: 1, total: 4 });
+    });
+
+    it('moves a changed response between response buckets', () => {
+        expect(buildPublicRsvpSummaryDelta({
+            summary: baseSummary,
+            playerId: 'player-1',
+            previousResponse: 'maybe',
+            nextResponse: 'not_going'
+        })).toEqual({ going: 1, maybe: 0, notGoing: 1, notResponded: 2, total: 4 });
+    });
+
+    it('leaves a repeated response unchanged', () => {
+        expect(buildPublicRsvpSummaryDelta({
+            summary: baseSummary,
+            playerId: 'player-1',
+            previousResponse: 'going',
+            nextResponse: 'going'
+        })).toEqual(baseSummary);
+    });
+
+    it('updates a tracked not-responded player list when present', () => {
+        const summary = { ...baseSummary, notRespondedPlayerIds: ['player-1', 'player-2'] };
+
+        expect(buildPublicRsvpSummaryDelta({
+            summary,
+            playerId: 'player-1',
+            previousResponse: '',
+            nextResponse: 'maybe'
+        })).toEqual({
+            going: 1,
+            maybe: 2,
+            notGoing: 0,
+            notResponded: 1,
+            total: 4,
+            notRespondedPlayerIds: ['player-2']
+        });
+    });
+
+    it('requires a full recompute for missing or ambiguous summary state', () => {
+        expect(buildPublicRsvpSummaryDelta({
+            summary: null,
+            previousResponse: '',
+            nextResponse: 'going'
+        })).toBeNull();
+        expect(buildPublicRsvpSummaryDelta({
+            summary: { ...baseSummary, going: 0 },
+            previousResponse: 'going',
+            nextResponse: 'maybe'
+        })).toBeNull();
+        expect(buildPublicRsvpSummaryDelta({
+            summary: { ...baseSummary, total: 99 },
+            previousResponse: '',
+            nextResponse: 'going'
+        })).toBeNull();
+    });
+});

--- a/tests/unit/public-rsvp-summary-delta.test.js
+++ b/tests/unit/public-rsvp-summary-delta.test.js
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const {
+    buildPublicRsvpSummaryProjection,
     buildPublicRsvpSummaryDelta,
     buildPublicRsvpSummaryJobPlan
 } = require('../../functions/public-rsvp-summary-core.cjs');
@@ -16,6 +17,20 @@ describe('public RSVP summary delta', () => {
         total: 4,
         notRespondedPlayerIds: ['player-3', 'player-4']
     };
+
+    it('projects only aggregate counts onto the public game document', () => {
+        const publicSummary = buildPublicRsvpSummaryProjection(baseSummary);
+
+        expect(publicSummary).toEqual({
+            going: 1,
+            maybe: 1,
+            notGoing: 0,
+            notResponded: 2,
+            total: 4
+        });
+        expect(publicSummary).not.toHaveProperty('notRespondedPlayerIds');
+        expect(JSON.stringify(publicSummary)).not.toContain('player-');
+    });
 
     it('moves a first response out of not responded', () => {
         expect(buildPublicRsvpSummaryDelta({

--- a/tests/unit/public-rsvp-summary-delta.test.js
+++ b/tests/unit/public-rsvp-summary-delta.test.js
@@ -5,7 +5,8 @@ const require = createRequire(import.meta.url);
 const {
     buildPublicRsvpSummaryProjection,
     buildPublicRsvpSummaryDelta,
-    buildPublicRsvpSummaryJobPlan
+    buildPublicRsvpSummaryJobPlan,
+    shouldPersistRecomputedPublicRsvpSummary
 } = require('../../functions/public-rsvp-summary-core.cjs');
 
 describe('public RSVP summary delta', () => {
@@ -174,5 +175,28 @@ describe('public RSVP summary delta', () => {
             },
             summary: latestPlan.summary
         })).toEqual({ mode: 'already_applied', summary: null });
+    });
+
+    it('rejects stale cross-player recompute persistence after shared state advances', () => {
+        expect(shouldPersistRecomputedPublicRsvpSummary({
+            jobId: 'player-a-job',
+            playerState: { latestJobId: 'player-a-job' },
+            baselineStateUpdateMillis: 1000,
+            currentStateUpdateMillis: 1000
+        })).toBe(true);
+
+        expect(shouldPersistRecomputedPublicRsvpSummary({
+            jobId: 'player-a-job',
+            playerState: { latestJobId: 'player-a-job' },
+            baselineStateUpdateMillis: 1000,
+            currentStateUpdateMillis: 2000
+        })).toBe(false);
+
+        expect(shouldPersistRecomputedPublicRsvpSummary({
+            jobId: 'player-a-job',
+            playerState: { latestJobId: 'newer-player-a-job' },
+            baselineStateUpdateMillis: 1000,
+            currentStateUpdateMillis: 1000
+        })).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

- Replace public RSVP submit-time full roster/RSVP scans with an atomically enqueued Firestore refresh job.
- Process refresh jobs in an awaited Firestore trigger lifecycle instead of a dropped in-process Promise.
- Apply safe first-response deltas through a single-game/per-player transaction.
- Order concurrent token submissions with a per-player latest/applied job ledger; changed, missing, inconsistent, or ambiguous summary state uses the durable full recompute.
- Add delta, concurrency, durable lifecycle, and endpoint source-contract coverage.

## Root cause

`submitPublicRsvp` originally awaited `buildPublicRsvpSummary` after every RSVP write, forcing the parent request to read the full active roster and full event RSVP collection. The first optimization moved that work to an in-process Promise, which was not durable after an HTTP response and still allowed concurrent-token deltas to use stale previous state.

## Impact

Successful public RSVP submissions now atomically commit the RSVP, token metadata, per-player sequencing state, and a durable refresh job before returning. Summary maintenance cannot make a saved response time out, and concurrent tokens cannot double-count one player. Token expiry, event/player validation, active-player checks, latest-response aggregation, and public page response choices remain unchanged.

## Validation

- Focused public RSVP Vitest suites: 17 tests passed.
- Adjacent public RSVP/CORS/reminder Vitest suites: 8 tests passed.
- `npm test --prefix functions`: 63 tests passed.
- `node --check functions/public-rsvp-summary-core.cjs`
- `node --check functions/index.js`
- `node --check functions/test/public-rsvp-summary.test.cjs`

Closes #3790
