### PR TITLE
Load inline tracker configs on open

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -62,8 +62,8 @@ vi.mock('@legacy/firebase.js', () => ({
     where: vi.fn()
 }));
 
-import { addGame as legacyAddGame } from '@legacy/db.js';
-import { addGame, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, buildSingleLegacyTournamentGameDocument, LegacyTournamentGameAdapterValidationError } from './legacyScheduleDb';
+import { addGame as legacyAddGame, getConfigs as legacyGetConfigs } from '@legacy/db.js';
+import { addGame, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, buildSingleLegacyTournamentGameDocument, getConfigs, LegacyTournamentGameAdapterValidationError } from './legacyScheduleDb';
 
 const buildValidLegacyGamePayload = (overrides: Record<string, unknown> = {}) => ({
     type: 'game',
@@ -221,5 +221,17 @@ describe('legacyScheduleDb game persistence', () => {
 
         expect(legacyAddGame).toHaveBeenCalledTimes(1);
         expect(legacyAddGame).toHaveBeenCalledWith('team-1', leagueDocument);
+    });
+});
+
+describe('legacyScheduleDb tracker config reads', () => {
+    it('forwards the schedule option limit to the legacy query boundary', async () => {
+        vi.mocked(legacyGetConfigs).mockResolvedValueOnce([{ id: 'config-1', name: 'Basketball Standard' }]);
+
+        await expect(getConfigs('team-1', { limit: 100 })).resolves.toEqual([
+            { id: 'config-1', name: 'Basketball Standard' }
+        ]);
+
+        expect(legacyGetConfigs).toHaveBeenCalledWith('team-1', { limit: 100 });
     });
 });

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -96,8 +96,8 @@ export async function getGames(teamId: string, options: GamesQueryOptions = {}) 
     return await Promise.resolve(legacyGetGames(teamId, options));
 }
 
-export async function getConfigs(teamId: string) {
-    return await Promise.resolve(legacyGetConfigs(teamId));
+export async function getConfigs(teamId: string, options?: { limit?: number }) {
+    return await Promise.resolve(options === undefined ? legacyGetConfigs(teamId) : legacyGetConfigs(teamId, options));
 }
 
 export async function getPracticePacketCompletions(teamId: string, sessionId: string) {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -139,6 +139,7 @@ import type { AuthUser } from './types';
 const buildPracticePacketCompletionPayloadBase = buildPracticePacketCompletionPayload;
 
 const primaryDataTimeoutMs = 5000;
+const MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS = 100;
 // Per-team schedule builds are network-bound (team + games + practiceSessions
 // reads each); 3 workers made a 5-team account load in two serialized waves
 // (~18 sequential-ish Firestore round trips measured via the parent schedule
@@ -843,8 +844,16 @@ async function nativeGetDocument(path: string) {
   }
 }
 
-async function nativeListCollection(path: string) {
-  const payload = await nativeFirestoreRequest(`/${path}`);
+async function nativeListCollection(path: string, options: { pageSize?: number; orderBy?: string } = {}) {
+  const requestedPageSize = Number(options.pageSize);
+  const pageSize = Number.isFinite(requestedPageSize)
+    ? Math.min(Math.max(Math.floor(requestedPageSize), 1), 100)
+    : null;
+  const params = new URLSearchParams();
+  if (pageSize) params.set('pageSize', String(pageSize));
+  if (options.orderBy) params.set('orderBy', options.orderBy);
+  const queryString = params.size ? `?${params.toString()}` : '';
+  const payload = await nativeFirestoreRequest(`/${path}${queryString}`);
   return ((payload.documents || []) as NativeFirestoreDocument[])
     .map((document) => mapFirestoreDocument(document))
     .filter(Boolean) as FirestoreDocument[];
@@ -1768,8 +1777,11 @@ export type UpdateScheduledPracticeOptions = {
 async function readScheduleStatTrackerConfigOptions(normalizedTeamId: string): Promise<ScheduleStatTrackerConfigOption[]> {
   const configs = await readWithNativeFallback(
     `schedule stat tracker configs ${normalizedTeamId}`,
-    () => Promise.resolve(getConfigs(normalizedTeamId)),
-    () => nativeListCollection(`teams/${encodeURIComponent(normalizedTeamId)}/statTrackerConfigs`)
+    () => Promise.resolve(getConfigs(normalizedTeamId, { limit: MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS })),
+    () => nativeListCollection(`teams/${encodeURIComponent(normalizedTeamId)}/statTrackerConfigs`, {
+      pageSize: MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS,
+      orderBy: 'name'
+    })
   ).catch(() => []);
   return (Array.isArray(configs) ? configs : [])
     .map((config: any) => ({

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1774,14 +1774,20 @@ export type UpdateScheduledPracticeOptions = {
   instanceDate?: string | null;
 };
 
-async function readScheduleStatTrackerConfigOptions(normalizedTeamId: string): Promise<ScheduleStatTrackerConfigOption[]> {
+async function readScheduleStatTrackerConfigOptions(
+  normalizedTeamId: string,
+  options: { limit?: number } = {}
+): Promise<ScheduleStatTrackerConfigOption[]> {
+  const boundedOptions = options.limit ? { limit: options.limit } : undefined;
   const configs = await readWithNativeFallback(
     `schedule stat tracker configs ${normalizedTeamId}`,
-    () => Promise.resolve(getConfigs(normalizedTeamId, { limit: MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS })),
-    () => nativeListCollection(`teams/${encodeURIComponent(normalizedTeamId)}/statTrackerConfigs`, {
-      pageSize: MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS,
-      orderBy: 'name'
-    })
+    () => Promise.resolve(boundedOptions
+      ? getConfigs(normalizedTeamId, boundedOptions)
+      : getConfigs(normalizedTeamId)),
+    () => nativeListCollection(
+      `teams/${encodeURIComponent(normalizedTeamId)}/statTrackerConfigs`,
+      options.limit ? { pageSize: options.limit, orderBy: 'name' } : {}
+    )
   ).catch(() => []);
   return (Array.isArray(configs) ? configs : [])
     .map((config: any) => ({
@@ -1810,7 +1816,7 @@ export async function loadScheduleStatTrackerConfigsForApp(teamId: string, user:
   const normalizedTeamId = compactString(teamId);
   if (!normalizedTeamId) throw new Error('Team is required.');
   await requireScheduleImportStaff(normalizedTeamId, user);
-  return readScheduleStatTrackerConfigOptions(normalizedTeamId);
+  return readScheduleStatTrackerConfigOptions(normalizedTeamId, { limit: MAX_SCHEDULE_TRACKER_CONFIG_OPTIONS });
 }
 
 export async function loadScorekeeperStatTrackerConfigsForApp(
@@ -1832,6 +1838,8 @@ export async function loadScorekeeperStatTrackerConfigsForApp(
   if (!canLoadForScorekeeping) {
     throw new Error('You do not have permission to load tracker setup for this game.');
   }
+  // Scorekeeping must retain access to the event's assigned config even when it
+  // sorts beyond the bounded set used by schedule form dropdowns.
   return readScheduleStatTrackerConfigOptions(normalizedTeamId);
 }
 

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -1303,12 +1303,13 @@ describe('Schedule', () => {
     expect(screen.getByRole('heading', { name: 'Add external calendar' })).toBeTruthy();
   });
 
-  it('defers desktop tracker config loading until staff starts using game creation', async () => {
+  it('loads desktop tracker configs when Manage schedule exposes inline game creation', async () => {
     shellLayoutMocks.isDesktopWeb = true;
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
-    scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp.mockResolvedValueOnce([
-      { id: 'config-1', name: 'Varsity Tracker' }
-    ]);
+    let resolveConfigLoad: ((configs: Array<{ id: string; name: string }>) => void) | null = null;
+    scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveConfigLoad = resolve;
+    }));
 
     renderSchedule();
 
@@ -1318,14 +1319,22 @@ describe('Schedule', () => {
     fireEvent.click(screen.getByRole('button', { name: /manage schedule/i }));
 
     expect(await screen.findByRole('heading', { name: 'Add game for Bears' })).toBeTruthy();
-    expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).not.toHaveBeenCalled();
-
-    fireEvent.focus(screen.getAllByLabelText('Opponent')[0]);
 
     await waitFor(() => {
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledWith('team-1', auth.user);
     });
-    expect((await screen.findAllByRole('option', { name: 'Varsity Tracker' })).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Tracker config')).toBeDisabled();
+    expect(screen.getByRole('option', { name: 'Loading tracker configs' })).toBeTruthy();
+
+    if (!resolveConfigLoad) {
+      throw new Error('Expected the tracker config request to start when Manage schedule opened.');
+    }
+    (resolveConfigLoad as (configs: Array<{ id: string; name: string }>) => void)([
+      { id: 'config-1', name: 'Basketball Standard' }
+    ]);
+
+    expect((await screen.findAllByRole('option', { name: 'Basketball Standard' })).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Tracker config')).not.toBeDisabled();
   });
 });

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -219,6 +219,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [savingGame, setSavingGame] = useState(false);
   const [gameFormError, setGameFormError] = useState<string | null>(null);
   const [gameTrackerConfigs, setGameTrackerConfigs] = useState<ScheduleStatTrackerConfigOption[]>([]);
+  const [gameTrackerConfigsLoading, setGameTrackerConfigsLoading] = useState(false);
   const [gameTrackerConfigError, setGameTrackerConfigError] = useState<string | null>(null);
   const [tournamentForm, setTournamentForm] = useState<ScheduleTournamentCreateFormInput>(() => getDefaultScheduleTournamentForm());
   const [savingTournament, setSavingTournament] = useState(false);
@@ -677,11 +678,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
   useEffect(() => {
     if (!selectedCalendarTeam) {
       setGameTrackerConfigs([]);
+      setGameTrackerConfigsLoading(false);
       setGameTrackerConfigError(null);
       return;
     }
     const cachedConfigs = trackerConfigCacheRef.current[selectedCalendarTeam.teamId];
     setGameTrackerConfigs(cachedConfigs || []);
+    setGameTrackerConfigsLoading(false);
     setGameTrackerConfigError(null);
   }, [selectedCalendarTeam]);
 
@@ -689,18 +692,21 @@ export function Schedule({ auth }: { auth: AuthState }) {
   useEffect(() => {
     let cancelled = false;
     if (!selectedCalendarTeam || !auth.user) return;
-    const shouldLoadTrackerConfigs = mobileStaffToolsOpen
+    const shouldLoadTrackerConfigs = desktopStaffToolsOpen
+      || mobileStaffToolsOpen
       || trackerConfigRequestedTeamIds[selectedCalendarTeam.teamId];
     if (!shouldLoadTrackerConfigs) return;
 
     const cachedConfigs = trackerConfigCacheRef.current[selectedCalendarTeam.teamId];
     if (cachedConfigs) {
       setGameTrackerConfigs(cachedConfigs);
+      setGameTrackerConfigsLoading(false);
       setGameTrackerConfigError(null);
       return;
     }
 
     setGameTrackerConfigs([]);
+    setGameTrackerConfigsLoading(true);
     setGameTrackerConfigError(null);
 
     const cachedPromise = trackerConfigRequestPromiseRef.current[selectedCalendarTeam.teamId]
@@ -713,17 +719,21 @@ export function Schedule({ auth }: { auth: AuthState }) {
         delete trackerConfigRequestPromiseRef.current[selectedCalendarTeam.teamId];
         if (!cancelled) {
           setGameTrackerConfigs(configs);
+          setGameTrackerConfigsLoading(false);
           setGameTrackerConfigError(null);
         }
       })
       .catch((configError: any) => {
         delete trackerConfigRequestPromiseRef.current[selectedCalendarTeam.teamId];
-        if (!cancelled) setGameTrackerConfigError(configError?.message || 'Unable to load tracker configs.');
+        if (!cancelled) {
+          setGameTrackerConfigsLoading(false);
+          setGameTrackerConfigError(configError?.message || 'Unable to load tracker configs.');
+        }
       });
     return () => {
       cancelled = true;
     };
-  }, [auth.user, mobileStaffToolsOpen, selectedCalendarTeam, trackerConfigRequestedTeamIds]);
+  }, [auth.user, desktopStaffToolsOpen, mobileStaffToolsOpen, selectedCalendarTeam, trackerConfigRequestedTeamIds]);
 
   const renderScheduleStaffToolsContent = () => {
     if (shouldShowManageScheduleTeamPicker) {
@@ -755,6 +765,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           teamName={selectedCalendarTeam.teamName}
           form={gameForm}
           configs={gameTrackerConfigs}
+          configsLoading={gameTrackerConfigsLoading}
           saving={savingGame}
           error={gameFormError}
           configError={gameTrackerConfigError}
@@ -1732,7 +1743,7 @@ function getDefaultSchedulePracticeForm(): SchedulePracticeFormInput {
   };
 }
 
-function ScheduleGameCreatePanel({ teamName, form, configs, saving, error, configError, onStartUsing, onChange, onSubmit }: { teamName: string; form: ScheduleGameFormInput; configs: ScheduleStatTrackerConfigOption[]; saving: boolean; error: string | null; configError: string | null; onStartUsing?: () => void; onChange: (form: ScheduleGameFormInput) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {
+function ScheduleGameCreatePanel({ teamName, form, configs, configsLoading, saving, error, configError, onStartUsing, onChange, onSubmit }: { teamName: string; form: ScheduleGameFormInput; configs: ScheduleStatTrackerConfigOption[]; configsLoading: boolean; saving: boolean; error: string | null; configError: string | null; onStartUsing?: () => void; onChange: (form: ScheduleGameFormInput) => void; onSubmit: (event: FormEvent<HTMLFormElement>) => void }) {
   const updateField = (field: keyof ScheduleGameFormInput, value: string | Date | boolean | null) => onChange({ ...form, [field]: value });
   return (
     <section className="app-card p-3 sm:p-4" aria-label="Create game" onFocusCapture={onStartUsing}>
@@ -1746,7 +1757,7 @@ function ScheduleGameCreatePanel({ teamName, form, configs, saving, error, confi
           <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Ends<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.endDate)} onChange={(event) => updateField('endDate', event.target.value ? new Date(event.target.value) : null)} /></label>
           <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Arrival<input type="datetime-local" className="auth-input mt-1" value={toDatetimeLocalInputValue(form.arrivalTime)} onChange={(event) => updateField('arrivalTime', event.target.value ? new Date(event.target.value) : null)} /></label>
           <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Home / away<select className="auth-input mt-1" value={form.isHome === false ? 'away' : form.isHome === true ? 'home' : 'neutral'} onChange={(event) => updateField('isHome', event.target.value === 'neutral' ? null : event.target.value === 'home')}><option value="home">Home</option><option value="away">Away</option><option value="neutral">Neutral</option></select></label>
-          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tracker config<select className="auth-input mt-1" value={form.statTrackerConfigId || ''} onChange={(event) => updateField('statTrackerConfigId', event.target.value)}><option value="">No tracker config</option>{configs.map((config) => <option key={config.id} value={config.id}>{config.name}</option>)}</select></label>
+          <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Tracker config<select className="auth-input mt-1" value={form.statTrackerConfigId || ''} disabled={configsLoading} onChange={(event) => updateField('statTrackerConfigId', event.target.value)}><option value="">{configsLoading ? 'Loading tracker configs' : 'No tracker config'}</option>{configs.map((config) => <option key={config.id} value={config.id}>{config.name}</option>)}</select></label>
           <label className="text-xs font-bold uppercase tracking-wide text-gray-600">Competition<select className="auth-input mt-1" value={form.competitionType || 'league'} onChange={(event) => updateField('competitionType', event.target.value)}><option value="league">League</option><option value="tournament">Tournament</option><option value="scrimmage">Scrimmage</option><option value="friendly">Friendly</option></select></label>
         </div>
         <label className="flex items-center gap-2 text-sm font-black text-gray-800"><input type="checkbox" checked={form.countsTowardSeasonRecord !== false} onChange={(event) => updateField('countsTowardSeasonRecord', event.target.checked)} /> Counts toward season record</label>

--- a/js/db.js
+++ b/js/db.js
@@ -4120,8 +4120,13 @@ export async function getSeriesMaster(teamId, seriesId) {
 }
 
 // Configs
-export async function getConfigs(teamId) {
-    const q = query(collection(db, `teams/${teamId}/statTrackerConfigs`), orderBy("name"));
+export async function getConfigs(teamId, options = {}) {
+    const constraints = [orderBy("name")];
+    const requestedLimit = Number(options?.limit);
+    if (Number.isFinite(requestedLimit)) {
+        constraints.push(limitQuery(Math.min(Math.max(Math.floor(requestedLimit), 1), 100)));
+    }
+    const q = query(collection(db, `teams/${teamId}/statTrackerConfigs`), ...constraints);
     const snapshot = await getDocs(q);
     return snapshot.docs.map(doc => normalizeStatTrackerConfig({ id: doc.id, ...doc.data() }));
 }

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -1097,6 +1097,44 @@ describe('React app schedule service contract integration', () => {
                 { id: 'cfg-b', name: 'Basketball', baseType: 'Basketball', isBasketball: true, columns: [], statDefinitions: [] },
                 { id: 'cfg-z', name: 'Zone Tracker', baseType: 'Soccer', isBasketball: false, columns: [], statDefinitions: [] }
             ]);
+        expect(dbMocks.getConfigs).toHaveBeenCalledWith('team-1', { limit: 100 });
+    });
+
+    it('keeps native schedule tracker config fallback reads bounded', async () => {
+        installWindow('capacitor:');
+        dbMocks.getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            adminEmails: []
+        });
+        dbMocks.getConfigs.mockRejectedValueOnce(new Error('web config read unavailable'));
+        authMocks.getNativeAuthIdToken.mockResolvedValue('native-token');
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: vi.fn().mockResolvedValue({
+                documents: [{
+                    name: 'projects/demo-allplays/databases/(default)/documents/teams/team-1/statTrackerConfigs/config-1',
+                    fields: {
+                        name: { stringValue: 'Basketball Standard' },
+                        baseType: { stringValue: 'Basketball' }
+                    }
+                }]
+            })
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(loadScheduleStatTrackerConfigsForApp('team-1', { uid: 'coach-1', email: 'coach@example.com' }))
+            .resolves.toEqual([
+                expect.objectContaining({ id: 'config-1', name: 'Basketball Standard' })
+            ]);
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://firestore.googleapis.com/v1/projects/demo-allplays/databases/(default)/documents/teams/team-1/statTrackerConfigs?pageSize=100&orderBy=name',
+            expect.objectContaining({
+                headers: expect.objectContaining({ Authorization: 'Bearer native-token' })
+            })
+        );
     });
 
     it('loads tracker configs for delegated scorekeeping without requiring schedule staff access', async () => {

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -1159,6 +1159,7 @@ describe('React app schedule service contract integration', () => {
                 statDefinitions: []
             }
         ]);
+        expect(dbMocks.getConfigs).toHaveBeenCalledWith('team-1');
         expect(dbMocks.getTeam).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/discover-public-teams-search-pagination.test.js
+++ b/tests/unit/discover-public-teams-search-pagination.test.js
@@ -208,6 +208,24 @@ describe('public team roster count', () => {
     });
 });
 
+describe('bounded stat tracker config reads', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('caps schedule-facing config queries without changing unbounded legacy callers', async () => {
+        firebaseMocks.getDocs.mockResolvedValue({
+            docs: [createTeamDoc('config-1', { name: 'Basketball Standard', baseType: 'Basketball' })]
+        });
+        const { getConfigs } = await import('../../js/db.js?v=91');
+
+        await expect(getConfigs('team-1', { limit: 100 })).resolves.toEqual([
+            expect.objectContaining({ id: 'config-1', name: 'Basketball Standard' })
+        ]);
+        expect(firebaseMocks.limit).toHaveBeenCalledWith(100);
+    });
+});
+
 describe('complete legacy collection helpers', () => {
     beforeEach(() => {
         vi.clearAllMocks();


### PR DESCRIPTION
## What changed

- Start loading a team’s stat tracker configs when desktop **Manage schedule** opens and exposes the inline Add game panel, matching the existing mobile behavior.
- Disable the tracker-config select with explicit `Loading tracker configs` copy during the first request, then enable it with the loaded options.
- Preserve the existing per-team promise/result cache so reopening staff tools or focusing the form does not duplicate requests.
- Cap schedule-facing tracker config reads at 100 on both the Firestore SDK and native REST fallback paths while leaving complete-list legacy callers unchanged.
- Add regressions for the panel-open timing, loading state, resulting `Basketball Standard` option, adapter forwarding, web query limit, and native REST page size.

## Why

The select already rendered `configs.map(...)`, but desktop Schedule deferred the async load until a focus event inside game creation. A coach could therefore open the select while the list was still empty and see only `No tracker config`. Loading as soon as the panel is intentionally opened removes that race, and the explicit loading state prevents an incomplete dropdown from opening on a slow connection.

## Validation

- `npm --prefix apps/app test -- --run src/pages/Schedule.test.tsx src/lib/adapters/legacyScheduleDb.test.ts --reporter=verbose` — 50 passed
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js tests/unit/discover-public-teams-search-pagination.test.js --reporter=verbose` — 43 passed across the current focused suites
- `npx vitest run tests/unit/app-schedule-desktop-controls.test.jsx tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose` — 48 passed
- `npm --prefix apps/app run build` — TypeScript check and Vite production build passed
- Focused app ESLint — no errors (existing repository warnings remain)
- `git diff --check` — passed

Closes #3817