### PR TITLE
Add app team creation flow

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -24,6 +24,7 @@ import type { AuthState } from './lib/types';
 const AuthPage = lazy(() => import('./pages/AuthPage').then((module) => ({ default: module.AuthPage })));
 const AcceptInvite = lazy(() => import('./pages/AcceptInvite').then((module) => ({ default: module.AcceptInvite })));
 const CapabilityPage = lazy(() => import('./pages/CapabilityPage').then((module) => ({ default: module.CapabilityPage })));
+const CreateTeam = lazy(() => import('./pages/CreateTeam').then((module) => ({ default: module.CreateTeam })));
 const GameDetail = lazy(() => import('./pages/GameDetail').then((module) => ({ default: module.GameDetail })));
 const HelpArticle = lazy(() => import('./pages/HelpArticle').then((module) => ({ default: module.HelpArticle })));
 const HelpPortal = lazy(() => import('./pages/HelpPortal').then((module) => ({ default: module.HelpPortal })));
@@ -242,6 +243,7 @@ export default function App() {
         <Route path="/messages/:teamId" element={<Protected auth={auth}><Messages auth={auth} /></Protected>} />
         <Route path="/ai" element={<Protected auth={auth}><PrivateAiChat auth={auth} /></Protected>} />
         <Route path="/teams" element={<Protected auth={auth}><Teams auth={auth} /></Protected>} />
+        <Route path="/teams/new" element={<Protected auth={auth}><CreateTeam auth={auth} /></Protected>} />
         <Route path="/teams/browse" element={<PublicPage auth={auth}><PublicTeamsBrowse /></PublicPage>} />
         <Route path="/teams/:teamId/public" element={<PublicPage auth={auth}><PublicTeamDetail /></PublicPage>} />
         <Route path="/teams/:teamId" element={auth.user || auth.loading ? <Protected auth={auth}><TeamDetail auth={auth} /></Protected> : <PublicPage auth={auth}><PublicTeamDetail /></PublicPage>} />

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -593,6 +593,25 @@ describe('AppShell', () => {
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
   });
 
+  it('routes Create team through the native app flow', async () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={signedInAuth}><div>Home</div></AppShell>} />
+          <Route path="/teams/new" element={<AppShell auth={signedInAuth}><div>Native create team</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    fireEvent.click(screen.getByRole('button', { name: /^Create team/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Native create team')).toBeTruthy();
+    });
+    expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['desktop web', true],
     ['mobile', false],

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -642,11 +642,11 @@ function buildAddWorkflows(): AddWorkflow[] {
     {
       id: 'create-team',
       label: 'Create team',
-      detail: 'New team, import shell, staff access',
+      detail: 'New team and sport setup',
       section: 'Team',
       icon: Users,
-      kind: 'website',
-      href: legacyUrl('dashboard.html'),
+      kind: 'native',
+      href: '/teams/new',
       badge: 'Coach/Admin'
     },
     {

--- a/apps/app/src/lib/adapters/legacyTeamCreation.ts
+++ b/apps/app/src/lib/adapters/legacyTeamCreation.ts
@@ -1,0 +1,16 @@
+import { createConfig as legacyCreateConfig, createTeam as legacyCreateTeam } from '@legacy/db.js';
+import {
+  getDefaultStatConfigForSport as legacyGetDefaultStatConfigForSport,
+  getStatConfigPresetOptions as legacyGetStatConfigPresetOptions
+} from '@legacy/stat-config-presets.js';
+
+export const createTeam = legacyCreateTeam as (teamData: Record<string, unknown>) => Promise<string>;
+export const createConfig = legacyCreateConfig as (teamId: string, configData: unknown) => Promise<string>;
+
+export function getDefaultStatConfigForSport(sport: string): unknown {
+  return legacyGetDefaultStatConfigForSport(sport);
+}
+
+export function getStatConfigPresetOptions(): unknown[] {
+  return legacyGetStatConfigPresetOptions() as unknown[];
+}

--- a/apps/app/src/lib/appDataCache.ts
+++ b/apps/app/src/lib/appDataCache.ts
@@ -39,6 +39,10 @@ export function getParentHomeSecondaryCacheKey(userId: string) {
   return `home-secondary:${userId}`;
 }
 
+export function getTeamsSummaryBootstrapCacheKey(userId: string) {
+  return `teams-summary-bootstrap:${userId}`;
+}
+
 export function getCachedAppData<T>(key: string, { maxStaleMs = defaultMaxStaleMs }: { maxStaleMs?: number } = {}): T | null {
   const now = Date.now();
   const entry = cache.get(key) as CacheEntry<T> | undefined;

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -8,7 +8,12 @@ import {
   type ParentHomeModel
 } from './homeLogic';
 import { createLogger } from './logger';
-import { getParentHomeSecondaryCacheKey, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
+import {
+  getParentHomeSecondaryCacheKey,
+  getParentScheduleSummaryCacheKey,
+  getTeamsSummaryBootstrapCacheKey,
+  loadCachedAppData
+} from './appDataCache';
 import { toAppServiceError, type AppServiceError } from './appErrors';
 import {
   hydrateParentScheduleDetails,
@@ -110,7 +115,7 @@ export async function loadParentTeamsSummaryBootstrap(
   }
 
   return loadCachedAppData(
-    `teams-summary-bootstrap:${user.uid}`,
+    getTeamsSummaryBootstrapCacheKey(user.uid),
     async () => {
       const timer = startUxTimer('teams summary load');
       try {

--- a/apps/app/src/lib/teamCreationService.test.ts
+++ b/apps/app/src/lib/teamCreationService.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const legacyMocks = vi.hoisted(() => ({
+  createTeam: vi.fn(),
+  createConfig: vi.fn(),
+  getDefaultStatConfigForSport: vi.fn(),
+  getStatConfigPresetOptions: vi.fn()
+}));
+
+vi.mock('./adapters/legacyTeamCreation', () => legacyMocks);
+
+import { createTeamForApp, getCreateTeamSportOptions } from './teamCreationService';
+
+const user = {
+  uid: 'coach-1',
+  email: 'coach@example.com',
+  displayName: 'Coach'
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  legacyMocks.createTeam.mockResolvedValue('team-new');
+  legacyMocks.createConfig.mockResolvedValue('config-new');
+  legacyMocks.getDefaultStatConfigForSport.mockReturnValue({ name: 'Soccer Standard', baseType: 'Soccer' });
+  legacyMocks.getStatConfigPresetOptions.mockReturnValue([
+    { baseType: 'Custom' },
+    { baseType: 'Basketball' },
+    { baseType: 'Soccer' },
+    { baseType: 'Basketball' }
+  ]);
+});
+
+describe('createTeamForApp', () => {
+  it('creates a team with owner fields and adds the default sport stat config', async () => {
+    const result = await createTeamForApp(user, {
+      name: '  KC Current U12  ',
+      sport: ' Soccer ',
+      zip: '66210-1234',
+      isPublic: false
+    });
+
+    expect(result).toEqual({
+      teamId: 'team-new',
+      defaultStatConfigCreated: true,
+      defaultStatConfigError: null
+    });
+    expect(legacyMocks.createTeam).toHaveBeenCalledWith({
+      name: 'KC Current U12',
+      sport: 'Soccer',
+      zip: '662101234',
+      isPublic: false,
+      ownerId: 'coach-1',
+      ownerEmail: 'coach@example.com',
+      adminEmails: []
+    });
+    expect(legacyMocks.getDefaultStatConfigForSport).toHaveBeenCalledWith('Soccer');
+    expect(legacyMocks.createConfig).toHaveBeenCalledWith('team-new', { name: 'Soccer Standard', baseType: 'Soccer' });
+  });
+
+  it('returns a non-blocking warning when the stat config write fails after team creation', async () => {
+    legacyMocks.createConfig.mockRejectedValueOnce(new Error('permission denied'));
+
+    await expect(createTeamForApp(user, {
+      name: 'Team',
+      sport: 'Basketball',
+      zip: '12345',
+      isPublic: true
+    })).resolves.toEqual({
+      teamId: 'team-new',
+      defaultStatConfigCreated: false,
+      defaultStatConfigError: 'permission denied'
+    });
+    expect(legacyMocks.createTeam).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips default stat config creation when no sport preset exists', async () => {
+    legacyMocks.getDefaultStatConfigForSport.mockReturnValueOnce(null);
+
+    await expect(createTeamForApp(user, {
+      name: 'Curling Club',
+      sport: 'Curling'
+    })).resolves.toEqual({
+      teamId: 'team-new',
+      defaultStatConfigCreated: false,
+      defaultStatConfigError: null
+    });
+    expect(legacyMocks.createConfig).not.toHaveBeenCalled();
+  });
+
+  it('validates required creator and team fields before writing', async () => {
+    await expect(createTeamForApp(null, { name: 'Team', sport: 'Soccer' })).rejects.toThrow('Sign in to create a team.');
+    await expect(createTeamForApp(user, { name: ' ', sport: 'Soccer' })).rejects.toThrow('Team name is required.');
+    await expect(createTeamForApp(user, { name: 'Team', sport: ' ' })).rejects.toThrow('Sport is required.');
+    expect(legacyMocks.createTeam).not.toHaveBeenCalled();
+  });
+});
+
+describe('getCreateTeamSportOptions', () => {
+  it('derives unique sports from default stat config presets', () => {
+    expect(getCreateTeamSportOptions()).toEqual(['Basketball', 'Soccer']);
+  });
+});

--- a/apps/app/src/lib/teamCreationService.test.ts
+++ b/apps/app/src/lib/teamCreationService.test.ts
@@ -74,6 +74,25 @@ describe('createTeamForApp', () => {
     expect(legacyMocks.createTeam).toHaveBeenCalledTimes(1);
   });
 
+  it('returns the created team id when preset resolution fails after the team write', async () => {
+    legacyMocks.getDefaultStatConfigForSport.mockImplementationOnce(() => {
+      throw new Error('preset unavailable');
+    });
+
+    await expect(createTeamForApp(user, {
+      name: 'Team',
+      sport: 'Basketball',
+      zip: '12345',
+      isPublic: true
+    })).resolves.toEqual({
+      teamId: 'team-new',
+      defaultStatConfigCreated: false,
+      defaultStatConfigError: 'preset unavailable'
+    });
+    expect(legacyMocks.createTeam).toHaveBeenCalledTimes(1);
+    expect(legacyMocks.createConfig).not.toHaveBeenCalled();
+  });
+
   it('skips default stat config creation when no sport preset exists', async () => {
     legacyMocks.getDefaultStatConfigForSport.mockReturnValueOnce(null);
 
@@ -88,6 +107,24 @@ describe('createTeamForApp', () => {
     expect(legacyMocks.createConfig).not.toHaveBeenCalled();
   });
 
+  it('does not attempt config creation when the team write fails or returns no id', async () => {
+    legacyMocks.createTeam.mockRejectedValueOnce(new Error('team write failed'));
+
+    await expect(createTeamForApp(user, {
+      name: 'Team',
+      sport: 'Soccer'
+    })).rejects.toThrow('team write failed');
+    expect(legacyMocks.createConfig).not.toHaveBeenCalled();
+
+    legacyMocks.createTeam.mockResolvedValueOnce('  ');
+
+    await expect(createTeamForApp(user, {
+      name: 'Team',
+      sport: 'Soccer'
+    })).rejects.toThrow('Team could not be created.');
+    expect(legacyMocks.createConfig).not.toHaveBeenCalled();
+  });
+
   it('validates required creator and team fields before writing', async () => {
     await expect(createTeamForApp(null, { name: 'Team', sport: 'Soccer' })).rejects.toThrow('Sign in to create a team.');
     await expect(createTeamForApp(user, { name: ' ', sport: 'Soccer' })).rejects.toThrow('Team name is required.');
@@ -99,5 +136,18 @@ describe('createTeamForApp', () => {
 describe('getCreateTeamSportOptions', () => {
   it('derives unique sports from default stat config presets', () => {
     expect(getCreateTeamSportOptions()).toEqual(['Basketball', 'Soccer']);
+  });
+
+  it('keeps every built-in sport available when the preset catalog is empty', () => {
+    legacyMocks.getStatConfigPresetOptions.mockReturnValueOnce([]);
+
+    expect(getCreateTeamSportOptions()).toEqual([
+      'Basketball',
+      'Soccer',
+      'Baseball',
+      'Softball',
+      'Football',
+      'Volleyball'
+    ]);
   });
 });

--- a/apps/app/src/lib/teamCreationService.test.ts
+++ b/apps/app/src/lib/teamCreationService.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearAppDataCache,
+  getTeamsSummaryBootstrapCacheKey,
+  loadCachedAppData
+} from './appDataCache';
 
 const legacyMocks = vi.hoisted(() => ({
   createTeam: vi.fn(),
@@ -20,6 +25,7 @@ const user = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearAppDataCache();
   legacyMocks.createTeam.mockResolvedValue('team-new');
   legacyMocks.createConfig.mockResolvedValue('config-new');
   legacyMocks.getDefaultStatConfigForSport.mockReturnValue({ name: 'Soccer Standard', baseType: 'Soccer' });
@@ -56,6 +62,24 @@ describe('createTeamForApp', () => {
     });
     expect(legacyMocks.getDefaultStatConfigForSport).toHaveBeenCalledWith('Soccer');
     expect(legacyMocks.createConfig).toHaveBeenCalledWith('team-new', { name: 'Soccer Standard', baseType: 'Soccer' });
+  });
+
+  it('invalidates only the creator team-summary cache after the team write succeeds', async () => {
+    const creatorCacheKey = getTeamsSummaryBootstrapCacheKey(user.uid);
+    const otherCacheKey = getTeamsSummaryBootstrapCacheKey('coach-2');
+    await loadCachedAppData(creatorCacheKey, async () => 'stale creator teams', { persist: false });
+    await loadCachedAppData(otherCacheKey, async () => 'other coach teams', { persist: false });
+
+    await createTeamForApp(user, { name: 'Team', sport: 'Soccer' });
+
+    const reloadCreatorTeams = vi.fn(async () => 'creator teams with new team');
+    const reloadOtherTeams = vi.fn(async () => 'unexpected reload');
+    await expect(loadCachedAppData(creatorCacheKey, reloadCreatorTeams, { persist: false }))
+      .resolves.toBe('creator teams with new team');
+    await expect(loadCachedAppData(otherCacheKey, reloadOtherTeams, { persist: false }))
+      .resolves.toBe('other coach teams');
+    expect(reloadCreatorTeams).toHaveBeenCalledTimes(1);
+    expect(reloadOtherTeams).not.toHaveBeenCalled();
   });
 
   it('returns a non-blocking warning when the stat config write fails after team creation', async () => {

--- a/apps/app/src/lib/teamCreationService.ts
+++ b/apps/app/src/lib/teamCreationService.ts
@@ -1,0 +1,89 @@
+import {
+  createConfig,
+  createTeam,
+  getDefaultStatConfigForSport,
+  getStatConfigPresetOptions
+} from './adapters/legacyTeamCreation';
+import type { AuthUser } from './types';
+
+export type CreateTeamForAppInput = {
+  name: string;
+  sport: string;
+  zip?: string;
+  isPublic?: boolean;
+};
+
+export type CreateTeamForAppResult = {
+  teamId: string;
+  defaultStatConfigCreated: boolean;
+  defaultStatConfigError: string | null;
+};
+
+const fallbackSportOptions = ['Basketball', 'Soccer', 'Baseball', 'Football', 'Volleyball'];
+
+export function getCreateTeamSportOptions() {
+  const presetSports = getStatConfigPresetOptions()
+    .map((option) => cleanString((option as { baseType?: unknown })?.baseType))
+    .filter((sport) => sport && sport.toLowerCase() !== 'custom');
+  const options = presetSports.length ? presetSports : fallbackSportOptions;
+  return [...new Set(options)];
+}
+
+export async function createTeamForApp(user: AuthUser | null, input: CreateTeamForAppInput): Promise<CreateTeamForAppResult> {
+  if (!user?.uid) {
+    throw new Error('Sign in to create a team.');
+  }
+
+  const name = cleanString(input?.name);
+  if (!name) throw new Error('Team name is required.');
+
+  const sport = cleanString(input?.sport);
+  if (!sport) throw new Error('Sport is required.');
+
+  const teamId = cleanString(await createTeam({
+    name,
+    sport,
+    zip: normalizeTeamZip(input?.zip),
+    isPublic: input?.isPublic !== false,
+    ownerId: user.uid,
+    ownerEmail: cleanString(user.email),
+    adminEmails: []
+  }));
+
+  if (!teamId) {
+    throw new Error('Team could not be created.');
+  }
+
+  const defaultStatConfig = getDefaultStatConfigForSport(sport);
+  if (!defaultStatConfig) {
+    return {
+      teamId,
+      defaultStatConfigCreated: false,
+      defaultStatConfigError: null
+    };
+  }
+
+  try {
+    await createConfig(teamId, defaultStatConfig);
+    return {
+      teamId,
+      defaultStatConfigCreated: true,
+      defaultStatConfigError: null
+    };
+  } catch (error: any) {
+    return {
+      teamId,
+      defaultStatConfigCreated: false,
+      defaultStatConfigError: error?.message || 'Unable to create the default stat config.'
+    };
+  }
+}
+
+function cleanString(value: unknown) {
+  return String(value || '').trim();
+}
+
+function normalizeTeamZip(value: unknown) {
+  const digits = cleanString(value).replace(/[^0-9]/g, '');
+  return digits.length >= 5 ? digits.slice(0, 9) : '';
+}

--- a/apps/app/src/lib/teamCreationService.ts
+++ b/apps/app/src/lib/teamCreationService.ts
@@ -4,6 +4,7 @@ import {
   getDefaultStatConfigForSport,
   getStatConfigPresetOptions
 } from './adapters/legacyTeamCreation';
+import { clearAppDataCache, getTeamsSummaryBootstrapCacheKey } from './appDataCache';
 import type { AuthUser } from './types';
 
 export type CreateTeamForAppInput = {
@@ -53,6 +54,8 @@ export async function createTeamForApp(user: AuthUser | null, input: CreateTeamF
   if (!teamId) {
     throw new Error('Team could not be created.');
   }
+
+  clearAppDataCache(getTeamsSummaryBootstrapCacheKey(user.uid));
 
   try {
     const defaultStatConfig = getDefaultStatConfigForSport(sport);

--- a/apps/app/src/lib/teamCreationService.ts
+++ b/apps/app/src/lib/teamCreationService.ts
@@ -19,7 +19,7 @@ export type CreateTeamForAppResult = {
   defaultStatConfigError: string | null;
 };
 
-const fallbackSportOptions = ['Basketball', 'Soccer', 'Baseball', 'Football', 'Volleyball'];
+const fallbackSportOptions = ['Basketball', 'Soccer', 'Baseball', 'Softball', 'Football', 'Volleyball'];
 
 export function getCreateTeamSportOptions() {
   const presetSports = getStatConfigPresetOptions()
@@ -54,16 +54,16 @@ export async function createTeamForApp(user: AuthUser | null, input: CreateTeamF
     throw new Error('Team could not be created.');
   }
 
-  const defaultStatConfig = getDefaultStatConfigForSport(sport);
-  if (!defaultStatConfig) {
-    return {
-      teamId,
-      defaultStatConfigCreated: false,
-      defaultStatConfigError: null
-    };
-  }
-
   try {
+    const defaultStatConfig = getDefaultStatConfigForSport(sport);
+    if (!defaultStatConfig) {
+      return {
+        teamId,
+        defaultStatConfigCreated: false,
+        defaultStatConfigError: null
+      };
+    }
+
     await createConfig(teamId, defaultStatConfig);
     return {
       teamId,

--- a/apps/app/src/pages/CreateTeam.test.tsx
+++ b/apps/app/src/pages/CreateTeam.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CreateTeam } from './CreateTeam';
@@ -113,6 +114,38 @@ describe('CreateTeam', () => {
     fireEvent.click(openTeamButton);
 
     expect(teamCreationMocks.createTeamForApp).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Team detail: team-new')).toBeTruthy();
+  });
+
+  it('starts only one team write for duplicate submissions in the same render turn', async () => {
+    let finishCreation!: (result: {
+      teamId: string;
+      defaultStatConfigCreated: boolean;
+      defaultStatConfigError: null;
+    }) => void;
+    teamCreationMocks.createTeamForApp.mockReturnValueOnce(new Promise((resolve) => {
+      finishCreation = resolve;
+    }));
+    const { container } = renderCreateTeam();
+
+    fireEvent.change(screen.getByPlaceholderText('Team name'), { target: { value: 'One Team' } });
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+
+    await act(async () => {
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+
+    expect(teamCreationMocks.createTeamForApp).toHaveBeenCalledTimes(1);
+
+    finishCreation({
+      teamId: 'team-new',
+      defaultStatConfigCreated: true,
+      defaultStatConfigError: null
+    });
+
     expect(await screen.findByText('Team detail: team-new')).toBeTruthy();
   });
 

--- a/apps/app/src/pages/CreateTeam.test.tsx
+++ b/apps/app/src/pages/CreateTeam.test.tsx
@@ -107,6 +107,7 @@ describe('CreateTeam', () => {
 
     expect(await screen.findByText(/Team created, but the default stat config could not be added/)).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Open team' })).toHaveAttribute('href', '/teams/team-new');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create team' })).not.toBeDisabled());
   });
 
   it('blocks direct rendering without a signed-in user', () => {

--- a/apps/app/src/pages/CreateTeam.test.tsx
+++ b/apps/app/src/pages/CreateTeam.test.tsx
@@ -107,7 +107,13 @@ describe('CreateTeam', () => {
 
     expect(await screen.findByText(/Team created, but the default stat config could not be added/)).toBeTruthy();
     expect(screen.getByRole('link', { name: 'Open team' })).toHaveAttribute('href', '/teams/team-new');
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Create team' })).not.toBeDisabled());
+    const openTeamButton = await screen.findByRole('button', { name: 'Open team' });
+    expect(openTeamButton).not.toBeDisabled();
+
+    fireEvent.click(openTeamButton);
+
+    expect(teamCreationMocks.createTeamForApp).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Team detail: team-new')).toBeTruthy();
   });
 
   it('blocks direct rendering without a signed-in user', () => {

--- a/apps/app/src/pages/CreateTeam.test.tsx
+++ b/apps/app/src/pages/CreateTeam.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreateTeam } from './CreateTeam';
+import type { AuthState } from '../lib/types';
+
+const teamCreationMocks = vi.hoisted(() => ({
+  createTeamForApp: vi.fn(),
+  getCreateTeamSportOptions: vi.fn(() => ['Basketball', 'Soccer', 'Baseball'])
+}));
+
+vi.mock('../lib/teamCreationService', () => teamCreationMocks);
+vi.mock('lucide-react', () => {
+  const Icon = () => null;
+  return {
+    ArrowLeft: Icon,
+    CheckCircle2: Icon,
+    Loader2: Icon,
+    Save: Icon,
+    Shield: Icon,
+    Users: Icon
+  };
+});
+
+const auth: AuthState = {
+  user: {
+    uid: 'coach-1',
+    email: 'coach@example.com',
+    displayName: 'Coach'
+  } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['coach'],
+  isParent: false,
+  isCoach: true,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function TeamDetailRoute() {
+  const { teamId } = useParams<{ teamId: string }>();
+  return <div>Team detail: {teamId}</div>;
+}
+
+function renderCreateTeam(authOverride = auth) {
+  return render(
+    <MemoryRouter initialEntries={['/teams/new']}>
+      <Routes>
+        <Route path="/teams/new" element={<CreateTeam auth={authOverride} />} />
+        <Route path="/teams/:teamId" element={<TeamDetailRoute />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('CreateTeam', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    teamCreationMocks.createTeamForApp.mockResolvedValue({
+      teamId: 'team-new',
+      defaultStatConfigCreated: true,
+      defaultStatConfigError: null
+    });
+    teamCreationMocks.getCreateTeamSportOptions.mockReturnValue(['Basketball', 'Soccer', 'Baseball']);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('validates required fields and creates a team from the app form', async () => {
+    renderCreateTeam();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create team' }));
+    expect(await screen.findByText('Team name is required.')).toBeTruthy();
+    expect(teamCreationMocks.createTeamForApp).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByPlaceholderText('Team name'), { target: { value: 'KC Current U12' } });
+    fireEvent.change(screen.getByLabelText('Sport'), { target: { value: 'Soccer' } });
+    fireEvent.change(screen.getByPlaceholderText('66210'), { target: { value: '66210-1234' } });
+    fireEvent.click(screen.getByLabelText('Public team'));
+    fireEvent.click(screen.getByRole('button', { name: 'Create team' }));
+
+    await waitFor(() => expect(teamCreationMocks.createTeamForApp).toHaveBeenCalledWith(auth.user, {
+      name: 'KC Current U12',
+      sport: 'Soccer',
+      zip: '66210-1234',
+      isPublic: false
+    }));
+    expect(await screen.findByText('Team detail: team-new')).toBeTruthy();
+  });
+
+  it('keeps the created team reachable when default stat config creation returns a warning', async () => {
+    teamCreationMocks.createTeamForApp.mockResolvedValueOnce({
+      teamId: 'team-new',
+      defaultStatConfigCreated: false,
+      defaultStatConfigError: 'permission denied'
+    });
+    renderCreateTeam();
+
+    fireEvent.change(screen.getByPlaceholderText('Team name'), { target: { value: 'Warn Team' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create team' }));
+
+    expect(await screen.findByText(/Team created, but the default stat config could not be added/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Open team' })).toHaveAttribute('href', '/teams/team-new');
+  });
+
+  it('blocks direct rendering without a signed-in user', () => {
+    renderCreateTeam({ ...auth, user: null, roles: [] });
+
+    expect(screen.getByText('Sign in to create a team')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Create team' })).toBeNull();
+  });
+});

--- a/apps/app/src/pages/CreateTeam.tsx
+++ b/apps/app/src/pages/CreateTeam.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type FormEvent } from 'react';
+import { useMemo, useRef, useState, type FormEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ArrowLeft, CheckCircle2, Loader2, Save, Shield, Users } from 'lucide-react';
 import { createTeamForApp, getCreateTeamSportOptions } from '../lib/teamCreationService';
@@ -19,12 +19,17 @@ export function CreateTeam({ auth }: { auth: AuthState }) {
   const [saveError, setSaveError] = useState('');
   const [statConfigWarning, setStatConfigWarning] = useState('');
   const [createdTeamId, setCreatedTeamId] = useState('');
+  const submissionInFlightRef = useRef(false);
+  const completedTeamIdRef = useRef('');
   const createdTeamPath = createdTeamId ? `/teams/${encodeURIComponent(createdTeamId)}` : '';
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (createdTeamPath) {
-      navigate(createdTeamPath, { replace: true });
+    if (completedTeamIdRef.current) {
+      navigate(`/teams/${encodeURIComponent(completedTeamIdRef.current)}`, { replace: true });
+      return;
+    }
+    if (submissionInFlightRef.current) {
       return;
     }
 
@@ -46,6 +51,7 @@ export function CreateTeam({ auth }: { auth: AuthState }) {
       return;
     }
 
+    submissionInFlightRef.current = true;
     setSaving(true);
     try {
       const result = await createTeamForApp(auth.user, {
@@ -54,6 +60,7 @@ export function CreateTeam({ auth }: { auth: AuthState }) {
         zip: form.zip,
         isPublic: form.isPublic
       });
+      completedTeamIdRef.current = result.teamId;
       if (result.defaultStatConfigError) {
         setCreatedTeamId(result.teamId);
         setStatConfigWarning(`Team created, but the default stat config could not be added: ${result.defaultStatConfigError}`);
@@ -70,6 +77,7 @@ export function CreateTeam({ auth }: { auth: AuthState }) {
         setSaveError(message);
       }
     } finally {
+      submissionInFlightRef.current = false;
       setSaving(false);
     }
   }

--- a/apps/app/src/pages/CreateTeam.tsx
+++ b/apps/app/src/pages/CreateTeam.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState, type FormEvent } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ArrowLeft, CheckCircle2, Loader2, Save, Shield, Users } from 'lucide-react';
+import { createTeamForApp, getCreateTeamSportOptions } from '../lib/teamCreationService';
+import type { AuthState } from '../lib/types';
+
+export function CreateTeam({ auth }: { auth: AuthState }) {
+  const navigate = useNavigate();
+  const sportOptions = useMemo(() => getCreateTeamSportOptions(), []);
+  const [form, setForm] = useState({
+    name: '',
+    sport: sportOptions[0] || 'Basketball',
+    zip: '',
+    isPublic: true
+  });
+  const [saving, setSaving] = useState(false);
+  const [nameError, setNameError] = useState('');
+  const [sportError, setSportError] = useState('');
+  const [saveError, setSaveError] = useState('');
+  const [statConfigWarning, setStatConfigWarning] = useState('');
+  const [createdTeamId, setCreatedTeamId] = useState('');
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setNameError('');
+    setSportError('');
+    setSaveError('');
+    setStatConfigWarning('');
+    setCreatedTeamId('');
+
+    const trimmedName = form.name.trim();
+    if (!trimmedName) {
+      setNameError('Team name is required.');
+      return;
+    }
+
+    const trimmedSport = form.sport.trim();
+    if (!trimmedSport) {
+      setSportError('Sport is required.');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const result = await createTeamForApp(auth.user, {
+        name: trimmedName,
+        sport: trimmedSport,
+        zip: form.zip,
+        isPublic: form.isPublic
+      });
+      if (result.defaultStatConfigError) {
+        setCreatedTeamId(result.teamId);
+        setStatConfigWarning(`Team created, but the default stat config could not be added: ${result.defaultStatConfigError}`);
+        return;
+      }
+      navigate(`/teams/${encodeURIComponent(result.teamId)}`, { replace: true });
+    } catch (failure: any) {
+      const message = failure?.message || 'Unable to create team.';
+      if (message === 'Team name is required.') {
+        setNameError(message);
+      } else if (message === 'Sport is required.') {
+        setSportError(message);
+      } else {
+        setSaveError(message);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!auth.user?.uid) {
+    return (
+      <section className="app-card p-5">
+        <Link to="/teams" className="ghost-button w-fit">
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Back to teams
+        </Link>
+        <div className="mt-4 flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4">
+          <Shield className="mt-0.5 h-5 w-5 flex-none text-amber-700" aria-hidden="true" />
+          <div>
+            <h1 className="text-lg font-black text-amber-950">Sign in to create a team</h1>
+            <p className="mt-1 text-sm font-semibold text-amber-800">Team ownership is tied to the signed-in coach account.</p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Link to="/teams" className="ghost-button w-fit">
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        Back to teams
+      </Link>
+
+      <section className="app-card p-4 sm:p-5">
+        <div className="flex items-start gap-3">
+          <div className="flex h-11 w-11 flex-none items-center justify-center rounded-xl bg-primary-50 text-primary-700">
+            <Users className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <div className="app-label">My Teams</div>
+            <h1 className="mt-1 text-2xl font-black text-gray-950">Create team</h1>
+            <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">Start a team with owner access and a sport stat template.</p>
+          </div>
+        </div>
+
+        <form className="mt-5 space-y-4" onSubmit={(event) => void handleSubmit(event)}>
+          <label className="block">
+            <span className="text-sm font-black text-gray-950">Team name</span>
+            <input
+              value={form.name}
+              onChange={(event) => {
+                setForm((current) => ({ ...current, name: event.target.value }));
+                if (nameError) setNameError('');
+              }}
+              className={`auth-input mt-1 ${nameError ? '!border-rose-400 !bg-rose-50' : ''}`}
+              placeholder="Team name"
+              autoFocus
+            />
+            {nameError ? <span className="mt-1 block text-xs font-semibold text-rose-700">{nameError}</span> : null}
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-black text-gray-950">Sport</span>
+            <select
+              value={form.sport}
+              onChange={(event) => {
+                setForm((current) => ({ ...current, sport: event.target.value }));
+                if (sportError) setSportError('');
+              }}
+              className={`auth-input mt-1 ${sportError ? '!border-rose-400 !bg-rose-50' : ''}`}
+            >
+              {sportOptions.map((sport) => <option key={sport} value={sport}>{sport}</option>)}
+            </select>
+            {sportError ? <span className="mt-1 block text-xs font-semibold text-rose-700">{sportError}</span> : null}
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-black text-gray-950">ZIP</span>
+            <input
+              value={form.zip}
+              onChange={(event) => setForm((current) => ({ ...current, zip: event.target.value }))}
+              inputMode="numeric"
+              className="auth-input mt-1"
+              placeholder="66210"
+            />
+          </label>
+
+          <label className="flex items-start gap-3 rounded-2xl border border-gray-200 bg-gray-50 p-4">
+            <input
+              type="checkbox"
+              aria-label="Public team"
+              checked={form.isPublic}
+              onChange={(event) => setForm((current) => ({ ...current, isPublic: event.target.checked }))}
+              className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600"
+            />
+            <span>
+              <span className="block text-sm font-black text-gray-950">Public team</span>
+              <span className="mt-1 block text-xs font-semibold leading-5 text-gray-500">If unchecked, the team is hidden from Browse Teams but still works by direct link.</span>
+            </span>
+          </label>
+
+          {saveError ? <div className="rounded-2xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-semibold text-rose-700">{saveError}</div> : null}
+          {statConfigWarning ? (
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-800">
+              <div>{statConfigWarning}</div>
+              {createdTeamId ? <Link to={`/teams/${encodeURIComponent(createdTeamId)}`} className="mt-2 inline-flex font-black text-amber-950">Open team</Link> : null}
+            </div>
+          ) : null}
+
+          <button type="submit" className="primary-button w-full justify-center" disabled={saving} aria-disabled={saving}>
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
+            Create team
+          </button>
+        </form>
+      </section>
+
+      <section className="app-card p-4">
+        <div className="flex items-start gap-3">
+          <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-primary-700" aria-hidden="true" />
+          <div>
+            <div className="text-sm font-black text-gray-950">Creator access</div>
+            <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">The team is created under {auth.user.email || 'this account'} with coach access.</div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/app/src/pages/CreateTeam.tsx
+++ b/apps/app/src/pages/CreateTeam.tsx
@@ -19,9 +19,15 @@ export function CreateTeam({ auth }: { auth: AuthState }) {
   const [saveError, setSaveError] = useState('');
   const [statConfigWarning, setStatConfigWarning] = useState('');
   const [createdTeamId, setCreatedTeamId] = useState('');
+  const createdTeamPath = createdTeamId ? `/teams/${encodeURIComponent(createdTeamId)}` : '';
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (createdTeamPath) {
+      navigate(createdTeamPath, { replace: true });
+      return;
+    }
+
     setNameError('');
     setSportError('');
     setSaveError('');
@@ -165,13 +171,13 @@ export function CreateTeam({ auth }: { auth: AuthState }) {
           {statConfigWarning ? (
             <div className="rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-800">
               <div>{statConfigWarning}</div>
-              {createdTeamId ? <Link to={`/teams/${encodeURIComponent(createdTeamId)}`} className="mt-2 inline-flex font-black text-amber-950">Open team</Link> : null}
+              {createdTeamPath ? <Link to={createdTeamPath} className="mt-2 inline-flex font-black text-amber-950">Open team</Link> : null}
             </div>
           ) : null}
 
           <button type="submit" className="primary-button w-full justify-center" disabled={saving} aria-disabled={saving}>
-            {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
-            Create team
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : createdTeamPath ? <CheckCircle2 className="h-4 w-4" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
+            {createdTeamPath ? 'Open team' : 'Create team'}
           </button>
         </form>
       </section>

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -91,6 +91,7 @@ function renderTeams({ strictMode = false, initialEntry = '/teams' }: { strictMo
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route path="/teams" element={<Teams auth={auth} />} />
+        <Route path="/teams/new" element={<div>Create team route</div>} />
         <Route path="/accept-invite" element={<div>Accept invite route</div>} />
         <Route path="/teams/browse" element={<div>Browse public teams route</div>} />
       </Routes>
@@ -166,6 +167,16 @@ describe('Teams empty state', () => {
     fireEvent.click(browseLink);
 
     expect(await screen.findByText('Browse public teams route')).toBeTruthy();
+    expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it('opens the native create team route from the empty state primary action', async () => {
+    renderTeams();
+
+    await screen.findByRole('heading', { name: 'No teams linked yet' });
+    fireEvent.click(screen.getByRole('link', { name: 'Create team' }));
+
+    expect(await screen.findByText('Create team route')).toBeTruthy();
     expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
   });
 

--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { StrictMode } from 'react';
 import { MemoryRouter, Route, Routes, useLocation, useParams } from 'react-router-dom';

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -655,7 +655,8 @@ function EmptyTeams() {
         <div className="min-w-0 flex-1">
           <div className="text-sm font-black text-gray-900">No teams available</div>
           <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Team access appears after an invite is accepted, a parent link is approved, or staff access is granted.</div>
-          <div className="mt-3 grid gap-2 sm:grid-cols-3">
+          <div className="mt-3 grid gap-2 sm:grid-cols-4">
+            <Link to="/teams/new" className="primary-button justify-center !min-h-9 text-xs">Create team</Link>
             <Link to="/accept-invite" className="secondary-button justify-center !min-h-9 text-xs">Accept invite</Link>
             <Link to="/home" className="ghost-button justify-center !min-h-9 text-xs">Back to Home</Link>
             <Link to="/teams/browse" className="ghost-button justify-center !min-h-9 text-xs">

--- a/tests/coverage/feature-coverage-map.json
+++ b/tests/coverage/feature-coverage-map.json
@@ -210,6 +210,7 @@
                 "teams.html"
             ],
             "appPages": [
+                "apps/app/src/pages/CreateTeam.tsx",
                 "apps/app/src/pages/Home.tsx",
                 "apps/app/src/pages/PlayerDetail.tsx",
                 "apps/app/src/pages/PublicTeamsBrowse.tsx",
@@ -240,6 +241,8 @@
                 "tests/unit/teams-public-visibility.test.js"
             ],
             "integrationTests": [
+                "apps/app/src/lib/teamCreationService.test.ts",
+                "apps/app/src/pages/CreateTeam.test.tsx",
                 "apps/app/src/pages/Home.test.tsx",
                 "apps/app/src/pages/PlayerDetail.test.tsx",
                 "apps/app/src/pages/TeamDetail.test.tsx",

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -551,6 +551,37 @@ async function mockPublicTeamsBrowseModule(page, { slowSearch = false } = {}) {
     });
 }
 
+async function mockTeamCreationModule(page) {
+    await page.addInitScript(() => {
+        window.__createdTeams = [];
+    });
+
+    await page.route(/\/src\/lib\/teamCreationService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export function getCreateTeamSportOptions() {
+                    return ['Basketball', 'Soccer', 'Baseball', 'Softball'];
+                }
+
+                export async function createTeamForApp(user, input) {
+                    window.__createdTeams.push({
+                        userId: user?.uid || '',
+                        ownerEmail: user?.email || '',
+                        input
+                    });
+                    return {
+                        teamId: 'team-created',
+                        defaultStatConfigCreated: true,
+                        defaultStatConfigError: null
+                    };
+                }
+            `
+        });
+    });
+}
+
 test.describe('mobile My Teams', () => {
     test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
@@ -616,11 +647,41 @@ test.describe('mobile My Teams', () => {
         await waitForTeamsRoute(page, emptyHeading, { requireSearchInput: false });
         const emptyState = page.locator('section').filter({ hasText: 'No teams available' });
         await expect(page.getByText('No teams available')).toBeVisible();
+        await expect(page.getByRole('link', { name: 'Create team' })).toHaveAttribute('href', '#/teams/new');
         await expect(page.getByRole('link', { name: 'Accept invite' })).toHaveAttribute('href', '#/accept-invite');
         await emptyState.getByRole('link', { name: 'Browse teams' }).click();
         await expect(page).toHaveURL(/#\/teams\/browse$/);
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls)).toEqual([]);
         await expect(page.getByText(/^Loading teams$/)).toHaveCount(0);
+    });
+
+    test('creates a team from the native app flow', async ({ page, baseURL }) => {
+        await mockTeamsModules(page, { scenario: 'empty' });
+        await mockTeamCreationModule(page);
+        await page.goto(appUrl(baseURL, '/teams?scenario=empty'), { waitUntil: 'domcontentloaded' });
+
+        await waitForTeamsRoute(page, page.getByRole('heading', { name: 'No teams linked yet' }), { requireSearchInput: false });
+        await page.getByRole('link', { name: 'Create team' }).click();
+
+        await expect(page).toHaveURL(/#\/teams\/new$/);
+        await expect(page.getByRole('heading', { name: 'Create team' })).toBeVisible();
+        await page.getByPlaceholder('Team name').fill('KC Current U12');
+        await page.getByLabel('Sport').selectOption('Soccer');
+        await page.getByPlaceholder('66210').fill('66210-1234');
+        await page.getByLabel('Public team').uncheck();
+        await page.getByRole('button', { name: 'Create team' }).click();
+
+        await expect(page).toHaveURL(/#\/teams\/team-created$/);
+        await expect.poll(() => page.evaluate(() => window.__createdTeams.at(-1))).toEqual({
+            userId: 'user-1',
+            ownerEmail: 'parent@example.com',
+            input: {
+                name: 'KC Current U12',
+                sport: 'Soccer',
+                zip: '66210-1234',
+                isPublic: false
+            }
+        });
     });
 
     test('browse teams paginates searched results on mobile without clearing the query', async ({ page, baseURL }) => {

--- a/tests/unit/app-async-operation-initiative-source-contract.test.js
+++ b/tests/unit/app-async-operation-initiative-source-contract.test.js
@@ -62,7 +62,7 @@ describe('app async operation initiative source contract', () => {
     });
 
     it('keeps high-traffic app services using shared cache and service-error adapters', () => {
-        expect(homeServiceSource).toContain("import { getParentHomeSecondaryCacheKey, getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';");
+        expect(homeServiceSource).toMatch(/import\s+\{[^}]*getParentScheduleSummaryCacheKey[^}]*loadCachedAppData[^}]*\}\s+from '\.\/appDataCache';/);
         expect(homeServiceSource).toContain("import { toAppServiceError, type AppServiceError } from './appErrors';");
         expect(homeServiceSource).toContain('return loadCachedAppData(');
         expect(homeServiceSource).toContain('function rethrowIfPermissionError(error: unknown, fallbackMessage: string)');

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -637,7 +637,8 @@ describe('React app shell search', () => {
 
         await clickButton(container, 'Add');
         await clickButton(container, 'Create team');
-        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/dashboard.html');
+        expect(container.querySelector('[data-testid="route"]').textContent).toBe('/teams/new');
+        expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalledWith('https://allplays.ai/dashboard.html');
     });
 
     it('supports Cmd/Ctrl+K and Enter keyboard navigation', async () => {


### PR DESCRIPTION
## Summary
- Add a protected native `/teams/new` route for creating teams in the React app.
- Add a shared app creation service that writes `ownerId`/`ownerEmail`, calls legacy `createTeam` so the creator gets coach access, and creates the sport default stat config.
- Route the `+ Add` Create team action and the My Teams empty state to the native flow.
- Register the new page and app tests in the feature coverage map.

## Validation
- `npm --prefix apps/app run test -- run src/lib/teamCreationService.test.ts src/pages/CreateTeam.test.tsx src/pages/Teams.test.tsx src/components/AppShell.test.tsx --reporter=verbose`
- `npx vitest run tests/unit/app-search-integration.test.jsx --reporter=verbose`
- `npx vitest run tests/unit/test-coverage-map.test.js --reporter=verbose`
- `npm run test:unit:ci`
- `npm run app:build`
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5176 SMOKE_BASE_URL=http://127.0.0.1:5176 npx playwright test tests/smoke/app-teams.spec.js --config=playwright.smoke.config.js --grep "creates a team from the native app flow" --reporter=line`
- PR checks are green on `2dbbe210`.

Fixes #3848