### PR TITLE
Bind team chat sender identity

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2067,6 +2067,41 @@ service cloud.firestore {
              data.get('imageSize', null) == null;
     }
 
+    function hasCanonicalChatSenderPresentation(data) {
+      let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
+      let userData = exists(userPath) ? get(userPath).data : {};
+      let senderName = data.get('senderName', null);
+      let senderPhotoUrl = data.get('senderPhotoUrl', null);
+      return isSignedIn() &&
+             (
+               senderName == null ||
+               (
+                 senderName is string &&
+                 senderName.size() > 0 &&
+                 senderName.size() <= 120 &&
+                 senderName in [
+                   request.auth.token.get('name', null),
+                   request.auth.token.get('email', null),
+                   userData.get('displayName', null),
+                   userData.get('fullName', null),
+                   userData.get('name', null)
+                 ]
+               )
+             ) &&
+             (
+               senderPhotoUrl == null ||
+               (
+                 senderPhotoUrl is string &&
+                 senderPhotoUrl.size() <= 2048 &&
+                 senderPhotoUrl.matches('https://.*') &&
+                 senderPhotoUrl in [
+                   request.auth.token.get('picture', null),
+                   userData.get('photoUrl', null)
+                 ]
+               )
+             );
+    }
+
     function isLegacyFullTeamChatMessageCreateValid(teamId, data) {
       return data.keys().hasAll([
                'text', 'senderId', 'attachments', 'createdAt', 'targetType', 'recipientIds'
@@ -2084,14 +2119,12 @@ service cloud.firestore {
              hasValidLegacyChatImageMetadata(data) &&
              (data.text.size() > 0 || data.attachments.size() > 0) &&
              data.senderId == request.auth.uid &&
-             isNullableBoundedChatString(data.get('senderName', null), 120) &&
+             hasCanonicalChatSenderPresentation(data) &&
              (data.get('senderEmail', null) == null ||
               (request.auth.token.email is string &&
                data.senderEmail is string &&
                data.senderEmail.size() <= 320 &&
                data.senderEmail.lower() == request.auth.token.email.lower())) &&
-             isNullableBoundedChatString(data.get('senderPhotoUrl', null), 2048) &&
-             (data.get('senderPhotoUrl', null) == null || data.senderPhotoUrl.matches('https://.*')) &&
              data.createdAt == request.time &&
              data.get('editedAt', null) == null &&
              data.get('deleted', false) == false &&
@@ -2153,14 +2186,12 @@ service cloud.firestore {
              hasValidNestedChatAttachments(teamId, conversationId, data) &&
              (data.text.size() > 0 || data.attachments.size() > 0) &&
              data.senderId == request.auth.uid &&
-             isNullableBoundedChatString(data.get('senderName', null), 120) &&
+             hasCanonicalChatSenderPresentation(data) &&
              (data.get('senderEmail', null) == null ||
               (request.auth.token.email is string &&
                data.senderEmail is string &&
                data.senderEmail.size() <= 320 &&
                data.senderEmail.lower() == request.auth.token.email.lower())) &&
-             isNullableBoundedChatString(data.get('senderPhotoUrl', null), 2048) &&
-             (data.get('senderPhotoUrl', null) == null || data.senderPhotoUrl.matches('https://.*')) &&
              data.get('imageUrl', null) == null &&
              data.get('imagePath', null) == null &&
              data.get('imageName', null) == null &&

--- a/functions/index.js
+++ b/functions/index.js
@@ -10000,6 +10000,26 @@ function buildTeamChatNotificationPlan({ text, actorUid = null, recipientContext
   };
 }
 
+async function resolveTeamChatSenderLabel(senderId, legacySenderName) {
+  const normalizedSenderId = String(senderId || '').trim();
+  if (normalizedSenderId) {
+    try {
+      const senderSnap = await firestore.doc(`users/${normalizedSenderId}`).get();
+      if (senderSnap.exists) {
+        const sender = senderSnap.data() || {};
+        const canonicalLabel = String(
+          sender.fullName || sender.displayName || sender.name || sender.email || ''
+        ).trim();
+        if (canonicalLabel) return canonicalLabel.slice(0, 120);
+      }
+    } catch (error) {
+      console.warn('Unable to resolve team chat sender profile', normalizedSenderId, error);
+    }
+  }
+
+  return String(legacySenderName || 'Team').trim().slice(0, 120) || 'Team';
+}
+
 async function handleTeamChatMessageCreated(snapshot, context) {
   const data = snapshot.data() || {};
   const text = String(data.text || '').trim();
@@ -10010,7 +10030,7 @@ async function handleTeamChatMessageCreated(snapshot, context) {
   const teamId = context.params.teamId;
   const actorUid = data.senderId || null;
   const conversationId = normalizeTeamChatConversationId(data.conversationId || context.params.conversationId);
-  const senderName = String(data.senderName || 'Team').trim();
+  const senderName = await resolveTeamChatSenderLabel(actorUid, data.senderName);
   const body = text
     ? (text.length > 120 ? `${text.slice(0, 117)}...` : text)
     : 'sent a photo';

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -39,6 +39,33 @@ function getBuildTeamChatNotificationPlan() {
     return new Function('detectMentionedUids', `${slice}; return buildTeamChatNotificationPlan;`)(detectMentionedUids);
 }
 
+function getTeamChatMessageCreatedHandler({ senderProfile, sendNotification }) {
+    const start = functionsSource.indexOf('async function resolveTeamChatSenderLabel(');
+    const end = functionsSource.indexOf('\nexports.notifyTeamChatMessageCreated');
+    const slice = functionsSource.slice(start, end);
+    const firestore = {
+        doc: () => ({
+            get: async () => ({ exists: Boolean(senderProfile), data: () => senderProfile })
+        })
+    };
+    return new Function(
+        'firestore',
+        'normalizeTeamChatConversationId',
+        'isPreEventReminderChatMessage',
+        'buildTeamChatNotificationContext',
+        'buildTeamChatNotificationPlan',
+        'sendDirectTargetsNotification',
+        `${slice}; return handleTeamChatMessageCreated;`
+    )(
+        firestore,
+        (value) => value || 'team',
+        () => false,
+        async () => ({ members: [], mutedUids: [], targetsByCategory: { mentions: [], liveChat: [] } }),
+        () => ({ mentionedUids: [], mentionTargets: [], liveChatTargets: [{ uid: 'recipient-1', token: 'token-1' }] }),
+        sendNotification
+    );
+}
+
 function getNotificationDestinationBuilders() {
     const start = functionsSource.indexOf('function buildScheduleSectionQuery(');
     const end = functionsSource.indexOf('\nfunction normalizeAccessNotificationStatus');
@@ -329,6 +356,27 @@ describe('buildTeamChatNotificationContext', () => {
 });
 
 describe('notifyTeamChatMessageCreated source wiring', () => {
+    it('uses the stored sender profile instead of forged message metadata in delivered titles', async () => {
+        const deliveries = [];
+        const handler = getTeamChatMessageCreatedHandler({
+            senderProfile: { fullName: 'Pat Parent' },
+            sendNotification: async (payload) => {
+                deliveries.push(payload);
+                return { success: true };
+            }
+        });
+        const snapshot = {
+            data: () => ({ text: 'Practice moved', senderId: 'parent-1', senderName: 'Coach Kim' }),
+            ref: { update: async () => {} }
+        };
+
+        await handler(snapshot, { params: { teamId: 'team-1', messageId: 'message-1' } });
+
+        expect(deliveries).toHaveLength(1);
+        expect(deliveries[0].title).toBe('Pat Parent: Team Chat');
+        expect(deliveries[0].title).not.toContain('Coach Kim');
+    });
+
     it('exports the notifyTeamChatMessageCreated Firestore trigger', () => {
         expect(notifyTeamChatMessageCreatedSource).toContain("exports.notifyTeamChatMessageCreated = functions.firestore");
         expect(notifyTeamChatMessageCreatedSource).toContain(".document('teams/{teamId}/chatMessages/{messageId}')");

--- a/tests/unit/team-chat-nested-message-payload-rules.test.js
+++ b/tests/unit/team-chat-nested-message-payload-rules.test.js
@@ -19,6 +19,8 @@ describe('nested team chat message payload contracts', () => {
         expect(rules).toContain("data.keys().hasAll([\n               'text', 'senderId', 'attachments', 'createdAt', 'targetType'");
         expect(rules).toContain("data.keys().hasOnly([\n               'clientMessageId', 'text', 'senderId'");
         expect(rules).toContain('data.senderId == request.auth.uid');
+        expect(rules).toContain('function hasCanonicalChatSenderPresentation(data)');
+        expect(rules).toContain('hasCanonicalChatSenderPresentation(data)');
         expect(rules).toContain('data.senderEmail.lower() == request.auth.token.email.lower()');
         expect(rules).toContain('data.createdAt == request.time');
         expect(rules).toContain("data.get('editedAt', null) == null");
@@ -173,6 +175,8 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
             });
             await setDoc(doc(firestore, 'users/coach-1'), {
                 email: 'coach@example.com',
+                fullName: 'Coach One',
+                photoUrl: 'https://example.com/coach.jpg',
                 isAdmin: false,
                 parentTeamIds: []
             });
@@ -183,6 +187,15 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
             });
             await setDoc(doc(firestore, 'users/parent-1'), {
                 email: 'parent@example.com',
+                fullName: 'Pat Parent',
+                photoUrl: 'https://example.com/parent.jpg',
+                isAdmin: false,
+                parentTeamIds: ['team-1']
+            });
+            await setDoc(doc(firestore, 'users/user-2'), {
+                email: 'user2@example.com',
+                fullName: 'Other Parent',
+                photoUrl: 'https://example.com/other.jpg',
                 isAdmin: false,
                 parentTeamIds: ['team-1']
             });
@@ -327,6 +340,13 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
         delete directWithoutStoredEmail.senderEmail;
 
         await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct'), directPayload()));
+        await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct-photo'), directPayload({
+            senderPhotoUrl: 'https://example.com/parent.jpg'
+        })));
+        await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct-null-presentation'), directPayload({
+            senderName: null,
+            senderPhotoUrl: null
+        })));
         await assertSucceeds(setDoc(messageRef(parentDb, directConversationId, 'valid-direct-no-email'), directWithoutStoredEmail));
         await assertSucceeds(setDoc(messageRef(coachDb, staffConversationId, 'valid-staff'), staffPayload()));
     });
@@ -402,6 +422,13 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
         const attachment = legacyAttachment();
 
         await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-text'), legacyPayload()));
+        await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-canonical-photo'), legacyPayload({
+            senderPhotoUrl: 'https://example.com/parent.jpg'
+        })));
+        await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-null-presentation'), legacyPayload({
+            senderName: null,
+            senderPhotoUrl: null
+        })));
         await assertSucceeds(setDoc(legacyMessageRef(parentDb, 'valid-media'), legacyPayload({
             text: '',
             attachments: [attachment]
@@ -436,6 +463,9 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
             legacyPayload({ attachments: [legacyAttachment({ size: 5 * 1024 * 1024 + 1 })] }),
             legacyPayload({ unexpectedField: true }),
             legacyPayload({ senderId: 'user-2' }),
+            legacyPayload({ senderName: 'Other Parent' }),
+            legacyPayload({ senderPhotoUrl: 'https://example.com/other.jpg' }),
+            legacyPayload({ senderPhotoUrl: 'https://attacker.example/tracker.gif' }),
             legacyPayload({ ai: true, aiName: 'ALL PLAYS' }),
             legacyPayload({ aiMeta: { forged: true } }),
             legacyPayload({ createdAt: Timestamp.fromMillis(1700000000000) }),
@@ -473,6 +503,9 @@ describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('nested team chat message 
             directPayload({ text: '', attachments: [] }),
             directPayload({ senderId: 'user-2' }),
             directPayload({ senderEmail: 'spoofed@example.com' }),
+            directPayload({ senderName: 'Other Parent' }),
+            directPayload({ senderPhotoUrl: 'https://example.com/other.jpg' }),
+            directPayload({ senderPhotoUrl: 'https://attacker.example/tracker.gif' }),
             directPayload({ createdAt: Timestamp.fromMillis(1700000000000) }),
             directPayload({ deleted: true }),
             directPayload({ ai: true, aiName: 'ALL PLAYS' }),


### PR DESCRIPTION
Closes #3941

## What changed
- Bound chat sender names and avatars to authenticated token or canonical user-profile fields on legacy and nested message paths.
- Resolved push-notification sender labels from `users/{senderId}` with a legacy fallback.
- Preserved historical message reads without migration.

## Root Cause
Firestore authenticated `senderId` and `senderEmail` but accepted arbitrary bounded names and HTTPS avatars. Notification titles also trusted message-level `senderName`.

## Prevention / Learning
Treat identity presentation as authorization-sensitive metadata. Bind client-written identity fields at the rules boundary and re-resolve attribution server-side before external delivery.

## Regression Tests
- Firestore emulator coverage verifies canonical and null metadata succeeds while other-user names, other-user avatars, and arbitrary HTTPS avatars fail on both paths.
- Notification handler coverage proves forged message metadata cannot control delivered titles.
- Existing focused React service and component tests confirm compliant metadata remains posted and rendered.

## Recurrence Risk
Low. Both message paths share one validator, and server notification attribution has focused regression coverage.