### PR TITLE
Reset roster windows on team change

### DIFF
--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1077,7 +1077,7 @@ describe('TeamDetail', () => {
     expect(screen.getByText('1/1 done')).toBeTruthy();
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamTrackingAdmin).toHaveBeenCalledWith('team-1', auth.user));
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Show players (1)' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Show players (1) for Waiver' }));
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
     await waitFor(() => expect(teamDetailServiceMocks.setPlayerTrackingStatusForApp).toHaveBeenCalledWith('team-1', auth.user, 'item-1', expect.objectContaining({ id: 'player-1', number: '9' }), true));
     expect(await screen.findByText('Pat Star marked done for Waiver.')).toBeTruthy();
@@ -1131,22 +1131,25 @@ describe('TeamDetail', () => {
         complete: playerIndex < itemIndex
       }))
     }));
-    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+    teamDetailServiceMocks.loadParentTeamDetail.mockImplementation(async (teamId: string) => ({
       ...model,
+      team: {
+        ...model.team,
+        id: teamId,
+        name: teamId === 'team-2' ? 'Tigers' : model.team.name
+      },
       canManageTeam: true,
       players: largePlayers,
       inactivePlayers,
       linkedPlayers: [largePlayers[0]]
-    });
+    }));
     teamDetailServiceMocks.loadTeamTrackingAdmin.mockResolvedValue(trackingItems);
 
-    render(
-      <MemoryRouter initialEntries={['/teams/team-1?tab=roster']}>
-        <Routes>
-          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
-        </Routes>
-      </MemoryRouter>
+    const router = createMemoryRouter(
+      [{ path: '/teams/:teamId', element: <TeamDetail auth={auth} /> }],
+      { initialEntries: ['/teams/team-1?tab=roster'] }
     );
+    render(<RouterProvider router={router} />);
 
     expect(await screen.findByText('120 active')).toBeTruthy();
     expect(await screen.findByText('Checklist 8')).toBeTruthy();
@@ -1168,11 +1171,21 @@ describe('TeamDetail', () => {
     expect(screen.getAllByTestId('roster-player-row')).toHaveLength(64);
     expect(screen.getAllByTestId('inactive-roster-player-row')).toHaveLength(12);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'Show players (120)' })[0]);
+    expect(screen.getByRole('button', { name: 'Show players (120) for Checklist 8' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Show players (120) for Checklist 1' }));
 
     expect(await screen.findAllByTestId('tracking-status-row')).toHaveLength(rosterRenderLimits.trackingStatuses);
     expect(screen.getAllByRole('button', { name: 'Open' })).toHaveLength(rosterRenderLimits.trackingStatuses);
-    expect(screen.getByRole('button', { name: 'Show 24 more statuses' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Show 24 more statuses for Checklist 1' })).toBeTruthy();
+
+    await act(async () => {
+      await router.navigate('/teams/team-2?tab=roster');
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Tigers' })).toBeTruthy();
+    expect(screen.getAllByTestId('roster-player-row')).toHaveLength(rosterRenderLimits.activePlayers);
+    expect(screen.getAllByTestId('inactive-roster-player-row')).toHaveLength(rosterRenderLimits.inactivePlayers);
+    expect(screen.queryAllByTestId('tracking-status-row')).toHaveLength(0);
   });
 
   it('links staff to the native awards studio from the team more tab', async () => {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -571,7 +571,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
           setDetailCollectionsReloadVersion((current) => current + 1);
         }} /> : <ScheduleTab model={model} auth={auth} onOpenStatTrackerConfigs={() => navigateToTab('more')} />
       ) : null}
-      {activeTab === 'roster' ? <RosterTab model={model} authUser={auth.user} onRefresh={refreshTeamDetail} rosterInviteLoading={rosterInviteLoading} rosterInviteError={rosterInviteError} rosterInviteSummaries={rosterInviteSummaries} onInviteCreated={refreshRosterInvites} trackingLoading={trackingLoading} trackingError={trackingError} trackingItems={trackingItems} onTrackingChanged={refreshTrackingItems} /> : null}
+      {activeTab === 'roster' ? <RosterTab key={model.team.id} model={model} authUser={auth.user} onRefresh={refreshTeamDetail} rosterInviteLoading={rosterInviteLoading} rosterInviteError={rosterInviteError} rosterInviteSummaries={rosterInviteSummaries} onInviteCreated={refreshRosterInvites} trackingLoading={trackingLoading} trackingError={trackingError} trackingItems={trackingItems} onTrackingChanged={refreshTrackingItems} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} loading={insightsLoading} error={insightsError} /> : null}
       {activeTab === 'more' ? (
         detailCollectionsLoading ? <InlineDeferredLoading copy="Loading team settings…" /> : detailCollectionsError ? <DeferredCollectionsErrorState message={detailCollectionsError} onRetry={() => {
@@ -1437,6 +1437,7 @@ function TrackingAdminCard({
       {trackingError ? <div className="mt-3 text-xs font-black text-rose-700">{trackingError}</div> : null}
       <div className="mt-3 space-y-3">
         {visibleItems.length ? visibleItems.map((item) => {
+          const itemName = item.name || 'Untitled item';
           const statusRowsExpanded = expandedStatusItemIds.has(item.id);
           const statusWindow = calculateRosterRenderWindow(item.playerStatuses.length, statusRowsExpanded ? (statusLimits[item.id] ?? rosterRenderLimits.trackingStatuses) : 0, rosterRenderLimits.trackingStatuses);
           const visibleStatuses = item.playerStatuses.slice(0, statusWindow.visibleCount);
@@ -1444,7 +1445,7 @@ function TrackingAdminCard({
           <div key={item.id} className="rounded-xl border border-white/80 bg-white p-3">
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div>
-                <div className="text-sm font-black text-gray-950">{item.name || 'Untitled item'}</div>
+                <div className="text-sm font-black text-gray-950">{itemName}</div>
                 {item.description ? <div className="mt-1 text-xs font-semibold text-gray-500">{item.description}</div> : null}
                 <div className="mt-2 flex flex-wrap gap-2">
                   <span className="rounded-full bg-primary-50 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] text-primary-700">{item.visibility}</span>
@@ -1453,7 +1454,7 @@ function TrackingAdminCard({
                 </div>
               </div>
               <div className="flex flex-wrap gap-2">
-                <button type="button" className="secondary-button !min-h-8 text-xs" onClick={() => toggleStatusRows(item.id)} aria-expanded={statusRowsExpanded} aria-controls={`tracking-statuses-${item.id}`}>
+                <button type="button" className="secondary-button !min-h-8 text-xs" onClick={() => toggleStatusRows(item.id)} aria-expanded={statusRowsExpanded} aria-controls={`tracking-statuses-${item.id}`} aria-label={`${statusRowsExpanded ? 'Hide players' : `Show players (${item.playerStatuses.length})`} for ${itemName}`}>
                   {statusRowsExpanded ? 'Hide players' : `Show players (${item.playerStatuses.length})`}
                 </button>
                 <button type="button" className="secondary-button !min-h-8 text-xs" onClick={() => beginEdit(item)} disabled={submitting || Boolean(busyKey)}>Edit</button>
@@ -1477,7 +1478,7 @@ function TrackingAdminCard({
                 </div>
               )) : <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-3 text-xs font-semibold text-gray-500">Add active roster players to manage statuses here.</div>}
               {statusWindow.hasMore ? (
-                <button type="button" className="secondary-button !min-h-9 text-xs sm:col-span-2" onClick={() => setStatusLimits((current) => ({ ...current, [item.id]: statusWindow.nextLimit }))}>
+                <button type="button" className="secondary-button !min-h-9 text-xs sm:col-span-2" onClick={() => setStatusLimits((current) => ({ ...current, [item.id]: statusWindow.nextLimit }))} aria-label={`Show ${Math.min(rosterRenderLimits.trackingStatuses, statusWindow.hiddenCount)} more statuses for ${itemName}`}>
                   Show {Math.min(rosterRenderLimits.trackingStatuses, statusWindow.hiddenCount)} more statuses
                 </button>
               ) : null}


### PR DESCRIPTION
## What changed

- Remount the Team Detail roster tab when the route switches to a different team, resetting active, inactive, and tracking pagination windows.
- Give each tracking-item disclosure and status-pagination control an item-specific accessible name.
- Extend the high-cardinality roster regression test to cover cross-team navigation and distinct control names.

## Why

PR #3806 bounded the initial roster DOM, but a direct team-to-team route change reused the existing roster component and preserved expanded pagination state. That could make the next team render more rows than the intended initial limits. Its tracking controls also repeated identical accessible names across checklist items, making them ambiguous for screen-reader and voice-control users.

## Impact

Each team now starts with the bounded roster window even after in-app navigation, and assistive-technology users can identify which checklist a tracking control affects.

## Validation

- `npm test -- --run src/pages/TeamDetail.test.tsx --reporter=verbose` (31/31)
- `npm run build`
- `npm exec eslint -- src/pages/TeamDetail.tsx src/pages/TeamDetail.test.tsx` (0 errors; pre-existing warnings only)
- `git diff --check`