### PR TITLE
Make password reset responses neutral

### DIFF
--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -95,6 +95,7 @@ vi.mock('./logger', () => ({
 }));
 
 import {
+  sendPasswordResetEmail,
   signInWithPopup,
   signInWithRedirect
 } from './firebaseAuthRuntime';
@@ -105,6 +106,7 @@ import {
   hydrateFirebaseUser,
   isValidAuthEmail,
   observeFirebaseUser,
+  sendResetEmail,
   signInWithEmail,
   signInWithGoogleAccount,
   signOut,
@@ -122,6 +124,42 @@ describe('auth email validation', () => {
       code: 'auth/invalid-email',
       message: 'Firebase: Error (auth/invalid-email).'
     })).toBe('Enter a valid email address.');
+  });
+
+  it('does not disclose whether a sign-in email belongs to an account', () => {
+    expect(describeAuthError({ code: 'auth/user-not-found' })).toBe('Email or password is incorrect.');
+  });
+});
+
+describe('sendResetEmail', () => {
+  const sendPasswordResetEmailMock = vi.mocked(sendPasswordResetEmail);
+
+  beforeEach(() => {
+    sendPasswordResetEmailMock.mockReset();
+  });
+
+  it('normalizes the email and configures the app reset destination', async () => {
+    sendPasswordResetEmailMock.mockResolvedValue(undefined);
+
+    await sendResetEmail(' Player@Example.COM ');
+
+    expect(sendPasswordResetEmailMock).toHaveBeenCalledWith(authState, 'player@example.com', {
+      url: 'https://allplays.ai/reset-password.html',
+      handleCodeInApp: true
+    });
+  });
+
+  it('treats a missing account like a successful reset request', async () => {
+    sendPasswordResetEmailMock.mockRejectedValue({ code: 'auth/user-not-found' });
+
+    await expect(sendResetEmail('missing@example.com')).resolves.toBeUndefined();
+  });
+
+  it('preserves actionable reset failures', async () => {
+    const error = { code: 'auth/too-many-requests' };
+    sendPasswordResetEmailMock.mockRejectedValue(error);
+
+    await expect(sendResetEmail('player@example.com')).rejects.toBe(error);
   });
 });
 

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -32,6 +32,7 @@ import { clearAppDataCache } from './appDataCache';
 import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
+export const passwordResetConfirmationMessage = "If an account exists for that email, we've sent a reset link.";
 
 const pendingActivationCodeKey = 'pendingActivationCode';
 const pendingInviteCodeKey = 'allplays-app-pending-invite-code';
@@ -219,16 +220,12 @@ export function describeAuthError(error: any) {
     return `Firebase is blocking this local origin (${origin}). Add it to the Firebase web API key restrictions.`;
   }
 
-  if (code === 'auth/invalid-credential' || code === 'auth/wrong-password') {
+  if (code === 'auth/invalid-credential' || code === 'auth/wrong-password' || code === 'auth/user-not-found') {
     return 'Email or password is incorrect.';
   }
 
   if (code === 'auth/invalid-email' || message.includes('auth/invalid-email') || message.includes('INVALID_EMAIL')) {
     return 'Enter a valid email address.';
-  }
-
-  if (code === 'auth/user-not-found') {
-    return 'No ALL PLAYS account was found for that email.';
   }
 
   if (code === 'auth/too-many-requests') {
@@ -1192,10 +1189,20 @@ export async function completeGoogleRedirect() {
 }
 
 export async function sendResetEmail(email: string) {
-  await sendPasswordResetEmail(auth, requireValidAuthEmail(email), {
-    url: 'https://allplays.ai/reset-password.html',
-    handleCodeInApp: true
-  });
+  try {
+    await sendPasswordResetEmail(auth, requireValidAuthEmail(email), {
+      url: 'https://allplays.ai/reset-password.html',
+      handleCodeInApp: true
+    });
+  } catch (error: unknown) {
+    // Older Firebase configurations can still return this error even though newer
+    // projects suppress it. Treat it as success so password reset cannot be used
+    // to discover whether an email address belongs to an account.
+    if ((error as { code?: string } | null)?.code === 'auth/user-not-found') {
+      return;
+    }
+    throw error;
+  }
 }
 
 export async function resendVerificationEmail() {

--- a/apps/app/src/pages/AuthPage.test.tsx
+++ b/apps/app/src/pages/AuthPage.test.tsx
@@ -21,6 +21,7 @@ const authServiceMocks = vi.hoisted(() => ({
     return parts.length === 2 && Boolean(parts[0] && parts[1]?.includes('.') && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized));
   },
   normalizeAuthEmail: (value: string | null | undefined) => String(value || '').trim().toLowerCase(),
+  passwordResetConfirmationMessage: "If an account exists for that email, we've sent a reset link.",
   rememberPendingInvite: vi.fn(),
   sendResetEmail: vi.fn(),
   signInWithEmail: vi.fn(),
@@ -227,5 +228,33 @@ describe('AuthPage sign-in error state', () => {
 
     fireEvent.change(emailInput, { target: { value: 'coach-updated@example.com' } });
     expect(screen.queryByText('Email or password is incorrect.')).toBeNull();
+  });
+});
+
+describe('AuthPage password reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth.refresh = vi.fn();
+    auth.signOut = vi.fn();
+    authServiceMocks.sendResetEmail.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows neutral confirmation copy after requesting a reset', async () => {
+    authServiceMocks.sendResetEmail.mockResolvedValue(undefined);
+    renderAuthPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Forgot password?' }));
+    fireEvent.change(screen.getByLabelText('Password reset email'), {
+      target: { value: ' Missing@Example.COM ' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send reset email' }));
+
+    await waitFor(() => expect(authServiceMocks.sendResetEmail).toHaveBeenCalledWith('missing@example.com'));
+    expect(await screen.findByText("If an account exists for that email, we've sent a reset link.")).toBeTruthy();
+    expect(screen.queryByText(/no all plays account/i)).toBeNull();
   });
 });

--- a/apps/app/src/pages/AuthPage.tsx
+++ b/apps/app/src/pages/AuthPage.tsx
@@ -10,6 +10,7 @@ import {
   hydrateFirebaseUser,
   isValidAuthEmail,
   normalizeAuthEmail,
+  passwordResetConfirmationMessage,
   rememberPendingInvite,
   sendResetEmail,
   signInWithEmail,
@@ -180,7 +181,7 @@ export function AuthPage({ auth }: { auth: AuthState }) {
         throw new Error('Enter a valid email address.');
       }
       await sendResetEmail(normalizedEmail);
-      setMessage('Password reset email sent. Check your inbox and spam folder.');
+      setMessage(passwordResetConfirmationMessage);
       setShowReset(false);
     } catch (resetError: any) {
       setError(describeAuthError(resetError));
@@ -295,8 +296,8 @@ export function AuthPage({ auth }: { auth: AuthState }) {
 
       {showReset ? (
         <form className="mt-3 rounded-xl border border-gray-200 bg-gray-50 p-3" onSubmit={handleReset}>
-          <label className="text-xs font-extrabold uppercase tracking-[0.04em] text-gray-500">Password reset email</label>
-          <input className="auth-input mt-2" type="email" value={resetEmail} onChange={(event) => setResetEmail(event.target.value)} placeholder={email || 'you@example.com'} />
+          <label htmlFor="password-reset-email" className="text-xs font-extrabold uppercase tracking-[0.04em] text-gray-500">Password reset email</label>
+          <input id="password-reset-email" className="auth-input mt-2" type="email" value={resetEmail} onChange={(event) => setResetEmail(event.target.value)} placeholder={email || 'you@example.com'} />
           <button type="submit" className="secondary-button mt-3 w-full" disabled={busy}>
             Send reset email
           </button>

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -1,10 +1,8 @@
+export const PASSWORD_RESET_CONFIRMATION_MESSAGE = "If an account exists for that email, we've sent a reset link.";
+
 export function getPasswordResetErrorMessage(error) {
     if (error?.code === 'auth/invalid-email') {
         return 'Invalid email address format.';
-    }
-
-    if (error?.code === 'auth/user-not-found') {
-        return 'No account found with this email address.';
     }
 
     if (error?.code === 'auth/too-many-requests') {
@@ -37,10 +35,15 @@ export function createForgotPasswordHandler({ emailInput, errorDiv, resetPasswor
             emailInput.value = '';
             showPasswordResetMessage(
                 errorDiv,
-                'Password reset email sent! Please check your inbox and spam folder.',
+                PASSWORD_RESET_CONFIRMATION_MESSAGE,
                 true
             );
         } catch (error) {
+            if (error?.code === 'auth/user-not-found') {
+                emailInput.value = '';
+                showPasswordResetMessage(errorDiv, PASSWORD_RESET_CONFIRMATION_MESSAGE, true);
+                return;
+            }
             showPasswordResetMessage(errorDiv, getPasswordResetErrorMessage(error), false);
             console.error('Password reset error:', error);
         }

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -105,6 +105,8 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             status: 200,
             contentType: 'application/javascript',
             body: `
+                export const passwordResetConfirmationMessage = "If an account exists for that email, we've sent a reset link.";
+
                 function mockUser() {
                     return window.__mockAuthState?.user || {
                         uid: 'user-1',
@@ -588,7 +590,7 @@ test('app auth screen exposes sign in, sign up, Google, activation code, invite,
     await page.getByRole('button', { name: 'Forgot password?' }).click();
     await page.locator('form').filter({ hasText: 'Password reset email' }).locator('input[type="email"]').fill('parent@example.com');
     await page.getByRole('button', { name: 'Send reset email' }).click();
-    await expect(page.getByText('Password reset email sent. Check your inbox and spam folder.')).toBeVisible();
+    await expect(page.getByText("If an account exists for that email, we've sent a reset link.")).toBeVisible();
     expect(await page.evaluate(() => window.__appAuthCalls.sendResetEmail)).toEqual(['parent@example.com']);
 
     await page.getByRole('button', { name: 'Sign up' }).first().click();

--- a/tests/unit/login-page-forgot-password.test.js
+++ b/tests/unit/login-page-forgot-password.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createForgotPasswordHandler, getPasswordResetErrorMessage } from '../../js/login-page.js';
+import {
+    createForgotPasswordHandler,
+    getPasswordResetErrorMessage,
+    PASSWORD_RESET_CONFIRMATION_MESSAGE
+} from '../../js/login-page.js';
 
 function createClassList(initialClasses = []) {
     const classes = new Set(initialClasses);
@@ -31,7 +35,7 @@ describe('createForgotPasswordHandler', () => {
 
         expect(resetPassword).toHaveBeenCalledWith('player@example.com');
         expect(emailInput.value).toBe('');
-        expect(errorDiv.textContent).toBe('Password reset email sent! Please check your inbox and spam folder.');
+        expect(errorDiv.textContent).toBe(PASSWORD_RESET_CONFIRMATION_MESSAGE);
         expect(errorDiv.classList.contains('text-green-600')).toBe(true);
         expect(errorDiv.classList.contains('text-red-500')).toBe(false);
     });
@@ -40,7 +44,6 @@ describe('createForgotPasswordHandler', () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         const scenarios = [
             ['auth/invalid-email', 'Invalid email address format.'],
-            ['auth/user-not-found', 'No account found with this email address.'],
             ['auth/too-many-requests', 'Too many requests. Please try again later.']
         ];
 
@@ -56,6 +59,18 @@ describe('createForgotPasswordHandler', () => {
         }
 
         consoleErrorSpy.mockRestore();
+    });
+
+    it('shows the same neutral success state when Firebase reports a missing account', async () => {
+        const resetPassword = vi.fn().mockRejectedValue({ code: 'auth/user-not-found' });
+        const { emailInput, errorDiv } = createElements({ email: 'missing@example.com' });
+
+        await createForgotPasswordHandler({ emailInput, errorDiv, resetPassword })();
+
+        expect(emailInput.value).toBe('');
+        expect(errorDiv.textContent).toBe(PASSWORD_RESET_CONFIRMATION_MESSAGE);
+        expect(errorDiv.classList.contains('text-green-600')).toBe(true);
+        expect(errorDiv.classList.contains('text-red-500')).toBe(false);
     });
 
     it('resets validation styling after a prior success state', async () => {


### PR DESCRIPTION
## What changed

- Return the same neutral password-reset confirmation whether Firebase sends a reset email or reports `auth/user-not-found`.
- Replace account-specific `auth/user-not-found` sign-in copy with the existing generic credential error.
- Apply the same neutral reset behavior to the legacy login fallback.
- Associate the React reset-email label with its input.
- Add regression coverage for the app auth service, React auth page, and legacy forgot-password handler.

## Why

The unauthenticated forgot-password flow exposed whether an email address belonged to an ALL PLAYS account. Treating a missing account as a successful request and using identical copy removes that account-enumeration signal while preserving malformed-email, throttling, and network errors.

## Validation

- `npm --prefix apps/app test -- --run src/lib/authService.test.ts src/pages/AuthPage.test.tsx --reporter=dot` — 27 passed
- `npx vitest run tests/unit/login-page-forgot-password.test.js --reporter=verbose` — 5 passed
- `npm --prefix apps/app run build` — passed
- `npm run typecheck` from `apps/app` — passed
- `npx eslint src/lib/authService.ts src/lib/authService.test.ts src/pages/AuthPage.tsx src/pages/AuthPage.test.tsx` from `apps/app` — 0 errors (13 pre-existing warnings)
- `git diff --check` — passed

Closes #3818