### PR TITLE
Prioritize live calendar subscriptions

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -706,6 +706,62 @@ describe('ParentTools access', () => {
         await waitFor(() => expect(parentToolsServiceMocks.loadParentCalendarTools).toHaveBeenNthCalledWith(3, linkedAuth.user, { force: true }));
     });
 
+    it('prioritizes live calendar subscriptions and preserves each feed action', async () => {
+        const privateFeedUrl = 'https://calendar.example.test/team-1.ics?token=private-token';
+        const appleFeedUrl = 'webcal://calendar.example.test/team-1.ics?token=private-token';
+        const googleFeedUrl = `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(privateFeedUrl)}`;
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText }
+        });
+        parentToolsServiceMocks.loadParentCalendarTools.mockResolvedValue({
+            events: [
+                {
+                    id: 'event-1',
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    type: 'practice',
+                    date: new Date('2100-06-01T18:00:00Z')
+                }
+            ],
+            teams: [{ teamId: 'team-1', teamName: 'Bears', eventCount: 1 }]
+        });
+        parentToolsServiceMocks.getPrivateTeamCalendarFeedUrl.mockResolvedValue(privateFeedUrl);
+        parentToolsServiceMocks.getAppleCalendarFeedUrl.mockReturnValue(appleFeedUrl);
+        parentToolsServiceMocks.getGoogleCalendarFeedUrl.mockReturnValue(googleFeedUrl);
+
+        renderParentTools(['/parent-tools/calendar'], false, linkedAuth);
+
+        const subscriptionsHeading = await screen.findByRole('heading', { name: 'Keep calendars updated' });
+        const moreOptionsHeading = screen.getByRole('heading', { name: 'More options' });
+        expect(subscriptionsHeading.compareDocumentPosition(moreOptionsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+        expect(screen.getByText('Subscribe to live games and practices. Schedule changes will sync automatically.')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Apple Calendar' }));
+        await waitFor(() => expect(openPublicUrl).toHaveBeenCalledWith(appleFeedUrl));
+        expect(parentToolsServiceMocks.getAppleCalendarFeedUrl).toHaveBeenCalledWith(privateFeedUrl);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Google Calendar' }));
+        await waitFor(() => expect(openPublicUrl).toHaveBeenCalledWith(googleFeedUrl));
+        expect(parentToolsServiceMocks.getGoogleCalendarFeedUrl).toHaveBeenCalledWith(privateFeedUrl);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Copy private link' }));
+        await waitFor(() => expect(writeText).toHaveBeenCalledWith(privateFeedUrl));
+        expect(parentToolsServiceMocks.getPrivateTeamCalendarFeedUrl).toHaveBeenCalledTimes(3);
+    });
+
+    it('keeps empty-calendar feedback without rendering subscription actions', async () => {
+        renderParentTools(['/parent-tools/calendar'], false, linkedAuth);
+
+        expect(await screen.findByText('No team schedules')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Copy agenda' })).toBeTruthy();
+        expect(screen.queryByRole('heading', { name: 'Keep calendars updated' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Apple Calendar' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Google Calendar' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Copy private link' })).toBeNull();
+    });
+
     it('keeps parent tool refresh effects stable during local rerenders', async () => {
         renderParentTools(['/parent-tools/access'], false, linkedAuth);
 

--- a/apps/app/src/pages/parent-tools/CalendarTool.tsx
+++ b/apps/app/src/pages/parent-tools/CalendarTool.tsx
@@ -101,10 +101,47 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
     return (
         <div className="space-y-3">
             <section className="app-card p-4">
-                <ToolHeader icon={CalendarDays} title="Calendar tools" detail="Download your family schedule or subscribe by team." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={() => { void refresh({ force: true }); }} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
+                <ToolHeader icon={CalendarDays} title="Calendar tools" detail="Subscribe to live team schedules or export a one-time snapshot." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={() => { void refresh({ force: true }); }} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
                 {error ? <RetryableStatus error={error} fallbackMessage="Unable to load calendar tools." onRetry={loading ? undefined : () => refresh({ force: true })} retrying={loading} /> : null}
                 {message ? <Status tone="success" message={message} /> : null}
-                <div className="mt-3 grid gap-2 sm:grid-cols-3">
+                <div className="mt-3">
+                    <MetricCard label="Events" value={String(events.length)} />
+                </div>
+            </section>
+
+            {!loadError && (loading ? <LoadingBlock label="Loading calendar teams" /> : (
+                teams.length ? (
+                    <section aria-labelledby="calendar-subscriptions-heading">
+                        <div className="mb-3">
+                            <h2 id="calendar-subscriptions-heading" className="text-base font-black text-gray-950">Keep calendars updated</h2>
+                            <p className="mt-1 text-xs font-semibold text-gray-500">Subscribe to live games and practices. Schedule changes will sync automatically.</p>
+                        </div>
+                        <div className="grid gap-3 lg:grid-cols-2">
+                            {teams.map((team) => (
+                                <div key={team.teamId} className="app-card p-4">
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <div className="truncate text-sm font-black text-gray-950">{team.teamName}</div>
+                                            <div className="mt-0.5 text-xs font-semibold text-gray-500">{team.eventCount} event{team.eventCount === 1 ? '' : 's'} on this schedule</div>
+                                        </div>
+                                        {busyTeamId === team.teamId ? <Loader2 className="h-5 w-5 animate-spin text-primary-600" aria-hidden="true" /> : <CalendarDays className="h-5 w-5 text-primary-600" aria-hidden="true" />}
+                                    </div>
+                                    <div className="mt-3 grid gap-2 sm:grid-cols-3">
+                                        <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed(team, 'apple')} disabled={busyTeamId === team.teamId}>Apple Calendar</button>
+                                        <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed(team, 'google')} disabled={busyTeamId === team.teamId}>Google Calendar</button>
+                                        <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed(team, 'copy')} disabled={busyTeamId === team.teamId}>Copy private link</button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+                ) : <div className="app-card p-5 text-center"><CalendarDays className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" /><div className="mt-3 text-sm font-black text-gray-950">No team schedules</div><div className="mt-1 text-xs font-semibold text-gray-500">Schedules appear after a player or team is linked.</div></div>
+            ))}
+
+            <section className="app-card p-4" aria-labelledby="calendar-more-options-heading">
+                <h2 id="calendar-more-options-heading" className="text-sm font-black text-gray-950">More options</h2>
+                <p className="mt-1 text-xs font-semibold text-gray-500">Download or copy a one-time snapshot of the current schedule.</p>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
                     <button type="button" className="secondary-button justify-center" onClick={() => { void download(); }} disabled={loading || exporting}>
                         {exporting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Download className="h-4 w-4" aria-hidden="true" />}
                         {exporting ? 'Preparing .ics' : 'Download .ics'}
@@ -113,30 +150,8 @@ export function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refres
                         <Copy className="h-4 w-4" aria-hidden="true" />
                         Copy agenda
                     </button>
-                    <MetricCard label="Events" value={String(events.length)} />
                 </div>
             </section>
-
-            {!loadError && (loading ? <LoadingBlock label="Loading calendar teams" /> : (
-                <section className="grid gap-3 lg:grid-cols-2">
-                    {teams.length ? teams.map((team) => (
-                        <div key={team.teamId} className="app-card p-4">
-                            <div className="flex items-start justify-between gap-3">
-                                <div className="min-w-0">
-                                    <div className="truncate text-sm font-black text-gray-950">{team.teamName}</div>
-                                    <div className="mt-0.5 text-xs font-semibold text-gray-500">{team.eventCount} event{team.eventCount === 1 ? '' : 's'} on this schedule</div>
-                                </div>
-                                {busyTeamId === team.teamId ? <Loader2 className="h-5 w-5 animate-spin text-primary-600" aria-hidden="true" /> : <CalendarDays className="h-5 w-5 text-primary-600" aria-hidden="true" />}
-                            </div>
-                            <div className="mt-3 grid grid-cols-3 gap-2">
-                                <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed(team, 'copy')} disabled={busyTeamId === team.teamId}>Copy</button>
-                                <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed(team, 'apple')} disabled={busyTeamId === team.teamId}>Apple</button>
-                                <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed(team, 'google')} disabled={busyTeamId === team.teamId}>Google</button>
-                            </div>
-                        </div>
-                    )) : <div className="app-card p-5 text-center"><CalendarDays className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" /><div className="mt-3 text-sm font-black text-gray-950">No team schedules</div><div className="mt-1 text-xs font-semibold text-gray-500">Schedules appear after a player or team is linked.</div></div>}
-                </section>
-            ))}
         </div>
     );
 }


### PR DESCRIPTION
Closes #3961

## What changed
- Lead with a clearly labeled live subscription section when teams exist.
- Add explicit Apple Calendar, Google Calendar, and Copy private link actions.
- Move one-time ICS download and agenda copy controls under More options.
- Preserve existing feed generation, authorization, export, error, and empty-state behavior.

## Root Cause
CalendarTool presented one-time exports before live team feeds and used terse action labels, making static snapshots appear to be the primary workflow while obscuring automatic schedule synchronization.

## Prevention / Learning
Calendar workflows should prioritize durable subscriptions over snapshot exports. Tests should lock both visual ordering and unchanged URL transformations whenever calendar actions are reorganized.

## Regression Tests
- Verified subscriptions render before More options for a loaded team.
- Verified Apple and Google open their generated feed URLs.
- Verified Copy private link copies the unmodified private feed URL.
- Verified empty calendars retain existing feedback and omit subscription actions.
- `cd apps/app && npx vitest run src/pages/ParentTools.test.tsx --reporter=verbose` passed 45 tests.
- Targeted ESLint passed.

## Recurrence Risk
Low. Focused component coverage now locks ordering, labels, feed behavior, and the empty state.