### PR TITLE
Support pasted schedule images in Bulk AI

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -652,7 +652,7 @@
                                     <label class="block text-sm font-semibold text-gray-800 mb-1">
                                         Upload schedule image (optional)
                                     </label>
-                                    <p class="text-xs text-gray-600 mb-2">Screenshot or photo of the schedule. You can still add text instructions below to guide the AI (e.g., “only home games”).</p>
+                                    <p class="text-xs text-gray-600 mb-2">Upload, paste (Ctrl/Cmd+V), or drop a screenshot of the schedule. You can still add text instructions below to guide the AI (e.g., “only home games”).</p>
                                     <input type="file" id="schedule-image-input" accept="image/*"
                                         class="w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
                                     <div id="schedule-image-preview" class="hidden mt-3">
@@ -971,6 +971,7 @@
         import { buildTournamentGroupOverrideKey, buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=4';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=4';
+        import { createBulkAiImageController } from './js/edit-schedule-ai-import.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -4059,22 +4060,16 @@
             }
         });
 
-        // Image upload and preview handlers
-        document.getElementById('schedule-image-input').addEventListener('change', (e) => {
-            const file = e.target.files[0];
-            if (file) {
-                const reader = new FileReader();
-                reader.onload = (event) => {
-                    document.getElementById('schedule-image-preview-img').src = event.target.result;
-                    document.getElementById('schedule-image-preview').classList.remove('hidden');
-                };
-                reader.readAsDataURL(file);
-            }
+        // Image upload, paste, drop, and preview handlers
+        const bulkAiImageController = createBulkAiImageController({
+            imageInput: document.getElementById('schedule-image-input'),
+            preview: document.getElementById('schedule-image-preview'),
+            previewImage: document.getElementById('schedule-image-preview-img'),
+            removeButton: document.getElementById('remove-schedule-image')
         });
-
-        document.getElementById('remove-schedule-image').addEventListener('click', () => {
-            document.getElementById('schedule-image-input').value = '';
-            document.getElementById('schedule-image-preview').classList.add('hidden');
+        bulkAiImageController.bindBulkAiImageControls({
+            container: document.getElementById('content-bulk-ai'),
+            textInput: document.getElementById('bulk-text-input')
         });
 
         // Helper function to convert file to generative part for Gemini
@@ -4665,8 +4660,7 @@
         // Process with AI
         document.getElementById('process-ai-btn').addEventListener('click', async () => {
             const textInput = document.getElementById('bulk-text-input').value.trim();
-            const imageInput = document.getElementById('schedule-image-input');
-            const imageFile = imageInput.files[0];
+            const imageFile = bulkAiImageController.getBulkAiImageFile();
 
             if (!textInput && !imageFile) {
                 alert('Please upload an image or enter additional instructions');

--- a/js/edit-schedule-ai-import.js
+++ b/js/edit-schedule-ai-import.js
@@ -27,6 +27,15 @@ function hasDraggedImage(event) {
     return Boolean(getDroppedImageFile(event));
 }
 
+function isEditablePasteTarget(target) {
+    if (!target || typeof target.closest !== 'function') return false;
+    return Boolean(target.closest('input, textarea, [contenteditable="true"], [contenteditable=""]'));
+}
+
+function isBulkAiContainerActive(container) {
+    return Boolean(container && container.isConnected !== false && !container.classList.contains('hidden'));
+}
+
 export function createBulkAiImageController({
     imageInput,
     preview,
@@ -106,12 +115,20 @@ export function createBulkAiImageController({
         return setBulkAiImage(file);
     }
 
-    function bindBulkAiImageControls({ container, textInput } = {}) {
+    function bindBulkAiImageControls({ container, textInput, documentTarget = globalThis.document } = {}) {
         imageInput?.addEventListener('change', handleBulkAiImageInputChange);
         removeButton?.addEventListener('click', clearBulkAiImage);
 
         const pasteTargets = new Set([textInput, container].filter(Boolean));
         pasteTargets.forEach((target) => target.addEventListener('paste', handleBulkAiImagePaste));
+
+        const handlePagePaste = (event) => {
+            if (!isBulkAiContainerActive(container)) return false;
+            if (container.contains(event.target)) return false;
+            if (isEditablePasteTarget(event.target)) return false;
+            return handleBulkAiImagePaste(event);
+        };
+        documentTarget?.addEventListener?.('paste', handlePagePaste);
 
         container?.addEventListener('dragover', handleBulkAiImageDragOver);
         container?.addEventListener('drop', handleBulkAiImageDrop);
@@ -120,6 +137,7 @@ export function createBulkAiImageController({
             imageInput?.removeEventListener('change', handleBulkAiImageInputChange);
             removeButton?.removeEventListener('click', clearBulkAiImage);
             pasteTargets.forEach((target) => target.removeEventListener('paste', handleBulkAiImagePaste));
+            documentTarget?.removeEventListener?.('paste', handlePagePaste);
             container?.removeEventListener('dragover', handleBulkAiImageDragOver);
             container?.removeEventListener('drop', handleBulkAiImageDrop);
         };

--- a/js/edit-schedule-ai-import.js
+++ b/js/edit-schedule-ai-import.js
@@ -1,0 +1,133 @@
+function isImageFile(file) {
+    return Boolean(file && typeof file.type === 'string' && file.type.startsWith('image/'));
+}
+
+function getImageFileFromItems(items = []) {
+    return Array.from(items)
+        .map((item) => {
+            if (!item || typeof item.type !== 'string' || !item.type.startsWith('image/')) return null;
+            return typeof item.getAsFile === 'function' ? item.getAsFile() : null;
+        })
+        .find(isImageFile) || null;
+}
+
+export function getClipboardImageFile(event) {
+    return getImageFileFromItems(event?.clipboardData?.items || []);
+}
+
+export function getDroppedImageFile(event) {
+    return Array.from(event?.dataTransfer?.files || []).find(isImageFile) || null;
+}
+
+function hasDraggedImage(event) {
+    const items = Array.from(event?.dataTransfer?.items || []);
+    if (items.some((item) => typeof item?.type === 'string' && item.type.startsWith('image/'))) {
+        return true;
+    }
+    return Boolean(getDroppedImageFile(event));
+}
+
+export function createBulkAiImageController({
+    imageInput,
+    preview,
+    previewImage,
+    removeButton,
+    FileReaderCtor = globalThis.FileReader
+} = {}) {
+    let bulkAiImageFile = null;
+
+    function renderImagePreview(file) {
+        if (!preview || !previewImage) return;
+
+        if (!FileReaderCtor) {
+            preview.classList.remove('hidden');
+            return;
+        }
+
+        const reader = new FileReaderCtor();
+        reader.onload = (event) => {
+            const result = event?.target?.result ?? reader.result;
+            previewImage.src = typeof result === 'string' ? result : '';
+            preview.classList.remove('hidden');
+        };
+        reader.readAsDataURL(file);
+    }
+
+    function setBulkAiImage(file) {
+        if (!isImageFile(file)) return false;
+        bulkAiImageFile = file;
+        renderImagePreview(file);
+        return true;
+    }
+
+    function clearBulkAiImage() {
+        bulkAiImageFile = null;
+        if (imageInput) imageInput.value = '';
+        if (previewImage) previewImage.removeAttribute('src');
+        if (preview) preview.classList.add('hidden');
+    }
+
+    function getBulkAiImageFile() {
+        return bulkAiImageFile || imageInput?.files?.[0] || null;
+    }
+
+    function handleBulkAiImageInputChange(event) {
+        const file = event?.target?.files?.[0] || null;
+        return setBulkAiImage(file);
+    }
+
+    function handleBulkAiImagePaste(event) {
+        const file = getClipboardImageFile(event);
+        if (!file) return false;
+
+        event.preventDefault();
+        event.stopPropagation?.();
+        return setBulkAiImage(file);
+    }
+
+    function handleBulkAiImageDragOver(event) {
+        if (!hasDraggedImage(event)) return false;
+
+        event.preventDefault();
+        if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
+        return true;
+    }
+
+    function handleBulkAiImageDrop(event) {
+        const file = getDroppedImageFile(event);
+        if (!file) return false;
+
+        event.preventDefault();
+        event.stopPropagation?.();
+        return setBulkAiImage(file);
+    }
+
+    function bindBulkAiImageControls({ container, textInput } = {}) {
+        imageInput?.addEventListener('change', handleBulkAiImageInputChange);
+        removeButton?.addEventListener('click', clearBulkAiImage);
+
+        const pasteTargets = new Set([textInput, container].filter(Boolean));
+        pasteTargets.forEach((target) => target.addEventListener('paste', handleBulkAiImagePaste));
+
+        container?.addEventListener('dragover', handleBulkAiImageDragOver);
+        container?.addEventListener('drop', handleBulkAiImageDrop);
+
+        return () => {
+            imageInput?.removeEventListener('change', handleBulkAiImageInputChange);
+            removeButton?.removeEventListener('click', clearBulkAiImage);
+            pasteTargets.forEach((target) => target.removeEventListener('paste', handleBulkAiImagePaste));
+            container?.removeEventListener('dragover', handleBulkAiImageDragOver);
+            container?.removeEventListener('drop', handleBulkAiImageDrop);
+        };
+    }
+
+    return {
+        bindBulkAiImageControls,
+        clearBulkAiImage,
+        getBulkAiImageFile,
+        handleBulkAiImageDrop,
+        handleBulkAiImageInputChange,
+        handleBulkAiImagePaste,
+        setBulkAiImage
+    };
+}

--- a/js/edit-schedule-ai-import.js
+++ b/js/edit-schedule-ai-import.js
@@ -50,6 +50,10 @@ export function createBulkAiImageController({
             previewImage.src = typeof result === 'string' ? result : '';
             preview.classList.remove('hidden');
         };
+        reader.onerror = () => {
+            previewImage.removeAttribute('src');
+            preview.classList.remove('hidden');
+        };
         reader.readAsDataURL(file);
     }
 

--- a/tests/smoke/edit-schedule-calendar-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-import.spec.js
@@ -553,6 +553,51 @@ test.describe('edit schedule imported calendar rows', () => {
     });
 });
 
+test.describe('edit schedule Bulk AI image input', () => {
+    test.beforeEach(async ({ page }) => {
+        await registerRoutes(page);
+    });
+
+    test('accepts pasted schedule screenshots without blocking plain text paste', async ({ page }) => {
+        await page.addInitScript((state) => {
+            window.__editScheduleTestState = state;
+            window.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+        }, buildState());
+
+        await page.goto(`${serverOrigin}/edit-schedule.html#teamId=team-1`, { waitUntil: 'domcontentloaded' });
+        await page.locator('#tab-bulk-ai').click();
+
+        const plainTextPrevented = await page.locator('#bulk-text-input').evaluate((textarea) => {
+            const dataTransfer = new DataTransfer();
+            dataTransfer.setData('text/plain', 'only home games');
+            const event = new ClipboardEvent('paste', {
+                bubbles: true,
+                cancelable: true,
+                clipboardData: dataTransfer
+            });
+            textarea.dispatchEvent(event);
+            return event.defaultPrevented;
+        });
+        expect(plainTextPrevented).toBe(false);
+
+        const imagePastePrevented = await page.locator('#bulk-text-input').evaluate((textarea) => {
+            const dataTransfer = new DataTransfer();
+            dataTransfer.items.add(new File(['schedule image'], 'schedule.png', { type: 'image/png' }));
+            const event = new ClipboardEvent('paste', {
+                bubbles: true,
+                cancelable: true,
+                clipboardData: dataTransfer
+            });
+            textarea.dispatchEvent(event);
+            return event.defaultPrevented;
+        });
+
+        expect(imagePastePrevented).toBe(true);
+        await expect(page.locator('#schedule-image-preview')).toBeVisible();
+        await expect(page.locator('#schedule-image-preview-img')).toHaveAttribute('src', /^data:image\/png;base64,/);
+    });
+});
+
 test.describe('edit schedule season record fields', () => {
     test.beforeEach(async ({ page }) => {
         await registerRoutes(page);

--- a/tests/unit/edit-schedule-ai-image-clipboard.test.js
+++ b/tests/unit/edit-schedule-ai-image-clipboard.test.js
@@ -17,6 +17,12 @@ class ImmediateFileReader {
     }
 }
 
+class FailingFileReader {
+    readAsDataURL() {
+        this.onerror?.(new Event('error'));
+    }
+}
+
 function createPasteEvent(items) {
     const event = new Event('paste', { bubbles: true, cancelable: true });
     Object.defineProperty(event, 'clipboardData', {
@@ -49,6 +55,24 @@ function setupController() {
         textInput: document.getElementById('bulk-text-input')
     });
     return controller;
+}
+
+function setupControllerWithReader(FileReaderCtor) {
+    document.body.innerHTML = `
+        <input type="file" id="schedule-image-input" accept="image/*">
+        <div id="schedule-image-preview" class="hidden">
+            <img id="schedule-image-preview-img" alt="Schedule preview" src="data:image/png;base64,old">
+            <button type="button" id="remove-schedule-image">Remove image</button>
+        </div>
+    `;
+
+    return createBulkAiImageController({
+        imageInput: document.getElementById('schedule-image-input'),
+        preview: document.getElementById('schedule-image-preview'),
+        previewImage: document.getElementById('schedule-image-preview-img'),
+        removeButton: document.getElementById('remove-schedule-image'),
+        FileReaderCtor
+    });
 }
 
 function readEditSchedule() {
@@ -105,6 +129,17 @@ describe('edit schedule Bulk AI image clipboard support', () => {
         ]);
 
         expect(getClipboardImageFile(event)).toBe(file);
+    });
+
+    it('keeps the selected image state when preview reading fails', () => {
+        const controller = setupControllerWithReader(FailingFileReader);
+        const file = new File(['schedule image'], 'schedule.png', { type: 'image/png' });
+
+        expect(controller.setBulkAiImage(file)).toBe(true);
+
+        expect(controller.getBulkAiImageFile()).toBe(file);
+        expect(document.getElementById('schedule-image-preview').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('schedule-image-preview-img').hasAttribute('src')).toBe(false);
     });
 
     it('wires edit-schedule.html to the shared paste/drop image controller', () => {

--- a/tests/unit/edit-schedule-ai-image-clipboard.test.js
+++ b/tests/unit/edit-schedule-ai-image-clipboard.test.js
@@ -121,6 +121,52 @@ describe('edit schedule Bulk AI image clipboard support', () => {
         expect(document.getElementById('schedule-image-preview').classList.contains('hidden')).toBe(true);
     });
 
+    it('captures image paste when Bulk AI is visible but focus is still outside the panel', () => {
+        const controller = setupController();
+        const file = new File(['schedule image'], 'schedule.png', { type: 'image/png' });
+        const event = createPasteEvent([
+            { type: 'image/png', getAsFile: () => file }
+        ]);
+
+        document.body.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(controller.getBulkAiImageFile()).toBe(file);
+        expect(document.getElementById('schedule-image-preview').classList.contains('hidden')).toBe(false);
+    });
+
+    it('does not capture page-level image paste while the Bulk AI panel is hidden', () => {
+        const controller = setupController();
+        const container = document.getElementById('content-bulk-ai');
+        const file = new File(['schedule image'], 'schedule.png', { type: 'image/png' });
+        const event = createPasteEvent([
+            { type: 'image/png', getAsFile: () => file }
+        ]);
+        container.classList.add('hidden');
+
+        const dispatchResult = document.body.dispatchEvent(event);
+
+        expect(dispatchResult).toBe(true);
+        expect(event.defaultPrevented).toBe(false);
+        expect(controller.getBulkAiImageFile()).toBeNull();
+    });
+
+    it('does not capture page-level image paste from unrelated editable fields', () => {
+        const controller = setupController();
+        const outsideInput = document.createElement('input');
+        document.body.append(outsideInput);
+        const file = new File(['schedule image'], 'schedule.png', { type: 'image/png' });
+        const event = createPasteEvent([
+            { type: 'image/png', getAsFile: () => file }
+        ]);
+
+        const dispatchResult = outsideInput.dispatchEvent(event);
+
+        expect(dispatchResult).toBe(true);
+        expect(event.defaultPrevented).toBe(false);
+        expect(controller.getBulkAiImageFile()).toBeNull();
+    });
+
     it('extracts only image files from clipboard items', () => {
         const file = new File(['schedule image'], 'schedule.jpg', { type: 'image/jpeg' });
         const event = createPasteEvent([

--- a/tests/unit/edit-schedule-ai-image-clipboard.test.js
+++ b/tests/unit/edit-schedule-ai-image-clipboard.test.js
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    createBulkAiImageController,
+    getClipboardImageFile
+} from '../../js/edit-schedule-ai-import.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+class ImmediateFileReader {
+    readAsDataURL(file) {
+        this.result = `data:${file.type};base64,c2NoZWR1bGU=`;
+        this.onload?.({ target: this });
+    }
+}
+
+function createPasteEvent(items) {
+    const event = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'clipboardData', {
+        value: { items }
+    });
+    return event;
+}
+
+function setupController() {
+    document.body.innerHTML = `
+        <div id="content-bulk-ai">
+            <input type="file" id="schedule-image-input" accept="image/*">
+            <div id="schedule-image-preview" class="hidden">
+                <img id="schedule-image-preview-img" alt="Schedule preview">
+                <button type="button" id="remove-schedule-image">Remove image</button>
+            </div>
+            <textarea id="bulk-text-input"></textarea>
+        </div>
+    `;
+
+    const controller = createBulkAiImageController({
+        imageInput: document.getElementById('schedule-image-input'),
+        preview: document.getElementById('schedule-image-preview'),
+        previewImage: document.getElementById('schedule-image-preview-img'),
+        removeButton: document.getElementById('remove-schedule-image'),
+        FileReaderCtor: ImmediateFileReader
+    });
+    controller.bindBulkAiImageControls({
+        container: document.getElementById('content-bulk-ai'),
+        textInput: document.getElementById('bulk-text-input')
+    });
+    return controller;
+}
+
+function readEditSchedule() {
+    return readFileSync(path.join(repoRoot, 'edit-schedule.html'), 'utf8');
+}
+
+function readHelperSource() {
+    return readFileSync(path.join(repoRoot, 'js/edit-schedule-ai-import.js'), 'utf8');
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('edit schedule Bulk AI image clipboard support', () => {
+    it('uses pasted image files for the Bulk AI image preview and process state', () => {
+        const controller = setupController();
+        const file = new File(['schedule image'], 'schedule.png', { type: 'image/png' });
+        const event = createPasteEvent([
+            { type: 'text/plain', getAsFile: () => null },
+            { type: 'image/png', getAsFile: () => file }
+        ]);
+
+        document.getElementById('bulk-text-input').dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(controller.getBulkAiImageFile()).toBe(file);
+        expect(document.getElementById('schedule-image-preview').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('schedule-image-preview-img').getAttribute('src')).toBe('data:image/png;base64,c2NoZWR1bGU=');
+    });
+
+    it('does not hijack plain text paste into the Bulk AI textarea', () => {
+        const controller = setupController();
+        const textarea = document.getElementById('bulk-text-input');
+        textarea.value = 'Keep typed context';
+        const event = createPasteEvent([
+            { type: 'text/plain', getAsFile: () => null }
+        ]);
+
+        const dispatchResult = textarea.dispatchEvent(event);
+
+        expect(dispatchResult).toBe(true);
+        expect(event.defaultPrevented).toBe(false);
+        expect(textarea.value).toBe('Keep typed context');
+        expect(controller.getBulkAiImageFile()).toBeNull();
+        expect(document.getElementById('schedule-image-preview').classList.contains('hidden')).toBe(true);
+    });
+
+    it('extracts only image files from clipboard items', () => {
+        const file = new File(['schedule image'], 'schedule.jpg', { type: 'image/jpeg' });
+        const event = createPasteEvent([
+            { type: 'text/html', getAsFile: () => new File(['html'], 'paste.html', { type: 'text/html' }) },
+            { type: 'image/jpeg', getAsFile: () => file }
+        ]);
+
+        expect(getClipboardImageFile(event)).toBe(file);
+    });
+
+    it('wires edit-schedule.html to the shared paste/drop image controller', () => {
+        const source = readEditSchedule();
+        const helperSource = readHelperSource();
+
+        expect(source).toContain("import { createBulkAiImageController } from './js/edit-schedule-ai-import.js?v=1';");
+        expect(source).toContain('Upload, paste (Ctrl/Cmd+V), or drop a screenshot of the schedule.');
+        expect(source).toContain("container: document.getElementById('content-bulk-ai')");
+        expect(source).toContain("textInput: document.getElementById('bulk-text-input')");
+        expect(source).toContain('bulkAiImageController.getBulkAiImageFile()');
+        expect(helperSource).toContain("addEventListener('paste'");
+        expect(helperSource).toContain("addEventListener('drop'");
+    });
+});


### PR DESCRIPTION
## Summary
- Add a shared Bulk AI image controller for edit-schedule image preview state.
- Wire the schedule image file picker, clipboard paste, and drag/drop paths through the same selected File state.
- Update helper copy and add unit plus focused smoke coverage for pasted screenshots and plain-text paste.

Fixes #3859

## Validation
- npm ci
- node --check js/edit-schedule-ai-import.js
- npx vitest run tests/unit/edit-schedule-ai-image-clipboard.test.js --reporter=verbose
- npx vitest run tests/unit/edit-schedule-ai-image-clipboard.test.js tests/unit/edit-schedule-csv-import-wiring.test.js tests/unit/edit-schedule-registration-import.test.js --reporter=verbose
- npx playwright test tests/smoke/edit-schedule-calendar-import.spec.js --config=playwright.smoke.config.js --grep "accepts pasted schedule screenshots" --reporter=line