### PR TITLE
Fix app event assignment management

### DIFF
--- a/apps/app/src/components/schedule/AssignmentCard.tsx
+++ b/apps/app/src/components/schedule/AssignmentCard.tsx
@@ -4,14 +4,18 @@ import {
   isScheduleAssignmentOpen,
   type ScheduleAssignment
 } from '../../lib/scheduleLogic';
+import { Pencil, Trash2 } from 'lucide-react';
 
-export function AssignmentCard({ assignment, userId, busy, disabled, onClaim, onRelease }: {
+export function AssignmentCard({ assignment, userId, busy, disabled, canManage = false, onClaim, onRelease, onEdit, onRemove }: {
   assignment: ScheduleAssignment;
   userId: string;
   busy: boolean;
   disabled: boolean;
+  canManage?: boolean;
   onClaim: () => void | Promise<void>;
   onRelease: () => void | Promise<void>;
+  onEdit?: () => void;
+  onRemove?: () => void | Promise<void>;
 }) {
   const role = String(assignment.role || 'Assignment').trim();
   const myOwn = isScheduleAssignmentClaimedByUser(assignment, userId);
@@ -30,25 +34,49 @@ export function AssignmentCard({ assignment, userId, busy, disabled, onClaim, on
             <div className="mt-1 text-[11px] font-semibold text-gray-500">Parent sign-up slot</div>
           ) : null}
         </div>
-        {myOwn ? (
-          <button
-            type="button"
-            className="min-h-8 flex-none rounded-full border border-emerald-200 bg-white px-3 text-xs font-black text-emerald-700"
-            onClick={onRelease}
-            disabled={disabled}
-          >
-            {busy ? 'Releasing' : 'Release'}
-          </button>
-        ) : open ? (
-          <button
-            type="button"
-            className="min-h-8 flex-none rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-800"
-            onClick={onClaim}
-            disabled={disabled}
-          >
-            {busy ? 'Signing up' : 'Sign up'}
-          </button>
-        ) : null}
+        <div className="flex flex-none flex-wrap items-center justify-end gap-2">
+          {canManage ? (
+            <>
+              <button
+                type="button"
+                className="inline-flex min-h-8 items-center gap-1 rounded-full border border-gray-200 bg-white px-3 text-xs font-black text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700"
+                onClick={onEdit}
+                disabled={disabled}
+              >
+                <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                Edit
+              </button>
+              <button
+                type="button"
+                className="inline-flex min-h-8 items-center gap-1 rounded-full border border-rose-200 bg-white px-3 text-xs font-black text-rose-700 transition hover:border-rose-300 hover:bg-rose-50"
+                onClick={onRemove}
+                disabled={disabled}
+              >
+                <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                Remove
+              </button>
+            </>
+          ) : null}
+          {myOwn ? (
+            <button
+              type="button"
+              className="min-h-8 rounded-full border border-emerald-200 bg-white px-3 text-xs font-black text-emerald-700"
+              onClick={onRelease}
+              disabled={disabled}
+            >
+              {busy ? 'Releasing' : 'Release'}
+            </button>
+          ) : open ? (
+            <button
+              type="button"
+              className="min-h-8 rounded-full border border-amber-200 bg-white px-3 text-xs font-black text-amber-800"
+              onClick={onClaim}
+              disabled={disabled}
+            >
+              {busy ? 'Signing up' : 'Sign up'}
+            </button>
+          ) : null}
+        </div>
       </div>
     </article>
   );

--- a/apps/app/src/components/schedule/AssignmentsSection.tsx
+++ b/apps/app/src/components/schedule/AssignmentsSection.tsx
@@ -86,7 +86,7 @@ export function AssignmentsSection() {
     } finally {
       if (showLoading) setLoading(false);
     }
-  }, [event.id, event.isCancelled, event.isDbGame, event.teamId, syncAssignments]);
+  }, [syncAssignments]);
 
   useEffect(() => {
     setAssignmentStatus(null);

--- a/apps/app/src/components/schedule/AssignmentsSection.tsx
+++ b/apps/app/src/components/schedule/AssignmentsSection.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useEffect, useState } from 'react';
-import { AlertCircle, CheckCircle2, ChevronDown, ChevronUp, ClipboardCheck, RefreshCw } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
+import { AlertCircle, CheckCircle2, ChevronDown, ChevronUp, ClipboardCheck, Plus, RefreshCw, X } from 'lucide-react';
 import {
   claimParentScheduleAssignmentSlot,
+  createScheduleAssignment,
   loadParentScheduleAssignments,
-  releaseParentScheduleAssignmentClaim
+  releaseParentScheduleAssignmentClaim,
+  removeScheduleAssignment,
+  updateScheduleAssignment,
+  type ScheduleAssignmentInput
 } from '../../lib/scheduleService';
 import {
   isScheduleAssignmentClaimedByUser,
@@ -20,14 +24,36 @@ function cloneScheduleAssignments(assignments: ScheduleAssignment[] = []) {
   }));
 }
 
+const assignmentFormBusyKey = '__assignment-form__';
+
+function createEmptyAssignmentForm(): ScheduleAssignmentInput {
+  return {
+    role: '',
+    value: '',
+    claimable: true
+  };
+}
+
+function createAssignmentFormFromAssignment(assignment: ScheduleAssignment): ScheduleAssignmentInput {
+  return {
+    role: String(assignment.role || '').trim(),
+    value: String(assignment.value || '').trim(),
+    claimable: assignment.claimable === true
+  };
+}
+
 export function AssignmentsSection() {
   const { auth, event, updateEvents } = useScheduleEventDetailContext();
+  const eventRef = useRef(event);
   const [assignments, setAssignments] = useState<ScheduleAssignment[]>(() => cloneScheduleAssignments(event.assignments));
   const [loading, setLoading] = useState(true);
   const [busyRole, setBusyRole] = useState<string | null>(null);
   const [assignmentStatus, setAssignmentStatus] = useState<string | null>(null);
   const [assignmentError, setAssignmentError] = useState<string | null>(null);
   const [showFilledAssignments, setShowFilledAssignments] = useState(false);
+  const [assignmentForm, setAssignmentForm] = useState<ScheduleAssignmentInput>(() => createEmptyAssignmentForm());
+  const [editingRole, setEditingRole] = useState<string | null>(null);
+  const [showAssignmentForm, setShowAssignmentForm] = useState(false);
 
   const handleAssignmentsChanged = useCallback((nextAssignments: ScheduleAssignment[]) => {
     updateEvents((current) => current.map((entry) => (
@@ -37,33 +63,45 @@ export function AssignmentsSection() {
     )));
   }, [event.id, event.teamId, updateEvents]);
 
+  const syncAssignments = useCallback((nextAssignments: ScheduleAssignment[]) => {
+    const cloned = cloneScheduleAssignments(nextAssignments);
+    setAssignments(cloned);
+    handleAssignmentsChanged(cloned);
+    return cloned;
+  }, [handleAssignmentsChanged]);
+
+  useEffect(() => {
+    eventRef.current = event;
+  });
+
   const refreshAssignments = useCallback(async (showLoading = true) => {
     if (showLoading) setLoading(true);
     setAssignmentError(null);
+    const event = eventRef.current;
     try {
-      const loaded = cloneScheduleAssignments(await loadParentScheduleAssignments(event));
-      setAssignments(loaded);
-      handleAssignmentsChanged(loaded);
+      syncAssignments(await loadParentScheduleAssignments(event));
     } catch (error: any) {
       setAssignmentError(error?.message || 'Unable to load assignments.');
       setAssignments(cloneScheduleAssignments(event.assignments));
     } finally {
       if (showLoading) setLoading(false);
     }
-  }, [event.id, event.isCancelled, event.isDbGame, event.teamId, handleAssignmentsChanged]);
+  }, [event.id, event.isCancelled, event.isDbGame, event.teamId, syncAssignments]);
 
   useEffect(() => {
     setAssignmentStatus(null);
     refreshAssignments();
   }, [refreshAssignments]);
 
-  const runAssignmentAction = async (role: string, action: () => Promise<void>, successMessage: string) => {
+  const runAssignmentAction = async (role: string, action: () => Promise<void>, successMessage: string, options: { refresh?: boolean } = {}) => {
     setBusyRole(role);
     setAssignmentStatus(null);
     setAssignmentError(null);
     try {
       await action();
-      await refreshAssignments(false);
+      if (options.refresh !== false) {
+        await refreshAssignments(false);
+      }
       setAssignmentStatus(successMessage);
     } catch (error: any) {
       setAssignmentError(error?.message || 'Unable to update assignment.');
@@ -92,8 +130,72 @@ export function AssignmentsSection() {
     );
   };
 
+  const resetAssignmentForm = () => {
+    setAssignmentForm(createEmptyAssignmentForm());
+    setEditingRole(null);
+    setShowAssignmentForm(false);
+  };
+
+  const startCreateAssignment = () => {
+    setAssignmentStatus(null);
+    setAssignmentError(null);
+    setAssignmentForm(createEmptyAssignmentForm());
+    setEditingRole(null);
+    setShowAssignmentForm(true);
+  };
+
+  const startEditAssignment = (assignment: ScheduleAssignment) => {
+    setAssignmentStatus(null);
+    setAssignmentError(null);
+    setAssignmentForm(createAssignmentFormFromAssignment(assignment));
+    setEditingRole(String(assignment.role || '').trim());
+    setShowAssignmentForm(true);
+  };
+
+  const submitAssignmentForm = (submitEvent: FormEvent<HTMLFormElement>) => {
+    submitEvent.preventDefault();
+    const currentUser = auth.user;
+    if (!currentUser) return;
+    const role = String(assignmentForm.role || '').trim();
+    if (!role) {
+      setAssignmentError('Role is required.');
+      return;
+    }
+    const isEditing = Boolean(editingRole);
+    void runAssignmentAction(
+      assignmentFormBusyKey,
+      async () => {
+        const nextAssignments = isEditing
+          ? await updateScheduleAssignment(event, currentUser, editingRole!, assignmentForm)
+          : await createScheduleAssignment(event, currentUser, assignmentForm);
+        syncAssignments(nextAssignments);
+        resetAssignmentForm();
+      },
+      isEditing ? `${role} updated.` : `${role} added.`,
+      { refresh: false }
+    );
+  };
+
+  const removeAssignment = (assignment: ScheduleAssignment) => {
+    const role = String(assignment.role || '').trim();
+    const currentUser = auth.user;
+    if (!currentUser || !role) return;
+    return runAssignmentAction(
+      role,
+      async () => {
+        const nextAssignments = await removeScheduleAssignment(event, currentUser, role);
+        syncAssignments(nextAssignments);
+        if (editingRole && editingRole === role) resetAssignmentForm();
+      },
+      `${role} removed.`,
+      { refresh: false }
+    );
+  };
+
   const openCount = assignments.filter(isScheduleAssignmentOpen).length;
   const userId = auth.user?.uid || '';
+  const canManageAssignments = Boolean(auth.user && event.isTeamAdmin && event.isDbGame && !event.isCancelled);
+  const formBusy = busyRole === assignmentFormBusyKey;
   const actionableAssignments = assignments.filter((assignment) => (
     isScheduleAssignmentOpen(assignment) || isScheduleAssignmentClaimedByUser(assignment, userId)
   ));
@@ -124,13 +226,38 @@ export function AssignmentsSection() {
               {assignments.length ? `${assignments.length} posted · ${openCount} open` : 'None posted'}
             </div>
           </div>
-          {loading ? <RefreshCw className="mt-1 h-4 w-4 animate-spin text-primary-600" aria-hidden="true" /> : null}
+          <div className="flex flex-none items-center gap-2">
+            {canManageAssignments ? (
+              <button
+                type="button"
+                className="inline-flex min-h-9 items-center gap-2 rounded-full border border-primary-200 bg-primary-50 px-3 text-xs font-black text-primary-700 transition hover:border-primary-300 hover:bg-primary-100"
+                onClick={startCreateAssignment}
+                disabled={Boolean(busyRole)}
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+                Add assignment
+              </button>
+            ) : null}
+            {loading ? <RefreshCw className="h-4 w-4 animate-spin text-primary-600" aria-hidden="true" /> : null}
+          </div>
         </div>
       </div>
 
       <div className="p-3 sm:p-4">
         {assignmentStatus ? <Status tone="success" message={assignmentStatus} /> : null}
         {assignmentError ? <div className="mt-2"><Status tone="error" message={assignmentError} /></div> : null}
+        {showAssignmentForm && canManageAssignments ? (
+          <div className="mt-2">
+            <AssignmentForm
+              form={assignmentForm}
+              editingRole={editingRole}
+              busy={formBusy}
+              onChange={setAssignmentForm}
+              onSubmit={submitAssignmentForm}
+              onCancel={resetAssignmentForm}
+            />
+          </div>
+        ) : null}
         <div className="mt-2 space-y-2">
           {assignments.length ? (
             <>
@@ -141,8 +268,11 @@ export function AssignmentsSection() {
                   userId={userId}
                   busy={busyRole === String(assignment.role || '').trim()}
                   disabled={Boolean(busyRole) || !event.isDbGame || event.isCancelled}
+                  canManage={canManageAssignments}
                   onClaim={() => claimSlot(assignment)}
                   onRelease={() => releaseSlot(assignment)}
+                  onEdit={() => startEditAssignment(assignment)}
+                  onRemove={() => removeAssignment(assignment)}
                 />
               ))}
               {filledAssignments.length && actionableAssignments.length ? (
@@ -165,8 +295,11 @@ export function AssignmentsSection() {
                           userId={userId}
                           busy={busyRole === String(assignment.role || '').trim()}
                           disabled={Boolean(busyRole) || !event.isDbGame || event.isCancelled}
+                          canManage={canManageAssignments}
                           onClaim={() => claimSlot(assignment)}
                           onRelease={() => releaseSlot(assignment)}
+                          onEdit={() => startEditAssignment(assignment)}
+                          onRemove={() => removeAssignment(assignment)}
                         />
                       ))}
                     </div>
@@ -175,14 +308,112 @@ export function AssignmentsSection() {
               ) : null}
             </>
           ) : (
-            <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">None posted</div>
+            <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4">
+              <div className="text-sm font-black text-gray-700">No assignments yet</div>
+              {canManageAssignments ? (
+                <button
+                  type="button"
+                  className="mt-3 inline-flex min-h-9 items-center gap-2 rounded-full border border-primary-200 bg-white px-3 text-xs font-black text-primary-700 transition hover:border-primary-300 hover:bg-primary-50"
+                  onClick={startCreateAssignment}
+                  disabled={Boolean(busyRole)}
+                >
+                  <Plus className="h-4 w-4" aria-hidden="true" />
+                  Add assignment
+                </button>
+              ) : null}
+            </div>
           )}
         </div>
         {!event.isDbGame || event.isCancelled ? (
-          <div className="mt-2 text-xs font-semibold text-gray-500">Assignment sign-up is available for active tracked schedule events.</div>
+          <div className="mt-2 text-xs font-semibold text-gray-500">Assignments are available for active tracked schedule events.</div>
         ) : null}
       </div>
     </section>
+  );
+}
+
+function AssignmentForm({
+  form,
+  editingRole,
+  busy,
+  onChange,
+  onSubmit,
+  onCancel
+}: {
+  form: ScheduleAssignmentInput;
+  editingRole: string | null;
+  busy: boolean;
+  onChange: (form: ScheduleAssignmentInput) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onCancel: () => void;
+}) {
+  const claimable = form.claimable === true;
+  const role = String(form.role || '');
+  const value = String(form.value || '');
+
+  return (
+    <form
+      aria-label={editingRole ? `Edit assignment ${editingRole}` : 'Add assignment'}
+      className="rounded-xl border border-primary-100 bg-primary-50/70 p-3"
+      onSubmit={onSubmit}
+    >
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <label className="text-xs font-black uppercase text-gray-500">
+          Task
+          <input
+            type="text"
+            className="mt-1 min-h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none transition focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+            value={role}
+            onChange={(event) => onChange({ ...form, role: event.target.value })}
+            disabled={busy}
+            placeholder="Snack table"
+          />
+        </label>
+        {!claimable ? (
+          <label className="text-xs font-black uppercase text-gray-500">
+            Assigned to
+            <input
+              type="text"
+              className="mt-1 min-h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none transition focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+              value={value}
+              onChange={(event) => onChange({ ...form, value: event.target.value })}
+              disabled={busy}
+              placeholder="Jamie"
+            />
+          </label>
+        ) : null}
+      </div>
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+        <label className="inline-flex min-h-9 items-center gap-2 rounded-full border border-gray-200 bg-white px-3 text-xs font-black text-gray-700">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+            checked={claimable}
+            onChange={(event) => onChange({ ...form, claimable: event.target.checked, value: event.target.checked ? '' : form.value })}
+            disabled={busy}
+          />
+          Let parents sign up
+        </label>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="inline-flex min-h-9 items-center gap-1 rounded-full border border-gray-200 bg-white px-3 text-xs font-black text-gray-700"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="primary-button min-h-9 px-4 text-xs"
+            disabled={busy || !role.trim()}
+          >
+            {busy ? 'Saving' : editingRole ? 'Save assignment' : 'Add assignment'}
+          </button>
+        </div>
+      </div>
+    </form>
   );
 }
 

--- a/apps/app/src/components/schedule/AssignmentsSection.tsx
+++ b/apps/app/src/components/schedule/AssignmentsSection.tsx
@@ -42,9 +42,15 @@ function createAssignmentFormFromAssignment(assignment: ScheduleAssignment): Sch
   };
 }
 
+function getAssignmentEventKey(event: { teamId: string; id: string }) {
+  return `${event.teamId}::${event.id}`;
+}
+
 export function AssignmentsSection() {
   const { auth, event, updateEvents } = useScheduleEventDetailContext();
   const eventRef = useRef(event);
+  const eventGenerationRef = useRef(0);
+  const refreshRequestRef = useRef(0);
   const [assignments, setAssignments] = useState<ScheduleAssignment[]>(() => cloneScheduleAssignments(event.assignments));
   const [loading, setLoading] = useState(true);
   const [busyRole, setBusyRole] = useState<string | null>(null);
@@ -74,39 +80,74 @@ export function AssignmentsSection() {
     eventRef.current = event;
   });
 
+  useEffect(() => {
+    eventGenerationRef.current += 1;
+  }, [event.id, event.teamId]);
+
   const refreshAssignments = useCallback(async (showLoading = true) => {
+    const requestId = ++refreshRequestRef.current;
+    const targetEvent = eventRef.current;
+    const targetEventKey = getAssignmentEventKey(targetEvent);
+    const isCurrentRequest = () => (
+      refreshRequestRef.current === requestId
+      && getAssignmentEventKey(eventRef.current) === targetEventKey
+    );
     if (showLoading) setLoading(true);
     setAssignmentError(null);
-    const event = eventRef.current;
     try {
-      syncAssignments(await loadParentScheduleAssignments(event));
+      const loaded = await loadParentScheduleAssignments(targetEvent);
+      if (!isCurrentRequest()) return;
+      syncAssignments(loaded);
     } catch (error: any) {
+      if (!isCurrentRequest()) return;
       setAssignmentError(error?.message || 'Unable to load assignments.');
-      setAssignments(cloneScheduleAssignments(event.assignments));
+      setAssignments(cloneScheduleAssignments(targetEvent.assignments));
     } finally {
-      if (showLoading) setLoading(false);
+      if (showLoading && isCurrentRequest()) setLoading(false);
     }
   }, [syncAssignments]);
 
   useEffect(() => {
+    refreshRequestRef.current += 1;
+    setAssignments(cloneScheduleAssignments(eventRef.current.assignments));
+    setBusyRole(null);
     setAssignmentStatus(null);
+    setAssignmentError(null);
+    setAssignmentForm(createEmptyAssignmentForm());
+    setEditingRole(null);
+    setShowAssignmentForm(false);
     refreshAssignments();
   }, [refreshAssignments]);
 
-  const runAssignmentAction = async (role: string, action: () => Promise<void>, successMessage: string, options: { refresh?: boolean } = {}) => {
+  const runAssignmentAction = async <T,>(
+    role: string,
+    action: () => Promise<T>,
+    successMessage: string,
+    options: { refresh?: boolean; onSuccess?: (result: T) => void | Promise<void> } = {}
+  ) => {
+    const targetEventKey = getAssignmentEventKey(eventRef.current);
+    const targetEventGeneration = eventGenerationRef.current;
+    const isCurrentEvent = () => (
+      eventGenerationRef.current === targetEventGeneration
+      && getAssignmentEventKey(eventRef.current) === targetEventKey
+    );
     setBusyRole(role);
     setAssignmentStatus(null);
     setAssignmentError(null);
     try {
-      await action();
+      const result = await action();
+      if (!isCurrentEvent()) return;
+      await options.onSuccess?.(result);
       if (options.refresh !== false) {
         await refreshAssignments(false);
       }
+      if (!isCurrentEvent()) return;
       setAssignmentStatus(successMessage);
     } catch (error: any) {
+      if (!isCurrentEvent()) return;
       setAssignmentError(error?.message || 'Unable to update assignment.');
     } finally {
-      setBusyRole(null);
+      if (isCurrentEvent()) setBusyRole(null);
     }
   };
 
@@ -164,15 +205,17 @@ export function AssignmentsSection() {
     const isEditing = Boolean(editingRole);
     void runAssignmentAction(
       assignmentFormBusyKey,
-      async () => {
-        const nextAssignments = isEditing
-          ? await updateScheduleAssignment(event, currentUser, editingRole!, assignmentForm)
-          : await createScheduleAssignment(event, currentUser, assignmentForm);
-        syncAssignments(nextAssignments);
-        resetAssignmentForm();
-      },
+      () => isEditing
+        ? updateScheduleAssignment(event, currentUser, editingRole!, assignmentForm)
+        : createScheduleAssignment(event, currentUser, assignmentForm),
       isEditing ? `${role} updated.` : `${role} added.`,
-      { refresh: false }
+      {
+        refresh: false,
+        onSuccess: (nextAssignments) => {
+          syncAssignments(nextAssignments);
+          resetAssignmentForm();
+        }
+      }
     );
   };
 
@@ -182,13 +225,15 @@ export function AssignmentsSection() {
     if (!currentUser || !role) return;
     return runAssignmentAction(
       role,
-      async () => {
-        const nextAssignments = await removeScheduleAssignment(event, currentUser, role);
-        syncAssignments(nextAssignments);
-        if (editingRole && editingRole === role) resetAssignmentForm();
-      },
+      () => removeScheduleAssignment(event, currentUser, role),
       `${role} removed.`,
-      { refresh: false }
+      {
+        refresh: false,
+        onSuccess: (nextAssignments) => {
+          syncAssignments(nextAssignments);
+          if (editingRole && editingRole === role) resetAssignmentForm();
+        }
+      }
     );
   };
 
@@ -362,6 +407,7 @@ function AssignmentForm({
           Task
           <input
             type="text"
+            maxLength={80}
             className="mt-1 min-h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none transition focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
             value={role}
             onChange={(event) => onChange({ ...form, role: event.target.value })}
@@ -374,6 +420,7 @@ function AssignmentForm({
             Assigned to
             <input
               type="text"
+              maxLength={100}
               className="mt-1 min-h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm font-semibold text-gray-900 outline-none transition focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
               value={value}
               onChange={(event) => onChange({ ...form, value: event.target.value })}

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2948,6 +2948,12 @@ function normalizeAssignmentRoleKey(role: unknown) {
   return normalizeAssignmentRole(role).toLowerCase();
 }
 
+function assertAssignmentRoleCanBeClaimDocumentId(role: string) {
+  if (role.includes('/') || role === '.' || role === '..' || /^__.*__$/.test(role)) {
+    throw new Error('Task name contains unsupported characters.');
+  }
+}
+
 function assertAssignmentEvent(event: ParentScheduleEvent) {
   if (!event.isDbGame) {
     throw new Error('Assignments open after this event is tracked in the schedule.');
@@ -2979,6 +2985,9 @@ function normalizeScheduleAssignmentInput(input: ScheduleAssignmentInput): Sched
     throw new Error('Role is required.');
   }
   const claimable = input?.claimable === true;
+  if (claimable) {
+    assertAssignmentRoleCanBeClaimDocumentId(role);
+  }
   const value = claimable ? '' : compactString(input?.value).slice(0, 100);
   return {
     role,
@@ -6232,6 +6241,7 @@ export async function claimParentScheduleAssignmentSlot(event: ParentScheduleEve
   if (!trimmedRole) {
     throw new Error('Role is required.');
   }
+  assertAssignmentRoleCanBeClaimDocumentId(trimmedRole);
   const name = String(user.displayName || user.email || 'Parent').trim();
   if (!name) {
     throw new Error('Name is required.');
@@ -6252,6 +6262,7 @@ export async function releaseParentScheduleAssignmentClaim(event: ParentSchedule
   if (!trimmedRole) {
     throw new Error('Role is required.');
   }
+  assertAssignmentRoleCanBeClaimDocumentId(trimmedRole);
 
   try {
     await withTimeout(Promise.resolve(releaseAssignmentClaim(event.teamId, event.id, trimmedRole)), 'Assignment release');

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -6201,7 +6201,7 @@ export async function updateScheduleAssignment(event: ParentScheduleEvent, user:
   ));
   const persistedAssignments = await persistScheduleAssignments(event, nextAssignments);
 
-  const roleChanged = normalizeAssignmentRoleKey(previousAssignment.role) !== normalizeAssignmentRoleKey(nextRole);
+  const roleChanged = normalizeAssignmentRole(previousAssignment.role || currentRole) !== normalizeAssignmentRole(nextRole);
   if (roleChanged) {
     await clearScheduleAssignmentClaim(event, previousAssignment.role || currentRole, 'assignment-update-old-claim-cleanup');
     await clearScheduleAssignmentClaim(event, nextRole, 'assignment-update-new-claim-cleanup');

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -311,6 +311,12 @@ export type StaffScheduleRsvpBreakdown = {
   counts: Required<ScheduleRsvpSummary>;
 };
 
+export type ScheduleAssignmentInput = {
+  role?: string | null;
+  value?: string | null;
+  claimable?: boolean | null;
+};
+
 type FirestoreDocument = FirestoreDecodedDocument;
 
 export type StaffRsvpReminderSendResult = StaffRsvpReminderPreview & {
@@ -2938,6 +2944,10 @@ function normalizeAssignmentRole(role: unknown) {
   return String(role || '').trim();
 }
 
+function normalizeAssignmentRoleKey(role: unknown) {
+  return normalizeAssignmentRole(role).toLowerCase();
+}
+
 function assertAssignmentEvent(event: ParentScheduleEvent) {
   if (!event.isDbGame) {
     throw new Error('Assignments open after this event is tracked in the schedule.');
@@ -2947,10 +2957,54 @@ function assertAssignmentEvent(event: ParentScheduleEvent) {
   }
 }
 
+function assertAssignmentManagementEvent(event: ParentScheduleEvent, user: AuthUser | null) {
+  assertAssignmentEvent(event);
+  if (!user?.uid) {
+    throw new Error('Sign in before managing assignments.');
+  }
+  if (!event.isTeamAdmin) {
+    throw new Error('Only team owners and admins can manage assignments.');
+  }
+}
+
 function normalizeAssignments(assignments: any[]): ScheduleAssignment[] {
   return (Array.isArray(assignments) ? assignments : [])
     .map((assignment) => normalizeScheduleAssignment(assignment))
     .filter((assignment) => assignment.role || assignment.value);
+}
+
+function normalizeScheduleAssignmentInput(input: ScheduleAssignmentInput): ScheduleAssignment {
+  const role = normalizeAssignmentRole(input?.role).slice(0, 80);
+  if (!role) {
+    throw new Error('Role is required.');
+  }
+  const claimable = input?.claimable === true;
+  const value = claimable ? '' : compactString(input?.value).slice(0, 100);
+  return {
+    role,
+    value,
+    claimable,
+    claim: null
+  };
+}
+
+function toPersistedScheduleAssignment(assignment: ScheduleAssignment): ScheduleAssignment {
+  const normalized = normalizeScheduleAssignment(assignment);
+  return {
+    role: normalized.role,
+    value: normalized.claimable ? '' : normalized.value,
+    claimable: normalized.claimable === true
+  };
+}
+
+function assertUniqueAssignmentRole(assignments: ScheduleAssignment[], role: string, ignoreIndex = -1) {
+  const nextKey = normalizeAssignmentRoleKey(role);
+  const duplicateIndex = assignments.findIndex((assignment, index) => (
+    index !== ignoreIndex && normalizeAssignmentRoleKey(assignment.role) === nextKey
+  ));
+  if (duplicateIndex >= 0) {
+    throw new Error('An assignment with that role already exists.');
+  }
 }
 
 function summarizeRsvps(rsvps: any[]): ScheduleRsvpSummary {
@@ -6074,6 +6128,102 @@ export async function loadParentScheduleAssignments(event: ParentScheduleEvent) 
   }
   const claims = await loadAssignmentClaims(event.teamId, event.id).catch(() => ({}));
   return normalizeAssignments(mergeAssignmentsWithClaims(assignments, claims) as ScheduleAssignment[]);
+}
+
+async function persistScheduleAssignments(event: ParentScheduleEvent, assignments: ScheduleAssignment[]) {
+  const persistedAssignments = normalizeAssignments(assignments)
+    .map(toPersistedScheduleAssignment);
+  const payload = { assignments: persistedAssignments };
+
+  try {
+    await withTimeout(Promise.resolve(updateGame(event.teamId, event.id, payload)), 'Assignment save');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    logScheduleWarning('Falling back to REST assignment updateGame.', 'assignment-update', error, { fallback: 'rest', teamId: event.teamId, gameId: event.id });
+    await nativePatchDocument(`teams/${encodeURIComponent(event.teamId)}/games/${encodeURIComponent(event.id)}`, payload);
+  }
+
+  return persistedAssignments;
+}
+
+async function clearScheduleAssignmentClaim(event: ParentScheduleEvent, role: string, operation: string) {
+  const trimmedRole = normalizeAssignmentRole(role);
+  if (!trimmedRole) return;
+
+  try {
+    await withTimeout(Promise.resolve(releaseAssignmentClaim(event.teamId, event.id, trimmedRole)), 'Assignment claim cleanup');
+  } catch (error) {
+    if (isNativeRuntime()) {
+      try {
+        await nativeReleaseAssignment(event, trimmedRole);
+        return;
+      } catch (nativeError) {
+        logScheduleWarning('Unable to clear assignment claim during native assignment management.', operation, nativeError, { teamId: event.teamId, gameId: event.id, role: trimmedRole });
+        return;
+      }
+    }
+    logScheduleWarning('Unable to clear assignment claim during assignment management.', operation, error, { teamId: event.teamId, gameId: event.id, role: trimmedRole });
+  }
+}
+
+async function reloadPersistedScheduleAssignments(event: ParentScheduleEvent, assignments: ScheduleAssignment[]) {
+  return loadParentScheduleAssignments({ ...event, assignments });
+}
+
+export async function createScheduleAssignment(event: ParentScheduleEvent, user: AuthUser | null, input: ScheduleAssignmentInput) {
+  assertAssignmentManagementEvent(event, user);
+  const currentAssignments = normalizeAssignments(event.assignments);
+  const nextAssignment = normalizeScheduleAssignmentInput(input);
+  const nextRole = nextAssignment.role || '';
+  assertUniqueAssignmentRole(currentAssignments, nextRole);
+
+  const persistedAssignments = await persistScheduleAssignments(event, [...currentAssignments, nextAssignment]);
+  await clearScheduleAssignmentClaim(event, nextRole, 'assignment-create-claim-cleanup');
+  return reloadPersistedScheduleAssignments(event, persistedAssignments);
+}
+
+export async function updateScheduleAssignment(event: ParentScheduleEvent, user: AuthUser | null, currentRole: string, input: ScheduleAssignmentInput) {
+  assertAssignmentManagementEvent(event, user);
+  const currentAssignments = normalizeAssignments(event.assignments);
+  const currentKey = normalizeAssignmentRoleKey(currentRole);
+  const assignmentIndex = currentAssignments.findIndex((assignment) => normalizeAssignmentRoleKey(assignment.role) === currentKey);
+  if (assignmentIndex < 0) {
+    throw new Error('Assignment not found.');
+  }
+
+  const previousAssignment = currentAssignments[assignmentIndex];
+  const nextAssignment = normalizeScheduleAssignmentInput(input);
+  const nextRole = nextAssignment.role || '';
+  assertUniqueAssignmentRole(currentAssignments, nextRole, assignmentIndex);
+
+  const nextAssignments = currentAssignments.map((assignment, index) => (
+    index === assignmentIndex ? nextAssignment : assignment
+  ));
+  const persistedAssignments = await persistScheduleAssignments(event, nextAssignments);
+
+  const roleChanged = normalizeAssignmentRoleKey(previousAssignment.role) !== normalizeAssignmentRoleKey(nextRole);
+  if (roleChanged) {
+    await clearScheduleAssignmentClaim(event, previousAssignment.role || currentRole, 'assignment-update-old-claim-cleanup');
+    await clearScheduleAssignmentClaim(event, nextRole, 'assignment-update-new-claim-cleanup');
+  } else if (!nextAssignment.claimable || nextAssignment.value) {
+    await clearScheduleAssignmentClaim(event, nextRole, 'assignment-update-claim-cleanup');
+  }
+
+  return reloadPersistedScheduleAssignments(event, persistedAssignments);
+}
+
+export async function removeScheduleAssignment(event: ParentScheduleEvent, user: AuthUser | null, role: string) {
+  assertAssignmentManagementEvent(event, user);
+  const currentAssignments = normalizeAssignments(event.assignments);
+  const currentKey = normalizeAssignmentRoleKey(role);
+  const nextAssignments = currentAssignments.filter((assignment) => normalizeAssignmentRoleKey(assignment.role) !== currentKey);
+  if (nextAssignments.length === currentAssignments.length) {
+    throw new Error('Assignment not found.');
+  }
+
+  const persistedAssignments = await persistScheduleAssignments(event, nextAssignments);
+  await clearScheduleAssignmentClaim(event, role, 'assignment-remove-claim-cleanup');
+  return reloadPersistedScheduleAssignments(event, persistedAssignments);
 }
 
 export async function claimParentScheduleAssignmentSlot(event: ParentScheduleEvent, user: AuthUser, role: string) {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -10,6 +10,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   cancelPracticeOccurrenceForApp: vi.fn(),
   cancelScheduledGameForApp: vi.fn(),
   claimParentScheduleAssignmentSlot: vi.fn(),
+  createScheduleAssignment: vi.fn(),
   createParentScheduleRideOffer: vi.fn(),
   loadScheduleStatTrackerConfigsForApp: vi.fn<(...args: any[]) => Promise<any[]>>(() => Promise.resolve([{ id: 'cfg-basketball', name: 'Basketball' }])),
   loadParentPracticePacket: vi.fn(),
@@ -44,6 +45,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   markParentPracticePacketComplete: vi.fn(),
   publishGamePlanForApp: vi.fn(),
   releaseParentScheduleAssignmentClaim: vi.fn(),
+  removeScheduleAssignment: vi.fn(),
   requestParentScheduleRideSpot: vi.fn(),
   sendStaffRsvpReminder: vi.fn(),
   setParentScheduleRideOfferStatus: vi.fn(),
@@ -51,6 +53,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
   submitParentScheduleRsvpForChildren: vi.fn(),
   submitStaffScheduleRsvpOverride: vi.fn(),
   summarizeParentScheduleRideOffers: vi.fn(() => ({ offerCount: 0, seatsLeft: 0, requests: 0, pending: 0, confirmed: 0, isFull: false })),
+  updateScheduleAssignment: vi.fn(),
   loadHomeScoringPlayers: vi.fn(),
   publishLiveScoreUpdateEvent: vi.fn(),
   recordPlayerGameStat: vi.fn(),
@@ -1398,6 +1401,111 @@ describe('ScheduleEventDetail assignments', () => {
     const warning = await within(tray).findByText('Score autosaved. Live play-by-play post failed.');
     expect(warning.className).toContain('text-amber-700');
     expect(warning.className).not.toContain('text-rose-700');
+  });
+
+  it('keeps the empty Tasks tab visible for team admins before assignments exist', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        isDbGame: false,
+        isTeamAdmin: true,
+        assignments: []
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue([]);
+
+    renderScheduleEventDetailWithLocation();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Assignments' }).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Assignments' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('No assignments yet')).toBeTruthy();
+    });
+    expect(screen.queryByRole('button', { name: 'Add assignment' })).toBeNull();
+  });
+
+  it('lets team admins add and edit assignments from the empty state', async () => {
+    const createdAssignments = [{ role: 'Snacks', value: '', claimable: true, claim: null }];
+    const updatedAssignments = [{ role: 'Scorebook', value: 'Jamie', claimable: false, claim: null }];
+
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamAdmin: true, assignments: [] })],
+      children: []
+    });
+    scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue([]);
+    scheduleServiceMocks.createScheduleAssignment.mockResolvedValue(createdAssignments);
+    scheduleServiceMocks.updateScheduleAssignment.mockResolvedValue(updatedAssignments);
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=assignments');
+
+    await waitFor(() => {
+      expect(screen.getByText('No assignments yet')).toBeTruthy();
+    });
+
+    const addButtons = screen.getAllByRole('button', { name: 'Add assignment' });
+    fireEvent.click(addButtons[addButtons.length - 1]);
+
+    const addForm = screen.getByRole('form', { name: 'Add assignment' });
+    fireEvent.change(within(addForm).getByLabelText('Task'), { target: { value: 'Snacks' } });
+    fireEvent.click(within(addForm).getByRole('button', { name: 'Add assignment' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.createScheduleAssignment).toHaveBeenCalled();
+    });
+    expect(scheduleServiceMocks.createScheduleAssignment.mock.calls[0][1]).toBe(auth.user);
+    expect(scheduleServiceMocks.createScheduleAssignment.mock.calls[0][2]).toEqual({
+      role: 'Snacks',
+      value: '',
+      claimable: true
+    });
+    expect(screen.getByText('Snacks added.')).toBeTruthy();
+    expect(screen.getByText('Snacks')).toBeTruthy();
+
+    const snacksCard = screen.getByText('Snacks').closest('article') as HTMLElement;
+    fireEvent.click(within(snacksCard).getByRole('button', { name: 'Edit' }));
+
+    const editForm = screen.getByRole('form', { name: 'Edit assignment Snacks' });
+    fireEvent.change(within(editForm).getByLabelText('Task'), { target: { value: 'Scorebook' } });
+    fireEvent.click(within(editForm).getByLabelText('Let parents sign up'));
+    fireEvent.change(within(editForm).getByLabelText('Assigned to'), { target: { value: 'Jamie' } });
+    fireEvent.click(within(editForm).getByRole('button', { name: 'Save assignment' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.updateScheduleAssignment).toHaveBeenCalled();
+    });
+    expect(scheduleServiceMocks.updateScheduleAssignment.mock.calls[0][1]).toBe(auth.user);
+    expect(scheduleServiceMocks.updateScheduleAssignment.mock.calls[0][2]).toBe('Snacks');
+    expect(scheduleServiceMocks.updateScheduleAssignment.mock.calls[0][3]).toEqual({
+      role: 'Scorebook',
+      value: 'Jamie',
+      claimable: false
+    });
+    expect(screen.getByText('Scorebook updated.')).toBeTruthy();
+    expect(screen.getByText('Scorebook: Jamie')).toBeTruthy();
+  });
+
+  it('hides assignment management controls for non-admin viewers', async () => {
+    const assignments = [{ role: 'Snacks', value: '', claimable: true, claim: null }];
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamAdmin: false, assignments })],
+      children: []
+    });
+    scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue(assignments);
+
+    renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=assignments');
+
+    await waitFor(() => {
+      expect(screen.getByText('1 posted · 1 open')).toBeTruthy();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Add assignment' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'Sign up' })).toBeTruthy();
   });
 
   it('surfaces sticky autosave failures and retries through the existing manual save path', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -248,6 +248,8 @@ import {
   shouldShowLiveScoreControls,
   shouldPersistLineupDraft
 } from './ScheduleEventDetail';
+import { AssignmentsSection } from '../components/schedule/AssignmentsSection';
+import { ScheduleEventDetailProvider } from './schedule/ScheduleEventDetailContext';
 import type { PracticeTimelineBlock } from '../lib/practiceTimelineService';
 import type { AuthState } from '../lib/types';
 
@@ -1334,6 +1336,121 @@ describe('ScheduleEventDetail rideshare permissions', () => {
 });
 
 describe('ScheduleEventDetail assignments', () => {
+  it('ignores a stale assignment response after the mounted section switches events', async () => {
+    let resolveFirstLoad: ((assignments: any[]) => void) | null = null;
+    scheduleServiceMocks.loadParentScheduleAssignments.mockImplementation(async (event) => {
+      if (event.id === 'game-1') {
+        return new Promise<any[]>((resolve) => {
+          resolveFirstLoad = resolve;
+        });
+      }
+      return [{ role: 'Second game task', value: 'Taylor', claimable: false, claim: null }];
+    });
+
+    const updateEvents = vi.fn();
+    const firstEvent = buildEvent({ id: 'game-1', assignments: [] });
+    const secondEvent = buildEvent({
+      eventKey: 'team-1::game-2::player-1::2026-06-05T18:00:00.000Z::game',
+      id: 'game-2',
+      assignments: []
+    });
+    const providerValue = (event: any) => ({
+      auth,
+      event,
+      childEvents: [event],
+      refreshEvent: vi.fn(),
+      updateEvents
+    });
+
+    const rendered = render(
+      <ScheduleEventDetailProvider value={providerValue(firstEvent)}>
+        <AssignmentsSection />
+      </ScheduleEventDetailProvider>
+    );
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadParentScheduleAssignments).toHaveBeenCalledWith(firstEvent);
+    });
+
+    rendered.rerender(
+      <ScheduleEventDetailProvider value={providerValue(secondEvent)}>
+        <AssignmentsSection />
+      </ScheduleEventDetailProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Second game task: Taylor')).toBeTruthy();
+    });
+
+    await act(async () => {
+      resolveFirstLoad?.([{ role: 'Stale first game task', value: 'Jordan', claimable: false, claim: null }]);
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('Stale first game task: Jordan')).toBeNull();
+    expect(screen.getByText('Second game task: Taylor')).toBeTruthy();
+  });
+
+  it('ignores a completed management action after the mounted section switches events', async () => {
+    let resolveCreate: ((assignments: any[]) => void) | null = null;
+    scheduleServiceMocks.loadParentScheduleAssignments.mockImplementation(async (event) => (
+      event.id === 'game-1'
+        ? []
+        : [{ role: 'Second game task', value: 'Taylor', claimable: false, claim: null }]
+    ));
+    scheduleServiceMocks.createScheduleAssignment.mockImplementation(() => (
+      new Promise<any[]>((resolve) => {
+        resolveCreate = resolve;
+      })
+    ));
+
+    const updateEvents = vi.fn();
+    const firstEvent = buildEvent({ id: 'game-1', isTeamAdmin: true, assignments: [] });
+    const secondEvent = buildEvent({
+      eventKey: 'team-1::game-2::player-1::2026-06-05T18:00:00.000Z::game',
+      id: 'game-2',
+      isTeamAdmin: true,
+      assignments: []
+    });
+    const providerValue = (event: any) => ({
+      auth,
+      event,
+      childEvents: [event],
+      refreshEvent: vi.fn(),
+      updateEvents
+    });
+
+    const rendered = render(
+      <ScheduleEventDetailProvider value={providerValue(firstEvent)}>
+        <AssignmentsSection />
+      </ScheduleEventDetailProvider>
+    );
+
+    await waitFor(() => expect(screen.getByText('No assignments yet')).toBeTruthy());
+    const addButtons = screen.getAllByRole('button', { name: 'Add assignment' });
+    fireEvent.click(addButtons[addButtons.length - 1]);
+    const form = screen.getByRole('form', { name: 'Add assignment' });
+    fireEvent.change(within(form).getByLabelText('Task'), { target: { value: 'First game task' } });
+    fireEvent.click(within(form).getByRole('button', { name: 'Add assignment' }));
+
+    await waitFor(() => expect(scheduleServiceMocks.createScheduleAssignment).toHaveBeenCalled());
+    rendered.rerender(
+      <ScheduleEventDetailProvider value={providerValue(secondEvent)}>
+        <AssignmentsSection />
+      </ScheduleEventDetailProvider>
+    );
+    await waitFor(() => expect(screen.getByText('Second game task: Taylor')).toBeTruthy());
+
+    await act(async () => {
+      resolveCreate?.([{ role: 'First game task', value: '', claimable: true, claim: null }]);
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText('First game task')).toBeNull();
+    expect(screen.queryByText('First game task added.')).toBeNull();
+    expect(screen.getByText('Second game task: Taylor')).toBeTruthy();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     liveGameReactionsServiceMocks.canUseLiveGameReactions.mockReturnValue(true);
@@ -1439,6 +1556,7 @@ describe('ScheduleEventDetail assignments', () => {
     scheduleServiceMocks.loadParentScheduleAssignments.mockResolvedValue([]);
     scheduleServiceMocks.createScheduleAssignment.mockResolvedValue(createdAssignments);
     scheduleServiceMocks.updateScheduleAssignment.mockResolvedValue(updatedAssignments);
+    scheduleServiceMocks.removeScheduleAssignment.mockResolvedValue([]);
 
     renderScheduleEventDetailWithLocation('/schedule/team-1/game-1?childId=player-1&section=assignments');
 
@@ -1486,6 +1604,17 @@ describe('ScheduleEventDetail assignments', () => {
     });
     expect(screen.getByText('Scorebook updated.')).toBeTruthy();
     expect(screen.getByText('Scorebook: Jamie')).toBeTruthy();
+
+    const scorebookCard = screen.getByText('Scorebook: Jamie').closest('article') as HTMLElement;
+    fireEvent.click(within(scorebookCard).getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.removeScheduleAssignment).toHaveBeenCalled();
+    });
+    expect(scheduleServiceMocks.removeScheduleAssignment.mock.calls[0][1]).toBe(auth.user);
+    expect(scheduleServiceMocks.removeScheduleAssignment.mock.calls[0][2]).toBe('Scorebook');
+    expect(screen.getByText('Scorebook removed.')).toBeTruthy();
+    expect(screen.getByText('No assignments yet')).toBeTruthy();
   });
 
   it('hides assignment management controls for non-admin viewers', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -268,6 +268,10 @@ function hasAssignmentsPosted(event?: ParentScheduleEvent | null) {
   return Array.isArray(event?.assignments) && event.assignments.length > 0;
 }
 
+function canManageEventAssignments(event?: ParentScheduleEvent | null) {
+  return event?.isTeamAdmin === true;
+}
+
 function getEventDetailSections(event?: ParentScheduleEvent | null): Array<{ id: EventDetailSectionId; label: string; shortLabel?: string }> {
   const eventLabel = event?.type === 'practice' ? 'More' : 'Game';
   const sections: Array<{ id: EventDetailSectionId; label: string; shortLabel?: string }> = [
@@ -278,7 +282,7 @@ function getEventDetailSections(event?: ParentScheduleEvent | null): Array<{ id:
     sections.push({ id: 'rideshare', label: 'Rideshare' });
   }
 
-  if (isActiveTrackedScheduleEvent(event) || hasAssignmentsPosted(event)) {
+  if (isActiveTrackedScheduleEvent(event) || hasAssignmentsPosted(event) || canManageEventAssignments(event)) {
     sections.push({ id: 'assignments', label: 'Assignments', shortLabel: 'Tasks' });
   }
 

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -618,6 +618,13 @@ async function mockHomePlayerModules(page) {
                 export async function submitParentScheduleRsvpForChildren() { return { response: 'going' }; }
                 export async function claimParentScheduleAssignmentSlot() { return { role: 'Volunteer' }; }
                 export async function releaseParentScheduleAssignmentClaim() {}
+                export async function createScheduleAssignment(_event, _user, input = {}) {
+                    return [{ role: String(input.role || 'Volunteer'), value: String(input.value || ''), claimable: input.claimable !== false, claim: null }];
+                }
+                export async function updateScheduleAssignment(_event, _user, _currentRole, input = {}) {
+                    return [{ role: String(input.role || 'Volunteer'), value: String(input.value || ''), claimable: input.claimable !== false, claim: null }];
+                }
+                export async function removeScheduleAssignment() { return []; }
                 export async function createParentScheduleRideOffer() { return { id: 'ride-1' }; }
                 export async function requestParentScheduleRideSpot() { return { id: 'ride-request-1' }; }
                 export async function updateParentScheduleRideRequestStatus() {}

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -822,6 +822,52 @@ async function mockScheduleModules(page, options = {}) {
                     window.__scheduleCalls.assignments.push({ action: 'release', role });
                 }
 
+                export async function createScheduleAssignment(event, user, input = {}) {
+                    const role = String(input.role || '').trim();
+                    if (!role) throw new Error('Role is required.');
+                    if (getAssignments().some((assignment) => String(assignment.role || '').toLowerCase() === role.toLowerCase())) {
+                        throw new Error('An assignment with that role already exists.');
+                    }
+                    const assignment = {
+                        role,
+                        value: input.claimable === false ? String(input.value || '').trim() : '',
+                        claimable: input.claimable !== false,
+                        claim: null
+                    };
+                    window.__mockAssignments = getAssignments().concat(assignment);
+                    window.__scheduleCalls.assignments.push({ action: 'create', role, userId: user?.uid || null, input });
+                    return getAssignments();
+                }
+
+                export async function updateScheduleAssignment(event, user, currentRole, input = {}) {
+                    const role = String(input.role || '').trim();
+                    if (!role) throw new Error('Role is required.');
+                    const currentKey = String(currentRole || '').trim().toLowerCase();
+                    const index = getAssignments().findIndex((assignment) => String(assignment.role || '').toLowerCase() === currentKey);
+                    if (index < 0) throw new Error('Assignment not found.');
+                    if (getAssignments().some((assignment, assignmentIndex) => assignmentIndex !== index && String(assignment.role || '').toLowerCase() === role.toLowerCase())) {
+                        throw new Error('An assignment with that role already exists.');
+                    }
+                    const assignment = {
+                        role,
+                        value: input.claimable === false ? String(input.value || '').trim() : '',
+                        claimable: input.claimable !== false,
+                        claim: null
+                    };
+                    window.__mockAssignments = getAssignments().map((item, assignmentIndex) => assignmentIndex === index ? assignment : item);
+                    window.__scheduleCalls.assignments.push({ action: 'update', currentRole, role, userId: user?.uid || null, input });
+                    return getAssignments();
+                }
+
+                export async function removeScheduleAssignment(event, user, role) {
+                    const roleKey = String(role || '').trim().toLowerCase();
+                    const before = getAssignments().length;
+                    window.__mockAssignments = getAssignments().filter((assignment) => String(assignment.role || '').toLowerCase() !== roleKey);
+                    if (window.__mockAssignments.length === before) throw new Error('Assignment not found.');
+                    window.__scheduleCalls.assignments.push({ action: 'remove', role, userId: user?.uid || null });
+                    return getAssignments();
+                }
+
                 export async function loadParentScheduleRideOffers() {
                     if (${JSON.stringify(rideshareLoadError)}) {
                         throw new Error(${JSON.stringify(rideshareLoadError)});

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -201,6 +201,7 @@ async function mockScheduleModules(page, options = {}) {
                         rideshareSummary: overrides.rideshareSummary || { offerCount: 1, seatsLeft: 2, requests: 1, pending: 1, confirmed: 0, isFull: false },
                         assignments: overrides.assignments || getAssignments(),
                         isTeamStaff: overrides.isTeamStaff === true,
+                        isTeamAdmin: overrides.isTeamAdmin === true || overrides.isTeamStaff === true,
                         availabilityLocked: false,
                         availabilityCutoffLabel: 'No cutoff',
                         availabilityPreferences: { cutoffMinutesBeforeStart: 0, noteVisibility: 'team' },
@@ -1287,7 +1288,7 @@ test('tournament game keeps RSVP, tracking, finalization, and reports on the sha
     await expect(page.getByText(/Pool: Pool A/).first()).toBeVisible();
 
     const availabilitySection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Availability' }) });
-    await availabilitySection.getByRole('button', { name: 'Going' }).click();
+    await availabilitySection.getByRole('button', { name: 'Going', exact: true }).click();
     await expect(page.getByText('2 children marked going.')).toBeVisible();
     expect(await page.evaluate(() => window.__scheduleCalls.rsvps)).toEqual([
         { eventKey: 'game-1-player-1', childId: 'player-1', userId: 'user-1', response: 'going', note: '' },
@@ -1820,6 +1821,58 @@ test('app schedule assignments supports parent sign up and release', async ({ pa
     await expect(assignmentsSection.getByText('4 posted · 1 open')).toBeVisible();
     await expect(snacksCard.getByRole('button', { name: 'Sign up' })).toBeVisible();
     expect(await page.evaluate(() => window.__scheduleCalls.assignments.some((call) => call.action === 'release' && call.role === 'Snacks'))).toBe(true);
+});
+
+test('app schedule lets team staff create, edit, and remove assignments', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockScheduleModules(page, { isCoach: true, staffManageable: true });
+    await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1&section=assignments'), { waitUntil: 'domcontentloaded' });
+
+    const assignmentsSection = page.locator('section').filter({ has: page.getByRole('heading', { name: 'Assignments' }) });
+    await waitForScheduleRoute(page, assignmentsSection.getByText('4 posted · 1 open'));
+
+    await assignmentsSection.getByRole('button', { name: 'Add assignment' }).click();
+    const addForm = assignmentsSection.getByRole('form', { name: 'Add assignment' });
+    await addForm.getByLabel('Task').fill('Team photos');
+    await addForm.getByRole('button', { name: 'Add assignment' }).click();
+
+    await expect(assignmentsSection.getByText('Team photos added.')).toBeVisible();
+    const createdCard = assignmentsSection.locator('article').filter({ hasText: 'Team photos' });
+    await expect(createdCard).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__scheduleCalls.assignments.find((call) => call.action === 'create'))).toMatchObject({
+        action: 'create',
+        role: 'Team photos',
+        userId: 'user-1',
+        input: { role: 'Team photos', value: '', claimable: true }
+    });
+
+    await createdCard.getByRole('button', { name: 'Edit' }).click();
+    const editForm = assignmentsSection.getByRole('form', { name: 'Edit assignment Team photos' });
+    await editForm.getByLabel('Task').fill('Scorebook backup');
+    await editForm.getByLabel('Let parents sign up').uncheck();
+    await editForm.getByLabel('Assigned to').fill('Jamie');
+    await editForm.getByRole('button', { name: 'Save assignment' }).click();
+
+    await expect(assignmentsSection.getByText('Scorebook backup updated.')).toBeVisible();
+    await assignmentsSection.getByRole('button', { name: 'Show filled assignments (3)' }).click();
+    const updatedCard = assignmentsSection.locator('article').filter({ hasText: 'Scorebook backup' });
+    await expect(updatedCard.getByText('Scorebook backup: Jamie')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__scheduleCalls.assignments.find((call) => call.action === 'update'))).toMatchObject({
+        action: 'update',
+        currentRole: 'Team photos',
+        role: 'Scorebook backup',
+        userId: 'user-1',
+        input: { role: 'Scorebook backup', value: 'Jamie', claimable: false }
+    });
+
+    await updatedCard.getByRole('button', { name: 'Remove' }).click();
+    await expect(assignmentsSection.getByText('Scorebook backup removed.')).toBeVisible();
+    await expect(updatedCard).toHaveCount(0);
+    await expect.poll(() => page.evaluate(() => window.__scheduleCalls.assignments.find((call) => call.action === 'remove'))).toMatchObject({
+        action: 'remove',
+        role: 'Scorebook backup',
+        userId: 'user-1'
+    });
 });
 
 test('app schedule keeps filters compact on phone', async ({ page, baseURL }) => {

--- a/tests/unit/app-schedule-assignments-service.test.js
+++ b/tests/unit/app-schedule-assignments-service.test.js
@@ -77,7 +77,10 @@ vi.mock('../../js/snack-helpers.js', () => ({
 
 import {
     claimParentScheduleAssignmentSlot,
+    createScheduleAssignment,
     loadParentScheduleAssignments,
+    removeScheduleAssignment,
+    updateScheduleAssignment,
     releaseParentScheduleAssignmentClaim
 } from '../../apps/app/src/lib/scheduleService.ts';
 
@@ -307,5 +310,77 @@ describe('React app schedule assignment service integration', () => {
         await expect(releaseParentScheduleAssignmentClaim(event({ isCancelled: true }), 'Snacks')).rejects.toThrow('cancelled');
         expect(dbMocks.claimAssignmentSlot).not.toHaveBeenCalled();
         expect(dbMocks.releaseAssignmentClaim).not.toHaveBeenCalled();
+    });
+
+    it('lets team admins create, update, and remove assignments with the legacy payload shape', async () => {
+        const adminUser = user({ uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach Carter' });
+        dbMocks.updateGame.mockResolvedValue(undefined);
+        dbMocks.claimAssignmentSlot.mockResolvedValue(undefined);
+        dbMocks.releaseAssignmentClaim.mockResolvedValue(undefined);
+        dbMocks.getAssignmentClaims.mockResolvedValue({});
+
+        const created = await createScheduleAssignment(
+            event({ assignments: [], isTeamAdmin: true }),
+            adminUser,
+            { role: ' Snacks ', value: 'Ignored while claimable', claimable: true }
+        );
+
+        expect(dbMocks.updateGame).toHaveBeenLastCalledWith('team-1', 'game-1', {
+            assignments: [{ role: 'Snacks', value: '', claimable: true }]
+        });
+        expect(dbMocks.releaseAssignmentClaim).toHaveBeenLastCalledWith('team-1', 'game-1', 'Snacks');
+        expect(created).toEqual([
+            expect.objectContaining({ role: 'Snacks', value: '', claimable: true, claim: null })
+        ]);
+
+        await claimParentScheduleAssignmentSlot(event({ assignments: created }), user(), 'Snacks');
+        expect(dbMocks.claimAssignmentSlot).toHaveBeenCalledWith('team-1', 'game-1', 'Snacks', { name: 'Pat Parent' });
+
+        dbMocks.updateGame.mockClear();
+        dbMocks.releaseAssignmentClaim.mockClear();
+        const updated = await updateScheduleAssignment(
+            event({ assignments: created, isTeamAdmin: true }),
+            adminUser,
+            'Snacks',
+            { role: ' Scorebook ', value: ' Jamie ', claimable: false }
+        );
+
+        expect(dbMocks.updateGame).toHaveBeenLastCalledWith('team-1', 'game-1', {
+            assignments: [{ role: 'Scorebook', value: 'Jamie', claimable: false }]
+        });
+        expect(dbMocks.releaseAssignmentClaim).toHaveBeenCalledWith('team-1', 'game-1', 'Snacks');
+        expect(dbMocks.releaseAssignmentClaim).toHaveBeenCalledWith('team-1', 'game-1', 'Scorebook');
+        expect(updated).toEqual([
+            expect.objectContaining({ role: 'Scorebook', value: 'Jamie', claimable: false, claim: null })
+        ]);
+
+        dbMocks.updateGame.mockClear();
+        dbMocks.releaseAssignmentClaim.mockClear();
+        const removed = await removeScheduleAssignment(
+            event({ assignments: updated, isTeamAdmin: true }),
+            adminUser,
+            'Scorebook'
+        );
+
+        expect(dbMocks.updateGame).toHaveBeenLastCalledWith('team-1', 'game-1', { assignments: [] });
+        expect(dbMocks.releaseAssignmentClaim).toHaveBeenLastCalledWith('team-1', 'game-1', 'Scorebook');
+        expect(removed).toEqual([]);
+    });
+
+    it('rejects assignment management for non-admin event viewers', async () => {
+        await expect(createScheduleAssignment(
+            event({ isTeamAdmin: false }),
+            user(),
+            { role: 'Snacks', claimable: true }
+        )).rejects.toThrow('team owners and admins');
+
+        await expect(updateScheduleAssignment(
+            event({ isTeamAdmin: false }),
+            user(),
+            'Snacks',
+            { role: 'Snacks', claimable: true }
+        )).rejects.toThrow('team owners and admins');
+
+        expect(dbMocks.updateGame).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/app-schedule-assignments-service.test.js
+++ b/tests/unit/app-schedule-assignments-service.test.js
@@ -367,6 +367,29 @@ describe('React app schedule assignment service integration', () => {
         expect(removed).toEqual([]);
     });
 
+    it('clears exact-case assignment claims when an admin changes only role casing', async () => {
+        const adminUser = user({ uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach Carter' });
+        dbMocks.updateGame.mockResolvedValue(undefined);
+        dbMocks.releaseAssignmentClaim.mockResolvedValue(undefined);
+        dbMocks.getAssignmentClaims.mockResolvedValue({});
+
+        await updateScheduleAssignment(
+            event({
+                assignments: [{ role: 'snacks', value: '', claimable: true }],
+                isTeamAdmin: true
+            }),
+            adminUser,
+            'snacks',
+            { role: ' Snacks ', value: '', claimable: true }
+        );
+
+        expect(dbMocks.updateGame).toHaveBeenLastCalledWith('team-1', 'game-1', {
+            assignments: [{ role: 'Snacks', value: '', claimable: true }]
+        });
+        expect(dbMocks.releaseAssignmentClaim).toHaveBeenCalledWith('team-1', 'game-1', 'snacks');
+        expect(dbMocks.releaseAssignmentClaim).toHaveBeenCalledWith('team-1', 'game-1', 'Snacks');
+    });
+
     it('rejects assignment management for non-admin event viewers', async () => {
         await expect(createScheduleAssignment(
             event({ isTeamAdmin: false }),

--- a/tests/unit/app-schedule-assignments-service.test.js
+++ b/tests/unit/app-schedule-assignments-service.test.js
@@ -307,6 +307,7 @@ describe('React app schedule assignment service integration', () => {
     it('rejects invalid assignment actions before hitting the data layer', async () => {
         await expect(claimParentScheduleAssignmentSlot(event({ isDbGame: false }), user(), 'Snacks')).rejects.toThrow('tracked');
         await expect(claimParentScheduleAssignmentSlot(event(), user(), '   ')).rejects.toThrow('Role is required');
+        await expect(claimParentScheduleAssignmentSlot(event(), user(), 'Setup / cleanup')).rejects.toThrow('unsupported characters');
         await expect(releaseParentScheduleAssignmentClaim(event({ isCancelled: true }), 'Snacks')).rejects.toThrow('cancelled');
         expect(dbMocks.claimAssignmentSlot).not.toHaveBeenCalled();
         expect(dbMocks.releaseAssignmentClaim).not.toHaveBeenCalled();
@@ -405,5 +406,43 @@ describe('React app schedule assignment service integration', () => {
         )).rejects.toThrow('team owners and admins');
 
         expect(dbMocks.updateGame).not.toHaveBeenCalled();
+    });
+
+    it('rejects task names that cannot safely identify assignment claim documents', async () => {
+        const adminUser = user({ uid: 'coach-1', email: 'coach@example.com' });
+
+        for (const role of ['Setup / cleanup', '.', '..', '__reserved__']) {
+            await expect(createScheduleAssignment(
+                event({ assignments: [], isTeamAdmin: true }),
+                adminUser,
+                { role, claimable: true }
+            )).rejects.toThrow('unsupported characters');
+        }
+
+        expect(dbMocks.updateGame).not.toHaveBeenCalled();
+        expect(dbMocks.releaseAssignmentClaim).not.toHaveBeenCalled();
+    });
+
+    it('keeps legacy static task names editable even when they are not valid claim document IDs', async () => {
+        const adminUser = user({ uid: 'coach-1', email: 'coach@example.com' });
+        dbMocks.updateGame.mockResolvedValue(undefined);
+        dbMocks.releaseAssignmentClaim.mockResolvedValue(undefined);
+        dbMocks.getAssignmentClaims.mockResolvedValue({});
+
+        await expect(updateScheduleAssignment(
+            event({
+                assignments: [{ role: 'Setup / cleanup', value: 'Jamie', claimable: false }],
+                isTeamAdmin: true
+            }),
+            adminUser,
+            'Setup / cleanup',
+            { role: 'Setup / cleanup', value: 'Taylor', claimable: false }
+        )).resolves.toEqual([
+            expect.objectContaining({ role: 'Setup / cleanup', value: 'Taylor', claimable: false })
+        ]);
+
+        expect(dbMocks.updateGame).toHaveBeenCalledWith('team-1', 'game-1', {
+            assignments: [{ role: 'Setup / cleanup', value: 'Taylor', claimable: false }]
+        });
     });
 });

--- a/tests/unit/game-read-rules.test.js
+++ b/tests/unit/game-read-rules.test.js
@@ -23,6 +23,12 @@ const eventsRules = eventsMatch?.[0] || '';
 const aggregatedStatsRules = aggregatedStatsMatch?.[0] || '';
 
 describe('game Firestore read rules', () => {
+    it('keeps staff assignment-array updates on the team-admin game write path', () => {
+        expect(teamGamesRules).toContain('allow update: if !isBroadcastSessionOnlyUpdate() &&');
+        expect(teamGamesRules).toContain('(isTeamOwnerOrAdmin(teamId) ||');
+        expect(teamGamesRules).toContain('allow update: if isBroadcastSessionOnlyUpdate() && isTeamOwnerOrAdmin(teamId);');
+    });
+
     it('replaces unconditional game reads with shared visibility helpers', () => {
         expect(rules).toContain('function canReadGameDocument(teamId, gameId, data)');
         expect(rules).toContain('function canReadGameSubcollectionDocument(teamId, gameId)');

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -107,7 +107,8 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
 
         expect(assignmentsSectionSource).toContain('export function AssignmentsSection');
         expect(assignmentsSectionSource).toContain('const { auth, event, updateEvents } = useScheduleEventDetailContext();');
-        expect(assignmentsSectionSource).toContain('loadParentScheduleAssignments(event)');
+        expect(assignmentsSectionSource).toContain('const targetEvent = eventRef.current;');
+        expect(assignmentsSectionSource).toContain('loadParentScheduleAssignments(targetEvent)');
         expect(assignmentsSectionSource).toContain('claimParentScheduleAssignmentSlot(event, auth.user!, role)');
         expect(assignmentsSectionSource).toContain('releaseParentScheduleAssignmentClaim(event, role)');
         expect(assignmentsSectionSource).toContain('<AssignmentCard');

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -204,7 +204,8 @@ describe('ScheduleEventDetail decomposition contract', () => {
 
         expect(section).toContain('export function AssignmentsSection');
         expect(section).toContain('useScheduleEventDetailContext()');
-        expect(section).toContain('loadParentScheduleAssignments(event)');
+        expect(section).toContain('const targetEvent = eventRef.current;');
+        expect(section).toContain('loadParentScheduleAssignments(targetEvent)');
         expect(section).toContain('claimParentScheduleAssignmentSlot(event, auth.user!, role)');
         expect(section).toContain('releaseParentScheduleAssignmentClaim(event, role)');
         expect(section).toContain('<AssignmentCard');


### PR DESCRIPTION
## Summary
- Let team owners and admins create, edit, and remove assignments from an event’s Tasks tab, including the empty state.
- Persist the existing legacy assignment-array shape while preserving parent sign-up and release behavior.
- Clean obsolete claims when task roles or claimability change, reject duplicate or unsafe claimable task names, and ignore stale assignment responses after event navigation.

## Security and compatibility
- Require an authenticated team-admin context in the UI and service; Firestore remains the authoritative owner/admin write boundary.
- Preserve legacy static task names and keep parent claim documents scoped to the selected team and event.
- No legacy cache-version update is needed; the app ships content-hashed Vite assets.

## Tests
- Focused assignment service/detail suite: 129 passed
- Rules/decomposition contracts: 22 passed
- Focused Playwright assignment flows: 2 passed
- npm run app:build
- git diff --check

Fixes #3862