### PR TITLE
Defer app search team hydration until query intent

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -654,6 +654,55 @@ describe('AppSearchDialog', () => {
     await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
   });
 
+  it('repeats a provisional search when hydration enriches the same team IDs', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears' }];
+    const hydratedTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Soccer', zip: '64114' }];
+    let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
+
+    getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
+    loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseHydration = resolve;
+    }));
+    searchAppTeamsMock.mockImplementation(async (query, searchTeams) => {
+      const normalizedQuery = query.trim().toLowerCase();
+      return searchTeams.filter((team) => [team.name, team.sport, team.zip]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedQuery));
+    });
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'soccer' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(430);
+      await Promise.resolve();
+    });
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
+    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'soccer', initialTeams, null);
+    expect(screen.queryByRole('button', { name: /Bears/i })).toBeNull();
+
+    await act(async () => {
+      releaseHydration(hydratedTeams);
+      await vi.advanceTimersByTimeAsync(50);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(searchAppTeamsMock).toHaveBeenCalledTimes(2);
+    expect(searchAppTeamsMock).toHaveBeenNthCalledWith(2, 'soccer', hydratedTeams, null);
+    expect(screen.getByRole('button', { name: /Bears/i })).not.toBeNull();
+    expect(screen.getByText('Soccer • 64114')).not.toBeNull();
+  });
+
   it('shows provisional local team matches while hydration is pending, then runs a provisional search before hydrating again', async () => {
     vi.useFakeTimers();
     const onClose = vi.fn();

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -49,7 +49,7 @@ const {
     if (normalizedQuery.length < 2) return teams;
     return teams.filter((team) => team.name.toLowerCase().includes(normalizedQuery));
   }),
-  getKnownAppSearchTeamsMock: vi.fn((): AppSearchTeam[] => []),
+  getKnownAppSearchTeamsMock: vi.fn((_user: AuthState['user']): AppSearchTeam[] => []),
   loadAppSearchTeamsMock: vi.fn(async (): Promise<AppSearchTeam[]> => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
   searchAppTeamsMock: vi.fn<(query: string, teams: AppSearchTeam[], user: AuthState['user']) => Promise<AppSearchTeam[]>>(),
   searchAppPlayersMock: vi.fn<(query: string, teamsById: Map<string, AppSearchTeam>, user: AuthState['user']) => Promise<any[]>>(),
@@ -505,7 +505,7 @@ describe('AppSearchDialog', () => {
     expect(preloadSearchRouteMock.mock.invocationCallOrder[0]).toBeLessThan(navigateMock.mock.invocationCallOrder[0]);
   });
 
-  it('starts loading accessible teams on open and reuses that warm load for the first query', async () => {
+  it('defers accessible-team hydration until the first meaningful query and reuses it', async () => {
     const onClose = vi.fn();
 
     render(
@@ -515,10 +515,15 @@ describe('AppSearchDialog', () => {
     );
 
     expect(await screen.findAllByRole('button', { name: /Browse Teams/ })).not.toHaveLength(0);
-    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
+    expect(loadAppSearchTeamsMock).not.toHaveBeenCalled();
     expect(searchAppTeamsMock).not.toHaveBeenCalled();
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'r' } });
+    expect(loadAppSearchTeamsMock).not.toHaveBeenCalled();
 
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledWith('ro', expect.arrayContaining([
       expect.objectContaining({ id: 'team-2', name: 'Rockets' })
     ]), null));
@@ -562,7 +567,7 @@ describe('AppSearchDialog', () => {
     expect(searchAppPlayersMock).toHaveBeenNthCalledWith(1, 'be', expect.any(Map), null);
   });
 
-  it('ignores stale hydrated teams after the dialog closes before warm loading finishes', async () => {
+  it('ignores stale hydrated teams after the dialog closes before query-time loading finishes', async () => {
     const onClose = vi.fn();
     const userA = { uid: 'user-a', email: 'a@example.com' } as NonNullable<AuthState['user']>;
     let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
@@ -578,6 +583,8 @@ describe('AppSearchDialog', () => {
     );
 
     await waitFor(() => expect(getKnownAppSearchTeamsMock).toHaveBeenCalledWith(userA));
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
 
     rerender(
       <MemoryRouter>
@@ -586,8 +593,46 @@ describe('AppSearchDialog', () => {
     );
 
     releaseHydration([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
-    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
     expect(screen.queryByRole('button', { name: /Rockets/ })).toBeNull();
+    expect(searchAppTeamsMock).not.toHaveBeenCalled();
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores stale hydrated teams after the signed-in user changes', async () => {
+    const onClose = vi.fn();
+    const userA = { uid: 'user-a', email: 'a@example.com' } as NonNullable<AuthState['user']>;
+    const userB = { uid: 'user-b', email: 'b@example.com' } as NonNullable<AuthState['user']>;
+    let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
+    getKnownAppSearchTeamsMock.mockImplementation((user) => user?.uid === userA.uid
+      ? [{ id: 'team-a', name: 'Bears', sport: 'Basketball', zip: '66210' }]
+      : [{ id: 'team-b', name: 'Tigers', sport: 'Soccer', zip: '64114' }]);
+    loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseHydration = resolve;
+    }));
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <AppSearchDialog auth={{ ...auth, user: userA }} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <MemoryRouter>
+        <AppSearchDialog auth={{ ...auth, user: userB }} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('button', { name: /Tigers/ })).toBeTruthy();
+    releaseHydration([{ id: 'team-stale', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
+    await Promise.resolve();
+
+    expect(screen.queryByRole('button', { name: /Rockets/ })).toBeNull();
+    expect(searchAppTeamsMock).not.toHaveBeenCalled();
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
   });
 
   it('does not rerun hydrated searches when accessible teams stay the same', async () => {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -31,7 +31,6 @@ const keyboardInsetActivationThresholdPx = 80;
 
 export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [query, setQuery] = useState('');
-  const [baseTeams, setBaseTeams] = useState<AppSearchTeam[]>([]);
   const [teams, setTeams] = useState<AppSearchTeam[]>([]);
   const [teamsLoading, setTeamsLoading] = useState(false);
   const [teamsError, setTeamsError] = useState('');
@@ -58,7 +57,6 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   useEffect(() => {
     if (!open) return;
-    let cancelled = false;
     openedAtRef.current = Date.now();
     preloadedRoutesRef.current = new Set<string>();
     hydratedTeamsPromiseRef.current = null;
@@ -68,28 +66,10 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setPlayersLoading(false);
     const knownTeams = getKnownAppSearchTeams(auth.user);
     baseTeamsRef.current = knownTeams;
-    setBaseTeams(knownTeams);
     setTeams(knownTeams);
     setActiveIndex(0);
     setTeamsLoading(false);
     setTeamsError('');
-
-    const hydratedTeamsPromise = loadAppSearchTeams(auth.user)
-      .then((loadedTeams) => mergeSearchTeams(knownTeams, loadedTeams))
-      .then((loadedTeams) => {
-        if (cancelled) return knownTeams;
-        baseTeamsRef.current = loadedTeams;
-        setBaseTeams(loadedTeams);
-        setTeams((currentTeams) => mergeSearchTeams(currentTeams, loadedTeams));
-        return loadedTeams;
-      })
-      .catch(() => knownTeams);
-
-    hydratedTeamsPromiseRef.current = hydratedTeamsPromise;
-
-    return () => {
-      cancelled = true;
-    };
   }, [auth.user, open]);
 
   useEffect(() => {
@@ -99,7 +79,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     const requestId = ++searchRequestId.current;
 
     if (trimmedQuery.length < 2) {
-      setTeams(baseTeams);
+      setTeams(baseTeamsRef.current);
       setTeamsLoading(false);
       setTeamsError('');
       setPlayers([]);
@@ -135,6 +115,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       };
 
       const runSearch = async (accessibleTeams: AppSearchTeam[]) => {
+        if (disposed || requestId !== searchRequestId.current) return;
         const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
         setImmediateTeamResults(accessibleTeams);
 
@@ -161,8 +142,12 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
         }
       };
 
-      const hydrationPromise = hydratedTeamsPromiseRef.current || loadAppSearchTeams(auth.user)
-        .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams));
+      let hydrationPromise = hydratedTeamsPromiseRef.current;
+      if (!hydrationPromise) {
+        hydrationPromise = loadAppSearchTeams(auth.user)
+          .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams));
+        hydratedTeamsPromiseRef.current = hydrationPromise;
+      }
 
       const resolveAccessibleTeams = async () => {
         // Keep search bounded when Firestore hydration is slow, then retry once the
@@ -179,6 +164,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
       void resolveAccessibleTeams()
         .then(async ({ teams: accessibleTeams, resolved }) => {
+          if (disposed || requestId !== searchRequestId.current) return;
           if (resolved) {
             await runSearch(accessibleTeams);
             return;

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -166,6 +166,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
         .then(async ({ teams: accessibleTeams, resolved }) => {
           if (disposed || requestId !== searchRequestId.current) return;
           if (resolved) {
+            baseTeamsRef.current = accessibleTeams;
             await runSearch(accessibleTeams);
             return;
           }
@@ -175,7 +176,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
           try {
             const hydratedTeams = await hydrationPromise;
             if (disposed || requestId !== searchRequestId.current) return;
-            if (haveSameSearchTeamScope(accessibleTeams, hydratedTeams)) return;
+            baseTeamsRef.current = hydratedTeams;
+            if (haveSameSearchTeamSearchData(accessibleTeams, hydratedTeams)) return;
             await runSearch(hydratedTeams);
           } catch {
             if (disposed || requestId !== searchRequestId.current) return;
@@ -570,11 +572,25 @@ function mergeSearchTeams(...teamLists: AppSearchTeam[][]) {
   return Array.from(teamsById.values());
 }
 
-function haveSameSearchTeamScope(left: AppSearchTeam[], right: AppSearchTeam[]) {
+function haveSameSearchTeamSearchData(left: AppSearchTeam[], right: AppSearchTeam[]) {
   const leftIds = left.map((team) => team.id).filter(Boolean).sort();
   const rightIds = right.map((team) => team.id).filter(Boolean).sort();
   if (leftIds.length !== rightIds.length) return false;
-  return leftIds.every((teamId, index) => teamId === rightIds[index]);
+  if (!leftIds.every((teamId, index) => teamId === rightIds[index])) return false;
+
+  const rightTeamsById = new Map(right.map((team) => [team.id, team]));
+  return left.every((team) => {
+    const hydratedTeam = rightTeamsById.get(team.id);
+    if (!hydratedTeam) return false;
+    return [
+      'name',
+      'sport',
+      'zip',
+      'city',
+      'state',
+      'location'
+    ].every((field) => String(team[field as keyof AppSearchTeam] || '') === String(hydratedTeam[field as keyof AppSearchTeam] || ''));
+  });
 }
 
 function getPlayerSearchError(error: any) {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -429,10 +429,12 @@ test.describe('app global search', () => {
         await expect(page.getByText('Rockets')).toBeVisible();
         await expect(page.getByText('Bears')).toBeHidden();
         await expect(page.getByText('Type at least 2 characters to search players')).toBeVisible();
+        await expect.poll(() => page.evaluate(() => window.__loadAppSearchTeamsCalls)).toBe(0);
 
         await page.getByLabel('Search teams, players, actions, help').fill('bea');
         await expect(page.getByRole('button', { name: /Bears Basketball/ })).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__teamSearchQueries)).toEqual(['bea']);
+        await expect.poll(() => page.evaluate(() => window.__loadAppSearchTeamsCalls)).toBe(1);
 
         await page.getByRole('button', { name: 'Clear search query' }).click();
         await expect(page.getByLabel('Search teams, players, actions, help')).toHaveValue('');
@@ -444,6 +446,7 @@ test.describe('app global search', () => {
         await page.getByLabel('Search teams, players, actions, help').fill('pat');
         await expect(page.getByText('#9 Pat Star')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual(['bea', 'pat']);
+        await expect.poll(() => page.evaluate(() => window.__loadAppSearchTeamsCalls)).toBe(1);
         await page.getByRole('button', { name: /#9 Pat Star/ }).click();
         await expect(page).toHaveURL(/#\/players\/team-1\/player-1$/);
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -258,6 +258,9 @@ describe('React app shell search', () => {
 
     it('opens mobile search results from the shell trigger', async () => {
         const { container } = await renderShell();
+        const initialHydrationCalls = homeMocks.loadParentHomeSummary.mock.calls.length;
+        const initialFirestoreCalls = firebaseMocks.getDocs.mock.calls.length;
+        const initialPublicSearchCalls = dbMocks.discoverPublicTeams.mock.calls.length;
 
         await clickButton(container, 'Search');
         await waitForText(container, 'Browse Teams');
@@ -265,9 +268,15 @@ describe('React app shell search', () => {
         expect(container.textContent).not.toContain('Bears');
         expect(container.textContent).not.toContain('PrivateSoccer');
         expect(container.textContent).toContain('Type at least 2 characters to search players');
+        expect(homeMocks.loadParentHomeSummary).toHaveBeenCalledTimes(initialHydrationCalls);
+        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(initialFirestoreCalls);
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledTimes(initialPublicSearchCalls);
 
         await fillSearch(container, 'bea');
         expect(container.textContent).toContain('Bears');
+        expect(homeMocks.loadParentHomeSummary.mock.calls.length).toBeGreaterThan(initialHydrationCalls);
+        expect(firebaseMocks.getDocs.mock.calls.length).toBeGreaterThan(initialFirestoreCalls);
+        expect(dbMocks.discoverPublicTeams.mock.calls.length).toBeGreaterThan(initialPublicSearchCalls);
 
         await fillSearch(container, 'pat');
         expect(firebaseMocks.getDocs).toHaveBeenCalled();


### PR DESCRIPTION
## Root cause

Opening `AppSearchDialog` immediately called `loadAppSearchTeams`, even with an empty query. For high-access users that warm load fans out into unbounded private/direct team reads before the user expresses search intent.

## Changes

- Initialize an open dialog from known auth teams only; do not hydrate or search on open or for one-character queries.
- Start team-scope hydration after the debounced query reaches two trimmed characters.
- Cache and reuse the hydration promise across team/player searches and later queries in the same dialog session.
- Preserve known-team immediate results and the existing 250 ms provisional-search fallback.
- Guard search work so hydration resolving after close, clear, query replacement, or user change cannot launch stale searches or update results.
- Keep bounded public discovery and player search behavior unchanged.
- Update component, integration, and Playwright smoke expectations for deferred and single-call hydration.

## Impact

Opening and dismissing global search no longer incurs full private team-scope reads. Parents still see known `parentOf` teams immediately, while meaningful searches retain public team enrichment and scoped player results.

## Validation

- `npm run test:ci -- src/components/AppSearchDialog.test.tsx` — 19 passed
- `npx vitest run tests/unit/app-search-integration.test.jsx --reporter=dot` — 18 passed
- `npx vitest run tests/unit/app-search-service.test.js --reporter=dot` — 31 passed
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5175 npx playwright test tests/smoke/app-search.spec.js --config=playwright.smoke.config.js --reporter=line` — 5 passed
- `npm run build` — TypeScript check and Vite production build passed
- `npm exec eslint -- src/components/AppSearchDialog.tsx src/components/AppSearchDialog.test.tsx` — 0 errors (2 pre-existing warnings)

Closes #3776