### PR TITLE
Capture optional player fields in AI roster import (fixes #3866)

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -566,6 +566,7 @@
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, hasConfiguredRegistrationProviderMetadata, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=2';
         import { buildRegistrationReviewCsv, buildRegistrationReviewCsvFilename, getDefaultRegistrationReviewCsvColumnKeys, getRegistrationReviewCsvColumnDefinitions, matchesRegistrationReviewScreeningStatus, summarizeRegistrationReviewScreening } from './js/registration-review.js?v=6';
         import { buildRosterPrintHtml } from './js/roster-print.js?v=2';
+        import { normalizePlayerCatalogFields, getPlayerCatalogFieldKeys } from './js/player-field-catalog.js?v=1';
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
@@ -2436,17 +2437,37 @@
                                     player: Schema.object({
                                         properties: {
                                             name: Schema.string(),
-                                            number: Schema.string()
+                                            number: Schema.string(),
+                                            preferredName: Schema.string(),
+                                            position: Schema.string(),
+                                            dob: Schema.string(),
+                                            gender: Schema.string(),
+                                            grade: Schema.string(),
+                                            school: Schema.string(),
+                                            jerseySize: Schema.string(),
+                                            dominantHand: Schema.string(),
+                                            dominantFoot: Schema.string(),
+                                            memberId: Schema.string()
                                         },
-                                        optionalProperties: ["number"]
+                                        optionalProperties: ["number", "preferredName", "position", "dob", "gender", "grade", "school", "jerseySize", "dominantHand", "dominantFoot", "memberId"]
                                     }),
                                     playerId: Schema.string(),
                                     changes: Schema.object({
                                         properties: {
                                             name: Schema.string(),
-                                            number: Schema.string()
+                                            number: Schema.string(),
+                                            preferredName: Schema.string(),
+                                            position: Schema.string(),
+                                            dob: Schema.string(),
+                                            gender: Schema.string(),
+                                            grade: Schema.string(),
+                                            school: Schema.string(),
+                                            jerseySize: Schema.string(),
+                                            dominantHand: Schema.string(),
+                                            dominantFoot: Schema.string(),
+                                            memberId: Schema.string()
                                         },
-                                        optionalProperties: ["name", "number"]
+                                        optionalProperties: ["name", "number", "preferredName", "position", "dob", "gender", "grade", "school", "jerseySize", "dominantHand", "dominantFoot", "memberId"]
                                     }),
                                     reason: Schema.string()
                                 },
@@ -2472,6 +2493,7 @@ PARSING RULES:
 6. Use action="update" with playerId and changes when an extracted player matches an existing player by the same number, same normalized name, or a likely name/number correction
 7. Use action="add" with player object only when no reasonable current player match exists
 8. Never add a second active player for a likely update to an existing player
+9. Capture these optional details when clearly present (leave out when unknown): preferredName, position, dob (as YYYY-MM-DD), gender, grade, school, jerseySize, dominantHand (left/right/both), dominantFoot (left/right/both), memberId. Do NOT extract parent/guardian contacts, phone numbers, emails, addresses, or medical info here.
 
 EXAMPLES:
 - "#10 John Smith" → if no current player matches, action: "add", player: { name: "John Smith", number: "10" }
@@ -2664,12 +2686,20 @@ EXAMPLES:
                         if (op.action === 'add') {
                             const playerData = {
                                 name: op.player.name,
-                                number: op.player.number || ''
+                                number: op.player.number || '',
+                                ...normalizePlayerCatalogFields(op.player)
                             };
                             await addPlayer(currentTeamId, playerData);
                             successCount++;
                         } else if (op.action === 'update') {
-                            await updatePlayer(currentTeamId, op.playerId, op.changes);
+                            const baseChanges = { ...op.changes };
+                            // Drop raw catalog values so only validated/normalized ones are written.
+                            getPlayerCatalogFieldKeys().forEach((key) => { delete baseChanges[key]; });
+                            const changes = {
+                                ...baseChanges,
+                                ...normalizePlayerCatalogFields(op.changes)
+                            };
+                            await updatePlayer(currentTeamId, op.playerId, changes);
                             successCount++;
                         } else if (op.action === 'delete') {
                             await deactivatePlayer(currentTeamId, op.playerId);

--- a/js/player-field-catalog.js
+++ b/js/player-field-catalog.js
@@ -1,0 +1,91 @@
+// Shared catalog of optional player profile fields, so the manual roster form,
+// CSV import, and AI roster import can all capture the same standard details
+// instead of just name + number (#3866).
+//
+// Only PUBLIC, non-sensitive fields belong here — these are safe to write to the
+// player doc. Contact/guardian/medical data is sensitive and must go to the
+// player's private profile subdocument (teams/{teamId}/players/{playerId}/private/profile),
+// never through this catalog. db.assertNoSensitivePlayerFields() enforces that.
+
+const HAND_FOOT_VALUES = new Set(['left', 'right', 'both']);
+
+function cleanText(value, maxLength = 120) {
+    return String(value ?? '').trim().slice(0, maxLength);
+}
+
+function normalizeDob(value) {
+    const text = cleanText(value, 10);
+    if (!text) return null;
+    // Accept ISO YYYY-MM-DD only; reject anything else so we never store garbage.
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(text);
+    if (!match) return null;
+    const [, y, m, d] = match;
+    const date = new Date(Number(y), Number(m) - 1, Number(d));
+    if (date.getFullYear() !== Number(y) || date.getMonth() !== Number(m) - 1 || date.getDate() !== Number(d)) {
+        return null;
+    }
+    return text;
+}
+
+function normalizeSide(value) {
+    const text = cleanText(value, 10).toLowerCase();
+    return HAND_FOOT_VALUES.has(text) ? text : null;
+}
+
+function normalizeHeightInches(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num) || num <= 0 || num > 96) return null;
+    return Math.round(num);
+}
+
+// key -> { label, storage: 'public', aliases, normalize }
+export const PLAYER_FIELD_CATALOG = [
+    { key: 'preferredName', label: 'Preferred name', aliases: ['nickname', 'preferred name'], normalize: (v) => cleanText(v) },
+    { key: 'position', label: 'Position', aliases: ['pos', 'positions'], normalize: (v) => cleanText(v, 60) },
+    { key: 'dob', label: 'Date of birth', aliases: ['dob', 'birthdate', 'date of birth', 'birthday'], normalize: normalizeDob },
+    { key: 'gender', label: 'Gender', aliases: ['sex'], normalize: (v) => cleanText(v, 32) },
+    { key: 'grade', label: 'Grade', aliases: ['grade level'], normalize: (v) => cleanText(v, 24) },
+    { key: 'school', label: 'School', aliases: ['school name'], normalize: (v) => cleanText(v) },
+    { key: 'jerseySize', label: 'Jersey size', aliases: ['jersey', 'shirt size', 'uniform size', 'size'], normalize: (v) => cleanText(v, 24) },
+    { key: 'dominantHand', label: 'Dominant hand', aliases: ['handedness', 'throws', 'bats'], normalize: normalizeSide },
+    { key: 'dominantFoot', label: 'Dominant foot', aliases: ['footedness', 'kicks'], normalize: normalizeSide },
+    { key: 'heightInches', label: 'Height (in)', aliases: ['height', 'height inches'], normalize: normalizeHeightInches },
+    { key: 'memberId', label: 'Association/member ID', aliases: ['member id', 'league id', 'aau', 'ussf id', 'usa hockey id'], normalize: (v) => cleanText(v, 60) }
+];
+
+const CATALOG_BY_KEY = new Map(PLAYER_FIELD_CATALOG.map((field) => [field.key, field]));
+const CATALOG_BY_ALIAS = new Map();
+PLAYER_FIELD_CATALOG.forEach((field) => {
+    CATALOG_BY_ALIAS.set(field.key.toLowerCase(), field);
+    CATALOG_BY_ALIAS.set(field.label.toLowerCase(), field);
+    field.aliases.forEach((alias) => CATALOG_BY_ALIAS.set(String(alias).toLowerCase(), field));
+});
+
+export function getPlayerCatalogFieldKeys() {
+    return PLAYER_FIELD_CATALOG.map((field) => field.key);
+}
+
+export function resolvePlayerCatalogField(keyOrLabel) {
+    const text = String(keyOrLabel || '').trim().toLowerCase();
+    return CATALOG_BY_KEY.get(keyOrLabel) || CATALOG_BY_ALIAS.get(text) || null;
+}
+
+/**
+ * Validate and normalize a raw object of optional player fields (from AI/CSV/form).
+ * Unknown keys are dropped; invalid values are dropped. Returns only the
+ * public catalog fields with non-empty normalized values — safe to spread onto
+ * an addPlayer/updatePlayer payload.
+ */
+export function normalizePlayerCatalogFields(raw = {}) {
+    const result = {};
+    if (!raw || typeof raw !== 'object') return result;
+    Object.keys(raw).forEach((rawKey) => {
+        const field = resolvePlayerCatalogField(rawKey);
+        if (!field) return;
+        const normalized = field.normalize(raw[rawKey]);
+        if (normalized !== null && normalized !== undefined && normalized !== '') {
+            result[field.key] = normalized;
+        }
+    });
+    return result;
+}

--- a/tests/unit/player-field-catalog.test.js
+++ b/tests/unit/player-field-catalog.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+    PLAYER_FIELD_CATALOG,
+    getPlayerCatalogFieldKeys,
+    normalizePlayerCatalogFields,
+    resolvePlayerCatalogField
+} from '../../js/player-field-catalog.js';
+
+const SENSITIVE_FORBIDDEN = [
+    'parents', 'parent', 'parentEmail', 'parentPhone', 'guardian', 'guardianEmail',
+    'contacts', 'contact', 'emergencyContact', 'medicalInfo', 'medicalNotes', 'address'
+];
+
+describe('player field catalog', () => {
+    it('contains only public non-sensitive keys', () => {
+        const keys = getPlayerCatalogFieldKeys();
+        SENSITIVE_FORBIDDEN.forEach((forbidden) => {
+            expect(keys).not.toContain(forbidden);
+        });
+        expect(keys).toContain('position');
+        expect(keys).toContain('dob');
+    });
+
+    it('resolves fields by key, label, and alias', () => {
+        expect(resolvePlayerCatalogField('position')?.key).toBe('position');
+        expect(resolvePlayerCatalogField('Date of birth')?.key).toBe('dob');
+        expect(resolvePlayerCatalogField('nickname')?.key).toBe('preferredName');
+        expect(resolvePlayerCatalogField('unknown-column')).toBeNull();
+    });
+});
+
+describe('normalizePlayerCatalogFields', () => {
+    it('keeps valid public fields and drops unknown keys', () => {
+        const result = normalizePlayerCatalogFields({
+            position: ' Point Guard ',
+            grade: '7',
+            somethingElse: 'ignored'
+        });
+        expect(result).toEqual({ position: 'Point Guard', grade: '7' });
+    });
+
+    it('validates dob as ISO YYYY-MM-DD and drops invalid dates', () => {
+        expect(normalizePlayerCatalogFields({ dob: '2015-03-09' })).toEqual({ dob: '2015-03-09' });
+        expect(normalizePlayerCatalogFields({ dob: '03/09/2015' })).toEqual({});
+        expect(normalizePlayerCatalogFields({ dob: '2015-13-40' })).toEqual({});
+    });
+
+    it('constrains dominant hand/foot to left/right/both', () => {
+        expect(normalizePlayerCatalogFields({ dominantHand: 'Left' })).toEqual({ dominantHand: 'left' });
+        expect(normalizePlayerCatalogFields({ dominantFoot: 'sideways' })).toEqual({});
+    });
+
+    it('never lets a sensitive contact key through', () => {
+        const result = normalizePlayerCatalogFields({
+            parentEmail: 'dad@allplays.ai',
+            medicalNotes: 'allergy',
+            position: 'Forward'
+        });
+        expect(result).toEqual({ position: 'Forward' });
+    });
+
+    it('drops empty values', () => {
+        expect(normalizePlayerCatalogFields({ position: '   ', school: '' })).toEqual({});
+    });
+});
+
+describe('edit-roster AI import wiring', () => {
+    const source = readFileSync(new URL('../../edit-roster.html', import.meta.url), 'utf8');
+
+    it('imports and applies the catalog in the AI import', () => {
+        expect(source).toContain("import { normalizePlayerCatalogFields, getPlayerCatalogFieldKeys } from './js/player-field-catalog.js");
+        expect(source).toContain('...normalizePlayerCatalogFields(op.player)');
+        expect(source).toContain('...normalizePlayerCatalogFields(op.changes)');
+    });
+
+    it('adds the string catalog fields to the AI response schema', () => {
+        // heightInches is numeric and intentionally not part of the string-only AI schema.
+        const schemaKeys = ['preferredName', 'position', 'dob', 'gender', 'grade', 'school', 'jerseySize', 'dominantHand', 'dominantFoot', 'memberId'];
+        schemaKeys.forEach((key) => {
+            expect(source).toContain(`${key}: Schema.string()`);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
Player intake captured only name + number in the AI roster import (and the manual form is nearly as thin), while the CSV importer already accepts richer columns — the three paths were inconsistent. This PR adds a **shared field catalog** and wires it into the AI import as the first increment.

### Research — fields worth capturing
Surveying youth-sports platforms (TeamSnap, SportsEngine, GameChanger, LeagueApps):
- **Public (safe on the player doc):** preferred name, position, DOB, gender, grade, school, jersey size, dominant hand/foot, height, association/member ID (AAU/USSF/USA Hockey, etc.).
- **Sensitive (must live in the private profile subdoc, NOT here):** parent/guardian contacts, emergency contact, address, allergies/medical, insurance, consents.

### Changes
- New `js/player-field-catalog.js`: `PLAYER_FIELD_CATALOG` (public fields only), `normalizePlayerCatalogFields(raw)` (validates — ISO dates, left/right/both for handedness, bounded height; drops unknown/invalid/sensitive keys), plus key/label/alias resolution shared across intake paths.
- AI roster import (`edit-roster.html`): response schema + prompt extended with the public optional fields; the prompt explicitly forbids extracting contacts/medical; add/update apply paths route values through `normalizePlayerCatalogFields` so only validated public data is written. `db.assertNoSensitivePlayerFields()` remains the backstop.

## Tests
- `tests/unit/player-field-catalog.test.js`: catalog has no sensitive keys; alias resolution; validation (dob ISO-only, handedness set, empties dropped); sensitive keys never pass; AI schema + apply wiring. 9 pass. Existing roster AI-import/profile tests green.

## Follow-up (noted in #3866)
- Extend the manual add/edit form with a collapsed "More details" section using the same catalog.
- Route AI/CSV-extracted guardian contacts to the private profile.
- Mirror the catalog in the React app roster.

## Manual test steps
1. edit-roster.html → AI import, paste e.g. `#10 Jane Doe, PG, DOB 2015-03-09, 7th grade`.
2. Apply → the player is created with position "PG", dob 2015-03-09, grade "7th" captured.

Fixes #3866

🤖 Generated with [Claude Code](https://claude.com/claude-code)