### PR TITLE
Show linked parents on roster for coaches (fixes #3865)

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -566,6 +566,7 @@
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, hasConfiguredRegistrationProviderMetadata, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=2';
         import { buildRegistrationReviewCsv, buildRegistrationReviewCsvFilename, getDefaultRegistrationReviewCsvColumnKeys, getRegistrationReviewCsvColumnDefinitions, matchesRegistrationReviewScreeningStatus, summarizeRegistrationReviewScreening } from './js/registration-review.js?v=6';
         import { buildRosterPrintHtml } from './js/roster-print.js?v=2';
+        import { buildLinkedParentContacts } from './js/roster-parent-contacts.js?v=1';
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
@@ -1563,6 +1564,19 @@
                     });
                     parentsByPlayerId.set(link.playerId, existing);
                 });
+            });
+            // Team owners/admins cannot list the /users directory (getAllUsers is
+            // gated to global admins), so merge in the linked-parent accounts that
+            // live on each player doc — those are readable by team staff and are the
+            // reliable source of parent chips for coaches (#3865).
+            players.forEach((player) => {
+                if (!player?.id) return;
+                const merged = buildLinkedParentContacts(player, parentsByPlayerId.get(player.id) || []);
+                if (merged.length) {
+                    parentsByPlayerId.set(player.id, merged);
+                } else {
+                    parentsByPlayerId.delete(player.id);
+                }
             });
             const pendingRequestsByPlayerId = new Map();
             (membershipRequests || [])

--- a/js/roster-parent-contacts.js
+++ b/js/roster-parent-contacts.js
@@ -1,0 +1,65 @@
+// Build the list of linked parent/guardian accounts to show as roster chips for
+// a player. Team owners/admins cannot list the whole /users collection (that is
+// gated to global admins), so relying on getAllUsers() silently hid every chip
+// for regular coaches. The linked accounts are already stored on the player doc
+// (player.parents, written by the invite/link flow and readable by team staff),
+// so use those as the primary source and merge any user-directory links on top.
+
+function isHouseholdOrRemovedParent(parent) {
+    return Boolean(
+        parent?.source === 'household' ||
+        parent?.accessSource === 'household' ||
+        parent?.organizerUserId ||
+        parent?.invitedByUserId ||
+        parent?.inviterUserId ||
+        parent?.status === 'removed'
+    );
+}
+
+function normalizeParentContact(parent) {
+    const userId = String(parent?.userId || '').trim();
+    if (!userId) return null;
+    return {
+        userId,
+        email: String(parent?.email || '').trim() || 'Pending',
+        name: String(parent?.name || parent?.fullName || parent?.displayName || parent?.email || 'Parent').trim(),
+        relation: parent?.relation || null
+    };
+}
+
+/**
+ * @param {object} player - roster player doc (may include a `parents` array)
+ * @param {Array<{userId,email,name,relation}>} usersDerivedLinks - links derived
+ *        from the /users directory (only available to global admins).
+ * @returns {Array<{userId,email,name,relation}>} deduped linked parent accounts.
+ */
+export function buildLinkedParentContacts(player = {}, usersDerivedLinks = []) {
+    const byUserId = new Map();
+
+    // Directory-derived links first (richest data when available).
+    (Array.isArray(usersDerivedLinks) ? usersDerivedLinks : []).forEach((link) => {
+        const normalized = normalizeParentContact(link);
+        if (normalized) byUserId.set(normalized.userId, normalized);
+    });
+
+    // Player-doc linked accounts (readable by team staff) — excludes household
+    // delegated contacts and removed links, which are shown separately.
+    (Array.isArray(player?.parents) ? player.parents : [])
+        .filter((parent) => parent?.userId && !isHouseholdOrRemovedParent(parent))
+        .forEach((parent) => {
+            const normalized = normalizeParentContact(parent);
+            if (!normalized) return;
+            const existing = byUserId.get(normalized.userId);
+            if (existing) {
+                // Prefer a real email over a "Pending" placeholder from either source.
+                if ((!existing.email || existing.email === 'Pending') && normalized.email !== 'Pending') {
+                    existing.email = normalized.email;
+                }
+                if (!existing.relation && normalized.relation) existing.relation = normalized.relation;
+            } else {
+                byUserId.set(normalized.userId, normalized);
+            }
+        });
+
+    return [...byUserId.values()];
+}

--- a/tests/unit/roster-parent-contacts.test.js
+++ b/tests/unit/roster-parent-contacts.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { buildLinkedParentContacts } from '../../js/roster-parent-contacts.js';
+
+describe('buildLinkedParentContacts', () => {
+    it('builds chips from player.parents when the /users directory is unavailable', () => {
+        // Regression: coaches (non-global-admins) get [] from getAllUsers, so
+        // chips must come from the player doc's linked parent accounts.
+        const player = {
+            id: 'player-1',
+            parents: [
+                { userId: 'u-coach', email: 'coach@allplays.ai', relation: 'Father' },
+                { userId: 'u-dad', email: 'dad@allplays.ai', relation: 'Guardian' }
+            ]
+        };
+        const result = buildLinkedParentContacts(player, []);
+        expect(result.map((p) => p.email)).toEqual(['coach@allplays.ai', 'dad@allplays.ai']);
+        expect(result.map((p) => p.userId)).toEqual(['u-coach', 'u-dad']);
+    });
+
+    it('excludes household delegated and removed contacts', () => {
+        const player = {
+            parents: [
+                { userId: 'u-linked', email: 'linked@allplays.ai' },
+                { userId: 'u-household', email: 'gran@allplays.ai', source: 'household' },
+                { userId: 'u-removed', email: 'old@allplays.ai', status: 'removed' },
+                { userId: 'u-invited', email: 'inv@allplays.ai', invitedByUserId: 'u-organizer' }
+            ]
+        };
+        const result = buildLinkedParentContacts(player, []);
+        expect(result.map((p) => p.userId)).toEqual(['u-linked']);
+    });
+
+    it('dedupes directory links and player-doc links by userId, preferring a real email', () => {
+        const player = { parents: [{ userId: 'u-dad', email: 'dad@allplays.ai', relation: 'Dad' }] };
+        const usersDerived = [{ userId: 'u-dad', email: 'Pending', name: 'Parent', relation: null }];
+        const result = buildLinkedParentContacts(player, usersDerived);
+        expect(result).toHaveLength(1);
+        expect(result[0].email).toBe('dad@allplays.ai');
+        expect(result[0].relation).toBe('Dad');
+    });
+
+    it('ignores parent entries without a userId', () => {
+        const player = { parents: [{ email: 'no-account@allplays.ai' }] };
+        expect(buildLinkedParentContacts(player, [])).toEqual([]);
+    });
+});
+
+describe('edit-roster parent chip wiring', () => {
+    it('imports and uses buildLinkedParentContacts to source parent chips', () => {
+        const source = readFileSync(new URL('../../edit-roster.html', import.meta.url), 'utf8');
+        expect(source).toContain("import { buildLinkedParentContacts } from './js/roster-parent-contacts.js");
+        expect(source).toContain('buildLinkedParentContacts(player, parentsByPlayerId.get(player.id)');
+    });
+});


### PR DESCRIPTION
## Summary
On edit-roster.html, linked parents (e.g. coach@/dad@allplays.ai) didn't appear for team owners/admins. The page built parent chips from `getAllUsers()`, but Firestore rules gate listing `/users` to **global admins** (`isBoundedGlobalAdminListQuery() || isOwner`), so a regular coach got `permission-denied`, `loadOptionalRosterData` swallowed it, and every chip silently vanished.

The linked-parent accounts are already stored on the **player doc** (`player.parents`, written by the invite/link flow — `removeParentFromPlayer` filters it by `userId`) and are readable by team staff. This PR sources chips from there.

- New `js/roster-parent-contacts.js` → `buildLinkedParentContacts(player, usersDerivedLinks)`: merges directory links (when available to admins) with the player-doc linked accounts, excludes household/removed contacts, dedupes by `userId`, and prefers a real email over a "Pending" placeholder.
- `edit-roster.html` merges each player's linked accounts into `parentsByPlayerId` after the (best-effort) directory load, so chips and the print contact map both render for coaches. The remove-parent button still works (entries carry `userId`).

## Tests
- `tests/unit/roster-parent-contacts.test.js`: chips from `player.parents` with no directory access; household/removed excluded; dedupe preferring real email; entries without `userId` ignored; edit-roster wiring assertion. 5 pass. Existing roster-print tests still green.

## Follow-up
A fuller fix could denormalize on invite redemption + a `_migration` backfill and surface a visible "directory unavailable" note; noted in #3865. This change fixes the visible bug using data coaches can already read.

## Manual test steps
1. As a team owner/admin (not global admin), open edit-roster.html for a team with linked parents.
2. Players with linked parents now show parent email chips; removing a chip still works.

Fixes #3865

🤖 Generated with [Claude Code](https://claude.com/claude-code)