### PR TITLE
Fix friendship list rule queries

### DIFF
--- a/apps/app/src/lib/socialService.ts
+++ b/apps/app/src/lib/socialService.ts
@@ -210,13 +210,27 @@ export async function loadVisibleSocialPosts(user: AuthUser, home: ParentHomeMod
 
 export async function loadFriendships(user: AuthUser): Promise<SocialFriend[]> {
   if (!user?.uid) return [];
-  const friendshipQuery = query(
+  const requestedFriendshipsQuery = query(
     collection(db, 'friendships'),
-    where('memberIds', 'array-contains', user.uid),
+    where('requesterId', '==', user.uid),
     limit(50)
   );
-  const snapshot = await withTimeout(getDocs(friendshipQuery), 'Friendships');
-  const friendships = snapshotToDocs(snapshot);
+  const receivedFriendshipsQuery = query(
+    collection(db, 'friendships'),
+    where('recipientId', '==', user.uid),
+    limit(50)
+  );
+  const snapshots = await withTimeout(Promise.all([
+    getDocs(requestedFriendshipsQuery),
+    getDocs(receivedFriendshipsQuery)
+  ]), 'Friendships');
+  const friendshipDocs = new Map<string, FirestoreDoc>();
+  snapshots.forEach((snapshot) => {
+    snapshotToDocs(snapshot).forEach((friendship) => friendshipDocs.set(friendship.id, friendship));
+  });
+  // Keep both bounded result sets. Applying a second global limit here could
+  // hide incoming requests whenever a user already has 50 outgoing records.
+  const friendships = [...friendshipDocs.values()];
   const friendDocs = await Promise.all(friendships.map(async (friendship) => {
     const otherUserId = (friendship.memberIds || []).find((id: string) => id !== user.uid);
     if (!otherUserId) return null;

--- a/firestore.rules
+++ b/firestore.rules
@@ -1637,6 +1637,8 @@ service cloud.firestore {
                'sharedTeamIds', 'sharedTeamNames', 'blockedBy',
                'respondedAt', 'createdAt', 'updatedAt'
              ]) &&
+             request.resource.data.get('requesterId', '') == resource.data.get('requesterId', '') &&
+             request.resource.data.get('recipientId', '') == resource.data.get('recipientId', '') &&
              request.resource.data.get('memberIds', []) == resource.data.get('memberIds', []) &&
              request.resource.data.get('status', '') in ['pending', 'accepted', 'declined', 'removed', 'blocked'] &&
              (

--- a/firestore.rules
+++ b/firestore.rules
@@ -1430,6 +1430,12 @@ service cloud.firestore {
              request.auth.uid in data.get('memberIds', []);
     }
 
+    function canListFriendship(data) {
+      return isSignedIn() &&
+             (data.get('requesterId', '') == request.auth.uid ||
+              data.get('recipientId', '') == request.auth.uid);
+    }
+
     function canGetMissingFriendship(friendshipId) {
       let friendshipPath = /databases/$(database)/documents/friendships/$(friendshipId);
       return isSignedIn() &&
@@ -2332,7 +2338,7 @@ service cloud.firestore {
       allow get: if canGetMissingFriendship(friendshipId) ||
                     canAccessFriendship(resource.data) ||
                     isGlobalAdmin();
-      allow list: if canAccessFriendship(resource.data) || isGlobalAdmin();
+      allow list: if canListFriendship(resource.data) || isGlobalAdmin();
       allow create: if isFriendshipCreatePayloadValid(friendshipId, request.resource.data) ||
                     isFriendInviteAcceptedFriendshipCreateValid(friendshipId, request.resource.data);
       allow update: if isFriendInviteAcceptedFriendshipUpdateValid(friendshipId) ||

--- a/tests/unit/app-social-rules.test.js
+++ b/tests/unit/app-social-rules.test.js
@@ -10,11 +10,13 @@ import {
     doc,
     getDoc,
     getDocs,
+    query,
     runTransaction,
     serverTimestamp,
     setDoc,
     Timestamp,
-    updateDoc
+    updateDoc,
+    where
 } from 'firebase/firestore';
 
 function rulesSource() {
@@ -189,7 +191,10 @@ describe('React app social Firestore rules', () => {
         expect(source).toContain("friendshipId.matches('^' + request.auth.uid + '__.+$')");
         expect(source).toContain("friendshipId.matches('^.+__' + request.auth.uid + '$')");
         expect(source).toContain('allow get: if canGetMissingFriendship(friendshipId) ||');
-        expect(source).toContain('allow list: if canAccessFriendship(resource.data) || isGlobalAdmin();');
+        expect(source).toContain('function canListFriendship(data)');
+        expect(source).toContain("data.get('requesterId', '') == request.auth.uid");
+        expect(source).toContain("data.get('recipientId', '') == request.auth.uid");
+        expect(source).toContain('allow list: if canListFriendship(resource.data) || isGlobalAdmin();');
     });
 
     it('locks down top-level users docs and routes discovery through projected public profiles', () => {
@@ -679,6 +684,54 @@ describe('React app social Firestore rules', () => {
             });
 
             await assertFails(getDoc(doc(authenticatedDb(attackerId), 'friendships', friendshipId)));
+        });
+
+        it('lists friendships through requester and recipient equality queries only', async () => {
+            const userId = 'friend-list-user';
+            const userDb = authenticatedDb(userId);
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const db = context.firestore();
+                await setDoc(doc(db, 'friendships', 'friend-a__friend-list-user'), {
+                    requesterId: 'friend-a',
+                    recipientId: userId,
+                    memberIds: ['friend-a', userId],
+                    status: 'pending'
+                });
+                await setDoc(doc(db, 'friendships', 'friend-b__friend-list-user'), {
+                    requesterId: userId,
+                    recipientId: 'friend-b',
+                    memberIds: [userId, 'friend-b'],
+                    status: 'accepted'
+                });
+                await setDoc(doc(db, 'friendships', 'friend-c__friend-d'), {
+                    requesterId: 'friend-c',
+                    recipientId: 'friend-d',
+                    memberIds: ['friend-c', 'friend-d'],
+                    status: 'accepted'
+                });
+            });
+
+            const requested = await assertSucceeds(getDocs(query(
+                collection(userDb, 'friendships'),
+                where('requesterId', '==', userId)
+            )));
+            const received = await assertSucceeds(getDocs(query(
+                collection(userDb, 'friendships'),
+                where('recipientId', '==', userId)
+            )));
+
+            expect(requested.docs.map((entry) => entry.id)).toEqual(['friend-b__friend-list-user']);
+            expect(received.docs.map((entry) => entry.id)).toEqual(['friend-a__friend-list-user']);
+            await assertFails(getDocs(collection(userDb, 'friendships')));
+            await assertFails(getDocs(query(
+                collection(userDb, 'friendships'),
+                where('memberIds', 'array-contains', userId)
+            )));
+            await assertFails(getDocs(query(
+                collection(userDb, 'friendships'),
+                where('requesterId', '==', 'friend-c')
+            )));
         });
     });
 

--- a/tests/unit/app-social-rules.test.js
+++ b/tests/unit/app-social-rules.test.js
@@ -157,6 +157,8 @@ describe('React app social Firestore rules', () => {
 
         expect(source).toContain("resource.data.get('status', '') != 'blocked'");
         expect(source).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly([\n               'requesterId',");
+        expect(source).toContain("request.resource.data.get('requesterId', '') == resource.data.get('requesterId', '')");
+        expect(source).toContain("request.resource.data.get('recipientId', '') == resource.data.get('recipientId', '')");
         expect(source).toContain("request.resource.data.get('blockedBy', resource.data.get('blockedBy', [])) == resource.data.get('blockedBy', [])");
         expect(source).toContain("request.resource.data.get('status', '') == 'blocked'");
         expect(source).toContain("request.auth.uid in request.resource.data.get('blockedBy', [])");
@@ -684,6 +686,35 @@ describe('React app social Firestore rules', () => {
             });
 
             await assertFails(getDoc(doc(authenticatedDb(attackerId), 'friendships', friendshipId)));
+        });
+
+        it('denies member updates that rewrite requester or recipient list keys', async () => {
+            const requesterId = 'friend-key-requester';
+            const recipientId = 'friend-key-recipient';
+            const friendshipId = [requesterId, recipientId].sort().join('__');
+            const recipientDb = authenticatedDb(recipientId);
+
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                await setDoc(doc(context.firestore(), 'friendships', friendshipId), {
+                    requesterId,
+                    recipientId,
+                    memberIds: [requesterId, recipientId].sort(),
+                    status: 'accepted',
+                    sharedTeamIds: [],
+                    sharedTeamNames: [],
+                    blockedBy: []
+                });
+            });
+
+            await assertFails(updateDoc(doc(recipientDb, 'friendships', friendshipId), {
+                requesterId: recipientId
+            }));
+            await assertFails(updateDoc(doc(recipientDb, 'friendships', friendshipId), {
+                recipientId: requesterId
+            }));
+            await assertSucceeds(updateDoc(doc(recipientDb, 'friendships', friendshipId), {
+                status: 'removed'
+            }));
         });
 
         it('lists friendships through requester and recipient equality queries only', async () => {

--- a/tests/unit/app-social-service.test.js
+++ b/tests/unit/app-social-service.test.js
@@ -200,7 +200,7 @@ describe('React app social service', () => {
                     media: []
                 }]);
             }
-            if (whereClause?.field === 'memberIds') {
+            if (whereClause?.field === 'recipientId') {
                 return snapshot([{
                     id: 'friend-1__user-1',
                     memberIds: ['friend-1', 'user-1'],
@@ -228,6 +228,70 @@ describe('React app social service', () => {
         expect(model.incomingRequests).toEqual([expect.objectContaining({ userId: 'friend-1', name: 'Jamie Friend' })]);
         expect(model.suggestions).toEqual([expect.objectContaining({ userId: 'friend-2', name: 'Morgan Parent' })]);
         expect(model.metrics.feedItems).toBeGreaterThanOrEqual(2);
+        expect(firebaseMocks.where).toHaveBeenCalledWith('requesterId', '==', 'user-1');
+        expect(firebaseMocks.where).toHaveBeenCalledWith('recipientId', '==', 'user-1');
+        expect(firebaseMocks.where).not.toHaveBeenCalledWith('memberIds', 'array-contains', 'user-1');
+    });
+
+    it('merges requested and received friendship queries without duplicate friends', async () => {
+        const { loadFriendships } = await import('../../apps/app/src/lib/socialService.ts');
+        const friendship = {
+            id: 'friend-1__user-1',
+            memberIds: ['friend-1', 'user-1'],
+            requesterId: 'user-1',
+            recipientId: 'friend-1',
+            status: 'accepted',
+            sharedTeamIds: [],
+            sharedTeamNames: []
+        };
+        firebaseMocks.getDocs.mockResolvedValue(snapshot([friendship]));
+        firebaseMocks.getDoc.mockResolvedValue({
+            id: 'friend-1',
+            exists: () => true,
+            data: () => ({ displayName: 'Jamie Friend' })
+        });
+
+        const friends = await loadFriendships(user);
+
+        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(2);
+        expect(friends).toEqual([expect.objectContaining({ userId: 'friend-1', name: 'Jamie Friend' })]);
+        expect(firebaseMocks.getDoc).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not drop received requests when the requested query reaches its limit', async () => {
+        const { loadFriendships } = await import('../../apps/app/src/lib/socialService.ts');
+        const requested = Array.from({ length: 50 }, (_, index) => ({
+            id: `friend-${index}__user-1`,
+            memberIds: [`friend-${index}`, 'user-1'],
+            requesterId: 'user-1',
+            recipientId: `friend-${index}`,
+            status: 'pending'
+        }));
+        const received = {
+            id: 'friend-incoming__user-1',
+            memberIds: ['friend-incoming', 'user-1'],
+            requesterId: 'friend-incoming',
+            recipientId: 'user-1',
+            status: 'pending'
+        };
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce(snapshot(requested))
+            .mockResolvedValueOnce(snapshot([received]));
+        firebaseMocks.getDoc.mockImplementation(async (ref) => ({
+            id: ref.path[1],
+            exists: () => true,
+            data: () => ({ displayName: ref.path[1] })
+        }));
+
+        const friends = await loadFriendships(user);
+
+        expect(friends).toHaveLength(51);
+        expect(friends).toContainEqual(expect.objectContaining({
+            userId: 'friend-incoming',
+            status: 'pending',
+            requesterId: 'friend-incoming',
+            recipientId: 'user-1'
+        }));
     });
 
     it('searches public profiles by hashed email and shared discovery teams', async () => {


### PR DESCRIPTION
## Summary

- Replace the unauthorizable memberIds array query with bounded requester and recipient equality queries.
- Deduplicate the two result sets without dropping incoming requests.
- Restrict Firestore list reads to matching requester or recipient fields.
- Add client and Firestore-emulator regression coverage.

## Validation

- Root unit suite: 4,168 passed, 46 skipped.
- Focused social tests: 19 passed, 11 skipped outside emulator.
- Firestore emulator rules suite: 22 passed.
- App production build and bundle visualizer passed.
- Firebase rules validator and coverage-map guard passed.

Follow-up to #3867 and #3895.