### PR TITLE
Surface friend request load errors

### DIFF
--- a/apps/app/src/lib/socialLogic.ts
+++ b/apps/app/src/lib/socialLogic.ts
@@ -85,6 +85,7 @@ export type SocialHomeModel = {
   suggestions: SocialFriend[];
   incomingRequests: SocialFriend[];
   outgoingRequests: SocialFriend[];
+  friendshipsError: string | null;
   metrics: {
     feedItems: number;
     friends: number;
@@ -211,6 +212,7 @@ export function emptySocialHome(): SocialHomeModel {
     suggestions: [],
     incomingRequests: [],
     outgoingRequests: [],
+    friendshipsError: null,
     metrics: {
       feedItems: 0,
       friends: 0,
@@ -301,12 +303,14 @@ export function buildSocialHomeModel({
   feedItems,
   friendshipFriends,
   suggestions,
-  currentUserId
+  currentUserId,
+  friendshipsError = null
 }: {
   feedItems: SocialFeedItem[];
   friendshipFriends: SocialFriend[];
   suggestions: SocialFriend[];
   currentUserId: string;
+  friendshipsError?: string | null;
 }): SocialHomeModel {
   const { active, incomingRequests, outgoingRequests } = categorizeFriends(friendshipFriends, currentUserId);
   const activeIds = new Set(active.map((friend) => friend.userId));
@@ -323,6 +327,7 @@ export function buildSocialHomeModel({
     suggestions: cleanSuggestions,
     incomingRequests,
     outgoingRequests,
+    friendshipsError,
     metrics: {
       feedItems: sortedFeedItems.length,
       friends: active.length,

--- a/apps/app/src/lib/socialService.ts
+++ b/apps/app/src/lib/socialService.ts
@@ -15,6 +15,7 @@ import {
 } from './adapters/legacySocialDb';
 import { loadParentHome } from './homeService';
 import { createLogger } from './logger';
+import { toAppServiceError } from './appErrors';
 import type { ParentHomeModel } from './homeLogic';
 import { uploadTeamChatAttachment } from './chatService';
 import type { AuthUser } from './types';
@@ -152,15 +153,18 @@ export async function loadSocialHome(user: AuthUser | null, homeOverride?: Paren
   const home = homeOverride || await loadParentHome(user);
   const authorName = getUserDisplayName(user);
   const derivedFeed = buildDerivedSocialFeedItems(home, user.uid, authorName);
-  const [posts, friendships, suggestions] = await Promise.all([
+  const [posts, friendshipLoad, suggestions] = await Promise.all([
     loadVisibleSocialPosts(user, home).catch((error) => {
       logger.warn('Unable to load social posts.', { error });
       return [];
     }),
-    loadFriendships(user).catch((error) => {
-      logger.warn('Unable to load friendships.', { error });
-      return [];
-    }),
+    loadFriendships(user)
+      .then((friendships) => ({ friendships, friendshipsError: null as string | null }))
+      .catch((error) => {
+        const appError = toAppServiceError(error, "Couldn't load friend requests.");
+        logger.warn('Unable to load friendships.', { error: appError });
+        return { friendships: [], friendshipsError: appError.message };
+      }),
     loadFriendSuggestions(user, home).catch((error) => {
       logger.warn('Unable to load friend suggestions.', { error });
       return [];
@@ -169,9 +173,10 @@ export async function loadSocialHome(user: AuthUser | null, homeOverride?: Paren
 
   return buildSocialHomeModel({
     feedItems: mergeSocialFeedItems(posts, derivedFeed),
-    friendshipFriends: friendships,
+    friendshipFriends: friendshipLoad.friendships,
     suggestions,
-    currentUserId: user.uid
+    currentUserId: user.uid,
+    friendshipsError: friendshipLoad.friendshipsError
   });
 }
 

--- a/apps/app/src/lib/socialService.ts
+++ b/apps/app/src/lib/socialService.ts
@@ -306,6 +306,7 @@ export async function sendFriendRequest(user: AuthUser, friend: SocialFriend) {
     sharedTeamIds: friend.sharedTeamIds || [],
     sharedTeamNames: friend.sharedTeamNames || [],
     blockedBy: [],
+    respondedAt: null,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp()
   }, { merge: true });

--- a/apps/app/src/pages/Home.test.tsx
+++ b/apps/app/src/pages/Home.test.tsx
@@ -152,6 +152,7 @@ const baseSocial = {
   incomingRequests: [],
   outgoingRequests: [],
   suggestions: [],
+  friendshipsError: null,
   metrics: {
     feedItems: 0,
     friends: 0,
@@ -779,6 +780,27 @@ describe('Home', () => {
       expect(socialServiceMocks.respondToFriendRequest).toHaveBeenCalledWith('friendship-1', 'accepted');
       expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('shows a retryable friend request load error instead of an empty request list', async () => {
+    socialServiceMocks.loadSocialHome.mockResolvedValueOnce({
+      ...baseSocial,
+      friendshipsError: 'Missing index for friendships.'
+    });
+
+    renderHome(signedInAuth, '/home?section=friends');
+
+    await screen.findByRole('heading', { name: 'Friends' });
+    expect(await screen.findByText("Couldn't load friend requests")).toBeTruthy();
+    expect(screen.getByText('Missing index for friendships.')).toBeTruthy();
+    expect(screen.queryByText('No requests right now')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(socialServiceMocks.loadSocialHome).toHaveBeenCalledTimes(2);
+    });
+    expect(await screen.findByText('No requests right now')).toBeTruthy();
   });
 
   it('renders Today content from larger Home payloads and keeps it visible after refresh', async () => {

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -330,6 +330,8 @@ export function Home({ auth }: { auth: AuthState }) {
   const topAction = home.actionItems[0] || null;
   const showBlockingErrorState = !loading && !hasLoadedHomeDetails && Boolean(homeLoadError);
   const displayName = auth.user?.displayName || auth.user?.email || 'ALL PLAYS User';
+  const friendRequestsUnavailable = Boolean(social.friendshipsError);
+  const friendRequestChipValue = friendRequestsUnavailable ? '!' : String(social.metrics.incomingRequests);
   const openCount = home.metrics.rsvpNeeded + home.metrics.packetsReady + home.metrics.unreadMessages + home.fees.length + social.metrics.incomingRequests;
   const today = new Date();
   const selectedComposerType = (searchParams.get('type') || 'manual_post') as SocialPostType;
@@ -464,7 +466,7 @@ export function Home({ auth }: { auth: AuthState }) {
           <PulseChip icon={ClipboardCheck} label="Packets" value={String(home.metrics.packetsReady)} urgent={home.metrics.packetsReady > 0} />
           <PulseChip icon={MessageCircle} label="Unread" value={String(home.metrics.unreadMessages)} urgent={home.metrics.unreadMessages > 0} />
           <PulseChip icon={Newspaper} label="Feed" value={String(social.metrics.feedItems)} />
-          <PulseChip icon={UserPlus} label="Requests" value={String(social.metrics.incomingRequests)} urgent={social.metrics.incomingRequests > 0} />
+          <PulseChip icon={UserPlus} label="Requests" value={friendRequestChipValue} urgent={social.metrics.incomingRequests > 0 || friendRequestsUnavailable} />
         </div>
       </section>
 
@@ -1154,7 +1156,7 @@ function FeedSection({
               </div>
               <div className="mt-2 grid grid-cols-3 gap-2 text-center">
                 <MiniMetric label="Friends" value={social.metrics.friends} />
-                <MiniMetric label="Requests" value={social.metrics.incomingRequests} urgent={social.metrics.incomingRequests > 0} />
+                <MiniMetric label="Requests" value={social.friendshipsError ? '!' : social.metrics.incomingRequests} urgent={social.metrics.incomingRequests > 0 || Boolean(social.friendshipsError)} />
                 <MiniMetric label="Ideas" value={social.metrics.suggestions} />
               </div>
               <Link to="/home?section=friends" className="mt-3 flex min-h-9 items-center justify-between rounded-lg bg-white px-3 text-xs font-black text-primary-700 ring-1 ring-gray-200">
@@ -1501,7 +1503,9 @@ function FriendsSection({
             </FriendPanel>
           ) : null}
 
-          {social.incomingRequests.length ? (
+          {social.friendshipsError ? (
+            <FriendRequestLoadErrorCard error={social.friendshipsError} onRetry={onRefresh} retrying={loading} />
+          ) : social.incomingRequests.length ? (
             <FriendPanel title="Needs response" count={social.incomingRequests.length} urgent>
               {social.incomingRequests.map((friend) => (
                 <FriendCard
@@ -1516,7 +1520,11 @@ function FriendsSection({
                 />
               ))}
             </FriendPanel>
-          ) : null}
+          ) : (
+            <FriendPanel title="Incoming requests" count={0}>
+              <EmptyFriendState title="No requests right now" detail="When another ALL PLAYS parent adds you, accept or decline here." />
+            </FriendPanel>
+          )}
 
           <FriendPanel title="Your friends" count={social.friends.length}>
             {social.friends.length ? social.friends.map((friend) => (
@@ -1571,6 +1579,24 @@ function FriendsSection({
           ) : null}
         </div>
       </div>
+    </section>
+  );
+}
+
+function FriendRequestLoadErrorCard({ error, onRetry, retrying }: { error: string; onRetry: () => Promise<void> | void; retrying: boolean }) {
+  return (
+    <section role="alert" className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-rose-900">
+      <div className="flex items-start gap-2">
+        <AlertCircle className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-black">Couldn't load friend requests</h3>
+          <p className="mt-1 text-xs font-semibold leading-5">{error}</p>
+        </div>
+      </div>
+      <button type="button" className="ghost-button mt-3 !min-h-9 !px-3 text-xs" onClick={() => onRetry()} disabled={retrying}>
+        {retrying ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+        Retry
+      </button>
     </section>
   );
 }
@@ -1928,7 +1954,7 @@ function SocialComposerModal({
   );
 }
 
-function MiniMetric({ label, value, urgent = false }: { label: string; value: number; urgent?: boolean }) {
+function MiniMetric({ label, value, urgent = false }: { label: string; value: number | string; urgent?: boolean }) {
   return (
     <div className={`rounded-xl border px-2 py-2 ${urgent ? 'border-amber-200 bg-amber-50' : 'border-gray-200 bg-white'}`}>
       <div className={`text-base font-black ${urgent ? 'text-amber-800' : 'text-gray-950'}`}>{value}</div>

--- a/tests/unit/app-social-service.test.js
+++ b/tests/unit/app-social-service.test.js
@@ -152,6 +152,7 @@ describe('React app social service', () => {
                 recipientId: 'friend-1',
                 memberIds: ['friend-1', 'user-1'],
                 status: 'pending',
+                respondedAt: null,
                 sharedTeamIds: ['team-1']
             }),
             { merge: true }

--- a/tests/unit/app-social-service.test.js
+++ b/tests/unit/app-social-service.test.js
@@ -227,7 +227,34 @@ describe('React app social service', () => {
         expect(model.feedItems.map((item) => item.id)).toEqual(expect.arrayContaining(['post-1', 'derived:player:team-1:player-1']));
         expect(model.incomingRequests).toEqual([expect.objectContaining({ userId: 'friend-1', name: 'Jamie Friend' })]);
         expect(model.suggestions).toEqual([expect.objectContaining({ userId: 'friend-2', name: 'Morgan Parent' })]);
+        expect(model.friendshipsError).toBeNull();
         expect(model.metrics.feedItems).toBeGreaterThanOrEqual(2);
+    });
+
+    it('surfaces friendship load failures on the social home model', async () => {
+        const { loadSocialHome } = await import('../../apps/app/src/lib/socialService.ts');
+        const home = {
+            players: [],
+            teams: [{ teamId: 'team-1', teamName: 'Bears', role: 'Parent', sport: 'Basketball', players: [], nextEvent: null, eventCount: 0, unreadCount: 0, openActions: 0 }],
+            upcomingEvents: [],
+            actionItems: [],
+            fees: [],
+            metrics: { players: 0, teams: 1, rsvpNeeded: 0, unreadMessages: 0, packetsReady: 0 }
+        };
+
+        firebaseMocks.getDocs.mockImplementation(async (queryRef) => {
+            const whereClause = queryRef.clauses.find((clause) => clause.field);
+            if (whereClause?.field === 'memberIds') {
+                throw new Error('Missing index for friendships.');
+            }
+            return snapshot([]);
+        });
+
+        const model = await loadSocialHome(user, home);
+
+        expect(model.friendshipsError).toBe('Missing index for friendships.');
+        expect(model.incomingRequests).toEqual([]);
+        expect(model.metrics.incomingRequests).toBe(0);
     });
 
     it('searches public profiles by hashed email and shared discovery teams', async () => {


### PR DESCRIPTION
## Summary
- Surface friendship load failures on `SocialHomeModel` via `friendshipsError` instead of silently treating requests as empty.
- Show a retryable Friends-tab alert and attention state on request metrics when friend requests fail to load.
- Keep the incoming request accept path covered and add focused regressions for service/UI error reporting.

## Tests
- `npx vitest run tests/unit/app-social-service.test.js apps/app/src/pages/Home.test.tsx --reporter=verbose`
- `npm run app:build`

Fixes #3867