### PR TITLE
Coalesce Game Hub live-chat scrolling

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -233,6 +233,7 @@ vi.mock('../lib/statsheetImportService', () => statsheetImportServiceMocks);
 
 import {
   ScheduleEventDetail,
+  createLiveGameChatScrollScheduler,
   isLiveGameChatNearBottom,
   loadGameDayLineupBuilderModule,
   loadGameReportSectionsModule,
@@ -382,6 +383,10 @@ function installScrollMetrics(
   element: HTMLElement,
   metrics: { scrollHeight: number; clientHeight: number }
 ) {
+  let scrollTop = element.scrollTop;
+  const setScrollTop = vi.fn((value: number) => {
+    scrollTop = value;
+  });
   Object.defineProperty(element, 'scrollHeight', {
     configurable: true,
     get: () => metrics.scrollHeight
@@ -390,7 +395,12 @@ function installScrollMetrics(
     configurable: true,
     get: () => metrics.clientHeight
   });
-  return metrics;
+  Object.defineProperty(element, 'scrollTop', {
+    configurable: true,
+    get: () => scrollTop,
+    set: setScrollTop
+  });
+  return Object.assign(metrics, { setScrollTop });
 }
 
 function buildLiveChatMessages(count: number) {
@@ -489,6 +499,38 @@ describe('ScheduleEventDetail deferred game hub loaders', () => {
 });
 
 describe('ScheduleEventDetail live chat scroll helpers', () => {
+  it('coalesces repeated scroll requests into one animation-frame adjustment', () => {
+    const callbacks = new Map<number, FrameRequestCallback>();
+    const adjustScroll = vi.fn();
+    const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+      const frameId = callbacks.size + 1;
+      callbacks.set(frameId, callback);
+      return frameId;
+    });
+    const cancelFrame = vi.fn((frameId: number) => callbacks.delete(frameId));
+    const scheduler = createLiveGameChatScrollScheduler(adjustScroll, requestFrame, cancelFrame);
+
+    scheduler.schedule();
+    scheduler.schedule();
+
+    expect(callbacks.size).toBe(1);
+    callbacks.values().next().value?.(0);
+    expect(adjustScroll).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels pending live-chat scroll work during cleanup', () => {
+    const adjustScroll = vi.fn();
+    const requestFrame = vi.fn(() => 42);
+    const cancelFrame = vi.fn();
+    const scheduler = createLiveGameChatScrollScheduler(adjustScroll, requestFrame, cancelFrame);
+
+    scheduler.schedule();
+    scheduler.cancel();
+
+    expect(cancelFrame).toHaveBeenCalledWith(42);
+    expect(adjustScroll).not.toHaveBeenCalled();
+  });
+
   it('treats live chat positions within 96 pixels of the bottom as near bottom', () => {
     expect(isLiveGameChatNearBottom(null)).toBe(true);
     expect(isLiveGameChatNearBottom({ scrollHeight: 1000, clientHeight: 400, scrollTop: 504 })).toBe(true);
@@ -2374,6 +2416,22 @@ describe('ScheduleEventDetail assignments', () => {
   });
 
   it('keeps mobile live chat pinned to latest messages unless the viewer scrolls up', async () => {
+    const frameCallbacks = new Map<number, FrameRequestCallback>();
+    let nextFrameId = 1;
+    const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      const frameId = nextFrameId++;
+      frameCallbacks.set(frameId, callback);
+      return frameId;
+    });
+    const cancelFrame = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((frameId) => {
+      frameCallbacks.delete(frameId);
+    });
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    const flushAnimationFrame = async () => {
+      const callbacks = [...frameCallbacks.values()];
+      frameCallbacks.clear();
+      await act(async () => callbacks.forEach((callback) => callback(performance.now())));
+    };
     let chatCallback: (messages: Array<{ id: string; text?: string | null; senderName?: string | null; createdAt?: unknown }>) => void = () => {};
     liveGameChatServiceMocks.subscribeToLiveGameChat.mockImplementation((_teamId, _gameId, callback) => {
       chatCallback = callback;
@@ -2385,7 +2443,7 @@ describe('ScheduleEventDetail assignments', () => {
       children: []
     });
 
-    renderScheduleEventDetail();
+    const { unmount } = renderScheduleEventDetail();
 
     await waitFor(() => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
@@ -2399,23 +2457,39 @@ describe('ScheduleEventDetail assignments', () => {
 
     const scroller = screen.getByTestId('live-game-chat-messages') as HTMLDivElement;
     const metrics = installScrollMetrics(scroller, { scrollHeight: 520, clientHeight: 160 });
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView
+    });
+    frameCallbacks.clear();
+    requestFrame.mockClear();
+    cancelFrame.mockClear();
+    scrollIntoView.mockClear();
+    setTimeoutSpy.mockClear();
 
     await act(async () => {
       chatCallback(buildLiveChatMessages(8));
     });
-    await waitFor(() => {
-      expect(scroller.scrollTop).toBe(360);
-    });
+    expect(requestFrame).toHaveBeenCalledTimes(1);
+    await flushAnimationFrame();
+    expect(scroller.scrollTop).toBe(360);
+    expect(metrics.setScrollTop).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    expect(scrollIntoView).not.toHaveBeenCalled();
 
     scroller.scrollTop = 330;
     fireEvent.scroll(scroller);
+    metrics.setScrollTop.mockClear();
+    requestFrame.mockClear();
     metrics.scrollHeight = 600;
     await act(async () => {
       chatCallback(buildLiveChatMessages(9));
     });
-    await waitFor(() => {
-      expect(scroller.scrollTop).toBe(440);
-    });
+    expect(requestFrame).toHaveBeenCalledTimes(1);
+    await flushAnimationFrame();
+    expect(scroller.scrollTop).toBe(440);
+    expect(metrics.setScrollTop).toHaveBeenCalledTimes(1);
 
     fireEvent.change(screen.getByLabelText('Live chat message'), { target: { value: "Let's go Bears" } });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
@@ -2436,15 +2510,17 @@ describe('ScheduleEventDetail assignments', () => {
       }
     ];
     metrics.scrollHeight = 680;
+    metrics.setScrollTop.mockClear();
     await act(async () => {
       chatCallback(messagesWithSentEcho);
     });
-    await waitFor(() => {
-      expect(scroller.scrollTop).toBe(520);
-    });
+    await flushAnimationFrame();
+    expect(scroller.scrollTop).toBe(520);
+    expect(metrics.setScrollTop).toHaveBeenCalledTimes(1);
 
     scroller.scrollTop = 160;
     fireEvent.scroll(scroller);
+    metrics.setScrollTop.mockClear();
     metrics.scrollHeight = 760;
     await act(async () => {
       chatCallback([
@@ -2461,10 +2537,12 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getByTestId('live-chat-message-m11')).toBeTruthy();
     });
     expect(scroller.scrollTop).toBe(160);
+    expect(metrics.setScrollTop).not.toHaveBeenCalled();
 
     scroller.scrollTop = 590;
     fireEvent.scroll(scroller);
     metrics.scrollHeight = 840;
+    metrics.setScrollTop.mockClear();
     await act(async () => {
       chatCallback([
         ...messagesWithSentEcho,
@@ -2482,9 +2560,24 @@ describe('ScheduleEventDetail assignments', () => {
         }
       ]);
     });
-    await waitFor(() => {
-      expect(scroller.scrollTop).toBe(680);
+    await flushAnimationFrame();
+    expect(scroller.scrollTop).toBe(680);
+    expect(metrics.setScrollTop).toHaveBeenCalledTimes(1);
+
+    metrics.setScrollTop.mockClear();
+    await act(async () => {
+      chatCallback([...buildLiveChatMessages(12), {
+        id: 'm13',
+        text: 'Pending during close',
+        senderName: 'Parent 13',
+        createdAt: '2026-06-04T18:13:00.000Z'
+      }]);
     });
+    const pendingFrameId = nextFrameId - 1;
+    unmount();
+    expect(cancelFrame).toHaveBeenCalledWith(pendingFrameId);
+    expect(frameCallbacks.size).toBe(0);
+    expect(metrics.setScrollTop).not.toHaveBeenCalled();
   });
 
   it('shows the locked live chat notice and disables the composer when chat is unavailable', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1593,12 +1593,14 @@ describe('ScheduleEventDetail assignments', () => {
   });
 
   it('warns when a score autosaves but the live play-by-play post fails', async () => {
+    const publishError = new Error('Live post unavailable');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ liveStatus: 'live', status: 'live', canUpdateScore: true, homeScore: 41, awayScore: 38 })],
       children: []
     });
     scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 42, awayScore: 38 });
-    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockRejectedValue(new Error('Live post unavailable'));
+    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockRejectedValue(publishError);
 
     renderScheduleEventDetailWithRouteControls();
 
@@ -1612,6 +1614,11 @@ describe('ScheduleEventDetail assignments', () => {
     const warning = await within(tray).findByText('Score autosaved. Live play-by-play post failed.');
     expect(warning.className).toContain('text-amber-700');
     expect(warning.className).not.toContain('text-rose-700');
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[schedule-event-detail] Score saved but live play-by-play posting failed:',
+      publishError
+    );
+    consoleWarn.mockRestore();
   });
 
   it('keeps the empty Tasks tab visible for team admins before assignments exist', async () => {
@@ -1956,6 +1963,8 @@ describe('ScheduleEventDetail assignments', () => {
   });
 
   it('keeps foul entry disabled when foul history fails to load', async () => {
+    const historyError = new Error('History unavailable');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({
         liveStatus: 'live',
@@ -1968,7 +1977,7 @@ describe('ScheduleEventDetail assignments', () => {
     scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([
       { id: 'p1', name: 'Avery Smith', number: '12', points: 10, fouls: 1 }
     ]);
-    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockRejectedValue(new Error('History unavailable'));
+    scheduleServiceMocks.loadGameDayLiveEventsForApp.mockRejectedValue(historyError);
     scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({ availablePlayers: [], goingPlayers: [], gamePlan: null });
     scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
 
@@ -1984,6 +1993,11 @@ describe('ScheduleEventDetail assignments', () => {
     fireEvent.click(addFoulButton);
 
     expect(scheduleServiceMocks.recordPlayerGameStat).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[schedule-event-detail] Unable to load foul tracker state:',
+      historyError
+    );
+    consoleWarn.mockRestore();
   });
 
   it('invalidates the shared scoring roster once when switching game hub events', async () => {
@@ -2416,6 +2430,7 @@ describe('ScheduleEventDetail assignments', () => {
   });
 
   it('keeps mobile live chat pinned to latest messages unless the viewer scrolls up', async () => {
+    const originalScrollIntoView = Object.getOwnPropertyDescriptor(Element.prototype, 'scrollIntoView');
     const frameCallbacks = new Map<number, FrameRequestCallback>();
     let nextFrameId = 1;
     const requestFrame = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
@@ -2578,6 +2593,15 @@ describe('ScheduleEventDetail assignments', () => {
     expect(cancelFrame).toHaveBeenCalledWith(pendingFrameId);
     expect(frameCallbacks.size).toBe(0);
     expect(metrics.setScrollTop).not.toHaveBeenCalled();
+
+    requestFrame.mockRestore();
+    cancelFrame.mockRestore();
+    setTimeoutSpy.mockRestore();
+    if (originalScrollIntoView) {
+      Object.defineProperty(Element.prototype, 'scrollIntoView', originalScrollIntoView);
+    } else {
+      delete (Element.prototype as { scrollIntoView?: Element['scrollIntoView'] }).scrollIntoView;
+    }
   });
 
   it('shows the locked live chat notice and disables the composer when chat is unavailable', async () => {
@@ -4224,13 +4248,15 @@ describe('ScheduleEventDetail wrap-up', () => {
   });
 
   it('completes wrap-up even when AI analysis fails', async () => {
+    const aiError = new Error('AI unavailable');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ isTeamStaff: true, canUpdateScore: true, homeScore: 51, awayScore: 47 })],
       children: []
     });
     scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 51, awayScore: 47 });
     scheduleServiceMocks.completeGameWrapupForApp.mockResolvedValue({ status: 'completed', liveStatus: 'completed' });
-    gameWrapupServiceMocks.generateGameWrapupArtifactsForApp.mockRejectedValue(new Error('AI unavailable'));
+    gameWrapupServiceMocks.generateGameWrapupArtifactsForApp.mockRejectedValue(aiError);
 
     renderScheduleEventDetail();
 
@@ -4269,15 +4295,19 @@ describe('ScheduleEventDetail wrap-up', () => {
     await waitFor(() => {
       expect(screen.getByText('Wrap-up saved. AI analysis failed, so you can retry by running wrap-up again.')).toBeTruthy();
     });
+    expect(consoleWarn).toHaveBeenCalledWith('[schedule-event-detail] Wrap-up AI failed:', aiError);
+    consoleWarn.mockRestore();
   });
 
   it('warns when wrap-up saves but the live score post fails', async () => {
+    const publishError = new Error('Live feed unavailable');
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({ isTeamStaff: true, canUpdateScore: true, homeScore: 51, awayScore: 47 })],
       children: []
     });
     scheduleServiceMocks.updateGameScore.mockResolvedValue({ homeScore: 52, awayScore: 47 });
-    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockRejectedValue(new Error('Live feed unavailable'));
+    scheduleServiceMocks.publishLiveScoreUpdateEvent.mockRejectedValue(publishError);
     scheduleServiceMocks.completeGameWrapupForApp.mockResolvedValue({ status: 'completed', liveStatus: 'completed' });
     gameWrapupServiceMocks.generateGameWrapupArtifactsForApp.mockResolvedValue({
       summary: 'Bears finished strong.',
@@ -4298,6 +4328,11 @@ describe('ScheduleEventDetail wrap-up', () => {
       expect(screen.getByText('Wrap-up saved, but the live score post failed. You can retry by running wrap-up again.')).toBeTruthy();
     });
     expect(scheduleServiceMocks.completeGameWrapupForApp).toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[schedule-event-detail] Wrap-up score saved but live play-by-play posting failed:',
+      publishError
+    );
+    consoleWarn.mockRestore();
   });
 
   it('allows wrap-up to skip AI generation and still complete', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1329,11 +1329,8 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
   const [sending, setSending] = useState(false);
   const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const messagesScrollRef = useRef<HTMLDivElement | null>(null);
-  const messagesContentRef = useRef<HTMLDivElement | null>(null);
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const stickToLatestRef = useRef(true);
   const shouldFollowLatestRef = useRef(true);
-  const scheduledScrollTimeoutsRef = useRef<number[]>([]);
 
   useEffect(() => {
     void loadLiveGameChatModule().then(setChatModule);
@@ -1348,39 +1345,22 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
     const container = messagesScrollRef.current;
     if (!container) return;
 
-    const nextHeight = Math.max(container.scrollHeight, messagesContentRef.current?.scrollHeight || 0);
-    container.scrollTop = Math.max(0, nextHeight - container.clientHeight);
-    if (typeof messagesEndRef.current?.scrollIntoView === 'function') {
-      messagesEndRef.current.scrollIntoView({ block: 'end', behavior: 'auto' });
-    }
+    container.scrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
     stickToLatestRef.current = true;
   }, []);
 
-  const clearScheduledScrolls = useCallback(() => {
-    scheduledScrollTimeoutsRef.current.forEach((timerId) => window.clearTimeout(timerId));
-    scheduledScrollTimeoutsRef.current = [];
-  }, []);
+  const followLatestIfNeeded = useCallback(() => {
+    const container = messagesScrollRef.current;
+    if (!container) return;
+    if (stickToLatestRef.current || isLiveGameChatNearBottom(container)) {
+      scrollToLatest();
+    }
+  }, [scrollToLatest]);
 
-  const scheduleScrollToLatest = useCallback(() => {
-    clearScheduledScrolls();
-    const followIfNeeded = () => {
-      const container = messagesScrollRef.current;
-      if (!container) return;
-      if (stickToLatestRef.current || isLiveGameChatNearBottom(container)) {
-        scrollToLatest();
-      }
-    };
-
-    followIfNeeded();
-    [120, 300, 700].forEach((delay) => {
-      let timerId = 0;
-      timerId = window.setTimeout(() => {
-        scheduledScrollTimeoutsRef.current = scheduledScrollTimeoutsRef.current.filter((id) => id !== timerId);
-        followIfNeeded();
-      }, delay);
-      scheduledScrollTimeoutsRef.current.push(timerId);
-    });
-  }, [clearScheduledScrolls, scrollToLatest]);
+  const scrollScheduler = useMemo(
+    () => createLiveGameChatScrollScheduler(followLatestIfNeeded),
+    [followLatestIfNeeded]
+  );
 
   const handleMessagesScroll = useCallback(() => {
     stickToLatestRef.current = isLiveGameChatNearBottom(messagesScrollRef.current);
@@ -1388,10 +1368,10 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
 
   useLayoutEffect(() => {
     if (!messages.length || !shouldFollowLatestRef.current) return;
-    scheduleScrollToLatest();
-  }, [latestMessageId, messages.length, scheduleScrollToLatest]);
+    scrollScheduler.schedule();
+  }, [latestMessageId, messages.length, scrollScheduler]);
 
-  useEffect(() => clearScheduledScrolls, [clearScheduledScrolls]);
+  useEffect(() => () => scrollScheduler.cancel(), [scrollScheduler]);
 
   useEffect(() => {
     if (!chatModule || !event.isDbGame || !event.teamId || !event.id) return undefined;
@@ -1410,9 +1390,10 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
     });
 
     return () => {
+      scrollScheduler.cancel();
       unsubscribe?.();
     };
-  }, [chatModule, event.id, event.isDbGame, event.teamId]);
+  }, [chatModule, event.id, event.isDbGame, event.teamId, scrollScheduler]);
 
   const sendMessage = async (submitEvent: FormEvent) => {
     submitEvent.preventDefault();
@@ -1458,7 +1439,7 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
           data-testid="live-game-chat-messages"
           onScroll={handleMessagesScroll}
         >
-          <div ref={messagesContentRef} className="space-y-2">
+          <div className="space-y-2">
             {loading ? (
               <div className="text-sm font-semibold text-gray-500">Loading live chat…</div>
             ) : messages.length ? messages.map((message) => (
@@ -1472,7 +1453,6 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
             )) : (
               <div className="text-sm font-semibold text-gray-500">No messages yet. Start the game-day chat.</div>
             )}
-            <div ref={messagesEndRef} aria-hidden="true" />
           </div>
         </div>
 
@@ -4476,6 +4456,31 @@ function GameHubDestinationCard({ destination, onShare }: {
 
 function sortLiveGameChatMessages(messages: LiveGameChatMessage[]) {
   return [...messages].sort((left, right) => getLiveGameChatTimestampValue(left.createdAt) - getLiveGameChatTimestampValue(right.createdAt));
+}
+
+export function createLiveGameChatScrollScheduler(
+  adjustScroll: () => void,
+  requestFrame: (callback: FrameRequestCallback) => number = (callback) => window.requestAnimationFrame(callback),
+  cancelFrame: (frameId: number) => void = (frameId) => window.cancelAnimationFrame(frameId)
+) {
+  let pendingFrameId: number | null = null;
+
+  return {
+    schedule() {
+      if (pendingFrameId !== null) {
+        cancelFrame(pendingFrameId);
+      }
+      pendingFrameId = requestFrame(() => {
+        pendingFrameId = null;
+        adjustScroll();
+      });
+    },
+    cancel() {
+      if (pendingFrameId === null) return;
+      cancelFrame(pendingFrameId);
+      pendingFrameId = null;
+    }
+  };
 }
 
 export function isLiveGameChatNearBottom(


### PR DESCRIPTION
Closes #3935

## What changed
- Replaced immediate scrolling and three timeout retries with one coalesced `requestAnimationFrame` scheduler.
- Limited adjustments to the live-chat container's `scrollTop`.
- Cancelled pending frames on newer snapshots, event changes, panel cleanup, and unmount.
- Preserved the existing 96-pixel near-bottom behavior.

## Root Cause
Each chat snapshot performed an immediate scroll plus retries at 120, 300, and 700 ms. Every pass combined a container `scrollTop` write with page-level `scrollIntoView`, multiplying layout work and potentially moving the outer page.

## Prevention / Learning
Render-driven stick-to-bottom behavior should use one cancellable animation-frame scheduler, mutate only its owned scroll container, and evaluate manual-scroll state when the frame executes.

## Regression Tests
- Added scheduler tests for request coalescing and cleanup cancellation.
- Updated component coverage for one adjustment per batch, zero retry timers, zero chat `scrollIntoView` calls, manual scroll-up preservation, and unmount cancellation.
- Passed focused live-chat Vitest coverage and app TypeScript validation.

## Recurrence Risk
Low. Focused tests constrain the scheduler, timer usage, container-only writes, cleanup behavior, and the existing near-bottom threshold.