### PR TITLE
Show schedule tools for empty staff teams

### DIFF
--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -260,6 +260,18 @@ export type ParentScheduleTeamOption = {
   calendarUrls: string[];
 };
 
+export function getManageableScheduleTeamOptions(
+  teamOptions: ParentScheduleTeamOption[],
+  events: ParentScheduleEvent[],
+  staffTeamIds: string[] = []
+): ParentScheduleTeamOption[] {
+  const staffTeamIdSet = new Set(staffTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean));
+  return teamOptions.filter((team) => (
+    staffTeamIdSet.has(team.teamId)
+    || events.some((event) => event.teamId === team.teamId && event.isTeamStaff === true)
+  ));
+}
+
 export type PracticePacketScheduleRow = {
   event: ParentScheduleEvent;
   completedChildIds: string[];

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -3037,6 +3037,56 @@ describe('partial parent schedule team failures (#3021)', () => {
 
 });
 
+describe('staff-only parent schedule placeholders (#3857)', () => {
+  const staffUser = {
+    uid: 'coach-1',
+    email: 'coach@example.com',
+    roles: ['coach'],
+    coachOf: ['team-1'],
+    parentOf: []
+  } as any;
+  const staffTeam = {
+    id: 'team-1',
+    name: 'Bears',
+    ownerId: 'coach-1',
+    adminEmails: [],
+    active: true
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (globalThis as any).window = { location: { protocol: 'https:' }, setTimeout, clearTimeout } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [] } as any);
+    vi.mocked(getTeams).mockResolvedValue([staffTeam] as any);
+    vi.mocked(getTeam).mockResolvedValue(staffTeam as any);
+    vi.mocked(getGames).mockResolvedValue([{
+      id: 'game-1',
+      type: 'game',
+      date: new Date('2026-06-25T18:00:00.000Z'),
+      opponent: 'Falcons',
+      location: 'Main Gym'
+    }] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+    vi.mocked(getDoc).mockResolvedValue(playerSnapshot('missing', null) as any);
+  });
+
+  it('uses staff placeholders internally without returning them as parent players', async () => {
+    const result = await loadParentSchedule(staffUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(result.staffTeamIds).toEqual(['team-1']);
+    expect(result.children).toEqual([]);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      teamId: 'team-1',
+      id: 'game-1',
+      childId: 'staff-team-team-1',
+      childName: 'Team schedule',
+      isTeamStaff: true
+    });
+    expect(getPlayers).not.toHaveBeenCalled();
+  });
+});
+
 describe('web-created tournament standings hydration (#1967)', () => {
   const parentUser = {
     uid: 'parent-1',

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -193,6 +193,7 @@ type ParentScopeLink = ParentScheduleChild & {
 export type ParentScheduleLoadResult = {
   children: ParentScheduleChild[];
   events: ParentScheduleEvent[];
+  staffTeamIds?: string[];
   isPartial?: boolean;
 };
 
@@ -3696,7 +3697,8 @@ async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<s
     }
   });
 
-  return { children, byTeam, staffTeams };
+  const scheduleChildren = [...byTeam.values()].flat();
+  return { children: scheduleChildren, byTeam, staffTeams };
 }
 
 /**
@@ -3973,7 +3975,12 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
       eventRows: events.length,
       isPartial
     });
-    return { children, events, isPartial };
+    return {
+      children,
+      events,
+      staffTeamIds: staffTeams.map((team: any) => compactString(team?.id)).filter(Boolean),
+      isPartial
+    };
   } catch (error: any) {
     timer.end({ hydrateDetails, expandStaffPlayers, error: error?.message || 'Unable to load parent schedule.' });
     throw error;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -3697,7 +3697,9 @@ async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<s
     }
   });
 
-  const scheduleChildren = [...byTeam.values()].flat();
+  // `byTeam` may include synthetic staff-team placeholders so staff-only teams
+  // can load schedules, but public children are consumed as real players.
+  const scheduleChildren = expandStaffPlayers ? [...byTeam.values()].flat() : children;
   return { children: scheduleChildren, byTeam, staffTeams };
 }
 

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -1045,6 +1045,56 @@ describe('Schedule', () => {
     expect(screen.queryByRole('button', { name: 'New tournament block' })).toBeNull();
   });
 
+  it('shows staff tools for an empty staff team schedule and refreshes after creating the first game', async () => {
+    scheduleServiceMocks.loadParentSchedule
+      .mockResolvedValueOnce({
+        children: [
+          { playerId: 'staff-team-team-1', playerName: 'Team schedule', teamId: 'team-1', teamName: 'Bears', isLinkedParentChild: false }
+        ],
+        events: [],
+        staffTeamIds: ['team-1']
+      })
+      .mockResolvedValueOnce({
+        children: [
+          { playerId: 'staff-team-team-1', playerName: 'Team schedule', teamId: 'team-1', teamName: 'Bears', isLinkedParentChild: false }
+        ],
+        events: [
+          buildScheduleEvent(1, {
+            childId: 'staff-team-team-1',
+            childName: 'Team schedule',
+            isLinkedParentChild: false,
+            isTeamStaff: true,
+            opponent: 'Falcons'
+          })
+        ],
+        staffTeamIds: ['team-1']
+      });
+    scheduleServiceMocks.createScheduledGameForApp.mockResolvedValueOnce('game-1');
+
+    renderSchedule();
+
+    expect(await screen.findByText('No events in this filter')).toBeTruthy();
+    expect(screen.getByLabelText('Team filter').innerHTML).toContain('Bears');
+
+    fireEvent.click(await screen.findByRole('button', { name: /manage schedule/i }));
+
+    expect(await screen.findByRole('heading', { name: 'Add game for Bears' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Add practice for Bears' })).toBeTruthy();
+
+    fireEvent.change(screen.getAllByLabelText('Opponent')[0], { target: { value: 'Falcons' } });
+    fireEvent.change(screen.getAllByLabelText('Location')[0], { target: { value: 'Main Gym' } });
+    fireEvent.click(screen.getByRole('button', { name: /^create game$/i }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.createScheduledGameForApp).toHaveBeenCalledWith('team-1', expect.objectContaining({
+        opponent: 'Falcons',
+        location: 'Main Gym'
+      }), auth.user);
+      expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText('Game created and schedule refreshed.')).toBeTruthy();
+  });
+
   it('opens the tournament shell from a staff action and cancels without creating data', async () => {
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce(buildStaffScheduleResult());
 
@@ -1324,7 +1374,7 @@ describe('Schedule', () => {
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledTimes(1);
       expect(scheduleServiceMocks.loadScheduleStatTrackerConfigsForApp).toHaveBeenCalledWith('team-1', auth.user);
     });
-    expect(screen.getByLabelText('Tracker config')).toBeDisabled();
+    expect((screen.getByLabelText('Tracker config') as HTMLSelectElement).disabled).toBe(true);
     expect(screen.getByRole('option', { name: 'Loading tracker configs' })).toBeTruthy();
 
     if (!resolveConfigLoad) {
@@ -1335,6 +1385,6 @@ describe('Schedule', () => {
     ]);
 
     expect((await screen.findAllByRole('option', { name: 'Basketball Standard' })).length).toBeGreaterThan(0);
-    expect(screen.getByLabelText('Tracker config')).not.toBeDisabled();
+    expect((screen.getByLabelText('Tracker config') as HTMLSelectElement).disabled).toBe(false);
   });
 });

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -29,6 +29,7 @@ import {
   getScheduleEventDetailPath,
   getWindowedCalendarScheduleEntries,
   getWindowedPracticePacketRows,
+  getManageableScheduleTeamOptions,
   getScheduleTitle,
   getScheduleTournamentInfo,
   getScheduleMapHref,
@@ -171,6 +172,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [timeRange, setTimeRange] = useState<ScheduleTimeRange>(() => getScheduleTimeRangeFromQuery(searchParams.get('range')) || 'all');
   const [children, setChildren] = useState<ParentScheduleChild[]>([]);
   const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
+  const [staffTeamIds, setStaffTeamIds] = useState<string[]>([]);
   const [scheduleLoadError, setScheduleLoadError] = useState<AppServiceError | null>(null);
   const {
     loading: scheduleReadLoading,
@@ -235,18 +237,21 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const pastHistoryLoadedRef = useRef(false);
   const childrenRef = useRef<ParentScheduleChild[]>([]);
   const eventsRef = useRef<ParentScheduleEvent[]>([]);
+  const staffTeamIdsRef = useRef<string[]>([]);
   const trackerConfigCacheRef = useRef<Record<string, ScheduleStatTrackerConfigOption[]>>({});
   const trackerConfigRequestPromiseRef = useRef<Record<string, Promise<ScheduleStatTrackerConfigOption[]>>>({});
   const [trackerConfigRequestedTeamIds, setTrackerConfigRequestedTeamIds] = useState<Record<string, true>>({});
 
-  const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
+  const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; staffTeamIds?: string[]; }) => {
     childrenRef.current = data.children;
     eventsRef.current = data.events;
+    staffTeamIdsRef.current = data.staffTeamIds || [];
     setChildren(data.children);
     setEvents(data.events);
+    setStaffTeamIds(data.staffTeamIds || []);
   };
 
-  const mergeScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
+  const mergeScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; staffTeamIds?: string[]; }) => {
     const mergedChildren = [...childrenRef.current];
     const childKeys = new Set(mergedChildren.map((child) => `${child.teamId}::${child.playerId}`));
     data.children.forEach((child) => {
@@ -266,7 +271,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
       }
     });
     mergedEvents.sort((a, b) => a.date.getTime() - b.date.getTime());
-    applyScheduleResult({ children: mergedChildren, events: mergedEvents });
+    const mergedStaffTeamIds = Array.from(new Set([...staffTeamIdsRef.current, ...(data.staffTeamIds || [])]));
+    applyScheduleResult({ children: mergedChildren, events: mergedEvents, staffTeamIds: mergedStaffTeamIds });
   };
 
   const buildPastScheduleRangeByTeam = () => {
@@ -317,7 +323,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
         });
         return {
           children: result.children,
-          events: result.events.filter((event) => !beforeKeys.has(event.eventKey))
+          events: result.events.filter((event) => !beforeKeys.has(event.eventKey)),
+          staffTeamIds: result.staffTeamIds
         };
       },
       {
@@ -328,7 +335,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
             setPastHistoryHasMore(false);
             return;
           }
-          mergeScheduleResult({ children: result.children, events: result.events });
+          mergeScheduleResult(result);
           setPastHistoryHasMore(true);
         }
       }
@@ -454,7 +461,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           const mappedError = toAppServiceError(loadError, 'Unable to load schedule.');
           setScheduleLoadError(mappedError);
           if (!hasExistingSchedule) {
-            applyScheduleResult({ children: [], events: [] });
+            applyScheduleResult({ children: [], events: [], staffTeamIds: [] });
           }
           setLoadedScheduleUserId(auth.user?.uid || null);
           timer.end({
@@ -477,7 +484,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setPastHistoryHasMore(false);
     if (!auth.user?.uid) {
       setLoadedScheduleUserId(null);
-      applyScheduleResult({ children: [], events: [] });
+      applyScheduleResult({ children: [], events: [], staffTeamIds: [] });
       return;
     }
     hasStartedInitialScheduleLoadRef.current = true;
@@ -618,8 +625,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
     rideRequests: windowedListEntries.rideRequests
   }), [counts.packetsReady, counts.rsvpNeeded, windowedListEntries.nextEvent, windowedListEntries.openAssignments, windowedListEntries.rideRequests]);
   const manageableTeamOptions = useMemo(() => (
-    teamOptions.filter((team) => events.some((event) => event.teamId === team.teamId && event.isTeamStaff === true))
-  ), [events, teamOptions]);
+    getManageableScheduleTeamOptions(teamOptions, events, staffTeamIds)
+  ), [events, staffTeamIds, teamOptions]);
   const [selectedStaffManageTeamId, setSelectedStaffManageTeamId] = useState('');
   const hasManageableScheduleTeams = manageableTeamOptions.length > 0;
   const selectedCalendarTeam = useMemo(() => {

--- a/tests/unit/app-schedule-async-operation-contract.test.js
+++ b/tests/unit/app-schedule-async-operation-contract.test.js
@@ -37,7 +37,7 @@ describe('Schedule async operation contract', () => {
         expect(refreshScheduleSource).toContain("getScheduleLoadErrorMessage(toAppServiceError(loadError, 'Unable to load schedule.'), hasExistingSchedule)");
         expect(refreshScheduleSource).toContain("const mappedError = toAppServiceError(loadError, 'Unable to load schedule.');");
         expect(refreshScheduleSource).toContain('if (!hasExistingSchedule) {');
-        expect(refreshScheduleSource).toContain('applyScheduleResult({ children: [], events: [] });');
+        expect(refreshScheduleSource).toContain('applyScheduleResult({ children: [], events: [], staffTeamIds: [] });');
         expect(refreshScheduleSource).toContain('setLoadedScheduleUserId(auth.user?.uid || null);');
     });
 

--- a/tests/unit/app-schedule-lazy-load.test.tsx
+++ b/tests/unit/app-schedule-lazy-load.test.tsx
@@ -40,7 +40,7 @@ describe('Schedule lazy-load guards', () => {
         expect(refreshSource).toContain('cacheHit: Boolean(cached) && !force');
         expect(refreshSource).toContain('onError: (loadError) => {');
         expect(refreshSource).toContain("const mappedError = toAppServiceError(loadError, 'Unable to load schedule.');");
-        expect(refreshSource).toContain('if (!hasExistingSchedule) {\n            applyScheduleResult({ children: [], events: [] });\n          }');
+        expect(refreshSource).toContain('if (!hasExistingSchedule) {\n            applyScheduleResult({ children: [], events: [], staffTeamIds: [] });\n          }');
         expect(refreshSource).not.toContain('setLoading(');
         expect(refreshSource).not.toContain('finally {');
     });

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -9,6 +9,7 @@ import {
     getCalendarScheduleEntries,
     getScheduleEventDetailPath,
     getNextRideConfirmedSeatCount,
+    getManageableScheduleTeamOptions,
     getOpenScheduleAssignments,
     getParentScheduleTeamOptions,
     getPracticePacketRows,
@@ -64,6 +65,21 @@ describe('React app parent schedule logic', () => {
             url: 'https://example.com/team.ics?token=abc',
             error: null
         });
+    });
+
+    it('derives manageable teams from staff team ids with event flags as a fallback', () => {
+        const teamOptions = getParentScheduleTeamOptions([
+            event({ teamId: 'team-2', teamName: 'Wolves', isTeamStaff: true }),
+            event({ teamId: 'team-3', teamName: 'Hawks', isTeamStaff: false })
+        ], [
+            { teamId: 'team-1', teamName: 'Bears', playerId: 'staff-team-team-1' }
+        ]);
+
+        expect(getManageableScheduleTeamOptions(teamOptions, [], ['team-1']).map((team) => team.teamId)).toEqual(['team-1']);
+        expect(getManageableScheduleTeamOptions(teamOptions, [
+            event({ teamId: 'team-2', teamName: 'Wolves', isTeamStaff: true }),
+            event({ teamId: 'team-3', teamName: 'Hawks', isTeamStaff: false })
+        ]).map((team) => team.teamId)).toEqual(['team-2']);
     });
 
     it('keeps parent task-targeted event detail routes explicit', () => {


### PR DESCRIPTION
## Summary
- Return staff team IDs from the app schedule service and keep staff placeholder children in the schedule result so empty staff teams still populate schedule team options.
- Derive Manage schedule teams from role-derived staff team IDs, with the previous event `isTeamStaff` flag as a fallback.
- Add regression coverage for empty-schedule staff tools and manageable team derivation.

## Tests
- `npx vitest run tests/unit/app-schedule-logic.test.js --reporter=verbose`
- `npx vitest run apps/app/src/pages/Schedule.test.tsx --reporter=verbose`
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=verbose`
- `npx vitest run apps/app/src/lib/scheduleService.test.ts --reporter=verbose`
- `npm run app:build`

Fixes #3857
