### PR TITLE
Protect statsheet replacement from failed saves

### DIFF
--- a/js/track-statsheet-apply.js
+++ b/js/track-statsheet-apply.js
@@ -97,7 +97,7 @@ export function buildTrackStatsheetApplyPlan({
             awayScore: Number(awayScore || 0) || 0,
             opponentStats,
             status: 'completed',
-            liveStatus: 'completed',
+            liveStatus: 'scheduled',
             liveHasData: false,
             liveClockMs: 0,
             liveClockRunning: false,

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -984,6 +984,8 @@ test('respects overwrite confirmation and renders rewritten stats on the game re
             path: 'teams/team-1/games/game-1',
             data: expect.objectContaining({
                 status: 'completed',
+                liveStatus: 'scheduled',
+                liveHasData: false,
                 homeScore: 19,
                 awayScore: 24
             })

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -380,13 +380,50 @@ async function installModuleMocks(page) {
                 update(ref, data) {
                     operations.push({ type: 'update', path: ref.path, data: clone(data) });
                 },
+                delete(ref) {
+                    const store = loadStore();
+                    store.batchDeleteCalls = store.batchDeleteCalls || [];
+                    store.batchDeleteCalls.push(ref.path);
+                    saveStore(store);
+
+                    if (store.batchDeleteFailurePath === ref.path) {
+                        throw new Error(store.batchDeleteFailureMessage || 'Injected replacement delete failure');
+                    }
+
+                    operations.push({ type: 'delete', path: ref.path });
+                },
                 async commit() {
                     const store = loadStore();
                     store.commitCalls = (store.commitCalls || 0) + 1;
                     store.batchOps = store.batchOps || [];
                     store.batchOps.push(...operations.map((operation) => clone(operation)));
 
+                    if (store.commitFailureMessage) {
+                        saveStore(store);
+                        throw new Error(store.commitFailureMessage);
+                    }
+
                     operations.forEach((operation) => {
+                        if (operation.type === 'delete') {
+                            const parts = String(operation.path || '').split('/');
+                            const collectionName = parts[parts.length - 2];
+                            const docId = parts[parts.length - 1];
+
+                            if (collectionName === 'events') {
+                                delete (store.events || {})[docId];
+                            }
+                            if (collectionName === 'aggregatedStats') {
+                                delete (store.aggregatedStats || {})[docId];
+                            }
+                            if (collectionName === 'liveEvents') {
+                                delete (store.liveEvents || {})[docId];
+                            }
+                            if (collectionName === 'privatePlayerStats') {
+                                delete (store.privatePlayerStats || {})[docId];
+                            }
+                            return;
+                        }
+
                         if (operation.path.includes('/aggregatedStats/')) {
                             const playerId = operation.path.split('/').pop();
                             store.aggregatedStats = store.aggregatedStats || {};
@@ -913,7 +950,8 @@ test('respects overwrite confirmation and renders rewritten stats on the game re
 
     store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
     expect(store.confirmResults).toEqual([false, true]);
-    expect(store.deleteCalls).toEqual([
+    expect(store.deleteCalls).toEqual([]);
+    expect(store.batchDeleteCalls).toEqual([
         'teams/team-1/games/game-1/events/oldEvent',
         'teams/team-1/games/game-1/aggregatedStats/legacyPlayer',
         'teams/team-1/games/game-1/liveEvents/oldLiveEvent',
@@ -963,4 +1001,118 @@ test('respects overwrite confirmation and renders rewritten stats on the game re
     await expect(page.locator('#opponent-stats-body')).toContainText('9');
     await expect(page.locator('#opponent-stats-body tr').first().locator('td').nth(3)).toContainText('—');
     await expect(page.locator('#opponent-stats-body tr').first().locator('td').nth(4)).toContainText('—');
+});
+
+test('preserves existing tracked stats when replacement batch commit fails', async ({ page, baseURL }) => {
+    await seedScenario(page, baseURL, createScenario({
+        aggregatedStats: {
+            legacyPlayer: {
+                playerName: 'Old Player',
+                playerNumber: '99',
+                stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
+            }
+        },
+        events: {
+            oldEvent: { type: 'score', timestamp: 1 }
+        },
+        liveEvents: {
+            oldLiveEvent: { type: 'assist', timestamp: 2 }
+        },
+        privatePlayerStats: {
+            oldPrivateStat: { playerId: 'p1', notes: 'private stale data' }
+        },
+        confirmResponses: [true],
+        commitFailureMessage: 'Injected replacement commit failure'
+    }));
+
+    await analyzeStatsheet(page, baseURL);
+    await page.locator('#home-rows tr').nth(1).locator('input[data-field="include"]').check();
+    await page.locator('#home-rows tr').nth(1).locator('select[data-field="mappedPlayerId"]').selectOption('p2');
+    await page.locator('#apply-btn').click();
+
+    await expect(page.locator('#apply-status')).toHaveText('Error: Injected replacement commit failure');
+    await expect(page.locator('#apply-btn')).toBeEnabled();
+    await expect(page.locator('#summary-section')).toHaveClass(/hidden/);
+
+    const store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(store.alerts).toContain('Failed to save stats: Injected replacement commit failure');
+    expect(store.confirmResults).toEqual([true]);
+    expect(store.deleteCalls).toEqual([]);
+    expect(store.batchDeleteCalls).toEqual([
+        'teams/team-1/games/game-1/events/oldEvent',
+        'teams/team-1/games/game-1/aggregatedStats/legacyPlayer',
+        'teams/team-1/games/game-1/liveEvents/oldLiveEvent',
+        'teams/team-1/games/game-1/privatePlayerStats/oldPrivateStat'
+    ]);
+    expect(store.commitCalls).toBe(1);
+    expect(store.events.oldEvent.type).toBe('score');
+    expect(store.liveEvents.oldLiveEvent.type).toBe('assist');
+    expect(store.privatePlayerStats.oldPrivateStat.notes).toBe('private stale data');
+    expect(store.aggregatedStats).toEqual({
+        legacyPlayer: {
+            playerName: 'Old Player',
+            playerNumber: '99',
+            stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
+        }
+    });
+    expect(store.game.status).toBe('scheduled');
+    expect(store.game.homeScore).toBe(0);
+    expect(store.game.awayScore).toBe(0);
+});
+
+test('stops replacement without committing new stats when staging a delete fails', async ({ page, baseURL }) => {
+    await seedScenario(page, baseURL, createScenario({
+        aggregatedStats: {
+            legacyPlayer: {
+                playerName: 'Old Player',
+                playerNumber: '99',
+                stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
+            }
+        },
+        events: {
+            oldEvent: { type: 'score', timestamp: 1 }
+        },
+        liveEvents: {
+            oldLiveEvent: { type: 'assist', timestamp: 2 }
+        },
+        privatePlayerStats: {
+            oldPrivateStat: { playerId: 'p1', notes: 'private stale data' }
+        },
+        confirmResponses: [true],
+        batchDeleteFailurePath: 'teams/team-1/games/game-1/liveEvents/oldLiveEvent',
+        batchDeleteFailureMessage: 'Injected replacement delete failure'
+    }));
+
+    await analyzeStatsheet(page, baseURL);
+    await page.locator('#home-rows tr').nth(1).locator('input[data-field="include"]').check();
+    await page.locator('#home-rows tr').nth(1).locator('select[data-field="mappedPlayerId"]').selectOption('p2');
+    await page.locator('#apply-btn').click();
+
+    await expect(page.locator('#apply-status')).toHaveText('Error: Injected replacement delete failure');
+    await expect(page.locator('#apply-btn')).toBeEnabled();
+    await expect(page.locator('#summary-section')).toHaveClass(/hidden/);
+
+    const store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(store.alerts).toContain('Failed to save stats: Injected replacement delete failure');
+    expect(store.confirmResults).toEqual([true]);
+    expect(store.commitCalls).toBe(0);
+    expect(store.batchOps).toEqual([]);
+    expect(store.batchDeleteCalls).toEqual([
+        'teams/team-1/games/game-1/events/oldEvent',
+        'teams/team-1/games/game-1/aggregatedStats/legacyPlayer',
+        'teams/team-1/games/game-1/liveEvents/oldLiveEvent'
+    ]);
+    expect(store.events.oldEvent.type).toBe('score');
+    expect(store.liveEvents.oldLiveEvent.type).toBe('assist');
+    expect(store.privatePlayerStats.oldPrivateStat.notes).toBe('private stale data');
+    expect(store.aggregatedStats).toEqual({
+        legacyPlayer: {
+            playerName: 'Old Player',
+            playerNumber: '99',
+            stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
+        }
+    });
+    expect(store.game.status).toBe('scheduled');
+    expect(store.game.homeScore).toBe(0);
+    expect(store.game.awayScore).toBe(0);
 });

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -62,10 +62,10 @@ function createScenario(overrides = {}) {
     };
 }
 
-function createLiveEvents(count) {
+function createTrackedEvents(count) {
     return Object.fromEntries(Array.from({ length: count }, (_, index) => {
         const eventNumber = String(index + 1).padStart(3, '0');
-        return [`largeLiveEvent${eventNumber}`, { type: 'touch', timestamp: index + 1 }];
+        return [`largeEvent${eventNumber}`, { type: 'touch', timestamp: index + 1 }];
     }));
 }
 
@@ -961,12 +961,13 @@ test('respects overwrite confirmation and renders rewritten stats on the game re
     expect(store.batchDeleteCalls).toEqual([
         'teams/team-1/games/game-1/events/oldEvent',
         'teams/team-1/games/game-1/aggregatedStats/legacyPlayer',
-        'teams/team-1/games/game-1/liveEvents/oldLiveEvent',
         'teams/team-1/games/game-1/privatePlayerStats/oldPrivateStat'
     ]);
     expect(store.commitCalls).toBe(1);
     expect(store.events).toEqual({});
-    expect(store.liveEvents).toEqual({});
+    expect(store.liveEvents).toEqual({
+        oldLiveEvent: { type: 'assist', timestamp: 2 }
+    });
     expect(store.privatePlayerStats).toEqual({});
     expect(Object.keys(store.aggregatedStats)).toEqual(['p1', 'p2']);
     expect(store.batchOps).toEqual(expect.arrayContaining([
@@ -1048,7 +1049,6 @@ test('preserves existing tracked stats when replacement batch commit fails', asy
     expect(store.batchDeleteCalls).toEqual([
         'teams/team-1/games/game-1/events/oldEvent',
         'teams/team-1/games/game-1/aggregatedStats/legacyPlayer',
-        'teams/team-1/games/game-1/liveEvents/oldLiveEvent',
         'teams/team-1/games/game-1/privatePlayerStats/oldPrivateStat'
     ]);
     expect(store.commitCalls).toBe(1);
@@ -1078,10 +1078,10 @@ test('preflights oversized replacement cleanup before staging batch deletes', as
                 stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
             }
         },
-        events: {
-            oldEvent: { type: 'score', timestamp: 1 }
+        events: createTrackedEvents(498),
+        liveEvents: {
+            oldLiveEvent: { type: 'assist', timestamp: 2 }
         },
-        liveEvents: createLiveEvents(497),
         privatePlayerStats: {
             oldPrivateStat: { playerId: 'p1', notes: 'private stale data' }
         },
@@ -1104,9 +1104,9 @@ test('preflights oversized replacement cleanup before staging batch deletes', as
     expect(store.batchOps).toEqual([]);
     expect(store.batchDeleteCalls || []).toEqual([]);
     expect(store.deleteCalls).toEqual([]);
-    expect(Object.keys(store.liveEvents)).toHaveLength(497);
-    expect(store.liveEvents.largeLiveEvent497.type).toBe('touch');
-    expect(store.events.oldEvent.type).toBe('score');
+    expect(Object.keys(store.events)).toHaveLength(498);
+    expect(store.events.largeEvent498.type).toBe('touch');
+    expect(store.liveEvents.oldLiveEvent.type).toBe('assist');
     expect(store.privatePlayerStats.oldPrivateStat.notes).toBe('private stale data');
     expect(store.aggregatedStats).toEqual({
         legacyPlayer: {
@@ -1139,7 +1139,7 @@ test('stops replacement without committing new stats when staging a delete fails
             oldPrivateStat: { playerId: 'p1', notes: 'private stale data' }
         },
         confirmResponses: [true],
-        batchDeleteFailurePath: 'teams/team-1/games/game-1/liveEvents/oldLiveEvent',
+        batchDeleteFailurePath: 'teams/team-1/games/game-1/privatePlayerStats/oldPrivateStat',
         batchDeleteFailureMessage: 'Injected replacement delete failure'
     }));
 
@@ -1160,7 +1160,7 @@ test('stops replacement without committing new stats when staging a delete fails
     expect(store.batchDeleteCalls).toEqual([
         'teams/team-1/games/game-1/events/oldEvent',
         'teams/team-1/games/game-1/aggregatedStats/legacyPlayer',
-        'teams/team-1/games/game-1/liveEvents/oldLiveEvent'
+        'teams/team-1/games/game-1/privatePlayerStats/oldPrivateStat'
     ]);
     expect(store.events.oldEvent.type).toBe('score');
     expect(store.liveEvents.oldLiveEvent.type).toBe('assist');

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -62,6 +62,13 @@ function createScenario(overrides = {}) {
     };
 }
 
+function createLiveEvents(count) {
+    return Object.fromEntries(Array.from({ length: count }, (_, index) => {
+        const eventNumber = String(index + 1).padStart(3, '0');
+        return [`largeLiveEvent${eventNumber}`, { type: 'touch', timestamp: index + 1 }];
+    }));
+}
+
 async function installModuleMocks(page) {
     await page.addInitScript(({ storeKey }) => {
         function loadStore() {
@@ -1047,6 +1054,59 @@ test('preserves existing tracked stats when replacement batch commit fails', asy
     expect(store.commitCalls).toBe(1);
     expect(store.events.oldEvent.type).toBe('score');
     expect(store.liveEvents.oldLiveEvent.type).toBe('assist');
+    expect(store.privatePlayerStats.oldPrivateStat.notes).toBe('private stale data');
+    expect(store.aggregatedStats).toEqual({
+        legacyPlayer: {
+            playerName: 'Old Player',
+            playerNumber: '99',
+            stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
+        }
+    });
+    expect(store.game.status).toBe('scheduled');
+    expect(store.game.homeScore).toBe(0);
+    expect(store.game.awayScore).toBe(0);
+});
+
+test('preflights oversized replacement cleanup before staging batch deletes', async ({ page, baseURL }) => {
+    const overLimitMessage = 'Replacement requires 503 writes, which exceeds the 500-write Firestore batch limit. Existing game data was not changed.';
+
+    await seedScenario(page, baseURL, createScenario({
+        aggregatedStats: {
+            legacyPlayer: {
+                playerName: 'Old Player',
+                playerNumber: '99',
+                stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
+            }
+        },
+        events: {
+            oldEvent: { type: 'score', timestamp: 1 }
+        },
+        liveEvents: createLiveEvents(497),
+        privatePlayerStats: {
+            oldPrivateStat: { playerId: 'p1', notes: 'private stale data' }
+        },
+        confirmResponses: [true]
+    }));
+
+    await analyzeStatsheet(page, baseURL);
+    await page.locator('#home-rows tr').nth(1).locator('input[data-field="include"]').check();
+    await page.locator('#home-rows tr').nth(1).locator('select[data-field="mappedPlayerId"]').selectOption('p2');
+    await page.locator('#apply-btn').click();
+
+    await expect(page.locator('#apply-status')).toHaveText(`Error: ${overLimitMessage}`);
+    await expect(page.locator('#apply-btn')).toBeEnabled();
+    await expect(page.locator('#summary-section')).toHaveClass(/hidden/);
+
+    const store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(store.alerts).toContain(`Failed to save stats: ${overLimitMessage}`);
+    expect(store.confirmResults).toEqual([true]);
+    expect(store.commitCalls).toBe(0);
+    expect(store.batchOps).toEqual([]);
+    expect(store.batchDeleteCalls || []).toEqual([]);
+    expect(store.deleteCalls).toEqual([]);
+    expect(Object.keys(store.liveEvents)).toHaveLength(497);
+    expect(store.liveEvents.largeLiveEvent497.type).toBe('touch');
+    expect(store.events.oldEvent.type).toBe('score');
     expect(store.privatePlayerStats.oldPrivateStat.notes).toBe('private stale data');
     expect(store.aggregatedStats).toEqual({
         legacyPlayer: {

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -204,6 +204,10 @@ describe('track statsheet apply helpers', () => {
     it('clears tracked, live, and private player state when replacing previously tracked game data', () => {
         expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
         expect(trackStatsheetSource).toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
+        expect(trackStatsheetSource).toContain('const FIRESTORE_BATCH_WRITE_LIMIT = 500;');
+        expect(trackStatsheetSource).toContain('const replacementCleanupWriteCount = eventsSnap.size + statsSnap.size + liveEventsSnap.size + privateStatsSnap.size;');
+        expect(trackStatsheetSource).toContain('const replacementWriteCount = replacementCleanupWriteCount + applyPlan.aggregatedStatsWrites.length + 1;');
+        expect(trackStatsheetSource).toMatch(/if \(replacementWriteCount > FIRESTORE_BATCH_WRITE_LIMIT\) \{[\s\S]*Existing game data was not changed\.[\s\S]*\}[\s\S]*const batch = writeBatch\(db\);/);
         expect(trackStatsheetSource).toContain('const batch = writeBatch(db);');
         expect(trackStatsheetSource).toMatch(/if \(hasExistingTrackedData\) \{[\s\S]*applyStatus\.textContent = 'Preparing replacement stats…';[\s\S]*eventsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*statsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*liveEventsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*privateStatsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*\}/);
         expect(trackStatsheetSource).toContain('const commitPromise = batch.commit();');

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -201,15 +201,17 @@ describe('track statsheet apply helpers', () => {
         ]);
     });
 
-    it('clears tracked, live, and private player state when replacing previously tracked game data', () => {
+    it('atomically clears mutable tracked state while preserving immutable live event history', () => {
         expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
         expect(trackStatsheetSource).toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
         expect(trackStatsheetSource).toContain('const FIRESTORE_BATCH_WRITE_LIMIT = 500;');
-        expect(trackStatsheetSource).toContain('const replacementCleanupWriteCount = eventsSnap.size + statsSnap.size + liveEventsSnap.size + privateStatsSnap.size;');
+        expect(trackStatsheetSource).toContain('const replacementCleanupWriteCount = eventsSnap.size + statsSnap.size + privateStatsSnap.size;');
+        expect(trackStatsheetSource).toContain('const hasExistingTrackedData = replacementCleanupWriteCount > 0 || liveEventsSnap.size > 0;');
         expect(trackStatsheetSource).toContain('const replacementWriteCount = replacementCleanupWriteCount + applyPlan.aggregatedStatsWrites.length + 1;');
         expect(trackStatsheetSource).toMatch(/if \(replacementWriteCount > FIRESTORE_BATCH_WRITE_LIMIT\) \{[\s\S]*Existing game data was not changed\.[\s\S]*\}[\s\S]*const batch = writeBatch\(db\);/);
         expect(trackStatsheetSource).toContain('const batch = writeBatch(db);');
-        expect(trackStatsheetSource).toMatch(/if \(hasExistingTrackedData\) \{[\s\S]*applyStatus\.textContent = 'Preparing replacement stats…';[\s\S]*eventsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*statsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*liveEventsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*privateStatsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*\}/);
+        expect(trackStatsheetSource).toMatch(/if \(hasExistingTrackedData\) \{[\s\S]*applyStatus\.textContent = 'Preparing replacement stats…';[\s\S]*eventsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*statsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*privateStatsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*\}/);
+        expect(trackStatsheetSource).not.toMatch(/liveEventsSnap\.docs\.forEach\(docItem => batch\.delete/);
         expect(trackStatsheetSource).toContain('const commitPromise = batch.commit();');
         expect(buildTrackStatsheetApplyPlan().gameUpdate).toMatchObject({
             liveStatus: 'completed',

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -103,7 +103,7 @@ describe('track statsheet apply helpers', () => {
                     }
                 },
                 status: 'completed',
-                liveStatus: 'completed',
+                liveStatus: 'scheduled',
                 liveHasData: false,
                 liveClockMs: 0,
                 liveClockRunning: false,
@@ -158,7 +158,7 @@ describe('track statsheet apply helpers', () => {
                     }
                 },
                 status: 'completed',
-                liveStatus: 'completed',
+                liveStatus: 'scheduled',
                 liveHasData: false,
                 liveClockMs: 0,
                 liveClockRunning: false,
@@ -201,7 +201,7 @@ describe('track statsheet apply helpers', () => {
         ]);
     });
 
-    it('atomically clears mutable tracked state while preserving immutable live event history', () => {
+    it('atomically clears mutable tracked state while removing stale replay eligibility', () => {
         expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
         expect(trackStatsheetSource).toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
         expect(trackStatsheetSource).toContain('const FIRESTORE_BATCH_WRITE_LIMIT = 500;');
@@ -214,7 +214,8 @@ describe('track statsheet apply helpers', () => {
         expect(trackStatsheetSource).not.toMatch(/liveEventsSnap\.docs\.forEach\(docItem => batch\.delete/);
         expect(trackStatsheetSource).toContain('const commitPromise = batch.commit();');
         expect(buildTrackStatsheetApplyPlan().gameUpdate).toMatchObject({
-            liveStatus: 'completed',
+            status: 'completed',
+            liveStatus: 'scheduled',
             liveHasData: false,
             liveClockMs: 0,
             liveClockRunning: false,

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -204,7 +204,9 @@ describe('track statsheet apply helpers', () => {
     it('clears tracked, live, and private player state when replacing previously tracked game data', () => {
         expect(trackStatsheetSource).toContain("const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));");
         expect(trackStatsheetSource).toContain("const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));");
-        expect(trackStatsheetSource).toMatch(/if \(eventsSnap\.size > 0 \|\| statsSnap\.size > 0 \|\| liveEventsSnap\.size > 0 \|\| privateStatsSnap\.size > 0\) \{[\s\S]*await Promise\.all\(eventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(statsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(liveEventsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);[\s\S]*await Promise\.all\(privateStatsSnap\.docs\.map\(docItem => deleteDoc\(docItem\.ref\)\)\);/);
+        expect(trackStatsheetSource).toContain('const batch = writeBatch(db);');
+        expect(trackStatsheetSource).toMatch(/if \(hasExistingTrackedData\) \{[\s\S]*applyStatus\.textContent = 'Preparing replacement stats…';[\s\S]*eventsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*statsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*liveEventsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*privateStatsSnap\.docs\.forEach\(docItem => batch\.delete\(docItem\.ref\)\);[\s\S]*\}/);
+        expect(trackStatsheetSource).toContain('const commitPromise = batch.commit();');
         expect(buildTrackStatsheetApplyPlan().gameUpdate).toMatchObject({
             liveStatus: 'completed',
             liveHasData: false,

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -209,6 +209,8 @@
     import { getApp } from './js/vendor/firebase-app.js';
     import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
+    const FIRESTORE_BATCH_WRITE_LIMIT = 500;
+
     renderFooter(document.getElementById('footer-container'));
 
     let currentTeamId = null;
@@ -784,7 +786,8 @@ RETURN JSON:
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
         const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
         const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
-        const hasExistingTrackedData = eventsSnap.size > 0 || statsSnap.size > 0 || liveEventsSnap.size > 0 || privateStatsSnap.size > 0;
+        const replacementCleanupWriteCount = eventsSnap.size + statsSnap.size + liveEventsSnap.size + privateStatsSnap.size;
+        const hasExistingTrackedData = replacementCleanupWriteCount > 0;
         if (hasExistingTrackedData) {
           const confirmClear = confirm('This game already has tracked data. Replace it with the stat sheet results?');
           if (!confirmClear) {
@@ -802,6 +805,11 @@ RETURN JSON:
           awayScore: visitorScore,
           statSheetPhotoUrl: statSheetUrl
         });
+
+        const replacementWriteCount = replacementCleanupWriteCount + applyPlan.aggregatedStatsWrites.length + 1;
+        if (replacementWriteCount > FIRESTORE_BATCH_WRITE_LIMIT) {
+          throw new Error(`Replacement requires ${replacementWriteCount} writes, which exceeds the ${FIRESTORE_BATCH_WRITE_LIMIT}-write Firestore batch limit. Existing game data was not changed.`);
+        }
 
         const batch = writeBatch(db);
         if (hasExistingTrackedData) {

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -786,8 +786,10 @@ RETURN JSON:
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
         const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
         const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
-        const replacementCleanupWriteCount = eventsSnap.size + statsSnap.size + liveEventsSnap.size + privateStatsSnap.size;
-        const hasExistingTrackedData = replacementCleanupWriteCount > 0;
+        // liveEvents are append-only under Firestore rules. Keep that audit history
+        // while replacing the mutable tracker state in one atomic commit.
+        const replacementCleanupWriteCount = eventsSnap.size + statsSnap.size + privateStatsSnap.size;
+        const hasExistingTrackedData = replacementCleanupWriteCount > 0 || liveEventsSnap.size > 0;
         if (hasExistingTrackedData) {
           const confirmClear = confirm('This game already has tracked data. Replace it with the stat sheet results?');
           if (!confirmClear) {
@@ -816,7 +818,6 @@ RETURN JSON:
           applyStatus.textContent = 'Preparing replacement stats…';
           eventsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
           statsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
-          liveEventsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
           privateStatsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
         }
         applyPlan.aggregatedStatsWrites.forEach(({ playerId, data }) => {

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -198,7 +198,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=91';
+    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, uploadStatSheetPhoto } from './js/db.js?v=91';
     import { db } from './js/firebase.js?v=20';
     import { writeBatch, doc, setDoc } from './js/firebase.js?v=20';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=15';
@@ -784,17 +784,13 @@ RETURN JSON:
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
         const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
         const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
-        if (eventsSnap.size > 0 || statsSnap.size > 0 || liveEventsSnap.size > 0 || privateStatsSnap.size > 0) {
+        const hasExistingTrackedData = eventsSnap.size > 0 || statsSnap.size > 0 || liveEventsSnap.size > 0 || privateStatsSnap.size > 0;
+        if (hasExistingTrackedData) {
           const confirmClear = confirm('This game already has tracked data. Replace it with the stat sheet results?');
           if (!confirmClear) {
             applyStatus.textContent = 'Cancelled.';
             return;
           }
-          applyStatus.textContent = 'Clearing existing stats…';
-          await Promise.all(eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
-          await Promise.all(statsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
-          await Promise.all(liveEventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
-          await Promise.all(privateStatsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
         }
 
         const applyPlan = buildTrackStatsheetApplyPlan({
@@ -808,6 +804,13 @@ RETURN JSON:
         });
 
         const batch = writeBatch(db);
+        if (hasExistingTrackedData) {
+          applyStatus.textContent = 'Preparing replacement stats…';
+          eventsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
+          statsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
+          liveEventsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
+          privateStatsSnap.docs.forEach(docItem => batch.delete(docItem.ref));
+        }
         applyPlan.aggregatedStatsWrites.forEach(({ playerId, data }) => {
           const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
           batch.set(statsRef, data);


### PR DESCRIPTION
## Summary
- Move statsheet replacement cleanup into the same Firestore batch as replacement writes so commit failures do not erase existing game data.
- Extend track-statsheet smoke mocks with batch delete and failure injection.
- Add replacement failure coverage for commit rejection and delete staging failure while preserving cancel/success assertions.

Fixes #3852

## Tests
- `SMOKE_BASE_URL=http://127.0.0.1:4173 npx playwright test tests/smoke/track-statsheet-apply.spec.js --config=playwright.smoke.config.js --reporter=line`

## Notes
- Initial targeted smoke run failed because no local server was listening on 127.0.0.1:4173; reran after starting `python3 -m http.server 4173 --bind 127.0.0.1`.
- `npm ci` emitted existing engine/deprecation/audit warnings, but completed successfully.