### PR TITLE
Keep unrecorded practice attendance not marked

### DIFF
--- a/apps/app/src/components/schedule/PracticeAttendancePanel.tsx
+++ b/apps/app/src/components/schedule/PracticeAttendancePanel.tsx
@@ -35,7 +35,7 @@ export function PracticeAttendancePanel({ attendance, loading, saving, savingPla
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="min-w-0">
                   <div className="text-sm font-black text-gray-950">{player.playerNumber ? `#${player.playerNumber} ` : ''}{player.displayName}</div>
-                  <div className="mt-1 text-xs font-bold text-gray-500">{player.status === 'absent' ? 'Absent' : player.status === 'late' ? 'Late' : 'Present'}</div>
+                  <div className="mt-1 text-xs font-bold text-gray-500">{player.status === 'not_marked' ? 'Not marked' : player.status === 'absent' ? 'Absent' : player.status === 'late' ? 'Late' : 'Present'}</div>
                 </div>
                 <div className="grid grid-cols-3 gap-1.5 sm:min-w-[220px]">
                   {(['present', 'late', 'absent'] as const).map((status) => (

--- a/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
+++ b/apps/app/src/components/schedule/ScheduleEventDetailPresentational.test.tsx
@@ -26,7 +26,7 @@ function buildAttendance(overrides: Partial<StaffPracticeAttendance> = {}): Staf
     checkedInCount: 1,
     players: [
       { playerId: 'p1', displayName: 'Avery Smith', playerNumber: '1', status: 'present', checkedInAt: new Date('2026-06-04T17:55:00.000Z') },
-      { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'absent', checkedInAt: null }
+      { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'not_marked', checkedInAt: null }
     ],
     ...overrides
   };
@@ -187,8 +187,10 @@ describe('ScheduleEventDetail presentational components', () => {
 
     expect(screen.getByText('1/2 checked in')).toBeTruthy();
     expect(screen.getByText('#2 Blake Jones')).toBeTruthy();
+    expect(screen.getByText('Not marked')).toBeTruthy();
 
     const row = screen.getByTestId('practice-attendance-row-p2');
+    expect(within(row).getByRole('button', { name: 'Absent' }).className).not.toContain('bg-amber-100');
     fireEvent.click(within(row).getByRole('button', { name: 'Late' }));
 
     expect(onSelectStatus).toHaveBeenCalledWith(attendance.players[1], 'late');

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2728,7 +2728,7 @@ describe('staff practice attendance', () => {
     vi.clearAllMocks();
   });
 
-  it('loads roster-backed attendance and defaults unrecorded players to absent', async () => {
+  it('loads roster-backed attendance and keeps unrecorded players not marked', async () => {
     vi.mocked(getPracticeSession).mockResolvedValue({
       id: 'session-1',
       attendance: {
@@ -2755,23 +2755,24 @@ describe('staff practice attendance', () => {
     expect(result.players).toEqual([
       expect.objectContaining({ playerId: 'p1', status: 'present' }),
       expect.objectContaining({ playerId: 'p2', status: 'late' }),
-      expect.objectContaining({ playerId: 'p3', status: 'absent' })
+      expect.objectContaining({ playerId: 'p3', status: 'not_marked' })
     ]);
   });
 
-  it('persists normalized present, late, and absent statuses through practice attendance updates', async () => {
+  it('persists only explicit attendance statuses and excludes not-marked players', async () => {
     vi.mocked(updatePracticeAttendance).mockResolvedValue(undefined as any);
 
     const result = await saveStaffPracticeAttendance(event, user as any, {
       sessionId: 'session-1',
       teamId: 'team-1',
       eventId: 'practice-1',
-      rosterSize: 3,
+      rosterSize: 4,
       checkedInCount: 1,
       players: [
         { playerId: 'p1', displayName: 'Avery Smith', playerNumber: '1', status: 'present' },
         { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'late' },
-        { playerId: 'p3', displayName: 'Casey Brown', playerNumber: '3', status: 'absent' }
+        { playerId: 'p3', displayName: 'Casey Brown', playerNumber: '3', status: 'absent' },
+        { playerId: 'p4', displayName: 'Devon Green', playerNumber: '4', status: 'not_marked' }
       ]
     });
 
@@ -2779,7 +2780,7 @@ describe('staff practice attendance', () => {
       'team-1',
       'session-1',
       expect.objectContaining({
-        rosterSize: 3,
+        rosterSize: 4,
         checkedInCount: 2,
         players: [
           expect.objectContaining({ playerId: 'p1', status: 'present' }),
@@ -2788,7 +2789,53 @@ describe('staff practice attendance', () => {
         ]
       })
     );
+    expect(updatePracticeAttendance).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        players: expect.arrayContaining([expect.objectContaining({ playerId: 'p4' })])
+      })
+    );
     expect(result.checkedInCount).toBe(2);
+    expect(result.players).toEqual(expect.arrayContaining([
+      expect.objectContaining({ playerId: 'p4', status: 'not_marked' })
+    ]));
+  });
+
+  it('summarizes only explicitly recorded absences for schedule events', async () => {
+    const parent = {
+      uid: 'parent-1',
+      email: 'parent@example.com',
+      roles: ['parent'],
+      parentOf: [{ teamId: 'team-1', playerId: 'p1', playerName: 'Avery Smith', teamName: 'Bears' }]
+    } as any;
+    vi.mocked(loadProfileDocument).mockResolvedValue({ parentOf: parent.parentOf } as any);
+    vi.mocked(getTeams).mockResolvedValue([] as any);
+    vi.mocked(getTeam).mockResolvedValue({ id: 'team-1', name: 'Bears', active: true } as any);
+    vi.mocked(getDoc).mockResolvedValue(playerSnapshot('p1', { id: 'p1', name: 'Avery Smith', active: true }) as any);
+    vi.mocked(getGames).mockResolvedValue([{
+      id: 'practice-1',
+      type: 'practice',
+      date: new Date('2026-07-20T18:00:00Z'),
+      title: 'Practice'
+    }] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValueOnce([{
+      id: 'session-1',
+      eventId: 'practice-1',
+      date: new Date('2026-07-20T18:00:00Z'),
+      attendance: { players: [] }
+    }] as any).mockResolvedValueOnce([{
+      id: 'session-1',
+      eventId: 'practice-1',
+      date: new Date('2026-07-20T18:00:00Z'),
+      attendance: { players: [{ playerId: 'p1', status: 'absent' }] }
+    }] as any);
+
+    const unrecorded = await loadParentSchedule(parent, { hydrateDetails: false, expandStaffPlayers: false });
+    const explicitlyAbsent = await loadParentSchedule(parent, { hydrateDetails: false, expandStaffPlayers: false });
+
+    expect(unrecorded.events[0].practiceAttendanceSummary).toBeNull();
+    expect(explicitlyAbsent.events[0].practiceAttendanceSummary).toBe('0/1 present, 1 absent');
   });
 
   it('rejects coach-only staff without admin write access', async () => {

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -2828,14 +2828,14 @@ describe('staff practice attendance', () => {
       id: 'session-1',
       eventId: 'practice-1',
       date: new Date('2026-07-20T18:00:00Z'),
-      attendance: { players: [{ playerId: 'p1', status: 'absent' }] }
+      attendance: { rosterSize: 12, players: [{ playerId: 'p1', status: 'absent' }] }
     }] as any);
 
     const unrecorded = await loadParentSchedule(parent, { hydrateDetails: false, expandStaffPlayers: false });
     const explicitlyAbsent = await loadParentSchedule(parent, { hydrateDetails: false, expandStaffPlayers: false });
 
     expect(unrecorded.events[0].practiceAttendanceSummary).toBeNull();
-    expect(explicitlyAbsent.events[0].practiceAttendanceSummary).toBe('0/1 present, 1 absent');
+    expect(explicitlyAbsent.events[0].practiceAttendanceSummary).toBe('0/12 present, 1 absent');
   });
 
   it('rejects coach-only staff without admin write access', async () => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -373,7 +373,7 @@ export type StaffPracticePacket = ParentPracticePacket & {
   totalMinutes: number;
 };
 
-export type PracticeAttendanceStatus = 'present' | 'late' | 'absent';
+export type PracticeAttendanceStatus = 'not_marked' | 'present' | 'late' | 'absent';
 
 export type PracticeAttendancePlayer = {
   playerId: string;
@@ -6284,7 +6284,7 @@ function getPracticePacketSessionId(event: ParentScheduleEvent) {
 }
 
 function normalizePracticeAttendanceStatus(value: unknown): PracticeAttendanceStatus {
-  return value === 'present' || value === 'late' ? value : 'absent';
+  return value === 'present' || value === 'late' || value === 'absent' ? value : 'not_marked';
 }
 
 function assertPracticeAttendanceManagementEvent(event: ParentScheduleEvent, user: AuthUser | null) {
@@ -6401,12 +6401,13 @@ export async function saveStaffPracticeAttendance(event: ParentScheduleEvent, us
       note: compactString(player?.note) || null
     }))
     .filter((player) => player.playerId);
+  const recordedPlayers = players.filter((player) => player.status !== 'not_marked');
 
   const payload = {
-    rosterSize: players.length,
-    checkedInCount: players.filter((player) => player.status === 'present' || player.status === 'late').length,
+    rosterSize: attendance.rosterSize,
+    checkedInCount: recordedPlayers.filter((player) => player.status === 'present' || player.status === 'late').length,
     editedAt: new Date(),
-    players
+    players: recordedPlayers
   };
 
   try {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2642,11 +2642,12 @@ function hasHomePacket(session: any) {
 function getPracticeAttendanceSummary(attendance: any) {
   if (!hasRecordedAttendance(attendance)) return null;
   const players: Array<{ status?: string }> = Array.isArray(attendance.players) ? attendance.players : [];
+  const rosterSize = Math.max(players.length, Number.parseInt(attendance?.rosterSize, 10) || 0);
   const present = players.filter((player) => player.status === 'present' || player.status === 'late').length;
   const late = players.filter((player) => player.status === 'late').length;
   const absent = players.filter((player) => player.status === 'absent').length;
   return [
-    `${present}/${players.length} present`,
+    `${present}/${rosterSize} present`,
     late > 0 ? `${late} late` : '',
     absent > 0 ? `${absent} absent` : ''
   ].filter(Boolean).join(', ');

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -3809,7 +3809,7 @@ describe('ScheduleEventDetail practice attendance', () => {
       checkedInCount: 1,
       players: [
         { playerId: 'p1', displayName: 'Avery Smith', playerNumber: '1', status: 'present', checkedInAt: new Date('2026-06-04T17:55:00Z') },
-        { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'absent', checkedInAt: null }
+        { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'not_marked', checkedInAt: null }
       ]
     });
     scheduleServiceMocks.saveStaffPracticeAttendance.mockResolvedValue({
@@ -3913,8 +3913,8 @@ describe('ScheduleEventDetail practice attendance', () => {
       rosterSize: 2,
       checkedInCount: 0,
       players: [
-        { playerId: 'p1', displayName: 'Avery Smith', playerNumber: '1', status: 'absent', checkedInAt: null },
-        { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'absent', checkedInAt: null }
+        { playerId: 'p1', displayName: 'Avery Smith', playerNumber: '1', status: 'not_marked', checkedInAt: null },
+        { playerId: 'p2', displayName: 'Blake Jones', playerNumber: '2', status: 'not_marked', checkedInAt: null }
       ]
     });
     scheduleServiceMocks.saveStaffPracticeAttendance.mockImplementation((_, __, payload) => new Promise((resolve) => {
@@ -3945,7 +3945,7 @@ describe('ScheduleEventDetail practice attendance', () => {
           checkedInCount: 1,
           players: [
             expect.objectContaining({ playerId: 'p1', status: 'present' }),
-            expect.objectContaining({ playerId: 'p2', status: 'absent' })
+            expect.objectContaining({ playerId: 'p2', status: 'not_marked' })
           ]
         })
       );
@@ -3959,6 +3959,56 @@ describe('ScheduleEventDetail practice attendance', () => {
     await waitFor(() => {
       expect(screen.getByText('Avery Smith marked present.')).toBeTruthy();
     });
+  });
+
+  it('rolls an explicit absent selection back to not marked when saving fails', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        id: 'practice-1',
+        eventKey: 'team-1::practice-1::staff-team-team-1::2026-06-04T18:00:00.000Z::practice',
+        type: 'practice',
+        childId: 'staff-team-team-1',
+        childName: 'Team schedule',
+        isTeamAdmin: true,
+        isTeamStaff: true,
+        practiceSessionId: 'session-1'
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadParentPracticePacket.mockResolvedValue(null);
+    scheduleServiceMocks.loadStaffPracticeAttendance.mockResolvedValue({
+      sessionId: 'session-1',
+      teamId: 'team-1',
+      eventId: 'practice-1',
+      rosterSize: 1,
+      checkedInCount: 0,
+      players: [
+        { playerId: 'p1', displayName: 'Avery Smith', playerNumber: '1', status: 'not_marked', checkedInAt: null }
+      ]
+    });
+    scheduleServiceMocks.saveStaffPracticeAttendance.mockRejectedValue(new Error('Save failed'));
+
+    renderScheduleEventDetail();
+    await waitFor(() => expect(screen.getAllByRole('button', { name: 'More' }).length).toBeGreaterThan(0));
+    fireEvent.click(screen.getAllByRole('button', { name: 'More' })[0]);
+    await waitFor(() => expect(screen.getByText('Not marked')).toBeTruthy());
+
+    const row = screen.getByTestId('practice-attendance-row-p1');
+    fireEvent.click(within(row).getByRole('button', { name: 'Absent' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.saveStaffPracticeAttendance).toHaveBeenCalledWith(
+        expect.any(Object),
+        auth.user,
+        expect.objectContaining({
+          checkedInCount: 0,
+          players: [expect.objectContaining({ playerId: 'p1', status: 'absent' })]
+        })
+      );
+    });
+    await waitFor(() => expect(screen.getByText('Save failed')).toBeTruthy());
+    expect(within(row).getByText('Not marked')).toBeTruthy();
+    expect(screen.getByText('0/1 checked in')).toBeTruthy();
   });
 });
 

--- a/drills.html
+++ b/drills.html
@@ -614,7 +614,7 @@
             createPracticeSession, updatePracticeSession,
             getPracticeSessionByEvent, upsertPracticeSessionForEvent, updatePracticeAttendance, getPracticeSessions, getPracticePacketCompletions,
             savePracticeTemplate, getPracticeTemplates, deletePracticeTemplate
-        } from './js/db.js?v=91';
+        } from './js/db.js?v=92';
         import { renderHeader, renderFooter, escapeHtml, shareOrCopy } from './js/utils.js?v=15';
         import { requireAuth } from './js/auth.js?v=50';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=5';

--- a/js/db.js
+++ b/js/db.js
@@ -8106,7 +8106,7 @@ export async function updatePracticeAttendance(teamId, sessionId, attendance) {
     const absentCount = players.filter(p => p.status === 'absent').length;
     const lateCount = players.filter(p => p.status === 'late').length;
     const normalized = {
-        rosterSize: players.length,
+        rosterSize: Math.max(players.length, Number.parseInt(attendance?.rosterSize, 10) || 0),
         checkedInCount,
         updatedAt: Timestamp.now(),
         editedAt,

--- a/tests/unit/practice-attendance-roster-size.test.js
+++ b/tests/unit/practice-attendance-roster-size.test.js
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const updateDoc = vi.fn();
+const doc = vi.fn((database, ...segments) => ({ database, path: segments.join('/') }));
+
+vi.mock('../../js/firebase.js?v=20', () => ({
+    db: { name: 'mock-db' },
+    auth: {},
+    storage: {},
+    collection: vi.fn(),
+    getDocs: vi.fn(),
+    getDoc: vi.fn(),
+    doc,
+    addDoc: vi.fn(),
+    updateDoc,
+    deleteDoc: vi.fn(),
+    setDoc: vi.fn(),
+    query: vi.fn(),
+    where: vi.fn(),
+    orderBy: vi.fn(),
+    Timestamp: {
+        now: vi.fn(() => 'mock-timestamp'),
+        fromDate: vi.fn((value) => value)
+    },
+    increment: vi.fn(),
+    arrayUnion: vi.fn(),
+    arrayRemove: vi.fn(),
+    deleteField: vi.fn(),
+    limit: vi.fn(),
+    startAfter: vi.fn(),
+    getCountFromServer: vi.fn(),
+    onSnapshot: vi.fn(),
+    serverTimestamp: vi.fn(),
+    collectionGroup: vi.fn(),
+    writeBatch: vi.fn(),
+    runTransaction: vi.fn(),
+    functions: {},
+    httpsCallable: vi.fn(),
+    ref: vi.fn(),
+    uploadBytes: vi.fn(),
+    getDownloadURL: vi.fn(),
+    deleteObject: vi.fn()
+}));
+
+vi.mock('../../js/firebase-images.js?v=9', () => ({
+    imageStorage: {},
+    ensureImageAuth: vi.fn(),
+    requireImageAuth: vi.fn()
+}));
+
+vi.mock('../../js/vendor/firebase-storage.js', () => ({
+    uploadBytesResumable: vi.fn()
+}));
+
+const { updatePracticeAttendance } = await import('../../js/db.js');
+
+describe('updatePracticeAttendance roster size', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('preserves the full roster denominator when only marked players are submitted', async () => {
+        await updatePracticeAttendance('team-1', 'session-1', {
+            rosterSize: 12,
+            players: [{ playerId: 'p1', displayName: 'Avery', status: 'present' }]
+        });
+
+        expect(updateDoc).toHaveBeenCalledWith(
+            { database: { name: 'mock-db' }, path: 'teams/team-1/practiceSessions/session-1' },
+            expect.objectContaining({
+                attendance: expect.objectContaining({
+                    rosterSize: 12,
+                    checkedInCount: 1,
+                    players: [expect.objectContaining({ playerId: 'p1', status: 'present' })]
+                })
+            })
+        );
+    });
+});

--- a/tests/unit/practice-attendance-roster-size.test.js
+++ b/tests/unit/practice-attendance-roster-size.test.js
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const drillsHtml = readFileSync(path.resolve(process.cwd(), 'drills.html'), 'utf8');
 
 const updateDoc = vi.fn();
 const doc = vi.fn((database, ...segments) => ({ database, path: segments.join('/') }));
@@ -75,5 +79,10 @@ describe('updatePracticeAttendance roster size', () => {
                 })
             })
         );
+    });
+
+    it('loads the roster-size fix through a fresh drills page cache key', () => {
+        expect(drillsHtml).toContain("from './js/db.js?v=92';");
+        expect(drillsHtml).not.toContain("from './js/db.js?v=91';");
     });
 });


### PR DESCRIPTION
Closes #3979

## What changed
- Added a distinct `not_marked` attendance state for active players without saved attendance.
- Kept Present, Late, and Absent as the only selectable actions.
- Excluded untouched Not marked rows from persistence and absence summaries.
- Preserved checked-in counts, optimistic updates, and save-failure rollback.

## Root Cause
The attendance normalizer treated every value other than `present` or `late`, including a missing saved record, as `absent`. Roster hydration therefore created false absences, which could then be persisted when another player's attendance was updated.

## Prevention / Learning
Model unknown workflow state explicitly and filter it at persistence boundaries. Never use a consequential business outcome such as absent as the fallback for missing data.

## Regression Tests
- Missing attendance records hydrate as Not marked.
- Persistence includes only explicit Present, Late, and Absent records.
- Empty attendance produces no summary; explicit absences appear in summaries.
- Not marked rows do not highlight an attendance action.
- Checked-in totals include only Present and Late.
- Failed absent saves roll the row back to Not marked.
- 250 focused Vitest tests passed.
- App TypeScript and production build passed.

## Recurrence Risk
Low. Focused service, component, and page tests now cover normalization, persistence, summaries, optimistic counts, and rollback.