### PR TITLE
Filter stale assigned games from upcoming configs

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -2010,7 +2010,6 @@ function dedupeStrings(values: string[]) {
 function isUpcomingAssignedGame(game: any) {
   if (!game || game?.type === 'practice') return false;
   if (isHistoricalGameStatus(game)) return false;
-  if (isActiveGameStatus(game)) return true;
   return isInUpcomingWindow(game?.date);
 }
 
@@ -2018,13 +2017,6 @@ function isHistoricalGameStatus(game: any) {
   const status = cleanString(game?.status).toLowerCase();
   const liveStatus = cleanString(game?.liveStatus).toLowerCase();
   return status === 'completed' || status === 'final' || status === 'cancelled' || liveStatus === 'completed';
-}
-
-function isActiveGameStatus(game: any) {
-  const status = cleanString(game?.status).toLowerCase();
-  const liveStatus = cleanString(game?.liveStatus).toLowerCase();
-  return ['active', 'in_progress', 'in-progress', 'live', 'started', 'running'].includes(status)
-    || ['active', 'in_progress', 'in-progress', 'live', 'started', 'running'].includes(liveStatus);
 }
 
 function normalizeEvents(games: any[], configById: Map<string, TeamDetailStatTrackerConfig> = new Map()) {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -817,7 +817,9 @@ describe('React app team detail model', () => {
                 { id: 'game-1', opponent: 'Falcons', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-basketball' },
                 { id: 'game-2', opponent: 'Tigers', date: new Date('2100-06-02T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-legacy' },
                 { id: 'game-3', opponent: 'Orphans', date: new Date('2100-06-03T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-missing' },
-                { id: 'live-game', opponent: 'Long Match', date: new Date(now - 4 * 60 * 60 * 1000), status: 'scheduled', liveStatus: 'live', statTrackerConfigId: 'cfg-legacy' },
+                { id: 'live-game', opponent: 'Long Match', date: new Date(now - 2 * 60 * 60 * 1000), status: 'scheduled', liveStatus: 'live', statTrackerConfigId: 'cfg-legacy' },
+                { id: 'stale-active-game', opponent: 'Old Active', date: new Date('2026-01-11T18:00:00Z'), status: 'active', statTrackerConfigId: 'cfg-legacy' },
+                { id: 'stale-live-game', opponent: 'Old Live', date: new Date('2026-01-20T18:00:00Z'), status: 'scheduled', liveStatus: 'live', statTrackerConfigId: 'cfg-legacy' },
                 { id: 'stale-game', opponent: 'Past Tigers', date: new Date('2020-06-02T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-legacy' }
             ],
             configs: [
@@ -876,6 +878,10 @@ describe('React app team detail model', () => {
                 expect.objectContaining({ gameId: 'live-game', title: 'vs. Long Match' }),
                 expect.objectContaining({ gameId: 'game-2', title: 'vs. Tigers' })
             ]);
+        const assignedLegacyGameIds = model.statTrackerConfigs.find((config) => config.id === 'cfg-legacy').assignedUpcomingGames.map((game) => game.gameId);
+        expect(assignedLegacyGameIds).not.toContain('stale-active-game');
+        expect(assignedLegacyGameIds).not.toContain('stale-live-game');
+        expect(assignedLegacyGameIds).not.toContain('stale-game');
         expect(model.upcomingEvents.find((event) => event.id === 'game-1')).toMatchObject({
             statTrackerConfigId: 'cfg-basketball',
             statTrackerConfigLabel: 'Varsity Basketball',


### PR DESCRIPTION
## Summary
- apply the shared team upcoming date window to stat tracker config assignments
- prevent stale active/live statuses from bypassing the upcoming date filter
- retain live assignments inside the existing three-hour event grace window
- add regression coverage for the reported January 2026 stale assignments

## Test plan
- npm exec vitest run -- tests/unit/app-team-detail-service.test.js --reporter=verbose (32 passed)
- npm exec vitest run -- apps/app/src/pages/TeamDetail.test.tsx --reporter=verbose (26 passed)
- npm run app:build
- focused app lint (0 errors; existing warnings remain)

Closes #3770