### PR TITLE
Add inquiry starter messages

### DIFF
--- a/apps/app/src/lib/opportunityLogic.test.ts
+++ b/apps/app/src/lib/opportunityLogic.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { emptyOpportunityInput, formatOpportunityLocation, getOpportunityKindLabel, opportunityToInput, type PublicOpportunity } from './opportunityLogic';
+import {
+  emptyOpportunityInput,
+  formatOpportunityLocation,
+  getOpportunityInquiryStarterMessages,
+  getOpportunityKindLabel,
+  opportunityToInput,
+  opportunityKinds,
+  type PublicOpportunity
+} from './opportunityLogic';
 
 describe('opportunityLogic', () => {
   it('builds safe defaults for looking-for-team posts', () => {
@@ -28,5 +36,19 @@ describe('opportunityLogic', () => {
     expect(getOpportunityKindLabel(item.kind)).toBe('Players wanted');
     expect(formatOpportunityLocation(item)).toBe('Austin, TX 78701');
     expect(opportunityToInput(item)).toEqual(expect.objectContaining({ teamId: 'team-1', city: 'Austin' }));
+  });
+
+  it('offers common and category-specific inquiry starters for every opportunity kind', () => {
+    const categorySpecificStarters = opportunityKinds.map(({ id }) => {
+      const starters = getOpportunityInquiryStarterMessages(id);
+      expect(starters).toHaveLength(3);
+      expect(starters.slice(0, 2)).toEqual([
+        'Is this opportunity still available?',
+        'What are the next steps?'
+      ]);
+      return starters[2];
+    });
+
+    expect(new Set(categorySpecificStarters).size).toBe(opportunityKinds.length);
   });
 });

--- a/apps/app/src/lib/opportunityLogic.ts
+++ b/apps/app/src/lib/opportunityLogic.ts
@@ -105,8 +105,23 @@ export const compensationOptions: Array<{ id: CompensationType; label: string }>
   { id: 'either', label: 'Paid or volunteer' }
 ];
 
+const opportunityInquiryKindStarters: Record<OpportunityKind, string> = {
+  team_seeking_players: 'What player positions or experience are you looking for?',
+  coach_or_staff: 'What experience or qualifications are you looking for?',
+  official_or_volunteer: 'What dates and responsibilities need coverage?',
+  player_seeking_team: "Could you share more about the player's availability and team preferences?"
+};
+
 export function getOpportunityKindLabel(kind: OpportunityKind) {
   return opportunityKinds.find((entry) => entry.id === kind)?.label || 'Opportunity';
+}
+
+export function getOpportunityInquiryStarterMessages(kind: OpportunityKind) {
+  return [
+    'Is this opportunity still available?',
+    'What are the next steps?',
+    opportunityInquiryKindStarters[kind]
+  ];
 }
 
 export function formatOpportunityLocation(item: Pick<PublicOpportunity, 'city' | 'state' | 'zip'>) {

--- a/apps/app/src/pages/Discover.test.tsx
+++ b/apps/app/src/pages/Discover.test.tsx
@@ -83,7 +83,7 @@ describe('public Discover experience', () => {
 
   it('keeps public contact details private and routes anonymous contact through sign-in', async () => {
     render(
-      <MemoryRouter initialEntries={['/discover/opportunities/listing-1']}>
+      <MemoryRouter initialEntries={['/discover/opportunities/listing-1?contact=1']}>
         <Routes>
           <Route path="/discover/opportunities/:listingId" element={<OpportunityDetail auth={signedOutAuth} />} />
           <Route path="/auth" element={<div>Sign-in route</div>} />
@@ -92,6 +92,7 @@ describe('public Discover experience', () => {
     );
     expect(await screen.findByRole('heading', { name: 'Assistant coach wanted' })).toBeTruthy();
     expect(screen.queryByText(/user@example.com/)).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Private inquiry' })).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Sign in to contact' }));
     expect(await screen.findByText('Sign-in route')).toBeTruthy();
   });
@@ -108,9 +109,16 @@ describe('public Discover experience', () => {
     );
     await screen.findByRole('heading', { name: 'Assistant coach wanted' });
     fireEvent.click(screen.getByRole('button', { name: 'Send private inquiry' }));
-    fireEvent.change(screen.getByPlaceholderText(/Introduce yourself/), { target: { value: 'Is this role still open?' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Send inquiry' }));
-    await waitFor(() => expect(opportunityMocks.createOpportunityInquiry).toHaveBeenCalledWith('listing-1', 'Is this role still open?'));
+    const starter = 'What experience or qualifications are you looking for?';
+    const submit = screen.getByRole('button', { name: 'Send inquiry' }) as HTMLButtonElement;
+    fireEvent.click(screen.getByRole('button', { name: starter }));
+    const message = screen.getByRole('textbox', { name: 'Inquiry message' }) as HTMLTextAreaElement;
+    expect(message.value).toBe(starter);
+    expect(message.disabled).toBe(false);
+    expect(message.readOnly).toBe(false);
+    expect(submit.disabled).toBe(false);
+    fireEvent.click(submit);
+    await waitFor(() => expect(opportunityMocks.createOpportunityInquiry).toHaveBeenCalledWith('listing-1', starter));
     expect(await screen.findByText('Private inquiry thread')).toBeTruthy();
   });
 

--- a/apps/app/src/pages/OpportunityDetail.tsx
+++ b/apps/app/src/pages/OpportunityDetail.tsx
@@ -5,6 +5,7 @@ import { Status } from '../components/TeamSummaryPrimitives';
 import {
   formatOpportunityDate,
   formatOpportunityLocation,
+  getOpportunityInquiryStarterMessages,
   getOpportunityKindLabel,
   type PublicOpportunity
 } from '../lib/opportunityLogic';
@@ -21,7 +22,7 @@ export function OpportunityDetail({ auth }: { auth: AuthState }) {
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
   const [status, setStatus] = useState('');
-  const [contactOpen, setContactOpen] = useState(searchParams.get('contact') === '1');
+  const [contactOpen, setContactOpen] = useState(Boolean(auth.user) && searchParams.get('contact') === '1');
 
   useEffect(() => {
     let active = true;
@@ -77,6 +78,7 @@ export function OpportunityDetail({ auth }: { auth: AuthState }) {
   if (error && !item) return <Status tone="error" message={error} />;
   if (!item) return null;
   const location = formatOpportunityLocation(item);
+  const inquiryStarters = getOpportunityInquiryStarterMessages(item.kind);
 
   return (
     <div className="mx-auto max-w-3xl space-y-4">
@@ -117,10 +119,19 @@ export function OpportunityDetail({ auth }: { auth: AuthState }) {
         </div>
       </article>
 
-      {contactOpen && item.status === 'active' ? <form className="app-card p-4 sm:p-5" onSubmit={submitInquiry}>
+      {contactOpen && Boolean(auth.user) && item.status === 'active' ? <form className="app-card p-4 sm:p-5" onSubmit={submitInquiry}>
         <h2 className="app-section-title">Private inquiry</h2>
         <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Your message is visible only to you and the listing owner or team administrators. Contact details are never shown on the public listing.</p>
-        <textarea className="auth-input mt-3 min-h-32" value={message} onChange={(event) => setMessage(event.target.value)} placeholder="Introduce yourself and ask about the opportunity. Do not include sensitive information." required />
+        <div className="mt-4" role="group" aria-label="Starter messages">
+          <div className="app-label">Start with a message</div>
+          <div className="mt-2 grid gap-2 sm:grid-cols-3">
+            {inquiryStarters.map((starter) => {
+              const selected = message === starter;
+              return <button key={starter} type="button" className={`min-h-10 rounded-xl border px-3 py-2 text-left text-sm font-bold transition ${selected ? 'border-primary-300 bg-primary-50 text-primary-800' : 'border-gray-200 bg-white text-gray-700 hover:border-primary-200 hover:bg-primary-50'}`} onClick={() => setMessage(starter)} aria-pressed={selected}>{starter}</button>;
+            })}
+          </div>
+        </div>
+        <textarea className="auth-input mt-3 min-h-32" aria-label="Inquiry message" value={message} onChange={(event) => setMessage(event.target.value)} placeholder="Introduce yourself and ask about the opportunity. Do not include sensitive information." required />
         <div className="mt-3 flex justify-end gap-2"><button type="button" className="ghost-button" onClick={() => setContactOpen(false)}>Cancel</button><button type="submit" className="primary-button" disabled={sending || !message.trim()}>{sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <MessageCircle className="h-4 w-4" />}Send inquiry</button></div>
       </form> : null}
     </div>

--- a/tests/smoke/app-discover.spec.js
+++ b/tests/smoke/app-discover.spec.js
@@ -71,4 +71,21 @@ test.describe('public sports Discover', () => {
     await expect.poll(() => page.evaluate(() => window.__opportunityCreates.length)).toBe(1);
     await expect(page).toHaveURL(/#\/discover\/opportunities\/listing-1$/);
   });
+
+  test('lets signed-in users send a starter message from opportunity detail', async ({ page, baseURL }) => {
+    await mockDiscoverModules(page, { signedIn: true });
+    await page.goto(appUrl(baseURL, '/discover/opportunities/listing-1'), { waitUntil: 'domcontentloaded' });
+    await page.getByRole('button', { name: 'Send private inquiry' }).click();
+
+    const starter = 'Is this opportunity still available?';
+    await page.getByRole('button', { name: starter }).click();
+    await expect(page.getByRole('textbox', { name: 'Inquiry message' })).toHaveValue(starter);
+    await expect(page.getByRole('button', { name: 'Send inquiry' })).toBeEnabled();
+    await page.getByRole('button', { name: 'Send inquiry' }).click();
+
+    await expect.poll(() => page.evaluate(() => window.__opportunityInquiries)).toEqual([
+      { id: 'listing-1', message: starter }
+    ]);
+    await expect(page).toHaveURL(/#\/discover\/inquiries\/inquiry-1$/);
+  });
 });


### PR DESCRIPTION
## Summary

- add two common and one listing-specific starter message to active private inquiry panels
- populate the existing editable textarea and preserve the existing submit/thread flow
- keep anonymous and inactive-listing gates intact
- add focused unit and browser regression coverage

## Verification

- `npx vitest run apps/app/src/lib/opportunityLogic.test.ts apps/app/src/pages/Discover.test.tsx --reporter=dot` (7 passed)
- `npx playwright test tests/smoke/app-discover.spec.js` (3 passed)
- app TypeScript check
- `npm run app:build`
- ESLint (0 errors; 3 unchanged warnings)

Fixes #3918