### PR TITLE
Improve verification email resend feedback

### DIFF
--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -1,7 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const authState = vi.hoisted(() => ({
+const authState = vi.hoisted((): {
+  currentUser: any;
+  app: {
+    options: {
+      apiKey: string;
+    };
+    name: string;
+  };
+} => ({
   currentUser: null,
   app: {
     options: {
@@ -100,6 +108,7 @@ vi.mock('./logger', () => ({
 }));
 
 import {
+  sendEmailVerification,
   sendPasswordResetEmail,
   signInWithPopup,
   signInWithRedirect
@@ -111,6 +120,7 @@ import {
   hydrateFirebaseUser,
   isValidAuthEmail,
   observeFirebaseUser,
+  resendVerificationEmail,
   sendResetEmail,
   signInWithEmail,
   signInWithGoogleAccount,
@@ -165,6 +175,87 @@ describe('sendResetEmail', () => {
     sendPasswordResetEmailMock.mockRejectedValue(error);
 
     await expect(sendResetEmail('player@example.com')).rejects.toBe(error);
+  });
+});
+
+describe('resendVerificationEmail', () => {
+  const sendEmailVerificationMock = vi.mocked(sendEmailVerification);
+  const verificationSettings = {
+    url: 'https://allplays.ai/app/#/verify-pending',
+    handleCodeInApp: true
+  };
+  const localStorageEntries = new Map<string, string>();
+
+  function installTestLocalStorage() {
+    localStorageEntries.clear();
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: vi.fn((key: string) => localStorageEntries.get(key) || null),
+        setItem: vi.fn((key: string, value: string) => {
+          localStorageEntries.set(key, String(value));
+        }),
+        removeItem: vi.fn((key: string) => {
+          localStorageEntries.delete(key);
+        })
+      }
+    });
+  }
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    installTestLocalStorage();
+    authState.currentUser = null;
+    sendEmailVerificationMock.mockReset();
+  });
+
+  afterEach(() => {
+    authState.currentUser = null;
+    vi.unstubAllGlobals();
+  });
+
+  it('sends web verification emails with the branded app return URL', async () => {
+    const user = {
+      uid: 'user-1',
+      email: 'player@example.com',
+      reload: vi.fn(async () => undefined)
+    };
+    authState.currentUser = user;
+    sendEmailVerificationMock.mockResolvedValue(undefined);
+
+    await resendVerificationEmail();
+
+    expect(user.reload).toHaveBeenCalledTimes(1);
+    expect(sendEmailVerificationMock).toHaveBeenCalledWith(user, verificationSettings);
+  });
+
+  it('includes the same continue URL when native REST sends the verification email', async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, _request?: RequestInit) => ({
+      ok: true,
+      json: async () => ({})
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+    window.localStorage.setItem('allplays-native-auth-session', JSON.stringify({
+      uid: 'native-user',
+      email: 'player@example.com',
+      idToken: 'native-id-token',
+      refreshToken: 'native-refresh-token',
+      expirationTime: Date.now() + 10 * 60 * 1000,
+      apiKey: 'test-api-key',
+      provider: 'rest'
+    }));
+
+    await resendVerificationEmail();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    expect(String(url)).toContain('accounts:sendOobCode');
+    expect(JSON.parse(String((request as RequestInit).body))).toMatchObject({
+      requestType: 'VERIFY_EMAIL',
+      idToken: 'native-id-token',
+      continueUrl: verificationSettings.url,
+      canHandleCodeInApp: verificationSettings.handleCodeInApp
+    });
   });
 });
 

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -181,7 +181,7 @@ describe('sendResetEmail', () => {
 describe('resendVerificationEmail', () => {
   const sendEmailVerificationMock = vi.mocked(sendEmailVerification);
   const verificationSettings = {
-    url: 'https://allplays.ai/app/#/verify-pending',
+    url: 'https://allplays.ai/app/#/reset-password',
     handleCodeInApp: true
   };
   const localStorageEntries = new Map<string, string>();
@@ -214,7 +214,7 @@ describe('resendVerificationEmail', () => {
     vi.unstubAllGlobals();
   });
 
-  it('sends web verification emails with the branded app return URL', async () => {
+  it('sends web verification emails to the action-code handler instead of the pending page', async () => {
     const user = {
       uid: 'user-1',
       email: 'player@example.com',
@@ -227,6 +227,7 @@ describe('resendVerificationEmail', () => {
 
     expect(user.reload).toHaveBeenCalledTimes(1);
     expect(sendEmailVerificationMock).toHaveBeenCalledWith(user, verificationSettings);
+    expect(verificationSettings.url).not.toContain('#/verify-pending');
   });
 
   it('includes the same continue URL when native REST sends the verification email', async () => {

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -33,7 +33,7 @@ import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
 export const passwordResetConfirmationMessage = "If an account exists for that email, we've sent a reset link.";
-export const verificationContinueUrl = 'https://allplays.ai/app/#/verify-pending';
+export const verificationContinueUrl = 'https://allplays.ai/app/#/reset-password';
 
 const pendingActivationCodeKey = 'pendingActivationCode';
 const pendingInviteCodeKey = 'allplays-app-pending-invite-code';

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -33,6 +33,7 @@ import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
 export const passwordResetConfirmationMessage = "If an account exists for that email, we've sent a reset link.";
+export const verificationContinueUrl = 'https://allplays.ai/app/#/verify-pending';
 
 const pendingActivationCodeKey = 'pendingActivationCode';
 const pendingInviteCodeKey = 'allplays-app-pending-invite-code';
@@ -1215,14 +1216,24 @@ export async function sendResetEmail(email: string) {
   }
 }
 
+export function getVerificationActionCodeSettings() {
+  return {
+    url: verificationContinueUrl,
+    handleCodeInApp: true
+  };
+}
+
 export async function resendVerificationEmail() {
   const user = getCurrentFirebaseUser();
+  const actionCodeSettings = getVerificationActionCodeSettings();
   if (!user) {
     const idToken = await getNativeAuthIdToken();
     if (idToken) {
       await callFirebaseAuthRest('accounts:sendOobCode', {
         requestType: 'VERIFY_EMAIL',
-        idToken
+        idToken,
+        continueUrl: actionCodeSettings.url,
+        canHandleCodeInApp: actionCodeSettings.handleCodeInApp
       });
       return;
     }
@@ -1232,7 +1243,7 @@ export async function resendVerificationEmail() {
   if (typeof user.reload === 'function') {
     await user.reload();
   }
-  await sendEmailVerification(user);
+  await sendEmailVerification(user, actionCodeSettings);
 }
 
 async function refreshNativeFallbackVerification() {

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -216,6 +216,32 @@ describe('Profile', () => {
     expect(sectionGrid?.className).not.toContain('min-w-max');
   });
 
+  it('shows delivery context and cooldown after resending verification email', async () => {
+    authServiceMocks.resendVerificationEmail.mockResolvedValueOnce(undefined);
+
+    renderProfile('/profile?section=security');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Resend email' }));
+
+    expect(await screen.findByText('Verification email sent to parent@example.com. It can take a couple of minutes; check spam too.')).toBeTruthy();
+    const cooldownButton = screen.getByRole('button', { name: 'Resend available soon' });
+    expect((cooldownButton as HTMLButtonElement).disabled).toBe(true);
+    expect(authServiceMocks.resendVerificationEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps verification resend throttling to a retry-later message and cooldown', async () => {
+    authServiceMocks.resendVerificationEmail.mockRejectedValueOnce({ code: 'auth/too-many-requests' });
+
+    renderProfile('/profile?section=security');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Resend email' }));
+
+    expect(await screen.findByText('Too many attempts. Try again in a few minutes.')).toBeTruthy();
+    const cooldownButton = screen.getByRole('button', { name: 'Resend available soon' });
+    expect((cooldownButton as HTMLButtonElement).disabled).toBe(true);
+    expect(authServiceMocks.describeAuthError).not.toHaveBeenCalled();
+  });
+
   it('disables account merge while parent team eligibility is loading', async () => {
     const parentTeamsRequest = createDeferredPromise<Array<{ id: string; name: string }>>();
     profileServiceMocks.loadParentTeams.mockImplementation(() => parentTeamsRequest.promise);

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -71,6 +71,7 @@ const notificationPreferenceGroups = NOTIFICATION_PREFERENCE_GROUPS as readonly 
 }[];
 const collapsedInviteCount = 3;
 const logger = createLogger('profile');
+const verificationResendCooldownMs = 60 * 1000;
 const profileSections: Array<{ id: ProfileSectionId; label: string }> = [
   { id: 'account', label: 'Account' },
   { id: 'alerts', label: 'Alerts' },
@@ -134,6 +135,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState('');
+  const [verificationResendCoolingDown, setVerificationResendCoolingDown] = useState(false);
   const [profileStatus, setProfileStatus] = useState<Status | null>(null);
   const [verificationStatus, setVerificationStatus] = useState<Status | null>(null);
   const [notificationStatus, setNotificationStatus] = useState<Status | null>(null);
@@ -162,6 +164,16 @@ export function Profile({ auth }: { auth: AuthState }) {
   const photoUrlRef = useRef('');
   const photoChangedRef = useRef(false);
   const selectedTeamIdRef = useRef('');
+
+  useEffect(() => {
+    if (!verificationResendCoolingDown) return undefined;
+
+    const timeout = window.setTimeout(() => {
+      setVerificationResendCoolingDown(false);
+    }, verificationResendCooldownMs);
+
+    return () => window.clearTimeout(timeout);
+  }, [verificationResendCoolingDown]);
 
   const revokeOwnedPhotoPreviewUrl = () => {
     const activePreviewUrl = ownedPhotoPreviewUrlRef.current;
@@ -830,9 +842,16 @@ export function Profile({ auth }: { auth: AuthState }) {
 
     try {
       await resendVerificationEmail();
-      setVerificationStatus({ message: 'Verification email sent. Check your inbox.', tone: 'success' });
-    } catch (error) {
-      setVerificationStatus({ message: describeAuthError(error), tone: 'error' });
+      setVerificationResendCoolingDown(true);
+      const destination = user?.email ? ` to ${user.email}` : '';
+      setVerificationStatus({ message: `Verification email sent${destination}. It can take a couple of minutes; check spam too.`, tone: 'success' });
+    } catch (error: any) {
+      if (error?.code === 'auth/too-many-requests') {
+        setVerificationResendCoolingDown(true);
+        setVerificationStatus({ message: 'Too many attempts. Try again in a few minutes.', tone: 'error' });
+      } else {
+        setVerificationStatus({ message: describeAuthError(error), tone: 'error' });
+      }
     } finally {
       setBusy('');
     }
@@ -1574,9 +1593,9 @@ export function Profile({ auth }: { auth: AuthState }) {
           </div>
           <div className="mt-3 flex flex-wrap gap-2">
             {!user.emailVerified ? (
-              <button type="button" className="secondary-button" onClick={resendVerification} disabled={busy === 'verification'}>
+              <button type="button" className="secondary-button" onClick={resendVerification} disabled={busy === 'verification' || verificationResendCoolingDown}>
                 {busy === 'verification' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Send className="h-4 w-4" aria-hidden="true" />}
-                Resend email
+                {verificationResendCoolingDown && busy !== 'verification' ? 'Resend available soon' : 'Resend email'}
               </button>
             ) : null}
             <button type="button" className="ghost-button" onClick={refreshVerification} disabled={busy === 'refresh-verification'}>


### PR DESCRIPTION
## Summary
- send verification emails with branded action-code settings that return users to `/app/#/verify-pending`
- include the same continue URL for native REST verification resend
- improve Profile resend feedback with destination-aware copy, spam/timing guidance, throttling copy, and a short resend cooldown

Fixes #3858

## Validation
- `npx vitest run apps/app/src/lib/authService.test.ts --reporter=verbose`
- `npx vitest run apps/app/src/pages/Profile.test.tsx -t "verification" --reporter=verbose`
- `npm run app:build`
