### PR TITLE
Fix stale team tab page height

### DIFF
--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -605,20 +605,20 @@ describe('TeamDetail', () => {
     fireEvent.click(tabControls.getByRole('button', { name: /schedule/i }));
     await waitFor(() => expect(router.state.location.search).toBe('?tab=schedule'));
     expect(tabControls.getByRole('button', { name: /schedule/i }).getAttribute('aria-pressed')).toBe('true');
-    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' }));
+    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' }));
     vi.mocked(window.scrollTo).mockClear();
 
     fireEvent.click(tabControls.getByRole('button', { name: /more/i }));
     await waitFor(() => expect(router.state.location.search).toBe('?tab=more'));
     expect(tabControls.getByRole('button', { name: /more/i }).getAttribute('aria-pressed')).toBe('true');
     expect(await screen.findByText('Stat tracker configs')).toBeTruthy();
-    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' }));
+    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' }));
     vi.mocked(window.scrollTo).mockClear();
 
     fireEvent.click(tabControls.getByRole('button', { name: /overview/i }));
     await waitFor(() => expect(router.state.location.search).toBe(''));
     expect(tabControls.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
-    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' }));
+    await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' }));
   });
 
   it('steps back to team overview before leaving the team hub', async () => {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { createMemoryRouter, MemoryRouter, Route, RouterProvider, Routes } from 'react-router-dom';
+import { createMemoryRouter, MemoryRouter, Outlet, Route, RouterProvider, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { calculateRosterRenderWindow, rosterRenderLimits, TeamDetail } from './TeamDetail';
+import { clearScrollRestorationForTests, ScrollRestoration } from '../components/ScrollRestoration';
 import type { AuthState } from '../lib/types';
 
 const teamDetailServiceMocks = vi.hoisted(() => ({
@@ -220,6 +221,7 @@ describe('calculateRosterRenderWindow', () => {
 describe('TeamDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearScrollRestorationForTests();
     Object.defineProperty(window, 'scrollTo', {
       value: vi.fn(),
       writable: true
@@ -270,6 +272,9 @@ describe('TeamDetail', () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'scrollY', { configurable: true, value: 0, writable: true });
+    Object.defineProperty(window, 'pageYOffset', { configurable: true, value: 0, writable: true });
   });
 
   it('shows the shared team skeleton while team detail is loading', () => {
@@ -657,78 +662,67 @@ describe('TeamDetail', () => {
     expect(await screen.findByText('Teams list')).toBeTruthy();
   });
 
-  it('defers route-driven tab scroll reset until after POP scroll restoration frames', async () => {
-    const originalRequestAnimationFrame = window.requestAnimationFrame;
-    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+  it('wins the final scroll position after ScrollRestoration restores a POP entry', async () => {
+    let scrollYValue = 0;
     const frames = new Map<number, FrameRequestCallback>();
     let nextFrameId = 1;
-    Object.defineProperty(window, 'requestAnimationFrame', {
-      configurable: true,
-      value: vi.fn((callback: FrameRequestCallback) => {
-        const frameId = nextFrameId;
-        nextFrameId += 1;
-        frames.set(frameId, callback);
-        return frameId;
-      })
+    const scrollTo = vi.fn((optionsOrX: ScrollToOptions | number, y?: number) => {
+      scrollYValue = typeof optionsOrX === 'number' ? Number(y || 0) : Number(optionsOrX.top || 0);
     });
-    Object.defineProperty(window, 'cancelAnimationFrame', {
-      configurable: true,
-      value: vi.fn((frameId: number) => {
-        frames.delete(frameId);
-      })
+    Object.defineProperty(window, 'scrollY', { configurable: true, get: () => scrollYValue });
+    Object.defineProperty(window, 'pageYOffset', { configurable: true, get: () => scrollYValue });
+    Object.defineProperty(window, 'scrollTo', { configurable: true, value: scrollTo });
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      const frameId = nextFrameId++;
+      frames.set(frameId, callback);
+      return frameId;
     });
-
-    function flushNextFrame() {
-      const queuedFrames = Array.from(frames.values());
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((frameId) => {
+      frames.delete(frameId);
+    });
+    const flushFrames = async () => {
+      const pendingFrames = Array.from(frames.values());
       frames.clear();
-      queuedFrames.forEach((callback) => callback(performance.now()));
-    }
+      pendingFrames.forEach((callback) => callback(performance.now()));
+      await Promise.resolve();
+    };
+    const router = createMemoryRouter([
+      {
+        path: '/',
+        element: <><ScrollRestoration /><Outlet /></>,
+        children: [
+          { path: 'teams/:teamId', element: <TeamDetail auth={auth} /> },
+          { path: 'players/:teamId/:playerId', element: <div>Player profile</div> }
+        ]
+      }
+    ], { initialEntries: ['/teams/team-1?tab=roster'] });
 
-    try {
-      const router = createMemoryRouter(
-        [
-          {
-            path: '/teams',
-            element: <div>Teams list</div>
-          },
-          {
-            path: '/teams/:teamId',
-            element: <TeamDetail auth={auth} />
-          }
-        ],
-        { initialEntries: ['/teams/team-1', '/teams/team-1?tab=roster'], initialIndex: 1 }
-      );
+    render(<RouterProvider router={router} />);
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    await act(flushFrames);
+    await act(flushFrames);
 
-      render(<RouterProvider router={router} />);
+    window.scrollTo({ top: 1600, behavior: 'auto' });
+    await act(async () => {
+      await router.navigate('/players/team-1/player-1');
+    });
+    expect(await screen.findByText('Player profile')).toBeTruthy();
+    await act(flushFrames);
+    expect(scrollYValue).toBe(0);
 
-      expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
-      frames.clear();
-      vi.mocked(window.scrollTo).mockClear();
+    const callsBeforePop = scrollTo.mock.calls.length;
+    await act(async () => {
+      await router.navigate(-1);
+    });
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    await act(flushFrames);
+    await act(flushFrames);
 
-      await act(async () => {
-        await router.navigate(-1);
-      });
-
-      await waitFor(() => expect(router.state.location.search).toBe(''));
-      expect(screen.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
-      expect(window.scrollTo).not.toHaveBeenCalled();
-
-      flushNextFrame();
-      window.scrollTo({ top: 420, left: 0, behavior: 'auto' });
-      expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 420, left: 0, behavior: 'auto' });
-
-      flushNextFrame();
-      expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 0, behavior: 'auto' });
-    } finally {
-      Object.defineProperty(window, 'requestAnimationFrame', {
-        configurable: true,
-        value: originalRequestAnimationFrame
-      });
-      Object.defineProperty(window, 'cancelAnimationFrame', {
-        configurable: true,
-        value: originalCancelAnimationFrame
-      });
-    }
+    expect(scrollTo.mock.calls.slice(callsBeforePop)).toEqual([
+      [{ top: 1600, left: 0, behavior: 'auto' }],
+      [{ top: 0, behavior: 'auto' }]
+    ]);
+    expect(scrollYValue).toBe(0);
   });
 
   it('renders native standings rows with the current team highlight and expandable overflow', async () => {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -657,6 +657,80 @@ describe('TeamDetail', () => {
     expect(await screen.findByText('Teams list')).toBeTruthy();
   });
 
+  it('defers route-driven tab scroll reset until after POP scroll restoration frames', async () => {
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 1;
+    Object.defineProperty(window, 'requestAnimationFrame', {
+      configurable: true,
+      value: vi.fn((callback: FrameRequestCallback) => {
+        const frameId = nextFrameId;
+        nextFrameId += 1;
+        frames.set(frameId, callback);
+        return frameId;
+      })
+    });
+    Object.defineProperty(window, 'cancelAnimationFrame', {
+      configurable: true,
+      value: vi.fn((frameId: number) => {
+        frames.delete(frameId);
+      })
+    });
+
+    function flushNextFrame() {
+      const queuedFrames = Array.from(frames.values());
+      frames.clear();
+      queuedFrames.forEach((callback) => callback(performance.now()));
+    }
+
+    try {
+      const router = createMemoryRouter(
+        [
+          {
+            path: '/teams',
+            element: <div>Teams list</div>
+          },
+          {
+            path: '/teams/:teamId',
+            element: <TeamDetail auth={auth} />
+          }
+        ],
+        { initialEntries: ['/teams/team-1', '/teams/team-1?tab=roster'], initialIndex: 1 }
+      );
+
+      render(<RouterProvider router={router} />);
+
+      expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+      frames.clear();
+      vi.mocked(window.scrollTo).mockClear();
+
+      await act(async () => {
+        await router.navigate(-1);
+      });
+
+      await waitFor(() => expect(router.state.location.search).toBe(''));
+      expect(screen.getByRole('button', { name: /overview/i }).getAttribute('aria-pressed')).toBe('true');
+      expect(window.scrollTo).not.toHaveBeenCalled();
+
+      flushNextFrame();
+      window.scrollTo({ top: 420, left: 0, behavior: 'auto' });
+      expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 420, left: 0, behavior: 'auto' });
+
+      flushNextFrame();
+      expect(window.scrollTo).toHaveBeenLastCalledWith({ top: 0, behavior: 'auto' });
+    } finally {
+      Object.defineProperty(window, 'requestAnimationFrame', {
+        configurable: true,
+        value: originalRequestAnimationFrame
+      });
+      Object.defineProperty(window, 'cancelAnimationFrame', {
+        configurable: true,
+        value: originalCancelAnimationFrame
+      });
+    }
+  });
+
   it('renders native standings rows with the current team highlight and expandable overflow', async () => {
     const standingsRows = [
       { rank: 1, team: 'Lions', w: 8, l: 1, t: 0, points: 16 },

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -97,6 +97,25 @@ function resetTeamTabScrollPosition() {
   }
 }
 
+function scheduleTeamTabScrollPositionReset() {
+  if (typeof window.requestAnimationFrame !== 'function') {
+    resetTeamTabScrollPosition();
+    return () => {};
+  }
+
+  let resetFrame: number | null = null;
+  const restorationFrame = window.requestAnimationFrame(() => {
+    resetFrame = window.requestAnimationFrame(resetTeamTabScrollPosition);
+  });
+
+  return () => {
+    window.cancelAnimationFrame(restorationFrame);
+    if (resetFrame !== null) {
+      window.cancelAnimationFrame(resetFrame);
+    }
+  };
+}
+
 export function TeamDetail({ auth }: { auth: AuthState }) {
   const { teamId = '' } = useParams();
   const location = useLocation();
@@ -402,8 +421,9 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
 
   useEffect(() => {
     // Also cover back/forward navigation and direct route changes that do not
-    // pass through the tab controls.
-    resetTeamTabScrollPosition();
+    // pass through the tab controls. ScrollRestoration restores POP entries in
+    // requestAnimationFrame, so this runs one frame later to win that race.
+    return scheduleTeamTabScrollPositionReset();
   }, [teamId, activeTab]);
 
   async function refreshTeamDetail() {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -89,6 +89,14 @@ function getTeamTabFromSearch(search: string): TeamTab {
   return 'overview';
 }
 
+function resetTeamTabScrollPosition() {
+  try {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  } catch {
+    // jsdom does not implement scrollTo; real browsers and WebViews do.
+  }
+}
+
 export function TeamDetail({ auth }: { auth: AuthState }) {
   const { teamId = '' } = useParams();
   const location = useLocation();
@@ -140,6 +148,11 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
 
   function navigateToTab(nextTab: TeamTab) {
     if (nextTab === activeTab) return;
+
+    // Reset while the current (possibly tall) tab still owns the document
+    // height. WebKit can otherwise preserve the old scroll range when a
+    // smooth reset races the shorter tab's render.
+    resetTeamTabScrollPosition();
 
     const nextParams = new URLSearchParams(location.search);
     if (nextTab === 'overview') {
@@ -388,18 +401,9 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   }, [activeTab, authUserId, auth.user, model?.canManageTeam, teamId, trackingAttempted]);
 
   useEffect(() => {
-    const scroll = () => {
-      try {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-      } catch {
-        // jsdom does not implement scrollTo; real browsers and WebViews do.
-      }
-    };
-    if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(scroll);
-    } else {
-      scroll();
-    }
+    // Also cover back/forward navigation and direct route changes that do not
+    // pass through the tab controls.
+    resetTeamTabScrollPosition();
   }, [teamId, activeTab]);
 
   async function refreshTeamDetail() {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -36,13 +36,14 @@ async function waitForTeamDetailRoute(page, teamName) {
     }).toPass({ timeout: 45000 });
 }
 
-async function mockTeamsModules(page, { scenario = '', managedTeam = false } = {}) {
-    await page.addInitScript(({ scenarioName, shouldManageTeam }) => {
+async function mockTeamsModules(page, { scenario = '', managedTeam = false, rosterPlayerCount = 2 } = {}) {
+    await page.addInitScript(({ scenarioName, shouldManageTeam, teamRosterPlayerCount }) => {
         window.__openedPublicUrls = [];
         window.__homeLoads = 0;
         window.__teamsScenario = scenarioName;
         window.__managedTeam = shouldManageTeam;
-    }, { scenarioName: scenario, shouldManageTeam: managedTeam });
+        window.__teamRosterPlayerCount = teamRosterPlayerCount;
+    }, { scenarioName: scenario, shouldManageTeam: managedTeam, teamRosterPlayerCount: rosterPlayerCount });
 
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {
         await route.fulfill({
@@ -422,10 +423,11 @@ async function mockTeamsModules(page, { scenario = '', managedTeam = false } = {
                                 summary: 'Team default reminder window: 24 hours before event start.'
                             }
                         },
-                        players: [
-                            { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: 'https://img.example.test/player.png', position: 'Guard', isLinked: true, active: true },
-                            { id: 'player-2', name: 'Sam Wing', number: '12', photoUrl: null, position: 'Forward', isLinked: false, active: true }
-                        ],
+                        players: Array.from({ length: window.__teamRosterPlayerCount }, (_, index) => index === 0
+                            ? { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: 'https://img.example.test/player.png', position: 'Guard', isLinked: true, active: true }
+                            : index === 1
+                                ? { id: 'player-2', name: 'Sam Wing', number: '12', photoUrl: null, position: 'Forward', isLinked: false, active: true }
+                                : { id: 'player-' + (index + 1), name: 'Roster Player ' + (index + 1), number: String(index + 1), photoUrl: null, position: 'Guard', isLinked: false, active: true }),
                         inactivePlayers: [],
                         linkedPlayers: [
                             { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: 'https://img.example.test/player.png', position: 'Guard', isLinked: true, active: true }
@@ -692,6 +694,37 @@ test.describe('mobile My Teams', () => {
         await expect(page).toHaveURL(/#\/teams\/team-1$/);
         await expect(tabNav.getByRole('button', { name: /Overview/ })).toHaveAttribute('aria-pressed', 'true');
         await expect(page.getByText('Parent actions')).toBeAttached();
+    });
+
+    test('shrinks the page after switching from a long roster to a shorter team tab', async ({ page, baseURL }) => {
+        await mockTeamsModules(page, { rosterPlayerCount: 12 });
+        await page.goto(appUrl(baseURL, '/teams/team-1?tab=roster'), { waitUntil: 'domcontentloaded' });
+
+        await waitForTeamDetailRoute(page, 'Bears');
+        const tabNav = page.getByTestId('team-detail-tab-nav');
+        await expect(page.getByText('Roster Player 12')).toBeVisible();
+        const rosterHeights = await page.evaluate(() => ({
+            documentHeight: document.documentElement.scrollHeight,
+            bodyHeight: document.body.scrollHeight,
+            rootHeight: document.querySelector('#root')?.scrollHeight || 0
+        }));
+        await page.evaluate(() => window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'instant' }));
+
+        await tabNav.getByRole('button', { name: /Insights/ }).click();
+        expect(await page.evaluate(() => window.scrollY)).toBe(0);
+        await expect(page).toHaveURL(/#\/teams\/team-1\?tab=insights$/);
+        await expect(page.getByText('Player checklist')).toBeVisible();
+
+        const shorterTabMetrics = await page.evaluate(() => ({
+            documentHeight: document.documentElement.scrollHeight,
+            bodyHeight: document.body.scrollHeight,
+            rootHeight: document.querySelector('#root')?.scrollHeight || 0,
+            teamPageBottom: Math.ceil((document.querySelector('.team-detail-page')?.getBoundingClientRect().bottom || 0) + window.scrollY)
+        }));
+        expect(shorterTabMetrics.documentHeight).toBeLessThan(rosterHeights.documentHeight);
+        expect(shorterTabMetrics.bodyHeight).toBeLessThan(rosterHeights.bodyHeight);
+        expect(shorterTabMetrics.rootHeight).toBeLessThan(rosterHeights.rootHeight);
+        expect(shorterTabMetrics.documentHeight - shorterTabMetrics.teamPageBottom).toBeLessThanOrEqual(200);
     });
 
     test('team detail tabs expose parent-facing team page features', async ({ page, baseURL }) => {


### PR DESCRIPTION
## Summary

- reset the team tab scroll position before replacing a tall tab with shorter content
- use an immediate, non-animated reset for tab clicks plus direct/back navigation
- add a mobile browser regression that verifies `document`, `body`, and `#root` heights contract after Roster → Insights

## Root cause

The team tab scroll reset waited for `requestAnimationFrame` and then started a smooth scroll after React had already rendered the next tab. On mobile WebKit, that ordering can preserve the prior tall tab's scroll range while the shorter tab is active, leaving a large blank region below the visible content.

## User impact

Switching from a long roster to a shorter team tab now starts at the top immediately, and the document height follows the active tab instead of retaining phantom scroll space.

## Validation

- `npm --prefix apps/app test -- --run src/pages/TeamDetail.test.tsx` (32 passed)
- `SMOKE_BASE_URL=http://127.0.0.1:4173 npx playwright test --config=playwright.smoke.config.js tests/smoke/app-teams.spec.js --grep "keeps team detail tabs reachable|shrinks the page" --reporter=line` (2 passed)
- `npm run app:build`
- `node scripts/lint-app-ci.mjs`
- `git diff --check`

Closes #3772
