### PR TITLE
Prevent private teams from sharing scoreboard widgets

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -276,6 +276,7 @@ export type TeamDetailModel = {
     description: string;
     zip: string;
     isPublic: boolean;
+    isExplicitlyPublic: boolean;
     active: boolean;
     leagueUrl: string | null;
     bracketUrl: string | null;
@@ -1733,6 +1734,7 @@ export function buildTeamDetailModel({
       description: cleanString(team?.description),
       zip: cleanString(team?.zip),
       isPublic: team?.isPublic !== false,
+      isExplicitlyPublic: team?.isPublic === true,
       active: team?.active !== false,
       leagueUrl: getFirstUrl(team?.leagueUrl),
       bracketUrl: getFirstUrl(team?.bracketUrl),

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -2215,7 +2215,7 @@ function ScoreboardWidgetCard({ model }: { model: TeamDetailModel }) {
   const embedCode = buildScoreboardWidgetEmbedCode(model.team);
   const [copyStatus, setCopyStatus] = useState<{ kind: 'embed' | 'link'; success: boolean } | null>(null);
 
-  if (!model.team.isPublic) {
+  if (model.team.isExplicitlyPublic !== true) {
     return (
       <section className="app-card p-4">
         <div className="flex items-start gap-3">

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -2215,6 +2215,22 @@ function ScoreboardWidgetCard({ model }: { model: TeamDetailModel }) {
   const embedCode = buildScoreboardWidgetEmbedCode(model.team);
   const [copyStatus, setCopyStatus] = useState<{ kind: 'embed' | 'link'; success: boolean } | null>(null);
 
+  if (!model.team.isPublic) {
+    return (
+      <section className="app-card p-4">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-gray-100 text-gray-600">
+            <Code2 className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="text-sm font-black text-gray-950">Scoreboard widget unavailable</div>
+            <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">This team is private. Make the team public before sharing a scoreboard link or embed.</div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
   async function copyValue(kind: 'embed' | 'link', value: string) {
     const result = await copyPublicText(value);
     setCopyStatus({ kind, success: result === 'copied' });

--- a/team.html
+++ b/team.html
@@ -3164,9 +3164,18 @@
                 section.innerHTML = '';
                 return;
             }
+            section.classList.remove('hidden');
+            if (currentTeam?.isPublic !== true) {
+                section.innerHTML = `
+                    <div class="bg-white rounded-2xl shadow-md border border-gray-200 p-6">
+                        <h2 class="text-xl font-bold text-gray-900">Scoreboard widget unavailable</h2>
+                        <p class="text-sm text-gray-600 mt-2">This team is private. Make the team public before sharing a scoreboard link or embed.</p>
+                    </div>
+                `;
+                return;
+            }
             const widgetUrl = getScoreboardWidgetUrl();
             const embedCode = buildScoreboardWidgetEmbedCode();
-            section.classList.remove('hidden');
             section.innerHTML = `
                 <div class="bg-white rounded-2xl shadow-md border border-gray-200 p-6">
                     <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -491,6 +491,24 @@ describe('React app TeamDetail page', () => {
         expect(hidden.container.textContent).not.toContain('Scoreboard widget');
     });
 
+    it('does not offer scoreboard sharing controls for a private managed team', async () => {
+        const privateManagerModel = model();
+        privateManagerModel.canManageTeam = true;
+        privateManagerModel.team.isPublic = false;
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(privateManagerModel);
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(privateManagerModel);
+
+        const { container } = await renderTeamDetail();
+
+        await clickButton(container, 'More');
+        expect(container.textContent).toContain('Scoreboard widget unavailable');
+        expect(container.textContent).toContain('This team is private. Make the team public before sharing a scoreboard link or embed.');
+        const widgetCard = Array.from(container.querySelectorAll('section')).find((section) => section.textContent?.includes('Scoreboard widget unavailable'));
+        expect(widgetCard).toBeTruthy();
+        expect(widgetCard.querySelector('#scoreboard-widget-embed')).toBeNull();
+        expect(widgetCard.querySelectorAll('button')).toHaveLength(0);
+    });
+
     it('lets team managers load and save reminder timing defaults from the More tab', async () => {
         const managerModel = model();
         managerModel.canManageTeam = true;

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -108,6 +108,7 @@ function model() {
             description: 'Fast, parent-friendly team page.',
             zip: '66210',
             isPublic: true,
+            isExplicitlyPublic: true,
             active: true,
             leagueUrl: 'https://league.example.test/standings',
             streamUrl: 'https://youtube.example.test/watch',
@@ -495,6 +496,7 @@ describe('React app TeamDetail page', () => {
         const privateManagerModel = model();
         privateManagerModel.canManageTeam = true;
         privateManagerModel.team.isPublic = false;
+        privateManagerModel.team.isExplicitlyPublic = false;
         teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(privateManagerModel);
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(privateManagerModel);
 
@@ -503,6 +505,23 @@ describe('React app TeamDetail page', () => {
         await clickButton(container, 'More');
         expect(container.textContent).toContain('Scoreboard widget unavailable');
         expect(container.textContent).toContain('This team is private. Make the team public before sharing a scoreboard link or embed.');
+        const widgetCard = Array.from(container.querySelectorAll('section')).find((section) => section.textContent?.includes('Scoreboard widget unavailable'));
+        expect(widgetCard).toBeTruthy();
+        expect(widgetCard.querySelector('#scoreboard-widget-embed')).toBeNull();
+        expect(widgetCard.querySelectorAll('button')).toHaveLength(0);
+    });
+
+    it('does not offer scoreboard sharing controls without explicit public visibility', async () => {
+        const legacyManagerModel = model();
+        legacyManagerModel.canManageTeam = true;
+        legacyManagerModel.team.isPublic = true;
+        legacyManagerModel.team.isExplicitlyPublic = false;
+        teamDetailMocks.loadParentTeamDetailBootstrap.mockResolvedValueOnce(legacyManagerModel);
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(legacyManagerModel);
+
+        const { container } = await renderTeamDetail();
+
+        await clickButton(container, 'More');
         const widgetCard = Array.from(container.querySelectorAll('section')).find((section) => section.textContent?.includes('Scoreboard widget unavailable'));
         expect(widgetCard).toBeTruthy();
         expect(widgetCard.querySelector('#scoreboard-widget-embed')).toBeNull();

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -832,6 +832,7 @@ describe('React app team detail model', () => {
         expect(model.team.photoUrl).toBe('https://img.example.test/team.png');
         expect(model.team.bracketUrl).toBe('https://bracket.example.test/path');
         expect(model.team.isPublic).toBe(true);
+        expect(model.team.isExplicitlyPublic).toBe(false);
         expect(model.team.active).toBe(true);
         expect(model.team.scheduleNotifications).toMatchObject({
             enabled: true,

--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -73,6 +73,15 @@ describe('scoreboard widget embed', () => {
         expect(source).toContain('<iframe src="${url}"');
     });
 
+    it('does not offer legacy scoreboard sharing controls for private teams', () => {
+        const source = readPage('team.html');
+
+        expect(source).toContain('if (currentTeam?.isPublic !== true)');
+        expect(source).toContain('Scoreboard widget unavailable');
+        expect(source).toContain('This team is private. Make the team public before sharing a scoreboard link or embed.');
+        expect(source.indexOf('if (currentTeam?.isPublic !== true)')).toBeLessThan(source.indexOf('const widgetUrl = getScoreboardWidgetUrl();', source.indexOf('function renderScoreboardWidgetTools()')));
+    });
+
     it('adds a read-only public widget page backed by team games', () => {
         const source = readPage('widget-scoreboard.html');
 


### PR DESCRIPTION
Closes #3951

## What changed
- Replaced scoreboard sharing controls with a clear private-team explanation in React Team Detail.
- Applied the same visibility guard to the legacy team page.
- Preserved existing sharing behavior for public teams.

## Root Cause
Both management surfaces gated scoreboard sharing only on manager access. They ignored team visibility even though the widget uses anonymous Firestore reads that require `isPublic == true`.

## Prevention / Learning
Gate every public link or embed control on the same visibility predicate enforced by its anonymous data path. Test denied visibility states alongside manager happy paths.

## Regression Tests
- React integration coverage verifies private-team managers see explanatory copy without widget fields or copy buttons.
- Legacy coverage verifies the public-team guard runs before link and embed generation.
- Focused scoreboard tests passed: 11 tests.

## Recurrence Risk
Low. Both supported management surfaces now enforce the public visibility contract, with focused regression coverage.