### PR TITLE
Avoid lineup preview reloads after autosave

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -4679,7 +4679,7 @@ describe('ScheduleEventDetail lineup builder', () => {
     });
   });
 
-  it('keeps the lineup autosave confirmation when the saved game plan refreshes the same event', async () => {
+  it('keeps the saved lineup interactive without reloading its locally hydrated preview', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
       events: [buildEvent({
         isTeamStaff: true,
@@ -4754,21 +4754,12 @@ describe('ScheduleEventDetail lineup builder', () => {
     });
 
     await waitFor(() => {
-      expect(scheduleServiceMocks.saveScheduledGameLineupDraftForApp).toHaveBeenCalled();
-      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledWith(
-        expect.objectContaining({
-          gamePlan: expect.objectContaining({
-            lineups: expect.objectContaining({
-              'Q1-pg': 'p1',
-              'Q1-sg': 'p2'
-            })
-          })
-        }),
-        auth.user,
-        'basketball-5v5'
-      );
+      expect(scheduleServiceMocks.saveScheduledGameLineupDraftForApp).toHaveBeenCalledTimes(1);
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Lineup draft autosaved.')).toBeTruthy();
       expect((screen.getByLabelText('Formation') as HTMLSelectElement).value).toBe('basketball-5v5');
+      expect(within(screen.getByTestId('lineup-slot-Q1-sg')).getByText('#2 Blake Jones')).toBeTruthy();
+      expect(screen.queryByText('Loading lineup builder…')).toBeNull();
     });
   });
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2862,6 +2862,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   const latestPreviewRef = useRef<LineupDraftPreviewResult | null>(null);
   const latestFormationIdRef = useRef(formationId);
   const previousEventKeyRef = useRef(event.eventKey);
+  const locallyHydratedGamePlanRef = useRef<Record<string, any> | null>(null);
 
   const formation = gameDayService?.LINEUP_FORMATIONS[formationId] || null;
   const lineupPeriods = useMemo(() => (
@@ -2898,6 +2899,7 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
     dirtyRef.current = false;
     latestDraftRef.current = {};
     latestPreviewRef.current = null;
+    locallyHydratedGamePlanRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -2920,6 +2922,10 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
   useEffect(() => {
     let cancelled = false;
     const currentEvent = eventRef.current;
+    if (currentEvent.gamePlan && locallyHydratedGamePlanRef.current === currentEvent.gamePlan) {
+      locallyHydratedGamePlanRef.current = null;
+      return undefined;
+    }
     if (!auth.user || !formationId || currentEvent.isCancelled) {
       setPreview(null);
       setDraftLineups({});
@@ -2971,7 +2977,10 @@ function GameHubLineupBuilderPanel({ auth, event, onGamePlanSaved }: { auth: Aut
       const result = await saveScheduledGameLineupDraftForApp(event, auth.user, formationId, { lineups });
       setPreview(result);
       latestPreviewRef.current = result;
-      if (result.gamePlan) onGamePlanSaved(result.gamePlan);
+      if (result.gamePlan) {
+        locallyHydratedGamePlanRef.current = result.gamePlan;
+        onGamePlanSaved(result.gamePlan);
+      }
       dirtyRef.current = false;
       if (reason !== 'publish') {
         setStatus({ tone: 'success', message: reason === 'autosave' ? 'Lineup draft autosaved.' : 'Lineup draft saved.' });


### PR DESCRIPTION
Closes #3991

## What changed
- Track the game plan already hydrated by the lineup save response.
- Skip preview hydration when the parent propagates that exact locally saved game plan.
- Preserve normal hydration for initial loads, event changes, formation changes, and different external game plans.

## Root Cause
The preview-loading effect depended on `event.gamePlan`. Autosave stored the complete preview returned by the save operation, then propagated its game plan to the parent. Replacing the parent event triggered the effect and duplicated roster and RSVP hydration.

## Prevention / Learning
When a mutation returns complete hydrated UI state, distinguish its local parent-state echo from external changes before rerunning read-side hydration. Scope the bypass to the exact returned identity so genuinely different updates still reload.

## Regression Tests
- Updated `ScheduleEventDetail.test.tsx` to assert one initial preview load, one autosave, no post-save reload, no loading message, and preservation of the saved assignment.
- Ran the focused lineup-builder test group: 5 passed.
- Ran `npm run typecheck`: passed.

## Recurrence Risk
Low. The bypass applies only to the exact game-plan object returned by the local save and is consumed after one parent echo.