### PR TITLE
Support practices in edit schedule AI import

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -961,7 +961,7 @@
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=3';
         import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';
-        import { buildBulkAiPracticePayload, normalizeBulkAiAssignments, normalizeBulkAiEventForAdd, normalizeBulkAiIsHome } from './js/edit-schedule-ai-import.js?v=1';
+        import { buildBulkAiPracticePayload, createBulkAiImageController, normalizeBulkAiAssignments, normalizeBulkAiEventForAdd, normalizeBulkAiIsHome } from './js/edit-schedule-ai-import.js?v=2';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';
         import { Timestamp, deleteField, auth } from "./js/firebase.js?v=20";
@@ -972,7 +972,6 @@
         import { buildTournamentGroupOverrideKey, buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=4';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=4';
-        import { createBulkAiImageController } from './js/edit-schedule-ai-import.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -4809,7 +4808,7 @@ PARSING RULES:
                 });
 
                 if (proposedOperations.length === 0) {
-                    alert('AI did not find any games to add/update/delete in the text. Please try being more specific with dates and opponents.');
+                    alert('AI did not find any games or practices in the schedule. Please try being more specific with dates, times, and event details.');
                 }
 
                 await renderProposedChanges();
@@ -4886,7 +4885,7 @@ PARSING RULES:
                                         ${isPractice ? `<input type="datetime-local" value="${formatIsoForInput(game.endTime)}"
                                             onchange="updateOperation(${index}, 'endTime', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1">` : ''}
-                                        <input type="text" value="${game.location || ''}" placeholder="Location"
+                                        <input type="text" value="${escapeHtml(game.location || '')}" placeholder="Location"
                                             onchange="updateOperation(${index}, 'location', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full">
                                         ${isPractice ? '' : `<select onchange="updateOperation(${index}, 'isHome', this.value)"
@@ -4904,7 +4903,7 @@ PARSING RULES:
                                         <textarea rows="2" placeholder="Notes"
                                             onchange="updateOperation(${index}, 'notes', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">${escapeHtml(game.notes || '')}</textarea>
-                                        <input type="text" value="${formatAssignmentsForInput(game.assignments)}" placeholder="Assignments: Role:Value; Role2:Value2"
+                                        <input type="text" value="${escapeHtml(formatAssignmentsForInput(game.assignments))}" placeholder="Assignments: Role:Value; Role2:Value2"
                                             onchange="updateOperation(${index}, 'assignments', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
                                     </div>

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -961,6 +961,7 @@
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=3';
         import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=2';
+        import { buildBulkAiPracticePayload, normalizeBulkAiAssignments, normalizeBulkAiEventForAdd, normalizeBulkAiIsHome } from './js/edit-schedule-ai-import.js?v=1';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';
         import { Timestamp, deleteField, auth } from "./js/firebase.js?v=20";
@@ -4085,14 +4086,7 @@
         }
 
         function normalizeIsHome(value) {
-            if (value === true || value === false || value === null) return value;
-            if (typeof value === 'string') {
-                const v = value.trim().toLowerCase();
-                if (v === 'home') return true;
-                if (v === 'away') return false;
-                if (v === '' || v === 'unknown' || v === 'null') return null;
-            }
-            return null;
+            return normalizeBulkAiIsHome(value);
         }
 
         function formatIsoForInput(value) {
@@ -4104,12 +4098,7 @@
 
         function normalizeAssignments(value) {
             if (!Array.isArray(value)) return [];
-            const normalized = value
-                .map((a) => ({
-                    role: String(a?.role || '').trim(),
-                    value: String(a?.value || '').trim()
-                }))
-                .filter((a) => a.role);
+            const normalized = normalizeBulkAiAssignments(value);
             if (value.length > normalized.length) {
                 console.warn('Bulk AI assignments: dropped malformed entries', {
                     provided: value.length,
@@ -4139,16 +4128,7 @@
         }
 
         function normalizeBulkGameForAdd(game) {
-            const normalizedIsHome = normalizeIsHome(game?.isHome);
-            const rawKitColor = typeof game?.kitColor === 'string' ? game.kitColor.trim() : '';
-            const kitColor = rawKitColor || (normalizedIsHome === true ? 'Home kit' : (normalizedIsHome === false ? 'Away kit' : 'TBD kit'));
-            return {
-                ...game,
-                isHome: normalizedIsHome,
-                kitColor,
-                notes: game?.notes ? String(game.notes).trim() : null,
-                assignments: normalizeAssignments(game?.assignments || [])
-            };
+            return normalizeBulkAiEventForAdd(game);
         }
 
         function showCsvImportErrors(errors = []) {
@@ -4705,12 +4685,15 @@
                                     action: Schema.string(),
                                     game: Schema.object({
                                         properties: {
+                                            eventType: Schema.string(),
                                             date: Schema.string(),
                                             opponent: Schema.string(),
+                                            title: Schema.string(),
                                             location: Schema.string(),
                                             isHome: Schema.boolean(),
                                             kitColor: Schema.string(),
                                             arrivalTime: Schema.string(),
+                                            endTime: Schema.string(),
                                             notes: Schema.string(),
                                             assignments: Schema.array({
                                                 items: Schema.object({
@@ -4724,7 +4707,7 @@
                                             homeScore: Schema.number(),
                                             awayScore: Schema.number()
                                         },
-                                        optionalProperties: ["isHome", "kitColor", "arrivalTime", "notes", "assignments", "status", "homeScore", "awayScore"]
+                                        optionalProperties: ["eventType", "opponent", "title", "isHome", "kitColor", "arrivalTime", "endTime", "notes", "assignments", "status", "homeScore", "awayScore"]
                                     }),
                                     gameId: Schema.string(),
                                     changes: Schema.object({
@@ -4756,22 +4739,24 @@
                 });
 
                 // Create AI prompt
-                let promptText = `Parse this sports schedule and extract game information.
+                let promptText = `Parse this sports schedule and extract game and practice information.
 
 CONTEXT:
 - Today: ${now.toISOString().split('T')[0]}
 - Team: ${currentTeam.name}
 - Current games in DB: ${gamesContext.length}
 
-${imageFile ? 'The schedule is provided as an image. Extract all game information from it.' : 'SCHEDULE TEXT:\n' + textInput}
+${imageFile ? 'The schedule is provided as an image. Extract all game and practice information from it.' : 'SCHEDULE TEXT:\n' + textInput}
 
 ${textInput && imageFile ? '\nADDITIONAL INSTRUCTIONS:\n' + textInput : ''}
 
 PARSING RULES:
-1. Extract all games from the ${imageFile ? 'image' : 'text'} (look for Date/Time/Home/Away/Location columns or any game entries)
-2. Skip headers, "Week X", "Thanksgiving", and non-game text
+1. Extract all games and practices from the ${imageFile ? 'image' : 'text'} (look for Date/Time/Home/Away/Location columns or any schedule entries)
+2. Skip headers, "Week X", "Thanksgiving", and text that is not a schedule event
 3. Team variations: "${currentTeam.name}", "${currentTeam.name}10", "${currentTeam.name}22" = same team
-4. Opponent: The team that is NOT ${currentTeam.name} (check Home/Away columns)
+4. Event type:
+   - Entries labeled "Practice", "Training", or practice-style scrimmage have no opponent. Emit eventType="practice" with title="Practice" unless another practice title is shown.
+   - Games have an opponent. Emit eventType="game" and set opponent to the team that is NOT ${currentTeam.name} (check Home/Away columns).
 5. Date format: Convert to ISO 8601 YYYY-MM-DDTHH:mm:ss (e.g., "2024-12-06T08:30:00")
    - "11/15" = November 15, "Sat 11/22" = November 22
    - Use year ${currentYear} for future dates, ${currentYear + 1} for past dates
@@ -4780,9 +4765,12 @@ PARSING RULES:
    - Home/Away -> isHome (true for home, false for away)
    - Kit/Uniform color -> kitColor
    - Arrival/check-in time -> arrivalTime (ISO 8601 datetime)
+   - Practice end time or duration -> endTime (ISO 8601 datetime)
    - Notes/comments -> notes
    - Assignments (snack, carpool, etc.) -> assignments array: [{ role, value }]
-8. For each game, create an operation with action="add" and game object with date, opponent, location, status="scheduled", homeScore=0, awayScore=0`;
+8. For each event, create an operation with action="add" and game object:
+   - Game example: { "eventType": "game", "date": "2026-04-02T18:30:00", "opponent": "Tigers", "location": "Main Field", "status": "scheduled", "homeScore": 0, "awayScore": 0 }
+   - Practice example for "Mon 13 / Practice / At Overland Trail Elementary / 6:00 PM": { "eventType": "practice", "date": "2026-07-13T18:00:00", "title": "Practice", "location": "Overland Trail Elementary", "status": "scheduled" }`;
 
                 // Call Firebase AI with structured output
                 const firebaseApp = getApp();
@@ -4854,7 +4842,7 @@ PARSING RULES:
             // Check conflicts for all ADD operations first
             const conflictChecks = await Promise.all(
                 proposedOperations.map(async (op) => {
-                    if (op.action === 'add') {
+                    if (op.action === 'add' && op.game?.eventType !== 'practice') {
                         return await checkForConflict(op.game);
                     }
                     return false;
@@ -4864,31 +4852,44 @@ PARSING RULES:
             list.innerHTML = proposedOperations.map((op, index) => {
                 if (op.action === 'add') {
                     const game = op.game;
+                    const isPractice = game.eventType === 'practice';
                     const date = new Date(game.date);
                     const dateStr = formatDate(date);
                     const timeStr = formatTime(date);
                     const hasConflict = conflictChecks[index];
+                    const accentClasses = isPractice
+                        ? 'border-emerald-300 bg-emerald-50'
+                        : (hasConflict ? 'border-yellow-400 bg-yellow-50' : 'border-green-300 bg-green-50');
+                    const labelClasses = isPractice
+                        ? 'text-emerald-700'
+                        : (hasConflict ? 'text-yellow-700' : 'text-green-700');
+                    const actionLabel = isPractice
+                        ? 'Add Practice'
+                        : (hasConflict ? 'Add Game (Conflict)' : 'Add Game');
 
                     return `
-                        <div class="border ${hasConflict ? 'border-yellow-400 bg-yellow-50' : 'border-green-300 bg-green-50'} rounded-lg p-3" data-index="${index}">
+                        <div class="border ${accentClasses} rounded-lg p-3" data-index="${index}">
                             <div class="flex justify-between items-start gap-2">
                                 <div class="flex-1">
                                     <div class="flex items-center gap-2 mb-1">
-                                        <span class="text-xs font-bold ${hasConflict ? 'text-yellow-700' : 'text-green-700'} uppercase">
-                                            ${hasConflict ? '⚠️ Add (Conflict)' : '➕ Add'}
+                                        <span class="text-xs font-bold ${labelClasses} uppercase">
+                                            ${actionLabel}
                                         </span>
                                     </div>
                                     <div class="text-sm">
-                                        <input type="text" value="${escapeHtml(game.opponent)}"
-                                            onchange="updateOperation(${index}, 'opponent', this.value)"
+                                        <input type="text" value="${escapeHtml(isPractice ? (game.title || 'Practice') : game.opponent)}"
+                                            onchange="updateOperation(${index}, '${isPractice ? 'title' : 'opponent'}', this.value)"
                                             class="font-semibold bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1">
                                         <input type="datetime-local" value="${formatIsoForInput(date)}"
                                             onchange="updateOperation(${index}, 'date', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1">
+                                        ${isPractice ? `<input type="datetime-local" value="${formatIsoForInput(game.endTime)}"
+                                            onchange="updateOperation(${index}, 'endTime', this.value)"
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1">` : ''}
                                         <input type="text" value="${game.location || ''}" placeholder="Location"
                                             onchange="updateOperation(${index}, 'location', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full">
-                                        <select onchange="updateOperation(${index}, 'isHome', this.value)"
+                                        ${isPractice ? '' : `<select onchange="updateOperation(${index}, 'isHome', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
                                             <option value="" ${game.isHome === null || game.isHome === undefined ? 'selected' : ''}>Home/Away Unknown</option>
                                             <option value="home" ${game.isHome === true ? 'selected' : ''}>Home</option>
@@ -4896,7 +4897,7 @@ PARSING RULES:
                                         </select>
                                         <input type="text" value="${game.kitColor || ''}" placeholder="Kit color"
                                             onchange="updateOperation(${index}, 'kitColor', this.value)"
-                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">`}
                                         <input type="datetime-local" value="${formatIsoForInput(game.arrivalTime)}"
                                             onchange="updateOperation(${index}, 'arrivalTime', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
@@ -4976,6 +4977,8 @@ PARSING RULES:
             if (proposedOperations[index].action === 'add') {
                 if (field === 'date') {
                     proposedOperations[index].game[field] = new Date(value).toISOString();
+                } else if (field === 'endTime') {
+                    proposedOperations[index].game[field] = value ? new Date(value).toISOString() : null;
                 } else if (field === 'arrivalTime') {
                     proposedOperations[index].game[field] = value ? new Date(value).toISOString() : null;
                 } else if (field === 'isHome') {
@@ -5023,6 +5026,16 @@ PARSING RULES:
                     try {
                         if (op.action === 'add') {
                             const normalizedGame = normalizeBulkGameForAdd(op.game);
+                            if (normalizedGame.eventType === 'practice') {
+                                const practiceData = buildBulkAiPracticePayload(normalizedGame, {
+                                    Timestamp,
+                                    getDefaultEndTime,
+                                    userId: currentUser?.uid || null
+                                });
+                                await addPractice(currentTeamId, practiceData);
+                                successCount++;
+                                continue;
+                            }
                             const gameData = {
                                 ...normalizedGame,
                                 type: 'game',

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -4756,6 +4756,7 @@ PARSING RULES:
 4. Event type:
    - Entries labeled "Practice", "Training", or practice-style scrimmage have no opponent. Emit eventType="practice" with title="Practice" unless another practice title is shown.
    - Games have an opponent. Emit eventType="game" and set opponent to the team that is NOT ${currentTeam.name} (check Home/Away columns).
+   - If a game opponent cannot be extracted, do not emit an add operation for that game.
 5. Date format: Convert to ISO 8601 YYYY-MM-DDTHH:mm:ss (e.g., "2024-12-06T08:30:00")
    - "11/15" = November 15, "Sat 11/22" = November 22
    - Use year ${currentYear} for future dates, ${currentYear + 1} for past dates

--- a/js/edit-schedule-ai-import.js
+++ b/js/edit-schedule-ai-import.js
@@ -153,3 +153,95 @@ export function createBulkAiImageController({
         setBulkAiImage
     };
 }
+
+export function normalizeBulkAiEventType(value) {
+    return String(value || '').trim().toLowerCase() === 'practice' ? 'practice' : 'game';
+}
+
+export function normalizeBulkAiAssignments(value) {
+    if (!Array.isArray(value)) return [];
+    return value
+        .map((a) => ({
+            role: String(a?.role || '').trim(),
+            value: String(a?.value || '').trim()
+        }))
+        .filter((a) => a.role);
+}
+
+export function normalizeBulkAiIsHome(value) {
+    if (value === true || value === false || value === null) return value;
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (normalized === 'home') return true;
+        if (normalized === 'away') return false;
+        if (normalized === '' || normalized === 'unknown' || normalized === 'null') return null;
+    }
+    return null;
+}
+
+export function normalizeBulkAiEventForAdd(event) {
+    const eventType = normalizeBulkAiEventType(event?.eventType);
+    const normalized = {
+        ...event,
+        eventType,
+        date: event?.date ? String(event.date).trim() : '',
+        location: event?.location ? String(event.location).trim() : '',
+        notes: event?.notes ? String(event.notes).trim() : null,
+        assignments: normalizeBulkAiAssignments(event?.assignments || []),
+        status: event?.status || 'scheduled'
+    };
+
+    if (eventType === 'practice') {
+        return {
+            ...normalized,
+            title: event?.title ? String(event.title).trim() : 'Practice',
+            opponent: null,
+            endTime: event?.endTime ? String(event.endTime).trim() : null,
+            arrivalTime: event?.arrivalTime ? String(event.arrivalTime).trim() : null
+        };
+    }
+
+    const normalizedIsHome = normalizeBulkAiIsHome(event?.isHome);
+    const rawKitColor = typeof event?.kitColor === 'string' ? event.kitColor.trim() : '';
+    const kitColor = rawKitColor || (normalizedIsHome === true ? 'Home kit' : (normalizedIsHome === false ? 'Away kit' : 'TBD kit'));
+    return {
+        ...normalized,
+        opponent: event?.opponent ? String(event.opponent).trim() : '',
+        isHome: normalizedIsHome,
+        kitColor,
+        arrivalTime: event?.arrivalTime ? String(event.arrivalTime).trim() : null,
+        homeScore: Number.isFinite(Number(event?.homeScore)) ? Number(event.homeScore) : 0,
+        awayScore: Number.isFinite(Number(event?.awayScore)) ? Number(event.awayScore) : 0
+    };
+}
+
+export function buildBulkAiPracticePayload(event, {
+    Timestamp,
+    getDefaultEndTime,
+    userId = null
+} = {}) {
+    if (!Timestamp || typeof Timestamp.fromDate !== 'function' || typeof getDefaultEndTime !== 'function') {
+        throw new Error('buildBulkAiPracticePayload requires Timestamp and getDefaultEndTime helpers');
+    }
+
+    const normalized = normalizeBulkAiEventForAdd({ ...event, eventType: 'practice' });
+    const startDate = new Date(normalized.date);
+    if (Number.isNaN(startDate.getTime())) {
+        throw new Error('Practice date is required.');
+    }
+    const endDate = normalized.endTime ? new Date(normalized.endTime) : getDefaultEndTime(startDate, 'practice');
+
+    return {
+        title: normalized.title || 'Practice',
+        date: Timestamp.fromDate(startDate),
+        end: Timestamp.fromDate(endDate),
+        location: normalized.location || '',
+        notes: normalized.notes,
+        arrivalTime: normalized.arrivalTime ? Timestamp.fromDate(new Date(normalized.arrivalTime)) : null,
+        source: 'bulk_ai',
+        sourceMetadata: {
+            importedBy: userId || null,
+            importedFrom: 'edit-schedule-bulk-ai'
+        }
+    };
+}

--- a/js/edit-schedule-ai-import.js
+++ b/js/edit-schedule-ai-import.js
@@ -230,6 +230,17 @@ export function buildBulkAiPracticePayload(event, {
         throw new Error('Practice date is required.');
     }
     const endDate = normalized.endTime ? new Date(normalized.endTime) : getDefaultEndTime(startDate, 'practice');
+    if (!(endDate instanceof Date) || Number.isNaN(endDate.getTime())) {
+        throw new Error('Practice end time must be a valid date.');
+    }
+    if (endDate.getTime() <= startDate.getTime()) {
+        throw new Error('Practice end time must be after the start time.');
+    }
+
+    const arrivalDate = normalized.arrivalTime ? new Date(normalized.arrivalTime) : null;
+    if (arrivalDate && Number.isNaN(arrivalDate.getTime())) {
+        throw new Error('Practice arrival time must be a valid date.');
+    }
 
     return {
         title: normalized.title || 'Practice',
@@ -237,7 +248,7 @@ export function buildBulkAiPracticePayload(event, {
         end: Timestamp.fromDate(endDate),
         location: normalized.location || '',
         notes: normalized.notes,
-        arrivalTime: normalized.arrivalTime ? Timestamp.fromDate(new Date(normalized.arrivalTime)) : null,
+        arrivalTime: arrivalDate ? Timestamp.fromDate(arrivalDate) : null,
         assignments: normalized.assignments,
         source: 'bulk_ai',
         sourceMetadata: {

--- a/js/edit-schedule-ai-import.js
+++ b/js/edit-schedule-ai-import.js
@@ -238,6 +238,7 @@ export function buildBulkAiPracticePayload(event, {
         location: normalized.location || '',
         notes: normalized.notes,
         arrivalTime: normalized.arrivalTime ? Timestamp.fromDate(new Date(normalized.arrivalTime)) : null,
+        assignments: normalized.assignments,
         source: 'bulk_ai',
         sourceMetadata: {
             importedBy: userId || null,

--- a/js/edit-schedule-ai-import.js
+++ b/js/edit-schedule-ai-import.js
@@ -202,11 +202,15 @@ export function normalizeBulkAiEventForAdd(event) {
     }
 
     const normalizedIsHome = normalizeBulkAiIsHome(event?.isHome);
+    const opponent = event?.opponent ? String(event.opponent).trim() : '';
+    if (!opponent) {
+        throw new Error('Game opponent is required.');
+    }
     const rawKitColor = typeof event?.kitColor === 'string' ? event.kitColor.trim() : '';
     const kitColor = rawKitColor || (normalizedIsHome === true ? 'Home kit' : (normalizedIsHome === false ? 'Away kit' : 'TBD kit'));
     return {
         ...normalized,
-        opponent: event?.opponent ? String(event.opponent).trim() : '',
+        opponent,
         isHome: normalizedIsHome,
         kitColor,
         arrivalTime: event?.arrivalTime ? String(event.arrivalTime).trim() : null,

--- a/tests/smoke/edit-schedule-calendar-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-import.spec.js
@@ -45,7 +45,12 @@ export async function updateGame(teamId, gameId, gameData) {
 }
 export async function updateTeam() {}
 export async function deleteGame() {}
-export async function addPractice() { return 'practice-created'; }
+export async function addPractice(teamId, practiceData) {
+    const testState = state();
+    testState.addPracticeCalls = testState.addPracticeCalls || [];
+    testState.addPracticeCalls.push({ teamId, practiceData });
+    return 'practice-created';
+}
 export async function updateEvent() {}
 export async function deleteEvent() {}
 export async function getConfigs() { return []; }
@@ -245,16 +250,33 @@ export function getApp() {
 }
 `,
     '/js/vendor/firebase-ai.js': `
+const state = () => window.__editScheduleTestState || {};
+
 export function getAI() {
     return {};
 }
 
 export function getGenerativeModel() {
-    return {};
+    return {
+        async generateContent(promptParts) {
+            state().aiPromptParts = promptParts;
+            return {
+                response: {
+                    text: () => JSON.stringify({ operations: state().aiOperations || [] })
+                }
+            };
+        }
+    };
 }
 
-export const GoogleAIBackend = {};
-export const Schema = {};
+export class GoogleAIBackend {}
+export const Schema = {
+    array: (value) => value,
+    boolean: () => ({}),
+    number: () => ({}),
+    object: (value) => value,
+    string: () => ({})
+};
 `,
     '/js/tournament-brackets.js': `
 export function buildPoolStandingsIndex() {
@@ -595,6 +617,51 @@ test.describe('edit schedule Bulk AI image input', () => {
         expect(imagePastePrevented).toBe(true);
         await expect(page.locator('#schedule-image-preview')).toBeVisible();
         await expect(page.locator('#schedule-image-preview-img')).toHaveAttribute('src', /^data:image\/png;base64,/);
+    });
+
+    test('previews and applies a recognized practice through the practice persistence path', async ({ page }) => {
+        await page.addInitScript((state) => {
+            window.__editScheduleTestState = state;
+            window.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+        }, buildState({
+            aiOperations: [{
+                action: 'add',
+                game: {
+                    eventType: 'practice',
+                    date: '2030-05-13T18:00:00',
+                    endTime: '2030-05-13T19:30:00',
+                    title: 'Practice',
+                    location: 'Overland Trail Elementary',
+                    assignments: [{ role: 'Snack', value: 'Taylor family' }]
+                }
+            }]
+        }));
+        page.on('dialog', (dialog) => dialog.accept());
+
+        await page.goto(`${serverOrigin}/edit-schedule.html#teamId=team-1`, { waitUntil: 'domcontentloaded' });
+        await page.locator('#tab-bulk-ai').click();
+        await page.locator('#bulk-text-input').fill('Mon 13\n- Practice\n- At Overland Trail Elementary\n- 6:00 PM');
+        await page.locator('#process-ai-btn').click();
+
+        const proposedChange = page.locator('#proposed-changes-list');
+        await expect(proposedChange).toContainText('Add Practice');
+        await expect(proposedChange.locator('input[placeholder="Location"]')).toHaveValue('Overland Trail Elementary');
+        await expect(proposedChange.locator('input[placeholder^="Assignments"]')).toHaveValue('Snack:Taylor family');
+
+        const promptText = await page.evaluate(() => window.__editScheduleTestState.aiPromptParts[0]);
+        expect(promptText).toContain('extract game and practice information');
+        expect(promptText).toContain('eventType="practice"');
+
+        await page.locator('#apply-changes-btn').click();
+        const practiceCall = await page.waitForFunction(() => window.__editScheduleTestState?.addPracticeCalls?.[0])
+            .then((handle) => handle.jsonValue());
+        expect(practiceCall.teamId).toBe('team-1');
+        expect(practiceCall.practiceData).toMatchObject({
+            title: 'Practice',
+            location: 'Overland Trail Elementary',
+            assignments: [{ role: 'Snack', value: 'Taylor family' }],
+            source: 'bulk_ai'
+        });
     });
 });
 

--- a/tests/unit/edit-schedule-ai-image-clipboard.test.js
+++ b/tests/unit/edit-schedule-ai-image-clipboard.test.js
@@ -192,7 +192,8 @@ describe('edit schedule Bulk AI image clipboard support', () => {
         const source = readEditSchedule();
         const helperSource = readHelperSource();
 
-        expect(source).toContain("import { createBulkAiImageController } from './js/edit-schedule-ai-import.js?v=1';");
+        expect(source).toContain('createBulkAiImageController');
+        expect(source).toContain("from './js/edit-schedule-ai-import.js?v=2';");
         expect(source).toContain('Upload, paste (Ctrl/Cmd+V), or drop a screenshot of the schedule.');
         expect(source).toContain("container: document.getElementById('content-bulk-ai')");
         expect(source).toContain("textInput: document.getElementById('bulk-text-input')");

--- a/tests/unit/edit-schedule-ai-import.test.js
+++ b/tests/unit/edit-schedule-ai-import.test.js
@@ -38,7 +38,11 @@ describe('edit schedule bulk AI import', () => {
             eventType: 'practice',
             date: '2026-07-13T18:00:00',
             title: 'Practice',
-            location: 'Overland Trail Elementary'
+            location: 'Overland Trail Elementary',
+            assignments: [
+                { role: ' Snack ', value: ' Coach Taylor ' },
+                { role: 'Carpool', value: 'Jordan family' }
+            ]
         }, {
             Timestamp,
             getDefaultEndTime: defaultEndTime,
@@ -49,6 +53,10 @@ describe('edit schedule bulk AI import', () => {
         expect(payload.location).toBe('Overland Trail Elementary');
         expect(payload.date).toEqual(new Date('2026-07-13T18:00:00'));
         expect(payload.end).toEqual(new Date('2026-07-13T19:30:00'));
+        expect(payload.assignments).toEqual([
+            { role: 'Snack', value: 'Coach Taylor' },
+            { role: 'Carpool', value: 'Jordan family' }
+        ]);
         expect(payload.source).toBe('bulk_ai');
         expect(payload.sourceMetadata).toEqual({
             importedBy: 'coach-1',

--- a/tests/unit/edit-schedule-ai-import.test.js
+++ b/tests/unit/edit-schedule-ai-import.test.js
@@ -86,6 +86,21 @@ describe('edit schedule bulk AI import', () => {
         });
     });
 
+    it('rejects game add operations without an opponent', () => {
+        expect(() => normalizeBulkAiEventForAdd({
+            eventType: 'game',
+            date: '2026-04-02T18:30:00',
+            location: 'Main Field'
+        })).toThrow('Game opponent is required.');
+
+        expect(() => normalizeBulkAiEventForAdd({
+            eventType: 'game',
+            date: '2026-04-02T18:30:00',
+            opponent: '   ',
+            location: 'Main Field'
+        })).toThrow('Game opponent is required.');
+    });
+
     it('rejects practice end times that are invalid or not after the start', () => {
         const dependencies = {
             Timestamp,
@@ -121,6 +136,7 @@ describe('edit schedule bulk AI import', () => {
 
         expect(source).toContain('eventType: Schema.string()');
         expect(source).toContain('Practice", "Training", or practice-style scrimmage have no opponent');
+        expect(source).toContain('If a game opponent cannot be extracted, do not emit an add operation for that game.');
         expect(source).toContain('"eventType": "practice"');
         expect(source).toContain('buildBulkAiPracticePayload(normalizedGame');
         expect(source).toContain('await addPractice(currentTeamId, practiceData);');

--- a/tests/unit/edit-schedule-ai-import.test.js
+++ b/tests/unit/edit-schedule-ai-import.test.js
@@ -86,6 +86,36 @@ describe('edit schedule bulk AI import', () => {
         });
     });
 
+    it('rejects practice end times that are invalid or not after the start', () => {
+        const dependencies = {
+            Timestamp,
+            getDefaultEndTime: defaultEndTime
+        };
+
+        expect(() => buildBulkAiPracticePayload({
+            eventType: 'practice',
+            date: '2026-07-13T18:00:00',
+            endTime: 'not-a-date'
+        }, dependencies)).toThrow('Practice end time must be a valid date.');
+
+        expect(() => buildBulkAiPracticePayload({
+            eventType: 'practice',
+            date: '2026-07-13T18:00:00',
+            endTime: '2026-07-13T17:59:00'
+        }, dependencies)).toThrow('Practice end time must be after the start time.');
+    });
+
+    it('rejects an invalid optional practice arrival time', () => {
+        expect(() => buildBulkAiPracticePayload({
+            eventType: 'practice',
+            date: '2026-07-13T18:00:00',
+            arrivalTime: 'not-a-date'
+        }, {
+            Timestamp,
+            getDefaultEndTime: defaultEndTime
+        })).toThrow('Practice arrival time must be a valid date.');
+    });
+
     it('keeps practice rules in the inline AI prompt and response schema', () => {
         const source = readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
 
@@ -94,5 +124,6 @@ describe('edit schedule bulk AI import', () => {
         expect(source).toContain('"eventType": "practice"');
         expect(source).toContain('buildBulkAiPracticePayload(normalizedGame');
         expect(source).toContain('await addPractice(currentTeamId, practiceData);');
+        expect(source).toContain("from './js/edit-schedule-ai-import.js?v=2';");
     });
 });

--- a/tests/unit/edit-schedule-ai-import.test.js
+++ b/tests/unit/edit-schedule-ai-import.test.js
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+    buildBulkAiPracticePayload,
+    normalizeBulkAiEventForAdd
+} from '../../js/edit-schedule-ai-import.js';
+
+describe('edit schedule bulk AI import', () => {
+    const Timestamp = {
+        fromDate: (value) => value
+    };
+
+    function defaultEndTime(startDate) {
+        return new Date(startDate.getTime() + 90 * 60 * 1000);
+    }
+
+    it('normalizes practice add operations without requiring an opponent', () => {
+        const normalized = normalizeBulkAiEventForAdd({
+            eventType: 'practice',
+            date: '2026-07-13T18:00:00',
+            title: 'Practice',
+            location: ' Overland Trail Elementary ',
+            notes: ' Bring water '
+        });
+
+        expect(normalized).toMatchObject({
+            eventType: 'practice',
+            title: 'Practice',
+            opponent: null,
+            location: 'Overland Trail Elementary',
+            notes: 'Bring water',
+            status: 'scheduled'
+        });
+    });
+
+    it('builds a practice payload for the issue 3860 fixture', () => {
+        const payload = buildBulkAiPracticePayload({
+            eventType: 'practice',
+            date: '2026-07-13T18:00:00',
+            title: 'Practice',
+            location: 'Overland Trail Elementary'
+        }, {
+            Timestamp,
+            getDefaultEndTime: defaultEndTime,
+            userId: 'coach-1'
+        });
+
+        expect(payload.title).toBe('Practice');
+        expect(payload.location).toBe('Overland Trail Elementary');
+        expect(payload.date).toEqual(new Date('2026-07-13T18:00:00'));
+        expect(payload.end).toEqual(new Date('2026-07-13T19:30:00'));
+        expect(payload.source).toBe('bulk_ai');
+        expect(payload.sourceMetadata).toEqual({
+            importedBy: 'coach-1',
+            importedFrom: 'edit-schedule-bulk-ai'
+        });
+    });
+
+    it('preserves game add behavior while adding eventType', () => {
+        const normalized = normalizeBulkAiEventForAdd({
+            eventType: 'game',
+            date: '2026-04-02T18:30:00',
+            opponent: ' Tigers ',
+            location: ' Main Field ',
+            isHome: 'away',
+            assignments: [{ role: 'Snack', value: 'Sam' }]
+        });
+
+        expect(normalized).toMatchObject({
+            eventType: 'game',
+            opponent: 'Tigers',
+            location: 'Main Field',
+            isHome: false,
+            kitColor: 'Away kit',
+            assignments: [{ role: 'Snack', value: 'Sam' }],
+            homeScore: 0,
+            awayScore: 0
+        });
+    });
+
+    it('keeps practice rules in the inline AI prompt and response schema', () => {
+        const source = readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+
+        expect(source).toContain('eventType: Schema.string()');
+        expect(source).toContain('Practice", "Training", or practice-style scrimmage have no opponent');
+        expect(source).toContain('"eventType": "practice"');
+        expect(source).toContain('buildBulkAiPracticePayload(normalizedGame');
+        expect(source).toContain('await addPractice(currentTeamId, practiceData);');
+    });
+});


### PR DESCRIPTION
## Summary
- teach the edit-schedule AI bulk import prompt/schema to emit game or practice event types
- normalize practice add operations into practice payloads and preview them distinctly
- add regression coverage for issue #3860 practice imports while preserving game normalization

Fixes #3860

## Tests
- npx vitest run tests/unit/edit-schedule-ai-import.test.js --reporter=verbose
- npx vitest run tests/unit/edit-schedule-ai-import.test.js tests/unit/edit-schedule-practice-payload.test.js --reporter=verbose
- node --check js/edit-schedule-ai-import.js
- extracted edit-schedule.html module script piped to node --check --input-type=module