### PR TITLE
Paste/drop schedule image in Bulk AI Update (fixes #3859)

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -652,7 +652,7 @@
                                     <label class="block text-sm font-semibold text-gray-800 mb-1">
                                         Upload schedule image (optional)
                                     </label>
-                                    <p class="text-xs text-gray-600 mb-2">Screenshot or photo of the schedule. You can still add text instructions below to guide the AI (e.g., “only home games”).</p>
+                                    <p class="text-xs text-gray-600 mb-2">Upload, paste (Ctrl/Cmd+V), or drop a screenshot or photo of the schedule. You can still add text instructions below to guide the AI (e.g., “only home games”).</p>
                                     <input type="file" id="schedule-image-input" accept="image/*"
                                         class="w-full text-sm text-gray-700 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
                                     <div id="schedule-image-preview" class="hidden mt-3">
@@ -4060,21 +4060,63 @@
         });
 
         // Image upload and preview handlers
+        function setBulkAiImage(file) {
+            if (!file || !file.type || !file.type.startsWith('image/')) return;
+            const imageInput = document.getElementById('schedule-image-input');
+            const dataTransfer = new DataTransfer();
+            dataTransfer.items.add(file);
+            imageInput.files = dataTransfer.files;
+            const reader = new FileReader();
+            reader.onload = (event) => {
+                document.getElementById('schedule-image-preview-img').src = event.target.result;
+                document.getElementById('schedule-image-preview').classList.remove('hidden');
+            };
+            reader.readAsDataURL(file);
+        }
+
         document.getElementById('schedule-image-input').addEventListener('change', (e) => {
             const file = e.target.files[0];
             if (file) {
-                const reader = new FileReader();
-                reader.onload = (event) => {
-                    document.getElementById('schedule-image-preview-img').src = event.target.result;
-                    document.getElementById('schedule-image-preview').classList.remove('hidden');
-                };
-                reader.readAsDataURL(file);
+                setBulkAiImage(file);
             }
         });
 
         document.getElementById('remove-schedule-image').addEventListener('click', () => {
             document.getElementById('schedule-image-input').value = '';
             document.getElementById('schedule-image-preview').classList.add('hidden');
+        });
+
+        // Paste or drop a schedule image anywhere on the Bulk AI tab
+        const bulkAiTabContent = document.getElementById('content-bulk-ai');
+        bulkAiTabContent.addEventListener('paste', (e) => {
+            const items = e.clipboardData && e.clipboardData.items;
+            if (!items) return;
+            for (const item of items) {
+                if (item.type && item.type.startsWith('image/')) {
+                    const file = item.getAsFile();
+                    if (file) {
+                        e.preventDefault();
+                        setBulkAiImage(file);
+                    }
+                    return;
+                }
+            }
+        });
+
+        bulkAiTabContent.addEventListener('dragover', (e) => {
+            if (e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files')) {
+                e.preventDefault();
+            }
+        });
+
+        bulkAiTabContent.addEventListener('drop', (e) => {
+            const files = e.dataTransfer && e.dataTransfer.files;
+            if (!files) return;
+            const file = Array.from(files).find((f) => f.type && f.type.startsWith('image/'));
+            if (file) {
+                e.preventDefault();
+                setBulkAiImage(file);
+            }
         });
 
         // Helper function to convert file to generative part for Gemini

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -4086,9 +4086,8 @@
             document.getElementById('schedule-image-preview').classList.add('hidden');
         });
 
-        // Paste or drop a schedule image anywhere on the Bulk AI tab
-        const bulkAiTabContent = document.getElementById('content-bulk-ai');
-        bulkAiTabContent.addEventListener('paste', (e) => {
+        function handleBulkAiImagePaste(e) {
+            if (bulkAiTabContent.classList.contains('hidden')) return;
             const items = e.clipboardData && e.clipboardData.items;
             if (!items) return;
             for (const item of items) {
@@ -4101,7 +4100,11 @@
                     return;
                 }
             }
-        });
+        }
+
+        // Paste or drop a schedule image anywhere while the Bulk AI tab is active
+        const bulkAiTabContent = document.getElementById('content-bulk-ai');
+        document.addEventListener('paste', handleBulkAiImagePaste);
 
         bulkAiTabContent.addEventListener('dragover', (e) => {
             if (e.dataTransfer && Array.from(e.dataTransfer.types).includes('Files')) {

--- a/tests/unit/edit-schedule-bulk-ai-image-paste.test.js
+++ b/tests/unit/edit-schedule-bulk-ai-image-paste.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readEditSchedule() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
+describe('edit schedule bulk AI image paste wiring', () => {
+    it('defines a shared setBulkAiImage helper that feeds the file input and preview', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('function setBulkAiImage(file)');
+        expect(source).toContain('new DataTransfer()');
+        expect(source).toContain('imageInput.files = dataTransfer.files');
+        expect(source).toContain("startsWith('image/')");
+        expect(source).toContain('schedule-image-preview-img');
+    });
+
+    it('routes the file input change handler through setBulkAiImage', () => {
+        const source = readEditSchedule();
+
+        const changeHandler = source.match(
+            /getElementById\('schedule-image-input'\)\.addEventListener\('change'[\s\S]*?\}\);/
+        );
+        expect(changeHandler).not.toBeNull();
+        expect(changeHandler[0]).toContain('setBulkAiImage(file)');
+    });
+
+    it('wires a paste listener on the Bulk AI tab that consumes clipboard images', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain("getElementById('content-bulk-ai')");
+        const pasteHandler = source.match(
+            /bulkAiTabContent\.addEventListener\('paste'[\s\S]*?\n {8}\}\);/
+        );
+        expect(pasteHandler).not.toBeNull();
+        expect(pasteHandler[0]).toContain('clipboardData');
+        expect(pasteHandler[0]).toContain('getAsFile()');
+        expect(pasteHandler[0]).toContain('setBulkAiImage(file)');
+        // Only prevent default once an image file is actually consumed,
+        // so plain text paste into the textarea keeps working.
+        expect(pasteHandler[0]).toMatch(/if \(file\) \{\s*e\.preventDefault\(\);\s*setBulkAiImage\(file\);/);
+    });
+
+    it('supports dropping an image onto the Bulk AI tab', () => {
+        const source = readEditSchedule();
+
+        const dropHandler = source.match(
+            /bulkAiTabContent\.addEventListener\('drop'[\s\S]*?\n {8}\}\);/
+        );
+        expect(dropHandler).not.toBeNull();
+        expect(dropHandler[0]).toContain('dataTransfer');
+        expect(dropHandler[0]).toContain('setBulkAiImage(file)');
+        expect(source).toContain("bulkAiTabContent.addEventListener('dragover'");
+    });
+
+    it('mentions paste and drop in the helper copy', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('Upload, paste (Ctrl/Cmd+V), or drop a screenshot');
+    });
+});

--- a/tests/unit/edit-schedule-bulk-ai-image-paste.test.js
+++ b/tests/unit/edit-schedule-bulk-ai-image-paste.test.js
@@ -26,14 +26,16 @@ describe('edit schedule bulk AI image paste wiring', () => {
         expect(changeHandler[0]).toContain('setBulkAiImage(file)');
     });
 
-    it('wires a paste listener on the Bulk AI tab that consumes clipboard images', () => {
+    it('wires a document paste listener that consumes clipboard images while Bulk AI is active', () => {
         const source = readEditSchedule();
 
         expect(source).toContain("getElementById('content-bulk-ai')");
         const pasteHandler = source.match(
-            /bulkAiTabContent\.addEventListener\('paste'[\s\S]*?\n {8}\}\);/
+            /function handleBulkAiImagePaste\(e\) \{[\s\S]*?\n {8}\}/
         );
         expect(pasteHandler).not.toBeNull();
+        expect(source).toContain("document.addEventListener('paste', handleBulkAiImagePaste)");
+        expect(pasteHandler[0]).toContain("bulkAiTabContent.classList.contains('hidden')");
         expect(pasteHandler[0]).toContain('clipboardData');
         expect(pasteHandler[0]).toContain('getAsFile()');
         expect(pasteHandler[0]).toContain('setBulkAiImage(file)');


### PR DESCRIPTION
## Summary
- Adds clipboard **paste** (Ctrl/Cmd+V) and **drag-and-drop** support for the schedule image on the edit-schedule Bulk AI Update tab. Previously the only way to attach an image was the file picker.
- Extracts the file-input preview logic into a shared `setBulkAiImage(file)` helper so file-picker, paste, and drop all funnel through one path (it stuffs the `File` into the existing `#schedule-image-input` via `DataTransfer`, so the downstream Process-with-AI handler needs no changes).
- Paste only calls `preventDefault()` when an actual image is on the clipboard, so plain-text paste into the textarea keeps working.

## Tests
- `tests/unit/edit-schedule-bulk-ai-image-paste.test.js` — asserts the shared helper, the change handler routing, the paste listener (consumes clipboard images, guards text paste), the drop/dragover wiring, and the updated copy. 5 tests pass.

## Manual test steps
1. Open edit-schedule.html → Bulk AI Update tab.
2. Copy a screenshot of a schedule, click the tab, press Cmd/Ctrl+V → preview appears.
3. Drag an image file onto the tab → preview appears.
4. Click "Process with AI" → uses the pasted/dropped image.

Fixes #3859

🤖 Generated with [Claude Code](https://claude.com/claude-code)