### PR TITLE
Add app performance measurement validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
             sleep 15
           done
 
+      - name: Validate app performance evidence when present
+        run: |
+          if [ -f docs/app-performance-measurements.json ]; then
+            npm run app:validate-performance-measurements -- docs/app-performance-measurements.json
+          else
+            echo "No app performance measurement artifact to validate."
+          fi
+
       - name: Run unit tests
         run: npm run test:unit:ci
 

--- a/docs/app-performance-baseline.md
+++ b/docs/app-performance-baseline.md
@@ -114,13 +114,15 @@ The JSON artifact must include:
 - `issue: 2050`, `baselineSha`, `afterSha`, and a shared `fixture` with
   `testAccount`, `teamOrOrganization`, `homeTeamCount`, `scheduleEventCount`,
   and `messageThreadCount`.
-- Four `profiles`: `desktop-web`, `throttled-4g-web`, `mid-range-android`, and
-  `iphone`, each with exact hardware, OS, runtime, browser/WebView, network, and
-  CPU notes.
+- Four `profiles` whose `id` is `desktop-web`, `throttled-4g-web`,
+  `mid-range-android`, or `iphone`. Each profile must also include a descriptive
+  `label` plus exact hardware, OS, runtime, browser/WebView, network, and CPU
+  notes.
 - `before` and `after` phases for every profile. Each phase must use the
   matching SHA, include an ISO `capturedAt` timestamp with a timezone, and
   include 3–100 clean raw `runs`.
-- Every run must include `coldStartHomeTtiMs`, `warmResumeMs`,
+- Every run must include a unique positive safe-integer `run` number plus
+  `coldStartHomeTtiMs`, `warmResumeMs`,
   `readsHomeMount`, `readsScheduleMount`, `readsMessagesMount`,
   `entryChunkGzipBytes`, `rsvpTapLatencyMs`, and `chatSendLatencyMs`.
 - Fixture volume counts must be positive safe integers so an empty account

--- a/docs/app-performance-baseline.md
+++ b/docs/app-performance-baseline.md
@@ -118,15 +118,22 @@ The JSON artifact must include:
   `iphone`, each with exact hardware, OS, runtime, browser/WebView, network, and
   CPU notes.
 - `before` and `after` phases for every profile. Each phase must use the
-  matching SHA, include a `capturedAt` timestamp, and include at least 3 clean
-  raw `runs`.
+  matching SHA, include an ISO `capturedAt` timestamp with a timezone, and
+  include 3–100 clean raw `runs`.
 - Every run must include `coldStartHomeTtiMs`, `warmResumeMs`,
   `readsHomeMount`, `readsScheduleMount`, `readsMessagesMount`,
   `entryChunkGzipBytes`, `rsvpTapLatencyMs`, and `chatSendLatencyMs`.
+- Fixture volume counts must be positive safe integers so an empty account
+  cannot masquerade as representative Home, Schedule, or Messages evidence.
+- Use a synthetic or anonymized fixture identifier. Never commit passwords,
+  access tokens, production user identifiers, or private team/member data in
+  the artifact; the validator rejects sensitive-looking field names.
 
 The validator rejects placeholders and missing profile/phase coverage, then
 prints a markdown median summary that can be pasted into the final comparison
-table and the GitHub issue.
+table and the GitHub issue. CI automatically validates
+`docs/app-performance-measurements.json` whenever that evidence file is
+committed.
 
 ## Baseline template
 

--- a/docs/app-performance-baseline.md
+++ b/docs/app-performance-baseline.md
@@ -100,6 +100,34 @@ beside the result.
    each run should start from a clean app launch unless the row explicitly says
    warm resume.
 
+## Raw evidence contract
+
+Before filling the tables or closing #2050, save the raw run evidence as JSON
+and validate it:
+
+```sh
+npm run app:validate-performance-measurements -- docs/app-performance-measurements.json
+```
+
+The JSON artifact must include:
+
+- `issue: 2050`, `baselineSha`, `afterSha`, and a shared `fixture` with
+  `testAccount`, `teamOrOrganization`, `homeTeamCount`, `scheduleEventCount`,
+  and `messageThreadCount`.
+- Four `profiles`: `desktop-web`, `throttled-4g-web`, `mid-range-android`, and
+  `iphone`, each with exact hardware, OS, runtime, browser/WebView, network, and
+  CPU notes.
+- `before` and `after` phases for every profile. Each phase must use the
+  matching SHA, include a `capturedAt` timestamp, and include at least 3 clean
+  raw `runs`.
+- Every run must include `coldStartHomeTtiMs`, `warmResumeMs`,
+  `readsHomeMount`, `readsScheduleMount`, `readsMessagesMount`,
+  `entryChunkGzipBytes`, `rsvpTapLatencyMs`, and `chatSendLatencyMs`.
+
+The validator rejects placeholders and missing profile/phase coverage, then
+prints a markdown median summary that can be pasted into the final comparison
+table and the GitHub issue.
+
 ## Baseline template
 
 Fill this table from `master` at the start of the push without changing the
@@ -143,6 +171,7 @@ Keep this summary table current as fixes land. Numbers are medians of 3 runs.
 
 ## Closing the loop
 
-When the perf/UX fixes have landed, re-measure, fill the final column, and paste
-the completed table into #2050 before closing it. The procedure above is the
-contract: anyone should be able to reproduce these numbers from a clean checkout.
+When the perf/UX fixes have landed, re-measure, validate the raw JSON artifact,
+fill the final column, and paste the completed table into #2050 before closing it.
+The procedure above is the contract: anyone should be able to reproduce these
+numbers from a clean checkout.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "app:dev": "npm --prefix apps/app run dev",
     "app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs",
     "app:preview": "npm --prefix apps/app run preview",
+    "app:validate-performance-measurements": "node scripts/validate-app-performance-measurements.mjs",
     "mobile:serve": "npm run app:dev",
     "mobile:sync": "npm run app:build && npx cap sync",
     "mobile:build:ios": "npm run mobile:sync && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/App/App.xcodeproj -scheme App -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build",

--- a/scripts/validate-app-performance-measurements.mjs
+++ b/scripts/validate-app-performance-measurements.mjs
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
@@ -11,6 +11,9 @@ export const REQUIRED_PROFILES = [
 ];
 
 export const REQUIRED_PHASES = ['before', 'after'];
+
+export const MAX_ARTIFACT_BYTES = 5 * 1024 * 1024;
+export const MAX_RUNS_PER_PHASE = 100;
 
 export const REQUIRED_FIXTURE_FIELDS = [
   'testAccount',
@@ -41,9 +44,20 @@ export const REQUIRED_METRICS = [
 ];
 
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
-const PLACEHOLDER_EVIDENCE_PATTERN = /^[_\W]*(?:tbd|todo|placeholder|pending|to[_\W]*be[_\W]*determined)[_\W]*$/i;
+const ISO_TIMESTAMP_PATTERN = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|([+-])(\d{2}):(\d{2}))$/;
+const PLACEHOLDER_EVIDENCE_PATTERN = /^[\s_<>{}\[\]()*`'".\-:]*?(?:tbd|todo|placeholder|pending|unknown|n\s*\/?\s*a|not[\s_-]*available|to[\s_-]*be[\s_-]*determined|fill[\s_-]*(?:me|in))(?=$|[\s_\W])/i;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/;
+const SENSITIVE_FIELD_NAME_PATTERN = /(?:^|_)(?:password|passcode|secret|token|credential|credentials|api_key|access_key|private_key)(?:$|_)/;
 
 export async function readMeasurementArtifact(filePath) {
+  const fileStats = await stat(filePath);
+  if (!fileStats.isFile()) {
+    throw new Error(`${filePath} must be a regular JSON file.`);
+  }
+  if (fileStats.size > MAX_ARTIFACT_BYTES) {
+    throw new Error(`${filePath} exceeds the ${MAX_ARTIFACT_BYTES}-byte performance evidence limit.`);
+  }
+
   const raw = await readFile(filePath, 'utf8');
   try {
     return JSON.parse(raw);
@@ -56,12 +70,22 @@ export function validateMeasurementArtifact(artifact) {
   const errors = [];
   const normalized = normalizeArtifact(artifact);
 
+  if (normalized !== artifact) {
+    errors.push('artifact must be a JSON object.');
+  }
+  if (containsSensitiveField(normalized)) {
+    errors.push('artifact must not include password, secret, token, credential, or private-key fields.');
+  }
+
   if (normalized.issue !== 2050) {
     errors.push('issue must be 2050.');
   }
 
   validateSha(normalized.baselineSha, 'baselineSha', errors);
   validateSha(normalized.afterSha, 'afterSha', errors);
+  if (shaValuesOverlap(normalized.baselineSha, normalized.afterSha)) {
+    errors.push('baselineSha and afterSha must identify different commits.');
+  }
   validateFixture(normalized.fixture, errors);
   validateProfiles(normalized.profiles, normalized, errors);
 
@@ -81,7 +105,7 @@ export function buildMarkdownSummary(summary) {
     for (const phase of REQUIRED_PHASES) {
       const medians = profile.phases[phase].medians;
       lines.push([
-        profile.label,
+        formatMarkdownCell(profile.label),
         phase,
         formatMs(medians.coldStartHomeTtiMs),
         formatMs(medians.warmResumeMs),
@@ -99,7 +123,20 @@ export function buildMarkdownSummary(summary) {
 }
 
 function normalizeArtifact(artifact) {
-  return artifact && typeof artifact === 'object' ? artifact : {};
+  return artifact && typeof artifact === 'object' && !Array.isArray(artifact) ? artifact : {};
+}
+
+function containsSensitiveField(value, seen = new WeakSet()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return false;
+  seen.add(value);
+
+  return Object.entries(value).some(([key, nestedValue]) => {
+    const normalizedKey = key
+      .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+      .replace(/[^a-z0-9]+/gi, '_')
+      .toLowerCase();
+    return SENSITIVE_FIELD_NAME_PATTERN.test(normalizedKey) || containsSensitiveField(nestedValue, seen);
+  });
 }
 
 function validateFixture(fixture, errors) {
@@ -112,8 +149,8 @@ function validateFixture(fixture, errors) {
     const value = fixture[field];
     const isCountField = field.endsWith('Count');
     if (isCountField) {
-      if (!Number.isInteger(value) || value < 0) {
-        errors.push(`fixture.${field} must be a non-negative integer.`);
+      if (!Number.isSafeInteger(value) || value < 1) {
+        errors.push(`fixture.${field} must be a positive safe integer.`);
       }
     } else {
       validateEvidenceString(value, `fixture.${field}`, errors);
@@ -124,6 +161,13 @@ function validateFixture(fixture, errors) {
 function validateProfiles(profiles, artifact, errors) {
   if (!Array.isArray(profiles)) {
     errors.push('profiles must be an array.');
+    return;
+  }
+
+  if (profiles.length !== REQUIRED_PROFILES.length) {
+    errors.push(`profiles must contain exactly ${REQUIRED_PROFILES.length} entries.`);
+  }
+  if (profiles.length > REQUIRED_PROFILES.length) {
     return;
   }
 
@@ -149,9 +193,7 @@ function validateProfile(profile, artifact, errors) {
   if (!REQUIRED_PROFILES.includes(id)) {
     errors.push(`profile ${id} must use one of: ${REQUIRED_PROFILES.join(', ')}.`);
   }
-  if (!isNonEmptyString(profile?.label)) {
-    errors.push(`profile ${id} must include a non-empty label.`);
-  }
+  validateEvidenceString(profile?.label, `profile ${id} label`, errors);
 
   validateEnvironment(profile?.environment, id, errors);
 
@@ -181,14 +223,12 @@ function validatePhase(phaseData, profile, phase, artifact, errors) {
 
   validateSha(phaseData.sha, `${context}.sha`, errors);
   const expectedSha = phase === 'before' ? artifact.baselineSha : artifact.afterSha;
-  if (isNonEmptyString(expectedSha) && phaseData.sha !== expectedSha) {
+  if (normalizeSha(expectedSha) && normalizeSha(phaseData.sha) !== normalizeSha(expectedSha)) {
     errors.push(`${context}.sha must match ${phase === 'before' ? 'baselineSha' : 'afterSha'}.`);
   }
 
-  if (!isNonEmptyString(phaseData.capturedAt)) {
-    errors.push(`${context}.capturedAt must be an ISO timestamp string.`);
-  } else if (Number.isNaN(Date.parse(phaseData.capturedAt))) {
-    errors.push(`${context}.capturedAt must be parseable as a date.`);
+  if (!isValidIsoTimestamp(phaseData.capturedAt)) {
+    errors.push(`${context}.capturedAt must be a valid ISO timestamp with a timezone.`);
   }
 
   if (!Array.isArray(phaseData.runs)) {
@@ -197,6 +237,10 @@ function validatePhase(phaseData, profile, phase, artifact, errors) {
   }
   if (phaseData.runs.length < 3) {
     errors.push(`${context}.runs must include at least 3 clean runs.`);
+  }
+  if (phaseData.runs.length > MAX_RUNS_PER_PHASE) {
+    errors.push(`${context}.runs must not exceed ${MAX_RUNS_PER_PHASE} runs.`);
+    return;
   }
 
   const runNumbers = new Set();
@@ -216,8 +260,8 @@ function validateRun(run, context, errors) {
     errors.push(`${context} must be an object.`);
     return;
   }
-  if (!Number.isInteger(run.run) || run.run <= 0) {
-    errors.push(`${context}.run must be a positive integer.`);
+  if (!Number.isSafeInteger(run.run) || run.run <= 0) {
+    errors.push(`${context}.run must be a positive safe integer.`);
   }
 
   for (const metric of REQUIRED_METRICS) {
@@ -226,8 +270,8 @@ function validateRun(run, context, errors) {
       errors.push(`${context}.${metric.key} must be a number >= ${metric.min}.`);
       continue;
     }
-    if (metric.integer && !Number.isInteger(value)) {
-      errors.push(`${context}.${metric.key} must be an integer.`);
+    if (metric.integer && !Number.isSafeInteger(value)) {
+      errors.push(`${context}.${metric.key} must be a safe integer.`);
     }
   }
 }
@@ -279,6 +323,42 @@ function validateSha(value, field, errors) {
   }
 }
 
+function normalizeSha(value) {
+  return isNonEmptyString(value) && SHA_PATTERN.test(value)
+    ? value.toLowerCase()
+    : '';
+}
+
+function shaValuesOverlap(left, right) {
+  const normalizedLeft = normalizeSha(left);
+  const normalizedRight = normalizeSha(right);
+  if (!normalizedLeft || !normalizedRight) return false;
+  return normalizedLeft.startsWith(normalizedRight) || normalizedRight.startsWith(normalizedLeft);
+}
+
+function isValidIsoTimestamp(value) {
+  if (!isNonEmptyString(value)) return false;
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
+  if (!match || Number.isNaN(Date.parse(value))) return false;
+
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, , offsetHourText, offsetMinuteText] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const offsetHour = offsetHourText === undefined ? 0 : Number(offsetHourText);
+  const offsetMinute = offsetMinuteText === undefined ? 0 : Number(offsetMinuteText);
+  const daysInMonth = month >= 1 && month <= 12
+    ? new Date(Date.UTC(year, month, 0)).getUTCDate()
+    : 0;
+
+  return day >= 1 && day <= daysInMonth &&
+    hour <= 23 && minute <= 59 && second <= 59 &&
+    offsetHour <= 23 && offsetMinute <= 59;
+}
+
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
@@ -288,7 +368,16 @@ function validateEvidenceString(value, field, errors) {
     errors.push(`${field} must be a non-empty string.`);
   } else if (PLACEHOLDER_EVIDENCE_PATTERN.test(value.trim())) {
     errors.push(`${field} must be real evidence, not a placeholder.`);
+  } else if (CONTROL_CHARACTER_PATTERN.test(value)) {
+    errors.push(`${field} must be a single-line string without control characters.`);
   }
+}
+
+function formatMarkdownCell(value) {
+  return String(value)
+    .replace(/\\/g, '\\\\')
+    .replace(/\|/g, '\\|')
+    .replace(/[\r\n]+/g, ' ');
 }
 
 function formatMs(value) {
@@ -296,7 +385,7 @@ function formatMs(value) {
 }
 
 function formatCount(value) {
-  return `${Math.round(value)}`;
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1);
 }
 
 function formatBytes(value) {

--- a/scripts/validate-app-performance-measurements.mjs
+++ b/scripts/validate-app-performance-measurements.mjs
@@ -41,6 +41,7 @@ export const REQUIRED_METRICS = [
 ];
 
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+const PLACEHOLDER_EVIDENCE_PATTERN = /^[_\W]*(?:tbd|todo|placeholder|pending|to[_\W]*be[_\W]*determined)[_\W]*$/i;
 
 export async function readMeasurementArtifact(filePath) {
   const raw = await readFile(filePath, 'utf8');
@@ -114,8 +115,8 @@ function validateFixture(fixture, errors) {
       if (!Number.isInteger(value) || value < 0) {
         errors.push(`fixture.${field} must be a non-negative integer.`);
       }
-    } else if (!isNonEmptyString(value)) {
-      errors.push(`fixture.${field} must be a non-empty string.`);
+    } else {
+      validateEvidenceString(value, `fixture.${field}`, errors);
     }
   }
 }
@@ -166,9 +167,7 @@ function validateEnvironment(environment, profileId, errors) {
   }
 
   for (const field of REQUIRED_ENVIRONMENT_FIELDS) {
-    if (!isNonEmptyString(environment[field])) {
-      errors.push(`profile ${profileId} environment.${field} must be a non-empty string.`);
-    }
+    validateEvidenceString(environment[field], `profile ${profileId} environment.${field}`, errors);
   }
 }
 
@@ -282,6 +281,14 @@ function validateSha(value, field, errors) {
 
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
+}
+
+function validateEvidenceString(value, field, errors) {
+  if (!isNonEmptyString(value)) {
+    errors.push(`${field} must be a non-empty string.`);
+  } else if (PLACEHOLDER_EVIDENCE_PATTERN.test(value.trim())) {
+    errors.push(`${field} must be real evidence, not a placeholder.`);
+  }
 }
 
 function formatMs(value) {

--- a/scripts/validate-app-performance-measurements.mjs
+++ b/scripts/validate-app-performance-measurements.mjs
@@ -1,0 +1,321 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const REQUIRED_PROFILES = [
+  'desktop-web',
+  'throttled-4g-web',
+  'mid-range-android',
+  'iphone'
+];
+
+export const REQUIRED_PHASES = ['before', 'after'];
+
+export const REQUIRED_FIXTURE_FIELDS = [
+  'testAccount',
+  'teamOrOrganization',
+  'homeTeamCount',
+  'scheduleEventCount',
+  'messageThreadCount'
+];
+
+export const REQUIRED_ENVIRONMENT_FIELDS = [
+  'hardware',
+  'os',
+  'runtime',
+  'browserOrWebView',
+  'network',
+  'cpu'
+];
+
+export const REQUIRED_METRICS = [
+  { key: 'coldStartHomeTtiMs', label: 'Cold-start TTI Home', min: 1 },
+  { key: 'warmResumeMs', label: 'Warm resume', min: 1 },
+  { key: 'readsHomeMount', label: 'Reads / Home mount', min: 0, integer: true },
+  { key: 'readsScheduleMount', label: 'Reads / Schedule mount', min: 0, integer: true },
+  { key: 'readsMessagesMount', label: 'Reads / Messages mount', min: 0, integer: true },
+  { key: 'entryChunkGzipBytes', label: 'Entry chunk gzip', min: 1, integer: true },
+  { key: 'rsvpTapLatencyMs', label: 'RSVP tap latency', min: 1 },
+  { key: 'chatSendLatencyMs', label: 'Chat send latency', min: 1 }
+];
+
+const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+
+export async function readMeasurementArtifact(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Unable to parse ${filePath} as JSON: ${error.message}`);
+  }
+}
+
+export function validateMeasurementArtifact(artifact) {
+  const errors = [];
+  const normalized = normalizeArtifact(artifact);
+
+  if (normalized.issue !== 2050) {
+    errors.push('issue must be 2050.');
+  }
+
+  validateSha(normalized.baselineSha, 'baselineSha', errors);
+  validateSha(normalized.afterSha, 'afterSha', errors);
+  validateFixture(normalized.fixture, errors);
+  validateProfiles(normalized.profiles, normalized, errors);
+
+  return {
+    errors,
+    summary: errors.length === 0 ? buildSummary(normalized) : null
+  };
+}
+
+export function buildMarkdownSummary(summary) {
+  const lines = [
+    '| Profile | Phase | Cold-start TTI Home | Warm resume | Reads / Home | Reads / Schedule | Reads / Messages | Entry gzip | RSVP tap | Chat send |',
+    '| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |'
+  ];
+
+  for (const profile of summary.profiles) {
+    for (const phase of REQUIRED_PHASES) {
+      const medians = profile.phases[phase].medians;
+      lines.push([
+        profile.label,
+        phase,
+        formatMs(medians.coldStartHomeTtiMs),
+        formatMs(medians.warmResumeMs),
+        formatCount(medians.readsHomeMount),
+        formatCount(medians.readsScheduleMount),
+        formatCount(medians.readsMessagesMount),
+        formatBytes(medians.entryChunkGzipBytes),
+        formatMs(medians.rsvpTapLatencyMs),
+        formatMs(medians.chatSendLatencyMs)
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function normalizeArtifact(artifact) {
+  return artifact && typeof artifact === 'object' ? artifact : {};
+}
+
+function validateFixture(fixture, errors) {
+  if (!fixture || typeof fixture !== 'object' || Array.isArray(fixture)) {
+    errors.push('fixture must describe the shared account/team/data volume.');
+    return;
+  }
+
+  for (const field of REQUIRED_FIXTURE_FIELDS) {
+    const value = fixture[field];
+    const isCountField = field.endsWith('Count');
+    if (isCountField) {
+      if (!Number.isInteger(value) || value < 0) {
+        errors.push(`fixture.${field} must be a non-negative integer.`);
+      }
+    } else if (!isNonEmptyString(value)) {
+      errors.push(`fixture.${field} must be a non-empty string.`);
+    }
+  }
+}
+
+function validateProfiles(profiles, artifact, errors) {
+  if (!Array.isArray(profiles)) {
+    errors.push('profiles must be an array.');
+    return;
+  }
+
+  const profileIds = profiles.map((profile) => profile?.id);
+  for (const requiredProfile of REQUIRED_PROFILES) {
+    if (!profileIds.includes(requiredProfile)) {
+      errors.push(`profiles must include ${requiredProfile}.`);
+    }
+  }
+
+  const duplicateProfiles = profileIds.filter((id, index) => id && profileIds.indexOf(id) !== index);
+  for (const duplicateProfile of new Set(duplicateProfiles)) {
+    errors.push(`profiles contains duplicate id ${duplicateProfile}.`);
+  }
+
+  for (const profile of profiles) {
+    validateProfile(profile, artifact, errors);
+  }
+}
+
+function validateProfile(profile, artifact, errors) {
+  const id = profile?.id || '<missing>';
+  if (!REQUIRED_PROFILES.includes(id)) {
+    errors.push(`profile ${id} must use one of: ${REQUIRED_PROFILES.join(', ')}.`);
+  }
+  if (!isNonEmptyString(profile?.label)) {
+    errors.push(`profile ${id} must include a non-empty label.`);
+  }
+
+  validateEnvironment(profile?.environment, id, errors);
+
+  for (const phase of REQUIRED_PHASES) {
+    validatePhase(profile?.[phase], profile, phase, artifact, errors);
+  }
+}
+
+function validateEnvironment(environment, profileId, errors) {
+  if (!environment || typeof environment !== 'object' || Array.isArray(environment)) {
+    errors.push(`profile ${profileId} environment must describe the capture environment.`);
+    return;
+  }
+
+  for (const field of REQUIRED_ENVIRONMENT_FIELDS) {
+    if (!isNonEmptyString(environment[field])) {
+      errors.push(`profile ${profileId} environment.${field} must be a non-empty string.`);
+    }
+  }
+}
+
+function validatePhase(phaseData, profile, phase, artifact, errors) {
+  const profileId = profile?.id || '<missing>';
+  const context = `profile ${profileId} ${phase}`;
+  if (!phaseData || typeof phaseData !== 'object' || Array.isArray(phaseData)) {
+    errors.push(`${context} must include sha, capturedAt, and runs.`);
+    return;
+  }
+
+  validateSha(phaseData.sha, `${context}.sha`, errors);
+  const expectedSha = phase === 'before' ? artifact.baselineSha : artifact.afterSha;
+  if (isNonEmptyString(expectedSha) && phaseData.sha !== expectedSha) {
+    errors.push(`${context}.sha must match ${phase === 'before' ? 'baselineSha' : 'afterSha'}.`);
+  }
+
+  if (!isNonEmptyString(phaseData.capturedAt)) {
+    errors.push(`${context}.capturedAt must be an ISO timestamp string.`);
+  } else if (Number.isNaN(Date.parse(phaseData.capturedAt))) {
+    errors.push(`${context}.capturedAt must be parseable as a date.`);
+  }
+
+  if (!Array.isArray(phaseData.runs)) {
+    errors.push(`${context}.runs must be an array.`);
+    return;
+  }
+  if (phaseData.runs.length < 3) {
+    errors.push(`${context}.runs must include at least 3 clean runs.`);
+  }
+
+  const runNumbers = new Set();
+  phaseData.runs.forEach((run, index) => {
+    validateRun(run, `${context}.runs[${index}]`, errors);
+    if (Number.isInteger(run?.run)) {
+      if (runNumbers.has(run.run)) {
+        errors.push(`${context}.runs contains duplicate run ${run.run}.`);
+      }
+      runNumbers.add(run.run);
+    }
+  });
+}
+
+function validateRun(run, context, errors) {
+  if (!run || typeof run !== 'object' || Array.isArray(run)) {
+    errors.push(`${context} must be an object.`);
+    return;
+  }
+  if (!Number.isInteger(run.run) || run.run <= 0) {
+    errors.push(`${context}.run must be a positive integer.`);
+  }
+
+  for (const metric of REQUIRED_METRICS) {
+    const value = run[metric.key];
+    if (!Number.isFinite(value) || value < metric.min) {
+      errors.push(`${context}.${metric.key} must be a number >= ${metric.min}.`);
+      continue;
+    }
+    if (metric.integer && !Number.isInteger(value)) {
+      errors.push(`${context}.${metric.key} must be an integer.`);
+    }
+  }
+}
+
+function buildSummary(artifact) {
+  return {
+    issue: artifact.issue,
+    baselineSha: artifact.baselineSha,
+    afterSha: artifact.afterSha,
+    profileCount: artifact.profiles.length,
+    runCount: artifact.profiles.reduce((total, profile) => (
+      total + REQUIRED_PHASES.reduce((phaseTotal, phase) => phaseTotal + profile[phase].runs.length, 0)
+    ), 0),
+    profiles: artifact.profiles.map((profile) => ({
+      id: profile.id,
+      label: profile.label,
+      phases: Object.fromEntries(REQUIRED_PHASES.map((phase) => [
+        phase,
+        {
+          sha: profile[phase].sha,
+          capturedAt: profile[phase].capturedAt,
+          runCount: profile[phase].runs.length,
+          medians: calculateMedians(profile[phase].runs)
+        }
+      ]))
+    }))
+  };
+}
+
+function calculateMedians(runs) {
+  return Object.fromEntries(REQUIRED_METRICS.map((metric) => [
+    metric.key,
+    median(runs.map((run) => run[metric.key]))
+  ]));
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[middle];
+  }
+  return (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function validateSha(value, field, errors) {
+  if (!isNonEmptyString(value) || !SHA_PATTERN.test(value)) {
+    errors.push(`${field} must be a 7-40 character hex SHA.`);
+  }
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function formatMs(value) {
+  return `${Math.round(value)}ms`;
+}
+
+function formatCount(value) {
+  return `${Math.round(value)}`;
+}
+
+function formatBytes(value) {
+  return `${(value / 1024).toFixed(1)} KiB`;
+}
+
+async function main() {
+  const fileArg = process.argv[2] || process.env.APP_PERFORMANCE_MEASUREMENTS_FILE;
+  if (!fileArg) {
+    throw new Error('Usage: node scripts/validate-app-performance-measurements.mjs <measurements.json>');
+  }
+
+  const filePath = path.resolve(process.cwd(), fileArg);
+  const artifact = await readMeasurementArtifact(filePath);
+  const result = validateMeasurementArtifact(artifact);
+  if (result.errors.length > 0) {
+    throw new Error(`Invalid app performance measurement artifact:\n- ${result.errors.join('\n- ')}`);
+  }
+
+  console.log(`Validated issue #${result.summary.issue} measurements: ${result.summary.profileCount} profiles, ${result.summary.runCount} raw runs.`);
+  console.log(buildMarkdownSummary(result.summary));
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/validate-app-performance-measurements.mjs
+++ b/scripts/validate-app-performance-measurements.mjs
@@ -223,7 +223,7 @@ function validatePhase(phaseData, profile, phase, artifact, errors) {
 
   validateSha(phaseData.sha, `${context}.sha`, errors);
   const expectedSha = phase === 'before' ? artifact.baselineSha : artifact.afterSha;
-  if (normalizeSha(expectedSha) && normalizeSha(phaseData.sha) !== normalizeSha(expectedSha)) {
+  if (normalizeSha(expectedSha) && !shaValuesOverlap(phaseData.sha, expectedSha)) {
     errors.push(`${context}.sha must match ${phase === 'before' ? 'baselineSha' : 'afterSha'}.`);
   }
 

--- a/tests/unit/app-performance-baseline-doc.test.js
+++ b/tests/unit/app-performance-baseline-doc.test.js
@@ -92,7 +92,11 @@ describe('app performance baseline documentation', () => {
             '`coldStartHomeTtiMs`',
             '`warmResumeMs`',
             '`entryChunkGzipBytes`',
-            'The validator rejects placeholders'
+            'The validator rejects placeholders',
+            'positive safe integers',
+            'synthetic or anonymized fixture identifier',
+            'Never commit passwords',
+            'CI automatically validates'
         ].forEach((needle) => {
             expect(doc).toContain(needle);
         });

--- a/tests/unit/app-performance-baseline-doc.test.js
+++ b/tests/unit/app-performance-baseline-doc.test.js
@@ -89,6 +89,8 @@ describe('app performance baseline documentation', () => {
             '`throttled-4g-web`',
             '`mid-range-android`',
             '`iphone`',
+            'descriptive\n  `label`',
+            'positive safe-integer `run` number',
             '`coldStartHomeTtiMs`',
             '`warmResumeMs`',
             '`entryChunkGzipBytes`',

--- a/tests/unit/app-performance-baseline-doc.test.js
+++ b/tests/unit/app-performance-baseline-doc.test.js
@@ -28,7 +28,9 @@ describe('app performance baseline documentation', () => {
             '| Mid-range Android |',
             '| iPhone |',
             'DevTools "Slow 4G" plus 4x CPU throttle',
-            'Numbers are medians of 3 runs'
+            'Numbers are medians of 3 runs',
+            'Raw evidence contract',
+            'npm run app:validate-performance-measurements -- docs/app-performance-measurements.json'
         ].forEach((needle) => {
             expect(doc).toContain(needle);
         });
@@ -73,6 +75,24 @@ describe('app performance baseline documentation', () => {
             'RSVP timing validation uses the',
             'lab action "open a Schedule event and tap Going"',
             'telemetry event filtered to label `rsvp tap latency`'
+        ].forEach((needle) => {
+            expect(doc).toContain(needle);
+        });
+    });
+
+    it('requires validated raw run evidence before issue closure', () => {
+        [
+            '`issue: 2050`',
+            '`baselineSha`',
+            '`afterSha`',
+            '`desktop-web`',
+            '`throttled-4g-web`',
+            '`mid-range-android`',
+            '`iphone`',
+            '`coldStartHomeTtiMs`',
+            '`warmResumeMs`',
+            '`entryChunkGzipBytes`',
+            'The validator rejects placeholders'
         ].forEach((needle) => {
             expect(doc).toContain(needle);
         });

--- a/tests/unit/app-performance-measurement-initiative-source-contract.test.js
+++ b/tests/unit/app-performance-measurement-initiative-source-contract.test.js
@@ -7,6 +7,7 @@ function readSource(path) {
 
 const packageSource = readSource('package.json');
 const appPackageSource = readSource('apps/app/package.json');
+const ciSource = readSource('.github/workflows/ci.yml');
 const baselineDocSource = readSource('docs/app-performance-baseline.md');
 const bundleSizeScriptSource = readSource('scripts/check-app-bundle-size.mjs');
 const measurementValidatorSource = readSource('scripts/validate-app-performance-measurements.mjs');
@@ -49,6 +50,8 @@ describe('app performance measurement initiative source contract', () => {
         expect(packageSource).toContain('"app:check-bundle-size": "node scripts/check-app-bundle-size.mjs"');
         expect(packageSource).toContain('"app:validate-performance-measurements": "node scripts/validate-app-performance-measurements.mjs"');
         expect(appPackageSource).toContain('"preview": "vite preview --host 0.0.0.0"');
+        expect(ciSource).toContain('Validate app performance evidence when present');
+        expect(ciSource).toContain('npm run app:validate-performance-measurements -- docs/app-performance-measurements.json');
 
         expect(bundleSizeScriptSource).toContain("const defaultEntryBudgetBytes = 1_420_000;");
         expect(bundleSizeScriptSource).toContain('process.env.APP_ENTRY_CHUNK_LIMIT_BYTES');
@@ -71,6 +74,8 @@ describe('app performance measurement initiative source contract', () => {
         ].forEach((snippet) => {
             expect(measurementValidatorSource).toContain(snippet);
         });
+        expect(measurementValidatorSource).toContain('MAX_ARTIFACT_BYTES');
+        expect(measurementValidatorSource).toContain('MAX_RUNS_PER_PHASE');
     });
 
     it('keeps canonical UX timing labels flowing through telemetry', () => {

--- a/tests/unit/app-performance-measurement-initiative-source-contract.test.js
+++ b/tests/unit/app-performance-measurement-initiative-source-contract.test.js
@@ -9,6 +9,7 @@ const packageSource = readSource('package.json');
 const appPackageSource = readSource('apps/app/package.json');
 const baselineDocSource = readSource('docs/app-performance-baseline.md');
 const bundleSizeScriptSource = readSource('scripts/check-app-bundle-size.mjs');
+const measurementValidatorSource = readSource('scripts/validate-app-performance-measurements.mjs');
 const uxTimingSource = readSource('apps/app/src/lib/uxTiming.ts');
 const telemetrySource = readSource('apps/app/src/lib/telemetry.ts');
 const mainSource = readSource('apps/app/src/main.tsx');
@@ -30,6 +31,8 @@ describe('app performance measurement initiative source contract', () => {
             'Entry chunk size (gzip)',
             'RSVP tap latency',
             'Chat send latency',
+            'Raw evidence contract',
+            'app:validate-performance-measurements',
             'paste',
             'the completed table into #2050 before closing it'
         ].forEach((snippet) => {
@@ -44,12 +47,30 @@ describe('app performance measurement initiative source contract', () => {
         expect(packageSource).toContain('"app:build": "npm --prefix apps/app run build && node scripts/verify-app-bundle-visualizer.mjs"');
         expect(packageSource).toContain('"app:preview": "npm --prefix apps/app run preview"');
         expect(packageSource).toContain('"app:check-bundle-size": "node scripts/check-app-bundle-size.mjs"');
+        expect(packageSource).toContain('"app:validate-performance-measurements": "node scripts/validate-app-performance-measurements.mjs"');
         expect(appPackageSource).toContain('"preview": "vite preview --host 0.0.0.0"');
 
         expect(bundleSizeScriptSource).toContain("const defaultEntryBudgetBytes = 1_420_000;");
         expect(bundleSizeScriptSource).toContain('process.env.APP_ENTRY_CHUNK_LIMIT_BYTES');
         expect(bundleSizeScriptSource).toContain('Unable to find the app entry chunk');
         expect(bundleSizeScriptSource).toContain('App entry chunk ${path.relative(repoRoot, entryChunkPath)} is ${entrySizeKb} KB');
+
+        [
+            'desktop-web',
+            'throttled-4g-web',
+            'mid-range-android',
+            'iphone',
+            'coldStartHomeTtiMs',
+            'warmResumeMs',
+            'readsHomeMount',
+            'readsScheduleMount',
+            'readsMessagesMount',
+            'entryChunkGzipBytes',
+            'rsvpTapLatencyMs',
+            'chatSendLatencyMs'
+        ].forEach((snippet) => {
+            expect(measurementValidatorSource).toContain(snippet);
+        });
     });
 
     it('keeps canonical UX timing labels flowing through telemetry', () => {

--- a/tests/unit/app-performance-measurement-validator.test.js
+++ b/tests/unit/app-performance-measurement-validator.test.js
@@ -163,7 +163,7 @@ describe('app performance measurement validator', () => {
         expect(result.errors).toContain('profile desktop-web before.runs[0].readsHomeMount must be a safe integer.');
     });
 
-    it('requires distinct build SHAs and compares phase SHAs case-insensitively', () => {
+    it('requires distinct build SHAs and compares phase SHAs case- and prefix-insensitively', () => {
         const sameBuild = buildArtifact({
             baselineSha: 'ABCDEF012345',
             afterSha: 'abcdef0'
@@ -182,6 +182,13 @@ describe('app performance measurement validator', () => {
         expect(validateMeasurementArtifact(casingOnly).errors).not.toContain(
             'profile desktop-web before.sha must match baselineSha.'
         );
+
+        const mixedLength = buildArtifact();
+        mixedLength.profiles[0].before.sha = baselineSha.slice(0, 7).toUpperCase();
+        mixedLength.profiles[0].after.sha = afterSha.slice(0, 7).toUpperCase();
+        const mixedLengthErrors = validateMeasurementArtifact(mixedLength).errors;
+        expect(mixedLengthErrors).not.toContain('profile desktop-web before.sha must match baselineSha.');
+        expect(mixedLengthErrors).not.toContain('profile desktop-web after.sha must match afterSha.');
     });
 
     it('requires real ISO timestamps with timezones and bounds raw run cost', () => {

--- a/tests/unit/app-performance-measurement-validator.test.js
+++ b/tests/unit/app-performance-measurement-validator.test.js
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    REQUIRED_METRICS,
+    REQUIRED_PROFILES,
+    buildMarkdownSummary,
+    validateMeasurementArtifact
+} from '../../scripts/validate-app-performance-measurements.mjs';
+
+const baselineSha = 'a60d0c56c5959b2d90fbf791d99a6fbc1a7d9ee1';
+const afterSha = '5976012e';
+
+function buildRun(run, overrides = {}) {
+    return {
+        run,
+        coldStartHomeTtiMs: 1800 + run,
+        warmResumeMs: 640 + run,
+        readsHomeMount: 24 + run,
+        readsScheduleMount: 18 + run,
+        readsMessagesMount: 12 + run,
+        entryChunkGzipBytes: 132000 + run,
+        rsvpTapLatencyMs: 420 + run,
+        chatSendLatencyMs: 520 + run,
+        ...overrides
+    };
+}
+
+function buildPhase(sha, capturedAt) {
+    return {
+        sha,
+        capturedAt,
+        runs: [
+            buildRun(1),
+            buildRun(2),
+            buildRun(3)
+        ]
+    };
+}
+
+function buildArtifact(overrides = {}) {
+    return {
+        issue: 2050,
+        baselineSha,
+        afterSha,
+        fixture: {
+            testAccount: 'perf-parent@example.com',
+            teamOrOrganization: 'Bears 12U seeded team',
+            homeTeamCount: 3,
+            scheduleEventCount: 20,
+            messageThreadCount: 5
+        },
+        profiles: REQUIRED_PROFILES.map((id) => ({
+            id,
+            label: id,
+            environment: {
+                hardware: `${id} device`,
+                os: 'Test OS 1.0',
+                runtime: id.includes('web') ? 'Chrome web' : 'Capacitor native',
+                browserOrWebView: 'Chrome 140',
+                network: id === 'throttled-4g-web' ? 'Slow 4G' : 'Wi-Fi',
+                cpu: id === 'throttled-4g-web' ? '4x throttle' : 'No throttle'
+            },
+            before: buildPhase(baselineSha, '2026-07-12T12:00:00.000Z'),
+            after: buildPhase(afterSha, '2026-07-12T13:00:00.000Z')
+        })),
+        ...overrides
+    };
+}
+
+describe('app performance measurement validator', () => {
+    it('accepts a complete issue 2050 before/after artifact and reports medians', () => {
+        const result = validateMeasurementArtifact(buildArtifact());
+
+        expect(result.errors).toEqual([]);
+        expect(result.summary.profileCount).toBe(4);
+        expect(result.summary.runCount).toBe(24);
+        expect(result.summary.profiles[0].phases.before.medians.coldStartHomeTtiMs).toBe(1802);
+
+        const markdown = buildMarkdownSummary(result.summary);
+        expect(markdown).toContain('| Profile | Phase | Cold-start TTI Home | Warm resume |');
+        expect(markdown).toContain('| desktop-web | before | 1802ms | 642ms |');
+    });
+
+    it('rejects missing profiles, incomplete phases, and placeholder metric values', () => {
+        const artifact = buildArtifact({
+            profiles: [
+                {
+                    ...buildArtifact().profiles[0],
+                    after: {
+                        sha: afterSha,
+                        capturedAt: 'not a date',
+                        runs: [
+                            buildRun(1, { coldStartHomeTtiMs: '_tbd_' }),
+                            buildRun(1)
+                        ]
+                    }
+                }
+            ]
+        });
+
+        const result = validateMeasurementArtifact(artifact);
+
+        expect(result.errors).toContain('profiles must include throttled-4g-web.');
+        expect(result.errors).toContain('profiles must include mid-range-android.');
+        expect(result.errors).toContain('profiles must include iphone.');
+        expect(result.errors).toContain('profile desktop-web after.capturedAt must be parseable as a date.');
+        expect(result.errors).toContain('profile desktop-web after.runs must include at least 3 clean runs.');
+        expect(result.errors).toContain('profile desktop-web after.runs contains duplicate run 1.');
+        expect(result.errors).toContain('profile desktop-web after.runs[0].coldStartHomeTtiMs must be a number >= 1.');
+    });
+
+    it('keeps the validator aligned with all issue 2050 metrics', () => {
+        expect(REQUIRED_METRICS.map((metric) => metric.key)).toEqual([
+            'coldStartHomeTtiMs',
+            'warmResumeMs',
+            'readsHomeMount',
+            'readsScheduleMount',
+            'readsMessagesMount',
+            'entryChunkGzipBytes',
+            'rsvpTapLatencyMs',
+            'chatSendLatencyMs'
+        ]);
+    });
+});

--- a/tests/unit/app-performance-measurement-validator.test.js
+++ b/tests/unit/app-performance-measurement-validator.test.js
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtemp, rm, truncate, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
+    MAX_ARTIFACT_BYTES,
+    MAX_RUNS_PER_PHASE,
     REQUIRED_ENVIRONMENT_FIELDS,
     REQUIRED_METRICS,
     REQUIRED_PROFILES,
     buildMarkdownSummary,
+    readMeasurementArtifact,
     validateMeasurementArtifact
 } from '../../scripts/validate-app-performance-measurements.mjs';
 
@@ -104,7 +110,7 @@ describe('app performance measurement validator', () => {
         expect(result.errors).toContain('profiles must include throttled-4g-web.');
         expect(result.errors).toContain('profiles must include mid-range-android.');
         expect(result.errors).toContain('profiles must include iphone.');
-        expect(result.errors).toContain('profile desktop-web after.capturedAt must be parseable as a date.');
+        expect(result.errors).toContain('profile desktop-web after.capturedAt must be a valid ISO timestamp with a timezone.');
         expect(result.errors).toContain('profile desktop-web after.runs must include at least 3 clean runs.');
         expect(result.errors).toContain('profile desktop-web after.runs contains duplicate run 1.');
         expect(result.errors).toContain('profile desktop-web after.runs[0].coldStartHomeTtiMs must be a number >= 1.');
@@ -135,6 +141,98 @@ describe('app performance measurement validator', () => {
             expect(validateMeasurementArtifact(artifact).errors).toContain(
                 `profile desktop-web environment.${field} must be real evidence, not a placeholder.`
             );
+        }
+    });
+
+    it('rejects descriptive placeholders, empty fixtures, and unsafe integer evidence', () => {
+        const artifact = buildArtifact();
+        artifact.fixture.testAccount = 'TBD - choose a synthetic account';
+        artifact.fixture.accessToken = 'must-not-be-committed';
+        artifact.fixture.homeTeamCount = 0;
+        artifact.fixture.scheduleEventCount = Number.MAX_SAFE_INTEGER + 1;
+        artifact.profiles[0].environment.hardware = 'unknown device';
+        artifact.profiles[0].before.runs[0].readsHomeMount = Number.MAX_SAFE_INTEGER + 1;
+
+        const result = validateMeasurementArtifact(artifact);
+
+        expect(result.errors).toContain('fixture.testAccount must be real evidence, not a placeholder.');
+        expect(result.errors).toContain('artifact must not include password, secret, token, credential, or private-key fields.');
+        expect(result.errors).toContain('fixture.homeTeamCount must be a positive safe integer.');
+        expect(result.errors).toContain('fixture.scheduleEventCount must be a positive safe integer.');
+        expect(result.errors).toContain('profile desktop-web environment.hardware must be real evidence, not a placeholder.');
+        expect(result.errors).toContain('profile desktop-web before.runs[0].readsHomeMount must be a safe integer.');
+    });
+
+    it('requires distinct build SHAs and compares phase SHAs case-insensitively', () => {
+        const sameBuild = buildArtifact({
+            baselineSha: 'ABCDEF012345',
+            afterSha: 'abcdef0'
+        });
+        sameBuild.profiles.forEach((profile) => {
+            profile.before.sha = 'abcdef012345';
+            profile.after.sha = 'ABCDEF0';
+        });
+
+        expect(validateMeasurementArtifact(sameBuild).errors).toContain(
+            'baselineSha and afterSha must identify different commits.'
+        );
+
+        const casingOnly = buildArtifact();
+        casingOnly.profiles[0].before.sha = baselineSha.toUpperCase();
+        expect(validateMeasurementArtifact(casingOnly).errors).not.toContain(
+            'profile desktop-web before.sha must match baselineSha.'
+        );
+    });
+
+    it('requires real ISO timestamps with timezones and bounds raw run cost', () => {
+        const artifact = buildArtifact();
+        artifact.profiles[0].before.capturedAt = '2026-02-30T12:00:00Z';
+        artifact.profiles[0].after.capturedAt = '2026-07-12T13:00:00';
+        artifact.profiles[1].before.runs = Array.from(
+            { length: MAX_RUNS_PER_PHASE + 1 },
+            (_, index) => buildRun(index + 1)
+        );
+
+        const result = validateMeasurementArtifact(artifact);
+
+        expect(result.errors).toContain('profile desktop-web before.capturedAt must be a valid ISO timestamp with a timezone.');
+        expect(result.errors).toContain('profile desktop-web after.capturedAt must be a valid ISO timestamp with a timezone.');
+        expect(result.errors).toContain(`profile throttled-4g-web before.runs must not exceed ${MAX_RUNS_PER_PHASE} runs.`);
+    });
+
+    it('escapes profile labels before emitting a paste-ready markdown table', () => {
+        const artifact = buildArtifact();
+        artifact.profiles[0].label = 'Desktop | primary';
+        const result = validateMeasurementArtifact(artifact);
+
+        expect(result.errors).toEqual([]);
+        expect(buildMarkdownSummary(result.summary)).toContain('| Desktop \\| primary | before |');
+    });
+
+    it('preserves half-count medians for an even number of read samples', () => {
+        const artifact = buildArtifact();
+        artifact.profiles[0].before.runs = [1, 2, 3, 4].map((run) => buildRun(run, {
+            readsHomeMount: run
+        }));
+        const result = validateMeasurementArtifact(artifact);
+
+        expect(result.errors).toEqual([]);
+        expect(result.summary.profiles[0].phases.before.medians.readsHomeMount).toBe(2.5);
+        expect(buildMarkdownSummary(result.summary)).toContain('| desktop-web | before | 1803ms | 643ms | 2.5 |');
+    });
+
+    it('rejects oversized raw evidence files before loading them into memory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'allplays-performance-evidence-'));
+        const artifactPath = join(tempDir, 'measurements.json');
+        try {
+            await writeFile(artifactPath, '{}');
+            await truncate(artifactPath, MAX_ARTIFACT_BYTES + 1);
+
+            await expect(readMeasurementArtifact(artifactPath)).rejects.toThrow(
+                `exceeds the ${MAX_ARTIFACT_BYTES}-byte performance evidence limit`
+            );
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
         }
     });
 

--- a/tests/unit/app-performance-measurement-validator.test.js
+++ b/tests/unit/app-performance-measurement-validator.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    REQUIRED_ENVIRONMENT_FIELDS,
     REQUIRED_METRICS,
     REQUIRED_PROFILES,
     buildMarkdownSummary,
@@ -107,6 +108,34 @@ describe('app performance measurement validator', () => {
         expect(result.errors).toContain('profile desktop-web after.runs must include at least 3 clean runs.');
         expect(result.errors).toContain('profile desktop-web after.runs contains duplicate run 1.');
         expect(result.errors).toContain('profile desktop-web after.runs[0].coldStartHomeTtiMs must be a number >= 1.');
+    });
+
+    it('rejects placeholder fixture account and environment evidence strings', () => {
+        const fixtureArtifact = buildArtifact({
+            fixture: {
+                ...buildArtifact().fixture,
+                testAccount: '_tbd_'
+            }
+        });
+
+        expect(validateMeasurementArtifact(fixtureArtifact).errors).toContain(
+            'fixture.testAccount must be real evidence, not a placeholder.'
+        );
+
+        for (const field of REQUIRED_ENVIRONMENT_FIELDS) {
+            const artifact = buildArtifact();
+            artifact.profiles[0] = {
+                ...artifact.profiles[0],
+                environment: {
+                    ...artifact.profiles[0].environment,
+                    [field]: '_tbd_'
+                }
+            };
+
+            expect(validateMeasurementArtifact(artifact).errors).toContain(
+                `profile desktop-web environment.${field} must be real evidence, not a placeholder.`
+            );
+        }
     });
 
     it('keeps the validator aligned with all issue 2050 metrics', () => {


### PR DESCRIPTION
## Summary
- Add `scripts/validate-app-performance-measurements.mjs` to validate the raw before/after evidence required by issue #2050.
- Document the raw JSON evidence contract in `docs/app-performance-baseline.md`, including required profiles, phases, fixture metadata, and metric fields.
- Add focused unit/source-contract coverage for the validator and closeout documentation.

## Impact
This is a bounded slice for the split-parent measurement issue. It does not claim to complete #2050; it makes the remaining empirical campaign auditable by rejecting placeholders, missing profiles, incomplete before/after phases, and malformed metric values before results are posted.

Refs #2050.

## Validation
- `npx vitest run tests/unit/app-performance-baseline-doc.test.js tests/unit/app-performance-baseline-contract.test.js tests/unit/app-performance-measurement-initiative-source-contract.test.js tests/unit/app-performance-measurement-validator.test.js --reporter=verbose`
- `npm run app:build`
- `npm run app:check-bundle-size`

## Remaining for #2050
- Capture the actual before/after runs on desktop web, Slow 4G + 4x CPU, mid-range Android, and iPhone with the same seeded account/team fixture.
- Commit or attach the validated raw evidence, fill the baseline/after tables, and paste the final comparison into #2050.

