### PR TITLE
Coalesce stale player searches

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -611,6 +611,37 @@ describe('AppSearchDialog', () => {
     expect(searchAppPlayersMock).toHaveBeenCalledWith('alex', expect.any(Map), null);
   });
 
+  it('waits for the shortened player coalesce window before running remote player search', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const knownTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Alexandria', sport: 'Soccer', zip: '64114' }];
+    getKnownAppSearchTeamsMock.mockReturnValue(knownTeams);
+    loadAppSearchTeamsMock.mockResolvedValue(knownTeams);
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'alex' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(299);
+      await Promise.resolve();
+    });
+    expect(searchAppTeamsMock).toHaveBeenCalledWith('alex', knownTeams, null);
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+    });
+
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
+    expect(searchAppPlayersMock).toHaveBeenCalledWith('alex', expect.any(Map), null);
+  });
+
   it('cancels a scheduled remote player search when the query is cleared', async () => {
     vi.useFakeTimers();
     const onClose = vi.fn();

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -567,6 +567,190 @@ describe('AppSearchDialog', () => {
     expect(searchAppPlayersMock).toHaveBeenNthCalledWith(1, 'be', expect.any(Map), null);
   });
 
+  it('coalesces superseded remote player searches while local teams and help keep updating', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const knownTeams: AppSearchTeam[] = [
+      { id: 'team-1', name: 'Alphas', sport: 'Basketball', zip: '66210' },
+      { id: 'team-2', name: 'Alexandria', sport: 'Soccer', zip: '64114' }
+    ];
+    getKnownAppSearchTeamsMock.mockReturnValue(knownTeams);
+    loadAppSearchTeamsMock.mockResolvedValue(knownTeams);
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByLabelText('Search teams, players, actions, help');
+    fireEvent.change(input, { target: { value: 'al' } });
+    expect(screen.getByRole('button', { name: /Alphas/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /Alexandria/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /Parent fee guide/i })).not.toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180);
+      await Promise.resolve();
+    });
+    expect(searchAppTeamsMock).toHaveBeenCalledWith('al', knownTeams, null);
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: 'alex' } });
+    expect(screen.queryByRole('button', { name: /Alphas/i })).toBeNull();
+    expect(screen.getByRole('button', { name: /Alexandria/i })).not.toBeNull();
+    expect(screen.getByRole('button', { name: /Parent fee guide/i })).not.toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(360);
+      await Promise.resolve();
+    });
+
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
+    expect(searchAppPlayersMock).toHaveBeenCalledWith('alex', expect.any(Map), null);
+  });
+
+  it('cancels a scheduled remote player search when the query is cleared', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const knownTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Alexandria', sport: 'Soccer', zip: '64114' }];
+    getKnownAppSearchTeamsMock.mockReturnValue(knownTeams);
+    loadAppSearchTeamsMock.mockResolvedValue(knownTeams);
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByLabelText('Search teams, players, actions, help');
+    fireEvent.change(input, { target: { value: 'alex' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search query' }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+      await Promise.resolve();
+    });
+
+    expect(input).toHaveValue('');
+    expect(screen.getByText('Type at least 2 characters to search players')).toBeTruthy();
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+  });
+
+  it('cancels a scheduled remote player search when the dialog closes', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const knownTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Alexandria', sport: 'Soccer', zip: '64114' }];
+    getKnownAppSearchTeamsMock.mockReturnValue(knownTeams);
+    loadAppSearchTeamsMock.mockResolvedValue(knownTeams);
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'alex' } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+
+    rerender(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={false} onClose={onClose} />
+      </MemoryRouter>
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+      await Promise.resolve();
+    });
+
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps stale player promises from replacing the latest player results', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const knownTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Alexandria', sport: 'Soccer', zip: '64114' }];
+    let releaseAl!: (players: AppSearchPlayer[]) => void;
+    let releaseAlex!: (players: AppSearchPlayer[]) => void;
+    const stalePlayer: AppSearchPlayer = {
+      id: 'player:team-1:al',
+      kind: 'player',
+      title: 'Al Older',
+      subtitle: 'Alexandria',
+      route: '/players/team-1/al',
+      teamId: 'team-1',
+      playerId: 'al',
+    };
+    const latestPlayer: AppSearchPlayer = {
+      id: 'player:team-1:alex',
+      kind: 'player',
+      title: 'Alex Latest',
+      subtitle: 'Alexandria',
+      route: '/players/team-1/alex',
+      teamId: 'team-1',
+      playerId: 'alex',
+    };
+
+    getKnownAppSearchTeamsMock.mockReturnValue(knownTeams);
+    loadAppSearchTeamsMock.mockResolvedValue(knownTeams);
+    searchAppPlayersMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseAl = resolve;
+      }))
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseAlex = resolve;
+      }));
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByLabelText('Search teams, players, actions, help');
+    fireEvent.change(input, { target: { value: 'al' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(360);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).toHaveBeenCalledWith('al', expect.any(Map), null);
+
+    fireEvent.change(input, { target: { value: 'alex' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(360);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).toHaveBeenCalledWith('alex', expect.any(Map), null);
+
+    await act(async () => {
+      releaseAlex([latestPlayer]);
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByRole('button', { name: /Alex Latest/i })).not.toBeNull();
+
+    await act(async () => {
+      releaseAl([stalePlayer]);
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByRole('button', { name: /Alex Latest/i })).not.toBeNull();
+    expect(screen.queryByRole('button', { name: /Al Older/i })).toBeNull();
+  });
+
   it('ignores stale hydrated teams after the dialog closes before query-time loading finishes', async () => {
     const onClose = vi.fn();
     const userA = { uid: 'user-a', email: 'a@example.com' } as NonNullable<AuthState['user']>;
@@ -740,23 +924,40 @@ describe('AppSearchDialog', () => {
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'be' } });
 
     expect(screen.getByRole('button', { name: /Bears/i })).not.toBeNull();
-    await vi.advanceTimersByTimeAsync(430);
-    await Promise.resolve();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(430);
+      await Promise.resolve();
+    });
     expect(searchAppTeamsMock).toHaveBeenCalledTimes(1);
-    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
     expect(searchAppTeamsMock).toHaveBeenNthCalledWith(1, 'be', initialTeams, null);
+    expect(searchAppPlayersMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
     expect(searchAppPlayersMock).toHaveBeenNthCalledWith(1, 'be', expect.any(Map), null);
     expect(Array.from(searchAppPlayersMock.mock.calls[0][1].values())).toEqual(initialTeams);
     expect(screen.queryByRole('button', { name: /Beacons/i })).toBeNull();
 
-    releaseHydration(hydratedTeams);
-    await vi.advanceTimersByTimeAsync(50);
-    await Promise.resolve();
-    await vi.advanceTimersByTimeAsync(0);
+    await act(async () => {
+      releaseHydration(hydratedTeams);
+      await vi.advanceTimersByTimeAsync(50);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
 
     expect(searchAppTeamsMock).toHaveBeenCalledTimes(2);
-    expect(searchAppPlayersMock).toHaveBeenCalledTimes(2);
     expect(searchAppTeamsMock).toHaveBeenNthCalledWith(2, 'be', hydratedTeams, null);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(2);
     expect(searchAppPlayersMock).toHaveBeenNthCalledWith(2, 'be', expect.any(Map), null);
     expect(Array.from(searchAppPlayersMock.mock.calls[1][1].values())).toEqual(hydratedTeams);
     expect(screen.getAllByRole('button', { name: /Beacons/i })).toHaveLength(2);

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -783,6 +783,88 @@ describe('AppSearchDialog', () => {
     expect(screen.queryByRole('button', { name: /Al Older/i })).toBeNull();
   });
 
+  it('keeps stale initial-scope player results from replacing hydrated-scope results for the same query', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+    const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+    const hydratedTeams: AppSearchTeam[] = [
+      ...initialTeams,
+      { id: 'team-2', name: 'Beacons', sport: 'Soccer', zip: '64114' }
+    ];
+    let releaseHydration!: (teams: AppSearchTeam[]) => void;
+    let releaseInitialPlayers!: (players: AppSearchPlayer[]) => void;
+    let releaseHydratedPlayers!: (players: AppSearchPlayer[]) => void;
+
+    getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
+    loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseHydration = resolve;
+    }));
+    searchAppPlayersMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseInitialPlayers = resolve;
+      }))
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        releaseHydratedPlayers = resolve;
+      }));
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'be' } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(550);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(1);
+    expect(Array.from(searchAppPlayersMock.mock.calls[0][1].keys())).toEqual(['team-1']);
+
+    await act(async () => {
+      releaseHydration(hydratedTeams);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(120);
+      await Promise.resolve();
+    });
+    expect(searchAppPlayersMock).toHaveBeenCalledTimes(2);
+    expect(Array.from(searchAppPlayersMock.mock.calls[1][1].keys())).toEqual(['team-1', 'team-2']);
+
+    const hydratedPlayer: AppSearchPlayer = {
+      id: 'player:team-2:latest',
+      kind: 'player',
+      title: 'Beacon Latest',
+      subtitle: 'Beacons',
+      route: '/players/team-2/latest',
+      teamId: 'team-2',
+      playerId: 'latest',
+    };
+    const stalePlayer: AppSearchPlayer = {
+      id: 'player:team-1:stale',
+      kind: 'player',
+      title: 'Bear Stale',
+      subtitle: 'Bears',
+      route: '/players/team-1/stale',
+      teamId: 'team-1',
+      playerId: 'stale',
+    };
+
+    await act(async () => {
+      releaseHydratedPlayers([hydratedPlayer]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('button', { name: /Beacon Latest/i })).not.toBeNull();
+
+    await act(async () => {
+      releaseInitialPlayers([stalePlayer]);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('button', { name: /Beacon Latest/i })).not.toBeNull();
+    expect(screen.queryByRole('button', { name: /Bear Stale/i })).toBeNull();
+  });
+
   it('ignores stale hydrated teams after the dialog closes before query-time loading finishes', async () => {
     const onClose = vi.fn();
     const userA = { uid: 'user-a', email: 'a@example.com' } as NonNullable<AuthState['user']>;

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -125,9 +125,10 @@ const auth: AuthState = {
 
 describe('AppSearchDialog', () => {
   afterEach(() => {
+    cleanup();
+    vi.clearAllTimers();
     vi.useRealTimers();
     vi.restoreAllMocks();
-    cleanup();
   });
 
   beforeEach(() => {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -28,6 +28,7 @@ type AppSearchDialogProps = {
 const backdropCloseGuardMs = 750;
 const hydrationSearchFallbackMs = 250;
 const keyboardInsetActivationThresholdPx = 80;
+const remotePlayerSearchCoalesceMs = 180;
 
 export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [query, setQuery] = useState('');
@@ -40,6 +41,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [keyboardInset, setKeyboardInset] = useState(0);
   const searchRequestId = useRef(0);
+  const playerSearchTimeoutRef = useRef<number | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const openedAtRef = useRef(Date.now());
   const preloadedRoutesRef = useRef(new Set<string>());
@@ -55,6 +57,12 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const helpResults = results.help ?? [];
   const flatResults = results.flat ?? [...results.actions, ...results.teams, ...helpResults, ...results.players];
 
+  const clearScheduledPlayerSearch = () => {
+    if (playerSearchTimeoutRef.current === null) return;
+    window.clearTimeout(playerSearchTimeoutRef.current);
+    playerSearchTimeoutRef.current = null;
+  };
+
   useEffect(() => {
     if (!open) return;
     openedAtRef.current = Date.now();
@@ -64,6 +72,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setPlayers([]);
     setPlayersError('');
     setPlayersLoading(false);
+    clearScheduledPlayerSearch();
     const knownTeams = getKnownAppSearchTeams(auth.user);
     baseTeamsRef.current = knownTeams;
     setTeams(knownTeams);
@@ -77,6 +86,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     let disposed = false;
     const trimmedQuery = query.trim();
     const requestId = ++searchRequestId.current;
+    clearScheduledPlayerSearch();
 
     if (trimmedQuery.length < 2) {
       setTeams(baseTeamsRef.current);
@@ -87,6 +97,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       setPlayersError('');
       return () => {
         disposed = true;
+        clearScheduledPlayerSearch();
       };
     }
 
@@ -103,42 +114,50 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setPlayersLoading(true);
     setPlayersError('');
     const timeoutId = window.setTimeout(() => {
-      const applyPlayerResults = (playersResult: PromiseSettledResult<AppSearchPlayer[]>) => {
+      const schedulePlayerSearch = (accessibleTeams: AppSearchTeam[]) => {
+        clearScheduledPlayerSearch();
+        playerSearchTimeoutRef.current = window.setTimeout(async () => {
+          playerSearchTimeoutRef.current = null;
+          if (disposed || requestId !== searchRequestId.current) return;
+          const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
+          const [playersResult] = await Promise.allSettled([
+            searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)
+          ]) as [PromiseSettledResult<AppSearchPlayer[]>];
+
+          if (disposed || requestId !== searchRequestId.current) return;
+          if (playersResult.status === 'fulfilled') {
+            setPlayers(playersResult.value);
+            setPlayersError('');
+          } else {
+            setPlayers([]);
+            setPlayersError(getPlayerSearchError(playersResult.reason));
+          }
+          setPlayersLoading(false);
+        }, remotePlayerSearchCoalesceMs);
+      };
+
+      const applyTeamResults = (teamsResult: PromiseSettledResult<AppSearchTeam[]>) => {
         if (disposed || requestId !== searchRequestId.current) return;
-        if (playersResult.status === 'fulfilled') {
-          setPlayers(playersResult.value);
-          setPlayersError('');
+        if (teamsResult.status === 'fulfilled') {
+          setTeams(teamsResult.value);
+          setTeamsError('');
           return;
         }
-        setPlayers([]);
-        setPlayersError(getPlayerSearchError(playersResult.reason));
+        setTeams([]);
+        setTeamsError(teamsResult.reason?.message || 'Team search unavailable.');
       };
 
       const runSearch = async (accessibleTeams: AppSearchTeam[]) => {
         if (disposed || requestId !== searchRequestId.current) return;
-        const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
         setImmediateTeamResults(accessibleTeams);
+        schedulePlayerSearch(accessibleTeams);
 
-        const [teamsResult, playersResult] = await Promise.allSettled([
-          searchAppTeams(trimmedQuery, accessibleTeams, auth.user),
-          searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)
-        ]) as [PromiseSettledResult<AppSearchTeam[]>, PromiseSettledResult<AppSearchPlayer[]>];
-
-        if (disposed || requestId !== searchRequestId.current) return;
-
-        if (teamsResult.status === 'fulfilled') {
-          setTeams(teamsResult.value);
-          setTeamsError('');
-        } else {
-          setTeams([]);
-          setTeamsError(teamsResult.reason?.message || 'Team search unavailable.');
-        }
-
-        applyPlayerResults(playersResult);
-
+        const [teamsResult] = await Promise.allSettled([
+          searchAppTeams(trimmedQuery, accessibleTeams, auth.user)
+        ]) as [PromiseSettledResult<AppSearchTeam[]>];
+        applyTeamResults(teamsResult);
         if (!disposed && requestId === searchRequestId.current) {
           setTeamsLoading(false);
-          setPlayersLoading(false);
         }
       };
 
@@ -187,6 +206,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
           if (!disposed && requestId === searchRequestId.current) {
             setTeamsLoading(false);
             setPlayersLoading(false);
+            clearScheduledPlayerSearch();
           }
         });
     }, 180);
@@ -194,6 +214,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     return () => {
       disposed = true;
       window.clearTimeout(timeoutId);
+      clearScheduledPlayerSearch();
     };
   }, [auth.user, open, query]);
 
@@ -289,6 +310,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   const clearQuery = () => {
     searchRequestId.current += 1;
+    clearScheduledPlayerSearch();
     setQuery('');
     searchInputRef.current?.focus();
   };

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -41,6 +41,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [keyboardInset, setKeyboardInset] = useState(0);
   const searchRequestId = useRef(0);
+  const playerSearchGenerationRef = useRef(0);
   const playerSearchTimeoutRef = useRef<number | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const openedAtRef = useRef(Date.now());
@@ -116,15 +117,16 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     const timeoutId = window.setTimeout(() => {
       const schedulePlayerSearch = (accessibleTeams: AppSearchTeam[]) => {
         clearScheduledPlayerSearch();
+        const generation = ++playerSearchGenerationRef.current;
         playerSearchTimeoutRef.current = window.setTimeout(async () => {
           playerSearchTimeoutRef.current = null;
-          if (disposed || requestId !== searchRequestId.current) return;
+          if (disposed || requestId !== searchRequestId.current || generation !== playerSearchGenerationRef.current) return;
           const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
           const [playersResult] = await Promise.allSettled([
             searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)
           ]) as [PromiseSettledResult<AppSearchPlayer[]>];
 
-          if (disposed || requestId !== searchRequestId.current) return;
+          if (disposed || requestId !== searchRequestId.current || generation !== playerSearchGenerationRef.current) return;
           if (playersResult.status === 'fulfilled') {
             setPlayers(playersResult.value);
             setPlayersError('');

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -28,7 +28,7 @@ type AppSearchDialogProps = {
 const backdropCloseGuardMs = 750;
 const hydrationSearchFallbackMs = 250;
 const keyboardInsetActivationThresholdPx = 80;
-const remotePlayerSearchCoalesceMs = 180;
+const remotePlayerSearchCoalesceMs = 120;
 
 export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [query, setQuery] = useState('');


### PR DESCRIPTION
Closes #3773

## What changed
- Added a cancellable remote player-search scheduler in `AppSearchDialog` so superseded typeahead queries are skipped before `searchAppPlayers` is invoked.
- Kept immediate local team/help results responsive while remote player results load only for the latest active query.
- Added fake-timer regression coverage for superseded typing, clear cancellation, close cancellation, and stale promise resolution.

## Root Cause
`AppSearchDialog` used `requestId` only to prevent stale UI updates after async results resolved. Once a query crossed the existing 180 ms debounce, the same search path still invoked `searchAppPlayers` for intermediate queries, so stale player-search fan-out consumed network and Firestore query budget even though the UI later discarded those results.

## Prevention / Learning
For expensive remote fan-out in typeahead flows, separate immediate local rendering from cancellable remote scheduling. Regression tests should assert superseded inputs do not call the remote service, not just that stale results are ignored in the UI.

## Regression Tests
- `npm --prefix apps/app test -- --run src/components/AppSearchDialog.test.tsx`
- `npm run app:build`