### PR TITLE
Bound fee-assignment notification recipient reads

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -9526,7 +9526,8 @@ async function resolveFeeAssignmentRecipientsForUser({
     for (let index = 0; index < uniquePlayerIds.length; index += 30) {
       queryPromises.push(
         recipientCollection.where('playerKey', 'in', uniquePlayerKeys.slice(index, index + 30)).get(),
-        recipientCollection.where('playerId', 'in', uniquePlayerIds.slice(index, index + 30)).get()
+        recipientCollection.where('playerId', 'in', uniquePlayerIds.slice(index, index + 30)).get(),
+        recipientCollection.where('childId', 'in', uniquePlayerIds.slice(index, index + 30)).get()
       );
     }
     const recipientSnaps = await Promise.all(queryPromises);

--- a/functions/index.js
+++ b/functions/index.js
@@ -9508,22 +9508,36 @@ async function resolveFeeAssignmentRecipientsForUser({
 
   const teamPlayerKeyPrefix = `${teamId}::`;
   const fallbackPlayerKey = getFeeAssignmentRecipientPlayerKey(teamId, fallbackRecipient || {});
-  const playerIds = Array.from(parentPlayerKeys)
+  const playerKeys = Array.from(parentPlayerKeys)
     .filter((playerKey) => playerKey.startsWith(teamPlayerKeyPrefix))
-    .map((playerKey) => playerKey.slice(teamPlayerKeyPrefix.length))
-    .filter((playerId) => playerId && !playerId.includes('/'))
-    .filter((playerId) => `${teamPlayerKeyPrefix}${playerId}` !== fallbackPlayerKey);
-  const uniquePlayerIds = Array.from(new Set(playerIds));
+    .filter((playerKey) => playerKey !== fallbackPlayerKey)
+    .filter((playerKey) => {
+      const playerId = playerKey.slice(teamPlayerKeyPrefix.length);
+      return playerId && !playerId.includes('/');
+    });
+  const uniquePlayerKeys = Array.from(new Set(playerKeys));
+  const uniquePlayerIds = uniquePlayerKeys
+    .map((playerKey) => playerKey.slice(teamPlayerKeyPrefix.length));
   if (!uniquePlayerIds.length) return fallback ? [fallback] : [];
 
   try {
-    const recipientRefs = uniquePlayerIds.map((playerId) => (
-      firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${playerId}`)
-    ));
-    const recipientSnaps = await firestore.getAll(...recipientRefs);
-    const recipients = recipientSnaps
-      .filter((docSnap) => docSnap.exists)
-      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }));
+    const recipientCollection = firestore.collection(`teams/${teamId}/feeBatches/${batchId}/feeRecipients`);
+    const queryPromises = [];
+    for (let index = 0; index < uniquePlayerIds.length; index += 30) {
+      queryPromises.push(
+        recipientCollection.where('playerKey', 'in', uniquePlayerKeys.slice(index, index + 30)).get(),
+        recipientCollection.where('playerId', 'in', uniquePlayerIds.slice(index, index + 30)).get()
+      );
+    }
+    const recipientSnaps = await Promise.all(queryPromises);
+    const recipientsById = new Map();
+    recipientSnaps.forEach((querySnap) => {
+      querySnap.docs.forEach((docSnap) => {
+        if (String(docSnap.id || '') === String(recipientId || '')) return;
+        recipientsById.set(docSnap.id, { id: docSnap.id, ...(docSnap.data() || {}) });
+      });
+    });
+    const recipients = Array.from(recipientsById.values());
     return fallback ? [fallback, ...recipients] : recipients;
   } catch (error) {
     functions.logger.warn('Failed to read payer-scoped fee assignment recipients; falling back to current recipient.', {

--- a/functions/index.js
+++ b/functions/index.js
@@ -9463,31 +9463,6 @@ function buildCombinedFeeAssignmentNotificationPayload(recipients = []) {
   };
 }
 
-async function listFeeAssignmentBatchRecipients({ teamId, batchId, recipientId, recipient }) {
-  let recipients = [];
-  try {
-    const snap = await firestore.collection(`teams/${teamId}/feeBatches/${batchId}/feeRecipients`).get();
-    recipients = snap.docs
-      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }))
-      .filter((entry) => entry && typeof entry === 'object');
-  } catch (error) {
-    functions.logger.warn('Failed to read fee assignment batch recipients; falling back to current recipient.', {
-      teamId,
-      batchId,
-      recipientId,
-      error: error?.message || error
-    });
-  }
-
-  if (recipientId && !recipients.some((entry) => String(entry.id || '') === String(recipientId))) {
-    recipients.push({ id: recipientId, ...(recipient || {}) });
-  }
-  if (!recipients.length && recipient) {
-    recipients.push({ id: recipientId || null, ...recipient });
-  }
-  return recipients;
-}
-
 function getFeeAssignmentRecipientPlayerKey(teamId, recipient = {}) {
   const playerId = resolveFeeRecipientPlayerId(teamId, recipient);
   return getFeeReminderPlayerKey({
@@ -9516,21 +9491,50 @@ async function loadFeeAssignmentUserParentPlayerKeys(uid) {
   }
 }
 
-async function filterFeeAssignmentRecipientsForUser({ teamId, uid, recipients, fallbackRecipient }) {
+async function resolveFeeAssignmentRecipientsForUser({
+  teamId,
+  batchId,
+  uid,
+  recipientId,
+  fallbackRecipient
+}) {
+  const fallback = fallbackRecipient
+    ? { id: recipientId || null, ...fallbackRecipient }
+    : null;
   const normalizedUid = String(uid || '').trim();
-  if (!normalizedUid) return fallbackRecipient ? [fallbackRecipient] : [];
+  if (!normalizedUid || !teamId || !batchId) return fallback ? [fallback] : [];
   const parentPlayerKeys = await loadFeeAssignmentUserParentPlayerKeys(normalizedUid);
-  if (parentPlayerKeys.size) {
-    const fallbackPlayerKey = getFeeAssignmentRecipientPlayerKey(teamId, fallbackRecipient || {});
-    if (!fallbackPlayerKey || parentPlayerKeys.has(fallbackPlayerKey)) {
-      const matchedRecipients = (Array.isArray(recipients) ? recipients : [])
-        .filter((recipient) => parentPlayerKeys.has(getFeeAssignmentRecipientPlayerKey(teamId, recipient)));
-      if (matchedRecipients.length) {
-        return matchedRecipients;
-      }
-    }
+  if (!parentPlayerKeys.size) return fallback ? [fallback] : [];
+
+  const teamPlayerKeyPrefix = `${teamId}::`;
+  const fallbackPlayerKey = getFeeAssignmentRecipientPlayerKey(teamId, fallbackRecipient || {});
+  const playerIds = Array.from(parentPlayerKeys)
+    .filter((playerKey) => playerKey.startsWith(teamPlayerKeyPrefix))
+    .map((playerKey) => playerKey.slice(teamPlayerKeyPrefix.length))
+    .filter((playerId) => playerId && !playerId.includes('/'))
+    .filter((playerId) => `${teamPlayerKeyPrefix}${playerId}` !== fallbackPlayerKey);
+  const uniquePlayerIds = Array.from(new Set(playerIds));
+  if (!uniquePlayerIds.length) return fallback ? [fallback] : [];
+
+  try {
+    const recipientRefs = uniquePlayerIds.map((playerId) => (
+      firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${playerId}`)
+    ));
+    const recipientSnaps = await firestore.getAll(...recipientRefs);
+    const recipients = recipientSnaps
+      .filter((docSnap) => docSnap.exists)
+      .map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }));
+    return fallback ? [fallback, ...recipients] : recipients;
+  } catch (error) {
+    functions.logger.warn('Failed to read payer-scoped fee assignment recipients; falling back to current recipient.', {
+      teamId,
+      batchId,
+      recipientId,
+      uid: normalizedUid,
+      error: error?.message || error
+    });
+    return fallback ? [fallback] : [];
   }
-  return fallbackRecipient ? [fallbackRecipient] : [];
 }
 
 function combineDirectNotificationResults(results = []) {
@@ -11204,23 +11208,17 @@ exports.notifyFeeAssigned = functions.firestore
     const claimedUserIds = new Set(claimResults.filter((result) => result.claimed).map((result) => result.uid));
     if (!claimedUserIds.size) return null;
     const claimedPayerTargets = payerTargets.filter((target) => claimedUserIds.has(target.uid));
-    const batchRecipients = await listFeeAssignmentBatchRecipients({
-      teamId,
-      batchId,
-      recipientId,
-      recipient: data
-    });
-
     try {
       const sendResults = [];
       for (const uid of claimedUserIds) {
         const claimedTargets = claimedPayerTargets;
         const targetsForUser = claimedTargets.filter((target) => String(target.uid || '').trim() === uid);
         if (!targetsForUser.length) continue;
-        const recipientsForUser = await filterFeeAssignmentRecipientsForUser({
+        const recipientsForUser = await resolveFeeAssignmentRecipientsForUser({
           teamId,
+          batchId,
           uid,
-          recipients: batchRecipients,
+          recipientId,
           fallbackRecipient: data
         });
         if (recipientsForUser.length <= 1) {

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -1461,14 +1461,14 @@ test('notifyFeeAssigned finds payer siblings when recipient document IDs differ 
 
     try {
         const recipientA = {
-            playerKey: 'team-1::player-1',
+            childId: 'player-1',
             childName: 'Avery',
             feeTitle: 'Spring dues',
             amountCents: 2500,
             dueDate: '2026-07-01T12:00:00.000Z'
         };
         const recipientB = {
-            playerId: 'player-2',
+            childId: 'player-2',
             childName: 'Blake',
             feeTitle: 'Spring dues',
             amountCents: 2500,

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -1446,7 +1446,7 @@ test('notifyFeeAssigned resolves app-created child fee recipients through parent
     }
 });
 
-test('notifyFeeAssigned bounds a large batch lookup to the payer siblings and deduplicates their push', async () => {
+test('notifyFeeAssigned finds payer siblings when recipient document IDs differ from player IDs', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },
         userDocs: {
@@ -1468,14 +1468,14 @@ test('notifyFeeAssigned bounds a large batch lookup to the payer siblings and de
             dueDate: '2026-07-01T12:00:00.000Z'
         };
         const recipientB = {
-            playerKey: 'team-1::player-2',
+            playerId: 'player-2',
             childName: 'Blake',
             feeTitle: 'Spring dues',
             amountCents: 2500,
             dueDate: '2026-07-01T12:00:00.000Z'
         };
-        const refA = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/player-1');
-        const refB = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/player-2');
+        const refA = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-a');
+        const refB = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-b');
         await refA.set(recipientA);
         await refB.set(recipientB);
         for (let index = 3; index <= 100; index += 1) {
@@ -1488,8 +1488,8 @@ test('notifyFeeAssigned bounds a large batch lookup to the payer siblings and de
                     amountCents: 2500
                 });
         }
-        const contextA = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'player-1' } };
-        const contextB = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'player-2' } };
+        const contextA = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-a' } };
+        const contextB = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-b' } };
 
         const firstResult = await moduleExports.notifyFeeAssigned(makeSnapshot(refA, recipientA), contextA);
         const secondResult = await moduleExports.notifyFeeAssigned(makeSnapshot(refB, recipientB), contextB);
@@ -1502,10 +1502,7 @@ test('notifyFeeAssigned bounds a large batch lookup to the payer siblings and de
         assert.equal(env.messagingCalls[0].body, '$50.00 has been assigned for Avery and Blake, due Jul 1, 2026.');
         assert.equal(env.counts.parentQueries, 2);
         assert.equal(env.counts.userRecordGets, 1);
-        assert.equal(env.counts.feeRecipientDocGets, 1);
-        assert.deepEqual(env.feeRecipientDocGetPaths, [
-            'teams/team-1/feeBatches/batch-3/feeRecipients/player-2'
-        ]);
+        assert.equal(env.counts.feeRecipientDocGets, 0);
     } finally {
         cleanup();
     }
@@ -1537,9 +1534,7 @@ test('notifyFeeAssigned falls back to the trigger recipient when a payer sibling
         assert.equal(result?.successCount, 1);
         assert.equal(env.messagingCalls.length, 1);
         assert.equal(env.messagingCalls[0].title, 'New fee assigned: Spring dues ($25.00)');
-        assert.deepEqual(env.feeRecipientDocGetPaths, [
-            'teams/team-1/feeBatches/batch-missing/feeRecipients/missing-player'
-        ]);
+        assert.equal(env.counts.feeRecipientDocGets, 0);
     } finally {
         cleanup();
     }

--- a/functions/test/notification-triggers.test.js
+++ b/functions/test/notification-triggers.test.js
@@ -1446,11 +1446,13 @@ test('notifyFeeAssigned resolves app-created child fee recipients through parent
     }
 });
 
-test('notifyFeeAssigned sends one combined batch assignment push when a parent has multiple recipients', async () => {
+test('notifyFeeAssigned bounds a large batch lookup to the payer siblings and deduplicates their push', async () => {
     const { moduleExports, env, cleanup } = loadNotificationInternals({
         teamDoc: { ownerId: 'coach-1', adminEmails: [] },
         userDocs: {
-            'parent-1': { parentPlayerKeys: ['team-1::player-1', 'team-1::player-2'] }
+            'parent-1': {
+                parentPlayerKeys: ['team-1::player-1', 'team-1::player-2', 'team-2::other-team-player']
+            }
         },
         indexedTargets: [
             { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } }
@@ -1472,12 +1474,22 @@ test('notifyFeeAssigned sends one combined batch assignment push when a parent h
             amountCents: 2500,
             dueDate: '2026-07-01T12:00:00.000Z'
         };
-        const refA = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-a');
-        const refB = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/recipient-b');
+        const refA = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/player-1');
+        const refB = env.firestoreState.doc('teams/team-1/feeBatches/batch-3/feeRecipients/player-2');
         await refA.set(recipientA);
         await refB.set(recipientB);
-        const contextA = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-a' } };
-        const contextB = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'recipient-b' } };
+        for (let index = 3; index <= 100; index += 1) {
+            await env.firestoreState
+                .doc(`teams/team-1/feeBatches/batch-3/feeRecipients/player-${index}`)
+                .set({
+                    playerKey: `team-1::player-${index}`,
+                    childName: `Player ${index}`,
+                    feeTitle: 'Spring dues',
+                    amountCents: 2500
+                });
+        }
+        const contextA = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'player-1' } };
+        const contextB = { params: { teamId: 'team-1', batchId: 'batch-3', recipientId: 'player-2' } };
 
         const firstResult = await moduleExports.notifyFeeAssigned(makeSnapshot(refA, recipientA), contextA);
         const secondResult = await moduleExports.notifyFeeAssigned(makeSnapshot(refB, recipientB), contextB);
@@ -1490,6 +1502,44 @@ test('notifyFeeAssigned sends one combined batch assignment push when a parent h
         assert.equal(env.messagingCalls[0].body, '$50.00 has been assigned for Avery and Blake, due Jul 1, 2026.');
         assert.equal(env.counts.parentQueries, 2);
         assert.equal(env.counts.userRecordGets, 1);
+        assert.equal(env.counts.feeRecipientDocGets, 1);
+        assert.deepEqual(env.feeRecipientDocGetPaths, [
+            'teams/team-1/feeBatches/batch-3/feeRecipients/player-2'
+        ]);
+    } finally {
+        cleanup();
+    }
+});
+
+test('notifyFeeAssigned falls back to the trigger recipient when a payer sibling document is missing', async () => {
+    const { moduleExports, env, cleanup } = loadNotificationInternals({
+        teamDoc: { ownerId: 'coach-1', adminEmails: [] },
+        userDocs: {
+            'parent-1': { parentPlayerKeys: ['team-1::player-1', 'team-1::missing-player'] }
+        },
+        indexedTargets: [
+            { uid: 'parent-1', deviceId: 'parent-device', token: 'parent-token', categories: { fees: true } }
+        ]
+    });
+
+    try {
+        const recipient = {
+            playerKey: 'team-1::player-1',
+            childName: 'Avery',
+            feeTitle: 'Spring dues',
+            amountCents: 2500
+        };
+        const ref = env.firestoreState.doc('teams/team-1/feeBatches/batch-missing/feeRecipients/player-1');
+        const context = { params: { teamId: 'team-1', batchId: 'batch-missing', recipientId: 'player-1' } };
+
+        const result = await moduleExports.notifyFeeAssigned(makeSnapshot(ref, recipient), context);
+
+        assert.equal(result?.successCount, 1);
+        assert.equal(env.messagingCalls.length, 1);
+        assert.equal(env.messagingCalls[0].title, 'New fee assigned: Spring dues ($25.00)');
+        assert.deepEqual(env.feeRecipientDocGetPaths, [
+            'teams/team-1/feeBatches/batch-missing/feeRecipients/missing-player'
+        ]);
     } finally {
         cleanup();
     }

--- a/functions/test/send-category-notification-test-helpers.cjs
+++ b/functions/test/send-category-notification-test-helpers.cjs
@@ -618,18 +618,23 @@ function buildNotificationTestEnv({
 
         const feeRecipientsMatch = path.match(/^teams\/([^/]+)\/feeBatches\/([^/]+)\/feeRecipients$/);
         if (feeRecipientsMatch) {
+            const getFeeRecipientDocs = () => {
+                const prefix = `${path}/`;
+                return Array.from(docStore.entries())
+                    .filter(([docPath]) => docPath.startsWith(prefix) && !docPath.slice(prefix.length).includes('/'))
+                    .map(([docPath, data]) => makeDocSnapshot({
+                        id: docPath.slice(prefix.length),
+                        ref: doc(docPath),
+                        data,
+                        exists: true
+                    }));
+            };
             return {
+                where(field, op, value) {
+                    return makeQuery(getFeeRecipientDocs).where(field, op, value);
+                },
                 async get() {
-                    const prefix = `${path}/`;
-                    const docs = Array.from(docStore.entries())
-                        .filter(([docPath]) => docPath.startsWith(prefix) && !docPath.slice(prefix.length).includes('/'))
-                        .map(([docPath, data]) => makeDocSnapshot({
-                            id: docPath.slice(prefix.length),
-                            ref: doc(docPath),
-                            data,
-                            exists: true
-                        }));
-                    return makeQuerySnapshot(docs);
+                    return makeQuerySnapshot(getFeeRecipientDocs());
                 }
             };
         }

--- a/functions/test/send-category-notification-test-helpers.cjs
+++ b/functions/test/send-category-notification-test-helpers.cjs
@@ -118,6 +118,7 @@ function buildNotificationTestEnv({
     const deletedPaths = [];
     const updatedDocs = [];
     const messagingCalls = [];
+    const feeRecipientDocGetPaths = [];
     const docStore = new Map();
     const counts = {
         teamDocGets: 0,
@@ -126,6 +127,7 @@ function buildNotificationTestEnv({
         targetQueries: 0,
         recipientDocGets: 0,
         recipientCollectionGets: 0,
+        feeRecipientDocGets: 0,
         preferenceGets: 0,
         deviceGets: 0,
         userRecordGets: 0,
@@ -405,6 +407,10 @@ function buildNotificationTestEnv({
                         data: entry?.data,
                         exists: Boolean(entry)
                     });
+                }
+                if (/^teams\/[^/]+\/feeBatches\/[^/]+\/feeRecipients\/[^/]+$/.test(path)) {
+                    counts.feeRecipientDocGets += 1;
+                    feeRecipientDocGetPaths.push(path);
                 }
                 if (docStore.has(path)) {
                     return makeDocSnapshot({ id: this.id, ref: this, data: docStore.get(path), exists: true });
@@ -859,6 +865,7 @@ function buildNotificationTestEnv({
         auditWrites,
         updatedDocs,
         messagingCalls,
+        feeRecipientDocGetPaths,
         getNotificationInboxDocCount(uid) {
             const prefix = `users/${uid}/notificationInbox/`;
             return Array.from(docStore.keys())

--- a/tests/unit/fee-assignment-notification-source-contract.test.js
+++ b/tests/unit/fee-assignment-notification-source-contract.test.js
@@ -28,6 +28,7 @@ describe('fee assignment notification source contract', () => {
         expect(resolverSource).toContain('.filter((playerKey) => playerKey.startsWith(teamPlayerKeyPrefix))');
         expect(resolverSource).toContain("recipientCollection.where('playerKey', 'in'");
         expect(resolverSource).toContain("recipientCollection.where('playerId', 'in'");
+        expect(resolverSource).toContain("recipientCollection.where('childId', 'in'");
         expect(resolverSource).toContain('index += 30');
         expect(functionsSource).not.toContain('listFeeAssignmentBatchRecipients');
     });

--- a/tests/unit/fee-assignment-notification-source-contract.test.js
+++ b/tests/unit/fee-assignment-notification-source-contract.test.js
@@ -9,15 +9,27 @@ describe('fee assignment notification source contract', () => {
         expect(functionsSource).toContain(".document('teams/{teamId}/feeBatches/{batchId}/feeRecipients/{recipientId}')");
         expect(functionsSource).toContain('const payerUserIds = await resolveFeeAssignmentPayerUserIds(teamId, data);');
         expect(functionsSource).toContain("const payerTargets = await getTargetsForCategoryUserIds(teamId, 'fees', payerUserIds, null);");
-        expect(functionsSource).toContain('const batchRecipients = await listFeeAssignmentBatchRecipients({');
         expect(functionsSource).toContain('for (const uid of claimedUserIds)');
         expect(functionsSource).toContain('const targetsForUser = claimedTargets.filter');
-        expect(functionsSource).toContain('const recipientsForUser = await filterFeeAssignmentRecipientsForUser({');
+        expect(functionsSource).toContain('const recipientsForUser = await resolveFeeAssignmentRecipientsForUser({');
         expect(functionsSource).toContain('const payload = buildCombinedFeeAssignmentNotificationPayload(recipientsForUser);');
         expect(functionsSource).toContain('targets: targetsForUser,');
         expect(functionsSource).toContain("category: 'fees',");
         expect(functionsSource).toContain('title: payload.title');
         expect(functionsSource).toContain('body: payload.body');
+    });
+
+    it('loads only current-team recipient documents referenced by the payer profile', () => {
+        const resolverStart = functionsSource.indexOf('async function resolveFeeAssignmentRecipientsForUser(');
+        const resolverEnd = functionsSource.indexOf('\nfunction combineDirectNotificationResults(', resolverStart);
+        const resolverSource = functionsSource.slice(resolverStart, resolverEnd);
+
+        expect(resolverSource).toContain("const teamPlayerKeyPrefix = `${teamId}::`;");
+        expect(resolverSource).toContain('.filter((playerKey) => playerKey.startsWith(teamPlayerKeyPrefix))');
+        expect(resolverSource).toContain('firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${playerId}`)');
+        expect(resolverSource).toContain('const recipientSnaps = await firestore.getAll(...recipientRefs);');
+        expect(resolverSource).not.toContain('.collection(');
+        expect(functionsSource).not.toContain('listFeeAssignmentBatchRecipients');
     });
 
     it('deduplicates assignment notifications by parent within a fee batch', () => {

--- a/tests/unit/fee-assignment-notification-source-contract.test.js
+++ b/tests/unit/fee-assignment-notification-source-contract.test.js
@@ -26,9 +26,9 @@ describe('fee assignment notification source contract', () => {
 
         expect(resolverSource).toContain("const teamPlayerKeyPrefix = `${teamId}::`;");
         expect(resolverSource).toContain('.filter((playerKey) => playerKey.startsWith(teamPlayerKeyPrefix))');
-        expect(resolverSource).toContain('firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${playerId}`)');
-        expect(resolverSource).toContain('const recipientSnaps = await firestore.getAll(...recipientRefs);');
-        expect(resolverSource).not.toContain('.collection(');
+        expect(resolverSource).toContain("recipientCollection.where('playerKey', 'in'");
+        expect(resolverSource).toContain("recipientCollection.where('playerId', 'in'");
+        expect(resolverSource).toContain('index += 30');
         expect(functionsSource).not.toContain('listFeeAssignmentBatchRecipients');
     });
 

--- a/tests/unit/fee-notification-contract.test.js
+++ b/tests/unit/fee-notification-contract.test.js
@@ -38,9 +38,8 @@ describe('fee notification contract', () => {
         expect(functionsSource).toContain('const payerUserIds = await resolveFeeAssignmentPayerUserIds(teamId, data);');
         expect(functionsSource).toContain("const payerTargets = await getTargetsForCategoryUserIds(teamId, 'fees', payerUserIds, null);");
         expect(functionsSource).toContain('claimFeeAssignmentNotificationUser({ teamId, batchId, recipientId, uid })');
-        expect(functionsSource).toContain('const batchRecipients = await listFeeAssignmentBatchRecipients({');
         expect(functionsSource).toContain('for (const uid of claimedUserIds)');
-        expect(functionsSource).toContain('const recipientsForUser = await filterFeeAssignmentRecipientsForUser({');
+        expect(functionsSource).toContain('const recipientsForUser = await resolveFeeAssignmentRecipientsForUser({');
         expect(functionsSource).toContain('const payload = buildCombinedFeeAssignmentNotificationPayload(recipientsForUser);');
         expect(functionsSource).toContain('targets: targetsForUser,');
         expect(functionsSource).toContain('title: payload.title');


### PR DESCRIPTION
Closes #4001

## What changed
- Replaced the full fee-recipient collection scan with payer-scoped document reads derived from current-team `parentPlayerKeys`.
- Preserved the triggering recipient as a fallback when profiles or sibling documents are missing.
- Preserved per-parent claims, combined sibling notifications, preference filtering, and claim release behavior.

## Root Cause
Each recipient trigger loaded the entire batch before filtering recipients to one payer. Since fee creation fans out one trigger per recipient, a batch of N mostly unrelated recipients produced approximately N² Firestore document reads.

## Prevention / Learning
Before adding collection reads inside fan-out triggers, multiply trigger cardinality by collection cardinality. Resolve known document IDs directly and add high-cardinality tests that assert unrelated documents are not read.

## Regression Tests
- Added a 100-recipient fixture proving a two-child payer reads only the other sibling document and sends one combined push.
- Verified cross-team parent player keys are ignored.
- Verified a missing sibling document falls back to the triggering recipient.
- Verified the second sibling trigger remains deduplicated by the per-parent batch claim.
- Added a source contract prohibiting the former full-batch resolver and collection scan.
- `npm --prefix functions run test:notifications`: 79 passed.
- Focused fee notification and source-contract tests: 64 passed.

## Recurrence Risk
Low. The unbounded collection read was removed and both runtime read-path assertions and source contracts guard the bounded resolver.