### PR TITLE
Fix admin search across paginated records

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -714,7 +714,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="js/admin.js?v=9"></script>
+    <script type="module" src="js/admin.js?v=10"></script>
 </body>
 
 </html>

--- a/js/admin-search.js
+++ b/js/admin-search.js
@@ -6,6 +6,26 @@ export function hasAdminGlobalSearchTerm(value = '') {
     return normalizeAdminSearchTerm(value).length > 0;
 }
 
+export async function loadCompleteAdminSearchCollection({ fetchPage, itemsKey, pageSize = 100 } = {}) {
+    if (typeof fetchPage !== 'function') {
+        throw new TypeError('fetchPage must be a function');
+    }
+
+    const items = [];
+    let cursor = null;
+
+    do {
+        const page = await fetchPage({
+            pageSize,
+            ...(cursor ? { cursor } : {})
+        });
+        items.push(...(Array.isArray(page?.[itemsKey]) ? page[itemsKey] : []));
+        cursor = page?.nextCursor || null;
+    } while (cursor);
+
+    return items;
+}
+
 export function selectAdminSearchCollection({ searchTerm = '', pageItems = [], globalItems = [] } = {}) {
     return hasAdminGlobalSearchTerm(searchTerm) ? globalItems : pageItems;
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -39,10 +39,11 @@ import {
 import { buildAdminTeamOfficialsSummary } from './admin-team-officials.js?v=1';
 import {
     hasAdminGlobalSearchTerm,
+    loadCompleteAdminSearchCollection,
     normalizeAdminSearchTerm,
     selectAdminItemById,
     selectAdminSearchCollection
-} from './admin-search.js?v=1';
+} from './admin-search.js?v=2';
 import {
     buildTrackedWorkflowLoadSummary,
     buildTelemetryPerformanceSummary,
@@ -150,9 +151,12 @@ function resetGlobalAdminSearchCollections() {
 async function ensureGlobalAdminTeamsForSearch() {
     if (globalSearchTeamsLoaded) return globalSearchTeams;
     if (!globalSearchTeamsPromise) {
-        globalSearchTeamsPromise = getAdminTeamsPage({ pageSize: 100 })
-            .then((page) => {
-                globalSearchTeams = Array.isArray(page?.teams) ? page.teams : [];
+        globalSearchTeamsPromise = loadCompleteAdminSearchCollection({
+            fetchPage: getAdminTeamsPage,
+            itemsKey: 'teams'
+        })
+            .then((teams) => {
+                globalSearchTeams = teams;
                 globalSearchTeamsLoaded = true;
                 return globalSearchTeams;
             })
@@ -166,9 +170,12 @@ async function ensureGlobalAdminTeamsForSearch() {
 async function ensureGlobalAdminUsersForSearch() {
     if (globalSearchUsersLoaded) return globalSearchUsers;
     if (!globalSearchUsersPromise) {
-        globalSearchUsersPromise = getAdminUsersPage({ pageSize: 100 })
-            .then((page) => {
-                globalSearchUsers = Array.isArray(page?.users) ? page.users : [];
+        globalSearchUsersPromise = loadCompleteAdminSearchCollection({
+            fetchPage: getAdminUsersPage,
+            itemsKey: 'users'
+        })
+            .then((users) => {
+                globalSearchUsers = users;
                 globalSearchUsersLoaded = true;
                 return globalSearchUsers;
             })

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -17,7 +17,7 @@ describe('admin dashboard statistics scope', () => {
         expect(loadDashboardBody).not.toContain('getAllUsers()');
     });
 
-    it('uses bounded page loaders for explicit broader admin searches', () => {
+    it('keeps initial reads bounded while paging through complete explicit searches', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
 
         const adminHtml = fs.readFileSync('admin.html', 'utf8');
@@ -34,8 +34,11 @@ describe('admin dashboard statistics scope', () => {
         expect(adminJs).toContain('await ensureCurrentUsersOfficialsLoaded();');
         expect(adminHtml).toContain('id="teams-pagination-status"');
         expect(adminHtml).toContain('id="users-pagination-status"');
-        expect(adminJs).toContain('getAdminTeamsPage({ pageSize: 100 })');
-        expect(adminJs).toContain('getAdminUsersPage({ pageSize: 100 })');
+        expect(adminJs).toContain('loadCompleteAdminSearchCollection({');
+        expect(adminJs).toContain('fetchPage: getAdminTeamsPage');
+        expect(adminJs).toContain("itemsKey: 'teams'");
+        expect(adminJs).toContain('fetchPage: getAdminUsersPage');
+        expect(adminJs).toContain("itemsKey: 'users'");
         expect(adminJs).not.toContain('globalSearchTeamsPromise = getTeams(');
         expect(adminJs).not.toContain('globalSearchUsersPromise = getAllUsers(');
     });

--- a/tests/unit/admin-search.test.js
+++ b/tests/unit/admin-search.test.js
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
     hasAdminGlobalSearchTerm,
+    loadCompleteAdminSearchCollection,
     normalizeAdminSearchTerm,
     selectAdminItemById,
     selectAdminSearchCollection
@@ -20,6 +21,22 @@ describe('admin search collection selection', () => {
         const globalItems = [{ id: 'user-99', email: 'zeta@example.com' }];
 
         expect(selectAdminSearchCollection({ searchTerm: 'zeta', pageItems, globalItems })).toBe(globalItems);
+    });
+
+    it('loads every admin page so search can find records after the first 100', async () => {
+        const firstPage = Array.from({ length: 100 }, (_, index) => ({ id: `team-${index + 1}` }));
+        const secondPage = Array.from({ length: 50 }, (_, index) => ({ id: `team-${index + 101}` }));
+        const firstCursor = { id: 'team-100' };
+        const fetchPage = vi.fn()
+            .mockResolvedValueOnce({ teams: firstPage, nextCursor: firstCursor })
+            .mockResolvedValueOnce({ teams: secondPage, nextCursor: null });
+
+        const teams = await loadCompleteAdminSearchCollection({ fetchPage, itemsKey: 'teams' });
+
+        expect(fetchPage).toHaveBeenNthCalledWith(1, { pageSize: 100 });
+        expect(fetchPage).toHaveBeenNthCalledWith(2, { pageSize: 100, cursor: firstCursor });
+        expect(teams).toHaveLength(150);
+        expect(teams.at(-1)).toEqual({ id: 'team-150' });
     });
 
     it('normalizes whitespace and casing before deciding whether search is global', () => {

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -53,7 +53,7 @@ describe('RSVP precedence cache delivery', () => {
 
     it('propagates fresh keys through cached wrapper and shared utility entry modules', () => {
         const consumerVersions = {
-            'admin.html': 'js/admin.js?v=9',
+            'admin.html': 'js/admin.js?v=10',
             'certificates.html': 'js/certificates/studio.js?v=13',
             'live-game.html': 'js/live-game.js?v=16',
             'live-tracker.html': 'js/live-tracker.js?v=2',


### PR DESCRIPTION
Closes #3925

## What changed
- Added a shared helper that follows admin pagination cursors until the complete collection is loaded.
- Updated team and user searches to use the complete paginated collection.
- Updated browser cache-bust versions for the changed modules.

## Root Cause
Non-empty searches used a global cache, but each cache was populated by only one 100-record page. The loaded flag was then set without following `nextCursor`, permanently excluding later records.

## Prevention / Learning
Any collection-wide client search backed by paginated APIs must follow cursors until exhaustion or use a server-side search query. Regression coverage must include a match beyond the first page boundary.

## Regression Tests
- Added coverage proving the search loader retrieves a record after the first 100 results.
- Added wiring assertions for complete team and user search pagination.
- Validated updated browser cache-bust keys.

## Recurrence Risk
Low. Team and user searches now share one tested cursor-exhaustion helper.