### PR TITLE
Deploy Firebase Storage rules in production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -30,6 +30,12 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,6 +23,12 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -126,7 +126,7 @@ jobs:
           for ((attempt = 1; attempt <= max_attempts; attempt += 1)); do
             deploy_log="$RUNNER_TEMP/firebase-prod-deploy-attempt-${attempt}.log"
             set +e
-            npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"
+            npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,storage,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"
             deploy_status="${PIPESTATUS[0]}"
             set -e
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",
-    "test:unit:ci": "vitest run tests/unit --reporter=dot",
+    "test:unit:ci": "vitest run tests/unit --reporter=dot && npm run test:storage-rules:ci",
+    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js --reporter=dot\"",
     "test:coverage-map": "node scripts/report-test-coverage-map.mjs --check",
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:functions:auth-email": "node --test functions/test/auth-email-*.test.cjs",

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -55,6 +55,28 @@ export function validatePreviewDeployCommand(deployPreview) {
     assertMatches(deployPreview, /\.\/node_modules\/\.bin\/firebase hosting:channel:deploy "\$CURRENT_CHANNEL" --project game-flow-c6311 --config "\$FIREBASE_PREVIEW_CONFIG"/, 'Preview deploy installed Firebase CLI project/config arguments');
 }
 
+export function validateProductionDeployCommand(deployProd) {
+    const deployCommand = (deployProd.match(/^\s*npx firebase-tools@\S+ deploy\b[^\n]*$/m) || [''])[0];
+    if (!deployCommand) {
+        throw new Error('Production Firebase deploy command is missing.');
+    }
+
+    const onlyList = (deployCommand.match(/(?:^|\s)--only(?:=|\s+)([^\s]+)/) || [])[1];
+    if (!onlyList) {
+        throw new Error('Production Firebase deploy --only list is missing.');
+    }
+
+    const deployTargets = new Set(onlyList.split(','));
+    for (const target of ['firestore:rules', 'firestore:indexes', 'storage']) {
+        if (!deployTargets.has(target)) {
+            throw new Error(`Production Firebase deploy --only list must include ${target}.`);
+        }
+    }
+
+    assertMatches(deployCommand, /(?:^|\s)--project game-flow-c6311(?:\s|$)/, 'Production Firebase deploy project');
+    assertMatches(deployCommand, /(?:^|\s)--config "\$FIREBASE_PROD_CONFIG"(?:\s|$)/, 'Production Firebase generated config');
+}
+
 export function validateFirebaseRulesCi() {
     const firebaseJson = JSON.parse(readText('firebase.json'));
     const firestoreRules = readText('firestore.rules');
@@ -134,8 +156,7 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, "data.recipientIds == conversationData.get('participantIds', [])", 'Nested chat conversation participant binding');
     assertIncludes(firestoreRules, 'isNestedChatMessageCreateValid(', 'Nested chat create rules');
 
-    assertIncludes(deployProd, 'firestore:rules', 'Production deploy');
-    assertIncludes(deployProd, 'firestore:indexes', 'Production deploy');
+    validateProductionDeployCommand(deployProd);
     assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
 
     assertMatches(deployPreview, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview deploy gate');

--- a/tests/unit/auth-email-resend-routing.test.js
+++ b/tests/unit/auth-email-resend-routing.test.js
@@ -93,7 +93,7 @@ describe('authentication email delivery routing', () => {
             .filter(line => /^(run: )?npx firebase-tools@14\.25\.0 deploy/.test(line));
 
         expect(firebaseDeployCommands).toEqual([
-            'npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"'
+            'npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,storage,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive 2>&1 | tee "$deploy_log"'
         ]);
         expect(productionSource.match(/--force/g) ?? []).toHaveLength(0);
         expect(productionSource).toContain('max_attempts=3');

--- a/tests/unit/pages-bundle-staging.test.js
+++ b/tests/unit/pages-bundle-staging.test.js
@@ -92,6 +92,9 @@ describe('pages bundle staging', () => {
             },
             firestore: {
                 rules: 'firestore.rules'
+            },
+            storage: {
+                rules: 'storage.rules'
             }
         }));
 
@@ -102,6 +105,7 @@ describe('pages bundle staging', () => {
         expect(config.hosting.public).toBe(path.resolve(publicDir));
         expect(config.hosting.rewrites).toEqual([{ source: '**', destination: '/index.html' }]);
         expect(config.firestore.rules).toBe('firestore.rules');
+        expect(config.storage.rules).toBe('storage.rules');
     });
 
     it('adds immutable headers only for concrete staged app asset files', () => {

--- a/tests/unit/storage-rules-team-boundary.test.js
+++ b/tests/unit/storage-rules-team-boundary.test.js
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment
+} from '@firebase/rules-unit-testing';
+
+const firestoreRules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const storageRules = readFileSync(new URL('../../storage.rules', import.meta.url), 'utf8');
+
+describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST || !process.env.FIREBASE_STORAGE_EMULATOR_HOST)(
+    'Storage rules team boundary',
+    () => {
+        let testEnv;
+
+        beforeAll(async () => {
+            testEnv = await initializeTestEnvironment({
+                projectId: 'demo-allplays',
+                firestore: { rules: firestoreRules },
+                storage: { rules: storageRules }
+            });
+        }, 30000);
+
+        beforeEach(async () => {
+            await testEnv.clearFirestore();
+            await testEnv.clearStorage();
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const firestore = context.firestore();
+                await firestore.doc('teams/team-a').set({ ownerId: 'owner-a', adminEmails: [] });
+                await firestore.doc('teams/team-b').set({ ownerId: 'owner-b', adminEmails: [] });
+                await firestore.doc('teams/team-a/mediaFolders/folder-a').set({ visibility: 'team' });
+                await firestore.doc('teams/team-b/mediaFolders/folder-b').set({ visibility: 'team' });
+                await firestore.doc('users/member-a').set({
+                    isAdmin: false,
+                    parentTeamIds: ['team-a'],
+                    teamMediaUploadTeamIds: ['team-a']
+                });
+
+                const storage = context.storage();
+                await storage.ref('team-media/team-a/folder-a/owner-a/existing.jpg').put(
+                    new Uint8Array([1]),
+                    { contentType: 'image/jpeg' }
+                );
+                await storage.ref('team-media/team-b/folder-b/owner-b/existing.jpg').put(
+                    new Uint8Array([1]),
+                    { contentType: 'image/jpeg' }
+                );
+            });
+        });
+
+        afterAll(async () => {
+            await testEnv?.cleanup();
+        });
+
+        it('allows authorized team-media access and denies the same user across the team boundary', async () => {
+            const memberStorage = testEnv.authenticatedContext('member-a', {
+                email: 'member-a@example.com'
+            }).storage();
+
+            await assertSucceeds(
+                memberStorage.ref('team-media/team-a/folder-a/owner-a/existing.jpg').getMetadata()
+            );
+            await assertSucceeds(
+                memberStorage.ref('team-media/team-a/folder-a/member-a/new.jpg').put(
+                    new Uint8Array([1]),
+                    { contentType: 'image/jpeg' }
+                )
+            );
+
+            await assertFails(
+                memberStorage.ref('team-media/team-b/folder-b/owner-b/existing.jpg').getMetadata()
+            );
+            await assertFails(
+                memberStorage.ref('team-media/team-b/folder-b/member-a/new.jpg').put(
+                    new Uint8Array([1]),
+                    { contentType: 'image/jpeg' }
+                )
+            );
+        });
+    }
+);

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
     assertPreviewDeploySkipHandling,
     extractMatchBlock,
-    validatePreviewDeployCommand
+    validatePreviewDeployCommand,
+    validateProductionDeployCommand
 } from '../../scripts/validate-firebase-rules-ci.mjs';
 
 describe('validate Firebase rules CI helpers', () => {
@@ -58,6 +59,17 @@ service firebase.storage {
       - name: Deploy preview channel
         run: npx --yes firebase-tools@15.22.1 hosting:channel:deploy "$CURRENT_CHANNEL" --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG"
 `)).toThrow('Preview deploy installed Firebase CLI project/config arguments');
+    });
+
+    it('requires production deploys to release Storage rules with the generated config', () => {
+        const validDeployCommand = `
+            npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,storage,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive
+        `;
+
+        expect(() => validateProductionDeployCommand(validDeployCommand)).not.toThrow();
+        expect(() => validateProductionDeployCommand(validDeployCommand.replace(',storage', ''))).toThrow(
+            'Production Firebase deploy --only list must include storage.'
+        );
     });
 
     it('requires preview deploy release-target outage handling', () => {


### PR DESCRIPTION
Closes #3933

## What changed
- Added `storage` to the production Firebase deployment allowlist.
- Added validation of the canonical production command, project, generated config, and required rule targets.
- Confirmed the generated production config preserves the root `storage.rules` declaration.

## Root Cause
The production command's `--only` allowlist omitted Storage. CI validated `storage.rules` and `firebase.json`, but never checked whether the production command actually released Storage rules.

## Prevention / Learning
Validate canonical deployment commands directly, including release targets, project, and generated configuration. Configuration declarations alone do not prove a resource is deployed.

## Regression Tests
- Production command validator accepts an allowlist containing Storage.
- The validator rejects the previous allowlist without Storage.
- Generated-config coverage confirms `storage.rules` remains rooted correctly.
- `npm run ci:firebase-rules` passes.

## Recurrence Risk
Low. Focused CI coverage now fails if Storage is removed from the production allowlist. Production log and bounded Team A/Team B smoke validation remain post-merge deployment checks.