### PR TITLE
Fix public team roster counts

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -314,6 +314,50 @@ describe('PublicTeamSearch', () => {
         expect(screen.getAllByRole('heading', { level: 3 }).length).toBe(2);
     });
 
+    it('shows the roster-backed count without treating the empty linked-player array as zero', async () => {
+        (getPublicTeamsPage as import('vitest').Mock).mockResolvedValueOnce({
+            teams: [{
+                ...mockTeams[0],
+                teamId: 'team-roster-1',
+                teamName: 'AI Score Reader',
+                publicRosterCount: 10,
+                publicRosterCountCapped: false,
+                players: [],
+            }],
+            nextCursor: null
+        });
+        renderSearch();
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(screen.getByText('AI Score Reader')).toBeTruthy());
+        const teamCard = screen.getByText('AI Score Reader').closest('article');
+        expect(teamCard).toBeTruthy();
+        expect(within(teamCard as HTMLElement).getByText('10 players')).toBeTruthy();
+        expect(within(teamCard as HTMLElement).queryByText('0 players')).toBeNull();
+    });
+
+    it('does not claim a team has zero players when its public roster count is unavailable', async () => {
+        (getPublicTeamsPage as import('vitest').Mock).mockResolvedValueOnce({
+            teams: [{
+                ...mockTeams[0],
+                teamId: 'team-count-unavailable',
+                publicRosterCount: null,
+                players: [],
+            }],
+            nextCursor: null
+        });
+        renderSearch();
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(screen.getByText('Atlanta United')).toBeTruthy());
+        const teamCard = screen.getByText('Atlanta United').closest('article');
+        expect(teamCard).toBeTruthy();
+        expect(within(teamCard as HTMLElement).getByText('Roster count unavailable')).toBeTruthy();
+        expect(within(teamCard as HTMLElement).queryByText('0 players')).toBeNull();
+    });
+
     it('routes to the native team page when app access is available', async () => {
         renderSearch();
 

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -289,6 +289,10 @@ export function PublicTeamSearch({ autoBrowseOnMount = false, showBackLink = fal
 function PublicTeamCard({ team, onOpenTeam }: { team: ParentHomeTeam; onOpenTeam: (team: ParentHomeTeam) => void | Promise<void> }) {
   const isActionable = Boolean(team.appAccess || team.webAccess);
   const actionLabel = team.appAccess ? 'View team' : 'Open website team page';
+  const hasRosterCount = typeof team.publicRosterCount === 'number';
+  const rosterCountLabel = hasRosterCount
+    ? `${team.publicRosterCount}${team.publicRosterCountCapped ? '+' : ''} player${team.publicRosterCount === 1 && !team.publicRosterCountCapped ? '' : 's'}`
+    : 'Roster count unavailable';
 
   return (
     <article className={`min-w-0 rounded-2xl border bg-white p-3 shadow-sm ${isActionable ? 'border-gray-200' : 'border-gray-200/80 bg-gray-50'}`}>
@@ -298,7 +302,7 @@ function PublicTeamCard({ team, onOpenTeam }: { team: ParentHomeTeam; onOpenTeam
           <span className="truncate text-sm font-black text-gray-950">{team.teamName}</span>
           <span className="mt-0.5 block truncate text-xs font-semibold text-gray-500">{team.location || 'Location Unknown'}</span>
           <span className="mt-1 flex min-w-0 flex-wrap gap-1.5">
-            <TeamLauncherChip label={`${team.players.length} player${team.players.length === 1 ? '' : 's'}`} />
+            <TeamLauncherChip label={rosterCountLabel} />
           </span>
         </span>
       </div>

--- a/apps/app/src/lib/adapters/legacyPublicTeamsDb.ts
+++ b/apps/app/src/lib/adapters/legacyPublicTeamsDb.ts
@@ -1,8 +1,20 @@
-import { discoverPublicTeams as legacyDiscoverPublicTeams } from '@legacy/db.js';
+import {
+  discoverPublicTeams as legacyDiscoverPublicTeams,
+  getPublicTeamRosterCount as getLegacyPublicTeamRosterCount,
+} from '@legacy/db.js';
 
 /**
  * Typed adapter boundary for the legacy js/ public-team discovery helper (#2066).
  */
 export function discoverPublicTeams(options?: { searchText?: string; cursor?: unknown; pageSize?: number }): Promise<any> {
   return legacyDiscoverPublicTeams(options);
+}
+
+export type PublicTeamRosterCount = {
+  count: number;
+  isCapped: boolean;
+};
+
+export function getPublicTeamRosterCount(teamId: string): Promise<PublicTeamRosterCount> {
+  return getLegacyPublicTeamRosterCount(teamId);
 }

--- a/apps/app/src/lib/homeLogic.ts
+++ b/apps/app/src/lib/homeLogic.ts
@@ -68,6 +68,8 @@ export type ParentHomeTeam = {
   appAccess?: boolean; // Added for public team search
   webAccess?: boolean; // Added for public team search
   isPublic?: boolean; // Added for public team search
+  publicRosterCount?: number | null;
+  publicRosterCountCapped?: boolean;
   players: ParentScheduleChild[];
   nextEvent: ParentScheduleEvent | null;
   eventCount: number;

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const dbMocks = vi.hoisted(() => ({
-    discoverPublicTeams: vi.fn()
+    discoverPublicTeams: vi.fn(),
+    getPublicTeamRosterCount: vi.fn()
 }));
 
 vi.mock('./adapters/legacyPublicTeamsDb', () => dbMocks);
@@ -11,6 +12,43 @@ import { getPublicTeamsByLocation, getPublicTeamsPage } from './publicTeamsServi
 describe('publicTeamsService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        dbMocks.getPublicTeamRosterCount.mockResolvedValue({ count: 0, isCapped: false });
+    });
+
+    it('hydrates public cards from bounded roster counts instead of the empty linked-player array', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [{ id: 'team-roster-1', name: 'AI Score Reader', zip: '64131' }],
+            nextCursor: null
+        });
+        dbMocks.getPublicTeamRosterCount.mockResolvedValue({ count: 10, isCapped: false });
+
+        await expect(getPublicTeamsPage()).resolves.toEqual({
+            teams: [expect.objectContaining({
+                teamId: 'team-roster-1',
+                players: [],
+                publicRosterCount: 10,
+                publicRosterCountCapped: false
+            })],
+            nextCursor: null
+        });
+        expect(dbMocks.getPublicTeamRosterCount).toHaveBeenCalledWith('team-roster-1');
+    });
+
+    it('omits a roster count when public aggregation access is denied', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [{ id: 'team-legacy-private-fields', name: 'Legacy Team', zip: '64131' }],
+            nextCursor: null
+        });
+        dbMocks.getPublicTeamRosterCount.mockRejectedValue({ code: 'permission-denied' });
+
+        await expect(getPublicTeamsPage()).resolves.toEqual({
+            teams: [expect.objectContaining({
+                teamId: 'team-legacy-private-fields',
+                publicRosterCount: null,
+                publicRosterCountCapped: false
+            })],
+            nextCursor: null
+        });
     });
 
     it('defaults public teams without access flags to website access', async () => {

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -1,5 +1,7 @@
-import { discoverPublicTeams } from './adapters/legacyPublicTeamsDb';
+import { discoverPublicTeams, getPublicTeamRosterCount, type PublicTeamRosterCount } from './adapters/legacyPublicTeamsDb';
 import { type ParentHomeTeam } from './homeLogic';
+
+const PUBLIC_ROSTER_COUNT_CONCURRENCY = 6;
 
 export type PublicTeamsPage = {
     teams: ParentHomeTeam[];
@@ -16,7 +18,20 @@ function teamLocation(team: { city?: string | null; state?: string | null; zip?:
     return null;
 }
 
-function mapPublicTeam(team: { id: string; name: string; sport?: string | null; photoUrl?: string | null; city?: string; state?: string; zip?: string; appAccess?: boolean; webAccess?: boolean; isPublic?: boolean }): ParentHomeTeam {
+type PublicTeamSearchResult = {
+    id: string;
+    name: string;
+    sport?: string | null;
+    photoUrl?: string | null;
+    city?: string | null;
+    state?: string | null;
+    zip?: string | null;
+    appAccess?: boolean;
+    webAccess?: boolean;
+    isPublic?: boolean;
+};
+
+function mapPublicTeam(team: PublicTeamSearchResult, rosterCount: PublicTeamRosterCount | null): ParentHomeTeam {
     return {
         teamId: team.id,
         teamName: team.name,
@@ -30,12 +45,36 @@ function mapPublicTeam(team: { id: string; name: string; sport?: string | null; 
         appAccess: team.appAccess ?? false,
         webAccess: team.webAccess ?? true,
         isPublic: true,
+        publicRosterCount: rosterCount?.count ?? null,
+        publicRosterCountCapped: rosterCount?.isCapped ?? false,
         players: [],
         nextEvent: null,
         eventCount: 0,
         unreadCount: 0,
         openActions: 0,
     };
+}
+
+async function mapPublicTeamsWithRosterCounts(teams: PublicTeamSearchResult[]): Promise<ParentHomeTeam[]> {
+    const mappedTeams: ParentHomeTeam[] = [];
+
+    for (let index = 0; index < teams.length; index += PUBLIC_ROSTER_COUNT_CONCURRENCY) {
+        const teamBatch = teams.slice(index, index + PUBLIC_ROSTER_COUNT_CONCURRENCY);
+        const mappedBatch = await Promise.all(teamBatch.map(async (team) => {
+            try {
+                const rosterCount = await getPublicTeamRosterCount(team.id);
+                return mapPublicTeam(team, rosterCount);
+            } catch {
+                // A legacy roster can contain a document that is not publicly
+                // readable. Preserve that boundary and omit the count instead
+                // of falling back to fetching roster records or showing zero.
+                return mapPublicTeam(team, null);
+            }
+        }));
+        mappedTeams.push(...mappedBatch);
+    }
+
+    return mappedTeams;
 }
 
 function matchesPublicTeamSearch(team: { name?: string | null; city?: string | null; state?: string | null; zip?: string | null }, searchText: string): boolean {
@@ -75,9 +114,9 @@ export async function getPublicTeamsPage({ searchText, locationFilter, cursor = 
         cursor,
         pageSize
     });
-    const teams = result.teams
-        .filter((team: { name?: string | null; city?: string | null; state?: string | null; zip?: string | null }) => matchesPublicTeamSearch(team, normalizedSearchText))
-        .map(mapPublicTeam);
+    const matchingTeams = result.teams
+        .filter((team: { name?: string | null; city?: string | null; state?: string | null; zip?: string | null }) => matchesPublicTeamSearch(team, normalizedSearchText));
+    const teams = await mapPublicTeamsWithRosterCounts(matchingTeams);
 
     return {
         teams,

--- a/js/db.js
+++ b/js/db.js
@@ -231,6 +231,7 @@ export { collection, getDocs, deleteDoc, query };
 const limitQuery = limit;
 const startAfterQuery = startAfter;
 const DEFAULT_PUBLIC_TEAM_DISCOVERY_PAGE_SIZE = 24;
+const MAX_PUBLIC_TEAM_ROSTER_COUNT = 200;
 export const DEFAULT_CHAT_CONVERSATION_PAGE_SIZE = 25;
 const CHAT_REACTIONS = [
     { key: 'thumbs_up', emoji: '👍' },
@@ -892,6 +893,27 @@ export async function discoverPublicTeams(options = {}) {
         nextCursor: hasMorePages
             ? buildPublicTeamSearchPageCursor(searchText, strategyCursors, bufferedTeams)
             : null
+    };
+}
+
+export async function getPublicTeamRosterCount(teamId) {
+    const normalizedTeamId = String(teamId || '').trim();
+    if (!normalizedTeamId) {
+        throw new Error('Team is required to count the public roster.');
+    }
+
+    // Aggregations return only a count, not public roster documents. Keep the
+    // query capped as well so browse pages cannot introduce an unbounded scan.
+    const rosterQuery = query(
+        collection(db, `teams/${normalizedTeamId}/players`),
+        limitQuery(MAX_PUBLIC_TEAM_ROSTER_COUNT + 1)
+    );
+    const snapshot = await getCountFromServer(rosterQuery);
+    const count = Math.max(0, Number(snapshot.data().count) || 0);
+
+    return {
+        count: Math.min(count, MAX_PUBLIC_TEAM_ROSTER_COUNT),
+        isCapped: count > MAX_PUBLIC_TEAM_ROSTER_COUNT
     };
 }
 

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -8,6 +8,7 @@ const firebaseMocks = vi.hoisted(() => ({
     limit: vi.fn((value) => ({ type: 'limit', value })),
     startAfter: vi.fn((value) => ({ type: 'startAfter', value })),
     getDocs: vi.fn(),
+    getCountFromServer: vi.fn(),
 }));
 
 vi.mock('../../js/firebase.js?v=20', () => ({
@@ -32,7 +33,7 @@ vi.mock('../../js/firebase.js?v=20', () => ({
     deleteField: vi.fn(),
     limit: firebaseMocks.limit,
     startAfter: firebaseMocks.startAfter,
-    getCountFromServer: vi.fn(),
+    getCountFromServer: firebaseMocks.getCountFromServer,
     onSnapshot: vi.fn(),
     serverTimestamp: vi.fn(),
     collectionGroup: vi.fn(),
@@ -170,6 +171,40 @@ describe('discoverPublicTeams search pagination', () => {
         });
         expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
         expect(firebaseMocks.startAfter).not.toHaveBeenCalled();
+    });
+});
+
+describe('public team roster count', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('uses a capped aggregation without loading roster documents', async () => {
+        firebaseMocks.getCountFromServer.mockResolvedValue({
+            data: () => ({ count: 10 })
+        });
+        const { getPublicTeamRosterCount } = await import('../../js/db.js?v=91');
+
+        await expect(getPublicTeamRosterCount('team-roster-1')).resolves.toEqual({
+            count: 10,
+            isCapped: false
+        });
+        expect(firebaseMocks.collection).toHaveBeenCalledWith(expect.anything(), 'teams/team-roster-1/players');
+        expect(firebaseMocks.limit).toHaveBeenCalledWith(201);
+        expect(firebaseMocks.getCountFromServer).toHaveBeenCalledTimes(1);
+        expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
+    });
+
+    it('reports a lower-bound count when the public roster exceeds the cap', async () => {
+        firebaseMocks.getCountFromServer.mockResolvedValue({
+            data: () => ({ count: 201 })
+        });
+        const { getPublicTeamRosterCount } = await import('../../js/db.js?v=91');
+
+        await expect(getPublicTeamRosterCount('team-large-roster')).resolves.toEqual({
+            count: 200,
+            isCapped: true
+        });
     });
 });
 


### PR DESCRIPTION
## What changed

- Load roster-backed counts for each public team card instead of treating the intentionally empty linked-player array as the roster.
- Use capped Firestore aggregation queries (201 entries maximum, six concurrent requests) so browse never downloads roster documents or performs an unbounded collection read.
- Display `200+ players` for rosters beyond the cap and `Roster count unavailable` when existing access rules reject an aggregation, rather than reporting a misleading zero.
- Add regression coverage at the Firestore helper, service mapping, and rendered card layers.

## Why

Public team search maps discovery results with `players: []` because those are not the signed-in user's linked player records. The card used that array's length, so every discovered team appeared to have zero players even when its roster was populated.

This keeps the existing public-roster access boundary intact: no Firestore rule changes are included, aggregation failures do not fall back to roster document reads, and the count query is capped.

## Validation

- `npm --prefix apps/app test -- --run src/lib/publicTeamsService.test.ts src/components/PublicTeamSearch.test.tsx --reporter=dot` — 30 passed
- `npx vitest run tests/unit/discover-public-teams-search-pagination.test.js --reporter=dot` — 6 passed
- `npm test -- --run tests/unit/discover-public-teams-search-pagination.test.js --reporter=verbose` — full root unit suite: 4,005 passed, 29 skipped
- `npm --prefix apps/app run build` — TypeScript check and Vite production build passed
- Focused app ESLint — no errors (two pre-existing `no-explicit-any` warnings)
- `git diff --check` — passed

Closes #3816