### PR TITLE
Prevent chat drafts from crossing conversations

### DIFF
--- a/apps/app/src/pages/messages/components/ChatWindow.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.tsx
@@ -105,6 +105,13 @@ type FilePreview = {
   url: string;
 };
 
+type ChatComposerDraft = {
+  text: string;
+  filePreviews: FilePreview[];
+  selectedRecipientTarget: ChatTargetType;
+  selectedRecipientIds: string[];
+};
+
 type OptimisticChatMessage = ChatMessage & {
   clientMessageId: string;
   sendStatus: 'pending' | 'failed';
@@ -241,6 +248,10 @@ export function normalizeConversationId(conversationId: string | null | undefine
   return String(conversationId || '').trim() || DEFAULT_TEAM_CONVERSATION_ID;
 }
 
+export function getChatComposerDraftKey(teamId: string, conversationId: string | null | undefined) {
+  return `${encodeURIComponent(String(teamId || '').trim())}|${encodeURIComponent(normalizeConversationId(conversationId))}`;
+}
+
 export function isSelectedConversation(conversationId: string, selectedConversationId: string) {
   return conversationId === selectedConversationId;
 }
@@ -360,6 +371,7 @@ export function ChatWindow({
   const olderLoadAnchorRef = useRef<{ previousScrollHeight: number; previousScrollTop: number } | null>(null);
   const pendingSendRequestsRef = useRef(new Map<string, PendingChatSendRequest>());
   const sendQueueRef = useRef(Promise.resolve());
+  const composerDraftsRef = useRef(new Map<string, ChatComposerDraft>());
 
   const resetChatSelectionState = useCallback(() => {
     setStatus(null);
@@ -395,6 +407,20 @@ export function ChatWindow({
     onTeamReset: resetChatSelectionState
   });
   const effectiveConversationId = normalizeConversationId(selectedConversationId);
+  const activeComposerDraftKey = getChatComposerDraftKey(teamId, effectiveConversationId);
+  const activeComposerDraftKeyRef = useRef(activeComposerDraftKey);
+  const latestComposerDraftRef = useRef<ChatComposerDraft>({
+    text,
+    filePreviews,
+    selectedRecipientTarget,
+    selectedRecipientIds
+  });
+  latestComposerDraftRef.current = {
+    text,
+    filePreviews,
+    selectedRecipientTarget,
+    selectedRecipientIds
+  };
   const activeConversationForRepair = conversations.find((conversation) => conversation.id === effectiveConversationId) || null;
   const activeConversationIsStaff = effectiveConversationId === CANONICAL_STAFF_CONVERSATION_ID
     || isStaffOnlyConversation(activeConversationForRepair);
@@ -798,6 +824,28 @@ export function ChatWindow({
     currentTeamIdRef.current = teamId;
   }, [teamId]);
 
+  useLayoutEffect(() => {
+    if (activeComposerDraftKeyRef.current === activeComposerDraftKey) return;
+    composerDraftsRef.current.set(activeComposerDraftKeyRef.current, {
+      ...latestComposerDraftRef.current,
+      filePreviews: [...latestComposerDraftRef.current.filePreviews],
+      selectedRecipientIds: [...latestComposerDraftRef.current.selectedRecipientIds]
+    });
+    const nextDraft = composerDraftsRef.current.get(activeComposerDraftKey) || {
+      text: '',
+      filePreviews: [],
+      selectedRecipientTarget: 'full_team' as ChatTargetType,
+      selectedRecipientIds: []
+    };
+    activeComposerDraftKeyRef.current = activeComposerDraftKey;
+    latestComposerDraftRef.current = nextDraft;
+    setText(nextDraft.text);
+    setFilePreviews([...nextDraft.filePreviews]);
+    setSelectedRecipientTarget(nextDraft.selectedRecipientTarget);
+    setSelectedRecipientIds([...nextDraft.selectedRecipientIds]);
+    setComposerCursorPosition(undefined);
+  }, [activeComposerDraftKey]);
+
   useEffect(() => {
     setMeasuredMessageHeights({});
     setMessageViewportState({ scrollTop: 0, viewportHeight: 0 });
@@ -915,6 +963,7 @@ export function ChatWindow({
   useEffect(() => {
     mountedRef.current = true;
     lastObservedViewportSignatureRef.current = '';
+    const composerDrafts = composerDraftsRef.current;
 
     return () => {
       mountedRef.current = false;
@@ -922,20 +971,43 @@ export function ChatWindow({
         window.cancelAnimationFrame(scheduledViewportFrameRef.current);
       }
       clearScheduledScrollToLatest();
-      filePreviews.forEach((preview) => URL.revokeObjectURL(preview.url));
+      const previewUrls = new Set(latestComposerDraftRef.current.filePreviews.map((preview) => preview.url));
+      composerDrafts.forEach((draft) => {
+        draft.filePreviews.forEach((preview) => previewUrls.add(preview.url));
+      });
+      previewUrls.forEach((url) => URL.revokeObjectURL(url));
       stopVoiceCapture();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clearScheduledScrollToLatest]);
 
   const switchConversation = (conversationId: string) => {
-    if (!conversationId || conversationId === selectedConversationId) return;
+    const nextConversationId = normalizeConversationId(conversationId);
+    if (!conversationId || nextConversationId === effectiveConversationId) return;
     pendingScrollRef.current = true;
     stickToLatestRef.current = true;
     setShowJumpToLatest(false);
     if (!switchChatConversation(conversationId)) return;
-    setSelectedRecipientTarget('full_team');
-    setSelectedRecipientIds([]);
+    composerDraftsRef.current.set(activeComposerDraftKeyRef.current, {
+      text,
+      filePreviews: [...filePreviews],
+      selectedRecipientTarget,
+      selectedRecipientIds: [...selectedRecipientIds]
+    });
+    const nextDraftKey = getChatComposerDraftKey(teamId, nextConversationId);
+    const nextDraft = composerDraftsRef.current.get(nextDraftKey) || {
+      text: '',
+      filePreviews: [],
+      selectedRecipientTarget: 'full_team' as ChatTargetType,
+      selectedRecipientIds: []
+    };
+    activeComposerDraftKeyRef.current = nextDraftKey;
+    latestComposerDraftRef.current = nextDraft;
+    setText(nextDraft.text);
+    setFilePreviews([...nextDraft.filePreviews]);
+    setSelectedRecipientTarget(nextDraft.selectedRecipientTarget);
+    setSelectedRecipientIds([...nextDraft.selectedRecipientIds]);
+    setComposerCursorPosition(undefined);
     setReactionMessageId('');
     setActionMessageId('');
     closeConversationSheet();
@@ -1214,6 +1286,13 @@ export function ChatWindow({
     pendingScrollRef.current = true;
     pendingSendRequestsRef.current.set(clientMessageId, request);
     setOptimisticMessages((current) => [...current, createOptimisticChatMessage(request)]);
+    composerDraftsRef.current.delete(getChatComposerDraftKey(teamId, request.selectedConversationId));
+    latestComposerDraftRef.current = {
+      text: '',
+      filePreviews: [],
+      selectedRecipientTarget: 'full_team',
+      selectedRecipientIds: []
+    };
     setText('');
     setComposerCursorPosition(undefined);
     setFilePreviews((current) => {

--- a/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
+++ b/apps/app/src/pages/messages/components/ChatWindow.virtualization.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ensureStaffChatConversation, type ChatConversation, type ChatMessage } from '../../../lib/chatService';
+import { ensureStaffChatConversation, loadChatRecipientOptions, sendTeamChatMessage, type ChatConversation, type ChatMessage } from '../../../lib/chatService';
 import type { AuthState } from '../../../lib/types';
 import {
   AudienceSheet,
@@ -12,6 +12,7 @@ import {
   areMessagesEquivalent,
   getMessageRevisionSignature,
   getSafeMessageAttachments,
+  getChatComposerDraftKey,
   buildVirtualizedChatLayout,
   buildVirtualizedChatWindow,
   buildVirtualizedChatWindowFromLayout
@@ -294,20 +295,37 @@ vi.mock('../hooks/useChatMessages', async () => {
 vi.mock('./ChatComposer', async () => {
   const React = await import('react');
   return {
-    Composer: ({ canSendTeamEmail, onTeamEmail }: { canSendTeamEmail: boolean; onTeamEmail: () => void }) => {
+    Composer: ({
+      teamName,
+      text,
+      filePreviews,
+      canModerate,
+      canSendTeamEmail,
+      audienceSummary,
+      onTextChange,
+      onSubmit,
+      onAudience,
+      onTeamEmail
+    }: any) => {
       const [showStaffActions, setShowStaffActions] = React.useState(false);
       return (
-        <div className="chat-composer">
+        <form className="chat-composer" onSubmit={onSubmit}>
           Composer
+          <textarea placeholder={`Message ${teamName}`} value={text} onChange={(event) => onTextChange(event.target.value)} />
+          {filePreviews.map((preview: any) => <img key={preview.url} src={preview.url} alt={preview.file.name} />)}
+          <button type="submit" aria-label="Send message">Send</button>
           {canSendTeamEmail ? (
             <>
               <button type="button" onClick={() => setShowStaffActions((current) => !current)} aria-label="Open staff actions">Staff actions</button>
               {showStaffActions ? (
-                <button type="button" onClick={onTeamEmail} aria-label="Open Team Email">Team Email</button>
+                <div role="menu">
+                  {canModerate ? <button type="button" role="menuitem" onClick={onAudience}>Message audience. Current: {audienceSummary}</button> : null}
+                  <button type="button" onClick={onTeamEmail} aria-label="Open Team Email">Team Email</button>
+                </div>
               ) : null}
             </>
           ) : null}
-        </div>
+        </form>
       );
     }
   };
@@ -372,6 +390,13 @@ beforeEach(() => {
     participantIds: [],
     participantRoles: ['staff']
   } as ChatConversation);
+  vi.mocked(loadChatRecipientOptions).mockReset();
+  vi.mocked(loadChatRecipientOptions).mockResolvedValue([]);
+  vi.mocked(sendTeamChatMessage).mockReset();
+  vi.mocked(sendTeamChatMessage).mockResolvedValue({
+    conversationId: 'team',
+    wantsAi: false
+  } as any);
   teamEmailSheetMocks.importModule.mockClear();
   teamEmailSheetMocks.render.mockClear();
 });
@@ -811,6 +836,94 @@ describe('ChatWindow deferred conversation hydration', () => {
 });
 
 describe('ChatWindow conversation switching', () => {
+  it('normalizes team and conversation IDs for composer draft ownership', () => {
+    expect(getChatComposerDraftKey(' team-1 ', '')).toBe(getChatComposerDraftKey('team-1', 'team'));
+    expect(getChatComposerDraftKey('team-1', ' travel-group ')).not.toBe(getChatComposerDraftKey('team-2', 'travel-group'));
+  });
+
+  it('isolates and restores text, attachments, and selected recipients across mobile quick switches', async () => {
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn()
+    });
+    useStatefulChatSheets = true;
+    mockChatTeamState.conversations = [
+      { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },
+      { id: 'travel-group', type: 'group', name: 'Tournament travel', participantIds: ['coach-1', 'parent-1'], participantRoles: ['staff', 'parent'] }
+    ];
+    mockChatTeamState.switchConversation.mockImplementation((conversationId: string) => {
+      mockChatTeamState.selectedConversationId = conversationId;
+      return true;
+    });
+    vi.mocked(loadChatRecipientOptions).mockResolvedValue([
+      { id: 'player-sam', name: 'Sam Player', detail: 'Player' }
+    ]);
+    vi.mocked(sendTeamChatMessage).mockResolvedValue({
+      conversationId: 'travel-group',
+      wantsAi: false
+    } as any);
+    const createObjectURL = vi.fn(() => 'blob:team-photo');
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+
+    const view = render(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+
+    const composer = screen.getByPlaceholderText('Message Bears');
+    fireEvent.change(composer, { target: { value: 'Team-only draft' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Open staff actions' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Message audience/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Selected members/i }));
+    const samCheckbox = (await screen.findByText('Sam Player')).closest('label')?.querySelector('input') as HTMLInputElement;
+    fireEvent.click(samCheckbox);
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+    const photo = new File(['photo'], 'team-photo.png', { type: 'image/png' });
+    const photoInput = view.container.querySelector('input[accept="image/*"]') as HTMLInputElement;
+    fireEvent.change(photoInput, { target: { files: [photo] } });
+    expect(screen.getByAltText('team-photo.png')).toBeVisible();
+
+    fireEvent.click(within(screen.getByTestId('mobile-conversation-chips')).getByRole('button', { name: 'Switch to Tournament travel' }));
+    expect(screen.getByPlaceholderText('Message Bears')).toHaveValue('');
+    expect(screen.queryByAltText('team-photo.png')).toBeNull();
+
+    view.rerender(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByPlaceholderText('Message Bears'), { target: { value: 'Travel draft' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => expect(sendTeamChatMessage).toHaveBeenCalledTimes(1));
+    expect(sendTeamChatMessage).toHaveBeenCalledWith(expect.objectContaining({
+      teamId: 'team-1',
+      text: 'Travel draft',
+      files: [],
+      selectedConversationId: 'travel-group',
+      selectedRecipientTarget: 'full_team',
+      selectedRecipientIds: []
+    }));
+
+    fireEvent.click(within(screen.getByTestId('mobile-conversation-chips')).getByRole('button', { name: 'Switch to Team chat' }));
+    expect(screen.getByPlaceholderText('Message Bears')).toHaveValue('Team-only draft');
+    expect(screen.getByAltText('team-photo.png')).toBeVisible();
+    expect(screen.getByRole('menuitem', { name: /Current:.*Sam Player/i })).toBeVisible();
+
+    view.rerender(
+      <MemoryRouter>
+        <ChatWindow auth={auth} teamId="team-1" />
+      </MemoryRouter>
+    );
+    fireEvent.click(within(screen.getByTestId('mobile-conversation-chips')).getByRole('button', { name: 'Switch to Tournament travel' }));
+    expect(screen.getByPlaceholderText('Message Bears')).toHaveValue('');
+    expect(sendTeamChatMessage).toHaveBeenCalledTimes(1);
+  });
+
   it('repairs an existing staff conversation before quick-switching to it', async () => {
     mockChatTeamState.conversations = [
       { id: 'team', type: 'team', name: 'Team chat', participantIds: [], participantRoles: ['team'] },


### PR DESCRIPTION
Closes #3980

## What changed
- Key in-memory composer drafts by normalized team and conversation IDs.
- Save and restore text, attachment previews, recipient target, and recipient IDs when switching conversations.
- Clear only the submitted conversation draft while preserving drafts in other conversations.
- Preserve one-tap mobile quick switching across web and Capacitor shells.

## Root Cause
`ChatWindow` maintained one shared composer state while conversation selection changed independently. Switching conversations reset recipient fields but retained text and attachment previews, exposing the previous conversation's unsent content under the destination conversation.

## Prevention / Learning
Any composer spanning multiple routing scopes must key its complete draft state by every send-routing dimension. Draft ownership must include content, attachments, and audience fields, and send handling must clear only the submitted scope.

## Regression Tests
- Added normalized team/conversation draft-key coverage.
- Added component coverage for text, attachment preview, selected-recipient, and audience-summary isolation and restoration through mobile quick-switch chips.
- Verified sending uses only the active conversation ID and audience, clears that draft, and preserves another conversation's draft.
- `npx vitest run src/pages/messages/components/ChatWindow.virtualization.test.tsx --reporter=dot` passed 31 tests.
- `npm run typecheck` passed.
- Focused ESLint completed with zero errors.

## Recurrence Risk
Low. The complete composer state and send routing are now covered together in the adjacent component suite.