### PR TITLE
Clarify registration provider card

### DIFF
--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -395,6 +395,54 @@ describe('canManageTeamAdmins adminEmails parity with legacy js/team-access.js',
   });
 });
 
+describe('buildTeamDetailModel registration provider details', () => {
+  it('does not expose the app team id as a registration provider fallback', () => {
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: {
+        id: 'team-1',
+        name: 'Bears',
+        sport: 'Basketball'
+      },
+      players: [],
+      configs: [],
+      games: []
+    });
+
+    expect(built.team.registrationProvider).toEqual([]);
+  });
+
+  it('returns provider registration details with human labels and friendly sync state', () => {
+    const syncedAt = new Date(2026, 0, 2, 9, 30);
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: {
+        id: 'team-1',
+        name: 'Bears',
+        sport: 'Basketball',
+        registrationSource: {
+          providerName: 'LeagueApps',
+          externalTeamId: 'league-team-22',
+          teamId: 'provider-team-44',
+          lastSyncStatus: 'sync_complete',
+          lastSyncedAt: syncedAt
+        }
+      },
+      players: [],
+      configs: [],
+      games: []
+    });
+
+    expect(built.team.registrationProvider).toEqual([
+      { label: 'Provider', value: 'LeagueApps' },
+      { label: 'External team ID', value: 'league-team-22', copyable: true },
+      { label: 'Provider team ID', value: 'provider-team-44', copyable: true },
+      expect.objectContaining({ label: 'Last sync', value: expect.stringContaining('Sync Complete') })
+    ]);
+    expect(built.team.registrationProvider[3].value).toContain('Jan 2, 2026');
+  });
+});
+
 describe('buildTeamDetailModel standings', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -402,14 +402,20 @@ describe('buildTeamDetailModel registration provider details', () => {
       team: {
         id: 'team-1',
         name: 'Bears',
-        sport: 'Basketball'
+        sport: 'Basketball',
+        registrationSource: {
+          providerName: 'Sports Connect',
+          teamId: 'team-1'
+        }
       },
       players: [],
       configs: [],
       games: []
     });
 
-    expect(built.team.registrationProvider).toEqual([]);
+    expect(built.team.registrationProvider).toEqual([
+      { label: 'Provider', value: 'Sports Connect' }
+    ]);
   });
 
   it('returns provider registration details with human labels and friendly sync state', () => {
@@ -423,7 +429,7 @@ describe('buildTeamDetailModel registration provider details', () => {
         registrationSource: {
           providerName: 'LeagueApps',
           externalTeamId: 'league-team-22',
-          teamId: 'provider-team-44',
+          teamId: 'team-1',
           lastSyncStatus: 'sync_complete',
           lastSyncedAt: syncedAt
         }
@@ -436,10 +442,32 @@ describe('buildTeamDetailModel registration provider details', () => {
     expect(built.team.registrationProvider).toEqual([
       { label: 'Provider', value: 'LeagueApps' },
       { label: 'External team ID', value: 'league-team-22', copyable: true },
-      { label: 'Provider team ID', value: 'provider-team-44', copyable: true },
       expect.objectContaining({ label: 'Last sync', value: expect.stringContaining('Sync Complete') })
     ]);
-    expect(built.team.registrationProvider[3].value).toContain('Jan 2, 2026');
+    expect(built.team.registrationProvider[2].value).toContain('Jan 2, 2026');
+  });
+
+  it('keeps a legacy provider-specific teamId when it is not the app team id', () => {
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: {
+        id: 'team-1',
+        name: 'Bears',
+        sport: 'Basketball',
+        registrationSource: {
+          providerName: 'LeagueApps',
+          teamId: 'provider-team-44'
+        }
+      },
+      players: [],
+      configs: [],
+      games: []
+    });
+
+    expect(built.team.registrationProvider).toEqual([
+      { label: 'Provider', value: 'LeagueApps' },
+      { label: 'Provider team ID', value: 'provider-team-44', copyable: true }
+    ]);
   });
 });
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -2201,10 +2201,16 @@ function getRegistrationProviderDetails(team: Record<string, any>) {
   const source = team?.registrationSource || team?.registrationProvider || {};
   const lastSyncStatus = cleanString(source.lastSyncStatus || source.syncStatus);
   const lastSyncTime = formatRegistrationProviderSyncTime(source.lastSyncedAt || source.lastSyncAt || source.syncedAt || source.updatedAt);
+  const appTeamId = cleanString(team?.id || team?.teamId);
+  const externalTeamId = cleanString(source.externalTeamId || source.externalTeamID || source.providerTeamId || source.providerTeamID || source.sourceTeamId);
+  const sourceTeamId = cleanString(source.teamId);
+  const legacyProviderTeamId = sourceTeamId && sourceTeamId !== appTeamId && sourceTeamId !== externalTeamId
+    ? sourceTeamId
+    : '';
   const rows = [
     { label: 'Provider', value: cleanString(source.provider || source.providerName) },
-    { label: 'External team ID', value: cleanString(source.externalTeamId), copyable: true },
-    { label: 'Provider team ID', value: cleanString(source.teamId), copyable: true },
+    { label: 'External team ID', value: externalTeamId, copyable: true },
+    { label: 'Provider team ID', value: legacyProviderTeamId, copyable: true },
     { label: 'Last sync', value: formatRegistrationProviderSyncDetail(lastSyncStatus, lastSyncTime) }
   ].filter((row) => row.value);
   return rows;

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -266,7 +266,7 @@ export type TeamDetailModel = {
     websiteUrl: string;
     editTeamUrl: string;
     mediaUrl: string;
-    registrationProvider: Array<{ label: string; value: string }>;
+    registrationProvider: Array<{ label: string; value: string; copyable?: boolean }>;
     scheduleNotifications: TeamScheduleNotificationSettings;
   };
   players: TeamDetailPlayer[];
@@ -1661,7 +1661,7 @@ export function buildTeamDetailModel({
       websiteUrl: getPublicHashUrl('team.html', teamId),
       editTeamUrl: getPublicHashUrl('edit-team.html', teamId),
       mediaUrl: getPublicHashUrl('team-media.html', teamId),
-      registrationProvider: getRegistrationProviderDetails(team, teamId),
+      registrationProvider: getRegistrationProviderDetails(team),
       scheduleNotifications: normalizeTeamScheduleNotifications(team?.scheduleNotifications)
     },
     players: normalizedPlayers,
@@ -2197,15 +2197,45 @@ function normalizeSponsorList(sponsors: any[]): TeamDetailSponsor[] {
     .filter((sponsor) => sponsor.id || sponsor.name);
 }
 
-function getRegistrationProviderDetails(team: Record<string, any>, teamId: string) {
+function getRegistrationProviderDetails(team: Record<string, any>) {
   const source = team?.registrationSource || team?.registrationProvider || {};
+  const lastSyncStatus = cleanString(source.lastSyncStatus || source.syncStatus);
+  const lastSyncTime = formatRegistrationProviderSyncTime(source.lastSyncedAt || source.lastSyncAt || source.syncedAt || source.updatedAt);
   const rows = [
     { label: 'Provider', value: cleanString(source.provider || source.providerName) },
-    { label: 'External Team ID', value: cleanString(source.externalTeamId) },
-    { label: 'Team ID', value: cleanString(source.teamId || teamId) },
-    { label: 'Last Sync', value: cleanString(source.lastSyncStatus || source.syncStatus) }
+    { label: 'External team ID', value: cleanString(source.externalTeamId), copyable: true },
+    { label: 'Provider team ID', value: cleanString(source.teamId), copyable: true },
+    { label: 'Last sync', value: formatRegistrationProviderSyncDetail(lastSyncStatus, lastSyncTime) }
   ].filter((row) => row.value);
   return rows;
+}
+
+function formatRegistrationProviderSyncDetail(status: string, time: string) {
+  const friendlyStatus = humanizeRegistrationProviderStatus(status);
+  if (friendlyStatus && time) return `${friendlyStatus} · ${time}`;
+  return friendlyStatus || time;
+}
+
+function humanizeRegistrationProviderStatus(status: string) {
+  const value = cleanString(status);
+  if (!value) return '';
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatRegistrationProviderSyncTime(value: any) {
+  const date = toNullableDate(value);
+  if (!date) return '';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
 }
 
 function getStreamUrl(team: Record<string, any>) {
@@ -2247,6 +2277,18 @@ function toDate(value: any) {
   if (typeof value?.seconds === 'number') return new Date(value.seconds * 1000);
   const date = new Date(value || Date.now());
   return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function toNullableDate(value: any) {
+  if (!value) return null;
+  const date = value instanceof Date
+    ? value
+    : typeof value?.toDate === 'function'
+      ? value.toDate()
+      : typeof value?.seconds === 'number'
+        ? new Date(value.seconds * 1000)
+        : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 function toNullableNumber(value: any) {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -626,6 +626,61 @@ describe('TeamDetail', () => {
     await waitFor(() => expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' }));
   });
 
+  it('does not render the registration provider card when provider rows are empty', async () => {
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      team: { ...model.team, registrationProvider: [] }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=more']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(screen.getByText('Team links')).toBeTruthy();
+    expect(screen.queryByText('Registration provider')).toBeNull();
+  });
+
+  it('renders registration provider context and copy buttons for provider ids', async () => {
+    const { copyPublicText } = await import('../lib/publicActions');
+    vi.mocked(copyPublicText).mockResolvedValue('copied');
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      team: {
+        ...model.team,
+        registrationProvider: [
+          { label: 'Provider', value: 'LeagueApps' },
+          { label: 'External team ID', value: 'league-team-22', copyable: true },
+          { label: 'Provider team ID', value: 'provider-team-44', copyable: true },
+          { label: 'Last sync', value: 'Sync Complete · Jan 2, 2026, 9:30 AM' }
+        ]
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=more']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Registration provider')).toBeTruthy();
+    expect(screen.getByText('LeagueApps syncs registrations from an external provider.')).toBeTruthy();
+    expect(screen.getByText('External team ID')).toBeTruthy();
+    expect(screen.getByText('Provider team ID')).toBeTruthy();
+    expect(screen.getByText('Sync Complete · Jan 2, 2026, 9:30 AM')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Provider team ID' }));
+
+    await waitFor(() => expect(copyPublicText).toHaveBeenCalledWith('provider-team-44'));
+    expect((await screen.findByRole('status')).textContent).toContain('Provider team ID copied.');
+  });
+
   it('steps back to team overview before leaving the team hub', async () => {
     const router = createMemoryRouter(
       [

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -1588,9 +1588,16 @@ function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loadin
 
 function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, sponsorsLoading, sponsorsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; sponsorsLoading: boolean; sponsorsError: string; onTeamDetailRefresh: () => Promise<void> }) {
   const statTrackerConfigs = model.statTrackerConfigs || [];
+  const [registrationProviderCopyStatus, setRegistrationProviderCopyStatus] = useState<{ label: string; success: boolean } | null>(null);
   const orphanedConfigAssignments = model.canManageTeam
     ? model.upcomingEvents.filter((event) => event.type === 'game' && event.statTrackerConfigId && !event.statTrackerConfigExists)
     : [];
+  const registrationProviderName = model.team.registrationProvider.find((row) => row.label === 'Provider')?.value || 'This team';
+
+  async function copyRegistrationProviderValue(row: TeamDetailModel['team']['registrationProvider'][number]) {
+    const result = await copyPublicText(row.value);
+    setRegistrationProviderCopyStatus({ label: row.label, success: result === 'copied' });
+  }
 
   return (
     <div className="space-y-4">
@@ -1635,14 +1642,28 @@ function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, 
       {model.team.registrationProvider.length ? (
         <section className="app-card p-4">
           <div className="text-sm font-black text-gray-950">Registration provider</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">{registrationProviderName} syncs registrations from an external provider.</div>
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
             {model.team.registrationProvider.map((row) => (
               <div key={row.label} className="rounded-xl border border-blue-100 bg-blue-50 p-3">
                 <div className="text-[11px] font-black uppercase tracking-[0.04em] text-blue-700">{row.label}</div>
-                <div className="mt-1 break-all text-sm font-black text-gray-950">{row.value}</div>
+                <div className="mt-1 flex items-start justify-between gap-2">
+                  <div className="min-w-0 break-all text-sm font-black text-gray-950">{row.value}</div>
+                  {row.copyable ? (
+                    <button type="button" className="secondary-button !min-h-8 shrink-0 px-2 text-xs" onClick={() => copyRegistrationProviderValue(row)} aria-label={`Copy ${row.label}`}>
+                      <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+                      Copy
+                    </button>
+                  ) : null}
+                </div>
               </div>
             ))}
           </div>
+          {registrationProviderCopyStatus ? (
+            <div className={`mt-2 text-xs font-black ${registrationProviderCopyStatus.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">
+              {registrationProviderCopyStatus.success ? `${registrationProviderCopyStatus.label} copied.` : `Unable to copy ${registrationProviderCopyStatus.label}.`}
+            </div>
+          ) : null}
         </section>
       ) : null}
 

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -764,7 +764,7 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Tournament bracket')).toBeVisible();
         await expect(page.getByText('Open official bracket.')).toBeVisible();
         await expect(page.getByText('League page')).toBeVisible();
-        await expect(page.getByText('Sports Connect')).toBeVisible();
+        await expect(page.getByText('Sports Connect', { exact: true })).toBeVisible();
         await expect(page.getByText('Pizza Place')).toBeVisible();
         await page.getByRole('link', { name: /Watch stream/ }).click();
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://youtube.example.test/watch');

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -840,8 +840,8 @@ describe('React app team detail model', () => {
         expect(model.team.mediaUrl).toBe('https://allplays.ai/team-media.html#teamId=team%2Fwith+slash');
         expect(model.team.registrationProvider).toEqual([
             { label: 'Provider', value: 'League Apps' },
-            { label: 'Team ID', value: 'remote-team-1' },
-            { label: 'Last Sync', value: 'ok' }
+            { label: 'Provider team ID', value: 'remote-team-1', copyable: true },
+            { label: 'Last sync', value: 'Ok' }
         ]);
         expect(model.players.map((player) => player.id)).toEqual(['player-2', 'player-10']);
         expect(model.linkedPlayers.map((player) => player.id)).toEqual(['player-2', 'player-10']);


### PR DESCRIPTION
## Summary
- Stop showing the app team ID as a fallback registration provider row when no provider source exists.
- Add clearer registration provider labels, friendly last-sync text, and copy buttons for provider ID rows.
- Cover empty and populated provider states in service and TeamDetail tests.

Fixes #3856

## Validation
- npx vitest run apps/app/src/lib/teamDetailService.test.ts --reporter=verbose
- npx vitest run apps/app/src/pages/TeamDetail.test.tsx --reporter=verbose
- npm run app:build

Note: focused Vitest runs still log existing missing Firebase vendor sourcemap / Firebase trace warnings, but the suites pass.