### PR TITLE
Honor legacy chat conversation deep links

### DIFF
--- a/team-chat.html
+++ b/team-chat.html
@@ -534,6 +534,13 @@
             return hashParams.get('teamId') || searchParams.get('teamId');
         }
 
+        function getConversationIdFromUrl() {
+            const hashParams = new URLSearchParams(window.location.hash.replace('#', ''));
+            const searchParams = new URLSearchParams(window.location.search);
+            return hashParams.get('conversationId') || hashParams.get('conversation') ||
+                searchParams.get('conversationId') || searchParams.get('conversation');
+        }
+
         // Initialize
         checkAuth(async (user) => {
             if (!user) {
@@ -550,6 +557,7 @@
                 window.location.href = 'dashboard.html';
                 return;
             }
+            selectedConversationId = getConversationIdFromUrl() || DEFAULT_TEAM_CONVERSATION_ID;
 
             try {
                 // Load team
@@ -1556,7 +1564,8 @@
             try {
                 conversations = await getChatConversations(teamId, currentUser, {
                     team: currentTeam,
-                    canModerate
+                    canModerate,
+                    activeConversationId: selectedConversationId
                 });
             } catch (error) {
                 console.warn('Failed to load chat conversations; falling back to team-wide channel:', error);

--- a/tests/unit/team-chat-url.test.js
+++ b/tests/unit/team-chat-url.test.js
@@ -5,10 +5,10 @@ function readTeamChat() {
     return readFileSync(new URL('../../team-chat.html', import.meta.url), 'utf8');
 }
 
-function buildGetTeamIdFromUrl({ hash = '', search = '' } = {}) {
+function buildUrlHelper(functionName, { hash = '', search = '' } = {}) {
     const source = readTeamChat();
-    const match = source.match(/function getTeamIdFromUrl\(\) \{([\s\S]*?)\n        \}\n\n        \/\/ Initialize/);
-    expect(match, 'getTeamIdFromUrl should exist').toBeTruthy();
+    const match = source.match(new RegExp(`function ${functionName}\\(\\) \\{([\\s\\S]*?)\\n        \\}`));
+    expect(match, `${functionName} should exist`).toBeTruthy();
 
     const createHelper = new Function('deps', `
         const { window, URLSearchParams } = deps;
@@ -25,14 +25,43 @@ ${match[1]}
 
 describe('team chat URL routing', () => {
     it('reads teamId from the existing hash route format', () => {
-        const getTeamIdFromUrl = buildGetTeamIdFromUrl({ hash: '#teamId=team-123' });
+        const getTeamIdFromUrl = buildUrlHelper('getTeamIdFromUrl', { hash: '#teamId=team-123' });
 
         expect(getTeamIdFromUrl()).toBe('team-123');
     });
 
     it('reads teamId from notification query-string links', () => {
-        const getTeamIdFromUrl = buildGetTeamIdFromUrl({ search: '?teamId=team-456' });
+        const getTeamIdFromUrl = buildUrlHelper('getTeamIdFromUrl', { search: '?teamId=team-456' });
 
         expect(getTeamIdFromUrl()).toBe('team-456');
+    });
+
+    it('reads and decodes conversationId from notification query-string links', () => {
+        const getConversationIdFromUrl = buildUrlHelper('getConversationIdFromUrl', {
+            search: '?teamId=team-456&conversationId=direct_user%3Acoach-1__user%3Aparent-1'
+        });
+
+        expect(getConversationIdFromUrl()).toBe('direct_user:coach-1__user:parent-1');
+    });
+
+    it('supports the conversation alias in hash routes', () => {
+        const getConversationIdFromUrl = buildUrlHelper('getConversationIdFromUrl', {
+            hash: '#teamId=team-123&conversation=staff-conversation'
+        });
+
+        expect(getConversationIdFromUrl()).toBe('staff-conversation');
+    });
+
+    it('selects and includes the deep-linked conversation before realtime starts', () => {
+        const source = readTeamChat();
+        const initialization = source.slice(source.indexOf('// Initialize'), source.indexOf('async function loadMessages'));
+        const loadConversations = source.slice(source.indexOf('async function loadConversations()'), source.indexOf('function getSelectedConversation()'));
+
+        expect(initialization).toContain('selectedConversationId = getConversationIdFromUrl() || DEFAULT_TEAM_CONVERSATION_ID;');
+        expect(initialization.indexOf('selectedConversationId = getConversationIdFromUrl()'))
+            .toBeLessThan(initialization.indexOf('await loadConversations();'));
+        expect(initialization.indexOf('await loadConversations();'))
+            .toBeLessThan(initialization.indexOf('startRealtimeUpdates();'));
+        expect(loadConversations).toContain('activeConversationId: selectedConversationId');
     });
 });


### PR DESCRIPTION
Closes #3921

## What changed
- Parse `conversationId` and `conversation` from legacy chat query-string and hash routes.
- Select the requested conversation before conversations load and realtime updates start.
- Pass the active conversation to `getChatConversations` so deep-linked conversations outside the initial page are fetched.

## Root Cause
The legacy page parsed only `teamId`, leaving `selectedConversationId` set to the team-wide default. Conversation loading therefore omitted the target conversation and realtime subscribed to the wrong channel.

## Prevention / Learning
Treat every routing parameter emitted by notification builders as an end-to-end contract. Regression coverage should verify parsing, initial state seeding, data loading, and subscription ordering.

## Regression Tests
- Added coverage for encoded `conversationId` query parameters.
- Added coverage for the `conversation` hash alias.
- Added source-level assertions that selection occurs before conversation loading and realtime startup, and that the active conversation is included in the data request.
- Verified the focused URL-routing and conversation suites: 10 tests passed.

## Recurrence Risk
Low. Both supported parameter aliases and the initialization ordering are now covered by focused regression tests.