### PR TITLE
Defer play-by-play audio controls

### DIFF
--- a/apps/app/src/components/schedule/GameReportSectionContent.tsx
+++ b/apps/app/src/components/schedule/GameReportSectionContent.tsx
@@ -144,12 +144,33 @@ function PlayerPerformanceRow({ player, statKeys, statLabels, hasPlayingTime, te
 function PlayByPlaySection({ plays }: { plays: GameReportPlay[] }) {
   const { supported, enabled, paused, toggleEnabled } = useLiveGameAnnouncer(plays);
 
+  if (!plays.length) {
+    return <EmptyReportState title="No events logged" detail="Play-by-play will appear here during or after the game." />;
+  }
+
   return (
     <div className="space-y-3">
-      <div className="rounded-xl border border-gray-200 bg-white p-3">
+      <div className="max-h-[430px] space-y-2 overflow-y-auto pr-1" aria-label="Play-by-play log">
+        {plays.map((play) => (
+          <div key={play.id || `${play.period}-${play.clock}-${play.text}`} className="rounded-r-xl border-l-4 border-primary-500 bg-gray-50 px-3 py-2.5">
+            <div className="flex items-start gap-2">
+              <span className="mt-0.5 inline-flex min-h-6 flex-none items-center rounded-md bg-primary-600 px-2 text-[11px] font-black text-white">{play.period}</span>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-semibold leading-5 text-gray-900">{play.text}</div>
+                <div className="mt-1 flex gap-2 text-xs font-semibold text-gray-500">
+                  {play.clock ? <span className="font-mono">{play.clock}</span> : null}
+                  {play.timestamp ? <span>{formatReportTime(play.timestamp)}</span> : null}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded-xl border border-gray-200 bg-gray-50 p-3" aria-label="Play-by-play audio controls">
         <div className="flex items-center justify-between gap-3">
           <div>
-            <div className="text-sm font-black text-gray-950">Audio announcements</div>
+            <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-700">Audio announcements</div>
             <div className="text-xs font-semibold text-gray-500">
               {supported
                 ? paused
@@ -170,27 +191,6 @@ function PlayByPlaySection({ plays }: { plays: GameReportPlay[] }) {
           </button>
         </div>
       </div>
-
-      {!plays.length ? (
-        <EmptyReportState title="No events logged" detail="Play-by-play will appear here during or after the game." />
-      ) : (
-        <div className="max-h-[430px] space-y-2 overflow-y-auto pr-1">
-          {plays.map((play) => (
-            <div key={play.id || `${play.period}-${play.clock}-${play.text}`} className="rounded-r-xl border-l-4 border-primary-500 bg-gray-50 px-3 py-2.5">
-              <div className="flex items-start gap-2">
-                <span className="mt-0.5 inline-flex min-h-6 flex-none items-center rounded-md bg-primary-600 px-2 text-[11px] font-black text-white">{play.period}</span>
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm font-semibold leading-5 text-gray-900">{play.text}</div>
-                  <div className="mt-1 flex gap-2 text-xs font-semibold text-gray-500">
-                    {play.clock ? <span className="font-mono">{play.clock}</span> : null}
-                    {play.timestamp ? <span>{formatReportTime(play.timestamp)}</span> : null}
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/app/src/components/schedule/GameReportSections.test.tsx
+++ b/apps/app/src/components/schedule/GameReportSections.test.tsx
@@ -8,8 +8,19 @@ const gameReportServiceMocks = vi.hoisted(() => ({
   loadGameReportPlays: vi.fn(),
   loadGameReportSections: vi.fn()
 }));
+const liveGameAnnouncerMocks = vi.hoisted(() => ({
+  toggleEnabled: vi.fn()
+}));
 
 vi.mock('../../lib/gameReportService', () => gameReportServiceMocks);
+vi.mock('../../lib/liveGameAnnouncer', () => ({
+  useLiveGameAnnouncer: () => ({
+    supported: true,
+    enabled: false,
+    paused: false,
+    toggleEnabled: liveGameAnnouncerMocks.toggleEnabled
+  })
+}));
 
 afterEach(() => {
   cleanup();
@@ -53,6 +64,38 @@ function buildReport(summary: string, gameOverrides: Record<string, unknown> = {
 }
 
 describe('GameReportSections', () => {
+  it('keeps the empty play state primary and hides audio controls until a play exists', async () => {
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('Live report.'));
+
+    render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => expect(screen.getByText('Live report.')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
+
+    expect(screen.getByText('No events logged')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Turn on audio announcements' })).toBeNull();
+    expect(screen.queryByLabelText('Play-by-play audio controls')).toBeNull();
+  });
+
+  it('renders plays before the secondary audio control and keeps the toggle behavior', async () => {
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('Live report.', {}, [
+      { id: 'event-1', text: 'Avery scores', period: 'Q1', clock: '7:42', timestamp: new Date(1717200000 * 1000) }
+    ]));
+
+    render(<GameReportSections event={buildEvent()} />);
+
+    await waitFor(() => expect(screen.getByText('Live report.')).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Plays' }));
+
+    const playLog = screen.getByLabelText('Play-by-play log');
+    const audioControls = screen.getByLabelText('Play-by-play audio controls');
+    expect(playLog.compareDocumentPosition(audioControls) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByText('Avery scores')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Turn on audio announcements' }));
+    expect(liveGameAnnouncerMocks.toggleEnabled).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps the active tab and loaded report mounted during same-event live score updates', async () => {
     gameReportServiceMocks.loadGameReportSections.mockResolvedValue(buildReport('First report.'));
 


### PR DESCRIPTION
## Summary

- show the no-events state without an audio announcement prompt when no plays exist
- render the play-by-play log before a compact secondary audio control when plays exist
- preserve the existing enable/disable, paused, and unsupported-browser behavior
- add focused coverage for empty-state priority, content order, and toggle wiring

## Why

The Plays tab should answer “what happened?” before asking viewers to configure an optional audio-follow mode.

## Validation

- `npm --prefix apps/app test -- run src/components/schedule/GameReportSections.test.tsx --reporter=verbose` — 9/9 passed
- `npm --prefix apps/app run typecheck` — passed
- targeted ESLint — no errors
- `git diff --check` — passed

Closes #3838