### PR TITLE
Improve app registration provider card (fixes #3856)

### DIFF
--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -429,6 +429,7 @@ describe('buildTeamDetailModel registration provider', () => {
   });
 
   it('returns human-labeled rows with copyable ids when a registration source is configured', () => {
+    const syncedAt = new Date(2026, 0, 2, 9, 30);
     const built = buildTeamDetailModel({
       teamId: 'team-1',
       team: {
@@ -439,7 +440,8 @@ describe('buildTeamDetailModel registration provider', () => {
           provider: 'LeagueApps',
           externalTeamId: 'ext-42',
           teamId: 'provider-team-7',
-          lastSyncStatus: 'Synced'
+          lastSyncStatus: 'sync_complete',
+          lastSyncedAt: syncedAt
         }
       }
     });
@@ -448,8 +450,9 @@ describe('buildTeamDetailModel registration provider', () => {
       { label: 'Provider', value: 'LeagueApps' },
       { label: 'External team ID', value: 'ext-42', copyable: true },
       { label: 'Provider team ID', value: 'provider-team-7', copyable: true },
-      { label: 'Last sync', value: 'Synced' }
+      expect.objectContaining({ label: 'Last sync', value: expect.stringContaining('Sync Complete') })
     ]);
+    expect(built.team.registrationProvider[3].value).toContain('Jan 2, 2026');
   });
 
   it('keeps a legacy provider-specific teamId when it is not the app team id', () => {

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -395,6 +395,45 @@ describe('canManageTeamAdmins adminEmails parity with legacy js/team-access.js',
   });
 });
 
+describe('buildTeamDetailModel registration provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns no registration provider rows when the team has no registration source', () => {
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: { id: 'team-1', name: 'Bears', sport: 'Basketball' }
+    });
+
+    expect(built.team.registrationProvider).toEqual([]);
+  });
+
+  it('returns human-labeled rows with copyable ids when a registration source is configured', () => {
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: {
+        id: 'team-1',
+        name: 'Bears',
+        sport: 'Basketball',
+        registrationSource: {
+          provider: 'LeagueApps',
+          externalTeamId: 'ext-42',
+          teamId: 'provider-team-7',
+          lastSyncStatus: 'Synced'
+        }
+      }
+    });
+
+    expect(built.team.registrationProvider).toEqual([
+      { label: 'Provider', value: 'LeagueApps' },
+      { label: 'External team ID', value: 'ext-42', copyable: true },
+      { label: 'Provider team ID', value: 'provider-team-7', copyable: true },
+      { label: 'Last sync', value: 'Synced' }
+    ]);
+  });
+});
+
 describe('buildTeamDetailModel standings', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/app/src/lib/teamDetailService.test.ts
+++ b/apps/app/src/lib/teamDetailService.test.ts
@@ -409,6 +409,25 @@ describe('buildTeamDetailModel registration provider', () => {
     expect(built.team.registrationProvider).toEqual([]);
   });
 
+  it('does not expose the app team id as a registration provider value', () => {
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: {
+        id: 'team-1',
+        name: 'Bears',
+        sport: 'Basketball',
+        registrationSource: {
+          providerName: 'Sports Connect',
+          teamId: 'team-1'
+        }
+      }
+    });
+
+    expect(built.team.registrationProvider).toEqual([
+      { label: 'Provider', value: 'Sports Connect' }
+    ]);
+  });
+
   it('returns human-labeled rows with copyable ids when a registration source is configured', () => {
     const built = buildTeamDetailModel({
       teamId: 'team-1',
@@ -430,6 +449,26 @@ describe('buildTeamDetailModel registration provider', () => {
       { label: 'External team ID', value: 'ext-42', copyable: true },
       { label: 'Provider team ID', value: 'provider-team-7', copyable: true },
       { label: 'Last sync', value: 'Synced' }
+    ]);
+  });
+
+  it('keeps a legacy provider-specific teamId when it is not the app team id', () => {
+    const built = buildTeamDetailModel({
+      teamId: 'team-1',
+      team: {
+        id: 'team-1',
+        name: 'Bears',
+        sport: 'Basketball',
+        registrationSource: {
+          providerName: 'LeagueApps',
+          teamId: 'provider-team-44'
+        }
+      }
+    });
+
+    expect(built.team.registrationProvider).toEqual([
+      { label: 'Provider', value: 'LeagueApps' },
+      { label: 'Provider team ID', value: 'provider-team-44', copyable: true }
     ]);
   });
 });

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -2199,10 +2199,16 @@ function normalizeSponsorList(sponsors: any[]): TeamDetailSponsor[] {
 
 function getRegistrationProviderDetails(team: Record<string, any>) {
   const source = team?.registrationSource || team?.registrationProvider || {};
+  const appTeamId = cleanString(team?.id || team?.teamId);
+  const externalTeamId = cleanString(source.externalTeamId || source.externalTeamID || source.providerTeamId || source.providerTeamID || source.sourceTeamId);
+  const sourceTeamId = cleanString(source.teamId);
+  const providerTeamId = sourceTeamId && sourceTeamId !== appTeamId && sourceTeamId !== externalTeamId
+    ? sourceTeamId
+    : '';
   const rows = [
     { label: 'Provider', value: cleanString(source.provider || source.providerName) },
-    { label: 'External team ID', value: cleanString(source.externalTeamId), copyable: true },
-    { label: 'Provider team ID', value: cleanString(source.teamId), copyable: true },
+    { label: 'External team ID', value: externalTeamId, copyable: true },
+    { label: 'Provider team ID', value: providerTeamId, copyable: true },
     { label: 'Last sync', value: cleanString(source.lastSyncStatus || source.syncStatus) }
   ].filter((row) => row.value);
   return rows;

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -2199,6 +2199,8 @@ function normalizeSponsorList(sponsors: any[]): TeamDetailSponsor[] {
 
 function getRegistrationProviderDetails(team: Record<string, any>) {
   const source = team?.registrationSource || team?.registrationProvider || {};
+  const lastSyncStatus = cleanString(source.lastSyncStatus || source.syncStatus);
+  const lastSyncTime = formatRegistrationProviderSyncTime(source.lastSyncedAt || source.lastSyncAt || source.syncedAt || source.updatedAt);
   const appTeamId = cleanString(team?.id || team?.teamId);
   const externalTeamId = cleanString(source.externalTeamId || source.externalTeamID || source.providerTeamId || source.providerTeamID || source.sourceTeamId);
   const sourceTeamId = cleanString(source.teamId);
@@ -2209,9 +2211,37 @@ function getRegistrationProviderDetails(team: Record<string, any>) {
     { label: 'Provider', value: cleanString(source.provider || source.providerName) },
     { label: 'External team ID', value: externalTeamId, copyable: true },
     { label: 'Provider team ID', value: providerTeamId, copyable: true },
-    { label: 'Last sync', value: cleanString(source.lastSyncStatus || source.syncStatus) }
+    { label: 'Last sync', value: formatRegistrationProviderSyncDetail(lastSyncStatus, lastSyncTime) }
   ].filter((row) => row.value);
   return rows;
+}
+
+function formatRegistrationProviderSyncDetail(status: string, time: string) {
+  const friendlyStatus = humanizeRegistrationProviderStatus(status);
+  if (friendlyStatus && time) return `${friendlyStatus} - ${time}`;
+  return friendlyStatus || time;
+}
+
+function humanizeRegistrationProviderStatus(status: string) {
+  const value = cleanString(status);
+  if (!value) return '';
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatRegistrationProviderSyncTime(value: any) {
+  const date = toNullableDate(value);
+  if (!date) return '';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
 }
 
 function getStreamUrl(team: Record<string, any>) {
@@ -2253,6 +2283,18 @@ function toDate(value: any) {
   if (typeof value?.seconds === 'number') return new Date(value.seconds * 1000);
   const date = new Date(value || Date.now());
   return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function toNullableDate(value: any) {
+  if (!value) return null;
+  const date = value instanceof Date
+    ? value
+    : typeof value?.toDate === 'function'
+      ? value.toDate()
+      : typeof value?.seconds === 'number'
+        ? new Date(value.seconds * 1000)
+        : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 function toNullableNumber(value: any) {

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -266,7 +266,7 @@ export type TeamDetailModel = {
     websiteUrl: string;
     editTeamUrl: string;
     mediaUrl: string;
-    registrationProvider: Array<{ label: string; value: string }>;
+    registrationProvider: Array<{ label: string; value: string; copyable?: boolean }>;
     scheduleNotifications: TeamScheduleNotificationSettings;
   };
   players: TeamDetailPlayer[];
@@ -1661,7 +1661,7 @@ export function buildTeamDetailModel({
       websiteUrl: getPublicHashUrl('team.html', teamId),
       editTeamUrl: getPublicHashUrl('edit-team.html', teamId),
       mediaUrl: getPublicHashUrl('team-media.html', teamId),
-      registrationProvider: getRegistrationProviderDetails(team, teamId),
+      registrationProvider: getRegistrationProviderDetails(team),
       scheduleNotifications: normalizeTeamScheduleNotifications(team?.scheduleNotifications)
     },
     players: normalizedPlayers,
@@ -2197,13 +2197,13 @@ function normalizeSponsorList(sponsors: any[]): TeamDetailSponsor[] {
     .filter((sponsor) => sponsor.id || sponsor.name);
 }
 
-function getRegistrationProviderDetails(team: Record<string, any>, teamId: string) {
+function getRegistrationProviderDetails(team: Record<string, any>) {
   const source = team?.registrationSource || team?.registrationProvider || {};
   const rows = [
     { label: 'Provider', value: cleanString(source.provider || source.providerName) },
-    { label: 'External Team ID', value: cleanString(source.externalTeamId) },
-    { label: 'Team ID', value: cleanString(source.teamId || teamId) },
-    { label: 'Last Sync', value: cleanString(source.lastSyncStatus || source.syncStatus) }
+    { label: 'External team ID', value: cleanString(source.externalTeamId), copyable: true },
+    { label: 'Provider team ID', value: cleanString(source.teamId), copyable: true },
+    { label: 'Last sync', value: cleanString(source.lastSyncStatus || source.syncStatus) }
   ].filter((row) => row.value);
   return rows;
 }

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1378,6 +1378,53 @@ describe('TeamDetail', () => {
     })));
   });
 
+  it('hides the registration provider card when the team has no registration source', async () => {
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=more']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Team links')).toBeTruthy();
+    expect(screen.queryByText('Registration provider')).toBeNull();
+  });
+
+  it('shows registration provider context and copies id values when a provider is configured', async () => {
+    const { copyPublicText } = await import('../lib/publicActions');
+    vi.mocked(copyPublicText).mockResolvedValue('copied');
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue({
+      ...model,
+      team: {
+        ...model.team,
+        registrationProvider: [
+          { label: 'Provider', value: 'LeagueApps' },
+          { label: 'Provider team ID', value: 'provider-team-7', copyable: true }
+        ]
+      }
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1?tab=more']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Registration provider')).toBeTruthy();
+    expect(screen.getByText('This team syncs registrations from an external provider.')).toBeTruthy();
+    expect(screen.getByText('LeagueApps')).toBeTruthy();
+    expect(screen.getByText('provider-team-7')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Copy Provider' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy Provider team ID' }));
+
+    await waitFor(() => expect(copyPublicText).toHaveBeenCalledWith('provider-team-7'));
+    expect(await screen.findByText('Provider team ID copied.')).toBeTruthy();
+  });
+
   it('loads roster invite summaries only once per roster visit when the result is empty', async () => {
     const managedModel = {
       ...model,

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -1632,19 +1632,7 @@ function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, 
         </div>
       </section>
 
-      {model.team.registrationProvider.length ? (
-        <section className="app-card p-4">
-          <div className="text-sm font-black text-gray-950">Registration provider</div>
-          <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            {model.team.registrationProvider.map((row) => (
-              <div key={row.label} className="rounded-xl border border-blue-100 bg-blue-50 p-3">
-                <div className="text-[11px] font-black uppercase tracking-[0.04em] text-blue-700">{row.label}</div>
-                <div className="mt-1 break-all text-sm font-black text-gray-950">{row.value}</div>
-              </div>
-            ))}
-          </div>
-        </section>
-      ) : null}
+      {model.team.registrationProvider.length ? <RegistrationProviderCard rows={model.team.registrationProvider} /> : null}
 
       {sponsorsLoading ? <InlineDeferredLoading copy="Loading local attractions and sponsors…" /> : null}
       {!sponsorsLoading && sponsorsError ? <InlineDeferredError title="Sponsors unavailable" message={sponsorsError} /> : null}
@@ -2177,6 +2165,47 @@ function FanFeedCard({ model }: { model: TeamDetailModel }) {
           {status ? <div className={`mt-2 text-xs font-black ${status.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{status.message}</div> : null}
         </div>
       </div>
+    </section>
+  );
+}
+
+function RegistrationProviderCard({ rows }: { rows: TeamDetailModel['team']['registrationProvider'] }) {
+  const [copyStatus, setCopyStatus] = useState<{ label: string; success: boolean } | null>(null);
+
+  async function copyValue(label: string, value: string) {
+    const result = await copyPublicText(value);
+    setCopyStatus({ label, success: result === 'copied' });
+  }
+
+  return (
+    <section className="app-card p-4">
+      <div className="text-sm font-black text-gray-950">Registration provider</div>
+      <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">This team syncs registrations from an external provider.</div>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        {rows.map((row) => (
+          <div key={row.label} className="rounded-xl border border-blue-100 bg-blue-50 p-3">
+            <div className="text-[11px] font-black uppercase tracking-[0.04em] text-blue-700">{row.label}</div>
+            <div className="mt-1 flex items-center justify-between gap-2">
+              <div className="min-w-0 break-all text-sm font-black text-gray-950">{row.value}</div>
+              {row.copyable ? (
+                <button
+                  type="button"
+                  className="flex-none rounded-lg border border-blue-200 bg-white px-2 py-1 text-[11px] font-black text-blue-700 hover:bg-blue-100"
+                  aria-label={`Copy ${row.label}`}
+                  onClick={() => void copyValue(row.label, row.value)}
+                >
+                  Copy
+                </button>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+      {copyStatus ? (
+        <div className={`mt-2 text-xs font-bold ${copyStatus.success ? 'text-emerald-700' : 'text-rose-700'}`}>
+          {copyStatus.success ? `${copyStatus.label} copied.` : `Unable to copy ${copyStatus.label}.`}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/paulsnider/allplays/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/paulsnider/allplays/node_modules

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -764,7 +764,7 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Tournament bracket')).toBeVisible();
         await expect(page.getByText('Open official bracket.')).toBeVisible();
         await expect(page.getByText('League page')).toBeVisible();
-        await expect(page.getByText('Sports Connect')).toBeVisible();
+        await expect(page.getByText('Sports Connect', { exact: true })).toBeVisible();
         await expect(page.getByText('Pizza Place')).toBeVisible();
         await page.getByRole('link', { name: /Watch stream/ }).click();
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://youtube.example.test/watch');

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -840,8 +840,8 @@ describe('React app team detail model', () => {
         expect(model.team.mediaUrl).toBe('https://allplays.ai/team-media.html#teamId=team%2Fwith+slash');
         expect(model.team.registrationProvider).toEqual([
             { label: 'Provider', value: 'League Apps' },
-            { label: 'Team ID', value: 'remote-team-1' },
-            { label: 'Last Sync', value: 'ok' }
+            { label: 'Provider team ID', value: 'remote-team-1', copyable: true },
+            { label: 'Last sync', value: 'ok' }
         ]);
         expect(model.players.map((player) => player.id)).toEqual(['player-2', 'player-10']);
         expect(model.linkedPlayers.map((player) => player.id)).toEqual(['player-2', 'player-10']);

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -841,7 +841,7 @@ describe('React app team detail model', () => {
         expect(model.team.registrationProvider).toEqual([
             { label: 'Provider', value: 'League Apps' },
             { label: 'Provider team ID', value: 'remote-team-1', copyable: true },
-            { label: 'Last sync', value: 'ok' }
+            { label: 'Last sync', value: 'Ok' }
         ]);
         expect(model.players.map((player) => player.id)).toEqual(['player-2', 'player-10']);
         expect(model.linkedPlayers.map((player) => player.id)).toEqual(['player-2', 'player-10']);


### PR DESCRIPTION
## Summary
- Removes the confusing bare `TEAM ID <firestore id>` box that rendered for every team on the app team page (More tab). `getRegistrationProviderDetails` no longer falls back to the internal app team id, so teams with no registration source render **no** card.
- When a provider IS configured, the card now shows an intro line ("This team syncs registrations from an external provider."), human labels ("Provider team ID", "External team ID", "Last sync"), and a copy-to-clipboard button on id values (reuses the existing `copyPublicText` helper).

## Root cause
`getRegistrationProviderDetails` in `apps/app/src/lib/teamDetailService.ts` used `source.teamId || teamId`, so the "Team ID" row always had a value (the internal Firestore id) even when `registrationSource`/`registrationProvider` was empty.

## Tests
- `teamDetailService.test.ts`: empty source → no rows; populated source → human-labeled rows with `copyable` flags.
- `TeamDetail.test.tsx`: card hidden with no provider; renders context + copies id via the copy button when configured.
- `apps/app` typecheck passes.

## Manual test steps
1. Open a team on the app More tab with no registration provider → no "Registration provider" card.
2. On a team with a configured provider → card shows the intro copy, human labels, and Copy buttons that copy the id values.

Fixes #3856

🤖 Generated with [Claude Code](https://claude.com/claude-code)