### PR TITLE
Improve user-facing app copy

### DIFF
--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -850,8 +850,8 @@ function PlayersSection({ players }: { players: ParentHomePlayer[] }) {
     <section className="home-section-content app-card p-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <div className="app-label">My players</div>
-          <h2 className="mt-1 app-section-title">Player Drill-In</h2>
+          <div className="app-label">Players</div>
+          <h2 className="mt-1 app-section-title">My players</h2>
         </div>
         <UserRound className="h-5 w-5 text-primary-600" aria-hidden="true" />
       </div>

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1788,6 +1788,9 @@ describe('ScheduleEventDetail assignments', () => {
     await waitFor(() => {
       expect(screen.getByTestId('live-game-clock-panel')).toBeTruthy();
     });
+    expect(screen.getByText('Start or pause the clock, then advance the period as the game progresses.')).toBeTruthy();
+    expect(screen.getByText('The clock stays accurate if you leave the app and come back.')).toBeTruthy();
+    expect(screen.queryByText(/legacy tracker|persisted timestamp/i)).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: 'Start clock' }));
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -3226,7 +3226,7 @@ function LiveGameClockPanel({ auth, event, onLiveClockUpdated }: { auth: AuthSta
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="text-xs font-black uppercase tracking-[0.04em] text-rose-700">Live game clock</div>
-          <div className="mt-1 text-sm font-semibold text-gray-950">Start, pause, and advance periods with the same persisted live clock fields the legacy tracker restores.</div>
+          <div className="mt-1 text-sm font-semibold text-gray-950">Start or pause the clock, then advance the period as the game progresses.</div>
         </div>
         <span className="rounded-full bg-white px-3 py-1 text-xs font-black text-rose-700 shadow-sm">{liveClockView?.label || activePeriod}</span>
       </div>
@@ -3254,7 +3254,7 @@ function LiveGameClockPanel({ auth, event, onLiveClockUpdated }: { auth: AuthSta
         </button>
       </div>
 
-      <div className="mt-2 text-xs font-semibold text-gray-500">Clock state is anchored with a persisted timestamp so app backgrounding restores correctly.</div>
+      <div className="mt-2 text-xs font-semibold text-gray-500">The clock stays accurate if you leave the app and come back.</div>
       {status ? <div className={`mt-2 text-xs font-bold ${status.tone === 'error' ? 'text-rose-700' : 'text-emerald-700'}`}>{status.message}</div> : null}
     </div>
   );

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -427,6 +427,24 @@ describe('TeamDetail', () => {
     expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
   });
 
+  it('uses singular wording when the team has one completed game', async () => {
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      record: { label: '1-0', wins: 1, losses: 0, ties: 0, gamesPlayed: 1, winPercentage: 100 }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('1 completed game · 100%')).toBeTruthy();
+    expect(screen.queryByText('1 completed games · 100%')).toBeNull();
+  });
+
   it('surfaces deferred team collection failures on the schedule tab and lets users retry', async () => {
     teamDetailServiceMocks.loadParentTeamDetailBootstrap.mockResolvedValue({
       ...model,
@@ -846,6 +864,8 @@ describe('TeamDetail', () => {
     expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /roster/i }));
     fireEvent.click(await screen.findByRole('button', { name: 'Add player' }));
+    expect(screen.getByText("Add a player to this team's roster.")).toBeTruthy();
+    expect(screen.queryByText(/legacy roster editor/i)).toBeNull();
 
     await waitFor(() => expect(teamDetailServiceMocks.loadRosterFieldDefinitionsForApp).toHaveBeenCalledWith('team-1', auth.user));
     fireEvent.change(screen.getByPlaceholderText('Player name'), { target: { value: 'Alex New' } });

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -625,7 +625,7 @@ function OverviewTab({ model }: { model: TeamDetailModel }) {
   return (
     <div className="space-y-4">
       <section className="grid gap-3 sm:grid-cols-2">
-        <InfoCard icon={Trophy} title={`Season record (${model.record.label})`} value={formatRecord(model.record)} detail={model.record.gamesPlayed ? `${model.record.gamesPlayed} completed games${model.record.winPercentage !== null ? ` · ${model.record.winPercentage}%` : ''}` : 'No completed games yet'} />
+        <InfoCard icon={Trophy} title={`Season record (${model.record.label})`} value={formatRecord(model.record)} detail={model.record.gamesPlayed ? `${model.record.gamesPlayed} completed ${model.record.gamesPlayed === 1 ? 'game' : 'games'}${model.record.winPercentage !== null ? ` · ${model.record.winPercentage}%` : ''}` : 'No completed games yet'} />
         <InfoCard icon={CalendarDays} title="Next event" value={model.nextEvent ? formatEventDate(model.nextEvent.date) : 'No upcoming'} detail={model.nextEvent ? `${model.nextEvent.title} · ${model.nextEvent.location}` : 'Schedule is clear for now'} to={`/schedule?teamId=${encodeURIComponent(model.team.id)}`} />
         <InfoCard icon={Users} title="Roster size" value={`${model.players.length}`} detail={`${model.linkedPlayers.length || 0} linked to your account`} />
         <InfoCard icon={BarChart3} title="Standings" value={getStandingValue(model)} detail={getStandingDetail(model)} href={model.team.leagueUrl || undefined} />
@@ -1154,7 +1154,7 @@ function AddPlayerCard({ teamId, authUser, onCreated }: {
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <div className="text-sm font-black text-gray-950">Add player</div>
-          <div className="mt-1 text-xs font-semibold text-gray-600">Create a roster player in the same public team doc shape the legacy roster editor uses.</div>
+          <div className="mt-1 text-xs font-semibold text-gray-600">Add a player to this team&apos;s roster.</div>
         </div>
         {!open ? (
           <button type="button" className="primary-button !min-h-10 text-xs" onClick={openForm}>

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -1204,7 +1204,7 @@ test('home dashboard drills into player detail with section submenus', async ({ 
     await expect(page.getByText('Jamie Friend')).toBeVisible();
 
     await page.getByRole('button', { name: 'Players' }).click();
-    await expect(page.getByRole('heading', { name: 'Player Drill-In' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'My players' })).toBeVisible();
     await page.locator('a[href="#/players/team-1/player-1"]').click();
 
     await expect(page.getByRole('heading', { name: 'Pat Star' })).toBeVisible();
@@ -1260,7 +1260,7 @@ test('parent core player drill-in sends workflow timer to telemetry storage payl
     await mockHomePlayerModules(page);
     await page.goto(appUrl(baseURL, '/home?section=players'), { waitUntil: 'domcontentloaded' });
 
-    await waitForHomeRoute(page, page.getByRole('heading', { name: 'Player Drill-In' }));
+    await waitForHomeRoute(page, page.getByRole('heading', { name: 'My players' }));
     await page.locator('a[href="#/players/team-1/player-1"]').click();
 
     await expect(page.getByRole('heading', { name: 'Pat Star' })).toBeVisible();
@@ -1350,7 +1350,7 @@ test('parent core workflows emit baseline timers from Home drill-ins', async ({ 
             startHash: '/home?section=players',
             expectedTargetPage: 'player',
             expectedTargetRoute: '/players/team-1/player-1',
-            readyHome: (testPage) => testPage.getByRole('heading', { name: 'Player Drill-In' }),
+            readyHome: (testPage) => testPage.getByRole('heading', { name: 'My players' }),
             action: async (testPage) => {
                 await testPage.locator('a[href="#/players/team-1/player-1"]').click();
             },
@@ -1488,7 +1488,7 @@ test('requested app workflows emit DB-ready view load baseline timers', async ({
             route: '/home?section=players',
             startHash: '/home?section=players',
             ready: async (testPage) => {
-                await waitForHomeRoute(testPage, testPage.getByRole('heading', { name: 'Player Drill-In' }));
+                await waitForHomeRoute(testPage, testPage.getByRole('heading', { name: 'My players' }));
             }
         },
         {

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -594,7 +594,7 @@ describe('React app Home and player drill-in integration', () => {
         expect(socialMocks.respondToFriendRequest).toHaveBeenCalledWith('friendship-3', 'accepted');
 
         await clickButton(container, 'Players');
-        await waitForText(container, 'Player Drill-In');
+        await waitForText(container, 'My players');
         const playerLink = Array.from(container.querySelectorAll('a')).find((link) => link.getAttribute('href') === '/players/team-1/player-1');
         expect(playerLink?.getAttribute('href')).toBe('/players/team-1/player-1');
 


### PR DESCRIPTION
## Summary
- replace implementation-oriented Add player and live-clock helper text with plain user-facing guidance
- rename the Home players section heading from “Player Drill-In” to “My players”
- pluralize the completed-game count correctly for one game versus multiple games
- update component, unit, and smoke coverage for the revised copy

## Why
The affected screens exposed internal persistence and legacy-editor terminology to parents and coaches, and the season summary always used the plural noun.

## Validation
- `npm test -- --run src/pages/TeamDetail.test.tsx src/pages/ScheduleEventDetail.test.tsx --reporter=dot` — 145 passed
- `npx vitest run tests/unit/app-home-player-integration.test.jsx --reporter=dot` — 9 passed
- `npm run build` in `apps/app` — passed
- focused ESLint on the changed app files — 0 errors (existing warnings only)
- focused Playwright smoke for Home player navigation and telemetry — 2 passed

Closes #3771