### PR TITLE
Fix public RSVP CORS origins

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7803,7 +7803,8 @@ exports._internal = {
   runWithConcurrencyLimit,
   syncNotificationRecipientForTeamUser,
   syncNotificationRecipientsForUserChange,
-  syncNotificationRecipientsForTeamChange
+  syncNotificationRecipientsForTeamChange,
+  isAllowedPublicRsvpOrigin
 };
 
 exports.sweepStaleNotificationDeviceTokens = functions.pubsub
@@ -10546,6 +10547,18 @@ exports.notifyPracticePacketCompleted = functions.firestore
 const PUBLIC_RSVP_TOKEN_TTL_DAYS = 14;
 const PUBLIC_RSVP_EMAIL_BATCH_WRITE_LIMIT = 500;
 const PUBLIC_RSVP_RESPONSES = new Set(['going', 'maybe', 'not_going']);
+const PUBLIC_RSVP_ALLOWED_ORIGINS = new Set([
+  'https://allplays.ai',
+  'https://www.allplays.ai',
+  'https://game-flow-c6311.web.app',
+  'https://game-flow-c6311.firebaseapp.com',
+  'http://localhost:8000',
+  'http://127.0.0.1:8000',
+  'http://localhost:8004',
+  'http://127.0.0.1:8004'
+]);
+const PUBLIC_RSVP_LOCAL_DEV_ORIGIN_PATTERN = /^http:\/\/(?:localhost|127\.0\.0\.1):\d+$/;
+const PUBLIC_RSVP_PREVIEW_ORIGIN_PATTERN = /^https:\/\/game-flow-c6311--[a-z0-9-]+\.web\.app$/;
 
 exports.notifyPracticePacketAssigned = functions.firestore
   .document('teams/{teamId}/practiceSessions/{sessionId}')
@@ -10556,19 +10569,17 @@ exports.notifyPracticePacketAssigned = functions.firestore
     return null;
   });
 
+function isAllowedPublicRsvpOrigin(origin) {
+  const normalizedOrigin = String(origin || '').trim();
+  if (!normalizedOrigin) return false;
+  return PUBLIC_RSVP_ALLOWED_ORIGINS.has(normalizedOrigin)
+    || PUBLIC_RSVP_LOCAL_DEV_ORIGIN_PATTERN.test(normalizedOrigin)
+    || PUBLIC_RSVP_PREVIEW_ORIGIN_PATTERN.test(normalizedOrigin);
+}
+
 function writePublicRsvpCors(req, res) {
-  const allowedOrigins = new Set([
-    'https://allplays.ai',
-    'https://www.allplays.ai',
-    'https://game-flow-c6311.web.app',
-    'https://game-flow-c6311.firebaseapp.com',
-    'http://localhost:8000',
-    'http://127.0.0.1:8000',
-    'http://localhost:8004',
-    'http://127.0.0.1:8004'
-  ]);
   const origin = req.headers.origin;
-  if (allowedOrigins.has(origin)) {
+  if (isAllowedPublicRsvpOrigin(origin)) {
     res.set('Access-Control-Allow-Origin', origin);
     res.set('Vary', 'Origin');
   }

--- a/tests/unit/public-rsvp-cors-origins.test.js
+++ b/tests/unit/public-rsvp-cors-origins.test.js
@@ -5,11 +5,11 @@ import { resolve } from 'node:path';
 const source = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
 
 function extractAllowedOrigins(functionsSource) {
-    const start = functionsSource.indexOf('function writePublicRsvpCors(');
-    expect(start, 'Expected writePublicRsvpCors to exist in functions/index.js').toBeGreaterThanOrEqual(0);
+    const start = functionsSource.indexOf('const PUBLIC_RSVP_ALLOWED_ORIGINS = new Set([');
+    expect(start, 'Expected PUBLIC_RSVP_ALLOWED_ORIGINS to exist in functions/index.js').toBeGreaterThanOrEqual(0);
 
     const setStart = functionsSource.indexOf('new Set([', start);
-    expect(setStart, 'Expected an allowedOrigins Set literal in writePublicRsvpCors').toBeGreaterThan(start);
+    expect(setStart, 'Expected PUBLIC_RSVP_ALLOWED_ORIGINS to use a Set literal').toBeGreaterThan(start);
     const setEnd = functionsSource.indexOf('])', setStart);
     expect(setEnd, 'Expected closing ]) for the allowedOrigins Set literal').toBeGreaterThan(setStart);
 
@@ -20,14 +20,48 @@ function extractAllowedOrigins(functionsSource) {
         .filter(Boolean);
 }
 
+function getPattern(patternName) {
+    const match = source.match(new RegExp(`const ${patternName} = /(.*)/;`));
+    expect(match, `Expected ${patternName} regex literal`).toBeTruthy();
+    return new RegExp(match[1]);
+}
+
 describe('public RSVP CORS origins', () => {
     const origins = extractAllowedOrigins(source);
+    const localDevPattern = getPattern('PUBLIC_RSVP_LOCAL_DEV_ORIGIN_PATTERN');
+    const previewPattern = getPattern('PUBLIC_RSVP_PREVIEW_ORIGIN_PATTERN');
 
     it('allows the production domains and Firebase Hosting default domains', () => {
         expect(origins).toContain('https://allplays.ai');
         expect(origins).toContain('https://www.allplays.ai');
         expect(origins).toContain('https://game-flow-c6311.web.app');
         expect(origins).toContain('https://game-flow-c6311.firebaseapp.com');
+    });
+
+    it('allows localhost and loopback dev origins, including Vite app ports', () => {
+        expect(localDevPattern.test('http://localhost:5174')).toBe(true);
+        expect(localDevPattern.test('http://localhost:5175')).toBe(true);
+        expect(localDevPattern.test('http://127.0.0.1:5174')).toBe(true);
+        expect(localDevPattern.test('http://127.0.0.1:5175')).toBe(true);
+    });
+
+    it('allows Firebase Hosting preview channel origins for pull requests', () => {
+        expect(previewPattern.test('https://game-flow-c6311--pr-3864.web.app')).toBe(true);
+        expect(previewPattern.test('https://game-flow-c6311--staff-rsvp-cors.web.app')).toBe(true);
+    });
+
+    it('rejects arbitrary third-party origins', () => {
+        expect(localDevPattern.test('https://localhost:5174')).toBe(false);
+        expect(localDevPattern.test('http://evil.example:5174')).toBe(false);
+        expect(previewPattern.test('https://game-flow-c6311--pr-3864.firebaseapp.com')).toBe(false);
+        expect(previewPattern.test('https://game-flow-c6311--pr-3864.example.com')).toBe(false);
+        expect(origins).not.toContain('https://evil.example');
+    });
+
+    it('uses the public RSVP origin helper from the CORS writer', () => {
+        expect(source).toContain('function isAllowedPublicRsvpOrigin(origin) {');
+        expect(source).toContain('isAllowedPublicRsvpOrigin');
+        expect(source).toContain('if (isAllowedPublicRsvpOrigin(origin)) {');
     });
 
     it('no longer allows the retired GitHub Pages origin', () => {


### PR DESCRIPTION
## Summary
- Factor public RSVP origin checks into `isAllowedPublicRsvpOrigin` for the CORS writer.
- Allow localhost/127.0.0.1 dev origins, including Vite ports 5174 and 5175.
- Allow Firebase Hosting preview-channel origins such as `game-flow-c6311--pr-*.web.app`.
- Extend the focused public RSVP CORS source contract tests for allowed and rejected origins.

Fixes #3864

## Validation
- `npx vitest run tests/unit/public-rsvp-cors-origins.test.js --reporter=verbose`
- `npx vitest run tests/unit/public-rsvp-functions-source.test.js --reporter=verbose`
- `node --check functions/index.js`