### PR TITLE
Show home foul totals in live viewer

### DIFF
--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -172,6 +172,20 @@ function renderViewerLineupList({
   }).join('');
 }
 
+export function resolveHomeStatColumns(statColumns = [], stats = {}) {
+  const columns = normalizeLiveStatColumns(statColumns);
+  const hasFoulAlias = columns.some((column) => statKeyMap[column] === 'fouls');
+  const hasFoulStats = Object.values(stats || {}).some((playerStats) => (
+    Object.prototype.hasOwnProperty.call(playerStats || {}, 'fouls')
+  ));
+
+  if (!hasFoulAlias && hasFoulStats) {
+    return [...columns, 'FLS'];
+  }
+
+  return columns;
+}
+
 export function renderViewerLineupSections({
   players = [],
   stats = {},
@@ -181,6 +195,7 @@ export function renderViewerLineupSections({
   lastStatChange = null
 } = {}) {
   const { onCourtIds, benchIds } = resolveViewerLineup({ players, onCourt, bench });
+  const columns = resolveHomeStatColumns(statColumns, stats);
   return {
     onCourtIds,
     benchIds,
@@ -189,7 +204,7 @@ export function renderViewerLineupSections({
       emptyLabel: 'No players currently on field',
       players,
       stats,
-      statColumns,
+      statColumns: columns,
       lastStatChange
     }),
     benchHtml: renderViewerLineupList({
@@ -197,7 +212,7 @@ export function renderViewerLineupSections({
       emptyLabel: 'No players currently on bench',
       players,
       stats,
-      statColumns,
+      statColumns: columns,
       lastStatChange
     })
   };

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -37,7 +37,7 @@ import { BROADCAST_SETUP_STATUSES, BROADCAST_STREAM_STATUSES, MAX_HIGHLIGHT_CLIP
 import { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, isRecordedReplayTeamPassGateEnabled, resolveTeamEntitlementSeasonId } from './team-entitlements.js?v=2';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } from './live-game-state.js?v=6';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } from './live-game-state.js?v=7';
 import { getDefaultLivePeriod } from './live-sport-config.js?v=2';
 import { BROADCAST_STREAM_HEARTBEAT_MS, buildBroadcastRuntimeSession } from './game-day-broadcast.js?v=5';
 

--- a/live-game.html
+++ b/live-game.html
@@ -590,6 +590,6 @@
 
   <div id="footer-container"></div>
 
-  <script type="module" src="js/live-game.js?v=16"></script>
+  <script type="module" src="js/live-game.js?v=17"></script>
 </body>
 </html>

--- a/tests/unit/live-game-lineup-sync.test.js
+++ b/tests/unit/live-game-lineup-sync.test.js
@@ -54,4 +54,31 @@ describe('live game viewer lineup sync', () => {
     expect(rendered.benchHtml).toContain('6 REB');
     expect(rendered.benchHtml).toContain('0 AST');
   });
+
+  it('renders persisted home fouls when configured columns omit FLS', () => {
+    const rendered = renderViewerLineupSections({
+      players: [{ id: 'p1', name: 'Ava', num: '1' }],
+      stats: { p1: { pts: 8, reb: 4, fouls: 5 } },
+      statColumns: ['PTS', 'REB'],
+      onCourt: ['p1'],
+      bench: []
+    });
+
+    expect(rendered.onCourtHtml).toContain('8 PTS');
+    expect(rendered.onCourtHtml).toContain('4 REB');
+    expect(rendered.onCourtHtml).toContain('5 FLS');
+  });
+
+  it.each(['FLS', 'FOULS'])('does not duplicate configured home %s foul alias', (foulColumn) => {
+    const rendered = renderViewerLineupSections({
+      players: [{ id: 'p1', name: 'Ava', num: '1' }],
+      stats: { p1: { pts: 8, fouls: 5 } },
+      statColumns: ['PTS', foulColumn],
+      onCourt: ['p1'],
+      bench: []
+    });
+
+    expect(rendered.onCourtHtml.match(new RegExp(`5 ${foulColumn}`, 'g'))).toHaveLength(1);
+    expect(rendered.onCourtHtml.match(/5 (?:FLS|FOULS)/g)).toHaveLength(1);
+  });
 });

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -55,7 +55,7 @@ describe('RSVP precedence cache delivery', () => {
         const consumerVersions = {
             'admin.html': 'js/admin.js?v=10',
             'certificates.html': 'js/certificates/studio.js?v=13',
-            'live-game.html': 'js/live-game.js?v=16',
+            'live-game.html': 'js/live-game.js?v=17',
             'live-tracker.html': 'js/live-tracker.js?v=2',
             'team-fees.html': 'js/team-fees-admin.js?v=14',
             'team-media.html': 'js/team-media.js?v=14',
@@ -72,5 +72,6 @@ describe('RSVP precedence cache delivery', () => {
         expect(readRepoFile('js/utils.js')).toContain("import('./global-search.js?v=9')");
         expect(readRepoFile('js/db.js')).toContain("from './utils.js?v=15';");
         expect(readRepoFile('parent-dashboard.html')).toContain('js/utils.js?v=15');
+        expect(readRepoFile('js/live-game.js')).toContain("from './live-game-state.js?v=7';");
     });
 });


### PR DESCRIPTION
Closes #3955

## What changed
- Append FLS to home-player live cards when persisted foul data exists and no foul alias is configured.
- Preserve configured FLS, FOULS, and FOUL aliases without duplication.

## Root Cause
Home live-view cards rendered only configured stat columns, despite home stats persisting fouls independently. Existing foul-aware column resolution applied only to opponent cards.

## Prevention / Learning
When stats are persisted independently of display configuration, resolve viewer columns from both configuration and available data. Deduplicate all supported aliases before rendering.

## Regression Tests
- Verifies five persisted home fouls render as `5 FLS` with only PTS and REB configured.
- Verifies configured FLS and FOULS aliases each render exactly once.
- Focused Vitest selection passed 32 tests.

## Recurrence Risk
Low. Focused coverage protects omitted and explicitly configured foul-column paths.