### PR TITLE
Persist live tracker log removals

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1143,6 +1143,7 @@ function renderLog() {
 
         // Remove the log entry
         state.log.splice(index, 1);
+        persistLocalTrackerState();
 
         // Re-render everything to reflect the changes
         renderAll();

--- a/tests/smoke/live-tracker-foul-workflow.spec.js
+++ b/tests/smoke/live-tracker-foul-workflow.spec.js
@@ -469,6 +469,18 @@ test('adds a home foul through the live tracker and removes it from the log with
         const store = await readStore(page);
         return store.aggregatedStats?.p1?.stats?.fouls;
     }).toBe(4);
+
+    await expect.poll(async () => {
+        return page.evaluate((stateKey) => {
+            const persisted = JSON.parse(localStorage.getItem(stateKey) || 'null');
+            return persisted?.state?.stats?.p1?.fouls;
+        }, LOCAL_STATE_KEY);
+    }).toBe(4);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#live-players')).toContainText(/FLS 4.*⚠️/);
+    await expect(page.locator('#live-players')).not.toContainText('FOULED OUT!');
+    await expect(page.locator('#log-mobile > div').filter({ hasText: '#3 FOULS +1' })).toHaveCount(1);
 });
 
 test('persists offline live scoring events and drains restored queue after reconnect', async ({ page, baseURL }) => {


### PR DESCRIPTION
Closes #3819

## What changed
- Persist the corrected live tracker local resume snapshot immediately after a log entry is removed.
- Extended the live tracker foul workflow smoke test to verify the corrected foul count is written to localStorage and survives a same-browser reload.

## Root Cause
The remove-log handler reversed the foul in memory and scheduled Firestore aggregate sync, but it did not rewrite the local tracker resume snapshot. On reload, `applyPersistedLocalTrackerState()` restored the stale localStorage copy with the removed foul and log entry still present.

## Prevention / Learning
Any live tracker mutation that changes `state.log` or derived stat totals must persist the local resume snapshot in the same success path before returning or relying on async sync work.

## Regression Tests
- `npx playwright test tests/smoke/live-tracker-foul-workflow.spec.js --config=playwright.smoke.config.js --grep "adds a home foul" --reporter=line`