### PR TITLE
Register push-open listener before channel setup

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -10,6 +10,15 @@ import type { AuthState } from './lib/types';
 const suspendedHomePromise = new Promise<never>(() => {});
 let homeRenderMode: 'suspend' | 'throw' | 'render' = 'suspend';
 let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 const authMock = vi.hoisted(() => {
   const signedInAuth: AuthState = {
     user: { uid: 'user-1', email: 'parent@example.com', displayName: 'Pat Parent', roles: ['parent'] },
@@ -395,6 +404,48 @@ describe('App protected route loading', () => {
     expect(await screen.findByText('Officials assignments page')).toBeTruthy();
     await waitFor(() => expect(pushServiceMock.ensureAndroidNotificationChannels).toHaveBeenCalledTimes(1));
     expect(pushServiceMock.addPushNotificationOpenListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers native push-open routing before deferred Android channel setup completes', async () => {
+    const channelSetup = createDeferred();
+    pushServiceMock.ensureAndroidNotificationChannels.mockImplementationOnce(() => channelSetup.promise);
+
+    render(
+      <MemoryRouter initialEntries={['/officials']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(pushServiceMock.addPushNotificationOpenListener).toHaveBeenCalledTimes(1));
+    expect(pushServiceMock.ensureAndroidNotificationChannels).toHaveBeenCalledTimes(1);
+    expect(pushServiceMock.addPushNotificationOpenListener.mock.invocationCallOrder[0]).toBeLessThan(
+      pushServiceMock.ensureAndroidNotificationChannels.mock.invocationCallOrder[0]
+    );
+
+    await act(async () => channelSetup.resolve());
+
+    expect(pushServiceMock.addPushNotificationOpenListener).toHaveBeenCalledTimes(1);
+    expect(pushServiceMock.ensureAndroidNotificationChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the native push-open listener once when unmounted during deferred channel setup', async () => {
+    const channelSetup = createDeferred();
+    pushServiceMock.ensureAndroidNotificationChannels.mockImplementationOnce(() => channelSetup.promise);
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/officials']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(pushServiceMock.removers).toHaveLength(1));
+    const remove = pushServiceMock.removers[0];
+
+    unmount();
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    await act(async () => channelSetup.resolve());
+    expect(remove).toHaveBeenCalledTimes(1);
   });
 
   it('does not repeat native push setup when auth refresh replaces the same uid object', async () => {

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -169,12 +169,15 @@ export default function App() {
       // Dynamically import the push stack (Firebase messaging) so it stays out of
       // the boot critical path; registration only needs to run after first paint.
       const { addPushNotificationOpenListener, ensureAndroidNotificationChannels } = await import('./lib/pushService');
-      await ensureAndroidNotificationChannels();
-      const remove = await addPushNotificationOpenListener((route) => {
+      const listenerRemoval = addPushNotificationOpenListener((route) => {
         if (authUserRef.current) {
           navigate(route, { replace: true });
         }
       });
+      // Channel provisioning is best-effort inside pushService and must not delay
+      // notification tap routing during native boot.
+      void ensureAndroidNotificationChannels();
+      const remove = await listenerRemoval;
       if (!active) {
         remove();
         return;

--- a/tests/unit/app-push-notification-wiring.test.js
+++ b/tests/unit/app-push-notification-wiring.test.js
@@ -14,8 +14,12 @@ describe('app push notification wiring', () => {
         const source = readFileSync(new URL('../../apps/app/src/App.tsx', import.meta.url), 'utf8');
         expect(source).toContain("import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';");
         expect(source).toContain("const { addPushNotificationOpenListener, ensureAndroidNotificationChannels } = await import('./lib/pushService');");
-        expect(source).toContain('await ensureAndroidNotificationChannels();');
-        expect(source).toContain('const remove = await addPushNotificationOpenListener');
+        const listenerRegistrationIndex = source.indexOf('const listenerRemoval = addPushNotificationOpenListener');
+        const channelSetupIndex = source.indexOf('void ensureAndroidNotificationChannels();');
+        expect(listenerRegistrationIndex).toBeGreaterThan(-1);
+        expect(channelSetupIndex).toBeGreaterThan(listenerRegistrationIndex);
+        expect(source).toContain('const remove = await listenerRemoval;');
+        expect(source).not.toContain('await ensureAndroidNotificationChannels();');
         expect(source).toContain('removeListener = remove;');
         expect(source).toContain('const pendingRoute = readPendingPushRoute();');
         expect(source).toContain('clearPendingPushRoute();');


### PR DESCRIPTION
## Summary

- start native push-open listener registration before Android channel provisioning
- keep channel creation as best-effort background work through the existing push-service behavior
- add deferred-channel regressions for call ordering, duplicate prevention, and exact-once listener cleanup

## Why

`App.tsx` awaited five Android notification-channel bridge calls before it attached the notification-tap listener. On a native cold launch, that could delay routing the notification that opened the app. The listener now starts first, while channel provisioning continues independently without changing channel definitions or route semantics.

## User impact

Push notification taps can route promptly during signed-in native startup even when Android channel setup is slow. Channel creation remains session-idempotent and retryable through `pushService`.

## Validation

- `npm test -- --run src/App.test.tsx --reporter=verbose` — 21 passed
- `npm test -- --run src/lib/pushService.test.ts --reporter=dot` — 18 passed
- `npx vitest run tests/unit/app-push-notification-wiring.test.js --reporter=verbose` — 2 passed
- `npx eslint src/App.tsx src/App.test.tsx` — passed
- `npm run build` — passed (TypeScript and Vite production build)
- `git diff --cached --check` — passed before commit

Closes #3807
