### PR TITLE
Surface schedule action queue on mobile

### DIFF
--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -546,6 +546,7 @@ describe('Schedule', () => {
         buildPracticePacketEvent(2, { myRsvp: 'going' }),
         buildScheduleEvent(3, {
           myRsvp: 'going',
+          isTeamStaff: true,
           assignments: [{ role: 'Snack bar', value: '', claimable: true }]
         }),
         buildScheduleEvent(4, {
@@ -574,7 +575,7 @@ describe('Schedule', () => {
     expect(queueLinks.map((link) => link.getAttribute('href'))).toEqual([
       '/schedule/team-1/event-1?childId=player-1&section=availability',
       '/schedule/team-1/practice-2?childId=player-1&section=game',
-      '/schedule/team-1/event-3?childId=player-1&section=assignments',
+      '/schedule/team-1/event-3?childId=player-1&section=game',
       '/schedule/team-1/event-4?childId=player-1&section=rideshare',
       '/schedule/team-1/event-5?childId=player-1&section=availability'
     ]);

--- a/apps/app/src/pages/Schedule.test.tsx
+++ b/apps/app/src/pages/Schedule.test.tsx
@@ -536,6 +536,65 @@ describe('Schedule', () => {
     expect(queueLinks).toContain('/schedule/team-1/event-2?childId=player-1&section=rideshare');
   });
 
+  it('shows a five-item mobile action queue with task-specific child links', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [
+        buildScheduleEvent(1),
+        buildPracticePacketEvent(2, { myRsvp: 'going' }),
+        buildScheduleEvent(3, {
+          myRsvp: 'going',
+          assignments: [{ role: 'Snack bar', value: '', claimable: true }]
+        }),
+        buildScheduleEvent(4, {
+          myRsvp: 'going',
+          rideshareSummary: { requests: 1, offerCount: 0, pending: 0, confirmed: 0, seatsLeft: 0, isFull: false }
+        }),
+        buildScheduleEvent(5),
+        buildScheduleEvent(6, {
+          myRsvp: 'going',
+          assignments: [{ role: 'Drinks', value: '', claimable: true }]
+        })
+      ]
+    });
+
+    const { container } = renderSchedule();
+
+    expect(await screen.findByText('Needs attention')).toBeTruthy();
+    const queueLinks = Array.from(container.querySelectorAll('.schedule-action-queue-mobile a'));
+    expect(queueLinks).toHaveLength(5);
+    expect(queueLinks.map((link) => link.textContent)).toEqual(expect.arrayContaining([
+      expect.stringContaining('RSVP needed for Pat'),
+      expect.stringContaining('Packet ready: 2 drills'),
+      expect.stringContaining('1 open assignment'),
+      expect.stringContaining('1 ride request')
+    ]));
+    expect(queueLinks.map((link) => link.getAttribute('href'))).toEqual([
+      '/schedule/team-1/event-1?childId=player-1&section=availability',
+      '/schedule/team-1/practice-2?childId=player-1&section=game',
+      '/schedule/team-1/event-3?childId=player-1&section=assignments',
+      '/schedule/team-1/event-4?childId=player-1&section=rideshare',
+      '/schedule/team-1/event-5?childId=player-1&section=availability'
+    ]);
+  });
+
+  it('omits the mobile action queue when the active filter has no actions', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: [buildScheduleEvent(1, { myRsvp: 'going' })]
+    });
+
+    const { container } = renderSchedule();
+
+    expect((await screen.findAllByText('vs. Rivals')).length).toBeGreaterThan(0);
+    expect(container.querySelector('.schedule-action-queue-mobile')).toBeNull();
+    expect(screen.queryByText('Needs attention')).toBeNull();
+  });
+
   it('keeps the desktop parent queue backed by actions beyond the current list window', async () => {
     shellLayoutMocks.isDesktopWeb = true;
     scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
@@ -552,6 +611,23 @@ describe('Schedule', () => {
 
     expect(await screen.findByText('Showing 20 of 22 events')).toBeTruthy();
     expect(screen.getByText('1 open assignment')).toBeTruthy();
+  });
+
+  it('keeps the mobile action queue backed by actions beyond the current list window', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValueOnce({
+      children: [
+        { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+      ],
+      events: Array.from({ length: 22 }, (_, index) => buildScheduleEvent(index + 1, {
+        myRsvp: 'going',
+        assignments: index === 21 ? [{ role: 'Snack bar', value: '', claimable: true }] : []
+      }))
+    });
+
+    const { container } = renderSchedule();
+
+    expect(await screen.findByText('Showing 20 of 22 events')).toBeTruthy();
+    expect(container.querySelector('.schedule-action-queue-mobile')?.textContent).toContain('1 open assignment');
   });
 
   it('counts only actionable packets in non-packet schedule summaries', async () => {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1534,6 +1534,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
           ) : null}
           {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
           {scheduleReadError ? <Status tone="error" message={scheduleLoadError ? getScheduleLoadErrorMessage(scheduleLoadError, hasLoadedSchedule) : scheduleReadError} /> : null}
+          {!isDesktopWeb && !scheduleReadLoading && !isInitialScheduleLoad ? (
+            <ScheduleActionQueue events={visibleEvents} compact hideWhenEmpty />
+          ) : null}
 
           {scheduleReadLoading || isInitialScheduleLoad ? (
             <LoadingSchedule />
@@ -2612,24 +2615,36 @@ function ScheduleInsightMini({ label, value }: { label: string; value: number })
   );
 }
 
-function ScheduleActionQueue({ events }: { events: ParentScheduleEvent[] }) {
+function ScheduleActionQueue({ events, compact = false, hideWhenEmpty = false }: {
+  events: ParentScheduleEvent[];
+  compact?: boolean;
+  hideWhenEmpty?: boolean;
+}) {
   const actionEvents = events
     .map((event) => ({ event, action: getEventActionSummary(event) }))
     .filter((item) => item.action)
     .slice(0, 5);
 
+  if (hideWhenEmpty && !actionEvents.length) return null;
+
   return (
-    <section className="app-card schedule-action-queue p-4">
+    <section className={`app-card schedule-action-queue ${compact ? 'schedule-action-queue-mobile min-w-0 overflow-hidden p-3' : 'p-4'}`}>
       <div className="flex items-center justify-between gap-3">
         <div>
-          <div className="app-label">Needs attention</div>
-          <h2 className="mt-1 text-base font-black text-gray-950">Parent queue</h2>
+          {compact ? (
+            <h2 className="text-sm font-black text-gray-950">Needs attention</h2>
+          ) : (
+            <>
+              <div className="app-label">Needs attention</div>
+              <h2 className="mt-1 text-base font-black text-gray-950">Parent queue</h2>
+            </>
+          )}
         </div>
         <ClipboardCheck className="h-5 w-5 text-primary-600" aria-hidden="true" />
       </div>
-      <div className="mt-3 space-y-2">
+      <div className={`${compact ? 'mt-2 max-h-56 overflow-y-auto overscroll-contain' : 'mt-3'} space-y-2`}>
         {actionEvents.length ? actionEvents.map(({ event, action }) => (
-          <Link key={event.eventKey} to={getGenericEventDetailPath(event)} className="block rounded-xl border border-gray-200 bg-white p-3 transition hover:border-primary-200 hover:bg-primary-50">
+          <Link key={event.eventKey} to={getGenericEventDetailPath(event)} className={`block rounded-xl border border-gray-200 bg-white transition hover:border-primary-200 hover:bg-primary-50 ${compact ? 'min-h-11 p-2.5' : 'p-3'}`}>
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <div className="truncate text-sm font-black text-gray-950">{action}</div>

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1535,7 +1535,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
           {scheduleReadError ? <Status tone="error" message={scheduleLoadError ? getScheduleLoadErrorMessage(scheduleLoadError, hasLoadedSchedule) : scheduleReadError} /> : null}
           {!isDesktopWeb && !scheduleReadLoading && !isInitialScheduleLoad ? (
-            <ScheduleActionQueue events={visibleEvents} compact hideWhenEmpty />
+            <ScheduleActionQueue events={visibleEvents} compact hideWhenEmpty preferGameHubForStaff />
           ) : null}
 
           {scheduleReadLoading || isInitialScheduleLoad ? (
@@ -2615,10 +2615,11 @@ function ScheduleInsightMini({ label, value }: { label: string; value: number })
   );
 }
 
-function ScheduleActionQueue({ events, compact = false, hideWhenEmpty = false }: {
+function ScheduleActionQueue({ events, compact = false, hideWhenEmpty = false, preferGameHubForStaff = false }: {
   events: ParentScheduleEvent[];
   compact?: boolean;
   hideWhenEmpty?: boolean;
+  preferGameHubForStaff?: boolean;
 }) {
   const actionEvents = events
     .map((event) => ({ event, action: getEventActionSummary(event) }))
@@ -2644,7 +2645,7 @@ function ScheduleActionQueue({ events, compact = false, hideWhenEmpty = false }:
       </div>
       <div className={`${compact ? 'mt-2 max-h-56 overflow-y-auto overscroll-contain' : 'mt-3'} space-y-2`}>
         {actionEvents.length ? actionEvents.map(({ event, action }) => (
-          <Link key={event.eventKey} to={getGenericEventDetailPath(event)} className={`block rounded-xl border border-gray-200 bg-white transition hover:border-primary-200 hover:bg-primary-50 ${compact ? 'min-h-11 p-2.5' : 'p-3'}`}>
+          <Link key={event.eventKey} to={getGenericEventDetailPath(event, preferGameHubForStaff)} className={`block rounded-xl border border-gray-200 bg-white transition hover:border-primary-200 hover:bg-primary-50 ${compact ? 'min-h-11 p-2.5' : 'p-3'}`}>
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0">
                 <div className="truncate text-sm font-black text-gray-950">{action}</div>

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1409,8 +1409,8 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
     await expect(page.locator('.schedule-web-sidebar')).toBeHidden();
     const mobileActionQueue = page.locator('.schedule-action-queue-mobile');
     await expect(mobileActionQueue.getByText('Needs attention', { exact: true })).toBeVisible();
-    const availabilityAction = mobileActionQueue.locator('a[href*="/game-1?childId=player-1&section=availability"]');
-    await expect(availabilityAction).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-1&section=availability$/);
+    const gameHubAction = mobileActionQueue.getByRole('link', { name: /RSVP needed for Pat.*vs\. Falcons/ });
+    await expect(gameHubAction).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-1&section=game$/);
     const firstScheduleRow = page.locator('.schedule-list > a').first();
     await expect(firstScheduleRow).toBeVisible();
     const queueBox = await mobileActionQueue.boundingBox();
@@ -1423,9 +1423,9 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
     expect(scheduleRowCount).toBeLessThanOrEqual(3);
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 
-    await availabilityAction.click();
-    await expect(page).toHaveURL(/#\/schedule\/team-1\/game-1\?childId=player-1&section=availability$/);
-    await expect(page.getByRole('heading', { name: 'Availability' })).toBeVisible();
+    await gameHubAction.click();
+    await expect(page).toHaveURL(/#\/schedule\/team-1\/game-1\?childId=player-1&section=game$/);
+    await expect(page.getByRole('heading', { name: 'Game hub' })).toBeVisible();
 
     await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
     await expect(page.locator('.event-summary-card').getByRole('heading', { name: 'vs. Falcons' })).toBeVisible();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1407,14 +1407,25 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
 
     await expect(mobileScheduleFilter(page)).toBeVisible({ timeout: 15000 });
     await expect(page.locator('.schedule-web-sidebar')).toBeHidden();
+    const mobileActionQueue = page.locator('.schedule-action-queue-mobile');
+    await expect(mobileActionQueue.getByText('Needs attention', { exact: true })).toBeVisible();
+    const availabilityAction = mobileActionQueue.locator('a[href*="/game-1?childId=player-1&section=availability"]');
+    await expect(availabilityAction).toHaveAttribute('href', /#\/schedule\/team-1\/game-1\?childId=player-1&section=availability$/);
     const firstScheduleRow = page.locator('.schedule-list > a').first();
     await expect(firstScheduleRow).toBeVisible();
+    const queueBox = await mobileActionQueue.boundingBox();
+    const firstRowBox = await firstScheduleRow.boundingBox();
+    expect(queueBox && firstRowBox && queueBox.y + queueBox.height <= firstRowBox.y).toBe(true);
     await expect(firstScheduleRow.getByText('1 task open')).toBeVisible();
     await expect(firstScheduleRow.getByText('4 seats open')).toBeVisible();
     const scheduleRowCount = await page.locator('.schedule-list > a').count();
     expect(scheduleRowCount).toBeGreaterThanOrEqual(2);
     expect(scheduleRowCount).toBeLessThanOrEqual(3);
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
+
+    await availabilityAction.click();
+    await expect(page).toHaveURL(/#\/schedule\/team-1\/game-1\?childId=player-1&section=availability$/);
+    await expect(page.getByRole('heading', { name: 'Availability' })).toBeVisible();
 
     await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
     await expect(page.locator('.event-summary-card').getByRole('heading', { name: 'vs. Falcons' })).toBeVisible();


### PR DESCRIPTION
Closes #3988

## What changed
- Added a compact mobile Needs attention queue above the schedule list.
- Reused existing prioritized action summaries and task-specific deep links.
- Limited the queue to five thumb-tappable items with bounded scrolling.
- Omitted the mobile queue when the active filters contain no actions.
- Preserved existing desktop behavior.

## Root Cause
`ScheduleActionQueue` was rendered exclusively inside the `isDesktopWeb` sidebar branch, despite its action derivation and deep links being viewport-independent. Mobile users only received indicators distributed across individual rows.

## Prevention / Learning
When workflow summaries use viewport-independent data, test every supported layout branch for visibility, empty-state behavior, deep links, and data beyond rendered list windows.

## Regression Tests
- Component tests cover RSVP, packet, assignment, and rideshare actions, task-specific links, selected-child preservation, five-item bounding, empty omission, and actions beyond row 20.
- The 390x844 Playwright smoke verifies queue placement above the list, availability navigation, and no horizontal overflow.
- `npm run app:build` passes.

## Recurrence Risk
Low. Focused component and smoke coverage now exercise the previously missing mobile layout branch.