### PR TITLE
Add schedule partial-success warnings

### DIFF
--- a/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
+++ b/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
@@ -123,14 +123,20 @@ describe('ScheduleEventDetail presentational components', () => {
     expect(screen.getByText('Avery Smith · Tigers')).toBeTruthy();
   });
 
-  it('renders schedule status messages for success and error tones', () => {
+  it('renders distinct schedule status treatments for success, warning, and error tones', () => {
     const { rerender } = render(<Status tone="success" message="Game schedule was updated." />);
 
-    expect(screen.getByText('Game schedule was updated.')).toBeTruthy();
+    expect(screen.getByText('Game schedule was updated.').className).toContain('border-emerald-200');
+
+    rerender(<Status tone="warning" message="Game saved, but notification failed." />);
+
+    const warning = screen.getByText('Game saved, but notification failed.');
+    expect(warning.className).toContain('border-amber-200');
+    expect(warning.querySelector('.lucide-triangle-alert')).toBeTruthy();
 
     rerender(<Status tone="error" message="Unable to update game." />);
 
-    expect(screen.getByText('Unable to update game.')).toBeTruthy();
+    expect(screen.getByText('Unable to update game.').className).toContain('border-rose-200');
   });
 
   it('keeps score controls disabled at zero and routes stepper clicks', () => {

--- a/apps/app/src/components/schedule/ScheduleStatus.tsx
+++ b/apps/app/src/components/schedule/ScheduleStatus.tsx
@@ -1,15 +1,30 @@
-import { AlertCircle, CheckCircle2 } from 'lucide-react';
+import { AlertCircle, AlertTriangle, CheckCircle2 } from 'lucide-react';
 
 interface StatusProps {
-  tone: 'success' | 'error';
+  tone: 'success' | 'warning' | 'error';
   message: string;
 }
 
 export function Status({ tone, message }: StatusProps) {
-  const isError = tone === 'error';
+  const config = {
+    success: {
+      className: 'border-emerald-200 bg-emerald-50 text-emerald-800',
+      icon: CheckCircle2
+    },
+    warning: {
+      className: 'border-amber-200 bg-amber-50 text-amber-800',
+      icon: AlertTriangle
+    },
+    error: {
+      className: 'border-rose-200 bg-rose-50 text-rose-800',
+      icon: AlertCircle
+    }
+  }[tone];
+  const Icon = config.icon;
+
   return (
-    <div className={`flex items-start gap-2 rounded-xl border p-3 text-sm font-semibold ${isError ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
-      {isError ? <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" /> : <CheckCircle2 className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />}
+    <div className={`flex items-start gap-2 rounded-xl border p-3 text-sm font-semibold ${config.className}`}>
+      <Icon className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
       {message}
     </div>
   );

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -3889,6 +3889,35 @@ describe('ScheduleEventDetail wrap-up', () => {
     });
   });
 
+  it('warns when wrap-up saves but the live score post fails', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamStaff: true, canUpdateScore: true, homeScore: 51, awayScore: 47 })],
+      children: []
+    });
+    scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 52, awayScore: 47 });
+    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockRejectedValue(new Error('Live feed unavailable'));
+    scheduleServiceMocks.completeGameWrapupForApp.mockResolvedValue({ status: 'completed', liveStatus: 'completed' });
+    gameWrapupServiceMocks.generateGameWrapupArtifactsForApp.mockResolvedValue({
+      summary: 'Bears finished strong.',
+      practiceFeedItems: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Post-game wrap-up' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Final home score up' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete wrap-up' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Wrap-up saved, but the live score post failed. You can retry by running wrap-up again.')).toBeTruthy();
+    });
+    expect(scheduleServiceMocks.completeGameWrapupForApp).toHaveBeenCalled();
+  });
+
   it('allows wrap-up to skip AI generation and still complete', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ isTeamStaff: true, canUpdateScore: true, homeScore: 51, awayScore: 47 })],

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1378,6 +1378,28 @@ describe('ScheduleEventDetail assignments', () => {
     });
   });
 
+  it('warns when a score autosaves but the live play-by-play post fails', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ liveStatus: 'live', status: 'live', canUpdateScore: true, homeScore: 41, awayScore: 38 })],
+      children: []
+    });
+    scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 42, awayScore: 38 });
+    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockRejectedValue(new Error('Live post unavailable'));
+
+    renderScheduleEventDetailWithRouteControls();
+
+    const tray = await screen.findByRole('region', { name: 'Mobile live score controls' });
+    fireEvent.click(within(tray).getByRole('button', { name: 'Sticky home score up' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', { homeScore: 42, awayScore: 38 }, auth.user);
+      expect(scheduleServiceMocks.publishLiveScoreUpdateEvent).toHaveBeenCalled();
+    }, { timeout: 2000 });
+    const warning = await within(tray).findByText('Score autosaved. Live play-by-play post failed.');
+    expect(warning.className).toContain('text-amber-700');
+    expect(warning.className).not.toContain('text-rose-700');
+  });
+
   it('surfaces sticky autosave failures and retries through the existing manual save path', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ liveStatus: 'live', status: 'live', canUpdateScore: true, homeScore: 12, awayScore: 9 })],

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1563,7 +1563,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
 }) {
   const { isDesktopWeb } = useShellLayout();
   const [shareStatus, setShareStatus] = useState<string | null>(null);
-  const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'warning' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
   const [openPanels, setOpenPanels] = useState<Record<string, boolean>>({});
   const [homeScoringPlayers, setHomeScoringPlayers] = useState<ScheduleHomeScoringPlayer[]>([]);
@@ -1671,7 +1671,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
       const result = await cancelScheduledGameForApp(event, auth.user);
       onGameCancelled();
       setCancelStatus(result.notificationError
-        ? { tone: 'error', message: `Game cancelled, but team chat notification failed: ${result.notificationError}` }
+        ? { tone: 'warning', message: `Game cancelled, but team chat notification failed: ${result.notificationError}` }
         : { tone: 'success', message: notifiesCounterpartTeam ? 'Game cancelled and both team chats notified.' : 'Game cancelled and team chat notified.' });
     } catch (error: any) {
       setCancelStatus({ tone: 'error', message: error?.message || 'Unable to cancel game.' });
@@ -2255,7 +2255,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
   const [shouldSendEmail, setShouldSendEmail] = useState(false);
   const [saving, setSaving] = useState(false);
   const [sharingFinalScore, setSharingFinalScore] = useState(false);
-  const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const [status, setStatus] = useState<{ tone: 'success' | 'warning' | 'error'; message: string } | null>(null);
 
   useEffect(() => {
     setHomeScore(savedHomeScore);
@@ -2316,7 +2316,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
     } catch (error: any) {
       const message = error?.message || 'Unable to post final score to team chat. Try again.';
       setStatus({
-        tone: 'error',
+        tone: scoreSaved ? 'warning' : 'error',
         message: scoreSaved
           ? `Final score saved, but team chat share failed: ${message}`
           : message
@@ -2408,7 +2408,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
       }
 
       setStatus({
-        tone: 'success',
+        tone: aiFailure ? 'warning' : 'success',
         message: aiFailure
           ? 'Wrap-up saved. AI analysis failed, so you can retry by running wrap-up again.'
           : shouldGenerateSummary
@@ -2482,7 +2482,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
         <span className="text-xs font-semibold text-gray-500">AI failures do not block completion. Uncheck AI summary to skip it, or run wrap-up again to regenerate.</span>
       </div>
 
-      {status ? <div className={`mt-3 text-sm font-semibold ${status.tone === 'error' ? 'text-rose-700' : 'text-emerald-700'}`}>{status.message}</div> : null}
+      {status ? <div className="mt-3"><Status tone={status.tone} message={status.message} /></div> : null}
 
       {practiceFeedItems.length ? (
         <div className="mt-3 rounded-2xl border border-gray-200 bg-white p-3">
@@ -2807,7 +2807,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   const [saving, setSaving] = useState(false);
   const [publishing, setPublishing] = useState(false);
   const [aiLoading, setAiLoading] = useState(false);
-  const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const [status, setStatus] = useState<{ tone: 'success' | 'warning' | 'error'; message: string } | null>(null);
   const saveTimeoutRef = useRef<number | null>(null);
   const dirtyRef = useRef(false);
   const latestDraftRef = useRef<Record<string, string>>({});
@@ -2978,7 +2978,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
       setStatus({ tone: 'success', message: 'AI lineup suggestion applied. You can still edit every slot.' });
     } catch {
       updateDraft(lineupBuilderModule.buildRoundRobinLineup(lineupPeriods, formation.positions, preview?.goingPlayers || []));
-      setStatus({ tone: 'success', message: 'AI was unavailable, so a balanced local lineup was applied instead.' });
+      setStatus({ tone: 'warning', message: 'AI was unavailable, so a balanced local lineup was applied instead.' });
     } finally {
       setAiLoading(false);
     }
@@ -2995,7 +2995,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
       onGamePlanSaved(result.gamePlan);
       const version = Number.parseInt(String(result.gamePlan?.publishedVersion || ''), 10) || 0;
       setStatus(result.notificationError
-        ? { tone: 'error', message: `Lineup saved${version ? ` as v${version}` : ''}, but team chat notification failed: ${result.notificationError}` }
+        ? { tone: 'warning', message: `Lineup saved${version ? ` as v${version}` : ''}, but team chat notification failed: ${result.notificationError}` }
         : { tone: 'success', message: `Lineup published${version ? ` as v${version}` : ''}. Team chat notified.` });
     } catch (error: any) {
       setStatus({ tone: 'error', message: error?.message || 'Unable to publish lineup.' });
@@ -3138,7 +3138,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
           {!preview.goingPlayers.length ? <div className="mt-3 text-sm font-semibold text-amber-800">No Going players are available to auto-fill this lineup. Manual roster edits still work.</div> : null}
         </>
       ) : null}
-      {status ? <div className={`mt-3 text-sm font-semibold ${status.tone === 'success' ? 'text-emerald-700' : 'text-amber-800'}`}>{status.message}</div> : null}
+      {status ? <div className="mt-3"><Status tone={status.tone} message={status.message} /></div> : null}
     </div>
   );
 }
@@ -3311,7 +3311,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showSti
   const [playerScoringId, setPlayerScoringId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [autosaveScheduled, setAutosaveScheduled] = useState(false);
-  const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const [status, setStatus] = useState<{ tone: 'success' | 'warning' | 'error'; message: string } | null>(null);
   const lastSavedScoreRef = useRef({ eventKey: event.eventKey, homeScore: savedHomeScore, awayScore: savedAwayScore });
   const pendingLocalSaveRef = useRef<ScoreSnapshot | null>(null);
   const autosaveTimeoutRef = useRef<number | null>(null);
@@ -3397,7 +3397,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showSti
         setStatus({ tone: 'success', message: mode === 'autosave' ? 'Score autosaved and posted to live play-by-play.' : 'Score saved and posted to live play-by-play.' });
       } catch (publishError) {
         console.warn('[schedule-event-detail] Score saved but live play-by-play posting failed:', publishError);
-        setStatus({ tone: 'success', message: mode === 'autosave' ? 'Score autosaved. Live play-by-play post failed.' : 'Score saved. Live play-by-play post failed.' });
+        setStatus({ tone: 'warning', message: mode === 'autosave' ? 'Score autosaved. Live play-by-play post failed.' : 'Score saved. Live play-by-play post failed.' });
       }
     } catch (error: any) {
       if (mode === 'autosave') {
@@ -3543,7 +3543,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showSti
               </button>
             ) : null}
           </div>
-          {status ? <span className={`text-xs font-bold ${status.tone === 'error' ? 'text-rose-700' : 'text-emerald-700'}`}>{status.message}</span> : null}
+          {status ? <span className={`text-xs font-bold ${status.tone === 'error' ? 'text-rose-700' : status.tone === 'warning' ? 'text-amber-700' : 'text-emerald-700'}`}>{status.message}</span> : null}
         </div>
       </div>
       {showStickyControls ? <div className="mobile-live-score-tray" data-testid="mobile-live-score-tray" role="region" aria-label="Mobile live score controls">
@@ -3557,7 +3557,7 @@ function LiveScoreEditor({ auth, event, homePlayers, loadingHomePlayers, showSti
             <ScoreStepper compact label="Away" controlLabel="Sticky away" value={awayScore} onDecrease={() => adjust('away', -1)} onIncrease={() => adjust('away', 1)} disabled={saving || Boolean(playerScoringId)} />
           </div>
           <div className="mt-2 flex min-h-11 items-center justify-between gap-2 px-1">
-            <span className={`min-w-0 text-xs font-bold ${status?.tone === 'error' ? 'text-rose-700' : dirty ? 'text-amber-700' : 'text-emerald-700'}`} aria-live="polite">
+            <span className={`min-w-0 text-xs font-bold ${status?.tone === 'error' ? 'text-rose-700' : status?.tone === 'warning' || dirty ? 'text-amber-700' : 'text-emerald-700'}`} aria-live="polite">
               {stickyStatusMessage}
             </span>
             <button

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2334,6 +2334,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
     setStatus(null);
     let finalSummary = String(event.summary || '');
     let finalPracticeFeedItems = Array.isArray(event.practiceFeedItems) ? event.practiceFeedItems as PracticeFeedItem[] : [];
+    let liveBroadcastFailure = false;
 
     try {
       const scorePayload = await updateGameScore(event.teamId, event.id, { homeScore, awayScore }, auth.user);
@@ -2347,6 +2348,7 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
           const { publishLiveScoreUpdateEvent } = await loadScheduleGameDayService();
           await publishLiveScoreUpdateEvent(event.teamId, event.id, { homeScore: nextHomeScore, awayScore: nextAwayScore }, auth.user, previousScore);
         } catch (publishError) {
+          liveBroadcastFailure = true;
           console.warn('[schedule-event-detail] Wrap-up score saved but live play-by-play posting failed:', publishError);
         }
       }
@@ -2408,9 +2410,13 @@ function GameWrapupPanel({ auth, event, onScoreUpdated, onWrapupCompleted }: {
       }
 
       setStatus({
-        tone: aiFailure ? 'warning' : 'success',
-        message: aiFailure
-          ? 'Wrap-up saved. AI analysis failed, so you can retry by running wrap-up again.'
+        tone: aiFailure || liveBroadcastFailure ? 'warning' : 'success',
+        message: aiFailure && liveBroadcastFailure
+          ? 'Wrap-up saved, but the live score post and AI analysis failed. You can retry by running wrap-up again.'
+          : liveBroadcastFailure
+            ? 'Wrap-up saved, but the live score post failed. You can retry by running wrap-up again.'
+            : aiFailure
+              ? 'Wrap-up saved. AI analysis failed, so you can retry by running wrap-up again.'
           : shouldGenerateSummary
             ? `Wrap-up saved with ${finalPracticeFeedItems.length} practice focus ${finalPracticeFeedItems.length === 1 ? 'item' : 'items'}.`
             : shouldSendEmail


### PR DESCRIPTION
## What changed

- Add a distinct `warning` tone to the shared schedule status component with amber styling and a warning-triangle icon.
- Use warning status only when the primary schedule action completed but a downstream notification, team-chat share, AI operation, or live play-by-play post failed.
- Keep clean completions green and failed primary actions red, including lineup and wrap-up statuses that now use the shared status presentation.
- Add presentational coverage for success, warning, and error plus a behavioral regression for a persisted score whose live post fails.

## Partial-success paths covered

- Game cancellation saved but chat notification failed.
- Final score saved but team-chat share failed.
- Wrap-up saved but AI analysis failed.
- Local lineup fallback applied after AI failed.
- Lineup saved but chat notification failed.
- Score saved or autosaved but live play-by-play publishing failed.

## Validation

- `npx vitest run apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx apps/app/src/pages/ScheduleEventDetail.test.tsx --reporter=verbose` (124/124 passed)
- `npm --prefix apps/app run build`
- `BASE_SHA=$(git merge-base origin/master HEAD) node scripts/lint-app-ci.mjs`
- Focused ESLint with strict hook dependency rule on all four changed app files
- `git diff --check`

Closes #3809