### PR TITLE
Grant coach role to team creators

### DIFF
--- a/_migration/backfill-owner-coach-roles.js
+++ b/_migration/backfill-owner-coach-roles.js
@@ -25,7 +25,12 @@ import { readFileSync } from 'fs';
 
 const APPLY = process.argv.includes('--apply');
 const teamFlagIdx = process.argv.indexOf('--team');
-const onlyTeamId = teamFlagIdx !== -1 ? String(process.argv[teamFlagIdx + 1] || '').trim() : null;
+const teamFlagValue = teamFlagIdx !== -1 ? String(process.argv[teamFlagIdx + 1] || '').trim() : null;
+if (teamFlagIdx !== -1 && (!teamFlagValue || teamFlagValue.startsWith('--'))) {
+    console.error('Missing team ID after --team. No changes were made.');
+    process.exit(1);
+}
+const onlyTeamId = teamFlagValue;
 
 let dbInstance = null;
 

--- a/_migration/backfill-owner-coach-roles.js
+++ b/_migration/backfill-owner-coach-roles.js
@@ -1,0 +1,118 @@
+/**
+ * Backfill coach roles for team owners.
+ *
+ * Repairs the gap where creating a team never granted the creator the coach
+ * role (issue #3846). Team creation only wrote the team doc with `ownerId`;
+ * the owner's `users/{uid}` doc was never updated with `coachOf` /
+ * `roles: ['coach']`, so the app's role derivation treated owners as
+ * parent-only (e.g. coach@allplays.ai owned a team but had roles:["parent"]).
+ *
+ * For every team, this ensures users/{ownerId} has:
+ *   - `coachOf` containing the teamId
+ *   - `roles` containing 'coach'
+ *
+ * DRY RUN by default. Pass --apply to write.
+ * Optionally scope to one team: --team teamId
+ *
+ * Usage:
+ *   node _migration/backfill-owner-coach-roles.js                # dry run, all teams
+ *   node _migration/backfill-owner-coach-roles.js --team abc123  # dry run, one team
+ *   node _migration/backfill-owner-coach-roles.js --apply        # write, all teams
+ */
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { readFileSync } from 'fs';
+
+const APPLY = process.argv.includes('--apply');
+const teamFlagIdx = process.argv.indexOf('--team');
+const onlyTeamId = teamFlagIdx !== -1 ? String(process.argv[teamFlagIdx + 1] || '').trim() : null;
+
+let dbInstance = null;
+
+function getAdminApp() {
+    if (!getApps().length) {
+        const sa = JSON.parse(readFileSync(new URL('./serviceAccountKey.json', import.meta.url), 'utf8'));
+        initializeApp({ credential: cert(sa), projectId: 'game-flow-c6311' });
+    }
+    return getApps()[0];
+}
+
+function getDb() {
+    if (!dbInstance) {
+        getAdminApp();
+        dbInstance = getFirestore();
+    }
+    return dbInstance;
+}
+
+async function main() {
+    const db = getDb();
+    console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY RUN (no writes)'}${onlyTeamId ? `  scope: team ${onlyTeamId}` : '  scope: all teams'}\n`);
+
+    // 1. Collect owner -> teamIds across teams.
+    const teamIdsByOwner = new Map(); // uid -> Set(teamId)
+    if (onlyTeamId) {
+        const teamSnap = await db.doc(`teams/${onlyTeamId}`).get();
+        if (!teamSnap.exists) {
+            console.log(`Team ${onlyTeamId} not found; nothing to do.`);
+            return;
+        }
+        const ownerId = String(teamSnap.data()?.ownerId || '').trim();
+        if (ownerId) {
+            teamIdsByOwner.set(ownerId, new Set([onlyTeamId]));
+        }
+    } else {
+        const teams = await db.collection('teams').get();
+        for (const teamDoc of teams.docs) {
+            const ownerId = String(teamDoc.data()?.ownerId || '').trim();
+            if (!ownerId) {
+                console.log(`  ! team ${teamDoc.id} has no ownerId; skipping`);
+                continue;
+            }
+            if (!teamIdsByOwner.has(ownerId)) teamIdsByOwner.set(ownerId, new Set());
+            teamIdsByOwner.get(ownerId).add(teamDoc.id);
+        }
+    }
+
+    // 2. For each owner, ensure coachOf covers their teams and roles has 'coach'.
+    let usersChanged = 0;
+    let teamLinksAdded = 0;
+    for (const [uid, teamIds] of teamIdsByOwner) {
+        const userRef = db.doc(`users/${uid}`);
+        const userSnap = await userRef.get();
+        if (!userSnap.exists) {
+            console.log(`  ! user ${uid} missing; skipping ${teamIds.size} team(s): ${[...teamIds].join(', ')}`);
+            continue;
+        }
+        const userData = userSnap.data() || {};
+        const existingCoachOf = new Set(Array.isArray(userData.coachOf) ? userData.coachOf.map(String) : []);
+        const existingRoles = Array.isArray(userData.roles) ? userData.roles.map(String) : [];
+        const missingTeamIds = [...teamIds].filter((teamId) => !existingCoachOf.has(teamId));
+        const needsCoachRole = !existingRoles.includes('coach');
+
+        if (missingTeamIds.length === 0 && !needsCoachRole) continue;
+
+        usersChanged += 1;
+        teamLinksAdded += missingTeamIds.length;
+        const email = userData.email || '(no email)';
+        console.log(`  ${uid} (${email}): +coachOf [${missingTeamIds.join(', ') || 'none'}]${needsCoachRole ? " +role 'coach'" : ''}`);
+
+        if (APPLY) {
+            const update = { roles: FieldValue.arrayUnion('coach') };
+            if (missingTeamIds.length > 0) {
+                update.coachOf = FieldValue.arrayUnion(...missingTeamIds);
+            }
+            await userRef.set(update, { merge: true });
+        }
+    }
+
+    console.log(`\n${APPLY ? 'Updated' : 'Would update'} ${usersChanged} user(s); ${APPLY ? 'added' : 'would add'} ${teamLinksAdded} coachOf link(s).`);
+    if (!APPLY) {
+        console.log('Dry run complete. Re-run with --apply to write.');
+    }
+}
+
+main().catch((error) => {
+    console.error('Backfill failed:', error);
+    process.exit(1);
+});

--- a/edit-team.html
+++ b/edit-team.html
@@ -573,7 +573,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=91';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=95';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=15';

--- a/js/db.js
+++ b/js/db.js
@@ -2115,7 +2115,24 @@ export async function createTeam(teamData) {
         teamData.deactivatedBy = null;
     }
     const docRef = await addDoc(collection(db, "teams"), teamData);
+    if (teamData.ownerId) {
+        await grantCoachRoleForTeam(teamData.ownerId, docRef.id);
+    }
     return docRef.id;
+}
+
+export async function grantCoachRoleForTeam(userId, teamId) {
+    if (!userId || !teamId) return false;
+    try {
+        await setDoc(doc(db, "users", userId), {
+            coachOf: arrayUnion(teamId),
+            roles: arrayUnion('coach')
+        }, { merge: true });
+        return true;
+    } catch (error) {
+        console.warn('Unable to grant coach role for team owner:', error);
+        return false;
+    }
 }
 
 export async function updateTeam(teamId, teamData) {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1560,6 +1560,7 @@ describe('React app messages integration', () => {
         expect(chatMocks.loadChatRecipientOptions).not.toHaveBeenCalled();
 
         await click(container, 'Team Email');
+        await waitForTeamEmailDialog(container);
         expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
 
         await click(container, 'Close Team Email');

--- a/tests/unit/backfill-owner-coach-roles.test.js
+++ b/tests/unit/backfill-owner-coach-roles.test.js
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migrationSource = readFileSync(new URL('../../_migration/backfill-owner-coach-roles.js', import.meta.url), 'utf8');
+
+describe('backfill owner coach roles migration', () => {
+    it('rejects a missing or flag-like team ID before running the migration', () => {
+        expect(migrationSource).toContain("!teamFlagValue || teamFlagValue.startsWith('--')");
+        expect(migrationSource).toContain('Missing team ID after --team. No changes were made.');
+        expect(migrationSource.indexOf("process.exit(1)")).toBeLessThan(migrationSource.indexOf('async function main()'));
+    });
+});

--- a/tests/unit/db-create-team-coach-role.test.js
+++ b/tests/unit/db-create-team-coach-role.test.js
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+function getFunctionSource(functionName) {
+    const start = dbSource.indexOf(`export async function ${functionName}(`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const nextExport = dbSource.indexOf('\nexport async function ', start + 1);
+    const nextImport = dbSource.indexOf('\nimport ', start + 1);
+    const candidates = [nextExport, nextImport].filter((value) => value !== -1);
+    const end = candidates.length > 0 ? Math.min(...candidates) : dbSource.length;
+    return dbSource.slice(start, end);
+}
+
+function buildCreateTeam(deps) {
+    const functionSource = getFunctionSource('createTeam')
+        .replace('export async function createTeam', 'return async function createTeam');
+
+    return new Function(
+        'Timestamp',
+        'buildPublicTeamSearchFields',
+        'addDoc',
+        'collection',
+        'db',
+        'grantCoachRoleForTeam',
+        functionSource
+    )(
+        deps.Timestamp,
+        deps.buildPublicTeamSearchFields,
+        deps.addDoc,
+        deps.collection,
+        deps.db,
+        deps.grantCoachRoleForTeam
+    );
+}
+
+function buildGrantCoachRoleForTeam(deps) {
+    const functionSource = getFunctionSource('grantCoachRoleForTeam')
+        .replace('export async function grantCoachRoleForTeam', 'return async function grantCoachRoleForTeam');
+
+    return new Function(
+        'setDoc',
+        'doc',
+        'db',
+        'arrayUnion',
+        functionSource
+    )(
+        deps.setDoc,
+        deps.doc,
+        deps.db,
+        deps.arrayUnion
+    );
+}
+
+function makeCreateTeamDeps(overrides = {}) {
+    return {
+        Timestamp: { now: () => 'NOW' },
+        buildPublicTeamSearchFields: () => ({}),
+        addDoc: vi.fn(async () => ({ id: 'team-new' })),
+        collection: (_db, path) => ({ path }),
+        db: {},
+        grantCoachRoleForTeam: vi.fn(async () => true),
+        ...overrides
+    };
+}
+
+describe('createTeam coach role grant', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('grants the coach role to the creator after the team is created', async () => {
+        const deps = makeCreateTeamDeps();
+        const createTeam = buildCreateTeam(deps);
+
+        const teamId = await createTeam({ name: 'Jr Current', ownerId: 'owner-uid' });
+
+        expect(teamId).toBe('team-new');
+        expect(deps.grantCoachRoleForTeam).toHaveBeenCalledTimes(1);
+        expect(deps.grantCoachRoleForTeam).toHaveBeenCalledWith('owner-uid', 'team-new');
+    });
+
+    it('skips the coach role grant when no ownerId is present', async () => {
+        const deps = makeCreateTeamDeps();
+        const createTeam = buildCreateTeam(deps);
+
+        const teamId = await createTeam({ name: 'Ownerless Team' });
+
+        expect(teamId).toBe('team-new');
+        expect(deps.grantCoachRoleForTeam).not.toHaveBeenCalled();
+    });
+
+    it('still resolves with the team id when the coach role grant fails', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const setDoc = vi.fn(async () => {
+            throw new Error('permission denied');
+        });
+        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
+            setDoc,
+            doc: (_db, collectionPath, id) => ({ path: `${collectionPath}/${id}` }),
+            db: {},
+            arrayUnion: (...values) => ({ __arrayUnion: values })
+        });
+        const deps = makeCreateTeamDeps({ grantCoachRoleForTeam });
+        const createTeam = buildCreateTeam(deps);
+
+        const teamId = await createTeam({ name: 'Jr Current', ownerId: 'owner-uid' });
+
+        expect(teamId).toBe('team-new');
+        expect(setDoc).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalled();
+    });
+});
+
+describe('grantCoachRoleForTeam', () => {
+    it('merges coachOf and the coach role onto the users doc', async () => {
+        const writes = [];
+        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
+            setDoc: vi.fn(async (ref, data, options) => {
+                writes.push({ path: ref.path, data, options });
+            }),
+            doc: (_db, collectionPath, id) => ({ path: `${collectionPath}/${id}` }),
+            db: {},
+            arrayUnion: (...values) => ({ __arrayUnion: values })
+        });
+
+        const result = await grantCoachRoleForTeam('owner-uid', 'team-new');
+
+        expect(result).toBe(true);
+        expect(writes).toEqual([
+            {
+                path: 'users/owner-uid',
+                data: {
+                    coachOf: { __arrayUnion: ['team-new'] },
+                    roles: { __arrayUnion: ['coach'] }
+                },
+                options: { merge: true }
+            }
+        ]);
+    });
+
+    it('returns false without throwing when the write is rejected', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
+            setDoc: vi.fn(async () => {
+                throw new Error('permission denied');
+            }),
+            doc: (_db, collectionPath, id) => ({ path: `${collectionPath}/${id}` }),
+            db: {},
+            arrayUnion: (...values) => ({ __arrayUnion: values })
+        });
+
+        await expect(grantCoachRoleForTeam('owner-uid', 'team-new')).resolves.toBe(false);
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    it('returns false when userId or teamId is missing', async () => {
+        const setDoc = vi.fn();
+        const grantCoachRoleForTeam = buildGrantCoachRoleForTeam({
+            setDoc,
+            doc: () => ({}),
+            db: {},
+            arrayUnion: (...values) => values
+        });
+
+        await expect(grantCoachRoleForTeam('', 'team-new')).resolves.toBe(false);
+        await expect(grantCoachRoleForTeam('owner-uid', '')).resolves.toBe(false);
+        expect(setDoc).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Add `grantCoachRoleForTeam(userId, teamId)` to `js/db.js`: merges `coachOf: arrayUnion(teamId)` and `roles: arrayUnion('coach')` onto `users/{uid}`, mirroring the admin-invite redemption write. Failures are logged and swallowed so a role-grant error never fails team creation.
- Call it from `createTeam` whenever `teamData.ownerId` is present, so the creator gets the coach role at creation time (previously only admin-invite redemption granted it, leaving owners with `roles: ["parent"]`).
- Firestore rules already permit this write: `isOwnerUserUpdatePayloadValid` only blocks `isAdmin`, parent-membership fields, and media-upload grants — `coachOf`/`roles` are owner-writable and carry no server-side privilege (rules never read them). No rules change needed; `npm run ci:firebase-rules` passes.
- Bump `edit-team.html` `db.js?v=91` -> `v=95` for the cache-bust guard.
- Add `_migration/backfill-owner-coach-roles.js` (NOT run): dry-run by default, `--apply` to write, `--team <id>` to scope; ensures every team owner's user doc has the `coachOf` link and `coach` role. Documented in the local `_migration/MIGRATION-README.md`.
- Regression tests in `tests/unit/db-create-team-coach-role.test.js`: creator grant fires with the new team id, no grant without `ownerId`, creation still resolves when the grant write is rejected, and the merge payload/fallback behavior of `grantCoachRoleForTeam`.

## Manual test steps
1. Sign in as a non-coach user and create a new team via `edit-team.html`.
2. In Firestore, confirm `users/{uid}` now contains the new team id in `coachOf` and `'coach'` in `roles`.
3. Open the app (`/app/`) as that user and confirm coach-only surfaces appear (role derivation in `rolesFromProfile` picks up `coachOf`/`roles`).
4. Existing owners missing the role: run `node _migration/backfill-owner-coach-roles.js` (dry run) and review the report before `--apply`.

Fixes #3846

🤖 Generated with [Claude Code](https://claude.com/claude-code)