### PR TITLE
Add baseball and softball edit team options

### DIFF
--- a/edit-config.html
+++ b/edit-config.html
@@ -96,6 +96,7 @@
                                 <option value="Basketball">Basketball</option>
                                 <option value="Soccer">Soccer</option>
                                 <option value="Baseball">Baseball</option>
+                                <option value="Softball">Softball</option>
                                 <option value="Football">Football</option>
                                 <option value="Volleyball">Volleyball</option>
                                 <option value="Custom">Custom</option>

--- a/edit-config.html
+++ b/edit-config.html
@@ -202,7 +202,7 @@
     <script type="module">
         import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=91';
         import { parseAdvancedStatDefinitions, validateStatDefinitionsForPublicLeaderboards } from './js/stat-leaderboards.js?v=2';
-        import { getStatConfigPresetOptions, getStatConfigPresetById, serializeAdvancedStatDefinitions } from './js/stat-config-presets.js?v=1';
+        import { getStatConfigPresetOptions, getStatConfigPresetById, serializeAdvancedStatDefinitions } from './js/stat-config-presets.js?v=2';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=15';
         import { checkAuth } from './js/auth.js?v=49';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-team.html
+++ b/edit-team.html
@@ -102,6 +102,8 @@
                         <option value="">Select a sport...</option>
                         <option value="Basketball">Basketball — PTS/REB/AST/STL/TO template</option>
                         <option value="Soccer">Soccer — GOALS/SHOTS/PASSES/BLOCKS/HUSTLE template</option>
+                        <option value="Baseball">Baseball — AB/H/R/RBI/BB/FP template</option>
+                        <option value="Softball">Softball — AB/H/R/RBI/BB/FP template</option>
                     </select>
                     <p class="text-xs text-gray-500 mt-1">Only sports with built-in stat tracker templates are listed.
                     </p>

--- a/edit-team.html
+++ b/edit-team.html
@@ -576,8 +576,8 @@
 
     <script type="module">
         import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } from './js/db.js?v=96';
-        import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
-        import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
+        import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=2';
+        import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=15';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=49';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/js/stat-config-presets.js
+++ b/js/stat-config-presets.js
@@ -1,5 +1,23 @@
 import { normalizeStatTrackerConfig } from './stat-leaderboards.js?v=2';
 
+const DIAMOND_STAT_COLUMNS = ['AB', 'H', 'R', 'RBI', 'BB', 'FP'];
+
+function createDiamondSportConfig(sport) {
+    return {
+        name: `${sport} Standard`,
+        baseType: sport,
+        columns: [...DIAMOND_STAT_COLUMNS],
+        statDefinitions: [
+            { label: 'AB', acronym: 'AB', group: 'Batting' },
+            { label: 'H', acronym: 'H', group: 'Batting', topStat: true },
+            { label: 'R', acronym: 'R', group: 'Batting', topStat: true },
+            { label: 'RBI', acronym: 'RBI', group: 'Batting', topStat: true },
+            { label: 'BB', acronym: 'BB', group: 'Plate Discipline', topStat: true },
+            { label: 'FP', acronym: 'FP', group: 'Fielding', format: 'percentage', precision: 3, topStat: true }
+        ]
+    };
+}
+
 const PRESET_DEFINITIONS = [
     {
         id: 'blank',
@@ -54,19 +72,14 @@ const PRESET_DEFINITIONS = [
     {
         id: 'baseball',
         label: 'Baseball Standard',
-        description: 'Core hitting, pitching, and fielding stats.',
-        config: {
-            name: 'Baseball Standard',
-            baseType: 'Baseball',
-            columns: ['R', 'H', 'RBI', 'SB', 'SO'],
-            statDefinitions: [
-                { label: 'R', acronym: 'R', group: 'Batting', topStat: true },
-                { label: 'H', acronym: 'H', group: 'Batting', topStat: true },
-                { label: 'RBI', acronym: 'RBI', group: 'Batting', topStat: true },
-                { label: 'SB', acronym: 'SB', group: 'Base Running', topStat: true },
-                { label: 'SO', acronym: 'SO', group: 'Pitching', rankingOrder: 'asc' }
-            ]
-        }
+        description: 'At-bats, hits, runs, RBI, walks, and fielding percentage.',
+        config: createDiamondSportConfig('Baseball')
+    },
+    {
+        id: 'softball',
+        label: 'Softball Standard',
+        description: 'At-bats, hits, runs, RBI, walks, and fielding percentage.',
+        config: createDiamondSportConfig('Softball')
     },
     {
         id: 'football',

--- a/js/stat-config-presets.js
+++ b/js/stat-config-presets.js
@@ -13,7 +13,7 @@ function createDiamondSportConfig(sport) {
             { label: 'R', acronym: 'R', group: 'Batting', topStat: true },
             { label: 'RBI', acronym: 'RBI', group: 'Batting', topStat: true },
             { label: 'BB', acronym: 'BB', group: 'Plate Discipline', topStat: true },
-            { label: 'FP', acronym: 'FP', group: 'Fielding', format: 'percentage', precision: 3, topStat: true }
+            { label: 'FP', acronym: 'FP', group: 'Fielding', topStat: true }
         ]
     };
 }
@@ -72,13 +72,13 @@ const PRESET_DEFINITIONS = [
     {
         id: 'baseball',
         label: 'Baseball Standard',
-        description: 'At-bats, hits, runs, RBI, walks, and fielding percentage.',
+        description: 'At-bats, hits, runs, RBI, walks, and fielding plays.',
         config: createDiamondSportConfig('Baseball')
     },
     {
         id: 'softball',
         label: 'Softball Standard',
-        description: 'At-bats, hits, runs, RBI, walks, and fielding percentage.',
+        description: 'At-bats, hits, runs, RBI, walks, and fielding plays.',
         config: createDiamondSportConfig('Softball')
     },
     {

--- a/js/team-stat-config-migration.js
+++ b/js/team-stat-config-migration.js
@@ -1,4 +1,4 @@
-import { getDefaultStatConfigForSport } from './stat-config-presets.js?v=1';
+import { getDefaultStatConfigForSport } from './stat-config-presets.js?v=2';
 
 function normalizeSportLabel(value) {
     return String(value || '').trim().toLowerCase();

--- a/tests/smoke/edit-config-access-control.spec.js
+++ b/tests/smoke/edit-config-access-control.spec.js
@@ -151,7 +151,7 @@ async function mockDependencies(page, { user, team }) {
     await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: buildAuthStub(user) }));
     await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
     await page.route('**/js/stat-leaderboards.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_LEADERBOARDS_STUB }));
-    await page.route('**/js/stat-config-presets.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_CONFIG_PRESETS_STUB }));
+    await page.route('**/js/stat-config-presets.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_CONFIG_PRESETS_STUB }));
 }
 
 test('team coach with case-different auth email can open stat config editor with real access checks', async ({ page, baseURL }) => {

--- a/tests/smoke/edit-config-platform-admin.spec.js
+++ b/tests/smoke/edit-config-platform-admin.spec.js
@@ -235,7 +235,7 @@ async function mockDependencies(page) {
     await page.route('**/js/edit-config-access.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));
     await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
     await page.route('**/js/stat-leaderboards.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_LEADERBOARDS_STUB }));
-    await page.route('**/js/stat-config-presets.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_CONFIG_PRESETS_STUB }));
+    await page.route('**/js/stat-config-presets.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_CONFIG_PRESETS_STUB }));
 }
 
 test('platform admin saves advanced stat definition metadata through edit-config controls', async ({ page, baseURL }) => {

--- a/tests/unit/edit-config-schema-workflow.test.js
+++ b/tests/unit/edit-config-schema-workflow.test.js
@@ -71,6 +71,23 @@ describe('edit config schema workflow', () => {
         expect(source).toContain('edit-btn');
     });
 
+    it('offers a base sport option for every editable standard preset', () => {
+        const source = readEditConfigSource();
+        const dom = new JSDOM(source);
+        const baseTypeValues = Array.from(dom.window.document.querySelectorAll('#baseType option'))
+            .map((option) => option.value);
+
+        expect(baseTypeValues).toEqual(expect.arrayContaining([
+            'Basketball',
+            'Soccer',
+            'Baseball',
+            'Softball',
+            'Football',
+            'Volleyball',
+            'Custom'
+        ]));
+    });
+
     it('wires the edit-config page to load owned-team schemas and support updates', () => {
         const source = readEditConfigSource();
 

--- a/tests/unit/edit-config-schema-workflow.test.js
+++ b/tests/unit/edit-config-schema-workflow.test.js
@@ -75,7 +75,7 @@ describe('edit config schema workflow', () => {
         const source = readEditConfigSource();
 
         expect(source).toContain("getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs");
-        expect(source).toContain("from './js/stat-config-presets.js?v=1'");
+        expect(source).toContain("from './js/stat-config-presets.js?v=2'");
         expect(source).toContain('loadImportConfigs()');
         expect(source).toContain('await updateConfig(currentTeamId, editingConfigId');
         expect(source).toContain('await resetTeamStatConfigs(currentTeamId);');

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -361,11 +361,11 @@ function extractEditTeamModule() {
             'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, getPlayerPrivateProfile, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame, getRegistrationSources, syncRegistrationProvider } = deps.db;'
         )
         .replace(
-            "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';",
+            "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=2';",
             'const { getDefaultStatConfigForSport } = deps.statConfigPresets;'
         )
         .replace(
-            "import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';",
+            "import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=2';",
             'const { buildTeamSportConfigMigrationPlan } = deps.teamStatConfigMigration;'
         )
         .replace(

--- a/tests/unit/edit-team-stat-schema-defaults.test.js
+++ b/tests/unit/edit-team-stat-schema-defaults.test.js
@@ -10,7 +10,7 @@ describe('edit team stat schema defaults', () => {
     it('uses the shared preset catalog when seeding a new team config', () => {
         const source = readEditTeamSource();
 
-        expect(source).toContain("from './js/stat-config-presets.js?v=1'");
+        expect(source).toContain("from './js/stat-config-presets.js?v=2'");
         expect(source).toContain('const defaultStatConfig = getDefaultStatConfigForSport(teamData.sport);');
         expect(source).toContain('const configId = await addConfig(newTeamId, defaultStatConfig);');
     });
@@ -18,7 +18,7 @@ describe('edit team stat schema defaults', () => {
     it('migrates stat config selection when an existing team changes sports', () => {
         const source = readEditTeamSource();
 
-        expect(source).toContain("from './js/team-stat-config-migration.js?v=1'");
+        expect(source).toContain("from './js/team-stat-config-migration.js?v=2'");
         expect(source).toContain('const [existingConfigs, existingGames] = await Promise.all([');
         expect(source).toContain('getConfigs(currentTeamId),');
         expect(source).toContain('getGames(currentTeamId)');

--- a/tests/unit/edit-team-stat-schema-defaults.test.js
+++ b/tests/unit/edit-team-stat-schema-defaults.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { getSportTemplateOptions } from '../../js/sport-templates.js';
 
 function readEditTeamSource() {
     return readFileSync(new URL('../../edit-team.html', import.meta.url), 'utf8');
@@ -27,5 +28,19 @@ describe('edit team stat schema defaults', () => {
         expect(source).toContain('statTrackerConfigId: targetConfigId');
         expect(source).toContain('sport: teamData.sport');
         expect(source).toContain('await updateTeam(currentTeamId, teamData);');
+    });
+
+    it('offers every built-in sport template in the required sport select', () => {
+        const source = readEditTeamSource();
+        const selectMatch = source.match(/<select id="sport" required[\s\S]*?<\/select>/);
+
+        expect(selectMatch).not.toBeNull();
+
+        const sportSelect = selectMatch[0];
+        const optionValues = [...sportSelect.matchAll(/<option value="([^"]+)"/g)]
+            .map(match => match[1])
+            .filter(Boolean);
+
+        expect(optionValues).toEqual(getSportTemplateOptions().map(template => template.sport));
     });
 });

--- a/tests/unit/stat-config-presets.test.js
+++ b/tests/unit/stat-config-presets.test.js
@@ -17,6 +17,7 @@ describe('stat config presets', () => {
             'basketball',
             'soccer',
             'baseball',
+            'softball',
             'football',
             'volleyball'
         ]));
@@ -46,6 +47,31 @@ describe('stat config presets', () => {
             columns: []
         }));
         expect(preset.statDefinitions).toEqual([]);
+    });
+
+    it('matches the advertised diamond sport stat templates', () => {
+        const expectedColumns = ['AB', 'H', 'R', 'RBI', 'BB', 'FP'];
+
+        expect(getDefaultStatConfigForSport('Baseball')).toEqual(expect.objectContaining({
+            name: 'Baseball Standard',
+            baseType: 'Baseball',
+            columns: expectedColumns,
+            statDefinitions: expect.arrayContaining([
+                expect.objectContaining({ id: 'ab', label: 'AB', group: 'Batting' }),
+                expect.objectContaining({ id: 'bb', label: 'BB', group: 'Plate Discipline', topStat: true }),
+                expect.objectContaining({ id: 'fp', label: 'FP', group: 'Fielding', format: 'percentage', precision: 3, topStat: true })
+            ])
+        }));
+        expect(getDefaultStatConfigForSport('softball')).toEqual(expect.objectContaining({
+            name: 'Softball Standard',
+            baseType: 'Softball',
+            columns: expectedColumns,
+            statDefinitions: expect.arrayContaining([
+                expect.objectContaining({ id: 'ab', label: 'AB', group: 'Batting' }),
+                expect.objectContaining({ id: 'bb', label: 'BB', group: 'Plate Discipline', topStat: true }),
+                expect.objectContaining({ id: 'fp', label: 'FP', group: 'Fielding', format: 'percentage', precision: 3, topStat: true })
+            ])
+        }));
     });
 
     it('serializes editable stat definitions for reload into the config form', () => {

--- a/tests/unit/stat-config-presets.test.js
+++ b/tests/unit/stat-config-presets.test.js
@@ -52,26 +52,30 @@ describe('stat config presets', () => {
     it('matches the advertised diamond sport stat templates', () => {
         const expectedColumns = ['AB', 'H', 'R', 'RBI', 'BB', 'FP'];
 
-        expect(getDefaultStatConfigForSport('Baseball')).toEqual(expect.objectContaining({
+        const baseball = getDefaultStatConfigForSport('Baseball');
+        const softball = getDefaultStatConfigForSport('softball');
+
+        expect(baseball).toEqual(expect.objectContaining({
             name: 'Baseball Standard',
             baseType: 'Baseball',
             columns: expectedColumns,
             statDefinitions: expect.arrayContaining([
                 expect.objectContaining({ id: 'ab', label: 'AB', group: 'Batting' }),
                 expect.objectContaining({ id: 'bb', label: 'BB', group: 'Plate Discipline', topStat: true }),
-                expect.objectContaining({ id: 'fp', label: 'FP', group: 'Fielding', format: 'percentage', precision: 3, topStat: true })
+                expect.objectContaining({ id: 'fp', label: 'FP', group: 'Fielding', type: 'base', format: 'number', precision: 0, topStat: true })
             ])
         }));
-        expect(getDefaultStatConfigForSport('softball')).toEqual(expect.objectContaining({
+        expect(softball).toEqual(expect.objectContaining({
             name: 'Softball Standard',
             baseType: 'Softball',
             columns: expectedColumns,
             statDefinitions: expect.arrayContaining([
                 expect.objectContaining({ id: 'ab', label: 'AB', group: 'Batting' }),
                 expect.objectContaining({ id: 'bb', label: 'BB', group: 'Plate Discipline', topStat: true }),
-                expect.objectContaining({ id: 'fp', label: 'FP', group: 'Fielding', format: 'percentage', precision: 3, topStat: true })
+                expect.objectContaining({ id: 'fp', label: 'FP', group: 'Fielding', type: 'base', format: 'number', precision: 0, topStat: true })
             ])
         }));
+
     });
 
     it('serializes editable stat definitions for reload into the config form', () => {


### PR DESCRIPTION
## Summary
- add Baseball and Softball to the required Edit Team sport selector
- add a unit guard that keeps the Edit Team sport options aligned with the built-in sport template catalog

Fixes #3842

## Validation
- `npm ci`
- `npx vitest run tests/unit/edit-team-stat-schema-defaults.test.js tests/unit/sport-templates.test.js --reporter=verbose`
