### PR TITLE
Restrict private AI history to owning users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2507,11 +2507,11 @@ service cloud.firestore {
       }
 
       match /privateAiMessages/{messageId} {
-        allow read, create, update, delete: if isOwner(userId) || isGlobalAdmin();
+        allow read, create, update, delete: if isOwner(userId);
       }
 
       match /privateAiConversations/{conversationId} {
-        allow read, create, update, delete: if isOwner(userId) || isGlobalAdmin();
+        allow read, create, update, delete: if isOwner(userId);
       }
 
       match /entitlements/{entitlementId} {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run tests/unit",
     "test:unit": "vitest run tests/unit",
     "test:unit:ci": "vitest run tests/unit --reporter=dot && npm run test:storage-rules:ci",
-    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js --reporter=dot\"",
+    "test:storage-rules:ci": "firebase emulators:exec --only firestore,storage --project demo-allplays \"vitest run tests/unit/storage-rules-team-boundary.test.js tests/unit/player-rules-privacy.test.js tests/unit/private-ai-rules.test.js --reporter=dot\"",
     "test:coverage-map": "node scripts/report-test-coverage-map.mjs --check",
     "test:functions:notifications": "npm run test:notifications --prefix functions",
     "test:functions:auth-email": "node --test functions/test/auth-email-*.test.cjs",

--- a/tests/unit/private-ai-rules.test.js
+++ b/tests/unit/private-ai-rules.test.js
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+    assertFails,
+    assertSucceeds,
+    initializeTestEnvironment
+} from '@firebase/rules-unit-testing';
+import {
+    collection,
+    deleteDoc,
+    doc,
+    getDoc,
+    getDocs,
+    setDoc,
+    updateDoc
+} from 'firebase/firestore';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const privateAiCollections = ['privateAiMessages', 'privateAiConversations'];
+
+function extractRuleBlock(marker, nextMarker) {
+    return rules.slice(rules.indexOf(marker), rules.indexOf(nextMarker));
+}
+
+describe('private AI Firestore rules', () => {
+    it('requires ownership and has no platform-admin bypass in either collection', () => {
+        const messageRules = extractRuleBlock(
+            'match /privateAiMessages/{messageId}',
+            'match /privateAiConversations/{conversationId}'
+        );
+        const conversationRules = extractRuleBlock(
+            'match /privateAiConversations/{conversationId}',
+            'match /entitlements/{entitlementId}'
+        );
+
+        for (const ruleBlock of [messageRules, conversationRules]) {
+            expect(ruleBlock).toContain('allow read, create, update, delete: if isOwner(userId);');
+            expect(ruleBlock).not.toContain('isGlobalAdmin()');
+        }
+    });
+
+    describe.skipIf(!process.env.FIRESTORE_EMULATOR_HOST)('emulator authorization coverage', () => {
+        let testEnv;
+
+        beforeAll(async () => {
+            testEnv = await initializeTestEnvironment({
+                projectId: `allplays-private-ai-${Date.now()}`,
+                firestore: { rules }
+            });
+        }, 30000);
+
+        beforeEach(async () => {
+            await testEnv.clearFirestore();
+            await testEnv.withSecurityRulesDisabled(async (context) => {
+                const adminDb = context.firestore();
+                await setDoc(doc(adminDb, 'users/platform-admin'), { isAdmin: true });
+                for (const collectionName of privateAiCollections) {
+                    await setDoc(doc(adminDb, `users/owner/${collectionName}/seeded`), {
+                        content: 'private history'
+                    });
+                }
+            });
+        });
+
+        afterAll(async () => {
+            await testEnv?.cleanup();
+        });
+
+        it.each(privateAiCollections)('allows owner CRUD and list for %s', async (collectionName) => {
+            const ownerDb = testEnv.authenticatedContext('owner').firestore();
+            const createdRef = doc(ownerDb, `users/owner/${collectionName}/created`);
+
+            await assertSucceeds(getDoc(doc(ownerDb, `users/owner/${collectionName}/seeded`)));
+            await assertSucceeds(getDocs(collection(ownerDb, `users/owner/${collectionName}`)));
+            await assertSucceeds(setDoc(createdRef, { content: 'created' }));
+            await assertSucceeds(updateDoc(createdRef, { content: 'updated' }));
+            await assertSucceeds(deleteDoc(createdRef));
+        });
+
+        it.each(privateAiCollections)('denies cross-user and anonymous access to %s', async (collectionName) => {
+            const actorDatabases = [
+                testEnv.authenticatedContext('platform-admin').firestore(),
+                testEnv.authenticatedContext('unrelated-user').firestore(),
+                testEnv.unauthenticatedContext().firestore()
+            ];
+
+            for (const actorDb of actorDatabases) {
+                const seededRef = doc(actorDb, `users/owner/${collectionName}/seeded`);
+                const createdRef = doc(actorDb, `users/owner/${collectionName}/unauthorized-create`);
+
+                await assertFails(getDoc(seededRef));
+                await assertFails(getDocs(collection(actorDb, `users/owner/${collectionName}`)));
+                await assertFails(setDoc(createdRef, { content: 'injected' }));
+                await assertFails(updateDoc(seededRef, { content: 'altered' }));
+                await assertFails(deleteDoc(seededRef));
+            }
+        });
+    });
+});


### PR DESCRIPTION
Closes #3993

## What changed
- Removed the platform-admin bypass from Private AI message and conversation rules.
- Added static assertions for owner-only access.
- Added Firestore emulator coverage for owner CRUD and cross-user denial.
- Added the emulator suite to the existing CI rules command.

## Root Cause
Private AI subcollections inherited the generic `isGlobalAdmin()` bypass, allowing platform admins to read and mutate account-scoped conversation history owned by other users.

## Prevention / Learning
Sensitive user-scoped collections must default to owner-only client access. Administrative access requires a separate, narrowly scoped, server-side workflow with authorization and audit controls. Rules tests must cover privileged denied actors, not only unrelated users.

## Regression Tests
- Static checks require `isOwner(userId)` and reject `isGlobalAdmin()` in both Private AI rule blocks.
- Firestore emulator tests verify owner get, list, create, update, and delete operations succeed.
- Emulator tests verify platform-admin, unrelated-user, and anonymous get, list, create, update, and delete operations fail for both collections.
- `npm run ci:firebase-rules` passes.
- `npm run test:storage-rules:ci` passes with 16 tests.