### PR TITLE
Invalidate schedule RSVP cache after availability writes

### DIFF
--- a/apps/app/src/lib/appDataCache.ts
+++ b/apps/app/src/lib/appDataCache.ts
@@ -12,6 +12,7 @@ const defaultMaxStaleMs = 24 * 60 * 60 * 1000;
 const storagePrefix = 'allplays:appDataCache:';
 const cache = new Map<string, CacheEntry<unknown>>();
 let cacheInvalidationVersion = 0;
+const cacheKeyInvalidationVersions = new Map<string, number>();
 const logger = createLogger('app-data-cache');
 
 type LoadCachedAppDataOptions<T> = {
@@ -32,6 +33,10 @@ type StoredCacheEntry = {
 
 export function getParentScheduleSummaryCacheKey(userId: string) {
   return `app-schedule-summary:${userId}`;
+}
+
+export function getParentHomeSecondaryCacheKey(userId: string) {
+  return `home-secondary:${userId}`;
 }
 
 export function getCachedAppData<T>(key: string, { maxStaleMs = defaultMaxStaleMs }: { maxStaleMs?: number } = {}): T | null {
@@ -100,7 +105,7 @@ export function clearAppDataCache(prefix = '') {
 }
 
 export function invalidateCachedAppData(key: string) {
-  cacheInvalidationVersion += 1;
+  cacheKeyInvalidationVersions.set(key, getCacheKeyInvalidationVersion(key) + 1);
   cache.delete(key);
   removeStoredCacheEntry(key);
 }
@@ -117,8 +122,12 @@ function loadAndStoreCachedAppData<T>(
   }: { ttlMs: number; persist: boolean; onRefresh?: (value: T) => void; shouldCache?: (value: T) => boolean }
 ) {
   const loadInvalidationVersion = cacheInvalidationVersion;
+  const loadKeyInvalidationVersion = getCacheKeyInvalidationVersion(key);
   const promise = loader().then((value) => {
-    if (loadInvalidationVersion !== cacheInvalidationVersion) {
+    if (
+      loadInvalidationVersion !== cacheInvalidationVersion
+      || loadKeyInvalidationVersion !== getCacheKeyInvalidationVersion(key)
+    ) {
       const current = cache.get(key);
       if (current?.promise === promise) {
         if (existing && hasCachedValue(existing)) {
@@ -181,6 +190,10 @@ function loadAndStoreCachedAppData<T>(
     hydratedFromStorage: existing?.hydratedFromStorage
   });
   return promise;
+}
+
+function getCacheKeyInvalidationVersion(key: string) {
+  return cacheKeyInvalidationVersions.get(key) ?? 0;
 }
 
 function hydrateMemoryCache<T>(key: string, now: number, maxStaleMs: number) {

--- a/apps/app/src/lib/appDataCache.ts
+++ b/apps/app/src/lib/appDataCache.ts
@@ -99,6 +99,12 @@ export function clearAppDataCache(prefix = '') {
   removeStoredCacheEntries(prefix);
 }
 
+export function invalidateCachedAppData(key: string) {
+  cacheInvalidationVersion += 1;
+  cache.delete(key);
+  removeStoredCacheEntry(key);
+}
+
 function loadAndStoreCachedAppData<T>(
   key: string,
   loader: () => Promise<T>,
@@ -249,6 +255,12 @@ function removeStoredCacheEntries(prefix: string) {
       storage.removeItem(key);
     }
   }
+}
+
+function removeStoredCacheEntry(key: string) {
+  const storage = getCacheStorage();
+  if (!storage) return;
+  storage.removeItem(toStorageKey(key));
 }
 
 function getCacheStorage() {

--- a/apps/app/src/lib/appDataCache.ts
+++ b/apps/app/src/lib/appDataCache.ts
@@ -207,6 +207,8 @@ function hydrateMemoryCache<T>(key: string, now: number, maxStaleMs: number) {
 }
 
 function readStoredCacheEntry<T>(key: string, now: number, maxStaleMs: number): CacheEntry<T> | null {
+  if (getCacheKeyInvalidationVersion(key) > 0) return null;
+
   const storage = getCacheStorage();
   if (!storage) return null;
 
@@ -260,20 +262,28 @@ function removeStoredCacheEntries(prefix: string) {
   const storage = getCacheStorage();
   if (!storage) return;
 
-  for (let index = storage.length - 1; index >= 0; index -= 1) {
-    const key = storage.key(index);
-    if (!key?.startsWith(storagePrefix)) continue;
-    const cacheKey = fromStorageKey(key);
-    if (!prefix || cacheKey.startsWith(prefix)) {
-      storage.removeItem(key);
+  try {
+    for (let index = storage.length - 1; index >= 0; index -= 1) {
+      const key = storage.key(index);
+      if (!key?.startsWith(storagePrefix)) continue;
+      const cacheKey = fromStorageKey(key);
+      if (!prefix || cacheKey.startsWith(prefix)) {
+        storage.removeItem(key);
+      }
     }
+  } catch (error) {
+    logger.warn('Unable to remove cached data.', { error });
   }
 }
 
 function removeStoredCacheEntry(key: string) {
   const storage = getCacheStorage();
   if (!storage) return;
-  storage.removeItem(toStorageKey(key));
+  try {
+    storage.removeItem(toStorageKey(key));
+  } catch (error) {
+    logger.warn('Unable to remove cached data.', { error });
+  }
 }
 
 function getCacheStorage() {

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -8,7 +8,7 @@ import {
   type ParentHomeModel
 } from './homeLogic';
 import { createLogger } from './logger';
-import { getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
+import { getParentHomeSecondaryCacheKey, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
 import { toAppServiceError, type AppServiceError } from './appErrors';
 import {
   hydrateParentScheduleDetails,
@@ -157,7 +157,7 @@ export async function loadParentHomeWithSecondaryData(
   }
 
   const onPartial = typeof options.onPartial === 'function' ? options.onPartial : null;
-  const cacheKey = `home-secondary:${user.uid}`;
+  const cacheKey = getParentHomeSecondaryCacheKey(user.uid);
   return loadCachedAppData(cacheKey, async () => {
     const schedule = options.schedule || await loadParentScheduleSummary(user, { force: options.force });
     const { children, events } = schedule;

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -208,13 +208,14 @@ vi.mock('./appDataCache', () => ({
   getCachedAppData: vi.fn(),
   loadCachedAppData: vi.fn((_key: string, loader: () => Promise<unknown>) => loader()),
   clearAppDataCache: vi.fn(),
+  invalidateCachedAppData: vi.fn(),
   getParentScheduleSummaryCacheKey: (userId: string) => `app-schedule-summary:${userId}`
 }));
 
 import { addGame, addPractice, broadcastLiveEvent, buildSingleLegacyTournamentGameDocument, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getTeam, getTeams, listRideOffersForEvent, submitRsvp, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
 import { getNativeAuthIdToken } from './authService';
 import { expandRecurrence, fetchAndParseCalendar, isTeamActive, mergeAssignmentsWithClaims } from './adapters/legacyScheduleHelpers';
-import { getCachedAppData, loadCachedAppData } from './appDataCache';
+import { getCachedAppData, invalidateCachedAppData, loadCachedAppData } from './appDataCache';
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
 import { getScheduleTournamentInfo } from './scheduleLogic';
@@ -2338,6 +2339,7 @@ describe('parent family RSVP submission', () => {
       response: 'going',
       note: 'Both need a ride'
     });
+    expect(invalidateCachedAppData).toHaveBeenCalledWith('app-schedule-summary:parent-1');
     expect(mocks.runTransactionMock).not.toHaveBeenCalled();
     expect(submitRsvpForPlayer).not.toHaveBeenCalled();
   });
@@ -2575,6 +2577,7 @@ describe('staff RSVP management', () => {
       playerId: 'player-override',
       response: 'going'
     }));
+    expect(invalidateCachedAppData).toHaveBeenCalledWith('app-schedule-summary:coach-1');
     expect(submitRsvpForPlayer).not.toHaveBeenCalledWith('team-1', 'game-1', 'coach-1', expect.objectContaining({
       playerId: 'child-event-player'
     }));

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -209,6 +209,7 @@ vi.mock('./appDataCache', () => ({
   loadCachedAppData: vi.fn((_key: string, loader: () => Promise<unknown>) => loader()),
   clearAppDataCache: vi.fn(),
   invalidateCachedAppData: vi.fn(),
+  getParentHomeSecondaryCacheKey: (userId: string) => `home-secondary:${userId}`,
   getParentScheduleSummaryCacheKey: (userId: string) => `app-schedule-summary:${userId}`
 }));
 
@@ -219,7 +220,7 @@ import { getCachedAppData, invalidateCachedAppData, loadCachedAppData } from './
 import { mapScheduleEventRecord } from './firestore/mappers';
 import { loadProfileDocument } from './profileService';
 import { getScheduleTournamentInfo } from './scheduleLogic';
-import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
+import { adjustGameScore, buildPlayerScoringLiveEvent, buildSingleGameTournamentLegacySchedulePayload, claimOfficialAssignmentItem, createScheduledGameForApp, createScheduledPracticeForApp, createScheduledTournamentBlockForApp, createStaffRsvpAvailabilityLoader, flushPendingLivePublishOperations, hydrateParentScheduleDetails, loadOfficialAssignments, loadParentSchedule, loadParentScheduleChildren, loadParentScheduleEventDetail, loadScheduledPracticeSeriesForEdit, loadStaffPracticeAttendance, loadStaffScheduleRsvpBreakdown, publishLiveScoreUpdateEvent, recordPlayerGameStat, recordPlayerScoringStat, releaseParentScheduleAssignmentClaim, resolveCachedParentScheduleEvents, resolveLiveGameClockSnapshot, resolveParentGameRoute, respondToOfficialAssignmentItem, revertScheduledPracticeOccurrenceForApp, saveScheduledGameLineupDraftForApp, saveStaffPracticeAttendance, submitParentScheduleRsvp, submitParentScheduleRsvpForChildren, submitStaffScheduleRsvpOverride, TournamentBlockPartialSaveError, undoRecordedPlayerGameStat, updateLiveGameClockState, updateScheduledPracticeForApp } from './scheduleService';
 
 function playerSnapshot(id: string, data: Record<string, unknown> | null) {
   return {
@@ -2311,6 +2312,32 @@ describe('parent family RSVP submission', () => {
     } as any;
   });
 
+  it('invalidates schedule and Home caches after a single-child RSVP succeeds', async () => {
+    const summary = { going: 1, maybe: 0, notGoing: 0, notResponded: 0, total: 1 };
+    vi.mocked(submitRsvpForPlayer).mockResolvedValue(summary as any);
+
+    await expect(submitParentScheduleRsvp(baseEvent, user as any, 'going', 'On time')).resolves.toEqual(summary);
+
+    expect(submitRsvpForPlayer).toHaveBeenCalledWith('team-1', 'game-1', 'parent-1', {
+      displayName: 'Parent One',
+      playerId: 'player-1',
+      response: 'going',
+      note: 'On time'
+    });
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(1, 'app-schedule-summary:parent-1');
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(2, 'home-secondary:parent-1');
+    expect(invalidateCachedAppData).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps cached schedule data when a single-child RSVP write fails', async () => {
+    const writeError = new Error('RSVP write failed');
+    vi.mocked(submitRsvpForPlayer).mockRejectedValueOnce(writeError);
+
+    await expect(submitParentScheduleRsvp(baseEvent, user as any, 'maybe')).rejects.toBe(writeError);
+
+    expect(invalidateCachedAppData).not.toHaveBeenCalled();
+  });
+
   afterEach(() => {
     if (previousWindow === undefined) {
       delete (globalThis as any).window;
@@ -2356,6 +2383,7 @@ describe('parent family RSVP submission', () => {
     ], user as any, 'maybe')).rejects.toBe(commitError);
 
     expect(submitRsvp).toHaveBeenCalledTimes(1);
+    expect(invalidateCachedAppData).not.toHaveBeenCalled();
     expect(mocks.runTransactionMock).not.toHaveBeenCalled();
   });
 

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2326,7 +2326,8 @@ describe('parent family RSVP submission', () => {
     });
     expect(invalidateCachedAppData).toHaveBeenNthCalledWith(1, 'app-schedule-summary:parent-1');
     expect(invalidateCachedAppData).toHaveBeenNthCalledWith(2, 'home-secondary:parent-1');
-    expect(invalidateCachedAppData).toHaveBeenCalledTimes(2);
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(3, 'event-details:team-1:game-1');
+    expect(invalidateCachedAppData).toHaveBeenCalledTimes(3);
   });
 
   it('keeps cached schedule data when a single-child RSVP write fails', async () => {
@@ -2368,7 +2369,8 @@ describe('parent family RSVP submission', () => {
     });
     expect(invalidateCachedAppData).toHaveBeenNthCalledWith(1, 'app-schedule-summary:parent-1');
     expect(invalidateCachedAppData).toHaveBeenNthCalledWith(2, 'home-secondary:parent-1');
-    expect(invalidateCachedAppData).toHaveBeenCalledTimes(2);
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(3, 'event-details:team-1:game-1');
+    expect(invalidateCachedAppData).toHaveBeenCalledTimes(3);
     expect(mocks.runTransactionMock).not.toHaveBeenCalled();
     expect(submitRsvpForPlayer).not.toHaveBeenCalled();
   });
@@ -2609,7 +2611,8 @@ describe('staff RSVP management', () => {
     }));
     expect(invalidateCachedAppData).toHaveBeenNthCalledWith(1, 'app-schedule-summary:coach-1');
     expect(invalidateCachedAppData).toHaveBeenNthCalledWith(2, 'home-secondary:coach-1');
-    expect(invalidateCachedAppData).toHaveBeenCalledTimes(2);
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(3, 'event-details:team-1:game-1');
+    expect(invalidateCachedAppData).toHaveBeenCalledTimes(3);
     expect(submitRsvpForPlayer).not.toHaveBeenCalledWith('team-1', 'game-1', 'coach-1', expect.objectContaining({
       playerId: 'child-event-player'
     }));

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2339,7 +2339,9 @@ describe('parent family RSVP submission', () => {
       response: 'going',
       note: 'Both need a ride'
     });
-    expect(invalidateCachedAppData).toHaveBeenCalledWith('app-schedule-summary:parent-1');
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(1, 'app-schedule-summary:parent-1');
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(2, 'home-secondary:parent-1');
+    expect(invalidateCachedAppData).toHaveBeenCalledTimes(2);
     expect(mocks.runTransactionMock).not.toHaveBeenCalled();
     expect(submitRsvpForPlayer).not.toHaveBeenCalled();
   });
@@ -2577,7 +2579,9 @@ describe('staff RSVP management', () => {
       playerId: 'player-override',
       response: 'going'
     }));
-    expect(invalidateCachedAppData).toHaveBeenCalledWith('app-schedule-summary:coach-1');
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(1, 'app-schedule-summary:coach-1');
+    expect(invalidateCachedAppData).toHaveBeenNthCalledWith(2, 'home-secondary:coach-1');
+    expect(invalidateCachedAppData).toHaveBeenCalledTimes(2);
     expect(submitRsvpForPlayer).not.toHaveBeenCalledWith('team-1', 'game-1', 'coach-1', expect.objectContaining({
       playerId: 'child-event-player'
     }));

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -150,10 +150,15 @@ const scheduleHydrationCacheTtlMs = 30 * 1000;
 const parentHomeHydrationLookAheadMs = 14 * 24 * 60 * 60 * 1000;
 const parentHomeHydrationLookBehindMs = 12 * 60 * 60 * 1000;
 
-function invalidateParentScheduleSummaryCache(user: AuthUser | null | undefined) {
+function getParentHomeSecondaryCacheKey(userId: string) {
+  return `home-secondary:${userId}`;
+}
+
+function invalidateParentScheduleCaches(user: AuthUser | null | undefined) {
   const userId = compactString(user?.uid);
   if (!userId) return;
   invalidateCachedAppData(getParentScheduleSummaryCacheKey(userId));
+  invalidateCachedAppData(getParentHomeSecondaryCacheKey(userId));
 }
 // Default games window for schedule views: ~13 months covers the current and
 // previous season so the "Past Events" filter still shows recent history before
@@ -1888,7 +1893,7 @@ export async function createScheduledGameForApp(
   if (options.requireCreatedId && !createdId) {
     throw new Error('Tournament game save failed because no game id was returned.');
   }
-  invalidateParentScheduleSummaryCache(user);
+  invalidateParentScheduleCaches(user);
   return createdId;
 }
 
@@ -1953,7 +1958,7 @@ export async function updateScheduledGameForApp(teamId: string, gameId: string, 
     logScheduleWarning('Falling back to REST scheduled game update.', 'scheduled-game-update', error, { fallback: 'rest', teamId: normalizedTeamId, gameId: normalizedGameId });
     await nativePatchDocument(`teams/${encodeURIComponent(normalizedTeamId)}/games/${encodeURIComponent(normalizedGameId)}`, payload);
   }
-  invalidateParentScheduleSummaryCache(user);
+  invalidateParentScheduleCaches(user);
   return { updated: true, eventId: normalizedGameId };
 }
 
@@ -2050,7 +2055,7 @@ export async function createScheduledPracticeForApp(teamId: string, input: Sched
 
   try {
     const createdId = await withTimeout(Promise.resolve(addPractice(normalizedTeamId, payload)), 'Scheduled practice create');
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return createdId;
   } catch (error) {
     if (!isNativeRuntime()) throw error;
@@ -2059,7 +2064,7 @@ export async function createScheduledPracticeForApp(teamId: string, input: Sched
       ...buildNativePracticePatchPayload(input, user as AuthUser),
       createdAt: new Date()
     });
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return doc?.id || '';
   }
 }
@@ -2093,7 +2098,7 @@ export async function updateScheduledPracticeForApp(teamId: string, input: Sched
         updatedBy: (user as AuthUser).uid
       });
     }
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return { updated: true, scope, eventId: occurrence.masterId, instanceDate: occurrence.instanceDate };
   }
 
@@ -2115,7 +2120,7 @@ export async function updateScheduledPracticeForApp(teamId: string, input: Sched
       updatedBy: (user as AuthUser).uid
     });
   }
-  invalidateParentScheduleSummaryCache(user);
+  invalidateParentScheduleCaches(user);
   return { updated: true, scope, eventId: normalizedEventId };
 }
 
@@ -2137,7 +2142,7 @@ export async function revertScheduledPracticeOccurrenceForApp(teamId: string, ev
       updatedBy: (user as AuthUser).uid
     });
   }
-  invalidateParentScheduleSummaryCache(user);
+  invalidateParentScheduleCaches(user);
   return { reverted: true, eventId: occurrence.masterId, instanceDate: occurrence.instanceDate };
 }
 
@@ -2192,7 +2197,7 @@ export async function createScheduleImportGame(teamId: string, row: ScheduleImpo
 
   try {
     const createdId = await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Schedule import game create');
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return createdId;
   } catch (error) {
     if (!isNativeRuntime()) throw error;
@@ -2201,7 +2206,7 @@ export async function createScheduleImportGame(teamId: string, row: ScheduleImpo
       ...payload,
       createdAt: new Date()
     });
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return doc?.id || '';
   }
 }
@@ -2233,7 +2238,7 @@ export async function createScheduleImportPractice(teamId: string, row: Schedule
 
   try {
     const createdId = await withTimeout(Promise.resolve(addPractice(normalizedTeamId, payload)), 'Schedule import practice create');
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return createdId;
   } catch (error) {
     if (!isNativeRuntime()) throw error;
@@ -2242,7 +2247,7 @@ export async function createScheduleImportPractice(teamId: string, row: Schedule
       ...payload,
       createdAt: new Date()
     });
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return doc?.id || '';
   }
 }
@@ -4182,7 +4187,7 @@ export async function submitStaffScheduleRsvpOverride(event: ParentScheduleEvent
     await nativeSubmitRsvpForPlayer(event.teamId, event.id, user!, normalizedPlayerId, response, '', event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
   }
 
-  invalidateParentScheduleSummaryCache(user);
+  invalidateParentScheduleCaches(user);
   return {
     playerId: normalizedPlayerId,
     response
@@ -4207,7 +4212,7 @@ export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user:
       response,
       note: compactString(note) || null
     })), 'RSVP submit');
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return result;
   } catch (error) {
     if (!isNativeRuntime()) {
@@ -4215,7 +4220,7 @@ export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user:
     }
     logScheduleWarning('Falling back to REST RSVP submit.', 'parent-rsvp-submit', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id, childId: event.childId });
     const result = await nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note, event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return result;
   }
 }
@@ -4255,7 +4260,7 @@ export async function submitParentScheduleRsvpForChildren(events: ParentSchedule
       response,
       note: compactString(note) || null
     })), 'Family RSVP submit');
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return result;
   } catch (error) {
     if (!isNativeRuntime()) {
@@ -4263,7 +4268,7 @@ export async function submitParentScheduleRsvpForChildren(events: ParentSchedule
     }
     logScheduleWarning('Falling back to REST family RSVP submit.', 'parent-family-rsvp-submit', error, { fallback: 'rest', teamId: firstEvent.teamId, gameId: firstEvent.id, childIds });
     const result = await nativeSubmitRsvpForChildren(firstEvent.teamId, firstEvent.id, user, childIds, response, note, firstEvent.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
-    invalidateParentScheduleSummaryCache(user);
+    invalidateParentScheduleCaches(user);
     return result;
   }
 }
@@ -5771,7 +5776,7 @@ export async function cancelScheduledGameForApp(event: ParentScheduleEvent, user
 
   const notificationError = notificationFailures.length > 0 ? notificationFailures.join('; ') : null;
 
-  invalidateParentScheduleSummaryCache(user);
+  invalidateParentScheduleCaches(user);
   return {
     cancelled: true,
     notificationError
@@ -5812,7 +5817,7 @@ export async function cancelPracticeOccurrenceForApp(event: ParentScheduleEvent,
     });
   }
 
-  invalidateParentScheduleSummaryCache(user);
+  invalidateParentScheduleCaches(user);
   return {
     cancelled: true,
     masterId: occurrence.masterId,

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -150,11 +150,24 @@ const scheduleHydrationCacheTtlMs = 30 * 1000;
 const parentHomeHydrationLookAheadMs = 14 * 24 * 60 * 60 * 1000;
 const parentHomeHydrationLookBehindMs = 12 * 60 * 60 * 1000;
 
-function invalidateParentScheduleCaches(user: AuthUser | null | undefined) {
+function getScheduleEventHydrationCacheKey(teamId: string, eventId: string) {
+  return `event-details:${teamId}:${eventId}`;
+}
+
+function invalidateParentScheduleCaches(
+  user: AuthUser | null | undefined,
+  event?: Pick<ParentScheduleEvent, 'teamId' | 'id'> | null
+) {
   const userId = compactString(user?.uid);
-  if (!userId) return;
-  invalidateCachedAppData(getParentScheduleSummaryCacheKey(userId));
-  invalidateCachedAppData(getParentHomeSecondaryCacheKey(userId));
+  if (userId) {
+    invalidateCachedAppData(getParentScheduleSummaryCacheKey(userId));
+    invalidateCachedAppData(getParentHomeSecondaryCacheKey(userId));
+  }
+  const teamId = compactString(event?.teamId);
+  const eventId = compactString(event?.id);
+  if (teamId && eventId) {
+    invalidateCachedAppData(getScheduleEventHydrationCacheKey(teamId, eventId));
+  }
 }
 // Default games window for schedule views: ~13 months covers the current and
 // previous season so the "Past Events" filter still shows recent history before
@@ -3649,7 +3662,7 @@ function shouldEagerlyHydrateParentHomeEvent(event: ParentScheduleEvent, nowMs =
 
 function loadCachedEventHydrationDetails(teamId: string, gameId: string) {
   return loadCachedAppData(
-    `event-details:${teamId}:${gameId}`,
+    getScheduleEventHydrationCacheKey(teamId, gameId),
     async () => {
       const results = await Promise.allSettled([
         loadRsvps(teamId, gameId),
@@ -4183,7 +4196,7 @@ export async function submitStaffScheduleRsvpOverride(event: ParentScheduleEvent
     await nativeSubmitRsvpForPlayer(event.teamId, event.id, user!, normalizedPlayerId, response, '', event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
   }
 
-  invalidateParentScheduleCaches(user);
+  invalidateParentScheduleCaches(user, event);
   return {
     playerId: normalizedPlayerId,
     response
@@ -4208,7 +4221,7 @@ export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user:
       response,
       note: compactString(note) || null
     })), 'RSVP submit');
-    invalidateParentScheduleCaches(user);
+    invalidateParentScheduleCaches(user, event);
     return result;
   } catch (error) {
     if (!isNativeRuntime()) {
@@ -4216,7 +4229,7 @@ export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user:
     }
     logScheduleWarning('Falling back to REST RSVP submit.', 'parent-rsvp-submit', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id, childId: event.childId });
     const result = await nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note, event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
-    invalidateParentScheduleCaches(user);
+    invalidateParentScheduleCaches(user, event);
     return result;
   }
 }
@@ -4256,7 +4269,7 @@ export async function submitParentScheduleRsvpForChildren(events: ParentSchedule
       response,
       note: compactString(note) || null
     })), 'Family RSVP submit');
-    invalidateParentScheduleCaches(user);
+    invalidateParentScheduleCaches(user, firstEvent);
     return result;
   } catch (error) {
     if (!isNativeRuntime()) {
@@ -4264,7 +4277,7 @@ export async function submitParentScheduleRsvpForChildren(events: ParentSchedule
     }
     logScheduleWarning('Falling back to REST family RSVP submit.', 'parent-family-rsvp-submit', error, { fallback: 'rest', teamId: firstEvent.teamId, gameId: firstEvent.id, childIds });
     const result = await nativeSubmitRsvpForChildren(firstEvent.teamId, firstEvent.id, user, childIds, response, note, firstEvent.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
-    invalidateParentScheduleCaches(user);
+    invalidateParentScheduleCaches(user, firstEvent);
     return result;
   }
 }

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -128,7 +128,7 @@ import {
 } from './scheduleLogic';
 import type { AutoFilledLineupPlayer, GamePlanPublishPayloadInput } from './gameDayLineupPublish';
 import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
-import { getCachedAppData, getParentScheduleSummaryCacheKey, invalidateCachedAppData, loadCachedAppData } from './appDataCache';
+import { getCachedAppData, getParentHomeSecondaryCacheKey, getParentScheduleSummaryCacheKey, invalidateCachedAppData, loadCachedAppData } from './appDataCache';
 import { toAppServiceError } from './appErrors';
 import { createLogger } from './logger';
 import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
@@ -149,10 +149,6 @@ const parentSchedulePlayerConcurrency = 8;
 const scheduleHydrationCacheTtlMs = 30 * 1000;
 const parentHomeHydrationLookAheadMs = 14 * 24 * 60 * 60 * 1000;
 const parentHomeHydrationLookBehindMs = 12 * 60 * 60 * 1000;
-
-function getParentHomeSecondaryCacheKey(userId: string) {
-  return `home-secondary:${userId}`;
-}
 
 function invalidateParentScheduleCaches(user: AuthUser | null | undefined) {
   const userId = compactString(user?.uid);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -128,7 +128,7 @@ import {
 } from './scheduleLogic';
 import type { AutoFilledLineupPlayer, GamePlanPublishPayloadInput } from './gameDayLineupPublish';
 import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
-import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
+import { getCachedAppData, getParentScheduleSummaryCacheKey, invalidateCachedAppData, loadCachedAppData } from './appDataCache';
 import { toAppServiceError } from './appErrors';
 import { createLogger } from './logger';
 import { getNativeRestDedupKey, loadDedupedNativeRestRequest, shouldDedupNativeRestRequest } from './nativeRestDedup';
@@ -149,6 +149,12 @@ const parentSchedulePlayerConcurrency = 8;
 const scheduleHydrationCacheTtlMs = 30 * 1000;
 const parentHomeHydrationLookAheadMs = 14 * 24 * 60 * 60 * 1000;
 const parentHomeHydrationLookBehindMs = 12 * 60 * 60 * 1000;
+
+function invalidateParentScheduleSummaryCache(user: AuthUser | null | undefined) {
+  const userId = compactString(user?.uid);
+  if (!userId) return;
+  invalidateCachedAppData(getParentScheduleSummaryCacheKey(userId));
+}
 // Default games window for schedule views: ~13 months covers the current and
 // previous season so the "Past Events" filter still shows recent history before
 // an explicit full-history load. Tune here if season length assumptions change.
@@ -1882,6 +1888,7 @@ export async function createScheduledGameForApp(
   if (options.requireCreatedId && !createdId) {
     throw new Error('Tournament game save failed because no game id was returned.');
   }
+  invalidateParentScheduleSummaryCache(user);
   return createdId;
 }
 
@@ -1946,6 +1953,7 @@ export async function updateScheduledGameForApp(teamId: string, gameId: string, 
     logScheduleWarning('Falling back to REST scheduled game update.', 'scheduled-game-update', error, { fallback: 'rest', teamId: normalizedTeamId, gameId: normalizedGameId });
     await nativePatchDocument(`teams/${encodeURIComponent(normalizedTeamId)}/games/${encodeURIComponent(normalizedGameId)}`, payload);
   }
+  invalidateParentScheduleSummaryCache(user);
   return { updated: true, eventId: normalizedGameId };
 }
 
@@ -2041,7 +2049,9 @@ export async function createScheduledPracticeForApp(teamId: string, input: Sched
   const payload = buildScheduledPracticePayload(input, user as AuthUser);
 
   try {
-    return await withTimeout(Promise.resolve(addPractice(normalizedTeamId, payload)), 'Scheduled practice create');
+    const createdId = await withTimeout(Promise.resolve(addPractice(normalizedTeamId, payload)), 'Scheduled practice create');
+    invalidateParentScheduleSummaryCache(user);
+    return createdId;
   } catch (error) {
     if (!isNativeRuntime()) throw error;
     logScheduleWarning('Falling back to REST scheduled practice create.', 'scheduled-practice-create', error, { fallback: 'rest', teamId: normalizedTeamId });
@@ -2049,6 +2059,7 @@ export async function createScheduledPracticeForApp(teamId: string, input: Sched
       ...buildNativePracticePatchPayload(input, user as AuthUser),
       createdAt: new Date()
     });
+    invalidateParentScheduleSummaryCache(user);
     return doc?.id || '';
   }
 }
@@ -2082,6 +2093,7 @@ export async function updateScheduledPracticeForApp(teamId: string, input: Sched
         updatedBy: (user as AuthUser).uid
       });
     }
+    invalidateParentScheduleSummaryCache(user);
     return { updated: true, scope, eventId: occurrence.masterId, instanceDate: occurrence.instanceDate };
   }
 
@@ -2103,6 +2115,7 @@ export async function updateScheduledPracticeForApp(teamId: string, input: Sched
       updatedBy: (user as AuthUser).uid
     });
   }
+  invalidateParentScheduleSummaryCache(user);
   return { updated: true, scope, eventId: normalizedEventId };
 }
 
@@ -2124,6 +2137,7 @@ export async function revertScheduledPracticeOccurrenceForApp(teamId: string, ev
       updatedBy: (user as AuthUser).uid
     });
   }
+  invalidateParentScheduleSummaryCache(user);
   return { reverted: true, eventId: occurrence.masterId, instanceDate: occurrence.instanceDate };
 }
 
@@ -2177,7 +2191,9 @@ export async function createScheduleImportGame(teamId: string, row: ScheduleImpo
   if (!payload.opponent) throw new Error('Game rows require an opponent.');
 
   try {
-    return await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Schedule import game create');
+    const createdId = await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Schedule import game create');
+    invalidateParentScheduleSummaryCache(user);
+    return createdId;
   } catch (error) {
     if (!isNativeRuntime()) throw error;
     logScheduleWarning('Falling back to REST schedule import game create.', 'schedule-import-game-create', error, { fallback: 'rest', teamId: normalizedTeamId });
@@ -2185,6 +2201,7 @@ export async function createScheduleImportGame(teamId: string, row: ScheduleImpo
       ...payload,
       createdAt: new Date()
     });
+    invalidateParentScheduleSummaryCache(user);
     return doc?.id || '';
   }
 }
@@ -2215,7 +2232,9 @@ export async function createScheduleImportPractice(teamId: string, row: Schedule
   const payload = buildScheduleImportPracticePayload(row, user as AuthUser);
 
   try {
-    return await withTimeout(Promise.resolve(addPractice(normalizedTeamId, payload)), 'Schedule import practice create');
+    const createdId = await withTimeout(Promise.resolve(addPractice(normalizedTeamId, payload)), 'Schedule import practice create');
+    invalidateParentScheduleSummaryCache(user);
+    return createdId;
   } catch (error) {
     if (!isNativeRuntime()) throw error;
     logScheduleWarning('Falling back to REST schedule import practice create.', 'schedule-import-practice-create', error, { fallback: 'rest', teamId: normalizedTeamId });
@@ -2223,6 +2242,7 @@ export async function createScheduleImportPractice(teamId: string, row: Schedule
       ...payload,
       createdAt: new Date()
     });
+    invalidateParentScheduleSummaryCache(user);
     return doc?.id || '';
   }
 }
@@ -4162,6 +4182,7 @@ export async function submitStaffScheduleRsvpOverride(event: ParentScheduleEvent
     await nativeSubmitRsvpForPlayer(event.teamId, event.id, user!, normalizedPlayerId, response, '', event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
   }
 
+  invalidateParentScheduleSummaryCache(user);
   return {
     playerId: normalizedPlayerId,
     response
@@ -4180,18 +4201,22 @@ export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user:
   }
 
   try {
-    return await withTimeout(Promise.resolve(submitRsvpForPlayer(event.teamId, event.id, user.uid, {
+    const result = await withTimeout(Promise.resolve(submitRsvpForPlayer(event.teamId, event.id, user.uid, {
       displayName: user.displayName || user.email,
       playerId: event.childId,
       response,
       note: compactString(note) || null
     })), 'RSVP submit');
+    invalidateParentScheduleSummaryCache(user);
+    return result;
   } catch (error) {
     if (!isNativeRuntime()) {
       throw error;
     }
     logScheduleWarning('Falling back to REST RSVP submit.', 'parent-rsvp-submit', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id, childId: event.childId });
-    return nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note, event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
+    const result = await nativeSubmitRsvpForPlayer(event.teamId, event.id, user, event.childId, response, note, event.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
+    invalidateParentScheduleSummaryCache(user);
+    return result;
   }
 }
 
@@ -4224,18 +4249,22 @@ export async function submitParentScheduleRsvpForChildren(events: ParentSchedule
   }
 
   try {
-    return await withTimeout(Promise.resolve(submitRsvp(firstEvent.teamId, firstEvent.id, user.uid, {
+    const result = await withTimeout(Promise.resolve(submitRsvp(firstEvent.teamId, firstEvent.id, user.uid, {
       displayName: user.displayName || user.email,
       playerIds: childIds,
       response,
       note: compactString(note) || null
     })), 'Family RSVP submit');
+    invalidateParentScheduleSummaryCache(user);
+    return result;
   } catch (error) {
     if (!isNativeRuntime()) {
       throw error;
     }
     logScheduleWarning('Falling back to REST family RSVP submit.', 'parent-family-rsvp-submit', error, { fallback: 'rest', teamId: firstEvent.teamId, gameId: firstEvent.id, childIds });
-    return nativeSubmitRsvpForChildren(firstEvent.teamId, firstEvent.id, user, childIds, response, note, firstEvent.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
+    const result = await nativeSubmitRsvpForChildren(firstEvent.teamId, firstEvent.id, user, childIds, response, note, firstEvent.availabilityNoteVisibility === 'team' ? 'team' : 'admins');
+    invalidateParentScheduleSummaryCache(user);
+    return result;
   }
 }
 
@@ -5742,6 +5771,7 @@ export async function cancelScheduledGameForApp(event: ParentScheduleEvent, user
 
   const notificationError = notificationFailures.length > 0 ? notificationFailures.join('; ') : null;
 
+  invalidateParentScheduleSummaryCache(user);
   return {
     cancelled: true,
     notificationError
@@ -5782,6 +5812,7 @@ export async function cancelPracticeOccurrenceForApp(event: ParentScheduleEvent,
     });
   }
 
+  invalidateParentScheduleSummaryCache(user);
   return {
     cancelled: true,
     masterId: occurrence.masterId,

--- a/tests/unit/app-async-operation-initiative-source-contract.test.js
+++ b/tests/unit/app-async-operation-initiative-source-contract.test.js
@@ -62,13 +62,13 @@ describe('app async operation initiative source contract', () => {
     });
 
     it('keeps high-traffic app services using shared cache and service-error adapters', () => {
-        expect(homeServiceSource).toContain("import { getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';");
+        expect(homeServiceSource).toContain("import { getParentHomeSecondaryCacheKey, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';");
         expect(homeServiceSource).toContain("import { toAppServiceError, type AppServiceError } from './appErrors';");
         expect(homeServiceSource).toContain('return loadCachedAppData(');
         expect(homeServiceSource).toContain('function rethrowIfPermissionError(error: unknown, fallbackMessage: string)');
         expect(homeServiceSource).toContain("rethrowIfPermissionError(error, 'Unable to load Home chat.')");
 
-        expect(scheduleServiceSource).toContain("import { getCachedAppData, getParentScheduleSummaryCacheKey, invalidateCachedAppData, loadCachedAppData } from './appDataCache';");
+        expect(scheduleServiceSource).toContain("import { getCachedAppData, getParentHomeSecondaryCacheKey, getParentScheduleSummaryCacheKey, invalidateCachedAppData, loadCachedAppData } from './appDataCache';");
         expect(scheduleServiceSource).toContain("import { toAppServiceError } from './appErrors';");
         expect(scheduleServiceSource).toContain("throw toAppServiceError(error, 'Unable to load schedule.');");
         expect(scheduleServiceSource).toContain("startUxTimer('parent schedule service load'");

--- a/tests/unit/app-async-operation-initiative-source-contract.test.js
+++ b/tests/unit/app-async-operation-initiative-source-contract.test.js
@@ -68,7 +68,7 @@ describe('app async operation initiative source contract', () => {
         expect(homeServiceSource).toContain('function rethrowIfPermissionError(error: unknown, fallbackMessage: string)');
         expect(homeServiceSource).toContain("rethrowIfPermissionError(error, 'Unable to load Home chat.')");
 
-        expect(scheduleServiceSource).toContain("import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';");
+        expect(scheduleServiceSource).toContain("import { getCachedAppData, getParentScheduleSummaryCacheKey, invalidateCachedAppData, loadCachedAppData } from './appDataCache';");
         expect(scheduleServiceSource).toContain("import { toAppServiceError } from './appErrors';");
         expect(scheduleServiceSource).toContain("throw toAppServiceError(error, 'Unable to load schedule.');");
         expect(scheduleServiceSource).toContain("startUxTimer('parent schedule service load'");

--- a/tests/unit/app-data-cache.test.ts
+++ b/tests/unit/app-data-cache.test.ts
@@ -157,6 +157,24 @@ describe('appDataCache', () => {
     expect(secondCache.getCachedAppData('user:b')).toEqual({ user: 'b' });
   });
 
+  it('invalidates one cached key in memory and persisted storage', async () => {
+    const firstCache = await loadCacheModule();
+    const loader = vi.fn()
+      .mockResolvedValueOnce({ version: 1 })
+      .mockResolvedValueOnce({ version: 2 });
+
+    await firstCache.loadCachedAppData('schedule:key', loader, { ttlMs: 60_000 });
+    await firstCache.loadCachedAppData('other:key', async () => ({ other: true }), { ttlMs: 60_000 });
+
+    firstCache.invalidateCachedAppData('schedule:key');
+
+    expect(firstCache.getCachedAppData('schedule:key')).toBeNull();
+    expect(window.localStorage.getItem('allplays:appDataCache:schedule%3Akey')).toBeNull();
+    expect(window.localStorage.getItem('allplays:appDataCache:other%3Akey')).toContain('other');
+    await expect(firstCache.loadCachedAppData('schedule:key', loader, { ttlMs: 60_000 })).resolves.toEqual({ version: 2 });
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
   it('uses one shared key for parent schedule summaries across pages', async () => {
     const cache = await loadCacheModule();
 

--- a/tests/unit/app-data-cache.test.ts
+++ b/tests/unit/app-data-cache.test.ts
@@ -11,6 +11,7 @@ async function loadCacheModule() {
 
 describe('appDataCache', () => {
   let localStorageMock: Storage & {
+    removeItem: ReturnType<typeof vi.fn>;
     setItem: ReturnType<typeof vi.fn>;
   };
 
@@ -172,6 +173,24 @@ describe('appDataCache', () => {
     expect(window.localStorage.getItem('allplays:appDataCache:schedule%3Akey')).toBeNull();
     expect(window.localStorage.getItem('allplays:appDataCache:other%3Akey')).toContain('other');
     await expect(firstCache.loadCachedAppData('schedule:key', loader, { ttlMs: 60_000 })).resolves.toEqual({ version: 2 });
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps cache invalidation best-effort when storage removal fails', async () => {
+    const cache = await loadCacheModule();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const loader = vi.fn()
+      .mockResolvedValueOnce({ version: 1 })
+      .mockResolvedValueOnce({ version: 2 });
+
+    await cache.loadCachedAppData('schedule:key', loader, { ttlMs: 60_000 });
+    localStorageMock.removeItem.mockImplementation(() => {
+      throw new DOMException('Storage disabled', 'SecurityError');
+    });
+
+    expect(() => cache.invalidateCachedAppData('schedule:key')).not.toThrow();
+    expect(cache.getCachedAppData('schedule:key')).toBeNull();
+    await expect(cache.loadCachedAppData('schedule:key', loader, { ttlMs: 60_000 })).resolves.toEqual({ version: 2 });
     expect(loader).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/unit/app-data-cache.test.ts
+++ b/tests/unit/app-data-cache.test.ts
@@ -175,10 +175,34 @@ describe('appDataCache', () => {
     expect(loader).toHaveBeenCalledTimes(2);
   });
 
+  it('prevents an invalidated in-flight key from repopulating without dropping unrelated loads', async () => {
+    const cache = await loadCacheModule();
+    let resolveSchedule: ((value: { schedule: string }) => void) | null = null;
+    let resolveOther: ((value: { other: string }) => void) | null = null;
+    const scheduleLoad = cache.loadCachedAppData('schedule:key', () => new Promise((resolve) => {
+      resolveSchedule = resolve;
+    }));
+    const otherLoad = cache.loadCachedAppData('other:key', () => new Promise((resolve) => {
+      resolveOther = resolve;
+    }));
+
+    cache.invalidateCachedAppData('schedule:key');
+    resolveSchedule?.({ schedule: 'stale' });
+    resolveOther?.({ other: 'fresh' });
+
+    await expect(scheduleLoad).resolves.toEqual({ schedule: 'stale' });
+    await expect(otherLoad).resolves.toEqual({ other: 'fresh' });
+    expect(cache.getCachedAppData('schedule:key')).toBeNull();
+    expect(cache.getCachedAppData('other:key')).toEqual({ other: 'fresh' });
+    expect(window.localStorage.getItem('allplays:appDataCache:schedule%3Akey')).toBeNull();
+    expect(window.localStorage.getItem('allplays:appDataCache:other%3Akey')).toContain('fresh');
+  });
+
   it('uses one shared key for parent schedule summaries across pages', async () => {
     const cache = await loadCacheModule();
 
     expect(cache.getParentScheduleSummaryCacheKey('parent-1')).toBe('app-schedule-summary:parent-1');
+    expect(cache.getParentHomeSecondaryCacheKey('parent-1')).toBe('home-secondary:parent-1');
   });
 
   it('routes handled cache failures through the shared logger', () => {


### PR DESCRIPTION
## Summary
- Add a single-key app data cache invalidation helper that clears memory and persisted storage.
- Invalidate the signed-in user's cached schedule summary after RSVP writes and schedule mutations that stale the schedule list.
- Add regression coverage for cache invalidation and RSVP-triggered schedule summary invalidation.

Fixes #3861

## Validation
- `npx vitest run tests/unit/app-data-cache.test.ts apps/app/src/lib/scheduleService.test.ts tests/unit/app-async-operation-initiative-source-contract.test.js --reporter=verbose`
- `npm run app:build`