### PR TITLE
Email parent invite links

### DIFF
--- a/apps/app/src/lib/adapters/legacyTeamDetail.ts
+++ b/apps/app/src/lib/adapters/legacyTeamDetail.ts
@@ -2,6 +2,7 @@
  * Bindings re-exported as-is so existing js/* test mocks apply via the @legacy alias. */
 import * as legacyDb from '@legacy/db.js';
 import { sendInviteEmail as legacy_sendInviteEmail } from '@legacy/auth.js';
+import { queueInviteEmail as legacy_queueInviteEmail } from '@legacy/invite-email.js';
 import { inviteExistingTeamAdmin as legacy_inviteExistingTeamAdmin } from '@legacy/edit-team-admin-invites.js';
 import * as legacyFirebase from '@legacy/firebase.js';
 import { normalizeRosterFieldDefinitions as legacy_normalizeRosterFieldDefinitions, splitRosterProfileValuesByVisibility as legacy_splitRosterProfileValuesByVisibility, validateRosterProfileValues as legacy_validateRosterProfileValues } from '@legacy/roster-profile-fields.js';
@@ -58,6 +59,7 @@ export const updateConfig = (...args: any[]) => callLegacyDb('updateConfig', arg
 export const uploadPlayerPhoto = (...args: any[]) => callLegacyDb('uploadPlayerPhoto', args);
 export const uploadTeamPhoto = (...args: any[]) => callLegacyDb('uploadTeamPhoto', args);
 export const sendInviteEmail = legacy_sendInviteEmail as (...args: any[]) => any;
+export const queueInviteEmail = legacy_queueInviteEmail as (...args: any[]) => any;
 export const inviteExistingTeamAdmin = legacy_inviteExistingTeamAdmin as (...args: any[]) => any;
 export const collection = (...args: any[]) => callLegacyFirebase('collection', args);
 export const collectionGroup = (...args: any[]) => callLegacyFirebase('collectionGroup', args);

--- a/apps/app/src/lib/parentHouseholdService.ts
+++ b/apps/app/src/lib/parentHouseholdService.ts
@@ -35,6 +35,8 @@ export type ParentHouseholdInviteRequest = {
 export type ParentHouseholdInviteResult = {
     code: string;
     inviteUrl: string;
+    email: string;
+    emailSent: boolean;
 };
 
 export async function loadParentHouseholdInviteModel(user: AuthUser | null): Promise<{ linkedPlayers: ParentHouseholdLinkedPlayer[]; members: ParentHouseholdFamilyMember[] }> {
@@ -77,7 +79,9 @@ export async function createParentHouseholdMemberInvite(user: AuthUser | null, r
     }, { existingMembers });
     return {
         code: compactString((result as any)?.code),
-        inviteUrl: toAbsoluteLegacyUrl((result as any)?.inviteUrl)
+        inviteUrl: toAbsoluteLegacyUrl((result as any)?.inviteUrl),
+        email,
+        emailSent: true
     };
 }
 

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -235,6 +235,8 @@ export type ParentHouseholdInviteRequest = {
 export type ParentHouseholdInviteResult = {
   code: string;
   inviteUrl: string;
+  email: string;
+  emailSent: boolean;
 };
 
 export type ParentCertificateCard = Record<string, any> & {
@@ -586,7 +588,9 @@ export async function createParentHouseholdMemberInvite(user: AuthUser | null, r
   }, { existingMembers });
   return {
     code: compactString((result as any)?.code),
-    inviteUrl: toAbsoluteLegacyUrl((result as any)?.inviteUrl)
+    inviteUrl: toAbsoluteLegacyUrl((result as any)?.inviteUrl),
+    email,
+    emailSent: true
   };
 }
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -1050,7 +1050,7 @@ export async function createRosterParentInviteForApp(
       await queueInviteEmail(code);
       emailSent = true;
     } catch (error) {
-      console.warn('Parent invite was created, but its email could not be queued:', error);
+      logger.warn('Parent invite was created, but its email could not be queued.', { error });
     }
   }
   invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -38,6 +38,7 @@ import {
   normalizeStatTrackerConfig,
   normalizeTrackingStatus,
   query,
+  queueInviteEmail,
   reactivatePlayer,
   revokeScorekeeperAccess,
   revokeVideographerAccess,
@@ -215,6 +216,8 @@ export type CreateRosterParentInviteForAppResult = {
   code: string;
   inviteUrl: string;
   status: 'pending' | 'accepted';
+  email: string | null;
+  emailSent: boolean;
   existingUser: boolean;
   autoLinked: boolean;
   teamName: string | null;
@@ -1017,26 +1020,41 @@ export async function revokeTeamAdminAccessForApp(teamId: string, email: string,
   invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 }
 
-export async function createRosterParentInviteForApp(teamId: string, user: AuthUser | null, player: Pick<TeamDetailPlayer, 'id' | 'number'>): Promise<CreateRosterParentInviteForAppResult> {
+export async function createRosterParentInviteForApp(
+  teamId: string,
+  user: AuthUser | null,
+  player: Pick<TeamDetailPlayer, 'id' | 'number'>,
+  invite: { email?: string; relation?: string } = {}
+): Promise<CreateRosterParentInviteForAppResult> {
   const normalizedTeamId = cleanString(teamId);
   const normalizedPlayerId = cleanString(player?.id);
+  const normalizedEmail = cleanString(invite?.email).toLowerCase();
+  const relation = cleanString(invite?.relation) || 'Parent';
   if (!normalizedTeamId) throw new Error('Team ID is required.');
   if (!normalizedPlayerId) throw new Error('Player ID is required.');
+  if (normalizedEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+    throw new Error('Enter a valid parent email address.');
+  }
 
   const { team } = await loadTeamDetailBaseSnapshot(normalizedTeamId);
   if (!team || !hasFullTeamAccess(user, team)) {
     throw new Error('You do not have permission to invite parents for this team.');
   }
 
-  const inviteResult = await inviteParent(normalizedTeamId, normalizedPlayerId, cleanString(player?.number), '', 'Parent');
+  const inviteResult = await inviteParent(normalizedTeamId, normalizedPlayerId, cleanString(player?.number), normalizedEmail, relation);
   const code = cleanString(inviteResult?.code).toUpperCase();
   if (!code) throw new Error('Invite code was not created.');
+  if (normalizedEmail) {
+    await queueInviteEmail(code);
+  }
   invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 
   return {
     code,
     inviteUrl: buildAppAcceptInviteUrl(code, 'parent'),
     status: inviteResult?.autoLinked ? 'accepted' : 'pending',
+    email: normalizedEmail || null,
+    emailSent: Boolean(normalizedEmail),
     existingUser: inviteResult?.existingUser === true,
     autoLinked: inviteResult?.autoLinked === true,
     teamName: inviteResult?.teamName || null,

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -1044,8 +1044,14 @@ export async function createRosterParentInviteForApp(
   const inviteResult = await inviteParent(normalizedTeamId, normalizedPlayerId, cleanString(player?.number), normalizedEmail, relation);
   const code = cleanString(inviteResult?.code).toUpperCase();
   if (!code) throw new Error('Invite code was not created.');
+  let emailSent = false;
   if (normalizedEmail) {
-    await queueInviteEmail(code);
+    try {
+      await queueInviteEmail(code);
+      emailSent = true;
+    } catch (error) {
+      console.warn('Parent invite was created, but its email could not be queued:', error);
+    }
   }
   invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 
@@ -1054,7 +1060,7 @@ export async function createRosterParentInviteForApp(
     inviteUrl: buildAppAcceptInviteUrl(code, 'parent'),
     status: inviteResult?.autoLinked ? 'accepted' : 'pending',
     email: normalizedEmail || null,
-    emailSent: Boolean(normalizedEmail),
+    emailSent,
     existingUser: inviteResult?.existingUser === true,
     autoLinked: inviteResult?.autoLinked === true,
     teamName: inviteResult?.teamName || null,

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1402,7 +1402,7 @@ describe('TeamDetail', () => {
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamRosterParentInvites).toHaveBeenCalledTimes(1));
   });
 
-  it('passes the signed-in user to parent invite creation and refreshes summaries after success', async () => {
+  it('sends the parent email and relation when creating an invite and refreshes summaries after success', async () => {
     const managedModel = {
       ...model,
       canManageTeam: true
@@ -1411,6 +1411,17 @@ describe('TeamDetail', () => {
     teamDetailServiceMocks.loadTeamRosterParentInvites
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ playerId: 'player-1', status: 'pending', acceptedParentCount: 0, pendingInviteCount: 1, latestPendingCode: 'ABCD1234' }]);
+    teamDetailServiceMocks.createRosterParentInviteForApp.mockResolvedValueOnce({
+      code: 'ABCD1234',
+      inviteUrl: 'https://allplays.ai/app#/accept-invite?code=ABCD1234&type=parent',
+      status: 'pending',
+      email: 'parent@example.com',
+      emailSent: true,
+      existingUser: false,
+      autoLinked: false,
+      teamName: 'Bears',
+      playerName: 'Pat Star'
+    });
 
     render(
       <MemoryRouter initialEntries={['/teams/team-1']}>
@@ -1424,11 +1435,18 @@ describe('TeamDetail', () => {
     fireEvent.click(screen.getByRole('button', { name: /roster/i }));
     expect(await screen.findByRole('button', { name: 'Invite parent' })).toBeTruthy();
 
+    fireEvent.change(screen.getByLabelText('Parent email for Pat Star'), { target: { value: 'parent@example.com' } });
+    fireEvent.change(screen.getByLabelText('Parent relation for Pat Star'), { target: { value: 'Guardian' } });
     fireEvent.click(screen.getByRole('button', { name: 'Invite parent' }));
 
-    await waitFor(() => expect(teamDetailServiceMocks.createRosterParentInviteForApp).toHaveBeenCalledWith('team-1', auth.user, expect.objectContaining({ id: 'player-1', number: '9' })));
+    await waitFor(() => expect(teamDetailServiceMocks.createRosterParentInviteForApp).toHaveBeenCalledWith(
+      'team-1',
+      auth.user,
+      expect.objectContaining({ id: 'player-1', number: '9' }),
+      { email: 'parent@example.com', relation: 'Guardian' }
+    ));
     await waitFor(() => expect(teamDetailServiceMocks.loadTeamRosterParentInvites).toHaveBeenCalledTimes(2));
-    expect(await screen.findByText('Parent invite is ready to copy or share.')).toBeTruthy();
+    expect(await screen.findByText('Invite emailed to parent@example.com with the code and signup link.')).toBeTruthy();
   });
 
   it('removes legacy staff link-out and supports native admin invite sharing and removal', async () => {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1449,6 +1449,47 @@ describe('TeamDetail', () => {
     expect(await screen.findByText('Invite emailed to parent@example.com with the code and signup link.')).toBeTruthy();
   });
 
+  it('keeps a created parent invite visible when its email cannot be sent', async () => {
+    const managedModel = {
+      ...model,
+      canManageTeam: true
+    };
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(managedModel);
+    teamDetailServiceMocks.loadTeamRosterParentInvites
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ playerId: 'player-1', status: 'pending', acceptedParentCount: 0, pendingInviteCount: 1, latestPendingCode: 'ABCD1234' }]);
+    teamDetailServiceMocks.createRosterParentInviteForApp.mockResolvedValueOnce({
+      code: 'ABCD1234',
+      inviteUrl: 'https://allplays.ai/app#/accept-invite?code=ABCD1234&type=parent',
+      status: 'pending',
+      email: 'parent@example.com',
+      emailSent: false,
+      existingUser: false,
+      autoLinked: false,
+      teamName: 'Bears',
+      playerName: 'Pat Star'
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /roster/i }));
+    expect(await screen.findByRole('button', { name: 'Invite parent' })).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Parent email for Pat Star'), { target: { value: 'parent@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Invite parent' }));
+
+    await waitFor(() => expect(teamDetailServiceMocks.loadTeamRosterParentInvites).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Invite created, but the email to parent@example.com could not be sent. Copy or share the code or link.')).toBeTruthy();
+    expect(screen.getByText('ABCD1234')).toBeTruthy();
+  });
+
   it('removes legacy staff link-out and supports native admin invite sharing and removal', async () => {
     const managedModel = {
       ...model,

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -2902,7 +2902,9 @@ function PlayerRow({
           ? `Existing parent linked automatically${result.emailSent && result.email ? ` and notified at ${result.email}` : ''}.`
           : result.emailSent && result.email
             ? `Invite emailed to ${result.email} with the code and signup link.`
-            : 'Parent invite is ready to copy or share.'
+            : result.email
+              ? `Invite created, but the email to ${result.email} could not be sent. Copy or share the code or link.`
+              : 'Parent invite is ready to copy or share.'
       });
       await onInviteCreated();
     } catch (error: any) {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -2875,6 +2875,8 @@ function PlayerRow({
   const [creatingInvite, setCreatingInvite] = useState(false);
   const [inviteResult, setInviteResult] = useState<CreateRosterParentInviteForAppResult | null>(null);
   const [inviteStatus, setInviteStatus] = useState<{ success: boolean; message: string } | null>(null);
+  const [parentEmail, setParentEmail] = useState('');
+  const [parentRelation, setParentRelation] = useState('Parent');
 
   const effectiveStatus = inviteResult?.status || inviteSummary?.status || 'none';
   const statusLabel = effectiveStatus === 'accepted' ? 'Accepted' : effectiveStatus === 'pending' ? 'Pending invite' : 'No parent linked';
@@ -2889,9 +2891,19 @@ function PlayerRow({
     setCreatingInvite(true);
     setInviteStatus(null);
     try {
-      const result = await createRosterParentInviteForApp(teamId, authUser || null, player);
+      const normalizedEmail = parentEmail.trim();
+      const result = normalizedEmail
+        ? await createRosterParentInviteForApp(teamId, authUser || null, player, { email: normalizedEmail, relation: parentRelation })
+        : await createRosterParentInviteForApp(teamId, authUser || null, player);
       setInviteResult(result);
-      setInviteStatus({ success: true, message: result.autoLinked ? 'Existing parent linked automatically.' : 'Parent invite is ready to copy or share.' });
+      setInviteStatus({
+        success: true,
+        message: result.autoLinked
+          ? `Existing parent linked automatically${result.emailSent && result.email ? ` and notified at ${result.email}` : ''}.`
+          : result.emailSent && result.email
+            ? `Invite emailed to ${result.email} with the code and signup link.`
+            : 'Parent invite is ready to copy or share.'
+      });
       await onInviteCreated();
     } catch (error: any) {
       setInviteStatus({ success: false, message: error?.message || 'Unable to create a parent invite.' });
@@ -2963,6 +2975,35 @@ function PlayerRow({
               </button>
             ) : null}
           </div>
+          {player.active ? (
+            <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_10rem]">
+              <label className="text-xs font-black text-gray-700">
+                Parent email
+                <input
+                  className="auth-input mt-1"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  aria-label={`Parent email for ${player.name}`}
+                  placeholder="parent@example.com"
+                  value={parentEmail}
+                  onChange={(event) => setParentEmail(event.target.value)}
+                  disabled={creatingInvite}
+                />
+              </label>
+              <label className="text-xs font-black text-gray-700">
+                Relation
+                <select className="auth-input mt-1" aria-label={`Parent relation for ${player.name}`} value={parentRelation} onChange={(event) => setParentRelation(event.target.value)} disabled={creatingInvite}>
+                  <option value="Parent">Parent</option>
+                  <option value="Mother">Mother</option>
+                  <option value="Father">Father</option>
+                  <option value="Guardian">Guardian</option>
+                  <option value="Other">Other</option>
+                </select>
+              </label>
+              <div className="text-[11px] font-semibold text-gray-500 sm:col-span-2">Enter an email to send the code and signup link, or leave it blank for a shareable code.</div>
+            </div>
+          ) : null}
           {inviteSummary?.status === 'accepted' && inviteSummary.acceptedParentCount > 0 ? <div className="mt-2 text-xs font-semibold text-emerald-700">{inviteSummary.acceptedParentCount} linked parent{inviteSummary.acceptedParentCount === 1 ? '' : 's'}.</div> : null}
           {inviteSummary?.status === 'pending' && inviteSummary.pendingInviteCount > 0 && !inviteResult ? <div className="mt-2 text-xs font-semibold text-amber-700">{inviteSummary.pendingInviteCount} pending invite{inviteSummary.pendingInviteCount === 1 ? '' : 's'}.</div> : null}
           {!player.active ? <div className="mt-2 text-xs font-semibold text-gray-500">Reactivate the player to send a parent invite.</div> : null}

--- a/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
+++ b/apps/app/src/pages/parent-tools/HouseholdInviteTool.tsx
@@ -12,7 +12,7 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
     const [displayName, setDisplayName] = useState('');
     const [email, setEmail] = useState('');
     const [relation, setRelation] = useState('');
-    const [createdInvite, setCreatedInvite] = useState<{ code: string; inviteUrl: string } | null>(null);
+    const [createdInvite, setCreatedInvite] = useState<{ code: string; inviteUrl: string; email: string; emailSent: boolean } | null>(null);
     const [message, setMessage] = useState('');
     const loadOperation = useParentToolAsyncOperation();
     const submitOperation = useParentToolAsyncOperation();
@@ -77,7 +77,9 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
             {
                 onSuccess: async (result) => {
                     setCreatedInvite(result);
-                    setMessage('Household invite created.');
+                    setMessage(result.emailSent
+                        ? `Invite emailed to ${result.email} with the code and signup link.`
+                        : 'Parent invite created. Copy the link below to share it.');
                     setDisplayName('');
                     setEmail('');
                     setRelation('');
@@ -90,7 +92,7 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
     return (
         <div className="space-y-3">
             <section className="app-card p-4">
-                <ToolHeader icon={Users} title="Household member invite" detail="Create one pending family plan invite for a linked player. This is separate from co-parent and token share links." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
+                <ToolHeader icon={Users} title="Invite another parent or caregiver" detail="Email an invite that connects their account to one of your linked players." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
                 {error ? <RetryableStatus error={error} fallbackMessage="Unable to load household invites." onRetry={loading ? undefined : refresh} retrying={loading} /> : null}
                 {message ? <Status tone="success" message={message} /> : null}
                 {createdInvite ? (
@@ -117,14 +119,14 @@ export function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState;
                         <input className="auth-input" value={relation} onChange={(event) => setRelation(event.target.value)} placeholder="Relation, like grandparent or guardian" autoComplete="off" enterKeyHint="next" disabled={saving || !linkedPlayers.length} />
                         <button type="submit" className="primary-button" disabled={saving || loading || !linkedPlayers.length}>
                             {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Users className="h-4 w-4" aria-hidden="true" />}
-                            Create household invite
+                            Email parent invite
                         </button>
                     </form>
                 )}
             </section>
 
             <section className="app-card p-4">
-                <ToolHeader icon={Users} title="Pending household invites" detail="Family membership invites that have not been redeemed or removed." />
+                <ToolHeader icon={Users} title="Pending parent & caregiver invites" detail="Invites that have not been redeemed or removed." />
                 <div className="mt-3 grid gap-3 lg:grid-cols-2">
                     {pendingMembers.length ? pendingMembers.map((member) => (
                         <div key={member.id} className="rounded-xl border border-gray-200 bg-gray-50 p-3">

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -558,7 +558,8 @@
         import { buildFullRosterCsvTemplate, buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, summarizeRosterContactInviteResults, validateRosterProfileValues } from './js/roster-profile-fields.js?v=4';
         import { buildTrackingStatusPayload, mergeTrackingStatusRows, normalizeTrackingItemDraft, summarizeTrackingStatus } from './js/tracking-status-admin.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=15';
-        import { checkAuth, sendInviteEmail } from './js/auth.js?v=46';
+        import { checkAuth } from './js/auth.js?v=46';
+        import { queueInviteEmail } from './js/invite-email.js?v=1';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { hasFullTeamAccess, normalizeTeamPermissions } from './js/team-access.js';
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, hasConfiguredRegistrationProviderMetadata, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=2';
@@ -1910,10 +1911,7 @@
                          // Always send a notification/invite email even for existing users
                          let emailSentForExisting = false;
                          try {
-                             await sendInviteEmail(email, result.code, 'parent', {
-                                 teamName: result.teamName,
-                                 playerName: result.playerName
-                             });
+                             await queueInviteEmail(result.code);
                              emailSentForExisting = true;
                          } catch (_emailError) {
                              console.warn('Could not send notification email to existing parent:', _emailError);
@@ -1938,10 +1936,7 @@
                      } else {
                          // New user - send email invite
                          try {
-                             await sendInviteEmail(email, result.code, 'parent', {
-                                 teamName: result.teamName,
-                                 playerName: result.playerName
-                             });
+                             await queueInviteEmail(result.code);
                              document.getElementById('invite-email-sent-message').textContent =
                                  `We sent an invite to ${email}. They'll receive a link to join and follow ${currentInvitePlayer.name}.`;
                              document.getElementById('fallback-code').textContent = result.code;
@@ -2088,10 +2083,7 @@
                 const result = await inviteParent(currentTeamId, playerId, playerNumber || '', request.email, request.relation || 'Parent');
                 let emailSent = false;
                 try {
-                    await sendInviteEmail(request.email, result.code, 'parent', {
-                        teamName: result.teamName,
-                        playerName: result.playerName
-                    });
+                    await queueInviteEmail(result.code);
                     emailSent = true;
                 } catch (emailError) {
                     console.warn('Could not email imported roster contact invite:', emailError);

--- a/functions/index.js
+++ b/functions/index.js
@@ -65,6 +65,7 @@ const {
 } = require('./team-email-core.cjs');
 const {
   buildParentInviteEmailMessage,
+  isValidInviteRecipientEmail,
   normalizeInviteEmailType
 } = require('./invite-email-core.cjs');
 const {
@@ -1910,7 +1911,7 @@ async function queueInviteEmailForCode(codeId, codeData = {}) {
   const type = String(codeData.type || '').trim().toLowerCase();
   const email = normalizeParentInviteEmail(codeData.email);
   const code = String(codeData.code || '').trim().toUpperCase();
-  if (!INVITE_EMAIL_TYPES.has(type) || !normalizeInviteEmailType(type) || !email || !code) {
+  if (!INVITE_EMAIL_TYPES.has(type) || !normalizeInviteEmailType(type) || !isValidInviteRecipientEmail(email) || !code) {
     return { queued: false, reason: 'not_email_eligible' };
   }
 
@@ -1976,8 +1977,8 @@ exports.queueInviteEmail = functions.https.onCall(async (data, context) => {
   if (!invite) {
     throw new functions.https.HttpsError('not-found', 'Invite could not be found.');
   }
-  if (!normalizeParentInviteEmail(invite.data.email)) {
-    throw new functions.https.HttpsError('failed-precondition', 'Invite does not have a recipient email.');
+  if (!isValidInviteRecipientEmail(invite.data.email)) {
+    throw new functions.https.HttpsError('failed-precondition', 'Invite does not have a valid recipient email.');
   }
 
   const result = await queueInviteEmailForCode(invite.id, invite.data);
@@ -1992,7 +1993,7 @@ exports.queueParentInviteEmail = functions.firestore
   .onCreate(async (snap, context) => {
     const codeData = snap.data() || {};
     if (!INVITE_EMAIL_TYPES.has(String(codeData.type || '').trim().toLowerCase()) ||
-        !normalizeParentInviteEmail(codeData.email)) {
+        !isValidInviteRecipientEmail(codeData.email)) {
       return null;
     }
     await queueInviteEmailForCode(context.params.codeId, codeData);

--- a/functions/index.js
+++ b/functions/index.js
@@ -64,6 +64,10 @@ const {
   buildTeamEmailMailJob
 } = require('./team-email-core.cjs');
 const {
+  buildParentInviteEmailMessage,
+  normalizeInviteEmailType
+} = require('./invite-email-core.cjs');
+const {
   normalizeEmail,
   normalizeAccountMergePreviewInput,
   hashAccountMergeVerificationToken,
@@ -146,6 +150,7 @@ if (admin.apps.length === 0) {
 }
 
 const firestore = admin.firestore();
+const INVITE_EMAIL_TYPES = new Set(['parent_invite', 'household_invite']);
 const TEAM_MEDIA_NOTIFICATION_BATCH_WINDOW_MS = 60 * 60 * 1000;
 const TEAM_MEDIA_NOTIFICATION_DISPATCH_LIMIT = 50;
 const FIRESTORE_BATCH_SAFE_WRITE_LIMIT = 450;
@@ -1891,6 +1896,108 @@ function isParentInviteExpired(expiresAt) {
     : new Date(expiresAt).getTime();
   return Number.isFinite(millis) && millis < Date.now();
 }
+
+function buildInviteMailDocId(codeId) {
+  const safeCodeId = String(codeId || '').replace(/[^\w.-]+/g, '_').slice(0, 240);
+  return `invite_${safeCodeId}`;
+}
+
+function isAlreadyExistsError(error) {
+  return error?.code === 6 || error?.code === '6' || error?.code === 'already-exists';
+}
+
+async function queueInviteEmailForCode(codeId, codeData = {}) {
+  const type = String(codeData.type || '').trim().toLowerCase();
+  const email = normalizeParentInviteEmail(codeData.email);
+  const code = String(codeData.code || '').trim().toUpperCase();
+  if (!INVITE_EMAIL_TYPES.has(type) || !normalizeInviteEmailType(type) || !email || !code) {
+    return { queued: false, reason: 'not_email_eligible' };
+  }
+
+  const message = buildParentInviteEmailMessage({ ...codeData, type, code });
+  const mailRef = firestore.collection('mail').doc(buildInviteMailDocId(codeId));
+  try {
+    await mailRef.create({
+      to: [email],
+      message: {
+        subject: message.subject,
+        text: message.text,
+        html: message.html
+      },
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      metadata: {
+        type: 'invite',
+        inviteType: type,
+        accessCodeId: String(codeId || '').trim(),
+        teamId: String(codeData.teamId || '').trim() || null,
+        playerId: String(codeData.playerId || '').trim() || null,
+        generatedBy: String(codeData.generatedBy || '').trim() || null
+      }
+    });
+    return { queued: true, deduplicated: false, signupUrl: message.signupUrl };
+  } catch (error) {
+    if (isAlreadyExistsError(error)) {
+      return { queued: true, deduplicated: true, signupUrl: message.signupUrl };
+    }
+    throw error;
+  }
+}
+
+async function findOwnedInviteCode(code, uid) {
+  const directSnap = await firestore.doc(`accessCodes/${code}`).get();
+  if (directSnap.exists) {
+    const directData = directSnap.data() || {};
+    if (INVITE_EMAIL_TYPES.has(String(directData.type || '').trim().toLowerCase()) &&
+        String(directData.generatedBy || '').trim() === uid) {
+      return { id: directSnap.id, data: directData };
+    }
+  }
+
+  const querySnap = await firestore.collection('accessCodes').where('code', '==', code).limit(10).get();
+  const owned = querySnap.docs.find((docSnap) => {
+    const candidate = docSnap.data() || {};
+    return INVITE_EMAIL_TYPES.has(String(candidate.type || '').trim().toLowerCase()) &&
+      String(candidate.generatedBy || '').trim() === uid;
+  });
+  return owned ? { id: owned.id, data: owned.data() || {} } : null;
+}
+
+exports.queueInviteEmail = functions.https.onCall(async (data, context) => {
+  const uid = String(context.auth?.uid || '').trim();
+  if (!uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in before sending an invite email.');
+  }
+  const code = String(data?.code || '').trim().toUpperCase();
+  if (!/^[A-Z0-9]{8}$/.test(code)) {
+    throw new functions.https.HttpsError('invalid-argument', 'A valid eight-character invite code is required.');
+  }
+
+  const invite = await findOwnedInviteCode(code, uid);
+  if (!invite) {
+    throw new functions.https.HttpsError('not-found', 'Invite could not be found.');
+  }
+  if (!normalizeParentInviteEmail(invite.data.email)) {
+    throw new functions.https.HttpsError('failed-precondition', 'Invite does not have a recipient email.');
+  }
+
+  const result = await queueInviteEmailForCode(invite.id, invite.data);
+  if (!result.queued) {
+    throw new functions.https.HttpsError('failed-precondition', 'Invite is not eligible for email delivery.');
+  }
+  return result;
+});
+
+exports.queueParentInviteEmail = functions.firestore
+  .document('accessCodes/{codeId}')
+  .onCreate(async (snap, context) => {
+    const codeData = snap.data() || {};
+    if (!INVITE_EMAIL_TYPES.has(String(codeData.type || '').trim().toLowerCase()) ||
+        !normalizeParentInviteEmail(codeData.email)) {
+      return null;
+    }
+    await queueInviteEmailForCode(context.params.codeId, codeData);
+    return null;
+  });
 
 function validateAutoAcceptParentInviteCode(data = {}) {
   if (!data || data.type !== 'parent_invite') {

--- a/functions/invite-email-core.cjs
+++ b/functions/invite-email-core.cjs
@@ -1,0 +1,80 @@
+'use strict';
+
+const ALLPLAYS_ORIGIN = 'https://allplays.ai';
+
+function normalizeInviteEmailType(value) {
+  const type = String(value || '').trim().toLowerCase();
+  if (type === 'parent_invite') return 'parent';
+  if (type === 'household_invite') return 'household';
+  return '';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildInviteSignupUrl(code, inviteType, origin = ALLPLAYS_ORIGIN) {
+  const normalizedCode = String(code || '').trim().toUpperCase();
+  const normalizedType = normalizeInviteEmailType(inviteType);
+  if (!normalizedCode || !normalizedType) return '';
+  const url = new URL('/accept-invite.html', origin);
+  url.searchParams.set('code', normalizedCode);
+  url.searchParams.set('type', normalizedType);
+  return url.toString();
+}
+
+function buildParentInviteEmailMessage(invite = {}, origin = ALLPLAYS_ORIGIN) {
+  const code = String(invite.code || '').trim().toUpperCase();
+  const inviteType = normalizeInviteEmailType(invite.type);
+  const signupUrl = buildInviteSignupUrl(code, invite.type, origin);
+  if (!code || !inviteType || !signupUrl) {
+    throw new Error('A supported invite type and code are required.');
+  }
+
+  const playerName = String(invite.playerName || '').trim() || 'a player';
+  const teamName = String(invite.teamName || '').trim();
+  const relation = String(invite.relation || '').trim();
+  const isHouseholdInvite = inviteType === 'household';
+  const subject = isHouseholdInvite
+    ? `You're invited to help with ${playerName} on ALL PLAYS`
+    : `You're invited to follow ${playerName} on ALL PLAYS`;
+  const context = teamName ? `${playerName} on ${teamName}` : playerName;
+  const intro = isHouseholdInvite
+    ? `A parent invited you to connect with ${context}${relation ? ` as ${relation}` : ''}.`
+    : `A coach invited you to connect with ${context}${relation ? ` as ${relation}` : ''}.`;
+  const text = [
+    intro,
+    '',
+    `Invite code: ${code}`,
+    `Sign up or accept the invite: ${signupUrl}`,
+    '',
+    'This invite expires in 7 days. If you already have an ALL PLAYS account, use the same email address that received this message.'
+  ].join('\n');
+  const html = `
+    <div style="font-family:Arial,sans-serif;line-height:1.5;color:#111827;max-width:560px;margin:0 auto">
+      <h1 style="font-size:24px;margin:0 0 16px">You're invited to ALL PLAYS</h1>
+      <p>${escapeHtml(intro)}</p>
+      <div style="margin:24px 0;padding:16px;border-radius:10px;background:#f3f4f6">
+        <div style="font-size:12px;font-weight:700;text-transform:uppercase;color:#4b5563">Invite code</div>
+        <div style="font-family:monospace;font-size:24px;font-weight:700;letter-spacing:2px;color:#111827">${escapeHtml(code)}</div>
+      </div>
+      <p><a href="${escapeHtml(signupUrl)}" style="display:inline-block;padding:12px 18px;border-radius:8px;background:#4f46e5;color:#ffffff;text-decoration:none;font-weight:700">Sign up or accept invite</a></p>
+      <p style="font-size:13px;color:#4b5563">This invite expires in 7 days. If you already have an ALL PLAYS account, use the same email address that received this message.</p>
+      <p style="font-size:12px;color:#6b7280;word-break:break-all">${escapeHtml(signupUrl)}</p>
+    </div>
+  `.trim();
+
+  return { subject, text, html, signupUrl, inviteType };
+}
+
+module.exports = {
+  ALLPLAYS_ORIGIN,
+  buildInviteSignupUrl,
+  buildParentInviteEmailMessage,
+  normalizeInviteEmailType
+};

--- a/functions/invite-email-core.cjs
+++ b/functions/invite-email-core.cjs
@@ -9,6 +9,11 @@ function normalizeInviteEmailType(value) {
   return '';
 }
 
+function isValidInviteRecipientEmail(value) {
+  const email = String(value || '').trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
 function escapeHtml(value) {
   return String(value ?? '')
     .replace(/&/g, '&amp;')
@@ -76,5 +81,6 @@ module.exports = {
   ALLPLAYS_ORIGIN,
   buildInviteSignupUrl,
   buildParentInviteEmailMessage,
+  isValidInviteRecipientEmail,
   normalizeInviteEmailType
 };

--- a/functions/test/invite-email-core.test.cjs
+++ b/functions/test/invite-email-core.test.cjs
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const {
   buildInviteSignupUrl,
   buildParentInviteEmailMessage,
+  isValidInviteRecipientEmail,
   normalizeInviteEmailType
 } = require('../invite-email-core.cjs');
 
@@ -12,6 +13,13 @@ test('normalizes supported parent invite types', () => {
   assert.equal(normalizeInviteEmailType('parent_invite'), 'parent');
   assert.equal(normalizeInviteEmailType('household_invite'), 'household');
   assert.equal(normalizeInviteEmailType('admin_invite'), '');
+});
+
+test('accepts normalized recipient emails and rejects malformed addresses', () => {
+  assert.equal(isValidInviteRecipientEmail(' Parent@Example.com '), true);
+  assert.equal(isValidInviteRecipientEmail('not-an-email'), false);
+  assert.equal(isValidInviteRecipientEmail('missing-domain@'), false);
+  assert.equal(isValidInviteRecipientEmail(''), false);
 });
 
 test('builds a parent signup link with the code and normalized invite type', () => {

--- a/functions/test/invite-email-core.test.cjs
+++ b/functions/test/invite-email-core.test.cjs
@@ -1,0 +1,53 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildInviteSignupUrl,
+  buildParentInviteEmailMessage,
+  normalizeInviteEmailType
+} = require('../invite-email-core.cjs');
+
+test('normalizes supported parent invite types', () => {
+  assert.equal(normalizeInviteEmailType('parent_invite'), 'parent');
+  assert.equal(normalizeInviteEmailType('household_invite'), 'household');
+  assert.equal(normalizeInviteEmailType('admin_invite'), '');
+});
+
+test('builds a parent signup link with the code and normalized invite type', () => {
+  assert.equal(
+    buildInviteSignupUrl(' abcd1234 ', 'parent_invite'),
+    'https://allplays.ai/accept-invite.html?code=ABCD1234&type=parent'
+  );
+});
+
+test('builds coach parent invite email text and html with code and signup link', () => {
+  const message = buildParentInviteEmailMessage({
+    code: 'PARENT12',
+    type: 'parent_invite',
+    teamName: 'Bears',
+    playerName: 'Pat Star',
+    relation: 'Guardian'
+  });
+
+  assert.match(message.subject, /Pat Star/);
+  assert.match(message.text, /A coach invited you/);
+  assert.match(message.text, /Invite code: PARENT12/);
+  assert.match(message.text, /accept-invite\.html\?code=PARENT12&type=parent/);
+  assert.match(message.html, /Sign up or accept invite/);
+  assert.match(message.html, /PARENT12/);
+});
+
+test('builds household invite copy without trusting html fields', () => {
+  const message = buildParentInviteEmailMessage({
+    code: 'HOME1234',
+    type: 'household_invite',
+    playerName: '<Pat>',
+    relation: '<Guardian>'
+  });
+
+  assert.match(message.text, /A parent invited you/);
+  assert.match(message.signupUrl, /type=household/);
+  assert.doesNotMatch(message.html, /<Pat>/);
+  assert.match(message.html, /&lt;Pat&gt;/);
+});

--- a/js/family-plan.js
+++ b/js/family-plan.js
@@ -128,7 +128,6 @@ export function buildFamilyPlanMarkup({ members = [], entitlementState = 'locked
     const normalizedPlayerLinks = normalizePlayerLinks(playerLinks);
     const counts = getFamilySlotCounts(normalized);
     const slotsFull = counts.used >= counts.max;
-    const entitlementActive = entitlementState === 'unlocked';
     const rows = normalized.length
         ? normalized.map((member) => {
             const label = member.displayName || member.email || 'Family member';
@@ -163,14 +162,13 @@ export function buildFamilyPlanMarkup({ members = [], entitlementState = 'locked
         <div class="p-6 border-b border-gray-100 bg-gray-50">
             <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
                 <div>
-                    <h2 class="text-xl font-bold text-gray-900">Family Plan</h2>
-                    <p class="text-xs text-gray-500 mt-1">Manage up to ${MAX_FAMILY_PLAN_SLOTS} household accounts or pending invites.</p>
+                    <h2 class="text-xl font-bold text-gray-900">Parent &amp; Caregiver Access</h2>
+                    <p class="text-xs text-gray-500 mt-1">Invite another parent or caregiver and connect them to one of your players. The email includes an invite code and signup link.</p>
                 </div>
-                <span class="self-start px-3 py-1 rounded-full border text-xs font-semibold ${entitlementActive ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-amber-200 bg-amber-50 text-amber-700'}">${entitlementActive ? 'Premium active' : 'Setup only'}</span>
+                <span class="self-start px-3 py-1 rounded-full border text-xs font-semibold border-indigo-200 bg-indigo-50 text-indigo-700">Family Plan · ${counts.remaining} slot${counts.remaining === 1 ? '' : 's'} left</span>
             </div>
         </div>
         <div class="p-6 space-y-4">
-            ${entitlementActive ? '' : '<div class="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">Billing and premium activation are not connected yet. These slots only capture the intended household members until an active account entitlement exists.</div>'}
             <div class="flex items-center justify-between gap-3 text-sm">
                 <div class="font-semibold text-gray-900">Member slots</div>
                 <div class="text-gray-600"><span class="font-bold text-gray-900">${counts.used}</span> / ${counts.max} used</div>
@@ -186,7 +184,7 @@ export function buildFamilyPlanMarkup({ members = [], entitlementState = 'locked
                     <input id="family-plan-member-email" type="email" placeholder="Email for pending invite" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" ${slotsFull ? 'disabled' : ''}>
                 </div>
                 <input id="family-plan-member-relation" type="text" placeholder="Relation (for example: guardian, step-parent)" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" ${slotsFull ? 'disabled' : ''}>
-                <button id="family-plan-add-member-btn" class="w-full bg-primary-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition disabled:bg-gray-300 disabled:cursor-not-allowed" ${slotsFull ? 'disabled' : ''}>Add pending member</button>
+                <button id="family-plan-add-member-btn" class="w-full bg-primary-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition disabled:bg-gray-300 disabled:cursor-not-allowed" ${slotsFull ? 'disabled' : ''}>Email parent invite</button>
                 <div id="family-plan-validation" class="${validationMessage || slotsFull ? '' : 'hidden'} text-xs rounded-lg px-3 py-2 ${validationMessage ? 'bg-red-50 text-red-700 border border-red-200' : 'bg-amber-50 text-amber-800 border border-amber-200'}">${escapeHtml(validationMessage || `Family Plan is limited to ${MAX_FAMILY_PLAN_SLOTS} active accounts or pending invites.`)}</div>
             </div>
         </div>
@@ -408,11 +406,11 @@ export async function addPendingFamilyMember(userId, member, { deps = {}, existi
     await updateDoc(doc(db, 'users', userId, 'familyMemberships', membershipRef.id), {
         accessCodeId: accessCodeRef.id,
         accessCode: code,
-        inviteUrl: `accept-invite.html?code=${code}`,
+        inviteUrl: `accept-invite.html?code=${code}&type=household`,
         updatedAt: timestamp
     });
 
-    return { code, inviteUrl: `accept-invite.html?code=${code}` };
+    return { code, inviteUrl: `accept-invite.html?code=${code}&type=household` };
 }
 
 

--- a/js/invite-email.js
+++ b/js/invite-email.js
@@ -1,0 +1,15 @@
+import { functions, httpsCallable } from './firebase.js?v=20';
+
+export async function queueInviteEmail(inviteCode) {
+    const code = String(inviteCode || '').trim().toUpperCase();
+    if (!/^[A-Z0-9]{8}$/.test(code)) {
+        throw new Error('A valid eight-character invite code is required.');
+    }
+    const callable = httpsCallable(functions, 'queueInviteEmail');
+    const response = await callable({ code });
+    const result = response?.data || response || {};
+    if (result.queued !== true) {
+        throw new Error('Invite email could not be queued.');
+    }
+    return result;
+}

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -424,7 +424,7 @@
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
         import { handleParentTeamFeeCheckoutClick, renderParentTeamFees } from './js/parent-dashboard-fees.js?v=6';
         import { initiateTeamFeeCheckout } from './js/stripe-service.js?v=1';
-        import { renderFamilyPlanSection } from './js/family-plan.js?v=3';
+        import { renderFamilyPlanSection } from './js/family-plan.js?v=4';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -204,6 +204,8 @@
                 "notifyInviteRedeemed",
                 "notifyParentMembershipRequestCreated",
                 "notifyParentMembershipRequestUpdated",
+                "queueInviteEmail",
+                "queueParentInviteEmail",
                 "syncApprovedParentMembershipRequestUserLink",
                 "syncPublicUserProfileProjection"
             ],

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -113,9 +113,13 @@ const AUTH_STUB = `
 export function checkAuth(callback) {
     callback({ uid: 'user-1', email: 'coach@example.com', isAdmin: false });
 }
-export async function sendInviteEmail(email, code, type, context) {
-    globalThis.__rosterCsvEmails = globalThis.__rosterCsvEmails || [];
-    globalThis.__rosterCsvEmails.push({ email, code, type, context });
+`;
+
+const INVITE_EMAIL_STUB = `
+export async function queueInviteEmail(code) {
+    globalThis.__rosterCsvInviteEmails = globalThis.__rosterCsvInviteEmails || [];
+    globalThis.__rosterCsvInviteEmails.push({ code });
+    return { queued: true };
 }
 `;
 
@@ -223,6 +227,7 @@ async function mockEditRosterDependencies(page) {
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route(/\/js\/utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/invite-email\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: INVITE_EMAIL_STUB }));
     await page.route(/\/js\/team-access\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
     await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
     await page.route(/\/js\/vendor\/firebase-app\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
@@ -334,7 +339,7 @@ test('CSV roster review saves family contacts and sends imported invitations', a
     expect(await page.evaluate(() => globalThis.__rosterCsvInvites || [])).toEqual([
         expect.objectContaining({ playerId: 'player-imported-1', email: 'pat@example.com', relation: 'Mother' })
     ]);
-    expect(await page.evaluate(() => globalThis.__rosterCsvEmails || [])).toEqual([
-        expect.objectContaining({ email: 'pat@example.com', code: 'INVITE123', type: 'parent' })
+    expect(await page.evaluate(() => globalThis.__rosterCsvInviteEmails || [])).toEqual([
+        { code: 'INVITE123' }
     ]);
 });

--- a/tests/smoke/edit-roster-xss-escaping.spec.js
+++ b/tests/smoke/edit-roster-xss-escaping.spec.js
@@ -70,8 +70,9 @@ const AUTH_STUB = `
 export function checkAuth(callback) {
     callback({ uid: 'user-1', email: 'coach@example.com', isAdmin: false });
 }
-export async function sendInviteEmail() {}
 `;
+
+const INVITE_EMAIL_STUB = `export async function queueInviteEmail() { return { queued: true }; }`;
 
 const TEAM_ACCESS_STUB = `
 export function hasFullTeamAccess() { return true; }
@@ -147,6 +148,7 @@ async function mockEditRosterDependencies(page) {
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route(/\/js\/utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/invite-email\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: INVITE_EMAIL_STUB }));
     await page.route(/\/js\/team-access\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
     await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
     await page.route(/\/js\/vendor\/firebase-app\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));

--- a/tests/unit/app-parent-tools-household-service.test.js
+++ b/tests/unit/app-parent-tools-household-service.test.js
@@ -92,20 +92,20 @@ const user = {
 beforeEach(() => {
     vi.clearAllMocks();
     familyPlanMocks.readFamilyMembers.mockResolvedValue([]);
-    familyPlanMocks.addPendingFamilyMember.mockResolvedValue({ code: 'HOME1234', inviteUrl: 'accept-invite.html?code=HOME1234' });
+    familyPlanMocks.addPendingFamilyMember.mockResolvedValue({ code: 'HOME1234', inviteUrl: 'accept-invite.html?code=HOME1234&type=household' });
     dbMocks.moveTeamMediaItems.mockResolvedValue(undefined);
     dbMocks.setTeamMediaAlbumCover.mockResolvedValue(undefined);
 });
 
 describe('Parent Tools household invite service', () => {
     it('loads linked players and pending family memberships for the signed-in parent', async () => {
-        familyPlanMocks.readFamilyMembers.mockResolvedValueOnce([{ id: 'member-1', email: 'home@example.com', status: 'pending', inviteUrl: 'accept-invite.html?code=HOME1234' }]);
+        familyPlanMocks.readFamilyMembers.mockResolvedValueOnce([{ id: 'member-1', email: 'home@example.com', status: 'pending', inviteUrl: 'accept-invite.html?code=HOME1234&type=household' }]);
 
         const model = await loadParentHouseholdInviteModel(user);
 
         expect(model.linkedPlayers).toEqual([expect.objectContaining({ teamId: 'team-1', playerId: 'player-1', playerName: 'Pat Star' })]);
         expect(familyPlanMocks.readFamilyMembers).toHaveBeenCalledWith('user-1');
-        expect(model.members[0].inviteUrl).toBe('https://allplays.ai/accept-invite.html?code=HOME1234');
+        expect(model.members[0].inviteUrl).toBe('https://allplays.ai/accept-invite.html?code=HOME1234&type=household');
     });
 
     it('validates required fields before creating a household member invite', async () => {
@@ -136,7 +136,12 @@ describe('Parent Tools household invite service', () => {
             playerName: 'Pat Star',
             playerNumber: '9'
         }), { existingMembers: [{ id: 'member-1', email: 'old@example.com', status: 'pending' }] });
-        expect(result).toEqual({ code: 'HOME1234', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME1234' });
+        expect(result).toEqual({
+            code: 'HOME1234',
+            inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME1234&type=household',
+            email: 'home@example.com',
+            emailSent: true
+        });
     });
 });
 

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -239,7 +239,7 @@ beforeEach(() => {
         linkedPlayers: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9' }],
         members: [{ id: 'member-1', email: 'grandma@example.com', displayName: 'Grandma', relation: 'Grandparent', status: 'pending', teamName: 'Bears', playerName: 'Pat Star', playerNumber: '9', accessCode: 'HOME1234', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME1234' }]
     });
-    serviceMocks.createParentHouseholdMemberInvite.mockResolvedValue({ code: 'HOME5678', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME5678' });
+    serviceMocks.createParentHouseholdMemberInvite.mockResolvedValue({ code: 'HOME5678', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME5678', email: 'aunt@example.com', emailSent: true });
     serviceMocks.loadParentFeesForApp.mockResolvedValue([{
         id: 'fee-1',
         title: 'Team dues',
@@ -325,13 +325,13 @@ describe('React app parent tools integration', () => {
         expect(accessServiceMocks.submitParentAccessRequest).toHaveBeenCalledWith('team-1', 'player-1', 'Parent');
 
         await clickButton(container, 'Household');
-        await waitForText(container, 'Household member invite');
+        await waitForText(container, 'Invite another parent or caregiver');
         expect(container.textContent).toContain('Grandma');
         const householdEmail = container.querySelector('input[placeholder="Household contact email"]');
         const householdRelation = container.querySelector('input[placeholder^="Relation"]');
         await changeValue(householdEmail, 'aunt@example.com');
         await changeValue(householdRelation, 'Aunt');
-        await submitForm(container, 'Create household invite');
+        await submitForm(container, 'Email parent invite');
         expect(serviceMocks.createParentHouseholdMemberInvite).toHaveBeenCalledWith(auth.user, {
             playerKey: 'team-1::player-1',
             displayName: '',
@@ -339,6 +339,7 @@ describe('React app parent tools integration', () => {
             relation: 'Aunt'
         });
         expect(container.textContent).toContain('HOME5678');
+        expect(container.textContent).toContain('Invite emailed to aunt@example.com with the code and signup link.');
 
         await clickButton(container, 'Fees');
         await waitForText(container, 'Team dues');

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -272,7 +272,6 @@ describe('React app team detail model', () => {
         getConfigs.mockResolvedValue([]);
         inviteParent.mockResolvedValue({ code: 'ABCD1234', autoLinked: false, existingUser: false, teamName: 'Bears', playerName: 'Pat Star' });
         queueInviteEmail.mockRejectedValue(new Error('mail unavailable'));
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
         const result = await createRosterParentInviteForApp(
             'team-1',
@@ -288,8 +287,6 @@ describe('React app team detail model', () => {
             emailSent: false,
             status: 'pending'
         });
-        expect(warnSpy).toHaveBeenCalled();
-        warnSpy.mockRestore();
     });
 
     it('loads normalized roster field definitions only for full team staff', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -57,6 +57,10 @@ vi.mock('../../js/auth.js', () => ({
     sendInviteEmail: vi.fn()
 }));
 
+vi.mock('../../js/invite-email.js', () => ({
+    queueInviteEmail: vi.fn()
+}));
+
 vi.mock('../../js/stat-leaderboards.js', async () => {
     const actual = await vi.importActual('../../js/stat-leaderboards.js');
     return {
@@ -83,6 +87,7 @@ import { __resetTeamDetailBaseSnapshotCacheForTests, addRosterPlayerForApp, buil
 import { collection, doc, getDoc, getDocs, query, where } from '../../js/firebase.js';
 import { addPlayer, getAggregatedStatsForGames, getAdSpaceSponsors, getAllUsers, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayerTrackingStatuses, getPlayers, getPublicTrackingItems, getRosterFieldDefinitions, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, inviteParent, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, deactivatePlayer, reactivatePlayer, setPlayerPrivateRosterProfileFields, updateEvent, updateGame, updateTeam, uploadPlayerPhoto, uploadTeamPhoto } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
+import { queueInviteEmail } from '../../js/invite-email.js';
 import { buildPlayerLeaderboardSnapshot } from '../../js/stat-leaderboards.js';
 import { getVisiblePlayerTrackingSummary } from '../../js/player-tracking-summary.js';
 
@@ -234,8 +239,30 @@ describe('React app team detail model', () => {
         expect(result).toMatchObject({
             code: 'ABCD1234',
             inviteUrl: 'http://localhost:3000/app#/accept-invite?code=ABCD1234&type=parent',
-            status: 'pending'
+            status: 'pending',
+            email: null,
+            emailSent: false
         });
+    });
+
+    it('emails a coach-created parent invite with the selected relation', async () => {
+        getTeam.mockResolvedValue({ id: 'team-1', ownerId: 'owner-1', adminEmails: ['coach@example.com'] });
+        getPlayers.mockResolvedValue([]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        inviteParent.mockResolvedValue({ code: 'ABCD1234', autoLinked: false, existingUser: false, teamName: 'Bears', playerName: 'Pat Star' });
+        queueInviteEmail.mockResolvedValue({ queued: true });
+
+        const result = await createRosterParentInviteForApp(
+            'team-1',
+            { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'] },
+            { id: 'player-1', number: '9' },
+            { email: ' Parent@Example.com ', relation: 'Guardian' }
+        );
+
+        expect(inviteParent).toHaveBeenCalledWith('team-1', 'player-1', '9', 'parent@example.com', 'Guardian');
+        expect(queueInviteEmail).toHaveBeenCalledWith('ABCD1234');
+        expect(result).toMatchObject({ email: 'parent@example.com', emailSent: true });
     });
 
     it('loads normalized roster field definitions only for full team staff', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -265,6 +265,33 @@ describe('React app team detail model', () => {
         expect(result).toMatchObject({ email: 'parent@example.com', emailSent: true });
     });
 
+    it('returns the created parent invite when email queuing fails', async () => {
+        getTeam.mockResolvedValue({ id: 'team-1', ownerId: 'owner-1', adminEmails: ['coach@example.com'] });
+        getPlayers.mockResolvedValue([]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        inviteParent.mockResolvedValue({ code: 'ABCD1234', autoLinked: false, existingUser: false, teamName: 'Bears', playerName: 'Pat Star' });
+        queueInviteEmail.mockRejectedValue(new Error('mail unavailable'));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const result = await createRosterParentInviteForApp(
+            'team-1',
+            { uid: 'coach-1', email: 'coach@example.com', roles: ['coach'] },
+            { id: 'player-1', number: '9' },
+            { email: 'parent@example.com', relation: 'Guardian' }
+        );
+
+        expect(queueInviteEmail).toHaveBeenCalledWith('ABCD1234');
+        expect(result).toMatchObject({
+            code: 'ABCD1234',
+            email: 'parent@example.com',
+            emailSent: false,
+            status: 'pending'
+        });
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
     it('loads normalized roster field definitions only for full team staff', async () => {
         getTeam.mockResolvedValue({ id: 'team-1', ownerId: 'owner-1', adminEmails: ['coach@example.com'] });
         getPlayers.mockResolvedValue([]);

--- a/tests/unit/family-plan.test.js
+++ b/tests/unit/family-plan.test.js
@@ -34,7 +34,7 @@ describe('family plan helpers', () => {
         expect(canAddFamilyMember(members)).toBe(false);
     });
 
-    it('renders the setup-only billing and premium activation notice without active entitlement', () => {
+    it('renders parent and caregiver invites with player access details', () => {
         const markup = buildFamilyPlanMarkup({
             entitlementState: 'locked',
             members: [
@@ -44,8 +44,9 @@ describe('family plan helpers', () => {
             ]
         });
 
-        expect(markup).toContain('Family Plan');
-        expect(markup).toContain('Billing and premium activation are not connected yet');
+        expect(markup).toContain('Parent &amp; Caregiver Access');
+        expect(markup).toContain('Email parent invite');
+        expect(markup).toContain('invite code and signup link');
         expect(markup).toContain('active');
         expect(markup).toContain('pending');
         expect(markup).toContain('Invite code');

--- a/tests/unit/parent-dashboard-ics-export.test.js
+++ b/tests/unit/parent-dashboard-ics-export.test.js
@@ -34,7 +34,7 @@ const Blob = deps.Blob;
         .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
         .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/parent-dashboard-fees\.js\?v=\d+';/, 'const { handleParentTeamFeeCheckoutClick, renderParentTeamFees } = deps.parentDashboardFees;')
         .replace(/import\s*\{\s*initiateTeamFeeCheckout\s*\}\s*from '\.\/js\/stripe-service\.js\?v=\d+';/, 'const { initiateTeamFeeCheckout } = deps.stripeService;')
-        .replace("import { renderFamilyPlanSection } from './js/family-plan.js?v=3';", 'const { renderFamilyPlanSection } = deps.familyPlan;')
+        .replace("import { renderFamilyPlanSection } from './js/family-plan.js?v=4';", 'const { renderFamilyPlanSection } = deps.familyPlan;')
         .replace("import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';", 'const { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } = deps.availabilityPreferences;')
         .replace(/\binit\(\);\s*$/, `
 window.__parentDashboardIcsTestHooks = {

--- a/tests/unit/parent-invite-auto-link.test.js
+++ b/tests/unit/parent-invite-auto-link.test.js
@@ -56,10 +56,10 @@ describe('parent invite auto-linking', () => {
         const existingUserIdx = source.indexOf('if (result.existingUser)');
         expect(existingUserIdx).toBeGreaterThanOrEqual(0);
         const existingUserBlock = source.slice(existingUserIdx, existingUserIdx + 2000);
-        // sendInviteEmail must be called inside the existingUser branch
-        expect(existingUserBlock).toContain('sendInviteEmail(email, result.code');
+        // The custom transactional invite email must be queued inside the existingUser branch.
+        expect(existingUserBlock).toContain('queueInviteEmail(result.code)');
         // Email is attempted before the autoLinked branch check
-        expect(existingUserBlock.indexOf('sendInviteEmail')).toBeLessThan(existingUserBlock.indexOf('if (result.autoLinked)'));
+        expect(existingUserBlock.indexOf('queueInviteEmail')).toBeLessThan(existingUserBlock.indexOf('if (result.autoLinked)'));
         // Notification message reflects email sent for auto-linked case
         expect(existingUserBlock).toContain('emailSentForExisting');
         expect(existingUserBlock).toContain('A notification email was also sent to');


### PR DESCRIPTION
## What changed
- queue custom parent and household invite emails through the existing Firestore/Resend mail pipeline
- include the eight-character invite code and signup/accept link in each message
- add coach parent-email and relationship fields in the app roster
- expose parent-to-parent caregiver invitations clearly in legacy and app parent tools
- keep invite mail queuing authenticated, server-authorized, and idempotent

## Why
Coach-created parent invites previously created codes but the app did not collect or email a recipient. Parent household invites created access records without a clear emailed onboarding path.

## Validation
- `npm test --prefix functions` (69 passed)
- `npx vitest run tests/unit --reporter=dot --testTimeout=10000` (4,008 passed; 29 skipped)
- `npm run app:build`
- authenticated local UI smoke checks for coach roster invites and parent caregiver invites
