### PR TITLE
Skip roster counts in global team search

### DIFF
--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -35,6 +35,44 @@ describe('publicTeamsService', () => {
         expect(dbMocks.getPublicTeamRosterCount).toHaveBeenCalledWith('team-roster-1');
     });
 
+    it('maps lightweight public team pages without waiting for roster counts', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [{
+                id: 'team-search-1',
+                name: 'Austin Bats',
+                sport: 'Baseball',
+                photoUrl: 'https://example.com/team.png',
+                city: 'Austin',
+                state: 'TX',
+                zip: '78701',
+                appAccess: true,
+                webAccess: false
+            }],
+            nextCursor: 'cursor-2'
+        });
+        dbMocks.getPublicTeamRosterCount.mockImplementation(() => new Promise(() => {}));
+
+        await expect(getPublicTeamsPage({ searchText: 'Austin', includeRosterCounts: false })).resolves.toEqual({
+            teams: [expect.objectContaining({
+                teamId: 'team-search-1',
+                teamName: 'Austin Bats',
+                sport: 'Baseball',
+                photoUrl: 'https://example.com/team.png',
+                location: 'Austin, TX',
+                city: 'Austin',
+                state: 'TX',
+                zip: '78701',
+                appAccess: true,
+                webAccess: false,
+                isPublic: true,
+                publicRosterCount: null,
+                publicRosterCountCapped: false
+            })],
+            nextCursor: 'cursor-2'
+        });
+        expect(dbMocks.getPublicTeamRosterCount).not.toHaveBeenCalled();
+    });
+
     it('omits a roster count when public aggregation access is denied', async () => {
         dbMocks.discoverPublicTeams.mockResolvedValue({
             teams: [{ id: 'team-legacy-private-fields', name: 'Legacy Team', zip: '64131' }],

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -8,6 +8,14 @@ export type PublicTeamsPage = {
     nextCursor: unknown | null;
 };
 
+type PublicTeamsPageOptions = {
+    searchText?: string;
+    locationFilter?: string;
+    cursor?: unknown | null;
+    pageSize?: number;
+    includeRosterCounts?: boolean;
+};
+
 export type PublicTeamProfile = {
     id: string;
     name: string;
@@ -119,7 +127,7 @@ function matchesPublicTeamSearch(team: { name?: string | null; city?: string | n
     return searchTokens.every((token) => combinedFields.includes(token));
 }
 
-export async function getPublicTeamsPage({ searchText, locationFilter, cursor = null, pageSize = 24 }: { searchText?: string; locationFilter?: string; cursor?: unknown | null; pageSize?: number } = {}): Promise<PublicTeamsPage> {
+export async function getPublicTeamsPage({ searchText, locationFilter, cursor = null, pageSize = 24, includeRosterCounts = true }: PublicTeamsPageOptions = {}): Promise<PublicTeamsPage> {
     const normalizedSearchText = String(searchText ?? locationFilter ?? '').trim();
     const result = await discoverPublicTeams({
         searchText: normalizedSearchText,
@@ -128,7 +136,9 @@ export async function getPublicTeamsPage({ searchText, locationFilter, cursor = 
     });
     const matchingTeams = result.teams
         .filter((team: { name?: string | null; city?: string | null; state?: string | null; zip?: string | null }) => matchesPublicTeamSearch(team, normalizedSearchText));
-    const teams = await mapPublicTeamsWithRosterCounts(matchingTeams);
+    const teams = includeRosterCounts
+        ? await mapPublicTeamsWithRosterCounts(matchingTeams)
+        : matchingTeams.map((team: PublicTeamSearchResult) => mapPublicTeam(team, null));
 
     return {
         teams,

--- a/apps/app/src/lib/searchService.test.ts
+++ b/apps/app/src/lib/searchService.test.ts
@@ -205,4 +205,43 @@ describe('searchService app search caches', () => {
     await searchAppTeams(uniqueQuery(0), [], null);
     expect(publicTeamsServiceMocks.getPublicTeamsPage.mock.calls.filter(([options]) => options.searchText === uniqueQuery(0))).toHaveLength(2);
   });
+
+  it('uses lightweight public team pages and caches normalized search metadata', async () => {
+    publicTeamsServiceMocks.getPublicTeamsPage.mockResolvedValue({
+      teams: [{
+        teamId: 'team-austin',
+        teamName: 'Austin Bats',
+        sport: 'Baseball',
+        photoUrl: 'https://example.com/team.png',
+        city: 'Austin',
+        state: 'TX',
+        zip: '78701',
+        location: 'Austin, TX',
+        isPublic: true
+      }],
+      nextCursor: null
+    });
+
+    await expect(searchAppTeams('Austin', [], null)).resolves.toEqual([
+      expect.objectContaining({
+        id: 'team-austin',
+        name: 'Austin Bats',
+        sport: 'Baseball',
+        photoUrl: 'https://example.com/team.png',
+        city: 'Austin',
+        state: 'TX',
+        zip: '78701',
+        location: 'Austin, TX',
+        isPublic: true
+      })
+    ]);
+    await searchAppTeams(' Austin ', [], null);
+
+    expect(publicTeamsServiceMocks.getPublicTeamsPage).toHaveBeenCalledTimes(1);
+    expect(publicTeamsServiceMocks.getPublicTeamsPage).toHaveBeenCalledWith({
+      searchText: 'Austin',
+      pageSize: 20,
+      includeRosterCounts: false
+    });
+  });
 });

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -629,7 +629,11 @@ async function getCachedPublicTeamSearchResults(queryText: string, user: AuthUse
   }
   if (cachedEntry?.promise) return cachedEntry.promise;
 
-  const promise = getPublicTeamsPage({ searchText: queryText, pageSize: teamSearchQueryLimit })
+  const promise = getPublicTeamsPage({
+    searchText: queryText,
+    pageSize: teamSearchQueryLimit,
+    includeRosterCounts: false
+  })
     .then((result) => {
       const teams = normalizePublicTeamSearchResults(result?.teams || []);
       setBoundedCompletedSearchCacheEntry(publicTeamSearchCache, cacheKey, { teams }, publicTeamSearchCacheMaxEntries);


### PR DESCRIPTION
Closes #3942

## What changed
- Added an explicit `includeRosterCounts` option to `getPublicTeamsPage`, defaulting to enabled.
- Disabled roster-count hydration exclusively for global team search.
- Preserved searchable team metadata, ordering, and query caching.

## Root Cause
Global search reused a browse-oriented service contract that unconditionally hydrated roster counts before resolving, even though search normalization discarded those fields.

## Prevention / Learning
Shared browse and search services should make secondary enrichment explicit. Keep rich behavior as the default for browse callers, while latency-sensitive callers request only data they consume.

## Regression Tests
- Proves lightweight page requests return identity, access, sport, image, and location metadata without calling `getPublicTeamRosterCount`, even when that mock would remain pending.
- Proves default browse requests still hydrate roster counts.
- Proves global search requests lightweight mode and preserves normalized cached results.
- Focused Vitest: 16 tests passed.
- App TypeScript typecheck passed.

## Recurrence Risk
Low. Focused service and search tests pin both the default browse behavior and the lightweight global-search contract.