### PR TITLE
Fix auth email production deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -116,5 +116,8 @@ jobs:
           printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
 
+      - name: Enable password-reset retry policy
+        run: npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force
+
       - name: Deploy Firebase production
         run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -116,7 +116,22 @@ jobs:
           printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
 
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Check password-reset retry policy
+        id: password-reset-retry-policy
+        run: |
+          gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
+          retry_policy="$(gcloud functions describe processPasswordResetEmailRequest --region us-central1 --project game-flow-c6311 --format='value(eventTrigger.failurePolicy.retry)')"
+          if [ "$retry_policy" = "True" ] || [ "$retry_policy" = "true" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Enable password-reset retry policy
+        if: steps.password-reset-retry-policy.outputs.enabled != 'true'
         run: npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force
 
       - name: Deploy Firebase production

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -116,23 +116,39 @@ jobs:
           printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
 
-      - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Check password-reset retry policy
-        id: password-reset-retry-policy
+      - name: Enable password-reset retry policy
+        shell: bash
         run: |
-          gcloud auth activate-service-account --key-file="$GOOGLE_APPLICATION_CREDENTIALS"
-          retry_policy="$(gcloud functions describe processPasswordResetEmailRequest --region us-central1 --project game-flow-c6311 --format='value(eventTrigger.failurePolicy.retry)')"
-          if [ "$retry_policy" = "True" ] || [ "$retry_policy" = "true" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if ! jq -e '.functions == {"source":"functions"}' "$FIREBASE_PROD_CONFIG" >/dev/null; then
+            echo "Refusing retry-policy migration for an unexpected Functions deploy source." >&2
+            exit 1
           fi
 
-      - name: Enable password-reset retry policy
-        if: steps.password-reset-retry-policy.outputs.enabled != 'true'
-        run: npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force
+          expected_functions_hash="102aad7b6547759d0fa8e5c85d06d2a704cd3768690ce889649efb34600b56a8"
+          functions_hash="$(git ls-files -z functions | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)"
+          retry_status="$({
+            npx firebase-tools@14.25.0 functions:list --project game-flow-c6311 --json
+          } | jq -er '
+            [.result[] | select(
+              .id == "processPasswordResetEmailRequest" and
+              .region == "us-central1"
+            )] |
+            if length == 0 then "missing"
+            elif length > 1 then error("duplicate password-reset workers")
+            elif .[0].eventTrigger.retry == true then "enabled"
+            else "disabled"
+            end
+          ')"
+
+          if [[ "$retry_status" == "enabled" ]]; then
+            echo "Password-reset retry policy is already enabled."
+          elif [[ "$functions_hash" == "$expected_functions_hash" ]]; then
+            npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force
+          else
+            echo "Refusing forced retry-policy migration for unreviewed Functions source." >&2
+            exit 1
+          fi
 
       - name: Deploy Firebase production
         run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -85,13 +85,18 @@ describe('authentication email delivery routing', () => {
         }
     });
 
-    it('enables the password-reset retry policy before the non-destructive production deploy', () => {
+    it('enables the password-reset retry policy only when production still needs the migration', () => {
         const productionSource = read('.github/workflows/deploy-prod.yml');
         const firebaseDeployCommands = productionSource
             .split('\n')
             .map(line => line.trim())
             .filter(line => line.startsWith('run: npx firebase-tools@14.25.0 deploy'));
 
+        expect(productionSource).toContain('id: password-reset-retry-policy');
+        expect(productionSource).toContain('google-github-actions/setup-gcloud@v3');
+        expect(productionSource).toContain('gcloud functions describe processPasswordResetEmailRequest');
+        expect(productionSource).toContain('eventTrigger.failurePolicy.retry');
+        expect(productionSource).toContain("if: steps.password-reset-retry-policy.outputs.enabled != 'true'");
         expect(firebaseDeployCommands).toEqual([
             'run: npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force',
             'run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive'

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -1,9 +1,15 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 function read(path) {
     return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+function sha256(value) {
+    return createHash('sha256').update(value).digest('hex');
 }
 
 describe('authentication email delivery routing', () => {
@@ -85,22 +91,40 @@ describe('authentication email delivery routing', () => {
         }
     });
 
-    it('enables the password-reset retry policy only when production still needs the migration', () => {
+    it('enables the password-reset retry policy before the non-destructive production deploy', () => {
         const productionSource = read('.github/workflows/deploy-prod.yml');
         const firebaseDeployCommands = productionSource
             .split('\n')
             .map(line => line.trim())
-            .filter(line => line.startsWith('run: npx firebase-tools@14.25.0 deploy'));
+            .filter(line => /^(run: )?npx firebase-tools@14\.25\.0 deploy/.test(line));
 
-        expect(productionSource).toContain('id: password-reset-retry-policy');
-        expect(productionSource).toContain('google-github-actions/setup-gcloud@v3');
-        expect(productionSource).toContain('gcloud functions describe processPasswordResetEmailRequest');
-        expect(productionSource).toContain('eventTrigger.failurePolicy.retry');
-        expect(productionSource).toContain("if: steps.password-reset-retry-policy.outputs.enabled != 'true'");
         expect(firebaseDeployCommands).toEqual([
-            'run: npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force',
+            'npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force',
             'run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive'
         ]);
+        expect(productionSource).toContain('npx firebase-tools@14.25.0 functions:list');
+        expect(productionSource).toContain('.eventTrigger.retry == true');
+        expect(productionSource).toContain('jq -e \'\.functions == {"source":"functions"}\' "$FIREBASE_PROD_CONFIG"');
+        expect(productionSource).toContain('Refusing retry-policy migration for an unexpected Functions deploy source.');
+        expect(productionSource).toContain('expected_functions_hash="102aad7b6547759d0fa8e5c85d06d2a704cd3768690ce889649efb34600b56a8"');
+        expect(productionSource).toContain('elif [[ "$functions_hash" == "$expected_functions_hash" ]]');
+        expect(productionSource).toContain('Refusing forced retry-policy migration for unreviewed Functions source.');
         expect(productionSource.match(/--force/g)).toHaveLength(1);
+    });
+
+    it('pins the forced migration to the reviewed tracked Functions tree', () => {
+        const productionSource = read('.github/workflows/deploy-prod.yml');
+        const approvedHash = productionSource.match(/expected_functions_hash="([a-f0-9]{64})"/)?.[1];
+        const trackedFunctionFiles = execFileSync('git', ['ls-files', 'functions'], { encoding: 'utf8' })
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .sort();
+        const functionsManifest = trackedFunctionFiles
+            .map(path => `${sha256(readFileSync(resolve(process.cwd(), path)))}  ${path}\n`)
+            .join('');
+
+        expect(trackedFunctionFiles).not.toHaveLength(0);
+        expect(approvedHash).toBe(sha256(functionsManifest));
     });
 });

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -84,4 +84,18 @@ describe('authentication email delivery routing', () => {
             expect(workflowSource).toContain('npm run test:functions:auth-email');
         }
     });
+
+    it('enables the password-reset retry policy before the non-destructive production deploy', () => {
+        const productionSource = read('.github/workflows/deploy-prod.yml');
+        const firebaseDeployCommands = productionSource
+            .split('\n')
+            .map(line => line.trim())
+            .filter(line => line.startsWith('run: npx firebase-tools@14.25.0 deploy'));
+
+        expect(firebaseDeployCommands).toEqual([
+            'run: npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force',
+            'run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive'
+        ]);
+        expect(productionSource.match(/--force/g)).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
## Summary
- force-deploy only the password-reset event trigger when enabling its retry policy
- preserve the existing non-force full Firebase production deployment
- add a regression contract for command ordering and force scope

## Why
Production deploy run 29210127861 passed predeploy gates but Firebase CLI rejected the new failure policy without --force. Applying --force only to the named trigger avoids broad deletion risk and creates the worker before updated callables can enqueue work.

## Validation
- npm run test:functions:auth-email (33 passed)
- npm run test:unit:ci (4,111 passed, 39 skipped)
- npm run ci:firebase-rules
- git diff --check