### PR TITLE
Hide team help CTAs without team context

### DIFF
--- a/help-watch-chat.html
+++ b/help-watch-chat.html
@@ -25,9 +25,11 @@
           <a
             class="hidden inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
             href="team.html"
+            hidden
             data-help-context-link
             data-guide-id="watch-game"
             data-quick-link-label="Team Page"
+            data-required-context="teamId"
             data-route-template="team.html#teamId={teamId}"
           >Team Page</a>
           <a
@@ -52,11 +54,13 @@
         </ul>
         <div class="mt-4 flex flex-wrap gap-2" aria-label="Chat navigation">
           <a
-            class="inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
+            class="hidden inline-flex items-center rounded-md bg-blue-700 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-800"
             href="team-chat.html"
+            hidden
             data-help-context-link
             data-guide-id="team-chat-basics"
             data-quick-link-label="Open Team Chat"
+            data-required-context="teamId"
             data-route-template="team-chat.html#teamId={teamId}"
           >Team Chat</a>
         </div>

--- a/tests/smoke/help-workflow-pages.spec.js
+++ b/tests/smoke/help-workflow-pages.spec.js
@@ -79,6 +79,24 @@ test.describe('help topic and workflow pages', () => {
         await expect(page.getByRole('link', { name: 'Team Chat' })).toHaveAttribute('href', 'team-chat.html#teamId=team-123');
     });
 
+    test('help-watch-chat hides team-scoped links without team context', async ({ page, baseURL }) => {
+        await assertPageBootsWithoutFatalErrors(page, {
+            baseURL,
+            path: '/help-watch-chat.html?role=parent',
+            titlePatterns: [/Help/i],
+            skipDefaultForbiddenTexts: true,
+            requiredSelectors: [
+                'a[data-help-context-link][data-quick-link-label="Team Page"]',
+                'a[data-help-context-link][data-quick-link-label="Game Viewer"]',
+                'a[data-help-context-link][data-quick-link-label="Open Team Chat"]'
+            ]
+        });
+
+        await expect(page.locator('a[data-quick-link-label="Team Page"]')).toBeHidden();
+        await expect(page.locator('a[data-quick-link-label="Game Viewer"]')).toBeHidden();
+        await expect(page.locator('a[data-quick-link-label="Open Team Chat"]')).toBeHidden();
+    });
+
     test('Getting Started exposes working account entry points instead of a nonexistent homepage CTA', async ({ page, baseURL }) => {
         await bootWorkflowPage(page, baseURL, '/workflow-getting-started.html');
 

--- a/tests/unit/help-center.test.js
+++ b/tests/unit/help-center.test.js
@@ -126,14 +126,18 @@ describe('help center deep workflow coverage', () => {
         });
     });
 
-    it('removes empty Help Watch Chat context parameters from CTA links', () => {
+    it('hides team-scoped Help Watch Chat CTAs without team context', () => {
         const document = renderHelpWatchChat('https://allplays.test/help-watch-chat.html?role=parent');
+        const teamPageLink = document.querySelector('[data-quick-link-label="Team Page"]');
         const gameViewerLink = document.querySelector('[data-quick-link-label="Game Viewer"]');
+        const teamChatLink = document.querySelector('[data-quick-link-label="Open Team Chat"]');
 
-        expect(document.querySelector('[data-quick-link-label="Team Page"]')?.getAttribute('href')).toBe('team.html');
+        expect(teamPageLink?.hidden).toBe(true);
+        expect(teamPageLink?.getAttribute('href')).toBe('team.html');
         expect(gameViewerLink?.hidden).toBe(true);
         expect(gameViewerLink?.getAttribute('href')).toBe('team.html');
-        expect(document.querySelector('[data-quick-link-label="Open Team Chat"]')?.getAttribute('href')).toBe('team-chat.html');
+        expect(teamChatLink?.hidden).toBe(true);
+        expect(teamChatLink?.getAttribute('href')).toBe('team-chat.html');
     });
 
     it('keeps team context when Help Watch Chat links have no game context', () => {


### PR DESCRIPTION
Closes #3938

## What changed
- Hide Team Page and Team Chat until `teamId` is available.
- Preserve valid team-context routes.
- Add focused unit and browser regression coverage.

## Root Cause
Team Page and Team Chat used team-scoped route templates without declaring `teamId` as required context. The shared resolver therefore removed empty parameters and exposed destination pages that cannot operate without a team.

## Prevention / Learning
Every context-templated help CTA must declare all required context keys and default to hidden until the resolver validates them.

## Regression Tests
- `npx vitest run tests/unit/help-center.test.js --reporter=verbose` (12 passed)
- `npx playwright test --config=playwright.smoke.config.js tests/smoke/help-workflow-pages.spec.js --grep 'help-watch-chat'` (4 passed)

## Recurrence Risk
Low. The affected CTAs now use the established required-context contract, with unit and browser tests covering missing and valid context.