### PR TITLE
Allow free online registrations

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -759,7 +759,7 @@ function addPublicRegistrationDays(date, days) {
   return next;
 }
 
-function validatePublicRegistrationSubmission(form, input) {
+function validatePublicRegistrationSubmission(form, input, feeSnapshot) {
   if (!form?.published) {
     throwPublicRegistrationError('failed-precondition', 'This registration form is not accepting submissions.');
   }
@@ -774,7 +774,9 @@ function validatePublicRegistrationSubmission(form, input) {
   if (form.installmentPlan?.enabled !== true && input.selectedPaymentPlanId !== 'pay_full') {
     throwPublicRegistrationError('invalid-argument', 'Please select a payment plan.');
   }
-  if (form.paymentSettings?.onlineCheckoutEnabled === true && !input.checkoutAttemptToken) {
+  if (form.paymentSettings?.onlineCheckoutEnabled === true
+      && Number(feeSnapshot?.finalAmountDueCents || 0) > 0
+      && !input.checkoutAttemptToken) {
     throwPublicRegistrationError('invalid-argument', 'A checkout attempt token is required.');
   }
 }
@@ -899,7 +901,8 @@ exports.submitPublicRegistration = functions.https.onCall(async (data, context =
 
     const formData = formSnap.data() || {};
     const latestForm = normalizePublicRegistrationForm(formData, input);
-    validatePublicRegistrationSubmission(latestForm, input);
+    const feeSnapshot = calculatePublicRegistrationFeeSnapshot(latestForm, { quantity: input.quantity, now: new Date() });
+    validatePublicRegistrationSubmission(latestForm, input, feeSnapshot);
 
     if (hasConfiguredPublicRegistrationOptions(latestForm) && !publicRegistrationRequiresOption(latestForm)) {
       throwPublicRegistrationError('failed-precondition', 'Registration is currently unavailable. No registration options are available.', {
@@ -938,7 +941,6 @@ exports.submitPublicRegistration = functions.https.onCall(async (data, context =
       status = placement.status;
     }
 
-    const feeSnapshot = calculatePublicRegistrationFeeSnapshot(latestForm, { quantity: input.quantity, now: new Date() });
     const registrationRecord = buildPublicPendingRegistrationRecord({
       form: latestForm,
       input,

--- a/functions/test/public-registration-submission.test.cjs
+++ b/functions/test/public-registration-submission.test.cjs
@@ -385,6 +385,58 @@ test('creates exactly one pending registration and reserves matching capacity', 
     assert.equal(registrations[0].data.selectedOption.countKey, 'u10');
 });
 
+test('accepts a free online-checkout registration without a checkout token', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState({
+        feeAmountCents: 0,
+        paymentSettings: { offlinePaymentEnabled: false, onlineCheckoutEnabled: true }
+    }));
+
+    const result = await submitPublicRegistration(buildSubmission(), context);
+
+    assert.equal(result.success, true);
+    assert.equal(result.feeSnapshot.finalAmountDueCents, 0);
+    const registrations = firestore.registrationDocs();
+    assert.equal(registrations.length, 1);
+    assert.equal(registrations[0].data.status, 'pending');
+    assert.equal('checkoutAttemptToken' in registrations[0].data, false);
+});
+
+test('accepts an online-checkout registration discounted to zero without a checkout token', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState({
+        paymentSettings: { offlinePaymentEnabled: false, onlineCheckoutEnabled: true },
+        discountRules: [{
+            id: 'free-registration',
+            type: 'quantity',
+            label: 'Free registration',
+            amountType: 'fixed',
+            amountValue: 5000,
+            minimumQuantity: 1,
+            active: true
+        }]
+    }));
+
+    const result = await submitPublicRegistration(buildSubmission(), context);
+
+    assert.equal(result.feeSnapshot.finalAmountDueCents, 0);
+    assert.equal(firestore.registrationDocs().length, 1);
+});
+
+test('requires a checkout token when an online registration has a balance', async () => {
+    const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState({
+        paymentSettings: { offlinePaymentEnabled: false, onlineCheckoutEnabled: true }
+    }));
+
+    await assert.rejects(
+        submitPublicRegistration(buildSubmission(), context),
+        (error) => {
+            assert.equal(error.code, 'invalid-argument');
+            assert.equal(error.message, 'A checkout attempt token is required.');
+            return true;
+        }
+    );
+    assert.equal(firestore.registrationDocs().length, 0);
+});
+
 test('normalizes guardian email casing for parent readback rules', async () => {
     const { firestore, submitPublicRegistration } = loadSubmitPublicRegistration(buildSeedState());
 

--- a/registration.html
+++ b/registration.html
@@ -686,20 +686,6 @@
                     return;
                 }
 
-                if (amountCents <= 0) {
-                    const result = requiresRegistrationOption(activeForm)
-                        ? await submitRegistrationWithCapacity(submission)
-                        : await submitRegistrationWithoutCapacity(submission);
-
-                    formElement.classList.add('hidden');
-                    if (result.status === 'waitlisted') {
-                        confirmationMessage.querySelector('h1').textContent = 'Registration waitlisted';
-                        confirmationMessage.querySelector('p').textContent = 'This option is currently full, so your registration has been added to the waitlist.';
-                    }
-                    confirmationMessage.classList.remove('hidden');
-                    return;
-                }
-
                 const retryKey = buildCheckoutRetryKey(submission, amountCents, currency);
                 const checkoutAttemptToken = preparedCheckoutRegistration?.retryKey === retryKey
                     ? preparedCheckoutRegistration.checkoutAttemptToken
@@ -719,6 +705,13 @@
                     return;
                 }
 
+                const authoritativeAmountCents = Math.max(0, Number(result.feeSnapshot?.finalAmountDueCents ?? amountCents));
+                if (authoritativeAmountCents <= 0) {
+                    formElement.classList.add('hidden');
+                    confirmationMessage.classList.remove('hidden');
+                    return;
+                }
+
                 if (!result.registrationId) {
                     throw new Error('Registration could not be prepared for checkout.');
                 }
@@ -730,8 +723,8 @@
                         teamId,
                         formId,
                         registrationId: result.registrationId,
-                        amount: amountCents,
-                        currency,
+                        amount: authoritativeAmountCents,
+                        currency: String(result.feeSnapshot?.currency || currency).toLowerCase(),
                         checkoutAttemptToken,
                         metadata: {
                             teamId,

--- a/registration.html
+++ b/registration.html
@@ -681,8 +681,22 @@
                 const feeSnapshot = submission.feeSnapshot;
                 const amountCents = Math.max(0, Number(feeSnapshot?.finalAmountDueCents || 0));
                 const currency = String(feeSnapshot?.currency || activeForm.currency || 'USD').toLowerCase();
-                if (!feeSnapshot || amountCents <= 0) {
+                if (!feeSnapshot) {
                     showFormError('No payment amount specified for this registration.');
+                    return;
+                }
+
+                if (amountCents <= 0) {
+                    const result = requiresRegistrationOption(activeForm)
+                        ? await submitRegistrationWithCapacity(submission)
+                        : await submitRegistrationWithoutCapacity(submission);
+
+                    formElement.classList.add('hidden');
+                    if (result.status === 'waitlisted') {
+                        confirmationMessage.querySelector('h1').textContent = 'Registration waitlisted';
+                        confirmationMessage.querySelector('p').textContent = 'This option is currently full, so your registration has been added to the waitlist.';
+                    }
+                    confirmationMessage.classList.remove('hidden');
                     return;
                 }
 

--- a/tests/smoke/registration-public.spec.js
+++ b/tests/smoke/registration-public.spec.js
@@ -303,8 +303,37 @@ test('free online registration submits without opening Stripe checkout', async (
         stripeCalls: window.__registrationStripeCalls
     }));
     expect(result.submitCalls).toHaveLength(1);
-    expect(result.submitCalls[0].payload.checkoutAttemptToken).toBe('');
+    expect(result.submitCalls[0].payload.checkoutAttemptToken).toMatch(/^[a-f0-9]{32}$/);
     expect(result.stripeCalls).toEqual([]);
+});
+
+test('zero client preview continues to Stripe when the server returns a balance', async ({ page, baseURL }) => {
+    await mockRegistrationModules(page, {
+        form: registrationForm({
+            feeAmountCents: 0,
+            paymentSettings: {
+                offlinePaymentEnabled: false,
+                onlineCheckoutEnabled: true
+            }
+        }),
+        submitResult: {
+            status: 'pending',
+            registrationId: 'reg-1',
+            feeSnapshot: { finalAmountDueCents: 12000, currency: 'USD' }
+        }
+    });
+    await page.goto(buildUrl(baseURL, '/registration.html?teamId=team-1&formId=form-1'), { waitUntil: 'domcontentloaded' });
+
+    await fillRequiredRegistrationFields(page);
+    await page.getByRole('button', { name: 'Pay registration with Stripe' }).click();
+    await expect(page).toHaveURL(/#stripe-checkout$/);
+
+    const result = await page.evaluate(() => ({
+        submitCalls: window.__registrationCalls.filter((call) => call.name === 'submitPublicRegistration'),
+        stripeCalls: window.__registrationStripeCalls
+    }));
+    expect(result.submitCalls[0].payload.checkoutAttemptToken).toMatch(/^[a-f0-9]{32}$/);
+    expect(result.stripeCalls[0]).toMatchObject({ amount: 12000, currency: 'usd' });
 });
 
 test('cancelled checkout retry waits for release before retrying without duplicate submission or re-entered form fields', async ({ page, baseURL }) => {

--- a/tests/smoke/registration-public.spec.js
+++ b/tests/smoke/registration-public.spec.js
@@ -282,6 +282,31 @@ test('online registration prepares one server registration and redirects to Stri
     });
 });
 
+test('free online registration submits without opening Stripe checkout', async ({ page, baseURL }) => {
+    await mockRegistrationModules(page, {
+        form: registrationForm({
+            feeAmountCents: 0,
+            paymentSettings: {
+                offlinePaymentEnabled: false,
+                onlineCheckoutEnabled: true
+            }
+        })
+    });
+    await page.goto(buildUrl(baseURL, '/registration.html?teamId=team-1&formId=form-1'), { waitUntil: 'domcontentloaded' });
+
+    await fillRequiredRegistrationFields(page);
+    await page.getByRole('button', { name: 'Pay registration with Stripe' }).click();
+    await expect(page.getByRole('heading', { name: 'Registration submitted' })).toBeVisible();
+
+    const result = await page.evaluate(() => ({
+        submitCalls: window.__registrationCalls.filter((call) => call.name === 'submitPublicRegistration'),
+        stripeCalls: window.__registrationStripeCalls
+    }));
+    expect(result.submitCalls).toHaveLength(1);
+    expect(result.submitCalls[0].payload.checkoutAttemptToken).toBe('');
+    expect(result.stripeCalls).toEqual([]);
+});
+
 test('cancelled checkout retry waits for release before retrying without duplicate submission or re-entered form fields', async ({ page, baseURL }) => {
     await mockRegistrationModules(page, {
         form: registrationForm({


### PR DESCRIPTION
Closes #3987

## What changed
- Submit zero-balance online registrations directly without invoking Stripe.
- Support both $0 base fees and discounts that reduce the final balance to zero.
- Preserve checkout-token enforcement for registrations with a positive balance.

## Root Cause
The public registration page routed every online-checkout form through Stripe but rejected non-positive balances. The server also required a checkout token whenever online checkout was enabled, regardless of the computed final balance.

## Prevention / Learning
Payment orchestration and checkout-only validation must depend on the computed final balance, not the online-checkout flag or configured base fee. Test both free base fees and discounts that reduce a paid registration to zero.

## Regression Tests
- `node --test functions/test/public-registration-submission.test.cjs`
- `npx vitest run tests/unit/registration-flow.test.js --reporter=verbose`
- `npx playwright test tests/smoke/registration-public.spec.js --config=playwright.smoke.config.js --reporter=line`

## Recurrence Risk
Low. Browser and server tests cover zero-balance completion while verifying that positive balances still require checkout tokens.