### PR TITLE
Retry transient Firebase production deploy failures

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -139,7 +139,7 @@ jobs:
               exit "$deploy_status"
             fi
 
-            if (( attempt >= max_attempts )); then
+            if (( attempt == max_attempts )); then
               echo "Firebase production deploy failed after ${max_attempts} transient attempts." >&2
               exit "$deploy_status"
             fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -116,39 +116,35 @@ jobs:
           printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
 
-      - name: Enable password-reset retry policy
+      - name: Deploy Firebase production
         shell: bash
         run: |
           set -euo pipefail
-          if ! jq -e '.functions == {"source":"functions"}' "$FIREBASE_PROD_CONFIG" >/dev/null; then
-            echo "Refusing retry-policy migration for an unexpected Functions deploy source." >&2
-            exit 1
-          fi
+          max_attempts=3
+          transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'
 
-          expected_functions_hash="102aad7b6547759d0fa8e5c85d06d2a704cd3768690ce889649efb34600b56a8"
-          functions_hash="$(git ls-files -z functions | sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)"
-          retry_status="$({
-            npx firebase-tools@14.25.0 functions:list --project game-flow-c6311 --json
-          } | jq -er '
-            [.result[] | select(
-              .id == "processPasswordResetEmailRequest" and
-              .region == "us-central1"
-            )] |
-            if length == 0 then "missing"
-            elif length > 1 then error("duplicate password-reset workers")
-            elif .[0].eventTrigger.retry == true then "enabled"
-            else "disabled"
-            end
-          ')"
+          for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
+            deploy_log="$RUNNER_TEMP/firebase-prod-deploy-attempt-${attempt}.log"
+            set +e
+            npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"
+            deploy_status="${PIPESTATUS[0]}"
+            set -e
 
-          if [[ "$retry_status" == "enabled" ]]; then
-            echo "Password-reset retry policy is already enabled."
-          elif [[ "$functions_hash" == "$expected_functions_hash" ]]; then
-            npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force
-          else
-            echo "Refusing forced retry-policy migration for unreviewed Functions source." >&2
-            exit 1
-          fi
+            if (( deploy_status == 0 )); then
+              exit 0
+            fi
 
-      - name: Deploy Firebase production
-        run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
+            if ! grep -Eiq "$transient_pattern" "$deploy_log"; then
+              echo "Firebase production deploy failed with a non-transient error; not retrying." >&2
+              exit "$deploy_status"
+            fi
+
+            if (( attempt >= max_attempts )); then
+              echo "Firebase production deploy failed after ${max_attempts} transient attempts." >&2
+              exit "$deploy_status"
+            fi
+
+            retry_delay_seconds=$((15 * (2 ** (attempt - 1))))
+            echo "Transient Firebase deploy failure; retrying in ${retry_delay_seconds} seconds (attempt $((attempt + 1))/${max_attempts})." >&2
+            sleep "$retry_delay_seconds"
+          done

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -98,7 +98,7 @@ describe('authentication email delivery routing', () => {
         expect(productionSource.match(/--force/g) ?? []).toHaveLength(0);
         expect(productionSource).toContain('max_attempts=3');
         expect(productionSource).toContain('for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do');
-        expect(productionSource).toContain('if (( attempt >= max_attempts )); then');
+        expect(productionSource).toContain('if (( attempt == max_attempts )); then');
         expect(productionSource).toContain('retry_delay_seconds=$((15 * (2 ** (attempt - 1))))');
     });
 
@@ -107,7 +107,8 @@ describe('authentication email delivery routing', () => {
         const deployStepStart = productionSource.indexOf('      - name: Deploy Firebase production');
         const deployStep = productionSource.slice(deployStepStart);
         const transientGuard = 'if ! grep -Eiq "$transient_pattern" "$deploy_log"; then';
-        const attemptLimitGuard = 'if (( attempt >= max_attempts )); then';
+        const attemptLimitGuard = 'if (( attempt == max_attempts )); then';
+        const retryDelay = 'retry_delay_seconds=$((15 * (2 ** (attempt - 1))))';
         const nonTransientBranch = deployStep.slice(
             deployStep.indexOf(transientGuard),
             deployStep.indexOf(attemptLimitGuard)
@@ -119,6 +120,7 @@ describe('authentication email delivery routing', () => {
         expect(deployStep).toContain('deploy_status="${PIPESTATUS[0]}"');
         expect(deployStep).toContain(transientGuard);
         expect(deployStep.indexOf(transientGuard)).toBeLessThan(deployStep.indexOf(attemptLimitGuard));
+        expect(deployStep.indexOf(attemptLimitGuard)).toBeLessThan(deployStep.indexOf(retryDelay));
         expect(nonTransientBranch).toContain('failed with a non-transient error; not retrying.');
         expect(nonTransientBranch).toContain('exit "$deploy_status"');
     });

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -1,15 +1,9 @@
-import { execFileSync } from 'node:child_process';
-import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 function read(path) {
     return readFileSync(resolve(process.cwd(), path), 'utf8');
-}
-
-function sha256(value) {
-    return createHash('sha256').update(value).digest('hex');
 }
 
 describe('authentication email delivery routing', () => {
@@ -91,7 +85,7 @@ describe('authentication email delivery routing', () => {
         }
     });
 
-    it('enables the password-reset retry policy before the non-destructive production deploy', () => {
+    it('bounds the normal non-destructive production deploy to three attempts', () => {
         const productionSource = read('.github/workflows/deploy-prod.yml');
         const firebaseDeployCommands = productionSource
             .split('\n')
@@ -99,32 +93,33 @@ describe('authentication email delivery routing', () => {
             .filter(line => /^(run: )?npx firebase-tools@14\.25\.0 deploy/.test(line));
 
         expect(firebaseDeployCommands).toEqual([
-            'npx firebase-tools@14.25.0 deploy --only functions:processPasswordResetEmailRequest --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive --force',
-            'run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive'
+            'npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"'
         ]);
-        expect(productionSource).toContain('npx firebase-tools@14.25.0 functions:list');
-        expect(productionSource).toContain('.eventTrigger.retry == true');
-        expect(productionSource).toContain('jq -e \'\.functions == {"source":"functions"}\' "$FIREBASE_PROD_CONFIG"');
-        expect(productionSource).toContain('Refusing retry-policy migration for an unexpected Functions deploy source.');
-        expect(productionSource).toContain('expected_functions_hash="102aad7b6547759d0fa8e5c85d06d2a704cd3768690ce889649efb34600b56a8"');
-        expect(productionSource).toContain('elif [[ "$functions_hash" == "$expected_functions_hash" ]]');
-        expect(productionSource).toContain('Refusing forced retry-policy migration for unreviewed Functions source.');
-        expect(productionSource.match(/--force/g)).toHaveLength(1);
+        expect(productionSource.match(/--force/g) ?? []).toHaveLength(0);
+        expect(productionSource).toContain('max_attempts=3');
+        expect(productionSource).toContain('for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do');
+        expect(productionSource).toContain('if (( attempt >= max_attempts )); then');
+        expect(productionSource).toContain('retry_delay_seconds=$((15 * (2 ** (attempt - 1))))');
     });
 
-    it('pins the forced migration to the reviewed tracked Functions tree', () => {
+    it('retries only transient production deploy failures and fails fast otherwise', () => {
         const productionSource = read('.github/workflows/deploy-prod.yml');
-        const approvedHash = productionSource.match(/expected_functions_hash="([a-f0-9]{64})"/)?.[1];
-        const trackedFunctionFiles = execFileSync('git', ['ls-files', 'functions'], { encoding: 'utf8' })
-            .trim()
-            .split('\n')
-            .filter(Boolean)
-            .sort();
-        const functionsManifest = trackedFunctionFiles
-            .map(path => `${sha256(readFileSync(resolve(process.cwd(), path)))}  ${path}\n`)
-            .join('');
+        const deployStepStart = productionSource.indexOf('      - name: Deploy Firebase production');
+        const deployStep = productionSource.slice(deployStepStart);
+        const transientGuard = 'if ! grep -Eiq "$transient_pattern" "$deploy_log"; then';
+        const attemptLimitGuard = 'if (( attempt >= max_attempts )); then';
+        const nonTransientBranch = deployStep.slice(
+            deployStep.indexOf(transientGuard),
+            deployStep.indexOf(attemptLimitGuard)
+        );
 
-        expect(trackedFunctionFiles).not.toHaveLength(0);
-        expect(approvedHash).toBe(sha256(functionsManifest));
+        expect(deployStepStart).toBeGreaterThan(-1);
+        expect(deployStep).toContain("transient_pattern='(^|[^[:alnum:]])(429|500|502|503|504)([^[:alnum:]]|$)|service[[:space:]_-]+unavailable|econnreset|connection[[:space:]_-]+reset|network[[:space:]_-]+reset|etimedout|timed[[:space:]_-]+out|timeout'");
+        expect(deployStep).toContain('2>&1 | tee "$deploy_log"');
+        expect(deployStep).toContain('deploy_status="${PIPESTATUS[0]}"');
+        expect(deployStep).toContain(transientGuard);
+        expect(deployStep.indexOf(transientGuard)).toBeLessThan(deployStep.indexOf(attemptLimitGuard));
+        expect(nonTransientBranch).toContain('failed with a non-transient error; not retrying.');
+        expect(nonTransientBranch).toContain('exit "$deploy_status"');
     });
 });


### PR DESCRIPTION
## Summary
- remove the completed one-time password-reset retry-policy migration
- keep the normal full Firebase production deploy non-force
- retry only recognized transient Firebase/API/network failures up to three times
- preserve non-transient exit codes and fail immediately on real configuration errors

## Why
Production run 29211639774 successfully enabled retries for processPasswordResetEmailRequest, then hit the Firebase Rules test API HTTP 503 on three clean full-deploy attempts. This makes that transient recovery bounded and automatic without weakening deploy safety.

## Validation
- auth email routing/deploy contract: 7 passed
- auth-email function behavior: 33 passed
- deploy-prod YAML parsed
- extracted deploy Bash passed bash -n
- git diff --check