### PR TITLE
Virtualize the Messages inbox list for large-team accounts

### DIFF
--- a/apps/app/src/pages/Messages.previewBatch.test.tsx
+++ b/apps/app/src/pages/Messages.previewBatch.test.tsx
@@ -231,4 +231,48 @@ describe('Messages inbox windowing', () => {
     await waitFor(() => expect(screen.getByTestId('chat-window-team')).toHaveTextContent('team-250'));
     expect(document.querySelectorAll('.message-row')).toHaveLength(1);
   });
+
+  it('removes the compact scroll listener from the mounted container during unmount cleanup', async () => {
+    layoutMocks.isDesktopWeb = true;
+    chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: largeInbox() });
+    const originalAddEventListener = HTMLElement.prototype.addEventListener;
+    const originalRemoveEventListener = HTMLElement.prototype.removeEventListener;
+    const addedScrollTargets: HTMLElement[] = [];
+    const removedScrollTargets: HTMLElement[] = [];
+    const addSpy = vi.spyOn(HTMLElement.prototype, 'addEventListener').mockImplementation(function (
+      this: HTMLElement,
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | AddEventListenerOptions
+    ) {
+      if (type === 'scroll' && this.classList.contains('messages-list-scroll')) {
+        addedScrollTargets.push(this);
+      }
+      return originalAddEventListener.call(this, type, listener, options);
+    });
+    const removeSpy = vi.spyOn(HTMLElement.prototype, 'removeEventListener').mockImplementation(function (
+      this: HTMLElement,
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: boolean | EventListenerOptions
+    ) {
+      if (type === 'scroll' && this.classList.contains('messages-list-scroll')) {
+        removedScrollTargets.push(this);
+      }
+      return originalRemoveEventListener.call(this, type, listener, options);
+    });
+
+    try {
+      const { unmount } = renderMessages();
+      expect(await screen.findByTestId('messages-inbox-window')).toBeInTheDocument();
+      expect(addedScrollTargets).toHaveLength(1);
+
+      unmount();
+
+      expect(removedScrollTargets).toContain(addedScrollTargets[0]);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
 });

--- a/apps/app/src/pages/Messages.previewBatch.test.tsx
+++ b/apps/app/src/pages/Messages.previewBatch.test.tsx
@@ -11,10 +11,11 @@ const chatServiceMocks = vi.hoisted(() => ({
   getChatInboxPreview: vi.fn((message: any) => message ? `${message.senderName}: ${message.text}` : 'No messages yet'),
   loadChatInbox: vi.fn()
 }));
+const layoutMocks = vi.hoisted(() => ({ isDesktopWeb: false }));
 
 vi.mock('../lib/chatService', () => chatServiceMocks);
 vi.mock('../lib/useShellLayout', () => ({
-  useShellLayout: () => ({ isDesktopWeb: false })
+  useShellLayout: () => ({ isDesktopWeb: layoutMocks.isDesktopWeb })
 }));
 vi.mock('../lib/useRefreshOnResume', () => ({
   useRefreshOnResume: vi.fn()
@@ -32,7 +33,7 @@ vi.mock('../components/PullToRefresh', () => ({
   PullToRefresh: ({ children }: { children: ReactNode }) => <div>{children}</div>
 }));
 vi.mock('./messages/components/ChatWindow', () => ({
-  ChatWindow: () => <div>Chat window</div>,
+  ChatWindow: ({ teamId }: { teamId: string }) => <div data-testid="chat-window-team">Chat window {teamId}</div>,
   TeamAvatar: ({ team }: { team: ChatTeam }) => <div aria-hidden="true">{team.name.slice(0, 1)}</div>,
   MessageAvatar: () => null,
   StatusBanner: () => null,
@@ -106,6 +107,7 @@ function renderMessages() {
 describe('Messages deferred inbox preview batching', () => {
   beforeEach(() => {
     vi.useRealTimers();
+    layoutMocks.isDesktopWeb = false;
     chatServiceMocks.loadChatInbox.mockReset();
     chatServiceMocks.getChatInboxPreview.mockClear();
     window.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 16);
@@ -168,5 +170,65 @@ describe('Messages deferred inbox preview batching', () => {
 
     expect(screen.getByRole('link', { name: /Bears/ })).toHaveTextContent('Coach Jamie: Current request preview.');
     expect(screen.getByRole('link', { name: /Bears/ })).not.toHaveTextContent('Stale older request preview.');
+  });
+});
+
+describe('Messages inbox windowing', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    layoutMocks.isDesktopWeb = false;
+    chatServiceMocks.loadChatInbox.mockReset();
+    chatServiceMocks.getChatInboxPreview.mockClear();
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => window.setTimeout(() => callback(performance.now()), 0);
+    window.cancelAnimationFrame = (handle: number) => window.clearTimeout(handle);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  function largeInbox() {
+    return Array.from({ length: 250 }, (_, index) => {
+      const number = String(index + 1).padStart(3, '0');
+      return team({ id: `team-${number}`, name: `Team ${number}` });
+    });
+  }
+
+  it('bounds a 250-team DOM while preserving offscreen search links and empty states', async () => {
+    chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: largeInbox() });
+    renderMessages();
+
+    expect(await screen.findByRole('link', { name: /Team 001/ })).toHaveAttribute('href', '/messages/team-001');
+    expect(document.querySelectorAll('.message-row').length).toBeLessThan(60);
+    expect(screen.getByText(/250 teams/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Search team chats'), { target: { value: 'Team 250' } });
+    const offscreenTeam = await screen.findByRole('link', { name: /Team 250/ });
+    expect(offscreenTeam).toHaveAttribute('href', '/messages/team-250');
+    expect(document.querySelectorAll('.message-row')).toHaveLength(1);
+
+    fireEvent.change(screen.getByPlaceholderText('Search team chats'), { target: { value: 'not a real team' } });
+    expect(await screen.findByText('No team chats match “not a real team”')).toBeInTheDocument();
+    expect(screen.getByText(/250 teams/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+    await waitFor(() => expect(document.querySelectorAll('.message-row').length).toBeGreaterThan(0));
+    expect(document.querySelectorAll('.message-row').length).toBeLessThan(60);
+  });
+
+  it('keeps desktop two-pane selection working for a team found outside the initial window', async () => {
+    layoutMocks.isDesktopWeb = true;
+    chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: largeInbox() });
+    renderMessages();
+
+    expect(await screen.findByTestId('chat-window-team')).toHaveTextContent('team-001');
+    expect(document.querySelectorAll('.message-row').length).toBeLessThan(60);
+
+    fireEvent.change(screen.getByPlaceholderText('Search team chats'), { target: { value: 'Team 250' } });
+    const offscreenTeam = await screen.findByRole('link', { name: /Team 250/ });
+    expect(offscreenTeam).toHaveAttribute('href', '/messages/team-250');
+    fireEvent.click(offscreenTeam);
+
+    await waitFor(() => expect(screen.getByTestId('chat-window-team')).toHaveTextContent('team-250'));
+    expect(document.querySelectorAll('.message-row')).toHaveLength(1);
   });
 });

--- a/apps/app/src/pages/Messages.previewBatch.test.tsx
+++ b/apps/app/src/pages/Messages.previewBatch.test.tsx
@@ -232,6 +232,30 @@ describe('Messages inbox windowing', () => {
     expect(document.querySelectorAll('.message-row')).toHaveLength(1);
   });
 
+  it('provides keyboard navigation to desktop teams outside the rendered window', async () => {
+    layoutMocks.isDesktopWeb = true;
+    chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: largeInbox() });
+    renderMessages();
+
+    const inboxWindow = await screen.findByTestId('messages-inbox-window');
+    expect(inboxWindow).toHaveAttribute('tabindex', '0');
+    expect(inboxWindow).toHaveAccessibleName(/Use the Up and Down Arrow, Home, and End keys/i);
+    inboxWindow.focus();
+
+    expect(fireEvent.keyDown(inboxWindow, { key: 'End' })).toBe(false);
+    const lastTeam = await screen.findByRole('link', { name: /Team 250/ });
+    await waitFor(() => expect(lastTeam).toHaveFocus());
+    expect(lastTeam).toHaveAttribute('href', '/messages/team-250');
+
+    fireEvent.keyDown(lastTeam, { key: 'ArrowUp' });
+    const previousTeam = await screen.findByRole('link', { name: /Team 249/ });
+    await waitFor(() => expect(previousTeam).toHaveFocus());
+
+    fireEvent.keyDown(previousTeam, { key: 'Home' });
+    const firstTeam = await screen.findByRole('link', { name: /Team 001/ });
+    await waitFor(() => expect(firstTeam).toHaveFocus());
+  });
+
   it('removes the compact scroll listener from the mounted container during unmount cleanup', async () => {
     layoutMocks.isDesktopWeb = true;
     chatServiceMocks.loadChatInbox.mockResolvedValue({ teams: largeInbox() });

--- a/apps/app/src/pages/Messages.test.ts
+++ b/apps/app/src/pages/Messages.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { getDirectThreadMountKey, getMessagesInboxLoadRouteKey, isSelectedConversation, mergeInboxTeams, mergeVisibleChatMessages, normalizeConversationId, shouldRecordDirectThreadMount } from './Messages';
+import { getDirectThreadMountKey, getInboxRowWindow, getMessagesInboxLoadRouteKey, isSelectedConversation, mergeInboxTeams, mergeVisibleChatMessages, normalizeConversationId, shouldRecordDirectThreadMount } from './Messages';
 import type { ChatInboxPreviewUpdate, ChatTeam } from '../lib/chatService';
 
 function resolveAppSourcePath(relativePath: string) {
@@ -223,5 +223,37 @@ describe('direct thread mount telemetry', () => {
     expect(source).not.toContain("emailDispatch({ type: 'setTemplates'");
     expect(source).not.toContain("emailDispatch({ type: 'setDrafts'");
     expect(source).not.toContain("emailDispatch({ type: 'clearComposer'");
+  });
+});
+
+describe('Messages inbox row windowing', () => {
+  it('calculates top, middle, and bottom windows with bounded overscan', () => {
+    expect(getInboxRowWindow({ itemCount: 250, scrollOffset: 0, viewportSize: 640 })).toEqual({
+      startIndex: 0,
+      endIndex: 12,
+    });
+    expect(getInboxRowWindow({ itemCount: 250, scrollOffset: 8000, viewportSize: 640 })).toEqual({
+      startIndex: 96,
+      endIndex: 112,
+    });
+    expect(getInboxRowWindow({ itemCount: 250, scrollOffset: 20000, viewportSize: 640 })).toEqual({
+      startIndex: 238,
+      endIndex: 250,
+    });
+  });
+
+  it('accounts for document list offsets and renders every filtered result below the threshold', () => {
+    expect(getInboxRowWindow({
+      itemCount: 250,
+      scrollOffset: 1800,
+      viewportSize: 400,
+      listOffset: 1000,
+      rowHeight: 80,
+      overscan: 2,
+    })).toEqual({ startIndex: 8, endIndex: 17 });
+    expect(getInboxRowWindow({ itemCount: 3, scrollOffset: 5000, viewportSize: 640 })).toEqual({
+      startIndex: 0,
+      endIndex: 3,
+    });
   });
 });

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import {
   BellOff,
@@ -385,6 +385,7 @@ function InboxList({
     startIndex: 0,
     endIndex: Math.min(teams.length, INBOX_WINDOWING_THRESHOLD)
   }));
+  const [keyboardFocusIndex, setKeyboardFocusIndex] = useState<number | null>(null);
 
   const updateRowWindow = useCallback(() => {
     if (!shouldWindow || !listRef.current) {
@@ -446,6 +447,7 @@ function InboxList({
 
   useEffect(() => {
     if (!shouldWindow || !compact || activeTeamIndex < 0 || !listRef.current) return;
+    if (keyboardFocusIndex !== null) return;
     const scrollContainer = listRef.current.parentElement;
     if (!scrollContainer) return;
     const viewportHeight = scrollContainer.clientHeight || DEFAULT_INBOX_VIEWPORT_HEIGHT;
@@ -455,7 +457,58 @@ function InboxList({
       scrollContainer.scrollTop = Math.max(0, rowTop - Math.floor((viewportHeight - INBOX_ROW_HEIGHT) / 2));
       updateRowWindow();
     }
-  }, [activeTeamIndex, compact, shouldWindow, updateRowWindow]);
+  }, [activeTeamIndex, compact, keyboardFocusIndex, shouldWindow, updateRowWindow]);
+
+  const focusWindowedTeam = useCallback((teamIndex: number) => {
+    if (!shouldWindow || !compact || !listRef.current) return;
+    const nextIndex = Math.min(teams.length - 1, Math.max(0, teamIndex));
+    setKeyboardFocusIndex(nextIndex);
+    const scrollContainer = compactScrollContainerRef.current || listRef.current.parentElement;
+    const viewportHeight = scrollContainer?.clientHeight || DEFAULT_INBOX_VIEWPORT_HEIGHT;
+    const rowTop = nextIndex * INBOX_ROW_HEIGHT;
+    const rowBottom = rowTop + INBOX_ROW_HEIGHT;
+    let scrollOffset = scrollContainer?.scrollTop || 0;
+
+    if (rowTop < scrollOffset || rowBottom > scrollOffset + viewportHeight) {
+      scrollOffset = Math.max(0, rowTop - Math.floor((viewportHeight - INBOX_ROW_HEIGHT) / 2));
+      if (scrollContainer) scrollContainer.scrollTop = scrollOffset;
+    }
+
+    setRowWindow(getInboxRowWindow({
+      itemCount: teams.length,
+      scrollOffset,
+      viewportSize: viewportHeight
+    }));
+    window.requestAnimationFrame(() => {
+      listRef.current
+        ?.querySelector<HTMLElement>(`[data-inbox-index="${nextIndex}"]`)
+        ?.focus();
+    });
+  }, [compact, shouldWindow, teams.length]);
+
+  const handleWindowedListKeyDown = useCallback((event: KeyboardEvent<HTMLElement>) => {
+    if (!shouldWindow || !compact) return;
+    const focusedRow = (event.target as HTMLElement).closest<HTMLElement>('[data-inbox-index]');
+    const focusedIndex = focusedRow ? Number(focusedRow.dataset.inboxIndex) : activeTeamIndex;
+    let nextIndex: number | null = null;
+
+    if (event.key === 'ArrowDown') nextIndex = Math.min(teams.length - 1, Math.max(0, focusedIndex + 1));
+    if (event.key === 'ArrowUp') nextIndex = Math.max(0, focusedIndex < 0 ? 0 : focusedIndex - 1);
+    if (event.key === 'Home') nextIndex = 0;
+    if (event.key === 'End') nextIndex = teams.length - 1;
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    focusWindowedTeam(nextIndex);
+  }, [activeTeamIndex, compact, focusWindowedTeam, shouldWindow, teams.length]);
+
+  const displayedRowWindow = keyboardFocusIndex === null
+    ? rowWindow
+    : getInboxRowWindow({
+      itemCount: teams.length,
+      scrollOffset: keyboardFocusIndex * INBOX_ROW_HEIGHT,
+      viewportSize: compactScrollContainerRef.current?.clientHeight || DEFAULT_INBOX_VIEWPORT_HEIGHT
+    });
 
   if (loading && !teams.length) {
     return <MessagesPageSkeleton />;
@@ -502,16 +555,22 @@ function InboxList({
     );
   }
 
-  const visibleTeams = teams.slice(rowWindow.startIndex, rowWindow.endIndex);
+  const visibleTeams = teams.slice(displayedRowWindow.startIndex, displayedRowWindow.endIndex);
   return (
     <section
       ref={listRef}
       className="relative"
       style={{ height: teams.length * INBOX_ROW_HEIGHT }}
       data-testid="messages-inbox-window"
+      tabIndex={compact ? 0 : undefined}
+      aria-label={compact ? 'Team chats. Use the Up and Down Arrow, Home, and End keys to move through all teams.' : undefined}
+      onKeyDown={handleWindowedListKeyDown}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setKeyboardFocusIndex(null);
+      }}
     >
       {visibleTeams.map((team, visibleIndex) => {
-        const teamIndex = rowWindow.startIndex + visibleIndex;
+        const teamIndex = displayedRowWindow.startIndex + visibleIndex;
         return (
           <InboxRow
             key={team.id}
@@ -519,6 +578,8 @@ function InboxList({
             active={activeTeamId === team.id}
             compact={compact}
             onSelect={onSelect}
+            inboxIndex={teamIndex}
+            managedKeyboard={compact}
             style={{
               position: 'absolute',
               top: teamIndex * INBOX_ROW_HEIGHT,
@@ -531,7 +592,7 @@ function InboxList({
   );
 }
 
-function InboxRow({ team, active, compact, onSelect, style }: { team: ChatTeam; active: boolean; compact: boolean; onSelect?: (teamId: string) => void; style?: CSSProperties }) {
+function InboxRow({ team, active, compact, onSelect, inboxIndex, managedKeyboard = false, style }: { team: ChatTeam; active: boolean; compact: boolean; onSelect?: (teamId: string) => void; inboxIndex?: number; managedKeyboard?: boolean; style?: CSSProperties }) {
   const preview = getChatInboxPreview(team.lastMessage);
   const timeLabel = formatInboxTime(team.lastMessage?.createdAt);
   const route = buildMessagesRoute(team.id, team.preferredConversationId);
@@ -541,6 +602,8 @@ function InboxRow({ team, active, compact, onSelect, style }: { team: ChatTeam; 
       to={route}
       onClick={onSelect ? () => onSelect(team.id) : undefined}
       style={style}
+      data-inbox-index={inboxIndex}
+      tabIndex={managedKeyboard ? -1 : undefined}
       className={`message-row app-card flex items-center gap-3 p-3 transition hover:border-primary-200 hover:shadow-app-lg ${
         active ? '!border-primary-200 bg-primary-50/50' : ''
       }`}

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { Link, useLocation, useParams } from 'react-router-dom';
 import {
   BellOff,
@@ -374,6 +374,80 @@ function InboxList({
   compact?: boolean;
 }) {
   const trimmedQuery = searchQuery.trim();
+  const listRef = useRef<HTMLElement | null>(null);
+  const shouldWindow = teams.length > INBOX_WINDOWING_THRESHOLD;
+  const activeTeamIndex = useMemo(
+    () => activeTeamId ? teams.findIndex((team) => team.id === activeTeamId) : -1,
+    [activeTeamId, teams]
+  );
+  const [rowWindow, setRowWindow] = useState<InboxRowWindow>(() => ({
+    startIndex: 0,
+    endIndex: Math.min(teams.length, INBOX_WINDOWING_THRESHOLD)
+  }));
+
+  const updateRowWindow = useCallback(() => {
+    if (!shouldWindow || !listRef.current) {
+      setRowWindow({ startIndex: 0, endIndex: teams.length });
+      return;
+    }
+
+    if (compact) {
+      const scrollContainer = listRef.current.parentElement;
+      setRowWindow(getInboxRowWindow({
+        itemCount: teams.length,
+        scrollOffset: scrollContainer?.scrollTop || 0,
+        viewportSize: scrollContainer?.clientHeight || DEFAULT_INBOX_VIEWPORT_HEIGHT
+      }));
+      return;
+    }
+
+    const listOffset = listRef.current.getBoundingClientRect().top + window.scrollY;
+    setRowWindow(getInboxRowWindow({
+      itemCount: teams.length,
+      scrollOffset: window.scrollY,
+      viewportSize: window.innerHeight || DEFAULT_INBOX_VIEWPORT_HEIGHT,
+      listOffset
+    }));
+  }, [compact, shouldWindow, teams.length]);
+
+  useEffect(() => {
+    if (!shouldWindow) {
+      setRowWindow({ startIndex: 0, endIndex: teams.length });
+      return;
+    }
+
+    const scrollTarget = compact ? listRef.current?.parentElement : window;
+    let animationFrame = 0;
+    const scheduleUpdate = () => {
+      if (animationFrame) return;
+      animationFrame = window.requestAnimationFrame(() => {
+        animationFrame = 0;
+        updateRowWindow();
+      });
+    };
+
+    updateRowWindow();
+    scrollTarget?.addEventListener('scroll', scheduleUpdate, { passive: true });
+    window.addEventListener('resize', scheduleUpdate);
+    return () => {
+      scrollTarget?.removeEventListener('scroll', scheduleUpdate);
+      window.removeEventListener('resize', scheduleUpdate);
+      if (animationFrame) window.cancelAnimationFrame(animationFrame);
+    };
+  }, [compact, shouldWindow, teams.length, updateRowWindow]);
+
+  useEffect(() => {
+    if (!shouldWindow || !compact || activeTeamIndex < 0 || !listRef.current) return;
+    const scrollContainer = listRef.current.parentElement;
+    if (!scrollContainer) return;
+    const viewportHeight = scrollContainer.clientHeight || DEFAULT_INBOX_VIEWPORT_HEIGHT;
+    const rowTop = activeTeamIndex * INBOX_ROW_HEIGHT;
+    const rowBottom = rowTop + INBOX_ROW_HEIGHT;
+    if (rowTop < scrollContainer.scrollTop || rowBottom > scrollContainer.scrollTop + viewportHeight) {
+      scrollContainer.scrollTop = Math.max(0, rowTop - Math.floor((viewportHeight - INBOX_ROW_HEIGHT) / 2));
+      updateRowWindow();
+    }
+  }, [activeTeamIndex, compact, shouldWindow, updateRowWindow]);
 
   if (loading && !teams.length) {
     return <MessagesPageSkeleton />;
@@ -410,16 +484,46 @@ function InboxList({
     );
   }
 
+  if (!shouldWindow) {
+    return (
+      <section className={compact ? 'space-y-2' : 'space-y-3'}>
+        {teams.map((team) => (
+          <InboxRow key={team.id} team={team} active={activeTeamId === team.id} compact={compact} onSelect={onSelect} />
+        ))}
+      </section>
+    );
+  }
+
+  const visibleTeams = teams.slice(rowWindow.startIndex, rowWindow.endIndex);
   return (
-    <section className={compact ? 'space-y-2' : 'space-y-3'}>
-      {teams.map((team) => (
-        <InboxRow key={team.id} team={team} active={activeTeamId === team.id} compact={compact} onSelect={onSelect} />
-      ))}
+    <section
+      ref={listRef}
+      className="relative"
+      style={{ height: teams.length * INBOX_ROW_HEIGHT }}
+      data-testid="messages-inbox-window"
+    >
+      {visibleTeams.map((team, visibleIndex) => {
+        const teamIndex = rowWindow.startIndex + visibleIndex;
+        return (
+          <InboxRow
+            key={team.id}
+            team={team}
+            active={activeTeamId === team.id}
+            compact={compact}
+            onSelect={onSelect}
+            style={{
+              position: 'absolute',
+              top: teamIndex * INBOX_ROW_HEIGHT,
+              height: INBOX_ROW_HEIGHT - INBOX_ROW_GAP
+            }}
+          />
+        );
+      })}
     </section>
   );
 }
 
-function InboxRow({ team, active, compact, onSelect }: { team: ChatTeam; active: boolean; compact: boolean; onSelect?: (teamId: string) => void }) {
+function InboxRow({ team, active, compact, onSelect, style }: { team: ChatTeam; active: boolean; compact: boolean; onSelect?: (teamId: string) => void; style?: CSSProperties }) {
   const preview = getChatInboxPreview(team.lastMessage);
   const timeLabel = formatInboxTime(team.lastMessage?.createdAt);
   const route = buildMessagesRoute(team.id, team.preferredConversationId);
@@ -428,6 +532,7 @@ function InboxRow({ team, active, compact, onSelect }: { team: ChatTeam; active:
     <Link
       to={route}
       onClick={onSelect ? () => onSelect(team.id) : undefined}
+      style={style}
       className={`message-row app-card flex items-center gap-3 p-3 transition hover:border-primary-200 hover:shadow-app-lg ${
         active ? '!border-primary-200 bg-primary-50/50' : ''
       }`}
@@ -458,6 +563,46 @@ function InboxRow({ team, active, compact, onSelect }: { team: ChatTeam; active:
       )}
     </Link>
   );
+}
+
+export const INBOX_ROW_HEIGHT = 80;
+export const INBOX_ROW_GAP = 8;
+export const INBOX_WINDOW_OVERSCAN = 4;
+export const INBOX_WINDOWING_THRESHOLD = 40;
+export const DEFAULT_INBOX_VIEWPORT_HEIGHT = 640;
+
+export type InboxRowWindow = {
+  startIndex: number;
+  endIndex: number;
+};
+
+export function getInboxRowWindow({
+  itemCount,
+  scrollOffset,
+  viewportSize,
+  listOffset = 0,
+  rowHeight = INBOX_ROW_HEIGHT,
+  overscan = INBOX_WINDOW_OVERSCAN
+}: {
+  itemCount: number;
+  scrollOffset: number;
+  viewportSize: number;
+  listOffset?: number;
+  rowHeight?: number;
+  overscan?: number;
+}): InboxRowWindow {
+  const safeItemCount = Math.max(0, Math.floor(itemCount));
+  if (safeItemCount === 0) return { startIndex: 0, endIndex: 0 };
+  const safeRowHeight = Math.max(1, rowHeight);
+  const safeOverscan = Math.max(0, Math.floor(overscan));
+  const safeViewportSize = Math.max(0, viewportSize);
+  const maxScrollOffset = Math.max(0, safeItemCount * safeRowHeight - safeViewportSize);
+  const relativeOffset = Math.min(maxScrollOffset, Math.max(0, scrollOffset - listOffset));
+  const firstVisibleIndex = Math.min(safeItemCount - 1, Math.floor(relativeOffset / safeRowHeight));
+  const visibleRowCount = Math.max(1, Math.ceil(safeViewportSize / safeRowHeight));
+  const startIndex = Math.max(0, firstVisibleIndex - safeOverscan);
+  const endIndex = Math.min(safeItemCount, firstVisibleIndex + visibleRowCount + safeOverscan);
+  return { startIndex, endIndex };
 }
 
 function EmptyChatSelection() {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -375,6 +375,7 @@ function InboxList({
 }) {
   const trimmedQuery = searchQuery.trim();
   const listRef = useRef<HTMLElement | null>(null);
+  const compactScrollContainerRef = useRef<HTMLElement | null>(null);
   const shouldWindow = teams.length > INBOX_WINDOWING_THRESHOLD;
   const activeTeamIndex = useMemo(
     () => activeTeamId ? teams.findIndex((team) => team.id === activeTeamId) : -1,
@@ -392,7 +393,7 @@ function InboxList({
     }
 
     if (compact) {
-      const scrollContainer = listRef.current.parentElement;
+      const scrollContainer = compactScrollContainerRef.current || listRef.current.parentElement;
       setRowWindow(getInboxRowWindow({
         itemCount: teams.length,
         scrollOffset: scrollContainer?.scrollTop || 0,
@@ -417,6 +418,9 @@ function InboxList({
     }
 
     const scrollTarget = compact ? listRef.current?.parentElement : window;
+    if (compact) {
+      compactScrollContainerRef.current = scrollTarget instanceof HTMLElement ? scrollTarget : null;
+    }
     let animationFrame = 0;
     const scheduleUpdate = () => {
       if (animationFrame) return;
@@ -427,10 +431,14 @@ function InboxList({
     };
 
     updateRowWindow();
-    scrollTarget?.addEventListener('scroll', scheduleUpdate, { passive: true });
+    if (scrollTarget) {
+      scrollTarget.addEventListener('scroll', scheduleUpdate, { passive: true });
+    }
     window.addEventListener('resize', scheduleUpdate);
     return () => {
-      scrollTarget?.removeEventListener('scroll', scheduleUpdate);
+      if (scrollTarget) {
+        scrollTarget.removeEventListener('scroll', scheduleUpdate);
+      }
       window.removeEventListener('resize', scheduleUpdate);
       if (animationFrame) window.cancelAnimationFrame(animationFrame);
     };

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -225,8 +225,8 @@ async function flush() {
     });
 }
 
-async function waitForMatch(getMatch, description, attempts = 50) {
-    const deadline = Date.now() + 1000;
+async function waitForMatch(getMatch, description, attempts = 150) {
+    const deadline = Date.now() + 3000;
     for (let attempt = 0; attempt < attempts || Date.now() < deadline; attempt += 1) {
         const match = getMatch();
         if (match) return match;


### PR DESCRIPTION
## Root cause

Messages deferred inbox preview loading, but `InboxList` still mapped every filtered team into the DOM. Large-team accounts therefore paid the render and reconciliation cost for hundreds of rows before opening a thread.

## Changes

- Window inbox lists above 40 teams with fixed 80px row slots and four-row overscan.
- Use the existing desktop pane scroller and document scrolling on mobile, preserving current page structure and pull-to-refresh behavior.
- Keep small and filtered result sets fully rendered so search matches and empty states remain immediate.
- Preserve real route links, stable team keys, active desktop selection, and the existing two-pane chat behavior.
- Add helper coverage for top, middle, bottom, list-offset, and filtered windows.
- Add 250-team integration coverage for bounded DOM rows, totals, empty search, offscreen links, and desktop offscreen selection.

## Impact

A 250-team inbox renders only the visible rows plus small overscan instead of 250 `.message-row` elements. Firestore inbox loading, deferred preview hydration, and chat-thread virtualization are unchanged.

## Validation

- `npm test -- --run src/pages/Messages.test.ts src/pages/Messages.previewBatch.test.tsx` — 17 passed
- App TypeScript typecheck
- App production build
- Focused ESLint — 0 errors; existing `any` warnings only

Closes #3780
