### PR TITLE
Persist public registration rate limits

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -549,6 +549,12 @@
       "indexes": [
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "publicRegistrationRateLimits",
+      "fieldPath": "expiresAt",
+      "ttl": true,
+      "indexes": []
     }
   ]
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -839,13 +839,21 @@ function buildPublicPendingRegistrationRecord({ form, input, selectedOption = nu
   return record;
 }
 
+function getHeaderValue(headers = {}, name = '') {
+  const direct = headers[name] || headers[name.toLowerCase()];
+  return Array.isArray(direct) ? direct[0] : String(direct || '');
+}
+
 function buildPublicRegistrationRateLimitBoundary(input, context = {}) {
   const rawRequest = context.rawRequest || {};
   const requestIp = getRequestIp(rawRequest);
+  const appCheck = String(context.app?.appId || getHeaderValue(rawRequest.headers, 'x-firebase-appcheck') || '').trim();
+  const email = String(input.guardian?.email || input.guardian?.guardianEmail || '').trim().toLowerCase();
   return [
     input.teamId,
     input.formId,
-    requestIp || 'unknown'
+    email || 'no-email',
+    appCheck || requestIp || 'unknown'
   ].join('|');
 }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -839,21 +839,13 @@ function buildPublicPendingRegistrationRecord({ form, input, selectedOption = nu
   return record;
 }
 
-function getHeaderValue(headers = {}, name = '') {
-  const direct = headers[name] || headers[name.toLowerCase()];
-  return Array.isArray(direct) ? direct[0] : String(direct || '');
-}
-
 function buildPublicRegistrationRateLimitBoundary(input, context = {}) {
   const rawRequest = context.rawRequest || {};
   const requestIp = getRequestIp(rawRequest);
-  const appCheck = String(context.app?.appId || getHeaderValue(rawRequest.headers, 'x-firebase-appcheck') || '').trim();
-  const email = String(input.guardian?.email || input.guardian?.guardianEmail || '').trim().toLowerCase();
   return [
     input.teamId,
     input.formId,
-    email || 'no-email',
-    appCheck || requestIp || 'unknown'
+    requestIp || 'unknown'
   ].join('|');
 }
 
@@ -880,9 +872,14 @@ exports.submitPublicRegistration = functions.https.onCall(async (data, context =
     throwPublicRegistrationError('invalid-argument', error.message || 'Invalid registration submission.');
   }
 
+  const formRef = buildRegistrationFormRef(input);
+  const initialFormSnap = await formRef.get();
+  if (!initialFormSnap.exists) {
+    throwPublicRegistrationError('not-found', 'Registration form not found.');
+  }
+
   await assertPublicRegistrationRateLimit(input, context);
 
-  const formRef = buildRegistrationFormRef(input);
   const registrationRef = formRef.collection('registrations').doc();
   let result = null;
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -207,12 +207,18 @@ const checkStripeWebhookRateLimit = createInMemoryRateLimiter({
   maxRequests: 120,
   maxKeys: 2_000
 });
-const checkPublicRegistrationSubmissionRateLimit = createFirestoreFixedWindowRateLimiter({
-  firestore,
-  collectionName: 'publicRegistrationRateLimits',
-  windowMs: 10 * 60_000,
-  maxRequests: 3
-});
+let checkPublicRegistrationSubmissionRateLimit;
+function getPublicRegistrationSubmissionRateLimit() {
+  if (!checkPublicRegistrationSubmissionRateLimit) {
+    checkPublicRegistrationSubmissionRateLimit = createFirestoreFixedWindowRateLimiter({
+      firestore,
+      collectionName: 'publicRegistrationRateLimits',
+      windowMs: 10 * 60_000,
+      maxRequests: 3
+    });
+  }
+  return checkPublicRegistrationSubmissionRateLimit;
+}
 const checkPublicOpportunityBrowseRateLimit = createInMemoryRateLimiter({
   windowMs: 60_000,
   maxRequests: 120,
@@ -853,7 +859,7 @@ function buildPublicRegistrationRateLimitBoundary(input, context = {}) {
 
 async function assertPublicRegistrationRateLimit(input, context = {}) {
   const boundary = buildPublicRegistrationRateLimitBoundary(input, context);
-  const rateLimit = await checkPublicRegistrationSubmissionRateLimit(boundary);
+  const rateLimit = await getPublicRegistrationSubmissionRateLimit()(boundary);
   if (!rateLimit.allowed) {
     throwPublicRegistrationError('resource-exhausted', 'Too many registration attempts. Please wait a few minutes and try again.', {
       reason: 'rate-limited',

--- a/functions/index.js
+++ b/functions/index.js
@@ -29,7 +29,7 @@ const {
   buildTeamFeePaidUpdate,
   buildTeamFeeStripeRefundUpdate
 } = require('./team-fees-core.cjs');
-const { createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
+const { createFirestoreFixedWindowRateLimiter, createInMemoryRateLimiter, getRequestIp } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
 const { buildCalendarFeedGamesQuery } = require('./calendar-feed-window-core.cjs');
 const {
@@ -207,10 +207,11 @@ const checkStripeWebhookRateLimit = createInMemoryRateLimiter({
   maxRequests: 120,
   maxKeys: 2_000
 });
-const checkPublicRegistrationSubmissionRateLimit = createInMemoryRateLimiter({
+const checkPublicRegistrationSubmissionRateLimit = createFirestoreFixedWindowRateLimiter({
+  firestore,
+  collectionName: 'publicRegistrationRateLimits',
   windowMs: 10 * 60_000,
-  maxRequests: 3,
-  maxKeys: 5_000
+  maxRequests: 3
 });
 const checkPublicOpportunityBrowseRateLimit = createInMemoryRateLimiter({
   windowMs: 60_000,
@@ -850,9 +851,9 @@ function buildPublicRegistrationRateLimitBoundary(input, context = {}) {
   ].join('|');
 }
 
-function assertPublicRegistrationRateLimit(input, context = {}) {
+async function assertPublicRegistrationRateLimit(input, context = {}) {
   const boundary = buildPublicRegistrationRateLimitBoundary(input, context);
-  const rateLimit = checkPublicRegistrationSubmissionRateLimit({ ip: boundary });
+  const rateLimit = await checkPublicRegistrationSubmissionRateLimit(boundary);
   if (!rateLimit.allowed) {
     throwPublicRegistrationError('resource-exhausted', 'Too many registration attempts. Please wait a few minutes and try again.', {
       reason: 'rate-limited',
@@ -873,7 +874,7 @@ exports.submitPublicRegistration = functions.https.onCall(async (data, context =
     throwPublicRegistrationError('invalid-argument', error.message || 'Invalid registration submission.');
   }
 
-  assertPublicRegistrationRateLimit(input, context);
+  await assertPublicRegistrationRateLimit(input, context);
 
   const formRef = buildRegistrationFormRef(input);
   const registrationRef = formRef.collection('registrations').doc();

--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -151,7 +151,11 @@ function createFirestoreFixedWindowRateLimiter({
         ? existingCount + 1
         : 1;
 
-      transaction.set(limitRef, { count, resetAt });
+      transaction.set(limitRef, {
+        count,
+        resetAt,
+        expiresAt: new Date(resetAt)
+      });
 
       return {
         allowed: count <= configuredMaxRequests,

--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -1,4 +1,5 @@
 const net = require('node:net');
+const crypto = require('node:crypto');
 const { isPrivateIpAddress } = require('./utils/ip-address-validation.js');
 
 function parsePositiveInteger(value, fallback) {
@@ -102,7 +103,49 @@ function createInMemoryRateLimiter({ windowMs = 60_000, maxRequests = 120, maxKe
   };
 }
 
+function createFirestoreFixedWindowRateLimiter({
+  firestore,
+  collectionName,
+  windowMs = 60_000,
+  maxRequests = 120
+} = {}) {
+  if (!firestore || typeof firestore.runTransaction !== 'function') {
+    throw new TypeError('A Firestore instance with transaction support is required.');
+  }
+  if (typeof collectionName !== 'string' || !collectionName.trim()) {
+    throw new TypeError('A Firestore collection name is required.');
+  }
+
+  const configuredWindowMs = parsePositiveInteger(windowMs, 60_000);
+  const configuredMaxRequests = parsePositiveInteger(maxRequests, 120);
+  const rateLimitCollection = firestore.collection(collectionName.trim());
+
+  return async function reserveRateLimitSlot(boundary, now = Date.now()) {
+    const normalizedBoundary = String(boundary || 'unknown');
+    const documentId = crypto.createHash('sha256').update(normalizedBoundary, 'utf8').digest('hex');
+    const limitRef = rateLimitCollection.doc(documentId);
+
+    return firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(limitRef);
+      const existing = snapshot.exists ? snapshot.data() || {} : {};
+      const existingResetAt = Number(existing.resetAt);
+      const windowActive = Number.isFinite(existingResetAt) && existingResetAt > now;
+      const resetAt = windowActive ? existingResetAt : now + configuredWindowMs;
+      const count = windowActive ? Number(existing.count) + 1 : 1;
+
+      transaction.set(limitRef, { count, resetAt });
+
+      return {
+        allowed: count <= configuredMaxRequests,
+        retryAfterSeconds: Math.max(1, Math.ceil((resetAt - now) / 1000)),
+        remaining: Math.max(0, configuredMaxRequests - count)
+      };
+    });
+  };
+}
+
 module.exports = {
+  createFirestoreFixedWindowRateLimiter,
   createInMemoryRateLimiter,
   getRequestIp
 };

--- a/functions/rate-limit.cjs
+++ b/functions/rate-limit.cjs
@@ -2,6 +2,8 @@ const net = require('node:net');
 const crypto = require('node:crypto');
 const { isPrivateIpAddress } = require('./utils/ip-address-validation.js');
 
+const MAX_RATE_LIMIT_BOUNDARY_BYTES = 2_048;
+
 function parsePositiveInteger(value, fallback) {
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -121,7 +123,17 @@ function createFirestoreFixedWindowRateLimiter({
   const rateLimitCollection = firestore.collection(collectionName.trim());
 
   return async function reserveRateLimitSlot(boundary, now = Date.now()) {
-    const normalizedBoundary = String(boundary || 'unknown');
+    if ((typeof boundary !== 'string' && typeof boundary !== 'number')
+      || (typeof boundary === 'number' && !Number.isFinite(boundary))) {
+      throw new TypeError('A string or finite number rate-limit boundary is required.');
+    }
+    const normalizedBoundary = String(boundary).trim();
+    if (!normalizedBoundary) {
+      throw new TypeError('A non-empty rate-limit boundary is required.');
+    }
+    if (Buffer.byteLength(normalizedBoundary, 'utf8') > MAX_RATE_LIMIT_BOUNDARY_BYTES) {
+      throw new RangeError('The rate-limit boundary is too long.');
+    }
     const documentId = crypto.createHash('sha256').update(normalizedBoundary, 'utf8').digest('hex');
     const limitRef = rateLimitCollection.doc(documentId);
 
@@ -131,7 +143,13 @@ function createFirestoreFixedWindowRateLimiter({
       const existingResetAt = Number(existing.resetAt);
       const windowActive = Number.isFinite(existingResetAt) && existingResetAt > now;
       const resetAt = windowActive ? existingResetAt : now + configuredWindowMs;
-      const count = windowActive ? Number(existing.count) + 1 : 1;
+      const existingCount = Number(existing.count);
+      const count = windowActive
+        && Number.isSafeInteger(existingCount)
+        && existingCount >= 0
+        && existingCount < Number.MAX_SAFE_INTEGER
+        ? existingCount + 1
+        : 1;
 
       transaction.set(limitRef, { count, resetAt });
 

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -333,6 +333,17 @@ test.afterEach(() => {
     stripeState = null;
 });
 
+test('loads unrelated callables without Firestore transaction support', () => {
+    const firestore = makeFirestore();
+    delete firestore.runTransaction;
+    installModuleStubs(firestore);
+
+    const mod = require('../index.js');
+
+    assert.equal(typeof mod.getFamilyShareSchedule, 'function');
+    assert.equal(typeof mod.listPublicOpportunities, 'function');
+});
+
 test('creates exactly one pending registration and reserves matching capacity', async () => {
     const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
 

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -475,24 +475,22 @@ test('throttles repeated anonymous submissions before reserving more capacity', 
     assert.equal(firestore.registrationDocs().length, registrationCountBeforeThrottle);
 });
 
-test('does not allow varying guardian emails to bypass the caller and form limit', async () => {
+test('isolates guardian submission limits for families sharing an IP address', async () => {
     const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+    const firstGuardian = buildSubmission({ guardian: { email: 'one@example.com' } });
 
-    await submitPublicRegistration(buildSubmission({ guardian: { email: 'one@example.com' } }), context);
-    await submitPublicRegistration(buildSubmission({ guardian: { email: 'two@example.com' } }), context);
-    await submitPublicRegistration(buildSubmission({ guardian: { email: 'three@example.com' } }), context);
+    await submitPublicRegistration(firstGuardian, context);
+    await submitPublicRegistration(firstGuardian, context);
+    await submitPublicRegistration(firstGuardian, context);
 
-    await assert.rejects(
-        submitPublicRegistration(buildSubmission({ guardian: { email: 'four@example.com' } }), context),
-        (error) => {
-            assert.equal(error.code, 'resource-exhausted');
-            assert.equal(error.details.reason, 'rate-limited');
-            return true;
-        }
+    const result = await submitPublicRegistration(
+        buildSubmission({ guardian: { email: 'two@example.com' } }),
+        context
     );
 
-    assert.equal(firestore.rateLimitDocs().length, 1);
-    assert.equal(firestore.registrationDocs().length, 3);
+    assert.equal(result.success, true);
+    assert.equal(firestore.rateLimitDocs().length, 2);
+    assert.equal(firestore.registrationDocs().length, 4);
 });
 
 test('shares submission throttling across independently loaded function handlers', async () => {

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -145,6 +145,11 @@ function makeFirestore(seed = {}) {
                 .filter(([path]) => path.startsWith('teams/team-1/registrationForms/form-1/registrations/'))
                 .map(([path, data]) => ({ path, data: clone(data) }));
         },
+        rateLimitDocs() {
+            return [...state.entries()]
+                .filter(([path]) => path.startsWith('publicRegistrationRateLimits/'))
+                .map(([path, data]) => ({ path, data: clone(data) }));
+        },
         failNextTransaction(error) {
             nextTransactionError = error;
         },
@@ -344,6 +349,21 @@ test('loads unrelated callables without Firestore transaction support', () => {
     assert.equal(typeof mod.listPublicOpportunities, 'function');
 });
 
+test('rejects nonexistent forms before creating a durable rate-limit document', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration({});
+
+    await assert.rejects(
+        submitPublicRegistration(buildSubmission(), context),
+        (error) => {
+            assert.equal(error.code, 'not-found');
+            return true;
+        }
+    );
+
+    assert.equal(firestore.rateLimitDocs().length, 0);
+    assert.equal(firestore.registrationDocs().length, 0);
+});
+
 test('creates exactly one pending registration and reserves matching capacity', async () => {
     const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
 
@@ -453,6 +473,26 @@ test('throttles repeated anonymous submissions before reserving more capacity', 
     const formAfterThrottle = firestore.snapshot('teams/team-1/registrationForms/form-1');
     assert.equal(formAfterThrottle.registrationOptionCounts.u10.enrolled, formBeforeThrottle.registrationOptionCounts.u10.enrolled);
     assert.equal(firestore.registrationDocs().length, registrationCountBeforeThrottle);
+});
+
+test('does not allow varying guardian emails to bypass the caller and form limit', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+
+    await submitPublicRegistration(buildSubmission({ guardian: { email: 'one@example.com' } }), context);
+    await submitPublicRegistration(buildSubmission({ guardian: { email: 'two@example.com' } }), context);
+    await submitPublicRegistration(buildSubmission({ guardian: { email: 'three@example.com' } }), context);
+
+    await assert.rejects(
+        submitPublicRegistration(buildSubmission({ guardian: { email: 'four@example.com' } }), context),
+        (error) => {
+            assert.equal(error.code, 'resource-exhausted');
+            assert.equal(error.details.reason, 'rate-limited');
+            return true;
+        }
+    );
+
+    assert.equal(firestore.rateLimitDocs().length, 1);
+    assert.equal(firestore.registrationDocs().length, 3);
 });
 
 test('shares submission throttling across independently loaded function handlers', async () => {

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -43,6 +43,7 @@ function setNested(target, path, value) {
 function makeFirestore(seed = {}) {
     const state = new Map(Object.entries(clone(seed)));
     let nextAutoId = 1;
+    let nextTransactionError = null;
     const fieldValue = {
         serverTimestamp: () => ({ __op: 'serverTimestamp' }),
         delete: () => ({ __op: 'delete' }),
@@ -124,6 +125,11 @@ function makeFirestore(seed = {}) {
         doc,
         collection,
         async runTransaction(handler) {
+            if (nextTransactionError) {
+                const error = nextTransactionError;
+                nextTransactionError = null;
+                throw error;
+            }
             const transaction = {
                 get: (ref) => ref.get(),
                 set: (ref, value, options) => ref.set(value, options),
@@ -138,6 +144,9 @@ function makeFirestore(seed = {}) {
             return [...state.entries()]
                 .filter(([path]) => path.startsWith('teams/team-1/registrationForms/form-1/registrations/'))
                 .map(([path, data]) => ({ path, data: clone(data) }));
+        },
+        failNextTransaction(error) {
+            nextTransactionError = error;
         },
         FieldValue: fieldValue
     };
@@ -251,6 +260,11 @@ function loadFunctionsModule(seed) {
 function loadSubmitPublicRegistration(seed) {
     delete require.cache[repoIndexPath];
     const firestore = makeFirestore(seed);
+    return loadSubmitPublicRegistrationWithFirestore(firestore);
+}
+
+function loadSubmitPublicRegistrationWithFirestore(firestore) {
+    delete require.cache[repoIndexPath];
     installModuleStubs(firestore);
     const mod = require('../index.js');
     return {
@@ -428,6 +442,46 @@ test('throttles repeated anonymous submissions before reserving more capacity', 
     const formAfterThrottle = firestore.snapshot('teams/team-1/registrationForms/form-1');
     assert.equal(formAfterThrottle.registrationOptionCounts.u10.enrolled, formBeforeThrottle.registrationOptionCounts.u10.enrolled);
     assert.equal(firestore.registrationDocs().length, registrationCountBeforeThrottle);
+});
+
+test('shares submission throttling across independently loaded function handlers', async () => {
+    const firstHandler = loadSubmitPublicRegistration(buildSeedState());
+    const input = buildSubmission();
+
+    await firstHandler.submitPublicRegistration(input, context);
+    await firstHandler.submitPublicRegistration(input, context);
+
+    const secondHandler = loadSubmitPublicRegistrationWithFirestore(firstHandler.firestore);
+    await secondHandler.submitPublicRegistration(input, context);
+    const formBeforeThrottle = firstHandler.firestore.snapshot('teams/team-1/registrationForms/form-1');
+    const registrationCountBeforeThrottle = firstHandler.firestore.registrationDocs().length;
+
+    await assert.rejects(
+        secondHandler.submitPublicRegistration(input, context),
+        (error) => {
+            assert.equal(error.code, 'resource-exhausted');
+            assert.equal(error.details.reason, 'rate-limited');
+            return true;
+        }
+    );
+
+    const formAfterThrottle = firstHandler.firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(formAfterThrottle.registrationOptionCounts.u10.enrolled, formBeforeThrottle.registrationOptionCounts.u10.enrolled);
+    assert.equal(firstHandler.firestore.registrationDocs().length, registrationCountBeforeThrottle);
+});
+
+test('does not bypass throttling when the durable reservation fails', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
+    firestore.failNextTransaction(new Error('rate-limit store unavailable'));
+
+    await assert.rejects(
+        submitPublicRegistration(buildSubmission(), context),
+        /rate-limit store unavailable/
+    );
+
+    const form = firestore.snapshot('teams/team-1/registrationForms/form-1');
+    assert.equal(form.registrationOptionCounts.u10.enrolled, 0);
+    assert.equal(firestore.registrationDocs().length, 0);
 });
 
 test('throttles forwarded public clients behind a private proxy before reserving more capacity', async () => {

--- a/functions/test/rate-limit.test.cjs
+++ b/functions/test/rate-limit.test.cjs
@@ -1,7 +1,44 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { createInMemoryRateLimiter, getRequestIp } = require('../rate-limit.cjs');
+const {
+    createFirestoreFixedWindowRateLimiter,
+    createInMemoryRateLimiter,
+    getRequestIp
+} = require('../rate-limit.cjs');
+
+function makeAtomicFirestore() {
+    const state = new Map();
+    let transactionQueue = Promise.resolve();
+
+    function collection(name) {
+        return {
+            doc(id) {
+                return { id, path: `${name}/${id}` };
+            }
+        };
+    }
+
+    function runTransaction(handler) {
+        const execute = async () => handler({
+            async get(ref) {
+                const value = state.get(ref.path);
+                return {
+                    exists: value !== undefined,
+                    data: () => value === undefined ? undefined : { ...value }
+                };
+            },
+            set(ref, value) {
+                state.set(ref.path, { ...value });
+            }
+        });
+        const result = transactionQueue.then(execute, execute);
+        transactionQueue = result.then(() => undefined, () => undefined);
+        return result;
+    }
+
+    return { collection, runTransaction, state };
+}
 
 test('uses the public address immediately before the trusted proxy hop', () => {
     const request = {
@@ -67,4 +104,60 @@ test('allows requests through the threshold, rejects excess, and resets after th
     assert.equal(rejected.allowed, false);
     assert.equal(rejected.retryAfterSeconds, 1);
     assert.equal(checkRateLimit(request, 2_000).allowed, true);
+});
+
+test('shares an atomic fixed-window count across durable limiter instances', async () => {
+    const firestore = makeAtomicFirestore();
+    const options = {
+        firestore,
+        collectionName: 'publicRegistrationRateLimits',
+        windowMs: 10_000,
+        maxRequests: 3
+    };
+    const limiterA = createFirestoreFixedWindowRateLimiter(options);
+    const limiterB = createFirestoreFixedWindowRateLimiter(options);
+
+    const results = await Promise.all([
+        limiterA('form-1|parent@example.com|203.0.113.10', 1_000),
+        limiterB('form-1|parent@example.com|203.0.113.10', 1_000),
+        limiterA('form-1|parent@example.com|203.0.113.10', 1_000),
+        limiterB('form-1|parent@example.com|203.0.113.10', 1_000)
+    ]);
+
+    assert.equal(results.filter((result) => result.allowed).length, 3);
+    assert.equal(results.filter((result) => !result.allowed).length, 1);
+});
+
+test('resets expired windows and isolates different boundaries', async () => {
+    const firestore = makeAtomicFirestore();
+    const limiter = createFirestoreFixedWindowRateLimiter({
+        firestore,
+        collectionName: 'publicRegistrationRateLimits',
+        windowMs: 10_000,
+        maxRequests: 1
+    });
+
+    assert.equal((await limiter('boundary-a', 1_000)).allowed, true);
+    const rejected = await limiter('boundary-a', 2_500);
+    assert.equal(rejected.allowed, false);
+    assert.equal(rejected.retryAfterSeconds, 9);
+    assert.equal((await limiter('boundary-b', 2_500)).allowed, true);
+    assert.equal((await limiter('boundary-a', 11_000)).allowed, true);
+});
+
+test('uses hashed document identifiers without persisting boundary values', async () => {
+    const firestore = makeAtomicFirestore();
+    const limiter = createFirestoreFixedWindowRateLimiter({
+        firestore,
+        collectionName: 'publicRegistrationRateLimits',
+        maxRequests: 3
+    });
+    const boundary = 'team-1|form-1|parent@example.com|203.0.113.10';
+
+    await limiter(boundary, 1_000);
+
+    const [[path, data]] = [...firestore.state.entries()];
+    assert.match(path, /^publicRegistrationRateLimits\/[a-f0-9]{64}$/);
+    assert.doesNotMatch(path, /parent@example\.com|203\.0\.113\.10/);
+    assert.doesNotMatch(JSON.stringify(data), /parent@example\.com|203\.0\.113\.10/);
 });

--- a/functions/test/rate-limit.test.cjs
+++ b/functions/test/rate-limit.test.cjs
@@ -160,6 +160,7 @@ test('uses hashed document identifiers without persisting boundary values', asyn
     assert.match(path, /^publicRegistrationRateLimits\/[a-f0-9]{64}$/);
     assert.doesNotMatch(path, /parent@example\.com|203\.0\.113\.10/);
     assert.doesNotMatch(JSON.stringify(data), /parent@example\.com|203\.0\.113\.10/);
+    assert.equal(data.expiresAt.toISOString(), '1970-01-01T00:01:01.000Z');
 });
 
 test('rejects invalid or oversized durable rate-limit boundaries', async () => {
@@ -189,5 +190,9 @@ test('recovers an active window with a corrupted count', async () => {
 
     assert.equal(result.allowed, true);
     assert.equal(result.remaining, 2);
-    assert.deepEqual(firestore.state.get(path), { count: 1, resetAt: 60_000 });
+    assert.deepEqual(firestore.state.get(path), {
+        count: 1,
+        resetAt: 60_000,
+        expiresAt: new Date(60_000)
+    });
 });

--- a/functions/test/rate-limit.test.cjs
+++ b/functions/test/rate-limit.test.cjs
@@ -161,3 +161,33 @@ test('uses hashed document identifiers without persisting boundary values', asyn
     assert.doesNotMatch(path, /parent@example\.com|203\.0\.113\.10/);
     assert.doesNotMatch(JSON.stringify(data), /parent@example\.com|203\.0\.113\.10/);
 });
+
+test('rejects invalid or oversized durable rate-limit boundaries', async () => {
+    const limiter = createFirestoreFixedWindowRateLimiter({
+        firestore: makeAtomicFirestore(),
+        collectionName: 'publicRegistrationRateLimits'
+    });
+
+    await assert.rejects(limiter('   '), /non-empty rate-limit boundary/);
+    await assert.rejects(limiter({ key: 'boundary' }), /string or finite number rate-limit boundary/);
+    await assert.rejects(limiter('x'.repeat(2_049)), /rate-limit boundary is too long/);
+});
+
+test('recovers an active window with a corrupted count', async () => {
+    const firestore = makeAtomicFirestore();
+    const limiter = createFirestoreFixedWindowRateLimiter({
+        firestore,
+        collectionName: 'publicRegistrationRateLimits',
+        maxRequests: 3
+    });
+
+    await limiter('boundary-a', 1_000);
+    const [path] = firestore.state.keys();
+    firestore.state.set(path, { count: 'corrupt', resetAt: 60_000 });
+
+    const result = await limiter('boundary-a', 2_000);
+
+    assert.equal(result.allowed, true);
+    assert.equal(result.remaining, 2);
+    assert.deepEqual(firestore.state.get(path), { count: 1, resetAt: 60_000 });
+});


### PR DESCRIPTION
Closes #3971

## What changed
- Replaced only the public-registration in-memory throttle with a Firestore-backed fixed-window limiter.
- Preserved the three-attempt, ten-minute policy and existing `resource-exhausted` response.
- Used SHA-256 document identifiers so guardian emails and client IPs are not stored in plaintext.
- Made limiter reservation failures fail closed before registration or capacity writes.

## Root Cause
The public-registration limiter stored counters in a module-local `Map`. Cloud Function instances therefore maintained independent counts, and cold starts discarded previous attempts.

## Prevention / Learning
Rate limits protecting shared durable resources must use an atomic shared store. Sensitive boundary values must be hashed before persistence, and storage failures must never bypass throttling.

## Regression Tests
- Verified two independently created limiter instances share one atomic count and reject the combined fourth attempt.
- Covered concurrent reservations, expiry, boundary isolation, retry timing, and hashed identifiers.
- Reloaded the Functions module while retaining Firestore state and verified the fourth submission causes no registration or capacity mutation.
- Verified durable reservation failures stop submission writes.
- Ran `node --test test/rate-limit.test.cjs test/public-registration-submission.test.cjs`: 21 tests passed.