### PR TITLE
Clarify pending invite code validation

### DIFF
--- a/apps/app/src/pages/AcceptInvite.test.tsx
+++ b/apps/app/src/pages/AcceptInvite.test.tsx
@@ -99,6 +99,7 @@ describe('AcceptInvite', () => {
             email: 'parent@example.com',
             refresh: auth.refresh
         });
+        expect(inviteRedemptionMocks.redeemSignedInInvite).toHaveBeenCalledTimes(1);
     });
 
     it('does not apply the delayed success redirect after leaving the invite route', async () => {

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { CheckCircle2, KeyRound, LogIn, ShieldCheck, UserPlus, XCircle } from 'lucide-react';
@@ -57,7 +57,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
     };
   }, []);
 
-  function scheduleRedirect(path: string) {
+  const scheduleRedirect = useCallback((path: string) => {
     if (!path) return;
 
     if (redirectTimerRef.current !== null) {
@@ -71,9 +71,9 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
       }
       navigate(path, { replace: true });
     }, 700);
-  }
+  }, [navigate]);
 
-  async function redeem(codeToRedeem: string) {
+  const redeem = useCallback(async (codeToRedeem: string) => {
     const normalizedCode = normalizeInviteCode(codeToRedeem);
     if (!auth.user) {
       rememberPendingInvite(normalizedCode, inviteType);
@@ -105,7 +105,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
       setState('error');
       setMessage(error?.message || 'Unable to accept this invite.');
     }
-  }
+  }, [auth.refresh, auth.user, inviteType, navigate, scheduleRedirect]);
 
   useEffect(() => {
     if (isEmailLink(window.location.href) && !auth.user) {
@@ -116,7 +116,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
     if (!auth.loading && auth.user && code) {
       redeem(code);
     }
-  }, [auth.loading, auth.user, code]);
+  }, [auth.loading, auth.user, code, redeem]);
 
   const handleManualSubmit = async (event: FormEvent) => {
     event.preventDefault();

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -168,8 +168,9 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
 
       {code && !auth.user && state !== 'email-link' ? (
         <div className="mt-4 rounded-xl border border-primary-100 bg-primary-50 p-3">
-          <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-primary-700">Invite found</div>
+          <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-primary-700">Invite code entered</div>
           <div className="mt-1 font-mono text-lg font-black tracking-widest text-primary-900">{code}</div>
+          <p className="mt-1 text-sm font-semibold text-primary-800">We’ll verify this code after you sign in or create your account.</p>
           <div className="mt-3 grid gap-2">
             <Link to={`${authUrl}&mode=login`} className="primary-button justify-center">
               <LogIn className="h-4 w-4" aria-hidden="true" />

--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -131,6 +131,14 @@ describe('AuthPage signup validation', () => {
     cleanup();
   });
 
+  it('describes an unverified invite code without claiming it was applied', () => {
+    renderAuthPage('/auth?mode=login&code=QQQQQQQQ&type=parent');
+
+    expect(screen.getByText(/Invite code entered:/).textContent).toContain('QQQQQQQQ');
+    expect(screen.getByText('We’ll verify it after you sign in or create your account.')).toBeTruthy();
+    expect(screen.queryByText(/Invite code applied:/)).toBeNull();
+  });
+
   it('stops signup before Firebase when the email is invalid for Firebase Auth', async () => {
     renderAuthPage('/auth?mode=signup&code=6WSSSW9V&type=parent');
 

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -203,8 +203,9 @@ export function AuthPage({ auth }: { auth: AuthState }) {
       </div>
 
       {inviteCode ? (
-        <div className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm font-semibold text-emerald-800">
-          Invite code applied: <span className="font-mono font-black tracking-widest">{inviteCode}</span>
+        <div className="mt-4 rounded-xl border border-primary-100 bg-primary-50 p-3 text-sm font-semibold text-primary-800">
+          <div>Invite code entered: <span className="font-mono font-black tracking-widest">{inviteCode}</span></div>
+          <div className="mt-1">We’ll verify it after you sign in or create your account.</div>
         </div>
       ) : null}
 

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -580,7 +580,8 @@ test('app auth screen exposes sign in, sign up, Google, activation code, invite,
     await page.goto(appUrl(baseURL, '/auth?code=AB12CD34&type=parent'), { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByRole('heading', { name: 'Create your account' })).toBeVisible();
-    await expect(page.getByText('Invite code applied:')).toBeVisible();
+    await expect(page.getByText('Invite code entered:')).toBeVisible();
+    await expect(page.getByText('We’ll verify it after you sign in or create your account.')).toBeVisible();
     await expect(page.getByLabel('Activation or invite code')).toHaveValue('AB12CD34');
     await expect(page.getByRole('button', { name: 'Continue with Google' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Enter invite code' })).toBeVisible();
@@ -715,7 +716,8 @@ test('profile exposes account, notification, invite, verification, password, upl
     await mockAppModules(recipientPage);
     await recipientPage.goto(sharedInviteUrl, { waitUntil: 'domcontentloaded' });
     await expect(recipientPage.getByRole('heading', { name: 'Accept invite' })).toBeVisible();
-    await expect(recipientPage.getByText('Invite found')).toBeVisible();
+    await expect(recipientPage.getByText('Invite code entered')).toBeVisible();
+    await expect(recipientPage.getByText('We’ll verify this code after you sign in or create your account.')).toBeVisible();
     await expect(recipientPage.getByText('NEWMVP42')).toBeVisible();
     await expect(recipientPage.getByRole('link', { name: 'Sign in to accept' })).toBeVisible();
     await expect(recipientPage.getByRole('link', { name: 'Create account with code' })).toBeVisible();

--- a/tests/unit/app-auth-invite-mode.test.jsx
+++ b/tests/unit/app-auth-invite-mode.test.jsx
@@ -122,7 +122,9 @@ describe('AuthPage invite mode defaults', () => {
         expect(container.querySelector('h1')?.textContent).toBe('Sign in');
         expect(findButton(container, 'Sign in')?.className).toContain('bg-white');
         expect(findInputByLabel(container, 'Activation or invite code')).toBeUndefined();
-        expect(container.textContent).toContain('Invite code applied:');
+        expect(container.textContent).toContain('Invite code entered:');
+        expect(container.textContent).toContain('We’ll verify it after you sign in or create your account.');
+        expect(container.textContent).not.toContain('Invite code applied:');
         expect(container.textContent).toContain('ABCDEFGH');
     });
 
@@ -139,6 +141,9 @@ describe('AcceptInvite auth handoff', () => {
     it('preserves invite code and login intent for existing-account redemption', async () => {
         const { container } = await renderAcceptInvite('/accept-invite?code=ABCDEFGH&type=parent');
 
+        expect(container.textContent).toContain('Invite code entered');
+        expect(container.textContent).toContain('We’ll verify this code after you sign in or create your account.');
+        expect(container.textContent).not.toContain('Invite found');
         expect(findLink(container, /sign in to accept/i)?.getAttribute('href')).toBe('/auth?code=ABCDEFGH&type=parent&mode=login');
         expect(findLink(container, /create account with code/i)?.getAttribute('href')).toBe('/auth?code=ABCDEFGH&type=parent&mode=signup');
     });


### PR DESCRIPTION
## What changed

- Replace the signed-out invite handoff’s false “applied” success state with neutral pending-verification copy.
- Remove the similarly misleading “Invite found” claim from the accept-invite screen.
- Preserve the existing sign-in and account-creation handoffs so authenticated signup/redemption continues to validate the code through the established backend flow.
- Add regression coverage for a garbage eight-character code and for both invite handoff screens.

## Why

Anonymous access-code validation intentionally returns a generic failure before querying code documents, which prevents invite enumeration. The prior UI nevertheless treated any eight-character query parameter as successfully applied. The safe behavior is to describe the code as entered and clearly say it will be verified after authentication.

## Validation

- `npx vitest run apps/app/src/pages/AuthPage.test.tsx tests/unit/app-auth-invite-mode.test.jsx --reporter=verbose` (12/12 passed)
- `npm --prefix apps/app run build`
- `./node_modules/.bin/eslint src/pages/AcceptInvite.tsx src/pages/AuthPage.tsx src/pages/AuthPage.test.tsx` from `apps/app` (0 errors; 8 existing warnings)
- `git diff --check`

Closes #3814