### PR TITLE
Clear stale album covers when moving photos

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -1475,6 +1475,22 @@ async function moveTeamMediaStorageBackedItem(teamId, item = {}, update = {}) {
     }
 }
 
+async function clearMovedTeamMediaAlbumCover(teamId, item = {}) {
+    const sourceFolderId = String(item.folderId || '').trim();
+    if (!sourceFolderId) return;
+
+    const sourceFolderRef = doc(db, `teams/${teamId}/mediaFolders`, sourceFolderId);
+    const sourceFolderSnapshot = await getDoc(sourceFolderRef);
+    if (!sourceFolderSnapshot.exists() || sourceFolderSnapshot.data()?.coverPhotoId !== item.id) return;
+
+    await updateDoc(sourceFolderRef, {
+        coverPhotoId: deleteField(),
+        coverPhotoUrl: deleteField(),
+        coverPhotoTitle: deleteField(),
+        updatedAt: serverTimestamp()
+    });
+}
+
 export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {}) {
     const cleanTeamId = String(teamId || '').trim();
     const cleanFolderId = String(folderId || '').trim();
@@ -1667,6 +1683,7 @@ export async function moveTeamMediaItems(teamId, itemIds = [], targetFolderId) {
 
         if (['photo', 'file'].includes(String(item.type || '').toLowerCase())) {
             await moveTeamMediaStorageBackedItem(teamId, item, update);
+            await clearMovedTeamMediaAlbumCover(teamId, item);
             continue;
         }
 

--- a/js/db.js
+++ b/js/db.js
@@ -1480,14 +1480,16 @@ async function clearMovedTeamMediaAlbumCover(teamId, item = {}, targetFolderId) 
     if (!sourceFolderId || sourceFolderId === String(targetFolderId || '').trim()) return;
 
     const sourceFolderRef = doc(db, `teams/${teamId}/mediaFolders`, sourceFolderId);
-    const sourceFolderSnapshot = await getDoc(sourceFolderRef);
-    if (!sourceFolderSnapshot.exists() || sourceFolderSnapshot.data()?.coverPhotoId !== item.id) return;
+    await runTransaction(db, async (transaction) => {
+        const sourceFolderSnapshot = await transaction.get(sourceFolderRef);
+        if (!sourceFolderSnapshot.exists() || sourceFolderSnapshot.data()?.coverPhotoId !== item.id) return;
 
-    await updateDoc(sourceFolderRef, {
-        coverPhotoId: deleteField(),
-        coverPhotoUrl: deleteField(),
-        coverPhotoTitle: deleteField(),
-        updatedAt: serverTimestamp()
+        transaction.update(sourceFolderRef, {
+            coverPhotoId: deleteField(),
+            coverPhotoUrl: deleteField(),
+            coverPhotoTitle: deleteField(),
+            updatedAt: serverTimestamp()
+        });
     });
 }
 

--- a/js/db.js
+++ b/js/db.js
@@ -1475,9 +1475,9 @@ async function moveTeamMediaStorageBackedItem(teamId, item = {}, update = {}) {
     }
 }
 
-async function clearMovedTeamMediaAlbumCover(teamId, item = {}) {
+async function clearMovedTeamMediaAlbumCover(teamId, item = {}, targetFolderId) {
     const sourceFolderId = String(item.folderId || '').trim();
-    if (!sourceFolderId) return;
+    if (!sourceFolderId || sourceFolderId === String(targetFolderId || '').trim()) return;
 
     const sourceFolderRef = doc(db, `teams/${teamId}/mediaFolders`, sourceFolderId);
     const sourceFolderSnapshot = await getDoc(sourceFolderRef);
@@ -1683,7 +1683,7 @@ export async function moveTeamMediaItems(teamId, itemIds = [], targetFolderId) {
 
         if (['photo', 'file'].includes(String(item.type || '').toLowerCase())) {
             await moveTeamMediaStorageBackedItem(teamId, item, update);
-            await clearMovedTeamMediaAlbumCover(teamId, item);
+            await clearMovedTeamMediaAlbumCover(teamId, item, update.folderId);
             continue;
         }
 

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem
-} from './db.js?v=96';
+} from './db.js?v=97';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,

--- a/team-media.html
+++ b/team-media.html
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=14"></script>
+    <script type="module" src="js/team-media.js?v=15"></script>
 </body>
 </html>

--- a/tests/unit/rsvp-precedence-cache-bust.test.js
+++ b/tests/unit/rsvp-precedence-cache-bust.test.js
@@ -20,7 +20,7 @@ describe('RSVP precedence cache delivery', () => {
             'team-chat.html': 'db.js?v=100',
             'js/auth.js': 'db.js?v=95',
             'profile.html': 'db.js?v=95',
-            'js/team-media.js': 'db.js?v=96'
+            'js/team-media.js': 'db.js?v=97'
         };
 
         for (const [path, expectedVersion] of Object.entries(runtimeSources)) {
@@ -58,7 +58,7 @@ describe('RSVP precedence cache delivery', () => {
             'live-game.html': 'js/live-game.js?v=19',
             'live-tracker.html': 'js/live-tracker.js?v=2',
             'team-fees.html': 'js/team-fees-admin.js?v=14',
-            'team-media.html': 'js/team-media.js?v=14',
+            'team-media.html': 'js/team-media.js?v=15',
             'track-basketball.html': 'js/track-basketball.js?v=2',
             'tracking-items.html': 'js/tracking-items-admin.js?v=2',
             'team.html': 'js/team-staff-permissions.js?v=3',

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -124,6 +124,7 @@ vi.mock('../../js/vendor/firebase-storage.js', () => ({
 describe('team media db ordering', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        firebaseMocks.getDoc.mockResolvedValue({ exists: () => false });
         folderState.nextMediaOrder = 0;
         addDocState.nextId = 1;
         batchState.batches = [];
@@ -520,6 +521,58 @@ describe('team media db ordering', () => {
             }
         );
         expect(firebaseMocks.deleteObject).toHaveBeenCalledWith({ fullPath: 'team-media/team-1/folder-team/user-1/original.jpg' });
+        expect(firebaseMocks.updateDoc).not.toHaveBeenCalledWith(
+            expect.objectContaining({ path: expect.stringContaining('/mediaFolders/') }),
+            expect.anything()
+        );
+    });
+
+    it('clears the source album cover when moving its storage-backed photo', async () => {
+        teamMediaUtilsMocks.buildMoveUpdates.mockReturnValue([
+            { id: 'media-cover', folderId: 'folder-private', order: 0 }
+        ]);
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({
+                docs: [{
+                    id: 'media-cover',
+                    data: () => ({
+                        folderId: 'folder-team',
+                        order: 0,
+                        type: 'photo',
+                        mimeType: 'image/jpeg',
+                        storagePath: 'team-media/team-1/folder-team/user-1/cover.jpg',
+                        uploadedBy: 'user-1',
+                        deleted: false
+                    })
+                }]
+            });
+        firebaseMocks.getDoc.mockResolvedValueOnce({
+            exists: () => true,
+            data: () => ({
+                coverPhotoId: 'media-cover',
+                coverPhotoUrl: 'https://cdn.example.test/cover.jpg',
+                coverPhotoTitle: 'Album cover'
+            })
+        });
+        firebaseMocks.getDownloadURL.mockResolvedValueOnce('https://cdn.example.test/cover.jpg');
+
+        const { moveTeamMediaItems } = await import('../../js/db.js');
+        await moveTeamMediaItems('team-1', ['media-cover'], 'folder-private');
+
+        expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
+            { path: 'teams/team-1/mediaFolders/folder-team' },
+            {
+                coverPhotoId: 'DELETE_FIELD',
+                coverPhotoUrl: 'DELETE_FIELD',
+                coverPhotoTitle: 'DELETE_FIELD',
+                updatedAt: 'server-ts'
+            }
+        );
+        expect(firebaseMocks.updateDoc).not.toHaveBeenCalledWith(
+            { path: 'teams/team-1/mediaFolders/folder-private' },
+            expect.anything()
+        );
     });
 
     it('preserves legacy media without order fields at the end of paginated reads', async () => {

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -575,6 +575,37 @@ describe('team media db ordering', () => {
         );
     });
 
+    it('preserves the album cover when moving its photo to the current album', async () => {
+        teamMediaUtilsMocks.buildMoveUpdates.mockReturnValue([
+            { id: 'media-cover', folderId: 'folder-team', order: 1 }
+        ]);
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({
+                docs: [{
+                    id: 'media-cover',
+                    data: () => ({
+                        folderId: 'folder-team',
+                        order: 0,
+                        type: 'photo',
+                        mimeType: 'image/jpeg',
+                        storagePath: 'team-media/team-1/folder-team/user-1/cover.jpg',
+                        uploadedBy: 'user-1',
+                        deleted: false
+                    })
+                }]
+            });
+
+        const { moveTeamMediaItems } = await import('../../js/db.js');
+        await moveTeamMediaItems('team-1', ['media-cover'], 'folder-team');
+
+        expect(firebaseMocks.getDoc).not.toHaveBeenCalled();
+        expect(firebaseMocks.updateDoc).not.toHaveBeenCalledWith(
+            expect.objectContaining({ path: expect.stringContaining('/mediaFolders/') }),
+            expect.anything()
+        );
+    });
+
     it('preserves legacy media without order fields at the end of paginated reads', async () => {
         const orderedDocs = [
             {

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -528,6 +528,59 @@ describe('team media db ordering', () => {
     });
 
     it('clears the source album cover when moving its storage-backed photo', async () => {
+        const transactionUpdate = vi.fn();
+        teamMediaUtilsMocks.buildMoveUpdates.mockReturnValue([
+            { id: 'media-cover', folderId: 'folder-private', order: 0 }
+        ]);
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({ docs: [] })
+            .mockResolvedValueOnce({
+                docs: [{
+                    id: 'media-cover',
+                    data: () => ({
+                        folderId: 'folder-team',
+                        order: 0,
+                        type: 'photo',
+                        mimeType: 'image/jpeg',
+                        storagePath: 'team-media/team-1/folder-team/user-1/cover.jpg',
+                        uploadedBy: 'user-1',
+                        deleted: false
+                    })
+                }]
+            });
+        firebaseMocks.runTransaction.mockImplementationOnce(async (_db, callback) => callback({
+            get: vi.fn(async () => ({
+                exists: () => true,
+                data: () => ({
+                    coverPhotoId: 'media-cover',
+                    coverPhotoUrl: 'https://cdn.example.test/cover.jpg',
+                    coverPhotoTitle: 'Album cover'
+                })
+            })),
+            update: transactionUpdate
+        }));
+        firebaseMocks.getDownloadURL.mockResolvedValueOnce('https://cdn.example.test/cover.jpg');
+
+        const { moveTeamMediaItems } = await import('../../js/db.js');
+        await moveTeamMediaItems('team-1', ['media-cover'], 'folder-private');
+
+        expect(transactionUpdate).toHaveBeenCalledWith(
+            { path: 'teams/team-1/mediaFolders/folder-team' },
+            {
+                coverPhotoId: 'DELETE_FIELD',
+                coverPhotoUrl: 'DELETE_FIELD',
+                coverPhotoTitle: 'DELETE_FIELD',
+                updatedAt: 'server-ts'
+            }
+        );
+        expect(firebaseMocks.updateDoc).not.toHaveBeenCalledWith(
+            { path: 'teams/team-1/mediaFolders/folder-private' },
+            expect.anything()
+        );
+    });
+
+    it('preserves a concurrently reassigned source album cover when moving the previous cover photo', async () => {
+        const transactionUpdate = vi.fn();
         teamMediaUtilsMocks.buildMoveUpdates.mockReturnValue([
             { id: 'media-cover', folderId: 'folder-private', order: 0 }
         ]);
@@ -549,28 +602,24 @@ describe('team media db ordering', () => {
             });
         firebaseMocks.getDoc.mockResolvedValueOnce({
             exists: () => true,
-            data: () => ({
-                coverPhotoId: 'media-cover',
-                coverPhotoUrl: 'https://cdn.example.test/cover.jpg',
-                coverPhotoTitle: 'Album cover'
-            })
+            data: () => ({ coverPhotoId: 'media-cover' })
         });
+        firebaseMocks.runTransaction.mockImplementationOnce(async (_db, callback) => callback({
+            get: vi.fn(async () => ({
+                exists: () => true,
+                data: () => ({ coverPhotoId: 'new-cover' })
+            })),
+            update: transactionUpdate
+        }));
         firebaseMocks.getDownloadURL.mockResolvedValueOnce('https://cdn.example.test/cover.jpg');
 
         const { moveTeamMediaItems } = await import('../../js/db.js');
         await moveTeamMediaItems('team-1', ['media-cover'], 'folder-private');
 
-        expect(firebaseMocks.updateDoc).toHaveBeenCalledWith(
-            { path: 'teams/team-1/mediaFolders/folder-team' },
-            {
-                coverPhotoId: 'DELETE_FIELD',
-                coverPhotoUrl: 'DELETE_FIELD',
-                coverPhotoTitle: 'DELETE_FIELD',
-                updatedAt: 'server-ts'
-            }
-        );
+        expect(firebaseMocks.runTransaction).toHaveBeenCalledTimes(1);
+        expect(transactionUpdate).not.toHaveBeenCalled();
         expect(firebaseMocks.updateDoc).not.toHaveBeenCalledWith(
-            { path: 'teams/team-1/mediaFolders/folder-private' },
+            { path: 'teams/team-1/mediaFolders/folder-team' },
             expect.anything()
         );
     });

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=96', () => {
+vi.mock('../../js/db.js?v=97', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-legacy-upload-forms.test.js
+++ b/tests/unit/team-media-legacy-upload-forms.test.js
@@ -17,7 +17,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=96', () => ({
+vi.mock('../../js/db.js?v=97', () => ({
     getTeam: mocks.getTeam,
     getTeamMediaFolders: mocks.getTeamMediaFolders,
     getTeamMediaItemsPage: mocks.getTeamMediaItemsPage,

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -24,7 +24,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=14"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=15"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
@@ -36,7 +36,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toMatch(/import \{ checkAuth \} from '\.\/auth\.js\?v=\d+';/);
-        expect(pageJs).toContain("from './db.js?v=96'");
+        expect(pageJs).toContain("from './db.js?v=97'");
         expect(pageJs).toContain('normalizeTeamMediaVideoDraft');
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -28,11 +28,11 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=14"');
+        expect(page).toContain('src="js/team-media.js?v=15"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=96'");
+        expect(source).toContain("from './db.js?v=97'");
         expect(source).toContain('normalizeTeamMediaVideoDraft');
         expect(source).toContain("import { checkAuth } from './auth.js?v=50';");
         expect(source).toContain('checkAuth(async (user) => {');
@@ -51,7 +51,7 @@ describe('team media page wiring', () => {
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
         const dbImportVersion = source.match(/from '\.\/db\.js\?v=(\d+)'/)?.[1];
 
-        expect(dbImportVersion).toBe('96');
+        expect(dbImportVersion).toBe('97');
 
         for (const testFile of [
             'tests/unit/team-media-item-rename.test.js',


### PR DESCRIPTION
Closes #3999

## What changed
- Clear the source album's cover metadata when its active cover photo is moved.
- Preserve unrelated source and destination album covers.
- Bump Team Media cache versions so clients receive the fix.

## Root Cause
The storage move path updated the media item and deleted its original Storage object without reconciling the source album's denormalized `coverPhotoId`, `coverPhotoUrl`, and `coverPhotoTitle` fields.

## Prevention / Learning
Whenever moving or deleting an entity invalidates denormalized references, reconcile those references within the same workflow. Test both matching-reference and ordinary non-matching cases.

## Regression Tests
- Added coverage proving that moving an active cover clears all source cover fields.
- Added coverage proving ordinary moves do not update album cover metadata.
- Ran 35 focused Vitest tests across six files successfully.
- Ran `node scripts/check-critical-cache-bust.mjs` successfully.

## Recurrence Risk
Low. The move path now conditionally clears all source cover fields, with focused regression and cache-delivery coverage.