### PR TITLE
Keep Android Back inside revoke confirmation

### DIFF
--- a/apps/app/src/components/Modal.test.tsx
+++ b/apps/app/src/components/Modal.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useState } from 'react';
 import { Modal } from './Modal';
+import { APP_BACK_DISMISS_EVENT } from '../lib/nativeBackButton';
 
 function ModalHarness({ onClose = vi.fn() }: { onClose?: () => void }) {
   const [open, setOpen] = useState(false);
@@ -72,5 +73,25 @@ describe('Modal', () => {
 
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Test modal' })).toBeNull());
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles native Back, releases scroll lock and restores trigger focus', async () => {
+    const onClose = vi.fn();
+    render(<ModalHarness onClose={onClose} />);
+
+    const trigger = screen.getByRole('button', { name: 'Open modal' });
+    trigger.focus();
+    fireEvent.click(trigger);
+    await screen.findByRole('dialog', { name: 'Test modal' });
+    expect(document.body.style.overflow).toBe('hidden');
+
+    const event = new Event(APP_BACK_DISMISS_EVENT, { cancelable: true });
+    fireEvent(window, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Test modal' })).toBeNull());
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.body.style.overflow).toBe('');
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -851,6 +851,34 @@ describe('ParentTools access', () => {
         expect(screen.getByText('https://allplays.ai/app/#/family/token-1')).toBeTruthy();
     });
 
+    it('keeps family share revocation open on native Back while saving', async () => {
+        parentToolsServiceMocks.loadFamilyShareModel.mockResolvedValue({
+            children: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Sam Player' }],
+            tokens: [{
+                id: 'token-1',
+                label: 'Grandma',
+                url: 'https://allplays.ai/app/#/family/token-1',
+                childCount: 1,
+                extraCalendarUrls: []
+            }]
+        });
+        parentToolsServiceMocks.revokeParentFamilyShare.mockImplementationOnce(() => new Promise(() => {}));
+
+        renderParentTools(['/parent-tools/share'], false, linkedAuth);
+
+        expect(await screen.findByText('Grandma')).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Revoke link' }));
+        await waitFor(() => expect((screen.getByRole('button', { name: 'Revoke link' }) as HTMLButtonElement).disabled).toBe(true));
+
+        const event = new Event(APP_BACK_DISMISS_EVENT, { cancelable: true });
+        fireEvent(window, event);
+
+        expect(event.defaultPrevented).toBe(true);
+        expect(screen.getByRole('dialog', { name: 'Revoke this share link?' })).toBeTruthy();
+        expect(parentToolsServiceMocks.revokeParentFamilyShare).toHaveBeenCalledTimes(1);
+    });
+
     it('shows a created family link when clipboard copy and refresh recovery miss it', async () => {
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getHorizontalScrollTarget, ParentTools, type ParentToolId } from './ParentTools';
 import type { AuthState } from '../lib/types';
-import { getNativeBackTarget } from '../lib/nativeBackButton';
+import { APP_BACK_DISMISS_EVENT, getNativeBackTarget } from '../lib/nativeBackButton';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
@@ -823,6 +823,34 @@ describe('ParentTools access', () => {
         expect(screen.getByRole('button', { name: 'Copy' })).toBeTruthy();
     });
 
+    it('dismisses family share revocation on native Back without leaving Share', async () => {
+        parentToolsServiceMocks.loadFamilyShareModel.mockResolvedValue({
+            children: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Sam Player' }],
+            tokens: [{
+                id: 'token-1',
+                label: 'Grandma',
+                url: 'https://allplays.ai/app/#/family/token-1',
+                childCount: 1,
+                extraCalendarUrls: []
+            }]
+        });
+
+        renderParentTools(['/parent-tools/share'], false, linkedAuth);
+
+        expect(await screen.findByText('Grandma')).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Revoke' }));
+        expect(await screen.findByRole('dialog', { name: 'Revoke this share link?' })).toBeTruthy();
+
+        const event = new Event(APP_BACK_DISMISS_EVENT, { cancelable: true });
+        fireEvent(window, event);
+
+        expect(event.defaultPrevented).toBe(true);
+        await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Revoke this share link?' })).toBeNull());
+        expect(parentToolsServiceMocks.revokeParentFamilyShare).not.toHaveBeenCalled();
+        expect(screen.getByRole('heading', { name: 'Family share' })).toBeTruthy();
+        expect(screen.getByText('https://allplays.ai/app/#/family/token-1')).toBeTruthy();
+    });
+
     it('shows a created family link when clipboard copy and refresh recovery miss it', async () => {
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,
@@ -925,6 +953,8 @@ describe('ParentTools access', () => {
 
         await waitFor(() => {
             expect(parentToolsServiceMocks.revokeParentFamilyShare).toHaveBeenCalledWith('token-2');
+            expect(parentToolsServiceMocks.revokeParentFamilyShare).toHaveBeenCalledTimes(1);
+            expect(parentToolsServiceMocks.loadFamilyShareModel).toHaveBeenCalledTimes(3);
             expect(screen.queryByText('New family link')).toBeNull();
             expect(screen.queryByRole('button', { name: 'Copy newly created family link' })).toBeNull();
             expect(screen.queryByRole('button', { name: 'Share newly created family link' })).toBeNull();

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { Copy, Loader2, RefreshCw, Share2 } from 'lucide-react';
+import { Modal } from '../../components/Modal';
 import { createParentFamilyShare, loadFamilyShareModel, revokeParentFamilyShare, updateParentFamilyShareCalendars, type FamilyShareTokenCard } from '../../lib/parentFamilyShareService';
 import { sharePublicUrl } from '../../lib/publicActions';
 import type { AuthState } from '../../lib/types';
@@ -177,8 +178,12 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
             ))}
 
             {pendingRevokeToken ? (
-                <div className="fixed inset-0 z-50 flex items-end justify-center bg-gray-950/40 px-4 py-5 sm:items-center" role="presentation">
-                    <div className="w-full max-w-sm rounded-2xl bg-white p-4 shadow-2xl" role="dialog" aria-modal="true" aria-labelledby="family-share-revoke-title">
+                <Modal
+                    ariaLabelledBy="family-share-revoke-title"
+                    onClose={() => setPendingRevokeToken(null)}
+                    overlayClassName="z-50 flex items-end justify-center bg-gray-950/40 px-4 py-5 sm:items-center"
+                >
+                    <div className="w-full max-w-sm rounded-2xl bg-white p-4 shadow-2xl">
                         <h3 id="family-share-revoke-title" className="text-base font-black text-gray-950">Revoke this share link?</h3>
                         <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
                             Anyone using the family share link{pendingRevokeToken.label ? ` for ${pendingRevokeToken.label}` : ''} will lose access.
@@ -191,7 +196,7 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
                             </button>
                         </div>
                     </div>
-                </div>
+                </Modal>
             ) : null}
         </div>
     );

--- a/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
+++ b/apps/app/src/pages/parent-tools/FamilyShareTool.tsx
@@ -180,7 +180,9 @@ export function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; ref
             {pendingRevokeToken ? (
                 <Modal
                     ariaLabelledBy="family-share-revoke-title"
-                    onClose={() => setPendingRevokeToken(null)}
+                    onClose={() => {
+                        if (!saving) setPendingRevokeToken(null);
+                    }}
                     overlayClassName="z-50 flex items-end justify-center bg-gray-950/40 px-4 py-5 sm:items-center"
                 >
                     <div className="w-full max-w-sm rounded-2xl bg-white p-4 shadow-2xl">


### PR DESCRIPTION
Closes #3965

## What changed
- Replaced the custom family-share revoke overlay with the shared `Modal`.
- Preserved the mobile bottom-sheet layout, warning, actions, busy state, and revoke flow.
- Added native Back regression coverage and strengthened confirmed-revoke assertions.

## Root Cause
`FamilyShareTool` rendered a custom fixed overlay that did not handle `APP_BACK_DISMISS_EVENT`. The unhandled event reached route navigation and moved the user from `/parent-tools/share` to `/parent-tools`.

## Prevention / Learning
Confirmation dialogs in the Capacitor app must use the shared `Modal` so native Back, Escape, overlay dismissal, focus containment, focus restoration, and body-scroll locking follow one tested contract.

## Regression Tests
- `Modal.test.tsx` verifies native Back prevents route fallback, closes the modal, releases the scroll lock, and restores focus.
- `ParentTools.test.tsx` verifies native Back dismisses the revoke confirmation without invoking revocation or leaving Share.
- Confirmed revocation is asserted to call the service exactly once and refresh the token model.
- Focused tests: 49 passed.
- TypeScript typecheck passed.

## Recurrence Risk
Low. The workflow now uses the repository-wide modal contract and has component plus integration regression coverage.