### PR TITLE
Scope schedule staff-team discovery

### DIFF
--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -288,4 +288,14 @@ describe('legacyScheduleDb staff team reads', () => {
         expect(where).toHaveBeenCalledWith('ownerId', '==', 'parent-1');
         expect(getDoc).not.toHaveBeenCalled();
     });
+
+    it('propagates owner and admin query failures so native callers can use the REST fallback', async () => {
+        const queryError = new Error('web sdk unavailable');
+        vi.mocked(getDocs).mockRejectedValueOnce(queryError);
+
+        await expect(getStaffTeams({ userId: 'coach-1', email: 'coach@example.com', coachTeamIds: [] })).rejects.toThrow('web sdk unavailable');
+
+        expect(getDocs).toHaveBeenCalledTimes(2);
+        expect(getDoc).not.toHaveBeenCalled();
+    });
 });

--- a/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.test.ts
@@ -62,8 +62,9 @@ vi.mock('@legacy/firebase.js', () => ({
     where: vi.fn()
 }));
 
-import { addGame as legacyAddGame, getConfigs as legacyGetConfigs } from '@legacy/db.js';
-import { addGame, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, buildSingleLegacyTournamentGameDocument, getConfigs, LegacyTournamentGameAdapterValidationError } from './legacyScheduleDb';
+import { addGame as legacyAddGame, getConfigs as legacyGetConfigs, getTeams as legacyGetTeams } from '@legacy/db.js';
+import { collection, doc, getDoc, getDocs, query, where } from '@legacy/firebase.js';
+import { addGame, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, buildSingleLegacyTournamentGameDocument, getConfigs, getStaffTeams, LegacyTournamentGameAdapterValidationError } from './legacyScheduleDb';
 
 const buildValidLegacyGamePayload = (overrides: Record<string, unknown> = {}) => ({
     type: 'game',
@@ -233,5 +234,58 @@ describe('legacyScheduleDb tracker config reads', () => {
         ]);
 
         expect(legacyGetConfigs).toHaveBeenCalledWith('team-1', { limit: 100 });
+    });
+});
+
+describe('legacyScheduleDb staff team reads', () => {
+    const snapshot = (id: string, data: Record<string, unknown>) => ({
+        id,
+        exists: () => true,
+        data: () => data
+    });
+
+    beforeEach(() => {
+        vi.mocked(collection).mockReturnValue({ path: 'teams' } as never);
+        vi.mocked(query).mockImplementation((base: unknown, ...constraints: unknown[]) => ({ base, constraints }) as never);
+        vi.mocked(where).mockImplementation((field: string, operation: string, value: unknown) => ({ field, operation, value }) as never);
+        vi.mocked(doc).mockImplementation((...parts: unknown[]) => ({ path: parts.filter((part) => typeof part === 'string').join('/') }) as never);
+    });
+
+    it('merges owner, normalized admin email, and unique coach team reads without a catalog load', async () => {
+        vi.mocked(getDocs)
+            .mockResolvedValueOnce({ docs: [snapshot('team-owner', { name: 'Owner' }), snapshot('team-shared', { name: 'Owner copy' })] } as never)
+            .mockResolvedValueOnce({ docs: [snapshot('team-admin', { name: 'Admin' }), snapshot('team-shared', { name: 'Admin copy' })] } as never);
+        vi.mocked(getDoc)
+            .mockResolvedValueOnce(snapshot('team-coach', { name: 'Coach' }) as never)
+            .mockRejectedValueOnce(new Error('Missing or insufficient permissions.'));
+
+        const teams = await getStaffTeams({
+            userId: 'user-1',
+            email: '  STAFF@EXAMPLE.COM ',
+            coachTeamIds: ['team-coach', 'team-coach', 'team-inaccessible']
+        });
+
+        expect(teams).toEqual([
+            { id: 'team-owner', name: 'Owner' },
+            { id: 'team-shared', name: 'Admin copy' },
+            { id: 'team-admin', name: 'Admin' },
+            { id: 'team-coach', name: 'Coach' }
+        ]);
+        expect(getDocs).toHaveBeenCalledTimes(2);
+        expect(where).toHaveBeenCalledWith('ownerId', '==', 'user-1');
+        expect(where).toHaveBeenCalledWith('adminEmails', 'array-contains', 'staff@example.com');
+        expect(getDoc).toHaveBeenCalledTimes(2);
+        expect(legacyGetTeams).not.toHaveBeenCalled();
+    });
+
+    it('skips the admin-email query and direct reads when affiliations are empty', async () => {
+        vi.mocked(getDocs).mockResolvedValueOnce({ docs: [] } as never);
+
+        await expect(getStaffTeams({ userId: 'parent-1', email: '   ', coachTeamIds: [] })).resolves.toEqual([]);
+
+        expect(getDocs).toHaveBeenCalledTimes(1);
+        expect(where).toHaveBeenCalledTimes(1);
+        expect(where).toHaveBeenCalledWith('ownerId', '==', 'parent-1');
+        expect(getDoc).not.toHaveBeenCalled();
     });
 });

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -168,10 +168,10 @@ export async function getStaffTeams({ userId, email, coachTeamIds = [], includeA
     const emptySnapshot = { docs: [] };
     const [ownedSnapshot, adminSnapshot, coachSnapshots] = await Promise.all([
         userId
-            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId))).catch(() => emptySnapshot)
+            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId)))
             : Promise.resolve(emptySnapshot),
         normalizedEmail
-            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail))).catch(() => emptySnapshot)
+            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail)))
             : Promise.resolve(emptySnapshot),
         Promise.all(uniqueCoachTeamIds.map((teamId) => (
             legacyFirebaseGetDoc(legacyFirebaseDoc(legacyFirebaseDb, 'teams', teamId)).catch(() => null)

--- a/apps/app/src/lib/adapters/legacyScheduleDb.ts
+++ b/apps/app/src/lib/adapters/legacyScheduleDb.ts
@@ -150,6 +150,44 @@ export async function getTeams(options?: { includePrivate?: boolean }) {
     return await Promise.resolve(options === undefined ? legacyGetTeams() : legacyGetTeams(options));
 }
 
+export type StaffTeamsQuery = {
+    userId: string;
+    email?: string | null;
+    coachTeamIds?: string[];
+    includeAll?: boolean;
+};
+
+export async function getStaffTeams({ userId, email, coachTeamIds = [], includeAll = false }: StaffTeamsQuery) {
+    if (includeAll) {
+        return await Promise.resolve(legacyGetTeams({ includePrivate: true }));
+    }
+
+    const teamsRef = legacyFirebaseCollection(legacyFirebaseDb, 'teams');
+    const normalizedEmail = String(email || '').trim().toLowerCase();
+    const uniqueCoachTeamIds = [...new Set(coachTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean))];
+    const emptySnapshot = { docs: [] };
+    const [ownedSnapshot, adminSnapshot, coachSnapshots] = await Promise.all([
+        userId
+            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('ownerId', '==', userId))).catch(() => emptySnapshot)
+            : Promise.resolve(emptySnapshot),
+        normalizedEmail
+            ? legacyFirebaseGetDocs(legacyFirebaseQuery(teamsRef, legacyFirebaseWhere('adminEmails', 'array-contains', normalizedEmail))).catch(() => emptySnapshot)
+            : Promise.resolve(emptySnapshot),
+        Promise.all(uniqueCoachTeamIds.map((teamId) => (
+            legacyFirebaseGetDoc(legacyFirebaseDoc(legacyFirebaseDb, 'teams', teamId)).catch(() => null)
+        )))
+    ]);
+
+    const teamsById = new Map<string, Record<string, unknown>>();
+    [...ownedSnapshot.docs, ...adminSnapshot.docs, ...coachSnapshots]
+        .filter((snapshot): snapshot is NonNullable<typeof snapshot> => Boolean(snapshot && ('exists' in snapshot ? snapshot.exists() : true)))
+        .forEach((snapshot) => {
+            const id = String(snapshot.id || '').trim();
+            if (id) teamsById.set(id, { id, ...snapshot.data() });
+        });
+    return [...teamsById.values()];
+}
+
 export class LegacyTournamentGameAdapterValidationError extends Error {
     readonly code = 'legacy-tournament-game-adapter-validation-error';
     readonly field: string;

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -47,6 +47,7 @@ vi.mock('./adapters/legacyScheduleDb', () => ({
   getRsvpSummaries: vi.fn(),
   getTeam: vi.fn(),
   getTeams: vi.fn(),
+  getStaffTeams: vi.fn(),
   addGame: vi.fn(),
   addPractice: vi.fn(),
   buildSingleLegacyTournamentGameDocument: vi.fn((games: Array<Record<string, unknown> | null | undefined>, tournament: Record<string, unknown>) => {
@@ -213,7 +214,7 @@ vi.mock('./appDataCache', () => ({
   getParentScheduleSummaryCacheKey: (userId: string) => `app-schedule-summary:${userId}`
 }));
 
-import { addGame, addPractice, broadcastLiveEvent, buildSingleLegacyTournamentGameDocument, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getTeam, getTeams, listRideOffersForEvent, submitRsvp, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
+import { addGame, addPractice, broadcastLiveEvent, buildSingleLegacyTournamentGameDocument, buildLegacyTournamentGameDocument, buildLegacyTournamentGameDocuments, claimOpenOfficiatingSlot, clearOccurrenceOverride, releaseAssignmentClaim, respondToOfficiatingAssignment, updateEvent, updateGame, updateOccurrence, getAssignmentClaims, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvpSummaries, getRsvps, getStaffTeams, getTeam, getTeams, listRideOffersForEvent, submitRsvp, submitRsvpForPlayer, updatePracticeAttendance, getDoc, getDocs } from './adapters/legacyScheduleDb';
 import { getNativeAuthIdToken } from './authService';
 import { expandRecurrence, fetchAndParseCalendar, isTeamActive, mergeAssignmentsWithClaims } from './adapters/legacyScheduleHelpers';
 import { getCachedAppData, invalidateCachedAppData, loadCachedAppData } from './appDataCache';
@@ -376,6 +377,38 @@ describe('parent schedule child scope', () => {
     expect(schedule.children).toEqual([
       { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Avery Lee', isLinkedParentChild: true }
     ]);
+  });
+
+  it('uses scoped staff discovery and excludes inactive affiliated teams', async () => {
+    const coachUser = { uid: 'coach-1', email: ' Coach@Example.com ', roles: ['coach'], coachOf: ['team-coach', 'team-coach'] } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: [] } as any);
+    vi.mocked(getStaffTeams).mockResolvedValue([
+      { id: 'team-owner', name: 'Owner Team', ownerId: 'coach-1', active: true },
+      { id: 'team-admin', name: 'Admin Team', adminEmails: ['coach@example.com'], active: true },
+      { id: 'team-coach', name: 'Coach Team', active: true },
+      { id: 'team-inactive', name: 'Inactive Team', ownerId: 'coach-1', active: false }
+    ] as any);
+    vi.mocked(getTeam).mockImplementation(async (teamId: string) => ({
+      'team-owner': { id: 'team-owner', name: 'Owner Team', ownerId: 'coach-1', active: true },
+      'team-admin': { id: 'team-admin', name: 'Admin Team', adminEmails: ['coach@example.com'], active: true },
+      'team-coach': { id: 'team-coach', name: 'Coach Team', active: true }
+    }[teamId] || null) as any);
+    vi.mocked(getGames).mockResolvedValue([] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+
+    const schedule = await loadParentSchedule(coachUser, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(getStaffTeams).toHaveBeenCalledWith({
+      userId: 'coach-1',
+      email: ' Coach@Example.com ',
+      coachTeamIds: ['team-coach', 'team-coach'],
+      includeAll: false
+    });
+    expect(getTeams).not.toHaveBeenCalled();
+    expect(schedule.children).toEqual([]);
+    expect(new Set(schedule.events.map((event) => event.teamId))).toEqual(new Set());
+    expect(getTeam).not.toHaveBeenCalledWith('team-inactive');
+    expect(getGames).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -12,7 +12,7 @@ import {
   getRsvps,
   getRsvpBreakdownByPlayer,
   getTeam,
-  getTeams,
+  getStaffTeams,
   addGame,
   addPractice,
   buildLegacyTournamentGameDocuments,
@@ -1514,12 +1514,14 @@ async function loadStaffTeams(user: AuthUser) {
     'staff teams',
     async () => {
       const coachTeamIds = Array.isArray(user.coachOf) ? user.coachOf.map(compactString).filter(Boolean) : [];
-      const [visibleTeams, coachTeams] = await Promise.all([
-        getTeams({ includePrivate: (user as any).isAdmin === true }),
-        Promise.all(coachTeamIds.map((teamId) => getTeam(teamId).catch(() => null)))
-      ]);
+      const visibleTeams = await getStaffTeams({
+        userId: user.uid,
+        email: user.email,
+        coachTeamIds,
+        includeAll: (user as any).isAdmin === true
+      });
       const teamsById = new Map<string, any>();
-      [...visibleTeams, ...coachTeams].filter(Boolean).forEach((team: any) => {
+      visibleTeams.filter(Boolean).forEach((team: any) => {
         if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
       });
       return [...teamsById.values()];

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -91,6 +91,16 @@ const firebaseMocks = vi.hoisted(() => {
                     data: () => player
                 };
             }
+            if (teamIndex >= 0) {
+                const teamId = pathParts[teamIndex + 1];
+                const team = await dbMocks.getTeam(teamId);
+                if (!team) return makeMissingSnapshot(teamId);
+                return {
+                    id: teamId,
+                    exists: () => true,
+                    data: () => team
+                };
+            }
             return makeMissingSnapshot();
         }),
         getDocs: vi.fn(async () => ({ docs: [] })),
@@ -434,6 +444,15 @@ afterEach(() => {
 });
 
 describe('React app schedule service contract integration', () => {
+    it('keeps ordinary staff discovery on the scoped adapter instead of the team catalog', () => {
+        const staffTeamSource = getScheduleServiceSlice('async function loadStaffTeams', 'async function saveTeamCalendarUrls');
+
+        expect(staffTeamSource).toContain('getStaffTeams({');
+        expect(staffTeamSource).not.toContain('getTeams(');
+        expect(staffTeamSource).toContain("nativeRunQuery('teams', 'ownerId', 'EQUAL', user.uid)");
+        expect(staffTeamSource).toContain("nativeRunQuery('teams', 'adminEmails', 'ARRAY_CONTAINS', normalizeEmail(user.email))");
+    });
+
     it('routes parent schedule event detail reads through typed schedule mappers', () => {
         const importSource = scheduleServiceSource.slice(0, scheduleServiceSource.indexOf('type StaffRsvpReminderContext'));
         const nativeMapperSource = getScheduleServiceSlice('async function nativeGetScheduleEventDocument', 'const nativeDeleteFieldSentinel');
@@ -715,6 +734,7 @@ describe('React app schedule service contract integration', () => {
 
         expect(dbMocks.getPlayers).not.toHaveBeenCalled();
         expect(dbMocks.getGames).not.toHaveBeenCalled();
+        expect(dbMocks.getTeams).not.toHaveBeenCalled();
         expect(result.events).toHaveLength(1);
         expect(result.events[0]).toMatchObject({
             id: 'game-1',


### PR DESCRIPTION
Closes #3932

## What changed
- Added a bounded staff-team adapter using owner and normalized admin-email queries.
- Directly reads each unique `coachOf` team ID and tolerates inaccessible documents.
- Deduplicates affiliations and preserves platform-admin catalog behavior.
- Excludes inactive teams before schedule expansion.

## Root Cause
`loadStaffTeams` reused the general-purpose `getTeams` catalog loader. Its ordinary-user path queried every public team before filtering results for staff affiliation, making Home and Schedule reads grow with the global catalog.

## Prevention / Learning
Primary user-scoped workflows must use bounded affiliation queries and direct document reads. Catalog loaders must not be reused for tenant-scoped discovery.

## Regression Tests
- Verifies owner, normalized admin-email, and unique `coachOf` results are merged and deduplicated without `getTeams`.
- Covers empty email, duplicate coach IDs, inaccessible documents, and inactive teams.
- Enforces the scoped adapter contract inside `loadStaffTeams`.
- Focused Vitest suites: 162 tests passed.
- App TypeScript typecheck passed.

## Recurrence Risk
Low. Adapter, service, and source-contract tests prevent ordinary staff discovery from returning to the global catalog path.