### PR TITLE
Hide invalid Game Viewer help link

### DIFF
--- a/help-watch-chat.html
+++ b/help-watch-chat.html
@@ -23,7 +23,7 @@
         </ul>
         <div class="mt-4 flex flex-wrap gap-2" aria-label="Watch navigation">
           <a
-            class="inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
+            class="hidden inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
             href="team.html"
             data-help-context-link
             data-guide-id="watch-game"
@@ -32,10 +32,12 @@
           >Team Page</a>
           <a
             class="inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
-            href="live-game.html"
+            href="team.html"
+            hidden
             data-help-context-link
             data-guide-id="watch-game"
             data-quick-link-label="Game Viewer"
+            data-required-context="teamId,gameId"
             data-route-template="live-game.html#teamId={teamId}&gameId={gameId}"
           >Game Viewer</a>
         </div>
@@ -96,7 +98,20 @@
         .replaceAll('{gameId}', encodeURIComponent(values.gameId)));
 
       document.querySelectorAll('[data-help-context-link]').forEach((link) => {
+        const requiredContext = (link.dataset.requiredContext || '')
+          .split(',')
+          .map((key) => key.trim())
+          .filter(Boolean);
+
+        if (requiredContext.some((key) => !values[key])) {
+          link.hidden = true;
+          link.classList.add('hidden');
+          return;
+        }
+
         link.href = resolveRouteTemplate(link.dataset.routeTemplate || link.getAttribute('href'));
+        link.hidden = false;
+        link.classList.remove('hidden');
       });
     })();
   </script>

--- a/tests/smoke/help-workflow-pages.spec.js
+++ b/tests/smoke/help-workflow-pages.spec.js
@@ -62,6 +62,23 @@ test.describe('help topic and workflow pages', () => {
         await expect(page.getByRole('link', { name: 'Team Chat' })).toHaveAttribute('href', 'team-chat.html#teamId=team-123');
     });
 
+    test('help-watch-chat does not expose an invalid viewer link without game context', async ({ page, baseURL }) => {
+        await assertPageBootsWithoutFatalErrors(page, {
+            baseURL,
+            path: '/help-watch-chat.html?context=team&teamId=team-123&role=parent',
+            titlePatterns: [/Help/i],
+            skipDefaultForbiddenTexts: true,
+            requiredSelectors: [
+                'a[data-help-context-link][data-quick-link-label="Team Page"]',
+                'a[data-help-context-link][data-quick-link-label="Open Team Chat"]'
+            ]
+        });
+
+        await expect(page.getByRole('link', { name: 'Team Page' })).toHaveAttribute('href', 'team.html#teamId=team-123');
+        await expect(page.locator('a[data-quick-link-label="Game Viewer"]')).toBeHidden();
+        await expect(page.getByRole('link', { name: 'Team Chat' })).toHaveAttribute('href', 'team-chat.html#teamId=team-123');
+    });
+
     test('Getting Started exposes working account entry points instead of a nonexistent homepage CTA', async ({ page, baseURL }) => {
         await bootWorkflowPage(page, baseURL, '/workflow-getting-started.html');
 

--- a/tests/unit/help-center.test.js
+++ b/tests/unit/help-center.test.js
@@ -128,17 +128,21 @@ describe('help center deep workflow coverage', () => {
 
     it('removes empty Help Watch Chat context parameters from CTA links', () => {
         const document = renderHelpWatchChat('https://allplays.test/help-watch-chat.html?role=parent');
+        const gameViewerLink = document.querySelector('[data-quick-link-label="Game Viewer"]');
 
         expect(document.querySelector('[data-quick-link-label="Team Page"]')?.getAttribute('href')).toBe('team.html');
-        expect(document.querySelector('[data-quick-link-label="Game Viewer"]')?.getAttribute('href')).toBe('live-game.html');
+        expect(gameViewerLink?.hidden).toBe(true);
+        expect(gameViewerLink?.getAttribute('href')).toBe('team.html');
         expect(document.querySelector('[data-quick-link-label="Open Team Chat"]')?.getAttribute('href')).toBe('team-chat.html');
     });
 
     it('keeps team context when Help Watch Chat links have no game context', () => {
         const document = renderHelpWatchChat('https://allplays.test/help-watch-chat.html?context=team&teamId=team-123&role=parent');
+        const gameViewerLink = document.querySelector('[data-quick-link-label="Game Viewer"]');
 
         expect(document.querySelector('[data-quick-link-label="Team Page"]')?.getAttribute('href')).toBe('team.html#teamId=team-123');
-        expect(document.querySelector('[data-quick-link-label="Game Viewer"]')?.getAttribute('href')).toBe('live-game.html#teamId=team-123');
+        expect(gameViewerLink?.hidden).toBe(true);
+        expect(gameViewerLink?.getAttribute('href')).toBe('team.html');
         expect(document.querySelector('[data-quick-link-label="Open Team Chat"]')?.getAttribute('href')).toBe('team-chat.html#teamId=team-123');
     });
 
@@ -152,6 +156,7 @@ describe('help center deep workflow coverage', () => {
         const encodedGameId = encodeURIComponent(gameId);
 
         expect(document.querySelector('[data-quick-link-label="Team Page"]')?.getAttribute('href')).toBe(`team.html#teamId=${encodedTeamId}`);
+        expect(document.querySelector('[data-quick-link-label="Game Viewer"]')).not.toHaveProperty('hidden', true);
         expect(document.querySelector('[data-quick-link-label="Game Viewer"]')?.getAttribute('href')).toBe(`live-game.html#teamId=${encodedTeamId}&gameId=${encodedGameId}`);
         expect(document.querySelector('[data-quick-link-label="Open Team Chat"]')?.getAttribute('href')).toBe(`team-chat.html#teamId=${encodedTeamId}`);
     });


### PR DESCRIPTION
## Summary
- keep the Game Viewer CTA hidden until both team and game context are present
- retain a safe Team Page fallback in the static markup
- preserve complete-context live/replay deep links

## Validation
- npx vitest run tests/unit/help-center.test.js tests/unit/help-workflow-pages.test.js --reporter=dot — 20 passed
- focused Playwright help-watch-chat smoke — 3 passed
- git diff --check

Fixes #3916