### PR TITLE
Fix Staff RSVP reminder 'Failed to fetch' via CORS allowlist (fixes #3864)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -58,6 +58,7 @@ const {
   validateRsvpTokenRedemption,
   buildRsvpTokenAuditPayload
 } = require('./rsvp-token-core.cjs');
+const { isAllowedPublicRsvpOrigin } = require('./public-rsvp-cors-core.cjs');
 const {
   normalizeText,
   resolveTeamEmailRecipients,
@@ -10557,18 +10558,8 @@ exports.notifyPracticePacketAssigned = functions.firestore
   });
 
 function writePublicRsvpCors(req, res) {
-  const allowedOrigins = new Set([
-    'https://allplays.ai',
-    'https://www.allplays.ai',
-    'https://game-flow-c6311.web.app',
-    'https://game-flow-c6311.firebaseapp.com',
-    'http://localhost:8000',
-    'http://127.0.0.1:8000',
-    'http://localhost:8004',
-    'http://127.0.0.1:8004'
-  ]);
   const origin = req.headers.origin;
-  if (allowedOrigins.has(origin)) {
+  if (isAllowedPublicRsvpOrigin(origin)) {
     res.set('Access-Control-Allow-Origin', origin);
     res.set('Vary', 'Origin');
   }

--- a/functions/public-rsvp-cors-core.cjs
+++ b/functions/public-rsvp-cors-core.cjs
@@ -1,0 +1,32 @@
+'use strict';
+
+// Origins allowed to call the public RSVP HTTPS functions with credentials.
+// Requests are additionally gated by a bearer ID token + team-permission check,
+// so dev/preview origins are safe to allow here — the CORS list only decides
+// which browsers may read the response, not who is authorized.
+const STATIC_ALLOWED_ORIGINS = new Set([
+  'https://allplays.ai',
+  'https://www.allplays.ai',
+  'https://game-flow-c6311.web.app',
+  'https://game-flow-c6311.firebaseapp.com',
+  'http://localhost:8000',
+  'http://127.0.0.1:8000',
+  'http://localhost:8004',
+  'http://127.0.0.1:8004'
+]);
+
+// Local dev servers (static site + Vite app) on localhost / loopback, any port.
+const LOCALHOST_ORIGIN = /^http:\/\/(localhost|127\.0\.0\.1):\d{1,5}$/;
+
+// Firebase Hosting preview channels: https://game-flow-c6311--<channel>.web.app
+const PREVIEW_CHANNEL_ORIGIN = /^https:\/\/game-flow-c6311--[a-z0-9-]+\.web\.app$/;
+
+function isAllowedPublicRsvpOrigin(origin) {
+  if (typeof origin !== 'string' || !origin) return false;
+  if (STATIC_ALLOWED_ORIGINS.has(origin)) return true;
+  if (LOCALHOST_ORIGIN.test(origin)) return true;
+  if (PREVIEW_CHANNEL_ORIGIN.test(origin)) return true;
+  return false;
+}
+
+module.exports = { isAllowedPublicRsvpOrigin };

--- a/functions/test/public-rsvp-cors-core.test.cjs
+++ b/functions/test/public-rsvp-cors-core.test.cjs
@@ -1,0 +1,40 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { isAllowedPublicRsvpOrigin } = require('../public-rsvp-cors-core.cjs');
+
+test('public RSVP CORS allows production origins', () => {
+  assert.equal(isAllowedPublicRsvpOrigin('https://allplays.ai'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('https://www.allplays.ai'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('https://game-flow-c6311.web.app'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('https://game-flow-c6311.firebaseapp.com'), true);
+});
+
+test('public RSVP CORS allows localhost dev server ports', () => {
+  assert.equal(isAllowedPublicRsvpOrigin('http://localhost:8000'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://127.0.0.1:8000'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://localhost:8004'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://127.0.0.1:8004'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://localhost:5173'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://localhost:5174'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://localhost:5175'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://127.0.0.1:5174'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('http://127.0.0.1:5175'), true);
+});
+
+test('public RSVP CORS allows Firebase preview channel origins', () => {
+  assert.equal(isAllowedPublicRsvpOrigin('https://game-flow-c6311--pr-3864-abc123.web.app'), true);
+  assert.equal(isAllowedPublicRsvpOrigin('https://game-flow-c6311--feature-x.web.app'), true);
+});
+
+test('public RSVP CORS rejects everything else', () => {
+  assert.equal(isAllowedPublicRsvpOrigin('https://evil.example'), false);
+  assert.equal(isAllowedPublicRsvpOrigin('https://game-flow-c6311--x.web.app.evil.com'), false);
+  assert.equal(isAllowedPublicRsvpOrigin('http://allplays.ai'), false);
+  assert.equal(isAllowedPublicRsvpOrigin('https://localhost:5174'), false);
+  assert.equal(isAllowedPublicRsvpOrigin('http://localhost:5174.evil.com'), false);
+  assert.equal(isAllowedPublicRsvpOrigin('http://localhost'), false);
+  assert.equal(isAllowedPublicRsvpOrigin('https://game-flow-c6311--.web.app'), false);
+  assert.equal(isAllowedPublicRsvpOrigin(''), false);
+  assert.equal(isAllowedPublicRsvpOrigin(undefined), false);
+  assert.equal(isAllowedPublicRsvpOrigin(null), false);
+});

--- a/functions/test/public-rsvp-cors-core.test.cjs
+++ b/functions/test/public-rsvp-cors-core.test.cjs
@@ -27,6 +27,7 @@ test('public RSVP CORS allows Firebase preview channel origins', () => {
 });
 
 test('public RSVP CORS rejects everything else', () => {
+  assert.equal(isAllowedPublicRsvpOrigin('*'), false);
   assert.equal(isAllowedPublicRsvpOrigin('https://evil.example'), false);
   assert.equal(isAllowedPublicRsvpOrigin('https://game-flow-c6311--x.web.app.evil.com'), false);
   assert.equal(isAllowedPublicRsvpOrigin('http://allplays.ai'), false);

--- a/js/schedule-notifications.js
+++ b/js/schedule-notifications.js
@@ -331,20 +331,27 @@ export async function sendPublicRsvpReminderEmails({
     }
 
     const token = await user.getIdToken();
-    const response = await fetch(`${getFunctionsBaseUrl(auth)}/sendPublicRsvpEmails`, {
-        method: 'POST',
-        headers: {
-            'Authorization': `Bearer ${token}`,
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            teamId,
-            gameId,
-            eventType,
-            eventTitle,
-            eventDate: eventDate instanceof Date ? eventDate.toISOString() : eventDate || null
-        })
-    });
+    let response;
+    try {
+        response = await fetch(`${getFunctionsBaseUrl(auth)}/sendPublicRsvpEmails`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `Bearer ${token}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                teamId,
+                gameId,
+                eventType,
+                eventTitle,
+                eventDate: eventDate instanceof Date ? eventDate.toISOString() : eventDate || null
+            })
+        });
+    } catch (networkError) {
+        // A blocked CORS request or offline network surfaces as a bare
+        // TypeError: Failed to fetch. Give the coach something actionable.
+        throw new Error('Could not reach the reminder service. Check your connection and try again.');
+    }
 
     const payload = await response.json().catch(() => ({}));
     if (!response.ok || payload.ok === false) {

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/paulsnider/allplays/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/paulsnider/allplays/node_modules

--- a/tests/unit/public-rsvp-cors-origins.test.js
+++ b/tests/unit/public-rsvp-cors-origins.test.js
@@ -1,37 +1,38 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 
-const source = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
-
-function extractAllowedOrigins(functionsSource) {
-    const start = functionsSource.indexOf('function writePublicRsvpCors(');
-    expect(start, 'Expected writePublicRsvpCors to exist in functions/index.js').toBeGreaterThanOrEqual(0);
-
-    const setStart = functionsSource.indexOf('new Set([', start);
-    expect(setStart, 'Expected an allowedOrigins Set literal in writePublicRsvpCors').toBeGreaterThan(start);
-    const setEnd = functionsSource.indexOf('])', setStart);
-    expect(setEnd, 'Expected closing ]) for the allowedOrigins Set literal').toBeGreaterThan(setStart);
-
-    const literal = functionsSource.slice(setStart + 'new Set(['.length, setEnd);
-    return literal
-        .split(',')
-        .map((entry) => entry.trim().replace(/^['"]|['"]$/g, ''))
-        .filter(Boolean);
-}
+const require = createRequire(import.meta.url);
+const functionsSource = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
+const corsCoreSource = readFileSync(resolve(process.cwd(), 'functions/public-rsvp-cors-core.cjs'), 'utf8');
+const { isAllowedPublicRsvpOrigin } = require(resolve(process.cwd(), 'functions/public-rsvp-cors-core.cjs'));
 
 describe('public RSVP CORS origins', () => {
-    const origins = extractAllowedOrigins(source);
+    it('keeps the HTTPS function wrapper delegated to the shared origin allowlist', () => {
+        expect(functionsSource).toContain("require('./public-rsvp-cors-core.cjs')");
+        expect(functionsSource).toContain('function writePublicRsvpCors(req, res)');
+        expect(functionsSource).toContain('isAllowedPublicRsvpOrigin(origin)');
+    });
 
     it('allows the production domains and Firebase Hosting default domains', () => {
-        expect(origins).toContain('https://allplays.ai');
-        expect(origins).toContain('https://www.allplays.ai');
-        expect(origins).toContain('https://game-flow-c6311.web.app');
-        expect(origins).toContain('https://game-flow-c6311.firebaseapp.com');
+        expect(isAllowedPublicRsvpOrigin('https://allplays.ai')).toBe(true);
+        expect(isAllowedPublicRsvpOrigin('https://www.allplays.ai')).toBe(true);
+        expect(isAllowedPublicRsvpOrigin('https://game-flow-c6311.web.app')).toBe(true);
+        expect(isAllowedPublicRsvpOrigin('https://game-flow-c6311.firebaseapp.com')).toBe(true);
+    });
+
+    it('allows expected dev and Firebase preview origins without widening to lookalikes', () => {
+        expect(isAllowedPublicRsvpOrigin('http://localhost:5174')).toBe(true);
+        expect(isAllowedPublicRsvpOrigin('http://127.0.0.1:5174')).toBe(true);
+        expect(isAllowedPublicRsvpOrigin('https://game-flow-c6311--pr-3864-abc123.web.app')).toBe(true);
+        expect(isAllowedPublicRsvpOrigin('https://game-flow-c6311--x.web.app.evil.com')).toBe(false);
+        expect(isAllowedPublicRsvpOrigin('http://localhost:5174.evil.com')).toBe(false);
     });
 
     it('no longer allows the retired GitHub Pages origin', () => {
-        expect(origins).not.toContain('https://pauljsnider.github.io');
-        expect(source).not.toContain('pauljsnider.github.io');
+        expect(isAllowedPublicRsvpOrigin('https://pauljsnider.github.io')).toBe(false);
+        expect(functionsSource).not.toContain('pauljsnider.github.io');
+        expect(corsCoreSource).not.toContain('pauljsnider.github.io');
     });
 });

--- a/tests/unit/public-rsvp-cors-origins.test.js
+++ b/tests/unit/public-rsvp-cors-origins.test.js
@@ -8,11 +8,24 @@ const functionsSource = readFileSync(resolve(process.cwd(), 'functions/index.js'
 const corsCoreSource = readFileSync(resolve(process.cwd(), 'functions/public-rsvp-cors-core.cjs'), 'utf8');
 const { isAllowedPublicRsvpOrigin } = require(resolve(process.cwd(), 'functions/public-rsvp-cors-core.cjs'));
 
+function extractPublicRsvpCorsWrapper(functionsFileSource) {
+    const start = functionsFileSource.indexOf('function writePublicRsvpCors(req, res)');
+    expect(start, 'Expected writePublicRsvpCors to exist in functions/index.js').toBeGreaterThanOrEqual(0);
+
+    const end = functionsFileSource.indexOf('\nfunction publicRsvpJsonError', start);
+    expect(end, 'Expected writePublicRsvpCors to end before publicRsvpJsonError').toBeGreaterThan(start);
+    return functionsFileSource.slice(start, end);
+}
+
 describe('public RSVP CORS origins', () => {
     it('keeps the HTTPS function wrapper delegated to the shared origin allowlist', () => {
+        const publicRsvpCorsWrapper = extractPublicRsvpCorsWrapper(functionsSource);
+
         expect(functionsSource).toContain("require('./public-rsvp-cors-core.cjs')");
-        expect(functionsSource).toContain('function writePublicRsvpCors(req, res)');
-        expect(functionsSource).toContain('isAllowedPublicRsvpOrigin(origin)');
+        expect(publicRsvpCorsWrapper).toContain('function writePublicRsvpCors(req, res)');
+        expect(publicRsvpCorsWrapper).toContain('isAllowedPublicRsvpOrigin(origin)');
+        expect(publicRsvpCorsWrapper).not.toContain("Access-Control-Allow-Origin', '*'");
+        expect(corsCoreSource).not.toContain("Access-Control-Allow-Origin': '*'");
     });
 
     it('allows the production domains and Firebase Hosting default domains', () => {
@@ -26,6 +39,7 @@ describe('public RSVP CORS origins', () => {
         expect(isAllowedPublicRsvpOrigin('http://localhost:5174')).toBe(true);
         expect(isAllowedPublicRsvpOrigin('http://127.0.0.1:5174')).toBe(true);
         expect(isAllowedPublicRsvpOrigin('https://game-flow-c6311--pr-3864-abc123.web.app')).toBe(true);
+        expect(isAllowedPublicRsvpOrigin('*')).toBe(false);
         expect(isAllowedPublicRsvpOrigin('https://game-flow-c6311--x.web.app.evil.com')).toBe(false);
         expect(isAllowedPublicRsvpOrigin('http://localhost:5174.evil.com')).toBe(false);
     });

--- a/tests/unit/schedule-notifications.test.js
+++ b/tests/unit/schedule-notifications.test.js
@@ -341,6 +341,28 @@ describe('schedule notification helpers', () => {
         vi.unstubAllGlobals();
     });
 
+    it('maps network fetch failures to an actionable reminder service error', async () => {
+        const fetchMock = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+        vi.stubGlobal('fetch', fetchMock);
+        vi.stubGlobal('window', { __ALLPLAYS_CONFIG__: { functionsBaseUrl: 'https://functions.example.test/' } });
+
+        const auth = {
+            currentUser: { getIdToken: vi.fn().mockResolvedValue('id-token') },
+            app: { options: { projectId: 'demo-project' } }
+        };
+
+        await expect(sendPublicRsvpReminderEmails({
+            auth,
+            teamId: 'team-1',
+            gameId: 'game-1',
+            eventType: 'game',
+            eventTitle: 'vs. Wildcats',
+            eventDate: new Date('2026-05-11T18:30:00.000Z')
+        })).rejects.toThrow('Could not reach the reminder service. Check your connection and try again.');
+
+        vi.unstubAllGlobals();
+    });
+
     it('builds parent email preview for no-response players', () => {
         const preview = buildAvailabilityReminderEmailPreview([
             { id: 'p1', name: 'A', parents: [{ userId: 'u1', email: 'one@example.com' }] },


### PR DESCRIPTION
## Summary
Sending a Staff RSVP reminder from the app failed with a bare `Failed to fetch`. The `sendPublicRsvpEmails` Cloud Function's CORS allowlist only included prod + a couple static localhost ports, so requests from the Vite dev server (`localhost:5174/5175`) and Firebase preview channels were blocked at preflight.

- New `functions/public-rsvp-cors-core.cjs` exports `isAllowedPublicRsvpOrigin(origin)` — a testable predicate allowing the existing static prod origins, `http://localhost|127.0.0.1:<port>` (dev), and `https://game-flow-c6311--<channel>.web.app` (preview). Requests are still gated by a bearer ID token + team-permission check, so widening CORS does not widen authorization.
- `writePublicRsvpCors` in `functions/index.js` now uses the predicate.
- `js/schedule-notifications.js` maps a network/CORS `TypeError` to "Could not reach the reminder service. Check your connection and try again." instead of a bare fetch error.

## Tests
- `functions/test/public-rsvp-cors-core.test.cjs` (node:test): allows prod/localhost/preview origins; rejects spoofed lookalikes (`…web.app.evil.com`, `localhost.evil.com`, empty channel, non-https). 4 tests pass.
- `tests/unit/schedule-notifications.test.js`: network fetch failure → actionable error. 17 tests pass.

## Deploy note
The functions change requires deploy to take effect: `firebase deploy --only functions:sendPublicRsvpEmails,functions:getPublicRsvp` (writePublicRsvpCors is shared by the public RSVP endpoints).

## Manual test steps
1. `npm run app:dev` (localhost:5174/5175), open an event as staff, Send reminder → succeeds (after deploy).
2. Repeat from a PR preview URL → succeeds.

Fixes #3864

🤖 Generated with [Claude Code](https://claude.com/claude-code)