### PR TITLE
Allow admins to edit inactive teams

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -980,7 +980,7 @@
 
         async function refreshRegistrationSourceFromTeam() {
             if (!currentTeamId) return null;
-            const latestTeam = await getTeam(currentTeamId);
+            const latestTeam = await getTeam(currentTeamId, { includeInactive: true });
             const storedRegistrationSource = getStoredRegistrationSource(latestTeam || {});
             if (storedRegistrationSource) {
                 currentRegistrationSource = storedRegistrationSource;

--- a/edit-team.html
+++ b/edit-team.html
@@ -1514,7 +1514,7 @@
 
             if (initialTeamId) {
                 document.getElementById('roster-rollover-section').classList.add('hidden');
-                const team = await getTeam(initialTeamId);
+                const team = await getTeam(initialTeamId, { includeInactive: true });
                 if (!team) {
                     alert('Team not found or no longer active.');
                     currentTeamId = null;

--- a/tests/unit/edit-team-registration-sync.test.js
+++ b/tests/unit/edit-team-registration-sync.test.js
@@ -102,6 +102,7 @@ describe('edit team Sports Connect registration sync wiring', () => {
         expect(storedSourceHelper).toContain('team?.registrationSource');
         expect(storedSourceHelper).toContain('team?.registrationProvider');
         expect(populateSource).toContain('currentRegistrationSource = getStoredRegistrationSource(team);');
+        expect(refreshSource).toContain('getTeam(currentTeamId, { includeInactive: true })');
         expect(refreshSource).toContain('const storedRegistrationSource = getStoredRegistrationSource(latestTeam || {});');
         expect(refreshSource).toContain('currentRegistrationSource = storedRegistrationSource;');
     });

--- a/tests/unit/team-management-access-wiring.test.js
+++ b/tests/unit/team-management-access-wiring.test.js
@@ -50,6 +50,15 @@ describe('team management page access wiring', () => {
         expect(html).toContain('Team not found or no longer active');
     });
 
+    it('loads inactive teams before applying edit access authorization', () => {
+        const html = readRepoFile('edit-team.html');
+        const loadTeamIndex = html.indexOf('getTeam(initialTeamId, { includeInactive: true })');
+        const authorizeTeamIndex = html.indexOf('hasFullTeamAccess(currentUser, { ...team');
+
+        expect(loadTeamIndex).toBeGreaterThan(-1);
+        expect(authorizeTeamIndex).toBeGreaterThan(loadTeamIndex);
+    });
+
     it('uses shared full-access helper in edit config page', () => {
         const html = readRepoFile('edit-config.html');
         expect(html).toContain("from './js/edit-config-access.js?v=2'");


### PR DESCRIPTION
Closes #3967

## What changed
- Load existing teams with `includeInactive: true` on `edit-team.html`.
- Preserve the existing full-team-access authorization check.
- Add focused regression coverage for inactive-team loading and authorization order.

## Root Cause
The edit-team boot path used the active-only default for `getTeam`, causing inactive teams linked from Admin Teams to resolve to `null` before authorization ran.

## Prevention / Learning
Management pages linked from include-inactive listings must explicitly request inactive records, then apply the same authorization controls used for active records.

## Regression Tests
- `npx vitest run tests/unit/team-management-access-wiring.test.js --reporter=verbose`
- Confirms the edit page requests inactive teams.
- Confirms authorization remains after the team load.

## Recurrence Risk
Low. Focused coverage locks both the inactive-read option and authorization order.