### PR TITLE
Brand and throttle-guard verification resend (fixes #3858)

### DIFF
--- a/apps/app/node_modules
+++ b/apps/app/node_modules
@@ -1,0 +1,1 @@
+/Users/paulsnider/allplays/apps/app/node_modules

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -105,12 +105,15 @@ import {
   signInWithRedirect
 } from './firebaseAuthRuntime';
 import { Capacitor } from '@capacitor/core';
+import { sendEmailVerification } from './firebaseAuthRuntime';
 import {
+  buildVerificationContinueUrl,
   describeAuthError,
   getRouteForUser,
   hydrateFirebaseUser,
   isValidAuthEmail,
   observeFirebaseUser,
+  resendVerificationEmail,
   sendResetEmail,
   signInWithEmail,
   signInWithGoogleAccount,
@@ -133,6 +136,43 @@ describe('auth email validation', () => {
 
   it('does not disclose whether a sign-in email belongs to an account', () => {
     expect(describeAuthError({ code: 'auth/user-not-found' })).toBe('Email or password is incorrect.');
+  });
+
+  it('maps REST too-many-attempts responses to the throttle message', () => {
+    expect(describeAuthError({ restCode: 'TOO_MANY_ATTEMPTS_TRY_LATER' }))
+      .toBe('Too many attempts. Wait a few minutes and try again.');
+    expect(describeAuthError({ code: 'auth/too-many-requests' }))
+      .toBe('Too many attempts. Wait a few minutes and try again.');
+  });
+});
+
+describe('resendVerificationEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.currentUser = null;
+  });
+
+  afterEach(() => {
+    authState.currentUser = null;
+  });
+
+  it('builds an in-app verify-pending continue URL', () => {
+    expect(buildVerificationContinueUrl()).toContain('/app/#/verify-pending');
+  });
+
+  it('sends the verification email with actionCodeSettings that return to the app', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    authState.currentUser = { reload, email: 'coach@allplays.ai' } as any;
+
+    await resendVerificationEmail();
+
+    expect(reload).toHaveBeenCalled();
+    expect(vi.mocked(sendEmailVerification)).toHaveBeenCalledTimes(1);
+    const [, actionCodeSettings] = vi.mocked(sendEmailVerification).mock.calls[0];
+    expect(actionCodeSettings).toMatchObject({
+      url: buildVerificationContinueUrl(),
+      handleCodeInApp: false
+    });
   });
 });
 

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -230,8 +230,8 @@ export function describeAuthError(error: any) {
     return 'Enter a valid email address.';
   }
 
-  if (code === 'auth/too-many-requests') {
-    return 'Too many attempts. Wait a bit and try again.';
+  if (code === 'auth/too-many-requests' || message.includes('TOO_MANY_ATTEMPTS_TRY_LATER')) {
+    return 'Too many attempts. Wait a few minutes and try again.';
   }
 
   if (code === 'auth/network-request-failed') {
@@ -1215,14 +1215,26 @@ export async function sendResetEmail(email: string) {
   }
 }
 
+// Continue URL the verification email returns to. Points back into the app's
+// verify-pending route so the user lands on our branded "check your email"
+// screen instead of Firebase's default hosted handler.
+export function buildVerificationContinueUrl() {
+  const base = (typeof window !== 'undefined' && /^https?:$/i.test(window.location.protocol))
+    ? window.location.origin
+    : 'https://allplays.ai';
+  return `${base}/app/#/verify-pending`;
+}
+
 export async function resendVerificationEmail() {
+  const actionCodeSettings = { url: buildVerificationContinueUrl(), handleCodeInApp: false };
   const user = getCurrentFirebaseUser();
   if (!user) {
     const idToken = await getNativeAuthIdToken();
     if (idToken) {
       await callFirebaseAuthRest('accounts:sendOobCode', {
         requestType: 'VERIFY_EMAIL',
-        idToken
+        idToken,
+        continueUrl: actionCodeSettings.url
       });
       return;
     }
@@ -1232,7 +1244,7 @@ export async function resendVerificationEmail() {
   if (typeof user.reload === 'function') {
     await user.reload();
   }
-  await sendEmailVerification(user);
+  await sendEmailVerification(user, actionCodeSettings);
 }
 
 async function refreshNativeFallbackVerification() {

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -136,6 +136,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [busy, setBusy] = useState('');
   const [profileStatus, setProfileStatus] = useState<Status | null>(null);
   const [verificationStatus, setVerificationStatus] = useState<Status | null>(null);
+  const [resendCooldown, setResendCooldown] = useState(0);
   const [notificationStatus, setNotificationStatus] = useState<Status | null>(null);
   const [notificationTeamsError, setNotificationTeamsError] = useState('');
   const [notificationPreferenceErrorsByTeamId, setNotificationPreferenceErrorsByTeamId] = useState<Record<string, string>>({});
@@ -824,13 +825,24 @@ export function Profile({ auth }: { auth: AuthState }) {
     }
   };
 
+  useEffect(() => {
+    if (resendCooldown <= 0) return;
+    const timer = setTimeout(() => setResendCooldown((seconds) => Math.max(0, seconds - 1)), 1000);
+    return () => clearTimeout(timer);
+  }, [resendCooldown]);
+
   const resendVerification = async () => {
+    if (resendCooldown > 0) return;
     setBusy('verification');
     setVerificationStatus(null);
 
     try {
       await resendVerificationEmail();
-      setVerificationStatus({ message: 'Verification email sent. Check your inbox.', tone: 'success' });
+      setVerificationStatus({
+        message: `Verification email sent to ${user?.email || 'your inbox'}. It can take a couple of minutes — check spam too.`,
+        tone: 'success'
+      });
+      setResendCooldown(60);
     } catch (error) {
       setVerificationStatus({ message: describeAuthError(error), tone: 'error' });
     } finally {
@@ -1574,9 +1586,9 @@ export function Profile({ auth }: { auth: AuthState }) {
           </div>
           <div className="mt-3 flex flex-wrap gap-2">
             {!user.emailVerified ? (
-              <button type="button" className="secondary-button" onClick={resendVerification} disabled={busy === 'verification'}>
+              <button type="button" className="secondary-button" onClick={resendVerification} disabled={busy === 'verification' || resendCooldown > 0}>
                 {busy === 'verification' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Send className="h-4 w-4" aria-hidden="true" />}
-                Resend email
+                {resendCooldown > 0 ? `Resend in ${resendCooldown}s` : 'Resend email'}
               </button>
             ) : null}
             <button type="button" className="ghost-button" onClick={refreshVerification} disabled={busy === 'refresh-verification'}>

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/paulsnider/allplays/node_modules


### PR DESCRIPTION
## Summary
"Resend email" reported success but the verification email often never arrived. `resendVerificationEmail` called Firebase `sendEmailVerification(user)` with no `actionCodeSettings` (default hosted handler, default sender) and the UI reported success optimistically, hiding throttling.

- `resendVerificationEmail` now passes `actionCodeSettings` with a continue URL back into the app's `verify-pending` route (`buildVerificationContinueUrl()`), on both the web SDK path and the native `accounts:sendOobCode` REST path (`continueUrl`).
- `describeAuthError` maps the REST `TOO_MANY_ATTEMPTS_TRY_LATER` response to the throttle message (already handled `auth/too-many-requests`).
- Profile: 60-second resend cooldown ("Resend in Ns") and clearer sent copy naming the address and mentioning spam + delivery delay.

Deliverability note (not code): the default Firebase sender is a common spam-folder cause. Recommend configuring a custom action-link domain + sender (SPF/DKIM) in the Firebase Console for the project; longer term the verification link could be sent via the existing functions mailer for branding parity. Called out in the issue.

## Tests
- `authService.test.ts`: continue URL contains `/app/#/verify-pending`; `sendEmailVerification` receives `actionCodeSettings` `{ url, handleCodeInApp: false }`; REST too-many-attempts maps to the throttle copy. 23 tests pass.
- `apps/app` typecheck passes.

## Manual test steps
1. Sign in with an unverified account, open Profile → Account settings.
2. Click Resend → success copy names your email; button shows "Resend in 60s" and disables.
3. Confirm the email arrives (check spam); the link returns to the app verify-pending screen.

Fixes #3858

🤖 Generated with [Claude Code](https://claude.com/claude-code)