### PR TITLE
Remove placeholder account action link

### DIFF
--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -264,7 +264,6 @@ export function AuthPage({ auth }: { auth: AuthState }) {
 
       <div className="mt-4 flex flex-wrap justify-center gap-3 text-xs font-bold text-gray-500">
         <Link to="/accept-invite" className="text-primary-700">Enter invite code</Link>
-        <Link to="/reset-password" className="text-primary-700">Account action</Link>
       </div>
     </AuthFrame>
   );

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -582,7 +582,7 @@ test('app auth screen exposes sign in, sign up, Google, activation code, invite,
     await expect(page.getByLabel('Activation or invite code')).toHaveValue('AB12CD34');
     await expect(page.getByRole('button', { name: 'Continue with Google' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Enter invite code' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Account action' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Account action' })).toHaveCount(0);
 
     await page.getByRole('button', { name: 'Sign in' }).first().click();
     await page.getByRole('button', { name: 'Forgot password?' }).click();

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -102,9 +102,10 @@ describe('React app auth/profile capability parity', () => {
             'activationCode',
             'Forgot password?',
             'Continue with Google',
-            'Enter invite code',
-            'Account action'
+            'Enter invite code'
         ]);
+        expect(authPage).not.toContain('Account action');
+        expect(authPage).not.toContain('<Link to="/reset-password"');
         expectContains(authService, [
             'signInWithNativeRestSession',
             'signInWithNativeGoogleCredential',


### PR DESCRIPTION
## Root cause

The signed-out auth footer exposed a placeholder-labeled **Account action** link to `/reset-password`. That route handles emailed action codes and has no useful standalone flow without query parameters, while the same screen already provides the valid **Forgot password?** reset-email workflow.

## Changes

- Remove the redundant placeholder footer link.
- Keep the **Enter invite code** footer action and inline **Forgot password?** flow unchanged.
- Update unit and Playwright smoke assertions to prevent the placeholder link from returning.

## Impact

Signed-out users no longer see a confusing duplicate/dead-end account action. Password recovery still begins from the existing visible **Forgot password?** control.

## Validation

- `npx vitest run tests/unit/app-auth-profile-capabilities.test.js --reporter=dot` — 19 passed
- `npm run test:ci -- src/pages/AuthPage.test.tsx` — 4 passed
- targeted `app-auth-profile.spec.js` Playwright auth flow — 1 passed
- `BASE_SHA=eea2515f... node scripts/lint-app-ci.mjs` — passed, including strict hook lint
- `npm run build` — TypeScript check and Vite production build passed

Closes #3767