### PR TITLE
Fix delegated team media upload rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1442,16 +1442,15 @@ service cloud.firestore {
     function isTeamMediaUploadCreate(teamId, data) {
       return hasTeamMediaUploadGrant(teamId) &&
              data.keys().hasAll([
-               'folderId', 'title', 'type', 'url', 'storagePath', 'uploadedBy',
+               'folderId', 'title', 'type', 'storagePath', 'uploadedBy',
                'size', 'mimeType', 'deleted', 'createdAt', 'updatedAt'
              ]) &&
              data.keys().hasOnly([
-               'folderId', 'title', 'fileName', 'type', 'url', 'storagePath', 'uploadedBy',
+               'folderId', 'title', 'fileName', 'type', 'storagePath', 'uploadedBy',
                'size', 'mimeType', 'order', 'deleted', 'createdAt', 'updatedAt'
              ]) &&
              canUploadTeamMediaFolder(teamId, data.folderId) &&
              data.type in ['photo', 'file'] &&
-             data.url is string &&
              data.storagePath is string &&
              data.storagePath.matches('team-media/' + teamId + '/' + data.folderId + '/' + request.auth.uid + '/.*') &&
              data.uploadedBy == request.auth.uid &&

--- a/tests/unit/team-media-rules.test.js
+++ b/tests/unit/team-media-rules.test.js
@@ -4,6 +4,16 @@ import { readFileSync } from 'node:fs';
 const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 const privilegedTeamMediaGrantFields = ['teamMediaUploadTeamIds', 'mediaUploadTeamIds'];
 
+function teamMediaUploadCreateRule() {
+    const start = rules.indexOf('function isTeamMediaUploadCreate(teamId, data) {');
+    const end = rules.indexOf('function isTeamMediaUploadCounterUpdate(teamId) {', start);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    return rules.slice(start, end);
+}
+
 function ownerProfileCreateWouldBeAllowed(data) {
     return data.isAdmin !== true &&
         !['parentOf', 'parentTeamIds', 'parentPlayerKeys', 'playerKeys'].some((field) => Object.hasOwn(data, field)) &&
@@ -61,6 +71,7 @@ describe('team media Firestore rules', () => {
         const mediaRulesStart = rules.indexOf('match /mediaFolders/{folderId}');
         const mediaRulesEnd = rules.indexOf('// Chat messages subcollection', mediaRulesStart);
         const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd);
+        const uploadCreateRule = teamMediaUploadCreateRule();
 
         expect(mediaRules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(mediaRules).toContain('allow create, delete: if isTeamOwnerOrAdmin(teamId);');
@@ -73,10 +84,21 @@ describe('team media Firestore rules', () => {
         expect(rules).toContain('function isTeamMediaUploadCounterUpdate(teamId) {');
         expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['nextMediaOrder', 'updatedAt'])");
         expect(rules).toContain("request.resource.data.get('nextMediaOrder', 0) == resource.data.get('nextMediaOrder', 0) + 1");
-        expect(rules).toContain('return hasTeamMediaUploadGrant(teamId) &&');
-        expect(rules).toContain('canUploadTeamMediaFolder(teamId, data.folderId)');
-        expect(rules).toContain("data.type in ['photo', 'file']");
-        expect(rules).toContain('isAllowedTeamMediaUploadType(data.mimeType)');
+        expect(uploadCreateRule).toContain('return hasTeamMediaUploadGrant(teamId) &&');
+        expect(uploadCreateRule).toContain('canUploadTeamMediaFolder(teamId, data.folderId)');
+        expect(uploadCreateRule).toContain("data.type in ['photo', 'file']");
+        expect(uploadCreateRule).toContain('isAllowedTeamMediaUploadType(data.mimeType)');
         expect(mediaRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
+    });
+
+    it('allows delegated storage-backed uploads without persisted download URLs', () => {
+        const uploadCreateRule = teamMediaUploadCreateRule();
+
+        expect(uploadCreateRule).toContain("'folderId', 'title', 'type', 'storagePath', 'uploadedBy'");
+        expect(uploadCreateRule).toContain("'folderId', 'title', 'fileName', 'type', 'storagePath', 'uploadedBy'");
+        expect(uploadCreateRule).toContain("data.storagePath.matches('team-media/' + teamId + '/' + data.folderId + '/' + request.auth.uid + '/.*')");
+        expect(uploadCreateRule).not.toContain("'folderId', 'title', 'type', 'url', 'storagePath', 'uploadedBy'");
+        expect(uploadCreateRule).not.toContain("'folderId', 'title', 'fileName', 'type', 'url', 'storagePath', 'uploadedBy'");
+        expect(uploadCreateRule).not.toContain('data.url is string');
     });
 });


### PR DESCRIPTION
Closes #3832

## What changed
- Updated `isTeamMediaUploadCreate` so delegated Team Media upload users can create storage-backed photo/file records without a persisted `url` field.
- Kept the delegated path constrained to team-visible folders, `team-media/{teamId}/{folderId}/{uid}/...` storage paths, uploader ownership, allowed MIME types, size limit, and non-deleted creates.
- Added a focused rules regression test that asserts the delegated create contract no longer requires or allows persisted download URLs.

## Root Cause
Firestore delegated Team Media create rules still enforced the old persisted download URL schema by requiring `url` in `hasAll`, allowing it in `hasOnly`, and checking `data.url is string`, while the upload code now persists storage-backed media items with `storagePath` and returns download URLs only at runtime.

## Prevention / Learning
When client media writes move from persisted download URLs to storage-backed paths, update Firestore required-field and allowlist rules in the same change and add coverage for the delegated non-admin create path, not only owner/admin paths.

## Regression Tests
- `npx vitest run tests/unit/team-media-rules.test.js --reporter=verbose`
- `npm run ci:firebase-rules`

## Recurrence Risk
Low. The storage-backed delegated create schema now has focused rule-contract coverage and the rule still preserves path ownership, MIME, size, visibility, uploader, and timestamp checks.