### PR TITLE
Send big-moment push notifications

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3019,8 +3019,14 @@ service cloud.firestore {
 
         // Live Events subcollection - for real-time game broadcasting
         match /liveEvents/{eventId} {
+          function hasValidLiveEventAttribution(data) {
+            return (!data.keys().hasAny(['createdBy']) || data.createdBy == null || data.createdBy == request.auth.uid) &&
+                   (!data.keys().hasAny(['actorUid']) || data.actorUid == null || data.actorUid == request.auth.uid);
+          }
+
           allow read: if canReadGameSubcollectionDocument(teamId, gameId);
-          allow create: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);  // Stat tracker writes
+          allow create: if (isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId)) &&
+                           hasValidLiveEventAttribution(request.resource.data);  // Stat tracker writes
           allow update, delete: if false;  // Events are immutable
         }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -138,6 +138,11 @@ const {
   buildNotificationDeliveryOptions
 } = require('./notification-delivery-metadata.cjs');
 const {
+  buildBigMomentLiveEventNotification,
+  buildLiveEventNotificationDedupKey,
+  getLiveEventActorUid
+} = require('./live-event-notification-core.cjs');
+const {
   getStaleNotificationTokenCutoffMillis
 } = require('./notification-token-sweep-core.cjs');
 const {
@@ -10325,6 +10330,43 @@ exports.notifyGameUpdated = functions.firestore
       title: payload.title,
       body: payload.body,
       actorUid
+    });
+  });
+
+exports.notifyLiveEventCreated = functions.firestore
+  .document('teams/{teamId}/games/{gameId}/liveEvents/{eventId}')
+  .onCreate(async (snapshot, context) => {
+    const event = snapshot.data() || {};
+    const teamId = String(context.params?.teamId || '').trim();
+    const gameId = String(context.params?.gameId || '').trim();
+    const documentEventId = String(context.params?.eventId || snapshot.id || '').trim();
+    if (!teamId || !gameId || !documentEventId) return null;
+
+    const payload = buildBigMomentLiveEventNotification(event);
+    if (!payload) return null;
+
+    const dedupKey = buildLiveEventNotificationDedupKey(event, documentEventId);
+    if (!dedupKey) return null;
+    const canSend = await checkAndSetNotificationDedup(teamId, 'liveScore', gameId, dedupKey);
+    if (!canSend) {
+      functions.logger.info('Notification dedup: skipping duplicate live event send', {
+        teamId,
+        gameId,
+        eventId: documentEventId,
+        dedupKey
+      });
+      return null;
+    }
+
+    return sendCategoryNotification({
+      teamId,
+      gameId,
+      eventId: documentEventId,
+      category: 'liveScore',
+      title: payload.title,
+      body: payload.body,
+      actorUid: getLiveEventActorUid(event),
+      dedupKey
     });
   });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -140,7 +140,9 @@ const {
 const {
   buildBigMomentLiveEventNotification,
   buildLiveEventNotificationDedupKey,
-  getLiveEventActorUid
+  buildLiveScoreStateNotificationDedupKey,
+  getLiveEventActorUid,
+  isLiveEventNotificationFresh
 } = require('./live-event-notification-core.cjs');
 const {
   getStaleNotificationTokenCutoffMillis
@@ -7654,22 +7656,55 @@ async function checkAndSetNotificationDedup(teamId, category, gameId, dedupKey =
   return result;
 }
 
-async function hasRecentBigMomentLiveEventForScore(teamId, gameId, after = {}) {
+async function checkAndSetNotificationDedupKeys(teamId, category, gameId, dedupKeys = []) {
+  const normalizedDedupKeys = [...new Set((Array.isArray(dedupKeys) ? dedupKeys : [dedupKeys])
+    .map((dedupKey) => String(dedupKey || '').trim())
+    .filter(Boolean))];
+  if (!normalizedDedupKeys.length) return false;
+
+  const dedupEntries = normalizedDedupKeys.map((dedupKey) => ({
+    dedupKey,
+    ref: buildNotificationDedupRef(teamId, category, buildNotificationDedupIdentity(gameId, dedupKey))
+  }));
+  return firestore.runTransaction(async (txn) => {
+    const snapshots = await Promise.all(dedupEntries.map(({ ref }) => txn.get(ref)));
+    const hasFreshClaim = snapshots.some((snapshot) => {
+      if (!snapshot.exists) return false;
+      const sentAt = snapshot.data()?.sentAt?.toMillis?.() || 0;
+      return Date.now() - sentAt < NOTIFICATION_DEDUP_WINDOW_MS;
+    });
+    if (hasFreshClaim) return false;
+
+    dedupEntries.forEach(({ dedupKey, ref }) => {
+      txn.set(ref, {
+        teamId,
+        category,
+        gameId: gameId || null,
+        dedupKey,
+        sentAt: admin.firestore.FieldValue.serverTimestamp()
+      });
+    });
+    return true;
+  });
+}
+
+async function hasRecentBigMomentLiveEventForScoreState(teamId, gameId, scoreStateDedupKey) {
   const normalizedTeamId = String(teamId || '').trim();
   const normalizedGameId = String(gameId || '').trim();
-  if (!normalizedTeamId || !normalizedGameId) return false;
+  const normalizedScoreStateDedupKey = String(scoreStateDedupKey || '').trim();
+  if (!normalizedTeamId || !normalizedGameId || !normalizedScoreStateDedupKey) return false;
 
-  const homeScore = toNumericScore(after.homeScore);
-  const awayScore = toNumericScore(after.awayScore);
+  const nowMillis = Date.now();
   try {
     const liveEventsSnap = await firestore.collection(`teams/${normalizedTeamId}/games/${normalizedGameId}/liveEvents`)
       .orderBy('createdAt', 'desc')
-      .limit(8)
+      .limit(25)
       .get();
     return liveEventsSnap.docs.some((docSnap) => {
       const event = docSnap.data() || {};
       if (!buildBigMomentLiveEventNotification(event)) return false;
-      return toNumericScore(event.homeScore) === homeScore && toNumericScore(event.awayScore) === awayScore;
+      if (!isLiveEventNotificationFresh(event, nowMillis)) return false;
+      return buildLiveScoreStateNotificationDedupKey(event) === normalizedScoreStateDedupKey;
     });
   } catch (error) {
     functions.logger.warn('Failed to check live events before live score notification', {
@@ -10326,16 +10361,21 @@ exports.notifyGameUpdated = functions.firestore
 
     if (category === 'liveScore') {
       const liveScoreDedupKey = `score:${toNumericScore(before.homeScore)}:${toNumericScore(before.awayScore)}->${toNumericScore(after.homeScore)}:${toNumericScore(after.awayScore)}`;
-      if (await hasRecentBigMomentLiveEventForScore(teamId, gameId, after)) {
+      const liveScoreStateDedupKey = buildLiveScoreStateNotificationDedupKey(after);
+      if (await hasRecentBigMomentLiveEventForScoreState(teamId, gameId, liveScoreStateDedupKey)) {
         functions.logger.info('Notification dedup: skipping generic live score send for live event-backed score', {
           teamId,
           category,
           gameId,
-          dedupKey: liveScoreDedupKey
+          dedupKey: liveScoreDedupKey,
+          scoreStateDedupKey: liveScoreStateDedupKey
         });
         return null;
       }
-      const canSendLiveScore = await checkAndSetNotificationDedup(teamId, category, gameId, liveScoreDedupKey);
+      const canSendLiveScore = await checkAndSetNotificationDedupKeys(teamId, category, gameId, [
+        liveScoreDedupKey,
+        liveScoreStateDedupKey
+      ]);
       if (!canSendLiveScore) {
         functions.logger.info('Notification dedup: skipping duplicate live score send', {
           teamId,
@@ -10380,16 +10420,26 @@ exports.notifyLiveEventCreated = functions.firestore
 
     const payload = buildBigMomentLiveEventNotification(event);
     if (!payload) return null;
+    if (!isLiveEventNotificationFresh(event)) {
+      functions.logger.info('Notification recency: skipping stale or undated live event', {
+        teamId,
+        gameId,
+        eventId: documentEventId
+      });
+      return null;
+    }
 
     const dedupKey = buildLiveEventNotificationDedupKey(event, documentEventId);
     if (!dedupKey) return null;
-    const canSend = await checkAndSetNotificationDedup(teamId, 'liveScore', gameId, dedupKey);
+    const scoreStateDedupKey = buildLiveScoreStateNotificationDedupKey(event);
+    const canSend = await checkAndSetNotificationDedupKeys(teamId, 'liveScore', gameId, [dedupKey, scoreStateDedupKey]);
     if (!canSend) {
       functions.logger.info('Notification dedup: skipping duplicate live event send', {
         teamId,
         gameId,
         eventId: documentEventId,
-        dedupKey
+        dedupKey,
+        scoreStateDedupKey
       });
       return null;
     }

--- a/functions/index.js
+++ b/functions/index.js
@@ -7654,6 +7654,33 @@ async function checkAndSetNotificationDedup(teamId, category, gameId, dedupKey =
   return result;
 }
 
+async function hasRecentBigMomentLiveEventForScore(teamId, gameId, after = {}) {
+  const normalizedTeamId = String(teamId || '').trim();
+  const normalizedGameId = String(gameId || '').trim();
+  if (!normalizedTeamId || !normalizedGameId) return false;
+
+  const homeScore = toNumericScore(after.homeScore);
+  const awayScore = toNumericScore(after.awayScore);
+  try {
+    const liveEventsSnap = await firestore.collection(`teams/${normalizedTeamId}/games/${normalizedGameId}/liveEvents`)
+      .orderBy('createdAt', 'desc')
+      .limit(8)
+      .get();
+    return liveEventsSnap.docs.some((docSnap) => {
+      const event = docSnap.data() || {};
+      if (!buildBigMomentLiveEventNotification(event)) return false;
+      return toNumericScore(event.homeScore) === homeScore && toNumericScore(event.awayScore) === awayScore;
+    });
+  } catch (error) {
+    functions.logger.warn('Failed to check live events before live score notification', {
+      teamId: normalizedTeamId,
+      gameId: normalizedGameId,
+      error: error?.message || String(error || 'Unknown error')
+    });
+    return false;
+  }
+}
+
 
 function mergeNotificationWebpushOptions(baseWebpush = {}, deliveryOptions = {}) {
   if (!deliveryOptions?.webpush) return baseWebpush;
@@ -10299,6 +10326,15 @@ exports.notifyGameUpdated = functions.firestore
 
     if (category === 'liveScore') {
       const liveScoreDedupKey = `score:${toNumericScore(before.homeScore)}:${toNumericScore(before.awayScore)}->${toNumericScore(after.homeScore)}:${toNumericScore(after.awayScore)}`;
+      if (await hasRecentBigMomentLiveEventForScore(teamId, gameId, after)) {
+        functions.logger.info('Notification dedup: skipping generic live score send for live event-backed score', {
+          teamId,
+          category,
+          gameId,
+          dedupKey: liveScoreDedupKey
+        });
+        return null;
+      }
       const canSendLiveScore = await checkAndSetNotificationDedup(teamId, category, gameId, liveScoreDedupKey);
       if (!canSendLiveScore) {
         functions.logger.info('Notification dedup: skipping duplicate live score send', {

--- a/functions/live-event-notification-core.cjs
+++ b/functions/live-event-notification-core.cjs
@@ -1,0 +1,121 @@
+const SCORING_STAT_KEYS = new Set([
+  'goal', 'goals', 'homerun', 'hr', 'point', 'points', 'pts', 'run', 'runs', 'score', 'scores'
+]);
+
+const FOOTBALL_SCORE_LABELS = Object.freeze({
+  touchdown: 'Touchdown',
+  fieldgoal: 'Field goal',
+  safety: 'Safety',
+  patkick: 'PAT kick',
+  twopointconversion: 'Two-point conversion'
+});
+
+function compactLiveEventText(value, maxLength = 120) {
+  const normalized = String(value ?? '')
+    .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function normalizeLiveEventToken(value) {
+  return compactLiveEventText(value, 80).toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function getFiniteLiveEventNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getLiveEventScore(event = {}) {
+  const hasHomeScore = Object.prototype.hasOwnProperty.call(event, 'homeScore');
+  const hasAwayScore = Object.prototype.hasOwnProperty.call(event, 'awayScore');
+  const homeScore = hasHomeScore ? getFiniteLiveEventNumber(event.homeScore) : null;
+  const awayScore = hasAwayScore ? getFiniteLiveEventNumber(event.awayScore) : null;
+  if (homeScore === null || awayScore === null) return '';
+  return `${Math.max(0, homeScore)}–${Math.max(0, awayScore)}`;
+}
+
+function getLiveEventPlayerName(event = {}) {
+  const isOpponent = event.isOpponent === true || normalizeLiveEventToken(event.teamSide) === 'away';
+  return compactLiveEventText(
+    isOpponent
+      ? event.opponentPlayerName || event.scorer || event.playerName
+      : event.playerName || event.scorer || event.opponentPlayerName,
+    60
+  );
+}
+
+function classifyBigMomentLiveEvent(event = {}) {
+  const type = normalizeLiveEventToken(event.type);
+  if (type === 'goal') return { label: 'Goal', kind: 'goal' };
+  if (type === 'footballscore') {
+    const action = normalizeLiveEventToken(event.footballScoringAction || event.scoringAction);
+    return { label: FOOTBALL_SCORE_LABELS[action] || 'Football score', kind: 'football-score' };
+  }
+  if (type === 'baseball') {
+    const action = normalizeLiveEventToken(event.baseballAction || event.action);
+    return action === 'homerun' ? { label: 'Home run', kind: 'home-run' } : null;
+  }
+  if (type !== 'stat') return null;
+
+  const statKey = normalizeLiveEventToken(event.statKey || event.stat);
+  const value = getFiniteLiveEventNumber(event.value);
+  if (!SCORING_STAT_KEYS.has(statKey) || value === null || value <= 0) return null;
+  if (statKey === 'goal' || statKey === 'goals') {
+    return { label: value === 1 ? 'Goal' : `${value} goals`, kind: 'scoring-stat' };
+  }
+  if (statKey === 'homerun' || statKey === 'hr') {
+    return { label: value === 1 ? 'Home run' : `${value} home runs`, kind: 'scoring-stat' };
+  }
+  if (statKey === 'run' || statKey === 'runs') {
+    return { label: `${value} ${value === 1 ? 'run' : 'runs'}`, kind: 'scoring-stat' };
+  }
+  return { label: `${value} ${value === 1 ? 'point' : 'points'}`, kind: 'scoring-stat' };
+}
+
+function buildBigMomentLiveEventNotification(event = {}) {
+  const classification = classifyBigMomentLiveEvent(event);
+  if (!classification) return null;
+
+  const playerName = getLiveEventPlayerName(event);
+  const side = normalizeLiveEventToken(event.teamSide) === 'away' || event.isOpponent === true
+    ? 'Away'
+    : normalizeLiveEventToken(event.teamSide) === 'home' || event.isOpponent === false
+      ? 'Home'
+      : '';
+  const title = compactLiveEventText(
+    playerName
+      ? `${classification.label}: ${playerName}`
+      : side
+        ? `${side} ${classification.label.toLowerCase()}`
+        : classification.label,
+    80
+  );
+  const period = compactLiveEventText(event.period, 24);
+  const score = getLiveEventScore(event);
+  const bodyParts = [period, score ? `Score ${score}` : ''].filter(Boolean);
+  const body = compactLiveEventText(
+    bodyParts.length ? bodyParts.join(' · ') : 'Open the live game for play-by-play.',
+    120
+  );
+  return { title, body, kind: classification.kind };
+}
+
+function buildLiveEventNotificationDedupKey(event = {}, documentId = '') {
+  const identity = compactLiveEventText(documentId, 200) || compactLiveEventText(event.eventId, 200);
+  return identity ? `live-event:${identity}` : '';
+}
+
+function getLiveEventActorUid(event = {}) {
+  return compactLiveEventText(event.actorUid || event.createdBy, 160) || null;
+}
+
+module.exports = {
+  buildBigMomentLiveEventNotification,
+  buildLiveEventNotificationDedupKey,
+  classifyBigMomentLiveEvent,
+  compactLiveEventText,
+  getLiveEventActorUid
+};

--- a/functions/live-event-notification-core.cjs
+++ b/functions/live-event-notification-core.cjs
@@ -153,18 +153,19 @@ function isLiveEventNotificationFresh(
   nowMillis = Date.now(),
   maxAgeMillis = LIVE_EVENT_NOTIFICATION_MAX_AGE_MS
 ) {
-  const createdAtMillis = getLiveEventTimestampMillis(event.createdAt);
+  const eventOriginMillis = getLiveEventTimestampMillis(event.clientCreatedAt) ??
+    getLiveEventTimestampMillis(event.createdAt);
   const normalizedNowMillis = Number(nowMillis);
   const normalizedMaxAgeMillis = Number(maxAgeMillis);
   if (
-    createdAtMillis === null
+    eventOriginMillis === null
     || !Number.isFinite(normalizedNowMillis)
     || !Number.isFinite(normalizedMaxAgeMillis)
     || normalizedMaxAgeMillis < 0
   ) {
     return false;
   }
-  const ageMillis = normalizedNowMillis - createdAtMillis;
+  const ageMillis = normalizedNowMillis - eventOriginMillis;
   return ageMillis >= -LIVE_EVENT_NOTIFICATION_FUTURE_TOLERANCE_MS && ageMillis <= normalizedMaxAgeMillis;
 }
 

--- a/functions/live-event-notification-core.cjs
+++ b/functions/live-event-notification-core.cjs
@@ -10,6 +10,9 @@ const FOOTBALL_SCORE_LABELS = Object.freeze({
   twopointconversion: 'Two-point conversion'
 });
 
+const LIVE_EVENT_NOTIFICATION_MAX_AGE_MS = 10 * 60 * 1000;
+const LIVE_EVENT_NOTIFICATION_FUTURE_TOLERANCE_MS = 60 * 1000;
+
 function compactLiveEventText(value, maxLength = 120) {
   const normalized = String(value ?? '')
     .replace(/[\u0000-\u001f\u007f]+/g, ' ')
@@ -24,17 +27,28 @@ function normalizeLiveEventToken(value) {
 }
 
 function getFiniteLiveEventNumber(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string' && !value.trim()) return null;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+function getLiveEventScoreSnapshot(event = {}) {
+  if (!Object.prototype.hasOwnProperty.call(event, 'homeScore') || !Object.prototype.hasOwnProperty.call(event, 'awayScore')) {
+    return null;
+  }
+  const homeScore = getFiniteLiveEventNumber(event.homeScore);
+  const awayScore = getFiniteLiveEventNumber(event.awayScore);
+  if (homeScore === null || awayScore === null || homeScore < 0 || awayScore < 0) return null;
+  return {
+    homeScore: Object.is(homeScore, -0) ? 0 : homeScore,
+    awayScore: Object.is(awayScore, -0) ? 0 : awayScore
+  };
+}
+
 function getLiveEventScore(event = {}) {
-  const hasHomeScore = Object.prototype.hasOwnProperty.call(event, 'homeScore');
-  const hasAwayScore = Object.prototype.hasOwnProperty.call(event, 'awayScore');
-  const homeScore = hasHomeScore ? getFiniteLiveEventNumber(event.homeScore) : null;
-  const awayScore = hasAwayScore ? getFiniteLiveEventNumber(event.awayScore) : null;
-  if (homeScore === null || awayScore === null) return '';
-  return `${Math.max(0, homeScore)}–${Math.max(0, awayScore)}`;
+  const score = getLiveEventScoreSnapshot(event);
+  return score ? `${score.homeScore}–${score.awayScore}` : '';
 }
 
 function getLiveEventPlayerName(event = {}) {
@@ -108,14 +122,63 @@ function buildLiveEventNotificationDedupKey(event = {}, documentId = '') {
   return identity ? `live-event:${identity}` : '';
 }
 
+function buildLiveScoreStateNotificationDedupKey(score = {}) {
+  const snapshot = getLiveEventScoreSnapshot(score);
+  return snapshot ? `score-state:${snapshot.homeScore}:${snapshot.awayScore}` : '';
+}
+
+function getLiveEventTimestampMillis(value) {
+  if (typeof value?.toMillis === 'function') {
+    const millis = value.toMillis();
+    return Number.isFinite(millis) ? millis : null;
+  }
+  if (value instanceof Date) {
+    const millis = value.getTime();
+    return Number.isFinite(millis) ? millis : null;
+  }
+  if (value && typeof value === 'object' && Number.isFinite(Number(value.seconds))) {
+    const nanos = Number(value.nanoseconds ?? value.nanos ?? 0);
+    return (Number(value.seconds) * 1000) + (Number.isFinite(nanos) ? Math.floor(nanos / 1e6) : 0);
+  }
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string' && value.trim()) {
+    const millis = Date.parse(value);
+    return Number.isFinite(millis) ? millis : null;
+  }
+  return null;
+}
+
+function isLiveEventNotificationFresh(
+  event = {},
+  nowMillis = Date.now(),
+  maxAgeMillis = LIVE_EVENT_NOTIFICATION_MAX_AGE_MS
+) {
+  const createdAtMillis = getLiveEventTimestampMillis(event.createdAt);
+  const normalizedNowMillis = Number(nowMillis);
+  const normalizedMaxAgeMillis = Number(maxAgeMillis);
+  if (
+    createdAtMillis === null
+    || !Number.isFinite(normalizedNowMillis)
+    || !Number.isFinite(normalizedMaxAgeMillis)
+    || normalizedMaxAgeMillis < 0
+  ) {
+    return false;
+  }
+  const ageMillis = normalizedNowMillis - createdAtMillis;
+  return ageMillis >= -LIVE_EVENT_NOTIFICATION_FUTURE_TOLERANCE_MS && ageMillis <= normalizedMaxAgeMillis;
+}
+
 function getLiveEventActorUid(event = {}) {
   return compactLiveEventText(event.actorUid || event.createdBy, 160) || null;
 }
 
 module.exports = {
+  LIVE_EVENT_NOTIFICATION_MAX_AGE_MS,
   buildBigMomentLiveEventNotification,
   buildLiveEventNotificationDedupKey,
+  buildLiveScoreStateNotificationDedupKey,
   classifyBigMomentLiveEvent,
   compactLiveEventText,
-  getLiveEventActorUid
+  getLiveEventActorUid,
+  isLiveEventNotificationFresh
 };

--- a/functions/test/live-event-notification-core.test.cjs
+++ b/functions/test/live-event-notification-core.test.cjs
@@ -2,10 +2,13 @@ const assert = require('node:assert/strict');
 const { describe, it } = require('node:test');
 
 const {
+  LIVE_EVENT_NOTIFICATION_MAX_AGE_MS,
   buildBigMomentLiveEventNotification,
   buildLiveEventNotificationDedupKey,
+  buildLiveScoreStateNotificationDedupKey,
   classifyBigMomentLiveEvent,
-  getLiveEventActorUid
+  getLiveEventActorUid,
+  isLiveEventNotificationFresh
 } = require('../live-event-notification-core.cjs');
 
 describe('big-moment live event notifications', () => {
@@ -67,5 +70,24 @@ describe('big-moment live event notifications', () => {
     assert.equal(buildLiveEventNotificationDedupKey({}, ''), '');
     assert.equal(getLiveEventActorUid({ actorUid: 'actor-1', createdBy: 'actor-2' }), 'actor-1');
     assert.equal(getLiveEventActorUid({ createdBy: 'actor-2' }), 'actor-2');
+  });
+
+  it('builds a shared score-state dedup key only from complete nonnegative scores', () => {
+    assert.equal(buildLiveScoreStateNotificationDedupKey({ homeScore: 12, awayScore: 8 }), 'score-state:12:8');
+    assert.equal(buildLiveScoreStateNotificationDedupKey({ homeScore: '12', awayScore: '8' }), 'score-state:12:8');
+    assert.equal(buildLiveScoreStateNotificationDedupKey({ homeScore: null, awayScore: 8 }), '');
+    assert.equal(buildLiveScoreStateNotificationDedupKey({ homeScore: '', awayScore: 8 }), '');
+    assert.equal(buildLiveScoreStateNotificationDedupKey({ homeScore: -1, awayScore: 8 }), '');
+    assert.equal(buildLiveScoreStateNotificationDedupKey({ homeScore: 12 }), '');
+  });
+
+  it('accepts only fresh event timestamps and rejects missing, stale, or future-dated events', () => {
+    const now = Date.parse('2026-07-13T12:00:00.000Z');
+    assert.equal(isLiveEventNotificationFresh({ createdAt: new Date(now - 1000) }, now), true);
+    assert.equal(isLiveEventNotificationFresh({ createdAt: { seconds: (now - 1000) / 1000 } }, now), true);
+    assert.equal(isLiveEventNotificationFresh({ createdAt: new Date(now - LIVE_EVENT_NOTIFICATION_MAX_AGE_MS).toISOString() }, now), true);
+    assert.equal(isLiveEventNotificationFresh({ createdAt: now - LIVE_EVENT_NOTIFICATION_MAX_AGE_MS - 1 }, now), false);
+    assert.equal(isLiveEventNotificationFresh({ createdAt: now + (60 * 1000) + 1 }, now), false);
+    assert.equal(isLiveEventNotificationFresh({}, now), false);
   });
 });

--- a/functions/test/live-event-notification-core.test.cjs
+++ b/functions/test/live-event-notification-core.test.cjs
@@ -1,0 +1,71 @@
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+
+const {
+  buildBigMomentLiveEventNotification,
+  buildLiveEventNotificationDedupKey,
+  classifyBigMomentLiveEvent,
+  getLiveEventActorUid
+} = require('../live-event-notification-core.cjs');
+
+describe('big-moment live event notifications', () => {
+  it('classifies scoring events while rejecting routine and reversal events', () => {
+    assert.deepEqual(classifyBigMomentLiveEvent({ type: 'goal' }), { label: 'Goal', kind: 'goal' });
+    assert.deepEqual(classifyBigMomentLiveEvent({ type: 'stat', statKey: 'PTS', value: 3 }), { label: '3 points', kind: 'scoring-stat' });
+    assert.deepEqual(classifyBigMomentLiveEvent({ type: 'baseball', baseballAction: 'homeRun' }), { label: 'Home run', kind: 'home-run' });
+    assert.deepEqual(classifyBigMomentLiveEvent({ type: 'football_score', footballScoringAction: 'touchdown' }), { label: 'Touchdown', kind: 'football-score' });
+
+    for (const type of ['clock_start', 'clock_pause', 'period_change', 'lineup', 'substitution', 'undo', 'note']) {
+      assert.equal(classifyBigMomentLiveEvent({ type }), null);
+    }
+    assert.equal(classifyBigMomentLiveEvent({ type: 'stat', statKey: 'rebounds', value: 1 }), null);
+    assert.equal(classifyBigMomentLiveEvent({ type: 'stat', statKey: 'pts', value: -2 }), null);
+    assert.equal(classifyBigMomentLiveEvent({ type: 'baseball', baseballAction: 'single' }), null);
+  });
+
+  it('builds bounded structured copy without forwarding arbitrary event notes', () => {
+    const payload = buildBigMomentLiveEventNotification({
+      type: 'goal',
+      teamSide: 'home',
+      playerName: 'Ava Cole',
+      period: 'H2',
+      homeScore: 2,
+      awayScore: 1,
+      description: 'Goal — medical detail that should not be pushed',
+      note: 'private sideline note'
+    });
+
+    assert.deepEqual(payload, {
+      title: 'Goal: Ava Cole',
+      body: 'H2 · Score 2–1',
+      kind: 'goal'
+    });
+    assert.equal(payload.title.includes('medical'), false);
+    assert.equal(payload.body.includes('private'), false);
+    assert.ok(payload.title.length <= 80);
+    assert.ok(payload.body.length <= 120);
+  });
+
+  it('uses opponent identity and degrades safely when period and score are absent', () => {
+    assert.deepEqual(buildBigMomentLiveEventNotification({
+      type: 'stat',
+      stat: 'goals',
+      value: 1,
+      isOpponent: true,
+      opponentPlayerName: 'Morgan Lee'
+    }), {
+      title: 'Goal: Morgan Lee',
+      body: 'Open the live game for play-by-play.',
+      kind: 'scoring-stat'
+    });
+  });
+
+  it('prefers the canonical document ID for dedup and accepts both actor fields', () => {
+    assert.equal(buildLiveEventNotificationDedupKey({ eventId: 'client-event-7' }, 'doc-event-8'), 'live-event:doc-event-8');
+    assert.equal(buildLiveEventNotificationDedupKey({ eventId: 'client-event-7' }), 'live-event:client-event-7');
+    assert.equal(buildLiveEventNotificationDedupKey({}, 'doc-event-8'), 'live-event:doc-event-8');
+    assert.equal(buildLiveEventNotificationDedupKey({}, ''), '');
+    assert.equal(getLiveEventActorUid({ actorUid: 'actor-1', createdBy: 'actor-2' }), 'actor-1');
+    assert.equal(getLiveEventActorUid({ createdBy: 'actor-2' }), 'actor-2');
+  });
+});

--- a/functions/test/live-event-notification-core.test.cjs
+++ b/functions/test/live-event-notification-core.test.cjs
@@ -90,4 +90,16 @@ describe('big-moment live event notifications', () => {
     assert.equal(isLiveEventNotificationFresh({ createdAt: now + (60 * 1000) + 1 }, now), false);
     assert.equal(isLiveEventNotificationFresh({}, now), false);
   });
+
+  it('prefers the client event creation time over the eventual Firestore write time', () => {
+    const now = Date.parse('2026-07-13T12:00:00.000Z');
+    assert.equal(isLiveEventNotificationFresh({
+      clientCreatedAt: new Date(now - LIVE_EVENT_NOTIFICATION_MAX_AGE_MS - 1).toISOString(),
+      createdAt: new Date(now - 1000).toISOString()
+    }, now), false);
+    assert.equal(isLiveEventNotificationFresh({
+      clientCreatedAt: new Date(now - 1000).toISOString(),
+      createdAt: new Date(now - LIVE_EVENT_NOTIFICATION_MAX_AGE_MS - 1).toISOString()
+    }, now), true);
+  });
 });

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -778,6 +778,38 @@ test('notifyLiveEventCreated shares a score-state claim with an earlier generic 
     }
 });
 
+test('notifyLiveEventCreated skips retried live events whose client creation time is stale', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { liveScore: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/games/game-retry/liveEvents/retried-event');
+        const result = await moduleExports.notifyLiveEventCreated(makeSnapshot(ref, {
+            type: 'stat',
+            statKey: 'PTS',
+            value: 2,
+            playerName: 'Ava Cole',
+            homeScore: 12,
+            awayScore: 8,
+            clientCreatedAt: new Date(Date.now() - (11 * 60 * 1000)).toISOString(),
+            createdAt: new Date().toISOString(),
+            createdBy: 'coach-1'
+        }), { params: { teamId: 'team-1', gameId: 'game-retry', eventId: 'retried-event' } });
+
+        assert.equal(result, null);
+        assert.equal(env.counts.dedupTransactions, 0);
+        assert.equal(env.messagingCalls.length, 0);
+        assert.equal(env.auditWrites.length, 0);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyLiveEventCreated ignores routine, generic, and reversed live events', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -613,6 +613,100 @@ test('notifyGameUpdated sends liveScore notifications and records once-only audi
     }
 });
 
+test('notifyLiveEventCreated sends one deduped big-moment notification to eligible recipients except the actor', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'coach-1', roles: ['staff'], deviceId: 'actor-device', token: 'actor-token', categories: { liveScore: true } },
+            { uid: 'assistant-1', roles: ['staff'], deviceId: 'assistant-device', token: 'assistant-token', categories: { liveScore: true } },
+            { uid: 'parent-1', roles: ['parent'], deviceId: 'parent-device', token: 'parent-token', categories: { liveScore: true } },
+            { uid: 'opted-out-1', roles: ['parent'], deviceId: 'opted-out-device', token: 'opted-out-token', categories: { liveScore: false } },
+            { uid: 'unrelated-1', roles: ['viewer'], deviceId: 'unrelated-device', token: 'unrelated-token', categories: { liveScore: true } }
+        ]
+    });
+
+    try {
+        const ref = env.firestoreState.doc('teams/team-1/games/game-3/liveEvents/doc-event-1');
+        const snapshot = makeSnapshot(ref, {
+            eventId: 'client-event-1',
+            type: 'stat',
+            statKey: 'PTS',
+            value: 3,
+            playerName: 'Ava Cole',
+            period: 'Q4',
+            homeScore: 55,
+            awayScore: 53,
+            createdBy: 'coach-1',
+            description: 'Ava hit a three while discussing a private sideline note'
+        });
+        const context = { params: { teamId: 'team-1', gameId: 'game-3', eventId: 'doc-event-1' } };
+
+        const firstResult = await moduleExports.notifyLiveEventCreated(snapshot, context);
+        const duplicateResult = await moduleExports.notifyLiveEventCreated(snapshot, context);
+
+        assert.equal(firstResult?.successCount, 2);
+        assert.equal(duplicateResult, null);
+        assert.equal(env.counts.dedupTransactions, 2);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.deepEqual(env.messagingCalls[0].tokens.sort(), ['assistant-token', 'parent-token']);
+        assert.equal(env.messagingCalls[0].title, '3 points: Ava Cole');
+        assert.equal(env.messagingCalls[0].body, 'Q4 · Score 55–53');
+        assert.equal(env.messagingCalls[0].body.includes('private'), false);
+        assert.equal(env.messagingCalls[0].data.category, 'liveScore');
+        assert.equal(env.messagingCalls[0].data.eventId, 'doc-event-1');
+        assert.equal(env.messagingCalls[0].data.appRoute, '/schedule/team-1/game-3?section=game');
+        assert.equal(env.messagingCalls[0].webLink, 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-3');
+        assert.equal(env.auditWrites.length, 1);
+        assert.deepEqual(env.auditWrites[0].value.targetUserIds.sort(), ['assistant-1', 'parent-1']);
+        assert.equal(env.auditWrites[0].value.dedupGuardApplied, false);
+        assert.equal(env.dedupWrites.some((write) => write.value?.dedupKey === 'live-event:doc-event-1'), true);
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyLiveEventCreated ignores routine, generic, and reversed live events', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { liveScore: true } }
+        ]
+    });
+
+    try {
+        const ignoredEvents = [
+            { type: 'clock_start' },
+            { type: 'clock_pause' },
+            { type: 'period_change' },
+            { type: 'lineup' },
+            { type: 'substitution' },
+            { type: 'undo' },
+            { type: 'note', text: 'Routine note' },
+            { type: 'stat', statKey: 'rebounds', value: 1 },
+            { type: 'stat', statKey: 'pts', value: -2 },
+            { type: 'baseball', baseballAction: 'single' }
+        ];
+
+        for (const [index, event] of ignoredEvents.entries()) {
+            const eventId = `ignored-${index}`;
+            const ref = env.firestoreState.doc(`teams/team-1/games/game-3/liveEvents/${eventId}`);
+            const result = await moduleExports.notifyLiveEventCreated(
+                makeSnapshot(ref, event),
+                { params: { teamId: 'team-1', gameId: 'game-3', eventId } }
+            );
+            assert.equal(result, null);
+        }
+
+        assert.equal(env.counts.dedupTransactions, 0);
+        assert.equal(env.messagingCalls.length, 0);
+        assert.equal(env.auditWrites.length, 0);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyTeamChatMessageCreated sends mentions and liveChat only to enabled recipients and records audit entries', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: ['assistant@example.com'] },

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -613,6 +613,42 @@ test('notifyGameUpdated sends liveScore notifications and records once-only audi
     }
 });
 
+test('notifyGameUpdated suppresses generic liveScore when a matching big-moment live event exists', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'coach-1', deviceId: 'coach-device', token: 'coach-token', categories: { liveScore: true } },
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { liveScore: true } }
+        ]
+    });
+
+    try {
+        await env.firestoreState.doc('teams/team-1/games/game-2/liveEvents/doc-event-1').set({
+            type: 'stat',
+            statKey: 'PTS',
+            value: 2,
+            playerName: 'Ava Cole',
+            homeScore: 12,
+            awayScore: 8,
+            createdAt: '2026-06-28T12:00:00.000Z'
+        });
+
+        const ref = env.firestoreState.doc('teams/team-1/games/game-2');
+        const change = makeChange(ref, { homeScore: 10, awayScore: 8 }, { homeScore: 12, awayScore: 8, updatedBy: 'coach-1' });
+        const context = { params: { teamId: 'team-1', gameId: 'game-2' } };
+
+        const result = await moduleExports.notifyGameUpdated(change, context);
+
+        assert.equal(result, null);
+        assert.equal(env.counts.dedupTransactions, 0);
+        assert.equal(env.messagingCalls.length, 0);
+        assert.equal(env.auditWrites.length, 0);
+    } finally {
+        cleanup();
+    }
+});
+
 test('notifyLiveEventCreated sends one deduped big-moment notification to eligible recipients except the actor', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -631,7 +631,7 @@ test('notifyGameUpdated suppresses generic liveScore when a matching big-moment 
             playerName: 'Ava Cole',
             homeScore: 12,
             awayScore: 8,
-            createdAt: '2026-06-28T12:00:00.000Z'
+            createdAt: new Date().toISOString()
         });
 
         const ref = env.firestoreState.doc('teams/team-1/games/game-2');
@@ -644,6 +644,39 @@ test('notifyGameUpdated suppresses generic liveScore when a matching big-moment 
         assert.equal(env.counts.dedupTransactions, 0);
         assert.equal(env.messagingCalls.length, 0);
         assert.equal(env.auditWrites.length, 0);
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyGameUpdated does not let a stale matching live event suppress a current score push', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { liveScore: true } }
+        ]
+    });
+
+    try {
+        await env.firestoreState.doc('teams/team-1/games/game-stale/liveEvents/stale-event').set({
+            type: 'stat',
+            statKey: 'PTS',
+            value: 2,
+            homeScore: 12,
+            awayScore: 8,
+            createdAt: new Date(Date.now() - (11 * 60 * 1000)).toISOString()
+        });
+
+        const gameRef = env.firestoreState.doc('teams/team-1/games/game-stale');
+        const result = await moduleExports.notifyGameUpdated(
+            makeChange(gameRef, { homeScore: 10, awayScore: 8 }, { homeScore: 12, awayScore: 8, updatedBy: 'coach-1' }),
+            { params: { teamId: 'team-1', gameId: 'game-stale' } }
+        );
+
+        assert.equal(result?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].title, 'Live score update');
     } finally {
         cleanup();
     }
@@ -673,6 +706,7 @@ test('notifyLiveEventCreated sends one deduped big-moment notification to eligib
             period: 'Q4',
             homeScore: 55,
             awayScore: 53,
+            createdAt: new Date().toISOString(),
             createdBy: 'coach-1',
             description: 'Ava hit a three while discussing a private sideline note'
         });
@@ -697,6 +731,48 @@ test('notifyLiveEventCreated sends one deduped big-moment notification to eligib
         assert.deepEqual(env.auditWrites[0].value.targetUserIds.sort(), ['assistant-1', 'parent-1']);
         assert.equal(env.auditWrites[0].value.dedupGuardApplied, false);
         assert.equal(env.dedupWrites.some((write) => write.value?.dedupKey === 'live-event:doc-event-1'), true);
+        assert.equal(env.dedupWrites.some((write) => write.value?.dedupKey === 'score-state:55:53'), true);
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyLiveEventCreated shares a score-state claim with an earlier generic liveScore send', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        parentUserIds: ['parent-1'],
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { liveScore: true } }
+        ]
+    });
+
+    try {
+        const gameRef = env.firestoreState.doc('teams/team-1/games/game-race');
+        const gameChange = makeChange(
+            gameRef,
+            { homeScore: 10, awayScore: 8 },
+            { homeScore: 12, awayScore: 8, updatedBy: 'coach-1' }
+        );
+        await moduleExports.notifyGameUpdated(gameChange, { params: { teamId: 'team-1', gameId: 'game-race' } });
+
+        const eventRef = env.firestoreState.doc('teams/team-1/games/game-race/liveEvents/event-late');
+        const eventResult = await moduleExports.notifyLiveEventCreated(makeSnapshot(eventRef, {
+            type: 'stat',
+            statKey: 'PTS',
+            value: 2,
+            playerName: 'Ava Cole',
+            homeScore: 12,
+            awayScore: 8,
+            createdAt: new Date().toISOString(),
+            createdBy: 'coach-1'
+        }), { params: { teamId: 'team-1', gameId: 'game-race', eventId: 'event-late' } });
+
+        assert.equal(eventResult, null);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].title, 'Live score update');
+        assert.equal(env.dedupWrites.some((write) => write.value?.dedupKey === 'score:10:8->12:8'), true);
+        assert.equal(env.dedupWrites.some((write) => write.value?.dedupKey === 'score-state:12:8'), true);
+        assert.equal(env.dedupWrites.some((write) => write.value?.dedupKey === 'live-event:event-late'), false);
     } finally {
         cleanup();
     }
@@ -722,7 +798,14 @@ test('notifyLiveEventCreated ignores routine, generic, and reversed live events'
             { type: 'note', text: 'Routine note' },
             { type: 'stat', statKey: 'rebounds', value: 1 },
             { type: 'stat', statKey: 'pts', value: -2 },
-            { type: 'baseball', baseballAction: 'single' }
+            { type: 'baseball', baseballAction: 'single' },
+            { type: 'goal', homeScore: 2, awayScore: 1 },
+            {
+                type: 'goal',
+                homeScore: 2,
+                awayScore: 1,
+                createdAt: new Date(Date.now() - (11 * 60 * 1000)).toISOString()
+            }
         ];
 
         for (const [index, event] of ignoredEvents.entries()) {

--- a/functions/test/send-category-notification-test-helpers.cjs
+++ b/functions/test/send-category-notification-test-helpers.cjs
@@ -547,6 +547,44 @@ function buildNotificationTestEnv({
             };
         }
 
+        const liveEventsMatch = path.match(/^teams\/([^/]+)\/games\/([^/]+)\/liveEvents$/);
+        if (liveEventsMatch) {
+            const getLiveEventDocs = () => {
+                const prefix = `${path}/`;
+                return Array.from(docStore.entries())
+                    .filter(([docPath]) => docPath.startsWith(prefix) && !docPath.slice(prefix.length).includes('/'))
+                    .map(([docPath, data]) => makeDocSnapshot({
+                        id: docPath.slice(prefix.length),
+                        ref: doc(docPath),
+                        data,
+                        exists: true
+                    }));
+            };
+            const sortByField = (docs, field, direction = 'asc') => docs.sort((left, right) => {
+                const leftMillis = comparableMillis(left.data()?.[field]);
+                const rightMillis = comparableMillis(right.data()?.[field]);
+                const leftValue = Number.isFinite(leftMillis) ? leftMillis : 0;
+                const rightValue = Number.isFinite(rightMillis) ? rightMillis : 0;
+                return direction === 'desc' ? rightValue - leftValue : leftValue - rightValue;
+            });
+            return {
+                async get() {
+                    return makeQuerySnapshot(getLiveEventDocs());
+                },
+                orderBy(field, direction = 'asc') {
+                    return {
+                        limit(limitCount) {
+                            return {
+                                async get() {
+                                    return makeQuerySnapshot(sortByField(getLiveEventDocs(), field, direction).slice(0, limitCount));
+                                }
+                            };
+                        }
+                    };
+                }
+            };
+        }
+
         if (path === `teams/${teamId}/notificationAudit`) {
             return {
                 async add(value) {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -116,12 +116,15 @@ function createLiveEventId() {
 function withStableLiveEventId(eventData) {
   const event = (eventData && typeof eventData === 'object') ? eventData : {};
   const existingId = typeof event.eventId === 'string' ? event.eventId.trim() : '';
+  const clientCreatedAt = event.clientCreatedAt || new Date().toISOString();
   if (existingId) {
-    return existingId === event.eventId ? event : { ...event, eventId: existingId };
+    if (existingId === event.eventId && event.clientCreatedAt) return event;
+    return { ...event, eventId: existingId, clientCreatedAt };
   }
   return {
     ...event,
-    eventId: createLiveEventId()
+    eventId: createLiveEventId(),
+    clientCreatedAt
   };
 }
 

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -565,13 +565,17 @@
                 "apps/app/src/pages/GameDetail.tsx",
                 "apps/app/src/pages/StandardTracker.tsx"
             ],
-            "cloudFunctions": [],
+            "cloudFunctions": [
+                "notifyLiveEventCreated"
+            ],
             "unitTests": [
                 "tests/unit/app-baseball-scorekeeping-service.test.ts",
                 "tests/unit/app-game-report-service.test.js",
                 "tests/unit/app-live-game-announcer.test.js",
                 "tests/unit/db-tracking-items.test.js",
                 "tests/unit/game-day-entry.test.js",
+                "functions/test/live-event-notification-core.test.cjs",
+                "functions/test/notification-triggers.test.js",
                 "tests/unit/live-game-replay-init.test.js",
                 "tests/unit/live-tracker-opponent-stats.test.js",
                 "tests/unit/scoreboard-widget.test.js",

--- a/tests/unit/game-update-push-notifications.test.js
+++ b/tests/unit/game-update-push-notifications.test.js
@@ -123,7 +123,7 @@ describe('game schedule update push notifications', () => {
             'toNumericScore',
             'buildScheduleUpdateNotificationPayload',
             `const exports = {};
-${functionsSource.slice(functionsSource.indexOf('exports.notifyGameUpdated = functions.firestore'), functionsSource.indexOf('const notifyGameCreated ='))}
+${functionsSource.slice(functionsSource.indexOf('exports.notifyGameUpdated = functions.firestore'), functionsSource.indexOf('exports.notifyLiveEventCreated = functions.firestore'))}
 return exports.notifyGameUpdated;`
         )(
             {

--- a/tests/unit/game-update-push-notifications.test.js
+++ b/tests/unit/game-update-push-notifications.test.js
@@ -115,11 +115,13 @@ describe('game schedule update push notifications', () => {
     it('deduplicates live score sends by the before/after score transition before delivering notifications', async () => {
         const sendCategoryNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
         const checkAndSetNotificationDedup = vi.fn(async () => true);
+        const hasRecentBigMomentLiveEventForScore = vi.fn(async () => false);
         const handler = new Function(
             'functions',
             'detectGameNotificationCategory',
             'sendCategoryNotification',
             'checkAndSetNotificationDedup',
+            'hasRecentBigMomentLiveEventForScore',
             'toNumericScore',
             'buildScheduleUpdateNotificationPayload',
             `const exports = {};
@@ -137,6 +139,7 @@ return exports.notifyGameUpdated;`
             () => 'liveScore',
             sendCategoryNotification,
             checkAndSetNotificationDedup,
+            hasRecentBigMomentLiveEventForScore,
             (value) => Number(value || 0),
             () => ({ title: 'unused', body: 'unused' })
         );

--- a/tests/unit/game-update-push-notifications.test.js
+++ b/tests/unit/game-update-push-notifications.test.js
@@ -114,14 +114,16 @@ describe('game schedule update push notifications', () => {
 
     it('deduplicates live score sends by the before/after score transition before delivering notifications', async () => {
         const sendCategoryNotification = vi.fn(async () => ({ successCount: 1, failureCount: 0 }));
-        const checkAndSetNotificationDedup = vi.fn(async () => true);
-        const hasRecentBigMomentLiveEventForScore = vi.fn(async () => false);
+        const checkAndSetNotificationDedupKeys = vi.fn(async () => true);
+        const hasRecentBigMomentLiveEventForScoreState = vi.fn(async () => false);
+        const buildLiveScoreStateNotificationDedupKey = vi.fn(() => 'score-state:2:0');
         const handler = new Function(
             'functions',
             'detectGameNotificationCategory',
             'sendCategoryNotification',
-            'checkAndSetNotificationDedup',
-            'hasRecentBigMomentLiveEventForScore',
+            'checkAndSetNotificationDedupKeys',
+            'hasRecentBigMomentLiveEventForScoreState',
+            'buildLiveScoreStateNotificationDedupKey',
             'toNumericScore',
             'buildScheduleUpdateNotificationPayload',
             `const exports = {};
@@ -138,8 +140,9 @@ return exports.notifyGameUpdated;`
             },
             () => 'liveScore',
             sendCategoryNotification,
-            checkAndSetNotificationDedup,
-            hasRecentBigMomentLiveEventForScore,
+            checkAndSetNotificationDedupKeys,
+            hasRecentBigMomentLiveEventForScoreState,
+            buildLiveScoreStateNotificationDedupKey,
             (value) => Number(value || 0),
             () => ({ title: 'unused', body: 'unused' })
         );
@@ -151,11 +154,16 @@ return exports.notifyGameUpdated;`
             params: { teamId: 'team-1', gameId: 'game-7' }
         });
 
-        expect(checkAndSetNotificationDedup).toHaveBeenCalledWith(
+        expect(hasRecentBigMomentLiveEventForScoreState).toHaveBeenCalledWith(
+            'team-1',
+            'game-7',
+            'score-state:2:0'
+        );
+        expect(checkAndSetNotificationDedupKeys).toHaveBeenCalledWith(
             'team-1',
             'liveScore',
             'game-7',
-            'score:1:0->2:0'
+            ['score:1:0->2:0', 'score-state:2:0']
         );
         expect(sendCategoryNotification).toHaveBeenCalledWith(expect.objectContaining({
             teamId: 'team-1',

--- a/tests/unit/live-tracker-retry-queue.test.js
+++ b/tests/unit/live-tracker-retry-queue.test.js
@@ -342,12 +342,14 @@ describe('live tracker retry queue persistence', () => {
         page.setContext({ teamId: 'team-1', gameId: 'game-9' });
         await page.broadcastEvent({ type: 'stat', statKey: 'pts', value: 2 });
 
-        const queuedEvent = {
+        const queuedEvent = attempts[0];
+        expect(queuedEvent).toMatchObject({
             type: 'stat',
             statKey: 'pts',
             value: 2,
             eventId: 'live-event-1'
-        };
+        });
+        expect(Date.parse(queuedEvent.clientCreatedAt)).toBeGreaterThan(0);
         expect(attempts).toEqual([queuedEvent]);
         expect(page.liveState.eventQueue).toEqual([queuedEvent]);
         expect(readPersistedLiveTrackerQueue(page.storage, 'team-1', 'game-9')).toEqual([queuedEvent]);
@@ -380,21 +382,25 @@ describe('live tracker retry queue persistence', () => {
         page.scheduleRetry({ resetBackoff: true });
         await page.flushOneTimer();
 
-        const queuedSecondEvent = {
+        const queuedSecondEvent = attempts[1];
+        expect(queuedSecondEvent).toMatchObject({
             ...secondEvent,
             eventId: 'live-event-2'
-        };
+        });
+        expect(Date.parse(queuedSecondEvent.clientCreatedAt)).toBeGreaterThan(0);
         expect(attempts).toEqual([
-            { ...firstEvent, eventId: 'live-event-1' },
+            attempts[0],
             queuedSecondEvent
         ]);
+        expect(attempts[0]).toMatchObject({ ...firstEvent, eventId: 'live-event-1' });
+        expect(Date.parse(attempts[0].clientCreatedAt)).toBeGreaterThan(0);
         expect(page.liveState.eventQueue).toEqual([queuedSecondEvent]);
         expect(readPersistedLiveTrackerQueue(page.storage, 'team-1', 'game-9')).toEqual([queuedSecondEvent]);
 
         await page.flushOneTimer();
 
         expect(attempts).toEqual([
-            { ...firstEvent, eventId: 'live-event-1' },
+            attempts[0],
             queuedSecondEvent,
             queuedSecondEvent
         ]);
@@ -480,11 +486,13 @@ describe('live tracker retry queue persistence', () => {
 
         await page.retryPendingFinalizationNow({ resetBackoff: true });
 
+        expect(operations[0]).toMatchObject({
+            type: 'live-event',
+            event: { type: 'stat', statKey: 'pts', value: 2, eventId: 'live-event-1' }
+        });
+        expect(Date.parse(operations[0].event.clientCreatedAt)).toBeGreaterThan(0);
         expect(operations).toEqual([
-            {
-                type: 'live-event',
-                event: { type: 'stat', statKey: 'pts', value: 2, eventId: 'live-event-1' }
-            },
+            operations[0],
             {
                 type: 'finalization',
                 finishPlan: pendingFinish.finishPlan

--- a/tests/unit/scorekeeping-access-wiring.test.js
+++ b/tests/unit/scorekeeping-access-wiring.test.js
@@ -43,5 +43,9 @@ describe('scorekeeping access wiring', () => {
         const privatePlayerStatsRule = rules.match(/match \/privatePlayerStats\/\{statId\} \{[\s\S]*?\n        \}/)?.[0] || '';
         expect(privatePlayerStatsRule).toContain('allow read, create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);');
         expect(privatePlayerStatsRule).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);');
+        const liveEventsRule = rules.match(/match \/liveEvents\/\{eventId\} \{[\s\S]*?\n        \}/)?.[0] || '';
+        expect(liveEventsRule).toContain('hasValidLiveEventAttribution(request.resource.data)');
+        expect(liveEventsRule).toContain("data.createdBy == request.auth.uid");
+        expect(liveEventsRule).toContain("data.actorUid == request.auth.uid");
     });
 });


### PR DESCRIPTION
Closes #3833

## What changed

- add a Firestore `onCreate` trigger for game `liveEvents`
- classify goals, positive scoring stats, home runs, and football scores as high-signal moments
- reuse the existing `liveScore` recipient lookup, push delivery, notification inbox, audit, and deep-link pipeline
- ignore routine clock, period, lineup, substitution, note, undo, non-scoring, and negative/reversal events
- add focused classifier and end-to-end notification trigger coverage

## Why

Live play-by-play already reaches viewers with the game open, but event-level scoring moments did not alert opted-in families and staff when the live page was closed.

## Privacy and delivery safety

- notification copy is built from bounded structured fields (event label, player, period, score); arbitrary event descriptions and sideline notes are not forwarded
- the event actor is excluded before fanout
- existing role and `liveScore` preference checks remain authoritative
- a transactional dedup claim keyed by the canonical live-event document ID prevents retry delivery from creating duplicate pushes
- web notifications link to the existing live game page; app notifications use the existing liveScore game route

## Validation

- `node --check functions/index.js`
- `node --test functions/test/live-event-notification-core.test.cjs` — 4 passed
- notification regression suite (`send-category-notification`, load, and trigger tests) — 74 passed
- `git diff --check`

## Manual testing

Not run; this is a server-side Firestore trigger and delivery fanout change covered by the function test harness.