### PR TITLE
Repair legacy staff chat access

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1061,7 +1061,6 @@ export async function ensureStaffChatConversation(teamId: string, user: AuthUser
     type: 'group',
     participantIds: [],
     participantRoles: ['staff'],
-    mutedBy: [],
     name: 'Staff only'
   })), 'Staff chat conversation create') as ChatConversation;
 }

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -1049,8 +1049,13 @@ export async function loadChatConversations(
 }
 
 function canReuseStaffChatConversation(conversation: ChatConversation | null | undefined) {
-  if (!isStaffConversation(conversation)) return false;
-  return !Array.isArray(conversation?.participantIds) || conversation.participantIds.length === 0;
+  const participantRoles = Array.isArray(conversation?.participantRoles)
+    ? conversation.participantRoles.map(compactString).filter(Boolean)
+    : [];
+  return conversation?.id === 'group_role%3Astaff'
+    && participantRoles.length === 1
+    && participantRoles[0].toLowerCase() === 'staff'
+    && (!Array.isArray(conversation.participantIds) || conversation.participantIds.length === 0);
 }
 
 export async function ensureStaffChatConversation(teamId: string, user: AuthUser, conversations: ChatConversation[] = []): Promise<ChatConversation> {

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -158,7 +158,7 @@ const STAFF_CONVERSATION_PLACEHOLDER_ID = '__staff_conversation__';
 const CANONICAL_STAFF_CONVERSATION_ID = 'group_role%3Astaff';
 
 function isStaffOnlyConversation(conversation?: ChatConversation | null) {
-  return conversation?.id === CANONICAL_STAFF_CONVERSATION_ID || isStaffConversation(conversation);
+  return conversation?.id === CANONICAL_STAFF_CONVERSATION_ID && isStaffConversation(conversation);
 }
 
 function getStaffConversationErrorMessage(error: unknown) {

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -156,6 +156,13 @@ const allTargetOptions: Array<{ value: ChatTargetType; label: string; descriptio
 ];
 const STAFF_CONVERSATION_PLACEHOLDER_ID = '__staff_conversation__';
 
+function isStaffOnlyConversation(conversation?: ChatConversation | null) {
+  const participantRoles = Array.isArray(conversation?.participantRoles)
+    ? conversation.participantRoles.map((role) => String(role || '').trim().toLowerCase()).filter(Boolean)
+    : [];
+  return participantRoles.length === 1 && participantRoles[0] === 'staff';
+}
+
 export async function sendLazyAllPlaysChatAnswer(input: Parameters<typeof sendAllPlaysChatAnswer>[0]) {
   const chatAiService = await import('../../../lib/chatAiService');
   return chatAiService.sendAllPlaysChatAnswer(input);
@@ -469,7 +476,7 @@ export function ChatWindow({
     conversations.find((conversation) => conversation.id === effectiveConversationId) || conversations[0] || null
   ), [conversations, effectiveConversationId]);
   const conversationSheetConversations = useMemo<ChatConversation[]>(() => {
-    if (!canModerate || conversations.some((conversation) => isStaffConversation(conversation))) {
+    if (!canModerate || conversations.some((conversation) => isStaffOnlyConversation(conversation))) {
       return conversations;
     }
     const staffPlaceholderConversation = {
@@ -825,7 +832,7 @@ export function ChatWindow({
       document.removeEventListener('visibilitychange', handleReturn);
       window.removeEventListener('focus', handleReturn);
     };
-  }, [auth.user, effectiveConversationId, messages.length, teamId]);
+  }, [auth.user, effectiveConversationId, initialSnapshotLoadedRef, messages.length, teamId]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -862,7 +869,7 @@ export function ChatWindow({
       const staffConversation = await ensureStaffChatConversation(teamId, auth.user, conversations);
       setConversations((current) => (
         current.some((conversation) => conversation.id === staffConversation.id)
-          ? current
+          ? current.map((conversation) => conversation.id === staffConversation.id ? staffConversation : conversation)
           : [...current, staffConversation]
       ));
       if (selectedConversationId !== staffConversation.id) {
@@ -875,11 +882,20 @@ export function ChatWindow({
   };
 
   const handleConversationSelect = (conversationId: string) => {
-    if (conversationId === STAFF_CONVERSATION_PLACEHOLDER_ID) {
+    const conversation = conversations.find((item) => item.id === conversationId);
+    if (conversationId === STAFF_CONVERSATION_PLACEHOLDER_ID || isStaffOnlyConversation(conversation)) {
       void ensureAndSwitchStaffConversation();
       return;
     }
     switchConversation(conversationId);
+  };
+
+  const handleBackFromError = () => {
+    if (messagesError && !teamError && !isDefaultTeamConversation(effectiveConversationId)) {
+      switchConversation(DEFAULT_TEAM_CONVERSATION_ID);
+      return;
+    }
+    navigate('/messages');
   };
 
   const handleAudienceTargetChange = async (target: ChatTargetType) => {
@@ -1372,7 +1388,7 @@ export function ChatWindow({
               Retry
             </button>
           ) : null}
-          <button type="button" className="secondary-button" onClick={() => navigate('/messages')}>Back to messages</button>
+          <button type="button" className="secondary-button" onClick={handleBackFromError}>Back to messages</button>
         </div>
       </section>
     );
@@ -1431,7 +1447,7 @@ export function ChatWindow({
                   className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-black transition ${
                     active ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-primary-50 hover:text-primary-700'
                   }`}
-                  onClick={() => switchConversation(conversation.id)}
+                  onClick={() => handleConversationSelect(conversation.id)}
                 >
                   {getConversationDisplayName(conversation, team || {})}
                 </button>

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -403,6 +403,7 @@ export function ChatWindow({
   const repairStaffConversation = useCallback(async (requestedConversationId = CANONICAL_STAFF_CONVERSATION_ID) => {
     if (!auth.user || !team) return null;
     const requestedKey = `${teamId}:${requestedConversationId}`;
+    setStatus(null);
     setStaffRepairState({ key: requestedKey, status: 'repairing', error: null });
     try {
       const staffConversation = await ensureStaffChatConversation(teamId, auth.user, conversations);
@@ -421,11 +422,13 @@ export function ChatWindow({
       });
       return staffConversation;
     } catch (error) {
+      const errorMessage = getStaffConversationErrorMessage(error);
       setStaffRepairState({
         key: requestedKey,
         status: 'error',
-        error: getStaffConversationErrorMessage(error)
+        error: errorMessage
       });
+      setStatus({ tone: 'error', message: errorMessage });
       return null;
     }
   }, [auth.user, conversations, setConversations, team, teamId]);

--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -87,7 +87,7 @@ import { startInteractionTimer, UX_TIMING } from '../../../lib/uxTiming';
 import type { sendAllPlaysChatAnswer } from '../../../lib/chatAiService';
 import { useChatSheets } from '../hooks/useChatSheets';
 import { useChatTeam } from '../hooks/useChatTeam';
-import { useChatMessages } from '../hooks/useChatMessages';
+import { getChatMessagesErrorMessage, useChatMessages } from '../hooks/useChatMessages';
 import { Composer } from './ChatComposer';
 
 const LazyTeamEmailSheet = lazy(() => import('./TeamEmailSheet'));
@@ -155,12 +155,18 @@ const allTargetOptions: Array<{ value: ChatTargetType; label: string; descriptio
   { value: 'individuals', label: 'Selected members', description: 'Starts a direct or group conversation.' }
 ];
 const STAFF_CONVERSATION_PLACEHOLDER_ID = '__staff_conversation__';
+const CANONICAL_STAFF_CONVERSATION_ID = 'group_role%3Astaff';
 
 function isStaffOnlyConversation(conversation?: ChatConversation | null) {
-  const participantRoles = Array.isArray(conversation?.participantRoles)
-    ? conversation.participantRoles.map((role) => String(role || '').trim().toLowerCase()).filter(Boolean)
-    : [];
-  return participantRoles.length === 1 && participantRoles[0] === 'staff';
+  return conversation?.id === CANONICAL_STAFF_CONVERSATION_ID || isStaffConversation(conversation);
+}
+
+function getStaffConversationErrorMessage(error: unknown) {
+  const safeMessage = getChatMessagesErrorMessage(error);
+  const rawMessage = error instanceof Error ? error.message.trim() : '';
+  return rawMessage && safeMessage === rawMessage
+    ? 'Unable to open staff chat. Please try again.'
+    : safeMessage;
 }
 
 export async function sendLazyAllPlaysChatAnswer(input: Parameters<typeof sendAllPlaysChatAnswer>[0]) {
@@ -314,6 +320,11 @@ export function ChatWindow({
   const [composerCursorPosition, setComposerCursorPosition] = useState<number | undefined>(undefined);
   const [messageViewportState, setMessageViewportState] = useState({ scrollTop: 0, viewportHeight: 0 });
   const [measuredMessageHeights, setMeasuredMessageHeights] = useState<Record<string, number>>({});
+  const [staffRepairState, setStaffRepairState] = useState<{
+    key: string;
+    status: 'idle' | 'repairing' | 'ready' | 'error';
+    error: string | null;
+  }>({ key: '', status: 'idle', error: null });
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const messagesContentRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -344,6 +355,7 @@ export function ChatWindow({
 
   const resetChatSelectionState = useCallback(() => {
     setStatus(null);
+    setStaffRepairState({ key: '', status: 'idle', error: null });
     recipientOptionsPromiseRef.current = null;
     recipientOptionsRequestIdRef.current += 1;
     setRecipientOptions([]);
@@ -375,6 +387,60 @@ export function ChatWindow({
     onTeamReset: resetChatSelectionState
   });
   const effectiveConversationId = normalizeConversationId(selectedConversationId);
+  const activeConversationForRepair = conversations.find((conversation) => conversation.id === effectiveConversationId) || null;
+  const activeConversationIsStaff = effectiveConversationId === CANONICAL_STAFF_CONVERSATION_ID
+    || isStaffOnlyConversation(activeConversationForRepair);
+  const activeStaffRepairKey = `${teamId}:${effectiveConversationId}`;
+  const activeStaffRepairError = activeConversationIsStaff
+    && staffRepairState.key === activeStaffRepairKey
+    && staffRepairState.status === 'error'
+    ? staffRepairState.error
+    : null;
+  const staffConversationReady = !activeConversationIsStaff || (
+    staffRepairState.key === activeStaffRepairKey && staffRepairState.status === 'ready'
+  );
+
+  const repairStaffConversation = useCallback(async (requestedConversationId = CANONICAL_STAFF_CONVERSATION_ID) => {
+    if (!auth.user || !team) return null;
+    const requestedKey = `${teamId}:${requestedConversationId}`;
+    setStaffRepairState({ key: requestedKey, status: 'repairing', error: null });
+    try {
+      const staffConversation = await ensureStaffChatConversation(teamId, auth.user, conversations);
+      setConversations((current) => {
+        const withoutLegacyStaffConversations = current.filter((conversation) => (
+          !isStaffOnlyConversation(conversation) || conversation.id === staffConversation.id
+        ));
+        return withoutLegacyStaffConversations.some((conversation) => conversation.id === staffConversation.id)
+          ? withoutLegacyStaffConversations.map((conversation) => conversation.id === staffConversation.id ? staffConversation : conversation)
+          : [...withoutLegacyStaffConversations, staffConversation];
+      });
+      setStaffRepairState({
+        key: `${teamId}:${staffConversation.id}`,
+        status: 'ready',
+        error: null
+      });
+      return staffConversation;
+    } catch (error) {
+      setStaffRepairState({
+        key: requestedKey,
+        status: 'error',
+        error: getStaffConversationErrorMessage(error)
+      });
+      return null;
+    }
+  }, [auth.user, conversations, setConversations, team, teamId]);
+
+  useEffect(() => {
+    if (!activeConversationIsStaff || loadingContext || !auth.user || !team) return;
+    if (staffRepairState.key === activeStaffRepairKey && (
+      staffRepairState.status === 'repairing' || staffRepairState.status === 'ready' || staffRepairState.status === 'error'
+    )) return;
+    void repairStaffConversation(effectiveConversationId).then((staffConversation) => {
+      if (staffConversation && staffConversation.id !== effectiveConversationId) {
+        switchChatConversation(staffConversation.id);
+      }
+    });
+  }, [activeConversationIsStaff, activeStaffRepairKey, auth.user, effectiveConversationId, loadingContext, repairStaffConversation, staffRepairState.key, staffRepairState.status, switchChatConversation, team]);
 
   const handleBeforeLiveUpdate = useCallback(() => isNearBottom(messagesRef.current), []);
   const handleLiveUpdateState = useCallback(({ isInitialSnapshot, wasNearBottom }: { isInitialSnapshot: boolean; wasNearBottom: boolean }) => {
@@ -411,6 +477,7 @@ export function ChatWindow({
     team,
     user: auth.user,
     selectedConversationId: effectiveConversationId,
+    enabled: !loadingContext && staffConversationReady,
     onBeforeLiveUpdate: handleBeforeLiveUpdate,
     onLiveUpdateState: handleLiveUpdateState,
     onMessagesReset: handleMessagesReset,
@@ -448,8 +515,8 @@ export function ChatWindow({
     viewportHeight: messageViewportState.viewportHeight,
     preferTopWindow: olderMessages.length > 0 && messageViewportState.scrollTop <= 0
   }), [messageLayout, messageViewportState.scrollTop, messageViewportState.viewportHeight, olderMessages.length, visibleMessages]);
-  const error = teamError || messagesError;
-  const canRetryMessagesError = Boolean(messagesError && !teamError);
+  const error = teamError || activeStaffRepairError || messagesError;
+  const canRetryMessagesError = Boolean((activeStaffRepairError || messagesError) && !teamError);
 
   const handleMessageRowHeightChange = useCallback((messageId: string, height: number) => {
     if (!messageId || !Number.isFinite(height) || height <= 0) return;
@@ -865,20 +932,14 @@ export function ChatWindow({
 
   const ensureAndSwitchStaffConversation = async () => {
     if (!auth.user || !team) return;
-    try {
-      const staffConversation = await ensureStaffChatConversation(teamId, auth.user, conversations);
-      setConversations((current) => (
-        current.some((conversation) => conversation.id === staffConversation.id)
-          ? current.map((conversation) => conversation.id === staffConversation.id ? staffConversation : conversation)
-          : [...current, staffConversation]
-      ));
-      if (selectedConversationId !== staffConversation.id) {
-        switchConversation(staffConversation.id);
-      }
-      closeConversationSheet();
-    } catch (staffError: any) {
-      setStatus({ tone: 'error', message: staffError?.message || 'Unable to open staff chat.' });
+    const staffConversation = await repairStaffConversation(
+      activeConversationIsStaff ? effectiveConversationId : CANONICAL_STAFF_CONVERSATION_ID
+    );
+    if (!staffConversation) return;
+    if (selectedConversationId !== staffConversation.id) {
+      switchConversation(staffConversation.id);
     }
+    closeConversationSheet();
   };
 
   const handleConversationSelect = (conversationId: string) => {
@@ -896,6 +957,20 @@ export function ChatWindow({
       return;
     }
     navigate('/messages');
+  };
+
+  const handleRetryMessages = async () => {
+    if (!activeConversationIsStaff) {
+      retryMessages();
+      return;
+    }
+    const staffConversation = await repairStaffConversation(effectiveConversationId);
+    if (!staffConversation) return;
+    if (staffConversation.id !== effectiveConversationId) {
+      switchConversation(staffConversation.id);
+      return;
+    }
+    retryMessages();
   };
 
   const handleAudienceTargetChange = async (target: ChatTargetType) => {
@@ -1383,7 +1458,7 @@ export function ChatWindow({
         <div className="text-base font-black text-rose-700">{error}</div>
         <div className="mt-4 flex flex-wrap gap-2">
           {canRetryMessagesError ? (
-            <button type="button" className="primary-button" onClick={retryMessages}>
+            <button type="button" className="primary-button" onClick={() => { void handleRetryMessages(); }}>
               <RefreshCw className="h-4 w-4" aria-hidden="true" />
               Retry
             </button>

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -652,6 +652,25 @@ describe('ChatWindow virtualization', () => {
     expect(mockRouter.navigate).toHaveBeenCalledTimes(1);
   });
 
+  it('returns an errored staff conversation to the team thread in place', () => {
+    mockThreadLoadScenario = 'retrySuccess';
+    mockChatTeamState.selectedConversationId = 'group_role%3Astaff';
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: [], participantRoles: ['staff'] }
+    ];
+    render(
+      <MemoryRouter initialEntries={['/messages/team-1']}>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to messages' }));
+
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('team');
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+  });
+
   it('replaces an open conversation sheet when the media gallery opens', async () => {
     useStatefulChatSheets = true;
     render(
@@ -779,13 +798,20 @@ describe('ChatWindow deferred conversation hydration', () => {
 });
 
 describe('ChatWindow conversation switching', () => {
-  it('quick-switches an existing mobile conversation without opening the selector sheet', () => {
+  it('repairs an existing staff conversation before quick-switching to it', async () => {
     mockChatTeamState.conversations = [
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
       { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] },
       { id: 'direct-parent', type: 'direct', name: 'Pat Parent', participantIds: ['parent-1'], participantRoles: ['parent'] },
       { id: 'travel-group', type: 'group', name: 'Tournament travel', participantIds: ['coach-1', 'parent-1'], participantRoles: ['staff', 'parent'] }
     ];
+    vi.mocked(ensureStaffChatConversation).mockResolvedValue({
+      id: 'group_role%3Astaff',
+      type: 'group',
+      name: 'Staff only',
+      participantIds: [],
+      participantRoles: ['staff']
+    } as ChatConversation);
 
     render(
       <MemoryRouter>
@@ -802,8 +828,8 @@ describe('ChatWindow conversation switching', () => {
 
     fireEvent.click(within(quickSwitcher).getByRole('button', { name: 'Switch to Staff only' }));
 
-    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
-    expect(ensureStaffChatConversation).not.toHaveBeenCalled();
+    await waitFor(() => expect(ensureStaffChatConversation).toHaveBeenCalledWith('team-1', auth.user, mockChatTeamState.conversations));
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('group_role%3Astaff');
     expect(mockChatSheetsState.openConversationSheet).not.toHaveBeenCalled();
   });
 
@@ -838,12 +864,19 @@ describe('ChatWindow conversation switching', () => {
     expect(mockChatSheetsState.openConversationSheet).not.toHaveBeenCalled();
   });
 
-  it('keeps staff chat reachable from the conversation selector without audience-sheet staff routing', () => {
+  it('repairs staff chat selected from the conversation selector', async () => {
     mockChatSheetsState.showConversationSheet = true;
     mockChatTeamState.conversations = [
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
       { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] }
     ];
+    vi.mocked(ensureStaffChatConversation).mockResolvedValue({
+      id: 'group_role%3Astaff',
+      type: 'group',
+      name: 'Staff only',
+      participantIds: [],
+      participantRoles: ['staff']
+    } as ChatConversation);
 
     render(
       <MemoryRouter>
@@ -853,8 +886,8 @@ describe('ChatWindow conversation switching', () => {
 
     fireEvent.click(screen.getAllByRole('button', { name: /Staff only/i })[0]);
 
-    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
-    expect(ensureStaffChatConversation).not.toHaveBeenCalled();
+    await waitFor(() => expect(ensureStaffChatConversation).toHaveBeenCalledWith('team-1', auth.user, mockChatTeamState.conversations));
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('group_role%3Astaff');
   });
 
   it('creates the staff conversation from the selector when a team has never opened it', async () => {

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -814,7 +814,7 @@ describe('ChatWindow conversation switching', () => {
   it('repairs an existing staff conversation before quick-switching to it', async () => {
     mockChatTeamState.conversations = [
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
-      { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff', 'coach'] },
+      { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff', 'coach'] },
       { id: 'direct-parent', type: 'direct', name: 'Pat Parent', participantIds: ['parent-1'], participantRoles: ['parent'] },
       { id: 'travel-group', type: 'group', name: 'Tournament travel', participantIds: ['coach-1', 'parent-1'], participantRoles: ['staff', 'parent'] }
     ];
@@ -843,6 +843,10 @@ describe('ChatWindow conversation switching', () => {
 
     await waitFor(() => expect(ensureStaffChatConversation).toHaveBeenCalledWith('team-1', auth.user, mockChatTeamState.conversations));
     expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('group_role%3Astaff');
+    const updateConversations = mockChatTeamState.setConversations.mock.calls[0][0];
+    expect(updateConversations(mockChatTeamState.conversations)).toContainEqual(
+      expect.objectContaining({ id: 'travel-group', participantRoles: ['staff', 'parent'] })
+    );
     expect(mockChatSheetsState.openConversationSheet).not.toHaveBeenCalled();
   });
 
@@ -913,7 +917,7 @@ describe('ChatWindow conversation switching', () => {
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
     ];
     vi.mocked(ensureStaffChatConversation).mockResolvedValue({
-      id: 'staff-conversation',
+      id: 'group_role%3Astaff',
       type: 'group',
       name: 'Staff only',
       participantIds: [],
@@ -935,7 +939,7 @@ describe('ChatWindow conversation switching', () => {
         { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
       ]);
     });
-    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('group_role%3Astaff');
     expect(mockChatSheetsState.openConversationSheet).not.toHaveBeenCalled();
   });
 
@@ -943,7 +947,7 @@ describe('ChatWindow conversation switching', () => {
     mockChatSheetsState.showConversationSheet = true;
     mockChatTeamState.conversations = [
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
-      { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] }
+      { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] }
     ];
     vi.mocked(ensureStaffChatConversation).mockResolvedValue({
       id: 'group_role%3Astaff',
@@ -971,7 +975,7 @@ describe('ChatWindow conversation switching', () => {
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
     ];
     vi.mocked(ensureStaffChatConversation).mockResolvedValue({
-      id: 'staff-conversation',
+      id: 'group_role%3Astaff',
       type: 'group',
       name: 'Staff only',
       participantIds: [],
@@ -992,7 +996,7 @@ describe('ChatWindow conversation switching', () => {
         { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
       ]);
     });
-    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('staff-conversation');
+    expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('group_role%3Astaff');
   });
 });
 

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -912,6 +912,25 @@ describe('ChatWindow conversation switching', () => {
     expect(screen.getByRole('button', { name: 'Retry' })).toBeVisible();
   });
 
+  it('surfaces a safe error when staff repair fails before leaving the team thread', async () => {
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }
+    ];
+    vi.mocked(ensureStaffChatConversation).mockRejectedValue(new Error('internal document payload leaked'));
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(within(screen.getByTestId('mobile-conversation-chips')).getByRole('button', { name: 'Switch to Staff only' }));
+
+    expect(await screen.findByText('Unable to open staff chat. Please try again.')).toBeVisible();
+    expect(screen.queryByText('internal document payload leaked')).toBeNull();
+    expect(mockChatTeamState.switchConversation).not.toHaveBeenCalled();
+  });
+
   it('creates and switches to Staff only from the mobile quick-switcher', async () => {
     mockChatTeamState.conversations = [
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] }

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -241,6 +241,12 @@ vi.mock('../hooks/useChatTeam', () => ({
 vi.mock('../hooks/useChatMessages', async () => {
   const React = await import('react');
   return {
+    getChatMessagesErrorMessage: (error: unknown) => {
+      const message = error instanceof Error ? error.message : '';
+      return /missing or insufficient permissions/i.test(message)
+        ? "We couldn't open this conversation. Your team access may have changed."
+        : (message || 'Unable to load chat messages.');
+    },
     useChatMessages: () => {
       const [phase, setPhase] = React.useState<'error' | 'loading' | 'ready'>('error');
       const [olderMessages, setOlderMessages] = React.useState<ChatMessage[]>([]);
@@ -359,6 +365,13 @@ beforeEach(() => {
   mockChatTeamState.switchConversation.mockReset();
   mockChatTeamState.switchConversation.mockReturnValue(true);
   vi.mocked(ensureStaffChatConversation).mockReset();
+  vi.mocked(ensureStaffChatConversation).mockResolvedValue({
+    id: 'group_role%3Astaff',
+    type: 'group',
+    name: 'Staff only',
+    participantIds: [],
+    participantRoles: ['staff']
+  } as ChatConversation);
   teamEmailSheetMocks.importModule.mockClear();
   teamEmailSheetMocks.render.mockClear();
 });
@@ -801,7 +814,7 @@ describe('ChatWindow conversation switching', () => {
   it('repairs an existing staff conversation before quick-switching to it', async () => {
     mockChatTeamState.conversations = [
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
-      { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff'] },
+      { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff', 'coach'] },
       { id: 'direct-parent', type: 'direct', name: 'Pat Parent', participantIds: ['parent-1'], participantRoles: ['parent'] },
       { id: 'travel-group', type: 'group', name: 'Tournament travel', participantIds: ['coach-1', 'parent-1'], participantRoles: ['staff', 'parent'] }
     ];
@@ -831,6 +844,68 @@ describe('ChatWindow conversation switching', () => {
     await waitFor(() => expect(ensureStaffChatConversation).toHaveBeenCalledWith('team-1', auth.user, mockChatTeamState.conversations));
     expect(mockChatTeamState.switchConversation).toHaveBeenCalledWith('group_role%3Astaff');
     expect(mockChatSheetsState.openConversationSheet).not.toHaveBeenCalled();
+  });
+
+  it('repairs a preferred canonical staff conversation before enabling its subscription', async () => {
+    mockChatTeamState.selectedConversationId = 'group_role%3Astaff';
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff', 'coach'] }
+    ];
+
+    render(
+      <MemoryRouter initialEntries={['/messages/team-1?conversation=group_role%253Astaff']}>
+        <ChatWindow auth={auth} teamId="team-1" preferredConversationId="group_role%3Astaff" />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(ensureStaffChatConversation).toHaveBeenCalledWith(
+      'team-1',
+      auth.user,
+      mockChatTeamState.conversations
+    ));
+    expect(mockChatTeamState.switchConversation).not.toHaveBeenCalled();
+    expect(within(screen.getByTestId('mobile-conversation-chips')).getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('repairs the selected staff conversation again before retrying its subscription', async () => {
+    mockThreadLoadScenario = 'retrySuccess';
+    mockChatTeamState.selectedConversationId = 'group_role%3Astaff';
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff', 'coach'] }
+    ];
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" preferredConversationId="group_role%3Astaff" />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(ensureStaffChatConversation).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => expect(ensureStaffChatConversation).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByText('Message recovered-message')).toBeVisible());
+  });
+
+  it('uses safe copy when staff conversation repair fails', async () => {
+    mockChatTeamState.selectedConversationId = 'group_role%3Astaff';
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['coach-1'], participantRoles: ['staff', 'coach'] }
+    ];
+    vi.mocked(ensureStaffChatConversation).mockRejectedValue(new Error('internal document payload leaked'));
+
+    render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" preferredConversationId="group_role%3Astaff" />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Unable to open staff chat. Please try again.')).toBeVisible();
+    expect(screen.queryByText('internal document payload leaked')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeVisible();
   });
 
   it('creates and switches to Staff only from the mobile quick-switcher', async () => {

--- a/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
+++ b/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import { useCallback } from 'react';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useChatMessages } from '../useChatMessages';
+import { getChatMessagesErrorMessage, useChatMessages } from '../useChatMessages';
 import { loadOlderTeamChatMessages, subscribeToTeamChatMessages } from '../../../../lib/chatService';
 import type { AuthState } from '../../../../lib/types';
 import type { ChatMessage } from '../../../../lib/chatService';
@@ -202,6 +202,22 @@ describe('useChatMessages', () => {
 
         await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
         expect(screen.getByTestId('message-ids').textContent).toBe('recovered');
+    });
+
+    it('replaces Firestore permission details with actionable, user-safe copy', async () => {
+        const permissionError = Object.assign(new Error('Missing or insufficient permissions.'), {
+            code: 'permission-denied'
+        });
+        render(<MessagesProbe conversationId="staff" />);
+
+        act(() => {
+            errorCallback?.(permissionError);
+        });
+
+        await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+        expect(screen.getByTestId('error').textContent).toBe("We couldn't open this conversation. Your team access may have changed.");
+        expect(screen.getByTestId('error').textContent).not.toContain('permissions');
+        expect(getChatMessagesErrorMessage({ code: 'permission-denied' })).toBe("We couldn't open this conversation. Your team access may have changed.");
     });
 
     it('resets the loading state when loading older messages fails and still rejects to the caller', async () => {

--- a/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
+++ b/apps/app/src/pages/messages/hooks/__tests__/useChatMessages.test.tsx
@@ -38,10 +38,12 @@ const probeTeam = { id: 'team-1', name: 'Bears' };
 
 function MessagesProbe({
     conversationId = 'team',
+    enabled = true,
     onMessagesReset,
     onLoadOlderError
 }: {
     conversationId?: string;
+    enabled?: boolean;
     onMessagesReset?: () => void;
     onLoadOlderError?: (error: unknown) => void;
 }) {
@@ -51,6 +53,7 @@ function MessagesProbe({
         team: probeTeam,
         user,
         selectedConversationId: conversationId,
+        enabled,
         onBeforeLiveUpdate: handleBeforeLiveUpdate,
         onMessagesReset
     });
@@ -106,6 +109,22 @@ describe('useChatMessages', () => {
         await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
         expect(screen.getByTestId('message-ids').textContent).toBe('older,newer');
         expect(screen.getByTestId('has-more').textContent).toBe('false');
+    });
+
+    it('waits for conversation preparation before subscribing', async () => {
+        const { rerender } = render(<MessagesProbe conversationId="group_role%3Astaff" enabled={false} />);
+
+        expect(subscribeToTeamChatMessages).not.toHaveBeenCalled();
+
+        rerender(<MessagesProbe conversationId="group_role%3Astaff" enabled />);
+
+        await waitFor(() => expect(subscribeToTeamChatMessages).toHaveBeenCalledTimes(1));
+        expect(subscribeToTeamChatMessages).toHaveBeenCalledWith(
+            'team-1',
+            'group_role%3Astaff',
+            expect.any(Function),
+            expect.any(Function)
+        );
     });
 
     it('resubscribes and clears messages when the selected conversation changes', async () => {

--- a/apps/app/src/pages/messages/hooks/useChatMessages.ts
+++ b/apps/app/src/pages/messages/hooks/useChatMessages.ts
@@ -22,6 +22,15 @@ function normalizeConversationId(conversationId: string) {
   return String(conversationId || '').trim() || DEFAULT_TEAM_CONVERSATION_ID;
 }
 
+export function getChatMessagesErrorMessage(error: unknown) {
+  const code = String((error as { code?: unknown } | null)?.code || '').trim().toLowerCase();
+  const message = error instanceof Error ? error.message.trim() : '';
+  if (code === 'permission-denied' || /missing or insufficient permissions/i.test(message)) {
+    return "We couldn't open this conversation. Your team access may have changed.";
+  }
+  return message || 'Unable to load chat messages.';
+}
+
 export function useChatMessages({
   teamId,
   team,
@@ -73,7 +82,7 @@ export function useChatMessages({
         onMarkRead?.();
       },
       (subscribeError) => {
-        setError(subscribeError.message || 'Unable to load chat messages.');
+        setError(getChatMessagesErrorMessage(subscribeError));
         setLoadingMessages(false);
       }
     );

--- a/apps/app/src/pages/messages/hooks/useChatMessages.ts
+++ b/apps/app/src/pages/messages/hooks/useChatMessages.ts
@@ -12,6 +12,7 @@ type UseChatMessagesParams = {
   team: Record<string, any> | null;
   user: AuthState['user'];
   selectedConversationId: string;
+  enabled?: boolean;
   onBeforeLiveUpdate?: () => boolean;
   onLiveUpdateState?: (state: { isInitialSnapshot: boolean; wasNearBottom: boolean }) => void;
   onMessagesReset?: () => void;
@@ -36,6 +37,7 @@ export function useChatMessages({
   team,
   user,
   selectedConversationId,
+  enabled = true,
   onBeforeLiveUpdate,
   onLiveUpdateState,
   onMessagesReset,
@@ -51,7 +53,7 @@ export function useChatMessages({
   const [retryVersion, setRetryVersion] = useState(0);
   const initialSnapshotLoadedRef = useRef(false);
   const conversationId = normalizeConversationId(selectedConversationId);
-  const canSubscribe = Boolean(team && user);
+  const canSubscribe = Boolean(enabled && team && user);
 
   const messages = useMemo(() => mergeChatMessageLists(olderMessages, liveMessages), [liveMessages, olderMessages]);
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1472,6 +1472,25 @@ service cloud.firestore {
              data.get('participantIds', []) == [];
     }
 
+    // Legacy clients stored coach ids on the canonical staff conversation. Team
+    // staff may read that conversation record only so a current client can
+    // normalize it; nested messages remain inaccessible until the record has the
+    // canonical empty participant list.
+    function canReadCanonicalStaffChatConversationForRepair(teamId, conversationId, data) {
+      return isTeamOwnerOrAdmin(teamId) &&
+             isCanonicalStaffChatConversation(conversationId) &&
+             data.get('type', '') == 'group' &&
+             isStaffRoleChatConversation(data);
+    }
+
+    function isCanonicalStaffChatConversationRepair(teamId, conversationId) {
+      return canReadCanonicalStaffChatConversationForRepair(teamId, conversationId, resource.data) &&
+             isCanonicalStaffChatConversationPayload(conversationId, request.resource.data) &&
+             request.resource.data.get('participantRoles', []) == ['staff'] &&
+             request.resource.data.diff(resource.data).affectedKeys()
+               .hasOnly(['type', 'name', 'participantIds', 'participantRoles', 'mutedBy', 'updatedAt']);
+    }
+
     function canAccessChatConversation(teamId, conversationId, conversationData) {
       let participantIds = conversationData.get('participantIds', []);
       return canAccessTeamChat(teamId) &&
@@ -3114,16 +3133,18 @@ service cloud.firestore {
       // remains teams/{teamId}/chatMessages for compatibility; targeted threads
       // store messages under their conversation record.
       match /chatConversations/{conversationId} {
-        allow get: if canAccessChatConversation(teamId, conversationId, resource.data);
+        allow get: if canAccessChatConversation(teamId, conversationId, resource.data) ||
+                      canReadCanonicalStaffChatConversationForRepair(teamId, conversationId, resource.data);
         allow list: if canListChatConversation(teamId, conversationId, resource.data);
         allow create: if canAccessTeamChat(teamId) &&
                          isChatConversationPayloadValid(request.resource.data) &&
                          canAccessChatConversation(teamId, conversationId, request.resource.data);
-        allow update: if canAccessChatConversation(teamId, conversationId, resource.data) &&
-                         canAccessChatConversation(teamId, conversationId, request.resource.data) &&
-                         isChatConversationPayloadValid(request.resource.data) &&
-                         (isTeamStaffChatConversationUpdate(teamId) ||
-                          isChatConversationParticipantMetadataUpdate());
+        allow update: if isChatConversationPayloadValid(request.resource.data) &&
+                         ((canAccessChatConversation(teamId, conversationId, resource.data) &&
+                           canAccessChatConversation(teamId, conversationId, request.resource.data) &&
+                           (isTeamStaffChatConversationUpdate(teamId) ||
+                            isChatConversationParticipantMetadataUpdate())) ||
+                          isCanonicalStaffChatConversationRepair(teamId, conversationId));
         allow delete: if isTeamOwnerOrAdmin(teamId);
 
         match /chatMessages/{messageId} {

--- a/js/db.js
+++ b/js/db.js
@@ -6542,27 +6542,57 @@ export async function upsertChatConversation(teamId, conversation = {}) {
     const existing = await getDoc(conversationRef);
     const normalizedMutedBy = Array.from(new Set(Array.isArray(mutedBy) ? mutedBy : []));
     const hasMutedByUpdate = Object.prototype.hasOwnProperty.call(conversation, 'mutedBy');
+    const isCanonicalStaffConversation = normalizedType === 'group' &&
+        normalizedParticipantIds.length === 0 &&
+        normalizedParticipantRoles.length === 1 &&
+        normalizedParticipantRoles[0] === 'staff';
 
     if (existing.exists()) {
         const existingData = existing.data() || {};
         const shouldBackfillName = Boolean(name && !existingData.name);
-        if (hasMutedByUpdate || shouldBackfillName) {
+        const shouldRepairCanonicalStaffConversation = isCanonicalStaffConversation && (
+            existingData.type !== normalizedType ||
+            !Array.isArray(existingData.participantIds) ||
+            existingData.participantIds.length !== 0 ||
+            !Array.isArray(existingData.participantRoles) ||
+            existingData.participantRoles.length !== 1 ||
+            existingData.participantRoles[0] !== 'staff'
+        );
+        const existingUpdate = {
+            ...(shouldRepairCanonicalStaffConversation ? {
+                type: normalizedType,
+                participantIds: normalizedParticipantIds,
+                participantRoles: normalizedParticipantRoles
+            } : {}),
+            ...(hasMutedByUpdate ? { mutedBy: normalizedMutedBy } : {}),
+            ...(shouldBackfillName ? { name } : {})
+        };
+        if (Object.keys(existingUpdate).length > 0) {
             await setDoc(conversationRef, {
-                ...(hasMutedByUpdate ? { mutedBy: normalizedMutedBy } : {}),
-                ...(shouldBackfillName ? { name } : {}),
+                ...existingUpdate,
                 updatedAt: now
             }, { merge: true });
         }
         return {
             id: conversationId,
             ...existingData,
+            ...(shouldRepairCanonicalStaffConversation ? {
+                type: normalizedType,
+                participantIds: normalizedParticipantIds,
+                participantRoles: normalizedParticipantRoles,
+                updatedAt: now
+            } : {}),
             ...(hasMutedByUpdate ? {
                 mutedBy: normalizedMutedBy,
                 updatedAt: now
             } : {}),
             ...(shouldBackfillName ? { name, updatedAt: now } : {}),
-            participantIds: existingData.participantIds || normalizedParticipantIds,
-            participantRoles: existingData.participantRoles || normalizedParticipantRoles,
+            participantIds: shouldRepairCanonicalStaffConversation
+                ? normalizedParticipantIds
+                : (existingData.participantIds || normalizedParticipantIds),
+            participantRoles: shouldRepairCanonicalStaffConversation
+                ? normalizedParticipantRoles
+                : (existingData.participantRoles || normalizedParticipantRoles),
             name: existingData.name || name || null
         };
     }

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,7 +344,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=15';
         import { checkAuth } from './js/auth.js?v=46';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=93';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=94';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=2';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -317,12 +317,12 @@ async function mockMessagesModules(page, options = {}) {
                     }
                     return [
                         { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
-                        { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
+                        { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
                     ];
                 }
 
                 export async function ensureStaffChatConversation() {
-                    return { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] };
+                    return { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] };
                 }
 
                 export async function loadChatRecipientOptions() {
@@ -599,7 +599,7 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
         },
         {
             text: '@ALL PLAYS who needs RSVP help?',
-            selectedConversationId: 'staff-conversation',
+            selectedConversationId: 'group_role%3Astaff',
             selectedConversationRoles: ['staff'],
             selectedRecipientTarget: 'full_team',
             selectedRecipientIds: [],

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1554,7 +1554,7 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Coach Jamie');
     });
 
-    it('loads recipient options once on first moderator tool open and reuses the cache', async () => {
+    it('loads recipient options once on first moderator tool open and reuses the cache', { timeout: 10000 }, async () => {
         const { container } = await renderMessages('/messages/team-1');
 
         expect(chatMocks.loadChatRecipientOptions).not.toHaveBeenCalled();

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1679,13 +1679,20 @@ describe('React app messages integration', () => {
     it('keeps staff conversation targeting contextual and sends the selected audience metadata', async () => {
         chatMocks.loadChatConversations.mockResolvedValueOnce([
             { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
-            { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
+            { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff', 'coach'] }
         ]);
+        chatMocks.ensureStaffChatConversation.mockResolvedValueOnce({
+            id: 'group_role%3Astaff',
+            type: 'group',
+            name: 'Staff only',
+            participantIds: [],
+            participantRoles: ['staff']
+        });
 
         const { container } = await renderMessages('/messages/team-1?conversationId=staff-conversation');
 
-        expect(chatMocks.ensureStaffChatConversation).not.toHaveBeenCalled();
-        expect(container.textContent).toContain('Staff only');
+        await waitForMockCallCount(chatMocks.ensureStaffChatConversation, 1, 'staff conversation repair');
+        await waitForText(container, 'Staff only');
 
         const textarea = container.querySelector('textarea');
         await setFieldValue(textarea, 'Staff update only');
@@ -1694,7 +1701,7 @@ describe('React app messages integration', () => {
         expect(chatMocks.sendTeamChatMessage).toHaveBeenCalledWith(expect.objectContaining({
             teamId: 'team-1',
             text: 'Staff update only',
-            selectedConversationId: 'staff-conversation',
+            selectedConversationId: 'group_role%3Astaff',
             selectedConversation: expect.objectContaining({ participantRoles: ['staff'] }),
             selectedRecipientIds: []
         }));

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1679,7 +1679,7 @@ describe('React app messages integration', () => {
     it('keeps staff conversation targeting contextual and sends the selected audience metadata', async () => {
         chatMocks.loadChatConversations.mockResolvedValueOnce([
             { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
-            { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff', 'coach'] }
+            { id: 'group_role%3Astaff', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff', 'coach'] }
         ]);
         chatMocks.ensureStaffChatConversation.mockResolvedValueOnce({
             id: 'group_role%3Astaff',
@@ -1689,7 +1689,7 @@ describe('React app messages integration', () => {
             participantRoles: ['staff']
         });
 
-        const { container } = await renderMessages('/messages/team-1?conversationId=staff-conversation');
+        const { container } = await renderMessages('/messages/team-1?conversationId=group_role%253Astaff');
 
         await waitForMockCallCount(chatMocks.ensureStaffChatConversation, 1, 'staff conversation repair');
         await waitForText(container, 'Staff only');

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -1199,6 +1199,32 @@ describe('React app chat recipient service', () => {
         }));
     });
 
+    it('normalizes a canonical staff conversation with legacy participant roles', async () => {
+        dbMocks.upsertChatConversation.mockResolvedValue({
+            id: 'group_role%3Astaff',
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff']
+        });
+
+        const { ensureStaffChatConversation } = await import('../../apps/app/src/lib/chatService.ts');
+        await ensureStaffChatConversation('team-1', {
+            uid: 'coach-1',
+            email: 'coach@example.com',
+            displayName: 'Coach Jamie'
+        }, [{
+            id: 'group_role%3Astaff',
+            type: 'group',
+            participantIds: ['coach-1'],
+            participantRoles: ['staff', 'coach']
+        }]);
+
+        expect(dbMocks.upsertChatConversation).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            participantIds: [],
+            participantRoles: ['staff']
+        }));
+    });
+
     it('routes staff-only messages into a non-default conversation before posting', async () => {
         dbMocks.upsertChatConversation.mockResolvedValue({
             id: 'staff-conversation',

--- a/tests/unit/db-chat-conversation-upsert.test.js
+++ b/tests/unit/db-chat-conversation-upsert.test.js
@@ -241,4 +241,53 @@ describe('upsertChatConversation', () => {
             createdAt: now
         });
     });
+
+    it('repairs legacy participant-scoped data on the canonical staff conversation', async () => {
+        const now = { seconds: 789 };
+        const conversationRef = { path: 'teams/team-1/chatConversations/group_role%3Astaff' };
+        const getDoc = vi.fn().mockResolvedValue(makeSnapshot({
+            type: 'group',
+            participantIds: ['coach-1'],
+            participantRoles: ['staff', 'coach'],
+            mutedBy: ['coach-2'],
+            name: 'Staff only',
+            createdAt: { seconds: 1 },
+            updatedAt: { seconds: 2 }
+        }));
+        const setDoc = vi.fn().mockResolvedValue(undefined);
+        const upsertChatConversation = buildUpsertChatConversation({
+            normalizeConversationType: vi.fn((value) => value),
+            normalizeConversationParticipantIds: vi.fn(() => []),
+            buildConversationId: vi.fn(() => 'group_role%3Astaff'),
+            Timestamp: { now: vi.fn(() => now) },
+            doc: vi.fn(() => conversationRef),
+            db: {},
+            getDoc,
+            setDoc
+        });
+
+        const result = await upsertChatConversation('team-1', {
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff'],
+            name: 'Staff only'
+        });
+
+        expect(setDoc).toHaveBeenCalledWith(conversationRef, {
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff'],
+            updatedAt: now
+        }, { merge: true });
+        expect(result).toEqual({
+            id: 'group_role%3Astaff',
+            type: 'group',
+            participantIds: [],
+            participantRoles: ['staff'],
+            mutedBy: ['coach-2'],
+            name: 'Staff only',
+            createdAt: { seconds: 1 },
+            updatedAt: now
+        });
+    });
 });

--- a/tests/unit/messages-decomposition-contract.test.js
+++ b/tests/unit/messages-decomposition-contract.test.js
@@ -15,7 +15,7 @@ describe('Messages decomposition contract', () => {
         expect(messages).toContain("import { ChatWindow, TeamAvatar } from './messages/components/ChatWindow';");
         expect(chatWindow).toContain("import { useChatSheets } from '../hooks/useChatSheets';");
         expect(chatWindow).toContain("import { useChatTeam } from '../hooks/useChatTeam';");
-        expect(chatWindow).toContain("import { useChatMessages } from '../hooks/useChatMessages';");
+        expect(chatWindow).toContain("import { getChatMessagesErrorMessage, useChatMessages } from '../hooks/useChatMessages';");
         expect(chatWindow).toContain('} = useChatSheets();');
         expect(chatWindow).toContain('} = useChatTeam({');
         expect(chatWindow).toContain('} = useChatMessages({');

--- a/tests/unit/messages-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/messages-decomposition-initiative-source-contract.test.js
@@ -20,7 +20,7 @@ const emailReducerTestSource = readSource('apps/app/src/pages/messages/state/__t
 describe('Messages decomposition initiative source contract', () => {
     it('keeps live message subscription and pagination state in useChatMessages', () => {
         expect(messagesSource).toContain("import { ChatWindow, TeamAvatar } from './messages/components/ChatWindow';");
-        expect(chatWindowSource).toContain("import { useChatMessages } from '../hooks/useChatMessages';");
+        expect(chatWindowSource).toContain("import { getChatMessagesErrorMessage, useChatMessages } from '../hooks/useChatMessages';");
         expect(chatWindowSource).toContain('} = useChatMessages({');
         expect(chatWindowSource).not.toMatch(/const\s+\[liveMessages\b/);
         expect(chatWindowSource).not.toMatch(/const\s+\[olderMessages\b/);

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -17,7 +17,7 @@ describe('RSVP precedence cache delivery', () => {
             'login.html': 'db.js?v=91',
             'parent-dashboard.html': 'db.js?v=91',
             'team.html': 'db.js?v=91',
-            'team-chat.html': 'db.js?v=93',
+            'team-chat.html': 'db.js?v=94',
             'js/auth.js': 'db.js?v=91',
             'js/team-media.js': 'db.js?v=91'
         };

--- a/tests/unit/team-chat-conversations.test.js
+++ b/tests/unit/team-chat-conversations.test.js
@@ -68,7 +68,8 @@ describe('team chat conversations', () => {
         const rules = readRepoFile('firestore.rules');
         const db = readRepoFile('js/db.js');
 
-        expect(rules).toContain('allow get: if canAccessChatConversation(teamId, conversationId, resource.data);');
+        expect(rules).toContain('allow get: if canAccessChatConversation(teamId, conversationId, resource.data) ||');
+        expect(rules).toContain('canReadCanonicalStaffChatConversationForRepair(teamId, conversationId, resource.data);');
         expect(rules).toContain('allow list: if canListChatConversation(teamId, conversationId, resource.data);');
         expect(rules).toContain('canAccessChatConversation(teamId, conversationId, request.resource.data) &&');
         expect(rules).toContain("allow read: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data);");
@@ -77,5 +78,10 @@ describe('team chat conversations', () => {
         expect(db).toContain("where('participantIds', 'array-contains', `email:${normalizedEmail}`)");
         expect(db).not.toContain("where('participantRoles', 'array-contains', 'team')");
         expect(rules).not.toContain("'team' in participantRoles");
+        const nestedMessageRules = rules.slice(
+            rules.indexOf('match /chatMessages/{messageId} {', rules.indexOf('match /chatConversations/{conversationId} {')),
+            rules.indexOf('// Server-only dedup log')
+        );
+        expect(nestedMessageRules).not.toContain('canReadCanonicalStaffChatConversationForRepair');
     });
 });

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -5,7 +5,7 @@ import {
     assertSucceeds,
     initializeTestEnvironment
 } from '@firebase/rules-unit-testing';
-import { doc, getDoc, serverTimestamp, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
+import { collection, doc, getDoc, getDocs, serverTimestamp, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
 
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
@@ -163,12 +163,22 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
         await testEnv.withSecurityRulesDisabled(async (context) => {
             const firestore = context.firestore();
             await setDoc(doc(firestore, 'teams/team-1'), {
-                ownerId: 'coach-1',
+                ownerId: 'owner-1',
                 adminEmails: ['coach@example.com']
+            });
+            await setDoc(doc(firestore, 'users/owner-1'), {
+                email: 'owner@example.com',
+                isAdmin: false,
+                parentTeamIds: []
             });
             await setDoc(doc(firestore, 'users/coach-1'), {
                 email: 'coach@example.com',
                 isAdmin: false,
+                parentTeamIds: []
+            });
+            await setDoc(doc(firestore, 'users/global-1'), {
+                email: 'global@example.com',
+                isAdmin: true,
                 parentTeamIds: []
             });
             await setDoc(doc(firestore, 'users/parent-1'), {
@@ -323,41 +333,68 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
 
     it('lets only team staff repair legacy canonical metadata before reading staff messages', async () => {
         const legacyCreatedAt = Timestamp.fromMillis(1700000000000);
-        await testEnv.withSecurityRulesDisabled(async (context) => {
-            const firestore = context.firestore();
-            await setDoc(doc(firestore, `teams/team-1/chatConversations/${staffConversationId}`), {
+        const seedConversation = async (conversationId, overrides = {}) => {
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await setDoc(doc(context.firestore(), `teams/team-1/chatConversations/${conversationId}`), {
+                    type: 'group',
+                    name: 'Staff only',
+                    participantIds: ['coach-1'],
+                    participantRoles: ['staff', 'coach'],
+                    mutedBy: [],
+                    createdAt: legacyCreatedAt,
+                    updatedAt: Timestamp.now(),
+                    ...overrides
+                });
+            });
+        };
+        const canonicalPayload = (overrides = {}) => ({
                 type: 'group',
                 name: 'Staff only',
-                participantIds: ['coach-1'],
+                participantIds: [],
                 participantRoles: ['staff'],
                 mutedBy: [],
                 createdAt: legacyCreatedAt,
-                updatedAt: Timestamp.now()
-            });
+                updatedAt: serverTimestamp(),
+                ...overrides
+        });
+
+        await seedConversation(staffConversationId);
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const firestore = context.firestore();
             await setDoc(messageRef(firestore, staffConversationId, 'legacy-staff-message'), {
                 text: 'Staff update'
             });
         });
 
-        const coachDb = authedFirestore('coach-1', 'coach@example.com');
+        const adminDb = authedFirestore('coach-1', 'coach@example.com');
+        const ownerDb = authedFirestore('owner-1', 'owner@example.com');
+        const globalAdminDb = authedFirestore('global-1', 'global@example.com');
         const parentDb = authedFirestore('parent-1', 'parent@example.com');
-        const coachConversationRef = doc(coachDb, `teams/team-1/chatConversations/${staffConversationId}`);
+        const adminConversationRef = doc(adminDb, `teams/team-1/chatConversations/${staffConversationId}`);
+        const ownerConversationRef = doc(ownerDb, `teams/team-1/chatConversations/${staffConversationId}`);
+        const globalAdminConversationRef = doc(globalAdminDb, `teams/team-1/chatConversations/${staffConversationId}`);
         const parentConversationRef = doc(parentDb, `teams/team-1/chatConversations/${staffConversationId}`);
 
-        await assertSucceeds(getDoc(coachConversationRef));
+        await assertSucceeds(getDoc(adminConversationRef));
+        await assertSucceeds(getDoc(ownerConversationRef));
+        await assertSucceeds(getDoc(globalAdminConversationRef));
         await assertFails(getDoc(parentConversationRef));
-        await assertFails(getDoc(messageRef(coachDb, staffConversationId, 'legacy-staff-message')));
-        await assertSucceeds(setDoc(coachConversationRef, {
-            type: 'group',
-            name: 'Staff only',
-            participantIds: [],
-            participantRoles: ['staff'],
-            mutedBy: [],
-            createdAt: legacyCreatedAt,
-            updatedAt: serverTimestamp()
-        }));
-        await assertSucceeds(getDoc(messageRef(coachDb, staffConversationId, 'legacy-staff-message')));
+        await assertFails(setDoc(parentConversationRef, canonicalPayload()));
+        await assertFails(getDoc(messageRef(adminDb, staffConversationId, 'legacy-staff-message')));
+        await assertFails(getDocs(collection(adminDb, `teams/team-1/chatConversations/${staffConversationId}/chatMessages`)));
+        await assertFails(setDoc(adminConversationRef, canonicalPayload({ participantRoles: ['staff', 'coach'] })));
+        await assertFails(setDoc(adminConversationRef, canonicalPayload({ unexpected: true })));
+
+        await assertSucceeds(setDoc(adminConversationRef, canonicalPayload()));
+        await assertSucceeds(getDoc(messageRef(adminDb, staffConversationId, 'legacy-staff-message')));
+        await assertSucceeds(getDocs(collection(adminDb, `teams/team-1/chatConversations/${staffConversationId}/chatMessages`)));
         await assertFails(getDoc(messageRef(parentDb, staffConversationId, 'legacy-staff-message')));
+
+        await seedConversation('legacy_staff');
+        await assertFails(getDoc(doc(adminDb, 'teams/team-1/chatConversations/legacy_staff')));
+
+        await seedConversation(staffConversationId, { participantRoles: ['coach'] });
+        await assertFails(getDoc(adminConversationRef));
     });
 
     it('allows legacy full-team text and exact scoped Firebase Storage uploads', async () => {

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -5,7 +5,7 @@ import {
     assertSucceeds,
     initializeTestEnvironment
 } from '@firebase/rules-unit-testing';
-import { doc, serverTimestamp, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
+import { doc, getDoc, serverTimestamp, setDoc, Timestamp, updateDoc } from 'firebase/firestore';
 
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
@@ -319,6 +319,45 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
         await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct'), directPayload()));
         await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct-no-email'), directWithoutStoredEmail));
         await assertSucceeds(setDoc(messageRef(coachDb, staffConversationId, 'valid-staff'), staffPayload()));
+    });
+
+    it('lets only team staff repair legacy canonical metadata before reading staff messages', async () => {
+        const legacyCreatedAt = Timestamp.fromMillis(1700000000000);
+        await testEnv.withSecurityRulesDisabled(async (context) => {
+            const firestore = context.firestore();
+            await setDoc(doc(firestore, `teams/team-1/chatConversations/${staffConversationId}`), {
+                type: 'group',
+                name: 'Staff only',
+                participantIds: ['coach-1'],
+                participantRoles: ['staff'],
+                mutedBy: [],
+                createdAt: legacyCreatedAt,
+                updatedAt: Timestamp.now()
+            });
+            await setDoc(messageRef(firestore, staffConversationId, 'legacy-staff-message'), {
+                text: 'Staff update'
+            });
+        });
+
+        const coachDb = authedFirestore('coach-1', 'coach@example.com');
+        const parentDb = authedFirestore('parent-1', 'parent@example.com');
+        const coachConversationRef = doc(coachDb, `teams/team-1/chatConversations/${staffConversationId}`);
+        const parentConversationRef = doc(parentDb, `teams/team-1/chatConversations/${staffConversationId}`);
+
+        await assertSucceeds(getDoc(coachConversationRef));
+        await assertFails(getDoc(parentConversationRef));
+        await assertFails(getDoc(messageRef(coachDb, staffConversationId, 'legacy-staff-message')));
+        await assertSucceeds(setDoc(coachConversationRef, {
+            type: 'group',
+            name: 'Staff only',
+            participantIds: [],
+            participantRoles: ['staff'],
+            mutedBy: [],
+            createdAt: legacyCreatedAt,
+            updatedAt: serverTimestamp()
+        }));
+        await assertSucceeds(getDoc(messageRef(coachDb, staffConversationId, 'legacy-staff-message')));
+        await assertFails(getDoc(messageRef(parentDb, staffConversationId, 'legacy-staff-message')));
     });
 
     it('allows legacy full-team text and exact scoped Firebase Storage uploads', async () => {

--- a/tests/unit/team-chat-targeted-rules.test.js
+++ b/tests/unit/team-chat-targeted-rules.test.js
@@ -201,7 +201,7 @@ describe('targeted team chat Firestore rules', () => {
         expect(rules).toContain('function isTeamStaffChatConversationUpdate(teamId)');
         expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) &&');
         expect(rules).toContain('(isTeamStaffChatConversationUpdate(teamId) ||');
-        expect(rules).toContain('isChatConversationParticipantMetadataUpdate());');
+        expect(rules).toContain('isChatConversationParticipantMetadataUpdate())) ||');
     });
 
     it('requires team staff/admin access and server-derived members for the canonical staff conversation', () => {
@@ -214,6 +214,19 @@ describe('targeted team chat Firestore rules', () => {
         expect(rules).toContain('isCanonicalStaffChatConversation(conversationId) &&');
         expect(rules).toContain('isTeamOwnerOrAdmin(teamId) &&');
         expect(rules).toContain('isCanonicalStaffChatConversationPayload(conversationId, conversationData)');
+    });
+
+    it('allows only team staff to repair legacy canonical staff metadata without exposing nested messages', () => {
+        expect(rules).toContain('function canReadCanonicalStaffChatConversationForRepair(teamId, conversationId, data)');
+        expect(rules).toContain('function isCanonicalStaffChatConversationRepair(teamId, conversationId)');
+        expect(rules).toContain("request.resource.data.get('participantRoles', []) == ['staff']");
+        expect(rules).toContain(".hasOnly(['type', 'name', 'participantIds', 'participantRoles', 'mutedBy', 'updatedAt'])");
+
+        const nestedMessageStart = rules.indexOf('match /chatMessages/{messageId} {', rules.indexOf('match /chatConversations/{conversationId} {'));
+        const nestedMessageEnd = rules.indexOf('// Server-only dedup log', nestedMessageStart);
+        const nestedMessageRules = rules.slice(nestedMessageStart, nestedMessageEnd);
+        expect(nestedMessageRules).not.toContain('canReadCanonicalStaffChatConversationForRepair');
+        expect(nestedMessageRules).not.toContain('isCanonicalStaffChatConversationRepair');
     });
 
     it('does not authorize staff-role conversations through caller-controlled participantIds', () => {
@@ -232,7 +245,7 @@ describe('targeted team chat Firestore rules', () => {
     });
 
     it('keeps conversation list authorization compatible with existing participant and moderator queries', () => {
-        expect(rules).toContain('allow get: if canAccessChatConversation(teamId, conversationId, resource.data);');
+        expect(rules).toContain('allow get: if canAccessChatConversation(teamId, conversationId, resource.data) ||');
         expect(rules).toContain('allow list: if canListChatConversation(teamId, conversationId, resource.data);');
         expect(rules).toContain('function canListChatConversation(teamId, conversationId, conversationData)');
 

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=93';");
+        expect(html).toContain("from './js/db.js?v=94';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {


### PR DESCRIPTION
Closes #3764

## What changed
- Normalize existing staff-only conversations before switching to them on desktop or mobile, so legacy participant-scoped records are repaired before the message subscription starts.
- Teach the conversation upsert to repair only the canonical empty-participant `staff` record while preserving existing mute metadata.
- Add a narrowly scoped Firestore migration path: owner/admin/global-admin users may read and canonicalize legacy staff conversation metadata; parents remain denied, and nested staff messages remain denied until the record is canonical.
- Replace raw Firestore permission text with user-safe copy and make **Back to messages** return an errored non-default thread to Team chat in place.

## Security boundary
- Does not add coaches through a new role source or broaden general team-chat access. Authorization remains `isTeamOwnerOrAdmin` (owner, normalized `adminEmails`, or global admin).
- Repair is limited to `group_role%3Astaff`, an existing group record carrying the `staff` role, an exact resulting role list of `[staff]`, an empty participant list, and a bounded metadata field diff.
- The repair exception is not used by nested message rules.

## Validation
- Focused review/CI unit and component matrix: **112 passed**; final ID-guard component/integration rerun: **98 passed**.
- Firestore emulator suite: **17 passed**, covering owner, admin-email, and global-admin repair plus parent/noncanonical/wrong-role/extra-field and pre-repair nested get/list denials.
- `npm run ci:firebase-rules`
- App ESLint `--quiet` plus strict `react-hooks/exhaustive-deps:error` for all changed app files
- App TypeScript check and production Vite build
- `git diff --check`

## Manual review focus
- Firestore repair scope in `firestore.rules`
- Existing malformed canonical record repair in `js/db.js`
- Staff selection/recovery behavior in `ChatWindow.tsx`

No rules were deployed. Independent security review findings were addressed; the PR is ready for CI and the repository review gate.
