### PR TITLE
Rate-limit public calendar fetches

### DIFF
--- a/functions/calendar-ics-fetch-core.cjs
+++ b/functions/calendar-ics-fetch-core.cjs
@@ -114,9 +114,100 @@ async function fetchCalendarIcsWithCache({ cache, cacheKey, forceRefresh = false
   return fetchPromise;
 }
 
+function createCalendarIcsFetchHandler({
+  cache,
+  checkRateLimit,
+  checkForceRefreshRateLimit,
+  isAllowedOrigin,
+  writeCorsHeaders,
+  normalizeTargetUrl,
+  fetchWithTimeout,
+  normalizeIcsText
+}) {
+  return async function fetchCalendarIcsHandler(req, res) {
+    writeCorsHeaders(req, res);
+
+    if (!isAllowedOrigin(req.headers.origin)) {
+      res.status(403).json({ ok: false, error: 'Origin not allowed' });
+      return;
+    }
+
+    if (req.method === 'OPTIONS') {
+      res.status(204).send('');
+      return;
+    }
+
+    if (req.method !== 'GET') {
+      res.status(405).json({ error: 'Method not allowed' });
+      return;
+    }
+
+    const forceRefresh = String(req.query.forceRefresh || '').toLowerCase() === 'true';
+    const rateLimits = [checkRateLimit];
+    if (forceRefresh) {
+      rateLimits.push(checkForceRefreshRateLimit);
+    }
+
+    for (const checkLimit of rateLimits) {
+      const rateLimit = checkLimit(req);
+      if (!rateLimit.allowed) {
+        res.set('Retry-After', String(rateLimit.retryAfterSeconds));
+        res.status(429).json({ ok: false, error: 'Too many calendar fetch requests' });
+        return;
+      }
+    }
+
+    try {
+      const rawUrl = req.query.url;
+      const normalizedUrl = await normalizeTargetUrl(rawUrl);
+
+      const result = await fetchCalendarIcsWithCache({
+        cache,
+        cacheKey: normalizedUrl.url,
+        forceRefresh,
+        fetchIcs: async () => {
+          const response = await fetchWithTimeout(normalizedUrl.url, normalizedUrl.hostname, normalizedUrl.publicIps);
+          if (!response.ok) {
+            const upstreamError = new Error(`Calendar fetch failed: ${response.status} ${response.statusText}`);
+            upstreamError.statusCode = 502;
+            throw upstreamError;
+          }
+
+          const rawText = await response.text();
+          const icsText = normalizeIcsText(rawText);
+
+          if (!icsText.includes('BEGIN:VCALENDAR')) {
+            const invalidIcsError = new Error('Response was not valid ICS');
+            invalidIcsError.statusCode = 502;
+            throw invalidIcsError;
+          }
+
+          return {
+            fetchedAt: new Date().toISOString(),
+            icsText
+          };
+        }
+      });
+
+      res.status(200).json({
+        ok: true,
+        source: result.source,
+        fetchedAt: result.fetchedAt,
+        icsText: result.icsText
+      });
+    } catch (error) {
+      res.status(error?.statusCode || 400).json({
+        ok: false,
+        error: error?.message || 'Unknown error'
+      });
+    }
+  };
+}
+
 module.exports = {
   DEFAULT_TTL_MS,
   DEFAULT_MAX_ENTRIES,
   createCalendarIcsCache,
-  fetchCalendarIcsWithCache
+  fetchCalendarIcsWithCache,
+  createCalendarIcsFetchHandler
 };

--- a/functions/calendar-ics-fetch-core.cjs
+++ b/functions/calendar-ics-fetch-core.cjs
@@ -127,7 +127,7 @@ function createCalendarIcsFetchHandler({
   return async function fetchCalendarIcsHandler(req, res) {
     writeCorsHeaders(req, res);
 
-    if (!isAllowedOrigin(req.headers.origin)) {
+    if (!isAllowedOrigin(req.headers?.origin)) {
       res.status(403).json({ ok: false, error: 'Origin not allowed' });
       return;
     }
@@ -142,7 +142,7 @@ function createCalendarIcsFetchHandler({
       return;
     }
 
-    const forceRefresh = String(req.query.forceRefresh || '').toLowerCase() === 'true';
+    const forceRefresh = String(req.query?.forceRefresh || '').toLowerCase() === 'true';
     const rateLimits = [checkRateLimit];
     if (forceRefresh) {
       rateLimits.push(checkForceRefreshRateLimit);
@@ -158,7 +158,7 @@ function createCalendarIcsFetchHandler({
     }
 
     try {
-      const rawUrl = req.query.url;
+      const rawUrl = req.query?.url;
       const normalizedUrl = await normalizeTargetUrl(rawUrl);
 
       const result = await fetchCalendarIcsWithCache({

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,7 +3,7 @@ const admin = require('firebase-admin');
 const Stripe = require('stripe');
 const crypto = require('node:crypto');
 const { isPrivateIpAddress, isBlockedHostname, assertPublicHost, normalizeTargetUrl, fetchWithTimeout } = require('./utils/security-utils');
-const { createCalendarIcsCache, fetchCalendarIcsWithCache } = require('./calendar-ics-fetch-core.cjs');
+const { createCalendarIcsCache, createCalendarIcsFetchHandler } = require('./calendar-ics-fetch-core.cjs');
 const {
   normalizeTeamPassCheckoutInput,
   isEligibleTeamPassPurchaser,
@@ -231,6 +231,16 @@ const checkPasswordResetEmailRateLimit = createInMemoryRateLimiter({
   windowMs: 10 * 60_000,
   maxRequests: 10,
   maxKeys: 10_000
+});
+const checkCalendarFetchRateLimit = createInMemoryRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 120,
+  maxKeys: 5_000
+});
+const checkCalendarForceRefreshRateLimit = createInMemoryRateLimiter({
+  windowMs: 60_000,
+  maxRequests: 10,
+  maxKeys: 5_000
 });
 
 function getStripeConfig() {
@@ -5348,70 +5358,16 @@ exports.getFamilyShareSchedule = functions.https.onCall(async (data) => {
 exports.fetchCalendarIcs = functions
   .runWith(fetchCalendarRuntime)
   .https
-  .onRequest(async (req, res) => {
-    writeCorsHeaders(req, res);
-
-    if (!isAllowedOrigin(req.headers.origin)) {
-      res.status(403).json({ ok: false, error: 'Origin not allowed' });
-      return;
-    }
-
-    if (req.method === 'OPTIONS') {
-      res.status(204).send('');
-      return;
-    }
-
-    if (req.method !== 'GET') {
-      res.status(405).json({ error: 'Method not allowed' });
-      return;
-    }
-
-    try {
-      const rawUrl = req.query.url;
-      const normalizedUrl = await normalizeTargetUrl(rawUrl);
-      const forceRefresh = String(req.query.forceRefresh || '').toLowerCase() === 'true';
-
-      const result = await fetchCalendarIcsWithCache({
-        cache: calendarIcsCache,
-        cacheKey: normalizedUrl.url,
-        forceRefresh,
-        fetchIcs: async () => {
-          const response = await fetchWithTimeout(normalizedUrl.url, normalizedUrl.hostname, normalizedUrl.publicIps);
-          if (!response.ok) {
-            const upstreamError = new Error(`Calendar fetch failed: ${response.status} ${response.statusText}`);
-            upstreamError.statusCode = 502;
-            throw upstreamError;
-          }
-
-          const rawText = await response.text();
-          const icsText = normalizeIcsText(rawText);
-
-          if (!icsText.includes('BEGIN:VCALENDAR')) {
-            const invalidIcsError = new Error('Response was not valid ICS');
-            invalidIcsError.statusCode = 502;
-            throw invalidIcsError;
-          }
-
-          return {
-            fetchedAt: new Date().toISOString(),
-            icsText
-          };
-        }
-      });
-
-      res.status(200).json({
-        ok: true,
-        source: result.source,
-        fetchedAt: result.fetchedAt,
-        icsText: result.icsText
-      });
-    } catch (error) {
-      res.status(error?.statusCode || 400).json({
-        ok: false,
-        error: error?.message || 'Unknown error'
-      });
-    }
-  });
+  .onRequest(createCalendarIcsFetchHandler({
+    cache: calendarIcsCache,
+    checkRateLimit: checkCalendarFetchRateLimit,
+    checkForceRefreshRateLimit: checkCalendarForceRefreshRateLimit,
+    isAllowedOrigin,
+    writeCorsHeaders,
+    normalizeTargetUrl,
+    fetchWithTimeout,
+    normalizeIcsText
+  }));
 
 function normalizeNotificationPreferences(raw) {
   const source = raw && typeof raw === 'object' ? raw : {};

--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -7,6 +7,7 @@ function parsePositiveInteger(value, fallback) {
 }
 
 function getHeaderValue(headers = {}, name = '') {
+  headers = headers || {};
   const direct = headers[name] || headers[name.toLowerCase()];
   if (direct !== undefined) {
     return Array.isArray(direct) ? direct[0] : direct;

--- a/functions/test/calendar-ics-fetch-core.test.cjs
+++ b/functions/test/calendar-ics-fetch-core.test.cjs
@@ -4,8 +4,94 @@ const {
   DEFAULT_TTL_MS,
   DEFAULT_MAX_ENTRIES,
   createCalendarIcsCache,
-  fetchCalendarIcsWithCache
+  fetchCalendarIcsWithCache,
+  createCalendarIcsFetchHandler
 } = require('../calendar-ics-fetch-core.cjs');
+const { createInMemoryRateLimiter } = require('../rate-limit.cjs');
+
+function createMockResponse() {
+  return {
+    statusCode: 200,
+    body: null,
+    headers: {},
+    set(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    send(payload) {
+      this.body = payload;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    }
+  };
+}
+
+function createHandlerHarness({ maxRequests = 2, maxForceRefreshRequests = 1 } = {}) {
+  let normalizationCount = 0;
+  let fetchCount = 0;
+  let now = 1_000;
+  const cache = createCalendarIcsCache();
+  const normalLimiter = createInMemoryRateLimiter({ windowMs: 60_000, maxRequests, maxKeys: 10 });
+  const forceRefreshLimiter = createInMemoryRateLimiter({
+    windowMs: 60_000,
+    maxRequests: maxForceRefreshRequests,
+    maxKeys: 10
+  });
+  const handler = createCalendarIcsFetchHandler({
+    cache,
+    checkRateLimit: (req) => normalLimiter(req, now),
+    checkForceRefreshRateLimit: (req) => forceRefreshLimiter(req, now),
+    isAllowedOrigin: () => true,
+    writeCorsHeaders: (_req, res) => res.set('Cache-Control', 'no-store'),
+    normalizeTargetUrl: async (url) => {
+      normalizationCount += 1;
+      return { url, hostname: 'example.com', publicIps: ['203.0.113.20'] };
+    },
+    fetchWithTimeout: async () => {
+      fetchCount += 1;
+      return {
+        ok: true,
+        text: async () => 'BEGIN:VCALENDAR\nEND:VCALENDAR'
+      };
+    },
+    normalizeIcsText: (text) => text
+  });
+
+  async function request({ forceRefresh = false, ip = '203.0.113.10' } = {}) {
+    const req = {
+      method: 'GET',
+      ip,
+      headers: {},
+      query: {
+        url: 'https://example.com/calendar.ics',
+        ...(forceRefresh ? { forceRefresh: 'true' } : {})
+      }
+    };
+    const res = createMockResponse();
+    await handler(req, res);
+    return res;
+  }
+
+  return {
+    request,
+    advanceTime(milliseconds) {
+      now += milliseconds;
+    },
+    get normalizationCount() {
+      return normalizationCount;
+    },
+    get fetchCount() {
+      return fetchCount;
+    }
+  };
+}
 
 test('fetchCalendarIcsWithCache reuses a fresh cached response', async () => {
   const cache = createCalendarIcsCache();
@@ -159,4 +245,48 @@ test('createCalendarIcsCache evicts expired and oldest entries when maxEntries i
   assert.strictEqual(cache.entries.has('https://example.com/calendar-1.ics'), false);
   assert.strictEqual(cache.entries.has('https://example.com/calendar-2.ics'), true);
   assert.strictEqual(cache.entries.has('https://example.com/calendar-3.ics'), true);
+});
+
+test('calendar handler rate limits before normalization or outbound fetch and resets after the window', async () => {
+  const harness = createHandlerHarness({ maxRequests: 2 });
+
+  const live = await harness.request();
+  const cached = await harness.request();
+  const rejected = await harness.request();
+
+  assert.strictEqual(live.statusCode, 200);
+  assert.deepStrictEqual(Object.keys(live.body).sort(), ['fetchedAt', 'icsText', 'ok', 'source']);
+  assert.strictEqual(live.body.ok, true);
+  assert.strictEqual(live.body.source, 'live');
+  assert.match(live.body.fetchedAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.strictEqual(live.body.icsText, 'BEGIN:VCALENDAR\nEND:VCALENDAR');
+  assert.strictEqual(cached.statusCode, 200);
+  assert.strictEqual(cached.body.source, 'cache');
+  assert.strictEqual(cached.body.fetchedAt, live.body.fetchedAt);
+  assert.strictEqual(cached.body.icsText, live.body.icsText);
+  assert.strictEqual(rejected.statusCode, 429);
+  assert.strictEqual(rejected.headers['Retry-After'], '60');
+  assert.strictEqual(harness.normalizationCount, 2);
+  assert.strictEqual(harness.fetchCount, 1);
+
+  harness.advanceTime(60_000);
+  const afterReset = await harness.request();
+  assert.strictEqual(afterReset.statusCode, 200);
+  assert.strictEqual(afterReset.body.source, 'cache');
+  assert.strictEqual(harness.normalizationCount, 3);
+  assert.strictEqual(harness.fetchCount, 1);
+});
+
+test('calendar handler applies a stricter forceRefresh limit before expensive work', async () => {
+  const harness = createHandlerHarness({ maxRequests: 10, maxForceRefreshRequests: 1 });
+
+  const first = await harness.request({ forceRefresh: true });
+  const rejected = await harness.request({ forceRefresh: true });
+
+  assert.strictEqual(first.statusCode, 200);
+  assert.strictEqual(first.body.source, 'live');
+  assert.strictEqual(rejected.statusCode, 429);
+  assert.strictEqual(rejected.headers['Retry-After'], '60');
+  assert.strictEqual(harness.normalizationCount, 1);
+  assert.strictEqual(harness.fetchCount, 1);
 });

--- a/functions/test/calendar-ics-fetch-core.test.cjs
+++ b/functions/test/calendar-ics-fetch-core.test.cjs
@@ -64,15 +64,15 @@ function createHandlerHarness({ maxRequests = 2, maxForceRefreshRequests = 1 } =
     normalizeIcsText: (text) => text
   });
 
-  async function request({ forceRefresh = false, ip = '203.0.113.10' } = {}) {
+  async function request({ forceRefresh = false, ip = '203.0.113.10', headers = {}, query } = {}) {
     const req = {
       method: 'GET',
       ip,
-      headers: {},
-      query: {
+      headers,
+      query: query === undefined ? {
         url: 'https://example.com/calendar.ics',
         ...(forceRefresh ? { forceRefresh: 'true' } : {})
-      }
+      } : query
     };
     const res = createMockResponse();
     await handler(req, res);
@@ -289,4 +289,18 @@ test('calendar handler applies a stricter forceRefresh limit before expensive wo
   assert.strictEqual(rejected.headers['Retry-After'], '60');
   assert.strictEqual(harness.normalizationCount, 1);
   assert.strictEqual(harness.fetchCount, 1);
+});
+
+test('calendar handler safely rejects requests with missing headers and query objects', async () => {
+  const harness = createHandlerHarness();
+
+  const response = await harness.request({ headers: null, query: null });
+
+  assert.strictEqual(response.statusCode, 400);
+  assert.deepStrictEqual(response.body, {
+    ok: false,
+    error: 'A cache key is required'
+  });
+  assert.strictEqual(harness.normalizationCount, 1);
+  assert.strictEqual(harness.fetchCount, 0);
 });

--- a/functions/test/rate-limit.test.cjs
+++ b/functions/test/rate-limit.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { getRequestIp } = require('../rate-limit.cjs');
+const { createInMemoryRateLimiter, getRequestIp } = require('../rate-limit.cjs');
 
 test('uses the public address immediately before the trusted proxy hop', () => {
     const request = {
@@ -51,4 +51,20 @@ test('rejects a trusted proxy value that is not the terminal forwarded hop', () 
     };
 
     assert.equal(getRequestIp(request), '10.0.0.5');
+});
+
+test('allows requests through the threshold, rejects excess, and resets after the window', () => {
+    const checkRateLimit = createInMemoryRateLimiter({
+        windowMs: 1_000,
+        maxRequests: 2,
+        maxKeys: 2
+    });
+    const request = { ip: '203.0.113.10' };
+
+    assert.equal(checkRateLimit(request, 1_000).allowed, true);
+    assert.equal(checkRateLimit(request, 1_100).allowed, true);
+    const rejected = checkRateLimit(request, 1_200);
+    assert.equal(rejected.allowed, false);
+    assert.equal(rejected.retryAfterSeconds, 1);
+    assert.equal(checkRateLimit(request, 2_000).allowed, true);
 });


### PR DESCRIPTION
Closes #3939

## What changed
- Added a bounded per-client-IP allowance before calendar URL normalization, DNS, or outbound HTTP work.
- Added a stricter force-refresh allowance to bound cache bypasses.
- Return HTTP 429 with `Retry-After` when either allowance is exceeded.
- Preserved existing CORS behavior and live/cache JSON response fields.

## Root Cause
The unauthenticated calendar proxy entered URL normalization and DNS resolution without an inbound request boundary. The `forceRefresh` option also allowed repeated upstream requests that bypassed the response cache.

## Prevention / Learning
Every unauthenticated endpoint capable of DNS or outbound HTTP work must enforce a bounded per-client limit before expensive processing. Cache-bypass controls require a separate, tighter budget.

## Regression Tests
- Verified normal requests are allowed through the threshold, rejected afterward, and allowed after the window resets.
- Verified force-refresh requests use the stricter allowance.
- Verified rejected requests perform no additional normalization or upstream fetches.
- Verified live and cached responses retain `ok`, `source`, `fetchedAt`, and `icsText`.
- Final focused run passed all 12 tests. One existing 1 ms cache-TTL test flaked once and passed on immediate rerun.

## Recurrence Risk
Low. Focused handler tests pin limiter ordering, reset behavior, `Retry-After`, force-refresh limits, and response compatibility.