### PR TITLE
Defer Game Hub foul history hydration

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -2372,6 +2372,14 @@ describe('ScheduleEventDetail assignments', () => {
     expect(screen.getByLabelText('Team foul bonus state').textContent).toContain('Q1 · Bonus');
     expect(screen.getByText('7 team fouls this period')).toBeTruthy();
 
+    fireEvent.click(screen.getByRole('button', { name: 'Foul tracker' }));
+    expect(screen.getByRole('button', { name: 'Foul tracker' }).getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByTestId('game-day-foul-panel').closest('[hidden]')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Foul tracker' }));
+    expect(screen.getByRole('button', { name: 'Undo last foul' })).toHaveProperty('disabled', false);
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(1);
+
     fireEvent.click(screen.getByRole('button', { name: 'Undo last foul' }));
 
     await waitFor(() => {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -825,6 +825,7 @@ describe('ScheduleEventDetail route state', () => {
   });
 
   it.each([
+    ['foul', 'foul'],
     ['chat', 'chat'],
     [' ReAcTiOnS ', 'reactions'],
     ['wrapup', 'wrapup'],
@@ -1916,13 +1917,13 @@ describe('ScheduleEventDetail assignments', () => {
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: '#12 Avery Smith plus 2 points' })).toBeTruthy();
-        expect(screen.getByText('0 team fouls this period')).toBeTruthy();
       });
+      expect(screen.getByRole('button', { name: 'Foul tracker' }).getAttribute('aria-expanded')).toBe('false');
+      expect(screen.queryByTestId('game-day-foul-panel')).toBeNull();
+      expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).not.toHaveBeenCalled();
 
       const liveScoreEditor = screen.getByTestId('live-score-editor');
-      const foulTrackerPanel = screen.getByTestId('game-day-foul-panel');
       const scoreEditorMarkup = liveScoreEditor.innerHTML;
-      const foulTrackerMarkup = foulTrackerPanel.innerHTML;
 
       await act(async () => {
         await new Promise((resolve) => window.setTimeout(resolve, 2_100));
@@ -1934,9 +1935,9 @@ describe('ScheduleEventDetail assignments', () => {
       expect(updatedHeaderClock).toBe(updatedPanelClock);
       expect(updatedHeaderClock).toBeGreaterThanOrEqual((initialHeaderClock ?? 0) + 1);
       expect(screen.getByTestId('live-score-editor').innerHTML).toBe(scoreEditorMarkup);
-      expect(screen.getByTestId('game-day-foul-panel').innerHTML).toBe(foulTrackerMarkup);
+      expect(screen.queryByTestId('game-day-foul-panel')).toBeNull();
       expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledTimes(1);
-      expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).not.toHaveBeenCalled();
     } finally {
       setIntervalSpy.mockRestore();
     }
@@ -1965,6 +1966,13 @@ describe('ScheduleEventDetail assignments', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '#12 Avery Smith plus 2 points' })).toBeTruthy();
+    });
+    expect(screen.queryByTestId('game-day-foul-panel')).toBeNull();
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Foul tracker' }));
+
+    await waitFor(() => {
       expect(screen.getByRole('button', { name: '#12 Avery Smith add foul' })).toBeTruthy();
       expect(screen.getByText('6 team fouls this period')).toBeTruthy();
     });
@@ -1994,6 +2002,8 @@ describe('ScheduleEventDetail assignments', () => {
     scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
 
     renderScheduleEventDetailWithRouteControls();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Foul tracker' }));
 
     await waitFor(() => {
       expect(screen.getByText('Foul history could not be loaded. Refresh before recording fouls.')).toBeTruthy();
@@ -2045,22 +2055,29 @@ describe('ScheduleEventDetail assignments', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '#12 Avery Smith plus 2 points' })).toBeTruthy();
-      expect(screen.getByRole('button', { name: '#12 Avery Smith add foul' })).toBeTruthy();
     });
+    expect(screen.queryByTestId('game-day-foul-panel')).toBeNull();
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Switch game' }));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '#7 Jordan Lee plus 2 points' })).toBeTruthy();
+    });
+    expect(screen.queryByTestId('game-day-foul-panel')).toBeNull();
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Foul tracker' }));
+
+    await waitFor(() => {
       expect(screen.getByRole('button', { name: '#7 Jordan Lee add foul' })).toBeTruthy();
     });
 
     expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenCalledTimes(2);
     expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenNthCalledWith(1, 'team-1', 'game-1');
     expect(scheduleServiceMocks.loadHomeScoringPlayers).toHaveBeenNthCalledWith(2, 'team-1', 'game-2');
-    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(2);
-    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenNthCalledWith(1, 'team-1', 'game-1');
-    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenNthCalledWith(2, 'team-1', 'game-2');
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(1);
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledWith('team-1', 'game-2');
   });
 
   it('preserves dirty game schedule edits when same-event score updates refresh the event object', async () => {
@@ -2335,6 +2352,8 @@ describe('ScheduleEventDetail assignments', () => {
     scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
 
     renderScheduleEventDetailWithRouteControls();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Foul tracker' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('game-day-foul-panel')).toBeTruthy();
@@ -2699,6 +2718,7 @@ describe('ScheduleEventDetail assignments', () => {
     expect(screen.getByRole('button', { name: 'Home score up' })).toBeTruthy();
     expect(liveGameChatServiceMocks.subscribeToLiveGameChat).not.toHaveBeenCalled();
     expect(liveGameReactionsServiceMocks.subscribeToLiveGameReactions).not.toHaveBeenCalled();
+    expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).not.toHaveBeenCalled();
     expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).not.toHaveBeenCalled();
     expect(gameReportServiceMocks.loadGameReportSections).not.toHaveBeenCalled();
 
@@ -2982,7 +3002,7 @@ describe('ScheduleEventDetail assignments', () => {
 
     await waitFor(() => {
       expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
-      expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(2);
+      expect(scheduleServiceMocks.loadGameDayLiveEventsForApp).toHaveBeenCalledTimes(1);
       expect(screen.getByLabelText('Out')).toBeTruthy();
       expect(screen.getByLabelText('In')).toBeTruthy();
     });

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -194,13 +194,14 @@ import { useStaffRsvpBreakdown } from '../hooks/schedule/useStaffRsvpBreakdown';
 export { getAvailabilityNoteSaveState } from '../components/schedule/AvailabilityPanels';
 
 type EventDetailSectionId = ScheduleEventDetailSectionId;
-export type GameHubPanelId = 'chat' | 'reactions' | 'wrapup' | 'statsheet' | 'lineup' | 'substitutions' | 'report';
+export type GameHubPanelId = 'foul' | 'chat' | 'reactions' | 'wrapup' | 'statsheet' | 'lineup' | 'substitutions' | 'report';
 type HomeScoringPlayersUpdater = (players: ScheduleHomeScoringPlayer[]) => ScheduleHomeScoringPlayer[];
 
 const eventDetailSectionIds = new Set<EventDetailSectionId>(['availability', 'rideshare', 'assignments', 'game']);
-const gameHubPanelIds = new Set<GameHubPanelId>(['chat', 'reactions', 'wrapup', 'statsheet', 'lineup', 'substitutions', 'report']);
+const gameHubPanelIds = new Set<GameHubPanelId>(['foul', 'chat', 'reactions', 'wrapup', 'statsheet', 'lineup', 'substitutions', 'report']);
 
 const gameHubPanelDetails: Record<GameHubPanelId, { label: string; elementId: string }> = {
+  foul: { label: 'Foul tracker', elementId: 'game-hub-foul-panel' },
   chat: { label: 'Live chat', elementId: 'game-hub-chat-panel' },
   reactions: { label: 'Live reactions', elementId: 'game-hub-reactions-panel' },
   wrapup: { label: 'Post-game wrap-up', elementId: 'game-hub-wrapup-panel' },
@@ -1605,12 +1606,13 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
   const standardTrackerHref = `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}/track`;
   const availablePanelIds = useMemo(() => {
     const panels: GameHubPanelId[] = [];
+    if (canUpdateScore) panels.push('foul');
     if (!isPractice) panels.push('reactions', 'chat');
     if (canWrapup) panels.push('wrapup', 'statsheet');
     if (canPublishLineup) panels.push('lineup', 'substitutions');
     if (!isPractice) panels.push('report');
     return panels;
-  }, [canPublishLineup, canWrapup, isPractice]);
+  }, [canPublishLineup, canUpdateScore, canWrapup, isPractice]);
   const requestedPanelAvailable = requestedPanel && availablePanelIds.includes(requestedPanel)
     ? requestedPanel
     : null;
@@ -1815,13 +1817,21 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
             />
           ) : null}
           {canUpdateScore ? (
-            <GameDayFoulTrackerPanel
-              auth={auth}
-              event={event}
-              homePlayers={homeScoringPlayers}
-              loadingHomePlayers={loadingHomeScoringPlayers}
-              onHomePlayersUpdated={updateHomeScoringPlayers}
-            />
+            <LazyGameHubPanel
+              panelId="game-hub-foul-panel"
+              title="Foul tracker"
+              description="Load foul history only when the scorekeeper needs it."
+              open={Boolean(openPanels.foul)}
+              onToggle={() => togglePanel('foul')}
+            >
+              <GameDayFoulTrackerPanel
+                auth={auth}
+                event={event}
+                homePlayers={homeScoringPlayers}
+                loadingHomePlayers={loadingHomeScoringPlayers}
+                onHomePlayersUpdated={updateHomeScoringPlayers}
+              />
+            </LazyGameHubPanel>
           ) : null}
 
           {!isPractice ? (

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1507,6 +1507,7 @@ function LazyGameHubPanel({
   description,
   open,
   onToggle,
+  keepMounted = false,
   children
 }: {
   panelId: string;
@@ -1514,8 +1515,15 @@ function LazyGameHubPanel({
   description: string;
   open: boolean;
   onToggle: () => void;
+  keepMounted?: boolean;
   children: ReactNode;
 }) {
+  const [hasOpened, setHasOpened] = useState(open);
+
+  useEffect(() => {
+    if (open) setHasOpened(true);
+  }, [open]);
+
   return (
     <div className="mt-3">
       <button
@@ -1532,7 +1540,9 @@ function LazyGameHubPanel({
         </div>
         <ChevronDown className={`h-4 w-4 flex-none text-gray-500 transition ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
       </button>
-      {open ? <div id={panelId} className="scroll-mt-40">{children}</div> : null}
+      {open || (keepMounted && hasOpened) ? (
+        <div id={panelId} className="scroll-mt-40" hidden={!open}>{children}</div>
+      ) : null}
     </div>
   );
 }
@@ -1823,6 +1833,7 @@ function GameHubSection({ auth, event, childEvents, requestedPanel, onPanelChang
               description="Load foul history only when the scorekeeper needs it."
               open={Boolean(openPanels.foul)}
               onToggle={() => togglePanel('foul')}
+              keepMounted
             >
               <GameDayFoulTrackerPanel
                 auth={auth}


### PR DESCRIPTION
Closes #3977

## What changed
- Added the foul tracker to the existing lazy Game Hub panel pattern.
- Kept score, clock, sticky controls, and the shared scoring roster available during initial rendering.
- Hydrates foul history only when an eligible scorekeeper opens the foul tracker.
- Resets the closed panel state when switching events.

## Root Cause
`GameDayFoulTrackerPanel` was always mounted for score-capable games. Its mount effect immediately called the unbounded `loadGameDayLiveEventsForApp`, even when the scorekeeper never used foul tracking.

## Prevention / Learning
Treat optional panels that perform history hydration, subscriptions, or potentially unbounded reads as lazy by default. Test both panel eligibility and the absence of hidden initial data work.

## Regression Tests
- Verifies the foul tracker is available but closed by default.
- Verifies initial score and clock rendering performs no foul-history read.
- Verifies opening the tracker performs exactly one read and renders seeded foul and bonus state.
- Verifies switching events does not hydrate foul history until the new event's tracker opens.
- Retains foul record, undo, period reset, sticky score, clock, and substitution coverage.
- Passed all 127 `ScheduleEventDetail` component tests and the app production build.

## Recurrence Risk
Low. The tracker now uses the established lazy-panel boundary, with focused tests enforcing zero initial hydration and one read after explicit intent.