### PR TITLE
Protect child-specific notes in family RSVP

### DIFF
--- a/apps/app/src/components/schedule/AvailabilityPanels.tsx
+++ b/apps/app/src/components/schedule/AvailabilityPanels.tsx
@@ -100,10 +100,11 @@ export function TeamRsvpToolsDisclosure({ summary, children }: {
   );
 }
 
-export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit, question }: {
+export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, canEditAvailabilityNote = canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit, question }: {
   event: ParentScheduleEvent;
   rsvp: RsvpResponse;
   canSubmitRsvp: boolean;
+  canEditAvailabilityNote?: boolean;
   submitting: RsvpResponse | null;
   availabilityNote: string;
   onAvailabilityNoteChange: (note: string) => void;
@@ -149,7 +150,7 @@ export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting,
             className="mt-2 min-h-8 rounded-full border border-gray-200 bg-white px-3 text-xs font-black text-gray-700 transition hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700 disabled:cursor-not-allowed disabled:opacity-60"
             aria-expanded={isNoteEditorOpen}
             aria-controls={`availability-note-${event.eventKey}-${event.childId}`}
-            disabled={!canSubmitRsvp || (isNoteEditorOpen && noteSaveState.isDirty)}
+            disabled={!canEditAvailabilityNote || (isNoteEditorOpen && noteSaveState.isDirty)}
             onClick={() => setIsNoteEditorOpen((current) => !current)}
           >
             {isNoteEditorOpen ? 'Hide note' : hasSavedNote ? 'Edit note' : 'Add note'}
@@ -163,7 +164,7 @@ export function QuickAvailabilityPanel({ event, rsvp, canSubmitRsvp, submitting,
                   className="auth-input min-h-16 resize-none !px-3 !py-2 text-xs font-semibold"
                   value={availabilityNote}
                   onChange={(changeEvent) => onAvailabilityNoteChange(changeEvent.target.value)}
-                  disabled={!canSubmitRsvp}
+                  disabled={!canEditAvailabilityNote}
                   placeholder="Optional note for coaches, rides, or arrival details"
                   rows={2}
                   maxLength={280}

--- a/apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx
+++ b/apps/app/src/hooks/schedule/useScheduleEventRsvp.test.tsx
@@ -59,13 +59,18 @@ function buildEvent(overrides: Record<string, unknown> = {}) {
     } as any;
 }
 
-function RsvpProbe({ availabilityNote, applyToAllChildren = false }: { availabilityNote: string; applyToAllChildren?: boolean }) {
-    const workflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren });
+function RsvpProbe({ availabilityNote, applyToAllChildren = false, sharedNoteExplicitlyChosen = false }: {
+    availabilityNote: string;
+    applyToAllChildren?: boolean;
+    sharedNoteExplicitlyChosen?: boolean;
+}) {
+    const workflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren, sharedNoteExplicitlyChosen });
     const { event, childEvents } = useScheduleEventDetailContext();
 
     return (
         <div>
             <div data-testid="can-submit">{String(workflow.canSubmit)}</div>
+            <div data-testid="requires-shared-note-choice">{String(workflow.requiresSharedNoteChoice)}</div>
             <div data-testid="current-rsvp">{String(event.myRsvp)}</div>
             <div data-testid="current-note">{String(event.myRsvpNote || '')}</div>
             <div data-testid="submitting">{String(workflow.submitting || '')}</div>
@@ -83,7 +88,7 @@ function RsvpProbe({ availabilityNote, applyToAllChildren = false }: { availabil
     );
 }
 
-function renderProbe(availabilityNote = 'Running late', options: { events?: any[]; applyToAllChildren?: boolean } = {}) {
+function renderProbe(availabilityNote = 'Running late', options: { events?: any[]; applyToAllChildren?: boolean; sharedNoteExplicitlyChosen?: boolean } = {}) {
     function Harness() {
         const [events, setEvents] = useState(options.events || [buildEvent()]);
 
@@ -97,7 +102,11 @@ function renderProbe(availabilityNote = 'Running late', options: { events?: any[
                     updateEvents: (updater) => setEvents((current) => updater(current))
                 }}
             >
-                <RsvpProbe availabilityNote={availabilityNote} applyToAllChildren={options.applyToAllChildren} />
+                <RsvpProbe
+                    availabilityNote={availabilityNote}
+                    applyToAllChildren={options.applyToAllChildren}
+                    sharedNoteExplicitlyChosen={options.sharedNoteExplicitlyChosen}
+                />
             </ScheduleEventDetailProvider>
         );
     }
@@ -202,6 +211,35 @@ describe('useScheduleEventRsvp', () => {
             expect.objectContaining({ childId: 'player-1', myRsvp: 'going', myRsvpNote: 'Both need a ride', rsvpSummary: summary }),
             expect.objectContaining({ childId: 'player-2', myRsvp: 'going', myRsvpNote: 'Both need a ride', rsvpSummary: summary })
         ]);
+    });
+
+    it('requires an explicit shared note choice before replacing differing child notes', async () => {
+        vi.mocked(submitParentScheduleRsvpForChildren).mockResolvedValue(null as any);
+        const events = [
+            buildEvent({ myRsvpNote: 'Arriving late' }),
+            buildEvent({
+                eventKey: 'team-1::game-1::player-2',
+                childId: 'player-2',
+                childName: 'Sam Lee',
+                myRsvpNote: 'Needs a ride'
+            })
+        ];
+
+        const firstRender = renderProbe('Arriving late', { events, applyToAllChildren: true });
+        expect(screen.getByTestId('requires-shared-note-choice').textContent).toBe('true');
+        fireEvent.click(screen.getByRole('button', { name: 'Submit going' }));
+        expect(submitParentScheduleRsvpForChildren).not.toHaveBeenCalled();
+        firstRender.unmount();
+
+        renderProbe('Shared family note', { events, applyToAllChildren: true, sharedNoteExplicitlyChosen: true });
+        fireEvent.click(screen.getByRole('button', { name: 'Submit going' }));
+
+        await waitFor(() => expect(submitParentScheduleRsvpForChildren).toHaveBeenCalledWith(
+            expect.any(Array),
+            auth.user,
+            'going',
+            'Shared family note'
+        ));
     });
 
     it('excludes staff-expanded roster rows from family RSVP writes', async () => {

--- a/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
+++ b/apps/app/src/hooks/schedule/useScheduleEventRsvp.ts
@@ -47,7 +47,11 @@ function waitForVisibleState() {
   });
 }
 
-export function useScheduleEventRsvp({ availabilityNote, applyToAllChildren = false }: { availabilityNote: string; applyToAllChildren?: boolean }) {
+export function useScheduleEventRsvp({ availabilityNote, applyToAllChildren = false, sharedNoteExplicitlyChosen = false }: {
+  availabilityNote: string;
+  applyToAllChildren?: boolean;
+  sharedNoteExplicitlyChosen?: boolean;
+}) {
   const { auth, event, childEvents, updateEvents } = useScheduleEventDetailContext();
   const [submitting, setSubmitting] = useState<RsvpResponse | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -58,10 +62,12 @@ export function useScheduleEventRsvp({ availabilityNote, applyToAllChildren = fa
   ));
   const targetEvents = applyToAllChildren && event.isLinkedParentChild === true ? matchingChildEvents : [event];
   const canSubmit = targetEvents.length > 0 && targetEvents.every(canSubmitScheduleEventRsvp);
+  const savedNotesDiffer = new Set(targetEvents.map((targetEvent) => String(targetEvent.myRsvpNote || '').trim())).size > 1;
+  const requiresSharedNoteChoice = applyToAllChildren && targetEvents.length > 1 && savedNotesDiffer && !sharedNoteExplicitlyChosen;
 
   const submit = async (response: Exclude<RsvpResponse, 'not_responded'>) => {
     const currentUser = auth.user;
-    if (!currentUser || !canSubmit) return;
+    if (!currentUser || !canSubmit || requiresSharedNoteChoice) return;
 
     const interaction = startInteractionTimer(UX_TIMING.rsvpTap, { response });
     const previousStateByChildId = new Map(targetEvents.map((targetEvent) => [targetEvent.childId, {
@@ -148,6 +154,7 @@ export function useScheduleEventRsvp({ availabilityNote, applyToAllChildren = fa
 
   return {
     canSubmit,
+    requiresSharedNoteChoice,
     submitting,
     message,
     error,

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -972,7 +972,9 @@ describe('ScheduleEventDetail family RSVP path', () => {
     expect(screen.getByRole('button', { name: 'Going' })).toBeDisabled();
     expect(screen.queryByDisplayValue('Arriving late')).toBeNull();
 
-    fireEvent.click(screen.getByRole('button', { name: 'use no shared note' }));
+    const sharedNote = screen.getByRole('textbox', { name: 'Availability note' });
+    expect(sharedNote).not.toBeDisabled();
+    fireEvent.change(sharedNote, { target: { value: 'Both need a ride' } });
     expect(screen.getByRole('button', { name: 'Going' })).not.toBeDisabled();
   });
 

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -897,7 +897,7 @@ describe('ScheduleEventDetail family RSVP path', () => {
     cleanup();
   });
 
-  it('shows the family response first and defers child-specific controls', async () => {
+  it('shows the family response first when linked children have no saved notes', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [
         buildEvent({ childId: 'player-1', childName: 'Avery Smith' }),
@@ -924,6 +924,56 @@ describe('ScheduleEventDetail family RSVP path', () => {
 
     fireEvent.click(within(screen.getByTestId('event-player-switcher')).getByRole('button', { name: 'Sam Lee' }));
     await waitFor(() => expect(screen.getByText('Is Sam Lee going?')).toBeTruthy());
+  });
+
+  it('shows the family response first when linked children have matching saved notes', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [
+        buildEvent({ childId: 'player-1', childName: 'Avery Smith', myRsvpNote: 'Both need a ride' }),
+        buildEvent({
+          eventKey: 'team-1::game-1::player-2::2026-06-04T18:00:00.000Z::game',
+          childId: 'player-2',
+          childName: 'Sam Lee',
+          myRsvpNote: 'Both need a ride'
+        })
+      ],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    expect(await screen.findByText('Family response')).toBeTruthy();
+    expect(screen.getByText('One choice updates Avery Smith and Sam Lee.')).toBeTruthy();
+    expect(screen.getByDisplayValue('Both need a ride')).toBeTruthy();
+  });
+
+  it('defaults to the selected child when linked children have different saved notes', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [
+        buildEvent({ childId: 'player-1', childName: 'Avery Smith', myRsvpNote: 'Arriving late' }),
+        buildEvent({
+          eventKey: 'team-1::game-1::player-2::2026-06-04T18:00:00.000Z::game',
+          childId: 'player-2',
+          childName: 'Sam Lee',
+          myRsvpNote: 'Needs a ride'
+        })
+      ],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    expect(await screen.findByText('Responding for Avery Smith')).toBeTruthy();
+    expect(screen.getByText(/Saved notes differ, so responses start separately/)).toBeTruthy();
+    expect(await screen.findByDisplayValue('Arriving late')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Respond together' }));
+    expect(screen.getByText('Choose one shared note before responding together.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Going' })).toBeDisabled();
+    expect(screen.queryByDisplayValue('Arriving late')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'use no shared note' }));
+    expect(screen.getByRole('button', { name: 'Going' })).not.toBeDisabled();
   });
 
   it('keeps the existing child-specific path for a single child', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1057,13 +1057,16 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
   onSelectSection: (sectionId: EventDetailSectionId) => void;
 }) {
   const { childEvents } = useScheduleEventDetailContext();
-  const [individualMode, setIndividualMode] = useState(false);
-  useEffect(() => {
-    setIndividualMode(false);
-  }, [event.id, event.teamId]);
   const matchingChildEvents = childEvents.filter((childEvent) => (
     childEvent.teamId === event.teamId && childEvent.id === event.id && Boolean(childEvent.childId) && childEvent.isLinkedParentChild === true
   ));
+  const savedNotesDiffer = new Set(matchingChildEvents.map((childEvent) => String(childEvent.myRsvpNote || '').trim())).size > 1;
+  const [individualMode, setIndividualMode] = useState(savedNotesDiffer);
+  const [sharedNoteExplicitlyChosen, setSharedNoteExplicitlyChosen] = useState(!savedNotesDiffer);
+  useEffect(() => {
+    setIndividualMode(savedNotesDiffer);
+    setSharedNoteExplicitlyChosen(!savedNotesDiffer);
+  }, [event.id, event.teamId, savedNotesDiffer]);
   const familyRsvpAvailable = event.isLinkedParentChild === true && matchingChildEvents.length > 1 && matchingChildEvents.every((childEvent) => (
     childEvent.isDbGame && !childEvent.isCancelled && !childEvent.availabilityLocked
   ));
@@ -1078,7 +1081,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
   const familyQuestion = familyNames.length === 2
     ? `Are ${familyNames[0]} and ${familyNames[1]} going?`
     : `Are all ${familyNames.length} children going?`;
-  const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });
+  const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp, sharedNoteExplicitlyChosen });
   const staffRsvpEventScopeKey = `${event.teamId}:${event.id}`;
   const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);
   const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);
@@ -1101,29 +1104,62 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
           <div className="min-w-0">
             <div className="text-xs font-black text-primary-900">{useFamilyRsvp ? 'Family response' : `Responding for ${event.childName}`}</div>
             <div className="mt-0.5 text-xs font-semibold text-primary-700">
-              {useFamilyRsvp ? `One choice updates ${familyNames.join(' and ')}.` : 'Use the player switcher above to choose a child.'}
+              {useFamilyRsvp
+                ? savedNotesDiffer
+                  ? 'Choose one shared note before responding together.'
+                  : `One choice updates ${familyNames.join(' and ')}.`
+                : savedNotesDiffer
+                  ? 'Saved notes differ, so responses start separately. Use the player switcher above to choose a child.'
+                  : 'Use the player switcher above to choose a child.'}
             </div>
           </div>
           <button
             type="button"
             className="min-h-8 rounded-full border border-primary-200 bg-white px-3 text-xs font-black text-primary-700 transition hover:border-primary-300 hover:bg-primary-100"
-            onClick={() => setIndividualMode((current) => !current)}
+            onClick={() => {
+              if (useFamilyRsvp) {
+                setIndividualMode(true);
+                return;
+              }
+              if (savedNotesDiffer) {
+                onAvailabilityNoteChange('');
+                setSharedNoteExplicitlyChosen(false);
+              }
+              setIndividualMode(false);
+            }}
           >
             {useFamilyRsvp ? 'Set individually' : 'Respond together'}
           </button>
         </div>
       ) : null}
       {rsvpWorkflow.canSubmit ? (
-        <QuickAvailabilityPanel
-          event={event}
-          rsvp={visibleRsvp}
-          canSubmitRsvp
-          submitting={rsvpWorkflow.submitting}
-          availabilityNote={availabilityNote}
-          onAvailabilityNoteChange={onAvailabilityNoteChange}
-          onSubmit={rsvpWorkflow.submit}
-          question={useFamilyRsvp ? familyQuestion : undefined}
-        />
+        <>
+          {rsvpWorkflow.requiresSharedNoteChoice ? (
+            <div className="border-b border-amber-200 bg-amber-50 px-3 py-2.5 text-xs font-semibold text-amber-900 sm:px-4">
+              Enter a shared note below, or{' '}
+              <button
+                type="button"
+                className="font-black underline underline-offset-2"
+                onClick={() => setSharedNoteExplicitlyChosen(true)}
+              >
+                use no shared note
+              </button>.
+            </div>
+          ) : null}
+          <QuickAvailabilityPanel
+            event={event}
+            rsvp={visibleRsvp}
+            canSubmitRsvp={!rsvpWorkflow.requiresSharedNoteChoice}
+            submitting={rsvpWorkflow.submitting}
+            availabilityNote={availabilityNote}
+            onAvailabilityNoteChange={(note) => {
+              onAvailabilityNoteChange(note);
+              if (useFamilyRsvp && savedNotesDiffer) setSharedNoteExplicitlyChosen(true);
+            }}
+            onSubmit={rsvpWorkflow.submit}
+            question={useFamilyRsvp ? familyQuestion : undefined}
+          />
+        </>
       ) : (
         <ReadOnlyAvailabilityPanel event={event} rsvp={visibleRsvp} />
       )}

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1150,6 +1150,7 @@ function AvailabilitySection({ event, rsvp, availabilityNote, onAvailabilityNote
             event={event}
             rsvp={visibleRsvp}
             canSubmitRsvp={!rsvpWorkflow.requiresSharedNoteChoice}
+            canEditAvailabilityNote={rsvpWorkflow.canSubmit}
             submitting={rsvpWorkflow.submitting}
             availabilityNote={availabilityNote}
             onAvailabilityNoteChange={(note) => {

--- a/tests/unit/app-schedule-detail-decomposition.test.js
+++ b/tests/unit/app-schedule-detail-decomposition.test.js
@@ -32,7 +32,7 @@ describe('ScheduleEventDetail decomposition', () => {
         expect(source).toContain("from '../hooks/schedule/useScheduleEventRsvp'");
         expect(source).toContain("from '../hooks/schedule/useStaffRsvpBreakdown'");
         expect(source).toContain('<ScheduleEventDetailProvider value={{');
-        expect(source).toContain('useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp })');
+        expect(source).toContain('useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp, sharedNoteExplicitlyChosen })');
         expect(source).toContain('useStaffRsvpBreakdown(staffRsvpLoader)');
         expect(source).toContain('<DeferredGameReportSections event={event} />');
         expect(source).toContain('<PlayerSwitcher events={events} selectedChildId={selectedEvent.childId} onSelect={selectChild} compact />');

--- a/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
+++ b/tests/unit/schedule-detail-decomposition-initiative-source-contract.test.js
@@ -58,7 +58,7 @@ describe('ScheduleEventDetail decomposition initiative source contract', () => {
 
     it('keeps parent RSVP mutation, optimistic update, and rollback logic in useScheduleEventRsvp', () => {
         expect(detailSource).toContain("import { useScheduleEventRsvp } from '../hooks/schedule/useScheduleEventRsvp';");
-        expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
+        expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp, sharedNoteExplicitlyChosen });');
         expect(detailSource).not.toMatch(/const\s+\[rsvpSubmitting\b/);
         expect(detailSource).not.toMatch(/submitParentScheduleRsvp\(/);
 

--- a/tests/unit/schedule-event-detail-decomposition-contract.test.js
+++ b/tests/unit/schedule-event-detail-decomposition-contract.test.js
@@ -92,7 +92,7 @@ describe('ScheduleEventDetail decomposition contract', () => {
         expect(page).toContain("import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';");
         expect(page).toContain("import { RideshareSection } from '../components/schedule/RideshareSection';");
         expect(page).toContain('<ScheduleEventDetailProvider value={{');
-        expect(page).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
+        expect(page).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp, sharedNoteExplicitlyChosen });');
         expect(page).toContain("const staffRsvpEventScopeKey = `${event.teamId}:${event.id}`;");
         expect(page).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);');
         expect(page).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');

--- a/tests/unit/staff-rsvp-panel-source-contract.test.js
+++ b/tests/unit/staff-rsvp-panel-source-contract.test.js
@@ -14,7 +14,7 @@ describe('staff RSVP panel decomposition contract', () => {
         expect(detailSource).toContain("const staffRsvpEventScopeKey = `${event.teamId}:${event.id}`;");
         expect(detailSource).toContain('const staffRsvpLoader = useMemo(() => createStaffRsvpAvailabilityLoader(staffRsvpEventScopeKey), [staffRsvpEventScopeKey]);');
         expect(detailSource).toContain('const staffRsvp = useStaffRsvpBreakdown(staffRsvpLoader);');
-        expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp });');
+        expect(detailSource).toContain('const rsvpWorkflow = useScheduleEventRsvp({ availabilityNote, applyToAllChildren: useFamilyRsvp, sharedNoteExplicitlyChosen });');
     });
 
     it('keeps staff override rows in the reusable schedule component', () => {


### PR DESCRIPTION
Closes #3929

## What changed
- Default linked children to individual RSVP mode when their saved notes differ.
- Keep family RSVP as the default for matching or empty notes.
- Require an explicit shared note or no-note choice before responding together when notes differ.
- Preserve linked-child, permission, cancellation, and availability-lock safeguards.

## Root Cause
ScheduleEventDetail always initialized eligible linked-child events in family mode while its single note state was seeded from only the selected child. The grouped RSVP hook could therefore submit that child-specific note for every linked child without confirming shared intent.

## Prevention / Learning
Bulk actions over child-scoped persisted fields must compare values across every target before defaulting to grouped mode. When values differ, require an explicit shared-value choice before allowing a grouped write.

## Regression Tests
- Added page coverage for empty, matching, and differing saved notes.
- Added hook coverage preventing grouped writes until a shared note choice is explicit.
- Verified individual submissions retain the selected child's note.
- `npx vitest run src/pages/ScheduleEventDetail.test.tsx src/hooks/schedule/useScheduleEventRsvp.test.tsx --reporter=verbose -t 'ScheduleEventDetail family RSVP path|useScheduleEventRsvp'` passed: 13 tests.
- `npm run typecheck` passed.

## Recurrence Risk
Low. Focused component and hook tests now cover the default-mode decision and grouped-write safety boundary.