### PR TITLE
Explain standard signup codes on signed-in accept-invite

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -158,7 +158,7 @@
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=46';
         import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemCoParentInvite, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=91';
         import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';
-        import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';
+        import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=9';
         import { renderHeader, renderFooter } from './js/utils.js?v=15';
 
         renderFooter(document.getElementById('footer-container'));

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -191,5 +191,11 @@ export async function processInviteCode(userId, code, deps, authEmail = null) {
         };
     }
 
-    throw new Error('Unknown invite type');
+    if (!validation.type || validation.type === 'standard') {
+        // Standard access codes are signup activation codes, not signed-in invites (#3843).
+        // Never consume the code here — it stays valid for the person it was meant for.
+        throw new Error("This is a signup code for creating a new account. You're already signed in — share this code with someone new instead of opening it yourself.");
+    }
+
+    throw new Error(`This invite code type isn't supported here (${validation.type}). Ask whoever sent it for a new invite link.`);
 }

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -348,4 +348,64 @@ describe('accept invite flow', () => {
         await expect(processInvite('user-2', 'ABCD1234')).rejects.toThrow('Code already used');
         expect(deps.markAccessCodeAsUsed).not.toHaveBeenCalled();
     });
+
+    it('explains standard signup codes to signed-in users without consuming them (#3843)', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                codeId: 'code-std-1',
+                type: 'standard',
+                data: { code: 'ABCD1234', type: 'standard' }
+            })),
+            redeemParentInvite: vi.fn(),
+            markAccessCodeAsUsed: vi.fn()
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-3', 'ABCD1234', 'signedin@example.com')).rejects.toThrow(
+            "This is a signup code for creating a new account. You're already signed in — share this code with someone new instead of opening it yourself."
+        );
+        expect(deps.markAccessCodeAsUsed).not.toHaveBeenCalled();
+        expect(deps.redeemParentInvite).not.toHaveBeenCalled();
+    });
+
+    it('treats a missing invite type like a standard signup code', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                codeId: 'code-std-2',
+                data: { code: 'EFGH5678' }
+            })),
+            redeemParentInvite: vi.fn(),
+            markAccessCodeAsUsed: vi.fn()
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-4', 'EFGH5678')).rejects.toThrow(
+            /signup code for creating a new account/
+        );
+        expect(deps.markAccessCodeAsUsed).not.toHaveBeenCalled();
+    });
+
+    it('names the invite type in the unsupported-type error', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                codeId: 'code-odd-1',
+                type: 'mystery_invite',
+                data: {}
+            })),
+            redeemParentInvite: vi.fn(),
+            markAccessCodeAsUsed: vi.fn()
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-5', 'WXYZ9012')).rejects.toThrow(
+            "This invite code type isn't supported here (mystery_invite). Ask whoever sent it for a new invite link."
+        );
+        expect(deps.markAccessCodeAsUsed).not.toHaveBeenCalled();
+    });
 });

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -117,7 +117,7 @@ const setTimeout = deps.setTimeout;
             'const { redeemAdminInviteAtomically } = deps.db;'
         )
         .replace(
-            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';",
+            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=9';",
             'const { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } = deps.acceptInviteFlow;'
         )
         .replace(

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -49,7 +49,7 @@ describe('admin invite signup cache busting', () => {
             "import { redeemAdminInviteAtomically } from './js/admin-invite.js?v=6';"
         );
         expect(acceptInviteSource).toContain(
-            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=8';"
+            "import { createInviteProcessor, getInviteDashboardUrl, isInviteAlreadyRedeemedError } from './js/accept-invite-flow.js?v=9';"
         );
     });
 

--- a/tests/unit/co-parent-invite-workflow.test.js
+++ b/tests/unit/co-parent-invite-workflow.test.js
@@ -18,7 +18,7 @@ describe('co-parent invite workflow regression', () => {
 
         expect(acceptInviteSource).toContain('redeemCoParentInvite');
         expect(acceptInviteSource).toContain("./js/db.js?v=91");
-        expect(acceptInviteSource).toContain("./js/accept-invite-flow.js?v=8");
+        expect(acceptInviteSource).toContain("./js/accept-invite-flow.js?v=9");
     });
 
     it('routes co-parent membership grants through a callable instead of browser membership writes', () => {


### PR DESCRIPTION
## Summary
- Opening `/app#/accept-invite?code=XXXX` while signed in with a `standard` access code (the kind generated from the app Profile invite generator) failed with a raw "Unknown invite type" error. `processInviteCode` in `js/accept-invite-flow.js` only handled the four signed-in invite types.
- `processInviteCode` now recognizes `standard` (and missing) code types and throws a friendly, actionable message: standard codes are signup activation codes, so a signed-in user is told to share the code with someone new instead. The code is never consumed, so it stays valid for its intended recipient.
- The generic fallback for truly unknown types now names the type in a human-readable message instead of "Unknown invite type".
- Bumped the `accept-invite-flow.js` cache-bust version to `?v=9` in `accept-invite.html` and the tests that pin it.
- Added regression unit tests: standard-type validation throws the friendly message without calling `markAccessCodeAsUsed`, missing type is treated like standard, and unknown types name the type in the error. No behavior change for parent, household, co-parent, or admin invites.

Fixes #3843

## Manual test steps
1. Sign in to the app, open Profile, and generate an invite code (creates a `type: 'standard'` access code).
2. While still signed in, open `/app#/accept-invite?code=<that code>` (or `accept-invite.html?code=<that code>` on the legacy site).
3. Verify the error now reads "This is a signup code for creating a new account. You're already signed in — share this code with someone new instead of opening it yourself." instead of "Unknown invite type".
4. Verify the code is still unused (not marked used in `/accessCodes`) and can still be redeemed through the signup flow.
5. Redeem a parent, household, co-parent, and admin invite while signed in and confirm they still work unchanged.

## Tests
- `npx vitest run tests/unit/accept-invite-flow.test.js tests/unit/accept-invite-page.test.js tests/unit/admin-invite-signup-cache-busting.test.js tests/unit/co-parent-invite-workflow.test.js --reporter=verbose` — 38 passed
- `npm test` — 4030 passed, 38 skipped
- `node scripts/check-critical-cache-bust.mjs` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)