### PR TITLE
Return registration detail to registrations

### DIFF
--- a/apps/app/src/lib/nativeBackButton.test.ts
+++ b/apps/app/src/lib/nativeBackButton.test.ts
@@ -23,7 +23,9 @@ describe('native back button helpers', () => {
     expect(getNativeBackTarget('/profile', '?section=alerts&teamId=team-2')).toBe('/profile');
     expect(getNativeBackTarget('/profile')).toBe('/home');
     expect(getNativeBackTarget('/teams/browse')).toBe('/teams');
-    expect(getNativeBackTarget('/parent-tools/registrations/team-1/form-1')).toBe('/parent-tools');
+    expect(getNativeBackTarget('/parent-tools/registrations/team-1/form-1')).toBe('/parent-tools/registrations');
+    expect(getNativeBackTarget('/parent-tools/registrations')).toBe('/parent-tools');
+    expect(getNativeBackTarget('/parent-tools/fees')).toBe('/parent-tools');
     expect(getNativeBackTarget('/help/game-day')).toBe('/help');
     expect(getNativeBackTarget('/home', '?section=feed&social=create')).toBe('/home?section=feed');
     expect(getNativeBackTarget('/home', '?section=friends')).toBe('/home');

--- a/apps/app/src/lib/nativeBackButton.ts
+++ b/apps/app/src/lib/nativeBackButton.ts
@@ -58,6 +58,7 @@ export function getNativeBackTarget(pathname: string, search = '') {
     }
   }
   if (/^\/teams\/[^/]+$/.test(path)) return '/teams';
+  if (/^\/parent-tools\/registrations\/[^/]+\/[^/]+$/.test(path)) return '/parent-tools/registrations';
   if (/^\/parent-tools\/.+/.test(path)) return '/parent-tools';
   if (/^\/players\//.test(path)) return '/home';
   if (/^\/games\//.test(path)) return '/schedule';

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ParentTools, type ParentToolId } from './ParentTools';
 import type { AuthState } from '../lib/types';
+import { getNativeBackTarget } from '../lib/nativeBackButton';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
@@ -1475,6 +1476,33 @@ describe('ParentTools access', () => {
 
         expect(await screen.findByText('Spring Skills')).toBeTruthy();
         expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
+
+    it('restores the registrations tab and list after native back from registration detail', async () => {
+        parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+            {
+                id: 'form-1',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                programName: 'Summer Camp',
+                description: 'Skills week',
+                season: 'Summer',
+                feeLabel: '$75.00',
+                paymentNotice: '',
+                onlineCheckout: true,
+                options: [],
+                url: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1'
+            }
+        ]);
+        const nativeBackTarget = getNativeBackTarget('/parent-tools/registrations/team-1/form-1');
+
+        expect(nativeBackTarget).toBe('/parent-tools/registrations');
+        renderParentTools([nativeBackTarget!], false, linkedAuth);
+
+        expect(await screen.findByText('Summer Camp')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Register' })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: 'Access' })).toHaveAttribute('aria-pressed', 'false');
+        expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledWith(linkedAuth.user);
     });
 
     it('defers public team and player loading until manual access starts', async () => {


### PR DESCRIPTION
## Summary

- Return native back from a Parent Tools registration detail to `/parent-tools/registrations`.
- Preserve the existing parent route behavior for tab-level routes such as Registrations and Fees.
- Add helper and route-level regressions proving the Register tab stays selected and its list reloads.

## Root cause

The generic `/parent-tools/*` native-back rule handled registration detail routes before their nested workflow target could be preserved. That sent users to bare `/parent-tools`, which defaults to Access.

## User impact

Android hardware back and Capacitor native-back navigation now return parents to the registration list they came from. The existing header Back to registrations link is unchanged.

## Validation

- `npm test -- --run src/lib/nativeBackButton.test.ts src/pages/ParentTools.test.tsx src/pages/RegistrationDetail.test.tsx --reporter=verbose` — 57 tests passed
- `npx eslint src/lib/nativeBackButton.ts src/lib/nativeBackButton.test.ts src/pages/ParentTools.test.tsx` — 0 errors; 3 pre-existing `no-explicit-any` warnings
- `npm run build` — passed
- `git diff --check` — passed

Closes #3805
